### PR TITLE
Require Ruby 1.9 to build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+abort "Please use Ruby 1.9 to build Amber.js!" if RUBY_VERSION !~ /^1\.9/
+
 require "bundler/setup"
 require "erb"
 require "uglifier"


### PR DESCRIPTION
Ruby 1.8 hangs and @wagenet says 1.9 is required.
