### PR TITLE
Self-closing div causes Metamorph error

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1902,6 +1902,27 @@ test("Ember.Button targets should respect keywords", function() {
   }
 });
 
+test("child view with self-closing div", function() {
+  expect(0);
+
+  view = Ember.View.create({
+    show: false,
+    arr: Ember.A(),
+    template: Ember.Handlebars.compile('{{#if show}}{{#view}}<div />{{/view}}{{/if}}')
+  });
+
+  appendView();
+
+  Ember.run(function() {
+    set(view, 'show', true);
+  });
+
+  Ember.run(function() {
+    set(view, 'show', false);
+  });
+
+});
+
 module("Ember.View - handlebars integration", {
   setup: function() {
     originalLog = Ember.Logger.log;


### PR DESCRIPTION
This PR contains a failing test. I get this error with a self-closing div:

```
Error: Cannot perform operations on a Metamorph that is not in the DOM.
    at Metamorph.checkRemoved (metamorph:393:13)
    at Metamorph.replaceWith (metamorph:372:10)
    at Object.DOMManager.replace (ember-handlebars/views/metamorph_view:37:13)
    at invoke (ember-metal/run_loop:45:19)
    at iter (ember-metal/run_loop:92:7)
    at Array.forEach (native)
    at Object.RunLoop.flush (ember-metal/run_loop:148:21)
    at Object.RunLoop.end (ember-metal/run_loop:64:10)
    at Function.Ember.run.end (ember-metal/run_loop:256:24)
    at Object.Ember.run (ember-metal/run_loop:217:9)
```

Changing the test to use a `<div></div>` instead of `<div/>` works.
