### PR TITLE
Replace '<' at the end of Metamorph script by \x3C

### DIFF
--- a/packages/metamorph/lib/main.js
+++ b/packages/metamorph/lib/main.js
@@ -53,11 +53,11 @@
   };
 
   startTagFunc = function() {
-    return "<script id='" + this.start + "' type='text/x-placeholder'></script>";
+    return "<script id='" + this.start + "' type='text/x-placeholder'>\x3C/script>";
   };
 
   endTagFunc = function() {
-    return "<script id='" + this.end + "' type='text/x-placeholder'></script>";
+    return "<script id='" + this.end + "' type='text/x-placeholder'>\x3C/script>";
   };
 
   // If we have the W3C range API, this process is relatively straight forward.


### PR DESCRIPTION
This pull-request aims to prevent an escaping problem.

Some mobile ISPs (at least in France) contain transparent proxies to "optimize" web pages by aggregating all the JS and CSS files in one HTML page...

During this process all files are escaped, and the end script tag are replaced by : 

``` html
</S"+"cript>" 
```

This problem is known. For example, to load JQuery script from the Google CDN, you can use the same solution as I used in the code attached. Like this:

http://stackoverflow.com/questions/8231048/why-use-x3c-instead-of-when-generating-html-from-javascript
