### PR TITLE
change `controllers` property to `router` in controllers injection

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -225,7 +225,7 @@ Ember.Application.registerInjection({
 
     controller.setProperties({
       target: router,
-      controllers: router,
+      router: router,
       namespace: app
     });
   }

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -312,7 +312,7 @@ test("ApplicationView and ApplicationController are assumed to exist in all Rout
 
 });
 
-test("ControllerObject class can be initialized with target, controllers and view properties", function() {
+test("ControllerObject class can be initialized with target, router and view properties", function() {
   var stateManager;
 
   Ember.run(function() {
@@ -330,6 +330,6 @@ test("ControllerObject class can be initialized with target, controllers and vie
   });
 
   equal(app.get('router.postController.target') instanceof Ember.StateManager, true, "controller has target");
-  equal(app.get('router.postController.controllers') instanceof Ember.StateManager, true, "controller has controllers");
+  strictEqual(app.get('router.postController.router'), stateManager, "controller has router");
   equal(app.get('router.postController.view') instanceof Ember.View, true, "controller has view");
 });

--- a/packages/ember-views/lib/system/controller.js
+++ b/packages/ember-views/lib/system/controller.js
@@ -4,7 +4,7 @@ var get = Ember.get, set = Ember.set;
 Ember.ControllerMixin.reopen(/** @scope Ember.ControllerMixin.prototype */ {
 
   target: null,
-  controllers: null,
+  router: null,
   namespace: null,
   view: null,
 
@@ -122,11 +122,11 @@ Ember.ControllerMixin.reopen(/** @scope Ember.ControllerMixin.prototype */ {
 
     if (name) {
       var namespace = get(this, 'namespace'),
-          controllers = get(this, 'controllers');
+          router    = get(this, 'router');
 
       var viewClassName = name.charAt(0).toUpperCase() + name.substr(1) + "View";
       viewClass = get(namespace, viewClassName);
-      controller = get(controllers, name + 'Controller');
+      controller = get(router, name + 'Controller');
 
       Ember.assert("The name you supplied " + name + " did not resolve to a view " + viewClassName, !!viewClass);
       Ember.assert("The name you supplied " + name + " did not resolve to a controller " + name + 'Controller', (!!controller && !!context) || !context);
@@ -152,13 +152,13 @@ Ember.ControllerMixin.reopen(/** @scope Ember.ControllerMixin.prototype */ {
     @param {String...} controllerNames the controllers to make available
   */
   connectControllers: function() {
-    var controllers = get(this, 'controllers'),
+    var router = get(this, 'router'),
         controllerNames = Array.prototype.slice.apply(arguments),
         controllerName;
 
     for (var i=0, l=controllerNames.length; i<l; i++) {
       controllerName = controllerNames[i] + 'Controller';
-      set(this, controllerName, get(controllers, controllerName));
+      set(this, controllerName, get(router, controllerName));
     }
   }
 });

--- a/packages/ember-views/tests/system/controller_test.js
+++ b/packages/ember-views/tests/system/controller_test.js
@@ -25,13 +25,13 @@ test("connectOutlet instantiates a view, controller, and connects them", functio
   var postController = Ember.Controller.create();
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController },
+    router: { postController: postController },
     namespace: { PostView: TestApp.PostView }
   });
   var view = appController.connectOutlet('post');
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's router");
   equal(appController.get('view'), view, "the app controller's view is set");
 });
 
@@ -39,13 +39,13 @@ test("connectOutlet takes an optional outlet name", function() {
   var postController = Ember.Controller.create();
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController },
+    router: { postController: postController },
     namespace: { PostView: TestApp.PostView }
   });
   var view = appController.connectOutlet({ name: 'post', outletName: 'mainView' });
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's router");
   equal(appController.get('mainView'), view, "the app controller's view is set");
 });
 
@@ -54,13 +54,13 @@ test("connectOutlet takes an optional controller context", function() {
       context = {};
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController },
+    router: { postController: postController },
     namespace: { PostView: TestApp.PostView }
   });
   var view = appController.connectOutlet('post', context);
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's router");
   equal(appController.get('view'), view, "the app controller's view is set");
   equal(view.get('controller.content'), context, "the controller receives the context");
 });
@@ -70,14 +70,14 @@ test("connectOutlet with outletName, name syntax", function() {
       context = {};
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController },
+    router: { postController: postController },
     namespace: { PostView: TestApp.PostView }
   });
 
   var view = appController.connectOutlet('main', 'post', context);
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's router");
   equal(appController.get('main'), view, "the app controller's view is set");
   equal(view.get('controller.content'), context, "the controller receives the context");
 });
@@ -87,13 +87,13 @@ test("connectOutlet works if all three parameters are provided", function() {
       context = {};
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController },
+    router: { postController: postController },
     namespace: { PostView: TestApp.PostView }
   });
   var view = appController.connectOutlet({ name: 'post', outletName: 'mainView', context: context });
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's router");
   equal(appController.get('mainView'), view, "the app controller's view is set");
   equal(view.get('controller.content'), context, "the controller receives the context");
 });
@@ -103,7 +103,7 @@ test("connectOutlet works if a hash of options is passed", function() {
       context = {};
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController }
+    router: { postController: postController }
   });
 
   var view = appController.connectOutlet({
@@ -114,7 +114,7 @@ test("connectOutlet works if a hash of options is passed", function() {
   });
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), postController, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), postController, "the controller is looked up on the parent's router");
   equal(appController.get('mainView'), view, "the app controller's view is set");
   equal(view.get('controller.content'), context, "the controller receives the context");
 });
@@ -124,7 +124,7 @@ test("if the controller is explicitly set to null while connecting an outlet, th
       context = {};
 
   var appController = TestApp.ApplicationController.create({
-    controllers: { postController: postController }
+    router: { postController: postController }
   });
 
   var view = appController.connectOutlet({
@@ -134,7 +134,7 @@ test("if the controller is explicitly set to null while connecting an outlet, th
   });
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), null, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), null, "the controller is looked up on the parent's router");
   equal(appController.get('mainView'), view, "the app controller's view is set");
 
   var containerView = Ember.ContainerView.create({
@@ -149,14 +149,14 @@ test("if the controller is not given while connecting an outlet, the instantiate
   var postController = Ember.Controller.create();
 
   var appController = TestApp.ApplicationController.create({
-    controllers: {},
+    router: {},
     namespace: TestApp
   });
 
   var view = appController.connectOutlet('post');
 
   ok(view instanceof TestApp.PostView, "the view is an instance of PostView");
-  equal(view.get('controller'), null, "the controller is looked up on the parent's controllers hash");
+  equal(view.get('controller'), null, "the controller is looked up on the parent's router");
   equal(appController.get('view'), view, "the app controller's view is set");
 
   var containerView = Ember.ContainerView.create({
@@ -172,7 +172,7 @@ test("connectControllers injects other controllers", function() {
   var postController = {}, commentController = {};
 
   var controller = Ember.Controller.create({
-    controllers: {
+    router: {
       postController: postController,
       commentController: commentController
     }


### PR DESCRIPTION
The documentation [here](https://github.com/emberjs/ember.js/blob/master/packages/ember-application/lib/system/application.js#L102) indicates that controllers automatically instantiated by a router end up with a `router` property pointing back to it. This would be useful not only for grabbing non-global references to other automatically instantiated controllers but also for sending events to the router. However, the property isn't actually set.

I initially thought to just add an additional `router` property in the controllers injection but noticed the `controllers` property and how it is used by controllers. Rather than doing this, it seemed to make more sense to just rename the `controllers` property rather than add yet another reference to the same object.

AFAICT the `controllers` property is only used internally. It's not documented and I haven't seen any example apps using it directly. 
