### PR TITLE
Adds select/option tag names to automatically set container/child mapping

### DIFF
--- a/packages/sproutcore-handlebars/lib/helpers/collection.js
+++ b/packages/sproutcore-handlebars/lib/helpers/collection.js
@@ -28,7 +28,8 @@ SC.Handlebars.CONTAINER_MAP = {
   thead: 'tr',
   tbody: 'tr',
   tfoot: 'tr',
-  tr: 'td'
+  tr: 'td',
+  select: 'option'
 };
 
 /**

--- a/packages/sproutcore-handlebars/tests/views/collection_view_test.js
+++ b/packages/sproutcore-handlebars/tests/views/collection_view_test.js
@@ -171,6 +171,21 @@ test("should re-render when the content object changes", function() {
 
 });
 
+test("select tagName on collection helper automatically sets child tagName to option", function() {
+  TemplateTests.RerenderTest = SC.CollectionView.extend({
+    content: ['foo']
+  });
+  
+  var view = SC.View.create({
+    template: SC.Handlebars.compile('{{#collection TemplateTests.RerenderTest tagName="select"}}{{content}}{{/collection}}')
+  });
+  
+  view.createElement();
+  
+  equals(view.$('option').length, 1, "renders the correct child tag name");
+  
+});
+
 test("tagName works in the #collection helper", function() {
   TemplateTests.RerenderTest = SC.CollectionView.extend({
     content: ['foo', 'bar']


### PR DESCRIPTION
`<select>` was missing from container mappings per https://twitter.com/wycats/status/81192316655775744
