### PR TITLE
Rename ember-tests.js to ember-tests.min.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ spec/reports
 test/tmp
 test/version_tmp
 test_*.html
-/tests/ember-tests.js
+/tests/ember-tests.min.js
 tmp
 tmp*.gem
 tmp.bpm

--- a/Assetfile
+++ b/Assetfile
@@ -51,10 +51,10 @@ input "packages" do
       id
     }
 
-    concat "ember-tests.js"
+    concat "ember-tests.min.js"
   end
 
-  match "ember-tests.js" do
+  match "ember-tests.min.js" do
     filter JSHintRC
   end
 end

--- a/tests/index.html
+++ b/tests/index.html
@@ -99,7 +99,7 @@
     // Close the script tag to make sure document.write happens
   </script>
 
-  <script type="text/javascript" src="ember-tests.js"></script>
+  <script type="text/javascript" src="ember-tests.min.js"></script>
 
   <script type="text/javascript">
 


### PR DESCRIPTION
Tagging minified JavaScript files with a .min.js extension helps search
tools like Ack auto-ignore them. That way your terminal doesn't get
flooded with a huge 600KB line from a matching minified file.
