### PR TITLE
`this._super` disappears when called asynchronously (failing test attached)

### DIFF
--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -167,3 +167,31 @@ test('applying several mixins at once with sup already defined causes infinite l
   obj.foo();
   equal(cnt, 3, 'should invoke all 3 methods');
 });
+
+test('_super disappears when called asynchronously', function() {
+  // our assertions are asynchronous
+  expect(0);
+
+  var hasRun = false;
+
+  var Base = Ember.Mixin.create({
+    foo: function() {
+      hasRun = true;
+    }
+  });
+
+  var Sub = Ember.Mixin.create({
+    foo: function() {
+      var self = this;
+      setTimeout(function() {
+        ok(self._super, 'should have a _super method');
+      });
+    }
+  });
+
+  var obj = {};
+  Ember.mixin(obj, Base);
+  Ember.mixin(obj, Sub);
+
+  obj.foo();
+});


### PR DESCRIPTION
Currently, `this._super` is designed as a wrapper function that sets and resets the `_super` property to whatever superclass method is appropriate.  A problem arises, however, as soon as you want to call a superclass method asynchronously, like so:

``` js
var MyClass = MyBaseClass.extend({
  someMethod: function() {
    var self = this;
    somethingAsynchronous().done(function() {
      self._super();
    });
  }
});
```

Since we're running the callback later, the function returns before `self._super` is called, and it's reset to `undefined` in the background.
