### PR TITLE
Chained dependent keys cause unnecessary evaluation of computed properties

### DIFF
--- a/packages/sproutcore-metal/lib/watching.js
+++ b/packages/sproutcore-metal/lib/watching.js
@@ -136,6 +136,11 @@ var ChainNode = function(parent, key, value, separator) {
     this._object = parent.value();
     if (this._object) addChainWatcher(this._object, this._key, this);
   }
+
+  // Special-case: the EachProxy relies on immediate evaluation to
+  // establish its observers.
+  if (this._parent && this._parent._key === '@each')
+    this.value();
 };
 
 
@@ -305,6 +310,11 @@ Wp.didChange = function() {
       addChainWatcher(obj, this._key, this);
     }
     this._value  = undefined;
+
+    // Special-case: the EachProxy relies on immediate evaluation to
+    // establish its observers.
+    if (this._parent && this._parent._key === '@each')
+      this.value();
   }
   
   // then notify chains...

--- a/packages/sproutcore-metal/lib/watching.js
+++ b/packages/sproutcore-metal/lib/watching.js
@@ -126,22 +126,28 @@ function isProto(pvalue) {
 // pass null for parent and key and object for value.
 var ChainNode = function(parent, key, value, separator) {
   var obj;
-  
   this._parent = parent;
   this._key    = key;
   this._watching = value===undefined;
-  this._value  = value || (parent._value && !isProto(parent._value) && get(parent._value, key));
+  this._value  = value;
   this._separator = separator || '.';
   this._paths = {};
-
   if (this._watching) {
-    this._object = parent._value;
+    this._object = parent.value();
     if (this._object) addChainWatcher(this._object, this._key, this);
   }
 };
 
 
 var Wp = ChainNode.prototype;
+
+Wp.value = function() {
+  if (this._value === undefined && this._watching){
+    var obj = this._parent.value();
+    this._value = (obj && !isProto(obj)) ? get(obj, this._key) : undefined;
+  }
+  return this._value;
+};
 
 Wp.destroy = function() {
   if (this._watching) {
@@ -170,7 +176,7 @@ Wp.add = function(path) {
   paths = this._paths;
   paths[path] = (paths[path] || 0) + 1 ;
 
-  obj = this._value;
+  obj = this.value();
   tuple = normalizeTuple(obj, path);
   if (tuple[0] && (tuple[0] === obj)) {
     path = tuple[1];
@@ -201,7 +207,7 @@ Wp.remove = function(path) {
   paths = this._paths;
   if (paths[path] > 0) paths[path]--;
 
-  obj = this._value;
+  obj = this.value();
   tuple = normalizeTuple(obj, path);
   if (tuple[0] === obj) {
     path = tuple[1];
@@ -272,9 +278,9 @@ Wp.chainWillChange = function(chain, path, depth) {
   if (this._parent) {
     this._parent.chainWillChange(this, path, depth+1);
   } else {
-    if (depth>1) SC.propertyWillChange(this._value, path);
+    if (depth>1) SC.propertyWillChange(this.value(), path);
     path = 'this.'+path;
-    if (this._paths[path]>0) SC.propertyWillChange(this._value, path);
+    if (this._paths[path]>0) SC.propertyWillChange(this.value(), path);
   }
 };
 
@@ -283,22 +289,22 @@ Wp.chainDidChange = function(chain, path, depth) {
   if (this._parent) {
     this._parent.chainDidChange(this, path, depth+1);
   } else {
-    if (depth>1) SC.propertyDidChange(this._value, path);
+    if (depth>1) SC.propertyDidChange(this.value(), path);
     path = 'this.'+path;
-    if (this._paths[path]>0) SC.propertyDidChange(this._value, path);
+    if (this._paths[path]>0) SC.propertyDidChange(this.value(), path);
   }
 };
 
 Wp.didChange = function() {
-  // update my own value first.
+  // invalidate my own value first.
   if (this._watching) {
-    var obj = this._parent._value;
+    var obj = this._parent.value();
     if (obj !== this._object) {
       removeChainWatcher(this._object, this._key, this);
       this._object = obj;
       addChainWatcher(obj, this._key, this);
     }
-    this._value  = obj && !isProto(obj) ? get(obj, this._key) : undefined;
+    this._value  = undefined;
   }
   
   // then notify chains...
@@ -321,7 +327,7 @@ function chainsFor(obj) {
   var m   = meta(obj), ret = m.chains;
   if (!ret) {
     ret = m.chains = new ChainNode(null, null, obj);
-  } else if (ret._value !== obj) {
+  } else if (ret.value() !== obj) {
     ret = m.chains = ret.copy(obj);
   }
   return ret ;
@@ -437,7 +443,7 @@ SC.rewatch = function(obj) {
   }  
 
   // make sure any chained watchers update.
-  if (chains && chains._value !== obj) chainsFor(obj);
+  if (chains && chains.value() !== obj) chainsFor(obj);
 
   // if the object has bindings then sync them..
   if (bindings && m.proto!==obj) {

--- a/packages/sproutcore-metal/tests/computed_test.js
+++ b/packages/sproutcore-metal/tests/computed_test.js
@@ -540,6 +540,31 @@ testBoth('depending on complex Global chain', function(get, set) {
 
 });
 
+testBoth('chained dependent keys should respect SC.beginPropertyChanges', function(get,set){
+  var run_count;
+
+  set(obj.foo, 'a', 1);
+  set(obj.foo, 'b', 2);
+
+  SC.defineProperty(obj.foo, 'c', SC.computed(function(){
+    run_count++;
+    return get(obj.foo, 'a') + get(obj.foo, 'b')
+  }).property('a', 'b').cacheable());
+
+  SC.addObserver(obj, 'foo.c', this, function(){});
+
+  run_count = 0;
+
+  SC.beginPropertyChanges();
+  set(obj.foo, 'a', 10);
+  set(obj.foo, 'b', 20);
+  SC.endPropertyChanges();
+
+  equals(run_count, 1, 'should only run once');
+});
+
+
+
 // ..........................................................
 // BUGS
 // 

--- a/packages/sproutcore-metal/tests/computed_test.js
+++ b/packages/sproutcore-metal/tests/computed_test.js
@@ -540,27 +540,10 @@ testBoth('depending on complex Global chain', function(get, set) {
 
 });
 
-testBoth('chained dependent keys should respect SC.beginPropertyChanges', function(get,set){
-  var run_count;
-
-  set(obj.foo, 'a', 1);
-  set(obj.foo, 'b', 2);
-
-  SC.defineProperty(obj.foo, 'c', SC.computed(function(){
-    run_count++;
-    return get(obj.foo, 'a') + get(obj.foo, 'b')
-  }).property('a', 'b').cacheable());
-
-  SC.addObserver(obj, 'foo.c', this, function(){});
-
-  run_count = 0;
-
-  SC.beginPropertyChanges();
-  set(obj.foo, 'a', 10);
-  set(obj.foo, 'b', 20);
-  SC.endPropertyChanges();
-
-  equals(run_count, 1, 'should only run once');
+testBoth('chained dependent keys should evaluate computed properties lazily', function(get,set){
+  SC.defineProperty(obj.foo.bar, 'b', SC.computed(func).property().cacheable());
+  SC.defineProperty(obj.foo, 'c', SC.computed(function(){}).property('bar.b').cacheable());
+  equals(count, 0, 'b should not run');
 });
 
 


### PR DESCRIPTION
The discussion in issue #108 made it apparent that chained dependent keys are too aggressive about evaluating their values.  When those values are computed properties, they get called multiple times even when nobody has asked for them.

This change makes the values update lazily, which prevents unnecessary evaluation.

A unit test is included, which fails without this feature.
