### PR TITLE
Add additional view insert methods

### DIFF
--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -8,7 +8,6 @@
 require("ember-views/system/event_dispatcher");
 
 var get = Ember.get, set = Ember.set;
-var indexOf = Ember.ArrayUtils.indexOf;
 
 /**
   @class

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -8,6 +8,7 @@
 require("ember-views/system/event_dispatcher");
 
 var get = Ember.get, set = Ember.set;
+var indexOf = Ember.ArrayUtils.indexOf;
 
 /**
   @class
@@ -62,15 +63,21 @@ Ember.Application = Ember.Namespace.extend(
 
   /** @private */
   init: function() {
+    this._super();
+    
     var eventDispatcher,
         rootElement = get(this, 'rootElement');
-    this._super();
 
     eventDispatcher = Ember.EventDispatcher.create({
       rootElement: rootElement
     });
 
     set(this, 'eventDispatcher', eventDispatcher);
+
+    if (!get(Ember, 'defaultApplication') || get(this, 'isDefaultApplication')) {
+      set(Ember, 'defaultApplication', this);
+    }
+		Ember.Application.APPLICATIONS.push(this);
 
     // jQuery 1.7 doesn't call the ready callback if already ready
     if (Ember.$.isReady) {
@@ -102,8 +109,17 @@ Ember.Application = Ember.Namespace.extend(
   /** @private */
   destroy: function() {
     get(this, 'eventDispatcher').destroy();
+    if (get(Ember, 'defaultApplication') === this) {
+      var applications = Ember.Application.APPLICATIONS;
+      applications.splice(indexOf(applications, this), 1);
+      if (applications.length > 0) {
+        set(Ember, 'defaultApplication', applications[0]);
+      } else {
+        set(Ember, 'defaultApplication', undefined);
+      }
+    }
     return this._super();
   }
 });
 
-
+Ember.Application.APPLICATIONS = [];

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -39,6 +39,8 @@ var indexOf = Ember.ArrayUtils.indexOf;
 Ember.Application = Ember.Namespace.extend(
 /** @scope Ember.Application.prototype */{
 
+  isApplication: true,
+
   /**
     The root DOM element of the Application.
 
@@ -64,7 +66,7 @@ Ember.Application = Ember.Namespace.extend(
   /** @private */
   init: function() {
     this._super();
-    
+
     var eventDispatcher,
         rootElement = get(this, 'rootElement');
 
@@ -77,7 +79,6 @@ Ember.Application = Ember.Namespace.extend(
     if (!get(Ember, 'defaultApplication') || get(this, 'isDefaultApplication')) {
       set(Ember, 'defaultApplication', this);
     }
-		Ember.Application.APPLICATIONS.push(this);
 
     // jQuery 1.7 doesn't call the ready callback if already ready
     if (Ember.$.isReady) {
@@ -110,16 +111,15 @@ Ember.Application = Ember.Namespace.extend(
   destroy: function() {
     get(this, 'eventDispatcher').destroy();
     if (get(Ember, 'defaultApplication') === this) {
-      var applications = Ember.Application.APPLICATIONS;
-      applications.splice(indexOf(applications, this), 1);
-      if (applications.length > 0) {
-        set(Ember, 'defaultApplication', applications[0]);
-      } else {
-        set(Ember, 'defaultApplication', undefined);
+      var applications = Ember.Namespace.NAMESPACES;
+      var nextApp;
+      // get next Ember.Application which is not this one
+      for (var i=0, len = applications.length; i < len && !nextApp; i++) {
+        var app = applications[i];
+        if (app.isApplication && app !== this) { nextApp = app; }
       }
+      set(Ember, 'defaultApplication', nextApp);
     }
     return this._super();
   }
 });
-
-Ember.Application.APPLICATIONS = [];

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -38,8 +38,6 @@ var get = Ember.get, set = Ember.set;
 Ember.Application = Ember.Namespace.extend(
 /** @scope Ember.Application.prototype */{
 
-  isApplication: true,
-
   /**
     The root DOM element of the Application.
 
@@ -115,7 +113,7 @@ Ember.Application = Ember.Namespace.extend(
       // get next Ember.Application which is not this one
       for (var i=0, len = applications.length; i < len && !nextApp; i++) {
         var app = applications[i];
-        if (app.isApplication && app !== this) { nextApp = app; }
+        if (Ember.Application.detectInstance(app) && app !== this) { nextApp = app; }
       }
       set(Ember, 'defaultApplication', nextApp);
     }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -679,6 +679,128 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
+    Inserts the view's element and invokes the given `callback` when the view is ready
+    to be added to DOM. It's the callback's responsibility to actually add the view to
+    the DOM. The view's element can be retrieved via `this.$()` inside the callback.
+
+    For example you would add the view to the element with #body id like this:
+      
+        view.insertView(function(){ this.$().appendTo('#body'); });
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing.
+
+    @param {Function} A callback which is invoked when the view shall be added to DOM
+    @returns {Ember.View} receiver
+  */
+  insertView: function(callback) {
+    if (Ember.none(callback)) {
+      return this.append();
+    }
+  
+    this._insertElementLater(callback);
+    return this;
+  },
+
+  /**
+    Replaces the specified target element with the view's element.
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing.
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {Ember.View} receiver
+  */
+  replaceWith: function(target) {
+    return this.insertView(function(){
+      Ember.$(target).replaceWith(this.$());
+    });
+  },
+
+  /**
+    Inserts the view's element before the specified target element.
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing.
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {Ember.View} receiver
+  */
+  insertBefore: function(target) {
+    return this.insertView(function(){
+      this.$().insertBefore(target);
+    });
+  },
+
+  /**
+    Inserts the view's element after the specified target element.
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing.
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {Ember.View} receiver
+  */
+  insertAfter: function(target) {
+    return this.insertView(function(){
+      this.$().insertAfter(target);
+    });
+  },
+
+  /**
+    Prepends the view's element to the document body.
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing.
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {Ember.View} receiver
+  */
+  prepend: function(application) {
+    var prependToElement = this.getRootElement(application);
+    return this.prependTo( prependToElement );
+  },
+
+  /**
+    Prepends the view's element to the specified target element.
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Note that this method just schedules the view to be appended; the DOM
+    element will not be appended to the given element until all bindings have
+    finished synchronizing.
+
+    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @returns {Ember.View} receiver
+  */
+  prependTo: function(target) {
+    return this.insertView(function(){
+      this.$().prependTo(target);
+    });
+  },
+
+  /**
     Appends the view's element to the specified parent element.
 
     If the view does not have an HTML representation yet, `createElement()`
@@ -692,13 +814,9 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @returns {Ember.View} receiver
   */
   appendTo: function(target) {
-    // Schedule the DOM element to be created and appended to the given
-    // element after bindings have synchronized.
-    this._insertElementLater(function() {
+    return this.insertView(function() {
       this.$().appendTo(target);
     });
-
-    return this;
   },
 
   /**
@@ -715,12 +833,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @returns {Ember.View} received
   */
   replaceIn: function(target) {
-    this._insertElementLater(function() {
+    return this.insertView(function() {
       Ember.$(target).empty();
       this.$().appendTo(target);
     });
-
-    return this;
   },
 
   /**
@@ -759,10 +875,15 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @returns {Ember.View} receiver
   */
   append: function(application) {
+    var appendToElement = this.getRootElement(application);
+    return this.appendTo( appendToElement );
+  },
+
+  getRootElement: function(application) {
     var appendToElement = document.body;
     if (!application) { application = Ember.get('defaultApplication'); }
     if (application) { appendToElement = application.get('rootElement'); }
-    return this.appendTo( appendToElement );
+    return appendToElement;
   },
 
   /**

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -766,6 +766,11 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   /**
     Prepends the view's element to the document body.
 
+    If an appliction is passed, the view is appended to its' `rootElement`.
+    If no appliction is passed, the `rootElement` of the default application
+    - set as Ember.defaultApplication - is used. If no application is available
+    `document.body` is used.
+
     If the view does not have an HTML representation yet, `createElement()`
     will be called automatically.
 
@@ -773,11 +778,11 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     element will not be appended to the given element until all bindings have
     finished synchronizing.
 
-    @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
+    @param {Ember.Application} (optional) application, this view shall be prepended to
     @returns {Ember.View} receiver
   */
   prepend: function(application) {
-    var prependToElement = this.getRootElement(application);
+    var prependToElement = this._getRootElement(application);
     return this.prependTo( prependToElement );
   },
 
@@ -864,22 +869,37 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   },
 
   /**
-    Appends the view's element to the document body. If the view does
-    not have an HTML representation yet, `createElement()` will be called
-    automatically.
+    Appends the view's element to the document body.
+
+    If an appliction is passed, the view is appended to its' `rootElement`.
+    If no appliction is passed, the `rootElement` of the default application
+    - set as Ember.defaultApplication - is used. If no application is available
+    `document.body` is used.
+
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
 
     Note that this method just schedules the view to be appended; the DOM
     element will not be appended to the document body until all bindings have
     finished synchronizing.
 
+    @param {Ember.Application} (optional) application, this view shall be prepended to
     @returns {Ember.View} receiver
   */
   append: function(application) {
-    var appendToElement = this.getRootElement(application);
+    var appendToElement = this._getRootElement(application);
     return this.appendTo( appendToElement );
   },
 
-  getRootElement: function(application) {
+  /**
+    @private
+
+    Get the `rootElement` of specified Ember.Application. If the application
+    is undefined, the `rootElement` of the default application - set as
+    Ember.defaultApplication - is returned. If no Ember.Application is available,
+    document.body is returned.
+  */
+  _getRootElement: function(application) {
     var appendToElement = document.body;
     if (!application) { application = Ember.get('defaultApplication'); }
     if (application) { appendToElement = application.get('rootElement'); }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -758,8 +758,11 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     @returns {Ember.View} receiver
   */
-  append: function() {
-    return this.appendTo(document.body);
+  append: function(application) {
+    var appendToElement = document.body;
+    if (!application) { application = Ember.get('defaultApplication'); }
+    if (application) { appendToElement = application.get('rootElement'); }
+    return this.appendTo( appendToElement );
   },
 
   /**

--- a/packages/ember-views/tests/system/application_test.js
+++ b/packages/ember-views/tests/system/application_test.js
@@ -68,7 +68,9 @@ module("Ember#defaultApplication", {
   setup: function() {
     Ember.$("#qunit-fixture").html("<div class='first' ></div><div class='second' ></div>");
     Ember.run(function() { set(Ember, 'defaultApplication', undefined); });
-    Ember.Application.APPLICATIONS = [];
+
+    // reset Ember.Namespace because it's polluted by Applications of other tests
+    Ember.Namespace.NAMESPACES = [Ember];
   },
 
   teardown: function() {
@@ -80,7 +82,6 @@ module("Ember#defaultApplication", {
     }
 
     Ember.run(function() { set(Ember, 'defaultApplication', undefined); });
-    Ember.Application.APPLICATIONS = [];
   }
 });
 

--- a/packages/ember-views/tests/system/application_test.js
+++ b/packages/ember-views/tests/system/application_test.js
@@ -61,3 +61,89 @@ test("acts like a namespace", function() {
   app.destroy();
   window.TestApp = undefined;
 });
+
+var FirstApp, SecondApp;
+
+module("Ember#defaultApplication", {
+  setup: function() {
+    Ember.$("#qunit-fixture").html("<div class='first' ></div><div class='second' ></div>");
+    Ember.run(function() { set(Ember, 'defaultApplication', undefined); });
+    Ember.Application.APPLICATIONS = [];
+  },
+
+  teardown: function() {
+    if (FirstApp) {
+      Ember.run(function() { FirstApp.destroy(); });
+    }
+    if (SecondApp) {
+      Ember.run(function() { SecondApp.destroy(); });
+    }
+
+    Ember.run(function() { set(Ember, 'defaultApplication', undefined); });
+    Ember.Application.APPLICATIONS = [];
+  }
+});
+
+test("is set to undefined when no application has been created", function() {
+  var defaultApplication = get(Ember, 'defaultApplication');
+  equal(Ember.typeOf(defaultApplication), 'undefined', 'defaultApplication is undefined');
+});
+
+test("is set when a new application is created", function() {
+  FirstApp = Ember.Application.create({ rootElement: '.first' });
+
+  var defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, FirstApp, 'defaultApplication is the created application');
+});
+
+test("is set to the first created application", function() {
+  FirstApp = Ember.Application.create({ rootElement: '.first' });
+  SecondApp = Ember.Application.create({ rootElement: '.second' });
+
+  var defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, FirstApp, 'defaultApplication is the first created application');
+});
+
+test("is overwritten when a new application is created with flag isDefaultApplication", function() {
+  FirstApp = Ember.Application.create({ rootElement: '.first' });
+
+  var defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, FirstApp, 'defaultApplication is defined');
+
+  SecondApp = Ember.Application.create({ rootElement: '.second', isDefaultApplication: true });
+
+  defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, SecondApp, 'defaultApplication is the second created application');
+});
+
+test("is set to the next available appliation if the default application is destroyed", function() {
+  FirstApp = Ember.Application.create({ rootElement: '.first' });
+  SecondApp = Ember.Application.create({ rootElement: '.second' });
+
+  var defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, FirstApp, 'defaultApplication is the first created application');
+
+  Ember.run(function() { FirstApp.destroy(); });
+  
+  defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, SecondApp, 'defaultApplication is the second created application');
+});
+
+test("is set to undefined when the default application is destroyed and there are no more applications available", function() {
+  FirstApp = Ember.Application.create({ rootElement: '.first' });
+
+  var defaultApplication = get(Ember, 'defaultApplication');
+  ok(defaultApplication, 'defaultApplication is defined');
+  equal(defaultApplication, FirstApp, 'defaultApplication is defined');
+
+  Ember.run(function() { FirstApp.destroy(); });
+
+  defaultApplication = get(Ember, 'defaultApplication');
+  ok(!defaultApplication, 'defaultApplication is undefined');
+});

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -18,7 +18,7 @@ module("Ember.View - append() and appendTo()", {
   }
 });
 
-test("should be added to the specified element when calling append()", function() {
+test("should be added to the specified element when calling appendTo()", function() {
   Ember.$("#qunit-fixture").html('<div id="menu"></div>');
 
   view = View.create();
@@ -33,7 +33,7 @@ test("should be added to the specified element when calling append()", function(
   ok(viewElem.length > 0, "creates and appends the view's element");
 });
 
-test("should be added to the document body when calling appendTo()", function() {
+test("should be added to the document body when calling append()", function() {
   view = View.create({
     render: function(buffer) {
       buffer.push("foo bar baz");

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -261,3 +261,33 @@ test("destroy removes a child view from its parent", function() {
   ok(Ember.getPath(view, 'childViews.length') === 0, "Destroyed child views should be removed from their parent");
 });
 
+var FirstApp, SecondApp;
+
+module("Ember.View#append appends to the rootElement of Ember.defaultApplication", {
+  setup: function() {
+    Ember.$("#qunit-fixture").html("<div id='first-app' ></div><div id='second-app' ></div>");
+    Ember.run(function() { FirstApp = Ember.Application.create({ rootElement: '#first-app' }); });
+    view = Ember.View.create({ elementId: 'myCoolView'  });
+  },
+  teardown: function() {
+    if (FirstApp) { Ember.run(function() { FirstApp.destroy(); }); }
+    if (SecondApp) { Ember.run(function() { SecondApp.destroy(); }); }
+  }
+});
+
+test("uses the rootElement of Ember.defaultApplication if no application is defined", function() {
+  equal(Ember.get('defaultApplication'), FirstApp, "precond: defaultApplication is FirstApp");
+
+  Ember.run(function() { view.append(); });
+
+  equal(Ember.$('#first-app').children().length, 1, "view is appened to rootElement of default application");
+});
+
+test("uses rootElement of passed application", function() {
+  SecondApp = Ember.Application.create({ rootElement: '#second-app' });
+  equal(Ember.get('defaultApplication'), FirstApp, "precond: defaultApplication is FirstApp");
+
+  Ember.run(function() { view.append(SecondApp); });
+
+  equal(Ember.$('#second-app').children().length, 1, "view is appened to rootElement of second application");
+});

--- a/packages/ember-views/tests/views/view/insertView_test.js
+++ b/packages/ember-views/tests/views/view/insertView_test.js
@@ -1,0 +1,243 @@
+var view;
+var get = Ember.get;
+
+module("Ember.View#insertView", {
+  setup: function() {
+    view = Ember.View.create({
+      elementId: 'testView'
+    });
+
+    Ember.run(function() {
+      Ember.$("#qunit-fixture").html('<div id="layout"><div class="header" /><div class="footer" /></div>');
+    });
+  },
+  teardowm: function() {
+    if (view && !view.isDestroyed) {
+      view.destroy();
+    }
+  }
+});
+
+test("insertView returns view", function() {
+  var returned;
+
+  Ember.run(function() {
+    returned = view.insertView();
+  });
+
+  equal(returned, view, "insertView returns view");
+});
+
+test("insertView invokes append() when no callback is specified", function() {
+  var appendCalled = false;
+
+  view = Ember.View.extend({
+    append: function() {
+      appendCalled = true;
+    }
+  }).create();
+
+  Ember.run(function() {
+    view.insertView();
+  });
+
+  ok(appendCalled, "insertView invoked append() when no callback is given");
+});
+
+test("insertView invokes callback", function() {
+  var callbackCalled;
+  var thisInCallback;
+
+  Ember.run(function() {
+    view.insertView(function() {
+      callbackCalled = true;
+      thisInCallback = this;
+    });
+  });
+
+  ok(callbackCalled, "callback called");
+  ok(thisInCallback.$(), "this.$() inside callback is available");
+  
+  // check for a jQuery object via instanceof recommened in http://stackoverflow.com/a/487047/65542
+  ok(thisInCallback.$() instanceof window.jQuery, "this.$() inside callback is a jQuery object");
+});
+
+test("insertView calls willInsertElement and didInsertElement callbacks", function() {
+  var willInsertElementCalled = false;
+  var willInsertElementCalledInChild = false;
+  var didInsertElementCalled = false;
+
+  var ViewWithCallback = Ember.View.extend({
+    willInsertElement: function() {
+      willInsertElementCalled = true;
+    },
+    didInsertElement: function() {
+      didInsertElementCalled = true;
+    },
+    render: function(buffer) {
+      this.appendChild(Ember.View.create({
+        willInsertElement: function() {
+          willInsertElementCalledInChild = true;
+        }
+      }));
+    }
+  });
+
+  view = ViewWithCallback.create();
+
+  Ember.run(function() {
+    view.insertView();
+  });
+
+  ok(willInsertElementCalled, "willInsertElement called");
+  ok(willInsertElementCalledInChild, "willInsertElement called in child");
+  ok(didInsertElementCalled, "didInsertElement called");
+});
+
+var getId = function(htmlString) {
+ return Ember.$(htmlString).attr('id');
+};
+
+var getClass = function(htmlString) {
+ return Ember.$(htmlString).attr('class');
+};
+
+var testInsertion = function(methodName, target, assertion) {
+
+ module("Ember.View#" + methodName, {
+  setup: function() {
+   view = Ember.View.create({
+    elementId: 'testView'
+   });
+   
+   Ember.run(function() {
+    Ember.$("#qunit-fixture").html('<div id="layout"><div class="header" /><div class="footer" /></div>');
+   });
+  },
+  teardowm: function() {
+   if (view) {
+    view.destroy();
+   }
+  }
+ });
+
+
+ test("adds view to specified target", function() {
+  var childs = Ember.$("#qunit-fixture").children();
+  equal(childs.length, 1, 'precond - qunit-fixture has one child');
+  equal(getId(childs[0]), 'layout', 'precond - child has id "layout"');
+  
+  ok(!get(view, 'element'), "precond - should not have an element");
+  ok(view[methodName], 'view has a method named ' + methodName);
+  
+  var returned;
+  
+  Ember.run(function() {
+    // invoke given method on view
+    returned = view[methodName](target);
+  });
+  
+  equal(returned, view, methodName + ' returned view');
+  
+  var fixture = Ember.$('#qunit-fixture');
+  
+  // invoke callback
+  assertion.call(this, fixture, fixture.children());
+ });
+
+  test("works with a View hierarchy", function() {
+   view = Ember.ContainerView.extend({
+    childViews: ['child'],
+    child: Ember.View.extend({
+     elementId: 'childViewId'
+    })
+   }).create();
+ 
+   var childs = Ember.$("#qunit-fixture").children();
+   equal(childs.length, 1, 'precond - qunit-fixture has one child');
+   equal(getId(childs[0]), 'layout', 'precond - child has id "layout"');
+
+   ok(!get(view, 'element'), "precond - should not have an element");
+   ok(view[methodName], 'view has a method named ' + methodName);
+
+   Ember.run(function() {
+     // invoke given method on view
+     view[methodName](target);
+   });
+
+   var fixture = Ember.$('#qunit-fixture');
+   
+   // invoke callback
+   assertion.call(this, fixture, fixture.children());
+
+   // test if containerView has a child with id 'childViewId'
+   var containerView = Ember.$(document.body).find('#' + get(view, 'elementId'));
+   equal(containerView.length, 1, 'containerView is added to document');
+   
+   var containerViewChildren = containerView.children();
+   equal(containerViewChildren.length, 1, 'containerView has one child');
+   equal(getId(containerViewChildren[0]), 'childViewId', 'child has correct id');
+  });
+
+};
+
+testInsertion('append', null, function() {
+  var children = Ember.$(document.body).children();
+  var childrenCount = children.length;
+
+  equal(getId(children[childrenCount - 1]), get(view, 'elementId'), 'view is added as last item on body');
+});
+
+testInsertion('appendTo', '#layout', function(fixture) {
+  var layout = fixture.find('#layout').children();
+  equal(layout.length, 3, '#layout has 3 childs');
+  equal(getId(layout[2]), get(view, 'elementId'), 'last item is added view');
+});
+
+testInsertion('replaceWith', '#layout .header', function(fixture) {
+  var layout = fixture.find('#layout').children();
+  equal(layout.length, 2, '#layout has 2 childs');
+  equal(getId(layout[0]), get(view, 'elementId'), 'testView replaces specified element');
+});
+
+testInsertion('replaceIn', '#layout .header', function(fixture, children) {
+  equal(children.length, 1, 'there is one element');
+  var refChilds = fixture.find('#layout .header').children();
+  equal(refChilds.length, 1, '.header has 1 child');
+  equal(getId(refChilds[0]), get(view, 'elementId'), 'content of .header is replaced with view');
+});
+
+testInsertion('insertBefore', '#layout .footer', function(fixture, children) {
+  equal(children.length, 1, 'there is one element');
+  var refChilds = fixture.find('#layout').children();
+  equal(refChilds.length, 3, '#layout has 3 childs');
+  equal(getClass(refChilds[0]), 'header', 'first element has class .header');
+  equal(getId(refChilds[1]), get(view, 'elementId'), 'second element is inserted view');
+  equal(getClass(refChilds[2]), 'footer', 'third element has class .footer');
+});
+
+testInsertion('insertAfter', '#layout .footer', function(fixture, children) {
+  equal(children.length, 1, 'there is one element');
+  var refChilds = fixture.find('#layout').children();
+  equal(refChilds.length, 3, '#layout has 3 childs');
+  equal(getClass(refChilds[0]), 'header', 'first element has class .header');
+  equal(getClass(refChilds[1]), 'footer', 'second element has class .footer');
+  equal(getId(refChilds[2]), get(view, 'elementId'), 'third element is inserted view');
+});
+
+testInsertion('prependTo', '#layout', function(fixture, children) {
+  equal(children.length, 1, 'there is one element');
+  var refChilds = fixture.find('#layout').children();
+  equal(refChilds.length, 3, '#layout has 3 childs');
+  equal(getId(refChilds[0]), get(view, 'elementId'), 'first element is inserted view');
+  equal(getClass(refChilds[1]), 'header', 'second element has class .header');
+  equal(getClass(refChilds[2]), 'footer', 'third element has class .footer');
+});
+
+testInsertion('prepend', null, function() {
+  var children = Ember.$(document.body).children();
+
+  var firstItem = children[0];
+  var firstItemId = getId(firstItem);
+  equal(firstItemId, get(view, 'elementId'), 'view is added as first item on body');
+});


### PR DESCRIPTION
This Pull Request introduces additional methods to add a view to DOM. Besides the existing `append`, `appendTo` and `replaceIn` a few more are added, namely:
- `prepend()` and `prependTo(target)`
- `insertBefore(target)` and `insertAfter(target)`
- `replaceWith(target)`

A new method `insertView(callback)` is added. This method takes a callback function which is invoked when the view shall be added to DOM. It's the callbacks responsibility to actually add the view, for example via

``` javascript
view.insertView(function(){
  Ember.$('.header-placeholder').remove();
  this.$().appendTo('.header');
});
```

`insertView(callback)` allows to add the view and implement more setup like removing previous placeholder element or so ...

I open this Pull Request for discussion. Especially about the tests. I don't know if the actual way of testing the stuff is sufficient enough. So please comment and add your 2 cents.

BTW, this addresses #587 and #574
