### PR TITLE
Do not pass jQuery event object if no context is given

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -214,11 +214,13 @@ Ember.State.reopenClass(
   transitionTo: function(target) {
 
     var transitionFunction = function(stateManager, contextOrEvent) {
-      var contexts, transitionArgs, Event;
-      Event = Ember.$ && Ember.$.Event;
+      var contexts = [], transitionArgs,
+          Event = Ember.$ && Ember.$.Event;
 
-      if (contextOrEvent && (Event && contextOrEvent instanceof Event) && contextOrEvent.hasOwnProperty('contexts')) {
-        contexts = contextOrEvent.contexts.slice();
+      if (contextOrEvent && (Event && contextOrEvent instanceof Event)) {
+        if (contextOrEvent.hasOwnProperty('contexts')) {
+          contexts = contextOrEvent.contexts.slice();
+        }
       }
       else {
         contexts = [].slice.call(arguments, 1);

--- a/packages/ember-states/tests/state_test.js
+++ b/packages/ember-states/tests/state_test.js
@@ -193,20 +193,23 @@ module("Ember.State.transitionTo", {
 });
 test("sets the transition target", function(){
   var receivedTarget,
+      receivedContext,
       stateManager,
       transitionFunction;
 
   stateManager = {
     transitionTo: function(target, context){
       receivedTarget = target;
+      receivedContext = context;
     }
   };
 
   transitionFunction = Ember.State.transitionTo('targetState');
 
-  transitionFunction(stateManager);
+  transitionFunction(stateManager, new Ember.$.Event());
 
-  equal( receivedTarget, 'targetState' );
+  equal(receivedTarget, 'targetState');
+  ok(!receivedContext, "does not pass a context when given an event without context");
 });
 
 test("passes no context arguments when there are no contexts", function(){


### PR DESCRIPTION
As of 19e2631 (merged this Friday), the transition function used by
State.transitionTo passes along a spurious jQuery event object if no
context is given.
