### PR TITLE
Don't read files off disk n times.

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -14,9 +14,9 @@ end
 
 class EmberLicenseFilter < Rake::Pipeline::Filter
   def generate_output(inputs, output)
+    license = File.read("generators/license.js")
     inputs.each do |input|
       file = File.read(input.fullpath)
-      license = File.read("generators/license.js")
       output.write "#{license}\n\n#{file}"
     end
   end
@@ -24,9 +24,9 @@ end
 
 class JSHintRC < Rake::Pipeline::Filter
   def generate_output(inputs, output)
+    jshintrc = File.read(".jshintrc")
     inputs.each do |input|
       file = File.read(input.fullpath)
-      jshintrc = File.read(".jshintrc")
       output.write "var JSHINTRC = #{jshintrc};\n\n#{file}"
     end
   end


### PR DESCRIPTION
When running through these rake pipeline filters we're reading a file off of disk for each input file. We can just read the file once.
