### PR TITLE
CollectionView can setup classNames on childViews via itemViewClassNames property

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -40,6 +40,13 @@ Ember.CollectionView = Ember.ContainerView.extend(
   */
   itemViewClass: Ember.View,
 
+  /**
+    A list  class names to be applied to the ChildViews.
+    @type Ember.Array
+    @default null
+  */
+  itemViewClassNames: null,
+
   init: function() {
     var ret = this._super();
     this._contentDidChange();
@@ -121,6 +128,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
   */
   arrayDidChange: function(content, start, removed, added) {
     var itemViewClass = get(this, 'itemViewClass'),
+        itemViewClassNames = get(this, 'itemViewClassNames'),
         childViews = get(this, 'childViews'),
         addedViews = [], view, item, idx, len, itemTagName;
 
@@ -136,6 +144,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
         item = content.objectAt(idx);
 
         view = this.createChildView(itemViewClass, {
+          classNames: itemViewClassNames, 
           content: item,
           contentIndex: idx
         });

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -240,3 +240,26 @@ test("should allow declaration of itemViewClass as a string", function() {
 
   equals(view.$('.ember-view').length, 3);
 });
+
+test("should be able to setup classNames on childViews with itemViewClassNames property", function() {
+
+  view = Ember.CollectionView.create({
+    content: Ember.A([1, 2]),
+    itemViewClass: Em.View,
+    itemViewClassNames: ['ui_item', 'item']
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  ok( view.$(':nth-child(1)').hasClass('ui_item') );
+  ok( view.$(':nth-child(1)').hasClass('item') );
+
+  ok( view.$(':nth-child(2)').hasClass('ui_item') );
+  ok( view.$(':nth-child(2)').hasClass('item') );
+  
+});
+
+
+


### PR DESCRIPTION
The following feature is useful to define Views which can be created to be used on different ways.

An example would be something like:

``` javascript
App.CarouselView = Em.CollectionView.extend(App.ScrollMixin, {
    classNames: ['carousel_collection'],
    itemViewClassNames: ['carousel_item']
    ..........
});

App.CarouselView.extend({
    itemViewClass: App.PromotionView,
});

App.CarouselView.extend({
    itemViewClass: App.PictureView,
});
```
