### PR TITLE
Adds "quickstring" method for connectOption

### DIFF
--- a/packages/ember-views/tests/system/controller_test.js
+++ b/packages/ember-views/tests/system/controller_test.js
@@ -28,6 +28,7 @@ test("connectOutlet instantiates a view, controller, and connects them", functio
     controllers: { postController: postController },
     namespace: { PostView: TestApp.PostView }
   });
+
   var view = appController.connectOutlet('post');
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
@@ -59,6 +60,24 @@ test("connectOutlet takes an optional controller context", function() {
   });
   var view = appController.connectOutlet('post', context);
 
+  ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(appController.get('view'), view, "the app controller's view is set");
+  equal(view.getPath('controller.content'), context, "the controller receives the context");
+});
+
+test("connectOutlet a simple string syntax", function() {
+  var postController = Ember.Controller.create(),
+      context = {};
+
+  var appController = TestApp.ApplicationController.create({
+    controllers: { postController: postController },
+    namespace: { PostView: TestApp.PostView }
+  });
+
+  var view = appController.connectOutlet('post:deathlessprose', context);
+
+  ok(appController.get('deathlessprose'), "Custom outlet 'deathlessprose' was set");
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
   equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
   equal(appController.get('view'), view, "the app controller's view is set");


### PR DESCRIPTION
This was discussed by @wagenet and @devinus this morning.

---

For greater ease of use one can now 

connectOutelet('hoot:owlet', { name: 'Woodsy' });

The first argument is split() into the value for 
'name' and the value for outletName'.  The second 
argument, the object, is assigned to 'context'.

Also includes:
- documentation update
- slight refactor, removal of in situ string
  munging
