### PR TITLE
Call preventDefault and stopPropagation on events handled through {{action}}

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -67,8 +67,18 @@ ActionHelper.registerAction = function(actionName, eventName, target, view, cont
   `jQuery.Event` object as its argument. The `jQuery.Event` object will be extended to include
   a `view` property that is set to the original view interacted with (in this case the `aView` object).
 
+  ### Event Propagation
+
+  Events triggered through the action helper will automatically have
+  `.preventDefault()` and `.stopPropagation()` called on them. You do not need
+  to do so in your event handlers, and you do not need to return `false`.
+
+  If you need the default handler to trigger, or if you need propagation,
+  you should either register your own event handler, or use event methods on
+  your view class.
 
   ### Specifying an Action Target
+
   A `target` option can be provided to change which object will receive the method call. This option must be
   a string representing a path to an object:
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -139,6 +139,7 @@ Ember.EventDispatcher = Ember.Object.extend(
           handler  = action.handler;
 
       if (action.eventName === eventName) {
+        evt.preventDefault();
         evt.stopPropagation();
         return handler(evt);
       }
@@ -166,6 +167,7 @@ Ember.EventDispatcher = Ember.Object.extend(
     var handler = object[eventName];
     if (Ember.typeOf(handler) === 'function') {
       result = handler.call(object, evt, view);
+      // Do not preventDefault in eventManagers.
       evt.stopPropagation();
     }
     else {

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -71,6 +71,8 @@ Ember.View.states.hasElement = {
   // Handle events from `Ember.EventDispatcher`
   handleEvent: function(view, eventName, evt) {
     if (view.has(eventName)) {
+      // Handler should be able to re-dispatch events, so we don't
+      // preventDefault or stopPropagation.
       return view.fire(eventName, evt);
     } else {
       return true; // continue event propagation


### PR DESCRIPTION
The idea is that we'd like to be able to use arbitrary view methods as
action handlers. As it is, they need to `return false` or call
`e.preventDefault(); e.stopPropagation();` to be usable as handlers.

For the (presumably few) cases where propagation or default handling is
desired, we can still register our own handlers/delegates with jQuery,
or use event handling on views or with eventManagers, which does not
have automatic preventDefault/stopPropagation.

---

I realize this change potentially breaks compatibility, so I'm targeting it at master, not 0-9-stable.

What do you guys think?

Also, can someone with a larger Ember app please test this and report back whether it breaks things?

Cc @ebryn, who introduced the test I'm changing.

IRC discussion:

```
[9:29pm] joliss: I'm bothered by the fact that all of my {{action}} handlers have to call `e.preventDefault(); e.stopPropagation()`. It means I can't just call arbitrary methods on my views as actions. Is there anything that's fundamentally stopping us from changing it to do this automatically?
[9:31pm] michaellatta: joliss: returning false from click events seems to be sufficient in the experimenting I have done to date.
[9:31pm] joliss: michaellatta: Right, unless they throw an exception though. And it's still the same problem, with fewer characters.
[9:39pm] joliss: Hm, there used to be an automatic stopProgagation, but dmarcotte changed it in 6e2d3515. I'm not sure why.
   (Note: This actually seems to be a different one, relating to event methods like `doubleClick`, not action handlers.)
[9:42pm] knassar: joliss: i am a bit bothered by the same thing
[9:43pm] peterwagenet: joliss: automatic stop propagation wasn't well implemented
[9:43pm] knassar: seems like the 90% case is that you don't want the events to propagate…
[9:43pm] peterwagenet: if anyone has a solution for normalizing that seems fine
[9:43pm] joliss: peterwagenet: Can you elaborate what the issue was?
[9:44pm] peterwagenet: inconsistent
[9:44pm] joliss: Looking at the diff, I'm just thinking preventDefault should be called as well, and it should be called *before* calling the handler.
[9:45pm] joliss: Hm, you mean there were cases (other events?) where it *didn't* stop propagation?
[9:57pm] endash: man there are certainly states where I'd like to ensure the end of propogation.
[10:32pm] joliss: peterwagenet: ping; before I submit a pull request, do you happen to remember what the issue with stopping event propagation was?
[10:33pm] peterwagenet: we weren't doing it across the board
[10:33pm] peterwagenet: so it only worked some places
[10:33pm] peterwagenet: and not others
```
