### PR TITLE
Fix a bug in multi-selects with primitive options

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -313,7 +313,7 @@ Ember.SelectOption = Ember.View.extend({
     var content = get(this, 'content'),
         selection = get(this, 'parentView.selection');
     if (get(this, 'parentView.multiple')) {
-      return selection && indexOf(selection, content) > -1;
+      return selection && indexOf(selection, content.valueOf()) > -1;
     } else {
       // Primitives get passed through bindings as objects... since
       // `new Number(4) !== 4`, we use `==` below
@@ -341,4 +341,3 @@ Ember.SelectOption = Ember.View.extend({
     }).property(valuePath).cacheable());
   }, 'parentView.optionValuePath')
 });
-

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -220,6 +220,21 @@ test("Ember.SelectedOption knows when it is selected when multiple=true", functi
   deepEqual(selectedOptions(), [false, true, true, false], "After changing it, selection should be correct");
 });
 
+test("Ember.SelectedOption knows when it is selected when multiple=true and options are primatives", function() {
+  select.set('content', Ember.A([1, 2, 3, 4]));
+  select.set('multiple', true);
+
+  select.set('selection', [1, 3]);
+
+  append();
+
+  deepEqual(selectedOptions(), [true, false, true, false], "Initial selection should be correct");
+
+  select.set('selection', [2, 3]);
+
+  deepEqual(selectedOptions(), [false, true, true, false], "After changing it, selection should be correct");
+});
+
 test("a prompt can be specified", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' },
       tom = { id: 2, firstName: 'Tom' };


### PR DESCRIPTION
The single select code path handled this case but the multi-select
did not.
