### PR TITLE
Call setupStateManager in initialize, not in didBecomeReady

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -130,21 +130,20 @@ Ember.Application = Ember.Namespace.extend(
         injection(namespace, router, property);
       });
     });
+
+    if (router && router instanceof Ember.Router) {
+      this.startRouting(router);
+    }
   },
 
   /** @private */
   didBecomeReady: function() {
     var eventDispatcher = get(this, 'eventDispatcher'),
-        stateManager    = get(this, 'stateManager'),
         customEvents    = get(this, 'customEvents');
 
     eventDispatcher.setup(customEvents);
 
     this.ready();
-
-    if (stateManager && stateManager instanceof Ember.Router) {
-      this.setupStateManager(stateManager);
-    }
   },
 
   /**
@@ -154,7 +153,7 @@ Ember.Application = Ember.Namespace.extend(
     to the current URL, and trigger a new call to `route`
     whenever the URL changes.
   */
-  setupStateManager: function(stateManager) {
+  startRouting: function(stateManager) {
     var location = get(stateManager, 'location'),
         rootElement = get(this, 'rootElement'),
         applicationController = get(stateManager, 'applicationController');

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -139,6 +139,7 @@ test('initialized application go to initial route', function() {
     });
   });
 
+  app.initialize(app.stateManager);
   equal(app.getPath('stateManager.currentState.path'), 'root.index', "The router moved the state into the right place");
 });
 


### PR DESCRIPTION
`initialize` needs to be called anyway in order to use routing, and as
it is, it requires being called before didBecomeReady is triggered,
since didBecomeReady checks if App.stateManager is defined.
This can introduce subtle ordering bugs or race conditions.

Moving all the router initialization code in one place solves these
issues.

Also rename setupStateManager to startRouting to be more descriptive.

This also addresses #911 and #889.
