### PR TITLE
Fix for Exception within helperMissing

### DIFF
--- a/packages/sproutcore-handlebars/lib/ext.js
+++ b/packages/sproutcore-handlebars/lib/ext.js
@@ -134,9 +134,12 @@ SC.Handlebars.compile = function(string) {
   @param {Hash} options
 */
 Handlebars.registerHelper('helperMissing', function(path, options) {
-  var error;
+  var error, view = "";
 
   error = "%@ Handlebars error: Could not find property '%@' on object %@.";
-  throw new SC.Error(SC.String.fmt(error, options.data.view, path, this));
+  if (options.data){
+    view = options.data.view;
+  }
+  throw new SC.Error(SC.String.fmt(error, [view, path, this]));
 });
 


### PR DESCRIPTION
The following program correctly triggers the helperMissing handler, but instead of a nice exception we get a TypeError because `options.data` is undefined.

``` html
<html> 
  <body> 
    <script type="text/html">
      {{#if A.value}}
      {{no_such_helper foo}}
      {{/if}}
    </script>
    <script type="text/javascript" src="/javascripts/jquery.js"></script> 
    <script type="text/javascript" src="/javascripts/sproutcore.js"></script> 
    <script type="text/javascript">
      A = SC.Application.create();
      A.set('value', true);
    </script>
  </body> 
</html> 
```
