### PR TITLE
Fix array_controller inline docs.

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -26,7 +26,7 @@ require('ember-runtime/system/array_proxy');
 
   Then, create a view that binds to your new controller:
 
-    {{collection contentBinding="MyApp.listController"}}
+    {{#collection contentBinding="MyApp.listController"}}
       {{content.firstName}} {{content.lastName}}
     {{/collection}}
 


### PR DESCRIPTION
Minor typo in the example for the 'container' helper in comments for array_controller. Block helpers need a #
