### PR TITLE
RadioButton support.

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -7,5 +7,6 @@
 require("ember-handlebars/controls/checkbox");
 require("ember-handlebars/controls/text_field");
 require("ember-handlebars/controls/button");
+require("ember-handlebars/controls/radio_button");
 require("ember-handlebars/controls/text_area");
 require("ember-handlebars/controls/tabs");

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -11,14 +11,13 @@ var set = Ember.set, get = Ember.get;
 
 Ember.RadioButton = Ember.View.extend({
   title: null,
-  value: null,
   checked: false,
   group: "radio_button",
   disabled: false,
 
   classNames: ['ember-radio-button'],
 
-  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="value" checked="checked"}}>{{title}}</input>'),
+  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="val" checked="checked"}}>{{title}}</input>'),
 
   change: function() {
     Ember.run.once(this, this._updateElementValue);
@@ -26,6 +25,6 @@ Ember.RadioButton = Ember.View.extend({
 
   _updateElementValue: function() {
     var input = this.$('input:radio');
-    set(this, 'value', input.attr('val'));
+    set(this, 'value', input.attr('value'));
   }
 });

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -1,0 +1,31 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require("ember-views/views/view");
+require("ember-handlebars/ext");
+
+var set = Ember.set, get = Ember.get;
+
+Ember.RadioButton = Ember.View.extend({
+  title: null,
+  value: null,
+  checked: false,
+  group: "radio_button",
+  disabled: false,
+
+  classNames: ['ember-radio-button'],
+
+  defaultTemplate: Ember.Handlebars.compile('<input type="radio" {{ bindAttr disabled="disabled" name="group" value="value" checked="checked"}}>{{title}}</input>'),
+
+  change: function() {
+    Ember.run.once(this, this._updateElementValue);
+  },
+
+  _updateElementValue: function() {
+    var input = this.$('input:radio');
+    set(this, 'value', input.attr('val'));
+  }
+});

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,0 +1,94 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var get = Ember.get, set = Ember.set, radioButtonView, application;
+
+module("Ember.RadioButton", {
+  setup: function() {
+    application = Ember.Application.create();
+  },
+  teardown: function() {
+    radioButtonView.destroy();
+    application.destroy();
+  }
+});
+
+function setAndFlush(view, key, value) {
+  Ember.run(function() {
+    Ember.set(view, key, value);
+  });
+}
+
+function append() {
+  Ember.run(function() {
+    radioButtonView.appendTo('#qunit-fixture');
+  });
+}
+
+test("should become disabled if the disabled attribute is true", function() {
+  radioButtonView = Ember.RadioButton.create({});
+
+  radioButtonView.set('disabled', true);
+  append();
+
+  ok(radioButtonView.$("input").is(":disabled"));
+});
+
+test("should become disabled if the disabled attribute is true", function() {
+  radioButtonView = Ember.RadioButton.create({});
+
+  append();
+  ok(radioButtonView.$("input").is(":not(:disabled)"));
+
+  Ember.run(function() { radioButtonView.set('disabled', true); });
+  ok(radioButtonView.$("input").is(":disabled"));
+
+  Ember.run(function() { radioButtonView.set('disabled', false); });
+  ok(radioButtonView.$("input").is(":not(:disabled)"));
+});
+
+test("value property mirrors input value", function() {
+  radioButtonView = Ember.RadioButton.create({ value: "value"});
+  Ember.run(function() { radioButtonView.append(); });
+
+  equals(get(radioButtonView, 'value'), "value", "initially starts with a string value");
+  equals(!!radioButtonView.$('input').prop('checked'), false, "the initial checked property is false");
+
+  setAndFlush(radioButtonView, 'checked', true);
+
+  equals(radioButtonView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+
+  radioButtonView.remove();
+  Ember.run(function() { radioButtonView.append(); });
+
+  equals(radioButtonView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+
+  Ember.run(function() { radioButtonView.remove(); });
+  Ember.run(function() { set(radioButtonView, 'checked', false); });
+  Ember.run(function() { radioButtonView.append(); });
+
+  equals(radioButtonView.$('input').prop('checked'), false, "changing the value property changes the DOM");
+});
+
+test("checking the radiobutton updates the value", function() {
+  radioButtonView = Ember.RadioButton.create({ value: "testing" });
+  Ember.run(function() { radioButtonView.appendTo('#qunit-fixture'); });
+
+  equals(!!radioButtonView.$('input').attr('checked'), false, "precond - the initial checked property is false");
+
+  // Can't find a way to programatically trigger a radiobutton in IE and have it generate the
+  // same events as if a user actually clicks.
+  if (!jQuery.browser.msie) {
+    radioButtonView.$('input')[0].click();
+  } else {
+    radioButtonView.$('input').trigger('click');
+    radioButtonView.$('input').removeAttr('checked').trigger('change');
+  }
+
+  equals(radioButtonView.$('input').prop('checked'), true, "after clicking a radiobutton, the checked property changed");
+  
+});
+


### PR DESCRIPTION
Allows you to use radio buttons like so:

{{view Em.RadioButton title=title val=value group="group_name" valueBinding="Object.value"}}

Updated the binding with the value passed in to val.
