### PR TITLE
ArrayProxy expects content to be an Ember array, so it probably shouldn't be null

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -32,7 +32,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
 
     @property {Ember.Array}
   */
-  content: null,
+  content: Ember.A(),
 
   /**
     Should actually retrieve the object at the specified index from the


### PR DESCRIPTION
Ran into this the other day when trying to push objects to an ArrayProxy without first setting content to an array. This should just work right out of the box.
