### PR TITLE
Restoring the 0.9.8.1 release notes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -166,6 +166,13 @@
 * Implement modelType guessing.
 * Add support for modelType in the router
 
+*Ember 0.9.8.1 (May 22, 2012)*
+
+* Fix bindAttr with global paths
+* Fix initialization with non routable stateManager
+* Better jQuery warning message
+* Documentation fixes
+
 *Ember 0.9.8 (May 21, 2012)*
 
 * Better docs


### PR DESCRIPTION
The release notes were previously added in af957ea2c58d434c14ea00d0381b20be39178a9f. However, they seem to have been removed in af957ea2c58d434c14ea00d0381b20be39178a9f.

This just restores the release notes to the changelog.
