### PR TITLE
Right now a Maximum call stack size exceeded is thrown in new sprout core app

### DIFF
--- a/packages/sproutcore-metal/lib/utils.js
+++ b/packages/sproutcore-metal/lib/utils.js
@@ -172,7 +172,8 @@ if (Object.freeze) Object.freeze(EMPTY_META);
   @returns {Hash}
 */
 SC.meta = function meta(obj, writable) {
-  sc_assert("You must pass an object to SC.meta. This was probably called from SproutCore internals, so you probably called a SproutCore method with undefined that was expecting an object", obj);
+  
+  sc_assert("You must pass an object to SC.meta. This was probably called from SproutCore internals, so you probably called a SproutCore method with undefined that was expecting an object", obj != undefined);
 
   var ret = obj[META_KEY];
   if (writable===false) return ret || EMPTY_META;


### PR DESCRIPTION
Fixed infinite loop. Don't pass the object to sc_assert, just check if it is there.
