### PR TITLE
Assert

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -394,6 +394,7 @@ Ember.StateManager = Ember.State.extend(
   errorOnUnhandledEvent: true,
 
   send: function(event, context) {
+    Ember.assert('Cannot send event "' + event + '" while currentState is ' + get(this, 'currentState'), get(this, 'currentState'));
     this.sendRecursively(event, get(this, 'currentState'), context);
   },
 

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -372,6 +372,7 @@ Ember.StateManager = Ember.State.extend(
 
     if (initialState) {
       this.transitionTo(initialState);
+      Ember.assert('Failed to transition to initial state "' + initialState + '"', get(this, 'currentState'));
     }
   },
   

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -250,6 +250,15 @@ test("it automatically transitions to multiple substates specified using either 
   ok(get(stateManager, 'currentState').isStart, "automatically transitions to final substate");
 });
 
+test("it throws an assertion error when the initialState does not exist", function() {
+  raises(function() {
+    Ember.StateManager.create({
+      initialState: 'foo',
+      bar: Ember.State.create()
+    });
+  }, Error, 'raises an exception');
+});
+
 module("Ember.StateManager - Transitions on Complex State Managers");
 
 /**


### PR DESCRIPTION
- Guard against currentState being null when sending events to StateManager
  
  This happened when I tried to use a Router without a root state. It
  doesn't make sense to send events to a state manager that doesn't have a
  current state, so this makes the error message a little more
  descriptive.
- Guard against missing initialState
  
  If for instance, you instantiate a Router without a root state, you'd
  just get an error message saying that the currentState is null. This
  clarifies to the user what's missing.

Supersedes #882, retargeted against 0-9-stable (I _thought_ something was missing), with more elaboration.
