### PR TITLE
New assertion to check for a valid viewClass on connectOutlet when name isn't defined.

### DIFF
--- a/packages/ember-views/lib/system/controller.js
+++ b/packages/ember-views/lib/system/controller.js
@@ -144,8 +144,10 @@ Ember.ControllerMixin.reopen({
     }
 
     outletName = outletName || 'view';
-
-    Ember.assert("You must supply a name or a view class to connectOutlet, but not both", (!!name && !viewClass && !controller) || (!name && !!viewClass));
+    
+    Ember.assert("The viewClass is either missing or the one provided did not resolve to a view", !!name || (!name && !!viewClass));
+    
+    Ember.assert("You must supply a name or a viewClass to connectOutlet, but not both", (!!name && !viewClass && !controller) || (!name && !!viewClass));
 
     if (name) {
       var namespace = get(this, 'namespace'),


### PR DESCRIPTION
This error really bugged me when I clearly wasn't providing both name and viewClass at the same time, but the viewClass I was providing just wasn't found. Now this assertion will run first if name is undefined, to check that viewClass is defined and resolving to a view. 

I'm not sure if this is a necessary addition or the best way to write it, but it sure would have saved me a lot of pain if the current assertion was more specific.

I've tested every case I can think of and the error output looks correct and more helpful to me now. 

Also changes the original error to say "viewClass" instead of "view class".
