### PR TITLE
Using invokeLater alternative

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,20 +31,21 @@ def compile_package_task(package)
 end
 
 namespace :sproutcore do
-  %w(metal runtime handlebars views datastore).each do |package|
+  %w(metal indexset runtime handlebars views datastore).each do |package|
     task package => compile_package_task("sproutcore-#{package}")
   end
 end
 
 task :handlebars => compile_package_task("handlebars")
 
-task :build => ["sproutcore:metal", "sproutcore:runtime", "sproutcore:handlebars", "sproutcore:views", "sproutcore:datastore", :handlebars]
+task :build => ["sproutcore:metal", "sproutcore:indexset", "sproutcore:runtime", "sproutcore:handlebars", "sproutcore:views", "sproutcore:datastore", :handlebars]
 
 file "tmp/static/sproutcore.js" => :build do
   File.open("tmp/static/sproutcore.js", "w") do |file|
     file.puts File.read("tmp/static/handlebars.js")
     file.puts File.read("tmp/static/sproutcore-metal.js")
     file.puts File.read("tmp/static/sproutcore-runtime.js")
+    file.puts File.read("tmp/static/sproutcore-indexset.js")
     file.puts File.read("tmp/static/sproutcore-views.js")
     file.puts File.read("tmp/static/sproutcore-handlebars.js")
   end

--- a/packages/sproutcore-datastore/lib/system/store.js
+++ b/packages/sproutcore-datastore/lib/system/store.js
@@ -1141,7 +1141,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     // if commit records is enabled
     if(get(this, 'commitRecordsAutomatically')){
-      this.invokeLast(this.commitRecords);
+      SC.run.schedule('sync', this, this.commitRecords);
     }
 
     // Finally return materialized record, after we propagate the status to
@@ -1315,7 +1315,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     // if commit records is enabled
     if(get(this, 'commitRecordsAutomatically')){
-      this.invokeLast(this.commitRecords);
+      SC.run.schedule('sync', this, this.commitRecords);
     }
 
     var that = this;
@@ -1472,7 +1472,7 @@ SC.Store = SC.Object.extend( /** @scope SC.Store.prototype */ {
 
     // if commit records is enabled
     if(get(this, 'commitRecordsAutomatically')){
-      this.invokeLast(this.commitRecords);
+      SC.run.schedule('sync', this, this.commitRecords);
     }
 
     return this ;


### PR DESCRIPTION
Hi!

I am quite new to SC 2.0. But when attempting to isolate the datastore functionality I occured SC 1.x to 2.x runtime omission. autocommit stores did not work.

Please have a look. Thanks!
Standa
