### PR TITLE
initial implementation of router v2 api (preserve old api)

### DIFF
--- a/packages/ember-routing/lib/routable.js
+++ b/packages/ember-routing/lib/routable.js
@@ -5,7 +5,7 @@ require('ember-routing/resolved_state');
 @submodule ember-routing
 */
 
-var get = Ember.get;
+var get = Ember.get, slice = Array.prototype.slice;
 
 // The Ember Routable mixin assumes the existance of a simple
 // routing shim that supports the following three behaviors:
@@ -44,9 +44,9 @@ Ember.Routable = Ember.Mixin.create({
     this.on('setup', this, this.stashContext);
 
     if (redirection = get(this, 'redirectsTo')) {
-      Ember.assert("You cannot use `redirectsTo` if you already have a `connectOutlets` method", this.connectOutlets === Ember.K);
+      Ember.assert("You cannot use `redirectsTo` if you already have a `setupControllers` method", this.setupControllers === Ember.K);
 
-      this.connectOutlets = function(router) {
+      this.setup = function(router) {
         router.transitionTo(redirection);
       };
     }
@@ -63,7 +63,13 @@ Ember.Routable = Ember.Mixin.create({
   },
 
   setup: function() {
-    return this.connectOutlets.apply(this, arguments);
+    if (typeof this.connectOutlets === 'function') {
+      Ember.deprecate("Ember.Routable#connectOutlets() is deprecated in favor or setupControllers().");
+      this.connectOutlets.apply(this, arguments);
+    } else {
+      this.setupControllers.apply(this, slice.call(arguments, 1));
+      this.renderTemplates();
+    }
   },
 
   /**
@@ -511,33 +517,71 @@ Ember.Routable = Ember.Mixin.create({
     }
   }),
 
+  _controller: Ember.computed(function(key, value) {
+    if (arguments.length > 1) { return value; }
+
+    value = get(this, 'controller');
+
+    if (!value) {
+      var template = get(this, '_template');
+      if (template) {
+        value = Ember.String.classify(template) + 'Controller';
+      }
+    }
+
+    if (Ember.typeOf(value) === 'string') {
+      value = get(get(this, 'router'), value);
+    }
+
+    return value;
+  }),
+
   render: function(options) {
     options = options || {};
 
     var template = options.template || get(this, '_template'),
         parentTemplate = options.into || get(this, 'parentTemplate'),
-        controller = get(this.router, parentTemplate + "Controller");
+        parentController = get(this, 'router.' + parentTemplate + 'Controller');
 
-    var viewName = Ember.String.classify(template) + "View",
-        viewClass = get(get(this.router, 'namespace'), viewName);
+    if (!parentController || !template || template === parentTemplate) {
+      return;
+    }
 
-    viewClass = (viewClass || Ember.View).extend({
-      templateName: template
+    options.controller = options.controller || get(this, '_controller');
+    options.viewClass = this.buildViewClass(options.viewClass, template);
+
+    parentController.connectOutlet(options);
+  },
+
+  buildViewClass: function(viewClass, templateName) {
+    var namespace = get(this, 'router.namespace');
+
+    if (!viewClass) {
+      viewClass = get(namespace, Ember.String.classify(templateName) + 'View');
+    }
+
+    return (viewClass || Ember.View).extend({
+      templateName: templateName
     });
-
-    controller.set('view', viewClass.create());
   },
 
   /**
-    The `connectOutlets` event will be triggered once a
+    The `setupControllers` method will be called once a
     state has been entered. It will be called with the
     route's context.
 
-    @event connectOutlets
-    @param router {Ember.Router}
+    @method setupControllers
     @param [context*]
   */
-  connectOutlets: Ember.K,
+  setupControllers: Ember.K,
+
+  /**
+    The `renderTemplates` method will be caled
+    once controllers are setup.
+
+    @method renderTemplates
+  */
+  renderTemplates: Ember.alias('render'),
 
   /**
    The `navigateAway` event will be triggered when the

--- a/packages/ember-routing/tests/routable_test.js
+++ b/packages/ember-routing/tests/routable_test.js
@@ -248,7 +248,7 @@ module("Routing Serialization and Deserialization", {
           show: Ember.Route.create({
             route: "/:post_id",
 
-            connectOutlets: function(manager, context) {
+            setupControllers: function(context) {
               equal(context.post.id, 2, "should be the same value regardless of entry point");
             },
 
@@ -328,7 +328,7 @@ module("default serialize and deserialize with modelType", {
           route: '/posts/:post_id',
           modelType: 'TestApp.Post',
 
-          connectOutlets: function(router, post) {
+          setupControllers: function(post) {
             equal(post, firstPost, "the post should have deserialized correctly");
           }
         }),
@@ -337,7 +337,7 @@ module("default serialize and deserialize with modelType", {
           route: '/users/:user_id',
           modelType: TestApp.User,
 
-          connectOutlets: function(router, user) {
+          setupControllers: function(user) {
             equal(user, firstUser, "the post should have deserialized correctly");
           }
         })
@@ -425,7 +425,7 @@ module("modelType with promise", {
             route: '/:user_id',
             modelType: 'TestApp.User',
 
-            connectOutlets: function(router, obj) {
+            setupControllers: function(obj) {
               connectedUser = obj;
             },
 
@@ -436,14 +436,14 @@ module("modelType with promise", {
                 route: '/:post_id',
                 modelType: 'TestApp.Post',
 
-                connectOutlets: function(router, obj) {
+                setupControllers: function(obj) {
                   connectedPost = obj;
                 },
 
                 show: Ember.Route.extend({
                   route: '/',
 
-                  connectOutlets: function(router) {
+                  setupControllers: function() {
                     connectedChild = true;
                   }
                 })
@@ -455,7 +455,7 @@ module("modelType with promise", {
         other: Ember.Route.extend({
           route: '/other',
 
-          connectOutlets: function() {
+          setupControllers: function() {
             connectedOther = true;
           }
         }),
@@ -607,7 +607,7 @@ module("default serialize and deserialize without modelType", {
         post: Ember.Route.extend({
           route: '/posts/:post_id',
 
-          connectOutlets: function(router, post) {
+          setupControllers: function(post) {
             equal(post, firstPost, "the post should have deserialized correctly");
           }
         })
@@ -658,7 +658,7 @@ test("if a leaf state has a redirectsTo, it automatically transitions into that 
   equal(router.get('currentState.path'), "root.someOtherState");
 });
 
-test("you cannot define connectOutlets AND redirectsTo", function() {
+test("you cannot define setupControllers AND redirectsTo", function() {
   raises(function() {
     Ember.Router.create({
       location: 'none',
@@ -666,7 +666,7 @@ test("you cannot define connectOutlets AND redirectsTo", function() {
         index: Ember.Route.create({
           route: '/',
           redirectsTo: 'someOtherState',
-          connectOutlets: function() {}
+          setupControllers: function() {}
         })
       })
     });

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -59,10 +59,8 @@ Ember.State = Ember.Object.extend(Ember.Evented,
     @param name
   */
   trigger: function(name) {
-    if (this[name]) {
-      this[name].apply(this, [].slice.call(arguments, 1));
-    }
     this._super.apply(this, arguments);
+    Ember.tryInvoke(this, name, [].slice.call(arguments, 1));
   },
 
   init: function() {


### PR DESCRIPTION
This is almost the same as #1510 but it preserves the old `connectOutlet` api.
