### PR TITLE
Identified bug with computed properties not triggering observers

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -146,9 +146,11 @@ function mkCpGetter(keyName, desc) {
 
   if (cacheable) {
     return function() {
-      var ret, cache = meta(this).cache;
+      var ret, m = meta(this), cache = m.cache;
       if (keyName in cache) { return cache[keyName]; }
       ret = cache[keyName] = func.call(this, keyName);
+      var watched = m.source === this && m.watching[keyName] > 0;
+      if (watched) { m.lastSetValues[keyName] = guidFor(ret); }
       return ret;
     };
   } else {
@@ -317,12 +319,15 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
 
 /** @private - impl descriptor API */
 ComputedPropertyPrototype.get = function(obj, keyName) {
-  var ret, cache;
+  var ret, cache, m;
 
   if (this._cacheable) {
-    cache = meta(obj).cache;
+    m = meta(obj);
+    cache = m.cache;
     if (keyName in cache) { return cache[keyName]; }
     ret = cache[keyName] = this.func.call(obj, keyName);
+    var watched = m.source === obj && m.watching[keyName] > 0;
+    if (watched) { m.lastSetValues[keyName] = guidFor(ret); }
   } else {
     ret = this.func.call(obj, keyName);
   }

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -642,3 +642,32 @@ testBoth('setting computed prop with same value should not trigger', function(ge
   set(obj, 'foo', 'baz');
   equal(count, 2, 'should not trigger observer again');
 });
+
+// The issue here is when a computed property is directly set with a value, then has a
+// dependent key change and trigger a cache expiration and recomputation, observers will
+// not be fired if the CP setter is explicitly called with the last set value.
+testBoth('setting a cached computed property whose value has changed should trigger', function(get, set) {
+  var obj = {};
+
+  Ember.defineProperty(obj, 'foo', Ember.computed(function(key, value) {
+    if (arguments.length === 2) { return value; }
+    return get(this, 'baz');
+  }).property('baz').cacheable());
+
+  var count = 0;
+
+  Ember.addObserver(obj, 'foo', function() { count++; });
+
+  set(obj, 'foo', 'bar');
+  equal(count, 1);
+  equal(get(obj, 'foo'), 'bar');
+
+  set(obj, 'baz', 'qux');
+  equal(count, 2);
+  equal(get(obj, 'foo'), 'qux');
+
+  get(obj, 'foo');
+  set(obj, 'foo', 'bar');
+  equal(count, 3);
+  equal(get(obj, 'foo'), 'bar');
+});


### PR DESCRIPTION
The issue here is when a computed property is directly set with a value, then has a dependent key change and trigger a cache expiration and recomputation, observers will not be fired if the CP setter is explicitly called with the last set value.

@kselden @wycats Curious if you guys have a cleaner solution in mind.
