### PR TITLE
Add an afterRender queue

### DIFF
--- a/packages/ember-views/lib/system/ext.js
+++ b/packages/ember-views/lib/system/ext.js
@@ -4,6 +4,7 @@
 */
 
 // Add a new named queue for rendering views that happens
-// after bindings have synced.
+// after bindings have synced, and a queue for scheduling actions
+// that that should occur after view rendering.
 var queues = Ember.run.queues;
-queues.splice(Ember.$.inArray('actions', queues)+1, 0, 'render');
+queues.splice(Ember.$.inArray('actions', queues)+1, 0, 'render', 'afterRender');

--- a/packages/ember-views/tests/system/ext_test.js
+++ b/packages/ember-views/tests/system/ext_test.js
@@ -1,0 +1,37 @@
+module("Ember.View additions to run queue");
+
+test("View hierarchy is done rendering to DOM when functions queued in afterRender execute", function() {
+  var lookup1, lookup2;
+  var childView = Ember.View.create({
+    elementId: 'child_view',
+    render: function(buffer) {
+      buffer.push('child');
+    },
+    didInsertElement: function(){
+      this.$().addClass('extra-class');
+    }
+  });
+  var parentView = Ember.View.create({
+    render: function(buffer) {
+      buffer.push('parent');
+      this.appendChild(childView);
+    },
+    didInsertElement: function() {
+      lookup1 = this.$('.extra-class');
+      Ember.run.scheduleOnce('afterRender', this, function(){
+        lookup2 = this.$('.extra-class');
+      });
+    }
+  });
+
+  Ember.run(function() {
+    parentView.appendTo('#qunit-fixture');
+  });
+
+  equal(lookup1.length, 0, "doesn't not find child in DOM on didInsertElement");
+  equal(lookup2.length, 1, "finds child in DOM afterRender");
+
+  Ember.run(function(){
+    parentView.destroy();
+  });
+});


### PR DESCRIPTION
This PR adds an afterRender queue for scheduling code to run after the render queue has been drained.

This provides an elegant way to execute code after a view hierarchy has been fully rendered.
