### PR TITLE
Manually assign custom message provided to new Ember.Error

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -376,6 +376,7 @@ Ember.Error = function() {
   for (var p in tmp) {
     if (tmp.hasOwnProperty(p)) { this[p] = tmp[p]; }
   }
+  this.message = tmp.message;
 };
 
 Ember.Error.prototype = Ember.create(Error.prototype);

--- a/packages/ember-runtime/tests/core/error_test.js
+++ b/packages/ember-runtime/tests/core/error_test.js
@@ -1,0 +1,9 @@
+module("Ember Error Throwing");
+
+test("new Ember.Error displays provided message", function() {
+  raises( function(){
+    throw new Ember.Error('A Message')
+  }, function(e){
+    return e.message === 'A Message'
+  }, 'the assigned message was displayed' )
+});


### PR DESCRIPTION
I believe this address #136. Name and message aren't caught in the hasOwnProperty checks: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
