### PR TITLE
Add helper for exception-safe beginPropertyChanges

### DIFF
--- a/packages/sproutcore-metal/lib/observer.js
+++ b/packages/sproutcore-metal/lib/observer.js
@@ -84,6 +84,15 @@ SC.endPropertyChanges = function() {
   if (suspended<=0) flushObserverQueue();
 };
 
+SC.batchPropertyChanges = function(cb){
+  SC.beginPropertyChanges();
+  try {
+    cb()
+  } finally {
+    SC.endPropertyChanges();
+  }
+}
+
 function changeEvent(keyName) {
   return keyName+AFTER_OBSERVERS;
 }

--- a/packages/sproutcore-metal/tests/observer_test.js
+++ b/packages/sproutcore-metal/tests/observer_test.js
@@ -74,6 +74,35 @@ testBoth('suspending property changes will defer', function(get,set) {
   equals(fooCount, 1, 'foo should have fired once');
 });
 
+testBoth('suspending property changes safely despite exceptions', function(get,set) {
+  var obj = { foo: 'foo' };
+  var fooCount = 0;
+  var exc = new Error("Something unexpected happened!");
+
+  expect(2);
+  SC.addObserver(obj, 'foo' ,function() { fooCount++; });
+
+  try {
+    SC.batchPropertyChanges(function(){
+      set(obj, 'foo', 'BIFF');
+      set(obj, 'foo', 'BAZ');
+      throw exc;
+    });
+  } catch(err) {
+    if (err != exc)
+      throw err;
+  }
+
+  equals(fooCount, 1, 'foo should have fired once');
+
+  SC.batchPropertyChanges(function(){
+    set(obj, 'foo', 'BIFF2');
+    set(obj, 'foo', 'BAZ2');
+  });
+
+  equals(fooCount, 2, 'foo should have fired again once');
+});
+
 testBoth('suspending property changes will not defer before observers', function(get,set) {
   var obj = { foo: 'foo' };
   var fooCount = 0;


### PR DESCRIPTION
I found myself using this pattern enough that I think it belongs in
the library.  This is a safer way to use beginPropertyChanges.  It's
analogous to using the block form of Ruby's "open", or using Python's
"with" statement.
