### PR TITLE
Simplified Ember.RadioButtonGroup implementation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*Ember 1.0.0-pre.3
+
+* RadioButton and RadioButtonGroup
+
 *Ember 1.0.0-pre.2 (October 25, 2012)*
 
 * Ember.SortableMixin: don't remove and reinsert items when their sort order doesn't change.  Fixes #1486.

--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -1,6 +1,7 @@
 require("ember-handlebars/controls/checkbox");
 require("ember-handlebars/controls/text_field");
 require("ember-handlebars/controls/button");
+require("ember-handlebars/controls/radio_button");
 require("ember-handlebars/controls/text_area");
 require("ember-handlebars/controls/tabs");
 require("ember-handlebars/controls/select");

--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -1,3 +1,4 @@
+require("ember-handlebars/controls/control");
 require("ember-handlebars/controls/checkbox");
 require("ember-handlebars/controls/text_field");
 require("ember-handlebars/controls/button");

--- a/packages/ember-handlebars/lib/controls/control.js
+++ b/packages/ember-handlebars/lib/controls/control.js
@@ -1,0 +1,24 @@
+require("ember-views/views/view");
+
+var get = Ember.get, getPath = Ember.getPath, set = Ember.set;
+
+
+/**
+  @class
+
+  A control is an Ember.View subclass which behaves slightly differently.
+
+  Specifically, a control uses itself as its context and is generally controller-less.
+
+  @extends Ember.View
+*/
+Ember.Control = Ember.View.extend({
+
+  init: function() {
+    this._super();
+    
+    // Once #1234 is merged in this can be moved out of init
+    set(this, '_context', this);
+  }
+
+});

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -52,11 +52,10 @@ Ember.RadioButton = Ember.Control.extend(
 
   selectedValueChanged: Ember.observer(function() {
     var selectedValue = get(this, "selectedValue");
-    if(Ember.empty(selectedValue)) {
-      set(this, "isChecked", false);
-    }
-    else if(get(this, "value") === selectedValue) {
+    if(!Ember.empty(selectedValue) && get(this, "value") === selectedValue) {
       set(this, "isChecked", true);
+    } else {
+      set(this, "isChecked", false);
     }
   }, 'selectedValue'),
 

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -14,7 +14,7 @@ var get = Ember.get, getPath = Ember.getPath, set = Ember.set, fmt = Ember.Strin
 Ember.RadioButton = Ember.Control.extend(
 /** @scope Ember.RadioButton.prototype */ {
 
-  attributeBindings: ["isDisabled:disabled", "type", "name", "value", "isChecked:checked"],
+  attributeBindings: ["disabled", "type", "name", "value", "checked"],
   classNames: ["ember-radio-button"],
 
   /**
@@ -45,7 +45,7 @@ Ember.RadioButton = Ember.Control.extend(
     @default false
     @type Boolean
   */
-  isChecked: false,
+  checked: false,
 
   tagName: "input",
   type: "radio",
@@ -53,15 +53,15 @@ Ember.RadioButton = Ember.Control.extend(
   selectedValueChanged: Ember.observer(function() {
     var selectedValue = get(this, "selectedValue");
     if(!Ember.empty(selectedValue) && get(this, "value") === selectedValue) {
-      set(this, "isChecked", true);
+      set(this, "checked", true);
     } else {
-      set(this, "isChecked", false);
+      set(this, "checked", false);
     }
   }, 'selectedValue'),
 
-  isCheckedChanged: Ember.observer(function() {
+  checkedChanged: Ember.observer(function() {
     this._updateElementValue();
-  }, 'isChecked'),
+  }, 'checked'),
 
   init: function() {
     this._super();
@@ -69,12 +69,12 @@ Ember.RadioButton = Ember.Control.extend(
   },
 
   change: function() {
-    set(this, 'isChecked', this.$().prop('checked'));
+    set(this, 'checked', this.$().prop('checked'));
     Ember.run.once(this, this._updateElementValue);
   },
 
   _updateElementValue: function() {
-    if(!get(this, 'isChecked')) return;
+    if(!get(this, 'checked')) return;
     set(this, 'selectedValue', get(this, 'value'));
   }
 

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -87,84 +87,91 @@ Ember.RadioButton = Ember.Control.extend(
 
   You can create radio buttons like this:
 
-      #handlebars
-      {{#view Ember.RadioButtonGroup name="someName"}}
-        <label>
-          {{view RadioButton value="option1"}}
-          Option 1
-        </label>
-        <label>
-          {{view RadioButton value="option2"}}
-        </label>
-      {{/view}}
+  ```handlebars
+  {{#view Ember.RadioButtonGroup name="someName"}}
+    <label>
+      {{view RadioButton value="option1"}}
+      Option 1
+    </label>
+    <label>
+      {{view RadioButton value="option2"}}
+    </label>
+  {{/view}}
+  ```
 
   ## Getting/Setting the selected radio button
 
-      #js
-      // get a reference to the selected radio button
-      group.get("selection");
+  ```javascript
+  // get a reference to the selected radio button
+  group.get("selection");
 
-      // select a different radio button
-      group.set("selection", someRadioButton);
-      // or set a button as selected
-      someRadioButton.set("isSelected", true);
+  // select a different radio button
+  group.set("selection", someRadioButton);
 
-      // clear the selection
-      group.set("selection", null);
-      // or deselect the selected button
-      selectedButton.set("isSelected", false);
+  // or set a button as selected
+  someRadioButton.set("isSelected", true);
+
+  // clear the selection
+  group.set("selection", null);
+
+  // or deselect the selected button
+  selectedButton.set("isSelected", false);
+  ```
 
   ## Getting/Setting the selected value
 
-      #js
-      // get the `value` property of the selected radio button
-      // or `null` if no buttons are selected
-      group.get("value");
+  ```javascipt
+  // get the `value` property of the selected radio button
+  // or `null` if no buttons are selected
+  group.get("value");
 
-      // select a different radio button by value
-      group.set("value", someValue);
+  // Select a different radio button by value.
+  // This also selects the proper radio button in the UI
+  group.set("value", someValue);
+  ```
 
   ## Real world example
 
-      #js
-      window.App = Ember.Application.create();
+  ```javascript
+  window.App = Ember.Application.create();
 
-      App.question = Ember.Object.create({
-        content: "Which of the following is the largest?",
-        possibleAnswers: [
-          Ember.Object.create({ label: "A peanut"      value: "peanut"      }),
-          Ember.Object.create({ label: "An elephant"   value: "elephant"    }),
-          Ember.Object.create({ label: "The moon"      value: "moon"        }),
-          Ember.Object.create({ label: "A tennis ball" value: "tennis ball" })
-        ],
-        selectedAnswer: null
-      });
+  App.question = Ember.Object.create({
+    content: "Which of the following is the largest?",
+    possibleAnswers: [
+      Ember.Object.create({ label: "A peanut"      value: "peanut"      }),
+      Ember.Object.create({ label: "An elephant"   value: "elephant"    }),
+      Ember.Object.create({ label: "The moon"      value: "moon"        }),
+      Ember.Object.create({ label: "A tennis ball" value: "tennis ball" })
+    ],
+    selectedAnswer: null
+  });
 
-      App.questionView = Ember.View.create({
-        templateName: "question",
-        questionBinding: "App.question",
-        group: Ember.RadioButtonGroup.create({
-          // create a two-way binding so changes in the
-          // view propogate to the `selectedAnswer` property
-          // on the question object.
-          value: "App.question.selectedAnswer"
-        })
-      });
+  App.questionView = Ember.View.create({
+    templateName: "question",
+    questionBinding: "App.question",
+    group: Ember.RadioButtonGroup.create({
+      // create a two-way binding so changes in the
+      // view propogate to the `selectedAnswer` property
+      // on the question object.
+      value: "App.question.selectedAnswer"
+    })
+  });
 
-      App.questionView.append();
+  App.questionView.append();
+  ```
 
   The question template could look like this:
 
-      <script type="text/x-handlebars" data-template-name="question">
-        <h2>{{question.content}}</h2>
-        {{#view Ember.RadioButtonGroup name="answer" value="App.question.selectedAnswer"}}
-        {{#each question.possibleAnswers}}
-          <label>
-            {{view RadioButton valueBinding="value"}}
-            {{label}}
-          </label>
-        {{/each}}
-      </script>
+  ```handlebars
+  <h2>{{question.content}}</h2>
+  {{#view Ember.RadioButtonGroup name="answer" value="App.question.selectedAnswer"}}
+  {{#each question.possibleAnswers}}
+    <label>
+      {{view RadioButton valueBinding="value"}}
+      {{label}}
+    </label>
+  {{/each}}
+  ```
 
   @extends Ember.View
 */

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -70,6 +70,7 @@ Ember.RadioButton = Ember.Control.extend(
   },
 
   change: function() {
+    set(this, 'isChecked', this.$().prop('checked'));
     Ember.run.once(this, this._updateElementValue);
   },
 

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -51,7 +51,11 @@ Ember.RadioButton = Ember.Control.extend(
   type: "radio",
 
   selectedValueChanged: Ember.observer(function() {
-    if(get(this, "value") === get(this, 'selectedValue')) {
+    var selectedValue = get(this, "selectedValue");
+    if(Ember.empty(selectedValue)) {
+      set(this, "isChecked", false);
+    }
+    else if(get(this, "value") === selectedValue) {
       set(this, "isChecked", true);
     }
   }, 'selectedValue'),
@@ -70,6 +74,7 @@ Ember.RadioButton = Ember.Control.extend(
   },
 
   _updateElementValue: function() {
+    if(!get(this, 'isChecked')) return;
     set(this, 'selectedValue', get(this, 'value'));
   }
 

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -14,7 +14,7 @@ var get = Ember.get, getPath = Ember.getPath, set = Ember.set, fmt = Ember.Strin
 Ember.RadioButton = Ember.View.extend(
 /** @scope Ember.RadioButton.prototype */ {
 
-  attributeBindings: ["isDisabled:disabled", "type"],
+  attributeBindings: ["isDisabled:disabled", "type", "name", "value"],
   classNames: ["ember-radio-button"],
 
   /**
@@ -35,6 +35,9 @@ Ember.RadioButton = Ember.View.extend(
 
   tagName: "input",
   type: "radio",
+  name: Ember.computed(function() {
+    return getPath(this, 'group.name');
+  }).property('group'),
 
   /** @private */
   init: function() {
@@ -207,7 +210,7 @@ Ember.RadioButton = Ember.View.extend(
 
   @extends Ember.Object
 */
-Ember.RadioButtonGroup = Ember.Object.extend(
+Ember.RadioButtonGroup = Ember.View.extend(
 /** @scope Ember.RadioButtonGroup.prototype */ {
 
   /**
@@ -217,9 +220,21 @@ Ember.RadioButtonGroup = Ember.Object.extend(
     @field
     @type Number
   */
+
+  classNames: ['ember-radio-button-group'],
+  attributeBindings: ['name:data-name'],
+
   numRadioButtons: Ember.computed(function() {
     return getPath(this, "_radioButtons.length");
   }).property("_radioButtons.length").cacheable(),
+
+  name: Ember.required(),
+
+  RadioButton: Ember.computed(function() {
+    return Ember.RadioButton.extend({
+      group: this
+    })
+  }),
 
   /**
     Contains a reference to the `value` property of the currently
@@ -240,7 +255,7 @@ Ember.RadioButtonGroup = Ember.Object.extend(
     // setter
     } else {
       if (!Ember.none(value)) {
-        var buttonForValue = get(this, "_radioButtons").findProperty("value", value);
+        var buttonForValue = this.buttonForValue(value);
 
         ember_assert(fmt("%@ - selectedValue can only be set to the value of a radio button in the group. You passed %@", [this, value]), !!buttonForValue);
 
@@ -250,6 +265,10 @@ Ember.RadioButtonGroup = Ember.Object.extend(
       }
     }
   }).property("selection").cacheable(),
+
+  buttonForValue: function(value) {
+    return get(this, "_radioButtons").findProperty("value", value);
+  },
 
   _selection: null,
 

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -1,0 +1,371 @@
+require("ember-views/views/view");
+
+var get = Ember.get, getPath = Ember.getPath, set = Ember.set, fmt = Ember.String.fmt;
+
+/**
+  @class
+
+  A radio button view that enables `Ember.RadioButtonGroup` membership and binding.
+
+  See the {@link Ember.RadioButtonGroup} documentation for more information.
+
+  @extends Ember.View
+*/
+Ember.RadioButton = Ember.View.extend(
+/** @scope Ember.RadioButton.prototype */ {
+
+  attributeBindings: ["isDisabled:disabled", "type"],
+  classNames: ["ember-radio-button"],
+
+  /**
+    Sets the disabled property on the element.
+
+    @default false
+    @type Boolean
+  */
+  isDisabled: false,
+
+  /**
+    Sets the checked property on the element.
+
+    @default false
+    @type Boolean
+  */
+  isSelected: false,
+
+  tagName: "input",
+  type: "radio",
+
+  /** @private */
+  init: function() {
+    this._super();
+    this._groupDidChange();
+  },
+
+  /**
+    The group this radio button is associated with.
+
+    @default null
+    @type Ember.RadioButtonGroup
+  */
+  group: null,
+
+  /**
+    Before the group changes, notify the current group to remove us.
+
+    @private
+  */
+  _groupWillChange: Ember.beforeObserver(function() {
+    var group = get(this, "group");
+
+    if(group) group._removeRadioButton(this);
+  }, "group"),
+
+  /**
+    After the group changes, notify the new group to add us.
+
+    @private
+  */
+  _groupDidChange: Ember.observer(function() {
+    var group = get(this, "group");
+
+    if(group) {
+      ember_assert("group must be an instance of Ember.RadioButtonGroup", Ember.RadioButtonGroup.detectInstance(group));
+
+      group._addRadioButton(this);
+    }
+  }, "group"),
+
+  /**
+    Watch for changes in the `checked` property of the
+    element and update the `isSelected` property accordingly.
+
+    @private
+  */
+  change: function() {
+    Ember.run.once(this, this._elementCheckedDidChange);
+  },
+
+  /** @private */
+  didInsertElement: function() {
+    this._isSelectedDidChange();
+  },
+
+  /** @private */
+  _elementCheckedDidChange: function() {
+    set(this, "isSelected", this.$().is(":checked"));
+  },
+
+  /**
+    Watch for changes in the `isSelected` property,
+    and update the `checked` property on the element.
+
+    @private
+  */
+  _isSelectedDidChange: Ember.observer(function() {
+    this.$().prop("checked", get(this, "isSelected"));
+  }, "isSelected")
+});
+
+/**
+  @class A controller for a group of radio buttons.
+
+  ## Creating a RadioButtonGroup
+
+  You can create an instance of `Ember.RadioButtonGroup` like this:
+
+      #js
+      var App = Ember.Application.create();
+      App.group = Ember.RadioButtonGroup.create();
+
+  The group will not have any radio buttons associated with it by default.
+
+  ## Adding/Removing radio buttons
+
+  Adding radio buttons to a group is simple, just set the `group` property
+  of an `Ember.RadioButton` instance to the group.
+
+      <script type="text/x-handlebars">
+        {{view Ember.RadioButton groupBinding="App.group" value="1" isSelected="true"}}
+        {{view Ember.RadioButton groupBinding="App.group" value="2"}}
+        {{view Ember.RadioButton groupBinding="App.group" value="3"}}
+      </script>
+
+  To remove a radio button from a group, set the `group` property to `null`
+  or another instance of `Ember.RadioButtonGroup`.
+
+      #js
+      // removes the button from the group
+      rb.set("group", null);
+
+  ## Getting/Setting the selected radio button
+
+      #js
+      // get a reference to the selected radio button
+      group.get("selection");
+
+      // select a different radio button
+      group.set("selection", someRadioButton);
+      // or set a button as selected
+      someRadioButton.set("isSelected", true);
+
+      // clear the selection
+      group.set("selection", null);
+      // or deselect the selected button
+      selectedButton.set("isSelected", false);
+
+  ## Getting/Setting the selected value
+
+      #js
+      // get the `value` property of the selected radio button
+      // or `null` if no buttons are selected
+      group.get("selectedValue");
+
+      // select a different radio button by value
+      group.set("selectedValue", someValue);
+
+  ## Real world example
+
+      #js
+      window.App = Ember.Application.create();
+
+      App.question = Ember.Object.create({
+        content: "Which of the following is the largest?",
+        possibleAnswers: [
+          Ember.Object.create({ label: "A peanut"      value: "peanut"      }),
+          Ember.Object.create({ label: "An elephant"   value: "elephant"    }),
+          Ember.Object.create({ label: "The moon"      value: "moon"        }),
+          Ember.Object.create({ label: "A tennis ball" value: "tennis ball" })
+        ],
+        selectedAnswer: null
+      });
+
+      App.questionView = Ember.View.create({
+        templateName: "question",
+        questionBinding: "App.question",
+        group: Ember.RadioButtonGroup.create({
+          // create a two-way binding so changes in the
+          // view propogate to the `selectedAnswer` property
+          // on the question object.
+          selectedValueBinding: "App.question.selectedAnswer"
+        })
+      });
+
+      App.questionView.append();
+
+  The question template could look like this:
+
+      <script type="text/x-handlebars" data-template-name="question">
+        <h2>{{question.content}}</h2>
+        {{#each question.possibleAnswers}}
+          <label>
+            {{view Ember.RadioButton groupBinding="group" valueBinding="value"}}
+            {{label}}
+          </label>
+        {{/each}}
+      </script>
+
+  @extends Ember.Object
+*/
+Ember.RadioButtonGroup = Ember.Object.extend(
+/** @scope Ember.RadioButtonGroup.prototype */ {
+
+  /**
+    The number of radio buttons that belong to this group.
+
+    @default 0
+    @field
+    @type Number
+  */
+  numRadioButtons: Ember.computed(function() {
+    return getPath(this, "_radioButtons.length");
+  }).property("_radioButtons.length").cacheable(),
+
+  /**
+    Contains a reference to the `value` property of the currently
+    selected RadioButton control in the group.
+
+    Setting `selectedValue` to the value of a radio button in the
+    group will change the `selection` to that button.
+
+    @field
+    @default null
+  */
+  selectedValue: Ember.computed(function(key, value) {
+    // getter
+    if (arguments.length === 1) {
+      var currentSelection = get(this, "selection");
+
+      return currentSelection ? currentSelection.get("value") : null;
+    // setter
+    } else {
+      if (!Ember.none(value)) {
+        var buttonForValue = get(this, "_radioButtons").findProperty("value", value);
+
+        ember_assert(fmt("%@ - selectedValue can only be set to the value of a radio button in the group. You passed %@", [this, value]), !!buttonForValue);
+
+        set(this, "selection", buttonForValue);
+
+        return value;
+      }
+    }
+  }).property("selection").cacheable(),
+
+  _selection: null,
+
+  /**
+    Contains a reference to the currently selected RadioButton control in the group.
+
+    @field
+    @default null
+    @type Ember.RadioButton
+  */
+  selection: Ember.computed(function(key, value) {
+    // getter
+    if(arguments.length === 1) {
+      return get(this, "_selection");
+
+    // setter
+    } else {
+      var radioButtons = get(this, "_radioButtons");
+
+      ember_assert(
+        fmt("%@ - selection accepts null or an Ember.RadioButton. You passed %@", [this, value]),
+        function() {
+          var isRadioButton   = Ember.RadioButton.detectInstance(value),
+              isValidArgument = Ember.none(value) || isRadioButton;
+
+          return isValidArgument;
+        });
+
+      ember_assert(
+        fmt("%@ - cannot set selection to %@ because it's not in the group", [this, value]),
+        function() {
+          var isRadioButton = Ember.RadioButton.detectInstance(value),
+              isGroupMember = radioButtons.contains(value);
+
+          if (isRadioButton) return isGroupMember;
+
+          // If it wasn't a radio button then it was handled by the previous assertion.
+          return true;
+        });
+
+      // Notify the current selection, if any, that it has been deselected.
+      // However, if the current selection just left the group we won't
+      // modify the isSelected property on it.
+      var currentSelection = get(this, "_selection"),
+          currentSelectionDidLeaveGroup = !radioButtons.contains(currentSelection);
+      if(currentSelection && !currentSelectionDidLeaveGroup) set(currentSelection, "isSelected", false);
+
+      // Notify the new selection, if any, that it has been selected.
+      if(value) set(value, "isSelected", true);
+
+      set(this, "_selection", value);
+
+      return value;
+    }
+  }).property("_selection").cacheable(),
+
+  /** @private */
+  init: function() {
+    this._super();
+
+    set(this, "_radioButtons", Ember.A());
+  },
+
+  /**
+    Adds an {Ember.RadioButton} to the group.
+
+    You should not really call this function directly. Instead use
+    the `group` property on {@link Ember.RadioButton}.
+
+    @param {Ember.RadioButton} radioButton The radio button to add.
+    @private
+  */
+  _addRadioButton: function(radioButton) {
+    get(this, "_radioButtons").pushObject(radioButton);
+
+    Ember.addObserver(radioButton, "isSelected", this, this._isSelectedDidChange);
+
+    // If the button is selected, it becomes the new selection.
+    if(get(radioButton, "isSelected")) set(this, "selection", radioButton);
+  },
+
+  /**
+    Removes a radio button from the group.
+
+    You should not really call this function directly. Instead use
+    the `group` property on {@link Ember.RadioButton}.
+
+    @param {Ember.RadioButton} radioButton The radio button to remove.
+    @private
+  */
+  _removeRadioButton: function(radioButton) {
+    var radioButtons = get(this, "_radioButtons"),
+        isSelection  = get(this, "selection") === radioButton;
+
+    radioButtons.removeObject(radioButton);
+
+    Ember.removeObserver(radioButton, "isSelected", this, this._isSelectedDidChange);
+
+    // Clear the selection if it was just removed.
+    if(isSelection) set(this, "selection", null);
+  },
+
+  /**
+    Watch for changes to the `isSelected` property on radio buttons
+    in this group and update the `selection` property accordingly.
+
+    @private
+  */
+  _isSelectedDidChange: function(radioButton, keyName, value) {
+    var isSelected  = get(radioButton, "isSelected"),
+        isSelection = get(this, "selection") === radioButton;
+
+    // If the button is now selected, it becomes the new selection.
+    if (isSelected) set(this, "selection", radioButton);
+    // If the button is now deselected, but was the selection,
+    // we must clear the selection.
+    else if (isSelection) set(this, "selection", null);
+  }
+});

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -111,35 +111,22 @@ Ember.RadioButton = Ember.View.extend(
 });
 
 /**
-  @class A controller for a group of radio buttons.
+  @class A view for a group of radio buttons.
 
   ## Creating a RadioButtonGroup
 
-  You can create an instance of `Ember.RadioButtonGroup` like this:
+  You can create radio buttons like this:
 
-      #js
-      var App = Ember.Application.create();
-      App.group = Ember.RadioButtonGroup.create();
-
-  The group will not have any radio buttons associated with it by default.
-
-  ## Adding/Removing radio buttons
-
-  Adding radio buttons to a group is simple, just set the `group` property
-  of an `Ember.RadioButton` instance to the group.
-
-      <script type="text/x-handlebars">
-        {{view Ember.RadioButton groupBinding="App.group" value="1" isSelected="true"}}
-        {{view Ember.RadioButton groupBinding="App.group" value="2"}}
-        {{view Ember.RadioButton groupBinding="App.group" value="3"}}
-      </script>
-
-  To remove a radio button from a group, set the `group` property to `null`
-  or another instance of `Ember.RadioButtonGroup`.
-
-      #js
-      // removes the button from the group
-      rb.set("group", null);
+      #handlebars
+      {{#view Ember.RadioButtonGroup name="someName"}}
+        <label>
+          {{view RadioButton value="option1"}}
+          Option 1
+        </label>
+        <label>
+          {{view RadioButton value="option2"}}
+        </label>
+      {{/view}}
 
   ## Getting/Setting the selected radio button
 
@@ -200,15 +187,16 @@ Ember.RadioButton = Ember.View.extend(
 
       <script type="text/x-handlebars" data-template-name="question">
         <h2>{{question.content}}</h2>
+        {{#view Ember.RadioButtonGroup name="answer" selectedValueBinding="App.question.selectedAnswer"}}
         {{#each question.possibleAnswers}}
           <label>
-            {{view Ember.RadioButton groupBinding="group" valueBinding="value"}}
+            {{view RadioButton valueBinding="value"}}
             {{label}}
           </label>
         {{/each}}
       </script>
 
-  @extends Ember.Object
+  @extends Ember.View
 */
 Ember.RadioButtonGroup = Ember.View.extend(
 /** @scope Ember.RadioButtonGroup.prototype */ {

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -5,9 +5,12 @@ var get = Ember.get, getPath = Ember.getPath, set = Ember.set, fmt = Ember.Strin
 /**
   @class
 
-  A radio button view that enables `Ember.RadioButtonGroup` membership and binding.
+  The `Ember.RadioButton` view class renders an html radio input, allowing the
+  user to select a single value from a list of values.
 
-  See the {@link Ember.RadioButtonGroup} documentation for more information.
+  Dealing with multiple radio buttons can be simplified by using an
+  `Ember.RadioButtonGroup`. See the {@link Ember.RadioButtonGroup} documentation
+  for more information.
 
   @extends Ember.View
 */
@@ -81,97 +84,52 @@ Ember.RadioButton = Ember.Control.extend(
 });
 
 /**
-  @class A view for a group of radio buttons.
+  @class
 
-  ## Creating a RadioButtonGroup
+  The `Ember.RadioButtonGroup` view class provides a simplfied method for dealing
+  with multiple `Ember.RadioButton` instances.
 
-  You can create radio buttons like this:
+  ## Simple Example
 
   ```handlebars
-  {{#view Ember.RadioButtonGroup name="someName"}}
-    <label>
-      {{view RadioButton value="option1"}}
-      Option 1
-    </label>
-    <label>
-      {{view RadioButton value="option2"}}
-    </label>
+  {{#view Ember.RadioButtonGroup name="role" valueBinding="content.role"}}
+    {{view RadioButton value="admin"}}
+    {{view RadioButton value="owner"}}
+    {{view RadioButton value="user"}}
   {{/view}}
   ```
 
-  ## Getting/Setting the selected radio button
+  Note that the radio buttons are declared as `{{view RadioButton ...}}` as opposed
+  to `{{view Ember.RadioButton ...}}`. When inside the body of a RadioButtonGroup,
+  a `RadioButton` view is provided which automatically picks up the same name and value
+  binding as the containing group.
+
+  ## More Complex Example
 
   ```javascript
-  // get a reference to the selected radio button
-  group.get("selection");
-
-  // select a different radio button
-  group.set("selection", someRadioButton);
-
-  // or set a button as selected
-  someRadioButton.set("isSelected", true);
-
-  // clear the selection
-  group.set("selection", null);
-
-  // or deselect the selected button
-  selectedButton.set("isSelected", false);
-  ```
-
-  ## Getting/Setting the selected value
-
-  ```javascipt
-  // get the `value` property of the selected radio button
-  // or `null` if no buttons are selected
-  group.get("value");
-
-  // Select a different radio button by value.
-  // This also selects the proper radio button in the UI
-  group.set("value", someValue);
-  ```
-
-  ## Real world example
-
-  ```javascript
-  window.App = Ember.Application.create();
-
-  App.question = Ember.Object.create({
-    content: "Which of the following is the largest?",
-    possibleAnswers: [
-      Ember.Object.create({ label: "A peanut"      value: "peanut"      }),
-      Ember.Object.create({ label: "An elephant"   value: "elephant"    }),
-      Ember.Object.create({ label: "The moon"      value: "moon"        }),
-      Ember.Object.create({ label: "A tennis ball" value: "tennis ball" })
-    ],
-    selectedAnswer: null
+  App.person = Ember.Object.create({name: 'Gordon', role: 'admin'})
+  App.PersonController = Ember.Controller.extend({
+    contentBinding: 'App.person',
+    roleOptions: ['admin', 'owner', 'user', 'banned']
   });
-
-  App.questionView = Ember.View.create({
-    templateName: "question",
-    questionBinding: "App.question",
-    group: Ember.RadioButtonGroup.create({
-      // create a two-way binding so changes in the
-      // view propogate to the `selectedAnswer` property
-      // on the question object.
-      value: "App.question.selectedAnswer"
-    })
-  });
-
-  App.questionView.append();
   ```
-
-  The question template could look like this:
 
   ```handlebars
-  <h2>{{question.content}}</h2>
-  {{#view Ember.RadioButtonGroup name="answer" value="App.question.selectedAnswer"}}
-  {{#each question.possibleAnswers}}
-    <label>
-      {{view RadioButton valueBinding="value"}}
-      {{label}}
-    </label>
-  {{/each}}
+  {{#view Ember.RadioButtonGroup name="role" valueBinding="content.role"}}
+    {{#each role in controller.roleOptions}}
+      <label>
+        {{view RadioButton valueBinding="role"}}
+        {{role}}
+      </label>
+    {{/each}}
+  {{/view}}
   ```
+
+  The above controller/template combination will render html containing a
+  radio input for each item in the `roleOptions` property of the controller.
+  Initially, the `admin` option will be checked. If the user selects a different
+  radio, the `role` property of the controller's `content` will be updated
+  accordingly.
 
   @extends Ember.View
 */

--- a/packages/ember-handlebars/lib/controls/radio_button.js
+++ b/packages/ember-handlebars/lib/controls/radio_button.js
@@ -221,7 +221,7 @@ Ember.RadioButtonGroup = Ember.View.extend(
   RadioButton: Ember.computed(function() {
     return Ember.RadioButton.extend({
       group: this
-    })
+    });
   }),
 
   /**

--- a/packages/ember-handlebars/tests/controls/control_test.js
+++ b/packages/ember-handlebars/tests/controls/control_test.js
@@ -1,0 +1,41 @@
+/*globals TemplateTests:true */
+
+var get = Ember.get, getPath = Ember.getPath, set = Ember.set, group, rb, rb2, application;
+
+var view;
+
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+module("Ember.Control", {
+  setup: function() {
+    window.TemplateTests = Ember.Namespace.create();
+  },
+
+  teardown: function() {
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+      view = null;
+    }
+    window.TemplateTests = undefined;
+  }
+});
+
+test("a nested Ember.Control should use itself as its context", function() {
+  TemplateTests.TestControl = Ember.Control.extend({
+    location: 'Lake Tahoe',
+    template: Ember.Handlebars.compile("{{location}}")
+  });
+
+  view = Ember.View.create({
+    location: 'Seattle',
+    template: Ember.Handlebars.compile("{{view TemplateTests.TestControl}}")
+  });
+
+  appendView();
+
+  equal(view.$().text(), 'Lake Tahoe');
+});

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,6 +1,6 @@
 var get = Ember.get, getPath = Ember.getPath, set = Ember.set, group, rb, rb2, application;
 
-var view;
+var view, dispatcher;
 
 var appendView = function() {
   Ember.run(function() { view.appendTo('#qunit-fixture'); });
@@ -55,9 +55,15 @@ test("setting isChecked should update the selected value", function() {
 
 module("Ember.RadioButtonGroup", {
   setup: function() {
+    dispatcher = Ember.EventDispatcher.create();
+    dispatcher.setup();
   },
 
   teardown: function() {
+    Ember.run(function() {
+      dispatcher.destroy();
+    });
+
     if (view) {
       Ember.run(function() {
         view.destroy();
@@ -125,5 +131,32 @@ test("should uncheck previous selection when new value is null", function() {
 
   equal(get(view, 'value'), null, 'value should be set');
   equal(view.$("[value='option1']").attr('checked'), null, 'checkbox should not be checked');
+  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
+});
+
+test("value should update correctly after change event", function() {
+  view = Ember.RadioButtonGroup.create({
+    name: 'testName',
+    template: Ember.Handlebars.compile(
+      '{{ view RadioButton value="option1" }}' +
+      '{{ view RadioButton value="option2" }}'
+    )
+  });
+
+  appendView();
+
+  var button = view.$("[value='option1']");
+
+  // Can't find a way to programatically trigger a checkbox in IE and have it generate the
+  // same events as if a user actually clicks.
+  if (!Ember.$.browser.msie) {
+    button[0].click();
+  } else {
+    button.trigger('click');
+    button.attr('checked', 'checked').trigger('change');
+  }
+
+  equal(get(view, 'value'), 'option1', 'value should be set');
+  equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
   equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
 });

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -106,3 +106,24 @@ test("value should work even if the view is not in the DOM", function() {
   equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
   equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
 });
+
+test("should uncheck previous selection when new value is null", function() {
+  view = Ember.RadioButtonGroup.create({
+    value: 'option1',
+    name: 'testName',
+    template: Ember.Handlebars.compile(
+      '{{ view RadioButton value="option1" }}' +
+      '{{ view RadioButton value="option2" }}'
+    )
+  });
+
+  appendView();
+
+  Ember.run(function() {
+    set(view, 'value', null);
+  });
+
+  equal(get(view, 'value'), null, 'value should be set');
+  equal(view.$("[value='option1']").attr('checked'), null, 'checkbox should not be checked');
+  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
+});

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -91,6 +91,14 @@ test("value should update correctly", function() {
   equal(get(view, 'value'), 'option1', 'value should be set');
   equal(view.$("[value='option1']").prop('checked'), true, 'checkbox should be checked');
   equal(view.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
+
+  Ember.run(function() {
+    set(view, 'value', 'option2');
+  });
+
+  equal(get(view, 'value'), 'option2', 'value should be set');
+  equal(view.$("[value='option2']").prop('checked'), true, 'checkbox should be checked');
+  equal(view.$("[value='option1']").prop('checked'), false, 'checkbox should not be checked');
 });
 
 test("value should work even if the view is not in the DOM", function() {
@@ -184,4 +192,3 @@ test("checked property is removed when value changes to an unknown value", funct
 
   equal(button1.prop('checked'), false, "option1 should not be checked");
 });
-

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -160,3 +160,28 @@ test("value should update correctly after change event", function() {
   equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
   equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
 });
+
+test("checked property is removed when value changes to an unknown value", function() {
+  view = Ember.RadioButtonGroup.create({
+    name: 'testName',
+    template: Ember.Handlebars.compile(
+      '{{ view RadioButton value="option1" }}' 
+    )
+  });
+
+  appendView();
+
+  var button1 = view.$("[value='option1']");
+
+  Ember.run(function() {
+    set(view, 'value', 'option1');
+  });
+  equal(button1.prop('checked'), true, "option1 should be checked");
+
+  Ember.run(function() {
+    set(view, 'value', 'foobar');
+  });
+
+  equal(button1.prop('checked'), false, "option1 should not be checked");
+});
+

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,307 +1,74 @@
 var get = Ember.get, getPath = Ember.getPath, set = Ember.set, group, rb, rb2, application;
 
-var msie = window.jQuery && window.jQuery.browser.msie;
+var view;
 
-function setAndFlush(obj, key, value) {
-  Ember.run(function() {
-    set(obj, key, value);
-  });
-}
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
 
 module("Ember.RadioButton", {
   setup: function() {
-    application = Ember.Application.create();
-    group = Ember.RadioButtonGroup.create();
-    rb = Ember.RadioButton.create();
   },
 
   teardown: function() {
-    rb.destroy();
-    if(rb2) rb2.destroy();
-    if(group) group.destroy();
-    application.destroy();
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+      view = null;
+    }
   }
 });
 
-function append(v) {
-  Ember.run(function() {
-    v.appendTo('#qunit-fixture');
+test("setting selectedValue should update the checked property", function() {
+  view = Ember.RadioButton.create({
+    name: 'radio_button',
+    value: 'tahoe'
   });
-}
 
-test("should have the class 'ember-radio-button'", function() {
-  rb.createElement();
+  appendView();
 
-  ok(rb.$().hasClass("ember-radio-button"));
+  strictEqual(view.$().is(":checked"), false, "precond - the element is not checked");
+  strictEqual(get(view, "isChecked"), false, "precond - isChecked returns false");
+
+  set(view, 'selectedValue', 'tahoe');
+
+  ok(view.$().is(":checked"), "after clicking a radio button, the checked property changed in the DOM.");
+  equal(get(view, "isChecked"), true, "after clicking a radio button, the isChecked property changed in the view.");
 });
 
-test("#isDisabled by default returns false", function() {
-  strictEqual(get(rb, "isDisabled"), false);
-  rb.createElement();
+test("setting isChecked should update the selected value", function() {
+  view = Ember.RadioButton.create({
+    name: 'radio_button',
+    value: 'tahoe'
+  });
 
-  ok(rb.$().is(":not(:disabled)"));
-});
+  appendView();
 
-test("#isDisabled= propogates changes to the disabled property on the element once inserted", function() {
-  rb.createElement();
+  Ember.run(function() {
+    set(view, 'isChecked', true);
+  });
 
-  setAndFlush(rb, "isDisabled", true);
-  ok(rb.$().is(":disabled"), "the element became disabled when set to 'true'");
-
-  setAndFlush(rb, "isDisabled", false);
-  ok(rb.$().is(":not(:disabled)"));
-});
-
-test("#isSelected by default returns false", function() {
-  strictEqual(get(rb, "isSelected"), false, "it returns false");
-});
-
-test("when #isSelected is false at render-time, the element 'checked' property should be false", function() {
-  strictEqual(get(rb, "isSelected"), false, "precond - isSelected returns false");
-
-  append(rb);
-  strictEqual(rb.$().is(":checked"), false, "the element is not checked");
-});
-
-test("when #isSelected is true at render-time, the element 'checked' property should be true", function() {
-  setAndFlush(rb, "isSelected", true);
-  strictEqual(get(rb, "isSelected"), true, "precond - isSelected returns true");
-
-  append(rb);
-  strictEqual(rb.$().is(":checked"), true, "the element is checked");
-});
-
-test("#isSelected= when the element is in the DOM updates the element's 'checked' property accordingly", function() {
-  append(rb);
-
-  strictEqual(rb.$().is(":checked"), false, "precond - the element is not checked");
-  setAndFlush(rb, "isSelected", true);
-  strictEqual(rb.$().is(":checked"), true, "changing from false to true works");
-
-  strictEqual(rb.$().is(":checked"), true, "precond - the element is checked");
-  setAndFlush(rb, "isSelected", false);
-  strictEqual(rb.$().is(":checked"), false, "changing from true to false works");
-});
-
-test("listens for user interaction and updates the 'isSelected' properly accordingly on the view", function() {
-  append(rb);
-
-  strictEqual(rb.$().is(":checked"), false, "precond - the element is not checked");
-  strictEqual(get(rb, "isSelected"), false, "precond - isSelected returns false");
-
-  // Can't find a way to programatically trigger a checkbox in IE and have it generate the
-  // same events as if a user actually clicks.
-  if (!msie) {
-    rb.$()[0].click();
-  } else {
-    rb.$().trigger('click');
-    rb.$().removeProp('checked').trigger('change');
-  }
-
-  ok(rb.$().is(":checked"), "after clicking a radio button, the checked property changed in the DOM.");
-  equal(get(rb, "isSelected"), true, "after clicking a radio button, the isSelected property changed in the view.");
-});
-
-test("#group by default returns false", function() {
-  strictEqual(get(rb, "group"), null, "it returns null");
-});
-
-test("#group= passed an Ember.RadioButtonGroup associates the radio button with the group", function() {
-  equal(get(group, "numRadioButtons"), 0, "precond - the group has no radio buttons");
-
-  rb2 = Ember.RadioButton.create({ group: group });
-  ok(get(group, "_radioButtons").contains(rb2), "it works if group is set when instantiated");
-
-  setAndFlush(rb, "group", group);
-  ok(get(group, "_radioButtons").contains(rb), "it works using the setter");
-});
-
-test("#group= when the button is in a group and null is passed removes the radio button from the group", function() {
-  setAndFlush(rb, "group", group);
-  ok(get(group, "_radioButtons").contains(rb), "precond - the radio button is associated with the group");
-
-  setAndFlush(rb, "group", null);
-  ok(!get(group, "_radioButtons").contains(rb), "the radio button was removed from the group");
-});
-
-test("#group= when the button is selected and an Ember.RadioButtonGroup is passed the button becomes the group's selection", function() {
-  equal(get(group, "numRadioButtons"), 0, "precond - the group has no radio buttons");
-
-  rb2 = Ember.RadioButton.create({ group: group });
-  ok(get(group, "_radioButtons").contains(rb2), "it works if group is set when instantiated");
-
-  setAndFlush(rb, "group", group);
-  ok(get(group, "_radioButtons").contains(rb), "it works using the setter");
+  ok(view.$().is(":checked"), "checked attribute should be set");
+  equal(get(view, 'selectedValue'), 'tahoe', 'selectedValue should be set');
 });
 
 module("Ember.RadioButtonGroup", {
   setup: function() {
-    application = Ember.Application.create();
-    group = Ember.RadioButtonGroup.create();
-    rb = Ember.RadioButton.create();
-    rb2 = Ember.RadioButton.create();
   },
 
   teardown: function() {
-    rb.destroy();
-    rb2.destroy();
-    group.destroy();
-    application.destroy();
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+      view = null;
+    }
   }
 });
 
-test("#numRadioButtons returns the number of radio buttons that belong to the group.", function() {
-  equal(get(group, "numRadioButtons"), 0);
-
-  group._addRadioButton(rb);
-  equal(get(group, "numRadioButtons"), 1);
-
-  group._addRadioButton(rb2);
-  equal(get(group, "numRadioButtons"), 2);
-
-  group._removeRadioButton(rb);
-  equal(get(group, "numRadioButtons"), 1);
-});
-
-test("#selectedValue when there is no selection returns null", function() {
-  strictEqual(get(group, "selection"), null, "precond - the group has no selection");
-  strictEqual(get(group, "selectedValue"), null, "selectedValue is null");
-});
-
-test("#selectedValue when there is a selection returns its value", function() {
-  var someValue = { foo: "bar" },
-      selectedButton = Ember.RadioButton.create({ isSelected: true, group: group, value: someValue });
-
-  strictEqual(get(group, "selection"), selectedButton, "precond - the group has a selection");
-  strictEqual(get(group, "selectedValue"), someValue, "selectedValue returned the value of the selected button");
-});
-
-test("#selectedValue changes when the selection changes", function() {
-  var originalValue = { baz: "bar" },
-      newValue      = { foo: "bar" },
-      originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group, value: originalValue }),
-      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group, value: newValue });
-
-  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
-  strictEqual(get(group, "selectedValue"), originalValue, "precond - selectedValue returned the value of the selected button");
-
-  setAndFlush(deselectedButton, "isSelected", true);
-
-  strictEqual(get(group, "selection"), deselectedButton, "precond - the selection changed");
-  strictEqual(get(group, "selectedValue"), newValue, "selectedValue returned the correct value");
-});
-
-test("#selectedValue= passed a non-null value changes the selection to the radio button with that value", function() {
-  var originalValue = { baz: "bar" },
-      newValue      = { foo: "bar" },
-      originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group, value: originalValue }),
-      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group, value: newValue });
-
-  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
-  strictEqual(get(group, "selectedValue"), originalValue, "precond - selectedValue returned the value of the selected button");
-
-  setAndFlush(group, "selectedValue", newValue);
-
-  strictEqual(get(group, "selection"), deselectedButton, "the selection changed");
-  strictEqual(get(group, "selectedValue"), newValue, "selectedValue returned the correct value");
-});
-
-test("#selection when the group has no radio buttons returns null", function() {
-  equal(get(group, "numRadioButtons"), 0, "precond - the group has no radio buttons");
-  strictEqual(get(group, "selection"), null, "#selection returns null");
-});
-
-test("#selection when the group has radio buttons but none are selected returns null", function() {
-  group._addRadioButton(rb);
-  equal(get(group, "numRadioButtons"), 1, "precond - the group has radio buttons");
-  strictEqual(get(rb, "isSelected"), false, "precond - no radio buttons are selected");
-  strictEqual(get(group, "selection"), null, "#selection returns null");
-});
-
-test("#selection when the group has radio buttons and one is selected returns the selected radio button", function() {
-  var selectedButton = Ember.RadioButton.create({ isSelected: true, group: group });
-  equal(get(group, "numRadioButtons"), 1, "precond - the group has radio buttons");
-  strictEqual(get(selectedButton, "isSelected"), true, "precond - a radio button is selected");
-  strictEqual(get(group, "selection"), selectedButton, "#selection returns the selected radio button");
-});
-
-test("#selection becomes null when the selected radio button is removed from the group", function() {
-  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group });
-
-  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
-
-  setAndFlush(originalSelection, "group", null);
-
-  strictEqual(get(group, "selection"), null, "the selection changed to null");
-  strictEqual(get(originalSelection, "isSelected"), true, "the 'isSelected' property on the did not change");
-});
-
-test("#selection will automatically change to radio buttons that are selected when joining the group", function() {
-  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group }), newAddition;
-
-  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
-
-  newAddition = Ember.RadioButton.create({ isSelected: true,  group: group });
-
-  strictEqual(get(group, "selection"), newAddition, "the selection changed to the new button");
-  strictEqual(get(originalSelection, "isSelected"), false, "the 'isSelected' property on the previous selection changed from true to false");
-});
-
-test("#selection= passed anything other than null or an instance of Ember.RadioButton raises an error", function() {
-  raises(function() {
-    set(group, "selection", "foo");
-  });
-});
-
-test("#selection= passed an Ember.RadioButton that isn't part of the group raises an error", function() {
-  raises(function() {
-    set(group, "selection", rb);
-  });
-});
-
-test("#selection= sets the 'isSelected' property to true on the new selection", function() {
-  var deselectedButton = Ember.RadioButton.create({ isSelected: false, group: group});
-
-  setAndFlush(group, "selection", deselectedButton);
-  strictEqual(get(group, "selection"), deselectedButton, "the change was successful");
-  strictEqual(get(deselectedButton, "isSelected"), true, "the 'isSelected' property on the button changed from false to true");
-});
-
-test("#selection= sets the 'isSelected' property to false on the old selection", function() {
-  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group }),
-      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group });
-
-  setAndFlush(group, "selection", deselectedButton);
-
-  strictEqual(get(group, "selection"), deselectedButton, "the change was successful");
-  strictEqual(get(originalSelection, "isSelected"), false, "the 'isSelected' property on the old selection changed from true to false");
-});
-
-test("#selection= when a selection exists and null was passed deselects the previous selection", function() {
-  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group });
-
-  setAndFlush(group, "selection", null);
-
-  strictEqual(get(group, "selection"), null, "precond - the change was successful");
-  strictEqual(get(originalSelection, "isSelected"), false, "the 'isSelected' property on the button changed from true to false");
-});
-
-test("watches for changes to 'isSelected' on the radio buttons and updates the selection accordingly", function() {
-  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group }),
-      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group });
-
-  setAndFlush(deselectedButton, "isSelected", true);
-
-  strictEqual(get(group, "selection"), deselectedButton, "setting 'isSelected' to true on a deselected button changes the selection to it");
-  strictEqual(get(originalSelection, "isSelected"), false, "the original selection was deselected");
-
-  setAndFlush(deselectedButton, "isSelected", false);
-
-  strictEqual(get(group, "selection"), null, "setting 'isSelected' on the selection to false changes the selection to null");
-});
-
-test("RadioButtonGroup as a view", function() {
-  group = Ember.RadioButtonGroup.create({
+test("value should update correctly", function() {
+  view = Ember.RadioButtonGroup.create({
     name: 'testName',
     template: Ember.Handlebars.compile(
       '{{ view RadioButton value="option1" }}' +
@@ -309,22 +76,19 @@ test("RadioButtonGroup as a view", function() {
     )
   });
 
-  append(group);
+  appendView();
 
-  var option1 = group.buttonForValue('option1');
-  var option2 = group.buttonForValue('option2');
+  Ember.run(function() {
+    set(view, 'value', 'option1');
+  });
 
-  equal(option1.$().attr('name'), 'testName');
-  equal(option1.$().val(), 'option1');
-  equal(get(option1, 'group'), group);
-
-  equal(option2.$().attr('name'), 'testName');
-  equal(option2.$().val(), 'option2');
-  equal(get(option2, 'group'), group);
+  equal(get(view, 'value'), 'option1', 'value should be set');
+  equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
+  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
 });
 
-test("selectedValue works even if the view is not in the DOM", function() {
-  group = Ember.RadioButtonGroup.create({
+test("value should work even if the view is not in the DOM", function() {
+  view = Ember.RadioButtonGroup.create({
     name: 'testName',
     template: Ember.Handlebars.compile(
       '{{ view RadioButton value="option1" }}' +
@@ -332,12 +96,13 @@ test("selectedValue works even if the view is not in the DOM", function() {
     )
   });
 
-  set(group, 'selectedValue', 'option1');
+  Ember.run(function() {
+    set(view, 'value', 'option1');
+  });
 
-  append(group);
+  appendView();
 
-  equal(get(group, 'selectedValue'), 'option1', 'selectedValue should be set');
-
-  console.log('FOOBAR');
-  equal(group.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
+  equal(get(view, 'value'), 'option1', 'value should be set');
+  equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
+  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
 });

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -28,12 +28,12 @@ test("setting selectedValue should update the checked property", function() {
 
   appendView();
 
-  strictEqual(view.$().is(":checked"), false, "precond - the element is not checked");
+  strictEqual(view.$().prop('checked'), false, "precond - the element is not checked");
   strictEqual(get(view, "isChecked"), false, "precond - isChecked returns false");
 
   set(view, 'selectedValue', 'tahoe');
 
-  ok(view.$().is(":checked"), "after clicking a radio button, the checked property changed in the DOM.");
+  ok(view.$().prop('checked'), "after clicking a radio button, the checked property changed in the DOM.");
   equal(get(view, "isChecked"), true, "after clicking a radio button, the isChecked property changed in the view.");
 });
 
@@ -49,7 +49,7 @@ test("setting isChecked should update the selected value", function() {
     set(view, 'isChecked', true);
   });
 
-  ok(view.$().is(":checked"), "checked attribute should be set");
+  ok(view.$().prop('checked'), "checked attribute should be set");
   equal(get(view, 'selectedValue'), 'tahoe', 'selectedValue should be set');
 });
 
@@ -89,8 +89,8 @@ test("value should update correctly", function() {
   });
 
   equal(get(view, 'value'), 'option1', 'value should be set');
-  equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
-  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
+  equal(view.$("[value='option1']").prop('checked'), true, 'checkbox should be checked');
+  equal(view.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
 });
 
 test("value should work even if the view is not in the DOM", function() {
@@ -109,8 +109,8 @@ test("value should work even if the view is not in the DOM", function() {
   appendView();
 
   equal(get(view, 'value'), 'option1', 'value should be set');
-  equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
-  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
+  equal(view.$("[value='option1']").prop('checked'), true, 'checkbox should be checked');
+  equal(view.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
 });
 
 test("should uncheck previous selection when new value is null", function() {
@@ -130,8 +130,8 @@ test("should uncheck previous selection when new value is null", function() {
   });
 
   equal(get(view, 'value'), null, 'value should be set');
-  equal(view.$("[value='option1']").attr('checked'), null, 'checkbox should not be checked');
-  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
+  equal(view.$("[value='option1']").prop('checked'), false, 'checkbox should not be checked');
+  equal(view.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
 });
 
 test("value should update correctly after change event", function() {
@@ -153,12 +153,12 @@ test("value should update correctly after change event", function() {
     button[0].click();
   } else {
     button.trigger('click');
-    button.attr('checked', 'checked').trigger('change');
+    button.prop('checked', true).trigger('change');
   }
 
   equal(get(view, 'value'), 'option1', 'value should be set');
-  equal(view.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
-  equal(view.$("[value='option2']").attr('checked'), null, 'checkbox should not be checked');
+  equal(view.$("[value='option1']").prop('checked'), true, 'checkbox should be checked');
+  equal(view.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
 });
 
 test("checked property is removed when value changes to an unknown value", function() {

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -29,15 +29,15 @@ test("setting selectedValue should update the checked property", function() {
   appendView();
 
   strictEqual(view.$().prop('checked'), false, "precond - the element is not checked");
-  strictEqual(get(view, "isChecked"), false, "precond - isChecked returns false");
+  strictEqual(get(view, "checked"), false, "precond - checked returns false");
 
   set(view, 'selectedValue', 'tahoe');
 
   ok(view.$().prop('checked'), "after clicking a radio button, the checked property changed in the DOM.");
-  equal(get(view, "isChecked"), true, "after clicking a radio button, the isChecked property changed in the view.");
+  equal(get(view, "checked"), true, "after clicking a radio button, the checked property changed in the view.");
 });
 
-test("setting isChecked should update the selected value", function() {
+test("setting checked should update the selected value", function() {
   view = Ember.RadioButton.create({
     name: 'radio_button',
     value: 'tahoe'
@@ -46,7 +46,7 @@ test("setting isChecked should update the selected value", function() {
   appendView();
 
   Ember.run(function() {
-    set(view, 'isChecked', true);
+    set(view, 'checked', true);
   });
 
   ok(view.$().prop('checked'), "checked attribute should be set");

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -157,7 +157,7 @@ test("value should update correctly after change event", function() {
 
   // Can't find a way to programatically trigger a checkbox in IE and have it generate the
   // same events as if a user actually clicks.
-  if (!Ember.$.browser.msie) {
+  if (Ember.$.support.changeBubbles) {
     button[0].click();
   } else {
     button.trigger('click');

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -21,9 +21,9 @@ module("Ember.RadioButton", {
   }
 });
 
-function append() {
+function append(v) {
   Ember.run(function() {
-    rb.appendTo('#qunit-fixture');
+    v.appendTo('#qunit-fixture');
   });
 }
 
@@ -57,7 +57,7 @@ test("#isSelected by default returns false", function() {
 test("when #isSelected is false at render-time, the element 'checked' property should be false", function() {
   strictEqual(get(rb, "isSelected"), false, "precond - isSelected returns false");
 
-  append();
+  append(rb);
   strictEqual(rb.$().is(":checked"), false, "the element is not checked");
 });
 
@@ -65,12 +65,12 @@ test("when #isSelected is true at render-time, the element 'checked' property sh
   setAndFlush(rb, "isSelected", true);
   strictEqual(get(rb, "isSelected"), true, "precond - isSelected returns true");
 
-  append();
+  append(rb);
   strictEqual(rb.$().is(":checked"), true, "the element is checked");
 });
 
 test("#isSelected= when the element is in the DOM updates the element's 'checked' property accordingly", function() {
-  append();
+  append(rb);
 
   strictEqual(rb.$().is(":checked"), false, "precond - the element is not checked");
   setAndFlush(rb, "isSelected", true);
@@ -82,7 +82,7 @@ test("#isSelected= when the element is in the DOM updates the element's 'checked
 });
 
 test("listens for user interaction and updates the 'isSelected' properly accordingly on the view", function() {
-  append();
+  append(rb);
 
   strictEqual(rb.$().is(":checked"), false, "precond - the element is not checked");
   strictEqual(get(rb, "isSelected"), false, "precond - isSelected returns false");
@@ -296,4 +296,27 @@ test("watches for changes to 'isSelected' on the radio buttons and updates the s
   setAndFlush(deselectedButton, "isSelected", false);
 
   strictEqual(get(group, "selection"), null, "setting 'isSelected' on the selection to false changes the selection to null");
+});
+
+test("RadioButtonGroup as a view", function() {
+  group = Ember.RadioButtonGroup.create({
+    name: 'testName',
+    template: Ember.Handlebars.compile(
+      '{{ view RadioButton value="option1" }}' +
+      '{{ view RadioButton value="option2" }}'
+    )
+  });
+
+  append(group);
+
+  var option1 = group.buttonForValue('option1');
+  var option2 = group.buttonForValue('option2');
+
+  equal(option1.$().attr('name'), 'testName');
+  equal(option1.$().val(), 'option1');
+  equal(get(option1, 'group'), group);
+
+  equal(option2.$().attr('name'), 'testName');
+  equal(option2.$().val(), 'option2');
+  equal(get(option2, 'group'), group);
 });

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,0 +1,299 @@
+var get = Ember.get, getPath = Ember.getPath, set = Ember.set, group, rb, rb2, application;
+
+function setAndFlush(obj, key, value) {
+  Ember.run(function() {
+    set(obj, key, value);
+  });
+}
+
+module("Ember.RadioButton", {
+  setup: function() {
+    application = Ember.Application.create();
+    group = Ember.RadioButtonGroup.create();
+    rb = Ember.RadioButton.create();
+  },
+
+  teardown: function() {
+    rb.destroy();
+    if(rb2) rb2.destroy();
+    if(group) group.destroy();
+    application.destroy();
+  }
+});
+
+function append() {
+  Ember.run(function() {
+    rb.appendTo('#qunit-fixture');
+  });
+}
+
+test("should have the class 'ember-radio-button'", function() {
+  rb.createElement();
+
+  ok(rb.$().hasClass("ember-radio-button"));
+});
+
+test("#isDisabled by default returns false", function() {
+  strictEqual(get(rb, "isDisabled"), false);
+  rb.createElement();
+
+  ok(rb.$().is(":not(:disabled)"));
+});
+
+test("#isDisabled= propogates changes to the disabled property on the element once inserted", function() {
+  rb.createElement();
+
+  setAndFlush(rb, "isDisabled", true);
+  ok(rb.$().is(":disabled"), "the element became disabled when set to 'true'");
+
+  setAndFlush(rb, "isDisabled", false);
+  ok(rb.$().is(":not(:disabled)"));
+});
+
+test("#isSelected by default returns false", function() {
+  strictEqual(get(rb, "isSelected"), false, "it returns false");
+});
+
+test("when #isSelected is false at render-time, the element 'checked' property should be false", function() {
+  strictEqual(get(rb, "isSelected"), false, "precond - isSelected returns false");
+
+  append();
+  strictEqual(rb.$().is(":checked"), false, "the element is not checked");
+});
+
+test("when #isSelected is true at render-time, the element 'checked' property should be true", function() {
+  setAndFlush(rb, "isSelected", true);
+  strictEqual(get(rb, "isSelected"), true, "precond - isSelected returns true");
+
+  append();
+  strictEqual(rb.$().is(":checked"), true, "the element is checked");
+});
+
+test("#isSelected= when the element is in the DOM updates the element's 'checked' property accordingly", function() {
+  append();
+
+  strictEqual(rb.$().is(":checked"), false, "precond - the element is not checked");
+  setAndFlush(rb, "isSelected", true);
+  strictEqual(rb.$().is(":checked"), true, "changing from false to true works");
+
+  strictEqual(rb.$().is(":checked"), true, "precond - the element is checked");
+  setAndFlush(rb, "isSelected", false);
+  strictEqual(rb.$().is(":checked"), false, "changing from true to false works");
+});
+
+test("listens for user interaction and updates the 'isSelected' properly accordingly on the view", function() {
+  append();
+
+  strictEqual(rb.$().is(":checked"), false, "precond - the element is not checked");
+  strictEqual(get(rb, "isSelected"), false, "precond - isSelected returns false");
+
+  // Can't find a way to programatically trigger a checkbox in IE and have it generate the
+  // same events as if a user actually clicks.
+  if (!jQuery.browser.msie) {
+    rb.$()[0].click();
+  } else {
+    rb.$().trigger('click');
+    rb.$().removeProp('checked').trigger('change');
+  }
+
+  ok(rb.$().is(":checked"), "after clicking a radio button, the checked property changed in the DOM.");
+  equals(get(rb, "isSelected"), true, "after clicking a radio button, the isSelected property changed in the view.");
+});
+
+test("#group by default returns false", function() {
+  strictEqual(get(rb, "group"), null, "it returns null");
+});
+
+test("#group= passed an Ember.RadioButtonGroup associates the radio button with the group", function() {
+  equal(get(group, "numRadioButtons"), 0, "precond - the group has no radio buttons");
+
+  rb2 = Ember.RadioButton.create({ group: group });
+  ok(get(group, "_radioButtons").contains(rb2), "it works if group is set when instantiated");
+
+  setAndFlush(rb, "group", group);
+  ok(get(group, "_radioButtons").contains(rb), "it works using the setter");
+});
+
+test("#group= when the button is in a group and null is passed removes the radio button from the group", function() {
+  setAndFlush(rb, "group", group);
+  ok(get(group, "_radioButtons").contains(rb), "precond - the radio button is associated with the group");
+
+  setAndFlush(rb, "group", null);
+  ok(!get(group, "_radioButtons").contains(rb), "the radio button was removed from the group");
+});
+
+test("#group= when the button is selected and an Ember.RadioButtonGroup is passed the button becomes the group's selection", function() {
+  equal(get(group, "numRadioButtons"), 0, "precond - the group has no radio buttons");
+
+  rb2 = Ember.RadioButton.create({ group: group });
+  ok(get(group, "_radioButtons").contains(rb2), "it works if group is set when instantiated");
+
+  setAndFlush(rb, "group", group);
+  ok(get(group, "_radioButtons").contains(rb), "it works using the setter");
+});
+
+module("Ember.RadioButtonGroup", {
+  setup: function() {
+    application = Ember.Application.create();
+    group = Ember.RadioButtonGroup.create();
+    rb = Ember.RadioButton.create();
+    rb2 = Ember.RadioButton.create();
+  },
+
+  teardown: function() {
+    rb.destroy();
+    rb2.destroy();
+    group.destroy();
+    application.destroy();
+  }
+});
+
+test("#numRadioButtons returns the number of radio buttons that belong to the group.", function() {
+  equal(get(group, "numRadioButtons"), 0);
+
+  group._addRadioButton(rb);
+  equal(get(group, "numRadioButtons"), 1);
+
+  group._addRadioButton(rb2);
+  equal(get(group, "numRadioButtons"), 2);
+
+  group._removeRadioButton(rb);
+  equal(get(group, "numRadioButtons"), 1);
+});
+
+test("#selectedValue when there is no selection returns null", function() {
+  strictEqual(get(group, "selection"), null, "precond - the group has no selection");
+  strictEqual(get(group, "selectedValue"), null, "selectedValue is null");
+});
+
+test("#selectedValue when there is a selection returns its value", function() {
+  var someValue = { foo: "bar" },
+      selectedButton = Ember.RadioButton.create({ isSelected: true, group: group, value: someValue });
+
+  strictEqual(get(group, "selection"), selectedButton, "precond - the group has a selection");
+  strictEqual(get(group, "selectedValue"), someValue, "selectedValue returned the value of the selected button");
+});
+
+test("#selectedValue changes when the selection changes", function() {
+  var originalValue = { baz: "bar" },
+      newValue      = { foo: "bar" },
+      originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group, value: originalValue }),
+      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group, value: newValue });
+
+  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
+  strictEqual(get(group, "selectedValue"), originalValue, "precond - selectedValue returned the value of the selected button");
+
+  setAndFlush(deselectedButton, "isSelected", true);
+
+  strictEqual(get(group, "selection"), deselectedButton, "precond - the selection changed");
+  strictEqual(get(group, "selectedValue"), newValue, "selectedValue returned the correct value");
+});
+
+test("#selectedValue= passed a non-null value changes the selection to the radio button with that value", function() {
+  var originalValue = { baz: "bar" },
+      newValue      = { foo: "bar" },
+      originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group, value: originalValue }),
+      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group, value: newValue });
+
+  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
+  strictEqual(get(group, "selectedValue"), originalValue, "precond - selectedValue returned the value of the selected button");
+
+  setAndFlush(group, "selectedValue", newValue);
+
+  strictEqual(get(group, "selection"), deselectedButton, "the selection changed");
+  strictEqual(get(group, "selectedValue"), newValue, "selectedValue returned the correct value");
+});
+
+test("#selection when the group has no radio buttons returns null", function() {
+  equal(get(group, "numRadioButtons"), 0, "precond - the group has no radio buttons");
+  strictEqual(get(group, "selection"), null, "#selection returns null");
+});
+
+test("#selection when the group has radio buttons but none are selected returns null", function() {
+  group._addRadioButton(rb);
+  equal(get(group, "numRadioButtons"), 1, "precond - the group has radio buttons");
+  strictEqual(get(rb, "isSelected"), false, "precond - no radio buttons are selected");
+  strictEqual(get(group, "selection"), null, "#selection returns null");
+});
+
+test("#selection when the group has radio buttons and one is selected returns the selected radio button", function() {
+  var selectedButton = Ember.RadioButton.create({ isSelected: true, group: group });
+  equal(get(group, "numRadioButtons"), 1, "precond - the group has radio buttons");
+  strictEqual(get(selectedButton, "isSelected"), true, "precond - a radio button is selected");
+  strictEqual(get(group, "selection"), selectedButton, "#selection returns the selected radio button");
+});
+
+test("#selection becomes null when the selected radio button is removed from the group", function() {
+  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group });
+
+  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
+
+  setAndFlush(originalSelection, "group", null);
+
+  strictEqual(get(group, "selection"), null, "the selection changed to null");
+  strictEqual(get(originalSelection, "isSelected"), true, "the 'isSelected' property on the did not change");
+});
+
+test("#selection will automatically change to radio buttons that are selected when joining the group", function() {
+  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group }), newAddition;
+
+  strictEqual(get(group, "selection"), originalSelection, "precond - the group has a selection");
+
+  newAddition = Ember.RadioButton.create({ isSelected: true,  group: group });
+
+  strictEqual(get(group, "selection"), newAddition, "the selection changed to the new button");
+  strictEqual(get(originalSelection, "isSelected"), false, "the 'isSelected' property on the previous selection changed from true to false");
+});
+
+test("#selection= passed anything other than null or an instance of Ember.RadioButton raises an error", function() {
+  raises(function() {
+    set(group, "selection", "foo");
+  });
+});
+
+test("#selection= passed an Ember.RadioButton that isn't part of the group raises an error", function() {
+  raises(function() {
+    set(group, "selection", rb);
+  });
+});
+
+test("#selection= sets the 'isSelected' property to true on the new selection", function() {
+  var deselectedButton = Ember.RadioButton.create({ isSelected: false, group: group});
+
+  setAndFlush(group, "selection", deselectedButton);
+  strictEqual(get(group, "selection"), deselectedButton, "the change was successful");
+  strictEqual(get(deselectedButton, "isSelected"), true, "the 'isSelected' property on the button changed from false to true");
+});
+
+test("#selection= sets the 'isSelected' property to false on the old selection", function() {
+  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group }),
+      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group });
+
+  setAndFlush(group, "selection", deselectedButton);
+
+  strictEqual(get(group, "selection"), deselectedButton, "the change was successful");
+  strictEqual(get(originalSelection, "isSelected"), false, "the 'isSelected' property on the old selection changed from true to false");
+});
+
+test("#selection= when a selection exists and null was passed deselects the previous selection", function() {
+  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group });
+
+  setAndFlush(group, "selection", null);
+
+  strictEqual(get(group, "selection"), null, "precond - the change was successful");
+  strictEqual(get(originalSelection, "isSelected"), false, "the 'isSelected' property on the button changed from true to false");
+});
+
+test("watches for changes to 'isSelected' on the radio buttons and updates the selection accordingly", function() {
+  var originalSelection = Ember.RadioButton.create({ isSelected: true,  group: group }),
+      deselectedButton  = Ember.RadioButton.create({ isSelected: false, group: group });
+
+  setAndFlush(deselectedButton, "isSelected", true);
+
+  strictEqual(get(group, "selection"), deselectedButton, "setting 'isSelected' to true on a deselected button changes the selection to it");
+  strictEqual(get(originalSelection, "isSelected"), false, "the original selection was deselected");
+
+  setAndFlush(deselectedButton, "isSelected", false);
+
+  strictEqual(get(group, "selection"), null, "setting 'isSelected' on the selection to false changes the selection to null");
+});

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -97,7 +97,7 @@ test("listens for user interaction and updates the 'isSelected' properly accordi
   }
 
   ok(rb.$().is(":checked"), "after clicking a radio button, the checked property changed in the DOM.");
-  equals(get(rb, "isSelected"), true, "after clicking a radio button, the isSelected property changed in the view.");
+  equal(get(rb, "isSelected"), true, "after clicking a radio button, the isSelected property changed in the view.");
 });
 
 test("#group by default returns false", function() {

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -322,3 +322,22 @@ test("RadioButtonGroup as a view", function() {
   equal(option2.$().val(), 'option2');
   equal(get(option2, 'group'), group);
 });
+
+test("selectedValue works even if the view is not in the DOM", function() {
+  group = Ember.RadioButtonGroup.create({
+    name: 'testName',
+    template: Ember.Handlebars.compile(
+      '{{ view RadioButton value="option1" }}' +
+      '{{ view RadioButton value="option2" }}'
+    )
+  });
+
+  set(group, 'selectedValue', 'option1');
+
+  append(group);
+
+  equal(get(group, 'selectedValue'), 'option1', 'selectedValue should be set');
+
+  console.log('FOOBAR');
+  equal(group.$("[value='option1']").attr('checked'), 'checked', 'checkbox should be checked');
+});

--- a/packages/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,5 +1,7 @@
 var get = Ember.get, getPath = Ember.getPath, set = Ember.set, group, rb, rb2, application;
 
+var msie = window.jQuery && window.jQuery.browser.msie;
+
 function setAndFlush(obj, key, value) {
   Ember.run(function() {
     set(obj, key, value);
@@ -89,7 +91,7 @@ test("listens for user interaction and updates the 'isSelected' properly accordi
 
   // Can't find a way to programatically trigger a checkbox in IE and have it generate the
   // same events as if a user actually clicks.
-  if (!jQuery.browser.msie) {
+  if (!msie) {
     rb.$()[0].click();
   } else {
     rb.$().trigger('click');


### PR DESCRIPTION
This PR contains the same API as #755 but has a simper implementation. `Ember.RadioButton` can also be used independently of `Ember.RadioButtonGroup`.

Also introduces Ember.Control which is a view that uses itself as its context, necessary for the `Ember.RadioButtonGroup` implementation.
