### PR TITLE
Fixing issue #91: SC.copy corrupts null values

### DIFF
--- a/packages/sproutcore-runtime/lib/core.js
+++ b/packages/sproutcore-runtime/lib/core.js
@@ -236,7 +236,7 @@ function _copy(obj, deep, seen, copies) {
   var ret, loc, key;
 
   // primitive data types are immutable, just return them.
-  if ('object' !== typeof obj) return obj;
+  if ('object' !== typeof obj || obj===null) return obj;
 
   // avoid cyclical loops
   if (deep && (loc=seen.indexOf(obj))>=0) return copies[loc];
@@ -283,7 +283,7 @@ function _copy(obj, deep, seen, copies) {
 */
 SC.copy = function(obj, deep) {
   // fast paths
-  if ('object' !== typeof obj) return obj; // can't copy primitives
+  if ('object' !== typeof obj || obj===null) return obj; // can't copy primitives
   if (SC.Copyable && SC.Copyable.detect(obj)) return obj.copy(deep);
   return _copy(obj, deep, deep ? [] : null, deep ? [] : null);
 };

--- a/packages/sproutcore-runtime/tests/core/copy_test.js
+++ b/packages/sproutcore-runtime/tests/core/copy_test.js
@@ -1,0 +1,14 @@
+// ==========================================================================
+// Project:  SproutCore Runtime
+// Copyright: ©2006-2011 Strobe Inc. and contributors.
+//            ©2008-2011 Apple Inc. All rights reserved.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+module("SproutCore Copy Method");
+
+test("SC.copy null", function() {
+  var obj = {field: null};
+  equal(SC.copy(obj, true).field, null, "null should still be null")
+});
+


### PR DESCRIPTION
SC.copy failed to treat 'null' as a primitive value.

Unit test included, all unit tests passing.
