### PR TITLE
SC.TextArea attempts to update element before it exists

### DIFF
--- a/packages/sproutcore-handlebars/lib/controls/text_area.js
+++ b/packages/sproutcore-handlebars/lib/controls/text_area.js
@@ -40,7 +40,7 @@ SC.TextArea = SC.View.extend({
   /**
     @private
   */
-  willInsertElement: function() {
+  didInsertElement: function() {
     this._updateElementValue();
   },
 


### PR DESCRIPTION
SC.TextArea writes its value into the DOM using `this.$().val(...)`,
but it's trying to do this from `willInsertElement`.
