### PR TITLE
add "elementId" support with "data-element-id" attribut in "script" tag of handlebars type at handlebars bootstrap

### DIFF
--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -36,7 +36,8 @@ Ember.Handlebars.bootstrap = function(ctx) {
       // Get the name of the script, used by Ember.View's templateName property.
       // First look for data-template-name attribute, then fall back to its
       // id if no name is found.
-      templateName = script.attr('data-template-name') || script.attr('id'),
+      templateName = script.attr('data-template-name'),
+      elementId = script.attr('data-element-id'),
       template = compile(script.html()),
       view, viewPath, tagName;
 
@@ -68,6 +69,7 @@ Ember.Handlebars.bootstrap = function(ctx) {
       tagName = script.attr('data-tag-name');
 
       view = view.create({
+        elementId: elementId,
         template: template,
         tagName: (tagName) ? tagName : undefined
       });


### PR DESCRIPTION
removing "|| script.attr('id');' for templateName variable because setting "id" directly in "script" tag cause silent error so the attribut "id" can't be properly used.
