### PR TITLE
Assert

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -76,7 +76,7 @@ function mergeMixins(mixins, m, descs, values, base) {
   for(idx=0;idx<len;idx++) {
 
     mixin = mixins[idx];
-    if (!mixin) throw new Error('Null value found in Ember.mixin()');
+    Ember.assert('Null value found in Ember.mixin()', !!mixin);
 
     if (mixin instanceof Mixin) {
       guid = Ember.guidFor(mixin);
@@ -224,7 +224,7 @@ function applyMixin(obj, mixins, partial) {
 
     if (desc === REQUIRED) {
       if (!(key in obj)) {
-        if (!partial) throw new Error('Required property not defined: '+key);
+        Ember.assert('Required property not defined: '+key, !!partial);
 
         // for partial applies add to hash of required keys
         req = writableReq(obj);
@@ -311,7 +311,8 @@ function applyMixin(obj, mixins, partial) {
       if (META_SKIP[key]) continue;
       keys.push(key);
     }
-    throw new Error('Required properties not defined: '+keys.join(','));
+    // TODO: Remove surrounding if clause from production build
+    Ember.assert('Required properties not defined: '+keys.join(','));
   }
   return obj;
 }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -76,7 +76,7 @@ function mergeMixins(mixins, m, descs, values, base) {
   for(idx=0;idx<len;idx++) {
 
     mixin = mixins[idx];
-    Ember.assert('Null value found in Ember.mixin()', !!mixin);
+    Ember.assert('Expected hash or Mixin instance, got ' + Object.prototype.toString.call(mixin), typeof mixin === 'object' && mixin !== null && Object.prototype.toString.call(mixin) !== '[object Array]');
 
     if (mixin instanceof Mixin) {
       guid = Ember.guidFor(mixin);
@@ -388,7 +388,8 @@ Mixin.prototype.reopen = function() {
 
   for(idx=0;idx<len;idx++) {
     mixin = arguments[idx];
-    Ember.assert("Expected Mixin or hash, got null or undefined.", !!mixin);
+    Ember.assert('Expected hash or Mixin instance, got ' + Object.prototype.toString.call(mixin), typeof mixin === 'object' && mixin !== null && Object.prototype.toString.call(mixin) !== '[object Array]');
+
     if (mixin instanceof Mixin) {
       mixins.push(mixin);
     } else {

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -387,6 +387,7 @@ Mixin.prototype.reopen = function() {
 
   for(idx=0;idx<len;idx++) {
     mixin = arguments[idx];
+    Ember.assert("Expected Mixin or hash, got null or undefined.", !!mixin);
     if (mixin instanceof Mixin) {
       mixins.push(mixin);
     } else {

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -390,7 +390,7 @@ Ember.StateManager = Ember.State.extend(
 
     if (initialState) {
       this.transitionTo(initialState);
-      Ember.assert('Failed to transition to initial state "' + initialState + '"', get(this, 'currentState'));
+      Ember.assert('Failed to transition to initial state "' + initialState + '"', !!get(this, 'currentState'));
     }
   },
 
@@ -414,7 +414,7 @@ Ember.StateManager = Ember.State.extend(
   errorOnUnhandledEvent: true,
 
   send: function(event, context) {
-    Ember.assert('Cannot send event "' + event + '" while currentState is ' + get(this, 'currentState'), get(this, 'currentState'));
+    Ember.assert('Cannot send event "' + event + '" while currentState is null or undefined.', !!get(this, 'currentState'));
     this.sendRecursively(event, get(this, 'currentState'), context);
   },
 


### PR DESCRIPTION
- Guard against undefined mixins
  
  This can easily happen with Ember.Object.extend(App.DoesNotExist, {...}).
- Use Ember.assert instead of throw
- Guard against implicit function application by Ember.assert
- Guard mergeMixins parameters more generally
  
  Previously we caught passing null or undefined into Object.create() or
  .extend(). Now we also catch any other invalid types like strings,
  numbers, or arrays.
  
  We cannot use Ember.typeOf, since runtime depends on metal and we don't
  want circular dependencies. For the weird array check, see
  http://stackoverflow.com/a/1058753/525872
