### PR TITLE
IE8 and IE7 legacy fixes

### DIFF
--- a/packages/sproutcore-metal/lib/mixin.js
+++ b/packages/sproutcore-metal/lib/mixin.js
@@ -374,7 +374,7 @@ var NAME_KEY = SC.GUID_KEY+'_name';
 function processNames(paths, root, seen) {
   var idx = paths.length;
   for(var key in root) {
-    if (!root.hasOwnProperty(key)) continue;
+    if (!root.hasOwnProperty || !root.hasOwnProperty(key)) continue;
     var obj = root[key];
     paths[idx] = key;
 

--- a/packages/sproutcore-metal/lib/platform.js
+++ b/packages/sproutcore-metal/lib/platform.js
@@ -94,8 +94,9 @@ if (SC.platform.defineProperty && !SC.platform.definePropertyOnDOM) {
 SC.platform.hasPropertyAccessors = true;
 
 //@if (legacy)
-if (!SC.platform.defineProperty) {
-  SC.platform.hasPropertyAccessors = !!SC.platform.defineProperty;
+if (!SC.platform.defineProperty || !Object.prototype.__defineGetter__) {
+  // IE8: check the __defineGetter__
+  SC.platform.hasPropertyAccessors = !!SC.platform.defineProperty && Object.prototype.__defineGetter__;
 
   SC.platform.defineProperty = function(obj, keyName, desc) {
     sc_assert("property descriptor cannot have `get` or `set` on this platform", !desc.get && !desc.set);

--- a/packages/sproutcore-runtime/lib/system/run_loop.js
+++ b/packages/sproutcore-runtime/lib/system/run_loop.js
@@ -15,6 +15,7 @@ require('sproutcore-runtime/system/object');
 //
 
 var slice = Array.prototype.slice;
+var argsEmpty = [];
 
 // invokes passed params - normalizing so you can pass target/func,
 // target/string or just func
@@ -27,7 +28,7 @@ function invoke(target, method, args, ignore) {
 
   if ('string'===typeof method) method = target[method];
   if (args && ignore>0) {
-    args = args.length>ignore ? slice.call(args, ignore) : null;
+    args = args.length>ignore ? slice.call(args, ignore) : argsEmpty;
   }
   return method.apply(target, args);
 }


### PR DESCRIPTION
IE7 and IE8
window.hasOwnProperty doesn't exist.
function.apply(context, null) fails - using an empty array instead.

IE8 only:
SC.platform.defineProperty simulated for IE8. Object.defineProperty is provided by IE8, but doesn't work properly. Added necessary **defineGetter** check.
