### PR TITLE
nearestWithProperty skips over immediate parent

### DIFF
--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -165,7 +165,7 @@ SC.View = SC.Object.extend(
     var view = this.parentView;
 
     while (view) {
-      if (property in view.parentView) { return view; }
+      if (property in view) { return view; }
       view = view.parentView;
     }
   },

--- a/packages/sproutcore-views/tests/views/view/nearest_view_test.js
+++ b/packages/sproutcore-views/tests/views/view/nearest_view_test.js
@@ -76,3 +76,23 @@ test("itemView should return the nearest child of a collection view", function()
   equals(itemViewChild.getPath('contentView.isAnItemView'), true, "finds a view with a content property in the hierarchy");
 });
 
+test("nearestWithProperty should search immediate parent", function(){
+  var childView;
+
+  var view = SC.View.create({
+    myProp: true,
+
+    render: function(buffer) {
+      this.appendChild(SC.View.create());
+    }
+  });
+
+  SC.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  childView = view.get('childViews')[0];
+  equals(childView.nearestWithProperty('myProp'), view);
+
+});
+


### PR DESCRIPTION
nearestWithProperty skips over the immediate parent, and runs off the top
of the tree when a property is not found.  This change fixes both problems.

Unit test included.
