### PR TITLE
Allow State.transitionTo handle multiple contexts

### DIFF
--- a/packages/ember-states/lib/main.js
+++ b/packages/ember-states/lib/main.js
@@ -1,5 +1,4 @@
 require('ember-runtime');
-require('ember-views');
 
 /**
 Ember States

--- a/packages/ember-states/lib/main.js
+++ b/packages/ember-states/lib/main.js
@@ -1,4 +1,5 @@
 require('ember-runtime');
+require('ember-views');
 
 /**
 Ember States

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -181,8 +181,6 @@ Ember.State = Ember.Object.extend(Ember.Evented,
   exit: Ember.K
 });
 
-var Event = Ember.$ && Ember.$.Event;
-
 Ember.State.reopenClass(
 /** @scope Ember.State */{
 
@@ -211,24 +209,26 @@ Ember.State.reopenClass(
   @static
   @param {String} target
   */
+
   transitionTo: function(target) {
-    var event = function(stateManager, context) {
-      if (Event && context instanceof Event) {
-        if (context.hasOwnProperty('context')) {
-          context = context.context;
-        } else {
-          // If we received an event and it doesn't contain
-          // a context, don't pass along a superfluous
-          // context to the target of the event.
-          return stateManager.transitionTo(target);
-        }
+
+    var transitionFunction = function(stateManager, contextOrEvent) {
+      var contexts, transitionArgs;
+
+      if (contextOrEvent && (contextOrEvent instanceof Ember.$.Event) && contextOrEvent.hasOwnProperty('contexts')) {
+        contexts = contextOrEvent.contexts.slice();
+      }
+      else {
+        contexts = [].slice.call(arguments, 1);
       }
 
-      stateManager.transitionTo(target, context);
+      contexts.unshift(target);
+      stateManager.transitionTo.apply(stateManager, contexts);
     };
 
-    event.transitionTarget = target;
+    transitionFunction.transitionTarget = target;
 
-    return event;
+    return transitionFunction;
   }
+
 });

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -213,9 +213,10 @@ Ember.State.reopenClass(
   transitionTo: function(target) {
 
     var transitionFunction = function(stateManager, contextOrEvent) {
-      var contexts, transitionArgs;
+      var contexts, transitionArgs, Event;
+      Event = Ember.$ && Ember.$.Event;
 
-      if (contextOrEvent && (contextOrEvent instanceof Ember.$.Event) && contextOrEvent.hasOwnProperty('contexts')) {
+      if (contextOrEvent && (Event && contextOrEvent instanceof Event) && contextOrEvent.hasOwnProperty('contexts')) {
         contexts = contextOrEvent.contexts.slice();
       }
       else {

--- a/packages/ember-states/package.json
+++ b/packages/ember-states/package.json
@@ -12,7 +12,8 @@
 
   "dependencies": {
     "spade":              "~> 1.0",
-    "ember-runtime": "1.0.pre"
+    "ember-runtime": "1.0.pre",
+    "ember-views": "1.0.pre"
   },
 
   "dependencies:development": {

--- a/packages/ember-states/package.json
+++ b/packages/ember-states/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "spade":              "~> 1.0",
     "ember-runtime": "1.0.pre",
-    "ember-views": "1.0.pre"
   },
 
   "dependencies:development": {

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -383,7 +383,7 @@ test("it sends exit events in the correct order when changing to a state multipl
   equal(exitOrder[1], 'exitedOuter', "outer exit is called second");
 });
 
-var passedContext, loadingEventCalled, loadedEventCalled, eventInChildCalled;
+var passedContext, passedContexts, loadingEventCalled, loadedEventCalled, eventInChildCalled;
 loadingEventCalled = loadedEventCalled = eventInChildCalled = 0;
 
 module("Ember.StateManager - Event Dispatching", {
@@ -393,6 +393,7 @@ module("Ember.StateManager - Event Dispatching", {
         anEvent: function(manager, context) {
           loadingEventCalled++;
           passedContext = context;
+          passedContexts = [].slice.call(arguments, 1);
         }
       }),
 
@@ -440,6 +441,12 @@ test("it does not dispatch events to parents if the child responds to it", funct
 test("it supports arguments to events", function() {
   stateManager.send('anEvent', { context: true });
   equal(passedContext.context, true, "send passes along a context");
+});
+
+test("it supports multiple arguments to events", function() {
+  stateManager.send('anEvent', {name: 'bestie'}, {name: 'crofty'});
+  equal(passedContexts[0].name, 'bestie', "send passes along the first context");
+  equal(passedContexts[1].name, 'crofty', "send passes along the second context");
 });
 
 test("it throws an exception if an event is dispatched that is unhandled", function() {

--- a/packages/ember-states/tests/state_test.js
+++ b/packages/ember-states/tests/state_test.js
@@ -1,3 +1,4 @@
+require('ember-views');
 var get = Ember.get, set = Ember.set;
 
 module("Ember.State");
@@ -219,28 +220,6 @@ test("Ember.State.transitionTo passes no context arguments when there are no con
   transitionFunction(stateManager, event);
 
   equal( contextArgsCount, 0);
-});
-
-test("Ember.State.transitionTo passes through a single context", function(){
-  var contextArgsCount,
-      stateManager,
-      transitionFunction,
-      event;
-
-  event = new Ember.$.Event();
-  event.contexts = [];
-
-  stateManager = {
-    transitionTo: function(){
-      contextArgsCount = [].slice.call(arguments, 1).length;
-    }
-  };
-
-  transitionFunction = Ember.State.transitionTo('targetState');
-
-  transitionFunction(stateManager, event);
-
-  equal(contextArgsCount, 0);
 });
 
 test("Ember.State.transitionTo passes through a single context", function(){

--- a/packages/ember-states/tests/state_test.js
+++ b/packages/ember-states/tests/state_test.js
@@ -1,5 +1,4 @@
-require('ember-views');
-var get = Ember.get, set = Ember.set;
+var get = Ember.get, set = Ember.set, _$;
 
 module("Ember.State");
 
@@ -182,7 +181,17 @@ test("the isLeaf property is false when a state has child states", function() {
   equal(definitelyInside.get('isLeaf'), true);
 });
 
-test("Ember.State.transitionTo sets the transition target", function(){
+module("Ember.State.transitionTo", {
+  setup: function(){
+    _$ = Ember.$;
+    Ember.$ = {};
+    Ember.$.Event = function(){};
+  },
+  teardown: function(){
+    Ember.$ = _$;
+  }
+});
+test("sets the transition target", function(){
   var receivedTarget,
       stateManager,
       transitionFunction;
@@ -200,7 +209,7 @@ test("Ember.State.transitionTo sets the transition target", function(){
   equal( receivedTarget, 'targetState' );
 });
 
-test("Ember.State.transitionTo passes no context arguments when there are no contexts", function(){
+test("passes no context arguments when there are no contexts", function(){
   var contextArgsCount,
       stateManager,
       transitionFunction,
@@ -222,7 +231,7 @@ test("Ember.State.transitionTo passes no context arguments when there are no con
   equal( contextArgsCount, 0);
 });
 
-test("Ember.State.transitionTo passes through a single context", function(){
+test("passes through a single context", function(){
   var receivedContext,
       stateManager,
       transitionFunction,
@@ -244,7 +253,7 @@ test("Ember.State.transitionTo passes through a single context", function(){
   equal( receivedContext, event.contexts[0]);
 });
 
-test("Ember.State.transitionTo passes through multiple contexts as additional arguments", function(){
+test("passes through multiple contexts as additional arguments", function(){
   var receivedContexts,
       stateManager,
       transitionFunction,
@@ -266,7 +275,7 @@ test("Ember.State.transitionTo passes through multiple contexts as additional ar
   deepEqual( receivedContexts, event.contexts);
 });
 
-test("Ember.State.transtionTo does not mutate the event contexts value", function(){
+test("does not mutate the event contexts value", function(){
   var receivedContexts,
       stateManager,
       transitionFunction,
@@ -291,7 +300,7 @@ test("Ember.State.transtionTo does not mutate the event contexts value", functio
   deepEqual(event.contexts, originalContext);
 });
 
-test("Ember.State.transitionTo passes no context arguments when called with no context or event", function(){
+test("passes no context arguments when called with no context or event", function(){
   var receivedContexts,
       stateManager,
       transitionFunction;
@@ -309,7 +318,7 @@ test("Ember.State.transitionTo passes no context arguments when called with no c
   equal( receivedContexts.length, 0, "transitionTo receives no context");
 });
 
-test("Ember.State.transitionTo handles contexts without an event", function(){
+test("handles contexts without an event", function(){
   var receivedContexts,
       stateManager,
       transitionFunction,

--- a/packages/ember-states/tests/state_test.js
+++ b/packages/ember-states/tests/state_test.js
@@ -180,3 +180,176 @@ test("the isLeaf property is false when a state has child states", function() {
   equal(otherInsideFirst.get('isLeaf'), false);
   equal(definitelyInside.get('isLeaf'), true);
 });
+
+test("Ember.State.transitionTo sets the transition target", function(){
+  var receivedTarget,
+      stateManager,
+      transitionFunction;
+
+  stateManager = {
+    transitionTo: function(target, context){
+      receivedTarget = target;
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager);
+
+  equal( receivedTarget, 'targetState' );
+});
+
+test("Ember.State.transitionTo passes no context arguments when there are no contexts", function(){
+  var contextArgsCount,
+      stateManager,
+      transitionFunction,
+      event;
+
+  event = new Ember.$.Event();
+  event.contexts = [];
+
+  stateManager = {
+    transitionTo: function(){
+      contextArgsCount = [].slice.call(arguments, 1).length;
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager, event);
+
+  equal( contextArgsCount, 0);
+});
+
+test("Ember.State.transitionTo passes through a single context", function(){
+  var contextArgsCount,
+      stateManager,
+      transitionFunction,
+      event;
+
+  event = new Ember.$.Event();
+  event.contexts = [];
+
+  stateManager = {
+    transitionTo: function(){
+      contextArgsCount = [].slice.call(arguments, 1).length;
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager, event);
+
+  equal(contextArgsCount, 0);
+});
+
+test("Ember.State.transitionTo passes through a single context", function(){
+  var receivedContext,
+      stateManager,
+      transitionFunction,
+      event;
+
+  event = new Ember.$.Event();
+  event.contexts = [{ value: 'context value' }];
+
+  stateManager = {
+    transitionTo: function(target, context){
+      receivedContext = context;
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager, event);
+
+  equal( receivedContext, event.contexts[0]);
+});
+
+test("Ember.State.transitionTo passes through multiple contexts as additional arguments", function(){
+  var receivedContexts,
+      stateManager,
+      transitionFunction,
+      event;
+
+  event = new Ember.$.Event();
+  event.contexts = [ { value: 'context1' }, { value: 'context2' } ];
+
+  stateManager = {
+    transitionTo: function(target){
+      receivedContexts = [].slice.call(arguments, 1);
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager, event);
+
+  deepEqual( receivedContexts, event.contexts);
+});
+
+test("Ember.State.transtionTo does not mutate the event contexts value", function(){
+  var receivedContexts,
+      stateManager,
+      transitionFunction,
+      originalContext,
+      event;
+
+  originalContext = [ { value: 'context1' }, { value: 'context2' } ];
+
+  event = new Ember.$.Event();
+  event.contexts = originalContext.slice();
+
+  stateManager = {
+    transitionTo: function(target){
+      receivedContexts = [].slice.call(arguments, 1);
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager, event);
+
+  deepEqual(event.contexts, originalContext);
+});
+
+test("Ember.State.transitionTo passes no context arguments when called with no context or event", function(){
+  var receivedContexts,
+      stateManager,
+      transitionFunction;
+
+  stateManager = {
+    transitionTo: function(target){
+      receivedContexts = [].slice.call(arguments, 1);
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager);
+
+  equal( receivedContexts.length, 0, "transitionTo receives no context");
+});
+
+test("Ember.State.transitionTo handles contexts without an event", function(){
+  var receivedContexts,
+      stateManager,
+      transitionFunction,
+      context1,
+      context2;
+
+  context1 = { value: 'context1', contexts: 'I am not an event'};
+  context2 = { value: 'context2', contexts: ''};
+
+  stateManager = {
+    transitionTo: function(target){
+      receivedContexts = [].slice.call(arguments, 1);
+    }
+  };
+
+  transitionFunction = Ember.State.transitionTo('targetState');
+
+  transitionFunction(stateManager, context1, context2);
+
+  equal( receivedContexts[0], context1, "the first context is passed through" );
+  equal( receivedContexts[1], context2, "the second context is passed through" );
+});


### PR DESCRIPTION
 Allows multiple contexts to be passed to `Ember.State.transitionTo` either as multiple arguments or as an array of contexts within an event.

Changed `StateManager.send` and `sendRecursively` to allow multiple context arguments.

Added missing test coverage for transitionTo.
