### PR TITLE
App#injectControllers should not blow up on existing instances named like classes

### DIFF
--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -89,8 +89,8 @@ Ember.Application = Ember.Namespace.extend(
 
     Example:
 
-      App.PostsController = Ember.ArrayController.create();
-      App.CommentsController = Ember.ArrayController.create();
+      App.PostsController = Ember.ArrayController.extend();
+      App.CommentsController = Ember.ArrayController.extend();
 
       var stateManager = Ember.StateManager.create({
         ...

--- a/packages/ember-views/lib/system/application.js
+++ b/packages/ember-views/lib/system/application.js
@@ -105,12 +105,14 @@ Ember.Application = Ember.Namespace.extend(
   */
   injectControllers: function(stateManager) {
     var properties = Ember.A(Ember.keys(this)),
-        namespace = this, controller, name;
+        namespace = this, controller, klass, name;
 
     properties.forEach(function(property) {
       if (!/^[A-Z].*Controller$/.test(property)) { return; }
       name = property[0].toLowerCase() + property.substr(1);
-      controller = namespace[property].create();
+      klass = namespace[property];
+      if (!Ember.Object.detect(klass)) { return; }
+      controller = klass.create();
       stateManager.set(name, controller);
       controller.set('stateManager', stateManager);
     });

--- a/packages/ember-views/tests/system/application_test.js
+++ b/packages/ember-views/tests/system/application_test.js
@@ -75,6 +75,8 @@ test("inject controllers into a state manager", function() {
 
   app.FooController = Ember.Object.extend();
   app.BarController = Ember.ArrayController.extend();
+  // instance that uses class naming conventions
+  app.BazController = Ember.ArrayController.create();
   app.Foo = Ember.Object.create();
   app.fooController = Ember.Object.create();
 
@@ -84,8 +86,10 @@ test("inject controllers into a state manager", function() {
 
   ok(get(stateManager, 'fooController') instanceof app.FooController, "fooController was assigned");
   ok(get(stateManager, 'barController') instanceof app.BarController, "barController was assigned");
+  ok(!get(stateManager, 'bazController'), "existing instances named like classes are not assigned");
   ok(get(stateManager, 'foo') === undefined, "foo was not assigned");
 
   equal(getPath(stateManager, 'fooController.stateManager'), stateManager, "the state manager is assigned");
   equal(getPath(stateManager, 'barController.stateManager'), stateManager, "the state manager is assigned");
+  ok(!get(app.BazController, "stateManager"), "the state manager is not set on existing instances named like classes");
 });


### PR DESCRIPTION
82b9c805 refers to [http://jsfiddle.net/Qpkz5/474/](this jsFiddle)
cefae578 would protect those who do not follow Ember naming conventions.

Feel free to cherry pick 82b9c805 if you would like handle cefae578 differently.
