### PR TITLE
The action helper should not trigger events for children of disabled buttons

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -10,6 +10,7 @@ ActionHelper.registerAction = function(actionName, eventName, target, view, cont
 
   function handler(event) {
     if (Ember.$(event.target).closest('[data-ember-action]').attr('data-ember-action') === actionId) {
+      if (Ember.$(event.target).closest('button:disabled').size()) return false;
       event.preventDefault();
 
       if ('function' === typeof target.send) {

--- a/packages/ember-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-handlebars/tests/helpers/action_test.js
@@ -146,6 +146,30 @@ test("should wrap an existing event handler on the parent view", function() {
   ok(originalEventHandlerWasCalled, "The parent view's event handler was called");
 });
 
+test("should not bubble events originating in children of a disabled button", function() {
+  var eventHandlerWasCalled = false;
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<button {{action "edit"}} {{bindAttr disabled="isDisabled"}}><span>click me</span></button>'),
+    isDisabled: false,
+    edit: function() { eventHandlerWasCalled = true; return false; }
+  });
+
+  appendView();
+
+  view.$('span').trigger('click');
+  ok(eventHandlerWasCalled, "The event handler was called");
+
+  eventHandlerWasCalled = false;
+  view.set('isDisabled', true);
+
+  view.rerender();
+  Ember.run.end();
+
+  view.$('span').trigger('click');
+  ok(!eventHandlerWasCalled, "The event handler wasn't called");
+});
+
 test("should be able to use action more than once for the same event within a view", function() {
   var editWasCalled = false,
       deleteWasCalled = false,


### PR DESCRIPTION
Events shouldn't be triggered if they originate from within a disabled button, which follows jQuery convention. Coincidentally, this was broken in 1.7.1 when using the `.on()` function (fixed in https://github.com/jquery/jquery/commit/8d9025ca50603e5404c6b50f7fa6c87046ee24c1) but `delegate()` seems to be doing the right thing for us here.
