### PR TITLE
Allow attributeBindings to be aliased.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -472,21 +472,25 @@ Ember.View = Ember.Object.extend(
 
     if (!attributeBindings) { return; }
 
-    attributeBindings.forEach(function(attributeName) {
+    attributeBindings.forEach(function(binding) {
+      var split = binding.split(':'),
+          property = split[0],
+          attributeName = split[1] || property;
+
       // Create an observer to add/remove/change the attribute if the
       // JavaScript property changes.
       var observer = function() {
         elem = this.$();
-        attributeValue = get(this, attributeName);
+        attributeValue = get(this, property);
 
         Ember.View.applyAttributeBindings(elem, attributeName, attributeValue);
       };
 
-      addObserver(this, attributeName, observer);
+      addObserver(this, property, observer);
 
       // Determine the current value and add it to the render buffer
       // if necessary.
-      attributeValue = get(this, attributeName);
+      attributeValue = get(this, property);
       Ember.View.applyAttributeBindings(buffer, attributeName, attributeValue);
     }, this);
   },

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -23,9 +23,10 @@ module("Ember.View - Attribute Bindings", {
 test("should render attribute bindings", function() {
   view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
-    attributeBindings: ['type', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
+    attributeBindings: ['type', 'isDisabled:disabled', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
 
     type: 'submit',
+    isDisabled: true,
     exploded: false,
     destroyed: false,
     exists: true,
@@ -36,7 +37,8 @@ test("should render attribute bindings", function() {
 
   view.createElement();
 
-  equal(view.$().attr('type'), 'submit', "updates type attribute");
+  equals(view.$().attr('type'), 'submit', "updates type attribute");
+  ok(view.$().attr('disabled'), "supports customizing attribute name for Boolean values");
   ok(!view.$().attr('exploded'), "removes exploded attribute when false");
   ok(!view.$().attr('destroyed'), "removes destroyed attribute when false");
   ok(view.$().attr('exists'), "adds exists attribute when true");
@@ -48,9 +50,10 @@ test("should render attribute bindings", function() {
 test("should update attribute bindings", function() {
   view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
-    attributeBindings: ['type', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
+    attributeBindings: ['type', 'isDisabled:disabled', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
 
     type: 'reset',
+    isDisabled: true,
     exploded: true,
     destroyed: true,
     exists: false,
@@ -61,7 +64,9 @@ test("should update attribute bindings", function() {
   });
 
   view.createElement();
-  equal(view.$().attr('type'), 'reset', "adds type attribute");
+
+  equals(view.$().attr('type'), 'reset', "adds type attribute");
+  ok(view.$().attr('disabled'), "adds disabled attribute when true");
   ok(view.$().attr('exploded'), "adds exploded attribute when true");
   ok(view.$().attr('destroyed'), "adds destroyed attribute when true");
   ok(!view.$().attr('exists'), "does not add exists attribute when false");
@@ -71,6 +76,7 @@ test("should update attribute bindings", function() {
   equal(view.$().attr('explosions'), "15", "adds integer attributes");
 
   view.set('type', 'submit');
+  view.set('isDisabled', false);
   view.set('exploded', false);
   view.set('destroyed', false);
   view.set('exists', true);
@@ -78,7 +84,8 @@ test("should update attribute bindings", function() {
   view.set('notDefined', undefined);
   view.set('notNumber', NaN);
 
-  equal(view.$().attr('type'), 'submit', "updates type attribute");
+  equals(view.$().attr('type'), 'submit', "updates type attribute");
+  ok(!view.$().attr('disabled'), "removes disabled attribute when false");
   ok(!view.$().attr('exploded'), "removes exploded attribute when false");
   ok(!view.$().attr('destroyed'), "removes destroyed attribute when false");
   ok(view.$().attr('exists'), "adds exists attribute when true");


### PR DESCRIPTION
**Use case:** I want to use descriptive properties in the view but alias them on the element.

``` javascript
attributeBindings: ['isDisabled:disabled'],
isDisabled: true
```
