### PR TITLE
Add date comparison to Ember.compare

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -214,6 +214,13 @@ Ember.compare = function compare(v, w) {
       }
       return 0;
 
+    case 'date':
+      var vNum = v.getTime();
+      var wNum = w.getTime();
+      if (vNum < wNum) { return -1; }
+      if (vNum > wNum) { return 1; }
+      return 0;
+
     default:
       return 0;
   }
@@ -329,7 +336,8 @@ Ember.ORDER_DEFINITION = Ember.ENV.ORDER_DEFINITION || [
   'object',
   'instance',
   'function',
-  'class'
+  'class',
+  'date'
 ];
 
 /**

--- a/packages/ember-runtime/tests/core/compare_test.js
+++ b/packages/ember-runtime/tests/core/compare_test.js
@@ -24,6 +24,8 @@ module("Ember.compare()", {
     v[11] = {a: 'hash'};
     v[12] = Ember.Object.create();
     v[13] = function (a) {return a;};
+    v[14] = new Date('2012/01/01');
+    v[15] = new Date('2012/06/06');
   }
 });
 


### PR DESCRIPTION
This commit adds date comparison to Ember.compare, I wasn't sure where to put it in the hierarchy, so it's at the bottom for now.

I was using Ember.Sortable for the first time and realised that dates weren't sortable.
Turns out they aren't part of Ember.ORDER_DEFINITION or Ember.compare.
I'm not sure if this was just missed or there is a specific reason??
