### PR TITLE
Add support for isVisibleInWindow

### DIFF
--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -156,6 +156,15 @@ SC.View = SC.Object.extend(
   isVisible: true,
 
   /**
+    Returns true if the view is visible in the windo.
+
+    @type Boolean
+  */
+  isVisibleInWindow: function(){
+    return this.$().is(':visible');
+  }.property().cacheable(),
+
+  /**
     Array of child views. You should never edit this array directly.
     Instead, use appendChild and removeFromParent.
 
@@ -753,6 +762,7 @@ SC.View = SC.Object.extend(
   */
   _notifyDidInsertElement: function() {
     this.invokeRecursively(function(view) {
+      view.propertyDidChange('isVisibleInWindow');
       view.didInsertElement();
     });
   },
@@ -1176,6 +1186,9 @@ SC.View = SC.Object.extend(
   */
   _isVisibleDidChange: function() {
     this.$().toggle(get(this, 'isVisible'));
+    this.invokeRecursively(function(view){
+      view.propertyDidChange('isVisibleInWindow');
+    });
   }.observes('isVisible'),
 
   clearBuffer: function() {

--- a/packages/sproutcore-views/tests/views/view/render_test.js
+++ b/packages/sproutcore-views/tests/views/view/render_test.js
@@ -136,6 +136,59 @@ test("should hide element if isVisible is false before element is created", func
   });
 });
 
+test("should not set isVisibleInWindow to true until rendered in DOM", function(){
+  var view = SC.View.create();
+
+  ok(!get(view, 'isVisibleInWindow'), "isVisibleInWindow is false");
+
+  SC.run(function() {
+    view.append();
+  });
+
+  ok(get(view, 'isVisibleInWindow'), "isVisibleInWindow is true");
+  view.remove();
+});
+
+test("should set isVisibleInWindow to false when isVisible is false", function(){
+  var view = SC.View.create({
+    isVisible: false
+  });
+
+  SC.run(function() {
+    view.append();
+  });
+
+  ok(!get(view, 'isVisibleInWindow'), "isVisibleInWindow is false");
+
+  set(view, 'isVisible', true);
+  ok(get(view, 'isVisibleInWindow'), "isVisibleInWindow is true");
+  view.remove();
+});
+
+test("should set isVisibleInWindow to false when parentView.isVisible is false", function(){
+  var view = SC.ContainerView.create({
+    isVisible: false,
+
+    childViews: [
+      SC.View.create({
+        isVisible: true
+      })
+    ]
+  });
+
+  var childView = get(view, 'childViews').objectAt(0);
+
+  SC.run(function() {
+    view.append();
+  });
+
+  ok(!get(childView, 'isVisibleInWindow'), "child isVisibleInWindow is false");
+
+  set(view, 'isVisible', true);
+  ok(get(childView, 'isVisibleInWindow'), "child isVisibleInWindow is true");
+  view.remove();
+});
+
 test("should add sc-view to views", function() {
   var view = SC.View.create();
 


### PR DESCRIPTION
This adds support for a new view property called `isVisibleInWindow`. This would ideally tell when a view is actually visible vs just saying when you want it to be visible. i.e. a child view might have `isVisible: true` while the parent has `isVisible: false`. In this case, the child would have `isVisibleInWindow: false`.

There are two reasons to be hesitant about integrating this. One, it's another property and it's nice to keep things lean. Two, the method of checking visibility is not entirely reliable. Also, what happens if someone changes visibility without going through the standard SC methods? i.e. `$('view-div').hide()`

For that reason, I'm opening this up to discussion.
