### PR TITLE
IE 7/8 gets really cranky when you access non-existent properties on window.external

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -405,6 +405,9 @@ function findNamespaces() {
     // Unfortunately, some versions of IE don't support window.hasOwnProperty
     if (window.hasOwnProperty && !window.hasOwnProperty(prop)) { continue; }
 
+    // IE errors out if you try to read a property of window.exteral which does not exist
+    if (prop === "external") { continue; }
+
     obj = window[prop];
 
     if (obj && get(obj, 'isNamespace')) {

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -405,7 +405,8 @@ function findNamespaces() {
     // Unfortunately, some versions of IE don't support window.hasOwnProperty
     if (window.hasOwnProperty && !window.hasOwnProperty(prop)) { continue; }
 
-    // IE errors out if you try to read a property of window.exteral which does not exist
+    // window.external is a bit... special, and reading its properties can cause
+    // errors in some (semi-broken) installs of IE.  We don't touch it since we don't need to.
     if (prop === "external") { continue; }
 
     obj = window[prop];


### PR DESCRIPTION
This change fixes 101 tests in IE7, and 102 tests in IE8.  Not bad for one line of code...
