### PR TITLE
Removes deprecated label wrapping behavior of Ember.Checkbox

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -12,22 +12,8 @@ var set = Ember.set, get = Ember.get;
 /**
   @class
 
-  Creates an HTML input view in one of two formats.
-
-  If a `title` property or binding is provided the input will be wrapped in
-  a `div` and `label` tag. View properties like `classNames` will be applied to
-  the outermost `div`. This behavior is deprecated and will issue a warning in development.
-
-
-      {{view Ember.Checkbox classNames="applicaton-specific-checkbox" title="Some title"}}
-
-
-      <div id="ember1" class="ember-view ember-checkbox applicaton-specific-checkbox">
-        <label><input type="checkbox" />Some title</label>
-      </div>
-
-  If `title` isn't provided the view will render as an input element of the 'checkbox' type and HTML
-  related properties will be applied directly to the input.
+  Creates an HTML input of type 'checkbox' with HTML related properties 
+  applied directly to the input.
 
       {{view Ember.Checkbox classNames="applicaton-specific-checkbox"}}
 
@@ -58,18 +44,6 @@ Ember.Checkbox = Ember.View.extend({
   checked: false,
   disabled: false,
 
-  /** @deprecated */
-  title: null,
-
-  value: Ember.computed(function(propName, value){
-    Ember.deprecate("Ember.Checkbox's 'value' property has been renamed to 'checked' to match the html element attribute name");
-    if (value !== undefined) {
-      return set(this, 'checked', value);
-    } else {
-      return get(this, 'checked');
-    }
-  }).property('checked').volatile(),
-
   change: function() {
     Ember.run.once(this, this._updateElementValue);
     // returning false will cause IE to not change checkbox state
@@ -79,7 +53,6 @@ Ember.Checkbox = Ember.View.extend({
     @private
   */
   _updateElementValue: function() {
-    var input = get(this, 'title') ? this.$('input:checkbox') : this.$();
-    set(this, 'checked', input.prop('checked'));
+    set(this, 'checked', this.$().prop('checked'));
   }
 });

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -95,24 +95,3 @@ test("checking the checkbox updates the value", function() {
   equal(checkboxView.$().prop('checked'), false, "after clicking a checkbox, the checked property changed");
   equal(get(checkboxView, 'checked'), false, "changing the checkbox causes the view's value to get updated");
 });
-
-test("proxies the checked attribute to value for backwards compatibility", function(){
-  Ember.TESTING_DEPRECATION = true;
-
-  try {
-    checkboxView = Ember.Checkbox.create({ title: "I have a title" });
-    append();
-
-    setAndFlush(checkboxView, 'value', true);
-    equal(get(checkboxView, 'checked'), true, 'checked is updated when value set');
-    equal(get(checkboxView, 'value'), true, 'value is updated when value set');
-
-    setAndFlush(checkboxView, 'checked', false);
-
-    equal(get(checkboxView, 'checked'), false, 'checked is updated when checked set');
-    equal(get(checkboxView, 'value'), false, 'value is updated when checked set');
-  } finally {
-    Ember.TESTING_DEPRECATION = false;
-  }
-});
-


### PR DESCRIPTION
in cleaning up runtime template compilations 9fce04129121884c522a887dc57fe0c6d5bbb2c2 effectively removed Ember.Checkbox label-wrapping behavior. This removes the rest of the deprecated code related to that and updates the documentation to remove references to the old behavior. 
