### PR TITLE
Don't use reserved word 'volatile' for non-cached properties

### DIFF
--- a/lib/ember.js
+++ b/lib/ember.js
@@ -1830,7 +1830,7 @@ Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPE
   In future releases this will default to `true`. For the 1.0 release,
   the option to turn off caching by default will be removed entirely.
 
-  When caching is enabled by default, you can use `volatile()` to disable
+  When caching is enabled by default, you can use `uncached()` to disable
   caching on individual computed properties.
 */
 Ember.CP_DEFAULT_CACHEABLE = !!Ember.ENV.CP_DEFAULT_CACHEABLE;
@@ -3379,13 +3379,13 @@ Cp.cacheable = function(aFlag) {
       MyApp.outsideService = Ember.Object.create({
         value: function() {
           return OutsideService.getValue();
-        }.property().volatile()
+        }.property().uncached()
       });
 
-  @name Ember.ComputedProperty.volatile
+  @name Ember.ComputedProperty.uncached
   @returns {Ember.ComputedProperty} receiver
 */
-Cp.volatile = function() {
+Cp.uncached = function() {
   return this.cacheable(false);
 };
 
@@ -7956,7 +7956,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
     ret = this.nextObject(0, null, context);
     pushCtx(context);
     return ret ;
-  }).property().volatile(),
+  }).property().uncached(),
 
   /**
     Helper method returns the last object from a collection. If your enumerable
@@ -7985,7 +7985,7 @@ Ember.Enumerable = Ember.Mixin.create( /** @lends Ember.Enumerable */ {
       pushCtx(context);
       return last;
     }
-  }).property().volatile(),
+  }).property().uncached(),
 
   /**
     Returns true if the passed object can be found in the receiver.  The
@@ -12752,13 +12752,13 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     } else {
       return parent;
     }
-  }).property('_parentView').volatile(),
+  }).property('_parentView').uncached(),
 
   // return the current view, not including virtual views
   concreteView: Ember.computed(function() {
     if (!this.isVirtual) { return this; }
     else { return get(this, 'parentView'); }
-  }).property('_parentView').volatile(),
+  }).property('_parentView').uncached(),
 
   /**
     If false, the view will appear hidden in DOM.
@@ -16957,7 +16957,7 @@ Ember._BindableSpanView = Ember.View.extend(Ember.Metamorph,
     }
 
     return valueNormalizer ? valueNormalizer(result) : result;
-  }).property('property', 'previousContext', 'valueNormalizerFunc').volatile(),
+  }).property('property', 'previousContext', 'valueNormalizerFunc').uncached(),
 
   rerenderIfNeeded: function() {
     if (!get(this, 'isDestroyed') && get(this, 'normalizedValue') !== this._lastNormalizedValue) {
@@ -18403,7 +18403,7 @@ Ember.Checkbox = Ember.View.extend({
     } else {
       return get(this, 'checked');
     }
-  }).property('checked').volatile(),
+  }).property('checked').uncached(),
 
   change: function() {
     Ember.run.once(this, this._updateElementValue);
@@ -18692,11 +18692,11 @@ var get = Ember.get, getPath = Ember.getPath;
 Ember.TabPaneView = Ember.View.extend({
   tabsContainer: Ember.computed(function() {
     return this.nearestInstanceOf(Ember.TabContainerView);
-  }).property().volatile(),
+  }).property().uncached(),
 
   isVisible: Ember.computed(function() {
     return get(this, 'viewName') === getPath(this, 'tabsContainer.currentView');
-  }).property('tabsContainer.currentView').volatile()
+  }).property('tabsContainer.currentView').uncached()
 });
 
 })();
@@ -18709,7 +18709,7 @@ var get = Ember.get, setPath = Ember.setPath;
 Ember.TabView = Ember.View.extend({
   tabsContainer: Ember.computed(function() {
     return this.nearestInstanceOf(Ember.TabContainerView);
-  }).property().volatile(),
+  }).property().uncached(),
 
   mouseUp: function() {
     setPath(this, 'tabsContainer.currentView', get(this, 'value'));
@@ -18856,7 +18856,7 @@ Ember.SelectOption = Ember.View.extend({
       // `new Number(4) !== 4`, we use `==` below
       return content == selection;
     }
-  }).property('content', 'parentView.selection').volatile(),
+  }).property('content', 'parentView.selection').uncached(),
 
   labelPathDidChange: Ember.observer(function() {
     var labelPath = getPath(this, 'parentView.optionLabelPath');

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -236,7 +236,7 @@ Ember.SelectOption = Ember.View.extend({
       // `new Number(4) !== 4`, we use `==` below
       return content == selection;
     }
-  }).property('content', 'parentView.selection').volatile(),
+  }).property('content', 'parentView.selection').uncached(),
 
   labelPathDidChange: Ember.observer(function() {
     var labelPath = getPath(this, 'parentView.optionLabelPath');

--- a/packages/ember-handlebars/lib/controls/tabs/tab_pane_view.js
+++ b/packages/ember-handlebars/lib/controls/tabs/tab_pane_view.js
@@ -3,9 +3,9 @@ var get = Ember.get, getPath = Ember.getPath;
 Ember.TabPaneView = Ember.View.extend({
   tabsContainer: Ember.computed(function() {
     return this.nearestInstanceOf(Ember.TabContainerView);
-  }).property().volatile(),
+  }).property().uncached(),
 
   isVisible: Ember.computed(function() {
     return get(this, 'viewName') === getPath(this, 'tabsContainer.currentView');
-  }).property('tabsContainer.currentView').volatile()
+  }).property('tabsContainer.currentView').uncached()
 });

--- a/packages/ember-handlebars/lib/controls/tabs/tab_view.js
+++ b/packages/ember-handlebars/lib/controls/tabs/tab_view.js
@@ -3,7 +3,7 @@ var get = Ember.get, setPath = Ember.setPath;
 Ember.TabView = Ember.View.extend({
   tabsContainer: Ember.computed(function() {
     return this.nearestInstanceOf(Ember.TabContainerView);
-  }).property().volatile(),
+  }).property().uncached(),
 
   mouseUp: function() {
     setPath(this, 'tabsContainer.currentView', get(this, 'value'));

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -117,7 +117,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
     }
 
     return valueNormalizer ? valueNormalizer(result) : result;
-  }).property('path', 'pathRoot', 'valueNormalizerFunc').volatile(),
+  }).property('path', 'pathRoot', 'valueNormalizerFunc').uncached(),
 
   rerenderIfNeeded: function() {
     if (!get(this, 'isDestroyed') && get(this, 'normalizedValue') !== this._lastNormalizedValue) {

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1843,7 +1843,7 @@ test("should be able to update when bound property updates", function(){
     valueBinding: 'MyApp.controller',
     computed: Ember.computed(function(){
       return this.getPath('value.name') + ' - computed';
-    }).property('value').volatile()
+    }).property('value').uncached()
   });
   
   Ember.run(function(){

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -226,13 +226,13 @@ ComputedPropertyPrototype.cacheable = function(aFlag) {
       MyApp.outsideService = Ember.Object.create({
         value: function() {
           return OutsideService.getValue();
-        }.property().volatile()
+        }.property().uncached()
       });
 
-  @name Ember.ComputedProperty.volatile
+  @name Ember.ComputedProperty.uncached
   @returns {Ember.ComputedProperty} receiver
 */
-ComputedPropertyPrototype.volatile = function() {
+ComputedPropertyPrototype.uncached = function() {
   return this.cacheable(false);
 };
 

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -107,7 +107,7 @@ Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPE
   Determines whether computed properties are cacheable by default.
   This option will be removed for the 1.1 release.
 
-  When caching is enabled by default, you can use `volatile()` to disable
+  When caching is enabled by default, you can use `uncached()` to disable
   caching on individual computed properties.
 */
 Ember.CP_DEFAULT_CACHEABLE = (Ember.ENV.CP_DEFAULT_CACHEABLE !== false);

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -15,7 +15,7 @@ testBoth("bindings should not sync twice in a single run loop", function(get, se
         getCalled++;
         return setValue;
       }
-    }).volatile());
+    }).uncached());
 
     b = {
       a: a

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -75,7 +75,7 @@ function delegate(key, value) {
   }
 }
 
-delegateDesc = Ember.computed(delegate).volatile();
+delegateDesc = Ember.computed(delegate).uncached();
 
 /**
   @class

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -53,7 +53,7 @@ module("object.get()", {
       numberVal: 24,
       toggleVal: true,
 
-      computed: Ember.computed(function() { return 'value'; }).property().volatile(),
+      computed: Ember.computed(function() { return 'value'; }).property().uncached(),
 
       method: function() { return "value"; },
 
@@ -103,7 +103,7 @@ module("Ember.get()", {
       numberVal: 24,
       toggleVal: true,
 
-      computed: Ember.computed(function() { return 'value'; }).property().volatile(),
+      computed: Ember.computed(function() { return 'value'; }).property().uncached(),
 
       method: function() { return "value"; },
 
@@ -177,7 +177,7 @@ module("Ember.getPath()");
 test("should return a property at a given path relative to the window", function() {
   window.Foo = ObservableObject.create({
     Bar: ObservableObject.create({
-      Baz: Ember.computed(function() { return "blargh"; }).property().volatile()
+      Baz: Ember.computed(function() { return "blargh"; }).property().uncached()
     })
   });
 
@@ -191,7 +191,7 @@ test("should return a property at a given path relative to the window", function
 test("should return a property at a given path relative to the passed object", function() {
   var foo = ObservableObject.create({
     bar: ObservableObject.create({
-      baz: Ember.computed(function() { return "blargh"; }).property().volatile()
+      baz: Ember.computed(function() { return "blargh"; }).property().uncached()
     })
   });
 
@@ -241,7 +241,7 @@ module("object.set()", {
           this._computed = value ;
         }
         return this._computed ;
-      }).property().volatile(),
+      }).property().uncached(),
 
       // method, but not a property
       _method: "method",
@@ -327,7 +327,7 @@ module("Computed properties", {
       computed: Ember.computed(function(key, value) {
         this.computedCalls.push(value);
         return 'computed';
-      }).property().volatile(),
+      }).property().uncached(),
 
       computedCachedCalls: [],
       computedCached: Ember.computed(function(key, value) {
@@ -344,13 +344,13 @@ module("Computed properties", {
       dependent: Ember.computed(function(key, value) {
         this.dependentCalls.push(value);
         return 'dependent';
-      }).property('changer').volatile(),
+      }).property('changer').uncached(),
 
       dependentFrontCalls: [],
       dependentFront: Ember.computed('changer', function(key, value) {
         this.dependentFrontCalls.push(value);
         return 'dependentFront';
-      }).volatile(),
+      }).uncached(),
 
       dependentCachedCalls: [],
       dependentCached: Ember.computed(function(key, value) {
@@ -375,12 +375,12 @@ module("Computed properties", {
       isOn: Ember.computed(function(key, value) {
         if (value !== undefined) this.set('state', 'on');
         return this.get('state') === 'on';
-      }).property('state').volatile(),
+      }).property('state').uncached(),
 
       isOff: Ember.computed(function(key, value) {
         if (value !== undefined) this.set('state', 'off');
         return this.get('state') === 'off';
-      }).property('state').volatile()
+      }).property('state').uncached()
 
     }) ;
   }
@@ -559,7 +559,7 @@ test("nested dependent keys should propagate after they update", function() {
 
       price: Ember.computed(function() {
         return this.getPath('restaurant.menu.price');
-      }).property('restaurant.menu.price').volatile()
+      }).property('restaurant.menu.price').uncached()
     });
 
     bindObj = ObservableObject.create({

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -130,7 +130,7 @@ test("should invalidate function property cache when notifyPropertyChange is cal
         return this;
       }
       return this._b;
-    }).volatile()
+    }).uncached()
   });
 
   a.set('b', 'foo');

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -143,7 +143,7 @@ test("can retrieve metadata for a computed property", function() {
 
   var ClassWithNoMetadata = Ember.Object.extend({
     computedProperty: Ember.computed(function() {
-    }).property().volatile(),
+    }).property().uncached(),
 
     staticProperty: 12
   });

--- a/packages/ember-runtime/tests/system/object/subclasses_test.js
+++ b/packages/ember-runtime/tests/system/object/subclasses_test.js
@@ -41,7 +41,7 @@ test('chains should copy forward to subclasses when prototype created', function
       hiBinding: 'obj.hi', // add chain
       hello: Ember.computed(function() {
           return this.getPath('obj.hi') + ' world';
-      }).property('hi').volatile(), // observe chain
+      }).property('hi').uncached(), // observe chain
       greetingBinding: 'hello'
     });
     SubSub = SubWithChains.extend();

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -614,7 +614,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     } else {
       return parent;
     }
-  }).property('_parentView').volatile(),
+  }).property('_parentView').uncached(),
 
   _parentView: null,
 
@@ -622,7 +622,7 @@ Ember.View = Ember.Object.extend(Ember.Evented,
   concreteView: Ember.computed(function() {
     if (!this.isVirtual) { return this; }
     else { return get(this, 'parentView'); }
-  }).property('_parentView').volatile(),
+  }).property('_parentView').uncached(),
 
   /**
     If false, the view will appear hidden in DOM.

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -24,7 +24,7 @@ test("should warn if a non-array is used for classNames", function() {
     Ember.View.create({
       classNames: Ember.computed(function() {
         return ['className'];
-      }).property().volatile()
+      }).property().uncached()
     });
   }, /Only arrays are allowed/i, 'should warn that an array was not used');
 });
@@ -34,7 +34,7 @@ test("should warn if a non-array is used for classNamesBindings", function() {
     Ember.View.create({
       classNameBindings: Ember.computed(function() {
         return ['className'];
-      }).property().volatile()
+      }).property().uncached()
     });
   }, /Only arrays are allowed/i, 'should warn that an array was not used');
 });


### PR DESCRIPTION
The verdict online seems mixed on whether _volatile_ is a reserved word in Javascript, but Closure Compiler seems to think that it is and spew many errors when I try to use it as my minifier.

This commit replaces the **volatile** function with **uncached**.
