### PR TITLE
Outlets reference context instead of controller.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -33,7 +33,11 @@ Ember.Handlebars.registerHelper('outlet', function(property, options) {
     property = 'view';
   }
 
-  options.hash.currentViewBinding = "controller." + property;
+  if(Ember.VIEW_PRESERVES_CONTEXT) {
+    options.hash.currentViewBinding = "view.context." + property;
+  } else {
+    options.hash.currentViewBinding = "controller." + property;
+  }
 
   return Ember.Handlebars.helpers.view.call(this, Ember.ContainerView, options);
 });

--- a/packages/ember-handlebars/tests/helpers/outlet_test.js
+++ b/packages/ember-handlebars/tests/helpers/outlet_test.js
@@ -58,6 +58,26 @@ test("outlet should allow controllers to fill in slots in prerender state", func
   equal(view.$().text(), 'HIBYE');
 });
 
+if(Ember.VIEW_PRESERVES_CONTEXT) {
+  test("outlet should allow a view's default context to fill in slots", function() {
+    var template = "<h1>HI</h1>{{outlet}}";
+    view = Ember.View.create({
+      template: Ember.Handlebars.compile(template)
+    });
+
+    appendView(view);
+
+    equal(view.$().text(), 'HI');
+
+    Ember.run(function() {
+      view.set('view', Ember.View.create({
+        template: compile("<p>BYE</p>")
+      }));
+    });
+
+    equal(view.$().text(), 'HIBYE');
+  });
+}
 
 test("outlet should support an optional name", function() {
   var controller = Ember.Object.create();


### PR DESCRIPTION
Previously, the `{{outlet}}` helper was hardcoded to reference the controller. This PR changes this to use the view's context (which will be the controller in most cases).

One use case for this is to allow view's which are using themselves as their context to still use the outlet helper. More generally, the outlet functionality is generic enough to not require a controller.
