### PR TITLE
Fixing 'jQuery git' tests on master. $.uuid was removed upstream.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -15,7 +15,7 @@ var ActionHelper = EmberHandlebars.ActionHelper = {
 };
 
 ActionHelper.registerAction = function(actionName, options) {
-  var actionId = (++Ember.$.uuid).toString();
+  var actionId = (++Ember.uuid).toString();
 
   ActionHelper.registeredActions[actionId] = {
     eventName: options.eventName,

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -316,7 +316,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
   // Generate a unique id for this element. This will be added as a
   // data attribute to the element so it can be looked up when
   // the bound property changes.
-  var dataId = ++Ember.$.uuid;
+  var dataId = ++Ember.uuid;
 
   // Handle classes differently, as we can bind multiple classes
   var classBindings = attrs['class'];

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -137,6 +137,15 @@ if ('undefined' === typeof ember_deprecateFunc) {
   exports.ember_deprecateFunc = function(_, func) { return func; };
 }
 
+/**
+  Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from jQuery master.
+  We'll just bootstrap our own uuid now.
+
+  @property uuid
+  @type Number
+  @private
+*/
+Ember.uuid = 0;
 
 // ..........................................................
 // LOGGER


### PR DESCRIPTION
Since `$.uuid` was removed from jQuery master, we're switching to using `Ember.uuid` instead. This fixes broken unit tests.
