### PR TITLE
Suppress JSON output of meta objects on browsers with simulated properties

### DIFF
--- a/lib/ember.js
+++ b/lib/ember.js
@@ -2186,7 +2186,18 @@ var EMPTY_META = {
 
 if (Object.freeze) Object.freeze(EMPTY_META);
 
-var createMeta = Ember.platform.defineProperty.isSimulated ? o_create : (function(meta) { return meta; });
+var createMeta = function (meta) { return meta; };
+if (Ember.platform.defineProperty.isSimulated) {
+  createMeta = function (meta) {
+    var ret = o_create(meta);
+
+    // Without non-enumerable properties, meta objects will be output in JSON
+    // unless explicitly suppressed
+    ret.toJSON = function () { };
+
+    return ret;
+  }
+}
 
 /**
   @private


### PR DESCRIPTION
This code changed substantially since emberjs-1.0 pre (which I still use and test against), but here's an untested reworking of it targeted at current head. This should at least give the gist of the idea.
