### PR TITLE
update doc for ArrayController

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -26,9 +26,9 @@ require('ember-runtime/system/array_proxy');
 
   Then, create a view that binds to your new controller:
 
-    {{#collection contentBinding="MyApp.listController"}}
-      {{content.firstName}} {{content.lastName}}
-    {{/collection}}
+    {{#each MyApp.listController}}
+      {{firstName}} {{lastName}}
+    {{/each}}
 
   The advantage of using an array controller is that you only have to set up
   your view bindings once; to change what's displayed, simply swap out the


### PR DESCRIPTION
The example for `ArrayController` uses `{{#collection}}` in the template.

Since it looks like `each` and I using `collection` made me run into [an issue](http://stackoverflow.com/questions/9234401/collection-using-contentbinding-does-not-automatically-update-when-rendering-in), I updated the doc to use `each`.
