### PR TITLE
Add basic attributeBinding docs

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -20,6 +20,20 @@ var get = Ember.get, set = Ember.set;
   Because HTML `textarea` elements do not contain inner HTML the `layout` and `layoutName` 
   properties will not be applied. See `Ember.View`'s layout section for more information.
 
+  ## HTML Attributes
+
+  By default `Ember.TextArea` provides support for `rows`, `cols`, `placeholder`, `disabled`,
+  `maxlength` and `tabindex` attributes on a textarea. If you need to support  more
+  attributes have a look at the `attributeBindings` property in `Ember.View`'s HTML Attributes section.
+
+  To globally add support for additional attributes you can reopen `Ember.TextArea` or `Ember.TextSupport`.
+
+  ``` javascript
+  Ember.TextSupport.reopen({
+    attributeBindings: ["required"]
+  })
+  ```
+
   @class TextArea
   @namespace Ember
   @extends Ember.View

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -25,6 +25,22 @@ var get = Ember.get, set = Ember.set;
   Because HTML `input` elements are self closing `layout` and `layoutName` properties will
   not be applied. See `Ember.View`'s layout section for more information.
 
+  ## HTML Attributes
+
+  By default `Ember.TextField` provides support for `type`, `value`, `size`, `placeholder`,
+  `disabled`, `maxlength` and `tabindex` attributes on a textarea. If you need to support
+  more attributes have a look at the `attributeBindings` property in `Ember.View`'s
+  HTML Attributes section.
+
+  To globally add support for additional attributes you can reopen `Ember.TextField` or
+  `Ember.TextSupport`.
+
+  ``` javascript
+  Ember.TextSupport.reopen({
+    attributeBindings: ["required"]
+  })
+  ```
+
   @class TextField
   @namespace Ember
   @extends Ember.View


### PR DESCRIPTION
Adds some documentation about adding extra attributes to inputs as this seems to be the most common area they are needed.

See discussion in #1444 and #1456.
