### PR TITLE
check to see if metamorph views are destroyed before rendering a replace

### DIFF
--- a/packages/sproutcore-handlebars/lib/views/metamorph_view.js
+++ b/packages/sproutcore-handlebars/lib/views/metamorph_view.js
@@ -66,6 +66,7 @@ SC.Metamorph = SC.Mixin.create({
       var buffer = view.renderToBuffer();
 
       SC.run.schedule('render', this, function() {
+        if (get(view, 'isDestroyed')) { return; }
         view._notifyWillInsertElement();
         morph.replaceWith(buffer.string());
         view.transitionTo('inDOM');


### PR DESCRIPTION
I was running into "Cannot perform operations on a Metamorph that is not in the DOM." errors, and had to add this little patch to fix the issue.
