### PR TITLE
Add an unbound output Handlebars helper

### DIFF
--- a/packages/sproutcore-handlebars/lib/helpers.js
+++ b/packages/sproutcore-handlebars/lib/helpers.js
@@ -7,3 +7,4 @@
 require("sproutcore-handlebars/helpers/binding");
 require("sproutcore-handlebars/helpers/collection");
 require("sproutcore-handlebars/helpers/view");
+require("sproutcore-handlebars/helpers/unbound");

--- a/packages/sproutcore-handlebars/lib/helpers/unbound.js
+++ b/packages/sproutcore-handlebars/lib/helpers/unbound.js
@@ -1,0 +1,24 @@
+// ==========================================================================
+// Project:   SproutCore Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals Handlebars */
+
+require('sproutcore-handlebars/ext');
+
+var get = SC.get, getPath = SC.getPath;
+
+/**
+  `raw` allows you to output a property without binding. *Important:* The 
+  output will not be updated if the property changes. Use with caution.
+
+      <div>{{raw somePropertyThatDoesntChange}}</div>
+
+  @name Handlebars.helpers.raw
+  @param {String} property
+  @returns {String} HTML string
+*/
+Handlebars.registerHelper('raw', function(property) {
+  return getPath(this, property);
+});

--- a/packages/sproutcore-handlebars/tests/handlebars_test.js
+++ b/packages/sproutcore-handlebars/tests/handlebars_test.js
@@ -1032,3 +1032,19 @@ test("should use the childView's renderBuffer", function() {
   
   ok(calledRenderBuffer);
 });
+
+test("should be able to output a property without binding", function(){
+  var template = SC.Handlebars.compile('<div>{{raw content.aRawString}}</div>');
+  var content = SC.Object.create({
+    aRawString: "No spans here, son."
+  });
+
+  var view = SC.View.create({
+    template: template,
+    content: content
+  });
+
+  view.createElement();
+
+  equals(view.$('div').html(), "No spans here, son.");
+});


### PR DESCRIPTION
Called it `raw`. Curious what everyone thinks. This may be a bad idea, but I think there are some legitimate uses for it.
