### PR TITLE
Bug Fix: Generated href for nested routes with multiple contexts

### DIFF
--- a/packages/ember-routing/lib/routable.js
+++ b/packages/ember-routing/lib/routable.js
@@ -121,16 +121,33 @@ Ember.Routable = Ember.Mixin.create({
 
     @method absoluteRoute
     @param manager {Ember.StateManager}
-    @param hash {Hash}
+    @param hashes {Array}
   */
-  absoluteRoute: function(manager, hash) {
-    var parentState = get(this, 'parentState');
-    var path = '', generated;
+  absoluteRoute: function(manager, hashes) {
+    var parentState = get(this, 'parentState'),
+      path = '', 
+      generated,
+      currentHash;
+
+    // check if object passed instead of array
+    // in this case set currentHash = hashes 
+    // this allows hashes to be a single hash 
+    // (it will be applied to state and all parents)
+    currentHash = null;
+    if (hashes) {
+      if (hashes instanceof Array) {
+        if (hashes.length > 0) {
+          currentHash = hashes.shift();
+        }
+      } else {
+        currentHash = hashes;
+      }
+    }
 
     // If the parent state is routable, use its current path
     // as this route's prefix.
     if (get(parentState, 'isRoutable')) {
-      path = parentState.absoluteRoute(manager, hash);
+      path = parentState.absoluteRoute(manager, hashes);
     }
 
     var matcher = get(this, 'routeMatcher'),
@@ -138,10 +155,10 @@ Ember.Routable = Ember.Mixin.create({
 
     // merge the existing serialized object in with the passed
     // in hash.
-    hash = hash || {};
-    merge(hash, serialized);
+    currentHash = currentHash || {};
+    merge(currentHash, serialized);
 
-    generated = matcher && matcher.generate(hash);
+    generated = matcher && matcher.generate(currentHash);
 
     if (generated) {
       path = path + '/' + generated;

--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -499,7 +499,7 @@ Ember.Router = Ember.StateManager.extend(
     }
   },
 
-  urlFor: function(path, hash) {
+  urlFor: function(path, hashes) {
     var currentState = get(this, 'currentState') || this,
         state = this.findStateByPath(currentState, path);
 
@@ -507,36 +507,42 @@ Ember.Router = Ember.StateManager.extend(
     Ember.assert(Ember.String.fmt("To get a URL for the state '%@', it must have a `route` property.", [path]), get(state, 'routeMatcher'));
 
     var location = get(this, 'location'),
-        absoluteRoute = state.absoluteRoute(this, hash);
+        absoluteRoute = state.absoluteRoute(this, hashes);
 
     return location.formatURL(absoluteRoute);
   },
 
   urlForEvent: function(eventName) {
-    var contexts = Array.prototype.slice.call(arguments, 1);
-    var currentState = get(this, 'currentState');
-    var targetStateName = currentState.lookupEventTransition(eventName);
+    var contexts = Array.prototype.slice.call(arguments, 1),
+      currentState = get(this, 'currentState'),
+      targetStateName = currentState.lookupEventTransition(eventName),
+      targetState,
+      hashes;
 
     Ember.assert(Ember.String.fmt("You must specify a target state for event '%@' in order to link to it in the current state '%@'.", [eventName, get(currentState, 'path')]), targetStateName);
 
-    var targetState = this.findStateByPath(currentState, targetStateName);
+    targetState = this.findStateByPath(currentState, targetStateName);
 
     Ember.assert("Your target state name " + targetStateName + " for event " + eventName + " did not resolve to a state", targetState);
 
-    var hash = this.serializeRecursively(targetState, contexts, {});
 
-    return this.urlFor(targetStateName, hash);
+    hashes = this.serializeRecursively(targetState, contexts, []);
+
+    return this.urlFor(targetStateName, hashes);
   },
 
-  serializeRecursively: function(state, contexts, hash) {
-    var parentState,
-        context = get(state, 'hasContext') ? contexts.pop() : null;
-    merge(hash, state.serialize(this, context));
-    parentState = state.get("parentState");
-    if (parentState && parentState instanceof Ember.Route) {
-      return this.serializeRecursively(parentState, contexts, hash);
+  serializeRecursively: function(state, contexts, hashes) {
+    var parentState, 
+			context = get(state, 'hasContext') ? contexts.pop() : null,
+      hash = context ? state.serialize(this, context) : null;
+
+		hashes.push(hash);
+		parentState = state.get("parentState");
+
+		if (parentState && parentState instanceof Ember.Route) {
+      return this.serializeRecursively(parentState, contexts, hashes);
     } else {
-      return hash;
+      return hashes;
     }
   },
 

--- a/packages/ember-routing/tests/routable_test.js
+++ b/packages/ember-routing/tests/routable_test.js
@@ -831,6 +831,33 @@ test("urlFor supports merging the current information for dynamic segments", fun
   expectURL('/dashboard/posts/1/manage/2');
 });
 
+
+test("urlForEvent supports nested routes that have different contexts but share property names", function() {
+  var router = Ember.Router.create({
+    location: locationStub,
+
+    root: Ember.Route.create({
+      goToComments: Ember.Route.transitionTo('root.dashboard.posts.comments'),
+
+      dashboard: Ember.Route.create({
+        route: '/dashboard',
+
+        posts: Ember.Route.create({
+          route: '/posts/:id',
+          comments: Ember.Route.create({
+            route: '/comments/:id'
+          })
+        })
+      })
+    })
+  });
+
+  var url = router.urlForEvent('goToComments', { id: 1 }, {id: 5});
+  equal(url, "/dashboard/posts/1/comments/5");
+  expectURL('/dashboard/posts/1/comments/5');
+});
+
+
 test("navigateAway is called if the URL changes", function() {
   var navigated = 0;
 


### PR DESCRIPTION
In the case where we have nested routes, each having it's own context and these contexts share property names (not values), URL generation (when setting `href=true`) fails.

It merges all the contexts together into one hash and applies this hash to all the routes, and if these contexts share a property name (such as id), all routes will use the value of the last property due to the merge (which is not what we want).

The transition works perfectly, but the generated href is wrong.
#### Example:

``` javascript
var router = Ember.Router.create({

    root: Ember.Route.create({
      goToComments: Ember.Route.transitionTo('root.dashboard.posts.comments'),

      dashboard: Ember.Route.create({
        route: '/dashboard',

        posts: Ember.Route.create({
          route: '/posts/:id',
          comments: Ember.Route.create({
            route: '/comments/:id'
          })
        })
      })
    })
  });
```

``` html

<a {{action goToComments controller.post controller.comment href="true" }}>Your Comment</a>

```

Assuming `controller.post = {id: 1}` and `controller.comment = {id: 5}`

The generated href should be `/posts/1/comments/5` .  
Unfortunately the generated one is `/posts/5/comments/5`

I added a failing test for this scenario, and a fix.

I modified some functions, but I made sure my changes are backwards compatible so I don't break any existing code.
