### PR TITLE
Add two new core methods to allow invoking possibly unknown methods on objects if they exist

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -338,3 +338,34 @@ Ember.makeArray = function(obj) {
   if (obj === null || obj === undefined) { return []; }
   return Ember.isArray(obj) ? obj : [obj];
 };
+
+function canInvoke(obj, methodName) {
+  return !!(obj && typeof obj[methodName] === 'function');
+}
+
+/**
+  Checks to see if the `methodName` exists on the `obj`.
+
+  @param {Object} obj The object to check for the method
+  @param {String} methodName The method name to check for
+*/
+Ember.canInvoke = canInvoke;
+
+/**
+  Checks to see if the `methodName` exists on the `obj`,
+  and if it does, invokes it with the arguments passed.
+
+  @function
+
+  @param {Object} obj The object to check for the method
+  @param {String} methodName The method name to check for
+  @param {Array} args The arguments to pass to the method
+
+  @returns {Boolean} true if the method does not return false
+  @returns {Boolean} false otherwise
+*/
+Ember.tryInvoke = function(obj, methodName, args) {
+  if (canInvoke(obj, methodName)) {
+    return obj[methodName].apply(obj, args);
+  }
+};

--- a/packages/ember-metal/tests/utils/can_invoke_test.js
+++ b/packages/ember-metal/tests/utils/can_invoke_test.js
@@ -1,0 +1,36 @@
+// ==========================================================================
+// Project:   Ember Runtime
+// Copyright: ©2012 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var obj;
+
+module("Ember.canInvoke", {
+  setup: function() {
+    obj = {
+      foobar: "foobar",
+      aMethodThatExists: function() {}
+    };
+  },
+
+  teardown: function() {
+    obj = undefined;
+  }
+});
+
+test("should return false if the object doesn't exist", function() {
+  equal(Ember.canInvoke(undefined, 'aMethodThatDoesNotExist'), false);
+});
+
+test("should return true if the method exists on the object", function() {
+  equal(Ember.canInvoke(obj, 'aMethodThatExists'), true);
+});
+
+test("should return false if the method doesn't exist on the object", function() {
+  equal(Ember.canInvoke(obj, 'aMethodThatDoesNotExist'), false);
+});
+
+test("should return false if the property exists on the object but is a non-function", function() {
+  equal(Ember.canInvoke(obj, 'foobar'), false);
+});

--- a/packages/ember-metal/tests/utils/try_invoke_test.js
+++ b/packages/ember-metal/tests/utils/try_invoke_test.js
@@ -1,0 +1,36 @@
+// ==========================================================================
+// Project:   Ember Runtime
+// Copyright: ©2012 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+var obj;
+
+module("Ember.tryInvoke", {
+  setup: function() {
+    obj = {
+      aMethodThatExists: function() { return true; },
+      aMethodThatTakesArguments: function(arg1, arg2) { return arg1 === arg2; }
+    };
+  },
+
+  teardown: function() {
+    obj = undefined;
+  }
+});
+
+test("should return undefined when the object doesn't exist", function() {
+  equal(Ember.tryInvoke(undefined, 'aMethodThatDoesNotExist'), undefined);
+});
+
+test("should return undefined when asked to perform a method that doesn't exist on the object", function() {
+  equal(Ember.tryInvoke(obj, 'aMethodThatDoesNotExist'), undefined);
+});
+
+test("should return what the method returns when asked to perform a method that exists on the object", function() {
+  equal(Ember.tryInvoke(obj, 'aMethodThatExists'), true);
+});
+
+test("should return what the method returns when asked to perform a method that takes arguments and exists on the object", function() {
+  equal(Ember.tryInvoke(obj, 'aMethodThatTakesArguments', [true, true]), true);
+});


### PR DESCRIPTION
Rationale:

This is such a common idiom throughout Ember and my Ember apps:

``` js
var foo = get(this, 'foo');
if (foo && typeof foo.bar === 'function') {
  foo.bar();
}
```

...that I think it makes perfect sense to solidify the paradigm in Ember, especially when the code is less than 10 lines long total. Great code exposing good patterns in small chunks feels like the new thing Ember is trying to achieve. For instance: `Ember.Evented`.

I ask for naming suggestions as I don't particularly like `tryToPerform`.

Two possible alternatives already suggested include:
- `methodExists` / `invokeIfExists`
- `canInvoke` / `tryInvoke`
