### PR TITLE
Allow Ember.View to set a default action for a target

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -228,6 +228,8 @@ EmberHandlebars.registerHelper('action', function(actionName) {
 
   if (hash.target) {
     target = getPath(this, hash.target, options);
+  } else if (view[actionName]) {
+    target = view;
   } else if (controller = options.data.keywords.controller) {
     target = get(controller, 'target');
   }

--- a/packages/ember-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-handlebars/tests/helpers/action_test.js
@@ -128,6 +128,31 @@ test("should allow a target to be specified", function() {
   ActionHelper.registerAction = originalRegisterAction;
 });
 
+test("should allow a method on a view to supercede the router as a default target for an action", function() {
+  var eventHandlerWasCalled = false;
+
+  view = Ember.View.create({
+    edit: function() { eventHandlerWasCalled = true; },
+    controller: Ember.Object.create({
+      target: Ember.Object.create({
+        isState: true,
+        edit: function() { eventHandlerWasCalled = false; }
+      })
+    }),
+    template: Ember.Handlebars.compile('<a id="ember-link" href="#" {{action "edit"}}>edit</a>')
+  });
+
+  appendView();
+
+  var actionId = view.$('a[data-ember-action]').attr('data-ember-action');
+
+  ok(Ember.Handlebars.ActionHelper.registeredActions[actionId], "The action was registered");
+
+  view.$('a').trigger('click');
+
+  ok(eventHandlerWasCalled, "The event handler was called");
+});
+
 test("should register an event handler", function() {
   var eventHandlerWasCalled = false;
 


### PR DESCRIPTION
- Modified ember-handlebars/lib/helpers/action (and tests) to include this behavior

Before Ember implemented the Router, the default target for an action was the View for a given template.  This is no longer the case if a View has been created via the Router.  Now, the Router is the default target.

What this means is that in order to target a View to handle an event, you need to specify `{{action actionName target="concreteView"}}`.  This seems a bit odd (as the responsibility of the View class is to handle events).

This change will allow the View to become the default target if it specifies a method that matches the name of it's target.  If the View does not specify a matching method name, it will perform the current behavior (and send it to the controller.target).
