### PR TITLE
Add {{#unbound}} block helper

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -75,6 +75,20 @@ Ember.Handlebars.JavaScriptCompiler.prototype.appendToBuffer = function(string) 
   return "data.buffer.push("+string+");";
 };
 
+Ember.Handlebars.Compiler.prototype.block = function(block) {
+  var parts = block.mustache.id.parts;
+
+  if (parts.length === 1 && parts[0] === 'unbound' &&
+      block.mustache.hash === null) {
+    // Use "this.options", because "this" doesn't survive the compilation step
+    this.options.isUnboundBlock = true;
+  }
+
+  var result = Handlebars.Compiler.prototype.block.call(this, block);
+  this.options.isUnboundBlock = false;
+  return result;
+};
+
 /**
   Rewrite simple mustaches from {{foo}} to {{bind "foo"}}. This means that all simple
   mustaches in Ember's Handlebars will also set up an observer to keep the DOM
@@ -83,7 +97,7 @@ Ember.Handlebars.JavaScriptCompiler.prototype.appendToBuffer = function(string) 
   @private
 */
 Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
-  if (mustache.params.length || mustache.hash) {
+  if (this.options.isUnboundBlock || mustache.params.length || mustache.hash) {
     return Handlebars.Compiler.prototype.mustache.call(this, mustache);
   } else {
     var id = new Handlebars.AST.IdNode(['_triageMustache']);
@@ -108,7 +122,7 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
 */
 Ember.Handlebars.compile = function(string) {
   var ast = Handlebars.parse(string);
-  var options = { data: true, stringParams: true };
+  var options = { data: true, stringParams: true, isUnboundBlock: false };
   var environment = new Ember.Handlebars.Compiler().compile(ast, options);
   var templateSpec = new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
 

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -122,7 +122,7 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
 */
 Ember.Handlebars.compile = function(string) {
   var ast = Handlebars.parse(string);
-  var options = { data: true, stringParams: true, isUnboundBlock: false };
+  var options = { data: true, stringParams: true };
   var environment = new Ember.Handlebars.Compiler().compile(ast, options);
   var templateSpec = new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
 

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -9,5 +9,12 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember.Metamorph, {
 Ember.Handlebars.registerHelper('each', function(path, options) {
   options.hash.contentBinding = path;
   options.hash.preserveContext = true;
+
+  // Use Handlebars #each helper
+  if (this.isUnboundBlock) {
+    var context = (options.contexts && options.contexts[0]) || this;
+    var raw = Ember.getPath(context, path);
+    return Handlebars.helpers.each(raw, options);
+  }
   return Ember.Handlebars.helpers.collection.call(this, 'Ember.Handlebars.EachView', options);
 });

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -19,7 +19,7 @@ var getPath = Ember.getPath;
 
       <div>
         {{#unbound}}
-          {somePropertyThatDoesntChange}}
+          {{somePropertyThatDoesntChange}}
           {{anotherPropertyThatDoesntChange}}
         {{/unbound}}
       </div>

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -29,9 +29,13 @@ var getPath = Ember.getPath;
   @returns {String} HTML string
 */
 Ember.Handlebars.registerHelper('unbound', function(property, fn) {
-  // Unbound as a block helper is a no-op
+  // Unbound as a block helper
   if (fn === undefined && Ember.typeOf(property) === 'function') {
-    return property(this);
+    // used e.g. in the #each helper
+    this.isUnboundBlock = true;
+    var result = property(this);
+    this.isUnboundBlock = false;
+    return result;
   }
 
   var context = (fn.contexts && fn.contexts[0]) || this;

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -15,11 +15,25 @@ var getPath = Ember.getPath;
 
       <div>{{unbound somePropertyThatDoesntChange}}</div>
 
+  It can also be used as a block statement:
+
+      <div>
+        {{#unbound}}
+          {somePropertyThatDoesntChange}}
+          {{anotherPropertyThatDoesntChange}}
+        {{/unbound}}
+      </div>
+
   @name Handlebars.helpers.unbound
   @param {String} property
   @returns {String} HTML string
 */
 Ember.Handlebars.registerHelper('unbound', function(property, fn) {
+  // Unbound as a block helper is a no-op
+  if (fn === undefined && Ember.typeOf(property) === 'function') {
+    return property(this);
+  }
+
   var context = (fn.contexts && fn.contexts[0]) || this;
   return getPath(context, property);
 });

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1236,6 +1236,49 @@ test("should be able to output a property without binding", function(){
   equals(view.$('#second').html(), "Not here, either.");
 });
 
+test("should be able to output a block without binding", function(){
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(
+      '<div id="first">{{#unbound}}{{content.anUnboundString}}{{/unbound}}</div>'+
+      '{{#unbound}}{{#with content}}<div id="second">{{../anotherUnboundString}}</div>{{/with}}{{/unbound}}'+
+      '{{#with content}}{{#unbound}}<div id="third">{{yetAnotherUnboundString}}</div>{{/unbound}}{{/with}}'
+    ),
+
+    content: Ember.Object.create({
+      anUnboundString: "No script tags here, son.",
+      yetAnotherUnboundString: "Not even here."
+    }),
+
+    anotherUnboundString: "Not here, either."
+  });
+
+  appendView();
+
+  equals(view.$('#first').html(), "No script tags here, son.");
+  equals(view.$('#second').html(), "Not here, either.");
+  equals(view.$('#third').html(), "Not even here.");
+});
+
+test("should be able to bind manually with an #unbound block", function(){
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(
+      '{{#unbound}}<div id="first">{{bind content.aBoundString}}</div>'+
+      '{{#with content}}<div id="second">{{bind ../anotherBoundString}}</div>{{/with}}{{/unbound}}'
+    ),
+
+    content: Ember.Object.create({
+      aBoundString: "Yay, tags were inserted."
+    }),
+
+    anotherBoundString: "Here too."
+  });
+
+  appendView();
+
+  ok(view.$('#first').children().length > 0);
+  ok(view.$('#second').children().length > 0);
+});
+
 test("should be able to log a property", function(){
   var originalLogger = Ember.Logger;
   additionalTeardown = function(){ Ember.Logger = originalLogger; };

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1358,6 +1358,32 @@ test("should be able to use unbound helper in #each helper (with objects)", func
   equals(view.$('li').children().length, 0, "No markers");
 });
 
+test("should have no makers when #unbound helper is around #each helper", function() {
+  view = Ember.View.create({
+    items: Ember.A(['a', 'b', 'c', 1, 2, 3]),
+      template: Ember.Handlebars.compile(
+        "{{#unbound}}<ul>{{#each items}}<li>{{this}}</li>{{/each}}</ul>{{/unbound}}")
+  });
+
+  appendView();
+
+  equals(view.$().text(), "abc123");
+  equals(view.$('ul').children(':not(li)').length, 0, "No markers");
+});
+
+test("should have no markers when #unbound helper is around #each helper (with objects)", function() {
+  view = Ember.View.create({
+    items: Ember.A([{wham: 'bam'}, {wham: 1}]),
+    template: Ember.Handlebars.compile(
+      "{{#unbound}}<ul>{{#each items}}<li>{{wham}}</li>{{/each}}</ul>{{/unbound}}")
+  });
+
+  appendView();
+
+  equals(view.$().text(), "bam1");
+  equals(view.$('li').children().length, 0, "No markers");
+});
+
 module("Templates redrawing and bindings", {
   setup: function(){
     MyApp = Ember.Object.create({});


### PR DESCRIPTION
With the {{#unbound}} block helper, you can prevent whole
blocks from being automatically bound. It is still possible
to bind properties within an {{#unbound}} block with
{{bind yourProperty}}.
