### PR TITLE
Ignore window.globalStorage in Ember#identifyNamespaces when it's old Firefox storage object

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -409,6 +409,9 @@ function findNamespaces() {
   if (Namespace.PROCESSED) { return; }
 
   for (var prop in window) {
+    //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
+    // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage
+    if (prop === "globalStorage" && window.StorageList && window.globalStorage instanceof window.StorageList) { continue; }
     // Unfortunately, some versions of IE don't support window.hasOwnProperty
     if (window.hasOwnProperty && !window.hasOwnProperty(prop)) { continue; }
 


### PR DESCRIPTION
As noted in https://github.com/emberjs/ember.js/issues/341, trying to read 'isNamespace'-property from `window.globalStorage` will cause security exception in older Firefoxes.

This patch tries to skip this troublesome property when we can be quite sure that it's the Firefox-version of the property.
