### PR TITLE
urlForEvent and action now take multiple contexts

### DIFF
--- a/packages/ember-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-handlebars/tests/helpers/action_test.js
@@ -387,3 +387,23 @@ test("should allow a context to be specified", function() {
 
   equal(passedContext, model, "the action was called with the passed context");
 });
+
+test("should allow multiple contexts to be specified, separated by spaces", function() {
+  var passedContexts,
+      models = [Ember.Object.create(), Ember.Object.create()];
+
+  view = Ember.View.create({
+    modelA: models[0],
+    modelB: models[1],
+    template: Ember.Handlebars.compile('<button {{action "edit" context="modelA modelB"}}>edit</button>'),
+    edit: function(event) {
+      passedContexts = event.contexts;
+    }
+  });
+
+  appendView();
+
+  view.$('button').trigger('click');
+
+  deepEqual(passedContexts, models, "the action was called with the passed contexts");
+});

--- a/packages/ember-routing/tests/router_test.js
+++ b/packages/ember-routing/tests/router_test.js
@@ -114,6 +114,43 @@ test("router.urlForEvent works with a context", function() {
   equal(url, "#!#/dashboard/1");
 });
 
+test("router.urlForEvent works with multiple contexts", function() {
+  var router = Ember.Router.create({
+    location: location,
+    namespace: namespace,
+    root: Ember.Route.create({
+      index: Ember.Route.create({
+        route: '/',
+
+        showDashboard: function(router) {
+          router.transitionTo('dashboard');
+        },
+
+        eventTransitions: {
+          showComment: 'post.comment'
+        }
+      }),
+
+      post: Ember.Route.create({
+        route: '/post/:post_id',
+
+        comment: Ember.Route.create({
+          route: '/comment/:comment_id'
+        })
+      })
+    })
+  });
+
+  Ember.run(function() {
+    router.route('/');
+  });
+
+  equal(router.getPath('currentState.path'), "root.index", "precond - the router is in root.index");
+
+  var url = router.urlForEvent('showComment', { post_id: 1 }, { comment_id: 2 });
+  equal(url, "#!#/post/1/comment/2");
+});
+
 test("router.urlForEvent works with changing context in the current state", function() {
   var router = Ember.Router.create({
     location: location,


### PR DESCRIPTION
This should fix #1160.

`urlForEvent` not follows the same conventions as `transitionTo` by taking multiple contexts through the arguments array.

The `{{action}}` helper can now accept multiple contexts separated by spaces.
