### PR TITLE
Added missing drag events to the even list in event_dispatcher.js

### DIFF
--- a/packages/sproutcore-views/lib/system/event_dispatcher.js
+++ b/packages/sproutcore-views/lib/system/event_dispatcher.js
@@ -57,7 +57,14 @@ SC.EventDispatcher = SC.Object.extend(
       mouseenter  : 'mouseEnter',
       mouseleave  : 'mouseLeave',
       submit      : 'submit',
-      change      : 'change'
+      change      : 'change',
+      dragstart   : 'dragStart',
+      drag        : 'drag',
+      dragenter   : 'dragEnter',
+      dragleave   : 'dragLeave',
+      dragover    : 'dragOver',
+      drop        : 'drop',
+      dragend     : 'dragEnd'
     };
 
     jQuery.extend(events, addedEvents || {});


### PR DESCRIPTION
The drag-related events (from HTML5) were missing from the list.
