### PR TITLE
Fix jQuery.extend for older browsers - fixes #344

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -150,6 +150,8 @@ var EMPTY_META = {
 
 if (Object.freeze) Object.freeze(EMPTY_META);
 
+var createMeta = Ember.platform.defineProperty.isSimulated ? o_create : function(meta) { return meta; };
+
 /**
   @private
   @function
@@ -178,26 +180,27 @@ Ember.meta = function meta(obj, writable) {
 
   if (!ret) {
     o_defineProperty(obj, META_KEY, META_DESC);
-    ret = obj[META_KEY] = {
+    ret = obj[META_KEY] = createMeta({
       descs: {},
       watching: {},
       values: {},
       lastSetValues: {},
       cache:  {},
       source: obj
-    };
+    });
 
     // make sure we don't accidentally try to create constructor like desc
     ret.descs.constructor = null;
 
   } else if (ret.source !== obj) {
-    ret = obj[META_KEY] = o_create(ret);
+    ret = o_create(ret);
     ret.descs    = o_create(ret.descs);
     ret.values   = o_create(ret.values);
     ret.watching = o_create(ret.watching);
     ret.lastSetValues = {};
     ret.cache    = {};
     ret.source   = obj;
+    ret = obj[META_KEY] = createMeta(ret);
   }
   return ret;
 };

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -40,3 +40,18 @@ test("getMeta and setMeta", function() {
   Ember.setMeta(obj, 'foo', "bar");
   equal(Ember.getMeta(obj, 'foo'), "bar", "foo property on meta now exists");
 });
+
+if (window.jQuery) {
+  // Tests fix for https://github.com/emberjs/ember.js/issues/344
+  // This is primarily for older browsers such as IE8
+  // We would use NativeArray but it's not defined in metal
+  test("jQuery.extend works on an extended Array", function() {
+    var mixin = Ember.Mixin.create({ prop: 'val' })
+        array = mixin.apply([1,2,3]),
+        result = {};
+
+    jQuery.extend(true, result, { arr: array });
+
+    equals(result.arr.length, 3);
+  });
+}


### PR DESCRIPTION
My only concern with this is possible performance. In newer browsers it just adds one extra essentially empty function call which should be ok. I just figured that someone else should double check.
