### PR TITLE
Accessing an unknown property of a watched object triggers call to unknow

### DIFF
--- a/packages/sproutcore-metal/lib/properties.js
+++ b/packages/sproutcore-metal/lib/properties.js
@@ -157,7 +157,11 @@ var WATCHED_DESC = {
 
 function w_get(obj, keyName) {
   var m = meta(obj, false);
-  return m.values ? m.values[keyName] : undefined;
+  if (m.values) {
+    if (m.values[keyName] !== undefined) { return m.values[keyName]; }
+    obj.unknownProperty(keyName);
+  };
+  return undefined;
 }
 
 function w_set(obj, keyName, value) {

--- a/packages/sproutcore-metal/tests/watching/watch_test.js
+++ b/packages/sproutcore-metal/tests/watching/watch_test.js
@@ -85,6 +85,21 @@ test("watching an object THEN defining it should work also", function() {
   
 });
 
+test("accessing a watched unknown property triggers call to unknownProperty", function(){
+  var unknownPropertyWasCalled = false;
+  var watchedPropertyName = 'foo'
+  
+  var obj = {
+    unknownProperty: function(propName){
+      if (propName === watchedPropertyName) { unknownPropertyWasCalled = true };
+    }
+  };
+  SC.watch(obj, watchedPropertyName);
+  SC.get(obj, watchedPropertyName)
+  
+  ok(unknownPropertyWasCalled);
+});
+
 test('watching an object value then unwatching should restore old value', function() {
 
   var obj = { foo: { bar: { baz: { biff: 'BIFF' } } } };


### PR DESCRIPTION
Accessing an unknown property of a watched object triggers call to unknownProperty
