### PR TITLE
Make "collection" handlebars helper accept relative class paths

### DIFF
--- a/packages/sproutcore-handlebars/lib/helpers/collection.js
+++ b/packages/sproutcore-handlebars/lib/helpers/collection.js
@@ -52,7 +52,7 @@ Handlebars.registerHelper('collection', function(path, options) {
   // If passed a path string, convert that into an object.
   // Otherwise, just default to the standard class.
   var collectionClass;
-  collectionClass = path ? SC.getPath(path) : SC.CollectionView;
+  collectionClass = path ? SC.getPath(this, path) : SC.CollectionView;
   sc_assert("%@ #collection: Could not find %@".fmt(data.view, path), !!collectionClass);
 
   var hash = options.hash, itemHash = {}, match;


### PR DESCRIPTION
The "view" helper already accepts relatives paths, so this results in
a more consistent API.
