### PR TITLE
Add version info (tag name and most recent commit into) to generated files

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -63,6 +63,26 @@ class JSHintRC < Rake::Pipeline::Filter
   end
 end
 
+class VersionInfo < Rake::Pipeline::Filter
+  def version_info
+    @version_info ||= begin
+      latest_tag = `git describe --tags`
+      last_commit = `git log -n 1 --format="%h (%ci)"`
+
+      out = "// Version: #{latest_tag}"
+      out << "// Last commit: #{last_commit}"
+      out
+    end
+  end
+
+  def generate_output(inputs, output)
+    inputs.each do |input|
+      file = File.read(input.fullpath)
+      output.write "#{version_info}\n\n#{file}"
+    end
+  end
+end
+
 distros = {
   :runtime => %w(ember-metal ember-runtime),
   :full    => %w(handlebars ember-metal ember-runtime ember-application ember-views ember-states ember-routing ember-viewstates metamorph ember-handlebars)
@@ -133,6 +153,7 @@ distros.each do |name, modules|
 
     # Add debug to the main distro
     match "{#{name}.js,ember-debug.js}" do
+      filter VersionInfo
       concat ["ember-debug.js"], "#{name}.js"
     end
 
@@ -144,6 +165,7 @@ distros.each do |name, modules|
     # Minify
     match "#{name}.min.js" do
       uglify{ "#{name}.min.js" }
+      filter VersionInfo
       filter EmberLicenseFilter
     end
   end


### PR DESCRIPTION
As mentioned in #1026 this adds some version info to generated files using a combination of `git log` and `git describe`.

Eg in latest master it adds this:

```
// Version: v0.9.8.1-382-g332d214
// Last commit: 332d214 (2012-06-18 14:41:41 -0400)
```

Obviously feedback welcome on what info should be in here & how it's formatted.
