### PR TITLE
ember-metal/instrumentation needs to load after ember-metal/core 

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -5,8 +5,8 @@ Ember Metal
 @submodule ember-metal
 */
 
-require('ember-metal/instrumentation');
 require('ember-metal/core');
+require('ember-metal/instrumentation');
 require('ember-metal/map');
 require('ember-metal/platform');
 require('ember-metal/utils');


### PR DESCRIPTION
ember-metal/instrumentation needs to load after ember-metal/core so that the Ember namespace exists. This is breaking at least the runtime production build currently.
