### PR TITLE
Make views use the public templateContext when rendering

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -777,7 +777,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     var template = get(this, 'layout') || get(this, 'template');
 
     if (template) {
-      var context = get(this, '_templateContext');
+      var context = get(this, 'templateContext');
       var keywords = this.cloneKeywords();
 
       var data = {


### PR DESCRIPTION
If I want to override the context a view's template uses when rendering, I have to override _templateContext instead of templateContext, contrary to what the docs say. This makes View.render use templateContext instead of _templateContext.
