### PR TITLE
Observer arguments array grows without bound

### DIFF
--- a/packages/sproutcore-metal/lib/observer.js
+++ b/packages/sproutcore-metal/lib/observer.js
@@ -103,9 +103,10 @@ function beforeKey(eventName) {
 function xformForArgs(args) {
   return function (target, method, params) {
     var obj = params[0], keyName = changeKey(params[1]), val;
+    var copy_args = args.slice();
     if (method.length>2) val = SC.getPath(obj, keyName);
-    args.unshift(obj, keyName, val);
-    method.apply(target, args);
+    copy_args.unshift(obj, keyName, val);
+    method.apply(target, copy_args);
   }
 }
 

--- a/packages/sproutcore-metal/tests/observer_test.js
+++ b/packages/sproutcore-metal/tests/observer_test.js
@@ -151,6 +151,7 @@ testBoth('addObserver should preserve additional context passed when firing the 
     didChange: function(obj, keyName, value, ctx1, ctx2) {
       equals(ctx1, "biff", "first context is passed");
       equals(ctx2, "bang", "second context is passed");
+      equals(5, arguments.length);
       this.count++;
     }
   };
@@ -159,6 +160,9 @@ testBoth('addObserver should preserve additional context passed when firing the 
 
   set(observed, 'foo', 'BAZ');
   equals(target1.count, 1, 'target1 observer should have fired');
+
+  set(observed, 'foo', 'BAZ2');
+  equals(target1.count, 2, 'target1 observer should have fired');
 });
 
 


### PR DESCRIPTION
This bug manifested itself as a stack overflow, but the stack itself wasn't very deep.  I was puzzled until I realized that maybe the problem wasn't the _number_ of stack frames, but the _size_ of the stack frames.

Sure enough, I found that the anonymous function inside xFormForArgs was being invoked with over 27000 arguments. Trying to look at them repeatedly crashed Chrome's debugger.  :-)

Fix and unit test included.
