### PR TITLE
add replace to Ember.View

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -647,6 +647,27 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
+    Replaces the given element with this view's element.
+    
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to replace the element; the DOM
+    element will not be added until all bindings have
+    finished synchronizing
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {Ember.View} received
+  */
+  replace: function(target) {
+    this._insertElementLater(function() {
+      Ember.$(target).replaceWith(this.$());
+    });
+
+    return this;
+  },
+
+  /**
     Replaces the view's element to the specified parent element.
     If the view does not have an HTML representation yet, `createElement()`
     will be called automatically.

--- a/packages/ember-views/tests/views/view/replace_test.js
+++ b/packages/ember-views/tests/views/view/replace_test.js
@@ -1,0 +1,47 @@
+// ==========================================================================
+// Project:   Ember Views
+// Copyright: ©2006-2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var set = Ember.set, get = Ember.get;
+
+var View, view, willDestroyCalled, childView;
+
+module("Ember.View - replace()", {
+  setup: function() {
+    View = Ember.View.extend({});
+  },
+
+  teardown: function() {
+    view.destroy();
+  }
+});
+
+test('should replace the specified element', function(){
+  Ember.$("#qunit-fixture").html('<div class="header"></div>');
+
+  view = View.create();
+
+  ok(!get(view, 'element'), "precond - should not have an element");
+
+  Ember.run(function() {
+    view.replace('.header');
+  });
+
+  var viewElem = Ember.$('#qunit-fixture').children();
+  ok(viewElem.length > 0, "creates and replaces the view's element");
+});
+
+test('should replace nothing when specified element does not exist', function(){
+  view = View.create();
+
+  ok(!get(view, 'element'), "precond - should not have an element");
+
+  Ember.run(function() {
+    view.replace('.not-existing-element');
+  });
+
+  var viewElem = Ember.$('#qunit-fixture').children();
+  ok(viewElem.length === 0, "is not added when the element which shall be replaces does not exist");
+});


### PR DESCRIPTION
This allows the replacement of an already existing (placeholder) element in DOM. Inspired by http://stackoverflow.com/questions/9617789/create-ember-view-from-a-jquery-object
