### PR TITLE
bindAttr fails to render pathless class names in IE8

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2034,7 +2034,7 @@ Ember.View.reopenClass({
 
   */
   _parsePropertyPath: function(path) {
-    var split = path.split(/:/),
+    var split = path.split(':'),
         propertyPath = split[0],
         classNames = "",
         className,


### PR DESCRIPTION
Ember's bindAttr helper relies on the bindClasses function to create the 'class=""' string for the element it's being called on. bindClasses gets passed the space separated string that we use in our Handlebars templates (ex. {{bindAttr class="thing:foo :baz"}}. When parsing the classes, bindClasses calls _parsePropertyPath, which uses split() to figure out the pathname and classname for the property. 

In the past, split was passed a string to match against:

<pre>path.split(':')</pre>


Today, we're using: 

<pre>path.split(/:/)</pre>


The problem with the regex implementation is that it returns inconsistent results in different browsers. Take the following:

<pre>":foo".split(/:/)</pre>


In Chrome, Safari, Firefox, and IE9 we get:

<pre>["", "foo"]</pre>


In IE8, we get:

<pre>["foo"]</pre>


This causes all non-property classes (not sure what the terminology is, but I suppose you could call them 'literal' classes in the form ":foo") passed to bindAttr to fail to render in IE8. Given that passing a string to split returns the most consistent results across all browsers, this pull request includes a commit that changes the relevant _parsePropertyPath line to:

<pre>path.split(':')</pre>

