### PR TITLE
Currently using the colon syntax property:class-name in classBindings will only work if the property is strictly equal to true. I believe this should work as expected if the property is merely truthy.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -330,9 +330,14 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
 
     var val = property !== '' ? getPath(context, property, options) : true;
 
+    // If the value is truthy and we're using the colon syntax,
+    // we should return the className directly
+    if (!!val && className) {
+      return className;
+
     // If value is a Boolean and true, return the dasherized property
     // name.
-    if (val === true) {
+    } else if (val === true) {
       if (className) { return className; }
 
       // Normalize property path to be suitable for use

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -338,8 +338,6 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
     // If value is a Boolean and true, return the dasherized property
     // name.
     } else if (val === true) {
-      if (className) { return className; }
-
       // Normalize property path to be suitable for use
       // as a class name. For exaple, content.foo.barBaz
       // becomes bar-baz.

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1089,6 +1089,31 @@ test("should be able to bind view class names to properties", function() {
   equal(view.$('.is-done').length, 0, "removes class name if bound property is set to false");
 });
 
+test("should be able to bind view class names to truthy properties", function() {
+  var templates = Ember.Object.create({
+    template: Ember.Handlebars.compile('{{#view "TemplateTests.classBindingView" classBinding="number:is-truthy"}}foo{{/view}}')
+  });
+
+  TemplateTests.classBindingView = Ember.View.extend({
+    number: 5
+  });
+
+  view = Ember.View.create({
+    templateName: 'template',
+    templates: templates
+  });
+
+  appendView();
+
+  equal(view.$('.is-truthy').length, 1, "sets class name");
+
+  Ember.run(function() {
+    set(firstChild(view), 'number', 0);
+  });
+
+  equal(view.$('.is-truthy').length, 0, "removes class name if bound property is set to falsey");
+});
+
 test("should be able to bind element attributes using {{bindAttr}}", function() {
   var template = Ember.Handlebars.compile('<img {{bindAttr src="content.url" alt="content.title"}}>');
 
@@ -1270,6 +1295,25 @@ test("should be able to bind class attribute with {{bindAttr}}", function() {
   });
 
   equal(view.$('img').attr('class'), 'baz', "updates class");
+});
+
+test("should be able to bind class attribute via a truthy property with {{bindAttr}}", function() {
+  var template = Ember.Handlebars.compile('<img {{bindAttr class="isNumber:is-truthy"}}>');
+
+  view = Ember.View.create({
+    template: template,
+    isNumber: 5
+  });
+
+  appendView();
+
+  equal(view.$('.is-truthy').length, 1, "sets class name");
+
+  Ember.run(function() {
+    set(view, 'isNumber', 0);
+  });
+
+  equal(view.$('.is-truthy').length, 0, "removes class name if bound property is set to something non-truthy");
 });
 
 test("should not allow XSS injection via {{bindAttr}} with class", function() {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -592,9 +592,14 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       val = Ember.getPath(window, property);
     }
 
+    // If the value is truthy and we're using the colon syntax,
+    // we should return the className directly
+    if (!!val && className) {
+      return className;
+			
     // If value is a Boolean and true, return the dasherized property
     // name.
-    if (val === true) {
+		} else if (val === true) {
       if (className) { return className; }
 
       // Normalize property path to be suitable for use

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -599,9 +599,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 			
     // If value is a Boolean and true, return the dasherized property
     // name.
-		} else if (val === true) {
-      if (className) { return className; }
-
+    } else if (val === true) {
       // Normalize property path to be suitable for use
       // as a class name. For exaple, content.foo.barBaz
       // becomes bar-baz.

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -11,12 +11,13 @@ module("Ember.View - Class Name Bindings");
 test("should apply bound class names to the element", function() {
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
-                        'canIgnore', 'messages.count', 'messages.resent:is-resent'],
+                        'canIgnore', 'messages.count', 'messages.resent:is-resent', 'isNumber:is-number'],
 
     priority: 'high',
     isUrgent: true,
     isClassified: true,
     canIgnore: false,
+		isNumber: 5,
 
     messages: {
       count: 'five-messages',
@@ -30,6 +31,7 @@ test("should apply bound class names to the element", function() {
   ok(view.$().hasClass('classified'), "supports customizing class name for Boolean values");
   ok(view.$().hasClass('five-messages'), "supports paths in bindings");
   ok(view.$().hasClass('is-resent'), "supports customing class name for paths");
+  ok(view.$().hasClass('is-number'), "supports colon syntax with truthy properties");
   ok(!view.$().hasClass('can-ignore'), "does not add false Boolean values as class");
 });
 


### PR DESCRIPTION
...ropagate the associated class
