### PR TITLE
Refer to ENV as Ember.ENV

### DIFF
--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -20,7 +20,7 @@ Ember.Handlebars.bootstrap = function(ctx) {
 
   if (Ember.ENV.LEGACY_HANDLEBARS_TAGS) { selectors += ', script[type="text/html"]'; }
 
-  ember_warn("Ember no longer parses text/html script tags by default. Set ENV.LEGACY_HANDLEBARS_TAGS = true to restore this functionality.", Ember.ENV.LEGACY_HANDLEBARS_TAGS || Ember.$('script[type="text/html"]').length === 0);
+  ember_warn("Ember no longer parses text/html script tags by default. Set Ember.ENV.LEGACY_HANDLEBARS_TAGS = true to restore this functionality.", Ember.ENV.LEGACY_HANDLEBARS_TAGS || Ember.$('script[type="text/html"]').length === 0);
 
   Ember.$(selectors, ctx)
     .each(function() {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -11,7 +11,7 @@ require('ember-metal/utils');
 require('ember-metal/properties');
 
 
-ember_warn("Computed properties will soon be cacheable by default. To enable this in your app, set `ENV.CP_DEFAULT_CACHEABLE = true`.", Ember.CP_DEFAULT_CACHEABLE);
+ember_warn("Computed properties will soon be cacheable by default. To enable this in your app, set `Ember.ENV.CP_DEFAULT_CACHEABLE = true`.", Ember.CP_DEFAULT_CACHEABLE);
 
 
 var meta = Ember.meta;

--- a/packages/ember-views/lib/views/states/in_buffer.js
+++ b/packages/ember-views/lib/views/states/in_buffer.js
@@ -24,7 +24,7 @@ Ember.View.states.inBuffer = {
   // when a view is rendered in a buffer, rerendering it simply
   // replaces the existing buffer with a new one
   rerender: function(view) {
-    ember_deprecate("Something you did caused a view to re-render after it rendered but before it was inserted into the DOM. Because this is avoidable and the cause of significant performance issues in applications, this behavior is deprecated. If you want to use the debugger to find out what caused this, you can set ENV.RAISE_ON_DEPRECATION to true.");
+    ember_deprecate("Something you did caused a view to re-render after it rendered but before it was inserted into the DOM. Because this is avoidable and the cause of significant performance issues in applications, this behavior is deprecated. If you want to use the debugger to find out what caused this, you can set `Ember.ENV.RAISE_ON_DEPRECATION = true`.");
 
     view._notifyWillRerender();
 


### PR DESCRIPTION
I thought at first that ENV was a global variable on window. This
clarifies the warnings to say Ember.ENV instead.
