### PR TITLE
Fix strip_require in the Rakefile to correctly strip requires with trailing comments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ end
 
 def strip_require(file)
   result = File.read(file)
-  result.gsub!(%r{^\s*require\(['"]([^'"])*['"]\);?\s*$}, "")
+  result.gsub!(%r{^\s*require\(['"]([^'"])*['"]\);?\s*}, "")
   result
 end
 


### PR DESCRIPTION
Fix strip_require in the Rakefile to correctly strip requires with trailing comments
