### PR TITLE
This fixes issue #54

### DIFF
--- a/packages/sproutcore-views/lib/system/event_dispatcher.js
+++ b/packages/sproutcore-views/lib/system/event_dispatcher.js
@@ -102,17 +102,12 @@ SC.EventDispatcher = SC.Object.extend(
           result = true, handler;
 
       SC.run(function() {
-        while (result !== false && view) {
-          handler = view[eventName];
-          if (SC.typeOf(handler) === 'function') {
-            result = handler.call(view, evt);
-          }
-
-          view = get(view, 'parentView');
+        handler = view[eventName];
+        if (SC.typeOf(handler) === 'function') {
+          result = handler.call(view, evt);
         }
       });
 
-      evt.stopPropagation();
       return result;
     });
   },

--- a/packages/sproutcore-views/tests/system/event_dispatcher_test.js
+++ b/packages/sproutcore-views/tests/system/event_dispatcher_test.js
@@ -101,3 +101,25 @@ test("should send change events up view hierarchy if view contains form elements
   equals(receivedEvent.target, SC.$('#is-done')[0], "target property is the element that was clicked");
 });
 
+test("should not interfere with event propagation", function() {
+  var receivedEvent;
+  view = SC.View.create({
+    render: function(buffer) {
+      buffer.push('<div id="propagate-test-div"></div>')
+    }
+  });
+
+  SC.run(function() {
+    view.append();
+  });
+
+  SC.$(window).bind('click', function(evt) {
+    receivedEvent = evt;
+  });
+
+  SC.$('#propagate-test-div').click();
+
+  ok(receivedEvent, "allowed event to propagate outside SC")
+  same(receivedEvent.target, SC.$('#propagate-test-div')[0], "target property is the element that was clicked");
+});
+


### PR DESCRIPTION
Use jquery native bubbling mechanism for sc views, and allow the events to bubble out of the sc app.

Note: sproutcore-views tests run clean, but I can't verify sproutcore-runtime right now (see issue #75).  Dunno if this change could possibly affect any of those tests...
