### PR TITLE
state manager has infinite loop in goToState

### DIFF
--- a/packages/ember-states/lib/main.js
+++ b/packages/ember-states/lib/main.js
@@ -1,5 +1,5 @@
 // ==========================================================================
-// Project:  Ember Storyboards
+// Project:  Ember Statecharts
 // Copyright: ©2011 Living Social Inc. and contributors.
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -6,7 +6,7 @@ Ember.LOG_STATE_TRANSITIONS = false;
 
 Ember.StateManager = Ember.State.extend({
   /**
-    When creating a new storyboard, look for a default state to transition
+    When creating a new statemanager, look for a default state to transition
     into. This state can either be named `start`, or can be specified using the
     `initialState` property.
   */
@@ -71,7 +71,7 @@ Ember.StateManager = Ember.State.extend({
     var action = currentState[event];
 
     if (action) {
-      if (log) { console.log(fmt("STORYBOARDS: Sending event '%@' to state %@.", [event, currentState.name])); }
+      if (log) { console.log(fmt("STATEMANAGER: Sending event '%@' to state %@.", [event, currentState.name])); }
       action.call(currentState, this, context);
     } else {
       var parentState = get(currentState, 'parentState');
@@ -80,6 +80,8 @@ Ember.StateManager = Ember.State.extend({
   },
 
   goToState: function(name) {
+    if (Ember.empty(name)) { return; }
+
     var currentState = get(this, 'currentState') || this, state, newState;
 
     var exitStates = Ember.A();
@@ -95,6 +97,8 @@ Ember.StateManager = Ember.State.extend({
         state = get(state, 'parentState');
         if (!state) {
           state = get(this, 'states');
+          newState = getPath(state, name);
+          if (!newState) { return; }
         }
         newState = getPath(state, name);
       }
@@ -161,7 +165,7 @@ Ember.StateManager = Ember.State.extend({
       state.exit(stateManager, transition);
     }, function() {
       this.asyncEach(enterStates, function(state, transition) {
-        if (log) { console.log("STORYBOARDS: Entering " + state.name); }
+        if (log) { console.log("STATEMANAGER: Entering " + state.name); }
         state.enter(stateManager, transition);
       }, function() {
         var startState = state, enteredState;

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -155,6 +155,18 @@ test("it accepts absolute paths when changing states", function() {
   ok(stateManager.get('currentState') === emptyState, "updates currentState property to state at absolute path");
 });
 
+test("it does not enter an infinite loop in goToState", function() {
+  var emptyState = loadedState.empty;
+
+  stateManager.goToState('loadedState.empty');
+
+  stateManager.goToState('');
+  ok(stateManager.get('currentState') === emptyState, "goToState does nothing when given empty name");
+
+  stateManager.goToState('nonexistentState');
+  ok(stateManager.get('currentState') === emptyState, "goToState does not infinite loop when given nonexistent State");
+});
+
 test("it automatically transitions to a default state", function() {
   stateManager = Ember.StateManager.create({
     start: Ember.State.create({


### PR DESCRIPTION
Any time an empty or non-existent state is provided to goToState the StateManager will enter an infinite loop.

Here's a fix and some tests.

Also, removed some outdated references to Storyboards to cut down on confusion.
