### PR TITLE
Add SC.Handlebars.precompile

### DIFF
--- a/packages/sproutcore-handlebars/lib/ext.js
+++ b/packages/sproutcore-handlebars/lib/ext.js
@@ -108,6 +108,19 @@ SC.Handlebars.Compiler.prototype.mustache = function(mustache) {
 };
 
 /**
+  SproutCore equivalent of Handlebars.precompile. This replaces the default Handlebars.precompile and
+  enables precompiling of SproutCore Handlebars templates to pure Javascript.
+
+  @param {String} string The template to compile
+*/
+SC.Handlebars.precompile = function(string) {
+  var ast = Handlebars.parse(string);
+  var options = { data: true, stringParams: true };
+  var environment = new SC.Handlebars.Compiler().compile(ast, options);
+  return new SC.Handlebars.JavaScriptCompiler().compile(environment, options);
+};
+
+/**
   The entry point for SproutCore Handlebars. This replaces the default Handlebars.compile and turns on
   template-local data and String parameters.
 


### PR DESCRIPTION
This is the SproutCore equivalent of Handlebars.precompile and enables
precompiling of SproutCore Handebars templates to pure Javascript.

This would be useful, for example, in a Node or Rails environment to
precompile templates before serving them. In Rails, this lets us plug
into Sprockets easily.
