### PR TITLE
Allow saved/named templates in the body

### DIFF
--- a/packages/sproutcore-handlebars/lib/loader.js
+++ b/packages/sproutcore-handlebars/lib/loader.js
@@ -11,50 +11,42 @@ require("sproutcore-handlebars/ext");
 // to SC.CoreView in the global SC.TEMPLATES object.
 
 SC.$(document).ready(function() {
-  SC.$('head script[type="text/html"]').each(function() {
+  SC.$('script[type="text/html"]')
+    .each(function() {
     // Get a reference to the script tag
-    var script = SC.$(this);
+    var script = SC.$(this),
+      // Get the name of the script, used by SC.View's templateName property.
+      // First look for data-template-name attribute, then fall back to its
+      // id if no name is found.
+      templateName = script.attr('data-template-name') || script.attr('id'),
+      template = SC.Handlebars.compile(script.html()),
+      view, viewPath;
 
-    // Get the name of the script, used by SC.View's templateName property.
-    // First look for data-template-name attribute, then fall back to its
-    // id if no name is found.
-    var templateName = script.attr('data-template-name') || script.attr('id');
+    if (templateName) {
+      SC.TEMPLATES[templateName] = template;
 
-    if (!templateName) {
-      throw new SC.Error("Template found without a name specified." +
+      // Remove script tag from DOM
+      script.remove();
+    } else {
+      if (script.parents('head').length !== 0) {
+        // don't allow inline templates in the head
+        throw new SC.Error("Template found in \<head\> without a name specified." +
                          "Please provide a data-template-name attribute.\n" +
                          script.html());
+      }
+      viewPath = script.attr('data-view')
+      view = viewPath ? SC.getPath(viewPath) : SC.View;
+
+      view = view.create({
+        template: template
+      });
+
+      view._insertElementLater(function() {
+        script.replaceWith(this.$());
+
+        // Avoid memory leak in IE
+        script = null;
+      });
     }
-
-    SC.TEMPLATES[templateName] = SC.Handlebars.compile(script.html());
-
-    // Remove script tag from DOM
-    script.remove();
-  });
-
-  // Finds templates stored inline in the HTML document, instantiates a new
-  // view, and replaces the script tag holding the template with the new
-  // view's DOM representation.
-  //
-  // Users can optionally specify a custom view subclass to use by setting the
-  // data-view attribute of the script tag.
-
-  SC.$('body script[type="text/html"]').each(function() {
-    var script = SC.$(this),
-        template = SC.Handlebars.compile(script.html()),
-        viewPath = script.attr('data-view');
-
-    var view = viewPath ? SC.getPath(viewPath) : SC.View;
-
-    view = view.create({
-      template: template
-    });
-
-    view._insertElementLater(function() {
-      script.replaceWith(this.$());
-
-      // Avoid memory leak in IE
-      script = null;
-    });
   });
 });

--- a/packages/sproutcore-handlebars/lib/loader.js
+++ b/packages/sproutcore-handlebars/lib/loader.js
@@ -23,6 +23,7 @@ SC.$(document).ready(function() {
       view, viewPath;
 
     if (templateName) {
+      // For templates which have a name, we save them and then remove them from the DOM
       SC.TEMPLATES[templateName] = template;
 
       // Remove script tag from DOM
@@ -34,6 +35,13 @@ SC.$(document).ready(function() {
                          "Please provide a data-template-name attribute.\n" +
                          script.html());
       }
+
+      // For templates which will be evaluated inline in the HTML document, instantiates a new
+      // view, and replaces the script tag holding the template with the new
+      // view's DOM representation.
+      //
+      // Users can optionally specify a custom view subclass to use by setting the
+      // data-view attribute of the script tag.
       viewPath = script.attr('data-view');
       view = viewPath ? SC.getPath(viewPath) : SC.View;
 

--- a/packages/sproutcore-handlebars/lib/loader.js
+++ b/packages/sproutcore-handlebars/lib/loader.js
@@ -30,11 +30,11 @@ SC.$(document).ready(function() {
     } else {
       if (script.parents('head').length !== 0) {
         // don't allow inline templates in the head
-        throw new SC.Error("Template found in \<head\> without a name specified." +
+        throw new SC.Error("Template found in \<head\> without a name specified. " +
                          "Please provide a data-template-name attribute.\n" +
                          script.html());
       }
-      viewPath = script.attr('data-view')
+      viewPath = script.attr('data-view');
       view = viewPath ? SC.getPath(viewPath) : SC.View;
 
       view = view.create({

--- a/packages/sproutcore-views/lib/views/collection_view.js
+++ b/packages/sproutcore-views/lib/views/collection_view.js
@@ -181,8 +181,7 @@ SC.CollectionView = SC.View.extend(
       for (idx = 0; idx < len; idx++) {
         item = addedObjects.objectAt(idx);
         view = this.createChildView(itemViewClass, {
-          content: item,
-          index: idx
+          content: item
         });
 
         buffer = buffer + view.renderToBuffer().string();

--- a/packages/sproutcore-views/lib/views/collection_view.js
+++ b/packages/sproutcore-views/lib/views/collection_view.js
@@ -181,7 +181,8 @@ SC.CollectionView = SC.View.extend(
       for (idx = 0; idx < len; idx++) {
         item = addedObjects.objectAt(idx);
         view = this.createChildView(itemViewClass, {
-          content: item
+          content: item,
+          index: idx
         });
 
         buffer = buffer + view.renderToBuffer().string();


### PR DESCRIPTION
I'm totally part of the target audience for SC2: someone who wants the sweetness, but can't let SC take over the page.

Part of not being able to take over the page is not having access to the head.  This allows named templates to be embedded in the body.  If a template has a name, it is saved in SC.TEMPLATES, otherwise it is rendered inline as before.
