### PR TITLE
Allow meta-click to open link in new window/tab

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -138,6 +138,10 @@ Ember.EventDispatcher = Ember.Object.extend(
           action   = Ember.Handlebars.ActionHelper.registeredActions[actionId],
           handler  = action.handler;
 
+      if (action.eventName === "click" && evt.metaKey) {
+        return;
+      }
+
       if (action.eventName === eventName) {
         evt.preventDefault();
         return handler(evt);


### PR DESCRIPTION
Currently meta-clicking a link which has an action handler just executes the handler in the current window. If an action has a href I'd expect this to open a new tab/window instead.

I'm not sure if this is the best approach to solving this, I can see there being situations where people might want meta-clicks to still execute handlers.

Also meta-click only applies to OSX (and linux?) whereas I think it's ctrl-click in Windows world.

Should also probably check to see if the target of the click has a href.

Haven't added tests yet as would be good to get feedback first on the best approach to this.
