### PR TITLE
Fix a bug in enterState so both initialState *and* start work

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -186,18 +186,26 @@ Ember.StateManager = Ember.State.extend(
         if (log) { console.log("STATEMANAGER: Entering " + state.name); }
         state.enter(stateManager, transition);
       }, function() {
-        var startState = state, enteredState, initialSubstate;
+        var startState = state, enteredState, initialState;
 
-        initialSubstate = get(startState, 'initialSubstate');
+        initialState = get(startState, 'initialState');
 
-        if (!initialSubstate) {
-          initialSubstate = 'start';
+        if (!initialState) {
+          initialState = 'start';
         }
 
         // right now, start states cannot be entered asynchronously
-        while (startState = get(startState, initialSubstate)) {
+        while (startState = get(startState, initialState)) {
           enteredState = startState;
+
+          if (log) { console.log("STATEMANAGER: Entering " + startState.name); }
           startState.enter(stateManager);
+
+          initialState = get(startState, 'initialState');
+
+          if (!initialState) {
+            initialState = 'start';
+          }
         }
 
         set(this, 'currentState', enteredState || state);

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -189,10 +189,10 @@ test("it automatically transitions to a default state specified using the initia
   ok(get(stateManager, 'currentState').isStart, "automatically transitions to beginning state");
 });
 
-test("it automatically transitions to a default substate specified using the initialSubstate property", function() {
+test("it automatically transitions to a default substate specified using the initialState property", function() {
   stateManager = Ember.StateManager.create({
     start: Ember.State.create({
-      initialSubstate: 'beginningSubstate',
+      initialState: 'beginningSubstate',
 
       beginningSubstate: Ember.State.create({
         isStart: true
@@ -201,6 +201,26 @@ test("it automatically transitions to a default substate specified using the ini
   });
 
   ok(get(stateManager, 'currentState').isStart, "automatically transitions to beginning substate");
+});
+
+test("it automatically transitions to multiple substates specified using either start or initialState property", function() {
+  stateManager = Ember.StateManager.create({
+    start: Ember.State.create({
+      initialState: 'beginningSubstate',
+
+      beginningSubstate: Ember.State.create({
+        start: Ember.State.create({
+          initialState: 'finalSubstate',
+
+          finalSubstate: Ember.State.create({
+            isStart: true
+          })
+        })
+      })
+    })
+  });
+
+  ok(get(stateManager, 'currentState').isStart, "automatically transitions to final substate");
 });
 
 test("it reports the view associated with the current view state, if any", function() {


### PR DESCRIPTION
Bug shows up when you have nested substates with a mix of different names provided to initialState and/or named 'start'.

The first time enterState runs it enters the state and then looks to see if that state has an initialState specified. If not it looks for a substate called 'start'. If either exist it enters and then loops to see if that state has an initialState with the same name (either whatever was specified previously or 'start'). The bug is that it only checked the name of initialState the first time. It now checks each time and defaults to 'start' if none was specified.

Fixed name of property for default substate transitions to be initialState instead of initialSubstate. This is clearer and consistent with what the stateManager already uses.

Added a logging statement when entering initialState/start states automatically.
