### PR TITLE
Use Ember.set when cloning keywords

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -775,8 +775,8 @@ Ember.View = Ember.Object.extend(Ember.Evented,
     var templateData = get(this, 'templateData');
 
     var keywords = templateData ? Ember.copy(templateData.keywords) : {};
-    keywords.view = get(this, 'concreteView');
-    keywords.controller = get(this, 'controller');
+    set(keywords, 'view', get(this, 'concreteView'));
+    set(keywords, 'controller', get(this, 'controller'));
 
     return keywords;
   },


### PR DESCRIPTION
For cases where keywords becomes watched and Object.defineProperty is unavailable. Resolves #1062.

I imagine a similar fix should be pulled into 0.9 stable, although given the shaky state of Router on that branch, I'll wait for comment.
