### PR TITLE
Doc

### DIFF
--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -250,7 +250,7 @@ var get = Ember.get, getPath = Ember.getPath, set = Ember.set;
   Will transition the application's state to 'root.bRoute' and trigger an update of the URL to
   '#/a/route/42/Life'.
 
-  The context argument will also be passed as the second argument to the `deserialize` method call.
+  The context argument will also be passed as the second argument to the `serialize` method call.
 
   ## Injection of Controller Singletons
   During application initialization Ember will detect properties of the application ending in 'Controller',

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -8,6 +8,8 @@ require('ember-runtime/system/array_proxy');
 require('ember-runtime/controllers/controller');
 require('ember-runtime/mixins/sortable');
 
+var get = Ember.get, set = Ember.set;
+
 /**
   @class
 
@@ -46,8 +48,6 @@ require('ember-runtime/mixins/sortable');
 
   @extends Ember.ArrayProxy
 */
-
-var get = Ember.get, set = Ember.set;
 
 Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
   Ember.SortableMixin);


### PR DESCRIPTION
- Make ArrayController show up in JsDoc
- Fix router docs
  
  `serialize`, not `deserialize` is called with the context object when
  transitioning between states from within the application.
