### PR TITLE
Fix spelling of META_DESC.configurable

### DIFF
--- a/packages/sproutcore-metal/lib/utils.js
+++ b/packages/sproutcore-metal/lib/utils.js
@@ -127,7 +127,7 @@ SC.guidFor = function(obj) {
 
 var META_DESC = {
   writable:    true,
-  confgurable: false,
+  configurable: false,
   enumerable:  false,
   value: null
 };


### PR DESCRIPTION
Typo in attribute of META_DESC.
