### PR TITLE
Assert that we do not accidentally specify a string for "template"

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -386,6 +386,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       // is the view by default. A hash of data is also passed that provides
       // the template with access to the view and render buffer.
 
+      ember_assert('template must be a function. Did you mean to specify templateName instead?', typeof template === 'function');
       // The template should write directly to the render buffer instead
       // of returning a string.
       var output = template(context, { data: data });


### PR DESCRIPTION
If you accidentally specify "template" instead of "templateName" in a
view, you get a cryptic error, like here:
http://stackoverflow.com/questions/10075118/ember-js-view-error-uncaught-typeerror-string-is-not-a-function

This guards against this mistake.

---

Is this kind of assertion reasonable, or is it overly defensive?
