### PR TITLE
Added support for attributeBinding alias

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -19,8 +19,15 @@ Ember.TextSupport = Ember.Mixin.create(
   placeholder: null,
   disabled: false,
 
+  deleteBackward: Ember.K,
+  insertTab: Ember.K,
   insertNewline: Ember.K,
   cancel: Ember.K,
+  moveLeft: Ember.K,
+  moveUp: Ember.K,
+  moveRight: Ember.K,
+  moveDown: Ember.K,
+  deleteForward: Ember.K,
 
   focusOut: function(event) {
     this._elementValueDidChange();
@@ -52,6 +59,13 @@ Ember.TextSupport = Ember.Mixin.create(
 });
 
 Ember.TextSupport.KEY_EVENTS = {
+  8: 'deleteBackward',
+  9: 'insertTab',
   13: 'insertNewline',
-  27: 'cancel'
+  27: 'cancel',
+  37: 'moveLeft',
+  38: 'moveUp',
+  39: 'moveRight',
+  40: 'moveDown',
+  46: 'deleteForward'
 };

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -105,6 +105,34 @@ test("value binding works properly for inputs that haven't been created", functi
   equals(textField.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
+test("should call the deleteBackward method when delete (backward) key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 8
+  });
+
+  textField.deleteBackward = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes deleteBackward method");
+});
+
+test("should call the insertTab method when tab key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 9
+  });
+
+  textField.insertTab = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes insertTab method");
+});
+
 test("should call the insertNewline method when return key is pressed", function() {
   var wasCalled;
   var event = Ember.Object.create({
@@ -131,6 +159,76 @@ test("should call the cancel method when escape key is pressed", function() {
 
   textField.keyUp(event);
   ok(wasCalled, "invokes cancel method");
+});
+
+test("should call the moveLeft method when arrow left key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 37
+  });
+
+  textField.moveLeft = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes moveLeft method");
+});
+
+test("should call the moveUp method when arrow up key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 38
+  });
+
+  textField.moveUp = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes moveUp method");
+});
+
+test("should call the moveRight method when arrow right key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 39
+  });
+
+  textField.moveRight = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes moveRight method");
+});
+
+test("should call the moveDown method when arrow down key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 40
+  });
+
+  textField.moveDown = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes moveDown method");
+});
+
+test("should call the deleteForward method when delete (forward) key is pressed", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 46
+  });
+
+  textField.deleteForward = function() {
+    wasCalled = true;
+  };
+
+  textField.keyUp(event);
+  ok(wasCalled, "invokes deleteForward method");
 });
 
 // test("listens for focus and blur events", function() {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -69,7 +69,8 @@ Ember.EventDispatcher = Ember.Object.extend(
       dragleave   : 'dragLeave',
       dragover    : 'dragOver',
       drop        : 'drop',
-      dragend     : 'dragEnd'
+      dragend     : 'dragEnd',
+      mousewheel  : 'mouseWheel'
     };
 
     jQuery.extend(events, addedEvents || {});
@@ -150,7 +151,7 @@ Ember.EventDispatcher = Ember.Object.extend(
   _dispatchEvent: function(object, evt, eventName, view) {
     var result = true;
 
-    handler = object[eventName];
+    var handler = object[eventName];
     if (Ember.typeOf(handler) === 'function') {
       result = handler.call(object, evt, view);
       evt.stopPropagation();

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -431,26 +431,35 @@ Ember.View = Ember.Object.extend(
     @param {Ember.RenderBuffer} buffer
   */
   _applyAttributeBindings: function(buffer) {
-    var attributeBindings = get(this, 'attributeBindings'),
-        attributeValue, elem, type;
+    var attributeBindings = get(this, 'attributeBindings');
 
     if (!attributeBindings) { return; }
 
     attributeBindings.forEach(function(attributeName) {
+      var attributeValue, attributeKey, elem, split;
+      
+      // Check if attribute has alias ['key:alias']
+      if (attributeName.match(/:/)) {
+        split = attributeName.split(':');
+        attributeName = split[0]; // attribute key
+        attributeKey = split[1]; // alias
+      } else {
+        attributeKey = attributeName; // attribute key is the same as the attribute name
+      }
+
       // Create an observer to add/remove/change the attribute if the
       // JavaScript property changes.
       var observer = function() {
         elem = this.$();
-        attributeValue = get(this, attributeName);
-
-        Ember.View.applyAttributeBindings(elem, attributeName, attributeValue)
+        attributeValue = get(this, attributeKey);
+        Ember.View.applyAttributeBindings(elem, attributeName, attributeValue);
       };
 
-      addObserver(this, attributeName, observer);
+      addObserver(this, attributeKey, observer);
 
       // Determine the current value and add it to the render buffer
       // if necessary.
-      attributeValue = get(this, attributeName);
+      attributeValue = get(this, attributeKey);
       Ember.View.applyAttributeBindings(buffer, attributeName, attributeValue);
     }, this);
   },
@@ -466,9 +475,10 @@ Ember.View = Ember.Object.extend(
   */
   _classStringForProperty: function(property) {
     var split = property.split(':'),
-        property = split[0],
         className = split[1];
 
+    property = split[0];
+        
     var val = Ember.getPath(this, property);
 
     // If value is a Boolean and true, return the dasherized property

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -38,7 +38,7 @@ test("should render attribute bindings", function() {
 test("should update attribute bindings", function() {
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
-    attributeBindings: ['type', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
+    attributeBindings: ['type', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions', 'value:fieldValue'],
 
     type: 'reset',
     exploded: true,
@@ -47,7 +47,8 @@ test("should update attribute bindings", function() {
     nothing: true,
     notDefined: true,
     notNumber: true,
-    explosions: 15
+    explosions: 15,
+    fieldValue: 'UY$ 1.00'
   });
 
   view.createElement();
@@ -59,6 +60,7 @@ test("should update attribute bindings", function() {
   ok(view.$().attr('notDefined'), "adds notDefined attribute when true");
   ok(view.$().attr('notNumber'), "adds notNumber attribute when true");
   equals(view.$().attr('explosions'), "15", "adds integer attributes");
+  equals(view.$().attr('value'), "UY$ 1.00", "adds value using alias attributes");
 
   view.set('type', 'submit');
   view.set('exploded', false);
@@ -67,6 +69,7 @@ test("should update attribute bindings", function() {
   view.set('nothing', null);
   view.set('notDefined', undefined);
   view.set('notNumber', NaN);
+  view.set('fieldValue', "UY$ 1000.00");
 
   equals(view.$().attr('type'), 'submit', "updates type attribute");
   ok(!view.$().attr('exploded'), "removes exploded attribute when false");
@@ -75,6 +78,7 @@ test("should update attribute bindings", function() {
   ok(!view.$().attr('nothing'), "removes nothing attribute when null");
   ok(!view.$().attr('notDefined'), "removes notDefined attribute when undefined");
   ok(!view.$().attr('notNumber'), "removes notNumber attribute when NaN");
+  ok(!view.$().attr('UY$ 1000.00'), "updates value using alias attribute");
 });
 
 test("should allow attributes to be set in the inBuffer state", function() {


### PR DESCRIPTION
Now can do: attributeBindings: [‘value:fieldValue']
