### PR TITLE
Fixed up a small typo in the run_loop.js docs.

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -574,7 +574,7 @@ Ember.run.next = function(target, method) {
       });
       Ember.run.cancel(runNext);
 
-      var runLater = Ember.run.next(myContext, function(){
+      var runLater = Ember.run.later(myContext, function(){
         // will not be executed
       }, 500);
       Ember.run.cancel(runLater);


### PR DESCRIPTION
Discovered a small typo in the docs. Figured I'd fix it up.
