### PR TITLE
Check that a controller inherits from Ember.Object before instantiating it to the router.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -219,7 +219,10 @@ Ember.Application.registerInjection({
     if (!/^[A-Z].*Controller$/.test(property)) { return; }
 
     var name = property.charAt(0).toLowerCase() + property.substr(1),
-        controller = app[property].create();
+        controllerClass = app[property], controller;
+
+    if(!Ember.Object.detect(controllerClass)){ return; }
+    controller = app[property].create();
 
     router.set(name, controller);
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -103,6 +103,7 @@ test("initialize controllers into a state manager", function() {
   app.BarController = Ember.ArrayController.extend();
   app.Foo = Ember.Object.create();
   app.fooController = Ember.Object.create();
+  app.BazController = {};
 
   var stateManager = Ember.Object.create();
 
@@ -111,6 +112,7 @@ test("initialize controllers into a state manager", function() {
   ok(get(stateManager, 'fooController') instanceof app.FooController, "fooController was assigned");
   ok(get(stateManager, 'barController') instanceof app.BarController, "barController was assigned");
   ok(get(stateManager, 'foo') === undefined, "foo was not assigned");
+  ok(get(stateManager, 'bazController') === undefined, "bazController was not assigned");
 
   equal(get(stateManager, 'fooController.target'), stateManager, "the state manager is assigned");
   equal(get(stateManager, 'barController.target'), stateManager, "the state manager is assigned");


### PR DESCRIPTION
Make sure that a Controller is at least an Ember.Object. This gives the ability for people to have capitalized controller objects or functions in their main application namespace.

See discussion on emberjs/data#352

cc/ @wagenet
