### PR TITLE
Rakefile :clean remove 'tmp' folder

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,6 +83,7 @@ task :clean do
   puts "Cleaning build..."
   rm_rf "dist" # Make sure even things RakeP doesn't know about are cleaned
   rm_f "tests/ember-tests.js"
+  rm_rf "tmp"
   puts "Done"
 end
 


### PR DESCRIPTION
As @raycohen said, some stashed tests were getting run by `rake test[all]` when the 'tmp' folder is not deleted :
https://github.com/emberjs/ember.js/pull/1117
