### PR TITLE
Introduce Ember.Form

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -9,3 +9,4 @@ require("ember-handlebars/controls/text_field");
 require("ember-handlebars/controls/button");
 require("ember-handlebars/controls/text_area");
 require("ember-handlebars/controls/tabs");
+require("ember-handlebars/controls/form");

--- a/packages/ember-handlebars/lib/controls/form.js
+++ b/packages/ember-handlebars/lib/controls/form.js
@@ -1,0 +1,22 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require('ember-runtime/mixins/target_action_support');
+
+Ember.Form = Ember.View.extend(Ember.TargetActionSupport, {
+  classNames:      ['ember-form'],
+  tagName:         'form',
+  target:          '*',            // default target = view itself
+  action:          'submitForm',   // default action = submitForm()
+  propagateEvents: false,
+
+  // trigger the action bound to this view when the form is submitted
+  submit: function(evt) {
+    evt.preventDefault();
+    this.triggerAction();
+    return Ember.get(this, 'propagateEvents');
+  }
+});

--- a/packages/ember-handlebars/tests/controls/form_test.js
+++ b/packages/ember-handlebars/tests/controls/form_test.js
@@ -1,0 +1,36 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var get = Ember.get, set = Ember.set, formView, application;
+
+module("Ember.Form", {
+  setup: function() {
+    application = Ember.Application.create();
+    formView = Ember.Form.create({});
+    append();
+  },
+  teardown: function() {
+    formView.destroy();
+    application.destroy();
+  }
+});
+
+function append() {
+  Ember.run(function() {
+    formView.appendTo('#qunit-fixture');
+  });
+}
+
+test("should call the submitForm method when the form is submitted", function() {
+  var wasCalled;
+
+  formView.submitForm = function() {
+    wasCalled = true;
+  };
+
+  formView.$().trigger("submit");
+  ok(wasCalled, "invokes submitForm method");
+});


### PR DESCRIPTION
I'd like to propose `Ember.Form` as a simple view class for `form` tags. This view captures the `submit` event and triggers an action (`submitForm` by default) either on itself or a specific `target`. By default, events won't be propagated, although this can be overridden.

I've created a Rails-backed CRUD application to demonstrate the usage of `Ember.Form` (as well as some simple classes for managing RESTful resources):

https://github.com/dgeb/ember_rest_example

This example app shows an `Ember.Form` based view that includes `Ember.TextField` inputs which keep the backing object's properties in sync with the inputs. The backing object is then saved when the form is submitted.

`Ember.Form` could also be extended to include serialization methods. This would allow forms to include non-bound inputs and still apply those values to a backing object in `submitForm()`. I've excluded a form serialization method to keep this pull request as simple as possible for now.
