### PR TITLE
compile handlebar scripts when they're dynamically introduced into the dom

### DIFF
--- a/packages/sproutcore-handlebars/lib/loader.js
+++ b/packages/sproutcore-handlebars/lib/loader.js
@@ -11,8 +11,7 @@ require("sproutcore-handlebars/ext");
 // to SC.CoreView in the global SC.TEMPLATES object. This will be run as as
 // jQuery DOM-ready callback.
 SC.Handlebars.bootstrap = function() {
-  SC.$('script[type="text/html"], script[type="text/x-handlebars"]')
-    .each(function() {
+  var bootstrap_method = function() {
     // Get a reference to the script tag
     var script = SC.$(this),
       // Get the name of the script, used by SC.View's templateName property.
@@ -56,7 +55,11 @@ SC.Handlebars.bootstrap = function() {
         script = null;
       });
     }
-  });
+  };
+
+  SC.$('script[type="text/html"], script[type="text/x-handlebars"]')
+    .live('DOMNodeInserted', bootstrap_method)
+    .each(bootstrap_method);
 };
 
 SC.$(document).ready(SC.Handlebars.bootstrap);


### PR DESCRIPTION
Whenever we introduce some new handlebars content with the `<script>` tag (might happen when using pjax for example), the new tag wasn't being compiled by handlebars.

This fixes the problem.
See #161
