### PR TITLE
Re-enable enumerable properties: [], firstObject and lastObject

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -376,7 +376,7 @@ Ember.computed = function(func) {
 Ember.cacheFor = function(obj, key) {
   var cache = meta(obj, false).cache;
 
-  if (cache && cache[key] !== undefined) {
+  if (cache && key in cache) {
     return cache[key];
   }
 };

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -116,6 +116,14 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     return this ;
   }).property().cacheable(),
 
+  firstObject: Ember.computed(function() {
+    return this.objectAt(0);
+  }).property().cacheable(),
+
+  lastObject: Ember.computed(function() {
+    return this.objectAt(get(this, 'length')-1);
+  }).property().cacheable(),
+
   /** @private (nodoc) - optimized version from Enumerable */
   contains: function(obj){
     return this.indexOf(obj) >= 0;
@@ -321,7 +329,13 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       removing = removeAmt;
     }
 
+    var len = this._originalLength = get(this, 'length'),
+        firstChanged = startIdx === 0,
+        lastChanged = startIdx + removeAmt >= len;
+
     this.enumerableContentWillChange(removing, addAmt);
+    if (firstChanged) { Ember.propertyWillChange(this, 'firstObject'); }
+    if (lastChanged)  { Ember.propertyWillChange(this, 'lastObject'); }
 
     // Make sure the @each proxy is set up if anyone is observing @each
     if (Ember.isWatching(this, '@each')) { get(this, '@each'); }
@@ -348,7 +362,13 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       adding = addAmt;
     }
 
+    var len = this._originalLength,
+        firstChanged = startIdx === 0,
+        lastChanged = startIdx + removeAmt >= len;
+
     this.enumerableContentDidChange(removeAmt, adding);
+    if (firstChanged) { Ember.propertyDidChange(this, 'firstObject'); }
+    if (lastChanged)  { Ember.propertyDidChange(this, 'lastObject'); }
     Ember.sendEvent(this, '@array:change', startIdx, removeAmt, addAmt);
     return this;
   },

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -329,16 +329,15 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       removing = removeAmt;
     }
 
-    var len = this._originalLength = get(this, 'length'),
-        firstChanged = startIdx === 0,
-        lastChanged = startIdx + removeAmt >= len;
-
     this.enumerableContentWillChange(removing, addAmt);
-    if (firstChanged) { Ember.propertyWillChange(this, 'firstObject'); }
-    if (lastChanged)  { Ember.propertyWillChange(this, 'lastObject'); }
 
     // Make sure the @each proxy is set up if anyone is observing @each
     if (Ember.isWatching(this, '@each')) { get(this, '@each'); }
+
+    // Make sure we've cached these for the check in arrayContentDidChange
+    get(this, 'firstObject');
+    get(this, 'lastObject');
+
     return this;
   },
 
@@ -362,14 +361,19 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       adding = addAmt;
     }
 
-    var len = this._originalLength,
-        firstChanged = startIdx === 0,
-        lastChanged = startIdx + removeAmt >= len;
-
     this.enumerableContentDidChange(removeAmt, adding);
-    if (firstChanged) { Ember.propertyDidChange(this, 'firstObject'); }
-    if (lastChanged)  { Ember.propertyDidChange(this, 'lastObject'); }
     Ember.sendEvent(this, '@array:change', startIdx, removeAmt, addAmt);
+
+    var length = get(this, 'length');
+    if (this.objectAt(0) !== get(this, 'firstObject')) {
+      Ember.propertyWillChange(this, 'firstObject');
+      Ember.propertyDidChange(this, 'firstObject');
+    }
+    if (this.objectAt(length-1) !== get(this, 'lastObject')) {
+      Ember.propertyWillChange(this, 'lastObject');
+      Ember.propertyDidChange(this, 'lastObject');
+    }
+
     return this;
   },
 

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -139,14 +139,13 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
   */
   firstObject: Ember.computed(function() {
     if (get(this, 'length')===0) return undefined ;
-    if (Ember.Array && Ember.Array.detect(this)) return this.objectAt(0);
 
     // handle generic enumerables
     var context = popCtx(), ret;
     ret = this.nextObject(0, null, context);
     pushCtx(context);
     return ret ;
-  }).property().volatile(),
+  }).property('[]').cacheable(),
 
   /**
     Helper method returns the last object from a collection. If your enumerable
@@ -164,18 +163,14 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
   lastObject: Ember.computed(function() {
     var len = get(this, 'length');
     if (len===0) return undefined ;
-    if (Ember.Array && Ember.Array.detect(this)) {
-      return this.objectAt(len-1);
-    } else {
-      var context = popCtx(), idx=0, cur, last = null;
-      do {
-        last = cur;
-        cur = this.nextObject(idx++, last, context);
-      } while (cur !== undefined);
-      pushCtx(context);
-      return last;
-    }
-  }).property().volatile(),
+    var context = popCtx(), idx=0, cur, last = null;
+    do {
+      last = cur;
+      cur = this.nextObject(idx++, last, context);
+    } while (cur !== undefined);
+    pushCtx(context);
+    return last;
+  }).property('[]').cacheable(),
 
   /**
     Returns true if the passed object can be found in the receiver.  The
@@ -710,6 +705,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     if (removing === -1) removing = null;
     if (adding   === -1) adding   = null;
 
+    Ember.propertyWillChange(this, '[]');
     if (hasDelta) Ember.propertyWillChange(this, 'length');
     Ember.sendEvent(this, '@enumerable:before', removing, adding);
 
@@ -757,6 +753,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
 
     Ember.sendEvent(this, '@enumerable:change', removing, adding);
     if (hasDelta) Ember.propertyDidChange(this, 'length');
+    Ember.propertyDidChange(this, '[]');
 
     return this ;
   }

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -147,6 +147,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
   /** @private (nodoc) */
   init: function() {
     this._super();
+    this.contentWillChange();
     this.contentDidChange();
   }
 

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -29,7 +29,7 @@ var EachArray = Ember.Object.extend(Ember.Array, {
   length: Ember.computed(function() {
     var content = this._content;
     return content ? get(content, 'length') : 0;
-  }).property('[]').cacheable()
+  }).property().cacheable()
 
 });
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -663,10 +663,11 @@ module("Observable objects & object properties ", {
 
       testArrayObserver: Ember.observer(function(){
         this.abnormal = 'notifiedObserver';
-      }, 'normalArray.@each')
+      }, 'normalArray.[]')
 
     });
   }
+
 });
 
 test('incrementProperty and decrementProperty',function(){

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -42,7 +42,7 @@ var TestArray = Ember.Object.extend(Ember.Array, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property('@each').cacheable(),
+  }).property().cacheable(),
 
   slice: function() {
     return this._content.slice();
@@ -90,13 +90,13 @@ var obj, observer;
 
 module('mixins/array/arrayContent[Will|Did]Change');
 
-test('should notify observers of @each', function() {
+test('should notify observers of []', function() {
 
   obj = DummyArray.create({
     _count: 0,
     enumerablePropertyDidChange: Ember.observer(function() {
       this._count++;
-    }, '@each')
+    }, '[]')
   });
 
   equal(obj._count, 0, 'should not have invoked yet');

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -32,7 +32,7 @@ var TestEnumerable = Ember.Object.extend(Ember.Enumerable, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property('[]').cacheable(),
+  }).property().cacheable(),
 
   slice: function() {
     return this._content.slice();
@@ -77,6 +77,24 @@ var obj, observer;
 //
 
 module('mixins/enumerable/enumerableContentDidChange');
+
+test('should notify observers of []', function() {
+
+  var obj = Ember.Object.create(Ember.Enumerable, {
+    nextObject: function() {}, // avoid exceptions
+
+    _count: 0,
+    enumerablePropertyDidChange: Ember.observer(function() {
+      this._count++;
+    }, '[]')
+  });
+
+  equal(obj._count, 0, 'should not have invoked yet');
+  obj.enumerableContentWillChange();
+  obj.enumerableContentDidChange();
+  equal(obj._count, 1, 'should have invoked');
+
+});
 
 // ..........................................................
 // NOTIFY CHANGES TO LENGTH

--- a/packages/ember-runtime/tests/mixins/mutable_array_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_array_test.js
@@ -39,7 +39,7 @@ var TestMutableArray = Ember.Object.extend(Ember.MutableArray, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property('[]').cacheable(),
+  }).property().cacheable(),
 
   slice: function() {
     return this._content.slice();

--- a/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
@@ -43,7 +43,7 @@ var TestMutableEnumerable = Ember.Object.extend(Ember.MutableEnumerable, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property('[]').cacheable(),
+  }).property().cacheable(),
 
   slice: function() {
     return this._content.slice();

--- a/packages/ember-runtime/tests/suites/mutable_array/addObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/addObject.js
@@ -24,7 +24,7 @@ suite.test("[A,B].addObject(C) => [A,B,C] + notify", function() {
   item   = this.newFixture(1)[0];
   after  = [before[0], before[1], item];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.addObject(item);
 
@@ -32,8 +32,12 @@ suite.test("[A,B].addObject(C) => [A,B,C] + notify", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
     equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
     equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
   }
 });
 
@@ -44,7 +48,7 @@ suite.test("[A,B,C].addObject(A) => [A,B,C] + NO notify", function() {
   after  = before;
   item   = before[0];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.addObject(item); // note: item in set
 
@@ -52,7 +56,10 @@ suite.test("[A,B,C].addObject(A) => [A,B,C] + NO notify", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.validate('[]'), false, 'should NOT have notified []');
     equal(observer.validate('@each'), false, 'should NOT have notified @each');
     equal(observer.validate('length'), false, 'should NOT have notified length');
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
   }
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/clear.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/clear.js
@@ -17,15 +17,18 @@ suite.test("[].clear() => [] + notify", function () {
   before = [];
   after  = [];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.clear(), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.validate('[]'), false, 'should NOT have notified [] once');
   equal(observer.validate('@each'), false, 'should NOT have notified @each once');
   equal(observer.validate('length'), false, 'should NOT have notified length once');
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.test("[X].clear() => [] + notify", function () {
@@ -34,14 +37,16 @@ suite.test("[X].clear() => [] + notify", function () {
   before = this.newFixture(1);
   after  = [];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.clear(), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
-
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
@@ -16,15 +16,18 @@ suite.test("[].insertAt(0, X) => [X] + notify", function() {
 
   after = this.newFixture(1);
   obj = this.newObject([]);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.insertAt(0, after[0]);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[].insertAt(200,X) => OUT_OF_RANGE_EXCEPTION exception", function() {
@@ -41,15 +44,19 @@ suite.test("[A].insertAt(0, X) => [X,A] + notify", function() {
   before = this.newFixture(1);
   after  = [item, before[0]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.insertAt(0, item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[A].insertAt(1, X) => [A,X] + notify", function() {
@@ -59,15 +66,19 @@ suite.test("[A].insertAt(1, X) => [A,X] + notify", function() {
   before = this.newFixture(1);
   after  = [before[0], item];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.insertAt(1, item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
 });
 
 suite.test("[A].insertAt(200,X) => OUT_OF_RANGE exception", function() {
@@ -84,15 +95,19 @@ suite.test("[A,B,C].insertAt(0,X) => [X,A,B,C] + notify", function() {
   before = this.newFixture(3);
   after  = [item, before[0], before[1], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.insertAt(0, item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[A,B,C].insertAt(1,X) => [A,X,B,C] + notify", function() {
@@ -102,15 +117,19 @@ suite.test("[A,B,C].insertAt(1,X) => [A,X,B,C] + notify", function() {
   before = this.newFixture(3);
   after  = [before[0], item, before[1], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.insertAt(1, item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[A,B,C].insertAt(3,X) => [A,B,C,X] + notify", function() {
@@ -120,13 +139,17 @@ suite.test("[A,B,C].insertAt(3,X) => [A,B,C,X] + notify", function() {
   before = this.newFixture(3);
   after  = [before[0], before[1], before[2], item];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.insertAt(3, item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/popObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/popObject.js
@@ -14,13 +14,17 @@ suite.test("[].popObject() => [] + returns undefined + NO notify", function() {
   var obj, observer;
 
   obj = this.newObject([]);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.popObject(), undefined, 'popObject results');
 
   deepEqual(this.toArray(obj), [], 'post item results');
+
+  equal(observer.validate('[]'), false, 'should NOT have notified []');
   equal(observer.validate('@each'), false, 'should NOT have notified @each');
   equal(observer.validate('length'), false, 'should NOT have notified length');
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[X].popObject() => [] + notify", function() {
@@ -29,15 +33,19 @@ suite.test("[X].popObject() => [] + notify", function() {
   before = this.newFixture(1);
   after  = [];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   ret = obj.popObject();
 
   equal(ret, before[0], 'return object');
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
-  equal(observer.validate('@each'), true, 'should NOT have notified @each');
-  equal(observer.validate('length'), true, 'should NOT have notified length');
+
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
+  equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
+  equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[A,B,C].popObject() => [A,B] + notify", function() {
@@ -46,7 +54,7 @@ suite.test("[A,B,C].popObject() => [A,B] + notify", function() {
   before = this.newFixture(3);
   after  = [before[0], before[1]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   ret = obj.popObject();
 
@@ -54,6 +62,10 @@ suite.test("[A,B,C].popObject() => [A,B] + notify", function() {
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
-  equal(observer.validate('@each'), true, 'should NOT have notified @each');
-  equal(observer.validate('length'), true, 'should NOT have notified length');
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
+  equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
+  equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/pushObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/pushObject.js
@@ -22,15 +22,18 @@ suite.test("[].pushObject(X) => [X] + notify", function() {
   before = [];
   after  = this.newFixture(1);
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.pushObject(after[0]);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[A,B,C].pushObject(X) => [A,B,C,X] + notify", function() {
@@ -40,13 +43,17 @@ suite.test("[A,B,C].pushObject(X) => [A,B,C,X] + notify", function() {
   item   = this.newFixture(1)[0];
   after  = [before[0], before[1], before[2], item];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.pushObject(item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
@@ -17,15 +17,18 @@ suite.test("[X].removeAt(0) => [] + notify", function() {
   before = this.newFixture(1);
   after  = [];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.removeAt(0), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[].removeAt(200) => OUT_OF_RANGE_EXCEPTION exception", function() {
@@ -41,15 +44,19 @@ suite.test("[A,B].removeAt(0) => [B] + notify", function() {
   before = this.newFixture(2);
   after  = [before[1]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.removeAt(0), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[A,B].removeAt(1) => [A] + notify", function() {
@@ -58,15 +65,19 @@ suite.test("[A,B].removeAt(1) => [A] + notify", function() {
   before = this.newFixture(2);
   after  = [before[0]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.removeAt(1), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
 });
 
 suite.test("[A,B,C].removeAt(1) => [A,C] + notify", function() {
@@ -75,15 +86,19 @@ suite.test("[A,B,C].removeAt(1) => [A,C] + notify", function() {
   before = this.newFixture(3);
   after  = [before[0], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.removeAt(1), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.test("[A,B,C,D].removeAt(1,2) => [A,D] + notify", function() {
@@ -92,15 +107,19 @@ suite.test("[A,B,C,D].removeAt(1,2) => [A,D] + notify", function() {
   before = this.newFixture(4);
   after  = [before[0], before[3]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.removeAt(1,2), obj, 'return self');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.notest("[A,B,C,D].removeAt(IndexSet<0,2-3>) => [B] + notify");

--- a/packages/ember-runtime/tests/suites/mutable_array/removeObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/removeObject.js
@@ -23,7 +23,7 @@ suite.test("[A,B,C].removeObject(B) => [A,C] + notify", function() {
   before = this.newFixture(3);
   after  = [before[0], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.removeObject(before[1]);
 
@@ -31,8 +31,12 @@ suite.test("[A,B,C].removeObject(B) => [A,C] + notify", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
     equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
     equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
   }
 });
 
@@ -43,7 +47,7 @@ suite.test("[A,B,C].removeObject(D) => [A,B,C]", function() {
   after  = before;
   item   = this.newFixture(1)[0];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.removeObject(item); // note: item not in set
 
@@ -51,7 +55,11 @@ suite.test("[A,B,C].removeObject(D) => [A,B,C]", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.validate('[]'), false, 'should NOT have notified []');
     equal(observer.validate('@each'), false, 'should NOT have notified @each');
     equal(observer.validate('length'), false, 'should NOT have notified length');
+
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
   }
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/replace.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/replace.js
@@ -15,14 +15,17 @@ suite.test("[].replace(0,0,'X') => ['X'] + notify", function() {
   var obj, exp, observer;
   exp = this.newFixture(1);
   obj = this.newObject([]);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.replace(0,0,exp) ;
 
   deepEqual(this.toArray(obj), exp, 'post item results');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[A,B,C,D].replace(1,2,X) => [A,X,D] + notify", function() {
@@ -33,14 +36,18 @@ suite.test("[A,B,C,D].replace(1,2,X) => [A,X,D] + notify", function() {
   after   = [before[0], replace[0], before[3]];
 
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.replace(1,2,replace) ;
 
   deepEqual(this.toArray(obj), after, 'post item results');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.test("[A,B,C,D].replace(1,2,[X,Y]) => [A,X,Y,D] + notify", function() {
@@ -51,14 +58,18 @@ suite.test("[A,B,C,D].replace(1,2,[X,Y]) => [A,X,Y,D] + notify", function() {
   after   = [before[0], replace[0], replace[1], before[3]];
 
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.replace(1,2,replace) ;
 
   deepEqual(this.toArray(obj), after, 'post item results');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.validate('length'), false, 'should NOT have notified length');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.test("[A,B].replace(1,0,[X,Y]) => [A,X,Y,B] + notify", function() {
@@ -69,14 +80,18 @@ suite.test("[A,B].replace(1,0,[X,Y]) => [A,X,Y,B] + notify", function() {
   after   = [before[0], replace[0], replace[1], before[1]];
 
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.replace(1,0,replace) ;
 
   deepEqual(this.toArray(obj), after, 'post item results');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.notest("[A,B,C,D].replace(2,2) => [A,B] + notify", function() {
@@ -86,14 +101,18 @@ suite.notest("[A,B,C,D].replace(2,2) => [A,B] + notify", function() {
   after   = [before[0], before[1]];
 
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.replace(2,2) ;
 
   deepEqual(this.toArray(obj), after, 'post item results');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.test('Adding object should notify enumerable observer', function() {

--- a/packages/ember-runtime/tests/suites/mutable_array/shiftObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/shiftObject.js
@@ -16,15 +16,19 @@ suite.test("[].shiftObject() => [] + returns undefined + NO notify", function() 
   before = [];
   after  = [];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.shiftObject(), undefined);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.validate('[]', undefined, 1), false, 'should NOT have notified [] once');
   equal(observer.validate('@each', undefined, 1), false, 'should NOT have notified @each once');
   equal(observer.validate('length', undefined, 1), false, 'should NOT have notified length once');
+
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject once');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });
 
 suite.test("[X].shiftObject() => [] + notify", function() {
@@ -33,15 +37,18 @@ suite.test("[X].shiftObject() => [] + notify", function() {
   before = this.newFixture(1);
   after  = [];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.shiftObject(), before[0], 'should return object');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[A,B,C].shiftObject() => [B,C] + notify", function() {
@@ -50,13 +57,17 @@ suite.test("[A,B,C].shiftObject() => [B,C] + notify", function() {
   before = this.newFixture(3);
   after  = [before[1], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   equal(obj.shiftObject(), before[0], 'should return object');
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject once');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/unshiftObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/unshiftObject.js
@@ -24,15 +24,18 @@ suite.test("[].unshiftObject(X) => [X] + notify", function() {
   item = this.newFixture(1)[0];
   after  = [item];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.unshiftObject(item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[A,B,C].unshiftObject(X) => [X,A,B,C] + notify", function() {
@@ -42,15 +45,19 @@ suite.test("[A,B,C].unshiftObject(X) => [X,A,B,C] + notify", function() {
   item = this.newFixture(1)[0];
   after  = [item, before[0], before[1], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.unshiftObject(item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[A,B,C].unshiftObject(A) => [A,A,B,C] + notify", function() {
@@ -60,13 +67,18 @@ suite.test("[A,B,C].unshiftObject(A) => [A,A,B,C] + notify", function() {
   item = before[0]; // note same object as current head. should end up twice
   after  = [item, before[0], before[1], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.unshiftObject(item);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  // Ideally we would not notify this, but the way observers are currently it's hard to avoid
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/unshiftObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/unshiftObject.js
@@ -77,8 +77,7 @@ suite.test("[A,B,C].unshiftObject(A) => [A,A,B,C] + notify", function() {
   equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
-  // Ideally we would not notify this, but the way observers are currently it's hard to avoid
-  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
 
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
   equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
@@ -22,15 +22,18 @@ suite.test("[].unshiftObjects([A,B,C]) => [A,B,C] + notify", function() {
   before = [];
   items = this.newFixture(3);
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.unshiftObjects(items);
 
   deepEqual(this.toArray(obj), items, 'post item results');
   equal(Ember.get(obj, 'length'), items.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
 suite.test("[A,B,C].unshiftObjects([X,Y]) => [X,Y,A,B,C] + notify", function() {
@@ -40,15 +43,19 @@ suite.test("[A,B,C].unshiftObjects([X,Y]) => [X,Y,A,B,C] + notify", function() {
   items  = this.newFixture(2);
   after  = items.concat(before);
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.unshiftObjects(items);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });
 
 suite.test("[A,B,C].unshiftObjects([A,B]) => [A,B,A,B,C] + notify", function() {
@@ -58,13 +65,18 @@ suite.test("[A,B,C].unshiftObjects([A,B]) => [A,B,A,B,C] + notify", function() {
   items = [before[0], before[1]]; // note same object as current head. should end up twice
   after  = items.concat(before);
   obj = this.newObject(before);
-  observer = this.newObserver(obj, '@each', 'length');
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
 
   obj.unshiftObjects(items);
 
   deepEqual(this.toArray(obj), after, 'post item results');
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  // Technically we shouldn't notify of a change here, but this is hard to avoid
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/unshiftObjects.js
@@ -75,8 +75,7 @@ suite.test("[A,B,C].unshiftObjects([A,B]) => [A,B,A,B,C] + notify", function() {
   equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
   equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
   equal(observer.timesCalled('length'), 1, 'should have notified length once');
-  // Technically we shouldn't notify of a change here, but this is hard to avoid
-  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
 
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
   equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
 });

--- a/packages/ember-runtime/tests/suites/mutable_enumerable/addObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_enumerable/addObject.js
@@ -24,7 +24,7 @@ suite.test("[A,B].addObject(C) => [A,B,C] + notify", function() {
   item   = this.newFixture(1)[0];
   after  = [before[0], before[1], item];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, 'length');
+  observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
 
   obj.addObject(item);
 
@@ -32,7 +32,11 @@ suite.test("[A,B].addObject(C) => [A,B,C] + notify", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
     equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+    // This gets called since MutableEnumerable is naive about changes
+    equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
   }
 });
 
@@ -43,7 +47,7 @@ suite.test("[A,B,C].addObject(A) => [A,B,C] + NO notify", function() {
   after  = before;
   item   = before[0];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, 'length');
+  observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
 
   obj.addObject(item); // note: item in set
 
@@ -51,7 +55,10 @@ suite.test("[A,B,C].addObject(A) => [A,B,C] + NO notify", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.validate('[]'), false, 'should NOT have notified []');
     equal(observer.validate('length'), false, 'should NOT have notified length');
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
   }
 });
 

--- a/packages/ember-runtime/tests/suites/mutable_enumerable/removeObject.js
+++ b/packages/ember-runtime/tests/suites/mutable_enumerable/removeObject.js
@@ -23,7 +23,7 @@ suite.test("[A,B,C].removeObject(B) => [A,C] + notify", function() {
   before = this.newFixture(3);
   after  = [before[0], before[2]];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, 'length');
+  observer = this.newObserver(obj, '[]', 'length');
 
   obj.removeObject(before[1]);
 
@@ -31,7 +31,11 @@ suite.test("[A,B,C].removeObject(B) => [A,C] + notify", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
     equal(observer.timesCalled('length'), 1, 'should have notified length once');
+
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
   }
 });
 
@@ -42,7 +46,7 @@ suite.test("[A,B,C].removeObject(D) => [A,B,C]", function() {
   after  = before;
   item   = this.newFixture(1)[0];
   obj = this.newObject(before);
-  observer = this.newObserver(obj, 'length');
+  observer = this.newObserver(obj, '[]', 'length');
 
   obj.removeObject(item); // note: item not in set
 
@@ -50,7 +54,10 @@ suite.test("[A,B,C].removeObject(D) => [A,B,C]", function() {
   equal(Ember.get(obj, 'length'), after.length, 'length');
 
   if (observer.isEnabled) {
+    equal(observer.validate('[]'), false, 'should NOT have notified []');
     equal(observer.validate('length'), false, 'should NOT have notified length');
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
   }
 });
 

--- a/packages/ember-runtime/tests/system/set/extra_test.js
+++ b/packages/ember-runtime/tests/system/set/extra_test.js
@@ -36,14 +36,20 @@ test('should clear a set of its content', function() {
 
   var get = Ember.get, set = Ember.set;
   var aSet = new Ember.Set([1,2,3]);
+  var count = 0;
 
   equal(get(aSet, 'length'), 3, 'should have three items');
+  ok(get(aSet, 'firstObject'), 'firstObject should return an object');
+  ok(get(aSet, 'lastObject'), 'lastObject should return an object');
+  Ember.addObserver(aSet, '[]', function() { count++; });
 
   aSet.clear();
   equal(get(aSet, 'length'), 0, 'should have 0 items');
-  equal(aSet.contains(1), false, 'should not contain items');
+  equal(count, 1, 'should have notified of content change');
+  equal(get(aSet, 'firstObject'), null, 'firstObject should return nothing');
+  equal(get(aSet, 'lastObject'), null, 'lastObject should return nothing');
 
-  var count = 0;
+  count = 0;
   aSet.forEach(function() { count++; });
   equal(count, 0, 'iterating over items should not invoke callback');
 


### PR DESCRIPTION
This were previously disabled due to over-zealous firing of firstObject and
lastObject. However, [] was still useful for non-array enumerables. 
Additionally, firstObject and lastObject were made smarter so as to only fire
notifications when necessary.
