### PR TITLE
Incorrect use of sc_assert

### DIFF
--- a/packages/sproutcore-views/lib/views/collection_view.js
+++ b/packages/sproutcore-views/lib/views/collection_view.js
@@ -65,7 +65,7 @@ SC.CollectionView = SC.ContainerView.extend(
     var content = get(this, 'content');
 
     if (content) {
-      sc_assert(fmt("an ArrayController's content must implement SC.Array. You passed %@", [content]), content.addArrayObserver);
+      sc_assert(fmt("an ArrayController's content must implement SC.Array. You passed %@", [content]), content.addArrayObserver != null);
       content.addArrayObserver(this);
     }
     this.arrayDidChange(content, 0, null, get(content, 'length'));


### PR DESCRIPTION
You can't test for the existence of a function by passing it directly
to sc_assert, because sc_assert will try to invoke the function instead.
