### PR TITLE
fix SC.run to pass extra arguments through (sproutcore20 issue #97)

### DIFF
--- a/packages/sproutcore-runtime/lib/system/run_loop.js
+++ b/packages/sproutcore-runtime/lib/system/run_loop.js
@@ -170,7 +170,7 @@ SC.run = run = function(target, method) {
 
   var ret, loop;
   run.begin();
-  if (target || method) ret = invoke(target, method);
+  if (target || method) ret = invoke(target, method, arguments, 2);
   run.end();
   return ret;
 };

--- a/packages/sproutcore-runtime/tests/system/run_loop/run_test.js
+++ b/packages/sproutcore-runtime/tests/system/run_loop/run_test.js
@@ -7,12 +7,14 @@
 module('system/run_loop/run_test');
 
 test('SC.run invokes passed function, returning value', function() {
-  var obj = { 
-    foo: function() { return [this.bar, 'FOO']; }, 
-    bar: 'BAR' 
+  var obj = {
+    foo: function() { return [this.bar, 'FOO']; },
+    bar: 'BAR',
+    checkArgs: function(arg1, arg2) { return [ arg1, this.bar, arg2 ]; }
   };
 
   equals(SC.run(function() { return 'FOO'; }), 'FOO', 'pass function only');
-  same(SC.run(obj, obj.foo), ['BAR', 'FOO'], 'pass obj.method');
-  same(SC.run(obj, 'foo'), ['BAR', 'FOO'], 'pass obj.method');
+  same(SC.run(obj, obj.foo), ['BAR', 'FOO'], 'pass obj and obj.method');
+  same(SC.run(obj, 'foo'), ['BAR', 'FOO'], 'pass obj and "method"');
+  same(SC.run(obj, obj.checkArgs, 'hello', 'world'), ['hello', 'BAR', 'world'], 'pass obj, obj.method, and extra arguments');
 });


### PR DESCRIPTION
Trivial fix to SC.run to pass extra arguments through to invoke.
