### PR TITLE
Remove data-tag-name "feature" from <script> tags

### DIFF
--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -36,7 +36,7 @@ Ember.Handlebars.bootstrap = function(ctx) {
       // id if no name is found.
       templateName = script.attr('data-template-name') || script.attr('id'),
       template = compile(script.html()),
-      view, viewPath, elementId, tagName, options;
+      view, viewPath, elementId, options;
 
     if (templateName) {
       // For templates which have a name, we save them and then remove them from the DOM
@@ -65,13 +65,8 @@ Ember.Handlebars.bootstrap = function(ctx) {
       // Look for data-element-id attribute.
       elementId = script.attr('data-element-id');
 
-      // Users can optionally specify a custom tag name to use by setting the
-      // data-tag-name attribute on the script tag.
-      tagName = script.attr('data-tag-name');
-
       options = { template: template };
       if (elementId) { options.elementId = elementId; }
-      if (tagName)   { options.tagName   = tagName; }
 
       view = view.create(options);
 

--- a/packages/ember-handlebars/tests/loader_test.js
+++ b/packages/ember-handlebars/tests/loader_test.js
@@ -51,20 +51,6 @@ test('inline template should be added', function() {
   equal(Ember.$('#qunit-fixture').text(), 'Tobias Fünke', 'template is rendered');
 });
 
-test('template with data-tag-name should add a template, wrapped in specific tag', function() {
-  Ember.$('#qunit-fixture').html('<script type="text/x-handlebars" data-tag-name="h1" >{{Tobias.firstName}} takes {{Tobias.drug}}</script>');
-
-  Ember.run(function() {
-    Ember.Handlebars.bootstrap(Ember.$('#qunit-fixture'));
-    Tobias = Ember.Object.create({
-      firstName: 'Tobias',
-      drug: 'teamocil'
-    });
-  });
-
-  equal(Ember.$('#qunit-fixture h1').text(), 'Tobias takes teamocil', 'template is rendered inside custom tag');
-});
-
 test('template with data-element-id should add an id attribute to the view', function() {
   Ember.$('#qunit-fixture').html('<script type="text/x-handlebars" data-element-id="application">Hello World !</script>');
 


### PR DESCRIPTION
This "feature" has been made available in #299. Now, 6 months later, to me this doesn't make much sense anymore since this gives the `<script>` tag too much power.

I also think that this possibility of defining the tag name within the script tag is not even known to many developers ...
