### PR TITLE
Add caching via route/path to StateManager

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -20,7 +20,7 @@ Ember.State = Ember.Object.extend({
       }
     }, this);
 
-    if (findStates) { set(this, 'states', states); }
+    if (Ember.keys(states).length > 0 && findStates) { set(this, 'states', states); }
   },
 
   enter: Ember.K,

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -6,14 +6,21 @@ Ember.State = Ember.Object.extend({
   start: null,
 
   init: function() {
+    var states = get(this, 'states'), findStates = false;
+
+    if (!states) { states = {}; findStates = true; }
     Ember.keys(this).forEach(function(name) {
       var value = this[name];
 
       if (value && value.isState) {
         set(value, 'parentState', this);
         set(value, 'name', (get(this, 'name') || '') + '.' + name);
+
+        if (findStates) { states[name] = value; }
       }
     }, this);
+
+    if (findStates) { set(this, 'states', states); }
   },
 
   enter: Ember.K,


### PR DESCRIPTION
StateManager builds a cache of routes.

e.g. 
  StateManager._cache['grandparent']                    = [grandparent]
  StateManager._cache['grandparent.parent']          = [grandparent, parent]
  StateManager._cache['grandparent.parent.child']  = [grandparent, parent, child]

Each cache entry is an array of states needed to fully transition to the target State.

goToState compares the smallest possible list of exitStates needed to leave the currentState to the list of new enterStates needed to goTo the target State. The unique lists are given to enterStates which handles dispatching exit/enters asynchronously.

Start / initialStates are not async yet.
