### PR TITLE
Doc2

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -82,7 +82,7 @@ function makeCtor() {
 var CoreObject = makeCtor();
 
 CoreObject.PrototypeMixin = Ember.Mixin.create(
-/** @scope Ember.CoreObject */ {
+/** @scope Ember.CoreObject.prototype */ {
 
   reopen: function() {
     Ember.Mixin._apply(this, arguments, true);
@@ -148,7 +148,8 @@ CoreObject.PrototypeMixin = Ember.Mixin.create(
 
 CoreObject.__super__ = null;
 
-var ClassMixin = Ember.Mixin.create({
+var ClassMixin = Ember.Mixin.create(
+/** @scope Ember.CoreObject */ {
 
   ClassMixin: Ember.required(),
 

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -12,6 +12,11 @@ Ember.CoreObject.subclasses = new Ember.Set();
 
 /**
   @class
+
+  `Ember.Object` is the main base class for all Ember objects. It is a subclass
+  of `Ember.CoreObject` with the `Ember.Observable` mixin applied. For details,
+  see the documentation for each of these.
+
   @extends Ember.CoreObject
   @extends Ember.Observable
 */


### PR DESCRIPTION
- Assign correct JsDoc scopes to CoreObject class and instance methods
- Add brief documentation for Ember.Object
