### PR TITLE
Introduce Ember.onerror.

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -30,8 +30,14 @@ function invoke(target, method, args, ignore) {
   if (args && ignore>0) {
     args = args.length>ignore ? slice.call(args, ignore) : null;
   }
-  // IE8's Function.prototype.apply doesn't accept undefined/null arguments.
-  return method.apply(target || this, args || []);
+
+  try {
+    // IE8's Function.prototype.apply doesn't accept undefined/null arguments.
+    return method.apply(target || this, args || []);
+  } catch (error) {
+    if ('function'===typeof Ember.onerror) Ember.onerror(error);
+    else throw error;
+  }
 }
 
 

--- a/packages/ember-metal/tests/run_loop/onerror_test.js
+++ b/packages/ember-metal/tests/run_loop/onerror_test.js
@@ -1,0 +1,33 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+module('system/run_loop/onerror_test');
+
+test('With Ember.onerror undefined, errors in Ember.run are thrown', function () {
+  var thrown = new Error('Boom!'),
+      caught;
+
+  try {
+    Ember.run(function() { throw thrown; });
+  } catch (error) {
+    caught = error;
+  }
+
+  same(caught, thrown);
+});
+
+test('With Ember.onerror set, errors in Ember.run are caught', function () {
+  var thrown = new Error('Boom!'),
+      caught;
+
+  Ember.onerror = function(error) { caught = error; }
+
+  Ember.run(function() { throw thrown; });
+
+  same(caught, thrown);
+
+  Ember.onerror = undefined;
+});


### PR DESCRIPTION
Application developers may assign a callback to Ember.onerror to catch errors thrown in the run loop.

(Motivation: access to backtraces. They aren't available in window.onerror.)
