### PR TITLE
SC.inspect still referenced SC.T_FUNCTION, which no longer exists

### DIFF
--- a/packages/sproutcore-runtime/lib/core.js
+++ b/packages/sproutcore-runtime/lib/core.js
@@ -301,7 +301,7 @@ SC.inspect = function(obj) {
     if (obj.hasOwnProperty(key)) {
       v = obj[key];
       if (v === 'toString') { continue; } // ignore useless items
-      if (SC.typeOf(v) === SC.T_FUNCTION) { v = "function() { ... }"; }
+      if (SC.typeOf(v) === 'function') { v = "function() { ... }"; }
       ret.push(key + ": " + v);
     }
   }

--- a/packages/sproutcore-runtime/lib/core.js
+++ b/packages/sproutcore-runtime/lib/core.js
@@ -292,7 +292,7 @@ SC.copy = function(obj, deep) {
   Convenience method to inspect an object. This method will attempt to
   convert the object into a useful string description.
 
-  @param {Object} obj The object you want to inspec.
+  @param {Object} obj The object you want to inspect.
   @returns {String} A description of the object
 */
 SC.inspect = function(obj) {


### PR DESCRIPTION
I changed it to just use the string 'function' like all code does now, and also fixed a typo in the comment.
