### PR TITLE
Remove unused and broken support for Ember.config.overrideAccessors

### DIFF
--- a/packages/ember-metal/lib/accessors.js
+++ b/packages/ember-metal/lib/accessors.js
@@ -302,11 +302,3 @@ Ember.trySetPath = Ember.deprecateFunc('trySetPath has been renamed to trySet', 
 Ember.isGlobalPath = function(path) {
   return IS_GLOBAL.test(path);
 };
-
-
-
-if (Ember.config.overrideAccessors) {
-  Ember.config.overrideAccessors();
-  get = Ember.get;
-  set = Ember.set;
-}


### PR DESCRIPTION
Support for Ember.config.overrideAccessors was broken with b7e82f43c3475ee7b166a2570b061f08c6c6c0f3.

Since no one's complaining, and there's no documentation for it, might as well remove it.
