### PR TITLE
Add autoStartRouting property to Ember.Application

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -58,6 +58,16 @@ Ember.Application = Ember.Namespace.extend(
   */
   customEvents: null,
 
+  /**
+    Determines whether URL routing should be started automatically (if
+    this Ember.Application has a router instance). Defaults to true, if set to
+    false you must manually call App.startRouting() to enable URL routing.
+
+    @type Boolean
+    @default true
+  */
+  autoStartRouting: true,
+
   /** @private */
   init: function() {
     var eventDispatcher,
@@ -132,7 +142,23 @@ Ember.Application = Ember.Namespace.extend(
     });
 
     if (router && router instanceof Ember.Router) {
-      this.startRouting(router);
+      var location = get(router, 'location'),
+          autoStartRouting = get(this, 'autoStartRouting'),
+          rootElement = get(this, 'rootElement'),
+          applicationController = get(router, 'applicationController');
+
+      Ember.assert("ApplicationView and ApplicationController must be defined on your application", (this.ApplicationView && applicationController) );
+
+      var applicationView = this.ApplicationView.create({
+        controller: applicationController
+      });
+      this._createdApplicationView = applicationView;
+
+      applicationView.appendTo(rootElement);
+
+      if (autoStartRouting) {
+        this.startRouting(router);
+      }
     }
   },
 
@@ -153,18 +179,7 @@ Ember.Application = Ember.Namespace.extend(
     trigger a new call to `route` whenever the URL changes.
   */
   startRouting: function(router) {
-    var location = get(router, 'location'),
-        rootElement = get(this, 'rootElement'),
-        applicationController = get(router, 'applicationController');
-
-    Ember.assert("ApplicationView and ApplicationController must be defined on your application", (this.ApplicationView && applicationController) );
-
-    var applicationView = this.ApplicationView.create({
-      controller: applicationController
-    });
-    this._createdApplicationView = applicationView;
-
-    applicationView.appendTo(rootElement);
+    var location = get(router, 'location');
 
     router.route(location.getURL());
     location.onUpdateURL(function(url) {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -212,6 +212,44 @@ test("initialize application with stateManager via initialize call from Router c
   equal(app.get('router.currentState.path'), 'root.index', "The router moved the state into the right place");
 });
 
+test("initialize application with a router but start url routing manually", function() {
+  Ember.run(function() {
+    app = Ember.Application.create({
+      rootElement: '#qunit-fixture',
+      autoStartRouting: false
+    });
+
+    app.Router = Ember.Router.extend({
+      location: 'none',
+
+      root: Ember.Route.extend({
+        initialState: 'loading',
+
+        index: Ember.Route.extend({
+          route: '/'
+        }),
+
+        loading: Ember.State.extend()
+      })
+    });
+
+    app.ApplicationView = Ember.View.extend({
+      template: function() { return "Hello!"; }
+    });
+
+    app.ApplicationController = Ember.Controller.extend();
+
+    app.initialize();
+  });
+
+  equal(app.get('router.currentState.path'), 'root.loading', "The router moved to its initial state");
+
+  app.startRouting(app.router);
+
+  equal(app.get('router.currentState.path'), 'root.index', "Router moved to the correct state after url routing was started manually");
+
+});
+
 test("injections can be registered in a specified order", function() {
 
   var oldInjections = Ember.Application.injections;


### PR DESCRIPTION
If router exists, flags whether startRouting is called automatically on App.initialize(). Defaults to true.

This is particularly useful for cases where you want the app to initialize but not start url routing immediately (such as determining whether a user has a valid session).
