### PR TITLE
View State passes stateManager to view during enter

### DIFF
--- a/packages/ember-viewstates/lib/view_state.js
+++ b/packages/ember-viewstates/lib/view_state.js
@@ -11,6 +11,7 @@ Ember.ViewState = Ember.State.extend({
     if (view) {
       if (Ember.View.detect(view)) {
         view = view.create();
+        set(view, 'stateManager', stateManager);
         set(this, 'view', view);
       }
 

--- a/packages/ember-viewstates/tests/view_state_test.js
+++ b/packages/ember-viewstates/tests/view_state_test.js
@@ -45,6 +45,24 @@ test("it throws an error when the view passed is not an Ember.View", function() 
   });
 });
 
+test("it passes the state manager to the view", function() {
+  var viewState = Ember.ViewState.extend({
+    view: Ember.View
+  });
+
+  var stateManager;
+
+  Ember.run(function() {
+    stateManager = Ember.StateManager.create({
+      start: viewState
+    });
+  });
+
+  equal(stateManager.getPath('currentState.view.stateManager'), stateManager, "State Manager passed to view");
+
+  stateManager.getPath('currentState.view').remove();
+});
+
 test("it creates and appends a view when it is entered", function() {
   var viewState = Ember.ViewState.extend({
     view: Ember.View.extend({


### PR DESCRIPTION
I am creating a stateManager with ViewStates/views. When a link is clicked in the view I would like the stateManager to transition to another state. This PR will pass the stateManager into the view so that the view can send actions back to the manager.

There are other ways to accomplish this, but I think it makes sense for ViewState to do this in the enter function. Without this it might encourage people to have views referencing state managers with global paths.
