### PR TITLE
Add caching of enter/exit states by route to States

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -6,14 +6,27 @@ Ember.State = Ember.Object.extend({
   start: null,
 
   init: function() {
-    Ember.keys(this).forEach(function(name) {
-      var value = this[name];
+    var states = get(this, 'states');
 
-      if (value && value.isState) {
-        set(value, 'parentState', this);
-        set(value, 'name', (get(this, 'name') || '') + '.' + name);
-      }
-    }, this);
+    if (!states) {
+      states = {};
+      Ember.keys(this).forEach(function(name) {
+        if (this.hasOwnProperty(name)) {
+          var value = this[name];
+
+          if (value && value.isState) {
+            set(value, 'parentState', this);
+            set(value, 'name', (get(this, 'name') || '') + '.' + name);
+
+            states[name] = value;
+          }
+        }
+      }, this);
+
+      if (Ember.keys(states).length > 0) { set(this, 'states', states); }
+    }
+
+    set(this, 'routes', {});
   },
 
   enter: Ember.K,

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -18,20 +18,6 @@ Ember.StateManager = Ember.State.extend(
   init: function() {
     this._super();
 
-    var states = get(this, 'states');
-    if (!states) {
-      states = {};
-      Ember.keys(this).forEach(function(name) {
-        var value = get(this, name);
-
-        if (value && value.isState) {
-          states[name] = value;
-        }
-      }, this);
-
-      set(this, 'states', states);
-    }
-
     var initialState = get(this, 'initialState');
 
     if (!initialState && get(this, 'start')) {


### PR DESCRIPTION
StateManager computes a set of enter/exit states whenever it goToState()'s

Now these sets are cached in a new property (State.routes) on the currentState.

e.g. currentState.routes['grandparent.uncle'] = { exitStates: [..], enterStates: [..], futureState: <state> }

The futureState is used to set the currentState after performing the necessary enter/exits. Storing it is necessary for cases where the StateManager transitions to a previously entered state "above" the currentState.

start / initialStates are not async yet.

Also getPaths is replaced with findStatesByRoute for perfs.
