### PR TITLE
Add support to argument passing in TargetActionSupport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 .bpm
 .bundle
 .config
-.idea
-.rvmrc
 .yardoc
 InstalledFiles
 _site

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .bpm
 .bundle
 .config
+.idea
+.rvmrc
 .yardoc
 InstalledFiles
 _site

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -3,6 +3,7 @@ var get = Ember.get, set = Ember.set;
 Ember.TargetActionSupport = Ember.Mixin.create({
   target: null,
   action: null,
+  argument: null,
 
   targetObject: Ember.computed(function() {
     var target = get(this, 'target');
@@ -16,7 +17,8 @@ Ember.TargetActionSupport = Ember.Mixin.create({
 
   triggerAction: function() {
     var action = get(this, 'action'),
-        target = get(this, 'targetObject');
+        target = get(this, 'targetObject'),
+        argument = get(this, 'argument');
 
     if (target && action) {
       if (typeof target.send === 'function') {
@@ -25,7 +27,7 @@ Ember.TargetActionSupport = Ember.Mixin.create({
         if (typeof action === 'string') {
           action = target[action];
         }
-        action.call(target, this);
+        action.call(target, this, argument);
       }
     }
   }

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -3,7 +3,7 @@ var get = Ember.get, set = Ember.set;
 Ember.TargetActionSupport = Ember.Mixin.create({
   target: null,
   action: null,
-  argument: null,
+  context: null,
 
   targetObject: Ember.computed(function() {
     var target = get(this, 'target');
@@ -18,16 +18,16 @@ Ember.TargetActionSupport = Ember.Mixin.create({
   triggerAction: function() {
     var action = get(this, 'action'),
         target = get(this, 'targetObject'),
-        argument = get(this, 'argument');
+        context = get(this, 'context');
 
     if (target && action) {
       if (typeof target.send === 'function') {
-        target.send(action, this);
+        target.send(action, this, context);
       } else {
         if (typeof action === 'string') {
           action = target[action];
         }
-        action.call(target, this, argument);
+        action.call(target, this, context);
       }
     }
   }

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -26,6 +26,24 @@ test("it should support actions specified as strings", function() {
   obj.triggerAction();
 });
 
+test("it should support actions argument passing", function() {
+  expect(2);
+
+  var obj = Ember.Object.create(Ember.TargetActionSupport, {
+    target: Ember.Object.create({
+      anEvent: function(source, argument) {
+        equal(argument, 42, "anEvent method was called");
+        ok(true, "anEvent method was called");
+      }
+    }),
+
+    action: 'anEvent',
+    argument: 42
+  });
+
+  obj.triggerAction();
+});
+
 test("it should invoke the send() method on objects that implement it", function() {
   expect(1);
 


### PR DESCRIPTION
Hi gents,

I found usefull to be able to pass an argument along with a call from a button generated by a {{#each}} rendered collection.

The proposed implementation is quite basic as it only support one argument. We could imagine another implementation with several arguments...

Hope this will help & be accepted.
Thank you.

Kind regards,

/\/\ike
