### PR TITLE
Fixed Ember.run.later so that it returns the timer object itself, not the guid (per the documentation).

### DIFF
--- a/lib/ember.js
+++ b/lib/ember.js
@@ -5854,7 +5854,7 @@ Ember.run.later = function(target, method) {
   guid    = Ember.guidFor(timer);
   timers[guid] = timer;
   run.once(timers, invokeLaterTimers);
-  return guid;
+  return timer;
 };
 
 /** @private */


### PR DESCRIPTION
Docs say the later method of the runloop should return the timer itself (so you can actually cancel it later), but it was implemented such that it only returns the guid of the timer. This fixes that issue. 
