### PR TITLE
App.initialize() ensures App(Controller|View)

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -157,14 +157,14 @@ Ember.Application = Ember.Namespace.extend(
         rootElement = get(this, 'rootElement'),
         applicationController = get(router, 'applicationController');
 
-    if (this.ApplicationView && applicationController) {
-      var applicationView = this.ApplicationView.create({
-        controller: applicationController
-      });
-      this._createdApplicationView = applicationView;
+    Ember.assert("ApplicationView and ApplicationController must be defined on your application", (this.ApplicationView && applicationController) );
 
-      applicationView.appendTo(rootElement);
-    }
+    var applicationView = this.ApplicationView.create({
+      controller: applicationController
+    });
+    this._createdApplicationView = applicationView;
+
+    applicationView.appendTo(rootElement);
 
     router.route(location.getURL());
     location.onUpdateURL(function(url) {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -139,9 +139,17 @@ test('initialized application go to initial route', function() {
         })
       })
     });
+
+
+    app.ApplicationView = Ember.View.extend({
+      template: function() { return "Hello!"; }
+    });
+
+    app.ApplicationController = Ember.Controller.extend();
+
+    app.initialize(app.stateManager);
   });
 
-  app.initialize(app.stateManager);
   equal(app.getPath('router.currentState.path'), 'root.index', "The router moved the state into the right place");
 });
 
@@ -160,6 +168,12 @@ test("initialize application with stateManager via initialize call", function() 
         })
       })
     });
+
+    app.ApplicationView = Ember.View.extend({
+      template: function() { return "Hello!"; }
+    });
+
+    app.ApplicationController = Ember.Controller.extend();
 
     app.initialize(app.Router.create());
   });
@@ -184,6 +198,12 @@ test("initialize application with stateManager via initialize call from Router c
         })
       })
     });
+
+    app.ApplicationView = Ember.View.extend({
+      template: function() { return "Hello!"; }
+    });
+
+    app.ApplicationController = Ember.Controller.extend();
 
     app.initialize();
   });
@@ -262,6 +282,34 @@ test("ApplicationView is inserted into the page", function() {
   });
 
   equal(Ember.$("#qunit-fixture").text(), "Hello!");
+});
+
+test("ApplicationView and ApplicationController are assumed to exist in all Routers", function() {
+
+  Ember.run(function() {
+    app = Ember.Application.create({
+      rootElement: '#qunit-fixture'
+    });
+
+    app.OneView = Ember.View.extend({
+      template: function() { return "Hello!"; }
+    });
+    app.OneController = Ember.Controller.extend();
+
+    app.Router = Ember.Router.extend({
+      location: 'hash',
+
+      root: Ember.Route.extend({
+        index: Ember.Route.extend({
+          route: '/'
+        })
+      })
+    });
+
+
+    raises(function(){ app.initialize(); }, Error);
+  });
+
 });
 
 test("ControllerObject class can be initialized with target, controllers and view properties", function() {


### PR DESCRIPTION
Hi Emberjs, long-time user, first time code PR,
be gentle. :)

As the test case shows, it _was_ possible to define
a Router on an application such that, while it had
Em.Controller(s) and / or Em.View(s), it would not
render anything to the screen.

In-line code documentation included in d06f4a4a
seemed to imply that this should be possible to
do,  cf. "Changing View Hierarchy in Response To
State Change."  This is because the names
Application(Controller|View) are special.  Added
assertions enforce this convention and will
helpfully Blow Up and advise how to proceed.

Please comment on PR if changes need to be made.

Steven
