### PR TITLE
Doc

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -87,19 +87,19 @@ Ember.Application = Ember.Namespace.extend(
 
     Example:
 
-      App.PostsController = Ember.ArrayController.extend();
-      App.CommentsController = Ember.ArrayController.extend();
+        App.PostsController = Ember.ArrayController.extend();
+        App.CommentsController = Ember.ArrayController.extend();
 
-      var stateManager = Ember.StateManager.create({
-        ...
-      });
+        var router = Ember.Router.create({
+          ...
+        });
 
-      App.initialize(router);
+        App.initialize(router);
 
-      router.get('postsController')     // <App.PostsController:ember1234>
-      router.get('commentsController')  // <App.CommentsController:ember1235>
+        router.get('postsController')     // <App.PostsController:ember1234>
+        router.get('commentsController')  // <App.CommentsController:ember1235>
 
-      router.getPath('postsController.router') // router
+        router.getPath('postsController.router') // router
   */
   initialize: function(router) {
     var properties = Ember.A(Ember.keys(this)),

--- a/packages/ember-application/lib/system/location.js
+++ b/packages/ember-application/lib/system/location.js
@@ -10,6 +10,9 @@ var get = Ember.get, set = Ember.set;
   onUpdateURL(callback): triggers the callback when the URL changes
 
   Calling setURL will not trigger onUpdateURL callbacks.
+
+  TODO: This, as well as the Ember.Location documentation below, should
+  perhaps be moved so that it's visible in the JsDoc output.
 */
 
 /**

--- a/packages/ember-application/lib/system/location.js
+++ b/packages/ember-application/lib/system/location.js
@@ -88,12 +88,12 @@ Ember.HashLocation = Ember.Object.extend({
 Ember.Location = {
   create: function(options) {
     var implementation = options && (options.style || options.implementation);
-    Ember.assert("you must provide an implementation to Ember.Location.create", !!implementation);
+    Ember.assert("Ember.Location.create: you must specify a 'style' option", !!implementation);
 
-    implementation = this.implementations[implementation];
-    Ember.assert("you must provide an implementation to Ember.Location.create", !!implementation);
+    var implementationClass = this.implementations[implementation];
+    Ember.assert("Ember.Location.create: " + implementation + " is not a valid implementation", !!implementationClass);
 
-    return implementation.create.apply(implementation, arguments);
+    return implementationClass.create.apply(implementationClass, arguments);
   },
 
   registerImplementation: function(name, implementation) {

--- a/packages/ember-states/lib/router.js
+++ b/packages/ember-states/lib/router.js
@@ -2,7 +2,25 @@ require('ember-states/state');
 require('ember-states/route_matcher');
 require('ember-states/routable');
 
-Ember.Router = Ember.StateManager.extend({
+/**
+  @class
+
+  `Ember.Router` is a state manager used for routing.
+
+  A special `Router` property name is recognized on applications:
+
+      var app = Ember.Application.create({
+        Router: Ember.Router.extend(...)
+      });
+      app.initialize();
+
+  Here, `app.initialize` will instantiate the `app.Router` and assign the
+  instance to the `app.stateManager` property.
+
+  @extends Ember.StateManager
+*/
+Ember.Router = Ember.StateManager.extend(
+/** @scope Ember.Router.prototype */ {
   route: function(path) {
     if (path.charAt(0) === '/') {
       path = path.substr(1);

--- a/packages/ember-viewstates/lib/view_state.js
+++ b/packages/ember-viewstates/lib/view_state.js
@@ -243,7 +243,8 @@ var get = Ember.get, set = Ember.set;
   `view` that references the `Ember.View` object that was interacted with.
   
 **/
-Ember.ViewState = Ember.State.extend({
+Ember.ViewState = Ember.State.extend(
+/** @scope Ember.ViewState.prototype */ {
   isViewState: true,
 
   enter: function(stateManager) {


### PR DESCRIPTION
- Add @scope so properties are picked up by JsDoc
- Add TODO note about Ember.Location documentation
- Fix indentation
- Make identical assertion messages distinguishable
- Add documentation stub for Ember.Router
