### PR TITLE
Add RubyMine ignore and rvmrc ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ tmp*.gem
 tmp.bpm
 tmp.spade
 tests/source
+.idea
+.rvmrc


### PR DESCRIPTION
RubyMine creates an .idea directory containing IDE specific files that should not be committed to the repository.  The .rvmrc should not be in the repository unless you intend to force the same ruby version on each user.
