### PR TITLE
Fix 'removing observer should stop firing' test

### DIFF
--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -378,6 +378,9 @@ testBoth('removing observer should stop firing', function(get,set) {
   equal(count, 1, 'should have invoked observer');
 
   Ember.removeObserver(obj, 'foo', F);
+
+  set(obj, 'foo', 'baz');
+  equal(count, 1, "removed observer shouldn't fire");
 });
 
 testBoth('local observers can be removed', function(get, set) {


### PR DESCRIPTION
Correct me if I'm wrong but it looks like this test wasn't testing if the observer was removed.
