### PR TITLE
Allow Handlebars definition passed by AMD (RequireJS)

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -21,7 +21,7 @@ var objectCreate = Ember.create;
   @description Helpers for Handlebars templates
 */
 
-Ember.assert("Ember Handlebars requires Handlebars 1.0.beta.5 or greater", window.Handlebars && window.Handlebars.VERSION.match(/^1\.0\.beta\.[56789]$|^1\.0\.rc\.[123456789]+/));
+Ember.assert("Ember Handlebars requires Handlebars 1.0.beta.5 or greater", Handlebars && Handlebars.VERSION.match(/^1\.0\.beta\.[56789]$|^1\.0\.rc\.[123456789]+/));
 
 /**
   @class


### PR DESCRIPTION
I'm using [RequireJS](http://requirejs.org/) in my ember project, and including ember and handlebars using the [shim configuration](http://requirejs.org/docs/api.html#config-shim) (where handlebars is declared as a dependancy of ember). This works fine in development mode but unfortunately when the [optimize step](http://requirejs.org/docs/optimization.html) is run using r.js I get the following assertions error:

`Uncaught Error: assertion failed: Ember Handlebars requires Handlebars 1.0.beta.5 or greater`

This is because Ember explicitly checks the `window` namespace for `Handlebars`, but because it is wrapped in an AMD module it is not avilable in the global namespace. 

By not explicitly checking `window.Handlebars` Ember is able to use the non-global `Handlebars` version supplied by the AMD module.
