### PR TITLE
add support for global objects in Ember.TargetActionSupport

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -10,8 +10,8 @@ Ember.TargetActionSupport = Ember.Mixin.create({
     if (Ember.typeOf(target) === "string") {
       var obj = Ember.getPath(this, target);
       if (Ember.none(obj)) {
-        // if the target cannot be found, try to get it from window object
-        obj = Ember.getPath(window, target);
+        // if the target cannot be found, try to get it as a global object
+        obj = Ember.getPath(target);
       }
       return obj;
     } else {

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -8,7 +8,12 @@ Ember.TargetActionSupport = Ember.Mixin.create({
     var target = get(this, 'target');
 
     if (Ember.typeOf(target) === "string") {
-      return Ember.getPath(this, target);
+      var obj = Ember.getPath(this, target);
+      if (Ember.none(obj)) {
+        // if the target cannot be found, try to get it from window object
+        obj = Ember.getPath(window, target);
+      }
+      return obj;
     } else {
       return target;
     }

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -62,3 +62,44 @@ test("it should find targets specified using a property path", function() {
 
   window.Test = undefined;
 });
+
+test('it should find top level targets defined as property path', function(){
+  expect(1);
+
+  window.TopLevelThing = Ember.Object.create({
+    helloWorld: function() {
+      ok(true, 'helloWorld called on the top level object');
+   }
+  });
+
+  var myObj = Ember.Object.create(Ember.TargetActionSupport, {
+    target: 'TopLevelThing',
+    action: 'helloWorld'
+  });
+
+  myObj.triggerAction();
+
+  window.TopLevelThing = undefined;
+
+});
+
+test('it should find Ember.Application as targets', function(){
+  expect(1);
+
+  window.MyApp = Ember.Application.create({
+    helloWorld: function() {
+      ok(true, 'helloWorld called on the application object');
+   }
+  });
+
+  var myObj = Ember.Object.create(Ember.TargetActionSupport, {
+    target: 'MyApp',
+    action: 'helloWorld'
+  });
+
+  myObj.triggerAction();
+
+  window.MyApp.destroy();
+  window.MyApp = undefined;
+
+});


### PR DESCRIPTION
added support for global objects used in `Ember.TargetActionSupport` which is not working as reported in #115
