### PR TITLE
Fix a stray variable missed in 3d5587

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -593,7 +593,7 @@ Ember.StateManager = Ember.State.extend(
           exitStates.shift();
         }
 
-        currentState.pathsCache[name] = {
+        currentState.pathsCache[path] = {
           exitStates: exitStates,
           enterStates: enterStates,
           resolveState: resolveState


### PR DESCRIPTION
A variable name was missed in commit 3d55878c609588e2757a690d2896e596bdcc8f4c.
