### PR TITLE
Do not try to destroy a childView that does not exist

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -98,7 +98,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
 
     len = get(childViews, 'length');
     for (idx = start + removedCount - 1; idx >= start; idx--) {
-      childViews[idx].destroy();
+      if (childViews[idx]) { childViews[idx].destroy(); }
     }
   },
 


### PR DESCRIPTION
I was getting an `Uncaught TypeError: Cannot call method 'destroy' of undefined` under conditions that I can't reproduce reliably (as in: click around for a while, sometimes it happens, most of the times it doesn't)

I guess this just covers a bug or weird condition somewhere else, but checking for the childView fixes this.
