### PR TITLE
Change default behavior for SC.Button mouse events, add disabled attribute binding.

### DIFF
--- a/packages/sproutcore-handlebars/lib/controls/button.js
+++ b/packages/sproutcore-handlebars/lib/controls/button.js
@@ -13,6 +13,7 @@ SC.Button = SC.View.extend({
   tagName: 'button',
   attributeBindings: ['type'],
   type: 'button',
+  propagateEvents: false,
   
   targetObject: function() {
     var target = get(this, 'target');
@@ -28,6 +29,7 @@ SC.Button = SC.View.extend({
     set(this, 'isActive', true);
     this._mouseDown = true;
     this._mouseEntered = true;
+    return this.get('propagateEvents');
   },
 
   mouseLeave: function() {
@@ -61,6 +63,7 @@ SC.Button = SC.View.extend({
 
     this._mouseDown = false;
     this._mouseEntered = false;
+    return this.get('propagateEvents');
   },
 
   // TODO: Handle proper touch behavior.  Including should make inactive when

--- a/packages/sproutcore-handlebars/lib/controls/button.js
+++ b/packages/sproutcore-handlebars/lib/controls/button.js
@@ -11,8 +11,9 @@ SC.Button = SC.View.extend({
   classNameBindings: ['isActive'],
 
   tagName: 'button',
-  attributeBindings: ['type'],
+  attributeBindings: ['type', 'disabled'],
   type: 'button',
+  disabled: false,
   propagateEvents: false,
   
   targetObject: function() {


### PR DESCRIPTION
Default behaviour is to not propagate events, but can be overridden
without having to create a new class. Related to issue #155.

Also added a disabled attribute binding.
