### PR TITLE
Add a flag to disable nice names for increased performance

### DIFF
--- a/packages/sproutcore-metal/lib/mixin.js
+++ b/packages/sproutcore-metal/lib/mixin.js
@@ -374,6 +374,8 @@ Mixin.prototype.keys = function() {
 
 /** @private - make Mixin's have nice displayNames */
 
+SC.NICE_NAMES = (SC.ENV.NICE_NAMES === undefined) ? true : SC.ENV.NICE_NAMES;
+
 var NAME_KEY = SC.GUID_KEY+'_name';
 
 function processNames(paths, root, seen) {
@@ -406,6 +408,8 @@ superClassString = function(mixin) {
 }
 
 classToString = function() {
+  if (!SC.NICE_NAMES) return "<class>";
+
   if (!this[NAME_KEY] && !classToString.processed) {
     classToString.processed = true;
     processNames([], window, {});


### PR DESCRIPTION
This patch creates a new ENV.NICE_NAMES flag. Set it to false and it
disables Sproutcore's intelligent class naming, which can provide a
substantial performance gain for a big production app.

In my case it's cutting app initialization time in half, from about
800ms to 400ms.
