### PR TITLE
Support :: syntax in classNameBindings of Ember.View

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -78,7 +78,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
       for (var b in extensions.classNameBindings) {
         var full = extensions.classNameBindings[b];
         if (typeof full === 'string') {
-          // Contextulaize the path of classNameBinding so this:
+          // Contextualize the path of classNameBinding so this:
           //
           //     classNameBinding="isGreen:green"
           //

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -75,40 +75,19 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
     // Evaluate the context of class name bindings:
     if (extensions.classNameBindings) {
-      var full,
-          parts;
-
       for (var b in extensions.classNameBindings) {
-        full = extensions.classNameBindings[b];
+        var full = extensions.classNameBindings[b];
         if (typeof full === 'string') {
-          if (full.indexOf(':') > 0) {
-            // When a classNameBinding contains a colon anywhere after the first character,
-            // then the part preceding the colon is a binding path that needs to be
-            // contextualized.
-            //
-            // For example:
-            //   classNameBinding="isGreen:green"
-            //
-            // Will be converted to:
-            //   classNameBinding="bindingContext.isGreen:green"
-
-            parts = full.split(':');
-            path = this.contextualizeBindingPath(parts[0], data);
-            if (path) { extensions.classNameBindings[b] = path + ':' + parts[1]; }
-
-          } else if (full.indexOf(':') === -1 ) {
-            // When a classNameBinding doesn't contain any colons, then the entire binding
-            // needs to be contextualized.
-            //
-            // For example:
-            //   classNameBinding="myClass"
-            //
-            // Will be converted to:
-            //   classNameBinding="bindingContext.myClass"
-
-            path = this.contextualizeBindingPath(full, data);
-            if (path) { extensions.classNameBindings[b] = path; }
-          }
+          // Contextulaize the path of classNameBinding so this:
+          //
+          //     classNameBinding="isGreen:green"
+          //
+          // is converted to this:
+          //
+          //     classNameBinding="bindingContext.isGreen:green"
+          var parsedPath = Ember.View._parsePropertyPath(full);
+          path = this.contextualizeBindingPath(parsedPath.path, data);
+          if (path) { extensions.classNameBindings[b] = path + parsedPath.classNames; }
         }
       }
     }

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1155,7 +1155,7 @@ test("{{view}} should evaluate class bindings set to global paths", function() {
   });
 
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{view Ember.TextField class="unbound" classBinding="App.isGreat:great App.directClass App.isApp App.isEnabled?enabled:disabled"}}')
+    template: Ember.Handlebars.compile('{{view Ember.TextField class="unbound" classBinding="App.isGreat:great App.directClass App.isApp App.isEnabled:enabled:disabled"}}')
   });
 
   appendView();
@@ -1187,7 +1187,7 @@ test("{{view}} should evaluate class bindings set in the current context", funct
     isEditable:  true,
     directClass: "view-direct",
     isEnabled: true,
-    template: Ember.Handlebars.compile('{{view Ember.TextField class="unbound" classBinding="isEditable:editable directClass isView isEnabled?enabled:disabled"}}')
+    template: Ember.Handlebars.compile('{{view Ember.TextField class="unbound" classBinding="isEditable:editable directClass isView isEnabled:enabled:disabled"}}')
   });
 
   appendView();
@@ -1218,7 +1218,7 @@ test("{{view}} should evaluate class bindings set with either classBinding or cl
   });
 
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{view Ember.TextField class="unbound" classBinding="App.isGreat:great App.isEnabled?enabled:disabled" classNameBindings="App.isGreat:really-great App.isEnabled?really-enabled:really-disabled"}}')
+    template: Ember.Handlebars.compile('{{view Ember.TextField class="unbound" classBinding="App.isGreat:great App.isEnabled:enabled:disabled" classNameBindings="App.isGreat:really-great App.isEnabled:really-enabled:really-disabled"}}')
   });
 
   appendView();
@@ -1572,7 +1572,7 @@ test("should not allow XSS injection via {{bindAttr}} with class", function() {
 });
 
 test("should be able to bind class attribute using ternary operator in {{bindAttr}}", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr class="content.isDisabled?disabled:enabled"}} />');
+  var template = Ember.Handlebars.compile('<img {{bindAttr class="content.isDisabled:disabled:enabled"}} />');
   var content = Ember.Object.create({
     isDisabled: true
   });
@@ -1596,7 +1596,7 @@ test("should be able to bind class attribute using ternary operator in {{bindAtt
 });
 
 test("should be able to add multiple classes using {{bindAttr class}}", function() {
-  var template = Ember.Handlebars.compile('<div {{bindAttr class="content.isAwesomeSauce content.isAlsoCool content.isAmazing:amazing :is-super-duper content.isEnabled?enabled:disabled"}}></div>');
+  var template = Ember.Handlebars.compile('<div {{bindAttr class="content.isAwesomeSauce content.isAlsoCool content.isAmazing:amazing :is-super-duper content.isEnabled:enabled:disabled"}}></div>');
   var content = Ember.Object.create({
     isAwesomeSauce: true,
     isAlsoCool: true,

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1019,7 +1019,15 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   */
   _classStringForProperty: function(property) {
     var parsedPath = Ember.View._parsePropertyPath(property);
-    return Ember.View._classStringForPath(this, parsedPath.path, parsedPath.className, parsedPath.falsyClassName);
+    var path = parsedPath.path;
+
+    // TODO: Remove this `false` when the `getPath` globals support is removed
+    var val = getPath(this, path, false);
+    if (val === undefined && Ember.isGlobalPath(path)) {
+      val = getPath(window, path);
+    }
+
+    return Ember.View._classStringForValue(path, val, parsedPath.className, parsedPath.falsyClassName);
   },
 
   // ..........................................................
@@ -2028,16 +2036,6 @@ Ember.View.reopenClass({
     } else {
       return null;
     }
-  },
-
-  _classStringForPath: function(root, path, className, falsyClassName, options) {
-    // TODO: Remove this `false` when the `getPath` globals support is removed
-    var val = getPath(root, path, options);
-    if (val === undefined && Ember.isGlobalPath(path)) {
-      val = getPath(window, path);
-    }
-
-    return Ember.View._classStringForValue(path, val, className, falsyClassName);
   }
 });
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -170,6 +170,23 @@ var invokeForState = {
 
       <div id="ember1" class="ember-view disabled"></div>
 
+  This syntax offers the convenience to add a class if a property is `false`:
+
+    // Applies no class when isEnabled is true and class 'disabled' when isEnabled is false
+    Ember.View.create({
+      classNameBindings: ['isEnabled::disabled']
+      isEnabled: true
+    });
+
+  Will result in view instances with an HTML representation of:
+
+    <div id="ember1" class="ember-view"></div>
+
+  When the `isEnabled` property on the view is set to `false`, it will result
+  in view instances with an HTML representation of:
+
+    <div id="ember1" class="ember-view disabled"></div>
+
 
   Updates to the the value of a class name binding will result in automatic update 
   of the  HTML `class` attribute in the view's rendered HTML representation.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2059,13 +2059,12 @@ Ember.View.reopenClass({
     if (!!val && className) {
       return className;
 
-    // catch syntax like isEnabled::not-enabled
-    } else if (val === true && !className && falsyClassName) {
-      return null;
-
     // If value is a Boolean and true, return the dasherized property
     // name.
     } else if (val === true) {
+      // catch syntax like isEnabled::not-enabled
+      if (val === true && !className && falsyClassName) { return null; }
+
       // Normalize property path to be suitable for use
       // as a class name. For exaple, content.foo.barBaz
       // becomes bar-baz.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1972,12 +1972,12 @@ Ember.View.reopen({
 
 Ember.View.reopenClass({
   _parsePropertyPath: function(path) {
-    var split = path.split(/\?|:/),
+    var split = path.split(/:/),
         propertyPath = split[0],
         className,
         falsyClassName;
 
-    // check if the property is defined as prop?trueClass:falseClass
+    // check if the property is defined as prop:class or prop:trueClass:falseClass
     if (split.length > 1) {
       className = split[1];
       if (split.length === 3) { falsyClassName = split[2]; }
@@ -1985,10 +1985,9 @@ Ember.View.reopenClass({
 
     var classNames = "";
     if (className) {
+      classNames += ':' + className;
       if (falsyClassName) {
-        classNames = '?' + className + ':' + falsyClassName;
-      } else {
-        classNames = ':' + className;
+        classNames += ':' + falsyClassName;
       }
     }
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1991,6 +1991,23 @@ Ember.View.reopen({
 });
 
 Ember.View.reopenClass({
+
+  /**
+    @private
+
+    Parse a path and return an object which holds the parsed properties.
+
+    For example a path like "content.isEnabled:enabled:disabled" wil return the
+    following object:
+
+        {
+          path: "content.isEnabled",
+          className: "enabled",
+          falsyClassName: "disabled",
+          classNames: ":enabled:disabled"
+        }
+
+  */
   _parsePropertyPath: function(path) {
     var split = path.split(/:/),
         propertyPath = split[0],
@@ -2019,6 +2036,19 @@ Ember.View.reopenClass({
     };
   },
 
+  /**
+    @private
+
+    Get the class name for a given value, based on the path, optional className
+    and optional falsyClassName.
+
+    - if the value is truthy and a className is defined, the className is returned
+    - if the value is true, the dasherized last part of the supplied path is returned
+    - if the value is false and a falsyClassName is supplied, the falsyClassName is returned
+    - if the value is truthy, the value is returned
+    - if none of the above rules apply, null is returned
+
+  */
   _classStringForValue: function(path, val, className, falsyClassName) {
     // If the value is truthy and we're using the colon syntax,
     // we should return the className directly

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -151,6 +151,18 @@ var invokeForState = {
 
       <div id="ember1" class="ember-view empty"></div>
 
+
+  If you want to add a class name for a property which evaluates to true and
+  and a different class name if it evaluates to false, you can pass a binding
+  like this:
+
+    // Applies 'enabled' class when isEnabled is true and 'disabled' when isEnabled is false
+    Ember.View.create({
+      classNameBindings: ['isEnabled:enabled:disabled']
+      isEnabled: true
+    });
+
+
   Updates to the the value of a class name binding will result in automatic update 
   of the  HTML `class` attribute in the view's rendered HTML representation.
   If the value becomes  `false` or `undefined` the class name will be removed.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2019,6 +2019,7 @@ Ember.View.reopenClass({
   _parsePropertyPath: function(path) {
     var split = path.split(/:/),
         propertyPath = split[0],
+        classNames = "",
         className,
         falsyClassName;
 
@@ -2026,20 +2027,15 @@ Ember.View.reopenClass({
     if (split.length > 1) {
       className = split[1];
       if (split.length === 3) { falsyClassName = split[2]; }
-    }
 
-    var classNames = "";
-    if (className) {
-      classNames += ':' + className;
-      if (falsyClassName) {
-        classNames += ':' + falsyClassName;
-      }
+      classNames = ':' + className;
+      if (falsyClassName) { classNames += ":" + falsyClassName; }
     }
 
     return {
       path: propertyPath,
       classNames: classNames,
-      className: className,
+      className: (className === '') ? undefined : className,
       falsyClassName: falsyClassName
     };
   },
@@ -2062,6 +2058,10 @@ Ember.View.reopenClass({
     // we should return the className directly
     if (!!val && className) {
       return className;
+
+    // catch syntax like isEnabled::not-enabled
+    } else if (val === true && !className && falsyClassName) {
+      return null;
 
     // If value is a Boolean and true, return the dasherized property
     // name.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -162,6 +162,14 @@ var invokeForState = {
       isEnabled: true
     });
 
+  Will result in view instances with an HTML representation of:
+
+      <div id="ember1" class="ember-view enabled"></div>
+
+  When isEnabled is `false`, the resulting HTML reprensentation looks like this:
+
+      <div id="ember1" class="ember-view disabled"></div>
+
 
   Updates to the the value of a class name binding will result in automatic update 
   of the  HTML `class` attribute in the view's rendered HTML representation.

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -12,7 +12,7 @@ test("should apply bound class names to the element", function() {
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
                         'canIgnore', 'messages.count', 'messages.resent:is-resent', 'isNumber:is-number',
-                        'isEnabled?enabled:disabled'],
+                        'isEnabled:enabled:disabled'],
 
     priority: 'high',
     isUrgent: true,
@@ -46,7 +46,7 @@ test("should add, remove, or change class names if changed after element is crea
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
                         'canIgnore', 'messages.count', 'messages.resent:is-resent',
-                        'isEnabled?enabled:disabled'],
+                        'isEnabled:enabled:disabled'],
 
     priority: 'high',
     isUrgent: true,

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -11,13 +11,15 @@ module("Ember.View - Class Name Bindings");
 test("should apply bound class names to the element", function() {
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
-                        'canIgnore', 'messages.count', 'messages.resent:is-resent', 'isNumber:is-number'],
+                        'canIgnore', 'messages.count', 'messages.resent:is-resent', 'isNumber:is-number',
+                        'isEnabled?enabled:disabled'],
 
     priority: 'high',
     isUrgent: true,
     isClassified: true,
     canIgnore: false,
-		isNumber: 5,
+    isNumber: 5,
+    isEnabled: true,
 
     messages: {
       count: 'five-messages',
@@ -36,17 +38,21 @@ test("should apply bound class names to the element", function() {
   ok(view.$().hasClass('is-resent'), "supports customing class name for paths");
   ok(view.$().hasClass('is-number'), "supports colon syntax with truthy properties");
   ok(!view.$().hasClass('can-ignore'), "does not add false Boolean values as class");
+  ok(view.$().hasClass('enabled'), "supports customizing class name for Boolean values with negation");
+  ok(!view.$().hasClass('disabled'), "does not add class name for negated binding");
 });
 
 test("should add, remove, or change class names if changed after element is created", function() {
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
-                        'canIgnore', 'messages.count', 'messages.resent:is-resent'],
+                        'canIgnore', 'messages.count', 'messages.resent:is-resent',
+                        'isEnabled?enabled:disabled'],
 
     priority: 'high',
     isUrgent: true,
     isClassified: true,
     canIgnore: false,
+    isEnabled: true,
 
     messages: Ember.Object.create({
       count: 'five-messages',
@@ -59,6 +65,7 @@ test("should add, remove, or change class names if changed after element is crea
     set(view, 'priority', 'orange');
     set(view, 'isUrgent', false);
     set(view, 'canIgnore', true);
+    set(view, 'isEnabled', false);
     setPath(view, 'messages.count', 'six-messages');
     setPath(view, 'messages.resent', true );
   });
@@ -73,6 +80,9 @@ test("should add, remove, or change class names if changed after element is crea
   ok(!view.$().hasClass('five-messages'), "removes old value when path changes");
 
   ok(view.$().hasClass('is-resent'), "adds customized class name when path changes");
+
+  ok(!view.$().hasClass('enabled'), "updates class name for negated binding");
+  ok(view.$().hasClass('disabled'), "adds negated class name for negated binding");
 });
 
 test("classNames should not be duplicated on rerender", function(){

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -85,6 +85,21 @@ test("should add, remove, or change class names if changed after element is crea
   ok(view.$().hasClass('disabled'), "adds negated class name for negated binding");
 });
 
+test(":: class name syntax works with an empty true class", function() {
+  var view = Ember.View.create({
+    isEnabled: false,
+    classNameBindings: ['isEnabled::not-enabled']
+  });
+
+  Ember.run(function(){ view.createElement(); });
+
+  equal(view.$().attr('class'), 'ember-view not-enabled', "false class is rendered when property is false");
+
+  Ember.run(function(){ view.set('isEnabled', true); });
+
+  equal(view.$().attr('class'), 'ember-view', "no class is added when property is true and the class is empty");
+});
+
 test("classNames should not be duplicated on rerender", function(){
   var view;
   

--- a/packages/ember-views/tests/views/view/class_string_for_value_test.js
+++ b/packages/ember-views/tests/views/view/class_string_for_value_test.js
@@ -1,0 +1,36 @@
+module("Ember.View - _classStringForValue");
+
+var cSFV = Ember.View._classStringForValue;
+
+test("returns dasherized version of last path part if value is true", function() {
+  equal(cSFV("propertyName", true), "property-name", "class is dasherized");
+  equal(cSFV("content.propertyName", true), "property-name", "class is dasherized");
+});
+
+test("returns className if value is true and className is specified", function() {
+  equal(cSFV("propertyName", true, "truthyClass"), "truthyClass", "returns className if given");
+  equal(cSFV("content.propertyName", true, "truthyClass"), "truthyClass", "returns className if given");
+});
+
+test("returns falsyClassName if value is false and falsyClassName is specified", function() {
+  equal(cSFV("propertyName", false, "truthyClass", "falsyClass"), "falsyClass", "returns falsyClassName if given");
+  equal(cSFV("content.propertyName", false, "truthyClass", "falsyClass"), "falsyClass", "returns falsyClassName if given");
+});
+
+test("returns null if value is false and falsyClassName is not specified", function() {
+  equal(cSFV("propertyName", false, "truthyClass"), null, "returns null if falsyClassName is not specified");
+  equal(cSFV("content.propertyName", false, "truthyClass"), null, "returns null if falsyClassName is not specified");
+});
+
+test("returns null if value is false", function() {
+  equal(cSFV("propertyName", false), null, "returns null if value is false");
+  equal(cSFV("content.propertyName", false), null, "returns null if value is false");
+});
+
+test("returns the value if the value is truthy", function() {
+  equal(cSFV("propertyName", "myString"), "myString", "returns value if the value is truthy");
+  equal(cSFV("content.propertyName", "myString"), "myString", "returns value if the value is truthy");
+
+  equal(cSFV("propertyName", "123"), 123, "returns value if the value is truthy");
+  equal(cSFV("content.propertyName", 123), 123, "returns value if the value is truthy");
+});

--- a/packages/ember-views/tests/views/view/class_string_for_value_test.js
+++ b/packages/ember-views/tests/views/view/class_string_for_value_test.js
@@ -27,6 +27,11 @@ test("returns null if value is false", function() {
   equal(cSFV("content.propertyName", false), null, "returns null if value is false");
 });
 
+test("returns null if value is true and className is not specified and falsyClassName is specified", function() {
+  equal(cSFV("propertyName", true, undefined, "falsyClassName"), null, "returns null if value is true");
+  equal(cSFV("content.propertyName", true, undefined, "falsyClassName"), null, "returns null if value is true");
+});
+
 test("returns the value if the value is truthy", function() {
   equal(cSFV("propertyName", "myString"), "myString", "returns value if the value is truthy");
   equal(cSFV("content.propertyName", "myString"), "myString", "returns value if the value is truthy");

--- a/packages/ember-views/tests/views/view/parse_property_path_test.js
+++ b/packages/ember-views/tests/views/view/parse_property_path_test.js
@@ -35,3 +35,12 @@ test("falsyClassName is extracted", function() {
   equal(parsed.falsyClassName, "falsyClass", "falsyClassName is extracted");
   equal(parsed.classNames, ":class:falsyClass", "there is a classNames");
 });
+
+test("it works with an empty true class", function() {
+  var parsed = Ember.View._parsePropertyPath("content.simpleProperty::falsyClass");
+
+  equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
+  equal(parsed.className, undefined, "className is undefined");
+  equal(parsed.falsyClassName, "falsyClass", "falsyClassName is extracted");
+  equal(parsed.classNames, "::falsyClass", "there is a classNames");
+});

--- a/packages/ember-views/tests/views/view/parse_property_path_test.js
+++ b/packages/ember-views/tests/views/view/parse_property_path_test.js
@@ -1,0 +1,37 @@
+module("Ember.View - _parsePropertyPath");
+
+test("it works with a simple property path", function() {
+  var parsed = Ember.View._parsePropertyPath("simpleProperty");
+
+  equal(parsed.path, "simpleProperty", "path is parsed correctly");
+  equal(parsed.className, undefined, "there is no className");
+  equal(parsed.falsyClassName, undefined, "there is no falsyClassName");
+  equal(parsed.classNames, "", "there is no classNames");
+});
+
+test("it works with a more complex property path", function() {
+  var parsed = Ember.View._parsePropertyPath("content.simpleProperty");
+
+  equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
+  equal(parsed.className, undefined, "there is no className");
+  equal(parsed.falsyClassName, undefined, "there is no falsyClassName");
+  equal(parsed.classNames, "", "there is no classNames");
+});
+
+test("className is extracted", function() {
+  var parsed = Ember.View._parsePropertyPath("content.simpleProperty:class");
+
+  equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
+  equal(parsed.className, "class", "className is extracted");
+  equal(parsed.falsyClassName, undefined, "there is no falsyClassName");
+  equal(parsed.classNames, ":class", "there is a classNames");
+});
+
+test("falsyClassName is extracted", function() {
+  var parsed = Ember.View._parsePropertyPath("content.simpleProperty?class:falsyClass");
+
+  equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
+  equal(parsed.className, "class", "className is extracted");
+  equal(parsed.falsyClassName, "falsyClass", "falsyClassName is extracted");
+  equal(parsed.classNames, "?class:falsyClass", "there is a classNames");
+});

--- a/packages/ember-views/tests/views/view/parse_property_path_test.js
+++ b/packages/ember-views/tests/views/view/parse_property_path_test.js
@@ -28,10 +28,10 @@ test("className is extracted", function() {
 });
 
 test("falsyClassName is extracted", function() {
-  var parsed = Ember.View._parsePropertyPath("content.simpleProperty?class:falsyClass");
+  var parsed = Ember.View._parsePropertyPath("content.simpleProperty:class:falsyClass");
 
   equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
   equal(parsed.className, "class", "className is extracted");
   equal(parsed.falsyClassName, "falsyClass", "falsyClassName is extracted");
-  equal(parsed.classNames, "?class:falsyClass", "there is a classNames");
+  equal(parsed.classNames, ":class:falsyClass", "there is a classNames");
 });


### PR DESCRIPTION
This commit extends bindings to class names by adding support for falsy class names by using the double colon\* syntax as following:

``` javascript
Ember.View.create({
  classNameBindings: ['isEnabled:enabled:disabled']
  isEnabled: true
});
```

This will add the class 'enabled' when isEnabled is true. If isEnabled is false the class 'disabled' is added instead.

*Inspired by recent semicolon discussion
