### PR TITLE
Removes duplicate SC.isArray implementation from sproutcore-runtime.

### DIFF
--- a/packages/sproutcore-runtime/lib/core.js
+++ b/packages/sproutcore-runtime/lib/core.js
@@ -133,29 +133,8 @@ SC.empty = function(obj) {
 };
 
 /**
-  @function
-  
-  Returns YES if the passed object is an array or Array-like.
-
-  SproutCore Array Protocol:
-
-    - the object has an objectAt property
-    - the object is a native Array
-    - the object is an Object, and has a length property
-
-  Unlike SC.typeOf this method returns true even if the passed object is
-  not formally array but appears to be array-like (i.e. implements SC.Array)
-
-  @param {Object} obj The object to test
-  @returns {Boolean}
-*/
-SC.isArray = function(obj) {
-  if (!obj || obj.setInterval) { return false; }
-  if (Array.isArray && Array.isArray(obj)) { return true; }
-  if (SC.Array && SC.Array.detect(obj)) { return true; }
-  if ((obj.length !== undefined) && 'object'===typeof obj) { return true; }
-  return false;
-};
+  SC.isArray defined in sproutcore-metal/lib/utils
+**/
 
 /**
  This will compare two javascript values of possibly different types.


### PR DESCRIPTION
runtime depends on metal, where SC.isArray is also defined. Higher level libraries in the framework also
require metal.
