### PR TITLE
Make 'state' property on View observable

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -213,7 +213,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
     // the DOM again.
     if (parent) { parent.removeChild(this); }
 
-    this.state = 'destroyed';
+    Ember.set(this, 'state', 'destroyed');
 
     // next remove view from global hash
     if (!this.isVirtual) delete Ember.View.views[get(this, 'elementId')];
@@ -2080,7 +2080,7 @@ Ember.View = Ember.CoreView.extend(
     // the DOM again.
     if (parent) { parent.removeChild(this); }
 
-    this.state = 'destroyed';
+    Ember.set(this, 'state', 'destroyed');
 
     childLen = childViews.length;
     for (var i=childLen-1; i>=0; i--) {
@@ -2199,7 +2199,7 @@ Ember.View = Ember.CoreView.extend(
   },
 
   transitionTo: function(state, children) {
-    this.state = state;
+    Ember.set(this, 'state', state);
 
     if (children !== false) {
       this.forEachChildView(function(view) {

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -324,3 +324,30 @@ test("should throw an exception when rerender is called after view is destroyed"
   }, null, "throws an exception when calling appendChild");
 });
 
+module("views/view/view_lifecycle_test - full lifecycle");
+
+
+test("should allow to observe state", function() {
+  Ember.run(function() {
+    view = Ember.View.create({
+      foo: Ember.computed(function() {
+        return this.get('state');
+      }).property('state')
+    });
+
+  });
+
+  equal(view.get('foo'), 'preRender');
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  equal(view.get('foo'), 'inDOM');
+
+  Ember.run(function() {
+    view.destroy();
+  });
+
+  equal(view.get('foo'), undefined);
+});


### PR DESCRIPTION
It's convenient to observe state to ensure that a computed property or
observer will be recalculated/fired when state changes. Because of
using it as javascript property, it was not possible.
