### PR TITLE
Use get, not direct access, to get stateManager events

### DIFF
--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -630,7 +630,7 @@ Ember.StateManager = Ember.State.extend({
 
   sendRecursively: function(event, currentState, context) {
     var log = this.enableLogging,
-        action = currentState[event];
+        action = get(currentState, event);
 
     // Test to see if the action is a method that
     // can be invoked. Don't blindly check just for


### PR DESCRIPTION
The motivation for this is to be able to have properties that return an
event handler function, e.g. like so:

```
doSomethingDynamic: (function() {
  if (...) {
    return Ember.Route.transitionTo('foo');
  } else {
    return Ember.Route.transitionTo('bar');
  }
}).property(...)
```
