### PR TITLE
More Runloop Unwinding

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -176,8 +176,11 @@ Ember.run = run = function(target, method) {
 
   var ret, loop;
   run.begin();
-  if (target || method) ret = invoke(target, method, arguments, 2);
-  run.end();
+  try {
+    if (target || method) ret = invoke(target, method, arguments, 2);
+  } finally {
+    run.end();
+  }
   return ret;
 };
 

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -26,3 +26,19 @@ test('RunLoop unwinds despite unhandled exception', function() {
 
 });
 
+test('Ember.run unwinds despite unhandled exception', function() {
+  var initialRunLoop = Ember.run.currentRunLoop;
+
+  raises(function(){
+    Ember.run(function() {
+      throw new Error("boom!");
+    });
+  }, Error, "boom!");
+
+  equal(Ember.run.currentRunLoop, initialRunLoop, "Previous run loop should be cleaned up despite exception");
+
+  // Prevent a failure in this test from breaking subsequent tests.
+  Ember.run.currentRunLoop = initialRunLoop;
+
+});
+


### PR DESCRIPTION
This change serves the same purpose as #263, but it covers a different entry point.

The previous change protected from exceptions during a run loop's `flush`. This protects against exceptions during direct calls to `Ember.run`. 

This keeps the application alive despite an unhandled exception in an event handler.
