### PR TITLE
Makes yield blocks optional

### DIFF
--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -11,6 +11,5 @@ Ember.Handlebars.registerHelper('yield', function(options) {
 
   template = get(view, 'template');
 
-  ember_assert("You called yield on " + view.toString() + " without supplying a template", !!template);
-  template(this, options);
+  if (template) { template(this, options); }
 });

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -102,3 +102,19 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
   equal(view.$('div#container div.nesting div#block').length, 1, 'nesting view yields correctly even within a view hierarchy in the nesting view');
 });
 
+test("block should not be required", function() {
+  TemplateTests.YieldingView = Ember.View.extend({
+    layout: Ember.Handlebars.compile('{{#view Ember.View tagName="div" classNames="yielding"}}{{yield}}{{/view}}')
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div id="container">{{view TemplateTests.YieldingView}}</div>')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div#container div.yielding').length, 1, 'yielding view is rendered as expected');
+});
+


### PR DESCRIPTION
I have been using the {{yield}} helper extensively to build some reusable controls, and it works great.  However, sometimes when a control is used, it may not need to specify a block to be yielded.  Ember currently requires a block to be specified.  If you write a view containing a {{yield}} block as...

```
{{view View.With.Yield}}
```

... it will throw:

```
You called yield on [view] without supplying a template
```

You can work around it today by writing it as:

```
{{#view View.With.Yield}}{{/view}}
```

This works because an empty template is created... but this seems unnecessary from both a coding standpoint and a performance standpoint.

This pull request prevents the exception from being thrown and instead simply renders nothing when {{yield}} is specified without a corresponding block.

The {{yield}} functionality certainly seems to be inspired by Ruby's implementation of yielding, and Ruby does not force a block to be specified.  In my opinion, Ember should not either.
