### PR TITLE
Faster Handlebars bindings for single properties

### DIFF
--- a/packages/ember-handlebars/lib/views/bindable_span.js
+++ b/packages/ember-handlebars/lib/views/bindable_span.js
@@ -15,8 +15,9 @@ require('ember-handlebars/views/metamorph_view');
   @private
   @class
 
-  Ember._BindableSpanView is a private view created by the Handlebars `{{bind}}`
-  helpers that is used to keep track of bound properties.
+  Ember._BindableSpanView is a private view created by the Handlebars helpers
+  that do not want to have a wrapping tag. Examples include `{{#if}}` and
+  `{{#each}}`.
 
   Every time a property is bound using a `{{mustache}}`, an anonymous subclass
   of Ember._BindableSpanView is created with the appropriate sub-template and

--- a/packages/ember-handlebars/lib/views/bound_property_view.js
+++ b/packages/ember-handlebars/lib/views/bound_property_view.js
@@ -1,0 +1,51 @@
+// ==========================================================================
+// Project:   Ember Handlebar Views
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+/*globals Handlebars */
+
+var getPath = Ember.getPath;
+
+require('ember-views/views/view');
+require('ember-handlebars/views/metamorph_view');
+
+/**
+  @ignore
+  @private
+  @class
+
+  Ember._BoundPropertyView is a private view created by the Handlebars `{{bind}}`
+  helper that is used to keep track of bound properties.
+*/
+Ember._BoundPropertyView = Ember.View.extend(Ember.Metamorph,
+/** @scope Ember._BoundPropertyView.prototype */{
+
+  context: null,
+  property: null,
+
+  propertyValue: function() {
+    var value = getPath(this.context, this.property);
+    if (this.isEscaped) { value = Handlebars.Utils.escapeExpression(value); }
+    return value;
+  },
+
+  render: function(buffer) {
+    buffer.push(this.propertyValue());
+  },
+
+  propertyDidChange: function() {
+    if (this.morph.isRemoved()) { return; }
+    this.morph.html(this.propertyValue());
+  },
+
+  didInsertElement: function() {
+    this.propertyDidChange();
+  },
+
+  init: function() {
+    this._super();
+    Ember.addObserver(this.context, this.property, this, 'propertyDidChange');
+  }
+
+});


### PR DESCRIPTION
Handlebars bindings support allows for complex situations. When just
rendering a single property we can use a faster path.
