### PR TITLE
The sniff regex is incorrect

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -5,5 +5,5 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)?(?=.*pre$)/)?$/));
+ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)(?=.*pre)/));
 Ember.$ = window.jQuery;

--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -5,5 +5,5 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)?$/));
+ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)?(?=.*pre$)/)?$/));
 Ember.$ = window.jQuery;

--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -5,5 +5,5 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)(?=.*pre)/));
+ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](.\d+)($|\.*pre$)/));
 Ember.$ = window.jQuery;


### PR DESCRIPTION
New regex does the right thing:

"1.7.1".match(/^1.[67](.d+)($|._pre$)/)
["1.7.1", ".1", ""]
"1.6.1".match(/^1.[67](.d+)($|._pre$)/)
["1.6.1", ".1", ""]

"1.7.1pre".match(/^1.[67](.d+)($|._pre$)/)
["1.7.1pre", ".1", "pre"]
"1.7.1.pre".match(/^1.[67](.d+)($|._pre$)/)
["1.7.1.pre", ".1", ".pre"]
