### PR TITLE
Add attributes=... to Handlebars #view helper similar to class=...

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -17,6 +17,7 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
   viewClassFromHTMLOptions: function(viewClass, options, thisContext) {
     var extensions = {},
         classes = options['class'],
+        attributes = options['attributes'],
         dup = false;
 
     if (options.id) {
@@ -30,6 +31,16 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
       dup = true;
     }
 
+    if (attributes) {
+      attribute_pairs = attributes.split(/\s+/);
+      extensions.attributes = {};
+      for(var i=0; i<attribute_pairs.length; i++) {
+        var attr = attribute_pairs[i].split('=');
+        extensions.attributes[attr[0]] = attr[1]
+      }
+      dup = true;
+    }
+
     if (options.classBinding) {
       extensions.classNameBindings = options.classBinding.split(' ');
       dup = true;
@@ -39,6 +50,7 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
       options = jQuery.extend({}, options);
       delete options.id;
       delete options['class'];
+      delete options['attributes'];
       delete options.classBinding;
     }
 

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -955,6 +955,24 @@ test("{{view}} class attribute should set class on layer", function() {
   equals(view.$('.bar').text(), 'baz', "emits content");
 });
 
+test("{{view}} attributes should set attributes on layer", function() {
+  var templates = Ember.Object.create({
+    foo: Ember.Handlebars.compile('{{#view "TemplateTests.IdView" attributes="data-attribute1=3 disabled=disabled"}}{{/view}}')
+  });
+
+  TemplateTests.IdView = Ember.View;
+
+  view = Ember.View.create({
+    templateName: 'foo',
+    templates: templates
+  });
+
+  appendView();
+
+  equals(view.$('[data-attribute1=3]').length, 1, "adds first data attribute to layer");
+  equals(view.$('[disabled=disabled]').length, 1, "adds disabled attribute to layer");
+});
+
 test("{{view}} should be able to point to a local view", function() {
   view = Ember.View.create({
     template: Ember.Handlebars.compile("{{view common}}"),

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -913,6 +913,14 @@ Ember.View = Ember.Object.extend(
 
 
     get(this, 'classNames').forEach(function(name){ buffer.addClass(name); });
+
+    var attributes = get(this, 'attributes');
+    if(attributes) {
+      for(var attributeName in attributes) {
+        buffer.attr(attributeName, attributes[attributeName]);
+      }
+    }
+
     buffer.id(get(this, 'elementId'));
 
     var role = get(this, 'ariaRole');


### PR DESCRIPTION
I came across this when I needed to do something like:

``` javascript
{{view SC.TextArea attributes="rows=3"}}
```

I'm not sure where the docs are living, so I didn't update those yet. Also, I'm not sure whether there should be support for a standalone attribute like "checked" or "disabled". It wouldn't be hard to add, but for now, I've left it so that one would specify `disabled=disabled`
