### PR TITLE
Ember.empty returns false for empty Ember.ArrayProxy

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -115,7 +115,7 @@ Ember.none = function(obj) {
   @returns {Boolean}
 */
 Ember.empty = function(obj) {
-  return obj === null || obj === undefined || (obj.length === 0 && typeof obj !== 'function');
+  return obj === null || obj === undefined || (obj.length === 0 && typeof obj !== 'function') || (typeof obj === 'object' && Ember.get(obj, 'length') === 0);
 };
 
 /**

--- a/packages/ember-runtime/tests/core/empty_test.js
+++ b/packages/ember-runtime/tests/core/empty_test.js
@@ -9,7 +9,8 @@ module("Ember.empty");
 
 test("Ember.empty", function() {
   var string = "string", fn = function() {},
-      object = {length: 0};
+      object = {length: 0},
+      arrayProxy = Ember.ArrayProxy.create({ content: Ember.A([]) });
 
   equal(true,  Ember.empty(null),      "for null");
   equal(true,  Ember.empty(undefined), "for undefined");
@@ -22,4 +23,5 @@ test("Ember.empty", function() {
   equal(true,  Ember.empty([]),        "for an empty Array");
   equal(false, Ember.empty({}),        "for an empty Object");
   equal(true,  Ember.empty(object),     "for an Object that has zero 'length'");
+  equal(true,  Ember.empty(arrayProxy), "for an ArrayProxy that has empty content");
 });


### PR DESCRIPTION
I'm not sure if I'm off base with this one whether its a problem with Ember.ArrayProxy, Ember.empty or I'm just assuming that Ember.ArrayProxy should act like an array.  If this were to work correctly either the length property needs to be updated on Ember.ArrayProxy or Ember.empty needs to check for length using Ember.get.

http://jsfiddle.net/Td7VT/1/
