### PR TITLE
Packaged code failing in browser.

### DIFF
--- a/packages/sproutcore-handlebars/lib/handlebars-format.js
+++ b/packages/sproutcore-handlebars/lib/handlebars-format.js
@@ -7,6 +7,8 @@
 // TODO: should actually compile the template and THEN return that function.
 // This way we won't have to compile templates on the fly.  This version just
 // makes the compile happen when used.
-exports.compileFormat = function(tmpl) {
-  return '\nrequire("sproutcore-handlebars");\nreturn SC.Handlebars.compile('+JSON.stringify(tmpl)+');';
-};
+if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
+  exports.compileFormat = function(tmpl) {
+    return '\nrequire("sproutcore-handlebars");\nreturn SC.Handlebars.compile('+JSON.stringify(tmpl)+');';
+  };
+}


### PR DESCRIPTION
When packaging the code, there is an unwrapped `exports` that will cause the code to error in the browser.
