### PR TITLE
Allow empty string as placeholder in SC.Binding.notNull

### DIFF
--- a/packages/sproutcore-runtime/lib/system/binding.js
+++ b/packages/sproutcore-runtime/lib/system/binding.js
@@ -472,7 +472,7 @@ var Binding = SC.Object.extend({
     // Display warning for users using the SC 1.x-style API.
     sc_assert("notEmpty should only take a placeholder as a parameter. You no longer need to pass null as the first parameter.", arguments.length < 2);
 
-    if (!placeholder) { placeholder = SC.EMPTY_PLACEHOLDER; }
+    if (placeholder == undefined) { placeholder = SC.EMPTY_PLACEHOLDER; }
 
     this.transform(function(val) { return empty(val) ? placeholder : val; });
 
@@ -488,7 +488,7 @@ var Binding = SC.Object.extend({
     @returns {SC.Binding} this
   */
   notNull: function(placeholder) {
-    if (!placeholder) { placeholder = SC.EMPTY_PLACEHOLDER; }
+    if (placeholder == undefined) { placeholder = SC.EMPTY_PLACEHOLDER; }
 
     this.transform(function(val) { return val == null ? placeholder : val; });
 

--- a/packages/sproutcore-runtime/tests/system/binding/notNull_test.js
+++ b/packages/sproutcore-runtime/tests/system/binding/notNull_test.js
@@ -1,0 +1,33 @@
+// ==========================================================================
+// Project:  SproutCore Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals MyApp */
+
+module('system/binding/notNull', {
+  setup: function() {
+    MyApp = SC.Object.create({
+      foo: SC.Object.create({ value: 'FOO' }),
+      bar: SC.Object.create({ value: 'BAR' })
+    });
+  },
+
+  teardown: function() {
+    MyApp = null;
+  }
+});
+
+test('allow empty string as placeholder', function() {
+  
+  var binding = SC.bind(MyApp, 'bar.value', 'foo.value').notNull('');
+
+  SC.run.sync();
+  same(SC.getPath('MyApp.bar.value'), 'FOO', 'value passes through');
+
+  SC.setPath('MyApp.foo.value', null);
+  SC.run.sync();
+  same(SC.getPath('MyApp.bar.value'), '', 'null gets replaced');
+
+});
+


### PR DESCRIPTION
The notNull binding transformer won't accept an empty string as a placeholder.  
