### PR TITLE
Fix bug in SortableMixin when changing item position

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -174,17 +174,16 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
   },
 
   insertItemSorted: function(item) {
-    var arrangedContent = get(this, 'arrangedContent');
-    var length = get(arrangedContent, 'length');
-
-    var idx = this._binarySearch(item, 0, length);
+    var arrangedContent = get(this, 'arrangedContent'),
+        idx = this._binarySearch(arrangedContent, item);
     arrangedContent.insertAt(idx, item);
   },
 
   contentItemSortPropertyDidChange: function(item) {
     var arrangedContent = get(this, 'arrangedContent'),
         oldIndex = arrangedContent.indexOf(item),
-        newIndex = this._binarySearch(item, 0, get(arrangedContent, 'length'));
+        arrangedContentWithoutItem = Ember.A(arrangedContent.filter(function(i){ return i !== item; })),
+        newIndex = this._binarySearch(arrangedContentWithoutItem, item);
 
     if (newIndex !== oldIndex) {
       arrangedContent.removeObject(item);
@@ -192,24 +191,28 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
     }
   },
 
-  _binarySearch: function(item, low, high) {
-    var mid, midItem, res, arrangedContent;
+  _binarySearch: function(array, item, low, high) {
+    var mid, midItem, res;
+    if (low == null){
+      low = 0;
+    }
+    if (high == null){
+      high = get(array, 'length');
+    }
 
     if (low === high) {
       return low;
     }
 
-    arrangedContent = get(this, 'arrangedContent');
-
     mid = low + Math.floor((high - low) / 2);
-    midItem = arrangedContent.objectAt(mid);
+    midItem = array.objectAt(mid);
 
     res = this.orderBy(midItem, item);
 
     if (res < 0) {
-      return this._binarySearch(item, mid+1, high);
+      return this._binarySearch(array, item, mid+1, high);
     } else if (res > 0) {
-      return this._binarySearch(item, low, mid);
+      return this._binarySearch(array, item, low, mid);
     }
 
     return mid;

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -1,6 +1,5 @@
 var get = Ember.get, set = Ember.set;
 
-var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
 
 var unsortedArray, sortedArrayController;
 
@@ -9,6 +8,7 @@ module("Ember.Sortable");
 module("Ember.Sortable with content", {
   setup: function() {
     Ember.run(function() {
+      var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
       unsortedArray = Ember.A(Ember.A(array).copy());
 
       sortedArrayController = Ember.ArrayProxy.create(Ember.SortableMixin, {
@@ -103,6 +103,7 @@ test("don't remove and insert if position didn't change", function() {
 module("Ember.Sortable with content and sortProperties", {
   setup: function() {
     Ember.run(function() {
+      var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
       unsortedArray = Ember.A(Ember.A(array).copy());
 
       sortedArrayController = Ember.ArrayController.create({
@@ -159,6 +160,15 @@ test("you can change a sort property and the content will rearrenge", function()
   set(sortedArrayController.objectAt(0), 'name', 'Scumbag Fucs');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Dale', 'dale is first now');
   equal(sortedArrayController.objectAt(1).name, 'Scumbag Fucs', 'foucs is second');
+});
+
+test("you can change the position of the middle item", function() {
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+
+  equal(sortedArrayController.objectAt(1).name, 'Scumbag Dale', 'Dale is second');
+  set(sortedArrayController.objectAt(1), 'name', 'Alice'); // Change Dale to Alice
+
+  equal(sortedArrayController.objectAt(0).name, 'Alice', 'Alice (previously Dale) is first now');
 });
 
 module("Ember.Sortable with sortProperties", {


### PR DESCRIPTION
This fixes a bug in the SortableMixin where the sort was being done incorrectly when the observed properties changed.

The reason for the bug was that the new index for an item was being determined by doing a binary search across an array that already included the item.  In order to determine the correct position, the binary search needs to be done across an array that doesn't already include the item.

I've changed the arguments that `_binarySearch` takes, it shouldn't be a big deal because this is part of the private API.  It now takes an array that it will do the search over as the first argument.  I've also specified defaults for the low and high arguments so that these can be left off in the most common use case for `_binarySearch`
