### PR TITLE
Use the same implementation for getEach and mapProperty.

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -209,18 +209,13 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
   },
 
   /**
-    Retrieves the named value on each member object. This is more efficient
-    than using one of the wrapper methods defined here. Objects that
-    implement Ember.Observable will use the get() method, otherwise the property
-    will be accessed directly.
+    Alias for mapProperty
 
-    @param {String} key The key to retrieve
-    @returns {Array} Extracted values
+    @params key {String} name of the property
+    @returns {Array} The mapped array.
   */
   getEach: function(key) {
-    return this.map(function(item) {
-      return get(item, key);
-    });
+    return this.mapProperty(key);
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -277,6 +277,7 @@ require('./enumerable/filter');
 require('./enumerable/find');
 require('./enumerable/firstObject');
 require('./enumerable/forEach');
+require('./enumerable/mapProperty');
 require('./enumerable/invoke');
 require('./enumerable/lastObject');
 require('./enumerable/map');

--- a/packages/ember-runtime/tests/suites/enumerable/mapProperty.js
+++ b/packages/ember-runtime/tests/suites/enumerable/mapProperty.js
@@ -1,0 +1,21 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require('ember-runtime/~tests/suites/enumerable');
+
+var suite = Ember.EnumerableTests;
+
+suite.module('mapProperty');
+
+suite.test('get value of each property', function() {
+  var obj = this.newObject([{a: 1},{a: 2}]);
+  equals(obj.mapProperty('a').join(''), '12');
+});
+
+suite.test('should work also through getEach alias', function() {
+  var obj = this.newObject([{a: 1},{a: 2}]);
+  equals(obj.getEach('a').join(''), '12');
+});


### PR DESCRIPTION
I've written tests for it because these methods have not been covered. 
Belongs to #292 
