### PR TITLE
Fixes a problem with adding an element right after a destroyed element

### DIFF
--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -20,11 +20,25 @@ var DOMManager = {
     });
   },
 
-  after: function(view, nextView) {
-    nextView._insertElementLater(function() {
-      var morph = view.morph;
-      morph.after(nextView.outerHTML);
-      nextView.outerHTML = null;
+  after: function(parentView, view, newView) {
+    newView._insertElementLater(function() {
+      var morph;
+      var nextView;
+      var prevView = view;
+
+      // Find a previous item that actually exists in the page
+      while (prevView !== null && prevView.get('state') === 'destroyed') {
+        prevView=prevView.get('prevView');
+      }
+      if (prevView === null) {
+        morph = parentView.get('morph');
+        morph.prepend(newView.outerHTML);
+        newView.outerHTML = null;
+      } else {
+        morph = prevView.morph;
+        morph.after(newView.outerHTML);
+        newView.outerHTML = null;
+      }
     });
   },
 

--- a/packages/ember-handlebars/tests/each_test.js
+++ b/packages/ember-handlebars/tests/each_test.js
@@ -70,6 +70,71 @@ test("it updates the view if an item is removed", function() {
   assertHTML(view, "Annabelle");
 });
 
+test("it updates the view if an item is replaced", function() {
+  Ember.run(function() {
+    people.removeAt(0);
+    people.insertAt(0, { name: "Kazuki" });
+  });
+
+  assertHTML(view, "KazukiAnnabelle");
+});
+
+test("can add and replace in the same runloop", function() {
+  Ember.run(function() {
+    people.pushObject({ name: "Tom Dale" });
+    people.removeAt(0);
+    people.insertAt(0, { name: "Kazuki" });
+  });
+
+  assertHTML(view, "KazukiAnnabelleTom Dale");
+});
+
+test("can add and replace the object before the add in the same runloop", function() {
+  Ember.run(function() {
+    people.pushObject({ name: "Tom Dale" });
+    people.removeAt(1);
+    people.insertAt(1, { name: "Kazuki" });
+  });
+
+  assertHTML(view, "Steve HoltKazukiTom Dale");
+});
+
+test("can add and replace complicatedly", function() {
+  Ember.run(function() {
+    people.pushObject({ name: "Tom Dale" });
+    people.removeAt(1);
+    people.insertAt(1, { name: "Kazuki" });
+    people.pushObject({ name: "Firestone" });
+    people.pushObject({ name: "McMunch" });
+    people.removeAt(3);
+  });
+
+  assertHTML(view, "Steve HoltKazukiTom DaleMcMunch");
+});
+
+test("can add and replace complicatedly harder", function() {
+  Ember.run(function() {
+    people.pushObject({ name: "Tom Dale" });
+    people.removeAt(1);
+    people.insertAt(1, { name: "Kazuki" });
+    people.pushObject({ name: "Firestone" });
+    people.pushObject({ name: "McMunch" });
+    people.removeAt(2);
+  });
+
+  assertHTML(view, "Steve HoltKazukiFirestoneMcMunch");
+});
+
+module("the #each helper", {
+  setup: function() {
+    people = Ember.A([{ name: "Steve Holt" }, { name: "Annabelle" }]);
+  },
+  teardown: function() {
+    if (view) { view.destroy(); }
+    view = null;
+  }
+});
+
 test("it works inside a ul element", function() {
   var ulView = Ember.View.create({
     template: templateFor('<ul>{{#each people}}<li>{{name}}</li>{{/each}}</ul>'),

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -216,6 +216,15 @@ Ember.CollectionView = Ember.ContainerView.extend(
       if (removingAll) { childView.removedFromDOM = true; }
       childView.destroy();
     }
+
+    // If there is an element before the ones we deleted
+    if (start>0) {
+      childViews[start-1].set('nextView', start<childViews.length ? childViews[start] : null);
+    }
+    // if there is an element after the ones we deleted
+    if (start<childViews.length) {
+      childViews[start].set('prevView', start>0 ? childViews[start-1] : null);
+    }
   },
 
   /**
@@ -255,7 +264,12 @@ Ember.CollectionView = Ember.ContainerView.extend(
           content: item,
           contentIndex: idx
         });
-
+        
+        // link together the chain of addedViews
+        if (addedViews.length>0) {
+          view.set('prevView', addedViews[addedViews.length-1]);
+          addedViews[addedViews.length-1].set('nextView', view);
+        }
         addedViews.push(view);
       }
     } else {
@@ -266,7 +280,19 @@ Ember.CollectionView = Ember.ContainerView.extend(
       addedViews.push(emptyView);
       set(this, 'emptyView', emptyView);
     }
-
+    
+    if (added>0) {
+      // if there is a childview before the ones we're adding
+      if (start>0) {
+        childViews.objectAt(start-1).set('nextView', addedViews[0]);
+        addedViews[0].set('prevView', childViews.objectAt(start-1));
+      }
+      // if there is a childview after the ones we're adding
+      if (start<childViews.length) {
+        childViews.objectAt(start).set('prevView', addedViews[addedViews.length-1]);
+        addedViews[addedViews.length-1].set('nextView', childViews.objectAt(start));
+      }
+    }
     childViews.replace(start, 0, addedViews);
   },
 

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -206,6 +206,10 @@ Ember.ContainerView = Ember.View.extend({
         view = this.createChildView(viewName);
       }
 
+      if (idx>0) {
+        _childViews[idx-1].nextView = view;
+	view.prevView = _childViews[idx-1];
+      }
       _childViews[idx] = view;
     }, this);
 
@@ -315,7 +319,7 @@ Ember.ContainerView = Ember.View.extend({
   */
   _scheduleInsertion: function(view, prev) {
     if (prev) {
-      prev.domManager.after(prev, view);
+      prev.domManager.after(this, prev, view);
     } else {
       this.domManager.prepend(this, view);
     }

--- a/packages/ember-views/lib/views/states/in_buffer.js
+++ b/packages/ember-views/lib/views/states/in_buffer.js
@@ -39,7 +39,13 @@ Ember.View.states.inBuffer = {
     var buffer = view.buffer;
 
     childView = this.createChildView(childView, options);
-    get(view, '_childViews').push(childView);
+    var childViews = get(view, '_childViews');
+
+    if (childViews.length > 0) {
+        childViews[childViews.length-1].nextView = childView;
+        childView.prevView = childViews[childViews.length-1];
+    }
+    childViews.push(childView);
 
     childView.renderToBuffer(buffer);
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -228,6 +228,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     }
   }).property('_parentView'),
 
+  // allow navigation between the next and previous views
+  prevView: null,
+  nextView: null,
+
   // return the current view, not including virtual views
   concreteView: Ember.computed(function() {
     if (!this.isVirtual) { return this; }
@@ -1506,10 +1510,22 @@ var DOMManager = {
     });
   },
 
-  after: function(view, nextView) {
-    nextView._insertElementLater(function() {
-      var element = view.$();
-      element.after(nextView.$());
+  after: function(parentView, view, newView) {
+    newView._insertElementLater(function() {
+      var nextView;
+      var prevView = view;
+      while (prevView !== null && prevView.get('state') !== 'inDOM') {
+        prevView=prevView.get('prevView');
+      }
+      var element;
+      if (prevView === null) {
+        element = parentView.$();
+        element.prepend(newView.$());
+      } else {
+        element = prevView.$();
+        element.after(newView.$());
+      }
+      
     });
   },
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -172,6 +172,166 @@ test("should remove an item from DOM when an item is removed from the content ar
   });
 });
 
+test("it updates the view if an item is replaced", function() {
+  var content = Ember.A(['foo', 'bar', 'baz']);
+  view = Ember.CollectionView.create({
+    content: content,
+
+    itemViewClass: Ember.View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content'));
+      }
+    })
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  forEach(content, function(item) {
+    equal(view.$(':contains("'+item+'")').length, 1, "precond - generates pre-existing items");
+  });
+
+  Ember.run(function() {
+    content.removeAt(1);
+    content.insertAt(1, "Kazuki" );
+  });
+
+  forEach(content, function(item, idx) {
+    equal(view.$(Ember.String.fmt(':nth-child(%@)', [String(idx+1)])).text(), item, "postcond - correct array update");
+  });
+});
+
+test("can add and replace in the same runloop", function() {
+  var content = Ember.A(['foo', 'bar', 'baz']);
+  view = Ember.CollectionView.create({
+    content: content,
+
+    itemViewClass: Ember.View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content'));
+      }
+    })
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  forEach(content, function(item) {
+    equal(view.$(':contains("'+item+'")').length, 1, "precond - generates pre-existing items");
+  });
+
+  Ember.run(function() {
+    content.pushObject("Tom Dale" );
+    content.removeAt(0);
+    content.insertAt(0, "Kazuki" );
+  });
+
+  forEach(content, function(item, idx) {
+    equal(view.$(Ember.String.fmt(':nth-child(%@)', [String(idx+1)])).text(), item, "postcond - correct array update");
+  });
+
+});
+
+test("can add and replace the object before the add in the same runloop", function() {
+  var content = Ember.A(['foo', 'bar', 'baz']);
+  view = Ember.CollectionView.create({
+    content: content,
+
+    itemViewClass: Ember.View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content'));
+      }
+    })
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  forEach(content, function(item) {
+    equal(view.$(':contains("'+item+'")').length, 1, "precond - generates pre-existing items");
+  });
+
+  Ember.run(function() {
+    content.pushObject("Tom Dale" );
+    content.removeAt(1);
+    content.insertAt(1, "Kazuki" );
+  });
+
+  forEach(content, function(item, idx) {
+    equal(view.$(Ember.String.fmt(':nth-child(%@)', [String(idx+1)])).text(), item, "postcond - correct array update");
+  });
+});
+
+test("can add and replace complicatedly", function() {
+  var content = Ember.A(['foo', 'bar', 'baz']);
+  view = Ember.CollectionView.create({
+    content: content,
+
+    itemViewClass: Ember.View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content'));
+      }
+    })
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  forEach(content, function(item) {
+    equal(view.$(':contains("'+item+'")').length, 1, "precond - generates pre-existing items");
+  });
+
+  Ember.run(function() {
+    content.pushObject("Tom Dale" );
+    content.removeAt(1);
+    content.insertAt(1, "Kazuki" );
+    content.pushObject("Firestone" );
+    content.pushObject("McMunch" );
+  });
+
+  forEach(content, function(item, idx) {
+    equal(view.$(Ember.String.fmt(':nth-child(%@)', [String(idx+1)])).text(), item, "postcond - correct array update: "+item.name+"!="+view.$(Ember.String.fmt(':nth-child(%@)', [String(idx+1)])).text());
+  });
+});
+
+test("can add and replace complicatedly harder", function() {
+  var content = Ember.A(['foo', 'bar', 'baz']);
+  view = Ember.CollectionView.create({
+    content: content,
+
+    itemViewClass: Ember.View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content'));
+      }
+    })
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  forEach(content, function(item) {
+    equal(view.$(':contains("'+item+'")').length, 1, "precond - generates pre-existing items");
+  });
+
+  Ember.run(function() {
+    content.pushObject("Tom Dale" );
+    content.removeAt(1);
+    content.insertAt(1, "Kazuki" );
+    content.pushObject("Firestone" );
+    content.pushObject("McMunch" );
+    content.removeAt(2);
+  });
+
+  forEach(content, function(item, idx) {
+    equal(view.$(Ember.String.fmt(':nth-child(%@)', [String(idx+1)])).text(), item, "postcond - correct array update");
+  });
+});
+
 test("should allow changes to content object before layer is created", function() {
   view = Ember.CollectionView.create({
     content: null


### PR DESCRIPTION
New elements get scheduled to be appended after an existing element in the DOM. However, removed elements get deleted immediately. When the new elements' scheduled appending happens, it crashes if the previous element is no longer in the DOM.
This patch adds a linked list implementation to child views so that inserted views can walk to a valid sibling, as well as tests that trigger the problem.
