### PR TITLE
Fix broken upload_latest task by specifying version for github_api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "uglifier", :git => "https://github.com/lautis/uglifier.git"
 group :development do
   gem "rack"
   gem "rest-client"
-  gem "github_api"
+  gem "github_api", "0.4.11"
   gem "ember-docs", :git => "https://github.com/emberjs/docs-generator.git"
   gem "kicker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,30 +33,30 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.2.8)
     colored (1.2)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    faraday (0.8.1)
+    faraday (0.7.6)
+      addressable (~> 2.2)
       multipart-post (~> 1.1)
-    github_api (0.5.2)
-      faraday (~> 0.8.0)
+      rack (~> 1.1)
+    github_api (0.4.11)
+      faraday (~> 0.7.6)
       hashie (~> 1.2.0)
       multi_json (~> 1.3)
       nokogiri (~> 1.5.2)
-      oauth2 (~> 0.7)
+      oauth2 (~> 0.5.2)
     hashie (1.2.0)
-    httpauth (0.1)
     kicker (2.5.0)
       rb-fsevent
     mime-types (1.18)
     multi_json (1.3.6)
     multipart-post (1.1.5)
     nokogiri (1.5.3)
-    oauth2 (0.7.1)
-      faraday (~> 0.8)
-      httpauth (~> 0.1)
+    oauth2 (0.5.2)
+      faraday (~> 0.7)
       multi_json (~> 1.0)
-      rack (~> 1.4)
     rack (1.4.1)
     rake (0.9.2.2)
     rb-fsevent (0.9.1)
@@ -70,7 +70,7 @@ PLATFORMS
 DEPENDENCIES
   colored
   ember-docs!
-  github_api
+  github_api (= 0.4.11)
   kicker
   rack
   rake-pipeline!

--- a/lib/github_uploader.rb
+++ b/lib/github_uploader.rb
@@ -16,7 +16,7 @@ class GithubUploader
   end
 
   def token_path
-    File.expand_path(".github-upload-token", @root) 
+    File.expand_path(".github-upload-token", @root)
   end
 
   def check_token


### PR DESCRIPTION
Without explicit version of `github_api`, executing `rake upload_latest` fails. A hot fix for this is to specify version `0.4.11` for the `github_api` gem.

```
rake upload_latest
Building Ember...
Done
Uploading ember-latest.min.js...rake aborted!
no such file to load -- addressable/uri

Tasks: TOP => upload_latest
(See full trace by running task with --trace)
```
