### PR TITLE
QUnit test runner: Run all packages by default

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -153,64 +153,59 @@
 
 
     // Load Tests and Depenencies
-    var packages = (QUnit.urlParams.package || "").split(","),
+    var packages = (QUnit.urlParams.package || "all").split(","),
         packageName, el, idx, len, re, match, moduleName;
 
-    if (!packages.length) {
-      el = document.getElementById('qunit-header');
-      el.innerHTML = 'Add package=package1,package2 in the URL to test packages';
-    } else {
-      if (packages[0] === 'all') {
-        packages = [
-          'ember-handlebars',
-          'ember-metal',
-          'ember-runtime',
-          'ember-states',
-          'ember-views',
-          'ember-viewstates',
-          'ember-application'
-        ];
-      }
+    if (packages[0] === 'all') {
+      packages = [
+        'ember-handlebars',
+        'ember-metal',
+        'ember-runtime',
+        'ember-states',
+        'ember-views',
+        'ember-viewstates',
+        'ember-application'
+      ];
+    }
 
-      len = packages.length;
+    len = packages.length;
 
-      // There is no require for this in the code
+    // There is no require for this in the code
+    if (dist == 'spade') {
+      minispade.require('handlebars');
+      minispade.require('ember-debug');
+    }
+
+    for (idx=0; idx<len; idx++) {
+      packageName = packages[idx];
+      re = new RegExp('^'+packageName+'/([^/]+)');
+
       if (dist == 'spade') {
-        minispade.require('handlebars');
-        minispade.require('ember-debug');
+        minispade.require(packageName);
       }
 
-      for (idx=0; idx<len; idx++) {
-        packageName = packages[idx];
-        re = new RegExp('^'+packageName+'/([^/]+)');
+      for (moduleName in minispade.modules) {
+        if (!minispade.modules.hasOwnProperty(moduleName)) { continue; }
 
-        if (dist == 'spade') {
-          minispade.require(packageName);
-        }
+        match = moduleName.match(re);
+        if (match) {
+          if (match[1] === '~tests') {
+            // Only require the actual tests since we already required the module
+            minispade.require(moduleName);
+          }
 
-        for (moduleName in minispade.modules) {
-          if (!minispade.modules.hasOwnProperty(moduleName)) { continue; }
-
-          match = moduleName.match(re);
-          if (match) {
-            if (match[1] === '~tests') {
-              // Only require the actual tests since we already required the module
-              minispade.require(moduleName);
-            }
-
-            if (jsHint) {
-              // JSHint all modules in this package, tests and code
-              // (closure to preserve variable values)
-              (function() {
-                var jshintModule = moduleName;
-                module(jshintModule);
-                test('should pass jshint', function() {
-                  var passed = JSHINT(minispade.modules[jshintModule], JSHINTRC),
-                      errors = jsHintReporter(jshintModule, JSHINT.errors);
-                  ok(passed, jshintModule+" should pass jshint."+(errors ? "\n"+errors : ''));
-                });
-              })();
-            }
+          if (jsHint) {
+            // JSHint all modules in this package, tests and code
+            // (closure to preserve variable values)
+            (function() {
+              var jshintModule = moduleName;
+              module(jshintModule);
+              test('should pass jshint', function() {
+                var passed = JSHINT(minispade.modules[jshintModule], JSHINTRC),
+                    errors = jsHintReporter(jshintModule, JSHINT.errors);
+                ok(passed, jshintModule+" should pass jshint."+(errors ? "\n"+errors : ''));
+              });
+            })();
           }
         }
       }


### PR DESCRIPTION
The test `if (!packages.length)` didn't actually do anything before,
because split always returns at least ['']. But it's more convenient
anyway to just run everything by default, rather than displaying an
error message. This way people can open the test runner without
parameters and it Just Works.

Note on the diff: The if main clause is deleted, and the rest is just a
dedent.
