### PR TITLE
Fixes issue #259

### DIFF
--- a/packages/ember-states/lib/view_state.js
+++ b/packages/ember-states/lib/view_state.js
@@ -6,10 +6,24 @@ Ember.ViewState = Ember.State.extend({
   isViewState: true,
 
   enter: function(stateManager) {
+    var state;
     var view = get(this, 'view');
-
-    if (view) {
+    var appendView = function(view, stateManager) {
       view.appendTo(stateManager.get('rootElement') || 'body');
+    };
+
+    
+    if (view) {
+      
+      if (Ember.$.isReady === YES) {
+        appendView(view, stateManager);
+      } else {
+        state = this;
+        Ember.$(document).ready(function() {
+          appendView(view, stateManager);
+        });
+      }
+      
     }
   },
 


### PR DESCRIPTION
The StateManager is too aggressive in transitioning to the initialState. 

For example, if the initial state is a ViewState, then Firefox cannot find the Handlebars template for it, resulting in an error and the view not rendering. 

This fix waits for the DOM to be ready before trying to transition to the initialState. 
