### PR TITLE
Append a view to it's applications' rootElement

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1530,19 +1530,63 @@ Ember.View = Ember.CoreView.extend(
   },
 
   /**
-    Appends the view's element to the document body. If the view does
-    not have an HTML representation yet, `createElement()` will be called
-    automatically.
+    Appends the view's element to application under which is has been defined.
+    If the view does not have an HTML representation yet, `createElement()`
+    will be called automatically.
+
+    Consider the following setup:
+
+        App = Ember.Application.create({ rootElement: '#my-root' });
+        App.MyView = Ember.View.extend({...});
+        App.view = Ember.View.create({...});
+
+    Invoking `append()` on a view instance, in this case `App.view`, adds it
+    to the rootElement of the application, in this case to the element
+    with id `my-root`.
+
+    Creating an instance of a view, which has been defined on an application,
+    it is appended to the rootElement. So `App.MyView.create().append()` is
+    appended to the element with id `my-root`.
+
+    Appending a general Ember.View, adds it to the first defined application,
+    so `Ember.View.create().append()` is appended to the element with id `my-root`.
+
+    If you pass an instance of an application, its `rootElement` will be used.
 
     Note that this method just schedules the view to be appended; the DOM
     element will not be appended to the document body until all bindings have
     finished synchronizing.
 
-    @method append
-    @return {Ember.View} receiver
+    @parameter {Ember.Application} application, to which this view shall be appended
+    @returns {Ember.View} receiver
   */
-  append: function() {
-    return this.appendTo(document.body);
+  append: function(application) {
+    Ember.assert('application must be an instance of Ember.Application', !application || Ember.Application.detectInstance(application));
+
+    Ember.identifyNamespaces();
+
+    var firstApp;
+    var app = Ember.A(Ember.Namespace.NAMESPACES).find(function(ns) {
+      // sorry, we're looking only for instances of Ember.Application
+      if (!Ember.Application.detectInstance(ns)) return;
+
+      if (!firstApp) firstApp = ns;
+
+      // check each property of the application
+      return Ember.A(Ember.keys(ns)).find(function(prop) {
+        // concrete instance
+        if (ns[prop] === this) return true;
+
+        // check if the property is a view and if this view is an instance of it
+        if (Ember.View.detect(ns[prop]) && ns[prop].detectInstance(this)) return true;
+      }, this);
+    }, this);
+
+    Ember.assert('appending to another application is not allowed', !app || !application || (application === app));
+
+    app = application || app || firstApp;
+
+    return this.appendTo(app ? app.get('rootElement') : document.body);
   },
 
   /**

--- a/packages/ember-views/tests/views/view/append_test.js
+++ b/packages/ember-views/tests/views/view/append_test.js
@@ -1,0 +1,94 @@
+// ==========================================================================
+// Project:   Ember Views
+// Copyright: ©2006-2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var view, view1, view2, App1, App2;
+
+var append = function(view, app) {
+  Ember.run(function() {
+    view.append(app);
+  });
+  return view;
+};
+
+module('Ember.View#append', {
+  setup: function() {
+    Ember.$("#qunit-fixture").html('<div id="app1"></div><div id="app2" ></div>');
+
+    Ember.run(function() {
+      App1 = Ember.Application.create({ rootElement: '#app1' });
+      App2 = Ember.Application.create({ rootElement: '#app2' });
+
+      App1.View1 = Ember.View.extend();
+      App2.View2 = Ember.View.extend();
+
+      view = Ember.View.create({ elementId: 'view' });
+      view1 = App1.view1 = Ember.View.create({ elementId: 'view1' });
+      view2 = App2.view2 = Ember.View.create({ elementId: 'view2' });
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      view.destroy();
+      view1.destroy();
+      view2.destroy();
+
+      App1.destroy();
+      App2.destroy();
+    });
+  }
+});
+
+test("append adds the view to the applications rootElement", function() {
+  append(App1.view1);
+  append(App2.view2);
+  
+  ok(Ember.$('#qunit-fixture').find('#app1 #view1').length === 1, 'App1.view1 is added to rootElement of it\'s App1');
+  ok(Ember.$('#qunit-fixture').find('#app2 #view2').length === 1, 'App2.view2 is added to rootElement of it\'s App2');
+});
+
+test("an instance of a view class, is added to the applications's rootElement", function() {
+  var v1 = append(App1.View1.create({ elementId: 'View1' }));
+  var v2 = append(App2.View2.create({ elementId: 'View2' }));
+  
+  ok(Ember.$('#qunit-fixture').find('#app1 #View1').length === 1, 'instance of App1.View1 is added to rootElement of it\'s App1');
+  ok(Ember.$('#qunit-fixture').find('#app2 #View2').length === 1, 'instance of App2.View2 is added to rootElement of it\'s App2');
+
+  Ember.run(function() {
+    v1.destroy();
+    v2.destroy();
+  });
+});
+
+test("a view, which is not a property of an application, is added to the first available application", function() {
+  append(view);
+  
+  ok(Ember.$('#qunit-fixture').find('#app1 #view').length === 1, 'view is added to rootElement of it\'s App1');
+});
+
+test("append accepts a parameter application", function() {
+  append(view, App2);
+
+  ok(Ember.$('#qunit-fixture').find('#app2 #view').length === 1, 'view is added to rootElement of application parameter');
+});
+
+test("an error is thrown if passed parameter is not an instance of Ember.Application", function() {
+  raises(function() {
+    append(view, Ember.Object.create());
+  }, Error, 'should raise an error when parameter to append is not an instance of Ember.Application');
+});
+
+test("case App.view - appending a view instance to another application throws an error", function() {
+  raises(function() {
+    append(App1.view1, App2);
+  }, Error, 'should raise an error when view instance of an application shall be appended to another application');
+});
+
+test("case App.View - appending a view instance to another application throws an error", function() {
+  raises(function() {
+    append(App1.View1.create(), App2);
+  }, Error, 'should raise an error when view instance of an application shall be appended to another application');
+});


### PR DESCRIPTION
This commit changes the behavior of Ember.View#append: it now appends the view to the rootElement of the application, in which it is defined.

Let's say you have the following setup:

```
App = Ember.Application.create({ rootElement: '#my-root' });
App.MyView = Ember.View.extend({...});
App.view = Ember.View.create({...});
```

If you invoke `append()` on a view instance, it is appended to the rootElement of the application:

```
App.view.append(); // appended to #my-root
```

If you create an instance of a view, it's appended also to the rootElement:

```
App.View.create().append(); // appended to #my-root
```

If you append a general Ember.View, it's added to the first application which has been defined.

```
Ember.View.create().append(); // appended to #my-root
```

This is the rebased to master version of PR #716
