### PR TITLE
Add replaceIn to replace an entire node's content with something new

### DIFF
--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -553,6 +553,28 @@ SC.View = SC.Object.extend(
   },
 
   /**
+    Replaces the view's element to the specified parent element.
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+    If the parent element already has some content, it will be removed.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {SC.View} received
+  */
+  replaceIn: function(target) {
+    this._insertElementLater(function() {
+      SC.$(target).empty();
+      this.$().appendTo(target);
+    });
+
+    return this;
+  },
+
+  /**
     @private
 
     Schedules a DOM operation to occur during the next render phase. This

--- a/packages/sproutcore-views/tests/views/view/replace_in_test.js
+++ b/packages/sproutcore-views/tests/views/view/replace_in_test.js
@@ -1,0 +1,80 @@
+// ==========================================================================
+// Project:   SproutCore Views
+// Copyright: ©2006-2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var set = SC.set, get = SC.get;
+
+var View, view, willDestroyCalled, childView;
+
+module("SC.View - replaceIn()", {
+  setup: function() {
+    View = SC.View.extend({});
+  },
+
+  teardown: function() {
+    view.destroy();
+  }
+});
+
+test("should be added to the specified element when calling replaceIn()", function() {
+  jQuery("#qunit-fixture").html('<div id="menu"></div>');
+
+  view = View.create();
+
+  ok(!get(view, 'element'), "precond - should not have an element");
+
+  SC.run(function() {
+    view.replaceIn('#menu');
+  });
+
+  var viewElem = SC.$('#menu').children();
+  ok(viewElem.length > 0, "creates and replaces the view's element");
+});
+
+test("should remove previous elements when calling replaceIn()", function() {
+  jQuery("#qunit-fixture").html('<div id="menu"><p>Foo</p></div>');
+  var viewElem = SC.$('#menu').children();
+
+  view = View.create();
+
+  ok(viewElem.length == 1, "should have one element");
+
+  SC.run(function() {
+    view.replaceIn('#menu');
+  });
+
+  ok(viewElem.length == 1, "should have one element");
+
+});
+
+module("SC.View - replaceIn() in a view hierarchy", {
+  setup: function() {
+    View = SC.ContainerView.extend({
+      childViews: ['child'],
+      child: SC.View.extend({
+        elementId: 'child'
+      })
+    });
+  },
+
+  teardown: function() {
+    view.destroy();
+  }
+});
+
+test("should be added to the specified element when calling replaceIn()", function() {
+  jQuery("#qunit-fixture").html('<div id="menu"></div>');
+
+  view = View.create();
+
+  ok(!get(view, 'element'), "precond - should not have an element");
+
+  SC.run(function() {
+    view.replaceIn('#menu');
+  });
+
+  var viewElem = SC.$('#menu #child');
+  ok(viewElem.length > 0, "creates and replaces the view's element");
+});


### PR DESCRIPTION
appendTo is great, but it append when it might, sometimes, be very useful to actually just remove the previous content and add something new.

This is what replaceIn intends to do : it clears the previous element's content, and puts the new one.
