### PR TITLE
Fix State.transitionTo documentation by removing @scope

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -182,33 +182,32 @@ Ember.State = Ember.Object.extend(Ember.Evented,
   exit: Ember.K
 });
 
-Ember.State.reopenClass(
-/** @scope Ember.State */{
+Ember.State.reopenClass({
 
   /**
-  Creates an action function for transitioning to the named state while preserving context.
+    Creates an action function for transitioning to the named state while preserving context.
 
-  The following example StateManagers are equivalent:
+    The following example StateManagers are equivalent:
 
-      aManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: Ember.State.transitionTo('stateTwo')
-        }),
-        stateTwo: Ember.State.create({})
-      })
+        aManager = Ember.StateManager.create({
+          stateOne: Ember.State.create({
+            changeToStateTwo: Ember.State.transitionTo('stateTwo')
+          }),
+          stateTwo: Ember.State.create({})
+        })
 
-      bManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: function(manager, context){
-            manager.transitionTo('stateTwo', context)
-          }
-        }),
-        stateTwo: Ember.State.create({})
-      })
+        bManager = Ember.StateManager.create({
+          stateOne: Ember.State.create({
+            changeToStateTwo: function(manager, context){
+              manager.transitionTo('stateTwo', context)
+            }
+          }),
+          stateTwo: Ember.State.create({})
+        })
 
-  @method transitionTo
-  @static
-  @param {String} target
+    @method transitionTo
+    @static
+    @param {String} target
   */
 
   transitionTo: function(target) {


### PR DESCRIPTION
With the `@scope`, the documentation would come out as a single garbled
(unformatted) paragraph.

Now it is `@scope`'d to Ember.State.prototype instead of Ember.State,
which I guess is not 100% correct, but we still have the `@static` tag
to tell it from an instance method. And at least it works. ;-)

---

See http://emberjs.com/api/classes/Ember.State.html#method_transitionTo for the garblement.
