### PR TITLE
childViews mutated during iteration

### DIFF
--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -314,7 +314,7 @@ SC.View = SC.Object.extend(
 
     // VIEW-TODO: Unit test this path.
     var childViews = get(this, 'childViews');
-    for (var i=lengthBefore; i<lengthAfter; i++) {
+    for (var i=lengthAfter-1; i>=lengthBefore; i--) {
       childViews[i] && childViews[i].destroy();
     }
   },

--- a/packages/sproutcore-views/tests/views/view/child_views_test.js
+++ b/packages/sproutcore-views/tests/views/view/child_views_test.js
@@ -41,9 +41,14 @@
       template: function() { return ''; }
     });
 
+     var inner2 = SC.View.create({
+       template: function() { return ''; }
+     });
+
     var middle = SC.View.create({
       render: function(buffer) {
         this.appendChild(inner);
+        this.appendChild(inner2);
       }
     });
 
@@ -57,13 +62,13 @@
       outer.renderToBuffer();
     });
 
-    equals(middle.getPath('childViews.length'), 1);
+    equals(middle.getPath('childViews.length'), 2);
 
     SC.run(function() {
       middle.rerender();
     });
 
-    equals(middle.getPath('childViews.length'), 1);
+    equals(middle.getPath('childViews.length'), 2);
 
   });
 


### PR DESCRIPTION
My earlier fix only worked right when deleting a single child view.
In general it's incorrect because I'm mutating the array during
iteration.

Resolving by reversing the order of deletion.  Improved unit test
included.
