### PR TITLE
Add underscore and camelize to String.prototype.

### DIFF
--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -14,8 +14,10 @@ var fmt = Ember.String.fmt,
     w   = Ember.String.w,
     loc = Ember.String.loc,
     decamelize = Ember.String.decamelize,
-    dasherize = Ember.String.dasherize;
-  
+    dasherize  = Ember.String.dasherize,
+    camelize   = Ember.String.camelize,
+    underscore = Ember.String.underscore;
+
 if (Ember.EXTEND_PROTOTYPES) {
 
   /**
@@ -24,35 +26,47 @@ if (Ember.EXTEND_PROTOTYPES) {
   String.prototype.fmt = function() {
     return fmt(this, arguments);
   };
-  
+
   /**
     @see Ember.String.w
   */
   String.prototype.w = function() {
     return w(this);
   };
-  
+
   /**
     @see Ember.String.loc
   */
   String.prototype.loc = function() {
     return loc(this, arguments);
   };
-  
+
   /**
     @see Ember.String.decamelize
   */
   String.prototype.decamelize = function() {
     return decamelize(this);
   };
-  
+
+  /**
+    @see Ember.String.camelize
+  */
+  String.prototype.camelize = function() {
+    return camelize(this);
+  };
+
   /**
     @see Ember.String.dasherize
   */
   String.prototype.dasherize = function() {
     return dasherize(this);
   };
+
+  /**
+    @see Ember.String.underscore
+  */
+  String.prototype.underscore = function() {
+    return underscore(this);
+  };
 }
-
-
 

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -199,13 +199,11 @@ Ember.String = {
     | action_name | action_name |
     | innerHTML | inner_html |
 
-    @returns {String} the camelized string.
+    @returns {String} the underscored string.
   */
   underscore: function(str) {
     return str.replace(STRING_UNDERSCORE_REGEXP_1, '$1_$2').
       replace(STRING_UNDERSCORE_REGEXP_2, '_').toLowerCase();
   }
 };
-
-
 


### PR DESCRIPTION
I thought that these methods mix automatically to String.prototype because tests passes with this:

```
if (Ember.EXTEND_PROTOTYPES) {
  same('innerHTML'.underscore(), 'inner_html');
}
```

But that code is never called.
Q: How to run tests with extended prototypes?

Thanks.
