### PR TITLE
Improve error handling for not allowed set of View#elementId

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -721,7 +721,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   }).cacheable(),
 
   /** @private */
-  _elementIdDidChange: Ember.observer(function() {
+  _elementIdDidChange: Ember.beforeObserver(function() {
     throw "Changing a view's elementId after creation is not allowed.";
   }, 'elementId'),
 

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -76,4 +76,6 @@ test("should not allow the elementId to be changed", function() {
   raises(function() {
     view.set('elementId', 'two');
   }, /Changing a view's elementId after creation is not allowed./, "raises elementId changed exception");
+
+  equal(view.get('elementId'), 'one', 'elementId is still "one"');
 });


### PR DESCRIPTION
Implement error handling for a not allowed set of elementId property on a view in a beforeObserver instead of a normal observer. Raising an error sooner prevents the actual change of the elementId.

This adresses change made in 286b7b008b7039d116a7bcf6d90ee5e3cfc71d90 which anon adresses #425
