### PR TITLE
Don't attempt to concat a concatenatedProperty onto an object that doesn...

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -106,7 +106,15 @@ function mergeMixins(mixins, m, descs, values, base) {
             }
           } else if ((concats && a_indexOf.call(concats, key) >= 0) || key === 'concatenatedProperties') {
             var baseValue = values[key] || base[key];
-            value = baseValue ? baseValue.concat(value) : Ember.makeArray(value);
+            if (baseValue) {
+              if ('function' === typeof baseValue.concat) {
+                value = baseValue.concat(value);
+              } else {
+                value = Ember.makeArray(baseValue).concat(value);
+              }
+            } else {
+              value = Ember.makeArray(value);
+            }
           }
 
           descs[key] = undefined;

--- a/packages/ember-metal/tests/mixin/concatenatedProperties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenatedProperties_test.js
@@ -65,3 +65,33 @@ test('adding a prop that is not an array should make array', function() {
   var obj = Ember.mixin({}, MixinA);
   deepEqual(Ember.get(obj, 'foo'), ['bar']);
 });
+
+test('adding a non-concatenable property that already has a defined value should result in an array with both values', function() {
+
+  var mixinA = Ember.Mixin.create({
+    foo: 1
+  });
+
+  var mixinB = Ember.Mixin.create({
+    concatenatedProperties: ['foo'],
+    foo: 2
+  });
+
+  var obj = Ember.mixin({}, mixinA, mixinB);
+  deepEqual(Ember.get(obj, 'foo'), [1, 2]);
+});
+
+test('adding a concatenable property that already has a defined value should result in a concatenated value', function() {
+
+  var mixinA = Ember.Mixin.create({
+    foobar: 'foo'
+  });
+
+  var mixinB = Ember.Mixin.create({
+    concatenatedProperties: ['foobar'],
+    foobar: 'bar'
+  });
+
+  var obj = Ember.mixin({}, mixinA, mixinB);
+  equal(Ember.get(obj, 'foobar'), 'foobar');
+});


### PR DESCRIPTION
...'t have a concat method

Try in any console:

Ember.Object.extend({foo: 1}, {concatenatedProperties:['foo'], foo: 2}).create();
=> TypeError: Object 1 has no method 'concat'

alternatively:
Ember.Object.extend({foobar: 'foo'}, {concatenatedProperties:['foobar'], foobar: 'bar'}).create().get('foobar');
=> "foobar"

If a previous value exists, #concat is blindly called on it assuming it is an array. I was previously taking advantage of this by creating a custom class that enables concatenating properties, and defining it on an anonymous mixin prior to my real mixin. Then, instead of wrapping my objects in an array, they got concatenated onto my root, custom object.

This is obviously a bug. How it is resolved is something of an open question. I would prefer a permissive solution, as I have implemented, which allows a pre-existing property the chance to handle the concatenation itself, otherwise the value gets wrapped into an array.  The restrictive solution would be simply to check to see if the pre-existing property is an array and concat if it is, or wrap it in an array and then concat if it is not.
