### PR TITLE
Allows setting a custom initial substate on states

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -175,10 +175,16 @@ Ember.StateManager = Ember.State.extend(
         if (log) { console.log("STATEMANAGER: Entering " + state.name); }
         state.enter(stateManager, transition);
       }, function() {
-        var startState = state, enteredState;
+        var startState = state, enteredState, initialSubstate;
+
+        initialSubstate = get(startState, 'initialSubstate');
+
+        if (!initialSubstate) {
+          initialSubstate = 'start';
+        }
 
         // right now, start states cannot be entered asynchronously
-        while (startState = get(startState, 'start')) {
+        while (startState = get(startState, initialSubstate)) {
           enteredState = startState;
           startState.enter(stateManager);
         }

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -189,6 +189,20 @@ test("it automatically transitions to a default state specified using the initia
   ok(get(stateManager, 'currentState').isStart, "automatically transitions to beginning state");
 });
 
+test("it automatically transitions to a default substate specified using the initialSubstate property", function() {
+  stateManager = Ember.StateManager.create({
+    start: Ember.State.create({
+      initialSubstate: 'beginningSubstate',
+
+      beginningSubstate: Ember.State.create({
+        isStart: true
+      })
+    })
+  });
+
+  ok(get(stateManager, 'currentState').isStart, "automatically transitions to beginning substate");
+});
+
 test("it reports the view associated with the current view state, if any", function() {
   var view = Ember.View.create();
 


### PR DESCRIPTION
Previously the inital substate had to be named `start`. This commit adds support for a `initialSubstate` property. If it's present, the Ember.StateManager will enter the given substate.

Example:

```
  Ember.StateManager.create({
    start: Ember.State.create({
      initialSubstate: 'beginningSubstate',

      beginningSubstate: Ember.State.create()
    })
  });
```
