### PR TITLE
Dynamic routes vs Static segments.

### DIFF
--- a/packages/ember-states/tests/routable_test.js
+++ b/packages/ember-states/tests/routable_test.js
@@ -77,6 +77,30 @@ test("a RouteMatcher generates routes with dynamic segments", function() {
   equal(url, "foo/1/Yehuda");
 });
 
+test("route matches routes based on the order they are defined", function() {
+  var state = Ember.State.create({
+    fooChild: Ember.State.create({
+      route: 'foo',
+
+      bazChild: Ember.State.create({
+        route: 'baz'
+      }),
+
+      barChild: Ember.State.create({
+        route: ':bar'
+      })
+    })
+  });
+
+  var router = Ember.Router.create({
+    root: state
+  });
+
+  router.route("/foo/baz");
+
+  equal(router.getPath('currentState.path'), 'root.fooChild.bazChild');
+});
+
 test("route repeatedly descends into a nested hierarchy", function() {
   var state = Ember.State.create({
     fooChild: Ember.State.create({

--- a/packages/ember-states/tests/routable_test.js
+++ b/packages/ember-states/tests/routable_test.js
@@ -101,30 +101,6 @@ test("route repeatedly descends into a nested hierarchy", function() {
   equal(router.getPath('currentState.path'), 'root.fooChild.barChild.bazChild');
 });
 
-test("route repeatedly descends into a nested hierarchy", function() {
-  var state = Ember.State.create({
-    fooChild: Ember.State.create({
-      route: 'foo',
-
-      barChild: Ember.State.create({
-        route: 'bar',
-
-        bazChild: Ember.State.create({
-          route: 'baz'
-        })
-      })
-    })
-  });
-
-  var router = Ember.Router.create({
-    root: state
-  });
-
-  router.route("/foo/bar/baz");
-
-  equal(router.getPath('currentState.path'), 'root.fooChild.barChild.bazChild');
-});
-
 test("when you descend into a state, the route is set", function() {
   var state = Ember.State.create({
     ready: function(manager) {


### PR DESCRIPTION
Currently when I try and access a route which has multiple possibilities, it seems to always use dynamic segments.

```
posts: Ember.State.create({
   route: 'posts',

  new: Ember.State.create({
    route: 'new'
  }),

  post: Ember.State.create({
    route: ':post_id'
  })
})
```

`/posts/new` seems to currently match 'posts.post' with a `post_id` of `new`

I have attached a failing test, but I don't know where I'd start to look for a fix.

Cheers, 
Brad
