### PR TITLE
Publish NPM package along with release process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -593,6 +593,7 @@ ERROR:  Multiple versions detected for external dependency
 
       package_json["version"] = npm_version base_package_json["version"]
       package_json["dependencies"] = external_dependencies
+      package_json["main"] = "./ember.js"
       File.open File.join(package_root, 'package.json'), 'w+' do |fd|
         fd.write JSON.pretty_generate(package_json)
       end

--- a/Rakefile
+++ b/Rakefile
@@ -607,10 +607,8 @@ ERROR:  Multiple versions detected for external dependency
     desc "Publish NPM package"
     task :deploy do
       puts "Publishing package to NPM..."
-      Dir['dist/node_modules/*'].each do |source_path|
-        puts "  publishing #{source_path}" 
-        puts `npm publish #{source_path}`
-      end
+      package_path = File.join 'dist', 'node_modules', 'ember'
+      puts `npm publish #{package_path}`
       puts "Done."
     end
 

--- a/packages/ember-states/package.json
+++ b/packages/ember-states/package.json
@@ -11,7 +11,8 @@
   },
 
   "dependencies": {
-    "spade":              "~> 1.0"
+    "spade":              "~> 1.0",
+    "ember-runtime": "0.9.7.1"
   },
 
   "dependencies:development": {


### PR DESCRIPTION
This patch adds a new set of 'npm' tasks to the Rakefile to generate a publish an "ember" package on NPM whenever you release a new version of ember.js. I have currently published 0.9.7.1 this way. If you want to try it just use npm and do:

   npm install ember
   node

> require('ember')

This will load the full Ember stack, including jQuery and a fake DOM into memory. If you want debug code activated, require 'ember/ember-debug' instead.

I can publish this package without taking this task into your repo, but having it in the repo would make it automatic and keep NPM always up to date.
## 

One potentially controversial thing here is that I am publishing all of ember as a single package. The reason for this is that this better fits with how you actually release ember.js (as a single file).  Since NPM only loads modules you require anyway, this actually makes it easier for devs to use ember; there is no penalty for having all the assets in one place.
