### PR TITLE
add Ember.Binding#notNull to mixin

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -630,6 +630,15 @@ mixinProperties(Binding,
   },
 
   /**
+    @see Ember.Binding.prototype.notNull
+  */
+  notNull: function(from, placeholder) {
+    var C = this, binding = new C(null, from);
+    return binding.notNull(placeholder);
+  },
+
+
+  /**
     @see Ember.Binding.prototype.bool
   */
   bool: function(from) {


### PR DESCRIPTION
Sorry if those Pull Request are not combined, but I am reading threw the code because I'm writing a blog post about Binding's and I thought the one case where a method was missing would have been the only one...
