### PR TITLE
Added childViewsDidChangeElementEnd on containerView

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1328,25 +1328,27 @@ Ember.View.reopen({
   domManagerClass: Ember.Object.extend({
     view: this,
 
-    prepend: function(childView) {
+    prepend: function(childView, fn) {
       var view = get(this, 'view');
 
       childView._insertElementLater(function() {
         var element = view.$();
         element.prepend(childView.$());
+        if ( fn ) { fn(); }
       });
     },
 
-    after: function(nextView) {
+    after: function(nextView, fn) {
       var view = get(this, 'view');
 
       nextView._insertElementLater(function() {
         var element = view.$();
         element.after(nextView.$());
+        if ( fn ) { fn(); }
       });
     },
 
-    replace: function() {
+    replace: function(fn) {
       var view = get(this, 'view');
       var element = get(view, 'element');
 
@@ -1354,16 +1356,18 @@ Ember.View.reopen({
 
       view._insertElementLater(function() {
         Ember.$(element).replaceWith(get(view, 'element'));
+        if ( fn ) { fn(); }
       });
     },
 
-    remove: function() {
+    remove: function(fn) {
       var view = get(this, 'view');
       var elem = get(view, 'element');
 
       set(view, 'element', null);
 
       Ember.$(elem).remove();
+      if ( fn ) { fn(); }
     }
   })
 });

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -53,3 +53,50 @@ test("should be able to observe properties that contain child views", function()
 
   ok(container.get('displayIsDisplayed'), "can bind to child view");
 });
+
+
+test("childViewsDidChangeElementEnd get called when updated the content", function() {
+
+  var container;
+  var isCalled = false;
+
+  container = Ember.ContainerView.create({
+    childViews: ['child'],
+
+    childViewsDidChangeElementEnd: function() {
+      isCalled = true;
+    },
+    child: Ember.View
+
+  });
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  ok(!isCalled, "after being the element inserted in the DOM, the method is NOT called");
+
+
+  var view = Ember.View.create({});
+
+  Ember.run(function() {
+    container.get('childViews').pushObject(view);
+  });
+
+
+
+  ok(isCalled, "when new views are inserted, the method is called");
+
+
+  isCalled = false;
+
+
+  Ember.run(function() {
+    container.get('childViews').popObject();
+    container.get('childViews').popObject();
+  });
+
+  ok(isCalled, "after removing all the elements , the method is called");
+
+
+});


### PR DESCRIPTION
I could not figure out how a ContainerView could also be notified when its new children content has been updated in the DOM.

My use case, is when a containerView (already in the DOM) must be notified that the content of its childViews has been updated because this must get the new $().css info to do any view updates.

This feature implements a **childViewsDidChangeElementEnd** which could be used on the views to do any job based on the updated view.$() element.

By the way, domManagerClass has been extended to support callback functions.

This Pull Request is similar to the requirements on this [issue](https://github.com/emberjs/ember.js/issues/391).
