### PR TITLE
Loosen regex test for jQuery versions

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -5,5 +5,5 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)?$/));
+ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)?(?=.*pre$)/)?$/));
 Ember.$ = window.jQuery;


### PR DESCRIPTION
Allow `pre` versions to be used with Ember.
