### PR TITLE
Collection view helper doesn't honor emptyViewClass attribute

### DIFF
--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -73,7 +73,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
     var emptyViewClass = Ember.View;
 
     if (hash.emptyViewClass) {
-      emptyViewClass = Ember.View.detect(emptyViewClass) ?
+      emptyViewClass = Ember.View.detect(hash.emptyViewClass) ?
                           hash.emptyViewClass : getPath(this, hash.emptyViewClass);
     }
 

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -95,6 +95,41 @@ test("empty views should be removed when content is added to the collection (reg
   Ember.run(function(){ window.App.destroy(); });
 });
 
+test("collection helper should accept emptyViewClass attribute", function() {
+  window.App = Ember.Application.create();
+
+  App.EmptyView = Ember.View.extend({
+    classNames: ['empty']
+  });
+
+  App.ListController = Ember.ArrayProxy.create({
+    content : Ember.A()
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#collection emptyViewClass="App.EmptyView" contentBinding="App.ListController" tagName="table"}} <td>{{content.title}}</td> {{/collection}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('tr').length, 0, 'emptyViewClass has no effect without inverse');
+  view.remove();
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#collection emptyViewClass="App.EmptyView" contentBinding="App.ListController" tagName="table"}} <td>{{content.title}}</td> {{else}} <td>No Rows Yet</td> {{/collection}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equals(view.$('tr').hasClass('empty'), 1, 'if emptyViewClass is given it is used for inverse');
+
+  Ember.run(function(){ window.App.destroy(); });
+});
+
 test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {
   TemplateTests.CollectionTestView = Ember.CollectionView.extend({
     tagName: 'ul',


### PR DESCRIPTION
I'm not sure if the test demonstrates the ideal behavior, but there is definitely a bug that makes `emptyViewClass` useless right now. Wouldn't it also make sense to allow `emptyViewClass` even when not rendering an `{{else}}` block? Then you could render a view that has a template set. The first check in the test demonstrates how it is now, but I think that it should actually render the view even without an inverse if a template property were set on the view (like in the test that precedes it).
