### PR TITLE
Support non-nested states with nested paths

### DIFF
--- a/packages/ember-routing/lib/routable.js
+++ b/packages/ember-routing/lib/routable.js
@@ -427,12 +427,21 @@ Ember.Routable = Ember.Mixin.create({
     // because the index ('/') state must be a leaf node.
     if (route !== '/') {
       // If the current path is a prefix of the path we're trying
-      // to go to, we're done.
+      // to go to, compute the next state to see if we're done.
       var index = path.indexOf(absolutePath),
           next = path.charAt(absolutePath.length);
 
       if (index === 0 && (next === "/" || next === "")) {
-        return;
+        // Compute the path to the next state beginning at the root state.
+        // If we are in the path, we're done.
+        var state = router.findStateByPath(router, 'root'),
+            remainingPath = path;
+        while (state && !get(state, 'isLeafRoute')) {
+          if (state === this) { return; }
+          var match = state.matchPath(remainingPath);
+          state = match.state;
+          remainingPath = match.remaining;
+        }
       }
     }
 

--- a/packages/ember-routing/lib/routable.js
+++ b/packages/ember-routing/lib/routable.js
@@ -33,6 +33,14 @@ var merge = function(original, hash) {
   }
 };
 
+var without = function(ary, value) {
+  var ret = [] ;
+  Ember.EnumerableUtils.forEach(ary, function(k) {
+    if (k !== value) ret[ret.length] = k;
+  }) ;
+  return ret ;
+};
+
 /**
   @class Routable
   @namespace Ember
@@ -338,34 +346,8 @@ Ember.Routable = Ember.Mixin.create({
   resolvePath: function(manager, path) {
     if (get(this, 'isLeafRoute')) { return Ember.A(); }
 
-    var childStates = get(this, 'childStates'), match;
-
-    childStates = Ember.A(childStates.filterProperty('isRoutable'));
-
-    childStates = childStates.sort(function(a, b) {
-      var aDynamicSegments = get(a, 'routeMatcher.identifiers.length'),
-          bDynamicSegments = get(b, 'routeMatcher.identifiers.length'),
-          aRoute = get(a, 'route'),
-          bRoute = get(b, 'route');
-
-      if (aRoute.indexOf(bRoute) === 0) {
-        return -1;
-      } else if (bRoute.indexOf(aRoute) === 0) {
-        return 1;
-      }
-
-      if (aDynamicSegments !== bDynamicSegments) {
-        return aDynamicSegments - bDynamicSegments;
-      }
-
-      return get(b, 'route.length') - get(a, 'route.length');
-    });
-
-    var state = childStates.find(function(state) {
-      var matcher = get(state, 'routeMatcher');
-      if (match = matcher.match(path)) { return true; }
-    });
-
+    var match = this.matchPath(path),
+        state = match.state;
     Ember.assert("Could not find state for path " + path, !!state);
 
     var resolvedState = Ember._ResolvedState.create({
@@ -509,6 +491,61 @@ Ember.Routable = Ember.Mixin.create({
     });
 
     controller.set('view', viewClass.create());
+  },
+
+  /**
+    @private
+
+    Find the state and RouteMatcher parameters for the state matching the
+    given path.
+  */
+  matchPath: function(path) {
+    var childStates = get(this, 'childStates'), match;
+
+    childStates = Ember.A(childStates.filterProperty('isRoutable'));
+    childStates = childStates.sort(function(a, b) {
+      var aRoute = get(a, 'route'),
+          bRoute = get(b, 'route'),
+          aSegments = without(aRoute.split('/'), ""),
+          bSegments = without(bRoute.split('/'), ""),
+          aSegment, bSegment;
+
+      while (aSegments.length > 0 && bSegments.length > 0) {
+        aSegment = aSegments.shift();
+        bSegment = bSegments.shift();
+
+        if (aSegment !== bSegment) {
+          // Prefer static segment over dynamic segment
+          if (aSegment.indexOf(':') === 0 && bSegment.indexOf(':') !== 0) {
+            return 1;
+          } else if (bSegment.indexOf(':') === 0 && aSegment.indexOf(':') !== 0) {
+            return -1;
+          }
+
+          // Prefer longer segment
+          if (aSegment.length !== bSegment.length) {
+            return bSegment.length - aSegment.length;
+          }
+
+          // Sort alphabetically to ensure deterministic search
+          return aSegment < bSegment ? -1 : 1;
+        }
+      }
+
+      // Prefer more segments
+      return bSegments.length - aSegments.length;
+    });
+
+    var state = childStates.find(function(state) {
+      var matcher = get(state, 'routeMatcher');
+      if (match = matcher.match(path)) { return true; }
+    });
+
+    return {
+      state: state,
+      remaining: match.remaining,
+      hash: match.hash
+    };
   },
 
   /**

--- a/packages/ember-routing/tests/router_test.js
+++ b/packages/ember-routing/tests/router_test.js
@@ -400,6 +400,39 @@ test("should be able to route with rootURL", function() {
   equal(get(router, 'currentState.path'), 'root.stateTwo', "should be in stateTwo");
 });
 
+test("should be able to route to non-nested states with nested paths", function() {
+  var router = Ember.Router.create({
+    location: location,
+    namespace: namespace,
+    root: Ember.Route.create({
+      products: Ember.Route.create({
+        route: '/products',
+        show: Ember.Route.create({
+          route: '/:product_id',
+          index: Ember.Route.create({
+            route: '/'
+          })
+        })
+      }),
+      users: Ember.Route.create({
+        route: '/users'
+      }),
+      services: Ember.Route.create({
+        route: '/products/:product_id/services',
+        show: Ember.Route.create({
+          route: '/:service_id',
+          index: Ember.Route.create({
+            route: '/'
+          })
+        })
+      })
+    })
+  });
+
+  router.route('/products/1/services/2');
+  equal(get(router, 'currentState.path'), 'root.services.show.index', "should go to the correct state");
+});
+
 test("should update route for redirections", function() {
   var router = Ember.Router.create({
     location: location,

--- a/packages/ember-routing/tests/router_test.js
+++ b/packages/ember-routing/tests/router_test.js
@@ -433,6 +433,42 @@ test("should be able to route to non-nested states with nested paths", function(
   equal(get(router, 'currentState.path'), 'root.services.show.index', "should go to the correct state");
 });
 
+test("should be able to unroute out of non-nested states with nested paths", function() {
+  var router = Ember.Router.create({
+    location: location,
+    namespace: namespace,
+    root: Ember.Route.create({
+      products: Ember.Route.create({
+        route: '/products',
+        show: Ember.Route.create({
+          route: '/:product_id',
+          index: Ember.Route.create({
+            route: '/'
+          })
+        })
+      }),
+      users: Ember.Route.create({
+        route: '/users'
+      }),
+      services: Ember.Route.create({
+        route: '/products/services',
+        show: Ember.Route.create({
+          route: '/:service_id',
+          index: Ember.Route.create({
+            route: '/'
+          })
+        })
+      })
+    })
+  });
+
+  router.route('/products/1');
+  equal(get(router, 'currentState.path'), 'root.products.show.index', "should go to the correct state");
+
+  router.route('/products/services/1');
+  equal(get(router, 'currentState.path'), 'root.services.show.index', "should go to the correct state");
+});
+
 test("should update route for redirections", function() {
   var router = Ember.Router.create({
     location: location,


### PR DESCRIPTION
This is my second attempt at improving support for non-nested states with nested paths. (see also emberjs/ember.js#1005).

Sometimes you want to add non-nested routes with nested paths. For example:

```
Ember.Router.create({
  root: Ember.Route.create({
    products: Ember.Route.create({
      route: '/products',
      show: Ember.Route.create({
        route: '/:product_id',
        index: Ember.Route.creaet({
          route: '/'
        })
      })
    }),
    services: Ember.Route.create({
      route: '/products/:product_id/services',
      show: Ember.Route.create({
        route: '/:service_id',
        index: Ember.Route.creaet({
          route: '/'
        })
      })
    })
  })
});
```

Currently, ember will not route to these states correctly using the back/forward buttons (`routePath` and `unroutePath`).

This fixes `routePath` by improving the sorting algorithm to sort by each segment in the URL (99e20d599b9).

It fixes `unroutePath` by computing the next state instead of relying on URL prefixes (b1556c6234f).

These fixes could both be improved by pre-caching routes, however this works for the time being.
