### PR TITLE
Clone exit states before reversing

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -191,7 +191,7 @@ Ember.StateManager = Ember.State.extend(
 
     var stateManager = this;
 
-    exitStates.reverse();
+    exitStates = exitStates.slice(0).reverse();
     this.asyncEach(exitStates, function(state, transition) {
       state.exit(stateManager, transition);
     }, function() {

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -329,6 +329,29 @@ test("it sends exit events in the correct order when changing to a top-level sta
   equal(exitOrder[1], 'exitedOuter', "outer exit is called second");
 });
 
+test("it sends exit events in the correct order when changing to a state multiple times", function() {
+  var exitOrder = [],
+      stateManager = Ember.StateManager.create({
+        start: Ember.State.create({
+          outer: Ember.State.create({
+            inner: Ember.State.create({
+              exit: function() { exitOrder.push('exitedInner'); }
+            }),
+            exit: function() { exitOrder.push('exitedOuter'); }
+          })
+        })
+      });
+
+  stateManager.goToState('start.outer.inner');
+  stateManager.goToState('start');
+  stateManager.goToState('start.outer.inner');
+  exitOrder = []
+  stateManager.goToState('start');
+  equal(exitOrder.length, 2, "precond - it calls both exits");
+  equal(exitOrder[0], 'exitedInner', "inner exit is called first");
+  equal(exitOrder[1], 'exitedOuter', "outer exit is called second");
+});
+
 var passedContext, loadingEventCalled, loadedEventCalled, eventInChildCalled;
 loadingEventCalled = loadedEventCalled = eventInChildCalled = 0;
 


### PR DESCRIPTION
If I enter the same state multiple times, exiting states are called in the wrong order every other time (2nd time, 4th time, etc.)

This appears to be because reversing the `exitStates` parameter in `enterState` is also reversing the cached copy. This pull request clones the array before reversing it.

Tests included.
