### PR TITLE
Small adjustment to 'default' fix

### DIFF
--- a/packages/sproutcore-views/lib/views/states/default.js
+++ b/packages/sproutcore-views/lib/views/states/default.js
@@ -10,7 +10,7 @@ require('sproutcore-views/views/view');
 var get = SC.get, set = SC.set;
 
 SC.View.states = {
-  "default": {
+  _default: {
     // appendChild is only legal while rendering the buffer.
     appendChild: function() {
       throw "You can't use appendChild outside of the rendering process";

--- a/packages/sproutcore-views/lib/views/states/destroyed.js
+++ b/packages/sproutcore-views/lib/views/states/destroyed.js
@@ -10,7 +10,7 @@ require('sproutcore-views/views/states/default');
 var destroyedError = "You can't call %@ on a destroyed view", fmt = SC.String.fmt;
 
 SC.View.states.destroyed = {
-  parentState: SC.View.states['default'],
+  parentState: SC.View.states._default,
 
   appendChild: function() {
     throw fmt(destroyedError, ['appendChild']);

--- a/packages/sproutcore-views/lib/views/states/in_buffer.js
+++ b/packages/sproutcore-views/lib/views/states/in_buffer.js
@@ -10,7 +10,7 @@ require('sproutcore-views/views/states/default');
 var get = SC.get, set = SC.set, meta = SC.meta;
 
 SC.View.states.inBuffer = {
-  parentState: SC.View.states['default'],
+  parentState: SC.View.states._default,
 
   $: function(view, sel) {
     // if we don't have an element yet, someone calling this.$() is

--- a/packages/sproutcore-views/lib/views/states/in_dom.js
+++ b/packages/sproutcore-views/lib/views/states/in_dom.js
@@ -10,7 +10,7 @@ require('sproutcore-views/views/states/default');
 var get = SC.get, set = SC.set, meta = SC.meta;
 
 SC.View.states.hasElement = {
-  parentState: SC.View.states['default'],
+  parentState: SC.View.states._default,
 
   $: function(view, sel) {
     var elem = get(view, 'element');

--- a/packages/sproutcore-views/lib/views/states/pre_render.js
+++ b/packages/sproutcore-views/lib/views/states/pre_render.js
@@ -8,7 +8,7 @@
 require('sproutcore-views/views/states/default');
 
 SC.View.states.preRender = {
-  parentState: SC.View.states['default'],
+  parentState: SC.View.states._default,
 
   // a view leaves the preRender state once its element has been
   // created (createElement).


### PR DESCRIPTION
Commit a34c3030a7d7c03206335ba4d500ce0139fbb841 fix prevents reserved keyword errors when using states.default.  This change is to rename the variable to _default to avoid future errors and to match the naming pattern used in jQuery and Metamorph
