### PR TITLE
Clear rendered children *recursively* when removing a view from DOM.

### DIFF
--- a/packages/sproutcore-handlebars/tests/handlebars_test.js
+++ b/packages/sproutcore-handlebars/tests/handlebars_test.js
@@ -1460,3 +1460,46 @@ test("should update bound values after the view is removed and then re-appended"
   });
   equal($.trim(view.$().text()), "bar");
 });
+
+test("should update bound values after view's parent is removed and then re-appended", function() {
+  var parentView = SC.ContainerView.create({
+    childViews: ['testView'],
+    testView: SC.View.create({
+      template: SC.Handlebars.compile("{{#if showStuff}}{{boundValue}}{{else}}Not true.{{/if}}"),
+      showStuff: true,
+      boundValue: "foo"
+    })
+  });
+
+  SC.run(function() {
+    parentView.appendTo('#qunit-fixture');
+  });
+  view = parentView.get('testView');
+
+  equal($.trim(view.$().text()), "foo");
+  SC.run(function() {
+    set(view, 'showStuff', false);
+  });
+  equal($.trim(view.$().text()), "Not true.");
+
+  SC.run(function() {
+    set(view, 'showStuff', true);
+  });
+  equal($.trim(view.$().text()), "foo");
+
+  parentView.remove();
+  SC.run(function() {
+    set(view, 'showStuff', false);
+  });
+  SC.run(function() {
+    set(view, 'showStuff', true);
+  });
+  SC.run(function() {
+    parentView.appendTo('#qunit-fixture');
+  });
+
+  SC.run(function() {
+    set(view, 'boundValue', "bar");
+  });
+  equal($.trim(view.$().text()), "bar");
+});

--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -637,7 +637,9 @@ SC.View = SC.Object.extend(
     // In the interim, we will just re-render if that happens. It is more
     // important than elements get garbage collected.
     this.destroyElement();
-    this.clearRenderedChildren();
+    this.invokeRecursively(function(view) {
+      view.clearRenderedChildren();
+    });
   },
 
   /**


### PR DESCRIPTION
After the earlier related fix by tomdale (74c934ea003), it was still possible to get the 'Cannot perform operations on a Metamorph that is not in the DOM' error if it was the template view's parent that was removed and then re-appended.
