### PR TITLE
Faster (and simpler) implementation of MutableArray's pushObjects

### DIFF
--- a/packages/sproutcore-runtime/lib/mixins/mutable_array.js
+++ b/packages/sproutcore-runtime/lib/mixins/mutable_array.js
@@ -129,9 +129,7 @@ SC.MutableArray = SC.Mixin.create(SC.Array, SC.MutableEnumerable,
     @returns {SC.Array} receiver
   */
   pushObjects: function(objects) {
-    this.beginPropertyChanges();
-    objects.forEach(function(obj) { this.pushObject(obj); }, this);
-    this.endPropertyChanges();
+    this.replace(get(this, 'length'), 0, objects);
     return this;
   },
 


### PR DESCRIPTION
This implementation is significantly faster when pushing big
arrays. All unit tests pass.

Pushing a 10000 object array onto another 10000 object array was
taking 400ms before this change. After this change it is less than
2ms.

While the original implementation tried to be performant by suspending
observers, it can't suspend dependent key invalidation, so the
dependent keys "length", "firstObject", "lastObject", and "[]" were
getting invalidated for every array element, leading to hundreds of
thousands of unnecessary function calls.
