### PR TITLE
Location: Add 'none' location, make 'hash' the default

### DIFF
--- a/packages/ember-application/lib/system.js
+++ b/packages/ember-application/lib/system.js
@@ -2,3 +2,4 @@ require('ember-application/system/application');
 require('ember-application/system/location');
 require('ember-application/system/hash_location');
 require('ember-application/system/history_location');
+require('ember-application/system/none_location');

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -158,12 +158,6 @@ Ember.Application = Ember.Namespace.extend(
         rootElement = get(this, 'rootElement'),
         applicationController = get(stateManager, 'applicationController');
 
-    if (typeof location === 'string') {
-      location = Ember.Location.create({implementation: location});
-      set(stateManager, 'location', location);
-      this._createdLocation = location;
-    }
-
     if (this.ApplicationView && applicationController) {
       var applicationView = this.ApplicationView.create({
         controller: applicationController
@@ -189,7 +183,6 @@ Ember.Application = Ember.Namespace.extend(
   willDestroy: function() {
     get(this, 'eventDispatcher').destroy();
     if (this._createdRouter)          { this._createdRouter.destroy(); }
-    if (this._createdLocation)        { this._createdLocation.destroy(); }
     if (this._createdApplicationView) { this._createdApplicationView.destroy(); }
   },
 

--- a/packages/ember-application/lib/system/none_location.js
+++ b/packages/ember-application/lib/system/none_location.js
@@ -1,0 +1,32 @@
+var get = Ember.get, set = Ember.set;
+
+/**
+  Ember.NoneLocation does not interact with the browser. It is useful for
+  testing, or when you need to manage state with your Router, but temporarily
+  don't want it to muck with the URL (for example when you embed your
+  application in a larger page).
+*/
+Ember.NoneLocation = Ember.Object.extend({
+  path: '',
+
+  getURL: function() {
+    return get(this, 'path');
+  },
+
+  setURL: function(path) {
+    set(this, 'path', path);
+  },
+
+  onUpdateURL: function(callback) {
+    // We are not wired up to the browser, so we'll never trigger the callback.
+  },
+
+  formatURL: function(url) {
+    // The return value is not overly meaningful, but we do not want to throw
+    // errors when test code renders templates containing {{action href=true}}
+    // helpers.
+    return url;
+  }
+});
+
+Ember.Location.registerImplementation('none', Ember.NoneLocation);

--- a/packages/ember-application/tests/system/action_url_test.js
+++ b/packages/ember-application/tests/system/action_url_test.js
@@ -60,6 +60,12 @@ test("it does not generate the URL when href property is not specified", functio
 
 test("it sets a URL with a context", function() {
   var router = Ember.Router.create({
+    location: {
+      formatURL: function(url) {
+        return url;
+      },
+      setURL: Ember.K
+    },
     namespace: namespace,
     root: Ember.State.create({
       index: Ember.State.create({

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -164,7 +164,7 @@ test("initialize application with stateManager via initialize call", function() 
     });
 
     app.Router = Ember.Router.extend({
-      location: 'hash',
+      location: 'none',
 
       root: Ember.State.extend({
         index: Ember.State.extend({
@@ -177,7 +177,7 @@ test("initialize application with stateManager via initialize call", function() 
   });
 
   equal(app.getPath('stateManager') instanceof Ember.Router, true, "Router was set from initialize call");
-  equal(app.getPath('stateManager.location') instanceof Ember.HashLocation, true, "Location was set from location implementation name");
+  equal(app.getPath('stateManager.location') instanceof Ember.NoneLocation, true, "Location was set from location implementation name");
   equal(app.getPath('stateManager.currentState.path'), 'root.index', "The router moved the state into the right place");
 });
 
@@ -188,7 +188,7 @@ test("initialize application with stateManager via initialize call from Router c
     });
 
     app.Router = Ember.Router.extend({
-      location: 'hash',
+      location: 'none',
 
       root: Ember.State.extend({
         index: Ember.State.extend({
@@ -261,7 +261,7 @@ test("ApplicationView is inserted into the page", function() {
     app.ApplicationController = Ember.Controller.extend();
 
     app.Router = Ember.Router.extend({
-      location: 'hash',
+      location: 'none',
 
       root: Ember.State.extend({
         index: Ember.State.extend({

--- a/packages/ember-states/lib/routable.js
+++ b/packages/ember-states/lib/routable.js
@@ -74,7 +74,7 @@ Ember.Routable = Ember.Mixin.create({
     In general, this will update the browser's URL.
   */
   updateRoute: function(manager, location) {
-    if (location && get(this, 'isLeaf')) {
+    if (get(this, 'isLeaf')) {
       var path = this.absoluteRoute(manager);
       location.setURL(path);
     }

--- a/packages/ember-states/lib/router.js
+++ b/packages/ember-states/lib/router.js
@@ -76,13 +76,9 @@ Ember.Router = Ember.StateManager.extend(
     Ember.assert("To get a URL for a state, it must have a `route` property.", !!get(state, 'routeMatcher'));
 
     var location = get(this, 'location'),
-        url = state.absoluteRoute(this, hash);
+        absoluteRoute = state.absoluteRoute(this, hash);
 
-    if (location) {
-      url = location.formatURL(url);
-    }
-
-    return url;
+    return location.formatURL(absoluteRoute);
   },
 
   urlForEvent: function(eventName, context) {

--- a/packages/ember-states/lib/router.js
+++ b/packages/ember-states/lib/router.js
@@ -1,6 +1,7 @@
 require('ember-states/state');
 require('ember-states/route_matcher');
 require('ember-states/routable');
+require('ember-application/system/location');
 
 var get = Ember.get, getPath = Ember.getPath, set = Ember.set;
 
@@ -81,5 +82,20 @@ Ember.Router = Ember.StateManager.extend(
     var hash = targetState.serialize(this, context);
 
     return this.urlFor(targetStateName, hash);
+  },
+
+  /** @private */
+  init: function() {
+    this._super();
+
+    var location = get(this, 'location');
+    if ('string' === typeof location) {
+      set(this, 'location', Ember.Location.create({ implementation: location }));
+    }
+  },
+
+  /** @private */
+  willDestroy: function() {
+    get(this, 'location').destroy();
   }
 });

--- a/packages/ember-states/lib/router.js
+++ b/packages/ember-states/lib/router.js
@@ -32,6 +32,21 @@ Ember.Router = Ember.StateManager.extend(
   initialState: 'root',
 
   /**
+    The `Ember.Location` implementation to be used to manage the application
+    URL state. The following values are supported:
+
+    * 'hash': Uses URL fragment identifiers (like #/blog/1) for routing.
+    * 'none': Does not read or set the browser URL, but still allows for
+      routing to happen. Useful for testing.
+
+    @type String
+    @default 'hash'
+  */
+  location: 'hash',
+
+  /**
+    On router, transitionEvent should be called connectOutlets
+
     @property {String}
     @default 'connectOutlets'
   */

--- a/packages/ember-states/tests/routable_test.js
+++ b/packages/ember-states/tests/routable_test.js
@@ -1,10 +1,9 @@
 module("Ember.Routable");
 
-var locationStub = { };
-
 test("it should have its updateRoute method called when it is entered", function() {
-  expect(2);
+  var locationStub = { };
 
+  expect(2);
 
   var state = Ember.State.create({
     route: 'foo',
@@ -429,24 +428,19 @@ test("you cannot have a redirectsTo in a non-leaf state", function () {
   });
 });
 
-var formatURLArgument = null;
+module("urlFor");
 
+var formatURLArgument = null;
+var locationStub = {
+  formatURL: function(url) {
+    formatURLArgument = url;
+    return url;
+  },
+  setURL: Ember.K
+};
 var expectURL = function(url) {
   equal(url, formatURLArgument, "should invoke formatURL with URL "+url);
 };
-
-module("urlFor", {
-  setup: function() {
-    locationStub = {
-      formatURL: function(url) {
-        formatURLArgument = url;
-        return url;
-      },
-
-      setURL: Ember.K
-    };
-  }
-});
 
 test("urlFor returns an absolute route", function() {
   expect(2);

--- a/packages/ember-states/tests/routable_test.js
+++ b/packages/ember-states/tests/routable_test.js
@@ -1,3 +1,6 @@
+require('ember-application/system/location');
+require('ember-application/system/none_location');
+
 module("Ember.Routable");
 
 test("it should have its updateRoute method called when it is entered", function() {
@@ -92,6 +95,7 @@ test("route repeatedly descends into a nested hierarchy", function() {
   });
 
   var router = Ember.Router.create({
+    location: 'none',
     root: state
   });
 
@@ -116,6 +120,7 @@ test("route repeatedly descends into a nested hierarchy", function() {
   });
 
   var router = Ember.Router.create({
+    location: 'none',
     root: state
   });
 
@@ -382,6 +387,7 @@ module("redirectsTo");
 
 test("if a leaf state has a redirectsTo, it automatically transitions into that state", function() {
    var router = Ember.Router.create({
+     location: 'none',
      root: Ember.State.create({
 
        index: Ember.State.create({
@@ -405,13 +411,14 @@ test("if a leaf state has a redirectsTo, it automatically transitions into that 
 test("you cannot define connectOutlets AND redirectsTo", function() {
   raises(function() {
     Ember.Router.create({
-     root: Ember.State.create({
-       index: Ember.State.create({
-         route: '/',
-         redirectsTo: 'someOtherState',
-         connectOutlets: function() {}
-       })
-     })
+      location: 'none',
+      root: Ember.State.create({
+        index: Ember.State.create({
+          route: '/',
+          redirectsTo: 'someOtherState',
+          connectOutlets: function() {}
+        })
+      })
     });
   });
 });
@@ -419,6 +426,7 @@ test("you cannot define connectOutlets AND redirectsTo", function() {
 test("you cannot have a redirectsTo in a non-leaf state", function () {
   raises(function() {
     Ember.Router.create({
+      location: 'none',
       root: Ember.State.create({
         redirectsTo: 'someOtherState',
 


### PR DESCRIPTION
- Add NoneLocation
  
  I am using this in my own test suite, and it's been working well. I'm
  not adding unit tests here, since the logic is trivial, and it will get
  exercised by many other tests.
- Instantiate Ember.Location implementation from Router
  
  It was instantiated in App.startRouting before, instead of Router.init.
  
  Now we can use string locations when testing the Router in isolation,
  without requiring `app.startRouting` to be called.
- Clean up location stubbing in routable_test
- Use 'hash' as default location implementation on Router
  
  Even when pushState is implemented later, 'hash' will be a reasonable
  default, since pushState URL manipulation requires server-side support.
- Router.location cannot be null or undefined
- Avoid using HashLocation in tests
  
  It interacts with the browser and might be a source of brittleness.

---

I'm sending a batch of commits because some of the earlier cleanup is required for the test suite to still pass for later commits, so it wasn't possible to send them separately.
