### PR TITLE
Ember.Handlebars.ViewHelper: extract viewClass lookup

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -119,18 +119,9 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
         data = options.data,
         view = data.view,
         fn = options.fn,
-        hash = options.hash,
-        newView;
+        hash = options.hash;
 
-    if ('string' === typeof path) {
-      newView = EmberHandlebars.get(thisContext, path, options);
-      Ember.assert("Unable to find view at path '" + path + "'", !!newView);
-    } else {
-      newView = path;
-    }
-
-    Ember.assert(Ember.String.fmt('You must pass a view class to the #view helper, not %@ (%@)', [path, newView]), Ember.View.detect(newView));
-
+    var newView = this.viewClass(thisContext, path, options);
     var viewOptions = this.propertiesFromHTMLOptions(options, thisContext);
     var currentView = data.view;
     viewOptions.templateData = options.data;
@@ -147,6 +138,19 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
     }
 
     currentView.appendChild(newView, viewOptions);
+  },
+
+  viewClass: function(thisContext, path, options) {
+    var result;
+    if ('string' === typeof path) {
+      result = EmberHandlebars.get(thisContext, path, options);
+      Ember.assert("Unable to find view at path '" + path + "'", !!result);
+    } else {
+      result = path;
+    }
+
+    Ember.assert(Ember.String.fmt('You must pass a view class to the #view helper, not %@ (%@)', [path, result]), Ember.View.detect(result));
+    return result;
   }
 });
 

--- a/packages/ember-handlebars/tests/helpers/view_lookup_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_lookup_test.js
@@ -1,0 +1,22 @@
+var originalLookup = Ember.lookup, lookup,
+    MyView = Ember.View.extend({ isMyView: true });
+
+module("Ember.Handlebars.ViewHelper.viewClass", {
+  setup: function() {
+    Ember.lookup = lookup = {
+      Ember: Ember,
+      Foo: {
+        MyView: MyView
+      }
+    };
+  },
+
+  teardown: function() {
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("it updates the view if an item is added", function() {
+  var viewClass = Ember.Handlebars.ViewHelper.viewClass({}, 'Foo.MyView');
+  equal( MyView, viewClass );
+});


### PR DESCRIPTION
We have been using CommonJS to clean up the structure of our code. This works great for JavaScript code:

``` javascript
var MyClass = Ember.Object.extend( require('app/userSettingsClient', {
  toString: function() {
    return this.get('userSettings.displayName');
  }
});
```

Unfortunately, it doesn't work for Handlebars view names:

``` handlebars
{{view "i/cannotUse/requireHereView"}}
```

I had hoped to be able to swap out `Ember.lookup`, but that needs to be an object, and `require` is a function. The code for actually looking up the view class was mixed in with the rest of the `{{view}}` helper code, but simply extracting it gives us the ability to override it easily.
