### PR TITLE
Avoid didInsertElement event to be fired twice when inserting a view in the didInsertElement event of a ContainerView

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1620,24 +1620,25 @@ Ember.View = Ember.CoreView.extend(
   */
   invokeRecursively: function(fn, includeSelf) {
     var childViews = (includeSelf === false) ? this._childViews : [this];
-    var currentViews, view;
-
+    var currentViews, view, currentChildViews;
+ 
     while (childViews.length) {
       currentViews = childViews.slice();
       childViews = [];
-
+ 
       for (var i=0, l=currentViews.length; i<l; i++) {
         view = currentViews[i];
+        currentChildViews = ( !!view._childViews ) ? view._childViews.slice(0) : null;
         fn.call(view, view);
-        if (view._childViews) {
-          childViews.push.apply(childViews, view._childViews);
+        if (currentChildViews) {
+          childViews.push.apply(childViews, currentChildViews);
         }
       }
     }
   },
 
   triggerRecursively: function(eventName) {
-    var childViews = [this], currentViews, view;
+    var childViews = [this], currentViews, view, currentChildViews;
 
     while (childViews.length) {
       currentViews = childViews.slice();
@@ -1645,10 +1646,12 @@ Ember.View = Ember.CoreView.extend(
 
       for (var i=0, l=currentViews.length; i<l; i++) {
         view = currentViews[i];
+        currentChildViews = ( !!view._childViews ) ? view._childViews.slice(0) : null;
         if (view.trigger) { view.trigger(eventName); }
-        if (view._childViews) {
-          childViews.push.apply(childViews, view._childViews);
+        if (currentChildViews) {
+          childViews.push.apply(childViews, currentChildViews);
         }
+ 
       }
     }
   },

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -564,3 +564,42 @@ test("should invalidate `element` on itself and childViews when being rendered b
     root.destroy();
   });
 });
+
+test("if a containerView appends a child in its didInsertElement event, the didInsertElement event of the child view should be fired once", function () {
+ 
+  var counter = 0,
+      root = Ember.ContainerView.create({});
+ 
+  container = Ember.ContainerView.create({
+ 
+    didInsertElement: function() {
+      
+      var view = Ember.ContainerView.create({
+        didInsertElement: function() {
+          counter++;
+        }
+      });
+ 
+      this.pushObject(view);
+ 
+    }
+  
+  });
+ 
+ 
+  Ember.run(function() {
+    root.appendTo('#qunit-fixture');
+  });
+ 
+  Ember.run(function() {
+    root.pushObject(container);
+  });
+ 
+  equal(container.get('childViews').get('length'), 1 , "containerView should only have a child");
+  equal(counter, 1 , "didInsertElement should be fired once");
+ 
+  Ember.run(function() {
+    root.destroy();
+  });
+ 
+});


### PR DESCRIPTION
Whenever a ContainerView inserted a view in its didInsertElement event, the child view was notified twice of its didInsertElement event. 

Below the new commit with latest master.

Ref to (emberjs/ember.js#1400) where the current API fails.
