### PR TITLE
Fix :: syntax in classNameBindings to work with falsy values

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1300,6 +1300,32 @@ test("{{view}} should be able to bind class names to truthy properties", functio
   equal(view.$('.is-truthy').length, 0, "removes class name if bound property is set to falsey");
 });
 
+test("{{view}} should be able to bind class names to truthy or falsy properties", function() {
+  var templates = Ember.Object.create({
+    template: Ember.Handlebars.compile('{{#view "TemplateTests.classBindingView" classBinding="number:is-truthy:is-falsy"}}foo{{/view}}')
+  });
+
+  TemplateTests.classBindingView = Ember.View.extend();
+
+  view = Ember.View.create({
+    number: 5,
+    templateName: 'template',
+    templates: templates
+  });
+
+  appendView();
+
+  equal(view.$('.is-truthy').length, 1, "sets class name to truthy value");
+  equal(view.$('.is-falsy').length, 0, "doesn't set class name to falsy value");
+
+  Ember.run(function() {
+    set(view, 'number', 0);
+  });
+
+  equal(view.$('.is-truthy').length, 0, "doesn't set class name to truthy value");
+  equal(view.$('.is-falsy').length, 1, "sets class name to falsy value");
+});
+
 test("should be able to bind element attributes using {{bindAttr}}", function() {
   var template = Ember.Handlebars.compile('<img {{bindAttr src="content.url" alt="content.title"}}>');
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2069,34 +2069,36 @@ Ember.View.reopenClass({
     Get the class name for a given value, based on the path, optional className
     and optional falsyClassName.
 
-    - if the value is truthy and a className is defined, the className is returned
+    - if a className or falsyClassName has been specified:
+      - if the value is truthy and className has been specified, className is returned
+      - if the value is falsy and falsyClassName has been specified, falsyClassName is returned
+      - otherwise null is returned
     - if the value is true, the dasherized last part of the supplied path is returned
-    - if the value is false and a falsyClassName is supplied, the falsyClassName is returned
-    - if the value is truthy, the value is returned
+    - if the value is not false, undefined or null, the value is returned
     - if none of the above rules apply, null is returned
-
   */
   _classStringForValue: function(path, val, className, falsyClassName) {
-    // If the value is truthy and we're using the colon syntax,
-    // we should return the className directly
-    if (!!val && className) {
-      return className;
+    // When using the colon syntax, evaluate the truthiness or falsiness
+    // of the value to determine which className to return
+    if (className || falsyClassName) {
+      if (className && !!val) {
+        return className;
+
+      } else if (falsyClassName && !val) {
+        return falsyClassName;
+
+      } else {
+        return null;
+      }
 
     // If value is a Boolean and true, return the dasherized property
     // name.
     } else if (val === true) {
-      // catch syntax like isEnabled::not-enabled
-      if (val === true && !className && falsyClassName) { return null; }
-
       // Normalize property path to be suitable for use
       // as a class name. For exaple, content.foo.barBaz
       // becomes bar-baz.
       var parts = path.split('.');
       return Ember.String.dasherize(parts[parts.length-1]);
-
-    // If the value is false and a falsyClassName is specified, return it
-    } else if (val === false && falsyClassName) {
-      return falsyClassName;
 
     // If the value is not false, undefined, or null, return the current
     // value of the property.

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -11,7 +11,8 @@ module("Ember.View - Class Name Bindings");
 test("should apply bound class names to the element", function() {
   var view = Ember.View.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
-                        'canIgnore', 'messages.count', 'messages.resent:is-resent', 'isNumber:is-number',
+                        'canIgnore', 'messages.count', 'messages.resent:is-resent',
+                        'isNumber:is-number', 'isFalsy::is-falsy', 'isTruthy::is-not-truthy',
                         'isEnabled:enabled:disabled'],
 
     priority: 'high',
@@ -19,6 +20,8 @@ test("should apply bound class names to the element", function() {
     isClassified: true,
     canIgnore: false,
     isNumber: 5,
+    isFalsy: 0,
+    isTruthy: 'abc',
     isEnabled: true,
 
     messages: {
@@ -37,6 +40,9 @@ test("should apply bound class names to the element", function() {
   ok(view.$().hasClass('five-messages'), "supports paths in bindings");
   ok(view.$().hasClass('is-resent'), "supports customing class name for paths");
   ok(view.$().hasClass('is-number'), "supports colon syntax with truthy properties");
+  ok(view.$().hasClass('is-falsy'), "supports colon syntax with falsy properties");
+  ok(!view.$().hasClass('abc'), "does not add values as classes when falsy classes have been specified");
+  ok(!view.$().hasClass('is-not-truthy'), "does not add falsy classes when values are truthy");
   ok(!view.$().hasClass('can-ignore'), "does not add false Boolean values as class");
   ok(view.$().hasClass('enabled'), "supports customizing class name for Boolean values with negation");
   ok(!view.$().hasClass('disabled'), "does not add class name for negated binding");


### PR DESCRIPTION
Currently, the double colon class name bindings work for true, truthy, and false values, but not falsy values. This commit corrects that.

For instance, `classNameBindings: ['isEnabled:enabled:disabled']` will now evaluate to `disabled` when `isEnabled` is falsy (and not just explicitly false).
