### PR TITLE
phantomjs 1.4.1 is now preinstalled on travis-ci.org Ruby workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
-before_install: sudo add-apt-repository ppa:jerome-etienne/neoip; sudo apt-get -qq update; sudo apt-get -q install phantomjs
 before_script: sh -e /etc/init.d/xvfb start; bundle exec rackup &
 script: DISPLAY=:99.0 phantomjs tests/qunit/run-qunit.js "http://localhost:9292/tests/index.html?package=all"


### PR DESCRIPTION
Find it at `/usr/local/bin/phantomjs`
