### PR TITLE
Add chain removal to Ember.destroy

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -401,16 +401,3 @@ Ember.createPrototype = function(obj, props) {
   if (META_KEY in ret) Ember.rewatch(ret); // setup watch chains if needed.
   return ret;
 };
-  
-
-/**
-  Tears down the meta on an object so that it can be garbage collected.
-  Multiple calls will have no effect.
-  
-  @param {Object} obj  the object to destroy
-  @returns {void}
-*/
-Ember.destroy = function(obj) {
-  if (obj[META_KEY]) obj[META_KEY] = null; 
-};
-

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -549,18 +549,16 @@ var propertyDidChange = Ember.propertyDidChange = function(obj, keyName) {
   @returns {void}
 */
 Ember.destroy = function (obj) {
-  var meta = obj[META_KEY], chains, watching, paths, path;
+  var meta = obj[META_KEY], chains, paths, path;
   if (meta) {
     obj[META_KEY] = null;
     // remove chains to remove circular references that would prevent GC
     chains = meta.chains;
     if (chains) {
-      watching = meta.watching;
       paths = chains._paths;
       for(path in paths) {
         if (!(paths[path] > 0)) continue; // this check will also catch non-number vals.
         chains.remove(path);
-        watching[path] = 0;
       }
     }
   }

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -123,3 +123,19 @@ testBoth('watching a global object that does not yet exist should queue', functi
   Global = null; // reset
 });
 
+testBoth('destroy should tear down chainWatchers', function(get, set) {
+
+  Global = { foo: 'bar' };
+  var obj = {};
+
+  Ember.watch(obj, 'Global.foo');
+
+  var metaGlobal = Ember.meta(Global);
+  equals(metaGlobal.watching.foo, 1, 'should be watching Global.foo');
+
+  Ember.destroy(obj);
+
+  equals(metaGlobal.watching.foo, 0, 'should not be watching Global.foo');
+
+  Global = null; // reset
+});

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -101,7 +101,7 @@ CoreObject.PrototypeMixin = Ember.Mixin.create(
     @private
   */
   _scheduledDestroy: function() {
-    this[Ember.META_KEY] = null;
+    Ember.destroy(this);
   },
 
   bind: function(to, from) {


### PR DESCRIPTION
This breaks circular references so Objects can be garbage collected after being destroyed.
