### PR TITLE
Some sugar for Router initialization

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -106,6 +106,12 @@ Ember.Application = Ember.Namespace.extend(
         injections = get(this.constructor, 'injections'),
         namespace = this, controller, name;
 
+    if (!stateManager && Ember.Router.detect(namespace['Router'])) {
+      stateManager = namespace['Router'].create();
+    }
+
+    set(this, 'stateManager', stateManager);
+
     Ember.runLoadHooks('application', this);
 
     properties.forEach(function(property) {
@@ -139,6 +145,11 @@ Ember.Application = Ember.Namespace.extend(
   */
   setupStateManager: function(stateManager) {
     var location = get(stateManager, 'location');
+
+    if (typeof location === 'string') {
+      location = Ember.Location.create({style: location});
+      set(stateManager, 'location', location);
+    }
 
     stateManager.route(location.getURL());
     location.onUpdateURL(function(url) {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -155,3 +155,50 @@ test("initialize application with non routable stateManager", function() {
 
   equal(app.getPath('stateManager.currentState.path'), 'start', "Application sucessfuly started");
 });
+
+test("initialize application with stateManager via initialize call", function() {
+  Ember.run(function() {
+    app = Ember.Application.create({
+      rootElement: '#qunit-fixture'
+    });
+
+    app.Router = Ember.Router.extend({
+      location: 'hash',
+
+      start: Ember.State.extend({
+        index: Ember.State.extend({
+          route: '/'
+        })
+      })
+    });
+
+    app.initialize(app.Router.create());
+  });
+
+  equal(app.getPath('stateManager') instanceof Ember.Router, true, "Router was set from initialize call");
+  equal(app.getPath('stateManager.location') instanceof Ember.HashLocation, true, "Location was set from location style name");
+  equal(app.getPath('stateManager.currentState.path'), 'start.index', "The router moved the state into the right place");
+});
+
+test("initialize application with stateManager via initialize call from Router class", function() {
+  Ember.run(function() {
+    app = Ember.Application.create({
+      rootElement: '#qunit-fixture'
+    });
+
+    app.Router = Ember.Router.extend({
+      location: 'hash',
+
+      start: Ember.State.extend({
+        index: Ember.State.extend({
+          route: '/'
+        })
+      })
+    });
+
+    app.initialize();
+  });
+
+  equal(app.getPath('stateManager') instanceof Ember.Router, true, "Router was set from initialize call");
+  equal(app.getPath('stateManager.currentState.path'), 'start.index', "The router moved the state into the right place");
+});


### PR DESCRIPTION
This will allow several shortcuts :
- you can set location property on `Ember.Router` instance to a name of location `style`
- the router/stateManager instance you pass to `initialize` method will be set on your application namespace
- if you pass no argument to `initialize` method it will try to look for a rooter class in `app.Router`
