### PR TITLE
HTML5 attributes for TextField and TextSupport

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -51,7 +51,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
 
   classNames: ['ember-text-field'],
   tagName: "input",
-  attributeBindings: ['type', 'value', 'size'],
+  attributeBindings: ['max', 'min', 'size', 'step','type', 'value'],
 
   /**
     The value attribute of the input element. As the user inputs text, this

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -19,7 +19,7 @@ var get = Ember.get, set = Ember.set;
 Ember.TextSupport = Ember.Mixin.create({
   value: "",
 
-  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex'],
+  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'required', 'tabindex'],
   placeholder: null,
   disabled: false,
   maxlength: null,


### PR DESCRIPTION
I added `max`, `min`, and `step` attributes to `TextField`. See [the MDN doc for `input`](https://developer.mozilla.org/en-US/docs/HTML/Element/Input) for details. In particular, `step` is important to me due to [this issue](http://code.google.com/p/chromium/issues/detail?id=44116) in Chrome.

Also, I added the `required` attribute to `TextSupport` which applies to both `TextField` and `TextArea`. See the [MDN doc on `textarea`](https://developer.mozilla.org/en-US/docs/HTML/HTML_Elements/textarea).
