### PR TITLE
Fix additional tests that cause automatic runloop creation

### DIFF
--- a/packages/ember-metal/tests/binding/multiple_test.js
+++ b/packages/ember-metal/tests/binding/multiple_test.js
@@ -19,23 +19,31 @@ module('system/binding/multiple', {
 });
 
 test('forces binding values to be multiple', function() {
-  var binding = Ember.bind(MyApp, 'bar.value', 'foo.value').multiple();
-
-  Ember.run.sync();
+  var binding;
+  Ember.run(function(){
+    binding = Ember.bind(MyApp, 'bar.value', 'foo.value').multiple();
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), ['FOO'], '1 MyApp.bar.value');
 
-  Ember.setPath('MyApp.foo.value', ['BAR']);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', ['BAR']);
+  });
+  
   deepEqual(Ember.getPath('MyApp.foo.value'), ['BAR'], '2 MyApp.foo.value');
   deepEqual(Ember.getPath('MyApp.bar.value'), ['BAR'], '2 MyApp.bar.value');
 
-  Ember.setPath('MyApp.foo.value', ['BAR', 'BAZ']);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', ['BAR', 'BAZ']);
+  });
+  
   deepEqual(Ember.getPath('MyApp.foo.value'), ['BAR', 'BAZ'], '3 MyApp.foo.value');
   deepEqual(Ember.getPath('MyApp.bar.value'), ['BAR', 'BAZ'], '3 MyApp.bar.value');
 
-  Ember.setPath('MyApp.foo.value', null);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', null);
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), [], '4 MyApp.bar.value');
 
 });

--- a/packages/ember-metal/tests/binding/notEmpty_test.js
+++ b/packages/ember-metal/tests/binding/notEmpty_test.js
@@ -19,18 +19,23 @@ module('system/binding/notEmpty', {
 });
 
 test('forces binding values to be notEmpty if enumerable', function() {
-
-  var binding = Ember.bind(MyApp, 'bar.value', 'foo.value').notEmpty('(EMPTY)');
-
-  Ember.run.sync();
+  var binding;
+  Ember.run(function(){
+    binding = Ember.bind(MyApp, 'bar.value', 'foo.value').notEmpty('(EMPTY)');
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), 'FOO', '1 MyApp.bar.value');
 
-  Ember.setPath('MyApp.foo.value', ['FOO']);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', ['FOO']);
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), ['FOO'], '2 Array passes through');
 
-  Ember.setPath('MyApp.foo.value', []);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', []);
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), '(EMPTY)', '3 uses empty placeholder');
 
 });

--- a/packages/ember-metal/tests/binding/notNull_test.js
+++ b/packages/ember-metal/tests/binding/notNull_test.js
@@ -19,14 +19,17 @@ module('system/binding/notNull', {
 });
 
 test('allow empty string as placeholder', function() {
-
-  var binding = Ember.bind(MyApp, 'bar.value', 'foo.value').notNull('');
-
-  Ember.run.sync();
+  var binding;
+  Ember.run(function(){
+    binding = Ember.bind(MyApp, 'bar.value', 'foo.value').notNull('');
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), 'FOO', 'value passes through');
 
-  Ember.setPath('MyApp.foo.value', null);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', null);
+  });
+  
   deepEqual(Ember.getPath('MyApp.bar.value'), '', 'null gets replaced');
 
 });

--- a/packages/ember-metal/tests/binding/oneWay_test.js
+++ b/packages/ember-metal/tests/binding/oneWay_test.js
@@ -19,19 +19,25 @@ module('system/mixin/binding/oneWay_test', {
 });
 
 test('oneWay(true) should only sync one way', function() {
-  var binding = Ember.oneWay(MyApp, 'bar.value', 'foo.value');
-  Ember.run.sync();
-
+  var binding;
+  Ember.run(function(){
+    binding = Ember.oneWay(MyApp, 'bar.value', 'foo.value');
+  });
+  
   equal(Ember.getPath('MyApp.foo.value'), 'FOO', 'foo synced');
   equal(Ember.getPath('MyApp.bar.value'), 'FOO', 'bar synced');
 
-  Ember.setPath('MyApp.bar.value', 'BAZ');
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.bar.value', 'BAZ');
+  });
+  
   equal(Ember.getPath('MyApp.foo.value'), 'FOO', 'foo synced');
   equal(Ember.getPath('MyApp.bar.value'), 'BAZ', 'bar not synced');
 
-  Ember.setPath('MyApp.foo.value', 'BIFF');
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', 'BIFF');
+  });
+  
   equal(Ember.getPath('MyApp.foo.value'), 'BIFF', 'foo synced');
   equal(Ember.getPath('MyApp.bar.value'), 'BIFF', 'foo synced');
 

--- a/packages/ember-metal/tests/binding/or_test.js
+++ b/packages/ember-metal/tests/binding/or_test.js
@@ -12,7 +12,10 @@ module('binding/or', {
       foo: false,
       bar: false
     };
-    Ember.Binding.or("foo", "bar").to("baz").connect(MyApp);
+    Ember.run(function(){
+      Ember.Binding.or("foo", "bar").to("baz").connect(MyApp);
+    });
+    
   },
 
   teardown: function() {
@@ -21,29 +24,37 @@ module('binding/or', {
 });
 
 test('should return first item when both are truthy', function() {
-  set(MyApp, 'foo', 'FOO');
-  set(MyApp, 'bar', 'BAR');
-  Ember.run.sync();
+  Ember.run(function(){
+    set(MyApp, 'foo', 'FOO');
+    set(MyApp, 'bar', 'BAR');
+  });
+  
   equal(get(MyApp, 'baz'), 'FOO', 'should be false');
 });
 
 test('should return true first item', function() {
-  set(MyApp, 'foo', 1);
-  set(MyApp, 'bar', false);
-  Ember.run.sync();
+  Ember.run(function(){
+    set(MyApp, 'foo', 1);
+    set(MyApp, 'bar', false);
+  });
+  
   equal(get(MyApp, 'baz'), 1, 'should be false');
 });
 
 test('should return true second item', function() {
-  set(MyApp, 'foo', false);
-  set(MyApp, 'bar', 10);
-  Ember.run.sync();
+  Ember.run(function(){
+    set(MyApp, 'foo', false);
+    set(MyApp, 'bar', 10);
+  });
+  
   equal(get(MyApp, 'baz'), 10, 'should be false');
 });
 
 test('should return second item when both are false', function() {
-  set(MyApp, 'foo', null);
-  set(MyApp, 'bar', 0);
-  Ember.run.sync();
+  Ember.run(function(){
+    set(MyApp, 'foo', null);
+    set(MyApp, 'bar', 0);
+  });
+  
   equal(get(MyApp, 'baz'), 0, 'should be false');
 });

--- a/packages/ember-metal/tests/binding/registerTransform_test.js
+++ b/packages/ember-metal/tests/binding/registerTransform_test.js
@@ -26,32 +26,39 @@ module('system/binding/registerTransform', {
 });
 
 test('registerTransform registers a custom transform for use in a binding', function() {
-  Ember.setPath('MyApp.foo', 0);
+  var binding;
+  
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo', 0);
 
-  var binding = Ember.bind(MyApp, 'bar', 'foo').gt(0);
-  Ember.run.sync();
-
+    binding = Ember.bind(MyApp, 'bar', 'foo').gt(0);
+  });
+  
   equal(Ember.getPath('MyApp.bar'), false);
 
-  Ember.setPath('MyApp.foo', 1);
-  Ember.run.sync();
-
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo', 1);
+  });
+  
   equal(Ember.getPath('MyApp.bar'), true);
 
   binding.disconnect(MyApp);
 });
 
 test('registerTransform adds a class method to Ember.Binding', function() {
-  Ember.setPath('MyApp.foo', 0);
-
-  var binding = Ember.Binding.gt('foo', 0).to('baz').connect(MyApp);
-  Ember.run.sync();
+  var binding;
+  
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo', 0);
+    binding = Ember.Binding.gt('foo', 0).to('baz').connect(MyApp);
+  });
 
   equal(Ember.getPath('MyApp.baz'), false);
 
-  Ember.setPath('MyApp.foo', 1);
-  Ember.run.sync();
-
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo', 1);
+  });
+  
   equal(Ember.getPath('MyApp.baz'), true);
 
   binding.disconnect(MyApp);

--- a/packages/ember-metal/tests/binding/single_test.js
+++ b/packages/ember-metal/tests/binding/single_test.js
@@ -21,35 +21,50 @@ module('system/binding/single', {
 });
 
 test('forces binding values to be single', function() {
-  var binding = Ember.bind(MyApp, 'bar.value', 'foo.value').single();
+  var binding;
+  Ember.run(function(){
+    binding = Ember.bind(MyApp, 'bar.value', 'foo.value').single();
+  });
+  
 
-  Ember.run.sync();
   equal(Ember.getPath('MyApp.bar.value'), 'FOO', 'passes single object');
 
-  Ember.setPath('MyApp.foo.value', ['BAR']);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', ['BAR']);
+  });
+  
   equal(Ember.getPath('MyApp.bar.value'), 'BAR', 'passes single object');
 
-  Ember.setPath('MyApp.foo.value', ['BAR', 'BAZ']);
-  Ember.run.sync();
+  Ember.run(function(){
+    Ember.setPath('MyApp.foo.value', ['BAR', 'BAZ']);
+  });
+  
   equal(Ember.getPath('MyApp.bar.value'), Ember.MULTIPLE_PLACEHOLDER, 'converts to placeholder');
 });
 
 test('Ember.Binding#single(fromPath, placeholder) is available', function() {
-  var obj = {
-        value: null,
-        boundValue: null
-      },
-      binding = Ember.Binding.single('value', 'placeholder').to('boundValue').connect(obj);
+  var binding;
 
-  Ember.run.sync();
+  var obj = {
+    value: null,
+    boundValue: null
+  };
+
+  Ember.run(function(){
+    binding = Ember.Binding.single('value', 'placeholder').to('boundValue').connect(obj);
+  });
+
   equal(get(obj, 'boundValue'), null, 'intial boundValue is null');
 
-  set(obj, 'value', [1]);
-  Ember.run.sync();
+  Ember.run(function(){
+    set(obj, 'value', [1]);
+  });
+  
   equal(get(obj, 'boundValue'), 1, 'passes single object');
 
-  set(obj, 'value', [1, 2]);
-  Ember.run.sync();
+  Ember.run(function(){
+    set(obj, 'value', [1, 2]);
+  });
+
   equal(get(obj, 'boundValue'), 'placeholder', 'converts to placeholder');
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
@@ -61,44 +61,46 @@ var bindModuleOpts = {
 module("bind() method", bindModuleOpts);
 
 test("bind(TestNamespace.fromObject.bar) should follow absolute path", function() {
-  // create binding
-  testObject.bind("foo", "TestNamespace.fromObject.bar") ;
-  Ember.run.sync() ; // actually sets up up the binding
-
-  // now make a change to see if the binding triggers.
-  set(fromObject, "bar", "changedValue") ;
-
-  // support new-style bindings if available
-  Ember.run.sync();
+  Ember.run(function(){
+    // create binding
+    testObject.bind("foo", "TestNamespace.fromObject.bar");
+    
+    // now make a change to see if the binding triggers.
+    set(fromObject, "bar", "changedValue");
+  });
+  
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
 test("bind(.bar) should bind to relative path", function() {
-  // create binding
-  testObject.bind("foo", ".bar") ;
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    // create binding
+    testObject.bind("foo", ".bar") ;
 
-  // now make a change to see if the binding triggers.
-  set(testObject, "bar", "changedValue") ;
-
-  Ember.run.sync();
+    // now make a change to see if the binding triggers.
+    set(testObject, "bar", "changedValue") ;
+  });
+  
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
 test("Ember.Binding.bool(TestNamespace.fromObject.bar)) should create binding with bool transform", function() {
-  // create binding
-  testObject.bind("foo", Ember.Binding.bool("TestNamespace.fromObject.bar")) ;
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    // create binding
+    testObject.bind("foo", Ember.Binding.bool("TestNamespace.fromObject.bar"));
+    
+    // now make a change to see if the binding triggers.
+    set(fromObject, "bar", 1);
+  });
+  
 
-  // now make a change to see if the binding triggers.
-  set(fromObject, "bar", 1) ;
-
-  Ember.run.sync();
   equal(true, get(testObject, "foo"), "testObject.foo == true");
 
-  set(fromObject, "bar", 0) ;
+  Ember.run(function(){
+    set(fromObject, "bar", 0);
+  });
+  
 
-  Ember.run.sync();
   equal(false, get(testObject, "foo"), "testObject.foo == false");
 });
 
@@ -115,36 +117,37 @@ module("bind() method - deprecated", {
 });
 
 test("bind(TestNamespace.fromObject*extraObject.foo) should create chained binding", function() {
-  testObject.bind("foo", "TestNamespace.fromObject*extraObject.foo");
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    testObject.bind("foo", "TestNamespace.fromObject*extraObject.foo");
+    set(fromObject, "extraObject", extraObject);
+  });
 
-  set(fromObject, "extraObject", extraObject) ;
-
-  Ember.run.sync();
   equal("extraObjectValue", get(testObject, "foo"), "testObject.foo") ;
 });
 
 test("bind(*extraObject.foo) should create locally chained binding", function() {
-  testObject.bind("foo", "*extraObject.foo");
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    testObject.bind("foo", "*extraObject.foo");
+    set(testObject, "extraObject", extraObject);
+  });
 
-  set(testObject, "extraObject", extraObject) ;
-
-  Ember.run.sync();
   equal("extraObjectValue", get(testObject, "foo"), "testObject.foo") ;
 });
 
 
 // The following contains no test
 test("bind(*extraObject.foo) should be disconnectable", function() {
-  var binding = testObject.bind("foo", "*extraObject.foo");
-  Ember.run.sync() ; // actually sets up up the binding
-
+  var binding;
+  Ember.run(function(){
+    binding = testObject.bind("foo", "*extraObject.foo");
+  });
+  
   binding.disconnect(testObject);
 
-  set(testObject, 'extraObject', extraObject);
-  Ember.run.sync() ;
-
+  Ember.run(function(){
+    set(testObject, 'extraObject', extraObject);
+  });
+  
   // there was actually a bug here - the binding above should have synced to
   // null as there was no original value
   equal(null, get(testObject, "foo"), "testObject.foo after disconnecting");
@@ -186,65 +189,68 @@ module("fooBinding method", fooBindingModuleOpts);
 
 test("fooBinding: TestNamespace.fromObject.bar should follow absolute path", function() {
   // create binding
-  testObject = TestObject.create({
-    fooBinding: "TestNamespace.fromObject.bar"
-  }) ;
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    testObject = TestObject.create({
+      fooBinding: "TestNamespace.fromObject.bar"
+    }) ;
 
-  // now make a change to see if the binding triggers.
-  set(fromObject, "bar", "changedValue") ;
+    // now make a change to see if the binding triggers.
+    set(fromObject, "bar", "changedValue") ;
+  });
+  
 
-  Ember.run.sync();
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
 test("fooBinding: .bar should bind to relative path", function() {
-
-  testObject = TestObject.create({
-    fooBinding: ".bar"
-  }) ;
-  Ember.run.sync() ; // actually sets up up the binding
-
-  // now make a change to see if the binding triggers.
-  set(testObject, "bar", "changedValue") ;
-
-  Ember.run.sync();
+  Ember.run(function(){
+    testObject = TestObject.create({
+      fooBinding: ".bar"
+    });
+    // now make a change to see if the binding triggers.
+    set(testObject, "bar", "changedValue");
+  });
+  
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
 test("fooBinding: Ember.Binding.bool(TestNamespace.fromObject.bar should create binding with bool transform", function() {
 
-  testObject = TestObject.create({
-    fooBinding: Ember.Binding.bool("TestNamespace.fromObject.bar")
-  }) ;
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    testObject = TestObject.create({
+      fooBinding: Ember.Binding.bool("TestNamespace.fromObject.bar")
+    });
 
-  // now make a change to see if the binding triggers.
-  set(fromObject, "bar", 1) ;
-
-  Ember.run.sync();
+    // now make a change to see if the binding triggers.
+    set(fromObject, "bar", 1);
+  });
+  
   equal(true, get(testObject, "foo"), "testObject.foo == true");
 
-  set(fromObject, "bar", 0) ;
-
-  Ember.run.sync();
+  Ember.run(function(){
+    set(fromObject, "bar", 0);
+  });
+  
   equal(false, get(testObject, "foo"), "testObject.foo == false");
 });
 
 test('fooBinding: should disconnect bindings when destroyed', function () {
+  Ember.run(function(){
+    testObject = TestObject.create({
+      fooBinding: "TestNamespace.fromObject.bar"
+    });
 
-  testObject = TestObject.create({
-    fooBinding: "TestNamespace.fromObject.bar"
-  }) ;
-  Ember.run.sync() ; // actually sets up up the binding
-
-  set(TestNamespace.fromObject, 'bar', 'BAZ');
-  Ember.run.sync();
+    set(TestNamespace.fromObject, 'bar', 'BAZ');
+  });
+  
   equal(get(testObject, 'foo'), 'BAZ', 'binding should have synced');
 
   Ember.destroy(testObject);
-  set(TestNamespace.fromObject, 'bar', 'BIFF');
-  Ember.run.sync();
+  
+  Ember.run(function(){
+    set(TestNamespace.fromObject, 'bar', 'BIFF');
+  });
+  
   ok(get(testObject, 'foo') !== 'bar', 'binding should not have synced');
 });
 
@@ -262,26 +268,24 @@ module("fooBinding method - deprecated", {
 
 test("fooBinding: TestNamespace.fromObject*extraObject.foo should create chained binding", function() {
 
-  testObject = TestObject.create({
-    fooBinding: "TestNamespace.fromObject*extraObject.foo"
-  }) ;
-  Ember.run.sync() ; // actually sets up up the binding
+  Ember.run(function(){
+    testObject = TestObject.create({
+      fooBinding: "TestNamespace.fromObject*extraObject.foo"
+    });
 
-  set(fromObject, "extraObject", extraObject) ;
+    set(fromObject, "extraObject", extraObject);
+  });
 
-  Ember.run.sync();
   equal("extraObjectValue", get(testObject, "foo"), "testObject.foo") ;
 });
 
 test("fooBinding: *extraObject.foo should create locally chained binding", function() {
+  Ember.run(function(){
+    testObject = TestObject.create({
+      fooBinding: "*extraObject.foo"
+    });
+    set(testObject, "extraObject", extraObject);
+  });
 
-  testObject = TestObject.create({
-    fooBinding: "*extraObject.foo"
-  }) ;
-  Ember.run.sync() ; // actually sets up up the binding
-
-  set(testObject, "extraObject", extraObject) ;
-
-  Ember.run.sync();
   equal("extraObjectValue", get(testObject, "foo"), "testObject.foo") ;
 });


### PR DESCRIPTION
these were causing additional un-related tests to fail as side effects of their specific timing, which is bad.

should allow #865, #866 to cleanly apply.
