### PR TITLE
Allow setting breakpoints in the error-throwing line of ember_assert

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -35,7 +35,9 @@ require("ember-metal");
 */
 window.ember_assert = window.sc_assert = function ember_assert(desc, test) {
   if ('function' === typeof test) test = test()!==false;
-  if (!test) throw new Error("assertion failed: "+desc);
+  if (!test){
+    throw new Error("assertion failed: "+desc);
+  }
 };
 
 


### PR DESCRIPTION
When ember_assert throws an error, I need to see stacktrace to identify the error. This commit splits the single line if statement to 3 lines and lets developers set a breakpoint to the line that throws the errors. 
