### PR TITLE
Change behavior of Ember.empty

### DIFF
--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -33,14 +33,6 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
     return this.get('tagName') === 'a' ? '#' : null;
   }).property('tagName').cacheable(),
 
-  click: function() {
-    // Actually invoke the button's target and action.
-    // This method comes from the Ember.TargetActionSupport mixin.
-    this.triggerAction();
-
-    return get(this, 'propagateEvents');
-  },
-
   mouseDown: function() {
     if (!get(this, 'disabled')) {
       set(this, 'isActive', true);
@@ -66,12 +58,29 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
   mouseUp: function(event) {
     if (get(this, 'isActive')) {
+      // Actually invoke the button's target and action.
+      // This method comes from the Ember.TargetActionSupport mixin.
+      this.triggerAction();
       set(this, 'isActive', false);
     }
 
     this._mouseDown = false;
     this._mouseEntered = false;
     return get(this, 'propagateEvents');
+  },
+
+  keyDown: function(event) {
+    // Handle space or enter
+    if (event.keyCode === 13 || event.keyCode === 32) {
+      this.mouseDown();
+    }
+  },
+
+  keyUp: function(event) {
+    // Handle space or enter
+    if (event.keyCode === 13 || event.keyCode === 32) {
+      this.mouseUp();
+    }
   },
 
   // TODO: Handle proper touch behavior.  Including should make inactive when

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -26,6 +26,12 @@ function synthesizeEvent(type, view) {
   view.$().trigger(type);
 }
 
+function synthesizeKeyEvent(type, keyCode, view) {
+  var event = jQuery.Event(type);
+  event.keyCode = keyCode;
+  view.$().trigger(event);
+}
+
 function append() {
   Ember.run(function() {
     button.appendTo('#qunit-fixture');
@@ -66,9 +72,99 @@ test("should trigger an action when clicked", function() {
     button.appendTo('#qunit-fixture');
   });
 
-  synthesizeEvent('click', button);
+  synthesizeEvent('mousedown', button);
+  synthesizeEvent('mouseup', button);
 
   ok(wasClicked);
+});
+
+test("should trigger an action when touched", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  synthesizeEvent('touchstart', button);
+  synthesizeEvent('touchend', button);
+
+  ok(wasClicked);
+});
+
+test("should trigger an action when space pressed", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  synthesizeKeyEvent('keydown', 13, button);
+  synthesizeKeyEvent('keyup', 13, button);
+
+  ok(wasClicked);
+});
+
+test("should trigger an action when enter pressed", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  synthesizeKeyEvent('keydown', 32, button);
+  synthesizeKeyEvent('keyup', 32, button);
+
+  ok(wasClicked);
+});
+
+test("should not trigger an action when another key is pressed", function() {
+  var wasClicked = false;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  button.set('target', actionObject);
+  button.set('action', 'myAction');
+
+  Ember.run(function() {
+    button.appendTo('#qunit-fixture');
+  });
+
+  // 'a' key
+  synthesizeKeyEvent('keydown', 65, button);
+  synthesizeKeyEvent('keyup', 65, button);
+
+  ok(!wasClicked);
 });
 
 test("should trigger an action on a String target when clicked", function() {
@@ -91,7 +187,8 @@ test("should trigger an action on a String target when clicked", function() {
     button.appendTo('#qunit-fixture');
   });
 
-  synthesizeEvent('click', button);
+  synthesizeEvent('mousedown', button);
+  synthesizeEvent('mouseup', button);
 
   ok(wasClicked);
 
@@ -130,7 +227,6 @@ test("should not trigger action if mouse leaves area before mouseup", function()
   synthesizeEvent('mouseleave', button);
   synthesizeEvent('mouseenter', button);
   synthesizeEvent('mouseup', button);
-  synthesizeEvent('click', button);
 
   ok(wasClicked);
 });

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -120,13 +120,19 @@ Ember.none = function(obj) {
 };
 
 /**
-  Verifies that a value is null or an empty string | array | function.
+  Verifies that a value is null or an empty string | array | object.
 
   @param {Object} obj Value to test
   @returns {Boolean}
 */
 Ember.empty = function(obj) {
-  return obj === null || obj === undefined || (obj.length === 0 && typeof obj !== 'function');
+  if (obj === null || obj === undefined) return true;
+  if (Ember.isArray(obj) || Ember.typeOf(obj) === 'string') return obj.length === 0;
+  if (Ember.typeOf(obj) === 'object') {
+    for (var key in obj) if (obj.hasOwnProperty(key)) return false;
+    return true;
+  }
+  return false;
 };
 
 /**

--- a/packages/ember-runtime/tests/core/empty_test.js
+++ b/packages/ember-runtime/tests/core/empty_test.js
@@ -9,7 +9,10 @@ module("Ember.empty");
 
 test("Ember.empty", function() {
   var string = "string", fn = function() {},
-      object = {length: 0};
+      object = {length: 0}
+      object = {length: 0},
+      objekt = {length: 1},
+      obj    = {abs:'abs'};
 
   equals(true,  Ember.empty(null),      "for null");
   equals(true,  Ember.empty(undefined), "for undefined");
@@ -20,6 +23,8 @@ test("Ember.empty", function() {
   equals(false, Ember.empty(fn),        "for a Function");
   equals(false, Ember.empty(0),         "for 0");
   equals(true,  Ember.empty([]),        "for an empty Array");
-  equals(false, Ember.empty({}),        "for an empty Object");
-  equals(true,  Ember.empty(object),     "for an Object that has zero 'length'");
+  equals(true,  Ember.empty({}),        "for an empty Object");
+  equals(true,  Ember.empty(object),    "for an Object that has zero 'length'");
+  equals(false, Ember.empty(objekt),    "for an Object that has 'length' equals 1");
+  equals(false, Ember.empty(obj),       "for an Object that has some properties");
 });

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -40,10 +40,14 @@ Ember.Application = Ember.Namespace.extend(
 /** @scope Ember.Application.prototype */{
 
   /**
+    The root DOM element of the Application.
+
+    Can be specified as DOMElement or a selector string.
+
     @type DOMElement
-    @default document.body
+    @default 'body'
   */
-  rootElement: document.body,
+  rootElement: 'body',
 
   /**
     @type Ember.EventDispatcher

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -23,10 +23,15 @@ Ember.EventDispatcher = Ember.Object.extend(
     The root DOM element to which event listeners should be attached. Event
     listeners will be attached to the document unless this is overridden.
 
+    Can be specified as a DOMElement or a selector string.
+
+    The default body is a string since this may be evaluated before document.body
+    exists in the DOM.
+
     @type DOMElement
-    @default document.body
+    @default 'body'
   */
-  rootElement: document.body,
+  rootElement: 'body',
 
   /**
     @private


### PR DESCRIPTION
Pull request implement this behavior:

```
Ember.empty({}) // => true
Ember.empty({length:0}) // => true
Ember.empty({length:1}) // => false
```

Because it uses Ember.isArray internally and `Ember.isArray({length: 1}) // => true`
