### PR TITLE
Fix classNameBindings to work correctly with rerenders

### DIFF
--- a/packages/sproutcore-views/lib/views/view.js
+++ b/packages/sproutcore-views/lib/views/view.js
@@ -382,6 +382,9 @@ SC.View = SC.Object.extend(
         // If we had previously added a class to the element, remove it.
         if (oldClass) {
           elem.removeClass(oldClass);
+          // Also remove from classNames so that if the view gets rerendered,
+          // the class doesn't get added back to the DOM.
+          classNames.removeObject(oldClass);
         }
 
         // If necessary, add a new class. Make sure we keep track of it so

--- a/packages/sproutcore-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/sproutcore-views/tests/views/view/class_name_bindings_test.js
@@ -87,3 +87,26 @@ test("classNames should not be duplicated on rerender", function(){
 
   equals(view.$().attr('class'), 'sc-view high');
 });
+
+test("classNames removed by a classNameBindings observer should not re-appear on rerender", function(){
+  var view = SC.View.create({
+    classNameBindings: ['isUrgent'],
+    isUrgent: true
+  });
+
+  view.createElement();
+
+  equals(view.$().attr('class'), 'sc-view is-urgent');
+
+  SC.run(function(){
+    view.set('isUrgent', false);
+  });
+
+  equals(view.$().attr('class'), 'sc-view');
+
+  SC.run(function(){
+    view.rerender();
+  });
+
+  equals(view.$().attr('class'), 'sc-view');
+});


### PR DESCRIPTION
Fix classNameBindings so that a class that was removed from DOM by an observer doesn't re-appear on the next rerender.

This happened because on the initial render, _applyClassNameBindings adds an observer _and_ adds the class to view's classNames array (if the targeted property currently so dictates, as checked in _classStringForProperty). Now if the property changes, the observer removes the class from DOM, but not from classNames, and thus the next rerender produces the element with that class again.

Removing the class from classNames in the observer seems like the most sensible fix to me. I believe it cannot be fixed by removing the old class from classNames in _applyClassNameBindings (outside the observer function, that is), because for non-boolean properties we don't know what the old class might have been (or whether it even has changed, in fact).

Another possible fix might be to split the logic into two parts: one set of observers that keeps the classNames array up-to-date based on the paths listed in classNameBindings, and a separate observer that keeps CSS classes in DOM in sync with the classNames array. This would be a bit bigger change I guess, but perhaps a little bit cleaner end result, and would have the added bonus of allowing classNames to be updated in other ways, not just through classNameBindings (which does appear to usually be enough, though).
