### PR TITLE
Fix Ember.run.later so it returns the timer object, per the docs.

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -451,7 +451,7 @@ Ember.run.later = function(target, method) {
   guid    = Ember.guidFor(timer);
   timers[guid] = timer;
   run.once(timers, invokeLaterTimers);
-  return guid;
+  return timer;
 };
 
 /** @private */


### PR DESCRIPTION
The current implementation returns the GUID instead of the timer itself, as the docs say it should. This commit fixes that. 
