### PR TITLE
Safer Runloop Unwinding

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -62,6 +62,9 @@ K.prototype = RunLoop.prototype;
 RunLoop.prototype = {
   end: function() {
     this.flush();
+  },
+
+  prev: function() {
     return this._prev;
   },
 
@@ -198,7 +201,12 @@ Ember.run.begin = function() {
 */
 Ember.run.end = function() {
   ember_assert('must have a current run loop', run.currentRunLoop);
-  run.currentRunLoop = run.currentRunLoop.end();
+  try {
+    run.currentRunLoop.end();
+  }
+  finally {
+    run.currentRunLoop = run.currentRunLoop.prev();
+  }
 };
 
 /**

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -1,0 +1,28 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+module('system/run_loop/unwind_test');
+
+test('RunLoop unwinds despite unhandled exception', function() {
+  var initialRunLoop = Ember.run.currentRunLoop;
+
+  raises(function(){
+    Ember.run(function() {
+      Ember.run.schedule('actions', function() { throw new Error("boom!") });
+    });
+  }, Error, "boom!");
+  
+  // The real danger at this point is that calls to autorun will stick
+  // tasks into the already-dead runloop, which will never get
+  // flushed. I can't easily demonstrate this in a unit test because
+  // autorun explicitly doesn't work in test mode. - ef4
+  equal(Ember.run.currentRunLoop, initialRunLoop, "Previous run loop should be cleaned up despite exception");
+
+  // Prevent a failure in this test from breaking subsequent tests.
+  Ember.run.currentRunLoop = initialRunLoop;
+
+});
+


### PR DESCRIPTION
Any unhandled exception thrown during RunLoop.flush leaves the
leftover RunLoop object in SC.run.currentRunLoop. This halts the
entire application, because nothing else can be successfully scheduled
to run.

While we can't make any guarantees about the things that failed to run
properly during the flush, we can at least leave the application in a
more consistent state by clearing out the dead RunLoop.

This allows the user to navigate away from a broken view and try
something else, instead of facing a completing frozen UI.
