### PR TITLE
:clean task does not remove ember-tests.js

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,7 @@ desc "Clean build artifacts from previous builds"
 task :clean do
   puts "Cleaning build..."
   rm_rf "dist" # Make sure even things RakeP doesn't know about are cleaned
+  rm_f "tests/ember-tests.js"
   puts "Done"
 end
 


### PR DESCRIPTION
I noticed that the task :clean does not remove the file "ember-tests.js".
I think it appears since this commit : https://github.com/emberjs/ember.js/commit/b5a5c115a83db849eb1a6bb4f022e45767ed4ab5

PS: tell me if I should not send you this kind of pull request!
