### PR TITLE
fixed test-states.js testcase - 'equal' instead of 'ok'

### DIFF
--- a/packages/ember-states/tests/state_test.js
+++ b/packages/ember-states/tests/state_test.js
@@ -11,7 +11,7 @@ test("creating a state with substates sets the parentState property", function()
     child: Ember.State.create()
   });
 
-  ok(state.getPath('child.parentState'), state, "A child state gets its parent state");
+  equal(state.getPath('child.parentState'), state, "A child state gets its parent state");
 });
 
 test("a state is passed its state manager when receiving an enter event", function() {


### PR DESCRIPTION
This is a quick fix for the "A child state gets its parent state" assertion in test case that "creating a state with substates sets the parentState property"
