### PR TITLE
initialize the content of ArrayController if not defined

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -184,6 +184,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
 
   /** @private (nodoc) */
   replace: function(idx, amt, objects) {
+    Ember.assert('The content property of '+ this.constructor + ' should be set before modifying it', this.get('content'));
     if (get(this, 'content')) this.replaceContent(idx, amt, objects);
     return this;
   },


### PR DESCRIPTION
Answering this question: http://stackoverflow.com/questions/11829626/ember-js-pushobject-not-pushing, it seems that users feel puzzled with the fact that the ArrayController content is null, and must define it at creation time.
