### PR TITLE
Allow extension of chosen prototypes instead of the current all or none.

### DIFF
--- a/packages/ember-handlebars/lib/string.js
+++ b/packages/ember-handlebars/lib/string.js
@@ -9,7 +9,7 @@ Ember.String.htmlSafe = function(str) {
 
 var htmlSafe = Ember.String.htmlSafe;
 
-if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.String)) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
     See {{#crossLink "Ember.String/htmlSafe"}}{{/crossLink}}
@@ -20,5 +20,4 @@ if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYP
   String.prototype.htmlSafe = function() {
     return htmlSafe(this);
   };
-
 }

--- a/packages/ember-handlebars/lib/string.js
+++ b/packages/ember-handlebars/lib/string.js
@@ -9,7 +9,7 @@ Ember.String.htmlSafe = function(str) {
 
 var htmlSafe = Ember.String.htmlSafe;
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.String)) {
 
   /**
     See {{#crossLink "Ember.String/htmlSafe"}}{{/crossLink}}

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -88,9 +88,29 @@ Ember.config = Ember.config || {};
 Ember.EXTEND_PROTOTYPES = (Ember.ENV.EXTEND_PROTOTYPES !== false);
 
 /**
+<<<<<<< HEAD
   Determines whether Ember logs a full stack trace during deprecation warnings
 
   @property LOG_STACKTRACE_ON_DEPRECATION
+=======
+  @static
+  @type Object
+  @constant
+
+  Determines which prototypes will be extended assuming Ember.EXTEND_PROTOTYPES
+  is true.
+*/
+Ember.PROTOTYPE_EXTENSIONS = Ember.ENV.PROTOTYPE_EXTENSIONS;
+
+if (Ember.PROTOTYPE_EXTENSIONS === undefined) {
+  Ember.PROTOTYPE_EXTENSIONS = {
+    all: true
+  };
+}
+
+/**
+  @static
+>>>>>>> 8750700... Allow extension of chosen prototypes instead of the current all or none.
   @type Boolean
   @default true
 */

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -75,7 +75,7 @@ Ember.config = Ember.config || {};
   Determines whether Ember should enhances some built-in object
   prototypes to provide a more friendly API.  If enabled, a few methods
   will be added to Function, String, and Array.  Object.prototype will not be
-  enhanced, which is the one that causes most troubles for people.
+  enhanced, which is the one that causes most trouble for people.
 
   In general we recommend leaving this option set to true since it rarely
   conflicts with other code.  If you need to turn it off however, you can
@@ -85,32 +85,16 @@ Ember.config = Ember.config || {};
   @type Boolean
   @default true
 */
-Ember.EXTEND_PROTOTYPES = (Ember.ENV.EXTEND_PROTOTYPES !== false);
+Ember.EXTEND_PROTOTYPES = Ember.ENV.EXTEND_PROTOTYPES;
 
-/**
-<<<<<<< HEAD
-  Determines whether Ember logs a full stack trace during deprecation warnings
-
-  @property LOG_STACKTRACE_ON_DEPRECATION
-=======
-  @static
-  @type Object
-  @constant
-
-  Determines which prototypes will be extended assuming Ember.EXTEND_PROTOTYPES
-  is true.
-*/
-Ember.PROTOTYPE_EXTENSIONS = Ember.ENV.PROTOTYPE_EXTENSIONS;
-
-if (Ember.PROTOTYPE_EXTENSIONS === undefined) {
-  Ember.PROTOTYPE_EXTENSIONS = {
-    all: true
-  };
+if (typeof Ember.EXTEND_PROTOTYPES === 'undefined') {
+  Ember.EXTEND_PROTOTYPES = true;
 }
 
 /**
-  @static
->>>>>>> 8750700... Allow extension of chosen prototypes instead of the current all or none.
+  Determines whether Ember logs a full stack trace during deprecation warnings
+
+  @property LOG_STACKTRACE_ON_DEPRECATION
   @type Boolean
   @default true
 */

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -7,11 +7,12 @@ require('ember-runtime/core');
 
 var a_slice = Array.prototype.slice;
 
-if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.Function)) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
   /**
     The `property` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES is true, which is the default.
+    when Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Function is true,
+    which is the default.
 
     Computed properties allow you to treat a function like a property:
 
@@ -67,7 +68,8 @@ if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYP
 
   /**
     The `observes` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES is true, which is the default.
+    when Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Function is true,
+    which is the default.
 
     You can observe property changes simply by adding the `observes`
     call to the end of your method declarations in classes that you write.
@@ -90,8 +92,9 @@ if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYP
   };
 
   /**
-    The `observesBefore` extension of Javascript's Function prototype is
-    available when Ember.EXTEND_PROTOTYPES is true, which is the default.
+    The `observesBefore` extension of Javascript's Function prototype is available
+    when Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Function is true,
+    which is the default.
 
     You can get notified when a property changes is about to happen by
     by adding the `observesBefore` call to the end of your method

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -7,7 +7,7 @@ require('ember-runtime/core');
 
 var a_slice = Array.prototype.slice;
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.Function)) {
 
   /**
     The `property` extension of Javascript's Function prototype is available

--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -16,7 +16,7 @@ var fmt = Ember.String.fmt,
     dasherize = Ember.String.dasherize,
     underscore = Ember.String.underscore;
 
-if (Ember.EXTEND_PROTOTYPES) {
+if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.String)) {
 
   /**
     See {{#crossLink "Ember.String/fmt"}}{{/crossLink}}

--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -16,7 +16,7 @@ var fmt = Ember.String.fmt,
     dasherize = Ember.String.dasherize,
     underscore = Ember.String.underscore;
 
-if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.String)) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
     See {{#crossLink "Ember.String/fmt"}}{{/crossLink}}

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -105,9 +105,9 @@ if (ignore.length>0) {
 /**
   The NativeArray mixin contains the properties needed to to make the native
   Array support Ember.MutableArray and all of its dependent APIs.  Unless you
-  have Ember.EXTEND_PROTOTYPES set to false, this will be applied automatically.
-  Otherwise you can apply the mixin at anytime by calling
-  `Ember.NativeArray.activate`.
+  have Ember.EXTEND_PROTOTYPES or Ember.PROTOTYPE_EXTENSIONS.Array set to false,
+  this will be applied automatically.
+  Otherwise you can apply the mixin at anytime by calling `Ember.NativeArray.activate`.
 
   @class NativeArray
   @namespace Ember
@@ -147,6 +147,7 @@ Ember.NativeArray.activate = function() {
   Ember.A = function(arr) { return arr || []; };
 };
 
-if (Ember.EXTEND_PROTOTYPES) Ember.NativeArray.activate();
-
+if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.Array)) {
+  Ember.NativeArray.activate();
+}
 

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -105,9 +105,9 @@ if (ignore.length>0) {
 /**
   The NativeArray mixin contains the properties needed to to make the native
   Array support Ember.MutableArray and all of its dependent APIs.  Unless you
-  have Ember.EXTEND_PROTOTYPES or Ember.PROTOTYPE_EXTENSIONS.Array set to false,
-  this will be applied automatically.
-  Otherwise you can apply the mixin at anytime by calling `Ember.NativeArray.activate`.
+  have Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Array set to false, this
+  will be applied automatically. Otherwise you can apply the mixin at anytime by
+  calling `Ember.NativeArray.activate`.
 
   @class NativeArray
   @namespace Ember
@@ -147,7 +147,7 @@ Ember.NativeArray.activate = function() {
   Ember.A = function(arr) { return arr || []; };
 };
 
-if (Ember.EXTEND_PROTOTYPES && (Ember.PROTOTYPE_EXTENSIONS.all || Ember.PROTOTYPE_EXTENSIONS.Array)) {
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Array) {
   Ember.NativeArray.activate();
 }
 

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -23,8 +23,8 @@ Ember.STRINGS = {};
 
 /**
   Defines string helper methods including string formatting and localization.
-  Unless Ember.EXTEND_PROTOTYPES = false these methods will also be added to the
-  String.prototype as well.
+  Unless Ember.EXTEND_PROTOTYPES or Ember.PROTOTYPE_EXTENSIONS.String are false
+  these methods will also be added to the String.prototype as well.
 
   @class String
   @namespace Ember
@@ -109,7 +109,7 @@ Ember.String = {
 
   /**
     Converts a camelized string into all lower case separated by underscores.
-    
+
         'innerHTML'.decamelize()         => 'inner_html'
         'action_name'.decamelize()       => 'action_name'
         'css-class-name'.decamelize()    => 'css-class-name'
@@ -125,7 +125,7 @@ Ember.String = {
 
   /**
     Replaces underscores or spaces with dashes.
-    
+
         'innerHTML'.dasherize()         => 'inner-html'
         'action_name'.dasherize()       => 'action-name'
         'css-class-name'.dasherize()    => 'css-class-name'

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -23,8 +23,8 @@ Ember.STRINGS = {};
 
 /**
   Defines string helper methods including string formatting and localization.
-  Unless Ember.EXTEND_PROTOTYPES or Ember.PROTOTYPE_EXTENSIONS.String are false
-  these methods will also be added to the String.prototype as well.
+  Unless Ember.EXTEND_PROTOTYPES.String is false these methods will also be added
+  to the String.prototype as well.
 
   @class String
   @namespace Ember


### PR DESCRIPTION
The update lets Window.ENV.EXTEND_PROTOTYPES be treated as a hash in order to more granularly control which prototypes are extended by Ember.   The updates are backwards compatible with the old boolean definition.

``` javascript
window.Env = {
  EXTEND_PROTOTYPES: {
    Function: true,
    String: true,
    Array: true
  }
}
```
