### PR TITLE
Resolved issue with cursor jumping in Ember.TextArea in IE/Opera

### DIFF
--- a/lib/ember.js
+++ b/lib/ember.js
@@ -18670,7 +18670,10 @@ Ember.TextArea = Ember.View.extend(Ember.TextSupport,
   },
 
   _updateElementValue: Ember.observer(function() {
-    this.$().val(get(this, 'value'));
+    var ele = this.$();
+    var pos = ele.prop('selectionStart');
+    ele.val(get(this,'value'));
+    ele.prop({ selectionStart: pos, selectionEnd: pos });
   }, 'value')
 
 });


### PR DESCRIPTION
In IE <= 9 and Opera, whenever the value of a textarea is changed, the current caret position is moved to the end of the textarea. This change saves the current position before updating the value and then moves the cursor back to that position after changing the value.
