### PR TITLE
Add support for tabindex in Ember Controls

### DIFF
--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -16,7 +16,7 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
 
   propagateEvents: false,
 
-  attributeBindings: ['type', 'disabled', 'href'],
+  attributeBindings: ['type', 'disabled', 'href', 'tabindex'],
 
   /** @private
     Overrides TargetActionSupport's targetObject computed

--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -42,7 +42,7 @@ Ember.Checkbox = Ember.View.extend({
 
   tagName: 'input',
 
-  attributeBindings: ['type', 'checked', 'disabled'],
+  attributeBindings: ['type', 'checked', 'disabled', 'tabindex'],
 
   type: "checkbox",
   checked: false,

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -97,7 +97,7 @@ Ember.Select = Ember.View.extend(
   tagName: 'select',
   classNames: ['ember-select'],
   defaultTemplate: Ember.Handlebars.compile('{{#if view.prompt}}<option value>{{view.prompt}}</option>{{/if}}{{#each view.content}}{{view Ember.SelectOption contentBinding="this"}}{{/each}}'),
-  attributeBindings: ['multiple'],
+  attributeBindings: ['multiple', 'tabindex'],
 
   /**
     The `multiple` attribute of the select element. Indicates whether multiple

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -15,7 +15,7 @@ Ember.TextSupport = Ember.Mixin.create(
 
   value: "",
 
-  attributeBindings: ['placeholder', 'disabled', 'maxlength'],
+  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex'],
   placeholder: null,
   disabled: false,
   maxlength: null,

--- a/packages/ember-handlebars/tests/controls/button_test.js
+++ b/packages/ember-handlebars/tests/controls/button_test.js
@@ -59,6 +59,17 @@ test("should become disabled if the disabled attribute is changed", function() {
   ok(button.$().is(":not(:disabled)"));
 });
 
+test("should support the tabindex property", function() {
+  button.set('tabindex', 6);
+  append();
+
+  equal(button.$().prop('tabindex'), '6', 'the initial button tabindex is set in the DOM');
+
+  button.set('tabindex', 3);
+  equal(button.$().prop('tabindex'), '3', 'the button tabindex changes when it is changed in the view');  
+});
+
+
 test("should trigger an action when clicked", function() {
   var wasClicked = false;
 

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -53,6 +53,19 @@ test("should become disabled if the disabled attribute is changed", function() {
   ok(checkboxView.$().is(":not(:disabled)"));
 });
 
+test("should support the tabindex property", function() {
+  checkboxView = Ember.Checkbox.create({});
+
+  checkboxView.set('tabindex', 6);
+  append();
+
+  equal(checkboxView.$().prop('tabindex'), '6', 'the initial checkbox tabindex is set in the DOM');
+
+  checkboxView.set('tabindex', 3);
+  equal(checkboxView.$().prop('tabindex'), '3', 'the checkbox tabindex changes when it is changed in the view');  
+});
+
+
 test("checked property mirrors input value", function() {
   checkboxView = Ember.Checkbox.create({});
   Ember.run(function() { checkboxView.append(); });

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -56,6 +56,18 @@ test("can have options", function() {
   equal(select.$().text(), "123", "Options should have content");
 });
 
+
+test("select tabindex is updated when setting tabindex property of view", function() {
+  select.set('tabindex', '4');
+  append();
+
+  equal(select.$().attr('tabindex'), "4", "renders select with the tabindex");
+
+  select.set('tabindex', '1');
+
+  equal(select.$().attr('tabindex'), "1", "updates select after tabindex changes");
+});
+
 test("can specify the property path for an option's label and value", function() {
   select.set('content', Ember.A([
     { id: 1, firstName: 'Yehuda' },

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -114,6 +114,19 @@ test("input cols is updated when setting cols property of view", function() {
   equal(textArea.$().attr('cols'), "40", "updates text area after cols changes");
 });
 
+test("input tabindex is updated when setting tabindex property of view", function() {
+  Ember.run(function() {
+    set(textArea, 'tabindex', '4');
+    textArea.append();
+  });
+
+  equal(textArea.$().attr('tabindex'), "4", "renders text area with the tabindex");
+
+  Ember.run(function() { set(textArea, 'tabindex', '1'); });
+
+  equal(textArea.$().attr('tabindex'), "1", "updates text area after tabindex changes");
+});
+
 test("value binding works properly for inputs that haven't been created", function() {
 
   Ember.run(function() {

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -101,6 +101,19 @@ test("input size is updated when setting size property of view", function() {
   equal(textField.$().attr('size'), "40", "updates text field after size changes");
 });
 
+test("input tabindex is updated when setting tabindex property of view", function() {
+  Ember.run(function() {
+    set(textField, 'tabindex', '5');
+    textField.append();
+  });
+
+  equal(textField.$().attr('tabindex'), "5", "renders text field with the tabindex");
+
+  Ember.run(function() { set(textField, 'tabindex', '3'); });
+
+  equal(textField.$().attr('tabindex'), "3", "updates text field after tabindex changes");
+});
+
 test("input type is configurable when creating view", function() {
   Ember.run(function() {
     set(textField, 'type', 'password');


### PR DESCRIPTION
For power users, having a well defined tab order on controls is a
must. The 'tabindex' property of HTML adds support for this, however
there was no way to add the attribute when using Ember controls.

This patch adds tabindex support and tests for all the major HTML
controls in Ember.
