### PR TITLE
Don't add duplicates in SortableMixin#addObject

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -33,6 +33,11 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
   sortProperties: null,
   sortAscending: true,
 
+  pushObject: function(obj) {
+    var content = get(this, 'content');
+    return content.pushObject(obj);
+  },
+
   addObject: function(obj) {
     var content = get(this, 'content');
     content.addObject(obj);

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -35,9 +35,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
 
   addObject: function(obj) {
     var content = get(this, 'content');
-    if (!content.contains(obj)) {
-      content.pushObject(obj);
-    }
+    content.addObject(obj);
   },
 
   removeObject: function(obj) {

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -33,21 +33,6 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
   sortProperties: null,
   sortAscending: true,
 
-  pushObject: function(obj) {
-    var content = get(this, 'content');
-    return content.pushObject(obj);
-  },
-
-  addObject: function(obj) {
-    var content = get(this, 'content');
-    content.addObject(obj);
-  },
-
-  removeObject: function(obj) {
-    var content = get(this, 'content');
-    content.removeObject(obj);
-  },
-
   orderBy: function(item1, item2) {
     var result = 0,
         sortProperties = get(this, 'sortProperties'),

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -35,7 +35,9 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
 
   addObject: function(obj) {
     var content = get(this, 'content');
-    content.pushObject(obj);
+    if (!content.contains(obj)) {
+      content.pushObject(obj);
+    }
   },
 
   removeObject: function(obj) {

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -82,28 +82,6 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
   },
 
   /**
-    Should actually replace the specified objects on the content array.
-    You can override this method in subclasses to transform the content item
-    into something new.
-
-    This method will only be called if content is non-null.
-
-    @param {Number} idx
-      The starting index
-
-    @param {Number} amt
-      The number of items to remove from the content.
-
-    @param {Array} objects
-      Optional array of objects to insert or null if no objects.
-
-    @returns {void}
-  */
-  replaceContent: function(idx, amt, objects) {
-    get(this, 'arrangedContent').replace(idx, amt, objects);
-  },
-
-  /**
     Invoked when the content property is about to change. Notifies observers that the
     entire array content will change.
   */
@@ -209,7 +187,8 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
 
   /** @private (nodoc) */
   replace: function(idx, amt, objects) {
-    if (get(this, 'content')) this.replaceContent(idx, amt, objects);
+    var content = get(this, 'content');
+    if (content) content.replace(idx, amt, objects);
     return this;
   },
 

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -117,6 +117,20 @@ test("you can add objects in sorted order", function() {
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
 });
 
+test("you can push objects in sorted order", function() {
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+
+  unsortedArray.pushObject({id: 4, name: 'Scumbag Chavard'});
+
+  equal(sortedArrayController.get('length'), 4, 'array has 4 items');
+  equal(sortedArrayController.objectAt(1).name, 'Scumbag Chavard', 'a new object added to content was inserted according to given constraint');
+
+  sortedArrayController.pushObject({id: 5, name: 'Scumbag Fucs'});
+
+  equal(sortedArrayController.get('length'), 5, 'array has 5 items');
+  equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
+});
+
 test("you can unshift objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -168,3 +168,16 @@ test("you can set content later and it will be sorted", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
+
+test("addObject does not insert duplicates", function() {
+  var sortedArrayProxy, obj = {};
+  sortedArrayProxy = Ember.ArrayProxy.create(Ember.SortableMixin, {
+    content: Ember.A([obj])
+  });
+
+  equal(sortedArrayProxy.get('length'), 1, 'array has 1 item');
+
+  sortedArrayProxy.addObject(obj);
+
+  equal(sortedArrayProxy.get('length'), 1, 'array still has 1 item');
+});


### PR DESCRIPTION
The docs for MutableEnumerable state that addObject should "add the passed object to the receiver if the object is not already present in the collection" but the current implementation in SortableMixin adds objects unconditionally. As a result, this also breaks the behavior for ArrayControllers.
