### PR TITLE
Switching emptyViews throws an exception

### DIFF
--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -9,6 +9,8 @@ var DOMManager = {
   remove: function(view) {
     var morph = view.morph;
     if (morph.isRemoved()) { return; }
+    set(view, 'element', null);
+    set(view, 'lastInsert', null);
     morph.remove();
   },
 

--- a/packages/ember-handlebars/tests/each_test.js
+++ b/packages/ember-handlebars/tests/each_test.js
@@ -134,6 +134,30 @@ test("it supports {{else}}", function() {
   });
 });
 
+test("it supports {{else}} with switching empty content ", function() {
+  view = Ember.View.create({
+    template: templateFor("{{#each items}}{{this}}{{else}}Nothing{{/each}}"),
+    items: Ember.A()
+  });
+
+  append(view);
+
+  assertHTML(view, "Nothing");
+
+  stop();
+
+  // We really need to make sure we get to the re-render
+  Ember.run.next(function() {
+    Ember.run(function() {
+      view.set('items', Ember.A([]));
+    });
+
+    start();
+
+    assertHTML(view, "Nothing");
+  });
+});
+
 test("it works with the controller keyword", function() {
   var controller = Ember.ArrayController.create({
     content: Ember.A(["foo", "bar", "baz"])

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -196,7 +196,6 @@ Ember.CollectionView = Ember.ContainerView.extend(
     var emptyView = get(this, '_emptyView');
     if (emptyView && emptyView instanceof Ember.View) {
       emptyView.removeFromParent();
-      emptyView.destroyElement();
     }
 
     // Loop through child views that correspond with the removed items.
@@ -268,9 +267,9 @@ Ember.CollectionView = Ember.ContainerView.extend(
         emptyView = this.createChildView(emptyViewClass);
         set(this, '_emptyView', emptyView);
       }
+      
       addedViews.push(emptyView);
     }
-
     childViews.replace(start, 0, addedViews);
   },
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -193,7 +193,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
   arrayWillChange: function(content, start, removedCount) {
     // If the contents were empty before and this template collection has an
     // empty view remove it now.
-    var emptyView = get(this, 'emptyView');
+    var emptyView = get(this, '_emptyView');
     if (emptyView && emptyView instanceof Ember.View) {
       emptyView.removeFromParent();
     }
@@ -264,7 +264,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
 
       emptyView = this.createChildView(emptyView);
       addedViews.push(emptyView);
-      set(this, 'emptyView', emptyView);
+      set(this, '_emptyView', emptyView);
     }
 
     childViews.replace(start, 0, addedViews);

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -196,6 +196,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
     var emptyView = get(this, '_emptyView');
     if (emptyView && emptyView instanceof Ember.View) {
       emptyView.removeFromParent();
+      emptyView.destroyElement();
     }
 
     // Loop through child views that correspond with the removed items.
@@ -259,12 +260,15 @@ Ember.CollectionView = Ember.ContainerView.extend(
         addedViews.push(view);
       }
     } else {
-      var emptyView = get(this, 'emptyView');
-      if (!emptyView) { return; }
+      var emptyViewClass = get(this, 'emptyView'),
+          emptyView = get(this, '_emptyView');
+      if (!emptyViewClass) { return; }
 
-      emptyView = this.createChildView(emptyView);
+      if (!emptyView) {
+        emptyView = this.createChildView(emptyViewClass);
+        set(this, '_emptyView', emptyView);
+      }
       addedViews.push(emptyView);
-      set(this, '_emptyView', emptyView);
     }
 
     childViews.replace(start, 0, addedViews);

--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -27,6 +27,12 @@ Ember.View.states = {
     // Handle events from `Ember.EventDispatcher`
     handleEvent: function() {
       return true; // continue event propagation
+    },
+
+    destroyElement: function(view) {
+      set(view, 'element', null);
+      set(view, 'lastInsert', null);
+      return view;
     }
   }
 };

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -53,6 +53,7 @@ Ember.View.states.hasElement = {
     view._notifyWillDestroyElement();
 
     view.domManager.remove(view);
+    view.transitionTo('preRender');
     return view;
   },
 

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -27,6 +27,7 @@ Ember.View.states.hasElement = {
   setElement: function(view, value) {
     if (value === null) {
       view.invalidateRecursively('element');
+
       view.transitionTo('preRender');
     } else {
       throw "You cannot set an element to a non-null value when the element is already in the DOM.";
@@ -48,12 +49,11 @@ Ember.View.states.hasElement = {
 
   // once the view is already in the DOM, destroying it removes it
   // from the DOM, nukes its element, and puts it back into the
-  // preRender state.
+  // preRender state if inDOM.
+
   destroyElement: function(view) {
     view._notifyWillDestroyElement();
-
     view.domManager.remove(view);
-    view.transitionTo('preRender');
     return view;
   },
 
@@ -82,7 +82,10 @@ Ember.View.states.hasElement = {
 Ember.View.states.inDOM = {
   parentState: Ember.View.states.hasElement,
 
-  insertElement: function() {
+  insertElement: function(view, fn) {
+    if (view.get('lastInsert') !== fn.insertGuid){
+      return;
+    }
     throw "You can't insert an element into the DOM that has already been inserted";
   }
 };

--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -13,6 +13,9 @@ Ember.View.states.preRender = {
   // a view leaves the preRender state once its element has been
   // created (createElement).
   insertElement: function(view, fn) {
+    if (view.get('lastInsert') !== fn.insertGuid){
+      return;
+    }
     view.createElement();
     view._notifyWillInsertElement(true);
     // after createElement, the view will be in the hasElement state.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -744,6 +744,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     @param {Function} fn the function that inserts the element into the DOM
   */
   _insertElementLater: function(fn) {
+    set(this, 'lastInsert', fn.insertGuid = Ember.generateGuid());
     Ember.run.schedule('render', this, this.invokeForState, 'insertElement', fn);
   },
 
@@ -1527,6 +1528,7 @@ var DOMManager = {
     var elem = get(view, 'element');
 
     set(view, 'element', null);
+    set(view, 'lastInsert', null);
 
     Ember.$(elem).remove();
   },

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -313,3 +313,30 @@ test("should allow declaration of itemViewClass as a string", function() {
 
   equal(view.$('.ember-view').length, 3);
 });
+
+test("should not render the emptyView if content is emptied and refilled in the same run loop", function() {
+  view = Ember.CollectionView.create({
+    tagName: 'div',
+    content: Ember.A(['NEWS GUVNAH']),
+
+    emptyView: Ember.View.create({
+      tagName: 'kbd',
+      render: function(buf) {
+        buf.push("OY SORRY GUVNAH NO NEWS TODAY EH");
+      }
+    })
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+  
+  equal(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, 0);
+
+  Ember.run(function() {
+    view.get('content').popObject();
+    view.get('content').pushObject(['NEWS GUVNAH']);
+  });
+  equal(view.$('div').length, 1);
+  equal(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, 0);
+});

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -95,5 +95,27 @@ test("does nothing if not in parentView", function() {
 });
 
 
+test("the DOM element is gone after doing append and remove in two separate runloops", function() {
+  var view = Ember.View.create();
+  Ember.run(function() {
+    view.append();
+  });
+  Ember.run(function() {
+    view.remove();
+  });
 
+  var viewElem = Ember.$('#'+get(view, 'elementId'));
+  ok(viewElem.length === 0, "view's element doesn't exist in DOM");
+});
+
+test("the DOM element is gone after doing append and remove in a single runloop", function() {
+  var view = Ember.View.create();
+  Ember.run(function() {
+    view.append();
+    view.remove();
+  });
+
+  var viewElem = Ember.$('#'+get(view, 'elementId'));
+  ok(viewElem.length === 0, "view's element doesn't exist in DOM");
+});
 


### PR DESCRIPTION
When switching from empty content to empty content in a #each, the emptyView throws an exception. See

http://jsfiddle.net/juggy/MjUbW/3/

This is because we are using the same attribute (emptyView) to store both the class and the view instance. The solution is to use one attributes for each. The view instance is now _emptyView.
