### PR TITLE
Add #setObjects to mutable array. A helper for replacing whole content of the array with a new one

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -238,6 +238,26 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
     return this;
   },
 
+  /**
+    Replace all the the receiver's content with content of the argument.
+    If argument is an empty array receiver will be cleared.
+
+        var colors = ["red", "green", "blue"];
+        colors.setObjects(["black", "white"]); => ["black", "white"]
+        colors.setObjects([]); => []
+
+    @param {Ember.Array} objects array whose content will be used for replacing
+        the content of the receiver
+    @return {Ember.Array} receiver with the new content
+   */
+  setObjects: function(objects) {
+    if (objects.length === 0) return this.clear();
+
+    var len = get(this, 'length');
+    this.replace(0, len, objects);
+    return this;
+  },
+
   // ..........................................................
   // IMPLEMENT Ember.MutableEnumerable
   //

--- a/packages/ember-runtime/tests/suites/mutable_array/setObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/setObjects.js
@@ -1,0 +1,53 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+require('ember-runtime/~tests/suites/mutable_array');
+
+var suite = Ember.MutableArrayTests;
+
+suite.module('setObjects');
+
+suite.test("[A,B,C].setObjects([]) = > [] + notify", function() {
+  var obj, before, after, observer;
+
+  before = this.newFixture(3);
+  after  = [];
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
+  obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
+
+  equal(obj.setObjects(after), obj, 'return self');
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(Ember.get(obj, 'length'), after.length, 'length');
+
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
+  equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
+  equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+});
+
+suite.test("[A,B,C].setObjects([D, E, F, G]) = > [D, E, F, G] + notify", function() {
+  var obj, before, after, observer;
+
+  before = this.newFixture(3);
+  after  = this.newFixture(4);
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', '@each', 'length', 'firstObject', 'lastObject');
+  obj.getProperties('firstObject', 'lastObject'); /* Prime the cache */
+
+  equal(obj.setObjects(after), obj, 'return self');
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(Ember.get(obj, 'length'), after.length, 'length');
+
+  equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
+  equal(observer.timesCalled('@each'), 1, 'should have notified @each once');
+  equal(observer.timesCalled('length'), 1, 'should have notified length once');
+  equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+});


### PR DESCRIPTION
It shall make a life a bit easier in cases one needs to replace whole content of the array but keep the original array object. So, instead of doing:

var arr = obj.get('arr');
arr.replace(0, arr.length, newContent);

you can do just:

obj.get('arr').setObjects(newContent);
