### PR TITLE
adding failing test for ArrayProxy observer invocation

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -33,16 +33,6 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable,
   sortProperties: null,
   sortAscending: true,
 
-  addObject: function(obj) {
-    var content = get(this, 'content');
-    content.pushObject(obj);
-  },
-
-  removeObject: function(obj) {
-    var content = get(this, 'content');
-    content.removeObject(obj);
-  },
-
   orderBy: function(item1, item2) {
     var result = 0,
         sortProperties = get(this, 'sortProperties'),

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -100,7 +100,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     @returns {void}
   */
   replaceContent: function(idx, amt, objects) {
-    get(this, 'arrangedContent').replace(idx, amt, objects);
+    get(this, 'content').replace(idx, amt, objects);
   },
 
   /**

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -117,6 +117,20 @@ test("you can add objects in sorted order", function() {
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
 });
 
+test("you can push objects in sorted order", function() {
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+
+  unsortedArray.pushObject({id: 4, name: 'Scumbag Chavard'});
+
+  equal(sortedArrayController.get('length'), 4, 'array has 4 items');
+  equal(sortedArrayController.objectAt(1).name, 'Scumbag Chavard', 'a new object added to content was inserted according to given constraint');
+
+  sortedArrayController.pushObject({id: 5, name: 'Scumbag Fucs'});
+
+  equal(sortedArrayController.get('length'), 5, 'array has 5 items');
+  equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
+});
+
 test("you can unshift objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
@@ -129,6 +143,19 @@ test("you can unshift objects in sorted order", function() {
 
   equal(sortedArrayController.get('length'), 5, 'array has 5 items');
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
+});
+
+test("addObject does not insert duplicates", function() {
+  var sortedArrayProxy, obj = {};
+  sortedArrayProxy = Ember.ArrayProxy.create(Ember.SortableMixin, {
+    content: Ember.A([obj])
+  });
+
+  equal(sortedArrayProxy.get('length'), 1, 'array has 1 item');
+
+  sortedArrayProxy.addObject(obj);
+
+  equal(sortedArrayProxy.get('length'), 1, 'array still has 1 item');
 });
 
 test("you can change a sort property and the content will rearrenge", function() {

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -1,0 +1,31 @@
+// ==========================================================================
+// Project:  Ember Runtime
+// Copyright: ©2011 Strobe Inc. and contributors.
+// License:   Licensed under MIT license (see license.js)
+// ==========================================================================
+
+module("Ember.ArrayProxy - content update");
+
+test("The `contentArrayDidChange` method is invoked after `content` is updated.", function() {
+
+  var proxy, observerCalled = false;
+
+  proxy = Ember.ArrayProxy.create({
+    content: Ember.A([]),
+
+    arrangedContent: Ember.computed('content', function(key, value) {
+      // setup arrangedContent as a different object than content,
+      // which is the default
+      return Ember.A(this.get('content').slice());
+    }).cacheable(),
+
+    contentArrayDidChange: function(array, idx, removedCount, addedCount) {
+      observerCalled = true;
+      return this._super(array, idx, removedCount, addedCount);
+    }
+  });
+
+  proxy.pushObject(1);
+
+  ok(observerCalled, "contentArrayDidChange is invoked");
+});


### PR DESCRIPTION
Adding test to demonstrate the underlying problem behind the `addObject`, `removeObject`, etc. wrappers in `SortableMixin`. c.f. #1311

@tomdale: this is what I was talking about yesterday afternoon in chat. In #1311 I suggested removing `replaceContent` from `ArrayProxy` and just having `ArrayProxy#replace` delegate to `content.replace`. If this is done, the above test will pass. But as @tchak points out, that's probably not a good idea. `replaceContent` is part of the public API for `ArrayProxy` and is useful.

That's fine but I want to resolve the issue of the array observers not firing if `replace` is ultimately called on `arrangedContent` instead of `content` (i.e. when `arrangedContent` and `content` are not the same object).

The above test is a simplified version of what happens inside of `SortableMixin` when you have `sortProperties` set.
