### PR TITLE
Metamorph's replace now recursively invalidates childView elements

### DIFF
--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -65,6 +65,7 @@ Ember.Metamorph = Ember.Mixin.create({
 
       Ember.run.schedule('render', this, function() {
         if (get(view, 'isDestroyed')) { return; }
+        view.invalidateRecursively('element');
         view._notifyWillInsertElement();
         morph.replaceWith(buffer.string());
         view.transitionTo('inDOM');

--- a/packages/ember-handlebars/tests/views/metamorph_view_test.js
+++ b/packages/ember-handlebars/tests/views/metamorph_view_test.js
@@ -107,6 +107,9 @@ test("a metamorph view can be rerendered", function() {
 });
 
 
+// Redefining without setup/teardown
+module("Metamorph views correctly handle DOM");
+
 test("a metamorph view calls its childrens' willInsertElement and didInsertElement", function(){
   var parentView;
   var willInsertElementCalled = false;
@@ -143,4 +146,36 @@ test("a metamorph view calls its childrens' willInsertElement and didInsertEleme
 
   parentView.destroy();
 
+});
+
+test("replacing a Metamorph should invalidate childView elements", function() {
+  var insertedElement;
+
+  view = Ember.View.create({
+    show: false,
+
+    CustomView: Ember.View.extend({
+      init: function() {
+        this._super();
+        // This will be called in preRender
+        // We want it to cache a null value
+        // Hopefully it will be invalidated when `show` is toggled
+        this.get('element');
+      },
+
+      didInsertElement: function(){
+        insertedElement = this.get('element');
+      }
+    }),
+
+    template: Ember.Handlebars.compile("{{#if show}}{{view CustomView}}{{/if}}")
+  });
+
+  Ember.run(function(){ view.append(); });
+
+  Ember.run(function(){ view.set('show', true); });
+
+  ok(insertedElement, "should have an element");
+
+  view.destroy();
 });


### PR DESCRIPTION
I'm still figuring out how all these internals work, but I think this is a valid bug as well as a valid fix.
