### PR TITLE
ember package.json prevents bpm build

### DIFF
--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -8,10 +8,10 @@
 
   "dependencies": {
     "spade":                 "~> 1.0.0",
-    "ember-runtime": "0.9.1"
-    "ember-views": "0.9.1"
-    "ember-states": "0.9.1"
-    "ember-handlebars": "0.9.1"
+    "ember-runtime": "0.9.1",
+    "ember-views": "0.9.1",
+    "ember-states": "0.9.1",
+    "ember-handlebars": "0.9.1",
     "ember-handlebars-format": "0.9"
   },
 


### PR DESCRIPTION
Several commas are missing from the package file. This fixes that issue.
