### PR TITLE
Add shared views handeling to containerView.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -606,8 +606,15 @@ Ember.View = Ember.Object.extend(Ember.Evented,
 
     @private
   */
-  _displayPropertyDidChange: Ember.observer(function() {
-    this.rerender();
+  _displayPropertyDidChange: Ember.observer(function(view, key) {
+    if (this._displayProperties[key] !== get(this, key)) {
+      this.rerender();
+    }
+    delete this._displayProperties[key];
+  }, 'context', 'controller'),
+
+  _displayPropertyWillChange: Ember.beforeObserver(function(view, key) {
+    this._displayProperties[key] = get(this, key);
   }, 'context', 'controller'),
 
   /**
@@ -1679,6 +1686,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
         set(viewController, 'view', this);
       }
     }
+
+    this._displayProperties = {};
   },
 
   appendChild: function(view, options) {

--- a/packages/ember-views/tests/system/controller_test.js
+++ b/packages/ember-views/tests/system/controller_test.js
@@ -167,3 +167,45 @@ test("if the controller is not given while connecting an outlet, the instantiate
   equal(view.get('controller'), postController, "the controller was inherited from the parent");
 });
 
+test("connectOutlet instantiates a shared view, controller, and connects them", function() {
+  var postController = Ember.Controller.create();
+
+  TestApp.PostView.reopen({isShared: true});
+
+  TestApp.CommentView = Ember.View.extend({isShared: true});
+
+  var appController = TestApp.ApplicationController.create({
+    controllers: { postController: postController, commentController: Ember.Controller.create() },
+    namespace: { PostView: TestApp.PostView, CommentView: TestApp.CommentView }
+  });
+  var outlets = appController._outlets;
+  var view = appController.connectOutlet('post');
+
+  ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(appController.get('view'), view, "the app controller's view is set");
+  equal(outlets.get('view').get(TestApp.PostView), view, "the shared view instance is set on the controller");
+
+  view = appController.connectOutlet('comment');
+  equal(appController.get('view'), view, "the app controller's view is set to the new view");
+  equal(outlets.get('view').get(TestApp.CommentView), view, "the new shared view instance is set on the controller");
+});
+
+test("connectOutlet takes an optional outlet name with shared view", function() {
+  var postController = Ember.Controller.create();
+
+  TestApp.PostView.reopen({isShared: true});
+
+  var appController = TestApp.ApplicationController.create({
+    controllers: { postController: postController },
+    namespace: { PostView: TestApp.PostView }
+  });
+  var outlets = appController._outlets;
+  var view = appController.connectOutlet({ name: 'post', outletName: 'mainView' });
+
+  ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(appController.get('mainView'), view, "the app controller's view is set");
+  equal(outlets.get('mainView').get(TestApp.PostView), view, "the shared view instance is set on the controller");
+});
+

--- a/packages/ember-views/tests/system/controller_test.js
+++ b/packages/ember-views/tests/system/controller_test.js
@@ -1,5 +1,7 @@
 /*globals TestApp*/
 
+var get = Ember.get, getPath = Ember.getPath, set = Ember.set;
+
 module("Ember.Controller#connectOutlet", {
   setup: function() {
     Ember.run(function () {
@@ -209,3 +211,20 @@ test("connectOutlet takes an optional outlet name with shared view", function() 
   equal(outlets.get('mainView').get(TestApp.PostView), view, "the shared view instance is set on the controller");
 });
 
+test("setting the same controller on a view should not trigger rerendering", function() {
+  var postView = TestApp.PostView.create();
+  var postController = TestApp.PostController.create();
+
+  set(postView, 'controller', postController);
+
+  Ember.run(function() {
+    postView.appendTo('#qunit-fixture');
+    equal(postView.state, 'preRender', 'view is in preRender state');
+  });
+
+  Ember.run(function() {
+    equal(postView.state, 'inDOM', 'view is in DOM state');
+    set(postView, 'controller', postController);
+    equal(postView.state, 'inDOM', 'view still in DOM state');
+  });
+});

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -303,3 +303,51 @@ test("if a ContainerView starts with a currentView and then a different currentV
   equal(getPath(container, 'childViews.length'), 1, "should have one child view");
   equal(getPath(container, 'childViews').objectAt(0), secondaryView, "should have the currentView as the only child view");
 });
+
+test("if a ContainerView starts with a shared currentView and then a different shared currentView is set, the old view is hiden and the new one is showed", function() {
+  var container = Ember.ContainerView.create();
+  var mainView = Ember.View.create({
+    isShared: true,
+    template: function() {
+      return "This is the main view.";
+    }
+  });
+
+  var secondaryView = Ember.View.create({
+    isShared: true,
+    template: function() {
+      return "This is the secondary view.";
+    }
+  });
+
+  Ember.run(function() {
+    set(container, 'currentView', mainView);
+  });
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  equal(container.$().text(), "This is the main view.", "should render its child");
+  equal(getPath(container, 'childViews.length'), 1, "should have one child view");
+  equal(getPath(container, 'childViews').objectAt(0), mainView, "should have the currentView as the only child view");
+
+  Ember.run(function() {
+    set(container, 'currentView', secondaryView);
+  });
+
+  equal(container.$('div:last-child').text(), "This is the secondary view.", "should render its child");
+  equal(getPath(container, 'childViews.length'), 2, "should have two child views");
+  equal(getPath(container, 'childViews').objectAt(0).get('isVisible'), false, "should hide the first child view");
+  equal(getPath(container, 'childViews').objectAt(1), secondaryView, "should have the currentView as the second child view");
+
+  Ember.run(function() {
+    set(container, 'currentView', mainView);
+  });
+
+  equal(container.$('div:first-child').text(), "This is the main view.", "should render its child");
+  equal(getPath(container, 'childViews').objectAt(1).get('isVisible'), false, "should hide the last child view");
+  equal(getPath(container, 'childViews.length'), 2, "should have two child views");
+  equal(getPath(container, 'childViews').objectAt(0).get('isVisible'), true, "should show the first child view");
+  equal(getPath(container, 'childViews').objectAt(0), mainView, "should have the currentView as the first child view");
+});


### PR DESCRIPTION
It helps in some cases where we need to not rerender child views on each
outlet connection.
We add two new methods to containerView :
`presentCurrentView` and `dismissCurrentView`

In cases where we need some special handeling like animations you can
override theus methods

Add willAppear / willDisappear and didAppear / didDisappear
