### PR TITLE
Teardown observers on rerender.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -58,6 +58,10 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
     // object ({{this}}) so updating it is not our responsibility.
     if (path !== '') {
       Ember.addObserver(pathRoot, path, observer);
+
+      view.one('willRerender', function() {
+        Ember.removeObserver(pathRoot, path, observer);
+      });
     }
   } else {
     // The object is not observable, so just render it out and
@@ -322,6 +326,10 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
     // unique data id and update the attribute to the new value.
     if (path !== 'this') {
       Ember.addObserver(pathRoot, path, invoker);
+
+      view.one('willRerender', function() {
+        Ember.removeObserver(pathRoot, path, invoker);
+      });
     }
 
     // if this changes, also change the logic in ember-views/lib/views/view.js
@@ -439,6 +447,10 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
 
     if (path !== '' && path !== 'this') {
       Ember.addObserver(pathRoot, path, invoker);
+
+      view.one('willRerender', function() {
+        Ember.removeObserver(pathRoot, path, invoker);
+      });
     }
 
     // We've already setup the observer; now we just need to figure out the

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -2383,3 +2383,37 @@ test("should accept bindings as a string or an Ember.Binding", function() {
 
   equal(Ember.$.trim(view.$().text()), "binding: down, string: down");
 });
+
+test("should teardown observers from bound properties on rerender", function() {
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile("{{view.foo}}"),
+    foo: 'bar'
+  });
+
+  appendView();
+
+  equal(Ember.observersFor(view, 'foo').length, 1);
+
+  Ember.run(function() {
+    view.rerender();
+  });
+
+  equal(Ember.observersFor(view, 'foo').length, 1);
+});
+
+test("should teardown observers from bindAttr on rerender", function() {
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<span {{bindAttr class="foo" name="foo"}}>wat</span>'),
+    foo: 'bar'
+  });
+
+  appendView();
+
+  equal(Ember.observersFor(view, 'foo').length, 2);
+
+  Ember.run(function() {
+    view.rerender();
+  });
+
+  equal(Ember.observersFor(view, 'foo').length, 2);
+});

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1120,6 +1120,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       }
 
       addObserver(this, parsedPath.path, observer);
+
+      this.one('willRerender', function() {
+        removeObserver(this, parsedPath.path, observer);
+      });
     }, this);
   },
 
@@ -1155,6 +1159,10 @@ Ember.View = Ember.Object.extend(Ember.Evented,
       };
 
       addObserver(this, property, observer);
+
+      this.one('willRerender', function() {
+        removeObserver(this, property, observer);
+      });
 
       // Determine the current value and add it to the render buffer
       // if necessary.

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -3,6 +3,10 @@ var set = Ember.set, get = Ember.get;
 
 var view;
 
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
 module("Ember.View - Attribute Bindings", {
   teardown: function() {
     if (view) {
@@ -163,4 +167,22 @@ test("should allow binding to String objects", function() {
   
 
   equal(view.$().attr('foo'), 'bar', "should convert String object to bare string");
+});
+
+test("should teardown observers on rerender", function() {
+  view = Ember.View.create({
+    attributeBindings: ['foo'],
+    classNameBindings: ['foo'],
+    foo: 'bar'
+  });
+
+  appendView();
+
+  equal(Ember.observersFor(view, 'foo').length, 2);
+
+  Ember.run(function() {
+    view.rerender();
+  });
+
+  equal(Ember.observersFor(view, 'foo').length, 2);
 });


### PR DESCRIPTION
We'll be renaming willRerender to willClearRender. It will also get
triggered when the view's destroy or remove methods are called.
