### PR TITLE
add support for data-tag-name attribute on handlebars script tag

### DIFF
--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -15,8 +15,8 @@ require("ember-handlebars/ext");
 // with Ember's Handlebars and are suitable for use as a view's template.
 // Those with type="text/x-raw-handlebars" will be compiled with regular
 // Handlebars and are suitable for use in views' computed properties.
-Ember.Handlebars.bootstrap = function() {
-  Ember.$('script[type="text/html"], script[type="text/x-handlebars"], script[type="text/x-raw-handlebars"]')
+Ember.Handlebars.bootstrap = function(ctx) {
+  Ember.$('script[type="text/html"], script[type="text/x-handlebars"], script[type="text/x-raw-handlebars"]', ctx)
     .each(function() {
     // Get a reference to the script tag
     var script = Ember.$(this),
@@ -72,4 +72,8 @@ Ember.Handlebars.bootstrap = function() {
   });
 };
 
-Ember.$(document).ready(Ember.Handlebars.bootstrap);
+Ember.$(document).ready(
+  function(){
+	Ember.Handlebars.bootstrap( Ember.$() );
+  }
+);

--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -74,6 +74,6 @@ Ember.Handlebars.bootstrap = function(ctx) {
 
 Ember.$(document).ready(
   function(){
-	Ember.Handlebars.bootstrap( Ember.$() );
+    Ember.Handlebars.bootstrap( Ember.$(document) );
   }
 );

--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -28,7 +28,7 @@ Ember.Handlebars.bootstrap = function() {
       // id if no name is found.
       templateName = script.attr('data-template-name') || script.attr('id'),
       template = compile(script.html()),
-      view, viewPath;
+      view, viewPath, tagName;
 
     if (templateName) {
       // For templates which have a name, we save them and then remove them from the DOM
@@ -53,8 +53,13 @@ Ember.Handlebars.bootstrap = function() {
       viewPath = script.attr('data-view');
       view = viewPath ? Ember.getPath(viewPath) : Ember.View;
 
+      // Users can optionally specify a custom tag name to use by setting the
+      // data-tag-name attribute on the script tag.
+      tagName = script.attr('data-tag-name');
+
       view = view.create({
-        template: template
+        template: template,
+        tagName: (tagName) ? tagName : undefined
       });
 
       view._insertElementLater(function() {

--- a/packages/ember-handlebars/tests/loader_test.js
+++ b/packages/ember-handlebars/tests/loader_test.js
@@ -1,8 +1,59 @@
 module("test Ember.Handlebars.bootstrap");
 
-test("templates located in head with data-template-name should add a new template to Ember.TEMPLATES", function() {
-	$('#qunit-fixture').html( '<head><script type="text/html" data-template-name="crazyTemplate" >{{App.version}}</script></head>' );
-	Ember.Handlebars.bootstrap( $('#qunit-fixture') );
-	
-	ok( Ember.TEMPLATES['crazyTemplate'] );
+test('template with data-template-name should add a new template to Ember.TEMPLATES', function() {
+    $('#qunit-fixture').html('<script type="text/html" data-template-name="funkyTemplate" >{{Tobias.firstName}} {{Tobias.lastName}}</script>');
+
+    Ember.run(function() {
+        Ember.Handlebars.bootstrap($('#qunit-fixture'));
+        Tobias = Ember.Object.create({
+            firstName: 'Tobias',
+            lastName: 'Fünke'
+        });
+    });
+
+    ok(Ember.TEMPLATES['funkyTemplate'], 'template with name funkyTemplate available');
+    equals($('#qunit-fixture').text(), '', 'no template content is added');
+});
+
+test('template with id instead of data-template-name should add a new template to Ember.TEMPLATES', function() {
+    $('#qunit-fixture').html('<script type="text/html" id="funkyTemplate" >{{Tobias.firstName}} takes {{Tobias.drug}}</script>');
+
+    Ember.run(function() {
+        Ember.Handlebars.bootstrap($('#qunit-fixture'));
+        Tobias = Ember.Object.create({
+            firstName: 'Tobias',
+            drug: 'teamocil'
+        });
+    });
+
+    ok(Ember.TEMPLATES['funkyTemplate'], 'template with name funkyTemplate available');
+    equals($('#qunit-fixture').text(), '', 'no template content is added');
+});
+
+test('inline template should be added', function() {
+    $('#qunit-fixture').html('<script type="text/x-handlebars" >{{Tobias.firstName}} {{Tobias.lastName}}</script>');
+
+    Ember.run(function() {
+        Ember.Handlebars.bootstrap($('#qunit-fixture'));
+        Tobias = Ember.Object.create({
+            firstName: 'Tobias',
+            lastName: 'Fünke'
+        });
+    });
+
+    equals($('#qunit-fixture').text(), 'Tobias Fünke', 'template is rendered');
+});
+
+test('template with data-tag-name should add a template, wrapped in specific tag', function() {
+    $('#qunit-fixture').html('<script type="text/x-handlebars" data-tag-name="h1" >{{Tobias.firstName}} takes {{Tobias.drug}}</script>');
+
+    Ember.run(function() {
+        Ember.Handlebars.bootstrap($('#qunit-fixture'));
+        Tobias = Ember.Object.create({
+            firstName: 'Tobias',
+            drug: 'teamocil'
+        });
+    });
+
+    equals($('#qunit-fixture h1').text(), 'Tobias takes teamocil', 'template is rendered');
 });

--- a/packages/ember-handlebars/tests/loader_test.js
+++ b/packages/ember-handlebars/tests/loader_test.js
@@ -1,0 +1,7 @@
+module("test Ember.Handlebars.bootstrap");
+
+test("scripts with data-template-name should be added to Ember.TEMPLATES", function() {
+});
+
+test("templates with data-tag-name should create templates with specific tag name", function() {
+});

--- a/packages/ember-handlebars/tests/loader_test.js
+++ b/packages/ember-handlebars/tests/loader_test.js
@@ -1,7 +1,8 @@
 module("test Ember.Handlebars.bootstrap");
 
-test("scripts with data-template-name should be added to Ember.TEMPLATES", function() {
-});
-
-test("templates with data-tag-name should create templates with specific tag name", function() {
+test("templates located in head with data-template-name should add a new template to Ember.TEMPLATES", function() {
+	$('#qunit-fixture').html( '<head><script type="text/html" data-template-name="crazyTemplate" >{{App.version}}</script></head>' );
+	Ember.Handlebars.bootstrap( $('#qunit-fixture') );
+	
+	ok( Ember.TEMPLATES['crazyTemplate'] );
 });

--- a/packages/ember-handlebars/tests/loader_test.js
+++ b/packages/ember-handlebars/tests/loader_test.js
@@ -55,5 +55,5 @@ test('template with data-tag-name should add a template, wrapped in specific tag
         });
     });
 
-    equals($('#qunit-fixture h1').text(), 'Tobias takes teamocil', 'template is rendered');
+    equals($('#qunit-fixture h1').text(), 'Tobias takes teamocil', 'template is rendered inside custom tag');
 });


### PR DESCRIPTION
Inspired by question http://stackoverflow.com/questions/8629287/how-do-you-specify-the-tag-name-for-sproutcore-emberjs-inline-script-templates I've added support for `data-tag-name` which defines the `tagName` on the view created for a handlebars template.

Example:

``` html
<script type="text/x-handlebars" data-tag-name="h1" >
    Foo
</script>
```

which outputs

``` html
<h1>Foo</h1>
```
