### PR TITLE
Make Ember.empty work with empty objects

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -108,6 +108,7 @@ Ember.none = function(obj) {
       Ember.empty(undefined);      => true
       Ember.empty('');             => true
       Ember.empty([]);             => true
+      Ember.empty({});             => true
       Ember.empty('tobias fünke'); => false
       Ember.empty([0,1,2]);        => false
 
@@ -115,7 +116,25 @@ Ember.none = function(obj) {
   @returns {Boolean}
 */
 Ember.empty = function(obj) {
-  return obj === null || obj === undefined || (obj.length === 0 && typeof obj !== 'function') || (typeof obj === 'object' && Ember.get(obj, 'length') === 0);
+  if (obj === null)
+    return true;
+  else if (obj === undefined)
+    return true;
+  else if (obj.length === 0 && typeof obj !== 'function')
+    return true;
+  else if (typeof(obj) === 'object') {
+    if (Ember.get(obj, 'length') === 0) {
+      return true;
+    } else {
+      var key;
+      for (key in obj) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  return false;
 };
 
 /**

--- a/packages/ember-runtime/tests/core/empty_test.js
+++ b/packages/ember-runtime/tests/core/empty_test.js
@@ -21,7 +21,7 @@ test("Ember.empty", function() {
   equal(false, Ember.empty(fn),        "for a Function");
   equal(false, Ember.empty(0),         "for 0");
   equal(true,  Ember.empty([]),        "for an empty Array");
-  equal(false, Ember.empty({}),        "for an empty Object");
+  equal(true,  Ember.empty({}),        "for an empty Object");
   equal(true,  Ember.empty(object),     "for an Object that has zero 'length'");
   equal(true,  Ember.empty(arrayProxy), "for an ArrayProxy that has empty content");
 });


### PR DESCRIPTION
Ember.empty implies that it works for anything that's 'empty' yet objects are not included:

```
 Ember.empty({}) // false
```

This pull requests makes Ember.empty also return true for empty objects.
