### PR TITLE
outlet helper support subclassed Ember.ContainerView

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     multi_json (1.3.6)
     multipart-post (1.1.5)
     nokogiri (1.5.3)
+    nokogiri (1.5.3-x86-mingw32)
     oauth2 (0.7.1)
       faraday (~> 0.8)
       httpauth (~> 0.1)
@@ -66,6 +67,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   colored

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -32,7 +32,7 @@ require('ember-handlebars/helpers/view');
       {{outlet masterView App.MasterOutlet}}        <- custom outlet name + custom outlet view
   
   @name Handlebars.helpers.outlet
-  @param {String} property the property on the controller
+  @param {String} property the property on the controller 
     that holds the view for this outlet
   @param {String} view a subclass of Ember.ContainerView 
     providing html settings for outlet block (id, tag, class, role, ...)
@@ -45,11 +45,7 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
 
   var container;
   
-<<<<<<< HEAD
   isContainer = function(container) {
-=======
-  function isContainer(container) {
->>>>>>> another try for travisbot fix !
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
     if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
     else return false;

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -32,7 +32,7 @@ require('ember-handlebars/helpers/view');
       {{outlet masterView App.MasterOutlet}}        <- custom outlet name + custom outlet view
   
   @name Handlebars.helpers.outlet
-  @param {String} property the property on the controller 
+  @param {String} property the property on the controller
     that holds the view for this outlet
   @param {String} view a subclass of Ember.ContainerView 
     providing html settings for outlet block (id, tag, class, role, ...)
@@ -45,7 +45,11 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
 
   var container;
   
+<<<<<<< HEAD
   isContainer = function(container) {
+=======
+  function isContainer(container) {
+>>>>>>> another try for travisbot fix !
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
     if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
     else return false;

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -22,24 +22,24 @@ require('ember-handlebars/helpers/view');
 
       controller.set('masterView', postsView);
       controller.set('detailView', postView);
- 
+
   The outlet can handle a subclass of Ember.ContainerView for html settings.
-  
-      {{outlet}}                              <- standard 
-      {{outlet view}}                         <- standard verbose 
-      {{outlet masterView}}                   <- custom outlet name 
-      {{outlet App.CustomOutlet}}             <- custom outlet view 
+
+      {{outlet}}                              <- standard
+      {{outlet view}}                         <- standard verbose
+      {{outlet masterView}}                   <- custom outlet name
+      {{outlet App.CustomOutlet}}             <- custom outlet view
       {{outlet masterView App.MasterOutlet}}  <- custom outlet name + custom outlet view
-  
+
   @name Handlebars.helpers.outlet
   @param {String} property the property on the controller
     that holds the view for this outlet
-  @param {String} view a subclass of Ember.ContainerView 
+  @param {String} view a subclass of Ember.ContainerView
     providing html settings for outlet block (id, tag, class, role, ...)
 */
 Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
   Ember.assert(
-    'you can provide an "outletName" as property and/or a subclass of Ember.ContainerView as "view" ... no more!', 
+    'you can provide an "outletName" as property and/or a subclass of Ember.ContainerView as "view".',
     arguments.length <= 3
   );
 
@@ -47,18 +47,18 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
     return viewPath !== null && Ember.ContainerView.detect(viewPath);
   }
-  
+
   switch (arguments.length) {
-    case 1: 
+    case 1:
       if (property && property.data && property.data.isRenderData) {
         options = property;
         property = 'view';
-      } 
+      }
       break;
     case 2:
       if (view && view.data && view.data.isRenderData) {
         options = view;
-        
+
         if (isContainer(property)) {
           view = property;
           property = 'view';
@@ -66,12 +66,12 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
       }
       break;
   }
-  
+
   if (!isContainer(view)) {
     view = Ember.ContainerView;
   }
-  
+
   options.hash.currentViewBinding = "controller." + property;
-  
+
   return Ember.Handlebars.helpers.view.call(this, view, options);
 });

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -39,11 +39,17 @@ require('ember-handlebars/helpers/view');
 */
 Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
   Ember.assert(
-    'you can provide an outletName as "property" and/or a subclass of Ember.ContainerView as "view"', 
+    'you can provide an "outletName" as property and/or a subclass of "Ember.ContainerView as view" ... no more!', 
     arguments.length <= 3
   );
+
+  var container;
   
-  var viewPath;
+  var isContainer = function(container) {
+    var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
+    if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
+    else return false;
+  };
   
   switch (arguments.length) {
     case 1: 
@@ -55,8 +61,8 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
     case 2:
       if (view && view.data && view.data.isRenderData) {
         options = view;
-        viewPath = (typeof property === "string" && Ember.getPath(property) !== undefined) ? Ember.getPath(property) : null;
-        if (viewPath !== null && Ember.ContainerView.detect(viewPath)) {
+        
+        if (isContainer(property)) {
           view = property;
           property = 'view';
         }
@@ -66,11 +72,10 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
       break;
   }
   
-  viewPath = (typeof view === "string" && Ember.getPath(view) !== undefined) ? Ember.getPath(view) : null;
-  if (viewPath === null || (viewPath !== null && !Ember.ContainerView.detect(viewPath))) {
+  if (!isContainer(view)) {
     view = Ember.ContainerView;
   }
-
+  
   options.hash.currentViewBinding = "controller." + property;
   
   return Ember.Handlebars.helpers.view.call(this, view, options);

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -45,7 +45,7 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
 
   var container;
   
-  isContainer = function(container) {
+  function isContainer(container) {
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
     if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
     else return false;

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -45,7 +45,7 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
 
   var container;
   
-  var isContainer = function(container) {
+  isContainer = function(container) {
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
     if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
     else return false;

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -22,18 +22,56 @@ require('ember-handlebars/helpers/view');
 
       controller.set('masterView', postsView);
       controller.set('detailView', postView);
-
+ 
+  The outlet can handle a subclass of Ember.ContainerView for html settings.
+  
+      {{outlet}}                                    <- standard 
+      {{outlet view}}                               <- standard verbose 
+      {{outlet masterView}}                         <- custom outlet name 
+      {{outlet App.CustomOutlet}}                   <- custom outlet view 
+      {{outlet masterView App.MasterOutlet}}        <- custom outlet name + custom outlet view
+  
   @name Handlebars.helpers.outlet
-  @param {String} property the property on the controller
+  @param {String} property the property on the controller 
     that holds the view for this outlet
+  @param {String} view a subclass of Ember.ContainerView 
+    providing html settings for outlet block (id, tag, class, role, ...)
 */
-Ember.Handlebars.registerHelper('outlet', function(property, options) {
-  if (property && property.data && property.data.isRenderData) {
-    options = property;
-    property = 'view';
+Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
+  Ember.assert(
+    'you can provide an outletName as "property" and/or a subclass of Ember.ContainerView as "view"', 
+    arguments.length <= 3
+  );
+  
+  var viewPath;
+  
+  switch (arguments.length) {
+    case 1: 
+      if (property && property.data && property.data.isRenderData) {
+        options = property;
+        property = 'view';
+      } 
+      break;
+    case 2:
+      if (view && view.data && view.data.isRenderData) {
+        options = view;
+        viewPath = (typeof property === "string" && Ember.getPath(property) !== undefined) ? Ember.getPath(property) : null;
+        if (viewPath !== null && Ember.ContainerView.detect(viewPath)) {
+          view = property;
+          property = 'view';
+        }
+      }
+      break;
+    case 3:
+      break;
+  }
+  
+  viewPath = (typeof view === "string" && Ember.getPath(view) !== undefined) ? Ember.getPath(view) : null;
+  if (viewPath === null || (viewPath !== null && !Ember.ContainerView.detect(viewPath))) {
+    view = Ember.ContainerView;
   }
 
   options.hash.currentViewBinding = "controller." + property;
-
-  return Ember.Handlebars.helpers.view.call(this, Ember.ContainerView, options);
+  
+  return Ember.Handlebars.helpers.view.call(this, view, options);
 });

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -25,30 +25,27 @@ require('ember-handlebars/helpers/view');
  
   The outlet can handle a subclass of Ember.ContainerView for html settings.
   
-      {{outlet}}                                    <- standard 
-      {{outlet view}}                               <- standard verbose 
-      {{outlet masterView}}                         <- custom outlet name 
-      {{outlet App.CustomOutlet}}                   <- custom outlet view 
-      {{outlet masterView App.MasterOutlet}}        <- custom outlet name + custom outlet view
+      {{outlet}}                              <- standard 
+      {{outlet view}}                         <- standard verbose 
+      {{outlet masterView}}                   <- custom outlet name 
+      {{outlet App.CustomOutlet}}             <- custom outlet view 
+      {{outlet masterView App.MasterOutlet}}  <- custom outlet name + custom outlet view
   
   @name Handlebars.helpers.outlet
-  @param {String} property the property on the controller 
+  @param {String} property the property on the controller
     that holds the view for this outlet
   @param {String} view a subclass of Ember.ContainerView 
     providing html settings for outlet block (id, tag, class, role, ...)
 */
 Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
   Ember.assert(
-    'you can provide an "outletName" as property and/or a subclass of "Ember.ContainerView as view" ... no more!', 
+    'you can provide an "outletName" as property and/or a subclass of Ember.ContainerView as "view" ... no more!', 
     arguments.length <= 3
   );
 
-  var container;
-  
   function isContainer(container) {
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
-    if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
-    else return false;
+    return viewPath !== null && Ember.ContainerView.detect(viewPath);
   }
   
   switch (arguments.length) {
@@ -67,8 +64,6 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
           property = 'view';
         }
       }
-      break;
-    case 3:
       break;
   }
   

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -28,7 +28,7 @@ require('ember-handlebars/helpers/view');
       {{outlet}}                              <- standard
       {{outlet view}}                         <- standard verbose
       {{outlet masterView}}                   <- custom outlet name
-      {{outlet App.CustomView}}               <- custom outlet view
+      {{outlet App.MasterView}}               <- custom outlet view
       {{outlet masterView App.MasterView}}    <- custom outlet name + custom outlet view
 
   @name Handlebars.helpers.outlet

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -28,8 +28,8 @@ require('ember-handlebars/helpers/view');
       {{outlet}}                              <- standard
       {{outlet view}}                         <- standard verbose
       {{outlet masterView}}                   <- custom outlet name
-      {{outlet App.CustomOutlet}}             <- custom outlet view
-      {{outlet masterView App.MasterOutlet}}  <- custom outlet name + custom outlet view
+      {{outlet App.CustomView}}               <- custom outlet view
+      {{outlet masterView App.MasterView}}    <- custom outlet name + custom outlet view
 
   @name Handlebars.helpers.outlet
   @param {String} property the property on the controller

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -39,7 +39,7 @@ require('ember-handlebars/helpers/view');
 */
 Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
   Ember.assert(
-    'you can provide an "outletName" as property and/or a subclass of Ember.ContainerView as "view".',
+    'you can provide an outletName as "property" and/or a subclass of Ember.ContainerView as "view".',
     arguments.length <= 3
   );
 

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -49,7 +49,7 @@ Ember.Handlebars.registerHelper('outlet', function(property, view, options) {
     var viewPath = (typeof container === "string" && Ember.getPath(container) !== undefined) ? Ember.getPath(container) : null;
     if (viewPath !== null && Ember.ContainerView.detect(viewPath)) return true;
     else return false;
-  };
+  }
   
   switch (arguments.length) {
     case 1: 

--- a/packages/ember-handlebars/tests/helpers/outlet_test.js
+++ b/packages/ember-handlebars/tests/helpers/outlet_test.js
@@ -62,3 +62,49 @@ test("outlet should support an optional name", function() {
 
   equal(view.$().text(), 'HIBYE');
 });
+
+
+test('outlet should support an optional subclassed Ember.ContainerView without an outlet name specified.', function() {
+  Ember.MyCustomContainerView = Ember.ContainerView.extend({
+    elementId: "custom-id",
+    tagName: "section"
+  });
+  
+  var controller = Ember.Object.create();
+
+  view = Ember.View.create({
+    controller: controller,
+    template: compile("<h1>HI</h1>{{outlet Ember.MyCustomContainerView}}")
+  });
+
+  appendView(view);
+
+  Ember.run(function() {
+    controller.set('view', Ember.View.create({ template: compile("<p>BYE</p>") }));
+  });
+
+  equal(view.$("section#custom-id").text(), 'BYE', 'outlet with custom ContainerView has been successfully founded !');
+});
+
+
+test('outlet should support an optional subclassed Ember.ContainerView with an outlet name specified..', function() {
+  Ember.MyCustomContainerView = Ember.ContainerView.extend({
+    elementId: "custom-id",
+    tagName: "section"
+  });
+  
+  var controller = Ember.Object.create();
+
+  view = Ember.View.create({
+    controller: controller,
+    template: compile("<h1>HI</h1>{{outlet customView Ember.MyCustomContainerView}}")
+  });
+
+  appendView(view);
+
+  Ember.run(function() {
+    controller.set('customView', Ember.View.create({ template: compile("<p>BYE</p>") }));
+  });
+
+  equal(view.$("section#custom-id").text(), 'BYE', 'outlet with custom ContainerView has been successfully founded !');
+});


### PR DESCRIPTION
allow the developper to pass a view for settings html for outlet helper.

App.MainView = Ember.ContainerView.extend({
  elementId: "main",
  ariaRole: "main",
  classNameBindings: ['isError'],
  isError: false
})

{{outlet App.MainView}}
or
{{outlet mainView App.MainView}}

instead of

{{outlet elementId="main" ariaRole="main"}}
or
{{outlet mainView elementId="main" ariaRole="main"}}

two way to achieve the same things, each can serve different usage.

you can combine the two way 

{{outlet App.MainView isError=true}}
