### PR TITLE
Fix an error in an example in the EventManager documentation

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -374,8 +374,8 @@ var invokeForState = {
   by the event manager will still trigger method calls on the descendent.
 
       OuterView = Ember.View.extend({
-        eventManager: Ember.Object.create({
-          template: Ember.Handlebars.compile("outer {{#view InnerView}}inner{{/view}} outer"),
+        template: Ember.Handlebars.compile("outer {{#view InnerView}}inner{{/view}} outer"),
+        eventManager: Ember.Object.create({          
           mouseEnter: function(event, view){
             // view might be instance of either
             // OutsideView or InnerView depending on


### PR DESCRIPTION
The template should be part of the view, not the event manager.
