### PR TITLE
WIP: Make transitionEvent work with async transitions.

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -612,8 +612,7 @@ Ember.StateManager = Ember.State.extend(
       };
     }
 
-    this.enterState(exitStates, enterStates, state);
-    this.triggerSetupContext(resolveState, segments);
+    this.enterState(exitStates, enterStates, state, resolveState, segments);
   },
 
   triggerSetupContext: function(root, segments) {
@@ -665,7 +664,7 @@ Ember.StateManager = Ember.State.extend(
     if (!async) { transition.resume(); }
   },
 
-  enterState: function(exitStates, enterStates, state) {
+  enterState: function(exitStates, enterStates, state, resolveState, segments) {
     var log = this.enableLogging,
         stateManager = this;
 
@@ -698,7 +697,7 @@ Ember.StateManager = Ember.State.extend(
             initialState = 'start';
           }
         }
-
+        this.triggerSetupContext(resolveState, segments);
         set(this, 'currentState', enteredState || state);
       });
     });


### PR DESCRIPTION
Currently, if you use an async transition, the `transitionEvent` will fire before the transition actually finishes. For example, `connectOutlets` will fire on an entered state before any asynchronous exits complete. I got a test case passing by moving the call to `triggerSetupContext` into the `doneCallback` for the `asyncEach` on the entered states. However, now I get a failure for _"redirectsTo: if a leaf state has a redirectsTo, it automatically transitions into that state."_

@wycats I have a feeling this will not be trivial. What are your thoughts?
