### PR TITLE
Make ApplicationView available on App.applicationView

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -128,7 +128,6 @@ Ember.Application = Ember.Namespace.extend(
 
     if (!router && Ember.Router.detect(namespace['Router'])) {
       router = namespace['Router'].create();
-      this._createdRouter = router;
     }
 
     if (router) {
@@ -191,7 +190,7 @@ Ember.Application = Ember.Namespace.extend(
     var applicationView = this.ApplicationView.create({
       controller: applicationController
     });
-    this._createdApplicationView = applicationView;
+    set(this, 'applicationView', applicationView);
 
     applicationView.appendTo(rootElement);
 
@@ -209,9 +208,12 @@ Ember.Application = Ember.Namespace.extend(
 
   /** @private */
   willDestroy: function() {
+    var router = get(this, 'router'),
+        applicationView = get(this, 'applicationView');
+
     get(this, 'eventDispatcher').destroy();
-    if (this._createdRouter)          { this._createdRouter.destroy(); }
-    if (this._createdApplicationView) { this._createdApplicationView.destroy(); }
+    if (router) { router.destroy(); }
+    if (applicationView) { applicationView.destroy(); }
   },
 
   registerInjection: function(options) {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -133,7 +133,8 @@ test('initialized application go to initial route', function() {
           return '/';
         },
         setURL: function() {},
-        onUpdateURL: function() {}
+        onUpdateURL: function() {},
+        destroy: function () {}
       },
 
       root: Ember.Route.extend({


### PR DESCRIPTION
This is analogous to App.applicationController.

The motivation for having App.applicationView is that you may have to
destroy the running app in teardown methods in your test suite, but you
don't want to destroy the entire app with App.destroy() (because then
you cannot start it up again).

This also means that we don't have to rely on private instance variables
anymore (_createdApplicationView, _createdRouter) when determining what
to destroy. Instead we use App.get('applicationView') and
App.get('router'). This is consistent with App.get('eventDispatcher').
