### PR TITLE
add from parameter to Ember.Binding#transform

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -616,8 +616,8 @@ mixinProperties(Binding,
   /**
     @see Ember.Binding.prototype.transform
   */
-  transform: function(func) {
-    var C = this, binding = new C();
+  transform: function(from, func) {
+    var C = this, binding = new C(null, from);
     return binding.transform(func);
   },
 


### PR DESCRIPTION
This allows to create a binding via `Ember.Binding.transform('value', function(value){...})` instead of `Ember.Binding.from('value').transform(function(value){...})`
