### PR TITLE
Fixed the bpm package requirements to work with 2.0.beta.2.pre and higher

### DIFF
--- a/packages/sproutcore-datastore/package.json
+++ b/packages/sproutcore-datastore/package.json
@@ -6,9 +6,9 @@
   "author": "Strobe Inc., Apple, Inc., and contributors",
   "version": "2.0.beta.2.pre",
   "dependencies": {
-    "sproutcore-runtime": "2.0",
-    "sproutcore-datetime": "2.0",
-    "sproutcore-indexset": "2.0"
+    "sproutcore-runtime": ">= 2.0.beta.2.pre",
+    "sproutcore-datetime": ">= 2.0.beta.2.pre",
+    "sproutcore-indexset": ">= 2.0.beta.2.pre"
   },
 
   "directories": {

--- a/packages/sproutcore-datetime/package.json
+++ b/packages/sproutcore-datetime/package.json
@@ -6,7 +6,7 @@
   "author": "Strobe Inc., Apple, Inc., and contributors",
   "version": "2.0.beta.2.pre",
   "dependencies": {
-    "sproutcore-runtime": "2.0"
+    "sproutcore-runtime": ">= 2.0.beta.2.pre"
   },
   "directories": {
     "lib"       : "./lib",

--- a/packages/sproutcore-handlebars/package.json
+++ b/packages/sproutcore-handlebars/package.json
@@ -7,8 +7,8 @@
   "version": "2.0.beta.2.pre",
   "dependencies": {
     "handlebars": "~> 1.0.0.beta.2",
-    "sproutcore-views": "2.0",
-    "sproutcore-runtime": "2.0"
+    "sproutcore-views": ">= 2.0.beta.2.pre",
+    "sproutcore-runtime": ">= 2.0.beta.2.pre"
   },
   "directories": {
     "lib"       : "./lib",

--- a/packages/sproutcore-indexset/package.json
+++ b/packages/sproutcore-indexset/package.json
@@ -6,7 +6,7 @@
   "author": "Strobe Inc., Apple, Inc., and contributors",
   "version": "2.0.beta.2.pre",
   "dependencies": {
-    "sproutcore-runtime": "2.0"
+    "sproutcore-runtime": ">= 2.0.beta.2.pre"
   },
   "directories": {
     "lib"       : "./lib",

--- a/packages/sproutcore-runtime/package.json
+++ b/packages/sproutcore-runtime/package.json
@@ -8,7 +8,7 @@
   "version": "2.0.beta.2.pre",
 
   "dependencies": {
-    "sproutcore-metal": "2.0"
+    "sproutcore-metal": ">= 2.0.beta.2.pre"
   },
 
   "directories": {

--- a/packages/sproutcore-views/package.json
+++ b/packages/sproutcore-views/package.json
@@ -7,7 +7,7 @@
   "version": "2.0.beta.2.pre",
   "dependencies": {
     "jquery": "1.6",
-    "sproutcore-runtime": "2.0"
+    "sproutcore-runtime": ">= 2.0.beta.2.pre"
   },
   "directories": {
     "lib"       : "./lib",

--- a/packages/sproutcore/package.json
+++ b/packages/sproutcore/package.json
@@ -6,10 +6,10 @@
   "author": "Charles Jolley",
   "version": "2.0",
   "dependencies": {
-    "sproutcore-runtime": "2.0",
-    "sproutcore-views": "2.0",
-    "sproutcore-datastore": "2.0",
-    "sproutcore-handlebars": "2.0"
+    "sproutcore-runtime": ">= 2.0.beta.2.pre",
+    "sproutcore-views": ">= 2.0.beta.2.pre",
+    "sproutcore-datastore": ">= 2.0.beta.2.pre",
+    "sproutcore-handlebars": ">= 2.0.beta.2.pre"
   },
   "directories": { "lib": "lib" },
   


### PR DESCRIPTION
The dependencies all said "2.0" and bpm complained that "2.0.beta.2.pre" doesn't satisfy the 2.0 requirement. Changed to ">= 2.0.beta.2.pre"
