### PR TITLE
Clear childViews when rerendering in buffer

### DIFF
--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -212,6 +212,22 @@ SC.View = SC.Object.extend(
     return this.invokeForState('rerender');
   },
 
+  clearRenderedChildren: function() {
+    var viewMeta = meta(this)['SC.View'],
+        lengthBefore = viewMeta.lengthBeforeRender,
+        lengthAfter  = viewMeta.lengthAfterRender;
+
+    // If there were child views created during the last call to render(),
+    // remove them under the assumption that they will be re-created when
+    // we re-render.
+
+    // VIEW-TODO: Unit test this path.
+    if (lengthBefore < lengthAfter) {
+      var childViews = get(this, 'childViews');
+      childViews.replace(lengthBefore, lengthAfter - lengthBefore);
+    }
+  },
+
   /**
     @private
 
@@ -1117,6 +1133,7 @@ SC.View.states = {
       var viewMeta = meta(view)['SC.View'],
           buffer = viewMeta.buffer;
 
+      view.clearRenderedChildren();
       view.renderToBuffer(buffer, 'replaceWith');
     },
 
@@ -1175,18 +1192,7 @@ SC.View.states = {
 
       view.invokeRecursively(function(v) { v.state = 'preRender'; })
 
-      var lengthBefore = viewMeta.lengthBeforeRender,
-          lengthAfter  = viewMeta.lengthAfterRender;
-
-      // If there were child views created during the last call to render(),
-      // remove them under the assumption that they will be re-created when
-      // we re-render.
-
-      // VIEW-TODO: Unit test this path.
-      if (lengthBefore < lengthAfter) {
-        var childViews = get(view, 'childViews');
-        childViews.replace(lengthBefore, lengthAfter - lengthBefore);
-      }
+      view.clearRenderedChildren();
 
       // Set element to null after the childViews.replace() call to prevent
       // a call to $() from inside _scheduleInsertion triggering a rerender.

--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -222,9 +222,9 @@ SC.View = SC.Object.extend(
     // we re-render.
 
     // VIEW-TODO: Unit test this path.
-    if (lengthBefore < lengthAfter) {
-      var childViews = get(this, 'childViews');
-      childViews.replace(lengthBefore, lengthAfter - lengthBefore);
+    var childViews = get(this, 'childViews');
+    for (var i=lengthBefore; i<lengthAfter; i++) {
+      childViews[i] && childViews[i].destroy();
     }
   },
 

--- a/packages/sproutcore-views/tests/views/view/child_views_test.js
+++ b/packages/sproutcore-views/tests/views/view/child_views_test.js
@@ -34,4 +34,37 @@
 
     equals(parentView.$().text(), 'SproutCore', 'renders the child view after the parent view');
   });
+
+  test("should not duplicate childViews when rerendering in buffer", function() {
+
+    var inner = SC.View.create({
+      template: function() { return ''; }
+    });
+
+    var middle = SC.View.create({
+      render: function(buffer) {
+        this.appendChild(inner);
+      }
+    });
+
+    var outer = SC.View.create({
+      render: function(buffer) {
+        this.appendChild(middle);
+      }
+    });
+
+    SC.run(function() {
+      outer.renderToBuffer();
+    });
+
+    equals(middle.getPath('childViews.length'), 1);
+
+    SC.run(function() {
+      middle.rerender();
+    });
+
+    equals(middle.getPath('childViews.length'), 1);
+
+  });
+
 })();


### PR DESCRIPTION
An in-buffer rerender leaks orphan child views.
