### PR TITLE
Remove label element surrounding checkboxes.

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -9,28 +9,93 @@ require("ember-handlebars/ext");
 
 var set = Ember.set, get = Ember.get;
 
-// TODO: Be explicit in the class documentation that you
-// *MUST* set the value of a checkbox through Ember.
-// Updating the value of a checkbox directly via jQuery objects
-// will not work.
+/**
+  @class
+  
+  Creates an HTML input view in one of two formats.
+  
+  If a `title` property or binding is provided the input will be wrapped in
+  a `div` and `label` tag. View properties like `classNames` will be applied to
+  the outermost `div`. This behavior is deprecated and will issue a warning in development.
+  
+  
+      {{view Ember.Checkbox classNames="applicaton-specific-checkbox" title="Some title"}}
+      
+      
+      <div id="ember1" class="ember-view ember-checkbox applicaton-specific-checkbox">
+        <label><input type="checkbox" />Some title</label>
+      </div>
+  
+  If `title` isn't provided the view will render as an input element of the 'checkbox' type and HTML
+  related properties will be applied directly to the input.
+  
+      {{view Ember.Checkbox classNames="applicaton-specific-checkbox"}}
+      
+      <input id="ember1" class="ember-view ember-checkbox applicaton-specific-checkbox" type="checkbox">
+  
+  You can add a `label` tag yourself in the template where the Ember.Checkbox is being used.
+  
+      <label>
+        Some Title
+        {{view Ember.Checkbox classNames="applicaton-specific-checkbox"}}
+      </label>
+      
+  
+  The `checked` attribute of an Ember.Checkbox object should always be set
+  through the Ember object or by interacting with its rendered element representation
+  via the mouse, keyboard, or touch.  Updating the value of the checkbox via jQuery will
+  result in the checked value of the object and its element losing synchronization.
 
+*/
 Ember.Checkbox = Ember.View.extend({
-  title: null,
-  value: false,
-  disabled: false,
-
   classNames: ['ember-checkbox'],
 
-  defaultTemplate: Ember.Handlebars.compile('<label><input type="checkbox" {{bindAttr checked="value" disabled="disabled"}}>{{title}}</label>'),
+  tagName: Ember.computed(function(){
+    return get(this, 'title') ? undefined : 'input';
+  }).property(),
+
+  attributeBindings: Ember.computed(function(){
+    return get(this, 'title') ? [] : ['type', 'checked', 'disabled'];
+  }).property(),
+
+  type: "checkbox",
+  checked: false,
+  disabled: false,
+
+  title:  Ember.computed(function(propName, value){
+    if (value !== undefined) {
+      ember_warn("Automatically surrounding Ember.Checkbox inputs with a label by providing a 'title' property is deprecated");
+      return value;
+    }
+  }).property().cacheable(),
+
+  defaultTemplate: Ember.computed(function(){
+    if (get(this, 'title')) {
+      return Ember.Handlebars.compile('<label><input type="checkbox" {{bindAttr checked="checked" disabled="disabled"}}>{{title}}</label>');
+    } else {
+      return undefined;
+    }
+  }).property().cacheable(),
+
+  value: Ember.computed(function(propName, value){
+    ember_warn("Ember.Checkbox's 'value' property has been renamed to 'checked' to match the html element attribute name");
+    if (value !== undefined) {
+      return set(this, 'checked', value);
+    } else {
+      return get(this, 'checked');
+    }
+  }).property('checked'),
 
   change: function() {
     Ember.run.once(this, this._updateElementValue);
     // returning false will cause IE to not change checkbox state
   },
-
+  
+  /**
+    @private
+  */
   _updateElementValue: function() {
-    var input = this.$('input:checkbox');
-    set(this, 'value', input.prop('checked'));
+    var input = get(this, 'title') ? this.$('input:checkbox') : this.$();
+    set(this, 'checked', input.prop('checked'));
   }
 });
-

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -36,85 +36,84 @@ test("should begin disabled if the disabled attribute is true", function() {
   checkboxView.set('disabled', true);
   append();
 
-  ok(checkboxView.$("input").is(":disabled"));
+  ok(checkboxView.$().is(":disabled"));
 });
 
 test("should become disabled if the disabled attribute is changed", function() {
   checkboxView = Ember.Checkbox.create({});
 
   append();
-  ok(checkboxView.$("input").is(":not(:disabled)"));
+  ok(checkboxView.$().is(":not(:disabled)"));
 
   Ember.run(function() { checkboxView.set('disabled', true); });
-  ok(checkboxView.$("input").is(":disabled"));
+  ok(checkboxView.$().is(":disabled"));
 
   Ember.run(function() { checkboxView.set('disabled', false); });
-  ok(checkboxView.$("input").is(":not(:disabled)"));
+  ok(checkboxView.$().is(":not(:disabled)"));
 });
 
-test("value property mirrors input value", function() {
+test("checked property mirrors input value", function() {
   checkboxView = Ember.Checkbox.create({});
   Ember.run(function() { checkboxView.append(); });
 
-  equal(get(checkboxView, 'value'), false, "initially starts with a false value");
-  equal(!!checkboxView.$('input').prop('checked'), false, "the initial checked property is false");
+  equal(get(checkboxView, 'checked'), false, "initially starts with a false value");
+  equal(!!checkboxView.$().prop('checked'), false, "the initial checked property is false");
 
-  setAndFlush(checkboxView, 'value', true);
+  setAndFlush(checkboxView, 'checked', true);
 
-  equal(checkboxView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+  equal(checkboxView.$().prop('checked'), true, "changing the value property changes the DOM");
 
   checkboxView.remove();
   Ember.run(function() { checkboxView.append(); });
 
-  equal(checkboxView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+  equal(checkboxView.$().prop('checked'), true, "changing the value property changes the DOM");
 
   Ember.run(function() { checkboxView.remove(); });
-  Ember.run(function() { set(checkboxView, 'value', false); });
+  Ember.run(function() { set(checkboxView, 'checked', false); });
   Ember.run(function() { checkboxView.append(); });
 
-  equal(checkboxView.$('input').prop('checked'), false, "changing the value property changes the DOM");
-});
-
-test("value property mirrors input value", function() {
-  checkboxView = Ember.Checkbox.create({ value: true });
-  Ember.run(function() { checkboxView.append(); });
-
-  equal(get(checkboxView, 'value'), true, "precond - initially starts with a true value");
-  equal(!!checkboxView.$('input').prop('checked'), true, "the initial checked property is true");
-
-  setAndFlush(checkboxView, 'value', false);
-
-  equal(!!checkboxView.$('input').prop('checked'), false, "changing the value property changes the DOM");
-
-  Ember.run(function() { checkboxView.remove(); });
-  Ember.run(function() { checkboxView.append(); });
-
-  equal(checkboxView.$('input').prop('checked'), false, "changing the value property changes the DOM");
-
-  Ember.run(function() { checkboxView.remove(); });
-  setAndFlush(checkboxView, 'value', true);
-  Ember.run(function() { checkboxView.append(); });
-
-  equal(checkboxView.$('input').prop('checked'), true, "changing the value property changes the DOM");
+  equal(checkboxView.$().prop('checked'), false, "changing the value property changes the DOM");
 });
 
 test("checking the checkbox updates the value", function() {
-  checkboxView = Ember.Checkbox.create({ value: true });
+  checkboxView = Ember.Checkbox.create({ checked: true });
   Ember.run(function() { checkboxView.appendTo('#qunit-fixture'); });
 
-  equal(get(checkboxView, 'value'), true, "precond - initially starts with a true value");
-  equal(!!checkboxView.$('input').attr('checked'), true, "precond - the initial checked property is true");
+  equal(get(checkboxView, 'checked'), true, "precond - initially starts with a true value");
+  equal(!!checkboxView.$().attr('checked'), true, "precond - the initial checked property is true");
 
   // Can't find a way to programatically trigger a checkbox in IE and have it generate the
   // same events as if a user actually clicks.
   if (!Ember.$.browser.msie) {
-    checkboxView.$('input')[0].click();
+    checkboxView.$()[0].click();
   } else {
-    checkboxView.$('input').trigger('click');
-    checkboxView.$('input').removeAttr('checked').trigger('change');
+    checkboxView.$().trigger('click');
+    checkboxView.$().removeAttr('checked').trigger('change');
   }
 
-  equal(checkboxView.$('input').prop('checked'), false, "after clicking a checkbox, the checked property changed");
-  equal(get(checkboxView, 'value'), false, "changing the checkbox causes the view's value to get updated");
+  equal(checkboxView.$().prop('checked'), false, "after clicking a checkbox, the checked property changed");
+  equal(get(checkboxView, 'checked'), false, "changing the checkbox causes the view's value to get updated");
+});
+
+// deprecated behaviors
+test("wraps the checkbox in a label if a title attribute is provided", function(){
+  checkboxView = Ember.Checkbox.create({ title: "I have a title" });
+  append();
+  equal(checkboxView.$('label').length, 1);
+});
+
+test("proxies the checked attribute to value for backwards compatibility", function(){
+  checkboxView = Ember.Checkbox.create({ title: "I have a title" });
+  append();
+  
+  set(checkboxView, 'value', true);
+  equal(get(checkboxView, 'checked'), true, 'checked is updated when value set');
+  equal(get(checkboxView, 'value'), true, 'value is updated when value set');
+  
+  set(checkboxView, 'checked', false);
+  
+  equal(get(checkboxView, 'checked'), false, 'checked is updated when checked set');
+  equal(get(checkboxView, 'value'), false, 'value is updated when checked set');
+  
 });
 


### PR DESCRIPTION
removes duplicate spec about checkbox object mirroring the element values and changes checkbox element attributes to attributeBindings away from bindAttr.

This will close #582
