### PR TITLE
Add a confirm option to the action helper

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -31,6 +31,10 @@ ActionHelper.registerAction = function(actionName, options) {
 
       event.preventDefault();
 
+      if (options.confirm && !window.confirm(options.confirm)) {
+        return;
+      }
+
       event.view = options.view;
 
       if (options.hasOwnProperty('context')) {
@@ -275,6 +279,10 @@ EmberHandlebars.registerHelper('action', function(actionName) {
     url = target.urlForEvent.apply(target, [actionName].concat(contexts));
     output.push('href="' + url + '"');
     action.link = true;
+  }
+
+  if (hash.confirm) {
+    action.confirm = hash.confirm;
   }
 
   var actionId = ActionHelper.registerAction(actionName, action);

--- a/packages/ember-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-handlebars/tests/helpers/action_test.js
@@ -407,3 +407,69 @@ test("should allow multiple contexts to be specified", function() {
 
   deepEqual(passedContexts, models, "the action was called with the passed contexts");
 });
+
+test("should allow a confirm dialog to be shown", function(){
+  var shown = 0,
+      _confirm = window.confirm;
+
+  window.confirm = function(){
+    return shown++;
+  };
+
+  view = Ember.View.create({
+    edit: function() {},
+    template: Ember.Handlebars.compile('<a href="#" {{action "edit" confirm="Are you sure?"}}>edit</a>')
+  });
+
+  appendView();
+
+  view.$('a').click();
+
+  equal(shown, 1, "the confirm dialog was shown");
+
+  window.confirm = _confirm;
+});
+
+test("should show the provided dialog text", function(){
+  var _confirm = window.confirm,
+      dialogText;
+
+  window.confirm = function(text){
+    dialogText = text;
+  };
+
+  view = Ember.View.create({
+    edit: function() {},
+    template: Ember.Handlebars.compile('<a href="#" {{action "edit" confirm="Are you sure?"}}>edit</a>')
+  });
+
+  appendView();
+
+  view.$('a').click();
+
+  equal(dialogText, "Are you sure?", "the dialog shows the passed text");
+
+  window.confirm = _confirm;
+});
+
+test("should not send the action to the target when canceled", function(){
+  var _confirm = window.confirm,
+      called = 0;
+
+  window.confirm = function(){
+    return false;
+  };
+
+  view = Ember.View.create({
+    edit: function() { called++; },
+    template: Ember.Handlebars.compile('<a href="#" {{action "edit" confirm="Are you sure?"}}>edit</a>')
+  });
+
+  appendView();
+
+  view.$('a').click();
+
+  equal(called, 0, "the action is not called when the dialog is canceled");
+
+  window.confirm = _confirm;
+});


### PR DESCRIPTION
If a confirm option is provided, a javascript confirm dialog will be shown with the provided text and the action will be executed if the dialog is accepted.

Usage:

``` .js
<a {{action "delete" confirm="Are you sure?"}}>Delete info</a>
```
