### PR TITLE
unshiftObjects should maintain the order of the inserted array

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -219,7 +219,7 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   */
   unshiftObjects: function(objects) {
     this.beginPropertyChanges();
-    forEach(objects, function(obj) { this.unshiftObject(obj); }, this);
+    forEach(objects.slice(0).reverse(), function(obj) { this.unshiftObject(obj); }, this);
     this.endPropertyChanges();
     return this;
   },

--- a/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
@@ -17,7 +17,7 @@ suite.test("returns receiver", function() {
 });
 
 suite.test("[].unshiftObjects([A,B,C]) => [A,B,C] + notify", function() {
-  var obj, before, after, item, observer;
+  var obj, before, after, items, observer;
 
   before = [];
   items = this.newFixture(3);
@@ -37,7 +37,7 @@ suite.test("[].unshiftObjects([A,B,C]) => [A,B,C] + notify", function() {
 });
 
 suite.test("[A,B,C].unshiftObjects([X,Y,Z]) => [X,Y,Z,A,B,C] + notify", function() {
-  var obj, before, after, item, observer;
+  var obj, before, after, items, observer;
 
   before = this.newFixture(3);
   items = this.newFixture(3);
@@ -57,7 +57,7 @@ suite.test("[A,B,C].unshiftObjects([X,Y,Z]) => [X,Y,Z,A,B,C] + notify", function
 });
 
 suite.test("[A,B,C].unshiftObjects([A,B,C]) => [A,B,C,A,B,C] + notify", function() {
-  var obj, before, after, item, observer;
+  var obj, before, after, items, observer;
 
   before = this.newFixture(3);
   items = before; // note same objects as current. should end up twice

--- a/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
@@ -1,0 +1,77 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require('ember-runtime/~tests/suites/mutable_array');
+
+var suite = Ember.MutableArrayTests;
+
+suite.module('unshiftObjects');
+
+suite.test("returns receiver", function() {
+  var obj = this.newObject([]);
+  var item = this.newFixture(1);
+  equal(obj.unshiftObjects(item), obj, 'should return receiver');
+});
+
+suite.test("[].unshiftObjects([A,B,C]) => [A,B,C] + notify", function() {
+  var obj, before, after, item, observer;
+
+  before = [];
+  items = this.newFixture(3);
+  after  = items;
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', 'length');
+
+  obj.unshiftObjects(items);
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(Ember.get(obj, 'length'), after.length, 'length');
+
+  if (observer.isEnabled) {
+    equal(observer.validate('[]'), true, 'should have notified []');
+    equal(observer.validate('length'), true, 'should have notified length');
+  }
+});
+
+suite.test("[A,B,C].unshiftObjects([X,Y,Z]) => [X,Y,Z,A,B,C] + notify", function() {
+  var obj, before, after, item, observer;
+
+  before = this.newFixture(3);
+  items = this.newFixture(3);
+  after  = [items[0], items[1], items[2], before[0], before[1], before[2]];
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', 'length');
+
+  obj.unshiftObjects(items);
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(Ember.get(obj, 'length'), after.length, 'length');
+
+  if (observer.isEnabled) {
+    equal(observer.validate('[]'), true, 'should have notified []');
+    equal(observer.validate('length'), true, 'should have notified length');
+  }
+});
+
+suite.test("[A,B,C].unshiftObjects([A,B,C]) => [A,B,C,A,B,C] + notify", function() {
+  var obj, before, after, item, observer;
+
+  before = this.newFixture(3);
+  items = before; // note same objects as current. should end up twice
+  after  = [before[0], before[1], before[2], before[0], before[1], before[2]];
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', 'length');
+
+  obj.unshiftObjects(items);
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(Ember.get(obj, 'length'), after.length, 'length');
+
+  if (observer.isEnabled) {
+    equal(observer.validate('[]'), true, 'should have notified []');
+    equal(observer.validate('length'), true, 'should have notified length');
+  }
+});


### PR DESCRIPTION
According to the documentation, `unshiftObjects` should maintain the order of the inserted array, as such:

```
var colors = ["red", "green", "blue"];
colors.unshiftObjects(["black", "white"]); => ["black", "white", "red", "green", "blue"]
```

However, currently the inserted array is added in reverse order because it unshifts one by one from the beginning:

```
var colors = ["red", "green", "blue"];
colors.unshiftObjects(["black", "white"]); => ["white", "black", "red", "green", "blue"]
```

I've added failing tests for `unshiftObjects` by duplicating the `unshiftObject` ones, then fixed the issue by unshifting the array in reverse order.
