### PR TITLE
Fixed typo in String.dasherize method definition

### DIFF
--- a/packages/sproutcore-runtime/lib/ext/string.js
+++ b/packages/sproutcore-runtime/lib/ext/string.js
@@ -49,7 +49,7 @@ if (SC.EXTEND_PROTOTYPES) {
   /**
     @see SC.String.dasherize
   */
-  String.prototype.dashersize = function() {
+  String.prototype.dasherize = function() {
     return dasherize(this);
   };
 }


### PR DESCRIPTION
Fixed typo in dasherize method definition (and made typo myself in commit message...)
