### PR TITLE
Fix `one` method on evented interface

### DIFF
--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -28,8 +28,11 @@ Ember.Evented = Ember.Mixin.create(
       target = null;
     }
 
+    var self = this;
     var wrapped = function() {
-      Ember.removeListener(this, name, target, wrapped);
+      Ember.removeListener(self, name, target, wrapped);
+
+      if ('string' === typeof method) { method = this[method]; }
 
       // Internally, a `null` target means that the target is
       // the first parameter to addListener. That means that

--- a/packages/ember-runtime/tests/system/object/events_test.js
+++ b/packages/ember-runtime/tests/system/object/events_test.js
@@ -89,3 +89,19 @@ test("binding an event can specify a different target", function() {
   equal(self, target);
 });
 
+test("a listener registered with one can take method as string and can be added with different target", function() {
+  var count = 0;
+  var target = {};
+  target.fn = function() { count++; };
+
+  var obj = Ember.Object.create(Ember.Evented);
+
+  obj.one('event!', target, 'fn');
+  obj.trigger('event!');
+
+  equal(count, 1, "the event was triggered");
+
+  obj.trigger('event!');
+
+  equal(count, 1, "the event was not triggered again");
+});


### PR DESCRIPTION
- it should be able to take method as string
- it should properly remove listener when using different target
