### PR TITLE
Fix to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ therubyracer`.
 
 1. Install Ruby 1.9.2. There are many resources on the web can help; one of the best is [rvm](http://rvm.beginrescueend.com/).
 
-3. Run `gem install bpm --pre` to install bpm, the browser package
+3. Run `gem install bpm` to install bpm, the browser package
    manager.
 
 4. To start the development server, run `bpm preview`.


### PR DESCRIPTION
The bpm install command shouldn't use the --pre flag. That causes an old version to be installed, leading to "ERROR:  https://getbpm.org/ does not appear to be a repository" anytime you try to do anything
