### PR TITLE
Add Ember.String.classify() to string extensions

### DIFF
--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -14,7 +14,8 @@ var fmt = Ember.String.fmt,
     camelize = Ember.String.camelize,
     decamelize = Ember.String.decamelize,
     dasherize = Ember.String.dasherize,
-    underscore = Ember.String.underscore;
+    underscore = Ember.String.underscore,
+    classify = Ember.String.classify;
 
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
@@ -88,5 +89,14 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
     return underscore(this);
   };
 
+  /**
+    See {{#crossLink "Ember.String/classify"}}{{/crossLink}}
+
+    @method classify
+    @for String
+  */
+  String.prototype.classify = function() {
+    return classify(this);
+  };
 }
 

--- a/packages/ember-runtime/tests/system/string/classify.js
+++ b/packages/ember-runtime/tests/system/string/classify.js
@@ -1,0 +1,29 @@
+module('Ember.String.classify');
+
+test("classify normal string", function() {
+  deepEqual(Ember.String.classify('my favorite items'), 'MyFavoriteItems');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('my favorite items'.classify(), 'MyFavoriteItems');
+  }
+});
+
+test("classify dasherized string", function() {
+  deepEqual(Ember.String.classify('css-class-name'), 'CssClassName');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('css-class-name'.classify(), 'CssClassName');
+  }
+});
+
+test("classify underscored string", function() {
+  deepEqual(Ember.String.classify('action_name'), 'ActionName');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('action_name'.classify(), 'ActionName');
+  }
+});
+
+test("does nothing with classified string", function() {
+  deepEqual(Ember.String.classify('InnerHTML'), 'InnerHTML');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('InnerHTML'.classify(), 'InnerHTML');
+  }
+});


### PR DESCRIPTION
Ember.String defined a classify() method, but it wasn't added to String.prototype like the other string extensions. Now it is. With tests and everything!
