### PR TITLE
urlForEvent for a route with a dynamic part doesn't serialize the context

### DIFF
--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -92,9 +92,21 @@ Ember.Router = Ember.StateManager.extend(
     var targetState = this.findStateByPath(currentState, targetStateName);
 
     Ember.assert("Your target state name " + targetStateName + " for event " + eventName + " did not resolve to a state", !!targetState);
-    var hash = targetState.serialize(this, context);
+
+    var hash = this.serializeRecursively(targetState, context);
 
     return this.urlFor(targetStateName, hash);
+  },
+
+  /** @private */
+  serializeRecursively: function(state, hash) {
+    hash = state.serialize(this, hash);
+    var parentState = state.get("parentState");
+    if (parentState && parentState instanceof Ember.Route) {
+      return this.serializeRecursively(parentState, hash);
+    } else {
+      return hash;
+    }
   },
 
   /** @private */

--- a/packages/ember-routing/tests/router_test.js
+++ b/packages/ember-routing/tests/router_test.js
@@ -148,6 +148,44 @@ test("router.urlForEvent works with changing context in the current state", func
 });
 
 
+test("router.urlForEvent works for nested routes with a context", function() {
+  var router = Ember.Router.create({
+    location: location,
+    namespace: namespace,
+    root: Ember.Route.create({
+      index: Ember.Route.create({
+        route: '/',
+
+        showDashboardActivity: function(router) {
+          router.transitionTo('dashboard.activity');
+        },
+
+        eventTransitions: {
+          showDashboardActivity: 'dashboard.activity'
+        }
+      }),
+
+      dashboard: Ember.Route.create({
+        route: '/dashboard/:component_id',
+
+        activity: Ember.Route.create({
+          route: '/activity'
+        })
+      })
+    })
+  });
+
+  Ember.run(function() {
+    router.route('/');
+  });
+
+  equal(router.getPath('currentState.path'), "root.index", "precond - the router is in root.index");
+
+  var url = router.urlForEvent('showDashboardActivity', { id: 1 });
+  equal(url, "#!#/dashboard/1/activity");
+});
+
+
 test("router.urlForEvent works with Ember.State.transitionTo", function() {
   var router = Ember.Router.create({
     location: location,


### PR DESCRIPTION
This is just a failing test for now, currently investigating.

Basically if we're in index of the following:

```
root: Ember.Route.create({
  index: Ember.Route.create({
    route: '/',
    showDashboard: Ember.Route.transitionTo('dashboard'),
    showActivity: Ember.Route.transitionTo('dashboard.activity')
  }),

  dashboard: Ember.Route.create({
    route: '/dashboard/:component_id',

    activity: Ember.Route.create({
      route: '/activity'
    })
  })
})
```

then:

```
> router.urlForEvent('showDashboard', { id: 1 });
=> #!#/dashboard/1
```

but going into the sub-state with the same context:

```
> router.urlForEvent('showActivity', { id: 1 });
=> #!#/dashboard/undefined/activity
```

this is because it's not calling serialize on the intermediate state, but on the final state which doesn't know how to transform `{id: 1}` into `{component_id: 1}`

If we call it with a pre-serialized hash then it "works": 

```
> router.urlForEvent('showActivity', { component_id: 1 });
=> #!#/dashboard/1/activity
```

It looks like urlForEvent will have to walk back up the parent states calling serialize on each one which has a dynamic route?
