### PR TITLE
Add upload_to_url task to Rakefile and execute this task in after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "rake clean"
 script: "rake test[all]"
+after_script: "rake upload_to_url"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "rake clean"
 script: "rake test[all]"
-after_script: "rake upload_to_url"
+notifications:
+  webhooks: http://emberjs-uploader.herokuapp.com/upload

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gem "rake-pipeline-web-filters", :git => "https://github.com/wycats/rake-pipelin
 gem "colored"
 # Using git to prevent deprecation warnings
 gem "uglifier", :git => "https://github.com/lautis/uglifier.git"
+gem "rest-client"
 
 group :development do
   gem "rack"
-  gem "rest-client"
   gem "github_api"
   gem "ember-docs", :git => "https://github.com/emberjs/docs-generator.git"
   gem "kicker"

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gem "rake-pipeline-web-filters", :git => "https://github.com/wycats/rake-pipelin
 gem "colored"
 # Using git to prevent deprecation warnings
 gem "uglifier", :git => "https://github.com/lautis/uglifier.git"
-gem "rest-client"
 
 group :development do
   gem "rack"
+  gem "rest-client"
   gem "github_api"
   gem "ember-docs", :git => "https://github.com/emberjs/docs-generator.git"
   gem "kicker"

--- a/Rakefile
+++ b/Rakefile
@@ -25,10 +25,12 @@ def setup_uploader
   #              git@github.com:emberjs/ember.js
 
   repoUrl = origin.match(/github\.com[\/:]((.+?)\/(.+?))(\.git)?$/)
-  username = repoUrl[2] # username part of origin url
-  repo = repoUrl[3] # repository name part of origin url
+  username = ENV['GH_USERNAME'] || repoUrl[2] # username part of origin url
+  repo = ENV['GH_REPO'] || repoUrl[3] # repository name part of origin url
 
-  uploader = GithubUploader.new(login, username, repo)
+  token = ENV['GH_OAUTH_TOKEN']
+
+  uploader = GithubUploader.new(login, username, repo, token)
   uploader.authorize
 
   uploader
@@ -76,7 +78,6 @@ task :upload_latest => :dist do
   upload_file(uploader, 'ember-latest.min.js', "Ember.js Master (minified)", "dist/ember.min.js")
   upload_file(uploader, 'ember-latest.js', "Ember.js Master", "dist/ember.js")
 end
-
 
 namespace :docs do
   def doc_args

--- a/lib/github_uploader.rb
+++ b/lib/github_uploader.rb
@@ -3,12 +3,12 @@ require "github_api"
 
 class GithubUploader
 
-  def initialize(login, username, repo, root=Dir.pwd)
+  def initialize(login, username, repo, token, root=Dir.pwd)
     @login    = login
     @username = username
     @repo     = repo
     @root     = root
-    @token    = check_token
+    @token    = token || check_token
   end
 
   def authorized?


### PR DESCRIPTION
This task POST's the latest build of Ember.js to a Heroku app, which in turn replaces the latest build in the ember.js downloads section on GitHub.

This task is added as after_script in the travis configuration. If the tests succeed, the after_script is invoked and the latest build of Ember.js is added to the downloads section.

---

The repository for the uploader is at https://github.com/pangratz/github-uploader

This is the result of the discussion in emberjs/ember-rails#4

A core contributor needs to clone the pangratz/github-uploader repository, and install the app on heroku as described in the README. The Heroku app should be named **emberjs-uploader**, as this name is used in the Rake task. I think this should be an environment variable someday ...

Before this eventually is merged, I think this should be discussed ...
