### PR TITLE
Fixed return type docs for Ember.run.later

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -430,7 +430,7 @@ function invokeLaterTimers() {
   @param {Number} wait
     Number of milliseconds to wait.
 
-  @returns {Timer} an object you can use to cancel a timer at a later time.
+  @returns {String} a string you can use to cancel the timer in Ember.run.cancel() later.
 */
 Ember.run.later = function(target, method) {
   var args, expires, timer, guid, wait;


### PR DESCRIPTION
To save other people from wasting time trying to figure out what to do with the wrongly documented return type, then save them more time so they don't try to make the code conform to the docs. 
