### PR TITLE
Fixed selecting items in ember multi-selects with prompts

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -280,7 +280,7 @@ Ember.Select = Ember.View.extend(
 
     if (options) {
       options.each(function() {
-        adjusted = this.index > -1 ? this.index + offset : -1;
+        adjusted = this.index > -1 ? this.index - offset : -1;
         this.selected = indexOf(selectedIndexes, adjusted) > -1;
       });
     }

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -159,6 +159,25 @@ test("selection can be set when multiple=true", function() {
   deepEqual(select.get('selection'), [yehuda], "After changing it, selection should be correct");
 });
 
+test("selection can be set when multiple=true and prompt", function() {
+  var yehuda = { id: 1, firstName: 'Yehuda' },
+      tom = { id: 2, firstName: 'Tom' },
+      david = { id: 3, firstName: 'David' },
+      brennain = { id: 4, firstName: 'Brennain' };
+  select.set('content', Ember.A([yehuda, tom, david, brennain]));
+  select.set('multiple', true);
+  select.set('prompt', 'Pick one!');
+  select.set('selection', tom);
+
+  append();
+
+  deepEqual(select.get('selection'), [tom], "Initial selection should be correct");
+
+  select.set('selection', yehuda);
+
+  deepEqual(select.get('selection'), [yehuda], "After changing it, selection should be correct");
+});
+
 test("multiple selections can be set when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' },
       tom = { id: 2, firstName: 'Tom' },


### PR DESCRIPTION
Worked fine through the API, but when you manually clicked on an option
it would loop around and select the option two in front of it.  Multi-selects without
prompts work fine.
