### PR TITLE
startAt location can be greater than length in lastIndexOf array method

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -182,7 +182,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   lastIndexOf: function(object, startAt) {
     var idx, len = get(this, 'length');
 
-    if (startAt === undefined) startAt = len-1;
+    if (startAt === undefined || startAt >= len) startAt = len-1;
     if (startAt < 0) startAt += len;
 
     for(idx=startAt;idx>=0;idx--) {

--- a/packages/ember-runtime/tests/suites/array.js
+++ b/packages/ember-runtime/tests/suites/array.js
@@ -41,4 +41,5 @@ Ember.ArrayTests = Ember.EnumerableTests.extend({
 Ember.ArrayTests.ObserverClass = ObserverClass;
 
 require('ember-runtime/~tests/suites/array/indexOf');
+require('ember-runtime/~tests/suites/array/lastIndexOf');
 require('ember-runtime/~tests/suites/array/objectAt');

--- a/packages/ember-runtime/tests/suites/array/lastIndexOf.js
+++ b/packages/ember-runtime/tests/suites/array/lastIndexOf.js
@@ -1,0 +1,69 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require('ember-runtime/~tests/suites/array');
+
+var suite = Ember.ArrayTests;
+
+suite.module('lastIndexOf');
+
+suite.test("should return index of object's last occurrence", function() {
+  var expected = this.newFixture(3),
+      obj      = this.newObject(expected),
+      len      = 3,
+      idx;
+      
+  for(idx=0;idx<len;idx++) {
+    equals(obj.lastIndexOf(expected[idx]), idx, 
+      Ember.String.fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
+  }
+  
+});
+
+suite.test("should return index of object's last occurrence even startAt\
+  search location is equal to length", function() {
+  var expected = this.newFixture(3),
+      obj      = this.newObject(expected),
+      len      = 3,
+      idx;
+      
+  for(idx=0;idx<len;idx++) {
+    equals(obj.lastIndexOf(expected[idx], len), idx, 
+      Ember.String.fmt('obj.lastIndexOfs(%@) should match idx', [expected[idx]]));
+  }
+  
+});
+
+suite.test("should return index of object's last occurrence even startAt\
+  search location is greater than length", function() {
+  var expected = this.newFixture(3),
+      obj      = this.newObject(expected),
+      len      = 3,
+      idx;
+
+  for(idx=0;idx<len;idx++) {
+    equals(obj.lastIndexOf(expected[idx], len + 1), idx, 
+      Ember.String.fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
+  }
+  
+});
+
+suite.test("should return -1 when no match is found", function() {
+  var obj = this.newObject(this.newFixture(3)), foo = {};
+  equals(obj.lastIndexOf(foo), -1, 'obj.lastIndexOf(foo) should be -1');
+});
+
+suite.test("should return -1 when no match is found even startAt\
+  search location is equal to length", function() {
+  var obj = this.newObject(this.newFixture(3)), foo = {};
+  equals(obj.lastIndexOf(foo, obj.length), -1, 'obj.lastIndexOf(foo) should be -1');
+});
+
+suite.test("should return -1 when no match is found even startAt\
+  search location is greater than length", function() {
+  var obj = this.newObject(this.newFixture(3)), foo = {};
+  equals(obj.lastIndexOf(foo, obj.length + 1), -1, 'obj.lastIndexOf(foo) should be -1');
+});


### PR DESCRIPTION
```
var arr = ["a"]
arr.lastIndexOf("a", 10000000);  =>  0
```

It's ok, but starting location value **(startAt)** is set to 10000000, even though the last position available is 0.
