### PR TITLE
Ember.Button doesn't respect propagateEvents for touches

### DIFF
--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -60,10 +60,10 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
   // which goes inactive as soon as mouse goes out of edges.)
 
   touchStart: function(touch) {
-    this.mouseDown(touch);
+    return this.mouseDown(touch);
   },
 
   touchEnd: function(touch) {
-    this.mouseUp(touch);
+    return this.mouseUp(touch);
   }
 });


### PR DESCRIPTION
Ember.Button's touch event handlers need to return a value, just like the mouse
event handlers. Otherwise we can't stop event propagation.
