### PR TITLE
Template context in ContainerView children is set to container

### DIFF
--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -257,3 +257,22 @@ test("if a ContainerView starts with a currentView and then a different currentV
   equal(getPath(container, 'childViews.length'), 1, "should have one child view");
   equal(getPath(container, 'childViews').objectAt(0), secondaryView, "should have the currentView as the only child view");
 });
+
+test("should set the child view context in template", function() {
+  var container = Ember.ContainerView.create({
+    name: 'container'
+  });
+
+  set(container, 'currentView', Ember.View.create({
+    name: 'child',
+    template: function(context, options) {
+      return 'In ' + context.get('name') + ' context';
+    }
+  }));
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  equal(container.$().text(), 'In child context', '');
+});


### PR DESCRIPTION
Given a container with a child view,

```
{{foo}}
```

in the child view will try to access the `foo` property on the container view, rather than the child view.

In other words, the template context is not set correctly.

I'm attaching a failing test case.

[Edit: This PR is targeted at 0-9-stable, and GitHub won't let me change it to master, but it merges cleanly on master as well.]
