### PR TITLE
Ember.SortableMixin: Add support of custom sortFunction

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -10,6 +10,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
   /** @scope Ember.Observable.prototype */ {
   sortProperties: null,
   sortAscending: true,
+  sortFunction: Ember.compare,
 
   addObject: function(obj) {
     var content = get(this, 'content');
@@ -24,13 +25,14 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
   orderBy: function(item1, item2) {
     var result = 0,
         sortProperties = get(this, 'sortProperties'),
-        sortAscending = get(this, 'sortAscending');
+        sortAscending = get(this, 'sortAscending'),
+        sortFunction = get(this, 'sortFunction');
 
     Ember.assert("you need to define `sortProperties`", !!sortProperties);
 
     forEach(sortProperties, function(propertyName) {
       if (result === 0) {
-        result = Ember.compare(get(item1, propertyName), get(item2, propertyName));
+        result = sortFunction(get(item1, propertyName), get(item2, propertyName));
         if ((result !== 0) && !sortAscending) {
           result = (-1) * result;
         }

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -168,3 +168,44 @@ test("you can set content later and it will be sorted", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
+
+module("Ember.Sortable with sortFunction and sortProperties", {
+  setup: function() {
+    Ember.run(function() {
+      sortedArrayController = Ember.ArrayController.create({
+        sortProperties: ['name'],
+        sortFunction: function(v, w){
+            var lowerV = v.toLowerCase(),
+                lowerW = w.toLowerCase();
+
+            if(lowerV < lowerW){
+              return -1;
+            }
+            if(lowerV > lowerW){
+              return 1;
+            }
+            return 0;
+        }
+      });
+      var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag bryn" }];
+      unsortedArray = Ember.A(Ember.A(array).copy());
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      sortedArrayController.destroy();
+    });
+  }
+});
+
+test("you can sort with custom sorting function", function() {
+  equal(sortedArrayController.get('length'), 0, 'array has 0 items');
+
+  Ember.run(function() {
+    sortedArrayController.set('content', unsortedArray);
+  });
+
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+  equal(sortedArrayController.objectAt(0).name, 'Scumbag bryn', 'array is sorted by custom sort');
+});


### PR DESCRIPTION
The default sorting algorithm used in the Routable mixin (based on Ember.compare) was not satisfying in our case.
For example we want 'a' to appear before 'B' (in ascending order)

I think this PR is not complete as we have to handle each type of sortProperties. 
