### PR TITLE
Handlebar blocks [#307]

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -7,5 +7,6 @@
 require("ember-handlebars/controls/checkbox");
 require("ember-handlebars/controls/text_field");
 require("ember-handlebars/controls/button");
+require("ember-handlebars/controls/radio_button");
 require("ember-handlebars/controls/text_area");
 require("ember-handlebars/controls/tabs");

--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -16,8 +16,9 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
   propagateEvents: false,
 
-  attributeBindings: ['type', 'disabled'],
+  attributeBindings: ['type', 'disabled', 'href'],
 
+  // Defaults to 'button' if tagName is 'input' or 'button'
   type: Ember.computed(function(key, value) {
     var tagName = this.get('tagName');
     if (value !== undefined) { this._type = value; }
@@ -26,6 +27,11 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
   }).property('tagName').cacheable(),
 
   disabled: false,
+
+  // Allow 'a' tags to act like buttons
+  href: Ember.computed(function() {
+    return this.get('tagName') === 'a' ? '#' : null;
+  }).property('tagName').cacheable(),
 
   click: function() {
     // Actually invoke the button's target and action.

--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -33,14 +33,6 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
     return this.get('tagName') === 'a' ? '#' : null;
   }).property('tagName').cacheable(),
 
-  click: function() {
-    // Actually invoke the button's target and action.
-    // This method comes from the Ember.TargetActionSupport mixin.
-    this.triggerAction();
-
-    return get(this, 'propagateEvents');
-  },
-
   mouseDown: function() {
     if (!get(this, 'disabled')) {
       set(this, 'isActive', true);
@@ -66,12 +58,29 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
   mouseUp: function(event) {
     if (get(this, 'isActive')) {
+      // Actually invoke the button's target and action.
+      // This method comes from the Ember.TargetActionSupport mixin.
+      this.triggerAction();
       set(this, 'isActive', false);
     }
 
     this._mouseDown = false;
     this._mouseEntered = false;
     return get(this, 'propagateEvents');
+  },
+
+  keyDown: function(event) {
+    // Handle space or enter
+    if (event.keyCode === 13 || event.keyCode === 32) {
+      this.mouseDown();
+    }
+  },
+
+  keyUp: function(event) {
+    // Handle space or enter
+    if (event.keyCode === 13 || event.keyCode === 32) {
+      this.mouseUp();
+    }
   },
 
   // TODO: Handle proper touch behavior.  Including should make inactive when

--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -13,10 +13,19 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
   classNameBindings: ['isActive'],
 
   tagName: 'button',
-  attributeBindings: ['type', 'disabled'],
-  type: 'button',
-  disabled: false,
+
   propagateEvents: false,
+
+  attributeBindings: ['type', 'disabled'],
+
+  type: Ember.computed(function(key, value) {
+    var tagName = this.get('tagName');
+    if (value !== undefined) { this._type = value; }
+    if (this._type !== undefined) { return this._type; }
+    if (tagName === 'input' || tagName === 'button') { return 'button'; }
+  }).property('tagName').cacheable(),
+
+  disabled: false,
 
   click: function() {
     // Actually invoke the button's target and action.

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -17,7 +17,7 @@ Ember.RadioButton = Ember.View.extend({
 
   classNames: ['ember-radio-button'],
 
-  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{bindAttr disabled="disabled" name="group" value="val" checked="checked"}}>{{title}}</input>'),
+  defaultTemplate: Ember.Handlebars.compile('<label><input type="radio" {{bindAttr disabled="disabled" name="group" value="val" checked="checked"}}>{{title}}</label>'),
 
   change: function() {
     Ember.run.once(this, this._updateElementValue);

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -11,14 +11,13 @@ var set = Ember.set, get = Ember.get;
 
 Ember.RadioButton = Ember.View.extend({
   title: null,
-  value: null,
   checked: false,
   group: "radio_button",
   disabled: false,
 
   classNames: ['ember-radio-button'],
 
-  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="value" checked="checked"}}>{{title}}</input>'),
+  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="val" checked="checked"}}>{{title}}</input>'),
 
   change: function() {
     Ember.run.once(this, this._updateElementValue);
@@ -26,6 +25,6 @@ Ember.RadioButton = Ember.View.extend({
 
   _updateElementValue: function() {
     var input = this.$('input:radio');
-    set(this, 'value', input.attr('val'));
+    set(this, 'value', input.attr('value'));
   }
 });

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -17,7 +17,7 @@ Ember.RadioButton = Ember.View.extend({
 
   classNames: ['ember-radio-button'],
 
-  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="val" checked="checked"}}>{{title}}</input>'),
+  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{bindAttr disabled="disabled" name="group" value="val" checked="checked"}}>{{title}}</input>'),
 
   change: function() {
     Ember.run.once(this, this._updateElementValue);

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -1,0 +1,31 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require("ember-views/views/view");
+require("ember-handlebars/ext");
+
+var set = Ember.set, get = Ember.get;
+
+Ember.RadioButton = Ember.View.extend({
+  title: null,
+  value: null,
+  checked: false,
+  group: "radio_button",
+  disabled: false,
+
+  classNames: ['ember-radio-button'],
+
+  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="value" checked="checked"}}>{{title}}</input>'),
+
+  change: function() {
+    Ember.run.once(this, this._updateElementValue);
+  },
+
+  _updateElementValue: function() {
+    var input = this.$('input:radio');
+    set(this, 'value', input.attr('val'));
+  }
+});

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -46,14 +46,7 @@ Ember.TextSupport = Ember.Mixin.create(
   },
 
   _elementValueDidChange: function() {
-    var element = this.$();
-
-    if (element.length) {
-      set(this, 'value', this.$().val());
-    } else {
-      // the element is receiving blur because it was
-      // removed, so don't do anything.
-    }
+    set(this, 'value', this.$().val());
   }
 
 });

--- a/packages/ember-handlebars/lib/helpers.js
+++ b/packages/ember-handlebars/lib/helpers.js
@@ -11,3 +11,4 @@ require("ember-handlebars/helpers/unbound");
 require("ember-handlebars/helpers/debug");
 require("ember-handlebars/helpers/each");
 require("ember-handlebars/helpers/template");
+require("ember-handlebars/helpers/yield");

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -92,8 +92,9 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
     var viewOptions = {};
 
     if (fn) {
-      ember_assert("You cannot provide a template block if you also specified a templateName", !get(viewOptions, 'templateName') && !newView.PrototypeMixin.keys().indexOf('templateName') >= 0);
-      viewOptions.template = fn;
+      // Block could be something to yield to, or simply a template. We don't know much about the view to make the determination here. Hence this decision is moved downstream into the view's computed property - template
+	    viewOptions.yieldContent = fn;
+	    viewOptions.yieldContext = get(currentView, 'templateContext');
     }
 
     currentView.appendChild(newView, viewOptions);

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -95,6 +95,7 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
       // Block could be something to yield to, or simply a template. We don't know much about the view to make the determination here. Hence this decision is moved downstream into the view's computed property - template
 	    viewOptions.yieldContent = fn;
 	    viewOptions.yieldContext = get(currentView, 'templateContext');
+	    viewOptions.yieldContainer = currentView;
     }
 
     currentView.appendChild(newView, viewOptions);

--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -2,20 +2,45 @@ require("ember-handlebars/ext");
 require("ember-views/views/view");
 require("ember-handlebars/views/metamorph_view");
 
+/*global ember_assert */
+
 Ember.Handlebars.YieldView = Ember.View.extend(Ember.Metamorph, {
   itemViewClass: Ember.View.extend(Ember.Metamorph),
   templateContext: null,
-  template: null
+  template: null,
+  blockContainer: null   
 });
 
-Ember.Handlebars.registerHelper('yield', function(options) {
-  var currentView = options.data.view;
-  if (currentView.isVirtual) {
-    currentView = Ember.get(currentView, 'parentView');
-  }
-  if (currentView && currentView.yieldContent) {
-    options.hash.templateContext = currentView.yieldContext;
-    options.hash.template = currentView.yieldContent;
-    return Ember.Handlebars.helpers.view.call(this, 'Ember.Handlebars.YieldView', options);
+Ember.Handlebars.yieldHelper = Ember.Object.create({
+  
+  _findContainingTemplateView: function(view) {
+    // We are using _parentView here, because we need to go through the virtual YieldViews, so we can treat them differently.
+    if (!view) {
+      return view;
+    }
+    else if (view instanceof Ember.Handlebars.YieldView) {
+      var blockContainer = Ember.get(view, 'blockContainer');
+      ember_assert("YieldView representing the current block doesn't have a blockContainer set.", blockContainer);
+      return this._findContainingTemplateView(Ember.get(blockContainer, '_parentView'));
+    }
+    else if (view.isVirtual) {
+      return this._findContainingTemplateView(Ember.get(view, '_parentView'));
+    }
+    else {
+      return view;
+    }
+  },
+
+  helper: function(options) {
+    var currentView = Ember.Handlebars.yieldHelper._findContainingTemplateView(options.data.view);
+
+    if (currentView && currentView.yieldContent) {
+      options.hash.templateContext = currentView.yieldContext;
+      options.hash.template = currentView.yieldContent;
+      options.hash.blockContainer = currentView;
+      return Ember.Handlebars.helpers.view.call(this, 'Ember.Handlebars.YieldView', options);
+    }
   }
 });
+
+Ember.Handlebars.registerHelper('yield', Ember.Handlebars.yieldHelper.helper);

--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -10,7 +10,10 @@ Ember.Handlebars.YieldView = Ember.View.extend(Ember.Metamorph, {
 
 Ember.Handlebars.registerHelper('yield', function(options) {
   var currentView = options.data.view;
-  if (currentView.yieldContent) {
+  if (currentView.isVirtual) {
+    currentView = Ember.get(currentView, 'parentView');
+  }
+  if (currentView && currentView.yieldContent) {
     options.hash.templateContext = currentView.yieldContext;
     options.hash.template = currentView.yieldContent;
     return Ember.Handlebars.helpers.view.call(this, 'Ember.Handlebars.YieldView', options);

--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -1,0 +1,18 @@
+require("ember-handlebars/ext");
+require("ember-views/views/view");
+require("ember-handlebars/views/metamorph_view");
+
+Ember.Handlebars.YieldView = Ember.View.extend(Ember.Metamorph, {
+  itemViewClass: Ember.View.extend(Ember.Metamorph),
+  templateContext: null,
+  template: null
+});
+
+Ember.Handlebars.registerHelper('yield', function(options) {
+  var currentView = options.data.view;
+  if (currentView.yieldContent) {
+    options.hash.templateContext = currentView.yieldContext;
+    options.hash.template = currentView.yieldContent;
+    return Ember.Handlebars.helpers.view.call(this, 'Ember.Handlebars.YieldView', options);
+  }
+});

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -213,6 +213,24 @@ test("should have a configurable type", function() {
   equals(button.$().attr('type'), 'submit');
 });
 
+test("should set href='#' if tagName is 'a'", function() {
+  button.set('tagName', 'a');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  equals(button.$().attr('href'), '#');
+});
+
+test("should not set href if tagName is not 'a'", function() {
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  equals(button.$().attr('href'), null);
+});
+
 test("should allow the target to be the parentView", function() {
   button.set('target', 'parentView');
   

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -155,12 +155,52 @@ test("should not trigger action if disabled and a non-standard input", function(
   ok(!get(button, 'isActive'), "button does not become active when pushed");
 });
 
-test("should by default be of type='button'", function() {
+test("should not have a type if tagName is not 'input' or 'button'", function() {
   Ember.run(function() {
+    button.set('tagName', 'a');
+    button.appendTo('#qunit-fixture');
+  });
+
+  equals(button.$().attr('type'), null);
+});
+
+test("should by default be of type='button' if tagName is 'input'", function() {
+  Ember.run(function() {
+    button.set('tagName', 'input');
     button.appendTo('#qunit-fixture');
   });
 
   equals(button.$().attr('type'), 'button');
+});
+
+test("should by default be of type='button' if tagName is 'button'", function() {
+  Ember.run(function() {
+    button.set('tagName', 'button');
+    button.appendTo('#qunit-fixture');
+  });
+
+  equals(button.$().attr('type'), 'button');
+});
+
+test("should allow setting of type when tagName is not 'input' or 'button'", function() {
+  button.set('tagName', 'a');
+  button.set('type', 'submit');
+
+  equals(button.get('type'), 'submit');
+});
+
+test("should allow setting of type when tagName is 'input'", function() {
+  button.set('tagName', 'input');
+  button.set('type', 'submit');
+
+  equals(button.get('type'), 'submit');
+});
+
+test("should allow setting of type when tagName is 'button'", function() {
+  button.set('tagName', 'button');
+  button.set('type', 'submit');
+
+  equals(button.get('type'), 'submit');
 });
 
 test("should have a configurable type", function() {

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -15,8 +15,10 @@ module("Ember.Button", {
   },
 
   teardown: function() {
-    button.destroy();
-    application.destroy();
+    Ember.run(function() {
+      button.destroy();
+      application.destroy();
+    });
   }
 });
 

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -30,14 +30,14 @@ function append() {
   });
 }
 
-test("should become disabled if the disabled attribute is true", function() {
+test("should begin disabled if the disabled attribute is true", function() {
   button.set('disabled', true);
   append();
 
   ok(button.$().is(":disabled"));
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+test("should become disabled if the disabled attribute is changed", function() {
   append();
   ok(button.$().is(":not(:disabled)"));
 

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -26,6 +26,12 @@ function synthesizeEvent(type, view) {
   view.$().trigger(type);
 }
 
+function synthesizeKeyEvent(type, keyCode, view) {
+  var event = jQuery.Event(type);
+  event.keyCode = keyCode;
+  view.$().trigger(event);
+}
+
 function append() {
   Ember.run(function() {
     button.appendTo('#qunit-fixture');
@@ -66,9 +72,99 @@ test("should trigger an action when clicked", function() {
     button.appendTo('#qunit-fixture');
   });
 
-  synthesizeEvent('click', button);
+  synthesizeEvent('mousedown', button);
+  synthesizeEvent('mouseup', button);
 
   ok(wasClicked);
+});
+
+test("should trigger an action when touched", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  synthesizeEvent('touchstart', button);
+  synthesizeEvent('touchend', button);
+
+  ok(wasClicked);
+});
+
+test("should trigger an action when space pressed", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  synthesizeKeyEvent('keydown', 13, button);
+  synthesizeKeyEvent('keyup', 13, button);
+
+  ok(wasClicked);
+});
+
+test("should trigger an action when enter pressed", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  synthesizeKeyEvent('keydown', 32, button);
+  synthesizeKeyEvent('keyup', 32, button);
+
+  ok(wasClicked);
+});
+
+test("should not trigger an action when another key is pressed", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  // 'a' key
+  synthesizeKeyEvent('keydown', 65, button);
+  synthesizeKeyEvent('keyup', 65, button);
+
+  ok(!wasClicked);
 });
 
 test("should trigger an action on a String target when clicked", function() {
@@ -91,7 +187,8 @@ test("should trigger an action on a String target when clicked", function() {
     button.appendTo('#qunit-fixture');
   });
 
-  synthesizeEvent('click', button);
+  synthesizeEvent('mousedown', button);
+  synthesizeEvent('mouseup', button);
 
   ok(wasClicked);
 
@@ -130,7 +227,6 @@ test("should not trigger action if mouse leaves area before mouseup", function()
   synthesizeEvent('mouseleave', button);
   synthesizeEvent('mouseenter', button);
   synthesizeEvent('mouseup', button);
-  synthesizeEvent('click', button);
 
   ok(wasClicked);
 });

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -28,7 +28,7 @@ function append() {
   });
 }
 
-test("should become disabled if the disabled attribute is true", function() {
+test("should begin disabled if the disabled attribute is true", function() {
   checkboxView = Ember.Checkbox.create({});
 
   checkboxView.set('disabled', true);
@@ -37,7 +37,7 @@ test("should become disabled if the disabled attribute is true", function() {
   ok(checkboxView.$("input").is(":disabled"));
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+test("should become disabled if the disabled attribute is changed", function() {
   checkboxView = Ember.Checkbox.create({});
 
   append();

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -11,8 +11,10 @@ module("Ember.Checkbox", {
     application = Ember.Application.create();
   },
   teardown: function() {
-    checkboxView.destroy();
-    application.destroy();
+    Ember.run(function() {
+      checkboxView.destroy();
+      application.destroy();
+    });
   }
 });
 

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,0 +1,94 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var get = Ember.get, set = Ember.set, radioButtonView, application;
+
+module("Ember.RadioButton", {
+  setup: function() {
+    application = Ember.Application.create();
+  },
+  teardown: function() {
+    radioButtonView.destroy();
+    application.destroy();
+  }
+});
+
+function setAndFlush(view, key, value) {
+  Ember.run(function() {
+    Ember.set(view, key, value);
+  });
+}
+
+function append() {
+  Ember.run(function() {
+    radioButtonView.appendTo('#qunit-fixture');
+  });
+}
+
+test("should become disabled if the disabled attribute is true", function() {
+  radioButtonView = Ember.RadioButton.create({});
+
+  radioButtonView.set('disabled', true);
+  append();
+
+  ok(radioButtonView.$("input").is(":disabled"));
+});
+
+test("should become disabled if the disabled attribute is true", function() {
+  radioButtonView = Ember.RadioButton.create({});
+
+  append();
+  ok(radioButtonView.$("input").is(":not(:disabled)"));
+
+  Ember.run(function() { radioButtonView.set('disabled', true); });
+  ok(radioButtonView.$("input").is(":disabled"));
+
+  Ember.run(function() { radioButtonView.set('disabled', false); });
+  ok(radioButtonView.$("input").is(":not(:disabled)"));
+});
+
+test("value property mirrors input value", function() {
+  radioButtonView = Ember.RadioButton.create({ value: "value"});
+  Ember.run(function() { radioButtonView.append(); });
+
+  equals(get(radioButtonView, 'value'), "value", "initially starts with a string value");
+  equals(!!radioButtonView.$('input').prop('checked'), false, "the initial checked property is false");
+
+  setAndFlush(radioButtonView, 'checked', true);
+
+  equals(radioButtonView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+
+  radioButtonView.remove();
+  Ember.run(function() { radioButtonView.append(); });
+
+  equals(radioButtonView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+
+  Ember.run(function() { radioButtonView.remove(); });
+  Ember.run(function() { set(radioButtonView, 'checked', false); });
+  Ember.run(function() { radioButtonView.append(); });
+
+  equals(radioButtonView.$('input').prop('checked'), false, "changing the value property changes the DOM");
+});
+
+test("checking the radiobutton updates the value", function() {
+  radioButtonView = Ember.RadioButton.create({ value: "testing" });
+  Ember.run(function() { radioButtonView.appendTo('#qunit-fixture'); });
+
+  equals(!!radioButtonView.$('input').attr('checked'), false, "precond - the initial checked property is false");
+
+  // Can't find a way to programatically trigger a radiobutton in IE and have it generate the
+  // same events as if a user actually clicks.
+  if (!jQuery.browser.msie) {
+    radioButtonView.$('input')[0].click();
+  } else {
+    radioButtonView.$('input').trigger('click');
+    radioButtonView.$('input').removeAttr('checked').trigger('change');
+  }
+
+  equals(radioButtonView.$('input').prop('checked'), true, "after clicking a radiobutton, the checked property changed");
+  
+});
+

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -11,8 +11,10 @@ module("Ember.RadioButton", {
     application = Ember.Application.create();
   },
   teardown: function() {
-    radioButtonView.destroy();
-    application.destroy();
+    Ember.run(function() {
+      radioButtonView.destroy();
+      application.destroy();
+    });
   }
 });
 

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -28,7 +28,7 @@ function append() {
   });
 }
 
-test("should become disabled if the disabled attribute is true", function() {
+test("should begin disabled if the disabled attribute is true", function() {
   radioButtonView = Ember.RadioButton.create({});
 
   radioButtonView.set('disabled', true);
@@ -37,7 +37,7 @@ test("should become disabled if the disabled attribute is true", function() {
   ok(radioButtonView.$("input").is(":disabled"));
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+test("should become disabled if the disabled attribute is changed", function() {
   radioButtonView = Ember.RadioButton.create({});
 
   append();

--- a/packages/ember-handlebars/tests/controls/tabs_test.js
+++ b/packages/ember-handlebars/tests/controls/tabs_test.js
@@ -27,7 +27,7 @@ module("Ember.TabContainerView and components", {
   },
 
   teardown: function() {
-    app.destroy();
+    Ember.run(function(){ app.destroy(); });
   }
 });
 

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1538,7 +1538,10 @@ test("should not enter an infinite loop when binding an attribute in Handlebars"
 
   parentView.destroy();
 
-  App = undefined;
+  Ember.run(function() {
+    App.destroy();
+    App = undefined;
+  });
 });
 
 test("should render other templates using the {{template}} helper", function() {

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -92,7 +92,7 @@ test("empty views should be removed when content is added to the collection (reg
 
   equals(view.$('tr').length, 1, 'has one row');
 
-  window.App.destroy();
+  Ember.run(function(){ window.App.destroy(); });
 });
 
 test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {

--- a/packages/ember-handlebars/tests/views/view_blocks_test.js
+++ b/packages/ember-handlebars/tests/views/view_blocks_test.js
@@ -55,7 +55,6 @@ test("Block should receive the calling view's templateContext as the context", f
   });
 
   TemplateTests.PersonContact = Ember.View.extend({
-    templateName: 'person-contact',
 	  template: Ember.Handlebars.compile('<div class="contact"><h1>{{content.name}}</h1>{{#view TemplateTests.PhoneDialer contentBinding="content.phone"}}{{content.name}}{{/view}}</div>')
   });
 
@@ -70,6 +69,90 @@ test("Block should receive the calling view's templateContext as the context", f
   equals(view.$('#owner').text(), TemplateTests.person.name, 'person is sent in as context to the child block inside phone');
 });
 
+test("Block should work properly even when templates are not hard-coded", function() {
+  var templates = Ember.Object.create({
+    nester: Ember.Handlebars.compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>'),
+    nested: Ember.Handlebars.compile('{{#view TemplateTests.BlockContainer title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
+  });
 
+  TemplateTests.BlockContainer = Ember.View.extend({
+	  templateName: 'nester',
+	  templates: templates
+  });
 
+  view = Ember.View.create({
+    templateName: 'nested',
+    templates: templates
+  });
 
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
+  
+});
+
+test("Templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
+  TemplateTests.TimesView = Ember.View.extend({
+    template: Ember.Handlebars.compile('<div class="times">{{#each index}}{{yield}}{{/each}}</div>'),
+    n: null,
+    index: Ember.computed(function() {
+      var n = Ember.get(this, 'n'), indexArray = Ember.A([]);
+      for (var i=0; i < n; i++) {
+        indexArray[i] = i;
+      }
+      return indexArray;
+    }).cacheable()
+  });
+  
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container"><div class="title">Counting to 5</div>{{#view TemplateTests.TimesView n=5}}<div class="times-item">Hello</div>{{/view}}</div>')
+  });
+  
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div#container div.times-item').length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
+});
+
+test("Templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
+  TemplateTests.NestingView = Ember.View.extend({
+    template: Ember.Handlebars.compile('{{#view Ember.View tagName="div" classNames="nesting"}}{{debugger}}{{yield}}{{/view}}')
+  });
+  
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container">{{#view TemplateTests.NestingView}}<div id="block">Hello</div>{{/view}}</div>')
+  });
+  
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div#container div.nesting div#block').length, 1, 'nesting view yields correctly even within a view hierarchy in the nesting view');
+});
+
+test("Block should be able to pass parameters to yielded block", function() {
+  TemplateTests.TimesView = Ember.View.extend({
+    template: Ember.Handlebars.compile('<div class="times">{{#each index}}{{yield count=this}}{{/each}}</div>'),
+    n: null,
+    index: Ember.computed(function() {
+      var n = Ember.get(this, 'n'), indexArray = Ember.A([]);
+      for (var i=0; i < n; i++) {
+        indexArray[i] = i;
+      }
+      return indexArray;
+    }).cacheable()
+  });
+  
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container"><div class="title">Counting to 5</div>{{#view TemplateTests.TimesView n=5}}<div class="times-item">{{count}}</div>{{/view}}</div>')
+  });
+  
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div#container div.times-item').length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
+});

--- a/packages/ember-handlebars/tests/views/view_blocks_test.js
+++ b/packages/ember-handlebars/tests/views/view_blocks_test.js
@@ -1,0 +1,75 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals TemplateTests, Ember, minispade */
+
+var set = Ember.set, get = Ember.get, setPath = Ember.setPath;
+
+var view;
+
+module("ember-handlebars/tests/views/view_blocks_test", {
+  setup: function() {
+    window.TemplateTests = Ember.Namespace.create();
+  },
+  teardown: function() {
+    if (view) {
+      view.destroy();
+    }
+
+    window.TemplateTests = undefined;
+  }
+});
+
+test("block support in template (#307)", function() {
+  TemplateTests.BlockContainer = Ember.View.extend({
+	  template: Ember.Handlebars.compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>') 
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#view TemplateTests.BlockContainer title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
+});
+
+
+test("Block should receive the calling view's templateContext as the context", function() {
+  TemplateTests.phone = Ember.Object.create({
+    name: 'mobile',
+    number: '404-555-1234'
+  });
+  
+  TemplateTests.person = Ember.Object.create({
+    name: 'Raghu Rajah',
+    phone: TemplateTests.phone
+  });
+  
+  TemplateTests.PhoneDialer = Ember.View.extend({
+	  template: Ember.Handlebars.compile('<div class="dialer"><div id="owner" {{bindAttr class=content.name}}>{{yield}}</div><div class="phone-number">{{content.number}}</div></div>')
+  });
+
+  TemplateTests.PersonContact = Ember.View.extend({
+    templateName: 'person-contact',
+	  template: Ember.Handlebars.compile('<div class="contact"><h1>{{content.name}}</h1>{{#view TemplateTests.PhoneDialer contentBinding="content.phone"}}{{content.name}}{{/view}}</div>')
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#view TemplateTests.PersonContact contentBinding="TemplateTests.person"}}{{/view}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('#owner').text(), TemplateTests.person.name, 'person is sent in as context to the child block inside phone');
+});
+
+
+
+

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -26,9 +26,11 @@ function pushCtx(ctx) {
 }
 
 function iter(key, value) {
+  var valueProvided = arguments.length === 2;
+
   function i(item) {
     var cur = get(item, key);
-    return value===undefined ? !!cur : value===cur;
+    return valueProvided ? value===cur : !!cur;
   } 
   return i ;
 }
@@ -336,7 +338,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Array} filtered array
   */
   filterProperty: function(key, value) {
-    return this.filter(iter(key, value));
+    return this.filter(iter.apply(this, arguments));
   },
 
   /**
@@ -391,7 +393,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Object} found item or null
   */
   findProperty: function(key, value) {
-    return this.find(iter(key, value));
+    return this.find(iter.apply(this, arguments));
   },
 
   /**
@@ -436,7 +438,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Array} filtered array
   */
   everyProperty: function(key, value) {
-    return this.every(iter(key, value));
+    return this.every(iter.apply(this, arguments));
   },
 
 
@@ -482,7 +484,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Boolean} true
   */
   someProperty: function(key, value) {
-    return this.some(iter(key, value));
+    return this.some(iter.apply(this, arguments));
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable/every.js
+++ b/packages/ember-runtime/tests/suites/enumerable/every.js
@@ -64,3 +64,23 @@ suite.test('should return true of every property is true', function() {
   equals(obj.everyProperty('foo'), true, 'everyProperty(foo)');
   equals(obj.everyProperty('bar'), false, 'everyProperty(bar)');
 });
+
+suite.test('should return true if every property matches null', function() {
+  var obj = this.newObject([
+    { foo: null, bar: 'BAZ' },
+    Ember.Object.create({ foo: null, bar: null })
+  ]);
+
+  equals(obj.everyProperty('foo', null), true, "everyProperty('foo', null)");
+  equals(obj.everyProperty('bar', null), false, "everyProperty('bar', null)");
+});
+
+suite.test('should return true if every property is undefined', function() {
+  var obj = this.newObject([
+    { foo: undefined, bar: 'BAZ' },
+    Ember.Object.create({ bar: undefined })
+  ]);
+
+  equals(obj.everyProperty('foo', undefined), true, "everyProperty('foo', undefined)");
+  equals(obj.everyProperty('bar', undefined), false, "everyProperty('bar', undefined)");
+});

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -61,3 +61,80 @@ suite.test('should include in result if property is true', function() {
   same(obj.filterProperty('foo'), ary, 'filterProperty(foo)');
   same(obj.filterProperty('bar'), [ary[0]], 'filterProperty(bar)');
 });
+
+suite.test('should filter on second argument if provided', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 2}),
+    { name: 'obj3', foo: 2},
+    Ember.Object.create({ name: 'obj4', foo: 3})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', 3), [ary[0], ary[3]], "filterProperty('foo', 3)')");
+});
+
+suite.test('should correctly filter null second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: null}),
+    { name: 'obj3', foo: null},
+    Ember.Object.create({ name: 'obj4', foo: 3})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', null), [ary[1], ary[2]], "filterProperty('foo', 3)')");
+});
+
+suite.test('should not return all objects on undefined second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 2})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', undefined), [], "filterProperty('foo', 3)')");
+});
+
+suite.test('should correctly filter explicit undefined second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 3}),
+    { name: 'obj3', foo: undefined},
+    Ember.Object.create({ name: 'obj4', foo: undefined}),
+    { name: 'obj5'},
+    Ember.Object.create({ name: 'obj6'})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', undefined), ary.slice(2), "filterProperty('foo', 3)')");
+});
+
+suite.test('should not match undefined properties without second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 3}),
+    { name: 'obj3', foo: undefined},
+    Ember.Object.create({ name: 'obj4', foo: undefined}),
+    { name: 'obj5'},
+    Ember.Object.create({ name: 'obj6'})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo'), ary.slice(0, 2), "filterProperty('foo', 3)')");
+});

--- a/packages/ember-runtime/tests/suites/enumerable/find.js
+++ b/packages/ember-runtime/tests/suites/enumerable/find.js
@@ -72,3 +72,31 @@ suite.test('should return first object with truthy prop', function() {
   equals(obj.findProperty('foo'), ary[0], 'findProperty(foo)');
   equals(obj.findProperty('bar'), ary[1], 'findProperty(bar)');
 });
+
+suite.test('should return first null property match', function() {
+  var ary, obj;
+
+  ary = [
+    { foo: null, bar: 'BAZ' },
+    Ember.Object.create({ foo: null, bar: null })
+  ];
+
+  obj = this.newObject(ary);
+
+  equals(obj.findProperty('foo', null), ary[0], "findProperty('foo', null)");
+  equals(obj.findProperty('bar', null), ary[1], "findProperty('bar', null)");
+});
+
+suite.test('should return first undefined property match', function() {
+  var ary, obj;
+
+  ary = [
+    { foo: undefined, bar: 'BAZ' },
+    Ember.Object.create({ })
+  ];
+
+  obj = this.newObject(ary);
+
+  equals(obj.findProperty('foo', undefined), ary[0], "findProperty('foo', undefined)");
+  equals(obj.findProperty('bar', undefined), ary[1], "findProperty('bar', undefined)");
+});

--- a/packages/ember-runtime/tests/suites/enumerable/some.js
+++ b/packages/ember-runtime/tests/suites/enumerable/some.js
@@ -65,3 +65,32 @@ suite.test('should return true of any property is true', function() {
   equals(obj.someProperty('bar'), true, 'someProperty(bar)');
   equals(obj.someProperty('BIFF'), false, 'someProperty(biff)');
 });
+
+suite.test('should return true if any property matches null', function() {
+  var obj = this.newObject([
+    { foo: null, bar: 'bar' },
+    Ember.Object.create({ foo: 'foo', bar: null })
+  ]);
+
+  equals(obj.someProperty('foo', null), true, "someProperty('foo', null)");
+  equals(obj.someProperty('bar', null), true, "someProperty('bar', null)");
+});
+
+suite.test('should return true if any property is undefined', function() {
+  var obj = this.newObject([
+    { foo: undefined, bar: 'bar' },
+    Ember.Object.create({ foo: 'foo' })
+  ]);
+
+  equals(obj.someProperty('foo', undefined), true, "someProperty('foo', undefined)");
+  equals(obj.someProperty('bar', undefined), true, "someProperty('bar', undefined)");
+});
+
+suite.test('should not match undefined properties without second argument', function() {
+  var obj = this.newObject([
+    { foo: undefined },
+    Ember.Object.create({ })
+  ]);
+
+  equals(obj.someProperty('foo'), false, "someProperty('foo', undefined)");
+});

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -41,9 +41,9 @@ Ember.Application = Ember.Namespace.extend(
 
   /**
     @type DOMElement
-    @default document
+    @default document.body
   */
-  rootElement: document,
+  rootElement: document.body,
 
   /**
     @type Ember.EventDispatcher

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -40,10 +40,14 @@ Ember.Application = Ember.Namespace.extend(
 /** @scope Ember.Application.prototype */{
 
   /**
+    The root DOM element of the Application.
+
+    Can be specified as DOMElement or a selector string.
+
     @type DOMElement
-    @default document.body
+    @default 'body'
   */
-  rootElement: document.body,
+  rootElement: 'body',
 
   /**
     @type Ember.EventDispatcher

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -24,9 +24,9 @@ Ember.EventDispatcher = Ember.Object.extend(
     listeners will be attached to the document unless this is overridden.
 
     @type DOMElement
-    @default document
+    @default document.body
   */
-  rootElement: document,
+  rootElement: document.body,
 
   /**
     @private
@@ -76,6 +76,8 @@ Ember.EventDispatcher = Ember.Object.extend(
     ember_assert('You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application', !rootElement.find('.ember-application').length);
 
     rootElement.addClass('ember-application');
+
+    ember_assert('Unable to add "ember-application" class to rootElement. Make sure you the body or an element in the body.', rootElement.is('.ember-application'));
 
     for (event in events) {
       if (events.hasOwnProperty(event)) {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -157,17 +157,9 @@ Ember.EventDispatcher = Ember.Object.extend(
 
   /** @private */
   _bubbleEvent: function(view, evt, eventName) {
-    var result = true, handler,
-        self = this;
-
-      Ember.run(function() {
-        handler = view[eventName];
-        if (Ember.typeOf(handler) === 'function') {
-          result = handler.call(view, evt);
-        }
-      });
-
-    return result;
+    return Ember.run(function() {
+      return view.handleEvent(eventName, evt);
+    });
   },
 
   /** @private */

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -23,10 +23,15 @@ Ember.EventDispatcher = Ember.Object.extend(
     The root DOM element to which event listeners should be attached. Event
     listeners will be attached to the document unless this is overridden.
 
+    Can be specified as a DOMElement or a selector string.
+
+    The default body is a string since this may be evaluated before document.body
+    exists in the DOM.
+
     @type DOMElement
-    @default document.body
+    @default 'body'
   */
-  rootElement: document.body,
+  rootElement: 'body',
 
   /**
     @private

--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -22,6 +22,11 @@ Ember.View.states = {
 
     getElement: function() {
       return null;
+    },
+
+    // Handle events from `Ember.EventDispatcher`
+    handleEvent: function() {
+      return true; // continue event propagation
     }
   }
 };

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -54,6 +54,16 @@ Ember.View.states.hasElement = {
 
     get(view, 'domManager').remove();
     return view;
+  },
+
+  // Handle events from `Ember.EventDispatcher`
+  handleEvent: function(view, eventName, evt) {
+    var handler = view[eventName];
+    if (Ember.typeOf(handler) === 'function') {
+      return handler.call(view, evt);
+    } else {
+      return true; // continue event propagation
+    }
   }
 };
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1273,6 +1273,19 @@ Ember.View = Ember.Object.extend(
         view.transitionTo(state);
       });
     }
+  },
+
+  // .......................................................
+  // EVENT HANDLING
+  //
+
+  /**
+    @private
+
+    Handle events from `Ember.EventDispatcher`
+  */
+  handleEvent: function(eventName, evt) {
+    return this.invokeForState('handleEvent', eventName, evt);
   }
 
 });

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -100,13 +100,19 @@ Ember.View = Ember.Object.extend(
 
     // If there is no template but a templateName has been specified,
     // try to lookup as a spade module
-    if (!template && templateName) {
-      if ('undefined' !== require && require.exists) {
-        if (require.exists(templateName)) { template = require(templateName); }
+    if (!template) {
+      if (templateName) {
+        if ('undefined' !== require && require.exists) {
+          if (require.exists(templateName)) { template = require(templateName); }
+        }
+      
+        if (!template) {
+          throw new Ember.Error(fmt('%@ - Unable to find template "%@".', [this, templateName]));
+        }
       }
-
-      if (!template) {
-        throw new Ember.Error(fmt('%@ - Unable to find template "%@".', [this, templateName]));
+      else {
+          // If templateName is not given and a block is given, treat the block as the template
+          template = get(this, 'yieldContent');
       }
     }
 
@@ -128,7 +134,29 @@ Ember.View = Ember.Object.extend(
   templateContext: Ember.computed(function(key, value) {
     return value !== undefined ? value : this;
   }).cacheable(),
-
+  
+  /**
+    The block to be yielded to, when requested.
+    
+    This is usually template of the block specified within the calling 
+    template. In general, you would never have to use this directly.
+    
+    @field
+    @type Function
+  */
+  yieldContent: null,
+  
+  /**
+    The object from which the yielded block should access properties.
+    
+    This object is passed in when the yielded block template (yieldContent) 
+    is evaulated. In general, you would never have to use this directly.
+    
+    @field
+    @type Object
+  */
+  yieldContext: null,
+  
   /**
     If the view is currently inserted into the DOM of a parent view, this
     property will point to the parent of the view.
@@ -1060,7 +1088,7 @@ Ember.View = Ember.Object.extend(
     var parentView = get(this, '_parentView');
 
     this._super();
-
+    
     // Register the view for event handling. This hash is used by
     // Ember.RootResponder to dispatch incoming events.
     Ember.View.views[get(this, 'elementId')] = this;
@@ -1081,7 +1109,7 @@ Ember.View = Ember.Object.extend(
   appendChild: function(view, options) {
     return this.invokeForState('appendChild', view, options);
   },
-
+  
   /**
     Removes the child view from the parent view.
 
@@ -1287,7 +1315,6 @@ Ember.View = Ember.Object.extend(
   handleEvent: function(eventName, evt) {
     return this.invokeForState('handleEvent', eventName, evt);
   }
-
 });
 
 /**

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -100,13 +100,19 @@ Ember.View = Ember.Object.extend(
 
     // If there is no template but a templateName has been specified,
     // try to lookup as a spade module
-    if (!template && templateName) {
-      if ('undefined' !== require && require.exists) {
-        if (require.exists(templateName)) { template = require(templateName); }
+    if (!template) {
+      if (templateName) {
+        if ('undefined' !== require && require.exists) {
+          if (require.exists(templateName)) { template = require(templateName); }
+        }
+      
+        if (!template) {
+          throw new Ember.Error(fmt('%@ - Unable to find template "%@".', [this, templateName]));
+        }
       }
-
-      if (!template) {
-        throw new Ember.Error(fmt('%@ - Unable to find template "%@".', [this, templateName]));
+      else {
+          // If templateName is not given and a block is given, treat the block as the template
+          template = get(this, 'yieldContent');
       }
     }
 
@@ -128,7 +134,29 @@ Ember.View = Ember.Object.extend(
   templateContext: Ember.computed(function(key, value) {
     return value !== undefined ? value : this;
   }).cacheable(),
-
+  
+  /**
+    The block to be yielded to, when requested.
+    
+    This is usually template of the block specified within the calling 
+    template. In general, you would never have to use this directly.
+    
+    @field
+    @type Function
+  */
+  yieldContent: null,
+  
+  /**
+    The object from which the yielded block should access properties.
+    
+    This object is passed in when the yielded block template (yieldContent) 
+    is evaulated. In general, you would never have to use this directly.
+    
+    @field
+    @type Object
+  */
+  yieldContext: null,
+  
   /**
     If the view is currently inserted into the DOM of a parent view, this
     property will point to the parent of the view.
@@ -1054,7 +1082,7 @@ Ember.View = Ember.Object.extend(
     var parentView = get(this, '_parentView');
 
     this._super();
-
+    
     // Register the view for event handling. This hash is used by
     // Ember.RootResponder to dispatch incoming events.
     Ember.View.views[get(this, 'elementId')] = this;
@@ -1075,7 +1103,7 @@ Ember.View = Ember.Object.extend(
   appendChild: function(view, options) {
     return this.invokeForState('appendChild', view, options);
   },
-
+  
   /**
     Removes the child view from the parent view.
 
@@ -1265,7 +1293,6 @@ Ember.View = Ember.Object.extend(
       });
     }
   }
-
 });
 
 /**

--- a/packages/ember-views/tests/system/application_test.js
+++ b/packages/ember-views/tests/system/application_test.js
@@ -16,7 +16,7 @@ module("Ember.Application", {
   },
 
   teardown: function() {
-    application.destroy();
+    Ember.run(function(){ application.destroy(); });
   }
 });
 

--- a/packages/ember-views/tests/system/application_test.js
+++ b/packages/ember-views/tests/system/application_test.js
@@ -43,6 +43,16 @@ test("you cannot make a new application that is a duplicate of an existing appli
   }, Error);
 });
 
+test("you cannot make two default applications without a rootElement error", function() {
+  // Teardown existing
+  application.destroy();
+
+  application = Ember.Application.create();
+  raises(function() {
+    Ember.Application.create();
+  }, Error);
+});
+
 test("acts like a namespace", function() {
   var app = window.TestApp = Ember.Application.create({rootElement: '#two'});
   app.Foo = Ember.Object.extend();

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -79,6 +79,43 @@ test("should dispatch events to views", function() {
   equals(parentKeyDownCalled, 0, "does not call keyDown on parent if child handles event");
 });
 
+test("should not dispatch events to views not inDOM", function() {
+  var receivedEvent;
+
+  view = Ember.View.create({
+    render: function(buffer) {
+      buffer.push('some <span id="awesome">awesome</span> content');
+      this._super(buffer);
+    },
+
+    mouseDown: function(evt) {
+      receivedEvent = evt;
+    }
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  var $element = view.$();
+
+  Ember.run(function() {
+    view.set('element', null); // Force into preRender
+  });
+
+  $element.trigger('mousedown');
+
+  ok(!receivedEvent, "does not pass event to associated event method");
+  receivedEvent = null;
+
+  $element.find('span#awesome').trigger('mousedown');
+  ok(!receivedEvent, "event does not bubble up to nearest Ember.View");
+  receivedEvent = null;
+
+  // Cleanup
+  $element.remove();
+});
+
 test("should send change events up view hierarchy if view contains form elements", function() {
   var receivedEvent;
   view = Ember.View.create({


### PR DESCRIPTION
Added support for Issue [#307].
- view helper now collect the block and context into a yieldContent/yieldContext of the child view
- Introduced a yield helper, that creates a virtual view to delegate to yieldContent
- Changed the logic to determine when to treat blocks as templates. Made it more lazy moving it into the computed property - template.
- Added some basic tests around block invocation and correctness of context at different levels 
