### PR TITLE
Use 'hash' as default location implementation on Router

### DIFF
--- a/packages/ember-application/tests/system/action_url_test.js
+++ b/packages/ember-application/tests/system/action_url_test.js
@@ -60,6 +60,7 @@ test("it does not generate the URL when href property is not specified", functio
 
 test("it sets a URL with a context", function() {
   var router = Ember.Router.create({
+    location: null,
     namespace: namespace,
     root: Ember.State.create({
       index: Ember.State.create({

--- a/packages/ember-states/lib/router.js
+++ b/packages/ember-states/lib/router.js
@@ -27,9 +27,24 @@ Ember.Router = Ember.StateManager.extend(
   initialState: 'root',
 
   /**
-    On router, transitionEvent should be called connectOutlets
+    The `Ember.Location` implementation to be used to manage the application
+    URL state. At the moment, only 'hash' is supported, which uses URL fragment
+    identifiers (like #/blog/1) for routing.
 
-    @property {String}
+    This can be either a string or an object returned by
+    `Ember.Location.create`.
+
+    @type String
+    @default 'hash'
+  */
+  location: 'hash',
+
+  /**
+    The name of the functions used to set up states. On Router, this is
+    `connectOutlets` instead of `setup`.
+
+    @type String
+    @default 'connectOutlets'
   */
   transitionEvent: 'connectOutlets',
 

--- a/packages/ember-states/tests/routable_test.js
+++ b/packages/ember-states/tests/routable_test.js
@@ -118,6 +118,7 @@ test("route repeatedly descends into a nested hierarchy", function() {
   });
 
   var router = Ember.Router.create({
+    location: null,
     root: state
   });
 
@@ -142,6 +143,7 @@ test("route repeatedly descends into a nested hierarchy", function() {
   });
 
   var router = Ember.Router.create({
+    location: null,
     root: state
   });
 
@@ -408,6 +410,7 @@ module("redirectsTo");
 
 test("if a leaf state has a redirectsTo, it automatically transitions into that state", function() {
    var router = Ember.Router.create({
+     location: null,
      root: Ember.State.create({
 
        index: Ember.State.create({
@@ -431,6 +434,7 @@ test("if a leaf state has a redirectsTo, it automatically transitions into that 
 test("you cannot define connectOutlets AND redirectsTo", function() {
   raises(function() {
     Ember.Router.create({
+     location: null,
      root: Ember.State.create({
        index: Ember.State.create({
          route: '/',
@@ -445,6 +449,7 @@ test("you cannot define connectOutlets AND redirectsTo", function() {
 test("you cannot have a redirectsTo in a non-leaf state", function () {
   raises(function() {
     Ember.Router.create({
+      location: null,
       root: Ember.State.create({
         redirectsTo: 'someOtherState',
 


### PR DESCRIPTION
Right now, 'hash' is the only implementation, but even when pushState is
implemented later, 'hash' will be a reasonable default, since pushState
URL manipulation requires server-side support.

Also polish documentation a little.
