### PR TITLE
SC.identifyNamespaces should skip non-own properties on window.

### DIFF
--- a/packages/sproutcore-metal/lib/mixin.js
+++ b/packages/sproutcore-metal/lib/mixin.js
@@ -401,8 +401,8 @@ function findNamespaces() {
   if (Namespace.PROCESSED) { return; }
 
   for (var prop in window) {
-    // Unforutnately, some versions of IE don't support window.hasProperty
-    if (window.hasOwnProperty && window.hasOwnProperty(prop)) { continue; }
+    // Unfortunately, some versions of IE don't support window.hasOwnProperty
+    if (window.hasOwnProperty && !window.hasOwnProperty(prop)) { continue; }
 
     obj = window[prop];
 


### PR DESCRIPTION
This fixes two failing unit tests for SC.Namespace:
1. SC.Namespace is found and named
2. Classes under SC.Namespace are properly named

All tests pass for all packages after fix.
