### PR TITLE
Fixes #312 Triage mustache late to determine target as either regular helper or binding 

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -86,7 +86,7 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
   if (mustache.params.length || mustache.hash) {
     return Handlebars.Compiler.prototype.mustache.call(this, mustache);
   } else {
-    var id = new Handlebars.AST.IdNode(['bind']);
+    var id = new Handlebars.AST.IdNode(['_triageMustache']);
 
     // Update the mustache node to include a hash value indicating whether the original node
     // was escaped. This will allow us to properly escape values when the underlying value

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -64,6 +64,30 @@ var get = Ember.get, getPath = Ember.getPath, set = Ember.set, fmt = Ember.Strin
       data.buffer.push(getPath(this, property));
     }
   };
+  
+  /**
+    '_triageMustache' is used internally select between a binding and helper for 
+    the given context. Until this point, it would be hard to determine if the 
+    mustache is a property reference or a regular helper reference. This triage
+    helper resolves that.
+    
+    This would not be typically invoked by directly.
+    
+    @private
+    @name Handlebars.helpers._triageMustache
+    @param {String} property Property/helperID to triage
+    @param {Function} fn Context to provide for rendering
+    @returns {String} HTML string
+  */
+  Ember.Handlebars.registerHelper('_triageMustache', function(property, fn) {
+    ember_assert("You cannot pass more than one argument to the _triageMustache helper", arguments.length <= 2);
+    if (Ember.Handlebars.helpers[property]) {
+      return Ember.Handlebars.helpers[property].call(this, fn);
+    }
+    else {
+      return Ember.Handlebars.helpers.bind.apply(this, arguments);
+    }
+  });
 
   /**
     `bind` can be used to display a value, then update that value if it 

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1572,3 +1572,32 @@ test("should update bound values after view's parent is removed and then re-appe
   });
   equal($.trim(view.$().text()), "bar");
 });
+
+test("should call a registered helper for mustache without parameters", function() {
+  Ember.Handlebars.registerHelper('foobar', function() {
+    return 'foobar';
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile("{{foobar}}")
+  });
+
+  appendView();
+
+  ok(view.$().text() === 'foobar', "Regular helper was invoked correctly");
+});
+
+test("should bind to the property if no registered helper found for a mustache without parameters", function() {
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile("{{foobarProperty}}"),
+    foobarProperty: Ember.computed(function() {
+      return 'foobarProperty';
+    })
+  });
+
+  appendView();
+
+  ok(view.$().text() === 'foobarProperty', "Property was bound to correctly");
+});
+
+


### PR DESCRIPTION
Fixes defect #312

Introduced a triageMustache helper to bind the property late during rendering after ensuring there is no registered helper with the same name. If a registered helper was found, that is invoked in place of the binding.
