### PR TITLE
HistoryLocation needs a way to setup the root path for apps that are not hosted at the actual root path

### DIFF
--- a/packages/ember-application/lib/system/history_location.js
+++ b/packages/ember-application/lib/system/history_location.js
@@ -11,6 +11,11 @@ Ember.HistoryLocation = Ember.Object.extend({
   },
 
   /**
+    Will be pre-pended to path upon state change
+   */
+  rootURL: '',
+
+  /**
     @private
 
     Used to give history a starting reference
@@ -35,7 +40,7 @@ Ember.HistoryLocation = Ember.Object.extend({
     var state = window.history.state,
         initialURL = get(this, '_initialURL');
 
-    if (path === "") { path = '/'; }
+    path = this.formatPath(path);
 
     if ((initialURL && initialURL !== path) || (state && state.path !== path)) {
       set(this, '_initialURL', null);
@@ -55,6 +60,21 @@ Ember.HistoryLocation = Ember.Object.extend({
     Ember.$(window).bind('popstate.ember-location-'+guid, function(e) {
       callback(location.pathname);
     });
+  },
+
+  /**
+    @private
+
+    returns the given path appended to rootURL
+   */
+  formatPath: function(path) {
+    var rootURL = get(this, 'rootURL');
+
+    if (rootURL.charAt(-1) === '/') {
+      rootURL = rootURL.substr(-1);
+    }
+
+    return rootURL + path;
   },
 
   /**

--- a/packages/ember-application/lib/system/history_location.js
+++ b/packages/ember-application/lib/system/history_location.js
@@ -13,7 +13,7 @@ Ember.HistoryLocation = Ember.Object.extend({
   /**
     Will be pre-pended to path upon state change
    */
-  rootURL: '',
+  rootURL: '/',
 
   /**
     @private
@@ -70,8 +70,8 @@ Ember.HistoryLocation = Ember.Object.extend({
   formatPath: function(path) {
     var rootURL = get(this, 'rootURL');
 
-    if (rootURL.charAt(-1) === '/') {
-      rootURL = rootURL.substr(-1);
+    if (path !== '') {
+      rootURL = rootURL.replace(/\/$/, '');
     }
 
     return rootURL + path;

--- a/packages/ember-application/tests/system/location_test.js
+++ b/packages/ember-application/tests/system/location_test.js
@@ -149,3 +149,16 @@ test("doesn't push a state if path has not changed", function() {
 
   locationObject.setURL(window.location.pathname);
 });
+
+test("it prepends rootURL to path", function() {
+  var setPath;
+
+  window.history.pushState = function(data, title, path) {
+    setPath = path;
+  };
+
+  locationObject.set('rootURL', '/test');
+  locationObject.setURL("/foo");
+
+  equal(setPath, '/test/foo');
+});

--- a/packages/ember-application/tests/system/location_test.js
+++ b/packages/ember-application/tests/system/location_test.js
@@ -150,6 +150,17 @@ test("doesn't push a state if path has not changed", function() {
   locationObject.setURL(window.location.pathname);
 });
 
+test("it handles an empty path as root", function() {
+  var setPath;
+
+  window.history.pushState = function(data, title, path) {
+    setPath = path;
+  };
+
+  locationObject.setURL('');
+  equal(setPath, '/', "The updated url is '/'");
+});
+
 test("it prepends rootURL to path", function() {
   var setPath;
 
@@ -160,5 +171,5 @@ test("it prepends rootURL to path", function() {
   locationObject.set('rootURL', '/test');
   locationObject.setURL("/foo");
 
-  equal(setPath, '/test/foo');
+  equal(setPath, '/test/foo', "The updated url is '/test/foot'");
 });

--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -383,10 +383,10 @@ Ember.Router = Ember.StateManager.extend(
     don't live at the root of the domain can append paths to their root.
 
     @type String
-    @default ''
+    @default '/'
   */
 
-  rootURL: '',
+  rootURL: '/',
 
   /**
     On router, transitionEvent should be called connectOutlets

--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -379,6 +379,16 @@ Ember.Router = Ember.StateManager.extend(
   location: 'hash',
 
   /**
+    This is only used when a history location is used so that applications that
+    don't live at the root of the domain can append paths to their root.
+
+    @type String
+    @default ''
+  */
+
+  rootURL: '',
+
+  /**
     On router, transitionEvent should be called connectOutlets
 
     @property {String}
@@ -462,9 +472,14 @@ Ember.Router = Ember.StateManager.extend(
   init: function() {
     this._super();
 
-    var location = get(this, 'location');
+    var location = get(this, 'location'),
+        rootURL = get(this, 'rootURL');
+
     if ('string' === typeof location) {
-      set(this, 'location', Ember.Location.create({ implementation: location }));
+      set(this, 'location', Ember.Location.create({
+        implementation: location,
+        rootURL: rootURL
+      }));
     }
   },
 


### PR DESCRIPTION
If an app is hosted somewhere other than the actual root path of the domain, HistoryLocation can potentially fail.  During setup, there should be a way to setup the root path the app will be hosted at so that each new state change always prepends the root path to the route.
