### PR TITLE
fix Enumerable *Property functions to correctly handle explicit undefined second argument

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -26,9 +26,11 @@ function pushCtx(ctx) {
 }
 
 function iter(key, value) {
+  var valueProvided = arguments.length === 2;
+
   function i(item) {
     var cur = get(item, key);
-    return value===undefined ? !!cur : value===cur;
+    return valueProvided ? value===cur : !!cur;
   } 
   return i ;
 }
@@ -336,7 +338,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Array} filtered array
   */
   filterProperty: function(key, value) {
-    return this.filter(iter(key, value));
+    return this.filter(iter.apply(this, arguments));
   },
 
   /**
@@ -391,7 +393,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Object} found item or null
   */
   findProperty: function(key, value) {
-    return this.find(iter(key, value));
+    return this.find(iter.apply(this, arguments));
   },
 
   /**
@@ -436,7 +438,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Array} filtered array
   */
   everyProperty: function(key, value) {
-    return this.every(iter(key, value));
+    return this.every(iter.apply(this, arguments));
   },
 
 
@@ -482,7 +484,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     @returns {Boolean} true
   */
   someProperty: function(key, value) {
-    return this.some(iter(key, value));
+    return this.some(iter.apply(this, arguments));
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable/every.js
+++ b/packages/ember-runtime/tests/suites/enumerable/every.js
@@ -64,3 +64,23 @@ suite.test('should return true of every property is true', function() {
   equals(obj.everyProperty('foo'), true, 'everyProperty(foo)');
   equals(obj.everyProperty('bar'), false, 'everyProperty(bar)');
 });
+
+suite.test('should return true if every property matches null', function() {
+  var obj = this.newObject([
+    { foo: null, bar: 'BAZ' },
+    Ember.Object.create({ foo: null, bar: null })
+  ]);
+
+  equals(obj.everyProperty('foo', null), true, "everyProperty('foo', null)");
+  equals(obj.everyProperty('bar', null), false, "everyProperty('bar', null)");
+});
+
+suite.test('should return true if every property is undefined', function() {
+  var obj = this.newObject([
+    { foo: undefined, bar: 'BAZ' },
+    Ember.Object.create({ bar: undefined })
+  ]);
+
+  equals(obj.everyProperty('foo', undefined), true, "everyProperty('foo', undefined)");
+  equals(obj.everyProperty('bar', undefined), false, "everyProperty('bar', undefined)");
+});

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -61,3 +61,80 @@ suite.test('should include in result if property is true', function() {
   same(obj.filterProperty('foo'), ary, 'filterProperty(foo)');
   same(obj.filterProperty('bar'), [ary[0]], 'filterProperty(bar)');
 });
+
+suite.test('should filter on second argument if provided', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 2}),
+    { name: 'obj3', foo: 2},
+    Ember.Object.create({ name: 'obj4', foo: 3})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', 3), [ary[0], ary[3]], "filterProperty('foo', 3)')");
+});
+
+suite.test('should correctly filter null second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: null}),
+    { name: 'obj3', foo: null},
+    Ember.Object.create({ name: 'obj4', foo: 3})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', null), [ary[1], ary[2]], "filterProperty('foo', 3)')");
+});
+
+suite.test('should not return all objects on undefined second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 2})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', undefined), [], "filterProperty('foo', 3)')");
+});
+
+suite.test('should correctly filter explicit undefined second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 3}),
+    { name: 'obj3', foo: undefined},
+    Ember.Object.create({ name: 'obj4', foo: undefined}),
+    { name: 'obj5'},
+    Ember.Object.create({ name: 'obj6'})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo', undefined), ary.slice(2), "filterProperty('foo', 3)')");
+});
+
+suite.test('should not match undefined properties without second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 3}),
+    { name: 'obj3', foo: undefined},
+    Ember.Object.create({ name: 'obj4', foo: undefined}),
+    { name: 'obj5'},
+    Ember.Object.create({ name: 'obj6'})
+  ];
+
+  obj = this.newObject(ary);
+
+  same(obj.filterProperty('foo'), ary.slice(0, 2), "filterProperty('foo', 3)')");
+});

--- a/packages/ember-runtime/tests/suites/enumerable/find.js
+++ b/packages/ember-runtime/tests/suites/enumerable/find.js
@@ -72,3 +72,31 @@ suite.test('should return first object with truthy prop', function() {
   equals(obj.findProperty('foo'), ary[0], 'findProperty(foo)');
   equals(obj.findProperty('bar'), ary[1], 'findProperty(bar)');
 });
+
+suite.test('should return first null property match', function() {
+  var ary, obj;
+
+  ary = [
+    { foo: null, bar: 'BAZ' },
+    Ember.Object.create({ foo: null, bar: null })
+  ];
+
+  obj = this.newObject(ary);
+
+  equals(obj.findProperty('foo', null), ary[0], "findProperty('foo', null)");
+  equals(obj.findProperty('bar', null), ary[1], "findProperty('bar', null)");
+});
+
+suite.test('should return first undefined property match', function() {
+  var ary, obj;
+
+  ary = [
+    { foo: undefined, bar: 'BAZ' },
+    Ember.Object.create({ })
+  ];
+
+  obj = this.newObject(ary);
+
+  equals(obj.findProperty('foo', undefined), ary[0], "findProperty('foo', undefined)");
+  equals(obj.findProperty('bar', undefined), ary[1], "findProperty('bar', undefined)");
+});

--- a/packages/ember-runtime/tests/suites/enumerable/some.js
+++ b/packages/ember-runtime/tests/suites/enumerable/some.js
@@ -65,3 +65,32 @@ suite.test('should return true of any property is true', function() {
   equals(obj.someProperty('bar'), true, 'someProperty(bar)');
   equals(obj.someProperty('BIFF'), false, 'someProperty(biff)');
 });
+
+suite.test('should return true if any property matches null', function() {
+  var obj = this.newObject([
+    { foo: null, bar: 'bar' },
+    Ember.Object.create({ foo: 'foo', bar: null })
+  ]);
+
+  equals(obj.someProperty('foo', null), true, "someProperty('foo', null)");
+  equals(obj.someProperty('bar', null), true, "someProperty('bar', null)");
+});
+
+suite.test('should return true if any property is undefined', function() {
+  var obj = this.newObject([
+    { foo: undefined, bar: 'bar' },
+    Ember.Object.create({ foo: 'foo' })
+  ]);
+
+  equals(obj.someProperty('foo', undefined), true, "someProperty('foo', undefined)");
+  equals(obj.someProperty('bar', undefined), true, "someProperty('bar', undefined)");
+});
+
+suite.test('should not match undefined properties without second argument', function() {
+  var obj = this.newObject([
+    { foo: undefined },
+    Ember.Object.create({ })
+  ]);
+
+  equals(obj.someProperty('foo'), false, "someProperty('foo', undefined)");
+});


### PR DESCRIPTION
Some functions in the Enumerable mixin such as filterProperty, findProperty, etc. behave oddly when the optional second argument is explicitly provided but is undefined.

For example,

``` javascript
var bar = Ember.Object.create({});
[{bar_id: 1},
 {bar_id: 2},
 {bar_id: 3}].filterProperty('bar_id', bar.get('id'));
```

returns `[{bar_id: 1}, {bar_id: 2}, {bar_id: 3}]` instead of `[]`. Analogous bugs exist for findProperty, someProperty, and everyProperty.

This commit fixes these bugs and adds additional tests for 2-arg versions of the Enumerable *Property functions.
