### PR TITLE
Block support in handlebars

### DIFF
--- a/packages/ember-handlebars/lib/helpers.js
+++ b/packages/ember-handlebars/lib/helpers.js
@@ -12,3 +12,4 @@ require("ember-handlebars/helpers/debug");
 require("ember-handlebars/helpers/each");
 require("ember-handlebars/helpers/template");
 require("ember-handlebars/helpers/action");
+require("ember-handlebars/helpers/yield");

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -92,8 +92,10 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
     var viewOptions = {};
 
     if (fn) {
-      ember_assert("You cannot provide a template block if you also specified a templateName", !get(viewOptions, 'templateName') && !newView.PrototypeMixin.keys().indexOf('templateName') >= 0);
-      viewOptions.template = fn;
+      // Block could be something to yield to, or simply a template. We don't know much about the view to make the determination here. Hence this decision is moved downstream into the view's computed property - template
+	    viewOptions.yieldContent = fn;
+	    viewOptions.yieldContext = get(currentView, 'templateContext');
+	    viewOptions.yieldContainer = currentView;
     }
 
     currentView.appendChild(newView, viewOptions);

--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -1,0 +1,46 @@
+require("ember-handlebars/ext");
+require("ember-views/views/view");
+require("ember-handlebars/views/metamorph_view");
+
+/*global ember_assert */
+
+Ember.Handlebars.YieldView = Ember.View.extend(Ember.Metamorph, {
+  itemViewClass: Ember.View.extend(Ember.Metamorph),
+  templateContext: null,
+  template: null,
+  blockContainer: null   
+});
+
+Ember.Handlebars.yieldHelper = Ember.Object.create({
+  
+  _findContainingTemplateView: function(view) {
+    // We are using _parentView here, because we need to go through the virtual YieldViews, so we can treat them differently.
+    if (!view) {
+      return view;
+    }
+    else if (view instanceof Ember.Handlebars.YieldView) {
+      var blockContainer = Ember.get(view, 'blockContainer');
+      ember_assert("YieldView representing the current block doesn't have a blockContainer set.", blockContainer);
+      return this._findContainingTemplateView(Ember.get(blockContainer, '_parentView'));
+    }
+    else if (view.isVirtual) {
+      return this._findContainingTemplateView(Ember.get(view, '_parentView'));
+    }
+    else {
+      return view;
+    }
+  },
+
+  helper: function(options) {
+    var currentView = Ember.Handlebars.yieldHelper._findContainingTemplateView(options.data.view);
+
+    if (currentView && currentView.yieldContent) {
+      options.hash.templateContext = Ember.mixin(currentView.yieldContext, options.hash);
+      options.hash.template = currentView.yieldContent;
+      options.hash.blockContainer = currentView;
+      return Ember.Handlebars.helpers.view.call(this, 'Ember.Handlebars.YieldView', options);
+    }
+  }
+});
+
+Ember.Handlebars.registerHelper('yield', Ember.Handlebars.yieldHelper.helper);

--- a/packages/ember-handlebars/tests/views/view_blocks_test.js
+++ b/packages/ember-handlebars/tests/views/view_blocks_test.js
@@ -1,0 +1,160 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals TemplateTests, Ember, minispade */
+
+var set = Ember.set, get = Ember.get, setPath = Ember.setPath;
+
+var view;
+
+module("ember-handlebars/tests/views/view_blocks_test", {
+  setup: function() {
+    window.TemplateTests = Ember.Namespace.create();
+  },
+  teardown: function() {
+    if (view) {
+      view.destroy();
+    }
+
+    window.TemplateTests = undefined;
+  }
+});
+
+test("block support in template (#307)", function() {
+  TemplateTests.BlockContainer = Ember.View.extend({
+	  template: Ember.Handlebars.compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>') 
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#view TemplateTests.BlockContainer title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
+});
+
+
+test("block should receive the calling view's templateContext as the context", function() {
+  TemplateTests.phone = Ember.Object.create({
+    name: 'mobile',
+    number: '404-555-1234'
+  });
+  
+  TemplateTests.person = Ember.Object.create({
+    name: 'Raghu Rajah',
+    phone: TemplateTests.phone
+  });
+  
+  TemplateTests.PhoneDialer = Ember.View.extend({
+	  template: Ember.Handlebars.compile('<div class="dialer"><div id="owner" {{bindAttr class=content.name}}>{{yield}}</div><div class="phone-number">{{content.number}}</div></div>')
+  });
+
+  TemplateTests.PersonContact = Ember.View.extend({
+	  template: Ember.Handlebars.compile('<div class="contact"><h1>{{content.name}}</h1>{{#view TemplateTests.PhoneDialer contentBinding="content.phone"}}{{content.name}}{{/view}}</div>')
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#view TemplateTests.PersonContact contentBinding="TemplateTests.person"}}{{/view}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('#owner').text(), TemplateTests.person.name, 'person is sent in as context to the child block inside phone');
+});
+
+test("block should work properly even when templates are not hard-coded", function() {
+  var templates = Ember.Object.create({
+    nester: Ember.Handlebars.compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>'),
+    nested: Ember.Handlebars.compile('{{#view TemplateTests.BlockContainer title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
+  });
+
+  TemplateTests.BlockContainer = Ember.View.extend({
+	  templateName: 'nester',
+	  templates: templates
+  });
+
+  view = Ember.View.create({
+    templateName: 'nested',
+    templates: templates
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
+  
+});
+
+test("templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
+  TemplateTests.TimesView = Ember.View.extend({
+    template: Ember.Handlebars.compile('<div class="times">{{#each index}}{{yield}}{{/each}}</div>'),
+    n: null,
+    index: Ember.computed(function() {
+      var n = Ember.get(this, 'n'), indexArray = Ember.A([]);
+      for (var i=0; i < n; i++) {
+        indexArray[i] = i;
+      }
+      return indexArray;
+    }).cacheable()
+  });
+  
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container"><div class="title">Counting to 5</div>{{#view TemplateTests.TimesView n=5}}<div class="times-item">Hello</div>{{/view}}</div>')
+  });
+  
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div#container div.times-item').length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
+});
+
+test("templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
+  TemplateTests.NestingView = Ember.View.extend({
+    template: Ember.Handlebars.compile('{{#view Ember.View tagName="div" classNames="nesting"}}{{yield}}{{/view}}')
+  });
+  
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container">{{#view TemplateTests.NestingView}}<div id="block">Hello</div>{{/view}}</div>')
+  });
+  
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('div#container div.nesting div#block').length, 1, 'nesting view yields correctly even within a view hierarchy in the nesting view');
+});
+
+test("block should be able to pass parameters to yielded block", function() {
+  TemplateTests.TimesView = Ember.View.extend({
+    template: Ember.Handlebars.compile('<div class="times">{{#each index}}{{yield count=this}}{{/each}}</div>'),
+    n: null,
+    index: Ember.computed(function() {
+      var n = Ember.get(this, 'n'), indexArray = Ember.A([]);
+      for (var i=0; i < n; i++) {
+        indexArray[i] = i;
+      }
+      return indexArray;
+    }).cacheable()
+  });
+  
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container"><div class="title">Counting to 5</div>{{#view TemplateTests.TimesView n=5}}<div class="times-item">{{count}}</div>{{/view}}</div>')
+  });
+  
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  var jqElements = view.$('div#container div.times-item');
+  equals(jqElements.length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
+  same(jqElements.map(function() { return $(this).text(); }).get(), ['0','1','2','3','4'], 'times-item received parameter');
+});

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -100,13 +100,19 @@ Ember.View = Ember.Object.extend(
 
     // If there is no template but a templateName has been specified,
     // try to lookup as a spade module
-    if (!template && templateName) {
-      if ('undefined' !== require && require.exists) {
-        if (require.exists(templateName)) { template = require(templateName); }
+    if (!template) {
+      if (templateName) {
+        if ('undefined' !== require && require.exists) {
+          if (require.exists(templateName)) { template = require(templateName); }
+        }
+      
+        if (!template) {
+          throw new Ember.Error(fmt('%@ - Unable to find template "%@".', [this, templateName]));
+        }
       }
-
-      if (!template) {
-        throw new Ember.Error(fmt('%@ - Unable to find template "%@".', [this, templateName]));
+      else {
+          // If templateName is not given and a block is given, treat the block as the template
+          template = get(this, 'yieldContent');
       }
     }
 
@@ -129,6 +135,28 @@ Ember.View = Ember.Object.extend(
     return value !== undefined ? value : this;
   }).cacheable(),
 
+  /**
+    The block to be yielded to, when requested.
+    
+    This is usually template of the block specified within the calling 
+    template. In general, you would never have to use this directly.
+    
+    @field
+    @type Function
+  */
+  yieldContent: null,
+  
+  /**
+    The object from which the yielded block should access properties.
+    
+    This object is passed in when the yielded block template (yieldContent) 
+    is evaulated. In general, you would never have to use this directly.
+    
+    @field
+    @type Object
+  */
+  yieldContext: null,
+  
   /**
     If the view is currently inserted into the DOM of a parent view, this
     property will point to the parent of the view.
@@ -443,7 +471,7 @@ Ember.View = Ember.Object.extend(
         elem = this.$();
         attributeValue = get(this, attributeName);
 
-        Ember.View.applyAttributeBindings(elem, attributeName, attributeValue)
+        Ember.View.applyAttributeBindings(elem, attributeName, attributeValue);
       };
 
       addObserver(this, attributeName, observer);


### PR DESCRIPTION
Added support for Issue [#307]. Replaces pull request [#309]
- view helper now collect the block and context into a yieldContent/yieldContext of the child view
- Introduced a yield helper, that creates a virtual view to delegate to yieldContent
- Changed the logic to determine when to treat blocks as templates. Made it more lazy moving it into the computed property - template.
- Added some basic tests around block invocation and correctness of context at different levels 
