### PR TITLE
{{action}} should also prevent default

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -140,6 +140,7 @@ Ember.EventDispatcher = Ember.Object.extend(
 
       if (action.eventName === eventName) {
         evt.stopPropagation();
+        evt.preventDefault();
         return handler(evt);
       }
     });


### PR DESCRIPTION
In order to make it work for <a /> elements, for example. As discussed in aaa22a7ced26ec4cc079818b6a8991baed51d77a /cc @wycats
