### PR TITLE
Tmp array cleanup

### DIFF
--- a/packages/ember-metal/lib/accessors.js
+++ b/packages/ember-metal/lib/accessors.js
@@ -279,7 +279,8 @@ Ember.getPath = function(root, path) {
     var tuple = normalizeTuple(root, path);
     root = tuple[0];
     path = tuple[1];
-  } 
+    tuple.length = 0;
+  }
   
   return getPath(root, path);
 };
@@ -298,6 +299,7 @@ Ember.setPath = function(root, path, value, tolerant) {
     var tuple = normalizeTuple(root, path);
     root = tuple[0];
     path = tuple[1];
+    tuple.length = 0;
   }
 
   if (path.indexOf('.') > 0) {

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -316,15 +316,17 @@ Mixin.prototype.reopen = function() {
 
 var TMP_ARRAY = [];
 Mixin.prototype.apply = function(obj) {
-  TMP_ARRAY.length=0;
   TMP_ARRAY[0] = this;
-  return applyMixin(obj, TMP_ARRAY, false);
+  var ret = applyMixin(obj, TMP_ARRAY, false);
+  TMP_ARRAY.length=0;
+  return ret;
 };
 
 Mixin.prototype.applyPartial = function(obj) {
-  TMP_ARRAY.length=0;
   TMP_ARRAY[0] = this;
-  return applyMixin(obj, TMP_ARRAY, true);
+  var ret = applyMixin(obj, TMP_ARRAY, true);
+  TMP_ARRAY.length=0;
+  return ret;
 };
 
 function _detect(curMixin, targetMixin, seen) {

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -206,6 +206,7 @@ Wp.add = function(path) {
   // put into a queue and try to connect later.
   } else if (!tuple[0]) {
     pendingQueue.push([this, path]);
+    tuple.length = 0;
     return;
 
   // global path, and object already exists
@@ -216,6 +217,7 @@ Wp.add = function(path) {
     path = tuple[1];
   }
 
+  tuple.length = 0;
   this.chain(key, path, src, separator);
 };
 
@@ -240,6 +242,7 @@ Wp.remove = function(path) {
     path = tuple[1];
   }
 
+  tuple.length = 0;
   this.unchain(key, path);
 };
 


### PR DESCRIPTION
While every use of normalizeTuple and apply overwrites the previous use, the last use will leak, making it a red herring for profiling memory leaks.

It is not uncommon for normalizeTuple to hold onto references to destroyed objects.
