### PR TITLE
Removed calls to sc_assert from SC.get, SC.set and SC.meta

### DIFF
--- a/packages/sproutcore-metal/lib/accessors.js
+++ b/packages/sproutcore-metal/lib/accessors.js
@@ -60,8 +60,6 @@ if (!USE_ACCESSORS) {
       obj = SC;
     }
 
-    sc_assert("You need to provide an object and key to `get`.", !!obj && keyName);
-
     if (!obj) return undefined;
     var desc = meta(obj, false).descs[keyName];
     if (desc) return desc.get(obj, keyName);
@@ -69,7 +67,6 @@ if (!USE_ACCESSORS) {
   };
 
   set = function(obj, keyName, value) {
-    sc_assert("You need to provide an object and key to `set`.", !!obj && keyName !== undefined);
     var desc = meta(obj, false).descs[keyName];
     if (desc) desc.set(obj, keyName, value);
     else o_set(obj, keyName, value);

--- a/packages/sproutcore-metal/lib/utils.js
+++ b/packages/sproutcore-metal/lib/utils.js
@@ -173,8 +173,6 @@ if (Object.freeze) Object.freeze(EMPTY_META);
 */
 SC.meta = function meta(obj, writable) {
   
-  sc_assert("You must pass an object to SC.meta. This was probably called from SproutCore internals, so you probably called a SproutCore method with undefined that was expecting an object", obj != undefined);
-
   var ret = obj[META_KEY];
   if (writable===false) return ret || EMPTY_META;
 

--- a/packages/sproutcore-views/lib/views/container_view.js
+++ b/packages/sproutcore-views/lib/views/container_view.js
@@ -192,7 +192,7 @@ SC.ContainerView.states = {
       // If the DOM element for this container view already exists,
       // schedule each child view to insert its DOM representation after
       // bindings have finished syncing.
-      prev = start === 0 ? null : views[start-1];
+      var prev = start === 0 ? null : views[start-1];
 
       for (var i=start; i<start+added; i++) {
         view = views[i];


### PR DESCRIPTION
We were getting a lot of long running script warnings in IE due largely to the very large number of calls to sc_assert throughout the framework. 500K or more calls to sc_assert was not uncommon in our application for a single event loop which is clearly too many times given that IE throws up the long running script warnings based on the number of operations rather than time spent.

We were able to dramatically reduce the number of times this function is called by removing it from SC.get, SC.set and SC.meta where it feels like it has limited value for ordinary usage of the framework. There are many other places were sc_assert is quite useful but it'd be great to see it removed from these functions considering it's impact on IE.
