### PR TITLE
Add Class.detectInstance() method to easily detect an instance of Class

### DIFF
--- a/packages/sproutcore-runtime/lib/system/core_object.js
+++ b/packages/sproutcore-runtime/lib/system/core_object.js
@@ -181,6 +181,14 @@ var ClassMixin = SC.Mixin.create({
       obj = obj.superclass;
     }
     return false;
+  },
+  
+  detectInstance: function(obj) {
+    if (obj !== null && typeof obj === 'object' && obj.constructor) {
+      return this.detect(obj.constructor);
+    } else {
+      return false;
+    }
   }
 
 });


### PR DESCRIPTION
Class.detect only works for detecting classes that extend another class.
Class.detectInstance works with instances of a Class.
