### PR TITLE
Stash view and context on event object in action handler

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -12,10 +12,13 @@ ActionHelper.registerAction = function(actionName, eventName, target, view, cont
   ActionHelper.registeredActions[actionId] = {
     eventName: eventName,
     handler: function(event) {
+      event.view = view;
+      event.context = context;
+
       if ('function' === typeof target.send) {
-        return target.send(actionName, { view: view, event: event, context: context });
+        return target.send(actionName, { event: event });
       } else {
-        return target[actionName].call(target, view, event, context);
+        return target[actionName].call(target, event);
       }
     }
   };

--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -16,7 +16,7 @@ ActionHelper.registerAction = function(actionName, eventName, target, view, cont
       event.context = context;
 
       if ('function' === typeof target.send) {
-        return target.send(actionName, { event: event });
+        return target.send(actionName, event);
       } else {
         return target[actionName].call(target, event);
       }

--- a/packages/ember-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-handlebars/tests/helpers/action_test.js
@@ -272,11 +272,9 @@ test("should send the view, event and current Handlebars context to the action",
   var passedContext;
 
   var aTarget = Ember.View.create({
-    edit: function(view, event, context) {
+    edit: function(event) {
       passedTarget = this;
-      passedView = view;
       passedEvent = event;
-      passedContext = context;
     }
   });
 
@@ -292,8 +290,8 @@ test("should send the view, event and current Handlebars context to the action",
   view.$('#edit').trigger('click');
 
   strictEqual(passedTarget, aTarget, "the action is called with the target as this");
-  strictEqual(passedView, view, "the view passed is the view containing the action helper");
-  deepEqual(passedContext, aContext, "the context passed is the context surrounding the action helper");
+  strictEqual(passedEvent.view, view, "the view passed is the view containing the action helper");
+  deepEqual(passedEvent.context, aContext, "the context passed is the context surrounding the action helper");
   equal(passedEvent.type, 'click', "the event passed is the event triggered for the action helper");
 });
 


### PR DESCRIPTION
Event handlers should be consistent, whether they're set up as standard [event listeners for views](https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/system/event_dispatcher.js#L36-73) or they're handlers for action helpers.

By stashing the `view` and `context` on the `event` object, we can pass `event` as the one and only argument to  handlers for action helpers. This meta-data might prove useful if, say, a different view has been targeted than the current one. 

For instance, the following action helper:

```
<a href="#" {{action "editRow" target="parentView"}}>Edit</a>
```

...could have this handler:

```
App.ListingView = Ember.View.extend({
  templateName: 'listing',

  editRow: function(event) {
    event.view.set('isEditing', true);
  }
});
```

I think this is much easier to remember and use than the order of the parameters currently passed: `view, event, context`.
