### PR TITLE
Controller instances not available in connectOutlets of root state.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -107,7 +107,7 @@ Ember.Application = Ember.Namespace.extend(
         namespace = this, controller, name;
 
     if (!router && Ember.Router.detect(namespace['Router'])) {
-      router = namespace['Router'].create();
+      router = namespace['Router'].create({ autoInitialState: false });
       this._createdRouter = router;
     }
 
@@ -166,6 +166,7 @@ Ember.Application = Ember.Namespace.extend(
       applicationView.appendTo(rootElement);
     }
 
+    router.initialize();
     router.route(location.getURL());
     location.onUpdateURL(function(url) {
       router.route(url);

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -373,6 +373,8 @@ require('ember-states/state');
 Ember.StateManager = Ember.State.extend(
 /** @scope Ember.StateManager.prototype */ {
 
+  autoInitialState: true,
+
   /**
     When creating a new statemanager, look for a default state to transition
     into. This state can either be named `start`, or can be specified using the
@@ -383,6 +385,16 @@ Ember.StateManager = Ember.State.extend(
 
     set(this, 'stateMeta', Ember.Map.create());
 
+    var initialState = get(this, 'initialState'),
+        autoInitialState = get(this, 'autoInitialState');
+
+
+    if (autoInitialState) {
+      this.initialize();
+    }
+  },
+
+  initialize: function() {
     var initialState = get(this, 'initialState');
 
     if (!initialState && getPath(this, 'states.start')) {

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -240,6 +240,15 @@ test("it triggers setup on initialSubstate", function() {
   ok(grandchildSetup, "sets up grandchild");
 });
 
+test("it does not automatically transition to a default state when autoInitialState is false", function() {
+  stateManager = Ember.StateManager.create({
+    autoInitialState: false,
+    start: Ember.State.create()
+  });
+
+  equal(get(stateManager, 'currentState'), undefined, "does not transition to initial state");
+});
+
 test("it throws an assertion error when the initialState does not exist", function() {
   raises(function() {
     Ember.StateManager.create({


### PR DESCRIPTION
I'm not sure if this is intended, but controller instances are not available in the root state when the connectOutlets event is fired.  This fiddle demonstrates.

http://jsfiddle.net/LuWqj/1/
