### PR TITLE
Fixed a bug with setting computed properties that modify the passed in value

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -290,8 +290,10 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
       ret;
   this._suspended = obj;
 
+  ret = this.func.call(obj, keyName, value);
+
   if (cacheable && keyName in meta.cache) {
-    if (meta.cache[keyName] === value) {
+    if (meta.cache[keyName] === ret) {
       return;
     }
     hadCachedValue = true;
@@ -302,8 +304,6 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
   if (cacheable && hadCachedValue) {
     delete meta.cache[keyName];
   }
-
-  ret = this.func.call(obj, keyName, value);
 
   if (cacheable) {
     if (!watched && !hadCachedValue) {

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -575,6 +575,35 @@ testBoth('setting a watched computed property', function(get, set) {
   equal(lastNameDidChange, 1);
 });
 
+testBoth('setting a cached computed property that modifies the value you give it', function(get, set) {
+  var obj = {};
+  Ember.defineProperty(obj, 'plusOne', Ember.computed(
+    function(key, value) {
+      if (arguments.length > 1) {
+        return value + 1;
+      }
+      return 0;
+    }).property().cacheable()
+  );
+  var plusOneWillChange = 0,
+      plusOneDidChange = 0;
+  Ember.addBeforeObserver(obj, 'plusOne', function () {
+    plusOneWillChange++;
+  });
+  Ember.addObserver(obj, 'plusOne', function () {
+    plusOneDidChange++;
+  });
+
+  equal(get(obj, 'plusOne'), 0);
+  set(obj, 'plusOne', 0);
+  equal(get(obj, 'plusOne'), 1);
+  set(obj, 'plusOne', 0);
+  equal(get(obj, 'plusOne'), 1);
+
+  equal(plusOneWillChange, 1);
+  equal(plusOneDidChange, 1);
+});
+
 module('CP macros');
 
 testBoth('Ember.computed.not', function(get, set) {


### PR DESCRIPTION
Found this because it broke a test in ember-data@relationship-improvements when we upgraded ember
