### PR TITLE
Extend prototypes FALSE

### DIFF
--- a/packages/sproutcore-datetime/lib/datetime.js
+++ b/packages/sproutcore-datetime/lib/datetime.js
@@ -1013,7 +1013,7 @@ SC.DateTime.reopenClass(SC.Comparable,
        if ( opts.month === 2 && opts.day > 29 ){
          return null;
        }
-       if ([4,6,9,11].contains(opts.month) && opts.day > 30) {
+       if (jQuery.inArray(opts.month, [4,6,9,11]) > -1 && opts.day > 30) {
          return null;
        }
      }

--- a/packages/sproutcore-datetime/tests/datetime_test.js
+++ b/packages/sproutcore-datetime/tests/datetime_test.js
@@ -33,14 +33,14 @@ function timeShouldBeEqualToHash(t, h, message) {
     return;
   }
     
-  equals(get(t, 'year'), h.year , message.fmt('year'));
-  equals(get(t, 'month'), h.month, message.fmt('month'));
-  equals(get(t, 'day'), h.day, message.fmt('day'));
-  equals(get(t, 'hour'), h.hour, message.fmt('hour'));
-  equals(get(t, 'minute'), h.minute, message.fmt('minute'));
-  equals(get(t, 'second'), h.second, message.fmt('second'));
-  equals(get(t, 'millisecond'), h.millisecond, message.fmt('millisecond'));
-  equals(get(t, 'timezone'), h.timezone, message.fmt('timezone'));
+  equals(get(t, 'year'), h.year , SC.String.fmt(message, 'year'));
+  equals(get(t, 'month'), h.month, SC.String.fmt(message, 'month'));
+  equals(get(t, 'day'), h.day, SC.String.fmt(message, 'day'));
+  equals(get(t, 'hour'), h.hour, SC.String.fmt(message, 'hour'));
+  equals(get(t, 'minute'), h.minute, SC.String.fmt(message, 'minute'));
+  equals(get(t, 'second'), h.second, SC.String.fmt(message, 'second'));
+  equals(get(t, 'millisecond'), h.millisecond, SC.String.fmt(message, 'millisecond'));
+  equals(get(t, 'timezone'), h.timezone, SC.String.fmt(message, 'timezone'));
 }
 
 function formatTimezone(offset) {

--- a/packages/sproutcore-handlebars/lib/controls/text_area.js
+++ b/packages/sproutcore-handlebars/lib/controls/text_area.js
@@ -25,8 +25,8 @@ SC.TextArea = SC.View.extend(SC.TextSupport, {
     this._updateElementValue();
   },
 
-  _updateElementValue: function() {
+  _updateElementValue: SC.observer(function() {
     this.$().val(get(this, 'value'));
-  }.observes('value')
+  }, 'value')
 
 });

--- a/packages/sproutcore-handlebars/lib/helpers/binding.js
+++ b/packages/sproutcore-handlebars/lib/helpers/binding.js
@@ -316,7 +316,8 @@ SC.Handlebars.bindClasses = function(context, classBindings, view, id) {
       // Normalize property path to be suitable for use
       // as a class name. For exaple, content.foo.barBaz
       // becomes bar-baz.
-      return SC.String.dasherize(get(property.split('.'), 'lastObject'));
+      var parts = property.split('.');
+      return SC.String.dasherize(parts[parts.length-1]);
 
     // If the value is not NO, undefined, or null, return the current
     // value of the property.

--- a/packages/sproutcore-handlebars/lib/helpers/collection.js
+++ b/packages/sproutcore-handlebars/lib/helpers/collection.js
@@ -77,9 +77,9 @@ SC.Handlebars.registerHelper('collection', function(path, options) {
   }
 
   if (hash.preserveContext) {
-    itemHash.templateContext = function() {
+    itemHash.templateContext = SC.computed(function() {
       return get(this, 'content');
-    }.property('content');
+    }).property('content');
     delete hash.preserveContext;
   }
 

--- a/packages/sproutcore-handlebars/lib/helpers/collection.js
+++ b/packages/sproutcore-handlebars/lib/helpers/collection.js
@@ -9,7 +9,7 @@
 require('sproutcore-handlebars');
 require('sproutcore-handlebars/helpers/view');
 
-var get = SC.get;
+var get = SC.get, fmt = SC.String.fmt;
 
 /**
   @name Handlebars.helpers.collection
@@ -35,7 +35,7 @@ SC.Handlebars.registerHelper('collection', function(path, options) {
   // Otherwise, just default to the standard class.
   var collectionClass;
   collectionClass = path ? SC.getPath(this, path) : SC.CollectionView;
-  sc_assert("%@ #collection: Could not find %@".fmt(data.view, path), !!collectionClass);
+  sc_assert(fmt("%@ #collection: Could not find %@", data.view, path), !!collectionClass);
 
   var hash = options.hash, itemHash = {}, match;
 
@@ -44,7 +44,7 @@ SC.Handlebars.registerHelper('collection', function(path, options) {
   var collectionPrototype = get(collectionClass, 'proto');
   delete hash.itemViewClass;
   itemViewClass = itemViewPath ? SC.getPath(collectionPrototype, itemViewPath) : collectionPrototype.itemViewClass;
-  sc_assert("%@ #collection: Could not find %@".fmt(data.view, itemViewPath), !!itemViewClass);
+  sc_assert(fmt("%@ #collection: Could not find %@", data.view, itemViewPath), !!itemViewClass);
 
   // Go through options passed to the {{collection}} helper and extract options
   // that configure item views instead of the collection itself.

--- a/packages/sproutcore-handlebars/tests/each_test.js
+++ b/packages/sproutcore-handlebars/tests/each_test.js
@@ -3,7 +3,7 @@ var people, view;
 module("the #each helper", {
   setup: function() {
     template = templateFor("{{#each people}}{{name}}{{/each}}");
-    people = SC.Array.apply([{ name: "Steve Holt" }, { name: "Annabelle" }]);
+    people = SC.NativeArray.apply([{ name: "Steve Holt" }, { name: "Annabelle" }]);
 
     view = SC.View.create({
       template: template,

--- a/packages/sproutcore-handlebars/tests/each_test.js
+++ b/packages/sproutcore-handlebars/tests/each_test.js
@@ -47,7 +47,7 @@ test("it updates the view if an item is added", function() {
 test("it allows you to access the current context using {{this}}", function() {
   view = SC.View.create({
     template: templateFor("{{#each people}}{{this}}{{/each}}"),
-    people: ['Black Francis', 'Joey Santiago', 'Kim Deal', 'David Lovering']
+    people: SC.NativeArray.apply(['Black Francis', 'Joey Santiago', 'Kim Deal', 'David Lovering'])
   });
 
   append(view);

--- a/packages/sproutcore-handlebars/tests/handlebars_test.js
+++ b/packages/sproutcore-handlebars/tests/handlebars_test.js
@@ -105,10 +105,10 @@ test("template view should call the function of the associated template with its
     _personName: "Tom DAAAALE",
     _i: 0,
 
-    personName: function() {
+    personName: SC.computed(function() {
       this._i++;
       return this._personName + this._i;
-    }.property().cacheable(),
+    }).cacheable(),
 
     templates: SC.Object.create({
       test_template: SC.Handlebars.compile("<h1 id='twas-called'>template was called for {{personName}}. Yea {{personName}}</h1>")
@@ -1234,9 +1234,9 @@ test("should be able to update when bound property updates", function(){
   var View = SC.View.extend({
     template: SC.Handlebars.compile('<i>{{value.name}}, {{computed}}</i>'),
     valueBinding: 'MyApp.controller',
-    computed: function(){
+    computed: SC.computed(function(){
       return this.getPath('value.name') + ' - computed';
-    }.property('value')
+    }).property('value')
   });
   
   view = View.create();

--- a/packages/sproutcore-handlebars/tests/handlebars_test.js
+++ b/packages/sproutcore-handlebars/tests/handlebars_test.js
@@ -561,7 +561,7 @@ test("should update the block when object passed to #if helper changes", functio
       set(view, 'inception', val);
     });
 
-    equals(view.$('h1').text(), '', "hides block when conditional is '%@'".fmt(val));
+    equals(view.$('h1').text(), '', SC.String.fmt("hides block when conditional is '%@'", String(val)));
 
     SC.run(function() {
       set(view, 'inception', true);
@@ -597,7 +597,7 @@ test("should update the block when object passed to #unless helper changes", fun
       set(view, 'onDrugs', val);
     });
 
-    equals(view.$('h1').text(), 'Eat your vegetables', "renders block when conditional is '%@'; %@".fmt(val, SC.typeOf(val)));
+    equals(view.$('h1').text(), 'Eat your vegetables', SC.String.fmt("renders block when conditional is '%@'; %@", String(val), SC.typeOf(val)));
 
     SC.run(function() {
       set(view, 'onDrugs', true);
@@ -636,7 +636,7 @@ test("should update the block when object passed to #if helper changes and an in
       set(view, 'inception', val);
     });
 
-    equals(view.$('h1').text(), 'BOONG?', "renders alternate if %@".fmt(val));
+    equals(view.$('h1').text(), 'BOONG?', SC.String.fmt("renders alternate if %@", String(val)));
 
     SC.run(function() {
       set(view, 'inception', true);
@@ -783,7 +783,7 @@ test("Collection views that specify an example view class have their children be
       isCustom: true
     }),
 
-    content: ['foo']
+    content: SC.NativeArray.apply(['foo'])
   });
 
   var parentView = SC.View.create({
@@ -801,7 +801,7 @@ test("Collection views that specify an example view class have their children be
 
 test("itemViewClass works in the #collection helper", function() {
   TemplateTests.ExampleController = SC.ArrayProxy.create({
-    content: ['alpha']
+    content: SC.NativeArray.apply(['alpha'])
   });
 
   TemplateTests.ExampleItemView = SC.View.extend({
@@ -823,7 +823,7 @@ test("itemViewClass works in the #collection helper", function() {
 
 test("itemViewClass works in the #collection helper relatively", function() {
   TemplateTests.ExampleController = SC.ArrayProxy.create({
-    content: ['alpha']
+    content: SC.NativeArray.apply(['alpha'])
   });
 
   TemplateTests.ExampleItemView = SC.View.extend({
@@ -1306,7 +1306,7 @@ test("the {{this}} helper should not fail on removal", function(){
   view = SC.View.create({
     template: SC.Handlebars.compile('{{#if show}}{{#each list}}{{this}}{{/each}}{{/if}}'),
     show: true,
-    list: ['a', 'b', 'c']
+    list: SC.NativeArray.apply(['a', 'b', 'c'])
   });
 
   appendView();

--- a/packages/sproutcore-handlebars/tests/views/collection_view_test.js
+++ b/packages/sproutcore-handlebars/tests/views/collection_view_test.js
@@ -382,7 +382,9 @@ test("should render multiple, bound nested collections (#68)", function() {
 
     TemplateTests.OuterListItem = SC.View.extend({
       template: SC.Handlebars.compile('{{#collection TemplateTests.InnerList class="inner"}}{{content}}{{/collection}}{{content}}'),
-      innerListContent: function() { return SC.NativeArray.apply([1,2,3]); }.property().cacheable()
+      innerListContent: SC.computed(function() {
+        return SC.NativeArray.apply([1,2,3]);
+      }).cacheable()
     });
 
     TemplateTests.OuterList = SC.CollectionView.extend({

--- a/packages/sproutcore-handlebars/tests/views/collection_view_test.js
+++ b/packages/sproutcore-handlebars/tests/views/collection_view_test.js
@@ -32,7 +32,7 @@ module("sproutcore-handlebars/tests/views/collection_view_test", {
 test("passing a block to the collection helper sets it as the template for example views", function() {
   TemplateTests.CollectionTestView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['foo', 'bar', 'baz']
+    content: SC.NativeArray.apply(['foo', 'bar', 'baz'])
   });
 
   view = SC.View.create({
@@ -52,7 +52,7 @@ test("collection helper should accept relative paths", function() {
     template: SC.Handlebars.compile('{{#collection collection}} <label></label> {{/collection}}'),
     collection: SC.CollectionView.extend({
       tagName: 'ul',
-      content: ['foo', 'bar', 'baz']
+      content: SC.NativeArray.apply(['foo', 'bar', 'baz'])
     })
   });
 
@@ -75,7 +75,7 @@ test("empty views should be removed when content is added to the collection (reg
   });
 
   App.ListController = SC.ArrayProxy.create({
-    content : []
+    content : SC.NativeArray.apply([])
   });
 
   view = SC.View.create({
@@ -98,7 +98,7 @@ test("empty views should be removed when content is added to the collection (reg
 test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {
   TemplateTests.CollectionTestView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: []
+    content: SC.NativeArray.apply([])
   });
 
   view = SC.View.create({
@@ -115,7 +115,7 @@ test("if no content is passed, and no 'else' is specified, nothing is rendered",
 test("if no content is passed, and 'else' is specified, the else block is rendered", function() {
   TemplateTests.CollectionTestView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: []
+    content: SC.NativeArray.apply([])
   });
 
   view = SC.View.create({
@@ -132,7 +132,7 @@ test("if no content is passed, and 'else' is specified, the else block is render
 test("a block passed to a collection helper defaults to the content property of the context", function() {
   TemplateTests.CollectionTestView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['foo', 'bar', 'baz']
+    content: SC.NativeArray.apply(['foo', 'bar', 'baz'])
   });
 
   view = SC.View.create({
@@ -149,7 +149,7 @@ test("a block passed to a collection helper defaults to the content property of 
 test("a block passed to a collection helper defaults to the view", function() {
   TemplateTests.CollectionTestView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['foo', 'bar', 'baz']
+    content: SC.NativeArray.apply(['foo', 'bar', 'baz'])
   });
 
   view = SC.View.create({
@@ -162,7 +162,7 @@ test("a block passed to a collection helper defaults to the view", function() {
   equals(view.$('li:has(label:contains("foo")) + li:has(label:contains("bar")) + li:has(label:contains("baz"))').length, 1, 'precond - one aside element is created for each content item');
 
   SC.run(function() {
-    set(firstChild(view), 'content', []);
+    set(firstChild(view), 'content', SC.NativeArray.apply([]));
   });
   equals(view.$('label').length, 0, "all list item views should be removed from DOM");
 });
@@ -170,7 +170,7 @@ test("a block passed to a collection helper defaults to the view", function() {
 test("should include an id attribute if id is set in the options hash", function() {
   TemplateTests.CollectionTestView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['foo', 'bar', 'baz']
+    content: SC.NativeArray.apply(['foo', 'bar', 'baz'])
   });
 
   var view = SC.View.create({
@@ -187,7 +187,7 @@ test("should include an id attribute if id is set in the options hash", function
 test("should give its item views the class specified by itemClass", function() {
   TemplateTests.itemClassTestCollectionView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['foo', 'bar', 'baz']
+    content: SC.NativeArray.apply(['foo', 'bar', 'baz'])
   });
   var view = SC.View.create({
     template: SC.Handlebars.compile('{{#collection "TemplateTests.itemClassTestCollectionView" itemClass="baz"}}foo{{/collection}}')
@@ -203,7 +203,7 @@ test("should give its item views the class specified by itemClass", function() {
 test("should give its item views the classBinding specified by itemClassBinding", function() {
   TemplateTests.itemClassBindingTestCollectionView = SC.CollectionView.extend({
     tagName: 'ul',
-    content: [SC.Object.create({ isBaz: false }), SC.Object.create({ isBaz: true }), SC.Object.create({ isBaz: true })]
+    content: SC.NativeArray.apply([SC.Object.create({ isBaz: false }), SC.Object.create({ isBaz: true }), SC.Object.create({ isBaz: true })])
   });
 
   var view = SC.View.create({
@@ -230,7 +230,7 @@ test("should give its item views the classBinding specified by itemClassBinding"
 });
 
 test("should work inside a bound {{#if}}", function() {
-  var testData = [SC.Object.create({ isBaz: false }), SC.Object.create({ isBaz: true }), SC.Object.create({ isBaz: true })];
+  var testData = SC.NativeArray.apply([SC.Object.create({ isBaz: false }), SC.Object.create({ isBaz: true }), SC.Object.create({ isBaz: true })]);
   TemplateTests.ifTestCollectionView = SC.CollectionView.extend({
     tagName: 'ul',
     content: testData
@@ -258,12 +258,14 @@ test("should pass content as context when using {{#each}} helper", function() {
   var view = SC.View.create({
     template: SC.Handlebars.compile('{{#each releases}}Mac OS X {{version}}: {{name}} {{/each}}'),
 
-    releases: [ { version: '10.7',
+    releases: SC.NativeArray.apply([
+                { version: '10.7',
                   name: 'Lion' },
                 { version: '10.6',
                   name: 'Snow Leopard' },
                 { version: '10.5',
-                  name: 'Leopard' } ]
+                  name: 'Leopard' }
+              ])
   });
 
   SC.run(function() { view.appendTo('#qunit-fixture'); });
@@ -274,7 +276,7 @@ test("should pass content as context when using {{#each}} helper", function() {
 test("should re-render when the content object changes", function() {
   TemplateTests.RerenderTest = SC.CollectionView.extend({
     tagName: 'ul',
-    content: []
+    content: SC.NativeArray.apply([])
   });
 
   var view = SC.View.create({
@@ -286,11 +288,11 @@ test("should re-render when the content object changes", function() {
   });
 
   SC.run(function() {
-    set(firstChild(view), 'content', ['bing', 'bat', 'bang']);
+    set(firstChild(view), 'content', SC.NativeArray.apply(['bing', 'bat', 'bang']));
   });
 
   SC.run(function() {
-    set(firstChild(view), 'content', ['ramalamadingdong']);
+    set(firstChild(view), 'content', SC.NativeArray.apply(['ramalamadingdong']));
   });
 
   equals(view.$('li').length, 1, "rerenders with correct number of items");
@@ -300,7 +302,7 @@ test("should re-render when the content object changes", function() {
 
 test("select tagName on collection helper automatically sets child tagName to option", function() {
   TemplateTests.RerenderTest = SC.CollectionView.extend({
-    content: ['foo']
+    content: SC.NativeArray.apply(['foo'])
   });
   
   var view = SC.View.create({
@@ -317,7 +319,7 @@ test("select tagName on collection helper automatically sets child tagName to op
 
 test("tagName works in the #collection helper", function() {
   TemplateTests.RerenderTest = SC.CollectionView.extend({
-    content: ['foo', 'bar']
+    content: SC.NativeArray.apply(['foo', 'bar'])
   });
 
   var view = SC.View.create({
@@ -332,7 +334,7 @@ test("tagName works in the #collection helper", function() {
   equals(view.$('li').length, 2, "rerenders with correct number of items");
 
   SC.run(function() {
-    set(firstChild(view), 'content', ['bing', 'bat', 'bang']);
+    set(firstChild(view), 'content', SC.NativeArray.apply(['bing', 'bat', 'bang']));
   });
 
   equals(view.$('li').length, 3, "rerenders with correct number of items");
@@ -343,12 +345,12 @@ test("should render nested collections", function() {
 
   TemplateTests.InnerList = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['one','two','three']
+    content: SC.NativeArray.apply(['one','two','three'])
   });
 
   TemplateTests.OuterList = SC.CollectionView.extend({
     tagName: 'ul',
-    content: ['foo']
+    content: SC.NativeArray.apply(['foo'])
   });
 
   var view = SC.View.create({
@@ -370,7 +372,7 @@ test("should render multiple, bound nested collections (#68)", function() {
 
   SC.run(function() {
     TemplateTests.contentController = SC.ArrayProxy.create({
-      content: ['foo','bar']
+      content: SC.NativeArray.apply(['foo','bar'])
     });
 
     TemplateTests.InnerList = SC.CollectionView.extend({
@@ -380,7 +382,7 @@ test("should render multiple, bound nested collections (#68)", function() {
 
     TemplateTests.OuterListItem = SC.View.extend({
       template: SC.Handlebars.compile('{{#collection TemplateTests.InnerList class="inner"}}{{content}}{{/collection}}{{content}}'),
-      innerListContent: function() { return [1,2,3]; }.property().cacheable()
+      innerListContent: function() { return SC.NativeArray.apply([1,2,3]); }.property().cacheable()
     });
 
     TemplateTests.OuterList = SC.CollectionView.extend({
@@ -436,7 +438,7 @@ test("should allow view objects to be swapped out without throwing an error (#78
   SC.run(function() {
     dataset = SC.Object.create({
       ready: true,
-      items: [1,2,3]
+      items: SC.NativeArray.apply([1,2,3])
     });
     TemplateTests.datasetController.set('dataset',dataset);
   });

--- a/packages/sproutcore-metal/tests/binding/transform_test.js
+++ b/packages/sproutcore-metal/tests/binding/transform_test.js
@@ -7,7 +7,15 @@
 
 var foo, bar, binding, set = SC.set, get = SC.get, setPath = SC.setPath;
 
-var CountObject = SC.Object.extend({
+var CountObject = function(data){
+  for (item in data){
+    this[item] = data[item];
+  }
+
+  SC.addObserver(this, 'value', this.valueDidChange);
+};
+
+CountObject.prototype = {
   value: null,
 
   _count: 0,
@@ -16,18 +24,18 @@ var CountObject = SC.Object.extend({
     this._count = 0;
     return this;
   },
-  
+
   valueDidChange: function() {
     this._count++;
-  }.observes('value')
-});
+  }
+};
 
 module('system/mixin/binding/transform_test', {
   setup: function() {
-    MyApp = SC.Object.create({
-      foo: CountObject.create({ value: 'FOO' }),
-      bar: CountObject.create({ value: 'BAR' })
-    });
+    MyApp = {
+      foo: new CountObject({ value: 'FOO' }),
+      bar: new CountObject({ value: 'BAR' })
+    };
     
     foo = SC.getPath('MyApp.foo');
     bar = SC.getPath('MyApp.bar');

--- a/packages/sproutcore-runtime/lib/core.js
+++ b/packages/sproutcore-runtime/lib/core.js
@@ -52,7 +52,7 @@ if (typeof console === 'undefined') {
   
   In general we recommend leaving this option set to true since it rarely
   conflicts with other code.  If you need to turn it off however, you can
-  define an ENV.ENHANCE_PROTOTYPES config to disable it.
+  define an ENV.EXTEND_PROTOTYPES config to disable it.
 */  
 SC.EXTEND_PROTOTYPES = (SC.ENV.EXTEND_PROTOTYPES !== false);
 

--- a/packages/sproutcore-runtime/lib/mixins/target_action_support.js
+++ b/packages/sproutcore-runtime/lib/mixins/target_action_support.js
@@ -4,7 +4,7 @@ SC.TargetActionSupport = SC.Mixin.create({
   target: null,
   action: null,
 
-  targetObject: function() {
+  targetObject: SC.computed(function() {
     var target = get(this, 'target');
 
     if (SC.typeOf(target) === "string") {
@@ -12,7 +12,7 @@ SC.TargetActionSupport = SC.Mixin.create({
     } else {
       return target;
     }
-  }.property('target').cacheable(),
+  }).property('target').cacheable(),
 
   triggerAction: function() {
     var action = get(this, 'action'),

--- a/packages/sproutcore-runtime/lib/system/array_proxy.js
+++ b/packages/sproutcore-runtime/lib/system/array_proxy.js
@@ -116,9 +116,8 @@ SC.ArrayProxy = SC.Object.extend(SC.MutableArray, {
     this.arrayContentDidChange(idx, removedCnt, addedCnt);
   },
   
-  init: function(content) {
+  init: function() {
     this._super();
-    if (content) set(this, 'content', content);
     this.contentDidChange();
   }
   

--- a/packages/sproutcore-runtime/lib/system/each_proxy.js
+++ b/packages/sproutcore-runtime/lib/system/each_proxy.js
@@ -25,10 +25,10 @@ var EachArray = SC.Object.extend(SC.Array, {
     return item && get(item, this._keyName);
   },
 
-  length: function() {
+  length: SC.computed(function() {
     var content = this._content;
     return content ? get(content, 'length') : 0;
-  }.property('[]').cacheable()
+  }).property('[]').cacheable()
 
 });
 

--- a/packages/sproutcore-runtime/tests/controllers/array_controller_test.js
+++ b/packages/sproutcore-runtime/tests/controllers/array_controller_test.js
@@ -15,7 +15,7 @@ SC.MutableArrayTests.extend({
   newObject: function(ary) {
     var ret = ary ? ary.slice() : this.newFixture(3);
     return SC.ArrayController.create({
-      content: ret
+      content: SC.NativeArray.apply(ret)
     });
   },
 

--- a/packages/sproutcore-runtime/tests/ext/function_test.js
+++ b/packages/sproutcore-runtime/tests/ext/function_test.js
@@ -11,7 +11,7 @@ module('Function.prototype.observes() helper');
 
 testBoth('global observer helper takes multiple params', function(get, set) {
 
-  if (SC.ENHANCE_PROTOTYPES === false) {
+  if (SC.EXTEND_PROTOTYPES === false) {
     ok('Function.prototype helper disabled');
     return ;
   }

--- a/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -30,7 +30,7 @@ test("chained observers on enumerable properties are triggered when the observed
   var child4 = SC.Object.create({ name: "Nancy" });
 
   set(family, 'momma', momma);
-  set(momma, 'children', [child1, child2, child3]);
+  set(momma, 'children', SC.NativeArray.apply([child1, child2, child3]));
 
   var observerFiredCount = 0;
   SC.addObserver(family, 'momma.children.@each.name', this, function() {

--- a/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -51,7 +51,7 @@ module("object.get()", {
       numberVal: 24,
       toggleVal: true,
 
-      computed: function() { return 'value'; }.property(),
+      computed: SC.computed(function() { return 'value'; }).property(),
 
       method: function() { return "value"; },
 
@@ -101,7 +101,7 @@ module("SC.get()", {
       numberVal: 24,
       toggleVal: true,
 
-      computed: function() { return 'value'; }.property(),
+      computed: SC.computed(function() { return 'value'; }).property(),
 
       method: function() { return "value"; },
 
@@ -176,7 +176,7 @@ module("SC.getPath()");
 test("should return a property at a given path relative to the window", function() {
   window.Foo = ObservableObject.create({
     Bar: ObservableObject.create({
-      Baz: function() { return "blargh"; }.property()
+      Baz: SC.computed(function() { return "blargh"; }).property()
     })
   });
 
@@ -190,7 +190,7 @@ test("should return a property at a given path relative to the window", function
 test("should return a property at a given path relative to the passed object", function() {
   var foo = ObservableObject.create({
     bar: ObservableObject.create({
-      baz: function() { return "blargh"; }.property()
+      baz: SC.computed(function() { return "blargh"; }).property()
     })
   });
 
@@ -235,12 +235,12 @@ module("object.set()", {
 
       // computed property
       _computed: "computed",
-      computed: function(key, value) {
+      computed: SC.computed(function(key, value) {
         if (value !== undefined) {
           this._computed = value ;
         }
         return this._computed ;
-      }.property(),
+      }).property(),
 
       // method, but not a property
       _method: "method",
@@ -323,16 +323,16 @@ module("Computed properties", {
       // REGULAR
 
       computedCalls: [],
-      computed: function(key, value) {
+      computed: SC.computed(function(key, value) {
         this.computedCalls.push(value);
         return 'computed';
-      }.property(),
+      }).property(),
 
       computedCachedCalls: [],
-      computedCached: function(key, value) {
+      computedCached: SC.computed(function(key, value) {
         this.computedCachedCalls.push(value);
         return 'computedCached';
-      }.property().cacheable(),
+      }).property().cacheable(),
 
 
       // DEPENDENT KEYS
@@ -340,40 +340,40 @@ module("Computed properties", {
       changer: 'foo',
 
       dependentCalls: [],
-      dependent: function(key, value) {
+      dependent: SC.computed(function(key, value) {
         this.dependentCalls.push(value);
         return 'dependent';
-      }.property('changer'),
+      }).property('changer'),
 
       dependentCachedCalls: [],
-      dependentCached: function(key, value) {
+      dependentCached: SC.computed(function(key, value) {
         this.dependentCachedCalls.push(value);
         return 'dependentCached';
-      }.property('changer').cacheable(),
+      }).property('changer').cacheable(),
 
       // everytime it is recomputed, increments call
       incCallCount: 0,
-      inc: function() {
+      inc: SC.computed(function() {
         return this.incCallCount++;
-      }.property('changer').cacheable(),
+      }).property('changer').cacheable(),
 
       // depends on cached property which depends on another property...
       nestedIncCallCount: 0,
-      nestedInc: function(key, value) {
+      nestedInc: SC.computed(function(key, value) {
         return this.nestedIncCallCount++;
-      }.property('inc').cacheable(),
+      }).property('inc').cacheable(),
 
       // two computed properties that depend on a third property
       state: 'on',
-      isOn: function(key, value) {
+      isOn: SC.computed(function(key, value) {
         if (value !== undefined) this.set('state', 'on');
         return this.get('state') === 'on';
-      }.property('state'),
+      }).property('state'),
 
-      isOff: function(key, value) {
+      isOff: SC.computed(function(key, value) {
         if (value !== undefined) this.set('state', 'off');
         return this.get('state') === 'off';
-      }.property('state')
+      }).property('state')
 
     }) ;
   }
@@ -528,9 +528,9 @@ test("dependent keys should be able to be specified as property paths", function
       price: 5
     }),
 
-    menuPrice: function() {
+    menuPrice: SC.computed(function() {
       return this.getPath('menu.price');
-    }.property('menu.price').cacheable()
+    }).property('menu.price').cacheable()
   });
 
   equals(depObj.get('menuPrice'), 5, "precond - initial value returns 5");
@@ -548,9 +548,9 @@ test("nested dependent keys should propagate after they update", function() {
       })
     }),
 
-    price: function() {
+    price: SC.computed(function() {
       return this.getPath('restaurant.menu.price');
-    }.property('restaurant.menu.price')
+    }).property('restaurant.menu.price')
   });
 
   var bindObj = ObservableObject.create({
@@ -584,9 +584,9 @@ test("cacheable nested dependent keys should clear after their dependencies upda
       })
     }),
 
-    price: function() {
+    price: SC.computed(function() {
       return this.getPath('restaurant.menu.price');
-    }.property('restaurant.menu.price').cacheable()
+    }).property('restaurant.menu.price').cacheable()
   });
 
   SC.run.sync();
@@ -649,13 +649,13 @@ module("Observable objects & object properties ", {
         this.abnormal = 'changedValueObserved';
       },
 
-      testObserver:function(){
+      testObserver: SC.observer(function(){
         this.abnormal = 'removedObserver';
-      }.observes('normal'),
+      }, 'normal'),
 
-      testArrayObserver:function(){
+      testArrayObserver: SC.observer(function(){
         this.abnormal = 'notifiedObserver';
-      }.observes('*normalArray.[]')
+      }, '*normalArray.[]')
 
     });
   }

--- a/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -382,20 +382,20 @@ module("Computed properties", {
 test("getting values should call function return value", function() {
 
   // get each property twice. Verify return.
-  var keys = 'computed computedCached dependent dependentCached'.w();
+  var keys = SC.String.w('computed computedCached dependent dependentCached');
 
   keys.forEach(function(key) {
-    equals(object.get(key), key, 'Try #1: object.get(%@) should run function'.fmt(key));
-    equals(object.get(key), key, 'Try #2: object.get(%@) should run function'.fmt(key));
+    equals(object.get(key), key, SC.String.fmt('Try #1: object.get(%@) should run function', key));
+    equals(object.get(key), key, SC.String.fmt('Try #2: object.get(%@) should run function', key));
   });
 
   // verify each call count.  cached should only be called once
-  'computedCalls dependentCalls'.w().forEach(function(key) {
-    equals(object[key].length, 2, 'non-cached property %@ should be called 2x'.fmt(key));
+  SC.String.w('computedCalls dependentCalls').forEach(function(key) {
+    equals(object[key].length, 2, SC.String.fmt('non-cached property %@ should be called 2x', key));
   });
 
-  'computedCachedCalls dependentCachedCalls'.w().forEach(function(key) {
-    equals(object[key].length, 1, 'non-cached property %@ should be called 1x'.fmt(key));
+  SC.String.w('computedCachedCalls dependentCachedCalls').forEach(function(key) {
+    equals(object[key].length, 1, SC.String.fmt('non-cached property %@ should be called 1x', key));
   });
 
 });
@@ -403,16 +403,16 @@ test("getting values should call function return value", function() {
 test("setting values should call function return value", function() {
 
   // get each property twice. Verify return.
-  var keys = 'computed dependent computedCached dependentCached'.w();
-  var values = 'value1 value2'.w();
+  var keys = SC.String.w('computed dependent computedCached dependentCached');
+  var values = SC.String.w('value1 value2');
 
   keys.forEach(function(key) {
 
-    equals(object.set(key, values[0]), object, 'Try #1: object.set(%@, %@) should run function'.fmt(key, values[0]));
+    equals(object.set(key, values[0]), object, SC.String.fmt('Try #1: object.set(%@, %@) should run function', key, values[0]));
 
-    equals(object.set(key, values[1]), object, 'Try #2: object.set(%@, %@) should run function'.fmt(key, values[1]));
+    equals(object.set(key, values[1]), object, SC.String.fmt('Try #2: object.set(%@, %@) should run function', key, values[1]));
     
-    equals(object.set(key, values[1]), object, 'Try #3: object.set(%@, %@) should not run function since it is setting same value as before'.fmt(key, values[1]));
+    equals(object.set(key, values[1]), object, SC.String.fmt('Try #3: object.set(%@, %@) should not run function since it is setting same value as before', key, values[1]));
 
   });
 
@@ -425,9 +425,9 @@ test("setting values should call function return value", function() {
     // Cached properties first check their cached value before setting the
     // property. Other properties blindly call set.
     expectedLength = 3;
-    equals(calls.length, expectedLength, 'set(%@) should be called the right amount of times'.fmt(key));
+    equals(calls.length, expectedLength, SC.String.fmt('set(%@) should be called the right amount of times', key));
     for(idx=0;idx<2;idx++) {
-      equals(calls[idx], values[idx], 'call #%@ to set(%@) should have passed value %@'.fmt(idx+1, key, values[idx]));
+      equals(calls[idx], values[idx], SC.String.fmt('call #%@ to set(%@) should have passed value %@', idx+1, key, values[idx]));
     }
   });
 
@@ -634,7 +634,7 @@ module("Observable objects & object properties ", {
       toggleVal: true,
       observedProperty: 'beingWatched',
       testRemove: 'observerToBeRemoved',
-      normalArray: [1,2,3,4,5],
+      normalArray: SC.NativeArray.apply([1,2,3,4,5]),
 
       getEach: function() {
         var keys = ['normal','abnormal'];

--- a/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
@@ -26,9 +26,7 @@ var ObservableObject = SC.Object.extend(SC.Observable);
 // GET()
 //
 
-module("object.observesForKey()", {
-
-});
+module("object.observesForKey()");
 
 test("should get observers", function() {
   var o1 = ObservableObject.create({ foo: 100 }),

--- a/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
@@ -36,14 +36,14 @@ test("should get observers", function() {
       o3 = ObservableObject.create({ func: function() {} }),
       observers = null;
       
-  equals(o1.observersForKey('foo').get('length'), 0, "o1.observersForKey should return empty array");
+  equals(SC.get(o1.observersForKey('foo'), 'length'), 0, "o1.observersForKey should return empty array");
   
   o1.addObserver('foo', o2, o2.func);
   o1.addObserver('foo', o3, o3.func);
   
   observers = o1.observersForKey('foo');
     
-  equals(observers.get('length'), 2, "o2.observersForKey should return an array with length 2");
+  equals(SC.get(observers, 'length'), 2, "o2.observersForKey should return an array with length 2");
   equals(observers[0][0], o2, "first item in observers array should be o2");
   equals(observers[1][0], o3, "second item in observers array should be o3");
 });

--- a/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -35,20 +35,20 @@ module("object.propertyChanges", {
       foo  : 'fooValue',
       prop : 'propValue',
             
-      action: function() {
+      action: SC.observer(function() {
         this.set('prop', 'changedPropValue');
-      }.observes('foo'),
+      }, 'foo'),
       
       newFoo : 'newFooValue',
       newProp: 'newPropValue',
       
-      notifyAction: function() {
+      notifyAction: SC.observer(function() {
         this.set('newProp', 'changedNewPropValue');
-      }.observes('newFoo'),
+      }, 'newFoo'),
       
-      notifyAllAction: function() {
+      notifyAllAction: SC.observer(function() {
         this.set('newFoo', 'changedNewFooValue');
-      }.observes('prop'),
+      }, 'prop'),
 
       starProp: null,
       starObserver: function(target, key, value, rev) {
@@ -124,13 +124,13 @@ test("should invalidate function property cache when notifyPropertyChange is cal
   
   var a = ObservableObject.create({
     _b: null,
-    b: function(key, value) {
+    b: SC.computed(function(key, value) {
       if (value !== undefined) {
         this._b = value;
         return this;
       }
       return this._b;
-    }.property()
+    })
   });
   
   a.set('b', 'foo');

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/binding_test.js
@@ -90,11 +90,11 @@ test("suspended observing during bindings", function() {
 
     callCount: 0,
 
-    observer: function() {
+    observer: SC.observer(function() {
       equals(get(this, 'value1'), 'CHANGED', 'value1 when observer fires');
       equals(get(this, 'value2'), 'CHANGED', 'value2 when observer fires');
       this.callCount++;
-    }.observes('value1', 'value2')
+    }, 'value1', 'value2')
   });
 
   var root = { fromObject: fromObject, toObject: toObject };
@@ -162,9 +162,9 @@ module("chained binding", {
       input: 'second',
       output: 'second',
 
-      inputDidChange: function() {
+      inputDidChange: SC.observer(function() {
         set(this, "output", get(this, "input")) ;
-      }.observes("input")
+      }, "input")
     }) ;
 
     third = SC.Object.create({ input: "third" }) ;

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/binding_test.js
@@ -404,7 +404,7 @@ test("toObject.value should be second value if first is falsy", function() {
 
 module("Binding with '[]'", {
   setup: function() {
-    fromObject = SC.Object.create({ value: [] });
+    fromObject = SC.Object.create({ value: SC.NativeArray.apply([]) });
     toObject = SC.Object.create({ value: '' });
     root = { toObject: toObject, fromObject: fromObject };
     

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/object/base_test.js
@@ -82,17 +82,17 @@ module("SC.Object observers", {
       prop1: null,
 
       // normal observer
-      observer: function(){
+      observer: SC.observer(function(){
         this._normal = YES;
-      }.observes("prop1"),
+      }, "prop1"),
 
-      globalObserver: function() {
+      globalObserver: SC.observer(function() {
         this._global = YES;
-      }.observes("TestNamespace.obj.value"),
+      }, "TestNamespace.obj.value"),
 
-      bothObserver: function() {
+      bothObserver: SC.observer(function() {
         this._both = YES;
-      }.observes("prop1", "TestNamespace.obj.value")
+      }, "prop1", "TestNamespace.obj.value")
     });
 
   }

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/object/base_test.js
@@ -151,10 +151,10 @@ test("Checking the detectInstance() function on an object and its subclass", fun
 });
 
 test("subclasses should contain defined subclasses", function() {
-  ok(obj.subclasses.contains(obj1), 'obj.subclasses should contain obj1');
+  ok(jQuery.inArray(obj1, obj.subclasses) > -1, 'obj.subclasses should contain obj1');
 
   equals(get(obj1.subclasses, 'length'),0,'obj1.subclasses should be empty');
 
   var kls2 = obj1.extend();
-  ok(obj1.subclasses.contains(kls2), 'obj1.subclasses should contain kls2');
+  ok(jQuery.inArray(kls2, obj1.subclasses) > -1, 'obj1.subclasses should contain kls2');
 });

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -37,7 +37,7 @@
 
     var values = get(obj, 'values'),
         expected = ['a', 'b', 'c', 'd', 'e', 'f'];
-    same(values, expected, "should concatenate values property (expected: %@, got: %@)".fmt(expected, values));
+    same(values, expected, SC.String.fmt("should concatenate values property (expected: %@, got: %@)", expected, values));
   });
 
   test("concatenates subclasses", function() {
@@ -48,7 +48,7 @@
 
     var values = get(obj, 'values'),
         expected = ['a', 'b', 'c', 'd', 'e', 'f'];
-    same(values, expected, "should concatenate values property (expected: %@, got: %@)".fmt(expected, values));
+    same(values, expected, SC.String.fmt("should concatenate values property (expected: %@, got: %@)", expected, values));
   });
 
   test("concatenates reopen", function() {
@@ -59,7 +59,7 @@
 
     var values = get(obj, 'values'),
         expected = ['a', 'b', 'c', 'd', 'e', 'f'];
-    same(values, expected, "should concatenate values property (expected: %@, got: %@)".fmt(expected, values));
+    same(values, expected, SC.String.fmt("should concatenate values property (expected: %@, got: %@)", expected, values));
   });
 
   test("concatenates mixin", function() {
@@ -73,7 +73,7 @@
 
     var values = get(obj, 'values'),
         expected = ['a', 'b', 'c', 'd', 'e', 'f'];
-    same(values, expected, "should concatenate values property (expected: %@, got: %@)".fmt(expected, values));
+    same(values, expected, SC.String.fmt("should concatenate values property (expected: %@, got: %@)", expected, values));
   });
 
   test("concatenates reopen, subclass, and instance", function() {
@@ -83,7 +83,7 @@
 
     var values = get(obj, 'values'),
         expected = ['a', 'b', 'c', 'd', 'e', 'f'];
-    same(values, expected, "should concatenate values property (expected: %@, got: %@)".fmt(expected, values));
+    same(values, expected, SC.String.fmt("should concatenate values property (expected: %@, got: %@)", expected, values));
   });
 
 

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -32,9 +32,9 @@ module("System:run_loop() - chained binding", {
       input: 'MyApp.second',
       output: 'MyApp.second',
     
-      inputDidChange: function() {
+      inputDidChange: SC.observer(function() {
         this.set("output", this.get("input")) ;
-      }.observes("input") 
+      }, "input") 
 
     }) ;
   
@@ -44,7 +44,7 @@ module("System:run_loop() - chained binding", {
   }
 });
 
-test("Should propograte bindings after the RunLoop completes (using SC.RunLoop)", function() {
+test("Should propagate bindings after the RunLoop completes (using SC.RunLoop)", function() {
   SC.RunLoop.begin();
     //Binding of output of MyApp.first object to input of MyApp.second object
       binding1 = SC.Binding.from("first.output")
@@ -75,7 +75,7 @@ test("Should propograte bindings after the RunLoop completes (using SC.RunLoop)"
   equals(MyApp.second.get("output"), "change") ;
 });
 
-test("Should propograte bindings after the RunLoop completes (using SC.beginRunLoop)", function() {
+test("Should propagate bindings after the RunLoop completes (using SC.beginRunLoop)", function() {
     //Binding of output of MyApp.first object to input of MyApp.second object
       binding1 = SC.Binding.from("first.output")
         .to("second.input").connect(MyApp) ;
@@ -104,7 +104,7 @@ test("Should propograte bindings after the RunLoop completes (using SC.beginRunL
   equals(MyApp.second.get("output"), "change") ;
 });
 
-test("Should propograte bindings after the RunLoop completes (checking invokeOnce() function)", function() {
+test("Should propagate bindings after the RunLoop completes (checking invokeOnce() function)", function() {
   SC.RunLoop.begin();
     //Binding of output of MyApp.first object to input of MyApp.second object
       binding1 = SC.Binding.from("first.output")

--- a/packages/sproutcore-runtime/tests/legacy_1x/system/set_test.js
+++ b/packages/sproutcore-runtime/tests/legacy_1x/system/set_test.js
@@ -41,7 +41,7 @@ test("SC.Set.create() should create empty set", function() {
 });
 
 test("SC.Set.create([1,2,3]) should create set with three items in them", function() {
-  var set = SC.Set.create([a,b,c]) ;
+  var set = SC.Set.create(SC.NativeArray.apply([a,b,c])) ;
   equals(set.length, 3) ;
   equals(set.contains(a), YES) ;
   equals(set.contains(b), YES) ;
@@ -174,11 +174,11 @@ module("SC.Set.remove + SC.Set.contains", {
   // generate a set with every type of object, but none of the specific
   // ones we add in the tests below...
   setup: function() {
-    set = SC.Set.create([
+    set = SC.Set.create(SC.NativeArray.apply([
       SC.Object.create({ dummy: YES }),
       { isHash: YES },
       "Not the String",
-      16, true, false, 0]) ;
+      16, true, false, 0])) ;
   },
   
   teardown: function() {
@@ -292,11 +292,11 @@ module("SC.Set.pop + SC.Set.copy", {
 // generate a set with every type of object, but none of the specific
 // ones we add in the tests below...
 	setup: function() {
-		set = SC.Set.create([
+		set = SC.Set.create(SC.NativeArray.apply([
 			SC.Object.create({ dummy: YES }),
 			{ isHash: YES },
 			"Not the String",
-			16, false]) ;
+			16, false])) ;
 		},
 		
 		teardown: function() {
@@ -312,10 +312,10 @@ test("the pop() should remove an arbitrary object from the set", function() {
 });
 
 test("should pop false and 0", function(){
-  set = SC.Set.create([false]);
+  set = SC.Set.create(SC.NativeArray.apply([false]));
   ok(set.pop() === false, "should pop false");
 
-  set = SC.Set.create([0]);
+  set = SC.Set.create(SC.NativeArray.apply([0]));
   ok(set.pop() === 0, "should pop 0");
 });
 

--- a/packages/sproutcore-runtime/tests/mixins/array_test.js
+++ b/packages/sproutcore-runtime/tests/mixins/array_test.js
@@ -520,7 +520,7 @@ test('modifying the array should also indicate the isDone prop itself has change
 testBoth("should be clear caches for computed properties that have dependent keys on arrays that are changed after object initialization", function(get, set) {
   var obj = SC.Object.create({
     init: function() {
-      set(this, 'resources', SC.MutableArray.apply([]));
+      set(this, 'resources', SC.NativeArray.apply([]));
     },
 
     common: SC.computed(function() {
@@ -541,7 +541,7 @@ testBoth("observers that contain @each in the path should fire only once the fir
   var obj = SC.Object.create({
     init: function() {
       // Observer fires once when resources changes
-      set(this, 'resources', SC.MutableArray.apply([]));
+      set(this, 'resources', SC.NativeArray.apply([]));
     },
 
     commonDidChange: function() {

--- a/packages/sproutcore-runtime/tests/mixins/array_test.js
+++ b/packages/sproutcore-runtime/tests/mixins/array_test.js
@@ -40,9 +40,9 @@ var TestArray = SC.Object.extend(SC.Array, {
     return this._content[idx];
   },
 
-  length: function() {
+  length: SC.computed(function() {
     return this._content.length;
-  }.property('[]').cacheable(),
+  }).property('[]').cacheable(),
 
   slice: function() {
     return this._content.slice();
@@ -94,9 +94,9 @@ test('should notify observers of []', function() {
 
   obj = DummyArray.create({
     _count: 0,
-    enumerablePropertyDidChange: function() {
+    enumerablePropertyDidChange: SC.observer(function() {
       this._count++;
-    }.observes('[]')
+    }, '[]')
   });
 
   equals(obj._count, 0, 'should not have invoked yet');
@@ -116,9 +116,9 @@ module('notify observers of length', {
   setup: function() {
     obj = DummyArray.create({
       _after: 0,
-      lengthDidChange: function() {
+      lengthDidChange: SC.observer(function() {
         this._after++;
-      }.observes('length')
+      }, 'length')
 
     });
 
@@ -544,9 +544,9 @@ testBoth("observers that contain @each in the path should fire only once the fir
       set(this, 'resources', SC.NativeArray.apply([]));
     },
 
-    commonDidChange: function() {
+    commonDidChange: SC.observer(function() {
       count++;
-    }.observes('resources.@each.common')
+    }, 'resources.@each.common')
   })
 
   // Observer fires second time when new object is added

--- a/packages/sproutcore-runtime/tests/mixins/enumerable_test.js
+++ b/packages/sproutcore-runtime/tests/mixins/enumerable_test.js
@@ -28,9 +28,9 @@ var TestEnumerable = SC.Object.extend(SC.Enumerable, {
     return idx >= SC.get(this, 'length') ? undefined : this._content[idx];
   },
   
-  length: function() {
+  length: SC.computed(function() {
     return this._content.length;
-  }.property('[]').cacheable(),
+  }).property('[]').cacheable(),
   
   slice: function() {
     return this._content.slice();
@@ -82,9 +82,9 @@ test('should notify observers of []', function() {
     nextObject: function() {}, // avoid exceptions
     
     _count: 0,
-    enumerablePropertyDidChange: function() {
+    enumerablePropertyDidChange: SC.observer(function() {
       this._count++;
-    }.observes('[]')
+    }, '[]')
   });
   
   equals(obj._count, 0, 'should not have invoked yet');
@@ -102,9 +102,9 @@ module('notify observers of length', {
   setup: function() {
     obj = DummyEnum.create({
       _after: 0,
-      lengthDidChange: function() {
+      lengthDidChange: SC.observer(function() {
         this._after++;
-      }.observes('length')
+      }, 'length')
       
     });
     

--- a/packages/sproutcore-runtime/tests/mixins/mutable_array_test.js
+++ b/packages/sproutcore-runtime/tests/mixins/mutable_array_test.js
@@ -15,7 +15,7 @@ var TestMutableArray = SC.Object.extend(SC.MutableArray, {
   _content: null,
 
   init: function(ary) {
-    this._content = ary || [];
+    this._content = SC.NativeArray.apply(ary || []);
   },
 
   replace: function(idx, amt, objects) {

--- a/packages/sproutcore-runtime/tests/mixins/mutable_array_test.js
+++ b/packages/sproutcore-runtime/tests/mixins/mutable_array_test.js
@@ -37,9 +37,9 @@ var TestMutableArray = SC.Object.extend(SC.MutableArray, {
     return this._content[idx];
   },
 
-  length: function() {
+  length: SC.computed(function() {
     return this._content.length;
-  }.property('[]').cacheable(),
+  }).property('[]').cacheable(),
 
   slice: function() {
     return this._content.slice();

--- a/packages/sproutcore-runtime/tests/mixins/mutable_enumerable_test.js
+++ b/packages/sproutcore-runtime/tests/mixins/mutable_enumerable_test.js
@@ -39,9 +39,9 @@ var TestMutableEnumerable = SC.Object.extend(SC.MutableEnumerable, {
     return idx>=SC.get(this, 'length') ? undefined : this._content[idx];
   },
   
-  length: function() {
+  length: SC.computed(function() {
     return this._content.length;
-  }.property('[]').cacheable(),
+  }).property('[]').cacheable(),
   
   slice: function() {
     return this._content.slice();

--- a/packages/sproutcore-runtime/tests/suites/array/indexOf.js
+++ b/packages/sproutcore-runtime/tests/suites/array/indexOf.js
@@ -17,7 +17,7 @@ suite.test("should return index of object", function() {
       idx;
       
   for(idx=0;idx<len;idx++) {
-    equals(obj.indexOf(expected[idx]), idx, 'obj.indexOf(%@) should match idx'.fmt(expected[idx]));
+    equals(obj.indexOf(expected[idx]), idx, SC.String.fmt('obj.indexOf(%@) should match idx', expected[idx]));
   }
   
 });

--- a/packages/sproutcore-runtime/tests/suites/array/objectAt.js
+++ b/packages/sproutcore-runtime/tests/suites/array/objectAt.js
@@ -17,7 +17,7 @@ suite.test("should return object at specified index", function() {
       idx;
       
   for(idx=0;idx<len;idx++) {
-    equals(obj.objectAt(idx), expected[idx], 'obj.objectAt(%@) should match'.fmt(idx));
+    equals(obj.objectAt(idx), expected[idx], SC.String.fmt('obj.objectAt(%@) should match', idx));
   }
   
 });

--- a/packages/sproutcore-runtime/tests/suites/enumerable.js
+++ b/packages/sproutcore-runtime/tests/suites/enumerable.js
@@ -190,9 +190,9 @@ var EnumerableTests = SC.Object.extend({
     
     @property {Boolean}
   */
-  canTestMutation: function() {
+  canTestMutation: SC.computed(function() {
     return this.mutate !== EnumerableTests.prototype.mutate;  
-  }.property().cacheable(),
+  }).property().cacheable(),
   
   /**
     Invoked to actually run the test - overridden by mixins

--- a/packages/sproutcore-runtime/tests/system/array_proxy/suite_test.js
+++ b/packages/sproutcore-runtime/tests/system/array_proxy/suite_test.js
@@ -10,7 +10,7 @@ SC.MutableArrayTests.extend({
   
   newObject: function(ary) {
     var ret = ary ? ary.slice() : this.newFixture(3);
-    return new SC.ArrayProxy(SC.NativeArray.apply(ret));
+    return SC.ArrayProxy.create({ content: SC.NativeArray.apply(ret) });
   },
 
   mutate: function(obj) {

--- a/packages/sproutcore-runtime/tests/system/array_proxy/suite_test.js
+++ b/packages/sproutcore-runtime/tests/system/array_proxy/suite_test.js
@@ -10,7 +10,7 @@ SC.MutableArrayTests.extend({
   
   newObject: function(ary) {
     var ret = ary ? ary.slice() : this.newFixture(3);
-    return new SC.ArrayProxy(ret);
+    return new SC.ArrayProxy(SC.NativeArray.apply(ret));
   },
 
   mutate: function(obj) {

--- a/packages/sproutcore-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/sproutcore-runtime/tests/system/native_array/copyable_suite_test.js
@@ -11,7 +11,7 @@ SC.CopyableTests.extend({
   name: 'NativeArray Copyable',
   
   newObject: function() {
-    return [SC.generateGuid()];
+    return SC.NativeArray.apply([SC.generateGuid()]);
   },
   
   isEqual: function(a,b) {

--- a/packages/sproutcore-runtime/tests/system/native_array/suite_test.js
+++ b/packages/sproutcore-runtime/tests/system/native_array/suite_test.js
@@ -9,7 +9,7 @@ SC.MutableArrayTests.extend({
   name: 'Native Array',
   
   newObject: function(ary) {
-    return ary ? ary.slice() : this.newFixture(3);
+    return SC.NativeArray.apply(ary ? ary.slice() : this.newFixture(3));
   },
 
   mutate: function(obj) {

--- a/packages/sproutcore-views/lib/system/ext.js
+++ b/packages/sproutcore-views/lib/system/ext.js
@@ -8,4 +8,4 @@
 // Add a new named queue for rendering views that happens
 // after bindings have synced.
 var queues = SC.run.queues;
-queues.insertAt(queues.indexOf('actions')+1, 'render');
+queues.splice(jQuery.inArray('actions', queues)+1, 0, 'render');

--- a/packages/sproutcore-views/lib/system/render_buffer.js
+++ b/packages/sproutcore-views/lib/system/render_buffer.js
@@ -98,10 +98,10 @@ SC._RenderBuffer = SC.Object.extend(
   init: function() {
     this._super();
 
-    set(this ,'elementClasses', []);
+    set(this ,'elementClasses', SC.NativeArray.apply([]));
     set(this, 'elementAttributes', {});
     set(this, 'elementStyle', {});
-    set(this, 'childBuffers', []);
+    set(this, 'childBuffers', SC.NativeArray.apply([]));
     set(this, 'elements', {});
   },
 

--- a/packages/sproutcore-views/lib/views/collection_view.js
+++ b/packages/sproutcore-views/lib/views/collection_view.js
@@ -46,13 +46,13 @@ SC.CollectionView = SC.ContainerView.extend(
     return ret;
   },
 
-  _contentWillChange: function() {
+  _contentWillChange: SC.beforeObserver(function() {
     var content = this.get('content');
 
     if (content) { content.removeArrayObserver(this); }
     var len = content ? get(content, 'length') : 0;
     this.arrayWillChange(content, 0, len);
-  }.observesBefore('content'),
+  }, 'content'),
 
   /**
     @private
@@ -62,7 +62,7 @@ SC.CollectionView = SC.ContainerView.extend(
     asynchronously, to allow the element to be created before
     bindings have synchronized and vice versa.
   */
-  _contentDidChange: function() {
+  _contentDidChange: SC.observer(function() {
     var content = get(this, 'content');
 
     if (content) {
@@ -72,7 +72,7 @@ SC.CollectionView = SC.ContainerView.extend(
 
     var len = content ? get(content, 'length') : 0;
     this.arrayDidChange(content, 0, null, len);
-  }.observes('content'),
+  }, 'content'),
 
   destroy: function() {
     var content = get(this, 'content');

--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -1047,7 +1047,7 @@ SC.View = SC.Object.extend(
     this.classNameBindings = SC.NativeArray.apply(get(this, 'classNameBindings').slice());
     this.classNames = SC.NativeArray.apply(get(this, 'classNames').slice());
 
-    this.set('domManager', this.domManagerClass.create({ view: this }));
+    set(this, 'domManager', this.domManagerClass.create({ view: this }));
 
     meta(this)["SC.View"] = {};
   },

--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -90,7 +90,7 @@ SC.View = SC.Object.extend(
     @field
     @type Function
   */
-  template: function(key, value) {
+  template: SC.computed(function(key, value) {
     if (value !== undefined) { return value; }
 
     var templateName = get(this, 'templateName'), template;
@@ -111,7 +111,7 @@ SC.View = SC.Object.extend(
 
     // return the template, or undefined if no template was found
     return template || get(this, 'defaultTemplate');
-  }.property('templateName').cacheable(),
+  }).property('templateName').cacheable(),
 
   /**
     The object from which templates should access properties.
@@ -124,9 +124,9 @@ SC.View = SC.Object.extend(
 
     @type Object
   */
-  templateContext: function(key, value) {
+  templateContext: SC.computed(function(key, value) {
     return value !== undefined ? value : this;
-  }.property().cacheable(),
+  }).cacheable(),
 
   /**
     If the view is currently inserted into the DOM of a parent view, this
@@ -137,7 +137,7 @@ SC.View = SC.Object.extend(
   */
   _parentView: null,
 
-  parentView: function() {
+  parentView: SC.computed(function() {
     var parent = get(this, '_parentView');
 
     if (parent && parent.isVirtual) {
@@ -145,7 +145,7 @@ SC.View = SC.Object.extend(
     } else {
       return parent;
     }
-  }.property('_parentView'),
+  }).property('_parentView'),
 
   /**
     If false, the view will appear hidden in DOM.
@@ -219,9 +219,9 @@ SC.View = SC.Object.extend(
 
     @returns SC.CollectionView
   */
-  collectionView: function() {
+  collectionView: SC.computed(function() {
     return this.nearestInstanceOf(SC.CollectionView);
-  }.property().cacheable(),
+  }).cacheable(),
 
   /**
     Return the nearest ancestor that is a direct child of
@@ -229,9 +229,9 @@ SC.View = SC.Object.extend(
 
     @returns SC.View
   */
-  itemView: function() {
+  itemView: SC.computed(function() {
     return this.nearestChildOf(SC.CollectionView);
-  }.property().cacheable(),
+  }).cacheable(),
 
   /**
     Return the nearest ancestor that has the property
@@ -239,9 +239,9 @@ SC.View = SC.Object.extend(
 
     @returns SC.View
   */
-  contentView: function() {
+  contentView: SC.computed(function() {
     return this.nearestWithProperty('content');
-  }.property().cacheable(),
+  }).cacheable(),
 
   /**
     @private
@@ -249,13 +249,13 @@ SC.View = SC.Object.extend(
     When the parent view changes, recursively invalidate
     collectionView, itemView, and contentView
   */
-  _parentViewDidChange: function() {
+  _parentViewDidChange: SC.observer(function() {
     this.invokeRecursively(function(view) {
       view.propertyDidChange('collectionView');
       view.propertyDidChange('itemView');
       view.propertyDidChange('contentView');
     });
-  }.observes('_parentView'),
+  }, '_parentView'),
 
   /**
     Called on your view when it should push strings of HTML into a
@@ -509,13 +509,13 @@ SC.View = SC.Object.extend(
     @field
     @type DOMElement
   */
-  element: function(key, value) {
+  element: SC.computed(function(key, value) {
     if (value !== undefined) {
       return this.invokeForState('setElement', value);
     } else {
       return this.invokeForState('getElement');
     }
-  }.property('_parentView').cacheable(),
+  }).property('_parentView').cacheable(),
 
   /**
     Returns a jQuery object for this view's element. If you pass in a selector
@@ -647,9 +647,9 @@ SC.View = SC.Object.extend(
     @type String
     @readOnly
   */
-  elementId: function(key, value) {
+  elementId: SC.computed(function(key, value) {
     return value !== undefined ? value : SC.guidFor(this);
-  }.property().cacheable(),
+  }).cacheable(),
 
   /**
     Attempts to discover the element in the parent element. The default
@@ -798,11 +798,11 @@ SC.View = SC.Object.extend(
   },
 
   /** @private (nodoc) */
-  _elementWillChange: function() {
+  _elementWillChange: SC.beforeObserver(function() {
     this.forEachChildView(function(view) {
       SC.propertyWillChange(view, 'element');
     });
-  }.observesBefore('element'),
+  }, 'element'),
 
   /**
     @private
@@ -813,11 +813,11 @@ SC.View = SC.Object.extend(
 
     @observes element
   */
-  _elementDidChange: function() {
+  _elementDidChange: SC.observer(function() {
     this.forEachChildView(function(view) {
       SC.propertyDidChange(view, 'element');
     });
-  }.observes('element'),
+  }, 'element'),
 
   /**
     Called when the parentView property has changed.
@@ -1179,9 +1179,9 @@ SC.View = SC.Object.extend(
     When the view's `isVisible` property changes, toggle the visibility
     element of the actual DOM element.
   */
-  _isVisibleDidChange: function() {
+  _isVisibleDidChange: SC.observer(function() {
     this.$().toggle(get(this, 'isVisible'));
-  }.observes('isVisible'),
+  }, 'isVisible'),
 
   clearBuffer: function() {
     this.invokeRecursively(function(view) {

--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -13,11 +13,11 @@ var getPath = SC.getPath, meta = SC.meta, fmt = SC.String.fmt;
 var childViewsProperty = SC.computed(function() {
   var childViews = get(this, '_childViews');
 
-  var ret = [];
+  var ret = SC.NativeArray.apply([]);
 
   childViews.forEach(function(view) {
     if (view.isVirtual) {
-      ret = ret.concat(get(view, 'childViews'));
+      ret.pushObjects(get(view, 'childViews'));
     } else {
       ret.push(view);
     }
@@ -105,7 +105,7 @@ SC.View = SC.Object.extend(
       }
 
       if (!template) {
-        throw new SC.Error('%@ - Unable to find template "%@".'.fmt(this, templateName));
+        throw new SC.Error(fmt('%@ - Unable to find template "%@".', this, templateName));
       }
     }
 
@@ -165,7 +165,7 @@ SC.View = SC.Object.extend(
   */
   childViews: childViewsProperty,
 
-  _childViews: [],
+  _childViews: SC.NativeArray.apply([]),
 
   /**
     Return the nearest ancestor that is an instance of the provided
@@ -484,7 +484,8 @@ SC.View = SC.Object.extend(
       // Normalize property path to be suitable for use
       // as a class name. For exaple, content.foo.barBaz
       // becomes bar-baz.
-      return SC.String.dasherize(get(property.split('.'), 'lastObject'));
+      parts = property.split('.');
+      return SC.String.dasherize(parts[parts.length-1]);
 
     // If the value is not NO, undefined, or null, return the current
     // value of the property.
@@ -1038,13 +1039,13 @@ SC.View = SC.Object.extend(
     // SC.RootResponder to dispatch incoming events.
     SC.View.views[get(this, 'elementId')] = this;
 
-    var childViews = get(this, '_childViews').slice();
+    var childViews = SC.NativeArray.apply(get(this, '_childViews').slice());
     // setup child views. be sure to clone the child views array first
     set(this, '_childViews', childViews);
 
 
-    this.classNameBindings = get(this, 'classNameBindings').slice();
-    this.classNames = get(this, 'classNames').slice();
+    this.classNameBindings = SC.NativeArray.apply(get(this, 'classNameBindings').slice());
+    this.classNames = SC.NativeArray.apply(get(this, 'classNames').slice());
 
     this.set('domManager', this.domManagerClass.create({ view: this }));
 

--- a/packages/sproutcore-views/tests/views/collection_test.js
+++ b/packages/sproutcore-views/tests/views/collection_test.js
@@ -20,7 +20,7 @@ module("SC.CollectionView", {
 
 test("should render a view for each item in its content array", function() {
   view = SC.CollectionView.create({
-    content: [1, 2, 3, 4]
+    content: SC.NativeArray.apply([1, 2, 3, 4])
   });
 
   SC.run(function() {
@@ -32,7 +32,7 @@ test("should render a view for each item in its content array", function() {
 test("should render the emptyView if content array is empty (view class)", function() {
   view = SC.CollectionView.create({
     tagName: 'del',
-    content: [],
+    content: SC.NativeArray.apply([]),
 
     emptyView: SC.View.extend({
       tagName: 'kbd',
@@ -52,7 +52,7 @@ test("should render the emptyView if content array is empty (view class)", funct
 test("should render the emptyView if content array is empty (view instance)", function() {
   view = SC.CollectionView.create({
     tagName: 'del',
-    content: [],
+    content: SC.NativeArray.apply([]),
 
     emptyView: SC.View.create({
       tagName: 'kbd',
@@ -72,7 +72,7 @@ test("should render the emptyView if content array is empty (view instance)", fu
 test("should be able to override the tag name of itemViewClass even if tag is in default mapping", function() {
   view = SC.CollectionView.create({
     tagName: 'del',
-    content: ['NEWS GUVNAH'],
+    content: SC.NativeArray.apply(['NEWS GUVNAH']),
 
     itemViewClass: SC.View.extend({
       tagName: 'kbd',
@@ -92,7 +92,7 @@ test("should be able to override the tag name of itemViewClass even if tag is in
 test("should allow custom item views by setting itemViewClass", function() {
   var passedContents = [];
   view = SC.CollectionView.create({
-    content: ['foo', 'bar', 'baz'],
+    content: SC.NativeArray.apply(['foo', 'bar', 'baz']),
 
     itemViewClass: SC.View.extend({
       render: function(buf) {
@@ -114,7 +114,7 @@ test("should allow custom item views by setting itemViewClass", function() {
 });
 
 test("should insert a new item in DOM when an item is added to the content array", function() {
-  var content = ['foo', 'bar', 'baz'];
+  var content = SC.NativeArray.apply(['foo', 'bar', 'baz']);
 
   view = SC.CollectionView.create({
     content: content,
@@ -142,7 +142,7 @@ test("should insert a new item in DOM when an item is added to the content array
 });
 
 test("should remove an item from DOM when an item is removed from the content array", function() {
-  var content = ['foo', 'bar', 'baz'];
+  var content = SC.NativeArray.apply(['foo', 'bar', 'baz']);
 
   view = SC.CollectionView.create({
     content: content,
@@ -167,7 +167,7 @@ test("should remove an item from DOM when an item is removed from the content ar
   });
 
   content.forEach(function(item, idx) {
-    equals(view.$(':nth-child(%@)'.fmt(idx+1)).text(), item);
+    equals(view.$(SC.String.fmt(':nth-child(%@)', String(idx+1))).text(), item);
   });
 });
 
@@ -176,9 +176,9 @@ test("should allow changes to content object before layer is created", function(
     content: null
   });
 
-  set(view, 'content', []);
-  set(view, 'content', [1, 2, 3]);
-  set(view, 'content', [1, 2]);
+  set(view, 'content', SC.NativeArray.apply([]));
+  set(view, 'content', SC.NativeArray.apply([1, 2, 3]));
+  set(view, 'content', SC.NativeArray.apply([1, 2]));
 
   SC.run(function() {
     view.append();
@@ -189,7 +189,7 @@ test("should allow changes to content object before layer is created", function(
 
 test("should allow changing content property to be null", function() {
   view = SC.CollectionView.create({
-    content: [1, 2, 3],
+    content: SC.NativeArray.apply([1, 2, 3]),
 
     emptyView: SC.View.extend({
       template: function() { return "(empty)"; }
@@ -211,7 +211,7 @@ test("should allow changing content property to be null", function() {
 
 test("should allow items to access to the CollectionView's current index in the content array", function() {
   view = SC.CollectionView.create({
-    content: ['zero', 'one', 'two'],
+    content: SC.NativeArray.apply(['zero', 'one', 'two']),
     itemViewClass: SC.View.extend({
       render: function(buf) {
         buf.push(get(this, 'contentIndex'));

--- a/packages/sproutcore-views/tests/views/view/nearest_view_test.js
+++ b/packages/sproutcore-views/tests/views/view/nearest_view_test.js
@@ -12,7 +12,7 @@ test("collectionView should return the nearest collection view", function() {
   var itemViewChild;
 
   var view = SC.CollectionView.create({
-    content: [1, 2, 3],
+    content: SC.NativeArray.apply([1, 2, 3]),
     isARealCollection: true,
 
     itemViewClass: SC.View.extend({
@@ -34,7 +34,7 @@ test("itemView should return the nearest child of a collection view", function()
   var itemViewChild;
 
   var view = SC.CollectionView.create({
-    content: [1, 2, 3],
+    content: SC.NativeArray.apply([1, 2, 3]),
 
     itemViewClass: SC.View.extend({
       isAnItemView: true,
@@ -57,7 +57,7 @@ test("itemView should return the nearest child of a collection view", function()
   var itemViewChild;
 
   var view = SC.CollectionView.create({
-    content: [1, 2, 3],
+    content: SC.NativeArray.apply([1, 2, 3]),
 
     itemViewClass: SC.View.extend({
       isAnItemView: true,


### PR DESCRIPTION
Make tests pass with EXTEND_PROTOTYPES=false.

Right now you have to manually change the code to always to be false. We should find a way to automatically test both states.
