### PR TITLE
Fix for #452 and re-org of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,9 @@
-before_script: sh -e /etc/init.d/xvfb start; bundle exec rackup &
-script: DISPLAY=:99.0 phantomjs tests/qunit/run-qunit.js "http://localhost:9292/tests/index.html?package=all"
+rvm:
+  - 1.9.3
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - bundle exec rackup &
+script:
+  - phantomjs tests/qunit/run-qunit.js "http://localhost:9292/tests/index.html?package=all&extendprototypes=true"
+  - phantomjs tests/qunit/run-qunit.js "http://localhost:9292/tests/index.html?package=all&extendprototypes=true&jquery=1.6.4"

--- a/tests/qunit/run-qunit.js
+++ b/tests/qunit/run-qunit.js
@@ -56,7 +56,7 @@ page.onConsoleMessage = function(msg) {
 page.open(phantom.args[0], function(status) {
   if (status !== "success") {
     console.log("Unable to access network");
-    phantom.exit();
+    phantom.exit(1);
   } else {
     waitFor(function() {
       return page.evaluate(function() {


### PR DESCRIPTION
Fix for #452

re-org .travis.yml and fix run-qunit.js to return 1 on network failure, also enable extendprototypes=true and add test for jQuery 1.6.4
