### PR TITLE
Make setProperties safer

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -4,9 +4,7 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-var get = Ember.get, set = Ember.set,
-    beginPropertyChanges = Ember.beginPropertyChanges,
-    endPropertyChanges = Ember.endPropertyChanges;
+var get = Ember.get, set = Ember.set;
   
 /**
   @class
@@ -144,14 +142,12 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @returns {Ember.Observable}
   */
   setProperties: function(hash) {
-    beginPropertyChanges();
-    try {
+    var self = this;
+    Ember.changeProperties(function(){
       for(var prop in hash) {
-        if (hash.hasOwnProperty(prop)) set(this, prop, hash[prop]);
+        if (hash.hasOwnProperty(prop)) set(self, prop, hash[prop]);
       }
-    } finally {
-      endPropertyChanges();
-    }
+    });
     return this;
   },
 

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -4,7 +4,9 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get, set = Ember.set,
+    beginPropertyChanges = Ember.beginPropertyChanges,
+    endPropertyChanges = Ember.endPropertyChanges;
   
 /**
   @class
@@ -142,11 +144,14 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @returns {Ember.Observable}
   */
   setProperties: function(hash) {
-    Ember.beginPropertyChanges(this);
-    for(var prop in hash) {
-      if (hash.hasOwnProperty(prop)) set(this, prop, hash[prop]);
+    beginPropertyChanges();
+    try {
+      for(var prop in hash) {
+        if (hash.hasOwnProperty(prop)) set(this, prop, hash[prop]);
+      }
+    } finally {
+      endPropertyChanges();
     }
-    Ember.endPropertyChanges(this);
     return this;
   },
 

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -17,3 +17,46 @@ test('should be able to use getProperties to get a POJO of provided keys', funct
   equals("Steve", pojo.firstName);
   equals("Jobs", pojo.lastName);
 });
+
+test('should be able to use setProperties to set multiple properties at once', function() {
+  var obj = Ember.Object.create({
+    firstName: "Steve",
+    lastName: "Jobs",
+    companyName: "Apple, Inc."
+  });
+
+  obj.setProperties({firstName: "Tim", lastName: "Cook"});
+  equals("Tim", obj.get("firstName"));
+  equals("Cook", obj.get("lastName"));
+});
+
+testBoth('calling setProperties completes safely despite exceptions', function(get,set) {
+  var exc = new Error("Something unexpected happened!");
+  var obj = Ember.Object.create({
+    firstName: "Steve",
+    lastName: "Jobs",
+    companyName: Ember.computed(function(key, value) {
+      if (value !== undefined) {
+        throw exc;
+      }
+      return "Apple, Inc."
+    })
+  });
+
+  var firstNameChangedCount = 0;
+
+  Ember.addObserver(obj, 'firstName', function() { firstNameChangedCount++; });
+
+  try {
+    obj.setProperties({
+      firstName: 'Tim',
+      lastName: 'Cook',
+      companyName: 'Fruit Co., Inc.'
+    });
+  } catch(err) {
+    if (err != exc)
+      throw err;
+  }
+
+  equals(firstNameChangedCount, 1, 'firstName should have fired once');
+});


### PR DESCRIPTION
As discussedin emberjs/ember.js#352, this commit makes setProperties in the Ember.Observable mixin always call endPropertyChanges(), even if an error is encountered while setting a property.
