### PR TITLE
Adds test specifically addressing template rerendering and binding with computed properties

### DIFF
--- a/packages/sproutcore-handlebars/tests/handlebars_test.js
+++ b/packages/sproutcore-handlebars/tests/handlebars_test.js
@@ -1091,3 +1091,41 @@ test("should be able to output a property without binding", function(){
 
   equals(view.$('div').html(), "No spans here, son.");
 });
+
+module("Templates redrawing and bindings", {
+  setup: function(){
+    MyApp = SC.Object.create({});
+  },
+  teardown: function(){
+    window.MyApp = null;
+  }
+})
+test("should be able to update when bound property updates", function(){
+  MyApp.set('Controller', SC.Object.create({name: 'first'}))
+  
+  var View = SC.View.extend({
+    template: SC.Handlebars.compile('<i>{{value.name}}, {{computed}}</i>'),
+    valueBinding: 'MyApp.Controller',
+    computed: function(){
+      return this.value ? this.value.get('name') +' - computed' : 'no value';
+    }.property('value')
+  });
+  
+  var view = View.create();
+  view.createElement();
+  
+  SC.run.sync();
+  
+  SC.run(function(){
+    MyApp.set('Controller', SC.Object.create({
+      name: 'second'
+    }))
+  })
+  
+  SC.run.sync();
+  
+  equals(view.get('computed'), "second - computed", "view computed properties correctly update");
+  equals(view.$('i').text(), 'second, second - computed', "view rerenders when bound properties change");
+  
+})
+

--- a/packages/sproutcore-handlebars/tests/handlebars_test.js
+++ b/packages/sproutcore-handlebars/tests/handlebars_test.js
@@ -1101,13 +1101,13 @@ module("Templates redrawing and bindings", {
   }
 })
 test("should be able to update when bound property updates", function(){
-  MyApp.set('Controller', SC.Object.create({name: 'first'}))
+  MyApp.set('controller', SC.Object.create({name: 'first'}))
   
   var View = SC.View.extend({
     template: SC.Handlebars.compile('<i>{{value.name}}, {{computed}}</i>'),
-    valueBinding: 'MyApp.Controller',
+    valueBinding: 'MyApp.controller',
     computed: function(){
-      return this.value ? this.value.get('name') +' - computed' : 'no value';
+      return this.getPath('value.name') + ' - computed';
     }.property('value')
   });
   
@@ -1117,12 +1117,11 @@ test("should be able to update when bound property updates", function(){
   SC.run.sync();
   
   SC.run(function(){
-    MyApp.set('Controller', SC.Object.create({
+    MyApp.set('controller', SC.Object.create({
       name: 'second'
     }))
   })
   
-  SC.run.sync();
   
   equals(view.get('computed'), "second - computed", "view computed properties correctly update");
   equals(view.$('i').text(), 'second, second - computed', "view rerenders when bound properties change");


### PR DESCRIPTION
Views with computed properties that depend on binding-related properties weren't triggering a rerender on change.  This got fixed by 4e7bf9ed94698f555f799bd0e68e388efea42a9b, but I wanted to make sure specific tests for the behavior are in to avoid regression.
