### PR TITLE
sproutcore-views tests fail if run after sproutcore-handlebars tests

### DIFF
--- a/packages/sproutcore-handlebars/tests/views/collection_view_test.js
+++ b/packages/sproutcore-handlebars/tests/views/collection_view_test.js
@@ -84,7 +84,7 @@ test("empty views should be removed when content is added to the collection (reg
 
   equals(view.$('tr').length, 1, 'has one row');
 
-  window.App = undefined;
+  window.App.destroy();
 });
 
 test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {


### PR DESCRIPTION
Running the following results in failed tests:
`http://localhost:4020/assets/spade-qunit/index.html?package=sproutcore-handlebars,sproutcore-views`

An undestroyed App in the handlebars tests continues to handle events in the sproutcore-views tests, causing tests which ensure handlers only run once to fail.  This pull fixes that.
