### PR TITLE
Lookup event transitions recursively in the ancestor states.

### DIFF
--- a/packages/ember-states/lib/router.js
+++ b/packages/ember-states/lib/router.js
@@ -43,7 +43,7 @@ Ember.Router = Ember.StateManager.extend(
 
   urlForEvent: function(eventName, context) {
     var currentState = get(this, 'currentState');
-    var targetStateName = currentState.eventTransitions[eventName];
+    var targetStateName = currentState.lookupEventTransition(eventName);
 
     Ember.assert(Ember.String.fmt("You must specify a target state for event '%@' in order to link to it in the current state '%@'.", [eventName, get(currentState, 'path')]), !!targetStateName);
 

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -85,6 +85,17 @@ Ember.State = Ember.Object.extend(Ember.Evented, {
     }
   },
 
+  lookupEventTransition: function(name) {
+    var path, state = this;
+
+    while(state && !path) {
+      path = state.eventTransitions[name];
+      state = state.get('parentState');
+    }
+
+    return path;
+  },
+
   /**
     A Boolean value indicating whether the state is a leaf state
     in the state hierarchy. This is false if the state has child

--- a/packages/ember-states/tests/router_test.js
+++ b/packages/ember-states/tests/router_test.js
@@ -48,6 +48,35 @@ test("router.urlForEvent looks in the current state's eventTransitions hash", fu
   equal(url, "#!#/dashboard");
 });
 
+test("router.urlForEvent looks in the eventTransitions hashes of the current state's ancestors", function() {
+  var router = Ember.Router.create({
+    location: locationStub,
+    namespace: namespace,
+    root: Ember.State.create({
+      eventTransitions: {
+        showDashboard: 'dashboard'
+      },
+
+      index: Ember.State.create({
+        route: '/'
+      }),
+
+      dashboard: Ember.State.create({
+        route: '/dashboard'
+      })
+    })
+  });
+
+  Ember.run(function() {
+    router.route('/');
+  });
+
+  equal(router.getPath('currentState.path'), "root.index", "precond - the router is in root.index");
+
+  var url = router.urlForEvent('showDashboard');
+  equal(url, "#!#/dashboard");
+});
+
 test("router.urlForEvent works with a context", function() {
   var router = Ember.Router.create({
     location: locationStub,


### PR DESCRIPTION
**Scenario:** From any descendant state of `root.loggedIn` we want an `eventTransition` called `logout` to be available.

``` javascript
App.Router = Ember.Router.extend({
  initialState: 'root.loggedOut',
  root: Ember.State.extend({
    loggedOut: Ember.State.extend({
      route: '/login',
      login: Ember.State.transitionTo("loggedIn.profile")
    }),
    loggedIn: Ember.State.extend({
      route: '/',
      // EVENTS
      logout: Ember.State.transitionTo("loggedOut"),

      // STATES
      profile: Ember.State.extend({
        route: '/profile'
      })
    })
  })
});
```

If we were talking about regular `StateManager` actions this would work as expected. However, the same is not true with `eventTransitions`. 

Once we connect the outlet for the `root.loggedIn.profile` state and try to render, you get an error in the console.

``` html
<a {{action logout href=true}}>logout</a>
```

_"You must specify a target state for event 'logout' in order to link to it in the current state 'root.loggedIn.profile'."_

This is because it will only check if the `eventTransitions` hash on the current state has the event. [See here](https://github.com/emberjs/ember.js/blob/master/packages/ember-states/lib/router.js#L74)

The quick fix is to just add it to the profile state.

``` javascript
profile: Ember.State.extend({
  route: '/profile',
  logout: Ember.State.transitionTo("loggedOut")
})
```

But you soon realize how this is going to end up...

``` javascript
loggedIn: Ember.State.extend({
  route: '/',

  profile: Ember.State.extend({
    route: '/profile',
    logout: Ember.State.transitionTo("loggedOut"),
    posts: Ember.State.transitionTo("posts"),
    settings: Ember.State.transitionTo("settings")
  }),
  posts: Ember.State.extend({
    route: '/posts',
    logout: Ember.State.transitionTo("loggedOut"),
    profile: Ember.State.transitionTo("profile"),
    settings: Ember.State.transitionTo("settings")
  }),
  settings: Ember.State.extend({
    route: '/settings',
    logout: Ember.State.transitionTo("loggedOut"),
    profile: Ember.State.transitionTo("profile"),
    posts: Ember.State.transitionTo("posts")
  })
})
```

My patch makes it work just like regular actions on the `StateManager`. So you can do this:

``` javascript
loggedIn: Ember.State.extend({
  route: '/',

  // EVENTS
  logout: Ember.State.transitionTo("loggedOut"),
  posts: Ember.State.transitionTo("posts"),
  settings: Ember.State.transitionTo("settings"),

  // STATES
  profile: Ember.State.extend({
    route: '/profile'
  }),
  posts: Ember.State.extend({
    route: '/posts'
  }),
  settings: Ember.State.extend({
    route: '/settings'
  })
})
```
