### PR TITLE
Use evented system for dom events

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -48,9 +48,9 @@ Ember.Checkbox = Ember.View.extend({
   checked: false,
   disabled: false,
 
-  change: function() {
-    Ember.run.once(this, this._updateElementValue);
-    // returning false will cause IE to not change checkbox state
+  init: function() {
+    this._super();
+    this.on("change", this, this._updateElementValue);
   },
 
   /**

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -102,7 +102,7 @@ Ember.Select = Ember.View.extend(
   */
   optionValuePath: 'content',
 
-  change: function() {
+  _change: function() {
     if (get(this, 'multiple')) {
       this._changeMultiple();
     } else {
@@ -146,7 +146,7 @@ Ember.Select = Ember.View.extend(
 
     if (selection) { this.selectionDidChange(); }
 
-    this.change();
+    this._change();
   },
 
   _changeSingle: function() {
@@ -207,8 +207,8 @@ Ember.Select = Ember.View.extend(
   init: function() {
     this._super();
     this.on("didInsertElement", this, this._triggerChange);
+    this.on("change", this, this._change);
   }
-
 });
 
 Ember.SelectOption = Ember.View.extend({

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -23,16 +23,11 @@ Ember.TextSupport = Ember.Mixin.create(
   insertNewline: Ember.K,
   cancel: Ember.K,
 
-  focusOut: function(event) {
-    this._elementValueDidChange();
-  },
-
-  change: function(event) {
-    this._elementValueDidChange();
-  },
-
-  keyUp: function(event) {
-    this.interpretKeyEvents(event);
+  init: function() {
+    this._super();
+    this.on("focusOut", this, this._elementValueDidChange);
+    this.on("change", this, this._elementValueDidChange);
+    this.on("keyUp", this, this.interpretKeyEvents);
   },
 
   /**

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -147,7 +147,7 @@ test("should call the insertNewline method when return key is pressed", function
     wasCalled = true;
   };
 
-  textArea.keyUp(event);
+  textArea.fire('keyUp', event);
   ok(wasCalled, "invokes insertNewline method");
 });
 
@@ -161,7 +161,7 @@ test("should call the cancel method when escape key is pressed", function() {
     wasCalled = true;
   };
 
-  textArea.keyUp(event);
+  textArea.fire('keyUp', event);
   ok(wasCalled, "invokes cancel method");
 });
 

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -143,7 +143,7 @@ test("should call the insertNewline method when return key is pressed", function
     wasCalled = true;
   };
 
-  textField.keyUp(event);
+  textField.fire('keyUp', event);
   ok(wasCalled, "invokes insertNewline method");
 });
 
@@ -157,7 +157,7 @@ test("should call the cancel method when escape key is pressed", function() {
     wasCalled = true;
   };
 
-  textField.keyUp(event);
+  textField.fire('keyUp', event);
   ok(wasCalled, "invokes cancel method");
 });
 

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1362,7 +1362,7 @@ test("should not reset cursor position when text field receives keyUp event", fu
   view.$().setCaretPosition(5);
 
   Ember.run(function() {
-    view.keyUp({});
+    view.fire('keyUp', {});
   });
 
   equal(view.$().caretPosition(), 5, "The keyUp event should not result in the cursor being reset due to the bindAttr observers");

--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -22,5 +22,9 @@ Ember.Evented = Ember.Mixin.create({
 
   off: function(name, target, method) {
     Ember.removeListener(this, name, target, method);
+  },
+
+  has: function(name) {
+    return Ember.hasListeners(this, name);
   }
 });

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -43,7 +43,7 @@ Ember.View.states.HasElementState = Ember.State.extend({
   // deferred to allow bindings to synchronize.
   rerender: function(manager) {
     var view = get(manager, 'view');
-    
+
     view._notifyWillRerender();
 
     view.clearRenderedChildren();
@@ -58,7 +58,7 @@ Ember.View.states.HasElementState = Ember.State.extend({
 
   destroyElement: function(manager) {
     var view = get(manager, 'view');
-    
+
     view._notifyWillDestroyElement();
     view.domManager.remove(view);
     return view;
@@ -66,7 +66,7 @@ Ember.View.states.HasElementState = Ember.State.extend({
 
   empty: function(manager) {
     var view = get(manager, 'view');
-    
+
     var _childViews = get(view, '_childViews'), len, idx;
     if (_childViews) {
       len = get(_childViews, 'length');
@@ -82,10 +82,9 @@ Ember.View.states.HasElementState = Ember.State.extend({
     var view = get(manager, 'view'),
         eventName = options.eventName,
         evt = options.event;
-    
-    var handler = view[eventName];
-    if (Ember.typeOf(handler) === 'function') {
-      return handler.call(view, evt);
+
+    if (view.has(eventName)) {
+      return view.fire(eventName, evt);
     } else {
       return true; // continue event propagation
     }
@@ -95,7 +94,7 @@ Ember.View.states.HasElementState = Ember.State.extend({
 Ember.View.states.InDomState = Ember.State.extend({
   insertElement: function(manager, fn) {
     var view = get(manager, 'view');
-    
+
     if (view._lastInsert !== Ember.guidFor(fn)){
       return;
     }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1859,10 +1859,14 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     also call methods with the given name.
   */
   fire: function(name) {
-    if (this[name]) {
-      this[name].apply(this, [].slice.call(arguments, 1));
-    }
     this._super.apply(this, arguments);
+    if (this[name]) {
+      return this[name].apply(this, [].slice.call(arguments, 1));
+    }
+  },
+
+  has: function(name) {
+    return Ember.typeOf(this[name]) === 'function' || this._super(name);
   },
 
   // .......................................................


### PR DESCRIPTION
Now we are using real events for all dom events on views. We check if
the callback is defined or if listeners are set. If you use callbacks,
you can return `false` in order to prevent default
In order to achive it goal, this commit adds `has` method to Evented
mixin.
