### PR TITLE
Benchmark love

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,7 @@
+# Extremely simple Ember benchmarks
+
+To run the benchmarks, serve the repository root on a web server (`gem install
+asdf; asdf`), run `rake` to build Ember, and open e.g.
+`http://localhost:9292/benchmarks/index.html?suitePath=plain_object.js` to run
+`benchmarks/suites/plain_object.js`. Run `cp -r dist distold` to benchmark
+different versions against each other.

--- a/benchmarks/iframe_runner.js
+++ b/benchmarks/iframe_runner.js
@@ -10,7 +10,6 @@ BenchWarmer.evalString = function(string, emberPath, logger, profile) {
   var benchWarmer = new BenchWarmer(emberPath, logger, profile);
 
   var bench = function(name, fn) {
-    ember_assert("Please pass in a name and function", arguments.length === 2);
     benchWarmer.bench(name, fn);
   };
 


### PR DESCRIPTION
- Remove old ember_assert call
  
  Ember is still undefined, so I'm deleting it instead of using Ember.assert.
- Add README for how to run benchmarks
