### PR TITLE
Collection Helper: itemHash bindings should be resolved in the proper context

### DIFF
--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -90,7 +90,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
     delete hash.preserveContext;
   }
 
-  hash.itemViewClass = Ember.Handlebars.ViewHelper.viewClassFromHTMLOptions(itemViewClass, itemHash);
+  hash.itemViewClass = Ember.Handlebars.ViewHelper.viewClassFromHTMLOptions(itemViewClass, itemHash, this);
 
   return Ember.Handlebars.helpers.view.call(this, collectionClass, options);
 });

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -229,6 +229,37 @@ test("should give its item views the classBinding specified by itemClassBinding"
   equals(view.$('ul li.is-baz').length, 2, "removes class when property changes");
 });
 
+test("should give its item views the property specified by itemPropertyBinding", function() {
+  TemplateTests.itemPropertyBindingTestItemView = Ember.View.extend({
+    tagName: 'li'
+  });
+
+  // Use preserveContext=false so the itemView handlebar context is the view context
+  // Set itemView bindings using item*
+  var view = Ember.View.create({
+    baz: "baz",
+    content: Ember.A([Ember.Object.create(), Ember.Object.create(), Ember.Object.create()]),
+    template: Ember.Handlebars.compile('{{#collection contentBinding="content" tagName="ul" itemViewClass="TemplateTests.itemPropertyBindingTestItemView" itemPropertyBinding="baz" preserveContext=false}}{{property}}{{/collection}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('ul li').length, 3, "adds 3 itemView");
+
+  view.$('ul li').each(function(i, li){
+    console.log( li)
+    equals($(li).text(), "baz", "creates the li with the property = baz");
+  })
+
+  Ember.run(function() {
+    setPath(view, 'baz', "yobaz");
+  });
+
+  equals(view.$('ul li:first').text(), "yobaz", "change property of sub view");
+});
+
 test("should work inside a bound {{#if}}", function() {
   var testData = Ember.A([Ember.Object.create({ isBaz: false }), Ember.Object.create({ isBaz: true }), Ember.Object.create({ isBaz: true })]);
   TemplateTests.ifTestCollectionView = Ember.CollectionView.extend({


### PR DESCRIPTION
The 3rd argument to Ember.Handlebars.ViewHelper.viewClassFromHTMLOptions was missing...
