### PR TITLE
Introduce Ember.Link

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -7,5 +7,6 @@
 require("ember-handlebars/controls/checkbox");
 require("ember-handlebars/controls/text_field");
 require("ember-handlebars/controls/button");
+require("ember-handlebars/controls/link");
 require("ember-handlebars/controls/text_area");
 require("ember-handlebars/controls/tabs");

--- a/packages/ember-handlebars/lib/controls/link.js
+++ b/packages/ember-handlebars/lib/controls/link.js
@@ -1,0 +1,23 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+Ember.Link = Ember.View.extend(Ember.TargetActionSupport, {
+  classNames:        ['ember-link'],
+  tagName:           'a',
+  attributeBindings: ['href'],
+  href:              '#',
+  target:            'parentView',
+  propagateEvents:   false,
+
+  click: function(evt) {
+    evt.preventDefault();
+
+    // Invoke the link's target and action.
+    this.triggerAction();
+
+    return Ember.get(this, 'propagateEvents');
+  }
+});

--- a/packages/ember-handlebars/tests/controls/link_test.js
+++ b/packages/ember-handlebars/tests/controls/link_test.js
@@ -1,0 +1,41 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var get = Ember.get, set = Ember.set, link, application;
+
+module('Ember.Link', {
+  setup: function() {
+    application = Ember.Application.create();
+    link = Ember.Link.create();
+    append();
+  },
+  teardown: function() {
+    link.destroy();
+    application.destroy();
+  }
+});
+
+function append() {
+  Ember.run(function() {
+    link.appendTo('#qunit-fixture');
+  });
+}
+
+test('should trigger an action when clicked', function() {
+  var wasClicked;
+
+  var actionObject = Ember.Object.create({
+    myAction: function() {
+      wasClicked = true;
+    }
+  });
+
+  link.set('target', actionObject);
+  link.set('action', 'myAction');
+
+  link.$().trigger('click');
+  ok(wasClicked, 'invokes action');
+});


### PR DESCRIPTION
`Ember.Link` is a simple view class for `a` tags that perform an action. This view captures the `click` event, prevents default behaviour, optionally propagates the event, and triggers an action on the `target` (which is the `parentView` by default).

Just like the `Ember.Form` proposal in #374, this was extracted from my Rails-based Ember example:

https://github.com/dgeb/ember_rest_example
