### PR TITLE
Ember.SortableMixin: Add support of custom sortFunction

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -79,12 +79,12 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
 
     forEach(sortProperties, function(propertyName) {
       if (result === 0) {
-        result = orderBy(get(item1, propertyName), get(item2, propertyName));
+        result = this.orderBy(get(item1, propertyName), get(item2, propertyName));
         if ((result !== 0) && !sortAscending) {
           result = (-1) * result;
         }
       }
-    });
+    }, this);
 
     return result;
   },

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -29,7 +29,7 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
   By default the sort algorithm uses Ember#compare in order to compare the elements.
   It is possible to modify this behavior by overriding the `orderBy` function.
-  This function as Ember#compare takes two parameters and must return an integer:
+  This function, like Ember#compare, takes two parameters and must return an integer:
     - -1 if the first parameter is smaller than the second,
     - 0 if both are equal,
     - 1 if the first parameter is greater than the second.

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -29,10 +29,10 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
   By default the sort algorithm uses Ember#compare in order to compare the elements.
   It is possible to modify this behavior by overriding the `orderBy` function.
-  This function as Ember#compare must return an integer:
-    - `-1` if `v < w`
-    - `0` if `v == w`
-    - `1` if `v > w`
+  This function as Ember#compare takes two parameters and must return an integer:
+    - -1 if the first parameter is smaller than the second,
+    - 0 if both are equal,
+    - 1 if the first parameter is greater than the second.
 
       songsController = Ember.ArrayController.create({
         content: [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag bryn" }],

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -29,6 +29,10 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
   By default the sort algorithm uses Ember#compare in order to compare the elements.
   It is possible to modify this behavior by overriding the `orderBy` function.
+  This function as Ember#compare must return an integer:
+    - `-1` if `v < w`
+    - `0` if `v == w`
+    - `1` if `v > w`
 
       songsController = Ember.ArrayController.create({
         content: [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag bryn" }],

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -36,6 +36,7 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
   sortProperties: null,
   sortAscending: true,
+  sortFunction: Ember.compare,
 
   addObject: function(obj) {
     var content = get(this, 'content');
@@ -50,13 +51,14 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
   orderBy: function(item1, item2) {
     var result = 0,
         sortProperties = get(this, 'sortProperties'),
-        sortAscending = get(this, 'sortAscending');
+        sortAscending = get(this, 'sortAscending'),
+        sortFunction = get(this, 'sortFunction');
 
     Ember.assert("you need to define `sortProperties`", !!sortProperties);
 
     forEach(sortProperties, function(propertyName) {
       if (result === 0) {
-        result = Ember.compare(get(item1, propertyName), get(item2, propertyName));
+        result = sortFunction(get(item1, propertyName), get(item2, propertyName));
         if ((result !== 0) && !sortAscending) {
           result = (-1) * result;
         }

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -72,8 +72,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
   _orderBy: function(item1, item2) {
     var result = 0,
         sortProperties = get(this, 'sortProperties'),
-        sortAscending = get(this, 'sortAscending'),
-        orderBy = get(this, 'orderBy');
+        sortAscending = get(this, 'sortAscending');
 
     Ember.assert("you need to define `sortProperties`", !!sortProperties);
 

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -212,8 +212,8 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
         oldIndex = arrangedContent.indexOf(item),
         leftItem = arrangedContent.objectAt(oldIndex - 1),
         rightItem = arrangedContent.objectAt(oldIndex + 1),
-        leftResult = leftItem && this.orderBy(item, leftItem),
-        rightResult = rightItem && this.orderBy(item, rightItem);
+        leftResult = leftItem && this._orderBy(item, leftItem),
+        rightResult = rightItem && this._orderBy(item, rightItem);
 
     if (leftResult < 0 || rightResult > 0) {
       arrangedContent.removeObject(item);

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -197,12 +197,12 @@ test("you can set content later and it will be sorted", function() {
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
 
-module("Ember.Sortable with sortFunction and sortProperties", {
+module("Ember.Sortable with custom orderBy function and sortProperties", {
   setup: function() {
     Ember.run(function() {
       sortedArrayController = Ember.ArrayController.create({
         sortProperties: ['name'],
-        sortFunction: function(v, w){
+        orderBy: function(v, w){
             var lowerV = v.toLowerCase(),
                 lowerW = w.toLowerCase();
 

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -196,3 +196,44 @@ test("you can set content later and it will be sorted", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
+
+module("Ember.Sortable with sortFunction and sortProperties", {
+  setup: function() {
+    Ember.run(function() {
+      sortedArrayController = Ember.ArrayController.create({
+        sortProperties: ['name'],
+        sortFunction: function(v, w){
+            var lowerV = v.toLowerCase(),
+                lowerW = w.toLowerCase();
+
+            if(lowerV < lowerW){
+              return -1;
+            }
+            if(lowerV > lowerW){
+              return 1;
+            }
+            return 0;
+        }
+      });
+      var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag bryn" }];
+      unsortedArray = Ember.A(Ember.A(array).copy());
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      sortedArrayController.destroy();
+    });
+  }
+});
+
+test("you can sort with custom sorting function", function() {
+  equal(sortedArrayController.get('length'), 0, 'array has 0 items');
+
+  Ember.run(function() {
+    sortedArrayController.set('content', unsortedArray);
+  });
+
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+  equal(sortedArrayController.objectAt(0).name, 'Scumbag bryn', 'array is sorted by custom sort');
+});


### PR DESCRIPTION
The default sorting algorithm used in the Routable mixin (based on Ember.compare) was not satisfying in our case.
For example we want 'a' to appear before 'B' (in ascending order)

(new clean PR, I closed #1194
