### PR TITLE
check for undefined jquery object on previous view

### DIFF
--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -410,7 +410,7 @@ Ember.ContainerView.states = {
         buffer = childView.renderToBufferIfNeeded();
         if (buffer) {
           childView._notifyWillInsertElement();
-          if (previous) {
+          if (previous && previous.$()) {
             previous.domManager.after(previous, buffer.string());
           } else {
             view.domManager.prepend(view, buffer.string());


### PR DESCRIPTION
I haven't had a chance to really review and understand the refactor of container view that was just checked in. All I know is that it broke a couple of things, one of which was an `undefined` error in `after` when trying to get the view's jQuery object (`view.$()`). I'm not sure why it should or wouldn't exist but after briefly looking through the code I'm convinced that `after` should not be called if it doesn't.
