### PR TITLE
Node support: added Ember.ROOT == window or global or this.

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -1,5 +1,5 @@
 /*global __fail__*/
-
+var root = Ember.root;
 /**
   Define an assertion that will throw an exception if the condition is not
   met.  Ember build tools will remove any calls to ember_assert() when
@@ -31,7 +31,7 @@
     will be executed.  If the function returns false an exception will be
     thrown.
 */
-window.ember_assert = function ember_assert(desc, test) {
+root.ember_assert = function ember_assert(desc, test) {
   if ('function' === typeof test) test = test()!==false;
   if (!test) throw new Error("assertion failed: "+desc);
 };
@@ -50,7 +50,7 @@ window.ember_assert = function ember_assert(desc, test) {
     An optional boolean or function. If the test returns false, the warning
     will be displayed.
 */
-window.ember_warn = function(message, test) {
+root.ember_warn = function(message, test) {
   if (arguments.length === 1) { test = false; }
   if ('function' === typeof test) test = test()!==false;
   if (!test) console.warn("WARNING: "+message);
@@ -70,7 +70,7 @@ window.ember_warn = function(message, test) {
     An optional boolean or function. If the test returns false, the deprecation
     will be displayed.
 */
-window.ember_deprecate = function(message, test) {
+root.ember_deprecate = function(message, test) {
   if (Ember && Ember.TESTING_DEPRECATION) { return; }
 
   if (arguments.length === 1) { test = false; }
@@ -119,9 +119,9 @@ window.ember_deprecate = function(message, test) {
   @param {Function} func
     The function to be deprecated.
 */
-window.ember_deprecateFunc = function(message, func) {
+root.ember_deprecateFunc = function(message, func) {
   return function() {
-    window.ember_deprecate(message);
+    root.ember_deprecate(message);
     return func.apply(this, arguments);
   };
 };

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -1,5 +1,5 @@
 /*global __fail__*/
-var root = Ember.root;
+var ROOT = Ember.ROOT;
 /**
   Define an assertion that will throw an exception if the condition is not
   met.  Ember build tools will remove any calls to ember_assert() when
@@ -31,7 +31,7 @@ var root = Ember.root;
     will be executed.  If the function returns false an exception will be
     thrown.
 */
-root.ember_assert = function ember_assert(desc, test) {
+ROOT.ember_assert = function ember_assert(desc, test) {
   if ('function' === typeof test) test = test()!==false;
   if (!test) throw new Error("assertion failed: "+desc);
 };
@@ -50,7 +50,7 @@ root.ember_assert = function ember_assert(desc, test) {
     An optional boolean or function. If the test returns false, the warning
     will be displayed.
 */
-root.ember_warn = function(message, test) {
+ROOT.ember_warn = function(message, test) {
   if (arguments.length === 1) { test = false; }
   if ('function' === typeof test) test = test()!==false;
   if (!test) console.warn("WARNING: "+message);
@@ -70,7 +70,7 @@ root.ember_warn = function(message, test) {
     An optional boolean or function. If the test returns false, the deprecation
     will be displayed.
 */
-root.ember_deprecate = function(message, test) {
+ROOT.ember_deprecate = function(message, test) {
   if (Ember && Ember.TESTING_DEPRECATION) { return; }
 
   if (arguments.length === 1) { test = false; }
@@ -119,9 +119,9 @@ root.ember_deprecate = function(message, test) {
   @param {Function} func
     The function to be deprecated.
 */
-root.ember_deprecateFunc = function(message, func) {
+ROOT.ember_deprecateFunc = function(message, func) {
   return function() {
-    root.ember_deprecate(message);
+    ROOT.ember_deprecate(message);
     return func.apply(this, arguments);
   };
 };

--- a/packages/ember-metal/lib/accessors.js
+++ b/packages/ember-metal/lib/accessors.js
@@ -13,6 +13,7 @@ var USE_ACCESSORS = Ember.platform.hasPropertyAccessors && Ember.ENV.USE_ACCESSO
 Ember.USE_ACCESSORS = !!USE_ACCESSORS;
 
 var meta = Ember.meta;
+var ROOT = Ember.ROOT;
 
 // ..........................................................
 // GET AND SET
@@ -200,7 +201,7 @@ function normalizeTuple(target, path) {
       isGlobal = !hasThis && IS_GLOBAL_PATH.test(path),
       key;
 
-  if (!target || isGlobal) target = window;
+  if (!target || isGlobal) target = ROOT;
   if (hasThis) path = path.slice(5);
 
   var idx = path.indexOf('*');
@@ -215,7 +216,7 @@ function normalizeTuple(target, path) {
     }
     path   = path.slice(idx+1);
 
-  } else if (target === window) {
+  } else if (target === ROOT) {
     key = firstKey(path);
     target = get(target, key);
     path   = path.slice(key.length+1);
@@ -288,14 +289,14 @@ Ember.getPath = function(root, path, _checkGlobal) {
   // If there is no root and path is a key name, return that
   // property from the global object.
   // E.g. getPath('Ember') -> Ember
-  if (root === null && !hasStar && path.indexOf('.') < 0) { return get(window, path); }
+  if (root === null && !hasStar && path.indexOf('.') < 0) { return get(ROOT, path); }
 
   // detect complicated paths and normalize them
   path = normalizePath(path);
   hasThis  = HAS_THIS.test(path);
 
   if (!root || hasThis || hasStar) {
-    ember_deprecate("Fetching globals with Ember.getPath is deprecated (root: "+root+", path: "+path+")", !root || root === window || !IS_GLOBAL.test(path));
+    ember_deprecate("Fetching globals with Ember.getPath is deprecated (root: "+root+", path: "+path+")", !root || root === ROOT || !IS_GLOBAL.test(path));
 
     var tuple = normalizeTuple(root, path);
     root = tuple[0];
@@ -305,9 +306,9 @@ Ember.getPath = function(root, path, _checkGlobal) {
 
   ret = getPath(root, path);
 
-  if (ret === undefined && !pathOnly && !hasThis && root !== window && IS_GLOBAL.test(path) && _checkGlobal !== false) {
+  if (ret === undefined && !pathOnly && !hasThis && root !== ROOT && IS_GLOBAL.test(path) && _checkGlobal !== false) {
     ember_deprecate("Fetching globals with Ember.getPath is deprecated (root: "+root+", path: "+path+")");
-    return Ember.getPath(window, path);
+    return Ember.getPath(ROOT, path);
   } else {
     return ret;
   }
@@ -324,7 +325,7 @@ Ember.setPath = function(root, path, value, tolerant) {
 
   path = normalizePath(path);
   if (path.indexOf('*')>0) {
-    ember_deprecate("Setting globals with Ember.setPath is deprecated (path: "+path+")", !root || root === window || !IS_GLOBAL.test(path));
+    ember_deprecate("Setting globals with Ember.setPath is deprecated (path: "+path+")", !root || root === ROOT || !IS_GLOBAL.test(path));
 
     var tuple = normalizeTuple(root, path);
     root = tuple[0];
@@ -340,7 +341,7 @@ Ember.setPath = function(root, path, value, tolerant) {
       root = Ember.getPath(root, path, false);
       if (!root && IS_GLOBAL.test(path)) {
         ember_deprecate("Setting globals with Ember.setPath is deprecated (path: "+path+")");
-        root = Ember.getPath(window, path);
+        root = Ember.getPath(ROOT, path);
       }
     }
 

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -11,6 +11,8 @@ require('ember-metal/utils'); // guidFor, isArray, meta
 require('ember-metal/observer'); // addObserver, removeObserver
 require('ember-metal/run_loop'); // Ember.run.schedule
 
+var ROOT = Ember.ROOT;
+
 // ..........................................................
 // CONSTANTS
 //
@@ -144,7 +146,7 @@ function empty(val) {
 
 /** @private */
 function getPathWithGlobals(obj, path) {
-  return getPath(isGlobalPath(path) ? window : obj, path);
+  return getPath(isGlobalPath(path) ? ROOT : obj, path);
 }
 
 /** @private */
@@ -564,10 +566,10 @@ Binding.prototype = /** @scope Ember.Binding.prototype */ {
         Ember.Logger.log(' ', this.toString(), '->', fromValue, obj);
       }
       if (this._oneWay) {
-        Ember.trySetPath(Ember.isGlobalPath(toPath) ? window : obj, toPath, fromValue);
+        Ember.trySetPath(Ember.isGlobalPath(toPath) ? ROOT : obj, toPath, fromValue);
       } else {
         Ember._suspendObserver(obj, toPath, this, this.toDidChange, function () {
-          Ember.trySetPath(Ember.isGlobalPath(toPath) ? window : obj, toPath, fromValue);
+          Ember.trySetPath(Ember.isGlobalPath(toPath) ? ROOT : obj, toPath, fromValue);
         });
       }
     // if we're synchronizing *to* the remote object
@@ -577,7 +579,7 @@ Binding.prototype = /** @scope Ember.Binding.prototype */ {
         Ember.Logger.log(' ', this.toString(), '<-', toValue, obj);
       }
       Ember._suspendObserver(obj, fromPath, this, this.fromDidChange, function () {
-        Ember.trySetPath(Ember.isGlobalPath(fromPath) ? window : obj, fromPath, toValue);
+        Ember.trySetPath(Ember.isGlobalPath(fromPath) ? ROOT : obj, fromPath, toValue);
       });
     }
   }

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -5,6 +5,8 @@
 // ==========================================================================
 /*globals Em:true ENV */
 
+var ROOT;
+
 if ('undefined' === typeof Ember) {
 /**
   @namespace
@@ -29,14 +31,21 @@ if ('undefined' === typeof Ember) {
 
 // Create core object. Make it act like an instance of Ember.Namespace so that
 // objects assigned to it are given a sane string representation.
-Ember = { isNamespace: true, toString: function() { return "Ember"; } };
+var Ember = { isNamespace: true, toString: function() { return "Ember"; } };
+
+ROOT = typeof window == 'undefined' ? typeof global == 'undefined' ? this : global : window;
 
 // aliases needed to keep minifiers from removing the global context
-if ('undefined' !== typeof window) {
-  window.Em = window.Ember = Em = Ember;
-}
+ROOT.Ember = ROOT.Em = Ember;
 
 }
+
+/**
+  @static
+  @type Object
+  @constant
+*/
+Ember.ROOT = ROOT;
 
 /**
   @static
@@ -160,15 +169,15 @@ Ember.K = function() { return this; };
 // Stub out the methods defined by the ember-debug package in case it's not loaded
 
 if ('undefined' === typeof ember_assert) {
-  window.ember_assert = Ember.K;
+  ROOT.ember_assert = Ember.K;
 }
 
-if ('undefined' === typeof ember_warn) { window.ember_warn = Ember.K; }
+if ('undefined' === typeof ember_warn) { ROOT.ember_warn = Ember.K; }
 
-if ('undefined' === typeof ember_deprecate) { window.ember_deprecate = Ember.K; }
+if ('undefined' === typeof ember_deprecate) { ROOT.ember_deprecate = Ember.K; }
 
 if ('undefined' === typeof ember_deprecateFunc) {
-  window.ember_deprecateFunc = function(_, func) { return func; };
+  ROOT.ember_deprecateFunc = function(_, func) { return func; };
 }
 
 // ..........................................................
@@ -178,7 +187,7 @@ if ('undefined' === typeof ember_deprecateFunc) {
 /**
   @class
 
-  Inside Ember-Metal, simply uses the window.console object.
+  Inside Ember-Metal, simply uses the ROOT.console object.
   Override this to provide more robust logging functionality.
 */
-Ember.Logger = window.console || { log: Ember.K, warn: Ember.K, error: Ember.K };
+Ember.Logger = ROOT.console || { log: Ember.K, warn: Ember.K, error: Ember.K };

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -15,6 +15,7 @@ require('ember-metal/binding');
 
 var Mixin, MixinDelegate, REQUIRED, Alias;
 var classToString, superClassString;
+var ROOT = Ember.ROOT;
 
 var a_map = Ember.ArrayUtils.map;
 var a_indexOf = Ember.ArrayUtils.indexOf;
@@ -473,17 +474,17 @@ function findNamespaces() {
 
   if (Namespace.PROCESSED) { return; }
 
-  for (var prop in window) {
-    //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
+  for (var prop in ROOT) {
+    //  get(ROOT.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
     // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage
-    if (prop === "globalStorage" && window.StorageList && window.globalStorage instanceof window.StorageList) { continue; }
-    // Unfortunately, some versions of IE don't support window.hasOwnProperty
-    if (window.hasOwnProperty && !window.hasOwnProperty(prop)) { continue; }
+    if (prop === "globalStorage" && ROOT.StorageList && ROOT.globalStorage instanceof ROOT.StorageList) { continue; }
+    // Unfortunately, some versions of IE don't support ROOT.hasOwnProperty
+    if (ROOT.hasOwnProperty && !ROOT.hasOwnProperty(prop)) { continue; }
 
     // At times we are not allowed to access certain properties for security reasons.
     // There are also times where even if we can access them, we are not allowed to access their properties.
     try {
-      obj = window[prop];
+      obj = ROOT[prop];
       isNamespace = obj && get(obj, 'isNamespace');
     } catch (e) {
       continue;

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -14,6 +14,7 @@ var AFTER_OBSERVERS = ':change';
 var BEFORE_OBSERVERS = ':before';
 var guidFor = Ember.guidFor;
 var normalizePath = Ember.normalizePath;
+var ROOT = Ember.ROOT;
 
 var deferred = 0;
 var array_Slice = Array.prototype.slice;
@@ -160,7 +161,7 @@ function xformForArgs(args) {
     var obj = params[0], keyName = changeKey(params[1]), val;
     var copy_args = args.slice();
     if (method.length>2) {
-      val = Ember.getPath(Ember.isGlobalPath(keyName) ? window : obj, keyName);
+      val = Ember.getPath(Ember.isGlobalPath(keyName) ? ROOT : obj, keyName);
     }
     copy_args.unshift(obj, keyName, val);
     method.apply(target, copy_args);

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -8,14 +8,16 @@
 require('ember-metal');
 
 var indexOf = Ember.ArrayUtils.indexOf;
+var ROOT = Ember.ROOT;
 
 // ........................................
 // GLOBAL CONSTANTS
 //
 
 // ensure no undefined errors in browsers where console doesn't exist
+// can this be removed? it's in ember-metal/core.js
 if (typeof console === 'undefined') {
-  window.console = {};
+  ROOT.console = {};
   console.log = console.info = console.warn = console.error = function() {};
 }
 

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -1,4 +1,4 @@
-var get = Ember.get, set = Ember.set, getPath = Ember.getPath;
+var get = Ember.get, set = Ember.set, getPath = Ember.getPath, ROOT = Ember.ROOT;
 
 Ember.TargetActionSupport = Ember.Mixin.create({
   target: null,
@@ -10,7 +10,7 @@ Ember.TargetActionSupport = Ember.Mixin.create({
     if (Ember.typeOf(target) === "string") {
       // TODO: Remove the false when deprecation is done
       var value = getPath(this, target, false);
-      if (value === undefined) { value = getPath(window, target); }
+      if (value === undefined) { value = getPath(ROOT, target); }
       return value;
     } else {
       return target;

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -6,7 +6,7 @@
 
 require('ember-runtime/system/object');
 
-var indexOf = Ember.ArrayUtils.indexOf;
+var indexOf = Ember.ArrayUtils.indexOf, ROOT = Ember.ROOT;
 
 /**
   @private
@@ -36,7 +36,7 @@ Ember.Namespace = Ember.Object.extend({
 
   destroy: function() {
     var namespaces = Ember.Namespace.NAMESPACES;
-    window[this.toString()] = undefined;
+    ROOT[this.toString()] = undefined;
     namespaces.splice(indexOf(namespaces, this), 1);
     this._super();
   }


### PR DESCRIPTION
Added Ember.ROOT, equal to `window` if defined, `global` if defined, otherwise `this`.  Added var ROOT = Ember.ROOT in relevant modules to optimize minification.

This makes it work in nodes.  All tests still pass (running `rake test[all]` and `rake test`).
