### PR TITLE
Add failing test case for ContainerView template context

### DIFF
--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -27,7 +27,7 @@ test("should be able to insert views after the DOM representation is created", f
   Ember.run(function(){
     container.destroy();
   });
-  
+
 });
 
 test("should be able to observe properties that contain child views", function() {
@@ -74,22 +74,22 @@ test("should set the parentView property on views that are added to the child vi
   Ember.run(function(){
     childViews.pushObject(view);
   });
-  
+
   equal(get(view, 'parentView'), container, "sets the parent view after the childView is appended");
 
   var secondView = View.create(),
       thirdView = View.create(),
       fourthView = View.create();
-  
+
   Ember.run(function(){
     childViews.pushObject(secondView);
     childViews.replace(1, 0, [thirdView, fourthView]);
   });
-  
+
   equal(get(secondView, 'parentView'), container, "sets the parent view of the second view");
   equal(get(thirdView, 'parentView'), container, "sets the parent view of the third view");
   equal(get(fourthView, 'parentView'), container, "sets the parent view of the fourth view");
-  
+
   childViews.replace(2, 2);
   equal(get(view, 'parentView'), container, "doesn't change non-removed view");
   equal(get(thirdView, 'parentView'), container, "doesn't change non-removed view");
@@ -489,4 +489,23 @@ test("should invalidate `element` on itself and childViews when being rendered b
 
   ok(!!container.get('element'), "Parent's element should have been recomputed after being rendered");
   ok(!!view.get('element'), "Child's element should have been recomputed after being rendered");
+});
+
+test("should set the child view context in template", function() {
+  var container = Ember.ContainerView.create({
+    name: 'container'
+  });
+
+  set(container, 'currentView', Ember.View.create({
+    name: 'child',
+    template: function(context, options) {
+      return 'In ' + context.get('name') + ' context';
+    }
+  }));
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  equal(container.$().text(), 'In child context', '');
 });


### PR DESCRIPTION
Given a container with a child view,

```
{{foo}}
```

in the child view will try to access the `foo` property on the container view, rather than the child view.

In other words, the template context is not set correctly.

I'm attaching a failing test case.

(Continuing from #900, retargeted at master.)
