### PR TITLE
Notify parentView of childView changes for virtual views

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -630,6 +630,28 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   _childViews: [],
 
   /**
+    When it's a virtual view, we need to notify the parent that their
+    childViews will change.
+  */
+  _childViewsWillChange: Ember.beforeObserver(function() {
+    if (this.isVirtual) {
+      var parentView = get(this, 'parentView');
+      if (parentView) { Ember.propertyWillChange(parentView, 'childViews'); }
+    }
+  }, 'childViews'),
+
+  /**
+    When it's a virtual view, we need to notify the parent that their
+    childViews did change.
+  */
+  _childViewsDidChange: Ember.observer(function() {
+    if (this.isVirtual) {
+      var parentView = get(this, 'parentView');
+      if (parentView) { Ember.propertyDidChange(parentView, 'childViews'); }
+    }
+  }, 'childViews'),
+
+  /**
     Return the nearest ancestor that is an instance of the provided
     class.
 

--- a/packages/ember-views/tests/views/view/virtual_views_test.js
+++ b/packages/ember-views/tests/views/view/virtual_views_test.js
@@ -41,3 +41,45 @@ test("a virtual view does not appear as a view's parentView", function() {
   equal(get(children, 'length'), 1, "there is one child element");
   equal(children.objectAt(0), childView, "the child element skips through the virtual view");
 });
+
+test("when a virtual view's child views change, the parent's childViews should reflect", function() {
+  var rootView = Ember.View.create({
+    elementId: 'root-view',
+
+    render: function(buffer) {
+      buffer.push("<h1>Hi</h1>");
+      this.appendChild(virtualView);
+    }
+  });
+
+  var virtualView = Ember.View.create({
+    isVirtual: true,
+    tagName: '',
+
+    render: function(buffer) {
+      buffer.push("<h2>Virtual</h2>");
+      this.appendChild(childView);
+    }
+  });
+
+  var childView = Ember.View.create({
+    render: function(buffer) {
+      buffer.push("<p>Bye!</p>");
+    }
+  });
+
+  Ember.run(function() {
+    Ember.$("#qunit-fixture").empty();
+    rootView.appendTo("#qunit-fixture");
+  });
+
+  equal(virtualView.getPath('childViews.length'), 1, "has childView - precond");
+  equal(rootView.getPath('childViews.length'), 1, "has childView - precond");
+
+  Ember.run(function() {
+    childView.removeFromParent();
+  });
+
+  equal(virtualView.getPath('childViews.length'), 0, "has no childView");
+  equal(rootView.getPath('childViews.length'), 0, "has no childView");
+});


### PR DESCRIPTION
Previously, if you had a standard view with a virtual child, we returned and
then cached the results of the virtual view's child views. However, if the
virtual view's child views change, the root level view is not notified of
this change and misreports the childViews. This commit corrects that issue.
