### PR TITLE
Fix for popstate firing on page load.

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -4,6 +4,7 @@
 */
 
 var get = Ember.get, set = Ember.set;
+var popstateReady = false;
 
 /**
   Ember.HistoryLocation implements the location API using the browser's
@@ -64,6 +65,7 @@ Ember.HistoryLocation = Ember.Object.extend({
     path = this.formatURL(path);
 
     if ((initialURL !== path && !state) || (state && state.path !== path)) {
+      popstateReady = true;
       window.history.pushState({ path: path }, null, path);
     }
   },
@@ -81,6 +83,9 @@ Ember.HistoryLocation = Ember.Object.extend({
     var guid = Ember.guidFor(this);
 
     Ember.$(window).bind('popstate.ember-location-'+guid, function(e) {
+      if(!popstateReady) {
+        return;
+      }
       callback(location.pathname);
     });
   },


### PR DESCRIPTION
On Chrome popstate is fired on page load (see http://stackoverflow.com/questions/6421769/popstate-on-pages-load-in-chrome). This causes the initial route to be entered twice. This PR fixes that.

I would add a test for this, but due it it requiring a fresh page load, it is very non-trivial.
