### PR TITLE
Ember.View should not require view method sharing event name.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1447,7 +1447,9 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     also call methods with the given name.
   */
   fire: function(name) {
-    this[name].apply(this, [].slice.call(arguments, 1));
+    if (this[name]) {
+      this[name].apply(this, [].slice.call(arguments, 1));
+    }
     this._super.apply(this, arguments);
   },
 

--- a/packages/ember-views/tests/views/view/evented_test.js
+++ b/packages/ember-views/tests/views/view/evented_test.js
@@ -1,0 +1,54 @@
+// ==========================================================================
+// Project:   Ember - JavaScript Application Framework
+// Copyright: ©2006-2011 Apple Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var set = Ember.set, get = Ember.get;
+
+module("Ember.View evented helpers");
+
+test("fire should call method sharing event name if it exists on the view", function() {
+  var eventFired = false;
+
+  var view = Ember.View.create({
+    fireMyEvent: function() {
+      this.fire('myEvent');
+    },
+
+    myEvent: function() {
+      eventFired = true;
+    }
+  });
+
+  Ember.run(function() {
+    view.fireMyEvent();
+  });
+
+  equal(eventFired, true, "fired the view method sharing the event name");
+});
+
+test("fire does not require a view method with the same name", function() {
+  var eventFired = false;
+
+  var view = Ember.View.create({
+    fireMyEvent: function() {
+      this.fire('myEvent');
+    }
+  });
+
+  var listenObject = Ember.Object.create({
+    onMyEvent: function() {
+      eventFired = true;
+    }
+  });
+
+  view.on('myEvent', listenObject, 'onMyEvent');
+
+  Ember.run(function() {
+    view.fireMyEvent();
+  });
+
+  equal(eventFired, true, "fired the event without a view method sharing its name");
+});
+


### PR DESCRIPTION
Presently, Ember.View's fire('someEvent') requires the view to define the method someEvent.
