### PR TITLE
Expose view and controller keywords to templates

### DIFF
--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -18,6 +18,20 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
   attributeBindings: ['type', 'disabled', 'href'],
 
+  /** @private
+    Overrides TargetActionSupport's targetObject computed
+    property to use Handlebars-specific path resolution.
+  */
+  targetObject: Ember.computed(function() {
+    var target = get(this, 'target'),
+        root = get(this, 'templateContext'),
+        data = get(this, 'templateData');
+
+    if (typeof target !== 'string') { return target; }
+
+    return Ember.Handlebars.getPath(root, target, { data: data });
+  }).property('target').cacheable(),
+
   // Defaults to 'button' if tagName is 'input' or 'button'
   type: Ember.computed(function(key, value) {
     var tagName = this.get('tagName');

--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -1,6 +1,6 @@
 require('ember-handlebars/ext');
 
-var EmberHandlebars = Ember.Handlebars, getPath = Ember.Handlebars.getPath;
+var EmberHandlebars = Ember.Handlebars, getPath = EmberHandlebars.getPath;
 
 var ActionHelper = EmberHandlebars.ActionHelper = {
   registeredActions: {}
@@ -38,7 +38,7 @@ EmberHandlebars.registerHelper('action', function(actionName, options) {
       target, context;
 
   if (view.isVirtual) { view = view.get('parentView'); }
-  target = hash.target ? getPath(this, hash.target) : view;
+  target = hash.target ? getPath(this, hash.target, options) : view;
   context = options.contexts[0];
 
   var actionId = ActionHelper.registerAction(actionName, eventName, target, view, context);

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -36,7 +36,8 @@ var EmberHandlebars = Ember.Handlebars, helpers = EmberHandlebars.helpers;
         inverseTemplate: inverse,
         property: property,
         previousContext: ctx,
-        isEscaped: options.hash.escaped
+        isEscaped: options.hash.escaped,
+        templateData: options.data
       });
 
       view.appendChild(bindView);
@@ -56,7 +57,7 @@ var EmberHandlebars = Ember.Handlebars, helpers = EmberHandlebars.helpers;
     } else {
       // The object is not observable, so just render it out and
       // be done with it.
-      data.buffer.push(getPath(this, property));
+      data.buffer.push(getPath(this, property, options));
     }
   };
 
@@ -215,7 +216,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
   // Handle classes differently, as we can bind multiple classes
   var classBindings = attrs['class'];
   if (classBindings !== null && classBindings !== undefined) {
-    var classResults = EmberHandlebars.bindClasses(this, classBindings, view, dataId);
+    var classResults = EmberHandlebars.bindClasses(this, classBindings, view, dataId, options);
     ret.push('class="' + classResults.join(' ') + '"');
     delete attrs['class'];
   }
@@ -229,7 +230,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
 
     ember_assert(fmt("You must provide a String for a bound attribute, not %@", [property]), typeof property === 'string');
 
-    var value = (property === 'this') ? ctx : getPath(ctx, property),
+    var value = (property === 'this') ? ctx : getPath(ctx, property, options),
         type = Ember.typeOf(value);
 
     ember_assert(fmt("Attributes must be numbers, strings or booleans, not %@", [value]), value === null || value === undefined || type === 'number' || type === 'string' || type === 'boolean');
@@ -238,7 +239,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
 
     /** @private */
     observer = function observer() {
-      var result = getPath(ctx, property);
+      var result = getPath(ctx, property, options);
 
       ember_assert(fmt("Attributes must be numbers, strings or booleans, not %@", [result]), result === null || result === undefined || typeof result === 'number' || typeof result === 'string' || typeof result === 'boolean');
 
@@ -308,7 +309,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
 
   @returns {Array} An array of class names to add
 */
-EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId) {
+EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId, options) {
   var ret = [], newClass, value, elem;
 
   // Helper method to retrieve the property from the context and
@@ -320,7 +321,7 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId)
 
     property = split[0];
 
-    var val = property !== '' ? getPath(context, property) : true;
+    var val = property !== '' ? getPath(context, property, options) : true;
 
     // If value is a Boolean and true, return the dasherized property
     // name.

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -21,7 +21,13 @@ var EmberHandlebars = Ember.Handlebars, helpers = EmberHandlebars.helpers;
         fn = options.fn,
         inverse = options.inverse,
         view = data.view,
-        ctx  = this;
+        ctx  = this,
+        normalized;
+
+    normalized = Ember.Handlebars.normalizePath(ctx, property, data);
+
+    ctx = normalized.root;
+    property = normalized.path;
 
     // Set up observers for observable objects
     if ('object' === typeof this) {

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -90,7 +90,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
     delete hash.preserveContext;
   }
 
-  hash.itemViewClass = Ember.Handlebars.ViewHelper.viewClassFromHTMLOptions(itemViewClass, itemHash, this);
+  hash.itemViewClass = Ember.Handlebars.ViewHelper.viewClassFromHTMLOptions(itemViewClass, { data: data, hash: itemHash }, this);
 
   return Ember.Handlebars.helpers.view.call(this, collectionClass, options);
 });

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -34,7 +34,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   // If passed a path string, convert that into an object.
   // Otherwise, just default to the standard class.
   var collectionClass;
-  collectionClass = path ? getPath(this, path) : Ember.CollectionView;
+  collectionClass = path ? getPath(this, path, options) : Ember.CollectionView;
   ember_assert(fmt("%@ #collection: Could not find %@", data.view, path), !!collectionClass);
 
   var hash = options.hash, itemHash = {}, match;
@@ -43,7 +43,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   var itemViewClass, itemViewPath = hash.itemViewClass;
   var collectionPrototype = collectionClass.proto();
   delete hash.itemViewClass;
-  itemViewClass = itemViewPath ? getPath(collectionPrototype, itemViewPath) : collectionPrototype.itemViewClass;
+  itemViewClass = itemViewPath ? getPath(collectionPrototype, itemViewPath, options) : collectionPrototype.itemViewClass;
   ember_assert(fmt("%@ #collection: Could not find %@", data.view, itemViewPath), !!itemViewClass);
 
   // Go through options passed to the {{collection}} helper and extract options
@@ -74,7 +74,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
 
     if (hash.emptyViewClass) {
       emptyViewClass = Ember.View.detect(hash.emptyViewClass) ?
-                          hash.emptyViewClass : getPath(this, hash.emptyViewClass);
+                          hash.emptyViewClass : getPath(this, hash.emptyViewClass, options);
     }
 
     hash.emptyView = emptyViewClass.extend({

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -21,5 +21,5 @@ var getPath = Ember.Handlebars.getPath;
 */
 Ember.Handlebars.registerHelper('unbound', function(property, fn) {
   var context = (fn.contexts && fn.contexts[0]) || this;
-  return getPath(context, property);
+  return getPath(context, property, fn);
 });

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -11,9 +11,10 @@ require("ember-handlebars");
 var get = Ember.get, set = Ember.set;
 var indexOf = Ember.ArrayUtils.indexOf;
 var PARENT_VIEW_PATH = /^parentView\./;
+var EmberHandlebars = Ember.Handlebars;
 
 /** @private */
-Ember.Handlebars.ViewHelper = Ember.Object.create({
+EmberHandlebars.ViewHelper = Ember.Object.create({
 
   viewClassFromHTMLOptions: function(viewClass, options, thisContext) {
     var extensions = {},
@@ -65,7 +66,10 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
       // Test if the property ends in "Binding"
       if (Ember.IS_BINDING.test(prop)) {
         path = options[prop];
-        if (!Ember.isGlobalPath(path)) {
+
+        if (EmberHandlebars.KEYWORD_REGEX.test(path)) {
+          options[prop] = 'templateData.'+path;
+        } else if (!Ember.isGlobalPath(path)) {
           if (path === 'this') {
             options[prop] = 'bindingContext';
           } else {
@@ -91,7 +95,7 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
         newView;
 
     if ('string' === typeof path) {
-      newView = Ember.Handlebars.getPath(thisContext, path);
+      newView = EmberHandlebars.getPath(thisContext, path, options);
       ember_assert("Unable to find view at path '" + path + "'", !!newView);
     } else {
       newView = path;
@@ -101,7 +105,9 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
 
     newView = this.viewClassFromHTMLOptions(newView, hash, thisContext);
     var currentView = data.view;
-    var viewOptions = {};
+    var viewOptions = {
+      templateData: options.data
+    };
 
     if (fn) {
       ember_assert("You cannot provide a template block if you also specified a templateName", !(get(viewOptions, 'templateName')) && (indexOf(newView.PrototypeMixin.keys(), 'templateName') >= 0));
@@ -118,7 +124,7 @@ Ember.Handlebars.ViewHelper = Ember.Object.create({
   @param {Hash} options
   @returns {String} HTML string
 */
-Ember.Handlebars.registerHelper('view', function(path, options) {
+EmberHandlebars.registerHelper('view', function(path, options) {
   ember_assert("The view helper only takes a single argument", arguments.length <= 2);
 
   // If no path is provided, treat path param as options.
@@ -127,6 +133,6 @@ Ember.Handlebars.registerHelper('view', function(path, options) {
     path = "Ember.View";
   }
 
-  return Ember.Handlebars.ViewHelper.helper(this, path, options);
+  return EmberHandlebars.ViewHelper.helper(this, path, options);
 });
 

--- a/packages/ember-handlebars/lib/views/bindable_span.js
+++ b/packages/ember-handlebars/lib/views/bindable_span.js
@@ -84,14 +84,15 @@ Ember._BindableSpanView = Ember.View.extend(Ember.Metamorph,
     var property = get(this, 'property'),
         context  = get(this, 'previousContext'),
         valueNormalizer = get(this, 'valueNormalizerFunc'),
-        result;
+        result, templateData;
 
     // Use the current context as the result if no
     // property is provided.
     if (property === '') {
       result = context;
     } else {
-      result = getPath(context, property);
+      templateData = get(this, 'templateData');
+      result = getPath(context, property, { data: templateData });
     }
 
     return valueNormalizer ? valueNormalizer(result) : result;

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1410,6 +1410,15 @@ test("should expose a controller keyword when present on the view", function() {
 
   equal(view.$().text(), "barbang", "renders values from controller and parent controller");
 
+  var controller = get(view, 'controller');
+
+  Ember.run(function() {
+    controller.set('foo', "BAR");
+    controller.set('baz', "BLARGH");
+  });
+
+  equal(view.$().text(), "BARBLARGH", "updates the DOM when a bound value is updated");
+
   view.destroy();
 
   view = Ember.View.create({
@@ -1422,6 +1431,29 @@ test("should expose a controller keyword when present on the view", function() {
   });
 
   equal(view.$().text(), "aString", "renders the controller itself if no additional path is specified");
+});
+
+test("should expose a controller keyword that can be used in conditionals", function() {
+  var templateString = "{{#view}}{{#if controller}}{{controller.foo}}{{/if}}{{/view}}";
+  view = Ember.View.create({
+    controller: Ember.Object.create({
+      foo: "bar"
+    }),
+
+    template: Ember.Handlebars.compile(templateString)
+  });
+
+  Ember.run(function() {
+    view.appendTo("#qunit-fixture");
+  });
+
+  equal(view.$().text(), "bar", "renders values from controller and parent controller");
+
+  Ember.run(function() {
+    view.set('controller', null);
+  });
+
+  equal(view.$().text(), "", "updates the DOM when the controller is changed");
 });
 
 test("should expose a view keyword", function() {

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1393,6 +1393,77 @@ test("should work with precompiled templates", function() {
   equal(view.$().text(), "updated", "the precompiled template was updated");
 });
 
+test("should expose a controller keyword when present on the view", function() {
+  var templateString = "{{controller.foo}}{{#view}}{{controller.baz}}{{/view}}";
+  view = Ember.View.create({
+    controller: Ember.Object.create({
+      foo: "bar",
+      baz: "bang"
+    }),
+
+    template: Ember.Handlebars.compile(templateString)
+  });
+
+  Ember.run(function() {
+    view.appendTo("#qunit-fixture");
+  });
+
+  equal(view.$().text(), "barbang", "renders values from controller and parent controller");
+
+  view.destroy();
+
+  view = Ember.View.create({
+    controller: "aString",
+    template: Ember.Handlebars.compile("{{controller}}")
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$().text(), "aString", "renders the controller itself if no additional path is specified");
+});
+
+test("should expose a view keyword", function() {
+  var templateString = '{{#with differentContent}}{{view.foo}}{{#view baz="bang"}}{{view.baz}}{{/view}}{{/with}}';
+  view = Ember.View.create({
+    differentContent: {
+      view: {
+        foo: "WRONG",
+        baz: "WRONG"
+      }
+    },
+
+    foo: "bar",
+
+    template: Ember.Handlebars.compile(templateString)
+  });
+
+  Ember.run(function() {
+    view.appendTo("#qunit-fixture");
+  });
+
+  equal(view.$().text(), "barbang", "renders values from view and child view");
+});
+
+test("Ember.Button targets should respect keywords", function() {
+  var templateString = '{{#with anObject}}{{view Ember.Button target="controller.foo"}}{{/with}}';
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(templateString),
+    anObject: {},
+    controller: {
+      foo: "bar"
+    }
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  var button = view.get('childViews').objectAt(0);
+  equal(button.get('targetObject'), "bar", "resolves the target");
+});
+
 module("Templates redrawing and bindings", {
   setup: function(){
     MyApp = Ember.Object.create({});
@@ -1507,6 +1578,31 @@ test("bindings should be relative to the current context", function() {
     }),
 
     template: Ember.Handlebars.compile('{{#if museumOpen}} {{view museumView nameBinding="museumDetails.name" dollarsBinding="museumDetails.price"}} {{/if}}')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "Name: SFMoMA Price: $20", "should print baz twice");
+});
+
+test("bindings should respect keywords", function() {
+  view = Ember.View.create({
+    museumOpen: true,
+
+    controller: {
+      museumDetails: Ember.Object.create({
+        name: "SFMoMA",
+        price: 20
+      })
+    },
+
+    museumView: Ember.View.extend({
+      template: Ember.Handlebars.compile('Name: {{name}} Price: ${{dollars}}')
+    }),
+
+    template: Ember.Handlebars.compile('{{#if museumOpen}}{{view museumView nameBinding="controller.museumDetails.name" dollarsBinding="controller.museumDetails.price"}}{{/if}}')
   });
 
   Ember.run(function() {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -122,6 +122,14 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   }).property('templateName').cacheable(),
 
   /**
+    The controller managing this view. If this property is set, it will be made
+    made available for use by the template.
+
+    @type Object
+  */
+  controller: null,
+
+  /**
     A view may contain a layout. A layout is a regular template but
     supercedes the `template` property during rendering. It is the
     responsibility of the layout template to retrieve the `template`
@@ -192,14 +200,14 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   }).cacheable(),
 
   /**
-    If the template context changes, the view should be re-rendered to display
-    the new value.
+    If a value that affects template rendering changes, the view should be
+    re-rendered to reflect the new value.
 
     @private
   */
-  templateContextDidChange: Ember.observer(function() {
+  _displayPropertyDidChange: Ember.observer(function() {
     this.rerender();
-  }, 'templateContext'),
+  }, 'templateContext', 'controller'),
 
   /**
     If the view is currently inserted into the DOM of a parent view, this
@@ -358,13 +366,21 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     if (template) {
       var context = get(this, '_templateContext'),
           templateData = this.get('templateData'),
-          controller = this.get('controller'),
-          data = { view: this, buffer: buffer, isRenderData: true };
+          controller = this.get('controller');
+
+      var data = {
+        view: this,
+        buffer: buffer,
+        isRenderData: true,
+        keywords: {
+          view: get(this, 'concreteView')
+        }
+      };
 
       // If the view has a controller specified, make it available to the
       // template. If not, pass along the parent template's controller,
       // if it exists.
-      data.controller = controller || (templateData && templateData.controller);
+      data.keywords.controller = controller || (templateData && templateData.keywords.controller);
 
       // Invoke the template with the provided template context, which
       // is the view by default. A hash of data is also passed that provides

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -113,7 +113,7 @@ test("should provide a controller to the template if a controller is specified o
     controller: controller1,
 
     template: function(buffer, options) {
-      strictEqual(options.data.controller, controller1, "passes the controller in the data");
+      strictEqual(options.data.keywords.controller, controller1, "passes the controller in the data");
     }
   });
 
@@ -131,10 +131,10 @@ test("should provide a controller to the template if a controller is specified o
         controller: controller2,
         templateData: options.data,
         template: function(buffer, options) {
-          strictEqual(options.data.controller, controller2, "passes the child view's controller in the data");
+          strictEqual(options.data.keywords.controller, controller2, "passes the child view's controller in the data");
         }
       }));
-      strictEqual(options.data.controller, controller1, "passes the controller in the data");
+      strictEqual(options.data.keywords.controller, controller1, "passes the controller in the data");
     }
   });
 
@@ -151,11 +151,11 @@ test("should provide a controller to the template if a controller is specified o
       options.data.view.appendChild(Ember.View.create({
         templateData: options.data,
         template: function(buffer, options) {
-          strictEqual(options.data.controller, controller1, "passes the original controller in the data");
+          strictEqual(options.data.keywords.controller, controller1, "passes the original controller in the data");
         }
       }));
 
-      strictEqual(options.data.controller, controller1, "passes the controller in the data to child views");
+      strictEqual(options.data.keywords.controller, controller1, "passes the controller in the data to child views");
     }
   });
 


### PR DESCRIPTION
This commit allows Handlebars template users to always have an "escape valve" out of the current Handlebars context to the current view and, if specified on a parent view, a `controller` property. See unit tests for examples.
