### PR TITLE
Documentation for State.transitionTo.

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -161,7 +161,34 @@ Ember.State = Ember.Object.extend(Ember.Evented,
 
 var Event = Ember.$ && Ember.$.Event;
 
-Ember.State.reopenClass({
+Ember.State.reopenClass(
+/** @scope Ember.State */{
+  
+  /**
+  @static
+  
+  Creates an action function for transitioning to the named state while preserving context.
+  
+  The following example StateManagers are equivalent: 
+  
+      aManager = Ember.StateManager.create({
+        stateOne: Ember.State.create({
+          changeToStateTwo: Ember.State.transitionTo('stateTwo')
+        }),
+        stateTwo: Ember.State.create({})
+      })
+      
+      bManager = Ember.StateManager.create({
+        stateOne: Ember.State.create({
+          changeToStateTwo: function(manager, context){
+            manager.transitionTo('stateTwo', context)
+          }
+        }),
+        stateTwo: Ember.State.create({})
+      })
+  
+  @param {String} target
+  */
   transitionTo: function(target) {
     var event = function(stateManager, context) {
       if (Event && context instanceof Event) {

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -351,6 +351,24 @@ require('ember-states/state');
       robotManager.send('beginExtermination', allHumans)
       robotManager.getPath('currentState.name') // 'rampaging'
 
+  Transition actions can also be created using the `transitionTo` method of the Ember.State class. The
+  following example StateManagers are equivalent: 
+  
+      aManager = Ember.StateManager.create({
+        stateOne: Ember.State.create({
+          changeToStateTwo: Ember.State.transitionTo('stateTwo')
+        }),
+        stateTwo: Ember.State.create({})
+      })
+      
+      bManager = Ember.StateManager.create({
+        stateOne: Ember.State.create({
+          changeToStateTwo: function(manager, context){
+            manager.transitionTo('stateTwo', context)
+          }
+        }),
+        stateTwo: Ember.State.create({})
+      })
 **/
 Ember.StateManager = Ember.State.extend(
 /** @scope Ember.StateManager.prototype */ {


### PR DESCRIPTION
Not sure why static documentation copy isn't being built into the site's HTML (it also fails to show up for other static properties like Ember.TEMPLATES and  Ember.CollectionView.CONTAINER_MAP too). I repeated the explanatory text in the section on StateManager state transitions.
