### PR TITLE
urlFor should raise an error when route property is not defined

### DIFF
--- a/packages/ember-states/lib/routable.js
+++ b/packages/ember-states/lib/routable.js
@@ -73,17 +73,20 @@ Ember.Routable = Ember.Mixin.create({
 
     hash = hash || {};
     merge(hash, meta);
+
+    Ember.assert("couldn't find route property for " + get(this, 'path'), !!matcher);
+
     var generated = matcher.generate(hash);
 
-    if (generated !== "") {
-      return path + '/' + matcher.generate(hash);
-    } else {
-      return path;
+    if (generated !== '') {
+      path = path + '/' + generated;
     }
+
+    return path;
   },
 
   isRoutable: Ember.computed(function() {
-    return typeof this.route === "string";
+    return typeof this.route === 'string';
   }).cacheable(),
 
   routeMatcher: Ember.computed(function() {

--- a/packages/ember-states/tests/routable_test.js
+++ b/packages/ember-states/tests/routable_test.js
@@ -486,8 +486,21 @@ test("urlFor returns an absolute route", function() {
   });
 
   var url = router.urlFor('root.dashboard');
-  equal(url, "/dashboard");
+  equal(url, '/dashboard');
   expectURL('/dashboard');
+});
+
+test("urlFor raises an error when route property is not defined", function() {
+  var router = Ember.Router.create({
+    location: locationStub,
+    root: Ember.State.create({
+      dashboard: Ember.State.create({}) // state without route property
+    })
+  });
+
+  raises(function (){
+    router.urlFor('root.dashboard');
+  });
 });
 
 test("urlFor supports dynamic segments", function() {


### PR DESCRIPTION
Having this code in `app_router.js`:

```
root: Ember.State.extend({
  index: Ember.State.extend({
    route: '/',

    connectOutlets: function(router) {
      router.get('applicationController').connectOutlet(App.HomeView);
    },

    showUsers: Ember.State.transitionTo('users')
  }),

  users: Ember.State.extend({}) // state without route property
});
```

and the following template:

```
<a {{action showUsers href=true}}>Users</a>
```

It returns a **TypeError: Cannot call method 'generate' of undefined**.
This change check if the route property is defined, if it's not raises
an error like: **route property is not defined for current_path**.
