### PR TITLE
Add return value to TargetActionSupport.triggerAction()

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -19,15 +19,19 @@ Ember.TargetActionSupport = Ember.Mixin.create({
         target = get(this, 'targetObject');
 
     if (target && action) {
+      var ret;
+      
       if (typeof target.send === 'function') {
-        target.send(action, this);
+        ret = target.send(action, this);
       } else {
         if (typeof action === 'string') {
           action = target[action];
         }
-        action.call(target, this);
+        ret = action.call(target, this);
       }
-      return true;
+      if (ret !== false) ret = true;
+      
+      return ret;
     } else {
       return false;
     }

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -27,6 +27,9 @@ Ember.TargetActionSupport = Ember.Mixin.create({
         }
         action.call(target, this);
       }
+      return true;
+    } else {
+      return false;
     }
   }
 });

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -1,17 +1,15 @@
 module("Ember.TargetActionSupport");
 
-test("it should not do anything if no target or action are specified", function() {
+test("it should return false if no target or action are specified", function() {
   expect(1);
 
   var obj = Ember.Object.create(Ember.TargetActionSupport);
 
-  obj.triggerAction();
-
-  ok(true, "no exception was thrown");
+  ok(false === obj.triggerAction(), "no target or action was specified");
 });
 
 test("it should support actions specified as strings", function() {
-  expect(1);
+  expect(2);
 
   var obj = Ember.Object.create(Ember.TargetActionSupport, {
     target: Ember.Object.create({
@@ -23,11 +21,11 @@ test("it should support actions specified as strings", function() {
     action: 'anEvent'
   });
 
-  obj.triggerAction();
+  ok(true === obj.triggerAction(), "a valid target and action were specified");
 });
 
 test("it should invoke the send() method on objects that implement it", function() {
-  expect(1);
+  expect(2);
 
   var obj = Ember.Object.create(Ember.TargetActionSupport, {
     target: Ember.Object.create({
@@ -39,11 +37,11 @@ test("it should invoke the send() method on objects that implement it", function
     action: 'anEvent'
   });
 
-  obj.triggerAction();
+  ok(true === obj.triggerAction(), "a valid target and action were specified");
 });
 
 test("it should find targets specified using a property path", function() {
-  expect(1);
+  expect(2);
 
   window.Test = {};
 
@@ -58,7 +56,7 @@ test("it should find targets specified using a property path", function() {
     action: 'anEvent'
   });
 
-  myObj.triggerAction();
+  ok(true === myObj.triggerAction(), "a valid target and action were specified");
 
   window.Test = undefined;
 });


### PR DESCRIPTION
It can be helpful to controls that extend `TargetActionSupport` to know whether `triggerAction()` succeeds. An event handler may respond differently depending upon whether an action and target are available.

Here's an example taken from the `Ember.Link` proposal (#381):

```
  click: function(evt) {
    if (this.triggerAction()) {
      evt.preventDefault();
      return Ember.get(this, 'propagateEvents');
    }
  }
```

In this example, if an action is not triggered, default `click` behaviour won't be prevented. This simple change would allow an `Ember.Link` to work as a standard or action link.
