### PR TITLE
Missing require. Referencing SC.SIMPLE_PROPERTY which is defined in sprou

### DIFF
--- a/packages/sproutcore-metal/lib/watching.js
+++ b/packages/sproutcore-metal/lib/watching.js
@@ -9,6 +9,7 @@ require('sproutcore-metal/core');
 require('sproutcore-metal/platform');
 require('sproutcore-metal/utils');
 require('sproutcore-metal/accessors');
+require('sproutcore-metal/properties');
 require('sproutcore-metal/observer');
 
 var guidFor = SC.guidFor;


### PR DESCRIPTION
Missing require. Referencing SC.SIMPLE_PROPERTY which is defined in sproutcore-metal/properties.js.
