### PR TITLE
Add Application#reset

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -343,6 +343,36 @@ Ember.Application = Ember.Namespace.extend(
     return this;
   },
 
+  /**
+    Reset the application. Useful for testing - run this before each test.
+
+    The application must have been initialized, and the ready event must have
+    fired.
+  */
+  reset: function(router) {
+    var oldRouter = get(this, 'router'),
+        applicationView = this._createdApplicationView,
+        eventDispatcher = get(this, 'eventDispatcher');
+
+    // Destroy stuff.
+    if (oldRouter) {
+      oldRouter.destroy();
+    }
+    if (applicationView) {
+      applicationView.destroy();
+    }
+    if (eventDispatcher) {
+      eventDispatcher.destroy();
+      this.createEventDispatcher();
+    }
+
+    // Mimic initialize.
+    router = this.setupRouter(router);
+    this.runInjections(router);
+    Ember.runLoadHooks('application', this);
+    this.didBecomeReady();
+  },
+
   /** @private */
   runInjections: function(router) {
     var injections = get(this.constructor, 'injections'),


### PR DESCRIPTION
This is mostly useful for testing.

---

As discussed with @wycats. Cc @twinturbo, he was interested in this too.

This is working great in my Konacha test suite.

Eventually it may be easier to allow for initialize being run more than once. I.e. #initialize will simply reset the app if it's called a second time. Still, #reset should be a good solution for now.

<del>This pull request includes #1317. You may want to merge that first, because it's a pure cleanup patch.</del> Merged.
