### PR TITLE
Documentation fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,31 @@ Syntax:
 * a = b and not a=b.
 * Follow the conventions you see used in the source already.
 
+Inline Documenation Guidelines:
+
+All inline documentation is written using YUIDoc. Follow these rules when
+updating or writing new documenation:
+
+1. All code blocks must be fenced
+2. All code blocks must have a language declared
+3. All code blocks must be valid code for syntax highlighting
+4. All examples in code blocks must be aligned
+5. Use two spaces between the code and the example: `foo();  // result`
+6. All references to code words must be enclosed in backticks
+7. Prefer a single space between sentences
+8. Reference Ember.js as Ember.
+9. Wrap long markdown blocks > 80 characters
+10. Don't include blank lines after `@param` defintions
+
+Code words are:
+
+* `thisPropertyName`
+* `Global.Class.attribute`
+* `thisFunction()`
+* `Global.CONSTANT_NAME`
+* `true`, `false`, `null`, `undefined` (when refering to programming values)
+* references to other properties/methods
+
 And in case we didn't emphasize it enough: we love tests!
 
 NOTE: Partially copied from https://raw.github.com/thoughtbot/factory_girl_rails/master/CONTRIBUTING.md

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -6,12 +6,12 @@
 var get = Ember.get, set = Ember.set;
 
 /**
-  An instance of `Ember.Application` is the starting point for every Ember.js
+  An instance of `Ember.Application` is the starting point for every Ember
   application. It helps to instantiate, initialize and coordinate the many
   objects that make up your app.
 
-  Each Ember.js app has one and only one `Ember.Application` object. In fact, the very
-  first thing you should do in your application is create the instance:
+  Each Ember app has one and only one `Ember.Application` object. In fact, the
+  very first thing you should do in your application is create the instance:
 
   ```javascript
   window.App = Ember.Application.create();
@@ -31,8 +31,8 @@ var get = Ember.get, set = Ember.set;
   application.
 
   Because `Ember.Application` inherits from `Ember.Namespace`, any classes
-  you create will have useful string representations when calling `toString()`;
-  see the `Ember.Namespace` documentation for more information.
+  you create will have useful string representations when calling `toString()`.
+  See the `Ember.Namespace` documentation for more information.
 
   While you can think of your `Ember.Application` as a container that holds the
   other classes in your application, there are several other responsibilities
@@ -40,24 +40,24 @@ var get = Ember.get, set = Ember.set;
 
   ### Event Delegation
 
-  Ember.js uses a technique called _event delegation_. This allows the framework
-  to set up a global, shared event listener instead of requiring each view to do
-  it manually. For example, instead of each view registering its own `mousedown`
-  listener on its associated element, Ember.js sets up a `mousedown` listener on
-  the `body`.
+  Ember uses a technique called _event delegation_. This allows the framework
+  to set up a global, shared event listener instead of requiring each view to
+  do it manually. For example, instead of each view registering its own
+  `mousedown` listener on its associated element, Ember sets up a `mousedown`
+  listener on the `body`.
 
-  If a `mousedown` event occurs, Ember.js will look at the target of the event and
-  start walking up the DOM node tree, finding corresponding views and invoking their
-  `mouseDown` method as it goes.
+  If a `mousedown` event occurs, Ember will look at the target of the event and
+  start walking up the DOM node tree, finding corresponding views and invoking
+  their `mouseDown` method as it goes.
 
-  `Ember.Application` has a number of default events that it listens for, as well
-  as a mapping from lowercase events to camel-cased view method names. For
+  `Ember.Application` has a number of default events that it listens for, as
+  well as a mapping from lowercase events to camel-cased view method names. For
   example, the `keypress` event causes the `keyPress` method on the view to be
   called, the `dblclick` event causes `doubleClick` to be called, and so on.
 
-  If there is a browser event that Ember.js does not listen for by default, you
-  can specify custom events and their corresponding view method names by setting
-  the application's `customEvents` property:
+  If there is a browser event that Ember does not listen for by default, you
+  can specify custom events and their corresponding view method names by
+  setting the application's `customEvents` property:
 
   ```javascript
   App = Ember.Application.create({
@@ -69,13 +69,13 @@ var get = Ember.get, set = Ember.set;
   });
   ```
 
-  By default, the application sets up these event listeners on the document body.
-  However, in cases where you are embedding an Ember.js application inside an
-  existing page, you may want it to set up the listeners on an element inside
-  the body.
+  By default, the application sets up these event listeners on the document
+  body. However, in cases where you are embedding an Ember application inside
+  an existing page, you may want it to set up the listeners on an element
+  inside the body.
 
-  For example, if only events inside a DOM element with the ID of `ember-app` should
-  be delegated, set your application's `rootElement` property:
+  For example, if only events inside a DOM element with the ID of `ember-app`
+  should be delegated, set your application's `rootElement` property:
 
   ```javascript
   window.App = Ember.Application.create({
@@ -84,22 +84,23 @@ var get = Ember.get, set = Ember.set;
   ```
 
   The `rootElement` can be either a DOM element or a jQuery-compatible selector
-  string. Note that *views appended to the DOM outside the root element will not
-  receive events.* If you specify a custom root element, make sure you only append
-  views inside it!
+  string. Note that *views appended to the DOM outside the root element will
+  not receive events.* If you specify a custom root element, make sure you only
+  append views inside it!
 
-  To learn more about the advantages of event delegation and the Ember.js view layer,
-  and a list of the event listeners that are setup by default, visit the
-  [Ember.js View Layer guide](http://emberjs.com/guides/view_layer#toc_event-delegation).
+  To learn more about the advantages of event delegation and the Ember view
+  layer, and a list of the event listeners that are setup by default, visit the
+  [Ember View Layer guide](http://emberjs.com/guides/view_layer#toc_event-delegation).
 
   ### Dependency Injection
 
-  One thing you may have noticed while using Ember.js is that you define *classes*, not
-  *instances*. When your application loads, all of the instances are created for you.
-  Creating these instances is the responsibility of `Ember.Application`.
+  One thing you may have noticed while using Ember is that you define
+  *classes*, not *instances*. When your application loads, all of the instances
+  are created for you. Creating these instances is the responsibility of
+  `Ember.Application`.
 
-  When the `Ember.Application` initializes, it will look for an `Ember.Router` class
-  defined on the applications's `Router` property, like this:
+  When the `Ember.Application` initializes, it will look for an `Ember.Router`
+  class defined on the applications's `Router` property, like this:
 
   ```javascript
   App.Router = Ember.Router.extend({
@@ -108,9 +109,9 @@ var get = Ember.get, set = Ember.set;
   ```
 
   If found, the router is instantiated and saved on the application's `router`
-  property (note the lowercase 'r'). While you should *not* reference this router
-  instance directly from your application code, having access to `App.router`
-  from the console can be useful during debugging.
+  property (note the lowercase 'r'). While you should *not* reference this
+  router instance directly from your application code, having access to
+  `App.router` from the console can be useful during debugging.
 
   After the router is created, the application loops through all of the
   registered _injections_ and invokes them once for each property on the
@@ -131,7 +132,7 @@ var get = Ember.get, set = Ember.set;
   Your router will receive an instance of `App.MyController` saved on its
   `myController` property.
 
-  Libraries on top of Ember.js can register additional injections. For example,
+  Libraries on top of Ember can register additional injections. For example,
   if your application is using Ember Data, it registers an injection that
   instantiates `DS.Store`:
 
@@ -150,16 +151,17 @@ var get = Ember.get, set = Ember.set;
 
   ### Routing
 
-  In addition to creating your application's router, `Ember.Application` is also
-  responsible for telling the router when to start routing.
+  In addition to creating your application's router, `Ember.Application` is
+  also responsible for telling the router when to start routing.
 
   By default, the router will begin trying to translate the current URL into
   application state once the browser emits the `DOMContentReady` event. If you
-  need to defer routing, you can call the application's `deferReadiness()` method.
-  Once routing can begin, call the `advanceReadiness()` method.
+  need to defer routing, you can call the application's `deferReadiness()`
+  method. Once routing can begin, call the `advanceReadiness()` method.
 
-  If there is any setup required before routing begins, you can implement a `ready()`
-  method on your app that will be invoked immediately before routing begins:
+  If there is any setup required before routing begins, you can implement a
+  `ready()` method on your app that will be invoked immediately before routing
+  begins:
 
   ```javascript
   window.App = Ember.Application.create({
@@ -231,13 +233,15 @@ Ember.Application = Ember.Namespace.extend(
     to a hash containing the DOM event name as the key and the
     corresponding view method name as the value. For example:
 
-        App = Ember.Application.create({
-          customEvents: {
-            // add support for the loadedmetadata media
-            // player event
-            'loadedmetadata': "loadedMetadata"
-          }
-        });
+    ```javascript
+    App = Ember.Application.create({
+      customEvents: {
+        // add support for the loadedmetadata media
+        // player event
+        'loadedmetadata': "loadedMetadata"
+      }
+    });
+    ```
 
     @property customEvents
     @type Object
@@ -245,6 +249,14 @@ Ember.Application = Ember.Namespace.extend(
   */
   customEvents: null,
 
+  /**
+    Should the application initialize itself after it's created. You can
+    set this to `false` if you'd like to choose when to initialize your 
+    application. This defaults to `!Ember.testing`
+
+    @property autoinit
+    @type Boolean
+  */
   autoinit: !Ember.testing,
 
   isInitialized: false,
@@ -309,17 +321,19 @@ Ember.Application = Ember.Namespace.extend(
 
     Example:
 
-        App.PostsController = Ember.ArrayController.extend();
-        App.CommentsController = Ember.ArrayController.extend();
+    ```javascript
+    App.PostsController = Ember.ArrayController.extend();
+    App.CommentsController = Ember.ArrayController.extend();
 
-        var router = Ember.Router.create({
-          ...
-        });
+    var router = Ember.Router.create({
+      ...
+    });
 
-        App.initialize(router);
+    App.initialize(router);
 
-        router.get('postsController')     // <App.PostsController:ember1234>
-        router.get('commentsController')  // <App.CommentsController:ember1235>
+    router.get('postsController');     // <App.PostsController:ember1234>
+    router.get('commentsController');  // <App.CommentsController:ember1235>
+    ```
 
     @method initialize
     @param router {Ember.Router}

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -27,18 +27,19 @@ if (!('MANDATORY_SETTER' in Ember.ENV)) {
 
 /**
   Define an assertion that will throw an exception if the condition is not
-  met.  Ember build tools will remove any calls to Ember.assert() when
+  met. Ember build tools will remove any calls to `Ember.assert()` when
   doing a production build. Example:
 
-      // Test for truthiness
-      Ember.assert('Must pass a valid object', obj);
-      // Fail unconditionally
-      Ember.assert('This code path should never be run')
+  ```javascript
+  // Test for truthiness
+  Ember.assert('Must pass a valid object', obj);
+  // Fail unconditionally
+  Ember.assert('This code path should never be run')
+  ```
 
   @method assert
-  @param {String} desc A description of the assertion.  This will become
+  @param {String} desc A description of the assertion. This will become
     the text of the Error thrown if the assertion fails.
-
   @param {Boolean} test Must be truthy for the assertion to pass. If
     falsy, an exception will be thrown.
 */
@@ -49,7 +50,7 @@ Ember.assert = function(desc, test) {
 
 /**
   Display a warning with the provided message. Ember build tools will
-  remove any calls to Ember.warn() when doing a production build.
+  remove any calls to `Ember.warn()` when doing a production build.
 
   @method warn
   @param {String} message A warning to display.
@@ -66,7 +67,7 @@ Ember.warn = function(message, test) {
 /**
   Display a deprecation warning with the provided message and a stack trace
   (Chrome and Firefox only). Ember build tools will remove any calls to
-  Ember.deprecate() when doing a production build.
+  `Ember.deprecate()` when doing a production build.
 
   @method deprecate
   @param {String} message A description of the deprecation.
@@ -113,7 +114,7 @@ Ember.deprecate = function(message, test) {
   Display a deprecation warning with the provided message and a stack trace
   (Chrome and Firefox only) when the wrapped method is called.
 
-  Ember build tools will not remove calls to Ember.deprecateFunc(), though
+  Ember build tools will not remove calls to `Ember.deprecateFunc()`, though
   no warnings will be shown in production.
 
   @method deprecateFunc

--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -27,7 +27,7 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
   /**
     @private
 
-    Overrides TargetActionSupport's targetObject computed
+    Overrides `TargetActionSupport`'s `targetObject` computed
     property to use Handlebars-specific path resolution.
 
     @property targetObject
@@ -107,7 +107,7 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
     }
   },
 
-  // TODO: Handle proper touch behavior.  Including should make inactive when
+  // TODO: Handle proper touch behavior. Including should make inactive when
   // finger moves more than 20x outside of the edge of the button (vs mouse
   // which goes inactive as soon as mouse goes out of edges.)
 

--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -9,33 +9,38 @@ require("ember-handlebars/ext");
 var set = Ember.set, get = Ember.get;
 
 /**
-  The `Ember.Checkbox` view class renders a checkbox [input](https://developer.mozilla.org/en/HTML/Element/Input)
-  element. It allows for binding an Ember property (`checked`) to the status of the checkbox.
+  The `Ember.Checkbox` view class renders a checkbox
+  [input](https://developer.mozilla.org/en/HTML/Element/Input) element. It
+  allows for binding an Ember property (`checked`) to the status of the
+  checkbox.
 
   Example:
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Checkbox checkedBinding="receiveEmail"}}
   ```
 
-  You can add a `label` tag yourself in the template where the Ember.Checkbox is being used.
+  You can add a `label` tag yourself in the template where the `Ember.Checkbox`
+  is being used.
 
-  ``` html
+  ```html
   <label>
     {{view Ember.Checkbox classNames="applicaton-specific-checkbox"}}
     Some Title
   </label>
   ```
 
-
-  The `checked` attribute of an Ember.Checkbox object should always be set
-  through the Ember object or by interacting with its rendered element representation
-  via the mouse, keyboard, or touch.  Updating the value of the checkbox via jQuery will
-  result in the checked value of the object and its element losing synchronization.
+  The `checked` attribute of an `Ember.Checkbox` object should always be set
+  through the Ember object or by interacting with its rendered element
+  representation via the mouse, keyboard, or touch. Updating the value of the
+  checkbox via jQuery will result in the checked value of the object and its
+  element losing synchronization.
 
   ## Layout and LayoutName properties
-  Because HTML `input` elements are self closing `layout` and `layoutName` properties will
-  not be applied. See `Ember.View`'s layout section for more information.
+
+  Because HTML `input` elements are self closing `layout` and `layoutName`
+  properties will not be applied. See `Ember.View`'s layout section for more
+  information.
 
   @class Checkbox
   @namespace Ember

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -13,50 +13,51 @@ var set = Ember.set,
     isArray = Ember.isArray;
 
 /**
-  The Ember.Select view class renders a
+  The `Ember.Select` view class renders a
   [select](https://developer.mozilla.org/en/HTML/Element/select) HTML element,
   allowing the user to choose from a list of options.
 
-  The text and `value` property of each `<option>` element within the `<select>` element
-  are populated from the objects in the Element.Select's `content` property. The
-  underlying data object of the selected `<option>` is stored in the
-  Element.Select's `value` property.
+  The text and `value` property of each `<option>` element within the
+  `<select>` element are populated from the objects in the `Element.Select`'s
+  `content` property. The underlying data object of the selected `<option>` is
+  stored in the `Element.Select`'s `value` property.
 
   ### `content` as an array of Strings
-  The simplest version of an Ember.Select takes an array of strings as its `content` property.
-  The string will be used as both the `value` property and the inner text of each `<option>`
-  element inside the rendered `<select>`.
+
+  The simplest version of an `Ember.Select` takes an array of strings as its
+  `content` property. The string will be used as both the `value` property and
+  the inner text of each `<option>` element inside the rendered `<select>`.
 
   Example:
 
-  ``` javascript
+  ```javascript
   App.names = ["Yehuda", "Tom"];
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select contentBinding="App.names"}}
   ```
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value="Yehuda">Yehuda</option>
     <option value="Tom">Tom</option>
   </select>
   ```
 
-  You can control which `<option>` is selected through the Ember.Select's
+  You can control which `<option>` is selected through the `Ember.Select`'s
   `value` property directly or as a binding:
 
-  ``` javascript
+  ```javascript
   App.names = Ember.Object.create({
     selected: 'Tom',
     content: ["Yehuda", "Tom"]
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.names.content"
          valueBinding="App.names.selected"
@@ -65,37 +66,38 @@ var set = Ember.set,
 
   Would result in the following HTML with the `<option>` for 'Tom' selected:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value="Yehuda">Yehuda</option>
     <option value="Tom" selected="selected">Tom</option>
   </select>
   ```
 
-  A user interacting with the rendered `<select>` to choose "Yehuda" would update
-  the value of `App.names.selected` to "Yehuda".
+  A user interacting with the rendered `<select>` to choose "Yehuda" would
+  update the value of `App.names.selected` to "Yehuda".
 
   ### `content` as an Array of Objects
-  An Ember.Select can also take an array of JavaScript or Ember objects
-  as its `content` property.
 
-  When using objects you need to tell the Ember.Select which property should be
-  accessed on each object to supply the `value` attribute of the `<option>`
+  An `Ember.Select` can also take an array of JavaScript or Ember objects as
+  its `content` property.
+
+  When using objects you need to tell the `Ember.Select` which property should
+  be accessed on each object to supply the `value` attribute of the `<option>`
   and which property should be used to supply the element text.
 
   The `optionValuePath` option is used to specify the path on each object to
-  the desired property for the `value` attribute.  The `optionLabelPath`
+  the desired property for the `value` attribute. The `optionLabelPath`
   specifies the path on each object to the desired property for the
-  element's text. Both paths must reference each object itself as 'content':
+  element's text. Both paths must reference each object itself as `content`:
 
-  ``` javascript
+  ```javascript
   App.programmers = [
-      Ember.Object.create({firstName: "Yehuda", id: 1}),
-      Ember.Object.create({firstName: "Tom",    id: 2})
-    ];
+    Ember.Object.create({firstName: "Yehuda", id: 1}),
+    Ember.Object.create({firstName: "Tom",    id: 2})
+  ];
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.programmers"
          optionValuePath="content.id"
@@ -104,7 +106,7 @@ var set = Ember.set,
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value>Please Select</option>
     <option value="1">Yehuda</option>
@@ -112,23 +114,22 @@ var set = Ember.set,
   </select>
   ```
 
-
-  The `value` attribute of the selected `<option>` within an Ember.Select
+  The `value` attribute of the selected `<option>` within an `Ember.Select`
   can be bound to a property on another object by providing a
   `valueBinding` option:
 
-  ``` javascript
+  ```javascript
   App.programmers = [
-      Ember.Object.create({firstName: "Yehuda", id: 1}),
-      Ember.Object.create({firstName: "Tom",    id: 2})
-    ];
+    Ember.Object.create({firstName: "Yehuda", id: 1}),
+    Ember.Object.create({firstName: "Tom",    id: 2})
+  ];
 
   App.currentProgrammer = Ember.Object.create({
     id: 2
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.programmers"
          optionValuePath="content.id"
@@ -138,7 +139,7 @@ var set = Ember.set,
 
   Would result in the following HTML with a selected option:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value>Please Select</option>
     <option value="1">Yehuda</option>
@@ -156,7 +157,7 @@ var set = Ember.set,
   will be updated to match the content object of the rendered `<option>`
   element:
 
-  ``` javascript
+  ```javascript
   App.controller = Ember.Object.create({
     selectedPerson: null,
     content: [
@@ -166,7 +167,7 @@ var set = Ember.set,
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.controller.content"
          optionValuePath="content.id"
@@ -176,14 +177,13 @@ var set = Ember.set,
 
   Would result in the following HTML with a selected option:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value>Please Select</option>
     <option value="1">Yehuda</option>
     <option value="2" selected="selected">Tom</option>
   </select>
   ```
-
 
   Interacting with the rendered element by selecting the first option
   ('Yehuda') will update the `selectedPerson` value of `App.controller`
@@ -192,10 +192,10 @@ var set = Ember.set,
 
   ### Supplying a Prompt
 
-  A `null` value for the Ember.Select's `value` or `selection` property
+  A `null` value for the `Ember.Select`'s `value` or `selection` property
   results in there being no `<option>` with a `selected` attribute:
 
-  ``` javascript
+  ```javascript
   App.controller = Ember.Object.create({
     selected: null,
     content: [
@@ -214,7 +214,7 @@ var set = Ember.set,
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option value="Yehuda">Yehuda</option>
     <option value="Tom">Tom</option>
@@ -224,10 +224,10 @@ var set = Ember.set,
   Although `App.controller.selected` is `null` and no `<option>`
   has a `selected` attribute the rendered HTML will display the
   first item as though it were selected. You can supply a string
-  value for the Ember.Select to display when there is no selection
+  value for the `Ember.Select` to display when there is no selection
   with the `prompt` option:
 
-  ``` javascript
+  ```javascript
   App.controller = Ember.Object.create({
     selected: null,
     content: [
@@ -237,7 +237,7 @@ var set = Ember.set,
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.Select
          contentBinding="App.controller.content"
          valueBinding="App.controller.selected"
@@ -247,7 +247,7 @@ var set = Ember.set,
 
   Would result in the following HTML:
 
-  ``` html
+  ```html
   <select class="ember-select">
     <option>Please select a name</option>
     <option value="Yehuda">Yehuda</option>
@@ -287,12 +287,16 @@ Ember.Select = Ember.View.extend(
 
     Otherwise, this should be a list of objects. For instance:
 
-        content: Ember.A([
-            { id: 1, firstName: 'Yehuda' },
-            { id: 2, firstName: 'Tom' }
-          ]),
-        optionLabelPath: 'content.firstName',
-        optionValuePath: 'content.id'
+    ```javascript
+    Ember.Select.create({
+      content: Ember.A([
+          { id: 1, firstName: 'Yehuda' },
+          { id: 2, firstName: 'Tom' }
+        ]),
+      optionLabelPath: 'content.firstName',
+      optionValuePath: 'content.id'
+    });
+    ```
 
     @property content
     @type Array
@@ -301,10 +305,10 @@ Ember.Select = Ember.View.extend(
   content: null,
 
   /**
-    When `multiple` is false, the element of `content` that is currently
+    When `multiple` is `false`, the element of `content` that is currently
     selected, if any.
 
-    When `multiple` is true, an array of such elements.
+    When `multiple` is `true`, an array of such elements.
 
     @property selection
     @type Object or Array
@@ -313,8 +317,8 @@ Ember.Select = Ember.View.extend(
   selection: null,
 
   /**
-    In single selection mode (when `multiple` is false), value can be used to get
-    the current selection's value or set the selection by it's value.
+    In single selection mode (when `multiple` is `false`), value can be used to
+    get the current selection's value or set the selection by it's value.
 
     It is not currently supported in multiple selection mode.
 

--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -17,18 +17,21 @@ var get = Ember.get, set = Ember.set;
 
   ## Layout and LayoutName properties
 
-  Because HTML `textarea` elements do not contain inner HTML the `layout` and `layoutName`
-  properties will not be applied. See `Ember.View`'s layout section for more information.
+  Because HTML `textarea` elements do not contain inner HTML the `layout` and
+  `layoutName` properties will not be applied. See `Ember.View`'s layout
+  section for more information.
 
   ## HTML Attributes
 
-  By default `Ember.TextArea` provides support for `rows`, `cols`, `placeholder`, `disabled`,
-  `maxlength` and `tabindex` attributes on a textarea. If you need to support  more
-  attributes have a look at the `attributeBindings` property in `Ember.View`'s HTML Attributes section.
+  By default `Ember.TextArea` provides support for `rows`, `cols`,
+  `placeholder`, `disabled`, `maxlength` and `tabindex` attributes on a
+  textarea. If you need to support  more attributes have a look at the
+  `attributeBindings` property in `Ember.View`'s HTML Attributes section.
 
-  To globally add support for additional attributes you can reopen `Ember.TextArea` or `Ember.TextSupport`.
+  To globally add support for additional attributes you can reopen
+  `Ember.TextArea` or `Ember.TextSupport`.
 
-  ``` javascript
+  ```javascript
   Ember.TextSupport.reopen({
     attributeBindings: ["required"]
   })

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -17,25 +17,27 @@ var get = Ember.get, set = Ember.set;
 
   Example:
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.TextField valueBinding="firstName"}}
   ```
 
   ## Layout and LayoutName properties
-  Because HTML `input` elements are self closing `layout` and `layoutName` properties will
-  not be applied. See `Ember.View`'s layout section for more information.
+
+  Because HTML `input` elements are self closing `layout` and `layoutName`
+  properties will not be applied. See `Ember.View`'s layout section for more
+  information.
 
   ## HTML Attributes
 
-  By default `Ember.TextField` provides support for `type`, `value`, `size`, `placeholder`,
-  `disabled`, `maxlength` and `tabindex` attributes on a textarea. If you need to support
-  more attributes have a look at the `attributeBindings` property in `Ember.View`'s
-  HTML Attributes section.
+  By default `Ember.TextField` provides support for `type`, `value`, `size`,
+  `placeholder`, `disabled`, `maxlength` and `tabindex` attributes on a
+  test field. If you need to support more attributes have a look at the
+  `attributeBindings` property in `Ember.View`'s HTML Attributes section.
 
-  To globally add support for additional attributes you can reopen `Ember.TextField` or
-  `Ember.TextSupport`.
+  To globally add support for additional attributes you can reopen
+  `Ember.TextField` or `Ember.TextSupport`.
 
-  ``` javascript
+  ```javascript
   Ember.TextSupport.reopen({
     attributeBindings: ["required"]
   })
@@ -54,7 +56,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   attributeBindings: ['type', 'value', 'size'],
 
   /**
-    The value attribute of the input element. As the user inputs text, this
+    The `value` attribute of the input element. As the user inputs text, this
     property is updated live.
 
     @property value
@@ -64,7 +66,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   value: "",
 
   /**
-    The type attribute of the input element.
+    The `type` attribute of the input element.
 
     @property type
     @type String
@@ -73,7 +75,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   type: "text",
 
   /**
-    The size of the text field in characters.
+    The `size` of the text field in characters.
 
     @property size
     @type String

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -9,7 +9,7 @@ require("ember-views/views/view");
 var get = Ember.get, set = Ember.set;
 
 /**
-  Shared mixin used by Ember.TextField and Ember.TextArea.
+  Shared mixin used by `Ember.TextField` and `Ember.TextArea`.
 
   @class TextSupport
   @namespace Ember

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -14,12 +14,12 @@ Ember.assert("Ember Handlebars requires Handlebars 1.0.beta.5 or greater", Handl
   Prepares the Handlebars templating library for use inside Ember's view
   system.
 
-  The Ember.Handlebars object is the standard Handlebars library, extended to use
-  Ember's get() method instead of direct property access, which allows
+  The `Ember.Handlebars` object is the standard Handlebars library, extended to
+  use Ember's `get()` method instead of direct property access, which allows
   computed properties to be used inside templates.
 
-  To create an Ember.Handlebars template, call Ember.Handlebars.compile().  This will
-  return a function that can be used by Ember.View for rendering.
+  To create an `Ember.Handlebars` template, call `Ember.Handlebars.compile()`.
+  This will return a function that can be used by `Ember.View` for rendering.
 
   @class Handlebars
   @namespace Ember
@@ -74,9 +74,9 @@ Ember.Handlebars.JavaScriptCompiler.prototype.initializeBuffer = function() {
 /**
   @private
 
-  Override the default buffer for Ember Handlebars. By default, Handlebars creates
-  an empty String at the beginning of each invocation and appends to it. Ember's
-  Handlebars overrides this to append to a single shared buffer.
+  Override the default buffer for Ember Handlebars. By default, Handlebars
+  creates an empty String at the beginning of each invocation and appends to
+  it. Ember's Handlebars overrides this to append to a single shared buffer.
 
   @method appendToBuffer
   @param string {String}
@@ -88,9 +88,9 @@ Ember.Handlebars.JavaScriptCompiler.prototype.appendToBuffer = function(string) 
 /**
   @private
 
-  Rewrite simple mustaches from `{{foo}}` to `{{bind "foo"}}`. This means that all simple
-  mustaches in Ember's Handlebars will also set up an observer to keep the DOM
-  up to date when the underlying property changes.
+  Rewrite simple mustaches from `{{foo}}` to `{{bind "foo"}}`. This means that
+  all simple mustaches in Ember's Handlebars will also set up an observer to
+  keep the DOM up to date when the underlying property changes.
 
   @method mustache
   @for Ember.Handlebars.Compiler
@@ -115,8 +115,8 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
 };
 
 /**
-  Used for precompilation of Ember Handlebars templates. This will not be used during normal
-  app execution.
+  Used for precompilation of Ember Handlebars templates. This will not be used
+  during normal app execution.
 
   @method precompile
   @for Ember.Handlebars
@@ -146,8 +146,9 @@ Ember.Handlebars.precompile = function(string) {
 // We don't support this for Handlebars runtime-only
 if (Handlebars.compile) {
   /**
-    The entry point for Ember Handlebars. This replaces the default Handlebars.compile and turns on
-    template-local data and String parameters.
+    The entry point for Ember Handlebars. This replaces the default
+    `Handlebars.compile` and turns on template-local data and String
+    parameters.
 
     @method compile
     @for Ember.Handlebars

--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -61,17 +61,17 @@ ActionHelper.registerAction = function(actionName, options) {
 };
 
 /**
-  The `{{action}}` helper registers an HTML element within a template for
-  DOM event handling and forwards that interaction to the view's `controller.target`
-  or supplied `target` option (see 'Specifying a Target'). By default the
-  `controller.target` is set to the Application's router.
+  The `{{action}}` helper registers an HTML element within a template for DOM
+  event handling and forwards that interaction to the view's
+  `controller.target` or supplied `target` option (see 'Specifying a Target').
+  By default the `controller.target` is set to the application's router.
 
   User interaction with that element will invoke the supplied action name on
   the appropriate target.
 
   Given the following Handlebars template on the page
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="view"}}>
       click me
@@ -81,7 +81,7 @@ ActionHelper.registerAction = function(actionName, options) {
 
   And application code
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     templateName: 'a-template',
     anActionName: function(event){}
@@ -93,7 +93,7 @@ ActionHelper.registerAction = function(actionName, options) {
 
   Will results in the following rendered HTML
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div data-ember-action="1">
       click me
@@ -114,7 +114,7 @@ ActionHelper.registerAction = function(actionName, options) {
   handler.
 
   If you need the default handler to trigger you should either register your
-  own event handler, or use event methods on your view class. See Ember.View
+  own event handler, or use event methods on your view class. See `Ember.View`
   'Responding to Browser Events' for more information.
 
   ### Specifying DOM event type
@@ -122,7 +122,7 @@ ActionHelper.registerAction = function(actionName, options) {
   By default the `{{action}}` helper registers for DOM `click` events. You can
   supply an `on` option to the helper to specify a different DOM event name:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName on="doubleClick"}}>
       click me
@@ -130,7 +130,7 @@ ActionHelper.registerAction = function(actionName, options) {
   </script>
   ```
 
-  See Ember.View 'Responding to Browser Events' for a list of
+  See `Ember.View` 'Responding to Browser Events' for a list of
   acceptable DOM event names.
 
   Because `{{action}}` depends on Ember's event dispatch system it will only
@@ -139,28 +139,29 @@ ActionHelper.registerAction = function(actionName, options) {
   `Ember.Application` is created. Having an instance of `Ember.Application`
   will satisfy this requirement.
 
-
   ### Specifying a Target
 
   There are several possible target objects for `{{action}}` helpers:
 
   In a typical `Ember.Router`-backed Application where views are managed
   through use of the `{{outlet}}` helper, actions will be forwarded to the
-  current state of the Applications's Router. See Ember.Router 'Responding
+  current state of the Applications's Router. See `Ember.Router` 'Responding
   to User-initiated Events' for more information.
 
   If you manually set the `target` property on the controller of a template's
-  `Ember.View` instance, the specifed `controller.target` will become the target
-  for any actions. Likely custom values for a controller's `target` are the
-  controller itself or a StateManager other than the Application's Router.
+  `Ember.View` instance, the specifed `controller.target` will become the
+  target for any actions. Likely custom values for a controller's `target` are
+  the controller itself or a StateManager other than the Application's
+  router.
 
-  If the templates's view lacks a controller property the view itself is the target.
+  If the templates's view lacks a controller property the view itself is the
+  target.
 
-  Finally, a `target` option can be provided to the helper to change which object
-  will receive the method call. This option must be a string representing a
-  path to an object:
+  Finally, a `target` option can be provided to the helper to change which
+  object will receive the method call. This option must be a string
+  representing a path to an object:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="MyApplication.someObject"}}>
       click me
@@ -176,7 +177,7 @@ ActionHelper.registerAction = function(actionName, options) {
   A path relative to the template's `Ember.View` instance can also be used as
   a target:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="parentView"}}>
       click me
@@ -195,7 +196,7 @@ ActionHelper.registerAction = function(actionName, options) {
   If an action's target does not implement a method that matches the supplied
   action name an error will be thrown.
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action aMethodNameThatIsMissing}}>
       click me
@@ -205,7 +206,7 @@ ActionHelper.registerAction = function(actionName, options) {
 
   With the following application code
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     templateName; 'a-template',
     // note: no method 'aMethodNameThatIsMissing'
@@ -221,12 +222,12 @@ ActionHelper.registerAction = function(actionName, options) {
 
   ### Specifying a context
 
-  You may optionally specify objects to pass as contexts to the `{{action}}` helper
-  by providing property paths as the subsequent parameters. These objects are made
-  available as the `contexts` (also `context` if there is only one) properties in the
-  `jQuery.Event` object:
+  You may optionally specify objects to pass as contexts to the `{{action}}`
+  helper by providing property paths as the subsequent parameters. These
+  objects are made available as the `contexts` (also `context` if there is only
+  one) properties in the `jQuery.Event` object:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name='a-template'>
     {{#each person in people}}
       <div {{action edit person}}>
@@ -236,8 +237,8 @@ ActionHelper.registerAction = function(actionName, options) {
   </script>
   ```
 
-  Clicking "click me" will trigger the `edit` method of the view's context with a
-  `jQuery.Event` object containing the person object as its context.
+  Clicking "click me" will trigger the `edit` method of the view's context with
+  a `jQuery.Event` object containing the person object as its context.
 
   @method action
   @for Ember.Handlebars.helpers

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -181,16 +181,16 @@ EmberHandlebars.registerHelper('_triageMustache', function(property, fn) {
   changes. For example, if you wanted to print the `title` property of
   `content`:
 
-  ``` handlebars
+  ```handlebars
   {{bind "content.title"}}
   ```
 
-  This will return the `title` property as a string, then create a new
-  observer at the specified path. If it changes, it will update the value in
-  DOM. Note that if you need to support IE7 and IE8 you must modify the
-  model objects properties using Ember.get() and Ember.set() for this to work as
-  it relies on Ember's KVO system.  For all other browsers this will be handled
-  for you automatically.
+  This will return the `title` property as a string, then create a new observer
+  at the specified path. If it changes, it will update the value in DOM. Note
+  that if you need to support IE7 and IE8 you must modify the model objects
+  properties using `Ember.get()` and `Ember.set()` for this to work as it
+  relies on Ember's KVO system. For all other browsers this will be handled for
+  you automatically.
 
   @method bind
   @for Ember.Handlebars.helpers
@@ -218,7 +218,7 @@ EmberHandlebars.registerHelper('bind', function(property, options) {
   Use the `boundIf` helper to create a conditional that re-evaluates
   whenever the truthiness of the bound value changes.
 
-  ``` handlebars
+  ```handlebars
   {{#boundIf "content.shouldDisplayTitle"}}
     {{content.title}}
   {{/boundIf}}
@@ -328,18 +328,17 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   `bindAttr` allows you to create a binding between DOM element attributes and
   Ember objects. For example:
 
-
-  ``` handlebars
+  ```handlebars
   <img {{bindAttr src="imageUrl" alt="imageTitle"}}>
   ```
 
-  The above handlebars template will fill the `<img>`'s `src` attribute
-  will the value of the property referenced with `"imageUrl"` and its
-  `alt` attribute with the value of the property referenced with `"imageTitle"`.
+  The above handlebars template will fill the `<img>`'s `src` attribute will
+  the value of the property referenced with `"imageUrl"` and its `alt`
+  attribute with the value of the property referenced with `"imageTitle"`.
 
   If the rendering context of this template is the following object:
 
-  ``` javascript
+  ```javascript
   {
     imageUrl: 'http://lolcats.info/haz-a-funny',
     imageTitle: 'A humorous image of a cat'
@@ -348,33 +347,34 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
 
   The resulting HTML output will be:
 
-  ``` html
-    <img src="http://lolcats.info/haz-a-funny" alt="A humorous image of a cat">
+  ```html
+  <img src="http://lolcats.info/haz-a-funny" alt="A humorous image of a cat">
   ```
 
-  `bindAttr` cannot redeclare existing DOM element attributes. The use
-  of `src` in the following `bindAttr` example will be ignored and the hard coded value
+  `bindAttr` cannot redeclare existing DOM element attributes. The use of `src`
+  in the following `bindAttr` example will be ignored and the hard coded value
   of `src="/failwhale.gif"` will take precedence:
 
-  ``` handlebars
+  ```handlebars
   <img src="/failwhale.gif" {{bindAttr src="imageUrl" alt="imageTitle"}}>
   ```
 
   ### `bindAttr` and the `class` attribute
+
   `bindAttr` supports a special syntax for handling a number of cases unique
   to the `class` DOM element attribute. The `class` attribute combines
   multiple discreet values into a single attribute as a space-delimited
-  list of strings. Each string can be
+  list of strings. Each string can be:
 
-    * a string return value of an object's property.
-    * a boolean return value of an object's property
-    * a hard-coded value
+  * a string return value of an object's property.
+  * a boolean return value of an object's property
+  * a hard-coded value
 
-  A string return value works identically to other uses of `bindAttr`. The return
-  value of the property will become the value of the attribute. For example,
-  the following view and template:
+  A string return value works identically to other uses of `bindAttr`. The
+  return value of the property will become the value of the attribute. For
+  example, the following view and template:
 
-  ``` javascript
+  ```javascript
     AView = Ember.View.extend({
       someProperty: function(){
         return "aValue";
@@ -382,48 +382,58 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
     })
   ```
 
-  ``` handlebars
+  ```handlebars
   <img {{bindAttr class="view.someProperty}}>
   ```
 
   Result in the following rendered output:
+
+  ```html 
   <img class="aValue">
+  ```
 
   A boolean return value will insert a specified class name if the property
   returns `true` and remove the class name if the property returns `false`.
 
-  A class name is provided via the syntax `somePropertyName:class-name-if-true`.
+  A class name is provided via the syntax 
+  `somePropertyName:class-name-if-true`.
 
-  ``` javascript
-    AView = Ember.View.extend({
-      someBool: true
-    })
+  ```javascript
+  AView = Ember.View.extend({
+    someBool: true
+  })
   ```
 
-  ``` handlebars
+  ```handlebars
   <img {{bindAttr class="view.someBool:class-name-if-true"}}>
   ```
 
   Result in the following rendered output:
+
+  ```html
   <img class="class-name-if-true">
+  ```
 
   An additional section of the binding can be provided if you want to
   replace the existing class instead of removing it when the boolean
   value changes:
 
-  ``` handlebars
+  ```handlebars
   <img {{bindAttr class="view.someBool:class-name-if-true:class-name-if-false"}}>
   ```
 
   A hard-coded value can be used by prepending `:` to the desired
   class name: `:class-name-to-always-apply`.
 
-  ``` handlebars
+  ```handlebars
   <img {{bindAttr class=":class-name-to-always-apply"}}>
   ```
 
   Results in the following rendered output:
-  <img class="class-name-to-always-apply">
+
+  ```html
+  <img class=":class-name-to-always-apply">
+  ```
 
   All three strategies - string return value, boolean return value, and
   hard-coded value – can be combined in a single declaration:
@@ -548,8 +558,10 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
   @method bindClasses
   @for Ember.Handlebars
   @param {Ember.Object} context The context from which to lookup properties
-  @param {String} classBindings A string, space-separated, of class bindings to use
-  @param {Ember.View} view The view in which observers should look for the element to update
+  @param {String} classBindings A string, space-separated, of class bindings 
+    to use
+  @param {Ember.View} view The view in which observers should look for the 
+    element to update
   @param {Srting} bindAttrId Optional bindAttr id used to lookup elements
   @return {Array} An array of class names to add
 */

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -13,29 +13,28 @@ var get = Ember.get, handlebarsGet = Ember.Handlebars.get, fmt = Ember.String.fm
 
 /**
   `{{collection}}` is a `Ember.Handlebars` helper for adding instances of
-  `Ember.CollectionView` to a template.  See `Ember.CollectionView` for additional
-  information on how a `CollectionView` functions.
+  `Ember.CollectionView` to a template. See `Ember.CollectionView` for
+  additional information on how a `CollectionView` functions.
 
-  `{{collection}}`'s primary use is as a block helper with a `contentBinding` option
-  pointing towards an `Ember.Array`-compatible object.  An `Ember.View` instance will
-  be created for each item in its `content` property. Each view will have its own
-  `content` property set to the appropriate item in the collection.
+  `{{collection}}`'s primary use is as a block helper with a `contentBinding`
+  option pointing towards an `Ember.Array`-compatible object. An `Ember.View`
+  instance will be created for each item in its `content` property. Each view
+  will have its own `content` property set to the appropriate item in the
+  collection.
 
   The provided block will be applied as the template for each item's view.
 
   Given an empty `<body>` the following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#collection contentBinding="App.items"}}
-      Hi {{view.content.name}}
-    {{/collection}}
-  </script>
+  ```handlebars
+  {{#collection contentBinding="App.items"}}
+    Hi {{view.content.name}}
+  {{/collection}}
   ```
 
   And the following application code
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create()
   App.items = [
     Ember.Object.create({name: 'Dave'}),
@@ -46,7 +45,7 @@ var get = Ember.get, handlebarsGet = Ember.Handlebars.get, fmt = Ember.String.fm
 
   Will result in the HTML structure below
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div class="ember-view">Hi Dave</div>
     <div class="ember-view">Hi Mary</div>
@@ -55,20 +54,19 @@ var get = Ember.get, handlebarsGet = Ember.Handlebars.get, fmt = Ember.String.fm
   ```
 
   ### Blockless Use
-  If you provide an `itemViewClass` option that has its own `template` you can omit
-  the block.
+
+  If you provide an `itemViewClass` option that has its own `template` you can
+  omit the block.
 
   The following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{collection contentBinding="App.items" itemViewClass="App.AnItemView"}}
-  </script>
+  ```handlebars
+  {{collection contentBinding="App.items" itemViewClass="App.AnItemView"}}
   ```
 
   And application code
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create();
   App.items = [
     Ember.Object.create({name: 'Dave'}),
@@ -83,7 +81,7 @@ var get = Ember.get, handlebarsGet = Ember.Handlebars.get, fmt = Ember.String.fm
 
   Will result in the HTML structure below
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div class="ember-view">Greetings Dave</div>
     <div class="ember-view">Greetings Mary</div>
@@ -93,38 +91,34 @@ var get = Ember.get, handlebarsGet = Ember.Handlebars.get, fmt = Ember.String.fm
 
   ### Specifying a CollectionView subclass
 
-  By default the `{{collection}}` helper will create an instance of `Ember.CollectionView`.
-  You can supply a `Ember.CollectionView` subclass to the helper by passing it
-  as the first argument:
+  By default the `{{collection}}` helper will create an instance of
+  `Ember.CollectionView`. You can supply a `Ember.CollectionView` subclass to
+  the helper by passing it as the first argument:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#collection App.MyCustomCollectionClass contentBinding="App.items"}}
-      Hi {{view.content.name}}
-    {{/collection}}
-  </script>
+  ```handlebars
+  {{#collection App.MyCustomCollectionClass contentBinding="App.items"}}
+    Hi {{view.content.name}}
+  {{/collection}}
   ```
-
 
   ### Forwarded `item.*`-named Options
 
-  As with the `{{view}}`, helper options passed to the `{{collection}}` will be set on
-  the resulting `Ember.CollectionView` as properties. Additionally, options prefixed with
-  `item` will be applied to the views rendered for each item (note the camelcasing):
+  As with the `{{view}}`, helper options passed to the `{{collection}}` will be
+  set on the resulting `Ember.CollectionView` as properties. Additionally,
+  options prefixed with `item` will be applied to the views rendered for each
+  item (note the camelcasing):
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#collection contentBinding="App.items"
-                  itemTagName="p"
-                  itemClassNames="greeting"}}
-      Howdy {{view.content.name}}
-    {{/collection}}
-  </script>
+  ```handlebars
+  {{#collection contentBinding="App.items"
+                itemTagName="p"
+                itemClassNames="greeting"}}
+    Howdy {{view.content.name}}
+  {{/collection}}
   ```
 
   Will result in the following HTML structure:
 
-  ``` html
+  ```html
   <div class="ember-view">
     <p class="ember-view greeting">Howdy Dave</p>
     <p class="ember-view greeting">Howdy Mary</p>

--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -13,7 +13,7 @@ var handlebarsGet = Ember.Handlebars.get, normalizePath = Ember.Handlebars.norma
   `log` allows you to output the value of a value in the current rendering
   context.
 
-  ``` handlebars
+  ```handlebars
   {{log myVariable}}
   ```
 
@@ -31,10 +31,9 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
 });
 
 /**
-  The `debugger` helper executes the `debugger` statement in the current
-  context.
+  Execute the `debugger` statement in the current context.
 
-  ``` handlebars
+  ```handlebars
   {{debugger}}
   ```
 

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -128,13 +128,14 @@ GroupedEach.prototype = {
 };
 
 /**
-  The `{{#each}}` helper loops over elements in a collection, rendering its block once for each item:
+  The `{{#each}}` helper loops over elements in a collection, rendering its
+  block once for each item:
 
-  ``` javascript
+  ```javascript
   Developers = [{name: 'Yehuda'},{name: 'Tom'}, {name: 'Paul'}];
   ```
 
-  ``` handlebars
+  ```handlebars
   {{#each Developers}}
     {{name}}
   {{/each}}
@@ -142,19 +143,20 @@ GroupedEach.prototype = {
 
   `{{each}}` supports an alternative syntax with element naming:
 
-  ``` handlebars
+  ```handlebars
   {{#each person in Developers}}
     {{person.name}}
   {{/each}}
   ```
 
-  When looping over objects that do not have properties, `{{this}}` can be used to render the object:
+  When looping over objects that do not have properties, `{{this}}` can be used
+  to render the object:
 
-  ``` javascript
+  ```javascript
   DeveloperNames = ['Yehuda', 'Tom', 'Paul']
   ```
 
-  ``` handlebars
+  ```handlebars
   {{#each DeveloperNames}}
     {{this}}
   {{/each}}
@@ -162,22 +164,21 @@ GroupedEach.prototype = {
 
   ### Blockless Use
 
-  If you provide an `itemViewClass` option that has its own `template` you can omit
-  the block in a similar way to how it can be done with the collection helper.
+  If you provide an `itemViewClass` option that has its own `template` you can
+  omit the block in a similar way to how it can be done with the collection
+  helper.
 
   The following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view App.MyView }}
-      {{each view.items itemViewClass="App.AnItemView"}}
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view App.MyView }}
+    {{each view.items itemViewClass="App.AnItemView"}} 
+  {{/view}}
   ```
 
   And application code
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create({
     MyView: Ember.View.extend({
       items: [
@@ -197,14 +198,13 @@ GroupedEach.prototype = {
 
   Will result in the HTML structure below
 
-  ``` html
+  ```html
   <div class="ember-view">
     <div class="ember-view">Greetings Dave</div>
     <div class="ember-view">Greetings Mary</div>
     <div class="ember-view">Greetings Sara</div>
   </div>
   ```
-
 
   @method each
   @for Ember.Handlebars.helpers

--- a/packages/ember-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-handlebars/lib/helpers/outlet.js
@@ -11,7 +11,7 @@ Ember.Handlebars.OutletView = Ember.ContainerView.extend(Ember._Metamorph);
   The `outlet` helper allows you to specify that the current
   view's controller will fill in the view for a given area.
 
-  ``` handlebars
+  ```handlebars
   {{outlet}}
   ```
 
@@ -19,23 +19,24 @@ Ember.Handlebars.OutletView = Ember.ContainerView.extend(Ember._Metamorph);
   outlet will replace its current view with the new view. You can set the
   `view` property directly, but it's normally best to use `connectOutlet`.
 
-  ``` javascript
+  ```javascript
   # Instantiate App.PostsView and assign to `view`, so as to render into outlet.
   controller.connectOutlet('posts');
   ```
 
   You can also specify a particular name other than `view`:
 
-  ``` handlebars
+  ```handlebars
   {{outlet masterView}}
   {{outlet detailView}}
   ```
 
   Then, you can control several outlets from a single controller.
 
-  ``` javascript
+  ```javascript
   # Instantiate App.PostsView and assign to controller.masterView.
   controller.connectOutlet('masterView', 'posts');
+
   # Also, instantiate App.PostInfoView and assign to controller.detailView.
   controller.connectOutlet('detailView', 'postInfo');
   ```

--- a/packages/ember-handlebars/lib/helpers/template.js
+++ b/packages/ember-handlebars/lib/helpers/template.js
@@ -9,27 +9,29 @@ require('ember-handlebars/ext');
   `template` allows you to render a template from inside another template.
   This allows you to re-use the same template in multiple places. For example:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
+  ```handlebars
+  <script type="text/x-handlebars" data-template-name="logged_in_user">
     {{#with loggedInUser}}
       Last Login: {{lastLogin}}
       User Info: {{template "user_info"}}
     {{/with}}
   </script>
+  ```
 
+  ```handlebars
   <script type="text/x-handlebars" data-template-name="user_info">
     Name: <em>{{name}}</em>
     Karma: <em>{{karma}}</em>
   </script>
   ```
 
-  This helper looks for templates in the global Ember.TEMPLATES hash. If you
-  add &lt;script&gt; tags to your page with the `data-template-name` attribute set,
+  This helper looks for templates in the global `Ember.TEMPLATES` hash. If you
+  add `<script>` tags to your page with the `data-template-name` attribute set,
   they will be compiled and placed in this hash automatically.
 
   You can also manually register templates by adding them to the hash:
 
-  ``` javascript
+  ```javascript
   Ember.TEMPLATES["my_cool_template"] = Ember.Handlebars.compile('<b>{{user}}</b>');
   ```
 

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -13,7 +13,7 @@ var handlebarsGet = Ember.Handlebars.get;
   `unbound` allows you to output a property without binding. *Important:* The
   output will not be updated if the property changes. Use with caution.
 
-  ``` handlebars
+  ```handlebars
   <div>{{unbound somePropertyThatDoesntChange}}</div>
   ```
 

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -151,23 +151,22 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 });
 
 /**
-  `{{view}}` inserts a new instance of `Ember.View` into a template passing its options
-  to the `Ember.View`'s `create` method and using the supplied block as the view's own template.
+  `{{view}}` inserts a new instance of `Ember.View` into a template passing its
+  options to the `Ember.View`'s `create` method and using the supplied block as
+  the view's own template.
 
   An empty `<body>` and the following template:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    A span:
-    {{#view tagName="span"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  A span:
+  {{#view tagName="span"}}
+    hello.
+  {{/view}}
   ```
 
   Will result in HTML structure:
 
-  ``` html
+  ```html
   <body>
     <!-- Note: the handlebars template script
          also results in a rendered Ember.View
@@ -182,12 +181,13 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   </body>
   ```
 
-  ### parentView setting
+  ### `parentView` setting
 
-  The `parentView` property of the new `Ember.View` instance created through `{{view}}`
-  will be set to the `Ember.View` instance of the template where `{{view}}` was called.
+  The `parentView` property of the new `Ember.View` instance created through
+  `{{view}}` will be set to the `Ember.View` instance of the template where
+  `{{view}}` was called.
 
-  ``` javascript
+  ```javascript
   aView = Ember.View.create({
     template: Ember.Handlebars.compile("{{#view}} my parent: {{parentView.elementId}} {{/view}}")
   });
@@ -197,7 +197,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   Will result in HTML structure:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">
     <div id="ember2" class="ember-view">
       my parent: ember1
@@ -207,20 +207,18 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   ### Setting CSS id and class attributes
 
-  The HTML `id` attribute can be set on the `{{view}}`'s resulting element with the `id` option.
-  This option will _not_ be passed to `Ember.View.create`.
+  The HTML `id` attribute can be set on the `{{view}}`'s resulting element with
+  the `id` option. This option will _not_ be passed to `Ember.View.create`.
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view tagName="span" id="a-custom-id"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view tagName="span" id="a-custom-id"}}
+    hello.
+  {{/view}}
   ```
 
   Results in the following HTML structure:
 
-  ``` html
+  ```html
   <div class="ember-view">
     <span id="a-custom-id" class="ember-view">
       hello.
@@ -228,23 +226,21 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   </div>
   ```
 
-  The HTML `class` attribute can be set on the `{{view}}`'s resulting element with
-  the `class` or `classNameBindings` options. The `class` option
-  will directly set the CSS `class` attribute and will not be passed to
+  The HTML `class` attribute can be set on the `{{view}}`'s resulting element
+  with the `class` or `classNameBindings` options. The `class` option will
+  directly set the CSS `class` attribute and will not be passed to
   `Ember.View.create`. `classNameBindings` will be passed to `create` and use
   `Ember.View`'s class name binding functionality:
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view tagName="span" class="a-custom-class"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view tagName="span" class="a-custom-class"}}
+    hello.
+  {{/view}}
   ```
 
   Results in the following HTML structure:
 
-  ``` html
+  ```html
   <div class="ember-view">
     <span id="ember2" class="ember-view a-custom-class">
       hello.
@@ -254,21 +250,20 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   ### Supplying a different view class
 
-  `{{view}}` can take an optional first argument before its supplied options to specify a
-  path to a custom view class.
+  `{{view}}` can take an optional first argument before its supplied options to
+  specify a path to a custom view class.
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{#view "MyApp.CustomView"}}
-      hello.
-    {{/view}}
-  </script>
+  ```handlebars
+  {{#view "MyApp.CustomView"}}
+    hello.
+  {{/view}}
   ```
 
-  The first argument can also be a relative path. Ember will search for the view class
-  starting at the `Ember.View` of the template where `{{view}}` was used as the root object:
+  The first argument can also be a relative path. Ember will search for the
+  view class starting at the `Ember.View` of the template where `{{view}}` was
+  used as the root object:
 
-  ``` javascript
+  ```javascript
   MyApp = Ember.Application.create({});
   MyApp.OuterView = Ember.View.extend({
     innerViewClass: Ember.View.extend({
@@ -282,7 +277,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
 
   Will result in the following HTML:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">
     <div id="ember2" class="ember-view a-custom-view-class-as-property">
       hi
@@ -293,21 +288,20 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   ### Blockless use
 
   If you supply a custom `Ember.View` subclass that specifies its own template
-  or provide a `templateName` option to `{{view}}` it can be used without supplying a block.
-  Attempts to use both a `templateName` option and supply a block will throw an error.
+  or provide a `templateName` option to `{{view}}` it can be used without
+  supplying a block. Attempts to use both a `templateName` option and supply a
+  block will throw an error.
 
-  ``` handlebars
-  <script type="text/x-handlebars">
-    {{view "MyApp.ViewWithATemplateDefined"}}
-  </script>
+  ```handlebars
+  {{view "MyApp.ViewWithATemplateDefined"}}
   ```
 
-  ### viewName property
+  ### `viewName` property
 
-  You can supply a `viewName` option to `{{view}}`. The `Ember.View` instance will
-  be referenced as a property of its parent view by this name.
+  You can supply a `viewName` option to `{{view}}`. The `Ember.View` instance
+  will be referenced as a property of its parent view by this name.
 
-  ``` javascript
+  ```javascript
   aView = Ember.View.create({
     template: Ember.Handlebars.compile('{{#view viewName="aChildByName"}} hi {{/view}}')
   });

--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -6,17 +6,16 @@
 var get = Ember.get, set = Ember.set;
 
 /**
-
-  When used in a Handlebars template that is assigned to an `Ember.View` instance's
-  `layout` property Ember will render the layout template first, inserting the view's
-  own rendered output at the `{{ yield }}` location.
+  When used in a Handlebars template that is assigned to an `Ember.View`
+  instance's `layout` property Ember will render the layout template first,
+  inserting the view's own rendered output at the `{{yield}}` location.
 
   An empty `<body>` and the following application code:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     classNames: ['a-view-with-layout'],
-    layout: Ember.Handlebars.compile('<div class="wrapper">{{ yield }}</div>'),
+    layout: Ember.Handlebars.compile('<div class="wrapper">{{yield}}</div>'),
     template: Ember.Handlebars.compile('<span>I am wrapped</span>')
   });
 
@@ -26,7 +25,7 @@ var get = Ember.get, set = Ember.set;
 
   Will result in the following HTML output:
 
-  ``` html
+  ```html
   <body>
     <div class='ember-view a-view-with-layout'>
       <div class="wrapper">
@@ -36,10 +35,10 @@ var get = Ember.get, set = Ember.set;
   </body>
   ```
 
-  The yield helper cannot be used outside of a template assigned to an `Ember.View`'s `layout` property
-  and will throw an error if attempted.
+  The `yield` helper cannot be used outside of a template assigned to an
+  `Ember.View`'s `layout` property and will throw an error if attempted.
 
-  ``` javascript
+  ```javascript
   BView = Ember.View.extend({
     classNames: ['a-view-with-layout'],
     template: Ember.Handlebars.compile('{{yield}}')

--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -11,12 +11,12 @@ require("ember-handlebars/ext");
   @private
 
   Find templates stored in the head tag as script tags and make them available
-  to Ember.CoreView in the global Ember.TEMPLATES object. This will be run as as
-  jQuery DOM-ready callback.
+  to `Ember.CoreView` in the global `Ember.TEMPLATES` object. This will be run
+  as as jQuery DOM-ready callback.
 
-  Script tags with "text/x-handlebars" will be compiled
+  Script tags with `text/x-handlebars` will be compiled
   with Ember's Handlebars and are suitable for use as a view's template.
-  Those with type="text/x-raw-handlebars" will be compiled with regular
+  Those with type `text/x-raw-handlebars` will be compiled with regular
   Handlebars and are suitable for use in views' computed properties.
 
   @method bootstrap

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -71,13 +71,13 @@ Ember._SimpleHandlebarsView = Ember._SimpleMetamorphView.extend({
 });
 
 /**
-  Ember._HandlebarsBoundView is a private view created by the Handlebars `{{bind}}`
-  helpers that is used to keep track of bound properties.
+  `Ember._HandlebarsBoundView` is a private view created by the Handlebars
+  `{{bind}}` helpers that is used to keep track of bound properties.
 
   Every time a property is bound using a `{{mustache}}`, an anonymous subclass
-  of Ember._HandlebarsBoundView is created with the appropriate sub-template and
-  context set up. When the associated property changes, just the template for
-  this view will re-render.
+  of `Ember._HandlebarsBoundView` is created with the appropriate sub-template
+  and context set up. When the associated property changes, just the template
+  for this view will re-render.
 
   @class _HandlebarsBoundView
   @namespace Ember
@@ -105,7 +105,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 
     For example, this is true when using the `{{#if}}` helper, because the
     template inside the helper should look up properties relative to the same
-    object as outside the block. This would be false when used with `{{#with
+    object as outside the block. This would be `false` when used with `{{#with
     foo}}` because the template should receive the object found by evaluating
     `foo`.
 
@@ -125,7 +125,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
   previousContext: null,
 
   /**
-    The template to render when `shouldDisplayFunc` evaluates to true.
+    The template to render when `shouldDisplayFunc` evaluates to `true`.
 
     @property displayTemplate
     @type Function
@@ -134,7 +134,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
   displayTemplate: null,
 
   /**
-    The template to render when `shouldDisplayFunc` evaluates to false.
+    The template to render when `shouldDisplayFunc` evaluates to `false`.
 
     @property inverseTemplate
     @type Function
@@ -147,7 +147,7 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
     The path to look up on `pathRoot` that is passed to
     `shouldDisplayFunc` to determine which template to render.
 
-    In addition, if `preserveContext` is false, the object at this path will
+    In addition, if `preserveContext` is `false,` the object at this path will
     be passed to the template when rendering.
 
     @property path
@@ -158,9 +158,9 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 
   /**
     The object from which the `path` will be looked up. Sometimes this is the
-    same as the `previousContext`, but in cases where this view has been generated
-    for paths that start with a keyword such as `view` or `controller`, the
-    path root will be that resolved object.
+    same as the `previousContext`, but in cases where this view has been
+    generated for paths that start with a keyword such as `view` or
+    `controller`, the path root will be that resolved object.
 
     @property pathRoot
     @type Object
@@ -195,15 +195,15 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
 
   /**
     Determines which template to invoke, sets up the correct state based on
-    that logic, then invokes the default Ember.View `render` implementation.
+    that logic, then invokes the default `Ember.View` `render` implementation.
 
     This method will first look up the `path` key on `pathRoot`,
     then pass that value to the `shouldDisplayFunc` function. If that returns
-    true, the `displayTemplate` function will be rendered to DOM. Otherwise,
+    `true,` the `displayTemplate` function will be rendered to DOM. Otherwise,
     `inverseTemplate`, if specified, will be rendered.
 
-    For example, if this Ember._HandlebarsBoundView represented the `{{#with foo}}`
-    helper, it would look up the `foo` property of its context, and
+    For example, if this `Ember._HandlebarsBoundView` represented the `{{#with
+    foo}}` helper, it would look up the `foo` property of its context, and
     `shouldDisplayFunc` would always return true. The object found by looking
     up `foo` would be passed to `displayTemplate`.
 

--- a/packages/ember-metal/lib/accessors.js
+++ b/packages/ember-metal/lib/accessors.js
@@ -23,28 +23,28 @@ var FIRST_KEY = /^([^\.\*]+)/;
 // object.
 
 /**
-  Gets the value of a property on an object.  If the property is computed,
-  the function will be invoked.  If the property is not defined but the
-  object implements the unknownProperty() method then that will be invoked.
+  Gets the value of a property on an object. If the property is computed,
+  the function will be invoked. If the property is not defined but the
+  object implements the `unknownProperty` method then that will be invoked.
 
   If you plan to run on IE8 and older browsers then you should use this
   method anytime you want to retrieve a property on an object that you don't
-  know for sure is private.  (My convention only properties beginning with
-  an underscore '_' are considered private.)
+  know for sure is private. (Properties beginning with an underscore '_' 
+  are considered private.)
 
   On all newer browsers, you only need to use this method to retrieve
   properties if the property might not be defined on the object and you want
-  to respect the unknownProperty() handler.  Otherwise you can ignore this
+  to respect the `unknownProperty` handler. Otherwise you can ignore this
   method.
 
-  Note that if the obj itself is null, this method will simply return
-  undefined.
+  Note that if the obj itself is `null`, this method will simply return
+  `undefined`.
 
   @method get
   @for Ember
   @param {Object} obj The object to retrieve from.
   @param {String} keyName The property key to retrieve
-  @return {Object} the property value or null.
+  @return {Object} the property value or `null`.
 */
 get = function get(obj, keyName) {
   // Helpers that operate with 'this' within an #each
@@ -84,18 +84,18 @@ get = function get(obj, keyName) {
 
 /**
   Sets the value of a property on an object, respecting computed properties
-  and notifying observers and other listeners of the change.  If the
-  property is not defined but the object implements the unknownProperty()
+  and notifying observers and other listeners of the change. If the
+  property is not defined but the object implements the `unknownProperty`
   method then that will be invoked as well.
 
   If you plan to run on IE8 and older browsers then you should use this
   method anytime you want to set a property on an object that you don't
-  know for sure is private.  (My convention only properties beginning with
-  an underscore '_' are considered private.)
+  know for sure is private. (Properties beginning with an underscore '_' 
+  are considered private.)
 
   On all newer browsers, you only need to use this method to set
   properties if the property might not be defined on the object and you want
-  to respect the unknownProperty() handler.  Otherwise you can ignore this
+  to respect the `unknownProperty` handler. Otherwise you can ignore this
   method.
 
   @method set
@@ -252,13 +252,13 @@ function setPath(root, path, value, tolerant) {
   @private
 
   Normalizes a target/path pair to reflect that actual target/path that should
-  be observed, etc.  This takes into account passing in global property
+  be observed, etc. This takes into account passing in global property
   paths (i.e. a path beginning with a captial letter not defined on the
   target) and * separators.
 
   @method normalizeTuple
   @for Ember
-  @param {Object} target The current target.  May be null.
+  @param {Object} target The current target. May be `null`.
   @param {String} path A path on the target or a global property path.
   @return {Array} a temporary array with the normalized target/path pair.
 */
@@ -281,8 +281,8 @@ Ember.set = set;
 Ember.setPath = Ember.deprecateFunc('setPath is deprecated since set now supports paths', Ember.set);
 
 /**
-  Error-tolerant form of Ember.set. Will not blow up if any part of the
-  chain is undefined, null, or destroyed.
+  Error-tolerant form of `Ember.set`. Will not blow up if any part of the
+  chain is `undefined`, `null`, or destroyed.
 
   This is primarily used when syncing bindings, which may try to update after
   an object has been destroyed.
@@ -299,8 +299,8 @@ Ember.trySet = function(root, path, value) {
 Ember.trySetPath = Ember.deprecateFunc('trySetPath has been renamed to trySet', Ember.trySet);
 
 /**
-  Returns true if the provided path is global (e.g., "MyApp.fooController.bar")
-  instead of local ("foo.bar.baz").
+  Returns true if the provided path is global (e.g., `MyApp.fooController.bar`)
+  instead of local (`foo.bar.baz`).
 
   @method isGlobalPath
   @for Ember

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -69,17 +69,17 @@ Binding.prototype = {
   //
 
   /**
-    This will set "from" property path to the specified value. It will not
+    This will set `from` property path to the specified value. It will not
     attempt to resolve this property path to an actual object until you
     connect the binding.
 
     The binding will search for the property path starting at the root object
-    you pass when you connect() the binding.  It follows the same rules as
+    you pass when you `connect()` the binding. It follows the same rules as
     `get()` - see that method for more information.
 
     @method from
     @param {String} propertyPath the property path to connect to
-    @return {Ember.Binding} receiver
+    @return {Ember.Binding} `this`
   */
   from: function(path) {
     this._from = path;
@@ -87,17 +87,17 @@ Binding.prototype = {
   },
 
   /**
-    This will set the "to" property path to the specified value. It will not
+    This will set the `to` property path to the specified value. It will not
     attempt to resolve this property path to an actual object until you
     connect the binding.
 
     The binding will search for the property path starting at the root object
-    you pass when you connect() the binding.  It follows the same rules as
+    you pass when you `connect()` the binding. It follows the same rules as
     `get()` - see that method for more information.
 
     @method to
     @param {String|Tuple} propertyPath A property path or tuple
-    @return {Ember.Binding} this
+    @return {Ember.Binding} `this`
   */
   to: function(path) {
     this._to = path;
@@ -106,12 +106,12 @@ Binding.prototype = {
 
   /**
     Configures the binding as one way. A one-way binding will relay changes
-    on the "from" side to the "to" side, but not the other way around. This
-    means that if you change the "to" side directly, the "from" side may have
+    on the `from` side to the `to` side, but not the other way around. This
+    means that if you change the `to` side directly, the `from` side may have
     a different value.
 
     @method oneWay
-    @return {Ember.Binding} receiver
+    @return {Ember.Binding} `this`
   */
   oneWay: function() {
     this._oneWay = true;
@@ -134,7 +134,7 @@ Binding.prototype = {
 
     @method connect
     @param {Object} obj The root object for this binding.
-    @return {Ember.Binding} this
+    @return {Ember.Binding} `this`
   */
   connect: function(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.connect()', !!obj);
@@ -159,7 +159,7 @@ Binding.prototype = {
 
     @method disconnect
     @param {Object} obj The root object you passed when connecting the binding.
-    @return {Ember.Binding} this
+    @return {Ember.Binding} `this`
   */
   disconnect: function(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.disconnect()', !!obj);
@@ -284,8 +284,8 @@ mixinProperties(Binding, {
 
   /**
     Creates a new Binding instance and makes it apply in a single direction.
-    A one-way binding will relay changes on the "from" side object (supplied
-    as the `from` argument) the "to" side, but not the other way around.
+    A one-way binding will relay changes on the `from` side object (supplied
+    as the `from` argument) the `to` side, but not the other way around.
     This means that if you change the "to" side directly, the "from" side may have
     a different value.
 
@@ -293,8 +293,9 @@ mixinProperties(Binding, {
 
     @method oneWay
     @param {String} from from path.
-    @param {Boolean} [flag] (Optional) passing nothing here will make the binding oneWay.  You can
-      instead pass false to disable oneWay, making the binding two way again.
+    @param {Boolean} [flag] (Optional) passing nothing here will make the
+      binding `oneWay`. You can instead pass `false` to disable `oneWay`, making the
+      binding two way again.
   */
   oneWay: function(from, flag) {
     var C = this, binding = new C(null, from);
@@ -304,18 +305,23 @@ mixinProperties(Binding, {
 });
 
 /**
-  An Ember.Binding connects the properties of two objects so that whenever the
-  value of one property changes, the other property will be changed also.
+  An `Ember.Binding` connects the properties of two objects so that whenever
+  the value of one property changes, the other property will be changed also.
 
   ## Automatic Creation of Bindings with `/^*Binding/`-named Properties
+
   You do not usually create Binding objects directly but instead describe
-  bindings in your class or object definition using automatic binding detection.
+  bindings in your class or object definition using automatic binding
+  detection.
 
-  Properties ending in a `Binding` suffix will be converted to Ember.Binding instances.
-  The value of this property should be a string representing a path to another object or
-  a custom binding instanced created using Binding helpers (see "Customizing Your Bindings"):
+  Properties ending in a `Binding` suffix will be converted to `Ember.Binding`
+  instances. The value of this property should be a string representing a path
+  to another object or a custom binding instanced created using Binding helpers
+  (see "Customizing Your Bindings"):
 
-      valueBinding: "MyApp.someController.title"
+  ```
+  valueBinding: "MyApp.someController.title"
+  ```
 
   This will create a binding from `MyApp.someController.title` to the `value`
   property of your object instance automatically. Now the two values will be
@@ -330,12 +336,14 @@ mixinProperties(Binding, {
   has changed, but your object will not be changing the preference itself, you
   could do:
 
-      bigTitlesBinding: Ember.Binding.oneWay("MyApp.preferencesController.bigTitles")
+  ```
+  bigTitlesBinding: Ember.Binding.oneWay("MyApp.preferencesController.bigTitles")
+  ```
 
-  This way if the value of MyApp.preferencesController.bigTitles changes the
-  "bigTitles" property of your object will change also. However, if you
-  change the value of your "bigTitles" property, it will not update the
-  preferencesController.
+  This way if the value of `MyApp.preferencesController.bigTitles` changes the
+  `bigTitles` property of your object will change also. However, if you
+  change the value of your `bigTitles` property, it will not update the
+  `preferencesController`.
 
   One way bindings are almost twice as fast to setup and twice as fast to
   execute because the binding only has to worry about changes to one side.
@@ -346,35 +354,39 @@ mixinProperties(Binding, {
 
   ## Adding Bindings Manually
 
-  All of the examples above show you how to configure a custom binding, but
-  the result of these customizations will be a binding template, not a fully
-  active Binding instance. The binding will actually become active only when you
+  All of the examples above show you how to configure a custom binding, but the
+  result of these customizations will be a binding template, not a fully active
+  Binding instance. The binding will actually become active only when you
   instantiate the object the binding belongs to. It is useful however, to
   understand what actually happens when the binding is activated.
 
-  For a binding to function it must have at least a "from" property and a "to"
-  property. The from property path points to the object/key that you want to
-  bind from while the to path points to the object/key you want to bind to.
+  For a binding to function it must have at least a `from` property and a `to`
+  property. The `from` property path points to the object/key that you want to
+  bind from while the `to` path points to the object/key you want to bind to.
 
   When you define a custom binding, you are usually describing the property
-  you want to bind from (such as "MyApp.someController.value" in the examples
+  you want to bind from (such as `MyApp.someController.value` in the examples
   above). When your object is created, it will automatically assign the value
-  you want to bind "to" based on the name of your binding key. In the
+  you want to bind `to` based on the name of your binding key. In the
   examples above, during init, Ember objects will effectively call
   something like this on your binding:
 
-      binding = Ember.Binding.from(this.valueBinding).to("value");
+  ```javascript
+  binding = Ember.Binding.from(this.valueBinding).to("value");
+  ```
 
   This creates a new binding instance based on the template you provide, and
-  sets the to path to the "value" property of the new object. Now that the
-  binding is fully configured with a "from" and a "to", it simply needs to be
-  connected to become active. This is done through the connect() method:
+  sets the to path to the `value` property of the new object. Now that the
+  binding is fully configured with a `from` and a `to`, it simply needs to be
+  connected to become active. This is done through the `connect()` method:
 
-      binding.connect(this);
+  ```javascript
+  binding.connect(this);
+  ```
 
   Note that when you connect a binding you pass the object you want it to be
-  connected to.  This object will be used as the root for both the from and
-  to side of the binding when inspecting relative paths.  This allows the
+  connected to. This object will be used as the root for both the from and
+  to side of the binding when inspecting relative paths. This allows the
   binding to be automatically inherited by subclassed objects as well.
 
   Now that the binding is connected, it will observe both the from and to side
@@ -382,20 +394,23 @@ mixinProperties(Binding, {
 
   If you ever needed to do so (you almost never will, but it is useful to
   understand this anyway), you could manually create an active binding by
-  using the Ember.bind() helper method. (This is the same method used by
+  using the `Ember.bind()` helper method. (This is the same method used by
   to setup your bindings on objects):
 
-      Ember.bind(MyApp.anotherObject, "value", "MyApp.someController.value");
+  ```javascript
+  Ember.bind(MyApp.anotherObject, "value", "MyApp.someController.value");
+  ```
 
   Both of these code fragments have the same effect as doing the most friendly
   form of binding creation like so:
 
-      MyApp.anotherObject = Ember.Object.create({
-        valueBinding: "MyApp.someController.value",
+  ```javascript
+  MyApp.anotherObject = Ember.Object.create({
+    valueBinding: "MyApp.someController.value",
 
-        // OTHER CODE FOR THIS OBJECT...
-
-      });
+    // OTHER CODE FOR THIS OBJECT...
+  });
+  ```
 
   Ember's built in binding creation method makes it easy to automatically
   create bindings for you. You should always use the highest-level APIs
@@ -409,19 +424,16 @@ Ember.Binding = Binding;
 
 
 /**
-  Global helper method to create a new binding.  Just pass the root object
-  along with a to and from path to create and connect the binding.
+  Global helper method to create a new binding. Just pass the root object
+  along with a `to` and `from` path to create and connect the binding.
 
   @method bind
   @for Ember
   @param {Object} obj The root object of the transform.
-
   @param {String} to The path to the 'to' side of the binding.
     Must be relative to obj.
-
   @param {String} from The path to the 'from' side of the binding.
     Must be relative to obj or a global path.
-
   @return {Ember.Binding} binding instance
 */
 Ember.bind = function(obj, to, from) {
@@ -432,13 +444,10 @@ Ember.bind = function(obj, to, from) {
   @method oneWay
   @for Ember
   @param {Object} obj The root object of the transform.
-
   @param {String} to The path to the 'to' side of the binding.
     Must be relative to obj.
-
   @param {String} from The path to the 'from' side of the binding.
     Must be relative to obj or a global path.
-
   @return {Ember.Binding} binding instance
 */
 Ember.oneWay = function(obj, to, from) {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -129,24 +129,26 @@ ComputedProperty.prototype = new Ember.Descriptor();
 var ComputedPropertyPrototype = ComputedProperty.prototype;
 
 /**
-  Call on a computed property to set it into cacheable mode.  When in this
+  Call on a computed property to set it into cacheable mode. When in this
   mode the computed property will automatically cache the return value of
   your function until one of the dependent keys changes.
 
-      MyApp.president = Ember.Object.create({
-        fullName: function() {
-          return this.get('firstName') + ' ' + this.get('lastName');
+  ```javascript
+  MyApp.president = Ember.Object.create({
+    fullName: function() {
+      return this.get('firstName') + ' ' + this.get('lastName');
 
-          // After calculating the value of this function, Ember.js will
-          // return that value without re-executing this function until
-          // one of the dependent properties change.
-        }.property('firstName', 'lastName')
-      });
+      // After calculating the value of this function, Ember will
+      // return that value without re-executing this function until
+      // one of the dependent properties change.
+    }.property('firstName', 'lastName')
+  });
+  ```
 
   Properties are cacheable by default.
 
   @method cacheable
-  @param {Boolean} aFlag optional set to false to disable caching
+  @param {Boolean} aFlag optional set to `false` to disable caching
   @chainable
 */
 ComputedPropertyPrototype.cacheable = function(aFlag) {
@@ -155,14 +157,16 @@ ComputedPropertyPrototype.cacheable = function(aFlag) {
 };
 
 /**
-  Call on a computed property to set it into non-cached mode.  When in this
+  Call on a computed property to set it into non-cached mode. When in this
   mode the computed property will not automatically cache the return value.
 
-      MyApp.outsideService = Ember.Object.create({
-        value: function() {
-          return OutsideService.getValue();
-        }.property().volatile()
-      });
+  ```javascript
+  MyApp.outsideService = Ember.Object.create({
+    value: function() {
+      return OutsideService.getValue();
+    }.property().volatile()
+  });
+  ```
 
   @method volatile
   @chainable
@@ -172,17 +176,19 @@ ComputedPropertyPrototype.volatile = function() {
 };
 
 /**
-  Sets the dependent keys on this computed property.  Pass any number of
+  Sets the dependent keys on this computed property. Pass any number of
   arguments containing key paths that this computed property depends on.
 
-      MyApp.president = Ember.Object.create({
-        fullName: Ember.computed(function() {
-          return this.get('firstName') + ' ' + this.get('lastName');
+  ```javascript
+  MyApp.president = Ember.Object.create({
+    fullName: Ember.computed(function() {
+      return this.get('firstName') + ' ' + this.get('lastName');
 
-          // Tell Ember.js that this computed property depends on firstName
-          // and lastName
-        }).property('firstName', 'lastName')
-      });
+      // Tell Ember that this computed property depends on firstName
+      // and lastName
+    }).property('firstName', 'lastName')
+  });
+  ```
 
   @method property
   @param {String} path* zero or more property paths
@@ -205,10 +211,12 @@ ComputedPropertyPrototype.property = function() {
 
   You can pass a hash of these values to a computed property like this:
 
-      person: function() {
-        var personId = this.get('personId');
-        return App.Person.create({ id: personId });
-      }.property().meta({ type: App.Person })
+  ```
+  person: function() {
+    var personId = this.get('personId');
+    return App.Person.create({ id: personId });
+  }.property().meta({ type: App.Person })
+  ```
 
   The hash that you pass to the `meta()` function will be saved on the
   computed property descriptor under the `_meta` key. Ember runtime
@@ -356,12 +364,12 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
 
 /**
   This helper returns a new property descriptor that wraps the passed
-  computed property function.  You can use this helper to define properties
-  with mixins or via Ember.defineProperty().
+  computed property function. You can use this helper to define properties
+  with mixins or via `Ember.defineProperty()`.
 
   The function you pass will be used to both get and set property values.
-  The function should accept two parameters, key and value.  If value is not
-  undefined you should set the value first.  In either case return the
+  The function should accept two parameters, key and value. If value is not
+  undefined you should set the value first. In either case return the
   current value of the property.
 
   @method computed
@@ -396,7 +404,7 @@ Ember.computed = function(func) {
   @for Ember
   @param {Object} obj the object whose property you want to check
   @param {String} key the name of the property whose cached value you want
-                      to return
+    to return
 */
 Ember.cacheFor = function cacheFor(obj, key) {
   var cache = metaFor(obj, false).cache;

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -6,17 +6,16 @@
 */
 
 /**
-  All Ember methods and functions are defined inside of this namespace.
-  You generally should not add new properties to this namespace as it may be
+  All Ember methods and functions are defined inside of this namespace. You
+  generally should not add new properties to this namespace as it may be
   overwritten by future versions of Ember.
 
-  You can also use the shorthand "Em" instead of "Ember".
+  You can also use the shorthand `Em` instead of `Ember`.
 
-  Ember-Runtime is a framework that provides core functions for
-  Ember including cross-platform functions, support for property
-  observing and objects. Its focus is on small size and performance. You can
-  use this in place of or along-side other cross-platform libraries such as
-  jQuery.
+  Ember-Runtime is a framework that provides core functions for Ember including
+  cross-platform functions, support for property observing and objects. Its
+  focus is on small size and performance. You can use this in place of or
+  along-side other cross-platform libraries such as jQuery.
 
   The core Runtime framework is based on the jQuery API with a number of
   performance optimizations.
@@ -56,7 +55,7 @@ Ember.toString = function() { return "Ember"; };
 Ember.VERSION = '1.0.0-pre.2';
 
 /**
-  Standard environmental variables.  You can define these in a global `ENV`
+  Standard environmental variables. You can define these in a global `ENV`
   variable before loading Ember to control various configuration
   settings.
 
@@ -72,14 +71,14 @@ Ember.config = Ember.config || {};
 //
 
 /**
-  Determines whether Ember should enhances some built-in object
-  prototypes to provide a more friendly API.  If enabled, a few methods
-  will be added to Function, String, and Array.  Object.prototype will not be
-  enhanced, which is the one that causes most trouble for people.
+  Determines whether Ember should enhances some built-in object prototypes to
+  provide a more friendly API. If enabled, a few methods will be added to
+  `Function`, `String`, and `Array`. `Object.prototype` will not be enhanced,
+  which is the one that causes most trouble for people.
 
   In general we recommend leaving this option set to true since it rarely
-  conflicts with other code.  If you need to turn it off however, you can
-  define an ENV.EXTEND_PROTOTYPES config to disable it.
+  conflicts with other code. If you need to turn it off however, you can
+  define an `ENV.EXTEND_PROTOTYPES` config to disable it.
 
   @property EXTEND_PROTOTYPES
   @type Boolean
@@ -110,7 +109,7 @@ Ember.LOG_STACKTRACE_ON_DEPRECATION = (Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION !
 Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPES;
 
 /**
-  Empty function.  Useful for some operations.
+  Empty function. Useful for some operations.
 
   @method K
   @private
@@ -138,8 +137,8 @@ if ('undefined' === typeof ember_deprecateFunc) {
 }
 
 /**
-  Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from jQuery master.
-  We'll just bootstrap our own uuid now.
+  Previously we used `Ember.$.uuid`, however `$.uuid` has been removed from
+  jQuery master. We'll just bootstrap our own uuid now.
 
   @property uuid
   @type Number
@@ -152,7 +151,7 @@ Ember.uuid = 0;
 //
 
 /**
-  Inside Ember-Metal, simply uses the imports.console object.
+  Inside Ember-Metal, simply uses the `imports.console` object.
   Override this to provide more robust logging functionality.
 
   @class Logger
@@ -166,8 +165,9 @@ Ember.Logger = imports.console || { log: Ember.K, warn: Ember.K, error: Ember.K,
 //
 
 /**
-  A function may be assigned to `Ember.onerror` to be called when Ember internals encounter an error.
-  This is useful for specialized error handling and reporting code.
+  A function may be assigned to `Ember.onerror` to be called when Ember
+  internals encounter an error. This is useful for specialized error handling
+  and reporting code.
 
   @event onerror
   @for Ember

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -5,15 +5,17 @@
 
   Subscribe to a listener by using `Ember.subscribe`:
 
-      Ember.subscribe("render", {
-        before: function(name, timestamp, payload) {
+  ```javascript
+  Ember.subscribe("render", {
+    before: function(name, timestamp, payload) {
 
-        },
+    },
 
-        after: function(name, timestamp, payload) {
+    after: function(name, timestamp, payload) {
 
-        }
-      });
+    }
+  });
+  ```
 
   If you return a value from the `before` callback, that same
   value will be passed as a fourth parameter to the `after`
@@ -21,9 +23,11 @@
 
   Instrument a block of code by using `Ember.instrument`:
 
-      Ember.instrument("render.handlebars", payload, function() {
-        // rendering logic
-      }, binding);
+  ```javascript
+  Ember.instrument("render.handlebars", payload, function() {
+    // rendering logic
+  }, binding);
+  ```
 
   Event names passed to `Ember.instrument` are namespaced
   by periods, from more general to more specific. Subscribers

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -11,12 +11,12 @@
   keys. Because it is commonly used in low-level bookkeeping, Map is
   implemented as a pure JavaScript object for performance.
 
-  This implementation follows the current iteration of the ES6 proposal
-  for maps (http://wiki.ecmascript.org/doku.php?id=harmony:simple_maps_and_sets),
-  with two exceptions. First, because we need our implementation to be
-  pleasant on older browsers, we do not use the `delete` name (using
-  `remove` instead). Second, as we do not have the luxury of in-VM
-  iteration, we implement a forEach method for iteration.
+  This implementation follows the current iteration of the ES6 proposal for
+  maps (http://wiki.ecmascript.org/doku.php?id=harmony:simple_maps_and_sets),
+  with two exceptions. First, because we need our implementation to be pleasant
+  on older browsers, we do not use the `delete` name (using `remove` instead).
+  Second, as we do not have the luxury of in-VM iteration, we implement a
+  forEach method for iteration.
 
   Map is mocked out to look like an Ember object, so you can do
   `Ember.Map.create()` for symmetry with other Ember classes.
@@ -50,7 +50,7 @@ var copyMap = function(original, newObject) {
 };
 
 /**
-  This class is used internally by Ember.js and Ember Data.
+  This class is used internally by Ember and Ember Data.
   Please do not use it at this time. We plan to clean it up
   and add many tests soon.
 
@@ -177,9 +177,8 @@ OrderedSet.prototype = {
 
   Internally, a Map has two data structures:
 
-    `keys`: an OrderedSet of all of the existing keys
-    `values`: a JavaScript Object indexed by the
-      Ember.guidFor(key)
+  1. `keys`: an OrderedSet of all of the existing keys
+  2. `values`: a JavaScript Object indexed by the `Ember.guidFor(key)`
 
   When a key/value pair is added for the first time, we
   add the key to the `keys` OrderedSet, and create or
@@ -210,7 +209,7 @@ Map.prototype = {
 
     @method get
     @param {anything} key
-    @return {anything} the value associated with the key, or undefined
+    @return {anything} the value associated with the key, or `undefined`
   */
   get: function(key) {
     var values = this.values,
@@ -324,7 +323,8 @@ var MapWithDefault = Ember.MapWithDefault = function(options) {
   @static
   @param [options]
     @param {anything} [options.defaultValue]
-  @return {Ember.MapWithDefault|Ember.Map} If options are passed, returns Ember.MapWithDefault otherwise returns Ember.Map
+  @return {Ember.MapWithDefault|Ember.Map} If options are passed, returns 
+    `Ember.MapWithDefault` otherwise returns `Ember.Map`
 */
 MapWithDefault.create = function(options) {
   if (options) {

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -39,8 +39,8 @@ function initMixin(mixin, args) {
     mixin.mixins = a_map.call(args, function(x) {
       if (x instanceof Mixin) { return x; }
 
-      // Note: Manually setup a primitive mixin here.  This is the only
-      // way to actually get a primitive mixin.  This way normal creation
+      // Note: Manually setup a primitive mixin here. This is the only
+      // way to actually get a primitive mixin. This way normal creation
       // of mixins will give you combined mixins...
       var mixin = new Mixin();
       mixin.properties = x;
@@ -333,22 +333,24 @@ Ember.mixin = function(obj) {
   The `Ember.Mixin` class allows you to create mixins, whose properties can be
   added to other classes. For instance,
 
-      App.Editable = Ember.Mixin.create({
-        edit: function() {
-          console.log('starting to edit');
-          this.set('isEditing', true);
-        },
-        isEditing: false
-      });
+  ```javascript
+  App.Editable = Ember.Mixin.create({
+    edit: function() {
+      console.log('starting to edit');
+      this.set('isEditing', true);
+    },
+    isEditing: false
+  });
 
-      // Mix mixins into classes by passing them as the first arguments to
-      // .extend or .create.
-      App.CommentView = Ember.View.extend(App.Editable, {
-        template: Ember.Handlebars.compile('{{#if isEditing}}...{{else}}...{{/if}}')
-      });
+  // Mix mixins into classes by passing them as the first arguments to
+  // .extend or .create.
+  App.CommentView = Ember.View.extend(App.Editable, {
+    template: Ember.Handlebars.compile('{{#if isEditing}}...{{else}}...{{/if}}')
+  });
 
-      commentView = App.CommentView.create();
-      commentView.edit(); // => outputs 'starting to edit'
+  commentView = App.CommentView.create();
+  commentView.edit(); // outputs 'starting to edit'
+  ```
 
   Note that Mixins are created with `Ember.Mixin.create`, not
   `Ember.Mixin.extend`.
@@ -627,17 +629,20 @@ Alias.prototype = new Ember.Descriptor();
 /**
   Makes a property or method available via an additional name.
 
-      App.PaintSample = Ember.Object.extend({
-        color: 'red',
-        colour: Ember.alias('color'),
-        name: function(){
-          return "Zed";
-        },
-        moniker: Ember.alias("name")
-      });
-      var paintSample = App.PaintSample.create()
-      paintSample.get('colour'); //=> 'red'
-      paintSample.moniker(); //=> 'Zed'
+  ```javascript
+  App.PaintSample = Ember.Object.extend({
+    color: 'red',
+    colour: Ember.alias('color'),
+    name: function(){
+      return "Zed";
+    },
+    moniker: Ember.alias("name")
+  });
+
+  var paintSample = App.PaintSample.create()
+  paintSample.get('colour');  // 'red'
+  paintSample.moniker();      // 'Zed'
+  ```
 
   @method alias
   @for Ember

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -106,10 +106,12 @@ Ember.endPropertyChanges = function() {
   Make a series of property changes together in an
   exception-safe way.
 
-      Ember.changeProperties(function() {
-        obj1.set('foo', mayBlowUpWhenSet);
-        obj2.set('bar', baz);
-      });
+  ```javascript
+  Ember.changeProperties(function() {
+    obj1.set('foo', mayBlowUpWhenSet);
+    obj2.set('bar', baz);
+  });
+  ```
 
   @method changeProperties
   @param {Function} callback

--- a/packages/ember-metal/lib/platform.js
+++ b/packages/ember-metal/lib/platform.js
@@ -17,7 +17,8 @@ var platform = Ember.platform = {};
 
 
 /**
-  Identical to Object.create().  Implements if not available natively.
+  Identical to `Object.create()`. Implements if not available natively.
+
   @method create
   @for Ember
 */
@@ -118,7 +119,7 @@ if (defineProperty) {
 */
 
 /**
-  Identical to Object.defineProperty().  Implements as much functionality
+  Identical to `Object.defineProperty()`. Implements as much functionality
   as possible if not available natively.
 
   @method defineProperty

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -22,7 +22,7 @@ var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
 /**
   Objects of this type can implement an interface to responds requests to
-  get and set.  The default implementation handles simple properties.
+  get and set. The default implementation handles simple properties.
 
   You generally won't need to create or subclass this directly.
 
@@ -40,42 +40,44 @@ var Descriptor = Ember.Descriptor = function() {};
 /**
   @private
 
-  NOTE: This is a low-level method used by other parts of the API.  You almost
-  never want to call this method directly.  Instead you should use Ember.mixin()
-  to define new properties.
+  NOTE: This is a low-level method used by other parts of the API. You almost
+  never want to call this method directly. Instead you should use
+  `Ember.mixin()` to define new properties.
 
-  Defines a property on an object.  This method works much like the ES5
-  Object.defineProperty() method except that it can also accept computed
+  Defines a property on an object. This method works much like the ES5
+  `Object.defineProperty()` method except that it can also accept computed
   properties and other special descriptors.
 
-  Normally this method takes only three parameters.  However if you pass an
-  instance of Ember.Descriptor as the third param then you can pass an optional
-  value as the fourth parameter.  This is often more efficient than creating
-  new descriptor hashes for each property.
+  Normally this method takes only three parameters. However if you pass an
+  instance of `Ember.Descriptor` as the third param then you can pass an
+  optional value as the fourth parameter. This is often more efficient than
+  creating new descriptor hashes for each property.
 
   ## Examples
 
-      // ES5 compatible mode
-      Ember.defineProperty(contact, 'firstName', {
-        writable: true,
-        configurable: false,
-        enumerable: true,
-        value: 'Charles'
-      });
+  ```javascript
+  // ES5 compatible mode
+  Ember.defineProperty(contact, 'firstName', {
+    writable: true,
+    configurable: false,
+    enumerable: true,
+    value: 'Charles'
+  });
 
-      // define a simple property
-      Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
+  // define a simple property
+  Ember.defineProperty(contact, 'lastName', undefined, 'Jolley');
 
-      // define a computed property
-      Ember.defineProperty(contact, 'fullName', Ember.computed(function() {
-        return this.firstName+' '+this.lastName;
-      }).property('firstName', 'lastName'));
+  // define a computed property
+  Ember.defineProperty(contact, 'fullName', Ember.computed(function() {
+    return this.firstName+' '+this.lastName;
+  }).property('firstName', 'lastName'));
+  ```
 
   @method defineProperty
   @for Ember
   @param {Object} obj the object to define this property on. This may be a prototype.
   @param {String} keyName the name of the property
-  @param {Ember.Descriptor} [desc] an instance of Ember.Descriptor (typically a
+  @param {Ember.Descriptor} [desc] an instance of `Ember.Descriptor` (typically a
     computed property) or an ES5 descriptor.
     You must provide this or `data` but not both.
   @param {anything} [data] something other than a descriptor, that will

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -109,7 +109,7 @@ RunLoop.prototype = {
       while (this._queues && (queue = this._queues[queueName])) {
         this._queues[queueName] = null;
 
-        // the sync phase is to allow property changes to propagate.  don't
+        // the sync phase is to allow property changes to propagate. don't
         // invoke observers until that is finished.
         if (queueName === 'sync') {
           log = Ember.LOG_BINDINGS;
@@ -141,7 +141,7 @@ RunLoop.prototype = {
         delete this._queues[queueName];
 
         if (queue) {
-          // the sync phase is to allow property changes to propagate.  don't
+          // the sync phase is to allow property changes to propagate. don't
           // invoke observers until that is finished.
           if (queueName === 'sync') {
             log = Ember.LOG_BINDINGS;
@@ -191,14 +191,16 @@ Ember.RunLoop = RunLoop;
   deferred actions including bindings and views updates are flushed at the
   end.
 
-  Normally you should not need to invoke this method yourself.  However if
+  Normally you should not need to invoke this method yourself. However if
   you are implementing raw event handlers when interfacing with other
   libraries or plugins, you should probably wrap all of your code inside this
   call.
 
-      Ember.run(function(){
-        // code to be execute within a RunLoop
-      });
+  ```javascript
+  Ember.run(function(){
+    // code to be execute within a RunLoop 
+  });
+  ```
 
   @class run
   @namespace Ember
@@ -206,7 +208,7 @@ Ember.RunLoop = RunLoop;
   @constructor
   @param {Object} [target] target of method to call
   @param {Function|String} method Method to invoke.
-    May be a function or a string.  If you pass a string
+    May be a function or a string. If you pass a string
     then it will be looked up on the passed target.
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
   @return {Object} return value from invoking the passed function.
@@ -226,13 +228,15 @@ var run = Ember.run;
 
 
 /**
-  Begins a new RunLoop.  Any deferred actions invoked after the begin will
-  be buffered until you invoke a matching call to Ember.run.end().  This is
-  an lower-level way to use a RunLoop instead of using Ember.run().
+  Begins a new RunLoop. Any deferred actions invoked after the begin will
+  be buffered until you invoke a matching call to `Ember.run.end()`. This is
+  an lower-level way to use a RunLoop instead of using `Ember.run()`.
 
-      Ember.run.begin();
-      // code to be execute within a RunLoop
-      Ember.run.end();
+  ```javascript
+  Ember.run.begin();
+  // code to be execute within a RunLoop 
+  Ember.run.end();
+  ```
 
   @method begin
   @return {void}
@@ -242,13 +246,15 @@ Ember.run.begin = function() {
 };
 
 /**
-  Ends a RunLoop.  This must be called sometime after you call Ember.run.begin()
-  to flush any deferred actions.  This is a lower-level way to use a RunLoop
-  instead of using Ember.run().
+  Ends a RunLoop. This must be called sometime after you call
+  `Ember.run.begin()` to flush any deferred actions. This is a lower-level way
+  to use a RunLoop instead of using `Ember.run()`.
 
-      Ember.run.begin();
-      // code to be execute within a RunLoop
-      Ember.run.end();
+  ```javascript
+  Ember.run.begin();
+  // code to be execute within a RunLoop 
+  Ember.run.end();
+  ```
 
   @method end
   @return {void}
@@ -264,9 +270,9 @@ Ember.run.end = function() {
 };
 
 /**
-  Array of named queues.  This array determines the order in which queues
-  are flushed at the end of the RunLoop.  You can define your own queues by
-  simply adding the queue name to this array.  Normally you should not need
+  Array of named queues. This array determines the order in which queues
+  are flushed at the end of the RunLoop. You can define your own queues by
+  simply adding the queue name to this array. Normally you should not need
   to inspect or modify this property.
 
   @property queues
@@ -277,38 +283,38 @@ Ember.run.queues = ['sync', 'actions', 'destroy', 'timers'];
 
 /**
   Adds the passed target/method and any optional arguments to the named
-  queue to be executed at the end of the RunLoop.  If you have not already
+  queue to be executed at the end of the RunLoop. If you have not already
   started a RunLoop when calling this method one will be started for you
   automatically.
 
   At the end of a RunLoop, any methods scheduled in this way will be invoked.
   Methods will be invoked in an order matching the named queues defined in
-  the run.queues property.
+  the `run.queues` property.
 
-      Ember.run.schedule('timers', this, function(){
-        // this will be executed at the end of the RunLoop, when timers are run
-        console.log("scheduled on timers queue");
-      });
-      Ember.run.schedule('sync', this, function(){
-        // this will be executed at the end of the RunLoop, when bindings are synced
-        console.log("scheduled on sync queue");
-      });
-      // Note the functions will be run in order based on the run queues order. Output would be:
-      //   scheduled on sync queue
-      //   scheduled on timers queue
+  ```javascript
+  Ember.run.schedule('timers', this, function(){
+    // this will be executed at the end of the RunLoop, when timers are run
+    console.log("scheduled on timers queue");
+  });
+
+  Ember.run.schedule('sync', this, function(){
+    // this will be executed at the end of the RunLoop, when bindings are synced
+    console.log("scheduled on sync queue");
+  });
+
+  // Note the functions will be run in order based on the run queues order. Output would be:
+  //   scheduled on sync queue
+  //   scheduled on timers queue
+  ```
 
   @method schedule
   @param {String} queue The name of the queue to schedule against.
     Default queues are 'sync' and 'actions'
-
   @param {Object} [target] target object to use as the context when invoking a method.
-
-  @param {String|Function} method The method to invoke.  If you pass a string it
+  @param {String|Function} method The method to invoke. If you pass a string it
     will be resolved on the target object at the time the scheduled item is
     invoked allowing you to change the target function.
-
   @param {Object} [arguments*] Optional arguments to be passed to the queued method.
-
   @return {void}
 */
 Ember.run.schedule = function(queue, target, method) {
@@ -346,10 +352,9 @@ Ember.run.cancelTimers = function () {
 
 /**
   Begins a new RunLoop if necessary and schedules a timer to flush the
-  RunLoop at a later time.  This method is used by parts of Ember to
-  ensure the RunLoop always finishes.  You normally do not need to call this
-  method directly.  Instead use Ember.run().
-
+  RunLoop at a later time. This method is used by parts of Ember to
+  ensure the RunLoop always finishes. You normally do not need to call this
+  method directly. Instead use `Ember.run()`
 
   @method autorun
   @example
@@ -371,14 +376,16 @@ Ember.run.autorun = function() {
 };
 
 /**
-  Immediately flushes any events scheduled in the 'sync' queue.  Bindings
+  Immediately flushes any events scheduled in the 'sync' queue. Bindings
   use this queue so this method is a useful way to immediately force all
   bindings in the application to sync.
 
   You should call this method anytime you need any changed state to propagate
   throughout the app immediately without repainting the UI.
 
-      Ember.run.sync();
+  ```javascript
+  Ember.run.sync();
+  ```
 
   @method sync
   @return {void}
@@ -417,30 +424,28 @@ function invokeLaterTimers() {
 
 /**
   Invokes the passed target/method and optional arguments after a specified
-  period if time.  The last parameter of this method must always be a number
+  period if time. The last parameter of this method must always be a number
   of milliseconds.
 
   You should use this method whenever you need to run some action after a
-  period of time instead of using setTimeout().  This method will ensure that
+  period of time instead of using `setTimeout()`. This method will ensure that
   items that expire during the same script execution cycle all execute
   together, which is often more efficient than using a real setTimeout.
 
-      Ember.run.later(myContext, function(){
-        // code here will execute within a RunLoop in about 500ms with this == myContext
-      }, 500);
+  ```javascript
+  Ember.run.later(myContext, function(){
+    // code here will execute within a RunLoop in about 500ms with this == myContext
+  }, 500);
+  ```
 
   @method later
   @param {Object} [target] target of method to invoke
-
   @param {Function|String} method The method to invoke.
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
-
   @param {Object} [args*] Optional arguments to pass to the timeout.
-
   @param {Number} wait
     Number of milliseconds to wait.
-
   @return {String} a string you can use to cancel the timer in
     {{#crossLink "Ember/run.cancel"}}{{/crossLink}} later.
 */
@@ -502,30 +507,28 @@ function scheduleOnce(queue, target, method, args) {
 }
 
 /**
-  Schedules an item to run one time during the current RunLoop.  Calling
+  Schedules an item to run one time during the current RunLoop. Calling
   this method with the same target/method combination will have no effect.
 
   Note that although you can pass optional arguments these will not be
-  considered when looking for duplicates.  New arguments will replace previous
+  considered when looking for duplicates. New arguments will replace previous
   calls.
 
-      Ember.run(function(){
-        var doFoo = function() { foo(); }
-        Ember.run.once(myContext, doFoo);
-        Ember.run.once(myContext, doFoo);
-        // doFoo will only be executed once at the end of the RunLoop
-      });
+  ```javascript
+  Ember.run(function(){
+    var doFoo = function() { foo(); }
+    Ember.run.once(myContext, doFoo);
+    Ember.run.once(myContext, doFoo);
+    // doFoo will only be executed once at the end of the RunLoop
+  });
+  ```
 
   @method once
   @param {Object} [target] target of method to invoke
-
   @param {Function|String} method The method to invoke.
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
-
   @param {Object} [args*] Optional arguments to pass to the timeout.
-
-
   @return {Object} timer
 */
 Ember.run.once = function(target, method) {
@@ -551,21 +554,20 @@ function invokeNextTimers() {
 
 /**
   Schedules an item to run after control has been returned to the system.
-  This is often equivalent to calling setTimeout(function...,1).
+  This is often equivalent to calling `setTimeout(function() {}, 1)`.
 
-      Ember.run.next(myContext, function(){
-        // code to be executed in the next RunLoop, which will be scheduled after the current one
-      });
+  ```javascript
+  Ember.run.next(myContext, function(){
+    // code to be executed in the next RunLoop, which will be scheduled after the current one
+  });
+  ```
 
   @method next
   @param {Object} [target] target of method to invoke
-
   @param {Function|String} method The method to invoke.
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
-
   @param {Object} [args*] Optional arguments to pass to the timeout.
-
   @return {Object} timer
 */
 Ember.run.next = function(target, method) {
@@ -585,23 +587,25 @@ Ember.run.next = function(target, method) {
 };
 
 /**
-  Cancels a scheduled item.  Must be a value returned by `Ember.run.later()`,
+  Cancels a scheduled item. Must be a value returned by `Ember.run.later()`,
   `Ember.run.once()`, or `Ember.run.next()`.
 
-      var runNext = Ember.run.next(myContext, function(){
-        // will not be executed
-      });
-      Ember.run.cancel(runNext);
+  ```javascript
+  var runNext = Ember.run.next(myContext, function(){
+    // will not be executed
+  });
+  Ember.run.cancel(runNext);
 
-      var runLater = Ember.run.later(myContext, function(){
-        // will not be executed
-      }, 500);
-      Ember.run.cancel(runLater);
+  var runLater = Ember.run.later(myContext, function(){
+    // will not be executed
+  }, 500);
+  Ember.run.cancel(runLater);
 
-      var runOnce = Ember.run.once(myContext, function(){
-        // will not be executed
-      });
-      Ember.run.cancel(runOnce);
+  var runOnce = Ember.run.once(myContext, function(){
+    // will not be executed
+  });
+  Ember.run.cancel(runOnce);
+  ```
 
   @method cancel
   @param {Object} timer Timer object to cancel

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -43,20 +43,18 @@ var GUID_DESC = {
   @private
 
   Generates a new guid, optionally saving the guid to the object that you
-  pass in.  You will rarely need to use this method.  Instead you should
-  call Ember.guidFor(obj), which return an existing guid if available.
+  pass in. You will rarely need to use this method. Instead you should
+  call `Ember.guidFor(obj)`, which return an existing guid if available.
 
   @method generateGuid
   @for Ember
-  @param {Object} [obj] Object the guid will be used for.  If passed in, the guid will
+  @param {Object} [obj] Object the guid will be used for. If passed in, the guid will
     be saved on the object and reused whenever you pass the same object
     again.
 
     If no object is passed, just generate a new guid.
-
-  @param {String} [prefix] Prefix to place in front of the guid.  Useful when you want to
+  @param {String} [prefix] Prefix to place in front of the guid. Useful when you want to
     separate the guid into separate namespaces.
-
   @return {String} the guid
 */
 Ember.generateGuid = function generateGuid(obj, prefix) {
@@ -72,9 +70,10 @@ Ember.generateGuid = function generateGuid(obj, prefix) {
 /**
   @private
 
-  Returns a unique id for the object.  If the object does not yet have
-  a guid, one will be assigned to it.  You can call this on any object,
-  Ember.Object-based or not, but be aware that it will add a _guid property.
+  Returns a unique id for the object. If the object does not yet have a guid,
+  one will be assigned to it. You can call this on any object,
+  `Ember.Object`-based or not, but be aware that it will add a `_guid`
+  property.
 
   You can also use this method on DOM Element objects.
 
@@ -176,11 +175,11 @@ if (isDefinePropertySimulated) {
 }
 
 /**
-  Retrieves the meta hash for an object.  If 'writable' is true ensures the
+  Retrieves the meta hash for an object. If `writable` is true ensures the
   hash is writable for this object as well.
 
   The meta object contains information about computed property descriptors as
-  well as any watched properties and other information.  You generally will
+  well as any watched properties and other information. You generally will
   not access this information directly but instead work with higher level
   methods that manipulate this hash indirectly.
 
@@ -189,10 +188,8 @@ if (isDefinePropertySimulated) {
   @private
 
   @param {Object} obj The object to retrieve meta for
-
-  @param {Boolean} [writable=true] Pass false if you do not intend to modify
+  @param {Boolean} [writable=true] Pass `false` if you do not intend to modify
     the meta hash, allowing the method to avoid making an unnecessary copy.
-
   @return {Hash}
 */
 Ember.meta = function meta(obj, writable) {
@@ -252,7 +249,7 @@ Ember.setMeta = function setMeta(obj, property, value) {
 
   This method allows extensions to deeply clone a series of nested hashes or
   other complex objects. For instance, the event system might pass
-  ['listeners', 'foo:change', 'ember157'] to `prepareMetaPath`, which will
+  `['listeners', 'foo:change', 'ember157']` to `prepareMetaPath`, which will
   walk down the keys provided.
 
   For each key, if the key does not exist, it is created. If it already
@@ -297,7 +294,7 @@ Ember.metaPath = function metaPath(obj, path, writable) {
   @private
 
   Wraps the passed function so that `this._super` will point to the superFunc
-  when the function is invoked.  This is the primitive we use to implement
+  when the function is invoked. This is the primitive we use to implement
   calls to super.
 
   @method wrap
@@ -331,12 +328,14 @@ Ember.wrap = function(func, superFunc) {
     - the object is a native Array
     - the object is an Object, and has a length property
 
-  Unlike Ember.typeOf this method returns true even if the passed object is
-  not formally array but appears to be array-like (i.e. implements Ember.Array)
+  Unlike `Ember.typeOf` this method returns true even if the passed object is
+  not formally array but appears to be array-like (i.e. implements `Ember.Array`)
 
-      Ember.isArray(); // false
-      Ember.isArray([]); // true
-      Ember.isArray( Ember.ArrayProxy.create({ content: [] }) ); // true
+  ```javascript
+  Ember.isArray();                                            // false
+  Ember.isArray([]);                                          // true
+  Ember.isArray( Ember.ArrayProxy.create({ content: [] }) );  // true
+  ```
 
   @method isArray
   @for Ember
@@ -352,18 +351,20 @@ Ember.isArray = function(obj) {
 };
 
 /**
-  Forces the passed object to be part of an array.  If the object is already
-  an array or array-like, returns the object.  Otherwise adds the object to
-  an array.  If obj is null or undefined, returns an empty array.
+  Forces the passed object to be part of an array. If the object is already
+  an array or array-like, returns the object. Otherwise adds the object to
+  an array. If obj is `null` or `undefined`, returns an empty array.
 
-      Ember.makeArray();          => []
-      Ember.makeArray(null);      => []
-      Ember.makeArray(undefined); => []
-      Ember.makeArray('lindsay'); => ['lindsay']
-      Ember.makeArray([1,2,42]);  => [1,2,42]
+  ```javascript
+  Ember.makeArray();                           // []
+  Ember.makeArray(null);                       // []
+  Ember.makeArray(undefined);                  // []
+  Ember.makeArray('lindsay');                  // ['lindsay']
+  Ember.makeArray([1,2,42]);                   // [1,2,42]
 
-      var controller = Ember.ArrayProxy.create({ content: [] });
-      Ember.makeArray(controller) === controller;   => true
+  var controller = Ember.ArrayProxy.create({ content: [] });
+  Ember.makeArray(controller) === controller;  // true
+  ```
 
   @method makeArray
   @for Ember

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -112,7 +112,7 @@ function removeChainWatcher(obj, keyName, node) {
 
 var pendingQueue = [];
 
-// attempts to add the pendingQueue chains again.  If some of them end up
+// attempts to add the pendingQueue chains again. If some of them end up
 // back in the queue and reschedule is true, schedules a timeout to try
 // again.
 function flushPendingChains() {
@@ -130,8 +130,8 @@ function isProto(pvalue) {
   return metaFor(pvalue, false).proto === pvalue;
 }
 
-// A ChainNode watches a single key on an object.  If you provide a starting
-// value for the key then the node won't actually watch it.  For a root node
+// A ChainNode watches a single key on an object. If you provide a starting
+// value for the key then the node won't actually watch it. For a root node
 // pass null for parent and key and object for value.
 var ChainNode = function(parent, key, value, separator) {
   var obj;
@@ -357,7 +357,7 @@ ChainNodePrototype.didChange = function(suppressEvent) {
   if (this._parent) { this._parent.chainDidChange(this, this._key, 1); }
 };
 
-// get the chains for the current object.  If the current object has
+// get the chains for the current object. If the current object has
 // chains inherited from the proto they will be cloned and reconfigured for
 // the current object.
 function chainsFor(obj) {
@@ -403,11 +403,11 @@ function chainsDidChange(obj, keyName, m) {
 /**
   @private
 
-  Starts watching a property on an object.  Whenever the property changes,
-  invokes Ember.propertyWillChange and Ember.propertyDidChange.  This is the
+  Starts watching a property on an object. Whenever the property changes,
+  invokes `Ember.propertyWillChange` and `Ember.propertyDidChange`. This is the
   primitive used by observers and dependent keys; usually you will never call
   this method directly but instead use higher level methods like
-  Ember.addObserver().
+  `Ember.addObserver()`
 
   @method watch
   @for Ember
@@ -502,8 +502,8 @@ Ember.unwatch = function(obj, keyName) {
 /**
   @private
 
-  Call on an object when you first beget it from another object.  This will
-  setup any chained watchers on the object instance as needed.  This method is
+  Call on an object when you first beget it from another object. This will
+  setup any chained watchers on the object instance as needed. This method is
   safe to call multiple times.
 
   @method rewatch

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -24,7 +24,7 @@ var get = Ember.get, set = Ember.set;
   Ember.Location returns an instance of the correct implementation of
   the `location` API.
 
-  You can pass it a `implementation` ('hash', 'history', 'none') to force a
+  You can pass it a `implementation` (`hash`, `history`, `none`) to force a
   particular implementation.
 
   @class Location

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -6,7 +6,7 @@
 var get = Ember.get, set = Ember.set;
 
 /**
-  Ember.HashLocation implements the location API using the browser's
+  `Ember.HashLocation` implements the location API using the browser's
   hash. At present, it relies on a hashchange event existing in the
   browser.
 
@@ -76,7 +76,7 @@ Ember.HashLocation = Ember.Object.extend({
     Given a URL, formats it to be placed into the page as part
     of an element's `href` attribute.
 
-    This is used, for example, when using the {{action}} helper
+    This is used, for example, when using the `{{action}}` helper
     to generate a URL based on an event.
 
     @method formatURL

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -7,8 +7,8 @@ var get = Ember.get, set = Ember.set;
 var popstateReady = false;
 
 /**
-  Ember.HistoryLocation implements the location API using the browser's
-  history.pushState API.
+  `Ember.HistoryLocation` implements the location API using the browser's
+  `history.pushState` API.
 
   @class HistoryLocation
   @namespace Ember
@@ -24,7 +24,7 @@ Ember.HistoryLocation = Ember.Object.extend({
   /**
     @private
 
-    Used to set state on first call to setURL
+    Used to set state on first call to `setURL`
 
     @method initState
   */
@@ -127,7 +127,7 @@ Ember.HistoryLocation = Ember.Object.extend({
   /**
     @private
 
-    Used when using `{{action}}` helper.  The url is always appended to the rootURL.
+    Used when using `{{action}}` helper. The url is always appended to the rootURL.
 
     @method formatURL
     @param url {String}

--- a/packages/ember-routing/lib/location/none_location.js
+++ b/packages/ember-routing/lib/location/none_location.js
@@ -6,8 +6,8 @@
 var get = Ember.get, set = Ember.set;
 
 /**
-  Ember.NoneLocation does not interact with the browser. It is useful for
-  testing, or when you need to manage state with your Router, but temporarily
+  `Ember.NoneLocation` does not interact with the browser. It is useful for
+  testing, or when you need to manage state with your router, but temporarily
   don't want it to muck with the URL (for example when you embed your
   application in a larger page).
 

--- a/packages/ember-routing/lib/routable.js
+++ b/packages/ember-routing/lib/routable.js
@@ -196,7 +196,7 @@ Ember.Routable = Ember.Mixin.create({
   /**
     @private
 
-    A _RouteMatcher object generated from the current route's `route`
+    A `_RouteMatcher` object generated from the current route's `route`
     string property.
 
     @property routeMatcher
@@ -325,7 +325,9 @@ Ember.Routable = Ember.Mixin.create({
     `blog_post_id` and the object is a `BlogPost` with an
     `id` of `12`, the serialize method will produce:
 
-        { blog_post_id: 12 }
+    ```javascript
+    { blog_post_id: 12 }
+    ```
 
     @method serialize
     @param manager {Ember.StateManager}
@@ -402,8 +404,8 @@ Ember.Routable = Ember.Mixin.create({
     Once `unroute` has finished unwinding, `routePath` will be called
     with the remainder of the route.
 
-    For example, if you were in the /posts/1/comments state, and you
-    moved into the /posts/2/comments state, `routePath` will be called
+    For example, if you were in the `/posts/1/comments` state, and you
+    moved into the `/posts/2/comments` state, `routePath` will be called
     on the state whose path is `/posts` with the path `/2/comments`.
 
     @method routePath

--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -19,299 +19,360 @@ var merge = function(original, hash) {
 };
 
 /**
-  `Ember.Router` is the subclass of `Ember.StateManager` responsible for providing URL-based
-  application state detection. The `Ember.Router` instance of an application detects the browser URL
-  at application load time and attempts to match it to a specific application state. Additionally
-  the router will update the URL to reflect an application's state changes over time.
+  `Ember.Router` is the subclass of `Ember.StateManager` responsible for
+  providing URL-based application state detection. The `Ember.Router` instance
+  of an application detects the browser URL at application load time and
+  attempts to match it to a specific application state. Additionally the router
+  will update the URL to reflect an application's state changes over time.
 
   ## Adding a Router Instance to Your Application
-  An instance of Ember.Router can be associated with an instance of Ember.Application in one of two ways:
 
-  You can provide a subclass of Ember.Router as the `Router` property of your application. An instance
-  of this Router class will be instantiated and route detection will be enabled when the application's
-  `initialize` method is called. The Router instance will be available as the `router` property
-  of the application:
+  An instance of `Ember.Router` can be associated with an instance of
+  `Ember.Application` in one of two ways:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({ ... })
-      });
+  You can provide a subclass of `Ember.Router` as the `Router` property of your
+  application. An instance of this `Router` class will be instantiated and
+  route detection will be enabled when the application's `initialize` method is
+  called. The `Router` instance will be available as the `router` property of
+  the application:
 
-      App.initialize();
-      App.get('router') // an instance of App.Router
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({ ... })
+  });
 
-  If you want to define a Router instance elsewhere, you can pass the instance to the application's
-  `initialize` method:
+  App.initialize();
+  App.get('router') // an instance of App.Router
+  ```
 
-      App = Ember.Application.create();
-      aRouter = Ember.Router.create({ ... });
+  If you want to define a `Router` instance elsewhere, you can pass the
+  instance to the application's `initialize` method:
 
-      App.initialize(aRouter);
-      App.get('router') // aRouter
+  ```javascript
+  App = Ember.Application.create();
+  aRouter = Ember.Router.create({ ... });
+
+  App.initialize(aRouter);
+  App.get('router') // aRouter
+  ```
 
   ## Adding Routes to a Router
-  The `initialState` property of Ember.Router instances is named `root`. The state stored in this
-  property must be a subclass of Ember.Route. The `root` route acts as the container for the
-  set of routable states but is not routable itself. It should have states that are also subclasses
-  of Ember.Route which each have a `route` property describing the URL pattern you would like to detect.
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            index: Ember.Route.extend({
-              route: '/'
-            }),
-            ... additional Ember.Routes ...
-          })
-        })
-      });
-      App.initialize();
+  The `initialState` property of `Ember.Router` instances is named `root`. The
+  state stored in this property must be a subclass of `Ember.Route`. The `root`
+  route acts as the container for the set of routable states but is not
+  routable itself. It should have states that are also subclasses of
+  `Ember.Route` which each have a `route` property describing the URL pattern
+  you would like to detect.
 
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        index: Ember.Route.extend({
+          route: '/'
+        }),
+        ... additional Ember.Routes ...
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  When an application loads, Ember will parse the URL and attempt to find an Ember.Route within
-  the application's states that matches. (The example URL-matching below will use the default
-  'hash syntax' provided by `Ember.HashLocation`.)
+  When an application loads, Ember will parse the URL and attempt to find an
+  Ember.Route within the application's states that matches. (The example
+  URL-matching below will use the default 'hash syntax' provided by
+  `Ember.HashLocation`.)
 
   In the following route structure:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/'
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/alphabeta'
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/'
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/alphabeta'
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  Loading the page at the URL '#/' will detect the route property of 'root.aRoute' ('/') and
-  transition the router first to the state named 'root' and then to the substate 'aRoute'.
+  Loading the page at the URL '#/' will detect the route property of
+  `root.aRoute` ('/') and transition the router first to the state named `root`
+  and then to the substate `aRoute`.
 
-  Respectively, loading the page at the URL '#/alphabeta' would detect the route property of
-  'root.bRoute' ('/alphabeta') and transition the router first to the state named 'root' and
-  then to the substate 'bRoute'.
+  Respectively, loading the page at the URL '#/alphabeta' would detect the
+  route property of `root.bRoute` ('/alphabeta') and transition the router
+  first to the state named `root` and then to the substate `bRoute`.
 
   ## Adding Nested Routes to a Router
-  Routes can contain nested subroutes each with their own `route` property describing the nested
-  portion of the URL they would like to detect and handle. Router, like all instances of StateManager,
-  cannot call `transitonTo` with an intermediary state. To avoid transitioning the Router into an
-  intermediary state when detecting URLs, a Route with nested routes must define both a base `route`
-  property for itself and a child Route with a `route` property of `'/'` which will be transitioned
-  to when the base route is detected in the URL:
+
+  Routes can contain nested subroutes each with their own `route` property
+  describing the nested portion of the URL they would like to detect and
+  handle. `Router`, like all instances of `StateManager`, cannot call
+  `transitonTo` with an intermediary state. To avoid transitioning the Router
+  into an intermediary state when detecting URLs, a Route with nested routes
+  must define both a base `route` property for itself and a child Route with a
+  `route` property of `'/'` which will be transitioned to when the base route
+  is detected in the URL:
 
   Given the following application code:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/theBaseRouteForThisSet',
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/theBaseRouteForThisSet',
 
-              indexSubRoute: Ember.Route.extend({
-                route: '/'
-              }),
+          indexSubRoute: Ember.Route.extend({
+            route: '/'
+          }),
 
-              subRouteOne: Ember.Route.extend({
-                route: '/subroute1'
-              }),
+          subRouteOne: Ember.Route.extend({
+            route: '/subroute1'
+          }),
 
-              subRouteTwo: Ember.Route.extend({
-                route: '/subRoute2'
-              })
-
-            })
+          subRouteTwo: Ember.Route.extend({
+            route: '/subRoute2'
           })
+
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  When the application is loaded at '/theBaseRouteForThisSet' the Router will transition to the route
-  at path 'root.aRoute' and then transition to state 'indexSubRoute'.
+  When the application is loaded at '/theBaseRouteForThisSet' the Router will
+  transition to the route at path `root.aRoute` and then transition to state
+  `indexSubRoute`.
 
-  When the application is loaded at '/theBaseRouteForThisSet/subRoute1' the Router will transition to
-  the route at path 'root.aRoute' and then transition to state 'subRouteOne'.
+  When the application is loaded at '/theBaseRouteForThisSet/subRoute1' the
+  Router will transition to the route at path `root.aRoute` and then transition
+  to state `subRouteOne`.
 
   ## Route Transition Events
-  Transitioning between Ember.Route instances (including the transition into the detected
-  route when loading the application)  triggers the same transition events as state transitions for
-  base `Ember.State`s. However, the default `setup` transition event is named `connectOutlets` on
-  Ember.Router instances (see 'Changing View Hierarchy in Response To State Change').
+
+  Transitioning between `Ember.Route` instances (including the transition into
+  the detected route when loading the application) triggers the same
+  transition events as state transitions for base `Ember.State`s. However, the
+  default `setup` transition event is named `connectOutlets` on `Ember.Router`
+  instances (see 'Changing View Hierarchy in Response To State Change').
 
   The following route structure when loaded with the URL "#/"
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/',
-              enter: function(router) {
-                console.log("entering root.aRoute from", router.get('currentState.name'));
-              },
-              connectOutlets: function(router) {
-                console.log("entered root.aRoute, fully transitioned to", router.get('currentState.path'));
-              }
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/',
+          enter: function(router) {
+            console.log("entering root.aRoute from", router.get('currentState.name'));
+          },
+          connectOutlets: function(router) {
+            console.log("entered root.aRoute, fully transitioned to", router.get('currentState.path'));
+          }
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
   Will result in console output of:
 
-      'entering root.aRoute from root'
-      'entered root.aRoute, fully transitioned to root.aRoute '
+  ```
+  'entering root.aRoute from root'
+  'entered root.aRoute, fully transitioned to root.aRoute '
+  ```
 
-  Ember.Route has two additional callbacks for handling URL serialization and deserialization. See
-  'Serializing/Deserializing URLs'
+  `Ember.Route` has two additional callbacks for handling URL serialization and
+  deserialization. See 'Serializing/Deserializing URLs'
 
   ## Routes With Dynamic Segments
-  An Ember.Route's `route` property can reference dynamic sections of the URL by prefacing a URL segment
-  with the ':' character.  The values of these dynamic segments will be passed as a hash to the
-  `deserialize` method of the matching Route (see 'Serializing/Deserializing URLs').
+
+  An `Ember.Route`'s `route` property can reference dynamic sections of the URL
+  by prefacing a URL segment with the ':' character. The values of these
+  dynamic segments will be passed as a hash to the `deserialize` method of the
+  matching `Route` (see 'Serializing/Deserializing URLs').
 
   ## Serializing/Deserializing URLs
-  Ember.Route has two callbacks for associating a particular object context with a URL: `serialize`
-  for converting an object into a parameters hash to fill dynamic segments of a URL and `deserialize`
-  for converting a hash of dynamic segments from the URL into the appropriate object.
+
+  `Ember.Route` has two callbacks for associating a particular object context
+  with a URL: `serialize` for converting an object into a parameters hash to
+  fill dynamic segments of a URL and `deserialize` for converting a hash of
+  dynamic segments from the URL into the appropriate object.
 
   ### Deserializing A URL's Dynamic Segments
-  When an application is first loaded or the URL is changed manually (e.g. through the browser's
-  back button) the `deserialize` method of the URL's matching Ember.Route will be called with
-  the application's router as its first argument and a hash of the URL's dynamic segments and values
-  as its second argument.
 
-  The following route structure when loaded with the URL "#/fixed/thefirstvalue/anotherFixed/thesecondvalue":
+  When an application is first loaded or the URL is changed manually (e.g.
+  through the browser's back button) the `deserialize` method of the URL's
+  matching `Ember.Route` will be called with the application's router as its
+  first argument and a hash of the URL's dynamic segments and values as its
+  second argument.
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/fixed/:dynamicSectionA/anotherFixed/:dynamicSectionB',
-              deserialize: function(router, params) {}
-            })
-          })
+  The following route structure when loaded with the URL 
+  "#/fixed/thefirstvalue/anotherFixed/thesecondvalue":
+
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/fixed/:dynamicSectionA/anotherFixed/:dynamicSectionB',
+          deserialize: function(router, params) {}
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-  Will call the 'deserialize' method of the Route instance at the path 'root.aRoute' with the
-  following hash as its second argument:
+  Will call the `deserialize` method of the Route instance at the path
+  `root.aRoute` with the following hash as its second argument:
 
-      {
-        dynamicSectionA: 'thefirstvalue',
-        dynamicSectionB: 'thesecondvalue'
-      }
+  ```javascript
+  {
+    dynamicSectionA: 'thefirstvalue',
+    dynamicSectionB: 'thesecondvalue'
+  }
+  ```
 
-  Within `deserialize` you should use this information to retrieve or create an appropriate context
-  object for the given URL (e.g. by loading from a remote API or accessing the browser's
-  `localStorage`). This object must be the `return` value of `deserialize` and will be
-  passed to the Route's `connectOutlets` and `serialize` methods.
+  Within `deserialize` you should use this information to retrieve or create an
+  appropriate context object for the given URL (e.g. by loading from a remote
+      API or accessing the browser's `localStorage`). This object must be the
+  `return` value of `deserialize` and will be passed to the `Route`'s
+  `connectOutlets` and `serialize` methods.
 
-  When an application's state is changed from within the application itself, the context provided for
-  the transition will be passed and `deserialize` is not called (see 'Transitions Between States').
+  When an application's state is changed from within the application itself,
+  the context provided for the transition will be passed and `deserialize` is
+  not called (see 'Transitions Between States').
 
   ### Serializing An Object For URLs with Dynamic Segments
-  When transitioning into a Route whose `route` property contains dynamic segments the Route's
-  `serialize` method is called with the Route's router as the first argument and the Route's
-  context as the second argument.  The return value of `serialize` will be used to populate the
-  dynamic segments and should be an object with keys that match the names of the dynamic sections.
+
+  When transitioning into a Route whose `route` property contains dynamic
+  segments the route's `serialize` method is called with the route's router as
+  the first argument and the route's context as the second argument. The return
+  value of `serialize` will be used to populate the dynamic segments and should
+  be an object with keys that match the names of the dynamic sections.
 
   Given the following route structure:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/'
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/staticSection/:someDynamicSegment',
-              serialize: function(router, context) {
-                return {
-                  someDynamicSegment: context.get('name')
-                }
-              }
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/'
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/staticSection/:someDynamicSegment',
+          serialize: function(router, context) {
+            return {
+              someDynamicSegment: context.get('name')
+            }
+          }
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
-
-  Transitioning to "root.bRoute" with a context of `Object.create({name: 'Yehuda'})` will call
-  the Route's `serialize` method with the context as its second argument and update the URL to
+  Transitioning to `root.bRoute` with a context of 
+  `Object.create({name: 'Yehuda'})` will call the `Route`'s `serialize` 
+  method with the context as its second argument and update the URL to
   '#/staticSection/Yehuda'.
 
   ## Transitions Between States
-  Once a routed application has initialized its state based on the entry URL, subsequent transitions to other
-  states will update the URL if the entered Route has a `route` property. Given the following route structure
-  loaded at the URL '#/':
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/',
-              moveElsewhere: Ember.Route.transitionTo('bRoute')
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/someOtherLocation'
-            })
-          })
+  Once a routed application has initialized its state based on the entry URL,
+  subsequent transitions to other states will update the URL if the entered
+  Route has a `route` property. Given the following route structure loaded at
+  the URL '#/':
+
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/',
+          moveElsewhere: Ember.Route.transitionTo('bRoute')
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/someOtherLocation'
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```
 
   And application code:
 
-      App.get('router').send('moveElsewhere');
+  ```javascript
+  App.get('router').send('moveElsewhere');
+  ```
 
-  Will transition the application's state to 'root.bRoute' and trigger an update of the URL to
-  '#/someOtherLocation'.
+  Will transition the application's state to `root.bRoute` and trigger an
+  update of the URL to `#/someOtherLocation`.
 
-  For URL patterns with dynamic segments a context can be supplied as the second argument to `send`.
-  The router will match dynamic segments names to keys on this object and fill in the URL with the
-  supplied values. Given the following state structure loaded at the URL '#/':
+  For URL patterns with dynamic segments a context can be supplied as the
+  second argument to `send`. The router will match dynamic segments names to
+  keys on this object and fill in the URL with the supplied values. Given the
+  following state structure loaded at the URL `#/`:
 
-      App = Ember.Application.create({
-        Router: Ember.Router.extend({
-          root: Ember.Route.extend({
-            aRoute: Ember.Route.extend({
-              route: '/',
-              moveElsewhere: Ember.Route.transitionTo('bRoute')
-            }),
-            bRoute: Ember.Route.extend({
-              route: '/a/route/:dynamicSection/:anotherDynamicSection',
-              connectOutlets: function(router, context) {},
-            })
-          })
+  ```javascript
+  App = Ember.Application.create({
+    Router: Ember.Router.extend({
+      root: Ember.Route.extend({
+        aRoute: Ember.Route.extend({
+          route: '/',
+          moveElsewhere: Ember.Route.transitionTo('bRoute')
+        }),
+        bRoute: Ember.Route.extend({
+          route: '/a/route/:dynamicSection/:anotherDynamicSection',
+          connectOutlets: function(router, context) {},
         })
-      });
-      App.initialize();
+      })
+    })
+  });
+  App.initialize();
+  ```javascript
 
   And application code:
 
-      App.get('router').send('moveElsewhere', {
-        dynamicSection: '42',
-        anotherDynamicSection: 'Life'
-      });
+  ```javascript
+  App.get('router').send('moveElsewhere', {
+    dynamicSection: '42',
+    anotherDynamicSection: 'Life'
+  });
+  ```
 
-  Will transition the application's state to 'root.bRoute' and trigger an update of the URL to
-  '#/a/route/42/Life'.
+  Will transition the application's state to `root.bRoute` and trigger an
+  update of the URL to `#/a/route/42/Life`.
 
-  The context argument will also be passed as the second argument to the `serialize` method call.
+  The context argument will also be passed as the second argument to the
+  `serialize` method call.
 
   ## Injection of Controller Singletons
-  During application initialization Ember will detect properties of the application ending in 'Controller',
-  create singleton instances of each class, and assign them as properties on the router.  The property name
-  will be the UpperCamel name converted to lowerCamel format. These controller classes should be subclasses
-  of Ember.ObjectController, Ember.ArrayController, Ember.Controller, or a custom Ember.Object that includes the
-  Ember.ControllerMixin mixin.
 
-  ``` javascript
+  During application initialization Ember will detect properties of the
+  application ending in 'Controller', create singleton instances of each class,
+  and assign them as properties on the router. The property name will be the
+  UpperCamel name converted to lowerCamel format. These controller classes
+  should be subclasses of `Ember.ObjectController`, `Ember.ArrayController`,
+  `Ember.Controller`, or a custom `Ember.Object` that includes the
+  `Ember.ControllerMixin` mixin.
+
+  ```javascript
   App = Ember.Application.create({
     FooController: Ember.Object.create(Ember.ControllerMixin),
     Router: Ember.Router.extend({ ... })
@@ -320,18 +381,23 @@ var merge = function(original, hash) {
   App.get('router.fooController'); // instance of App.FooController
   ```
 
-  The controller singletons will have their `namespace` property set to the application and their `target`
-  property set to the application's router singleton for easy integration with Ember's user event system.
-  See 'Changing View Hierarchy in Response To State Change' and 'Responding to User-initiated Events.'
+  The controller singletons will have their `namespace` property set to the
+  application and their `target` property set to the application's router
+  singleton for easy integration with Ember's user event system. See 'Changing
+  View Hierarchy in Response To State Change' and 'Responding to User-initiated
+  Events.'
 
   ## Responding to User-initiated Events
-  Controller instances injected into the router at application initialization have their `target` property
-  set to the application's router instance. These controllers will also be the default `context` for their
-  associated views.  Uses of the `{{action}}` helper will automatically target the application's router.
 
-  Given the following application entered at the URL '#/':
+  Controller instances injected into the router at application initialization
+  have their `target` property set to the application's router instance. These
+  controllers will also be the default `context` for their associated views.
+  Uses of the `{{action}}` helper will automatically target the application's
+  router.
 
-  ``` javascript
+  Given the following application entered at the URL `#/`:
+
+  ```javascript
   App = Ember.Application.create({
     Router: Ember.Router.extend({
       root: Ember.Route.extend({
@@ -355,20 +421,22 @@ var merge = function(original, hash) {
 
   The following template:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name="aView">
       <h1><a {{action anActionOnTheRouter}}>{{title}}</a></h1>
   </script>
   ```
 
-  Will delegate `click` events on the rendered `h1` to the application's router instance. In this case the
-  `anActionOnTheRouter` method of the state at 'root.aRoute' will be called with the view's controller
-  as the context argument. This context will be passed to the `connectOutlets` as its second argument.
+  Will delegate `click` events on the rendered `h1` to the application's router
+  instance. In this case the `anActionOnTheRouter` method of the state at
+  'root.aRoute' will be called with the view's controller as the context
+  argument. This context will be passed to the `connectOutlets` as its second
+  argument.
 
-  Different `context` can be supplied from within the `{{action}}` helper, allowing specific context passing
-  between application states:
+  Different `context` can be supplied from within the `{{action}}` helper,
+  allowing specific context passing between application states:
 
-  ``` handlebars
+  ```handlebars
   <script type="text/x-handlebars" data-template-name="photos">
     {{#each photo in controller}}
       <h1><a {{action showPhoto photo}}>{{title}}</a></h1>
@@ -378,14 +446,14 @@ var merge = function(original, hash) {
 
   See `Handlebars.helpers.action` for additional usage examples.
 
-
   ## Changing View Hierarchy in Response To State Change
 
-  Changes in application state that change the URL should be accompanied by associated changes in view
-  hierarchy.  This can be accomplished by calling 'connectOutlet' on the injected controller singletons from
-  within the 'connectOutlets' event of an Ember.Route:
+  Changes in application state that change the URL should be accompanied by
+  associated changes in view hierarchy. This can be accomplished by calling
+  `connectOutlet` on the injected controller singletons from within the
+  'connectOutlets' event of an `Ember.Route`:
 
-  ``` javascript
+  ```javascript
   App = Ember.Application.create({
     OneController: Ember.ObjectController.extend(),
     OneView: Ember.View.extend(),
@@ -407,15 +475,17 @@ var merge = function(original, hash) {
   App.initialize();
   ```
 
+  This will detect the `{{outlet}}` portion of `oneController`'s view (an
+  instance of `App.OneView`) and fill it with a rendered instance of
+  `App.AnotherView` whose `context` will be the single instance of
+  `App.AnotherController` stored on the router in the `anotherController`
+  property.
 
-  This will detect the '{{outlet}}' portion of `oneController`'s view (an instance of `App.OneView`) and
-  fill it with a rendered instance of `App.AnotherView` whose `context` will be the single instance of
-  `App.AnotherController` stored on the router in the `anotherController` property.
-
-  For more information about Outlets, see `Ember.Handlebars.helpers.outlet`. For additional information on
-  the `connectOutlet` method, see `Ember.Controller.connectOutlet`. For more information on
-  controller injections, see `Ember.Application#initialize()`. For additional information about view context,
-  see `Ember.View`.
+  For more information about Outlets, see `Ember.Handlebars.helpers.outlet`.
+  For additional information on the `connectOutlet` method, see
+  `Ember.Controller.connectOutlet`. For more information on controller
+  injections, see `Ember.Application#initialize()`. For additional information
+  about view context, see `Ember.View`.
 
   @class Router
   @namespace Ember
@@ -435,11 +505,11 @@ Ember.Router = Ember.StateManager.extend(
     The `Ember.Location` implementation to be used to manage the application
     URL state. The following values are supported:
 
-    * 'hash': Uses URL fragment identifiers (like #/blog/1) for routing.
-    * 'history': Uses the browser's history.pushstate API for routing. Only works in
-       modern browsers with pushstate support.
-    * 'none': Does not read or set the browser URL, but still allows for
-      routing to happen. Useful for testing.
+    * `hash`: Uses URL fragment identifiers (like #/blog/1) for routing.
+    * `history`: Uses the browser's history.pushstate API for routing. Only
+       works in modern browsers with pushstate support.
+    * `none`: Does not read or set the browser URL, but still allows for
+       routing to happen. Useful for testing.
 
     @property location
     @type String

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -10,18 +10,18 @@ require('ember-runtime/mixins/sortable');
 var get = Ember.get, set = Ember.set;
 
 /**
-  Ember.ArrayController provides a way for you to publish a collection of objects
-  so that you can easily bind to the collection from a Handlebars #each helper,
-  an Ember.CollectionView, or other controllers.
+  `Ember.ArrayController` provides a way for you to publish a collection of
+  objects so that you can easily bind to the collection from a Handlebars
+  `#each` helper, an `Ember.CollectionView`, or other controllers.
 
-  The advantage of using an ArrayController is that you only have to set up
+  The advantage of using an `ArrayController` is that you only have to set up
   your view bindings once; to change what's displayed, simply swap out the
   `content` property on the controller.
 
   For example, imagine you wanted to display a list of items fetched via an XHR
-  request. Create an Ember.ArrayController and set its `content` property:
+  request. Create an `Ember.ArrayController` and set its `content` property:
 
-  ``` javascript
+  ```javascript
   MyApp.listController = Ember.ArrayController.create();
 
   $.get('people.json', function(data) {
@@ -31,7 +31,7 @@ var get = Ember.get, set = Ember.set;
 
   Then, create a view that binds to your new controller:
 
-  ``` handlebars
+  ```handlebars
   {{#each MyApp.listController}}
     {{firstName}} {{lastName}}
   {{/each}}

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -7,27 +7,30 @@ require('ember-runtime/system/string');
 */
 
 /**
-  Ember.ControllerMixin provides a standard interface for all classes
-  that compose Ember's controller layer: Ember.Controller, Ember.ArrayController,
-  and Ember.ObjectController.
+  `Ember.ControllerMixin` provides a standard interface for all classes that
+  compose Ember's controller layer: `Ember.Controller`,
+  `Ember.ArrayController`, and `Ember.ObjectController`.
 
-  Within an Ember.Router-managed application single shared instaces of every
+  Within an `Ember.Router`-managed application single shared instaces of every
   Controller object in your application's namespace will be added to the
-  application's Ember.Router instance. See `Ember.Application#initialize`
+  application's `Ember.Router` instance. See `Ember.Application#initialize`
   for additional information.
 
   ## Views
+
   By default a controller instance will be the rendering context
-  for its associated Ember.View. This connection is made during calls to
+  for its associated `Ember.View.` This connection is made during calls to
   `Ember.ControllerMixin#connectOutlet`.
 
-  Within the view's template, the Ember.View instance can be accessed
+  Within the view's template, the `Ember.View` instance can be accessed
   through the controller with `{{view}}`.
 
   ## Target Forwarding
-  By default a controller will target your application's Ember.Router instance.
-  Calls to `{{action}}` within the template of a controller's view are forwarded
-  to the router. See `Ember.Handlebars.helpers.action` for additional information.
+
+  By default a controller will target your application's `Ember.Router`
+  instance. Calls to `{{action}}` within the template of a controller's view
+  are forwarded to the router. See `Ember.Handlebars.helpers.action` for
+  additional information.
 
   @class ControllerMixin
   @namespace Ember

--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -7,13 +7,13 @@ require('ember-runtime/controllers/controller');
 */
 
 /**
-  Ember.ObjectController is part of Ember's Controller layer. A single
-  shared instance of each Ember.ObjectController subclass in your application's
+  `Ember.ObjectController` is part of Ember's Controller layer. A single shared
+  instance of each `Ember.ObjectController` subclass in your application's
   namespace will be created at application initialization and be stored on your
-  application's Ember.Router instance.
+  application's `Ember.Router` instance.
 
-  Ember.ObjectController derives its functionality from its superclass
-  Ember.ObjectProxy and the Ember.ControllerMixin mixin.
+  `Ember.ObjectController` derives its functionality from its superclass
+  `Ember.ObjectProxy` and the `Ember.ControllerMixin` mixin.
 
   @class ObjectController
   @namespace Ember

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -26,7 +26,7 @@ var toString = Object.prototype.toString;
 
   Use this instead of the built-in `typeof` to get the type of an item.
   It will return the same result across all browsers and includes a bit
-  more detail.  Here is what will be returned:
+  more detail. Here is what will be returned:
 
       | Return Value  | Meaning                                              |
       |---------------|------------------------------------------------------|
@@ -44,20 +44,22 @@ var toString = Object.prototype.toString;
 
   Examples:
 
-      Ember.typeOf();                      => 'undefined'
-      Ember.typeOf(null);                  => 'null'
-      Ember.typeOf(undefined);             => 'undefined'
-      Ember.typeOf('michael');             => 'string'
-      Ember.typeOf(101);                   => 'number'
-      Ember.typeOf(true);                  => 'boolean'
-      Ember.typeOf(Ember.makeArray);       => 'function'
-      Ember.typeOf([1,2,90]);              => 'array'
-      Ember.typeOf(Ember.Object.extend()); => 'class'
-      Ember.typeOf(Ember.Object.create()); => 'instance'
-      Ember.typeOf(new Error('teamocil')); => 'error'
+  ```javascript
+  Ember.typeOf();                       // 'undefined'
+  Ember.typeOf(null);                   // 'null'
+  Ember.typeOf(undefined);              // 'undefined'
+  Ember.typeOf('michael');              // 'string'
+  Ember.typeOf(101);                    // 'number'
+  Ember.typeOf(true);                   // 'boolean'
+  Ember.typeOf(Ember.makeArray);        // 'function'
+  Ember.typeOf([1,2,90]);               // 'array'
+  Ember.typeOf(Ember.Object.extend());  // 'class'
+  Ember.typeOf(Ember.Object.create());  // 'instance'
+  Ember.typeOf(new Error('teamocil'));  // 'error'
 
-      // "normal" JavaScript object
-      Ember.typeOf({a: 'b'});              => 'object'
+  // "normal" JavaScript object
+  Ember.typeOf({a: 'b'});              // 'object'
+  ```
 
   @method typeOf
   @for Ember
@@ -81,16 +83,18 @@ Ember.typeOf = function(item) {
 };
 
 /**
-  Returns true if the passed value is null or undefined.  This avoids errors
+  Returns true if the passed value is null or undefined. This avoids errors
   from JSLint complaining about use of ==, which can be technically
   confusing.
 
-      Ember.none();             => true
-      Ember.none(null);         => true
-      Ember.none(undefined);    => true
-      Ember.none('');           => false
-      Ember.none([]);           => false
-      Ember.none(function(){}); => false
+  ```javascript
+  Ember.none();              // true
+  Ember.none(null);          // true
+  Ember.none(undefined);     // true
+  Ember.none('');            // false
+  Ember.none([]);            // false
+  Ember.none(function(){});  // false
+  ```
 
   @method none
   @for Ember
@@ -102,18 +106,21 @@ Ember.none = function(obj) {
 };
 
 /**
-  Verifies that a value is null or an empty string | array | function.
+  Verifies that a value is `null` or an empty string, empty array,
+  or empty function.
 
   Constrains the rules on `Ember.none` by returning false for empty
   string and empty arrays.
 
-      Ember.empty();               => true
-      Ember.empty(null);           => true
-      Ember.empty(undefined);      => true
-      Ember.empty('');             => true
-      Ember.empty([]);             => true
-      Ember.empty('tobias fünke'); => false
-      Ember.empty([0,1,2]);        => false
+  ```javascript
+  Ember.empty();                // true
+  Ember.empty(null);            // true
+  Ember.empty(undefined);       // true
+  Ember.empty('');              // true
+  Ember.empty([]);              // true
+  Ember.empty('Adam Hawkins');  // false
+  Ember.empty([0,1,2]);         // false
+  ```
 
   @method empty
   @for Ember
@@ -132,12 +139,14 @@ Ember.empty = function(obj) {
   - 0 if both are equal,
   - 1 if the first is greater than the second.
 
- The order is calculated based on Ember.ORDER_DEFINITION, if types are different.
+ The order is calculated based on `Ember.ORDER_DEFINITION`, if types are different.
  In case they have the same type an appropriate comparison for this type is made.
 
-    Ember.compare('hello', 'hello');  => 0
-    Ember.compare('abc', 'dfg');      => -1
-    Ember.compare(2, 1);              => 1
+  ```javascript
+  Ember.compare('hello', 'hello');  // 0
+  Ember.compare('abc', 'dfg');      // -1
+  Ember.compare(2, 1);              // 1
+  ```javascript
 
  @method compare
  @for Ember
@@ -245,7 +254,7 @@ function _copy(obj, deep, seen, copies) {
 
   Ember.assert('Cannot clone an Ember.Object that does not implement Ember.Copyable', !(obj instanceof Ember.Object) || (Ember.Copyable && Ember.Copyable.detect(obj)));
 
-  // IMPORTANT: this specific test will detect a native array only.  Any other
+  // IMPORTANT: this specific test will detect a native array only. Any other
   // object will need to implement Copyable.
   if (Ember.typeOf(obj) === 'array') {
     ret = obj.slice();
@@ -276,7 +285,7 @@ function _copy(obj, deep, seen, copies) {
   any type of object and create a clone of it, including primitive values
   (which are not actually cloned because they are immutable).
 
-  If the passed object implements the clone() method, then this function
+  If the passed object implements the `clone()` method, then this function
   will simply call that method and return the result.
 
   @method copy
@@ -315,14 +324,16 @@ Ember.inspect = function(obj) {
 };
 
 /**
-  Compares two objects, returning true if they are logically equal.  This is
+  Compares two objects, returning true if they are logically equal. This is
   a deeper comparison than a simple triple equal. For sets it will compare the
-  internal objects.  For any other object that implements `isEqual()` it will
+  internal objects. For any other object that implements `isEqual()` it will
   respect that method.
 
-      Ember.isEqual('hello', 'hello');  => true
-      Ember.isEqual(1, 2);              => false
-      Ember.isEqual([4,2], [4,2]);      => false
+  ```javascript
+  Ember.isEqual('hello', 'hello');  // true
+  Ember.isEqual(1, 2);              // false
+  Ember.isEqual([4,2], [4,2]);      // false
+  ```
 
   @method isEqual
   @for Ember
@@ -352,8 +363,8 @@ Ember.ORDER_DEFINITION = Ember.ENV.ORDER_DEFINITION || [
 
 /**
   Returns all of the keys defined on an object or hash. This is useful
-  when inspecting objects for debugging.  On browsers that support it, this
-  uses the native Object.keys implementation.
+  when inspecting objects for debugging. On browsers that support it, this
+  uses the native `Object.keys` implementation.
 
   @method keys
   @for Ember

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -11,45 +11,49 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
   /**
     The `property` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Function is true,
-    which is the default.
+    when `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Function` is
+    `true`, which is the default.
 
     Computed properties allow you to treat a function like a property:
 
-        MyApp.president = Ember.Object.create({
-          firstName: "Barack",
-          lastName: "Obama",
+    ```javascript
+    MyApp.president = Ember.Object.create({
+      firstName: "Barack",
+      lastName: "Obama",
 
-          fullName: function() {
-            return this.get('firstName') + ' ' + this.get('lastName');
+      fullName: function() {
+        return this.get('firstName') + ' ' + this.get('lastName');
 
-            // Call this flag to mark the function as a property
-          }.property()
-        });
+        // Call this flag to mark the function as a property
+      }.property()
+    });
 
-        MyApp.president.get('fullName');    => "Barack Obama"
+    MyApp.president.get('fullName');    // "Barack Obama"
+    ```
 
     Treating a function like a property is useful because they can work with
     bindings, just like any other property.
 
     Many computed properties have dependencies on other properties. For
     example, in the above example, the `fullName` property depends on
-    `firstName` and `lastName` to determine its value. You can tell Ember.js
+    `firstName` and `lastName` to determine its value. You can tell Ember
     about these dependencies like this:
 
-        MyApp.president = Ember.Object.create({
-          firstName: "Barack",
-          lastName: "Obama",
+    ```javascript
+    MyApp.president = Ember.Object.create({
+      firstName: "Barack",
+      lastName: "Obama",
 
-          fullName: function() {
-            return this.get('firstName') + ' ' + this.get('lastName');
+      fullName: function() {
+        return this.get('firstName') + ' ' + this.get('lastName');
 
-            // Tell Ember.js that this computed property depends on firstName
-            // and lastName
-          }.property('firstName', 'lastName')
-        });
+        // Tell Ember.js that this computed property depends on firstName
+        // and lastName
+      }.property('firstName', 'lastName')
+    });
+    ```
 
-    Make sure you list these dependencies so Ember.js knows when to update
+    Make sure you list these dependencies so Ember knows when to update
     bindings that connect to a computed property. Changing a dependency
     will not immediately trigger an update of the computed property, but
     will instead clear the cache so that it is updated when the next `get`
@@ -68,18 +72,20 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
   /**
     The `observes` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Function is true,
-    which is the default.
+    when `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Function` is
+    true, which is the default.
 
     You can observe property changes simply by adding the `observes`
     call to the end of your method declarations in classes that you write.
     For example:
 
-        Ember.Object.create({
-          valueObserver: function() {
-            // Executes whenever the "value" property changes
-          }.observes('value')
-        });
+    ```javascript
+    Ember.Object.create({
+      valueObserver: function() {
+        // Executes whenever the "value" property changes
+      }.observes('value')
+    });
+    ```
 
     See {{#crossLink "Ember.Observable/observes"}}{{/crossLink}}
 
@@ -92,19 +98,21 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
   };
 
   /**
-    The `observesBefore` extension of Javascript's Function prototype is available
-    when Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Function is true,
-    which is the default.
+    The `observesBefore` extension of Javascript's Function prototype is
+    available when `Ember.EXTEND_PROTOTYPES` or
+    `Ember.EXTEND_PROTOTYPES.Function` is true, which is the default.
 
     You can get notified when a property changes is about to happen by
     by adding the `observesBefore` call to the end of your method
     declarations in classes that you write. For example:
 
-        Ember.Object.create({
-          valueObserver: function() {
-            // Executes whenever the "value" property is about to change
-          }.observesBefore('value')
-        });
+    ```javascript
+    Ember.Object.create({
+      valueObserver: function() {
+        // Executes whenever the "value" property is about to change
+      }.observesBefore('value')
+    });
+    ```
 
     See {{#crossLink "Ember.Observable/observesBefore"}}{{/crossLink}}
 

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -17,12 +17,12 @@ function none(obj) { return obj===null || obj===undefined; }
 // ARRAY
 //
 /**
-  This module implements Observer-friendly Array-like behavior.  This mixin is
+  This module implements Observer-friendly Array-like behavior. This mixin is
   picked up by the Array class as well as other controllers, etc. that want to
   appear to be arrays.
 
-  Unlike Ember.Enumerable, this mixin defines methods specifically for
-  collections that provide index-ordered access to their contents.  When you
+  Unlike `Ember.Enumerable,` this mixin defines methods specifically for
+  collections that provide index-ordered access to their contents. When you
   are designing code that needs to accept any kind of Array-like object, you
   should use these methods instead of Array primitives because these will
   properly notify observers of changes to the array.
@@ -33,15 +33,15 @@ function none(obj) { return obj===null || obj===undefined; }
   as controllers and collections.
 
   You can use the methods defined in this module to access and modify array
-  contents in a KVO-friendly way.  You can also be notified whenever the
+  contents in a KVO-friendly way. You can also be notified whenever the
   membership if an array changes by changing the syntax of the property to
-  .observes('*myProperty.[]') .
+  `.observes('*myProperty.[]')`.
 
-  To support Ember.Array in your own class, you must override two
-  primitives to use it: replace() and objectAt().
+  To support `Ember.Array` in your own class, you must override two
+  primitives to use it: `replace()` and `objectAt()`.
 
-  Note that the Ember.Array mixin also incorporates the Ember.Enumerable mixin.  All
-  Ember.Array-like objects are also enumerable.
+  Note that the Ember.Array mixin also incorporates the `Ember.Enumerable`
+  mixin. All `Ember.Array`-like objects are also enumerable.
 
   @class Array
   @namespace Ember
@@ -55,7 +55,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   isSCArray: true,
 
   /**
-    Your array must support the length property. Your replace methods should
+    Your array must support the `length` property. Your replace methods should
     set this property whenever it changes.
 
     @property {Number} length
@@ -63,24 +63,25 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   length: Ember.required(),
 
   /**
-    Returns the object at the given index. If the given index is negative or
-    is greater or equal than the array length, returns `undefined`.
+    Returns the object at the given `index`. If the given `index` is negative
+    or is greater or equal than the array length, returns `undefined`.
 
     This is one of the primitives you must implement to support `Ember.Array`.
     If your object supports retrieving the value of an array item using `get()`
     (i.e. `myArray.get(0)`), then you do not need to implement this method
     yourself.
 
-        var arr = ['a', 'b', 'c', 'd'];
-        arr.objectAt(0);  => "a"
-        arr.objectAt(3);  => "d"
-        arr.objectAt(-1); => undefined
-        arr.objectAt(4);  => undefined
-        arr.objectAt(5);  => undefined
+    ```javascript
+    var arr = ['a', 'b', 'c', 'd'];
+    arr.objectAt(0);   // "a"
+    arr.objectAt(3);   // "d"
+    arr.objectAt(-1);  // undefined
+    arr.objectAt(4);   // undefined
+    arr.objectAt(5);   // undefined
+    ```
 
     @method objectAt
-    @param {Number} idx
-      The index of the item to return.
+    @param {Number} idx The index of the item to return.
   */
   objectAt: function(idx) {
     if ((idx < 0) || (idx>=get(this, 'length'))) return undefined ;
@@ -90,13 +91,14 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   /**
     This returns the objects at the specified indexes, using `objectAt`.
 
-        var arr = ['a', 'b', 'c', 'd'];
-        arr.objectsAt([0, 1, 2]) => ["a", "b", "c"]
-        arr.objectsAt([2, 3, 4]) => ["c", "d", undefined]
+    ```javascript
+    var arr = ['a', 'b', 'c', 'd'];
+    arr.objectsAt([0, 1, 2]);  // ["a", "b", "c"]
+    arr.objectsAt([2, 3, 4]);  // ["c", "d", undefined]
+    ```
 
     @method objectsAt
-    @param {Array} indexes
-      An array of indexes of items to return.
+    @param {Array} indexes An array of indexes of items to return.
    */
   objectsAt: function(indexes) {
     var self = this;
@@ -109,11 +111,11 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   },
 
   /**
-    This is the handler for the special array content property.  If you get
-    this property, it will return this.  If you set this property it a new
+    This is the handler for the special array content property. If you get
+    this property, it will return this. If you set this property it a new
     array, it will replace the current content.
 
-    This property overrides the default property defined in Ember.Enumerable.
+    This property overrides the default property defined in `Ember.Enumerable`.
 
     @property []
   */
@@ -141,10 +143,12 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     uses the observable array methods to retrieve the objects for the new
     slice.
 
-        var arr = ['red', 'green', 'blue'];
-        arr.slice(0);      => ['red', 'green', 'blue']
-        arr.slice(0, 2);   => ['red', 'green']
-        arr.slice(1, 100); => ['green', 'blue']
+    ```javascript
+    var arr = ['red', 'green', 'blue'];
+    arr.slice(0);       // ['red', 'green', 'blue']
+    arr.slice(0, 2);    // ['red', 'green']
+    arr.slice(1, 100);  // ['green', 'blue']
+    ```
 
     @method slice
     @param beginIndex {Integer} (Optional) index to begin slicing from.
@@ -164,17 +168,19 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Returns the index of the given object's first occurrence.
-    If no startAt argument is given, the starting location to
+    If no `startAt` argument is given, the starting location to
     search is 0. If it's negative, will count backward from
     the end of the array. Returns -1 if no match is found.
 
-        var arr = ["a", "b", "c", "d", "a"];
-        arr.indexOf("a");      =>  0
-        arr.indexOf("z");      => -1
-        arr.indexOf("a", 2);   =>  4
-        arr.indexOf("a", -1);  =>  4
-        arr.indexOf("b", 3);   => -1
-        arr.indexOf("a", 100); => -1
+    ```javascript
+    var arr = ["a", "b", "c", "d", "a"];
+    arr.indexOf("a");       //  0
+    arr.indexOf("z");       // -1
+    arr.indexOf("a", 2);    //  4
+    arr.indexOf("a", -1);   //  4
+    arr.indexOf("b", 3);    // -1
+    arr.indexOf("a", 100);  // -1
+    ```javascript
 
     @method indexOf
     @param {Object} object the item to search for
@@ -195,17 +201,19 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Returns the index of the given object's last occurrence.
-    If no startAt argument is given, the search starts from
+    If no `startAt` argument is given, the search starts from
     the last position. If it's negative, will count backward
     from the end of the array. Returns -1 if no match is found.
 
-        var arr = ["a", "b", "c", "d", "a"];
-        arr.lastIndexOf("a");      =>  4
-        arr.lastIndexOf("z");      => -1
-        arr.lastIndexOf("a", 2);   =>  0
-        arr.lastIndexOf("a", -1);  =>  4
-        arr.lastIndexOf("b", 3);   =>  1
-        arr.lastIndexOf("a", 100); =>  4
+    ```javascript
+    var arr = ["a", "b", "c", "d", "a"];
+    arr.lastIndexOf("a");       //  4
+    arr.lastIndexOf("z");       // -1
+    arr.lastIndexOf("a", 2);    //  0
+    arr.lastIndexOf("a", -1);   //  4
+    arr.lastIndexOf("b", 3);    //  1
+    arr.lastIndexOf("a", 100);  //  4
+    ```
 
     @method lastIndexOf
     @param {Object} object the item to search for
@@ -229,7 +237,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   //
 
   /**
-    Adds an array observer to the receiving array.  The array observer object
+    Adds an array observer to the receiving array. The array observer object
     normally must implement two methods:
 
     * `arrayWillChange(start, removeCount, addCount)` - This method will be
@@ -238,7 +246,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       called just after the array is modified.
 
     Both callbacks will be passed the starting index of the change as well a
-    a count of the items to be removed and added.  You can use these callbacks
+    a count of the items to be removed and added. You can use these callbacks
     to optionally inspect the array during the change, clear caches, or do
     any other bookkeeping necessary.
 
@@ -249,7 +257,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     @method addArrayObserver
     @param {Object} target The observer object.
     @param {Hash} opts Optional hash of configuration options including
-      willChange, didChange, and a context option.
+      `willChange`, `didChange`, and a `context` option.
     @return {Ember.Array} receiver
   */
   addArrayObserver: function(target, opts) {
@@ -266,7 +274,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Removes an array observer from the object if the observer is current
-    registered.  Calling this method multiple times with the same object will
+    registered. Calling this method multiple times with the same object will
     have no effect.
 
     @method removeArrayObserver
@@ -296,15 +304,17 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   }).property(),
 
   /**
-    If you are implementing an object that supports Ember.Array, call this
+    If you are implementing an object that supports `Ember.Array`, call this
     method just before the array content changes to notify any observers and
-    invalidate any related properties.  Pass the starting index of the change
+    invalidate any related properties. Pass the starting index of the change
     as well as a delta of the amounts to change.
 
     @method arrayContentWillChange
     @param {Number} startIdx The starting index in the array that will change.
-    @param {Number} removeAmt The number of items that will be removed.  If you pass null assumes 0
-    @param {Number} addAmt The number of items that will be added.  If you pass null assumes 0.
+    @param {Number} removeAmt The number of items that will be removed. If you 
+      pass `null` assumes 0
+    @param {Number} addAmt The number of items that will be added  If you 
+      pass `null` assumes 0.
     @return {Ember.Array} receiver
   */
   arrayContentWillChange: function(startIdx, removeAmt, addAmt) {
@@ -381,7 +391,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
 
   /**
     Returns a special object that can be used to observe individual properties
-    on the array.  Just get an equivalent property on this object and it will
+    on the array. Just get an equivalent property on this object and it will
     return an enumerable that maps automatically to the named key on the
     member objects.
 

--- a/packages/ember-runtime/lib/mixins/comparable.js
+++ b/packages/ember-runtime/lib/mixins/comparable.js
@@ -10,7 +10,7 @@ require('ember-runtime/core');
   Implements some standard methods for comparing objects. Add this mixin to
   any class you create that can compare its instances.
 
-  You should implement the compare() method.
+  You should implement the `compare()` method.
 
   @class Comparable
   @namespace Ember
@@ -32,9 +32,9 @@ Ember.Comparable = Ember.Mixin.create( /** @scope Ember.Comparable.prototype */{
     Override to return the result of the comparison of the two parameters. The
     compare method should return:
 
-      - `-1` if `a < b`
-      - `0` if `a == b`
-      - `1` if `a > b`
+    - `-1` if `a < b`
+    - `0` if `a == b`
+    - `1` if `a > b`
 
     Default implementation raises an exception.
 

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -10,14 +10,15 @@ require('ember-runtime/system/string');
 var get = Ember.get, set = Ember.set;
 
 /**
-  Implements some standard methods for copying an object.  Add this mixin to
-  any object you create that can create a copy of itself.  This mixin is
+  Implements some standard methods for copying an object. Add this mixin to
+  any object you create that can create a copy of itself. This mixin is
   added automatically to the built-in array.
 
-  You should generally implement the copy() method to return a copy of the
+  You should generally implement the `copy()` method to return a copy of the
   receiver.
 
-  Note that frozenCopy() will only work if you also implement Ember.Freezable.
+  Note that `frozenCopy()` will only work if you also implement
+  `Ember.Freezable`.
 
   @class Copyable
   @namespace Ember
@@ -28,18 +29,18 @@ Ember.Copyable = Ember.Mixin.create(
 /** @scope Ember.Copyable.prototype */ {
 
   /**
-    Override to return a copy of the receiver.  Default implementation raises
+    Override to return a copy of the receiver. Default implementation raises
     an exception.
 
     @method copy
-    @param deep {Boolean} if true, a deep copy of the object should be made
+    @param deep {Boolean} if `true`, a deep copy of the object should be made
     @return {Object} copy of receiver
   */
   copy: Ember.required(Function),
 
   /**
-    If the object implements Ember.Freezable, then this will return a new copy
-    if the object is not frozen and the receiver if the object is frozen.
+    If the object implements `Ember.Freezable`, then this will return a new
+    copy if the object is not frozen and the receiver if the object is frozen.
 
     Raises an exception if you try to call this method on a object that does
     not support freezing.
@@ -59,6 +60,3 @@ Ember.Copyable = Ember.Mixin.create(
     }
   }
 });
-
-
-

--- a/packages/ember-runtime/lib/mixins/deferred.js
+++ b/packages/ember-runtime/lib/mixins/deferred.js
@@ -27,7 +27,7 @@ Ember.Deferred = Ember.Mixin.create({
   },
 
   /**
-    Resolve a Deferred object and call any doneCallbacks with the given args.
+    Resolve a Deferred object and call any `doneCallbacks` with the given args.
 
     @method resolve
   */
@@ -36,7 +36,7 @@ Ember.Deferred = Ember.Mixin.create({
   },
 
   /**
-    Reject a Deferred object and call any failCallbacks with the given args.
+    Reject a Deferred object and call any `failCallbacks` with the given args.
 
     @method reject
   */

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -34,33 +34,33 @@ function iter(key, value) {
 
 /**
   This mixin defines the common interface implemented by enumerable objects
-  in Ember.  Most of these methods follow the standard Array iteration
+  in Ember. Most of these methods follow the standard Array iteration
   API defined up to JavaScript 1.8 (excluding language-specific features that
   cannot be emulated in older versions of JavaScript).
 
   This mixin is applied automatically to the Array class on page load, so you
-  can use any of these methods on simple arrays.  If Array already implements
+  can use any of these methods on simple arrays. If Array already implements
   one of these methods, the mixin will not override them.
 
   ## Writing Your Own Enumerable
 
   To make your own custom class enumerable, you need two items:
 
-  1. You must have a length property.  This property should change whenever
-     the number of items in your enumerable object changes.  If you using this
-     with an Ember.Object subclass, you should be sure to change the length
-     property using set().
+  1. You must have a length property. This property should change whenever
+     the number of items in your enumerable object changes. If you using this
+     with an `Ember.Object` subclass, you should be sure to change the length
+     property using `set().`
 
-  2. If you must implement nextObject().  See documentation.
+  2. If you must implement `nextObject().` See documentation.
 
-  Once you have these two methods implement, apply the Ember.Enumerable mixin
+  Once you have these two methods implement, apply the `Ember.Enumerable` mixin
   to your class and you will be able to enumerate the contents of your object
   like any other collection.
 
   ## Using Ember Enumeration with Other Libraries
 
   Many other libraries provide some kind of iterator or enumeration like
-  facility.  This is often where the most common API conflicts occur.
+  facility. This is often where the most common API conflicts occur.
   Ember's API is designed to be as friendly as possible with other
   libraries by implementing only methods that mostly correspond to the
   JavaScript 1.8 API.
@@ -79,24 +79,24 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Implement this method to make your class enumerable.
 
-    This method will be call repeatedly during enumeration.  The index value
-    will always begin with 0 and increment monotonically.  You don't have to
+    This method will be call repeatedly during enumeration. The index value
+    will always begin with 0 and increment monotonically. You don't have to
     rely on the index value to determine what object to return, but you should
     always check the value and start from the beginning when you see the
     requested index is 0.
 
-    The previousObject is the object that was returned from the last call
-    to nextObject for the current iteration.  This is a useful way to
+    The `previousObject` is the object that was returned from the last call
+    to `nextObject` for the current iteration. This is a useful way to
     manage iteration if you are tracing a linked list, for example.
 
     Finally the context parameter will always contain a hash you can use as
     a "scratchpad" to maintain any other state you need in order to iterate
-    properly.  The context object is reused and is not reset between
+    properly. The context object is reused and is not reset between
     iterations so make sure you setup the context with a fresh state whenever
     the index parameter is 0.
 
-    Generally iterators will continue to call nextObject until the index
-    reaches the your current length-1.  If you run out of data before this
+    Generally iterators will continue to call `nextObject` until the index
+    reaches the your current length-1. If you run out of data before this
     time for some reason, you should simply return undefined.
 
     The default implementation of this method simply looks up the index.
@@ -104,27 +104,30 @@ Ember.Enumerable = Ember.Mixin.create(
 
     @method nextObject
     @param {Number} index the current index of the iteration
-    @param {Object} previousObject the value returned by the last call to nextObject.
+    @param {Object} previousObject the value returned by the last call to 
+      `nextObject`.
     @param {Object} context a context object you can use to maintain state.
     @return {Object} the next object in the iteration or undefined
   */
   nextObject: Ember.required(Function),
 
   /**
-    Helper method returns the first object from a collection.  This is usually
+    Helper method returns the first object from a collection. This is usually
     used by bindings and other parts of the framework to extract a single
     object if the enumerable contains only one item.
 
     If you override this method, you should implement it so that it will
-    always return the same value each time it is called.  If your enumerable
+    always return the same value each time it is called. If your enumerable
     contains only one object, this method should always return that object.
-    If your enumerable is empty, this method should return undefined.
+    If your enumerable is empty, this method should return `undefined`.
 
-        var arr = ["a", "b", "c"];
-        arr.firstObject(); => "a"
+    ```javascript
+    var arr = ["a", "b", "c"];
+    arr.firstObject();  // "a"
 
-        var arr = [];
-        arr.firstObject(); => undefined
+    var arr = [];
+    arr.firstObject();  // undefined
+    ```
 
     @property firstObject
     @return {Object} the object or undefined
@@ -142,13 +145,15 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Helper method returns the last object from a collection. If your enumerable
     contains only one object, this method should always return that object.
-    If your enumerable is empty, this method should return undefined.
+    If your enumerable is empty, this method should return `undefined`.
 
-        var arr = ["a", "b", "c"];
-        arr.lastObject(); => "c"
+    ```javascript
+    var arr = ["a", "b", "c"];
+    arr.lastObject();  // "c"
 
-        var arr = [];
-        arr.lastObject(); => undefined
+    var arr = [];
+    arr.lastObject();  // undefined
+    ```
 
     @property lastObject
     @return {Object} the last object or undefined
@@ -166,17 +171,19 @@ Ember.Enumerable = Ember.Mixin.create(
   }).property('[]'),
 
   /**
-    Returns true if the passed object can be found in the receiver.  The
+    Returns `true` if the passed object can be found in the receiver. The
     default version will iterate through the enumerable until the object
-    is found.  You may want to override this with a more efficient version.
+    is found. You may want to override this with a more efficient version.
 
-        var arr = ["a", "b", "c"];
-        arr.contains("a"); => true
-        arr.contains("z"); => false
+    ```javascript
+    var arr = ["a", "b", "c"];
+    arr.contains("a"); // true
+    arr.contains("z"); // false
+    ```
 
     @method contains
     @param {Object} obj The object to search for.
-    @return {Boolean} true if object is found in enumerable.
+    @return {Boolean} `true` if object is found in enumerable.
   */
   contains: function(obj) {
     return this.find(function(item) { return item===obj; }) !== undefined;
@@ -184,20 +191,22 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Iterates through the enumerable, calling the passed function on each
-    item. This method corresponds to the forEach() method defined in
+    item. This method corresponds to the `forEach()` method defined in
     JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method forEach
@@ -222,7 +231,7 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Alias for mapProperty
+    Alias for `mapProperty`
 
     @method getEach
     @param {String} key name of the property
@@ -235,8 +244,8 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Sets the value on the named property for each member. This is more
     efficient than using other methods defined on this helper. If the object
-    implements Ember.Observable, the value will be changed to set(), otherwise
-    it will be set directly. null objects are skipped.
+    implements Ember.Observable, the value will be changed to `set(),` otherwise
+    it will be set directly. `null` objects are skipped.
 
     @method setEach
     @param {String} key The key to set
@@ -251,21 +260,23 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Maps all of the items in the enumeration to another value, returning
-    a new array. This method corresponds to map() defined in JavaScript 1.6.
+    a new array. This method corresponds to `map()` defined in JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-        function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
     It should return the mapped value.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method map
@@ -297,22 +308,25 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Returns an array with all of the items in the enumeration that the passed
-    function returns true for. This method corresponds to filter() defined in
+    function returns true for. This method corresponds to `filter()` defined in
     JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true to include the item in the results, false otherwise.
+    It should return the `true` to include the item in the results, `false`
+    otherwise.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method filter
@@ -329,9 +343,9 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns an array with just the items with the matched property.  You
-    can pass an optional second argument with the target value.  Otherwise
-    this will match any property that evaluates to true.
+    Returns an array with just the items with the matched property. You
+    can pass an optional second argument with the target value. Otherwise
+    this will match any property that evaluates to `true`.
 
     @method filterProperty
     @param {String} key the property to test
@@ -344,28 +358,31 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Returns the first item in the array for which the callback returns true.
-    This method works similar to the filter() method defined in JavaScript 1.6
+    This method works similar to the `filter()` method defined in JavaScript 1.6
     except that it will stop working on the array once a match is found.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true to include the item in the results, false otherwise.
+    It should return the `true` to include the item in the results, `false`
+    otherwise.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     @method find
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
-    @return {Object} Found item or null.
+    @return {Object} Found item or `null`.
   */
   find: function(callback, target) {
     var len = get(this, 'length') ;
@@ -384,43 +401,47 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns the first item with a property matching the passed value.  You
-    can pass an optional second argument with the target value.  Otherwise
-    this will match any property that evaluates to true.
+    Returns the first item with a property matching the passed value. You
+    can pass an optional second argument with the target value. Otherwise
+    this will match any property that evaluates to `true`.
 
-    This method works much like the more generic find() method.
+    This method works much like the more generic `find()` method.
 
     @method findProperty
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
-    @return {Object} found item or null
+    @return {Object} found item or `null`
   */
   findProperty: function(key, value) {
     return this.find(iter.apply(this, arguments));
   },
 
   /**
-    Returns true if the passed function returns true for every item in the
-    enumeration. This corresponds with the every() method in JavaScript 1.6.
+    Returns `true` if the passed function returns true for every item in the
+    enumeration. This corresponds with the `every()` method in JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true or false.
+    It should return the `true` or `false`.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     Example Usage:
 
-          if (people.every(isEngineer)) { Paychecks.addBigBonus(); }
+    ```javascript
+    if (people.every(isEngineer)) { Paychecks.addBigBonus(); }
+    ```
 
     @method every
     @param {Function} callback The callback to execute
@@ -434,8 +455,8 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns true if the passed property resolves to true for all items in the
-    enumerable.  This method is often simpler/faster than using a callback.
+    Returns `true` if the passed property resolves to `true` for all items in
+    the enumerable. This method is often simpler/faster than using a callback.
 
     @method everyProperty
     @param {String} key the property to test
@@ -448,27 +469,32 @@ Ember.Enumerable = Ember.Mixin.create(
 
 
   /**
-    Returns true if the passed function returns true for any item in the
-    enumeration. This corresponds with the every() method in JavaScript 1.6.
+    Returns `true` if the passed function returns true for any item in the
+    enumeration. This corresponds with the `every()` method in JavaScript 1.6.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(item, index, enumerable);
+    ```javascript
+    function(item, index, enumerable);
+    ```
 
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
-    It should return the true to include the item in the results, false otherwise.
+    It should return the `true` to include the item in the results, `false`
+    otherwise.
 
     Note that in addition to a callback, you can also pass an optional target
-    object that will be set as "this" on the context. This is a good way
+    object that will be set as `this` on the context. This is a good way
     to give your iterator function access to the current object.
 
     Usage Example:
 
-          if (people.some(isManager)) { Paychecks.addBiggerBonus(); }
+    ```javascript
+    if (people.some(isManager)) { Paychecks.addBiggerBonus(); }
+    ```
 
     @method some
     @param {Function} callback The callback to execute
@@ -482,13 +508,13 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns true if the passed property resolves to true for any item in the
-    enumerable.  This method is often simpler/faster than using a callback.
+    Returns `true` if the passed property resolves to `true` for any item in
+    the enumerable. This method is often simpler/faster than using a callback.
 
     @method someProperty
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
-    @return {Boolean} true
+    @return {Boolean} `true`
   */
   someProperty: function(key, value) {
     return this.some(iter.apply(this, arguments));
@@ -497,21 +523,23 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     This will combine the values of the enumerator into a single value. It
     is a useful way to collect a summary value from an enumeration. This
-    corresponds to the reduce() method defined in JavaScript 1.8.
+    corresponds to the `reduce()` method defined in JavaScript 1.8.
 
     The callback method you provide should have the following signature (all
     parameters are optional):
 
-          function(previousValue, item, index, enumerable);
+    ```javascript
+    function(previousValue, item, index, enumerable);
+    ```
 
-    - *previousValue* is the value returned by the last call to the iterator.
-    - *item* is the current item in the iteration.
-    - *index* is the current index in the iteration
-    - *enumerable* is the enumerable object itself.
+    - `previousValue` is the value returned by the last call to the iterator.
+    - `item` is the current item in the iteration.
+    - `index` is the current index in the iteration.
+    - `enumerable` is the enumerable object itself.
 
     Return the new cumulative value.
 
-    In addition to the callback you can also pass an initialValue. An error
+    In addition to the callback you can also pass an `initialValue`. An error
     will be raised if you do not pass an initial value and the enumerator is
     empty.
 
@@ -539,7 +567,7 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Invokes the named method on every object in the receiver that
-    implements it.  This method corresponds to the implementation in
+    implements it. This method corresponds to the implementation in
     Prototype 1.6.
 
     @method invoke
@@ -562,8 +590,8 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Simply converts the enumerable into a genuine array.  The order is not
-    guaranteed.  Corresponds to the method implemented by Prototype.
+    Simply converts the enumerable into a genuine array. The order is not
+    guaranteed. Corresponds to the method implemented by Prototype.
 
     @method toArray
     @return {Array} the enumerable as an array.
@@ -577,8 +605,10 @@ Ember.Enumerable = Ember.Mixin.create(
   /**
     Returns a copy of the array with all null elements removed.
 
-        var arr = ["a", null, "c", null];
-        arr.compact(); => ["a", "c"]
+    ```javascript
+    var arr = ["a", null, "c", null];
+    arr.compact();  // ["a", "c"]
+    ```
 
     @method compact
     @return {Array} the array without null elements.
@@ -586,12 +616,14 @@ Ember.Enumerable = Ember.Mixin.create(
   compact: function() { return this.without(null); },
 
   /**
-    Returns a new enumerable that excludes the passed value.  The default
+    Returns a new enumerable that excludes the passed value. The default
     implementation returns an array regardless of the receiver type unless
     the receiver does not contain the value.
 
-        var arr = ["a", "b", "a", "c"];
-        arr.without("a"); => ["b", "c"]
+    ```javascript
+    var arr = ["a", "b", "a", "c"];
+    arr.without("a");  // ["b", "c"]
+    ```
 
     @method without
     @param {Object} value
@@ -607,11 +639,13 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
-    Returns a new enumerable that contains only unique values.  The default
+    Returns a new enumerable that contains only unique values. The default
     implementation returns an array regardless of the receiver type.
 
-        var arr = ["a", "a", "b", "b"];
-        arr.uniq(); => ["a", "b"]
+    ```javascript
+    var arr = ["a", "a", "b", "b"];
+    arr.uniq();  // ["a", "b"]
+    ```
 
     @method uniq
     @return {Ember.Enumerable}
@@ -629,7 +663,7 @@ Ember.Enumerable = Ember.Mixin.create(
     You can observe this property to be notified of changes to the enumerables
     content.
 
-    For plain enumerables, this property is read only.  Ember.Array overrides
+    For plain enumerables, this property is read only. `Ember.Array` overrides
     this method.
 
     @property []
@@ -644,7 +678,7 @@ Ember.Enumerable = Ember.Mixin.create(
   //
 
   /**
-    Registers an enumerable observer.   Must implement Ember.EnumerableObserver
+    Registers an enumerable observer. Must implement `Ember.EnumerableObserver`
     mixin.
 
     @method addEnumerableObserver
@@ -696,7 +730,7 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Invoke this method just before the contents of your enumerable will
-    change.  You can either omit the parameters completely or pass the objects
+    change. You can either omit the parameters completely or pass the objects
     to be removed or added if available or just a count.
 
     @method enumerableContentWillChange
@@ -732,7 +766,7 @@ Ember.Enumerable = Ember.Mixin.create(
 
   /**
     Invoke this method when the contents of your enumerable has changed.
-    This will notify any observers watching for content changes.  If your are
+    This will notify any observers watching for content changes. If your are
     implementing an ordered enumerable (such as an array), also pass the
     start and end values where the content changed so that it can be used to
     notify range observers.
@@ -770,6 +804,3 @@ Ember.Enumerable = Ember.Mixin.create(
   }
 
 }) ;
-
-
-

--- a/packages/ember-runtime/lib/mixins/freezable.js
+++ b/packages/ember-runtime/lib/mixins/freezable.js
@@ -7,8 +7,8 @@
 var get = Ember.get, set = Ember.set;
 
 /**
-  The Ember.Freezable mixin implements some basic methods for marking an object
-  as frozen. Once an object is frozen it should be read only. No changes
+  The `Ember.Freezable` mixin implements some basic methods for marking an
+  object as frozen. Once an object is frozen it should be read only. No changes
   may be made the internal state of the object.
 
   ## Enforcement
@@ -16,47 +16,47 @@ var get = Ember.get, set = Ember.set;
   To fully support freezing in your subclass, you must include this mixin and
   override any method that might alter any property on the object to instead
   raise an exception. You can check the state of an object by checking the
-  isFrozen property.
+  `isFrozen` property.
 
   Although future versions of JavaScript may support language-level freezing
   object objects, that is not the case today. Even if an object is freezable,
   it is still technically possible to modify the object, even though it could
   break other parts of your application that do not expect a frozen object to
   change. It is, therefore, very important that you always respect the
-  isFrozen property on all freezable objects.
+  `isFrozen` property on all freezable objects.
 
   ## Example Usage
 
-  The example below shows a simple object that implement the Ember.Freezable
+  The example below shows a simple object that implement the `Ember.Freezable`
   protocol.
 
-        Contact = Ember.Object.extend(Ember.Freezable, {
+  ```javascript
+  Contact = Ember.Object.extend(Ember.Freezable, {
+    firstName: null,
+    lastName: null,
 
-          firstName: null,
+    // swaps the names
+    swapNames: function() {
+      if (this.get('isFrozen')) throw Ember.FROZEN_ERROR;
+      var tmp = this.get('firstName');
+      this.set('firstName', this.get('lastName'));
+      this.set('lastName', tmp);
+      return this;
+    }
 
-          lastName: null,
+  });
 
-          // swaps the names
-          swapNames: function() {
-            if (this.get('isFrozen')) throw Ember.FROZEN_ERROR;
-            var tmp = this.get('firstName');
-            this.set('firstName', this.get('lastName'));
-            this.set('lastName', tmp);
-            return this;
-          }
-
-        });
-
-        c = Context.create({ firstName: "John", lastName: "Doe" });
-        c.swapNames();  => returns c
-        c.freeze();
-        c.swapNames();  => EXCEPTION
+  c = Context.create({ firstName: "John", lastName: "Doe" });
+  c.swapNames();  // returns c
+  c.freeze();
+  c.swapNames();  // EXCEPTION
+  ```
 
   ## Copying
 
-  Usually the Ember.Freezable protocol is implemented in cooperation with the
-  Ember.Copyable protocol, which defines a frozenCopy() method that will return
-  a frozen object, if the object implements this method as well.
+  Usually the `Ember.Freezable` protocol is implemented in cooperation with the
+  `Ember.Copyable` protocol, which defines a `frozenCopy()` method that will
+  return a frozen object, if the object implements this method as well.
 
   @class Freezable
   @namespace Ember
@@ -67,8 +67,8 @@ Ember.Freezable = Ember.Mixin.create(
 /** @scope Ember.Freezable.prototype */ {
 
   /**
-    Set to true when the object is frozen.  Use this property to detect whether
-    your object is frozen or not.
+    Set to `true` when the object is frozen. Use this property to detect
+    whether your object is frozen or not.
 
     @property isFrozen
     @type Boolean
@@ -76,7 +76,7 @@ Ember.Freezable = Ember.Mixin.create(
   isFrozen: false,
 
   /**
-    Freezes the object.  Once this method has been called the object should
+    Freezes the object. Once this method has been called the object should
     no longer allow any properties to be edited.
 
     @method freeze

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -21,7 +21,7 @@ var EMPTY = [];
 var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
 /**
-  This mixin defines the API for modifying array-like objects.  These methods
+  This mixin defines the API for modifying array-like objects. These methods
   can be applied only to a collection that keeps its items in an ordered set.
 
   Note that an Array can change even if it does not implement this mixin.
@@ -40,17 +40,17 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   /**
     __Required.__ You must implement this method to apply this mixin.
 
-    This is one of the primitives you must implement to support Ember.Array.  You
-    should replace amt objects started at idx with the objects in the passed
-    array.  You should also call this.enumerableContentDidChange() ;
+    This is one of the primitives you must implement to support `Ember.Array`.
+    You should replace amt objects started at idx with the objects in the
+    passed array. You should also call `this.enumerableContentDidChange()`
 
     @method replace
-    @param {Number} idx Starting index in the array to replace.  If idx >= length,
-      then append to the end of the array.
-    @param {Number} amt Number of elements that should be removed from the array,
-      starting at *idx*.
-    @param {Array} objects An array of zero or more objects that should be inserted
-      into the array at *idx*
+    @param {Number} idx Starting index in the array to replace. If 
+      idx >= length, then append to the end of the array.
+    @param {Number} amt Number of elements that should be removed from 
+      the array, starting at *idx*.
+    @param {Array} objects An array of zero or more objects that should be 
+      inserted into the array at *idx*
   */
   replace: Ember.required(),
 
@@ -58,10 +58,12 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
     Remove all elements from self. This is useful if you
     want to reuse an existing array without having to recreate it.
 
-        var colors = ["red", "green", "blue"];
-        color.length();  => 3
-        colors.clear();  => []
-        colors.length(); => 0
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    color.length();   //  3
+    colors.clear();   //  []
+    colors.length();  //  0
+    ```
 
     @method clear
     @return {Ember.Array} An empty Array.
@@ -74,12 +76,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    This will use the primitive replace() method to insert an object at the
+    This will use the primitive `replace()` method to insert an object at the
     specified index.
 
-        var colors = ["red", "green", "blue"];
-        colors.insertAt(2, "yellow"); => ["red", "green", "yellow", "blue"]
-        colors.insertAt(5, "orange"); => Error: Index out of range
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.insertAt(2, "yellow");  // ["red", "green", "yellow", "blue"]
+    colors.insertAt(5, "orange");  // Error: Index out of range
+    ```javascript
 
     @method insertAt
     @param {Number} idx index of insert the object at.
@@ -92,16 +96,18 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Remove an object at the specified index using the replace() primitive
-    method.  You can pass either a single index, or a start and a length.
+    Remove an object at the specified index using the `replace()` primitive
+    method. You can pass either a single index, or a start and a length.
 
     If you pass a start and length that is beyond the
-    length this method will throw an Ember.OUT_OF_RANGE_EXCEPTION
+    length this method will throw an `Ember.OUT_OF_RANGE_EXCEPTION`
 
-        var colors = ["red", "green", "blue", "yellow", "orange"];
-        colors.removeAt(0); => ["green", "blue", "yellow", "orange"]
-        colors.removeAt(2, 2); => ["green", "blue"]
-        colors.removeAt(4, 2); => Error: Index out of range
+    ```javascript
+    var colors = ["red", "green", "blue", "yellow", "orange"];
+    colors.removeAt(0);     // ["green", "blue", "yellow", "orange"]
+    colors.removeAt(2, 2);  // ["green", "blue"]
+    colors.removeAt(4, 2);  // Error: Index out of range
+    ```
 
     @method removeAt
     @param {Number} start index, start of range
@@ -124,12 +130,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Push the object onto the end of the array.  Works just like push() but it
+    Push the object onto the end of the array. Works just like `push()` but it
     is KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.pushObject("black"); => ["red", "green", "blue", "black"]
-        colors.pushObject(["yellow", "orange"]); => ["red", "green", "blue", "black", ["yellow", "orange"]]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.pushObject("black");               // ["red", "green", "blue", "black"]
+    colors.pushObject(["yellow", "orange"]);  // ["red", "green", "blue", "black", ["yellow", "orange"]]
+    ```
 
     @method pushObject
     @param {anything} obj object to push
@@ -140,12 +148,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Add the objects in the passed numerable to the end of the array.  Defers
+    Add the objects in the passed numerable to the end of the array. Defers
     notifying observers of the change until all objects are added.
 
-        var colors = ["red", "green", "blue"];
-        colors.pushObjects("black"); => ["red", "green", "blue", "black"]
-        colors.pushObjects(["yellow", "orange"]); => ["red", "green", "blue", "black", "yellow", "orange"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.pushObjects("black");               // ["red", "green", "blue", "black"]
+    colors.pushObjects(["yellow", "orange"]);  // ["red", "green", "blue", "black", "yellow", "orange"]
+    ```
 
     @method pushObjects
     @param {Ember.Enumerable} objects the objects to add
@@ -157,12 +167,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Pop object from array or nil if none are left.  Works just like pop() but
+    Pop object from array or nil if none are left. Works just like `pop()` but
     it is KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.popObject(); => "blue"
-        console.log(colors); => ["red", "green"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.popObject();   // "blue"
+    console.log(colors);  // ["red", "green"]
+    ```
 
     @method popObject
     @return object
@@ -177,12 +189,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Shift an object from start of array or nil if none are left.  Works just
-    like shift() but it is KVO-compliant.
+    Shift an object from start of array or nil if none are left. Works just
+    like `shift()` but it is KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.shiftObject(); => "red"
-        console.log(colors); => ["green", "blue"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.shiftObject();  // "red"
+    console.log(colors);   // ["green", "blue"]
+    ```
 
     @method shiftObject
     @return object
@@ -195,12 +209,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Unshift an object to start of array.  Works just like unshift() but it is
+    Unshift an object to start of array. Works just like `unshift()` but it is
     KVO-compliant.
 
-        var colors = ["red", "green", "blue"];
-        colors.unshiftObject("yellow"); => ["yellow", "red", "green", "blue"]
-        colors.unshiftObject(["black", "white"]); => [["black", "white"], "yellow", "red", "green", "blue"]
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.unshiftObject("yellow");             // ["yellow", "red", "green", "blue"]
+    colors.unshiftObject(["black", "white"]);   // [["black", "white"], "yellow", "red", "green", "blue"]
+    ```
 
     @method unshiftObject
     @param {anything} obj object to unshift
@@ -211,12 +227,14 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Adds the named objects to the beginning of the array.  Defers notifying
+    Adds the named objects to the beginning of the array. Defers notifying
     observers until all objects have been added.
 
-        var colors = ["red", "green", "blue"];
-        colors.unshiftObjects(["black", "white"]); => ["black", "white", "red", "green", "blue"]
-        colors.unshiftObjects("yellow"); => Type Error: 'undefined' is not a function
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.unshiftObjects(["black", "white"]);   // ["black", "white", "red", "green", "blue"]
+    colors.unshiftObjects("yellow");             // Type Error: 'undefined' is not a function
+    ```
 
     @method unshiftObjects
     @param {Ember.Enumerable} objects the objects to add
@@ -228,7 +246,7 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   },
 
   /**
-    Reverse objects in the array.  Works just like reverse() but it is
+    Reverse objects in the array. Works just like `reverse()` but it is
     KVO-compliant.
 
     @method reverseObjects
@@ -246,9 +264,11 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
     Replace all the the receiver's content with content of the argument.
     If argument is an empty array receiver will be cleared.
 
-        var colors = ["red", "green", "blue"];
-        colors.setObjects(["black", "white"]); => ["black", "white"]
-        colors.setObjects([]); => []
+    ```javascript
+    var colors = ["red", "green", "blue"];
+    colors.setObjects(["black", "white"]);  // ["black", "white"]
+    colors.setObjects([]);                  // []
+    ```
 
     @method setObjects
     @param {Ember.Array} objects array whose content will be used for replacing

--- a/packages/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -8,7 +8,7 @@ require('ember-runtime/mixins/enumerable');
 var forEach = Ember.EnumerableUtils.forEach;
 
 /**
-  This mixin defines the API for modifying generic enumerables.  These methods
+  This mixin defines the API for modifying generic enumerables. These methods
   can be applied to an object regardless of whether it is ordered or
   unordered.
 
@@ -18,24 +18,28 @@ var forEach = Ember.EnumerableUtils.forEach;
 
   ## Adding Objects
 
-  To add an object to an enumerable, use the addObject() method.  This
+  To add an object to an enumerable, use the `addObject()` method. This
   method will only add the object to the enumerable if the object is not
   already present and the object if of a type supported by the enumerable.
 
-      set.addObject(contact);
+  ```javascript
+  set.addObject(contact);
+  ```
 
   ## Removing Objects
 
-  To remove an object form an enumerable, use the removeObject() method.  This
+  To remove an object form an enumerable, use the `removeObject()` method. This
   will only remove the object if it is already in the enumerable, otherwise
   this method has no effect.
 
-      set.removeObject(contact);
+  ```javascript
+  set.removeObject(contact);
+  ```
 
   ## Implementing In Your Own Code
 
   If you are implementing an object and want to support this API, just include
-  this mixin in your class and implement the required methods.  In your unit
+  this mixin in your class and implement the required methods. In your unit
   tests, be sure to apply the Ember.MutableEnumerableTests to your object.
 
   @class MutableEnumerable
@@ -80,7 +84,7 @@ Ember.MutableEnumerable = Ember.Mixin.create(Ember.Enumerable,
     __Required.__ You must implement this method to apply this mixin.
 
     Attempts to remove the passed object from the receiver collection if the
-    object is in present in the collection.  If the object is not present,
+    object is in present in the collection. If the object is not present,
     this method has no effect.
 
     If the passed object is of a type not supported by the receiver

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -17,14 +17,14 @@ var get = Ember.get, set = Ember.set, defineProperty = Ember.defineProperty;
   application.
 
   Any object that has this mixin applied can be used in observer
-  operations. That includes Ember.Object and most objects you will
+  operations. That includes `Ember.Object` and most objects you will
   interact with as you write your Ember application.
 
   Note that you will not generally apply this mixin to classes yourself,
   but you will use the features provided by this module frequently, so it
   is important to understand how to use it.
 
-  ## Using get() and set()
+  ## Using `get()` and `set()`
 
   Because of Ember's support for bindings and observers, you will always
   access properties using the get method, and set properties using the
@@ -39,21 +39,25 @@ var get = Ember.get, set = Ember.set, defineProperty = Ember.defineProperty;
   call to the end of your method declarations in classes that you write.
   For example:
 
-      Ember.Object.create({
-        valueObserver: function() {
-          // Executes whenever the "value" property changes
-        }.observes('value')
-      });
+  ```javascript
+  Ember.Object.create({
+    valueObserver: function() {
+      // Executes whenever the "value" property changes
+    }.observes('value')
+  });
+  ```
 
   Although this is the most common way to add an observer, this capability
-  is actually built into the Ember.Object class on top of two methods
+  is actually built into the `Ember.Object` class on top of two methods
   defined in this mixin: `addObserver` and `removeObserver`. You can use
   these two methods to add and remove observers yourself if you need to
   do so at runtime.
 
   To add an observer for a property, call:
 
-      object.addObserver('propertyKey', targetObject, targetAction)
+  ```javascript
+  object.addObserver('propertyKey', targetObject, targetAction)
+  ```
 
   This will call the `targetAction` method on the `targetObject` to be called
   whenever the value of the `propertyKey` changes.
@@ -75,7 +79,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Retrieves the value of a property from the object.
 
-    This method is usually similar to using object[keyName] or object.keyName,
+    This method is usually similar to using `object[keyName]` or `object.keyName`,
     however it supports both computed properties and the unknownProperty
     handler.
 
@@ -88,9 +92,11 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Computed properties are methods defined with the `property` modifier
     declared at the end, such as:
 
-          fullName: function() {
-            return this.getEach('firstName', 'lastName').compact().join(' ');
-          }.property('firstName', 'lastName')
+    ```javascript
+    fullName: function() {
+      return this.getEach('firstName', 'lastName').compact().join(' ');
+    }.property('firstName', 'lastName')
+    ```
 
     When you call `get` on a computed property, the function will be
     called and the return value will be returned instead of the function
@@ -99,8 +105,8 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     ### Unknown Properties
 
     Likewise, if you try to call `get` on a property whose value is
-    undefined, the unknownProperty() method will be called on the object.
-    If this method returns any value other than undefined, it will be returned
+    `undefined`, the `unknownProperty()` method will be called on the object.
+    If this method returns any value other than `undefined`, it will be returned
     instead. This allows you to implement "virtual" properties that are
     not defined upfront.
 
@@ -113,14 +119,18 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    To get multiple properties at once, call getProperties
+    To get multiple properties at once, call `getProperties`
     with a list of strings or an array:
 
-          record.getProperties('firstName', 'lastName', 'zipCode'); // => { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```javascript
+    record.getProperties('firstName', 'lastName', 'zipCode');  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```
 
-   is equivalent to:
+    is equivalent to:
 
-          record.getProperties(['firstName', 'lastName', 'zipCode']); // => { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```javascript
+    record.getProperties(['firstName', 'lastName', 'zipCode']);  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    ```
 
     @method getProperties
     @param {String...|Array} list of keys to get
@@ -141,14 +151,14 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Sets the provided key or path to the value.
 
-    This method is generally very similar to calling object[key] = value or
-    object.key = value, except that it provides support for computed
-    properties, the unknownProperty() method and property observers.
+    This method is generally very similar to calling `object[key] = value` or
+    `object.key = value`, except that it provides support for computed
+    properties, the `unknownProperty()` method and property observers.
 
     ### Computed Properties
 
     If you try to set a value on a key that has a computed property handler
-    defined (see the get() method for an example), then set() will call
+    defined (see the `get()` method for an example), then `set()` will call
     that method, passing both the value and key instead of simply changing
     the value itself. This is useful for those times when you need to
     implement a property that is composed of one or more member
@@ -157,31 +167,33 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     ### Unknown Properties
 
     If you try to set a value on a key that is undefined in the target
-    object, then the unknownProperty() handler will be called instead. This
+    object, then the `unknownProperty()` handler will be called instead. This
     gives you an opportunity to implement complex "virtual" properties that
-    are not predefined on the object. If unknownProperty() returns
-    undefined, then set() will simply set the value on the object.
+    are not predefined on the object. If `unknownProperty()` returns
+    undefined, then `set()` will simply set the value on the object.
 
     ### Property Observers
 
-    In addition to changing the property, set() will also register a
-    property change with the object. Unless you have placed this call
-    inside of a beginPropertyChanges() and endPropertyChanges(), any "local"
-    observers (i.e. observer methods declared on the same object), will be
-    called immediately. Any "remote" observers (i.e. observer methods
-    declared on another object) will be placed in a queue and called at a
-    later time in a coalesced manner.
+    In addition to changing the property, `set()` will also register a property
+    change with the object. Unless you have placed this call inside of a
+    `beginPropertyChanges()` and `endPropertyChanges(),` any "local" observers
+    (i.e. observer methods declared on the same object), will be called
+    immediately. Any "remote" observers (i.e. observer methods declared on
+    another object) will be placed in a queue and called at a later time in a
+    coalesced manner.
 
     ### Chaining
 
-    In addition to property changes, set() returns the value of the object
+    In addition to property changes, `set()` returns the value of the object
     itself so you can do chaining like this:
 
-          record.set('firstName', 'Charles').set('lastName', 'Jolley');
+    ```javascript
+    record.set('firstName', 'Charles').set('lastName', 'Jolley');
+    ```
 
     @method set
     @param {String} key The property to set
-    @param {Object} value The value to set or null.
+    @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
   */
   set: function(keyName, value) {
@@ -190,10 +202,12 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    To set multiple properties at once, call setProperties
+    To set multiple properties at once, call `setProperties`
     with a Hash:
 
-          record.setProperties({ firstName: 'Charles', lastName: 'Jolley' });
+    ```javascript
+    record.setProperties({ firstName: 'Charles', lastName: 'Jolley' });
+    ```
 
     @method setProperties
     @param {Hash} hash the hash of keys and values to set
@@ -210,8 +224,9 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     will not be sent until the changes are finished. If you plan to make a
     large number of changes to an object at one time, you should call this
     method at the beginning of the changes to begin deferring change
-    notifications. When you are done making changes, call endPropertyChanges()
-    to deliver the deferred change notifications and end deferring.
+    notifications. When you are done making changes, call
+    `endPropertyChanges()` to deliver the deferred change notifications and end
+    deferring.
 
     @method beginPropertyChanges
     @return {Ember.Observable}
@@ -227,7 +242,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     You can use this method to group property changes so that notifications
     will not be sent until the changes are finished. If you plan to make a
     large number of changes to an object at one time, you should call
-    beginPropertyChanges() at the beginning of the changes to defer change
+    `beginPropertyChanges()` at the beginning of the changes to defer change
     notifications. When you are done making changes, call this method to
     deliver the deferred change notifications and end deferring.
 
@@ -243,14 +258,15 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Notify the observer system that a property is about to change.
 
     Sometimes you need to change a value directly or indirectly without
-    actually calling get() or set() on it. In this case, you can use this
-    method and propertyDidChange() instead. Calling these two methods
+    actually calling `get()` or `set()` on it. In this case, you can use this
+    method and `propertyDidChange()` instead. Calling these two methods
     together will notify all observers that the property has potentially
     changed value.
 
-    Note that you must always call propertyWillChange and propertyDidChange as
-    a pair. If you do not, it may get the property change groups out of order
-    and cause notifications to be delivered more often than you would like.
+    Note that you must always call `propertyWillChange` and `propertyDidChange`
+    as a pair. If you do not, it may get the property change groups out of
+    order and cause notifications to be delivered more often than you would
+    like.
 
     @method propertyWillChange
     @param {String} key The property key that is about to change.
@@ -265,14 +281,15 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Notify the observer system that a property has just changed.
 
     Sometimes you need to change a value directly or indirectly without
-    actually calling get() or set() on it. In this case, you can use this
-    method and propertyWillChange() instead. Calling these two methods
+    actually calling `get()` or `set()` on it. In this case, you can use this
+    method and `propertyWillChange()` instead. Calling these two methods
     together will notify all observers that the property has potentially
     changed value.
 
-    Note that you must always call propertyWillChange and propertyDidChange as
-    a pair. If you do not, it may get the property change groups out of order
-    and cause notifications to be delivered more often than you would like.
+    Note that you must always call `propertyWillChange` and `propertyDidChange`
+    as a pair. If you do not, it may get the property change groups out of
+    order and cause notifications to be delivered more often than you would
+    like.
 
     @method propertyDidChange
     @param {String} keyName The property key that has just changed.
@@ -320,19 +337,23 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     ### Observer Methods
 
     Observer methods you pass should generally have the following signature if
-    you do not pass a "context" parameter:
+    you do not pass a `context` parameter:
 
-          fooDidChange: function(sender, key, value, rev);
+    ```javascript
+    fooDidChange: function(sender, key, value, rev) { };
+    ```
 
     The sender is the object that changed. The key is the property that
     changes. The value property is currently reserved and unused. The rev
     is the last property revision of the object when it changed, which you can
     use to detect if the key value has really changed or not.
 
-    If you pass a "context" parameter, the context will be passed before the
+    If you pass a `context` parameter, the context will be passed before the
     revision like so:
 
-          fooDidChange: function(sender, key, value, context, rev);
+    ```javascript
+    fooDidChange: function(sender, key, value, context, rev) { };
+    ```
 
     Usually you will not need the value, context or revision parameters at
     the end. In this case, it is common to write observer methods that take
@@ -351,7 +372,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
 
   /**
     Remove an observer you have previously registered on this object. Pass
-    the same key, target, and method you passed to addObserver() and your
+    the same key, target, and method you passed to `addObserver()` and your
     target will no longer receive notifications.
 
     @method removeObserver
@@ -365,7 +386,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    Returns true if the object currently has observers registered for a
+    Returns `true` if the object currently has observers registered for a
     particular key. You can use this method to potentially defer performing
     an expensive action until someone begins observing a particular property
     on the object.
@@ -420,7 +441,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @deprecated
     @method setPath
     @param {String} path The path to the property that will be set
-    @param {Object} value The value to set or null.
+    @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
   */
   setPath: function(path, value) {
@@ -429,10 +450,12 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   },
 
   /**
-    Retrieves the value of a property, or a default value in the case that the property
-    returns undefined.
+    Retrieves the value of a property, or a default value in the case that the
+    property returns `undefined`.
 
-        person.getWithDefault('lastName', 'Doe');
+    ```javascript
+    person.getWithDefault('lastName', 'Doe');
+    ```
 
     @method getWithDefault
     @param {String} keyName The name of the property to retrieve
@@ -446,8 +469,10 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Set the value of a property to the current value plus some amount.
 
-        person.incrementProperty('age');
-        team.incrementProperty('score', 2);
+    ```javascript
+    person.incrementProperty('age');
+    team.incrementProperty('score', 2);
+    ```
 
     @method incrementProperty
     @param {String} keyName The name of the property to increment
@@ -463,8 +488,10 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
   /**
     Set the value of a property to the current value minus some amount.
 
-        player.decrementProperty('lives');
-        orc.decrementProperty('health', 5);
+    ```javascript
+    player.decrementProperty('lives');
+    orc.decrementProperty('health', 5);
+    ```
 
     @method decrementProperty
     @param {String} keyName The name of the property to decrement
@@ -481,7 +508,9 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     Set the value of a boolean property to the opposite of it's
     current value.
 
-        starship.toggleProperty('warpDriveEnaged');
+    ```javascript
+    starship.toggleProperty('warpDriveEnaged');
+    ```
 
     @method toggleProperty
     @param {String} keyName The name of the property to toggle

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -6,27 +6,28 @@
 var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach;
 
 /**
-  Ember.SortableMixin provides a standard interface for array proxies
+  `Ember.SortableMixin` provides a standard interface for array proxies
   to specify a sort order and maintain this sorting when objects are added,
   removed, or updated without changing the implicit order of their underlying
   content array:
 
-      songs = [
-        {trackNumber: 4, title: 'Ob-La-Di, Ob-La-Da'},
-        {trackNumber: 2, title: 'Back in the U.S.S.R.'},
-        {trackNumber: 3, title: 'Glass Onion'},
-      ];
+  ```javascript
+  songs = [
+    {trackNumber: 4, title: 'Ob-La-Di, Ob-La-Da'},
+    {trackNumber: 2, title: 'Back in the U.S.S.R.'},
+    {trackNumber: 3, title: 'Glass Onion'},
+  ];
 
-      songsController = Ember.ArrayController.create({
-        content: songs,
-        sortProperties: ['trackNumber']
-      });
+  songsController = Ember.ArrayController.create({
+    content: songs,
+    sortProperties: ['trackNumber']
+  });
 
-      songsController.get('firstObject'); // {trackNumber: 2, title: 'Back in the U.S.S.R.'}
+  songsController.get('firstObject');  // {trackNumber: 2, title: 'Back in the U.S.S.R.'}
 
-      songsController.addObject({trackNumber: 1, title: 'Dear Prudence'});
-      songsController.get('firstObject'); // {trackNumber: 1, title: 'Dear Prudence'}
-
+  songsController.addObject({trackNumber: 1, title: 'Dear Prudence'});
+  songsController.get('firstObject');  // {trackNumber: 1, title: 'Dear Prudence'}
+  ```
 
   @class SortableMixin
   @namespace Ember

--- a/packages/ember-runtime/lib/system/application.js
+++ b/packages/ember-runtime/lib/system/application.js
@@ -6,24 +6,26 @@ require('ember-runtime/system/namespace');
 */
 
 /**
-  Defines a namespace that will contain an executable application.  This is
+  Defines a namespace that will contain an executable application. This is
   very similar to a normal namespace except that it is expected to include at
   least a 'ready' function which can be run to initialize the application.
 
-  Currently Ember.Application is very similar to Ember.Namespace.  However, this
-  class may be augmented by additional frameworks so it is important to use
-  this instance when building new applications.
+  Currently `Ember.Application` is very similar to `Ember.Namespace.`  However,
+  this class may be augmented by additional frameworks so it is important to
+  use this instance when building new applications.
 
   # Example Usage
 
-      MyApp = Ember.Application.create({
-        VERSION: '1.0.0',
-        store: Ember.Store.create().from(Ember.fixtures)
-      });
+  ```javascript
+  MyApp = Ember.Application.create({
+    VERSION: '1.0.0',
+    store: Ember.Store.create().from(Ember.fixtures)
+  });
 
-      MyApp.ready = function() {
-        //..init code goes here...
-      }
+  MyApp.ready = function() {
+    //..init code goes here...
+  }
+  ```
 
   @class Application
   @namespace Ember

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -10,32 +10,37 @@ require('ember-runtime/system/object');
 var get = Ember.get, set = Ember.set;
 
 /**
-  An ArrayProxy wraps any other object that implements Ember.Array and/or
-  Ember.MutableArray, forwarding all requests. This makes it very useful for
+  An ArrayProxy wraps any other object that implements `Ember.Array` and/or
+  `Ember.MutableArray,` forwarding all requests. This makes it very useful for
   a number of binding use cases or other cases where being able to swap
   out the underlying array is useful.
 
   A simple example of usage:
 
-      var pets = ['dog', 'cat', 'fish'];
-      var ap = Ember.ArrayProxy.create({ content: Ember.A(pets) });
-      ap.get('firstObject'); // => 'dog'
-      ap.set('content', ['amoeba', 'paramecium']);
-      ap.get('firstObject'); // => 'amoeba'
+  ```javascript
+  var pets = ['dog', 'cat', 'fish'];
+  var ap = Ember.ArrayProxy.create({ content: Ember.A(pets) });
+
+  ap.get('firstObject');                        // 'dog'
+  ap.set('content', ['amoeba', 'paramecium']);
+  ap.get('firstObject');                        // 'amoeba'
+  ```
 
   This class can also be useful as a layer to transform the contents of
   an array, as they are accessed. This can be done by overriding
   `objectAtContent`:
 
-      var pets = ['dog', 'cat', 'fish'];
-      var ap = Ember.ArrayProxy.create({
-          content: Ember.A(pets),
-          objectAtContent: function(idx) {
-              return this.get('content').objectAt(idx).toUpperCase();
-          }
-      });
-      ap.get('firstObject'); // => 'DOG'
+  ```javascript
+  var pets = ['dog', 'cat', 'fish'];
+  var ap = Ember.ArrayProxy.create({
+      content: Ember.A(pets),
+      objectAtContent: function(idx) {
+          return this.get('content').objectAt(idx).toUpperCase();
+      }
+  });
 
+  ap.get('firstObject'); // . 'DOG'
+  ```
 
   @class ArrayProxy
   @namespace Ember
@@ -46,8 +51,8 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
 /** @scope Ember.ArrayProxy.prototype */ {
 
   /**
-    The content array.  Must be an object that implements Ember.Array and/or
-    Ember.MutableArray.
+    The content array. Must be an object that implements `Ember.Array` and/or
+    `Ember.MutableArray.`
 
     @property content
     @type Ember.Array
@@ -70,7 +75,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     content. You can override this method in subclasses to transform the
     content item to something new.
 
-    This method will only be called if content is non-null.
+    This method will only be called if content is non-`null`.
 
     @method objectAtContent
     @param {Number} idx The index to retrieve.
@@ -85,12 +90,13 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     You can override this method in subclasses to transform the content item
     into something new.
 
-    This method will only be called if content is non-null.
+    This method will only be called if content is non-`null`.
 
     @method replaceContent
     @param {Number} idx The starting index
     @param {Number} amt The number of items to remove from the content.
-    @param {Array} objects Optional array of objects to insert or null if no objects.
+    @param {Array} objects Optional array of objects to insert or null if no
+      objects.
     @return {void}
   */
   replaceContent: function(idx, amt, objects) {
@@ -126,7 +132,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
   /**
     @private
 
-    Invoked when the content property changes.  Notifies observers that the
+    Invoked when the content property changes. Notifies observers that the
     entire array content has changed.
 
     @method _contentDidChange

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -4,8 +4,8 @@
 */
 
 
-// NOTE: this object should never be included directly.  Instead use Ember.
-// Ember.Object.  We only define this separately so that Ember.Set can depend on it
+// NOTE: this object should never be included directly. Instead use Ember.
+// Ember.Object. We only define this separately so that Ember.Set can depend on it
 
 
 var set = Ember.set, get = Ember.get,
@@ -36,7 +36,7 @@ var undefinedDescriptor = {
 function makeCtor() {
 
   // Note: avoid accessing any properties on the object since it makes the
-  // method a lot faster.  This is glue code so we want it to be as fast as
+  // method a lot faster. This is glue code so we want it to be as fast as
   // possible.
 
   var wasApplied = false, initMixins;
@@ -112,7 +112,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   isDestroying: false,
 
   /**
-    Destroys an object by setting the isDestroyed flag and removing its
+    Destroys an object by setting the `isDestroyed` flag and removing its
     metadata, which effectively destroys observers and bindings.
 
     If you try to set a property on a destroyed object, an exception will be
@@ -231,21 +231,25 @@ var ClassMixin = Mixin.create({
 
   /**
     In some cases, you may want to annotate computed properties with additional
-    metadata about how they function or what values they operate on. For example,
-    computed property functions may close over variables that are then no longer
-    available for introspection.
+    metadata about how they function or what values they operate on. For
+    example, computed property functions may close over variables that are then
+    no longer available for introspection.
 
     You can pass a hash of these values to a computed property like this:
 
-        person: function() {
-          var personId = this.get('personId');
-          return App.Person.create({ id: personId });
-        }.property().meta({ type: App.Person })
+    ```javascript
+    person: function() {
+      var personId = this.get('personId');
+      return App.Person.create({ id: personId });
+    }.property().meta({ type: App.Person })
+    ```
 
     Once you've done this, you can retrieve the values saved to the computed
     property from your class like this:
 
-        MyClass.metaForProperty('person');
+    ```javascript
+    MyClass.metaForProperty('person');
+    ```
 
     This will return the original hash that was passed to `meta()`.
 

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -71,8 +71,8 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
 }
 
 /**
-  This is the object instance returned when you get the @each property on an
-  array.  It uses the unknownProperty handler to automatically create
+  This is the object instance returned when you get the `@each` property on an
+  array. It uses the unknownProperty handler to automatically create
   EachArray instances for property names.
 
   @private
@@ -96,7 +96,7 @@ Ember.EachProxy = Ember.Object.extend({
 
   /**
     You can directly access mapped properties by simply requesting them.
-    The unknownProperty handler will generate an EachArray of each item.
+    The `unknownProperty` handler will generate an EachArray of each item.
 
     @method unknownProperty
     @param keyName {String}

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -9,14 +9,16 @@ var indexOf = Ember.ArrayPolyfills.indexOf;
 
 /**
   A Namespace is an object usually used to contain other objects or methods
-  such as an application or framework.  Create a namespace anytime you want
+  such as an application or framework. Create a namespace anytime you want
   to define one of these new containers.
 
   # Example Usage
 
-      MyFramework = Ember.Namespace.create({
-        VERSION: '1.0.0'
-      });
+  ```javascript
+  MyFramework = Ember.Namespace.create({
+    VERSION: '1.0.0'
+  });
+  ```
 
   @class Namespace
   @namespace Ember

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -10,7 +10,7 @@ require('ember-runtime/mixins/copyable');
 
 var get = Ember.get, set = Ember.set;
 
-// Add Ember.Array to Array.prototype.  Remove methods with native
+// Add Ember.Array to Array.prototype. Remove methods with native
 // implementations and supply some more optimized versions of generic methods
 // because they are so common.
 var NativeArray = Ember.Mixin.create(Ember.MutableArray, Ember.Observable, Ember.Copyable, {
@@ -33,7 +33,7 @@ var NativeArray = Ember.Mixin.create(Ember.MutableArray, Ember.Observable, Ember
     if (this.isFrozen) throw Ember.FROZEN_ERROR ;
 
     // if we replaced exactly the same number of items, then pass only the
-    // replaced range.  Otherwise, pass the full remaining array length
+    // replaced range. Otherwise, pass the full remaining array length
     // since everything has shifted
     var len = objects ? get(objects, 'length') : 0;
     this.arrayContentWillChange(idx, amt, len);
@@ -108,10 +108,10 @@ if (ignore.length>0) {
 
 /**
   The NativeArray mixin contains the properties needed to to make the native
-  Array support Ember.MutableArray and all of its dependent APIs.  Unless you
-  have Ember.EXTEND_PROTOTYPES or Ember.EXTEND_PROTOTYPES.Array set to false, this
-  will be applied automatically. Otherwise you can apply the mixin at anytime by
-  calling `Ember.NativeArray.activate`.
+  Array support Ember.MutableArray and all of its dependent APIs. Unless you
+  have `Ember.EXTEND_PROTOTYPES or `Ember.EXTEND_PROTOTYPES.Array` set to
+  false, this will be applied automatically. Otherwise you can apply the mixin
+  at anytime by calling `Ember.NativeArray.activate`.
 
   @class NativeArray
   @namespace Ember
@@ -124,7 +124,7 @@ if (ignore.length>0) {
 Ember.NativeArray = NativeArray;
 
 /**
-  Creates an Ember.NativeArray from an Array like object.
+  Creates an `Ember.NativeArray` from an Array like object.
   Does not modify the original object.
 
   @method A
@@ -137,7 +137,7 @@ Ember.A = function(arr){
 };
 
 /**
-  Activates the mixin on the Array.prototype if not already applied.  Calling
+  Activates the mixin on the Array.prototype if not already applied. Calling
   this method more than once is safe.
 
   @method activate

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -31,53 +31,64 @@ function contentPropertyDidChange(content, contentKey) {
   `Ember.ObjectProxy` forwards all properties not defined by the proxy itself
   to a proxied `content` object.
 
-      object = Ember.Object.create({
-        name: 'Foo'
-      });
-      proxy = Ember.ObjectProxy.create({
-        content: object
-      });
+  ```javascript
+  object = Ember.Object.create({
+    name: 'Foo'
+  });
 
-      // Access and change existing properties
-      proxy.get('name') // => 'Foo'
-      proxy.set('name', 'Bar');
-      object.get('name') // => 'Bar'
+  proxy = Ember.ObjectProxy.create({
+    content: object
+  });
 
-      // Create new 'description' property on `object`
-      proxy.set('description', 'Foo is a whizboo baz');
-      object.get('description') // => 'Foo is a whizboo baz'
+  // Access and change existing properties
+  proxy.get('name')          // 'Foo'
+  proxy.set('name', 'Bar');
+  object.get('name')         // 'Bar'
 
-  While `content` is unset, setting a property to be delegated will throw an Error.
+  // Create new 'description' property on `object`
+  proxy.set('description', 'Foo is a whizboo baz');
+  object.get('description')  // 'Foo is a whizboo baz'
+  ```
 
-      proxy = Ember.ObjectProxy.create({
-        content: null,
-        flag: null
-      });
-      proxy.set('flag', true);
-      proxy.get('flag'); // => true
-      proxy.get('foo'); // => undefined
-      proxy.set('foo', 'data'); // throws Error
+  While `content` is unset, setting a property to be delegated will throw an
+  Error.
+
+  ```javascript
+  proxy = Ember.ObjectProxy.create({
+    content: null,
+    flag: null
+  });
+  proxy.set('flag', true);
+  proxy.get('flag');         // true
+  proxy.get('foo');          // undefined
+  proxy.set('foo', 'data');  // throws Error
+  ```
 
   Delegated properties can be bound to and will change when content is updated.
 
   Computed properties on the proxy itself can depend on delegated properties.
 
-      ProxyWithComputedProperty = Ember.ObjectProxy.extend({
-        fullName: function () {
-          var firstName = this.get('firstName'),
-              lastName = this.get('lastName');
-          if (firstName && lastName) {
-            return firstName + ' ' + lastName;
-          }
-          return firstName || lastName;
-        }.property('firstName', 'lastName')
-      });
-      proxy = ProxyWithComputedProperty.create();
-      proxy.get('fullName'); => undefined
-      proxy.set('content', {
-        firstName: 'Tom', lastName: 'Dale'
-      }); // triggers property change for fullName on proxy
-      proxy.get('fullName'); => 'Tom Dale'
+  ```javascript
+  ProxyWithComputedProperty = Ember.ObjectProxy.extend({
+    fullName: function () {
+      var firstName = this.get('firstName'),
+          lastName = this.get('lastName');
+      if (firstName && lastName) {
+        return firstName + ' ' + lastName;
+      }
+      return firstName || lastName;
+    }.property('firstName', 'lastName')
+  });
+
+  proxy = ProxyWithComputedProperty.create();
+
+  proxy.get('fullName');  // undefined
+  proxy.set('content', {
+    firstName: 'Tom', lastName: 'Dale'
+  }); // triggers property change for fullName on proxy
+
+  proxy.get('fullName');  // 'Tom Dale'
+  ```
 
   @class ObjectProxy
   @namespace Ember

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -14,10 +14,10 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
 /**
   An unordered collection of objects.
 
-  A Set works a bit like an array except that its items are not ordered.
-  You can create a set to efficiently test for membership for an object. You
-  can also iterate through a set just like an array, even accessing objects
-  by index, however there is no guarantee as to their order.
+  A Set works a bit like an array except that its items are not ordered. You
+  can create a set to efficiently test for membership for an object. You can
+  also iterate through a set just like an array, even accessing objects by
+  index, however there is no guarantee as to their order.
 
   All Sets are observable via the Enumerable Observer API - which works
   on any enumerable object including both Sets and Arrays.
@@ -25,25 +25,26 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
   ## Creating a Set
 
   You can create a set like you would most objects using
-  `new Ember.Set()`.  Most new sets you create will be empty, but you can
+  `new Ember.Set()`. Most new sets you create will be empty, but you can
   also initialize the set with some content by passing an array or other
   enumerable of objects to the constructor.
 
   Finally, you can pass in an existing set and the set will be copied. You
   can also create a copy of a set by calling `Ember.Set#copy()`.
 
-      #js
-      // creates a new empty set
-      var foundNames = new Ember.Set();
+  ```javascript
+  // creates a new empty set
+  var foundNames = new Ember.Set();
 
-      // creates a set with four names in it.
-      var names = new Ember.Set(["Charles", "Tom", "Juan", "Alex"]); // :P
+  // creates a set with four names in it.
+  var names = new Ember.Set(["Charles", "Tom", "Juan", "Alex"]); // :P
 
-      // creates a copy of the names set.
-      var namesCopy = new Ember.Set(names);
+  // creates a copy of the names set.
+  var namesCopy = new Ember.Set(names);
 
-      // same as above.
-      var anotherNamesCopy = names.copy();
+  // same as above.
+  var anotherNamesCopy = names.copy();
+  ```
 
   ## Adding/Removing Objects
 
@@ -57,8 +58,8 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
   remove the object the first time and have no effect on future calls until
   you add the object to the set again.
 
-  NOTE: You cannot add/remove null or undefined to a set. Any attempt to do so
-  will be ignored.
+  NOTE: You cannot add/remove `null` or `undefined` to a set. Any attempt to do
+  so will be ignored.
 
   In addition to add/remove you can also call `push()`/`pop()`. Push behaves
   just like `add()` but `pop()`, unlike `remove()` will pick an arbitrary
@@ -73,9 +74,9 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
   ## Observing changes
 
   When using `Ember.Set`, you can observe the `"[]"` property to be
-  alerted whenever the content changes.  You can also add an enumerable
+  alerted whenever the content changes. You can also add an enumerable
   observer to the set to be notified of specific objects that are added and
-  removed from the set.  See `Ember.Enumerable` for more information on
+  removed from the set. See `Ember.Enumerable` for more information on
   enumerables.
 
   This is often unhelpful. If you are filtering sets of objects, for instance,
@@ -86,16 +87,16 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.none
 
   ## Other Methods
 
-  `Ember.Set` primary implements other mixin APIs.  For a complete reference
+  `Ember.Set` primary implements other mixin APIs. For a complete reference
   on the methods you will use with `Ember.Set`, please consult these mixins.
   The most useful ones will be `Ember.Enumerable` and
   `Ember.MutableEnumerable` which implement most of the common iterator
   methods you are used to on Array.
 
   Note that you can also use the `Ember.Copyable` and `Ember.Freezable`
-  APIs on `Ember.Set` as well.  Once a set is frozen it can no longer be
-  modified.  The benefit of this is that when you call frozenCopy() on it,
-  Ember will avoid making copies of the set.  This allows you to write
+  APIs on `Ember.Set` as well. Once a set is frozen it can no longer be
+  modified. The benefit of this is that when you call `frozenCopy()` on it,
+  Ember will avoid making copies of the set. This allows you to write
   code that can know with certainty when the underlying set data will or
   will not be modified.
 
@@ -127,10 +128,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
     Clears the set. This is useful if you want to reuse an existing set
     without having to recreate it.
 
-        var colors = new Ember.Set(["red", "green", "blue"]);
-        colors.length;  => 3
-        colors.clear();
-        colors.length;  => 0
+    ```javascript
+    var colors = new Ember.Set(["red", "green", "blue"]);
+    colors.length;  // 3
+    colors.clear();
+    colors.length;  // 0
+    ```
 
     @method clear
     @return {Ember.Set} An empty Set
@@ -166,10 +169,13 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
     Returns true if the passed object is also an enumerable that contains the
     same objects as the receiver.
 
-        var colors = ["red", "green", "blue"],
-            same_colors = new Ember.Set(colors);
-        same_colors.isEqual(colors); => true
-        same_colors.isEqual(["purple", "brown"]); => false
+    ```javascript
+    var colors = ["red", "green", "blue"],
+        same_colors = new Ember.Set(colors);
+
+    same_colors.isEqual(colors);               // true
+    same_colors.isEqual(["purple", "brown"]);  // false
+    ```
 
     @method isEqual
     @param {Ember.Set} obj the other object.
@@ -190,18 +196,20 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   },
 
   /**
-    Adds an object to the set. Only non-null objects can be added to a set
+    Adds an object to the set. Only non-`null` objects can be added to a set
     and those can only be added once. If the object is already in the set or
     the passed value is null this method will have no effect.
 
     This is an alias for `Ember.MutableEnumerable.addObject()`.
 
-        var colors = new Ember.Set();
-        colors.add("blue");    => ["blue"]
-        colors.add("blue");    => ["blue"]
-        colors.add("red");     => ["blue", "red"]
-        colors.add(null);      => ["blue", "red"]
-        colors.add(undefined); => ["blue", "red"]
+    ```javascript
+    var colors = new Ember.Set();
+    colors.add("blue");     // ["blue"]
+    colors.add("blue");     // ["blue"]
+    colors.add("red");      // ["blue", "red"]
+    colors.add(null);       // ["blue", "red"]
+    colors.add(undefined);  // ["blue", "red"]
+    ```
 
     @method add
     @param {Object} obj The object to add.
@@ -210,14 +218,16 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   add: Ember.alias('addObject'),
 
   /**
-    Removes the object from the set if it is found.  If you pass a null value
+    Removes the object from the set if it is found. If you pass a `null` value
     or an object that is already not in the set, this method will have no
     effect. This is an alias for `Ember.MutableEnumerable.removeObject()`.
 
-        var colors = new Ember.Set(["red", "green", "blue"]);
-        colors.remove("red");    => ["blue", "green"]
-        colors.remove("purple"); => ["blue", "green"]
-        colors.remove(null);     => ["blue", "green"]
+    ```javascript
+    var colors = new Ember.Set(["red", "green", "blue"]);
+    colors.remove("red");     // ["blue", "green"]
+    colors.remove("purple");  // ["blue", "green"]
+    colors.remove(null);      // ["blue", "green"]
+    ```
 
     @method remove
     @param {Object} obj The object to remove
@@ -226,12 +236,14 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   remove: Ember.alias('removeObject'),
 
   /**
-    Removes the last element from the set and returns it, or null if it's empty.
+    Removes the last element from the set and returns it, or `null` if it's empty.
 
-        var colors = new Ember.Set(["green", "blue"]);
-        colors.pop(); => "blue"
-        colors.pop(); => "green"
-        colors.pop(); => null
+    ```javascript
+    var colors = new Ember.Set(["green", "blue"]);
+    colors.pop();  // "blue"
+    colors.pop();  // "green"
+    colors.pop();  // null
+    ```
 
     @method pop
     @return {Object} The removed object from the set or null.
@@ -249,10 +261,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias for `Ember.MutableEnumerable.addObject()`.
 
-        var colors = new Ember.Set();
-        colors.push("red");   => ["red"]
-        colors.push("green"); => ["red", "green"]
-        colors.push("blue");  => ["red", "green", "blue"]
+    ```javascript
+    var colors = new Ember.Set();
+    colors.push("red");   // ["red"]
+    colors.push("green"); // ["red", "green"]
+    colors.push("blue");  // ["red", "green", "blue"]
+    ```
 
     @method push
     @return {Ember.Set} The set itself.
@@ -260,14 +274,16 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   push: Ember.alias('addObject'),
 
   /**
-    Removes the last element from the set and returns it, or null if it's empty.
+    Removes the last element from the set and returns it, or `null` if it's empty.
 
     This is an alias for `Ember.Set.pop()`.
 
-        var colors = new Ember.Set(["green", "blue"]);
-        colors.shift(); => "blue"
-        colors.shift(); => "green"
-        colors.shift(); => null
+    ```javascript
+    var colors = new Ember.Set(["green", "blue"]);
+    colors.shift();  // "blue"
+    colors.shift();  // "green"
+    colors.shift();  // null
+    ```
 
     @method shift
     @return {Object} The removed object from the set or null.
@@ -280,10 +296,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias of `Ember.Set.push()`
 
-        var colors = new Ember.Set();
-        colors.unshift("red");   => ["red"]
-        colors.unshift("green"); => ["red", "green"]
-        colors.unshift("blue");  => ["red", "green", "blue"]
+    ```javascript
+    var colors = new Ember.Set();
+    colors.unshift("red");    // ["red"]
+    colors.unshift("green");  // ["red", "green"]
+    colors.unshift("blue");   // ["red", "green", "blue"]
+    ```
 
     @method unshift
     @return {Ember.Set} The set itself.
@@ -295,8 +313,8 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias of `Ember.MutableEnumerable.addObjects()`
 
-        var colors = new Ember.Set();
-        colors.addEach(["red", "green", "blue"]); => ["red", "green", "blue"]
+    var colors = new Ember.Set();
+    colors.addEach(["red", "green", "blue"]);  // ["red", "green", "blue"]
 
     @method addEach
     @param {Ember.Enumerable} objects the objects to add.
@@ -309,8 +327,10 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
 
     This is an alias of `Ember.MutableEnumerable.removeObjects()`
 
-        var colors = new Ember.Set(["red", "green", "blue"]);
-        colors.removeEach(["red", "blue"]); => ["green"]
+    ```javascript
+    var colors = new Ember.Set(["red", "green", "blue"]);
+    colors.removeEach(["red", "blue"]);  //  ["green"]
+    ```
 
     @method removeEach
     @param {Ember.Enumerable} objects the objects to remove.

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -11,8 +11,8 @@ var STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
 var STRING_UNDERSCORE_REGEXP_2 = (/\-|\s+/g);
 
 /**
-  Defines the hash of localized strings for the current language.  Used by
-  the `Ember.String.loc()` helper.  To localize, add string values to this
+  Defines the hash of localized strings for the current language. Used by
+  the `Ember.String.loc()` helper. To localize, add string values to this
   hash.
 
   @property STRINGS
@@ -23,8 +23,8 @@ Ember.STRINGS = {};
 
 /**
   Defines string helper methods including string formatting and localization.
-  Unless Ember.EXTEND_PROTOTYPES.String is false these methods will also be added
-  to the String.prototype as well.
+  Unless `Ember.EXTEND_PROTOTYPES.String` is `false` these methods will also be
+  added to the `String.prototype` as well.
 
   @class String
   @namespace Ember
@@ -33,17 +33,19 @@ Ember.STRINGS = {};
 Ember.String = {
 
   /**
-    Apply formatting options to the string.  This will look for occurrences
-    of %@ in your string and substitute them with the arguments you pass into
-    this method.  If you want to control the specific order of replacement,
+    Apply formatting options to the string. This will look for occurrences
+    of "%@" in your string and substitute them with the arguments you pass into
+    this method. If you want to control the specific order of replacement,
     you can add a number after the key as well to indicate which argument
     you want to insert.
 
     Ordered insertions are most useful when building loc strings where values
     you need to insert may appear in different orders.
 
-        "Hello %@ %@".fmt('John', 'Doe') => "Hello John Doe"
-        "Hello %@2, %@1".fmt('John', 'Doe') => "Hello Doe, John"
+    ```javascript
+    "Hello %@ %@".fmt('John', 'Doe');     // "Hello John Doe"
+    "Hello %@2, %@1".fmt('John', 'Doe');  // "Hello Doe, John"
+    ```
 
     @method fmt
     @param {Object...} [args]
@@ -61,23 +63,22 @@ Ember.String = {
 
   /**
     Formats the passed string, but first looks up the string in the localized
-    strings hash.  This is a convenient way to localize text.  See
+    strings hash. This is a convenient way to localize text. See
     `Ember.String.fmt()` for more information on formatting.
 
     Note that it is traditional but not required to prefix localized string
     keys with an underscore or other character so you can easily identify
     localized strings.
 
-        Ember.STRINGS = {
-          '_Hello World': 'Bonjour le monde',
-          '_Hello %@ %@': 'Bonjour %@ %@'
-        };
+    ```javascript
+    Ember.STRINGS = {
+      '_Hello World': 'Bonjour le monde',
+      '_Hello %@ %@': 'Bonjour %@ %@'
+    };
 
-        Ember.String.loc("_Hello World");
-        => 'Bonjour le monde';
-
-        Ember.String.loc("_Hello %@ %@", ["John", "Smith"]);
-        => "Bonjour John Smith";
+    Ember.String.loc("_Hello World");  // 'Bonjour le monde';
+    Ember.String.loc("_Hello %@ %@", ["John", "Smith"]);  // "Bonjour John Smith";
+    ```
 
     @method loc
     @param {String} str The string to format
@@ -91,15 +92,18 @@ Ember.String = {
 
   /**
     Splits a string into separate units separated by spaces, eliminating any
-    empty strings in the process.  This is a convenience method for split that
-    is mostly useful when applied to the String.prototype.
+    empty strings in the process. This is a convenience method for split that
+    is mostly useful when applied to the `String.prototype`.
 
-        Ember.String.w("alpha beta gamma").forEach(function(key) {
-          console.log(key);
-        });
-        > alpha
-        > beta
-        > gamma
+    ```javascript
+    Ember.String.w("alpha beta gamma").forEach(function(key) {
+      console.log(key);
+    });
+
+    // > alpha
+    // > beta
+    // > gamma
+    ```
 
     @method w
     @param {String} str The string to split
@@ -110,10 +114,12 @@ Ember.String = {
   /**
     Converts a camelized string into all lower case separated by underscores.
 
-        'innerHTML'.decamelize()         => 'inner_html'
-        'action_name'.decamelize()       => 'action_name'
-        'css-class-name'.decamelize()    => 'css-class-name'
-        'my favorite items'.decamelize() => 'my favorite items'
+    ```javascript
+    'innerHTML'.decamelize();           // 'inner_html'
+    'action_name'.decamelize();        // 'action_name'
+    'css-class-name'.decamelize();     // 'css-class-name'
+    'my favorite items'.decamelize();  // 'my favorite items'
+    ```
 
     @method decamelize
     @param {String} str The string to decamelize.
@@ -126,10 +132,12 @@ Ember.String = {
   /**
     Replaces underscores or spaces with dashes.
 
-        'innerHTML'.dasherize()         => 'inner-html'
-        'action_name'.dasherize()       => 'action-name'
-        'css-class-name'.dasherize()    => 'css-class-name'
-        'my favorite items'.dasherize() => 'my-favorite-items'
+    ```javascript
+    'innerHTML'.dasherize();          // 'inner-html'
+    'action_name'.dasherize();        // 'action-name'
+    'css-class-name'.dasherize();     // 'css-class-name'
+    'my favorite items'.dasherize();  // 'my-favorite-items'
+    ```
 
     @method dasherize
     @param {String} str The string to dasherize.
@@ -152,10 +160,12 @@ Ember.String = {
   /**
     Returns the lowerCaseCamel form of a string.
 
-        'innerHTML'.camelize()         => 'innerHTML'
-        'action_name'.camelize()       => 'actionName'
-        'css-class-name'.camelize()    => 'cssClassName'
-        'my favorite items'.camelize() => 'myFavoriteItems'
+    ```javascript
+    'innerHTML'.camelize();          // 'innerHTML'
+    'action_name'.camelize();        // 'actionName'
+    'css-class-name'.camelize();     // 'cssClassName'
+    'my favorite items'.camelize();  // 'myFavoriteItems'
+    ```
 
     @method camelize
     @param {String} str The string to camelize.
@@ -170,10 +180,12 @@ Ember.String = {
   /**
     Returns the UpperCamelCase form of a string.
 
-        'innerHTML'.classify()         => 'InnerHTML'
-        'action_name'.classify()       => 'ActionName'
-        'css-class-name'.classify()    => 'CssClassName'
-        'my favorite items'.classify() => 'MyFavoriteItems'
+    ```javascript
+    'innerHTML'.classify();          // 'InnerHTML'
+    'action_name'.classify();        // 'ActionName'
+    'css-class-name'.classify();     // 'CssClassName'
+    'my favorite items'.classify();  // 'MyFavoriteItems'
+    ``` 
 
     @method classify
     @param {String} str the string to classify
@@ -185,13 +197,15 @@ Ember.String = {
   },
 
   /**
-    More general than decamelize. Returns the lower_case_and_underscored
+    More general than decamelize. Returns the lower\_case\_and\_underscored
     form of a string.
 
-        'innerHTML'.underscore()         => 'inner_html'
-        'action_name'.underscore()       => 'action_name'
-        'css-class-name'.underscore()    => 'css_class_name'
-        'my favorite items'.underscore() => 'my_favorite_items'
+    ```javascript
+    'innerHTML'.underscore();          // 'inner_html'
+    'action_name'.underscore();        // 'action_name'
+    'css-class-name'.underscore();     // 'css_class_name'
+    'my favorite items'.underscore();  // 'my_favorite_items'
+    ```
 
     @property underscore
     @param {String} str The string to underscore.

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -52,7 +52,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
   /**
     @private
 
-    Override the default event firing from Ember.Evented to
+    Override the default event firing from `Ember.Evented` to
     also call methods with the given name.
 
     @method trigger
@@ -136,7 +136,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
 
   /**
     A Boolean value indicating whether the state is a leaf state
-    in the state hierarchy. This is false if the state has child
+    in the state hierarchy. This is `false` if the state has child
     states; otherwise it is true.
 
     @property isLeaf
@@ -185,25 +185,28 @@ Ember.State = Ember.Object.extend(Ember.Evented,
 Ember.State.reopenClass({
 
   /**
-    Creates an action function for transitioning to the named state while preserving context.
+    Creates an action function for transitioning to the named state while
+    preserving context.
 
     The following example StateManagers are equivalent:
 
-        aManager = Ember.StateManager.create({
-          stateOne: Ember.State.create({
-            changeToStateTwo: Ember.State.transitionTo('stateTwo')
-          }),
-          stateTwo: Ember.State.create({})
-        })
+    ```javascript
+    aManager = Ember.StateManager.create({
+      stateOne: Ember.State.create({
+        changeToStateTwo: Ember.State.transitionTo('stateTwo')
+      }),
+      stateTwo: Ember.State.create({})
+    })
 
-        bManager = Ember.StateManager.create({
-          stateOne: Ember.State.create({
-            changeToStateTwo: function(manager, context){
-              manager.transitionTo('stateTwo', context)
-            }
-          }),
-          stateTwo: Ember.State.create({})
-        })
+    bManager = Ember.StateManager.create({
+      stateOne: Ember.State.create({
+        changeToStateTwo: function(manager, context){
+          manager.transitionTo('stateTwo', context)
+        }
+      }),
+      stateTwo: Ember.State.create({})
+    })
+    ```
 
     @method transitionTo
     @static

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -168,369 +168,406 @@ Transition.prototype = {
 };
 
 /**
-  StateManager is part of Ember's implementation of a finite state machine. A StateManager
-  instance manages a number of properties that are instances of `Ember.State`,
+  StateManager is part of Ember's implementation of a finite state machine. A
+  StateManager instance manages a number of properties that are instances of
+  `Ember.State`,
   tracks the current active state, and triggers callbacks when states have changed.
 
   ## Defining States
 
-  The states of StateManager can be declared in one of two ways. First, you can define
-  a `states` property that contains all the states:
+  The states of StateManager can be declared in one of two ways. First, you can
+  define a `states` property that contains all the states:
 
-      managerA = Ember.StateManager.create({
-        states: {
-          stateOne: Ember.State.create(),
-          stateTwo: Ember.State.create()
-        }
-      })
+  ```javascript
+  managerA = Ember.StateManager.create({
+    states: {
+      stateOne: Ember.State.create(),
+      stateTwo: Ember.State.create()
+    }
+  })
 
-      managerA.get('states')
-      // {
-      //   stateOne: Ember.State.create(),
-      //   stateTwo: Ember.State.create()
-      // }
+  managerA.get('states')
+  // {
+  //   stateOne: Ember.State.create(),
+  //   stateTwo: Ember.State.create()
+  // }
+  ```
 
-  You can also add instances of `Ember.State` (or an `Ember.State` subclass) directly as properties
-  of a StateManager. These states will be collected into the `states` property for you.
+  You can also add instances of `Ember.State` (or an `Ember.State` subclass)
+  directly as properties of a StateManager. These states will be collected into
+  the `states` property for you.
 
-      managerA = Ember.StateManager.create({
-        stateOne: Ember.State.create(),
-        stateTwo: Ember.State.create()
-      })
+  ```javascript
+  managerA = Ember.StateManager.create({
+    stateOne: Ember.State.create(),
+    stateTwo: Ember.State.create()
+  })
 
-      managerA.get('states')
-      // {
-      //   stateOne: Ember.State.create(),
-      //   stateTwo: Ember.State.create()
-      // }
+  managerA.get('states')
+  // {
+  //   stateOne: Ember.State.create(),
+  //   stateTwo: Ember.State.create()
+  // }
+  ```
 
   ## The Initial State
+
   When created a StateManager instance will immediately enter into the state
   defined as its `start` property or the state referenced by name in its
   `initialState` property:
 
-      managerA = Ember.StateManager.create({
-        start: Ember.State.create({})
-      })
+  ```javascript
+  managerA = Ember.StateManager.create({
+    start: Ember.State.create({})
+  })
 
-      managerA.get('currentState.name') // 'start'
+  managerA.get('currentState.name') // 'start'
 
-      managerB = Ember.StateManager.create({
-        initialState: 'beginHere',
-        beginHere: Ember.State.create({})
-      })
+  managerB = Ember.StateManager.create({
+    initialState: 'beginHere',
+    beginHere: Ember.State.create({})
+  })
 
-      managerB.get('currentState.name') // 'beginHere'
+  managerB.get('currentState.name') // 'beginHere'
+  ```
 
-  Because it is a property you may also provide a computed function if you wish to derive
-  an `initialState` programmatically:
+  Because it is a property you may also provide a computed function if you wish
+  to derive an `initialState` programmatically:
 
-      managerC = Ember.StateManager.create({
-        initialState: function(){
-          if (someLogic) {
-            return 'active';
-          } else {
-            return 'passive';
-          }
-        }.property(),
-        active: Ember.State.create({}),
-        passive: Ember.State.create({})
-      })
+  ```javascript
+  managerC = Ember.StateManager.create({
+    initialState: function(){
+      if (someLogic) {
+        return 'active';
+      } else {
+        return 'passive';
+      }
+    }.property(),
+    active: Ember.State.create({}),
+    passive: Ember.State.create({})
+  })
+  ```
 
   ## Moving Between States
-  A StateManager can have any number of Ember.State objects as properties
+
+  A StateManager can have any number of `Ember.State` objects as properties
   and can have a single one of these states as its current state.
 
   Calling `transitionTo` transitions between states:
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({}),
-        poweredUp: Ember.State.create({})
-      })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({}),
+    poweredUp: Ember.State.create({})
+  })
 
-      robotManager.get('currentState.name') // 'poweredDown'
-      robotManager.transitionTo('poweredUp')
-      robotManager.get('currentState.name') // 'poweredUp'
+  robotManager.get('currentState.name') // 'poweredDown'
+  robotManager.transitionTo('poweredUp')
+  robotManager.get('currentState.name') // 'poweredUp'
+  ```
 
-  Before transitioning into a new state the existing `currentState` will have its
-  `exit` method called with the StateManager instance as its first argument and
-  an object representing the transition as its second argument.
+  Before transitioning into a new state the existing `currentState` will have
+  its `exit` method called with the StateManager instance as its first argument
+  and an object representing the transition as its second argument.
 
   After transitioning into a new state the new `currentState` will have its
-  `enter` method called with the StateManager instance as its first argument and
-  an object representing the transition as its second argument.
+  `enter` method called with the StateManager instance as its first argument
+  and an object representing the transition as its second argument.
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          exit: function(stateManager){
-            console.log("exiting the poweredDown state")
-          }
-        }),
-        poweredUp: Ember.State.create({
-          enter: function(stateManager){
-            console.log("entering the poweredUp state. Destroy all humans.")
-          }
-        })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      exit: function(stateManager){
+        console.log("exiting the poweredDown state")
+      }
+    }),
+    poweredUp: Ember.State.create({
+      enter: function(stateManager){
+        console.log("entering the poweredUp state. Destroy all humans.")
+      }
+    })
+  })
+
+  robotManager.get('currentState.name') // 'poweredDown'
+  robotManager.transitionTo('poweredUp')
+
+  // will log
+  // 'exiting the poweredDown state'
+  // 'entering the poweredUp state. Destroy all humans.'
+  ```
+
+  Once a StateManager is already in a state, subsequent attempts to enter that
+  state will not trigger enter or exit method calls. Attempts to transition
+  into a state that the manager does not have will result in no changes in the
+  StateManager's current state:
+
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      exit: function(stateManager){
+        console.log("exiting the poweredDown state")
+      }
+    }),
+    poweredUp: Ember.State.create({
+      enter: function(stateManager){
+        console.log("entering the poweredUp state. Destroy all humans.")
+      }
+    })
+  })
+
+  robotManager.get('currentState.name') // 'poweredDown'
+  robotManager.transitionTo('poweredUp')
+  // will log
+  // 'exiting the poweredDown state'
+  // 'entering the poweredUp state. Destroy all humans.'
+  robotManager.transitionTo('poweredUp') // no logging, no state change
+
+  robotManager.transitionTo('someUnknownState') // silently fails
+  robotManager.get('currentState.name') // 'poweredUp'
+  ```
+
+  Each state property may itself contain properties that are instances of
+  `Ember.State`. The StateManager can transition to specific sub-states in a
+  series of transitionTo method calls or via a single transitionTo with the
+  full path to the specific state. The StateManager will also keep track of the
+  full path to its currentState
+
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      charging: Ember.State.create(),
+      charged: Ember.State.create()
+    }),
+    poweredUp: Ember.State.create({
+      mobile: Ember.State.create(),
+      stationary: Ember.State.create()
+    })
+  })
+
+  robotManager.get('currentState.name') // 'poweredDown'
+
+  robotManager.transitionTo('poweredUp')
+  robotManager.get('currentState.name') // 'poweredUp'
+
+  robotManager.transitionTo('mobile')
+  robotManager.get('currentState.name') // 'mobile'
+
+  // transition via a state path
+  robotManager.transitionTo('poweredDown.charging')
+  robotManager.get('currentState.name') // 'charging'
+
+  robotManager.get('currentState.path') // 'poweredDown.charging'
+  ```
+
+  Enter transition methods will be called for each state and nested child state
+  in their hierarchical order. Exit methods will be called for each state and
+  its nested states in reverse hierarchical order.
+
+  Exit transitions for a parent state are not called when entering into one of
+  its child states, only when transitioning to a new section of possible states
+  in the hierarchy.
+
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown',
+    poweredDown: Ember.State.create({
+      enter: function(){},
+      exit: function(){
+        console.log("exited poweredDown state")
+      },
+      charging: Ember.State.create({
+        enter: function(){},
+        exit: function(){}
+      }),
+      charged: Ember.State.create({
+        enter: function(){
+          console.log("entered charged state")
+        },
+        exit: function(){
+          console.log("exited charged state")
+        }
       })
-
-      robotManager.get('currentState.name') // 'poweredDown'
-      robotManager.transitionTo('poweredUp')
-      // will log
-      // 'exiting the poweredDown state'
-      // 'entering the poweredUp state. Destroy all humans.'
-
-
-  Once a StateManager is already in a state, subsequent attempts to enter that state will
-  not trigger enter or exit method calls. Attempts to transition into a state that the
-  manager does not have will result in no changes in the StateManager's current state:
-
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          exit: function(stateManager){
-            console.log("exiting the poweredDown state")
-          }
-        }),
-        poweredUp: Ember.State.create({
-          enter: function(stateManager){
-            console.log("entering the poweredUp state. Destroy all humans.")
-          }
-        })
+    }),
+    poweredUp: Ember.State.create({
+      enter: function(){
+        console.log("entered poweredUp state")
+      },
+      exit: function(){},
+      mobile: Ember.State.create({
+        enter: function(){
+          console.log("entered mobile state")
+        },
+        exit: function(){}
+      }),
+      stationary: Ember.State.create({
+        enter: function(){},
+        exit: function(){}
       })
-
-      robotManager.get('currentState.name') // 'poweredDown'
-      robotManager.transitionTo('poweredUp')
-      // will log
-      // 'exiting the poweredDown state'
-      // 'entering the poweredUp state. Destroy all humans.'
-      robotManager.transitionTo('poweredUp') // no logging, no state change
-
-      robotManager.transitionTo('someUnknownState') // silently fails
-      robotManager.get('currentState.name') // 'poweredUp'
+    })
+  })
 
 
-  Each state property may itself contain properties that are instances of Ember.State.
-  The StateManager can transition to specific sub-states in a series of transitionTo method calls or
-  via a single transitionTo with the full path to the specific state. The StateManager will also
-  keep track of the full path to its currentState
+  robotManager.get('currentState.path') // 'poweredDown'
+  robotManager.transitionTo('charged')
+  // logs 'entered charged state'
+  // but does *not* log  'exited poweredDown state'
+  robotManager.get('currentState.name') // 'charged
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          charging: Ember.State.create(),
-          charged: Ember.State.create()
-        }),
-        poweredUp: Ember.State.create({
-          mobile: Ember.State.create(),
-          stationary: Ember.State.create()
-        })
-      })
+  robotManager.transitionTo('poweredUp.mobile')
+  // logs
+  // 'exited charged state'
+  // 'exited poweredDown state'
+  // 'entered poweredUp state'
+  // 'entered mobile state'
+  ```
 
-      robotManager.get('currentState.name') // 'poweredDown'
+  During development you can set a StateManager's `enableLogging` property to
+  `true` to receive console messages of state transitions.
 
-      robotManager.transitionTo('poweredUp')
-      robotManager.get('currentState.name') // 'poweredUp'
-
-      robotManager.transitionTo('mobile')
-      robotManager.get('currentState.name') // 'mobile'
-
-      // transition via a state path
-      robotManager.transitionTo('poweredDown.charging')
-      robotManager.get('currentState.name') // 'charging'
-
-      robotManager.get('currentState.path') // 'poweredDown.charging'
-
-  Enter transition methods will be called for each state and nested child state in their
-  hierarchical order.  Exit methods will be called for each state and its nested states in
-  reverse hierarchical order.
-
-  Exit transitions for a parent state are not called when entering into one of its child states,
-  only when transitioning to a new section of possible states in the hierarchy.
-
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown',
-        poweredDown: Ember.State.create({
-          enter: function(){},
-          exit: function(){
-            console.log("exited poweredDown state")
-          },
-          charging: Ember.State.create({
-            enter: function(){},
-            exit: function(){}
-          }),
-          charged: Ember.State.create({
-            enter: function(){
-              console.log("entered charged state")
-            },
-            exit: function(){
-              console.log("exited charged state")
-            }
-          })
-        }),
-        poweredUp: Ember.State.create({
-          enter: function(){
-            console.log("entered poweredUp state")
-          },
-          exit: function(){},
-          mobile: Ember.State.create({
-            enter: function(){
-              console.log("entered mobile state")
-            },
-            exit: function(){}
-          }),
-          stationary: Ember.State.create({
-            enter: function(){},
-            exit: function(){}
-          })
-        })
-      })
-
-
-      robotManager.get('currentState.path') // 'poweredDown'
-      robotManager.transitionTo('charged')
-      // logs 'entered charged state'
-      // but does *not* log  'exited poweredDown state'
-      robotManager.get('currentState.name') // 'charged
-
-      robotManager.transitionTo('poweredUp.mobile')
-      // logs
-      // 'exited charged state'
-      // 'exited poweredDown state'
-      // 'entered poweredUp state'
-      // 'entered mobile state'
-
-  During development you can set a StateManager's `enableLogging` property to `true` to
-  receive console messages of state transitions.
-
-      robotManager = Ember.StateManager.create({
-        enableLogging: true
-      })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    enableLogging: true
+  })
+  ```
 
   ## Managing currentState with Actions
-  To control which transitions between states are possible for a given state, StateManager
-  can receive and route action messages to its states via the `send` method.  Calling to `send` with
-  an action name will begin searching for a method with the same name starting at the current state
-  and moving up through the parent states in a state hierarchy until an appropriate method is found
-  or the StateManager instance itself is reached.
 
-  If an appropriately named method is found it will be called with the state manager as the first
-  argument and an optional `context` object as the second argument.
+  To control which transitions between states are possible for a given state,
+  StateManager can receive and route action messages to its states via the
+  `send` method. Calling to `send` with an action name will begin searching for
+  a method with the same name starting at the current state and moving up
+  through the parent states in a state hierarchy until an appropriate method is
+  found or the StateManager instance itself is reached.
 
-      managerA = Ember.StateManager.create({
-        initialState: 'stateOne.substateOne.subsubstateOne',
-        stateOne: Ember.State.create({
-          substateOne: Ember.State.create({
-            anAction: function(manager, context){
-              console.log("an action was called")
-            },
-            subsubstateOne: Ember.State.create({})
-          })
-        })
+  If an appropriately named method is found it will be called with the state
+  manager as the first argument and an optional `context` object as the second
+  argument.
+
+  ```javascript
+  managerA = Ember.StateManager.create({
+    initialState: 'stateOne.substateOne.subsubstateOne',
+    stateOne: Ember.State.create({
+      substateOne: Ember.State.create({
+        anAction: function(manager, context){
+          console.log("an action was called")
+        },
+        subsubstateOne: Ember.State.create({})
       })
+    })
+  })
 
-      managerA.get('currentState.name') // 'subsubstateOne'
-      managerA.send('anAction')
-      // 'stateOne.substateOne.subsubstateOne' has no anAction method
-      // so the 'anAction' method of 'stateOne.substateOne' is called
-      // and logs "an action was called"
-      // with managerA as the first argument
-      // and no second argument
+  managerA.get('currentState.name') // 'subsubstateOne'
+  managerA.send('anAction')
+  // 'stateOne.substateOne.subsubstateOne' has no anAction method
+  // so the 'anAction' method of 'stateOne.substateOne' is called
+  // and logs "an action was called"
+  // with managerA as the first argument
+  // and no second argument
 
-      someObject = {}
-      managerA.send('anAction', someObject)
-      // the 'anAction' method of 'stateOne.substateOne' is called again
-      // with managerA as the first argument and
-      // someObject as the second argument.
+  someObject = {}
+  managerA.send('anAction', someObject)
+  // the 'anAction' method of 'stateOne.substateOne' is called again
+  // with managerA as the first argument and
+  // someObject as the second argument.
+  ```
 
+  If the StateManager attempts to send an action but does not find an
+  appropriately named method in the current state or while moving upwards
+  through the state hierarchy it will throw a new `Ember.Error`. Action
+  detection only moves upwards through the state hierarchy from the current
+  state. It does not search in other portions of the hierarchy.
 
-  If the StateManager attempts to send an action but does not find an appropriately named
-  method in the current state or while moving upwards through the state hierarchy
-  it will throw a new Ember.Error. Action detection only moves upwards through the state hierarchy
-  from the current state. It does not search in other portions of the hierarchy.
-
-      managerB = Ember.StateManager.create({
-        initialState: 'stateOne.substateOne.subsubstateOne',
-        stateOne: Ember.State.create({
-          substateOne: Ember.State.create({
-            subsubstateOne: Ember.State.create({})
-          })
-        }),
-        stateTwo: Ember.State.create({
-         anAction: function(manager, context){
-           // will not be called below because it is
-           // not a parent of the current state
-         }
-        })
+  ```javascript
+  managerB = Ember.StateManager.create({
+    initialState: 'stateOne.substateOne.subsubstateOne',
+    stateOne: Ember.State.create({
+      substateOne: Ember.State.create({
+        subsubstateOne: Ember.State.create({})
       })
+    }),
+    stateTwo: Ember.State.create({
+     anAction: function(manager, context){
+       // will not be called below because it is
+       // not a parent of the current state
+     }
+    })
+  })
 
-      managerB.get('currentState.name') // 'subsubstateOne'
-      managerB.send('anAction')
-      // Error: <Ember.StateManager:ember132> could not
-      // respond to event anAction in state stateOne.substateOne.subsubstateOne.
+  managerB.get('currentState.name') // 'subsubstateOne'
+  managerB.send('anAction')
+  // Error: <Ember.StateManager:ember132> could not
+  // respond to event anAction in state stateOne.substateOne.subsubstateOne.
+  ```
 
   Inside of an action method the given state should delegate `transitionTo` calls on its
   StateManager.
 
-      robotManager = Ember.StateManager.create({
-        initialState: 'poweredDown.charging',
-        poweredDown: Ember.State.create({
-          charging: Ember.State.create({
-            chargeComplete: function(manager, context){
-              manager.transitionTo('charged')
-            }
-          }),
-          charged: Ember.State.create({
-            boot: function(manager, context){
-              manager.transitionTo('poweredUp')
-            }
-          })
-        }),
-        poweredUp: Ember.State.create({
-          beginExtermination: function(manager, context){
-            manager.transitionTo('rampaging')
-          },
-          rampaging: Ember.State.create()
-        })
+  ```javascript
+  robotManager = Ember.StateManager.create({
+    initialState: 'poweredDown.charging',
+    poweredDown: Ember.State.create({
+      charging: Ember.State.create({
+        chargeComplete: function(manager, context){
+          manager.transitionTo('charged')
+        }
+      }),
+      charged: Ember.State.create({
+        boot: function(manager, context){
+          manager.transitionTo('poweredUp')
+        }
       })
+    }),
+    poweredUp: Ember.State.create({
+      beginExtermination: function(manager, context){
+        manager.transitionTo('rampaging')
+      },
+      rampaging: Ember.State.create()
+    })
+  })
 
-      robotManager.get('currentState.name') // 'charging'
-      robotManager.send('boot') // throws error, no boot action
-                                // in current hierarchy
-      robotManager.get('currentState.name') // remains 'charging'
+  robotManager.get('currentState.name') // 'charging'
+  robotManager.send('boot') // throws error, no boot action
+                            // in current hierarchy
+  robotManager.get('currentState.name') // remains 'charging'
 
-      robotManager.send('beginExtermination') // throws error, no beginExtermination
-                                              // action in current hierarchy
-      robotManager.get('currentState.name') // remains 'charging'
+  robotManager.send('beginExtermination') // throws error, no beginExtermination
+                                          // action in current hierarchy
+  robotManager.get('currentState.name')   // remains 'charging'
 
-      robotManager.send('chargeComplete')
-      robotManager.get('currentState.name') // 'charged'
+  robotManager.send('chargeComplete')
+  robotManager.get('currentState.name')   // 'charged'
 
-      robotManager.send('boot')
-      robotManager.get('currentState.name') // 'poweredUp'
+  robotManager.send('boot')
+  robotManager.get('currentState.name')   // 'poweredUp'
 
-      robotManager.send('beginExtermination', allHumans)
-      robotManager.get('currentState.name') // 'rampaging'
+  robotManager.send('beginExtermination', allHumans)
+  robotManager.get('currentState.name')   // 'rampaging'
+  ```
 
-  Transition actions can also be created using the `transitionTo` method of the Ember.State class. The
+  Transition actions can also be created using the `transitionTo` method of the `Ember.State` class. The
   following example StateManagers are equivalent:
 
-      aManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: Ember.State.transitionTo('stateTwo')
-        }),
-        stateTwo: Ember.State.create({})
-      })
+  ```javascript
+  aManager = Ember.StateManager.create({
+    stateOne: Ember.State.create({
+      changeToStateTwo: Ember.State.transitionTo('stateTwo')
+    }),
+    stateTwo: Ember.State.create({})
+  })
 
-      bManager = Ember.StateManager.create({
-        stateOne: Ember.State.create({
-          changeToStateTwo: function(manager, context){
-            manager.transitionTo('stateTwo', context)
-          }
-        }),
-        stateTwo: Ember.State.create({})
-      })
+  bManager = Ember.StateManager.create({
+    stateOne: Ember.State.create({
+      changeToStateTwo: function(manager, context){
+        manager.transitionTo('stateTwo', context)
+      }
+    }),
+    stateTwo: Ember.State.create({})
+  })
+  ```
 
   @class StateManager
   @namespace Ember
@@ -585,7 +622,7 @@ Ember.StateManager = Ember.State.extend({
 
   /**
     The current state from among the manager's possible states. This property should
-    not be set directly.  Use `transitionTo` to move between states by name.
+    not be set directly. Use `transitionTo` to move between states by name.
 
     @property currentState
     @type Ember.State
@@ -674,15 +711,17 @@ Ember.StateManager = Ember.State.extend({
 
     Example:
 
-        manager = Ember.StateManager.create({
-          root: Ember.State.create({
-            dashboard: Ember.State.create()
-          })
-        });
+    ```javascript
+    manager = Ember.StateManager.create({
+      root: Ember.State.create({
+        dashboard: Ember.State.create()
+      })
+    });
 
-        manager.getStateByPath(manager, "root.dashboard")
+    manager.getStateByPath(manager, "root.dashboard")
 
-        // returns the dashboard state
+    // returns the dashboard state
+    ```
 
     @method getStateByPath
     @param {Ember.State} root the state to start searching from

--- a/packages/ember-views/lib/system/controller.js
+++ b/packages/ember-views/lib/system/controller.js
@@ -32,7 +32,7 @@ Ember.ControllerMixin.reopen({
     For example, an application view's template may look like
     this:
 
-    ``` handlebars
+    ```handlebars
     <h1>My Blog</h1>
     {{outlet}}
     ```
@@ -42,7 +42,7 @@ Ember.ControllerMixin.reopen({
     following code will assign a new `App.PostsView` to
     that outlet:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet('posts');
     ```
 
@@ -62,14 +62,14 @@ Ember.ControllerMixin.reopen({
     You can supply a `content` for the controller by supplying
     a final argument after the view class:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet('posts', App.Post.find());
     ```
 
     You can specify a particular outlet to use. For example, if your main
     template looks like:
 
-    ``` handlebars
+    ```handlebars
     <h1>My Blog</h1>
     {{outlet masterView}}
     {{outlet detailView}}
@@ -77,7 +77,7 @@ Ember.ControllerMixin.reopen({
 
     You can assign an `App.PostsView` to the masterView outlet:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet({
       outletName: 'masterView',
       name: 'posts',
@@ -87,10 +87,9 @@ Ember.ControllerMixin.reopen({
 
     You can write this as:
 
-    ``` javascript
+    ```javascript
     applicationController.connectOutlet('masterView', 'posts', App.Post.find());
     ```
-
 
     @method connectOutlet
     @param {String} outletName a name for the outlet to set
@@ -178,7 +177,9 @@ Ember.ControllerMixin.reopen({
     For example, to make the `personController` and the `postController` available
     on the `overviewController`, you would call:
 
-        overviewController.connectControllers('person', 'post');
+    ```javascript
+    overviewController.connectControllers('person', 'post');
+    ```
 
     @method connectControllers
     @param {String...} controllerNames the controllers to make available

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -6,9 +6,10 @@
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
 /**
-  Ember.EventDispatcher handles delegating browser events to their corresponding
-  Ember.Views. For example, when you click on a view, Ember.EventDispatcher ensures
-  that that view's `mouseDown` method gets called.
+  `Ember.EventDispatcher` handles delegating browser events to their
+  corresponding `Ember.Views.` For example, when you click on a view,
+  `Ember.EventDispatcher` ensures that that view's `mouseDown` method gets
+  called.
 
   @class EventDispatcher
   @namespace Ember
@@ -40,7 +41,7 @@ Ember.EventDispatcher = Ember.Object.extend(
 
     Sets up event listeners for standard browser events.
 
-    This will be called after the browser sends a DOMContentReady event. By
+    This will be called after the browser sends a `DOMContentReady` event. By
     default, it will set up all of the listeners on the document body. If you
     would like to register the listeners on a different element, set the event
     dispatcher's `root` property.
@@ -102,17 +103,18 @@ Ember.EventDispatcher = Ember.Object.extend(
     @private
 
     Registers an event listener on the document. If the given event is
-    triggered, the provided event handler will be triggered on the target
-    view.
+    triggered, the provided event handler will be triggered on the target view.
 
     If the target view does not implement the event handler, or if the handler
-    returns false, the parent view will be called. The event will continue to
+    returns `false`, the parent view will be called. The event will continue to
     bubble to each successive parent view until it reaches the top.
 
     For example, to have the `mouseDown` method called on the target view when
     a `mousedown` event is received from the browser, do the following:
 
-        setupHandler('mousedown', 'mouseDown');
+    ```javascript
+    setupHandler('mousedown', 'mouseDown');
+    ```
 
     @method setupHandler
     @param {Element} rootElement

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -25,8 +25,8 @@ ClassSet.prototype = {
 };
 
 /**
-  Ember.RenderBuffer gathers information regarding the a view and generates the
-  final representation. Ember.RenderBuffer will generate HTML which can be pushed
+  `Ember.RenderBuffer` gathers information regarding the a view and generates the
+  final representation. `Ember.RenderBuffer` will generate HTML which can be pushed
   to the DOM.
 
   @class RenderBuffer
@@ -46,10 +46,10 @@ Ember._RenderBuffer.prototype =
 /** @scope Ember.RenderBuffer.prototype */ {
 
   /**
-    Array of class-names which will be applied in the class="" attribute
+    Array of class-names which will be applied in the class attribute.
 
     You should not maintain this array yourself, rather, you should use
-    the addClass() method of Ember.RenderBuffer.
+    the `addClass()` method of `Ember.RenderBuffer.`
 
     @property elementClasses
     @type Array
@@ -58,10 +58,10 @@ Ember._RenderBuffer.prototype =
   elementClasses: null,
 
   /**
-    The id in of the element, to be applied in the id="" attribute
+    The id in of the element, to be applied in the id attribute.
 
     You should not set this property yourself, rather, you should use
-    the id() method of Ember.RenderBuffer.
+    the `id()` method of `Ember.RenderBuffer`.
 
     @property elementId
     @type String
@@ -72,11 +72,11 @@ Ember._RenderBuffer.prototype =
   /**
     A hash keyed on the name of the attribute and whose value will be
     applied to that attribute. For example, if you wanted to apply a
-    data-view="Foo.bar" property to an element, you would set the
-    elementAttributes hash to {'data-view':'Foo.bar'}
+    `data-view="Foo.bar"` property to an element, you would set the
+    elementAttributes hash to `{'data-view':'Foo.bar'}`.
 
     You should not maintain this hash yourself, rather, you should use
-    the attr() method of Ember.RenderBuffer.
+    the `attr()` method of `Ember.RenderBuffer`.
 
     @property elementAttributes
     @type Hash
@@ -85,12 +85,14 @@ Ember._RenderBuffer.prototype =
   elementAttributes: null,
 
   /**
-    The tagname of the element an instance of Ember.RenderBuffer represents.
+    The tagname of the element an instance of `Ember.RenderBuffer` represents.
 
-    Usually, this gets set as the first parameter to Ember.RenderBuffer. For
+    Usually, this gets set as the first parameter to `Ember.RenderBuffer`. For
     example, if you wanted to create a `p` tag, then you would call
 
-      Ember.RenderBuffer('p')
+    ```javascript
+    Ember.RenderBuffer('p')
+    ```
 
     @property elementTag
     @type String
@@ -101,11 +103,11 @@ Ember._RenderBuffer.prototype =
   /**
     A hash keyed on the name of the style attribute and whose value will
     be applied to that attribute. For example, if you wanted to apply a
-    background-color:black;" style to an element, you would set the
-    elementStyle hash to {'background-color':'black'}
+    `background-color:black;` style to an element, you would set the
+    elementStyle hash to `{'background-color':'black'}`.
 
     You should not maintain this hash yourself, rather, you should use
-    the style() method of Ember.RenderBuffer.
+    the `style()` method of `Ember.RenderBuffer`.
 
     @property elementStyle
     @type Hash
@@ -114,7 +116,7 @@ Ember._RenderBuffer.prototype =
   elementStyle: null,
 
   /**
-    Nested RenderBuffers will set this to their parent RenderBuffer
+    Nested `RenderBuffers` will set this to their parent `RenderBuffer`
     instance.
 
     @property parentBuffer
@@ -123,7 +125,7 @@ Ember._RenderBuffer.prototype =
   parentBuffer: null,
 
   /**
-    Adds a string of HTML to the RenderBuffer.
+    Adds a string of HTML to the `RenderBuffer`.
 
     @method push
     @param {String} string HTML to push into the buffer
@@ -269,9 +271,9 @@ Ember._RenderBuffer.prototype =
   },
 
   /**
-    Creates a new Ember.RenderBuffer object with the provided tagName as
-    the element tag and with its parentBuffer property set to the current
-    Ember.RenderBuffer.
+    Creates a new `Ember.RenderBuffer` object with the provided tagName as
+    the element tag and with its `parentBuffer` property set to the current
+    `Ember.RenderBuffer`.
 
     @method begin
     @param {String} tagName Tag name to use for the child buffer's element

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -9,17 +9,18 @@ require('ember-runtime/system/string');
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
 /**
-  `Ember.CollectionView` is an `Ember.View` descendent responsible for managing a
-  collection (an array or array-like object) by maintaing a child view object and
-  associated DOM representation for each item in the array and ensuring that child
-  views and their associated rendered HTML are updated when items in the array
-  are added, removed, or replaced.
+  `Ember.CollectionView` is an `Ember.View` descendent responsible for managing
+  a collection (an array or array-like object) by maintaing a child view object
+  and associated DOM representation for each item in the array and ensuring
+  that child views and their associated rendered HTML are updated when items in
+  the array are added, removed, or replaced.
 
   ## Setting content
-  The managed collection of objects is referenced as the `Ember.CollectionView` instance's
-  `content` property.
 
-  ``` javascript
+  The managed collection of objects is referenced as the `Ember.CollectionView`
+  instance's `content` property.
+
+  ```javascript
   someItemsView = Ember.CollectionView.create({
     content: ['A', 'B','C']
   })
@@ -29,13 +30,14 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   to the item.
 
   ## Specifying itemViewClass
-  By default the view class for each item in the managed collection will be an instance
-  of `Ember.View`. You can supply a different class by setting the `CollectionView`'s
-  `itemViewClass` property.
+
+  By default the view class for each item in the managed collection will be an
+  instance of `Ember.View`. You can supply a different class by setting the
+  `CollectionView`'s `itemViewClass` property.
 
   Given an empty `<body>` and the following code:
 
-  ``` javascript
+  ```javascript 
   someItemsView = Ember.CollectionView.create({
     classNames: ['a-collection'],
     content: ['A','B','C'],
@@ -49,7 +51,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   Will result in the following HTML structure
 
-  ``` html
+  ```html
   <div class="ember-view a-collection">
     <div class="ember-view">the letter: A</div>
     <div class="ember-view">the letter: B</div>
@@ -63,10 +65,9 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   "ul", "ol", "table", "thead", "tbody", "tfoot", "tr", or "select" will result
   in the item views receiving an appropriately matched `tagName` property.
 
-
   Given an empty `<body>` and the following code:
 
-  ``` javascript
+  ```javascript
   anUndorderedListView = Ember.CollectionView.create({
     tagName: 'ul',
     content: ['A','B','C'],
@@ -80,7 +81,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   Will result in the following HTML structure
 
-  ``` html
+  ```html
   <ul class="ember-view a-collection">
     <li class="ember-view">the letter: A</li>
     <li class="ember-view">the letter: B</li>
@@ -88,17 +89,20 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   </ul>
   ```
 
-  Additional tagName pairs can be provided by adding to `Ember.CollectionView.CONTAINER_MAP `
+  Additional `tagName` pairs can be provided by adding to
+  `Ember.CollectionView.CONTAINER_MAP `
 
-  ``` javascript
+  ```javascript
   Ember.CollectionView.CONTAINER_MAP['article'] = 'section'
   ```
-  ## Programatic creation of child views
-  For cases where additional customization beyond the use of a single `itemViewClass`
-  or `tagName` matching is required CollectionView's `createChildView` method can be
-  overidden:
 
-  ``` javascript
+  ## Programatic creation of child views
+
+  For cases where additional customization beyond the use of a single
+  `itemViewClass` or `tagName` matching is required CollectionView's
+  `createChildView` method can be overidden:
+
+  ```javascript
   CustomCollectionView = Ember.CollectionView.extend({
     createChildView: function(viewClass, attrs) {
       if (attrs.content.kind == 'album') {
@@ -112,11 +116,13 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   ```
 
   ## Empty View
-  You can provide an `Ember.View` subclass to the `Ember.CollectionView` instance as its
-  `emptyView` property. If the `content` property of a `CollectionView` is set to `null`
-  or an empty array, an instance of this view will be the `CollectionView`s only child.
 
-  ``` javascript
+  You can provide an `Ember.View` subclass to the `Ember.CollectionView`
+  instance as its `emptyView` property. If the `content` property of a
+  `CollectionView` is set to `null` or an empty array, an instance of this view
+  will be the `CollectionView`s only child.
+
+  ```javascript
   aListWithNothing = Ember.CollectionView.create({
     classNames: ['nothing']
     content: null,
@@ -130,7 +136,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
   Will result in the following HTML structure
 
-  ``` html
+  ```html
   <div class="ember-view nothing">
     <div class="ember-view">
       The collection is empty
@@ -139,13 +145,16 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   ```
 
   ## Adding and Removing items
-  The `childViews` property of a `CollectionView` should not be directly manipulated. Instead,
-  add, remove, replace items from its `content` property. This will trigger
-  appropriate changes to its rendered HTML.
 
-  ## Use in templates via the `{{collection}}` Ember.Handlebars helper
-  Ember.Handlebars provides a helper specifically for adding `CollectionView`s to templates.
-  See `Ember.Handlebars.collection` for more details
+  The `childViews` property of a `CollectionView` should not be directly
+  manipulated. Instead, add, remove, replace items from its `content` property.
+  This will trigger appropriate changes to its rendered HTML.
+
+  ## Use in templates via the `{{collection}}` `Ember.Handlebars` helper
+
+  `Ember.Handlebars` provides a helper specifically for adding
+  `CollectionView`s to templates. See `Ember.Handlebars.collection` for more
+  details
 
   @class CollectionView
   @namespace Ember
@@ -156,7 +165,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
 /** @scope Ember.CollectionView.prototype */ {
 
   /**
-    A list of items to be displayed by the Ember.CollectionView.
+    A list of items to be displayed by the `Ember.CollectionView`.
 
     @property content
     @type Ember.Array
@@ -266,9 +275,9 @@ Ember.CollectionView = Ember.ContainerView.extend(
     Called when a mutation to the underlying content array occurs.
 
     This method will replay that mutation against the views that compose the
-    Ember.CollectionView, ensuring that the view reflects the model.
+    `Ember.CollectionView`, ensuring that the view reflects the model.
 
-    This array observer is added in contentDidChange.
+    This array observer is added in `contentDidChange`.
 
     @method arrayDidChange
     @param {Array} addedObjects the objects that were added to the content

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -13,23 +13,26 @@ var childViewsProperty = Ember.computed(function() {
 }).property('_childViews');
 
 /**
-  A `ContainerView` is an `Ember.View` subclass that allows for manual or programatic
-  management of a view's `childViews` array that will correctly update the `ContainerView`
-  instance's rendered DOM representation.
+  A `ContainerView` is an `Ember.View` subclass that allows for manual or
+  programatic management of a view's `childViews` array that will correctly
+  update the `ContainerView` instance's rendered DOM representation.
 
   ## Setting Initial Child Views
-  The initial array of child views can be set in one of two ways. You can provide
-  a `childViews` property at creation time that contains instance of `Ember.View`:
 
-  ``` javascript
+  The initial array of child views can be set in one of two ways. You can
+  provide a `childViews` property at creation time that contains instance of
+  `Ember.View`:
+
+  ```javascript
   aContainer = Ember.ContainerView.create({
     childViews: [Ember.View.create(), Ember.View.create()]
   });
   ```
 
-  You can also provide a list of property names whose values are instances of `Ember.View`:
+  You can also provide a list of property names whose values are instances of
+  `Ember.View`:
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     childViews: ['aView', 'bView', 'cView'],
     aView: Ember.View.create(),
@@ -40,25 +43,27 @@ var childViewsProperty = Ember.computed(function() {
 
   The two strategies can be combined:
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     childViews: ['aView', Ember.View.create()],
     aView: Ember.View.create()
   });
   ```
 
-  Each child view's rendering will be inserted into the container's rendered HTML in the same
-  order as its position in the `childViews` property.
+  Each child view's rendering will be inserted into the container's rendered
+  HTML in the same order as its position in the `childViews` property.
 
   ## Adding and Removing Child Views
-  The views in a container's `childViews` array should be added and removed by manipulating
-  the `childViews` property directly.
 
-  To remove a view pass that view into a `removeObject` call on the container's `childViews` property.
+  The views in a container's `childViews` array should be added and removed by
+  manipulating the `childViews` property directly.
+
+  To remove a view pass that view into a `removeObject` call on the container's
+  `childViews` property.
 
   Given an empty `<body>` the following code
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
@@ -75,7 +80,7 @@ var childViewsProperty = Ember.computed(function() {
 
   Results in the HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
@@ -84,27 +89,26 @@ var childViewsProperty = Ember.computed(function() {
 
   Removing a view
 
-  ``` javascript
-  aContainer.get('childViews'); // [aContainer.aView, aContainer.bView]
+  ```javascript
+  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView]
   aContainer.get('childViews').removeObject(aContainer.get('bView'));
-  aContainer.get('childViews'); // [aContainer.aView]
+  aContainer.get('childViews');  // [aContainer.aView]
   ```
 
   Will result in the following HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
   </div>
   ```
-
 
   Similarly, adding a child view is accomplished by adding `Ember.View` instances to the
   container's `childViews` property.
 
   Given an empty `<body>` the following code
 
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
@@ -121,7 +125,7 @@ var childViewsProperty = Ember.computed(function() {
 
   Results in the HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
@@ -130,19 +134,19 @@ var childViewsProperty = Ember.computed(function() {
 
   Adding a view
 
-  ``` javascript
+  ```javascript
   AnotherViewClass = Ember.View.extend({
     template: Ember.Handlebars.compile("Another view")
   });
 
-  aContainer.get('childViews'); // [aContainer.aView, aContainer.bView]
+  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView]
   aContainer.get('childViews').pushObject(AnotherViewClass.create());
-  aContainer.get('childViews'); // [aContainer.aView, aContainer.bView, <AnotherViewClass instance>]
+  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView, <AnotherViewClass instance>]
   ```
 
   Will result in the following HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
@@ -150,21 +154,21 @@ var childViewsProperty = Ember.computed(function() {
   </div>
   ```
 
+  Direct manipulation of `childViews` presence or absence in the DOM via calls
+  to `remove` or `removeFromParent` or calls to a container's `removeChild` may
+  not behave correctly.
 
-  Direct manipulation of childViews presence or absence in the DOM via calls to
-  `remove` or `removeFromParent` or calls to a container's `removeChild` may not behave
-  correctly.
+  Calling `remove()` on a child view will remove the view's HTML, but it will
+  remain as part of its container's `childView`s property.
 
-  Calling `remove()` on a child view will remove the view's HTML, but it will remain as part of its
-  container's `childView`s property.
+  Calling `removeChild()` on the container will remove the passed view instance
+  from the container's `childView`s but keep its HTML within the container's
+  rendered view.
 
-  Calling `removeChild()` on the container will remove the passed view instance from the container's
-  `childView`s but keep its HTML within the container's rendered view.
+  Calling `removeFromParent()` behaves as expected but should be avoided in
+  favor of direct manipulation of a container's `childViews` property.
 
-  Calling `removeFromParent()` behaves as expected but should be avoided in favor of direct
-  manipulation of a container's `childViews` property.
-
-  ``` javascript
+  ```javascript
   aContainer = Ember.ContainerView.create({
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
@@ -181,16 +185,17 @@ var childViewsProperty = Ember.computed(function() {
 
   Results in the HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">A</div>
     <div class="ember-view">B</div>
   </div>
   ```
 
-  Calling `aContainer.get('aView').removeFromParent()` will result in the following HTML
+  Calling `aContainer.get('aView').removeFromParent()` will result in the
+  following HTML
 
-  ``` html
+  ```html
   <div class="ember-view the-container">
     <div class="ember-view">B</div>
   </div>
@@ -201,24 +206,25 @@ var childViewsProperty = Ember.computed(function() {
 
   ## Templates and Layout
 
-  A `template`, `templateName`, `defaultTemplate`, `layout`, `layoutName` or `defaultLayout`
-  property on a container view will not result in the template or layout being rendered.
-  The HTML contents of a `Ember.ContainerView`'s DOM representation will only be the rendered HTML
-  of its child views.
+  A `template`, `templateName`, `defaultTemplate`, `layout`, `layoutName` or
+  `defaultLayout` property on a container view will not result in the template
+  or layout being rendered. The HTML contents of a `Ember.ContainerView`'s DOM
+  representation will only be the rendered HTML of its child views.
 
   ## Binding a View to Display
 
-  If you would like to display a single view in your ContainerView, you can set its `currentView`
-  property. When the `currentView` property is set to a view instance, it will be added to the
-  ContainerView's `childViews` array. If the `currentView` property is later changed to a
-  different view, the new view will replace the old view. If `currentView` is set to `null`, the
-  last `currentView` will be removed.
+  If you would like to display a single view in your ContainerView, you can set
+  its `currentView` property. When the `currentView` property is set to a view
+  instance, it will be added to the ContainerView's `childViews` array. If the
+  `currentView` property is later changed to a different view, the new view
+  will replace the old view. If `currentView` is set to `null`, the last
+  `currentView` will be removed.
 
-  This functionality is useful for cases where you want to bind the display of a ContainerView to
-  a controller or state manager. For example, you can bind the `currentView` of a container to
-  a controller like this:
+  This functionality is useful for cases where you want to bind the display of
+  a ContainerView to a controller or state manager. For example, you can bind
+  the `currentView` of a container to a controller like this:
 
-  ``` javascript
+  ```javascript
   App.appController = Ember.Object.create({
     view: Ember.View.create({
       templateName: 'person_template'
@@ -226,7 +232,7 @@ var childViewsProperty = Ember.computed(function() {
   });
   ```
 
-  ``` handlebars
+  ```handlebars
   {{view Ember.ContainerView currentViewBinding="App.appController.view"}}
   ```
 
@@ -336,10 +342,10 @@ Ember.ContainerView = Ember.View.extend({
     When a child view is added, make sure the DOM gets updated appropriately.
 
     If the view has already rendered an element, we tell the child view to
-    create an element and insert it into the DOM. If the enclosing container view
-    has already written to a buffer, but not yet converted that buffer into an
-    element, we insert the string representation of the child into the appropriate
-    place in the buffer.
+    create an element and insert it into the DOM. If the enclosing container
+    view has already written to a buffer, but not yet converted that buffer
+    into an element, we insert the string representation of the child into the
+    appropriate place in the buffer.
 
     @method childViewsDidChange
     @param {Ember.Array} views the array of child views afte the mutation has occurred

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -85,9 +85,9 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   }).property('_parentView').volatile(),
 
   /**
-    Creates a new renderBuffer with the passed tagName. You can override this
-    method to provide further customization to the buffer if needed. Normally
-    you will not need to call or override this method.
+    Creates a new `renderBuffer` with the passed `tagName`. You can override
+    this method to provide further customization to the buffer if needed.
+    Normally you will not need to call or override this method.
 
     @method renderBuffer
     @param [tagName] {String}
@@ -179,7 +179,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   /**
     @private
 
-    Override the default event firing from Ember.Evented to
+    Override the default event firing from `Ember.Evented` to
     also call methods with the given name.
 
     @method trigger
@@ -229,15 +229,17 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 });
 
 /**
-  `Ember.View` is the class in Ember responsible for encapsulating templates of HTML
-  content, combining templates with data to render as sections of a page's DOM, and
-  registering and responding to user-initiated events.
+  `Ember.View` is the class in Ember responsible for encapsulating templates of
+  HTML content, combining templates with data to render as sections of a page's
+  DOM, and registering and responding to user-initiated events.
 
   ## HTML Tag
-  The default HTML tag name used for a view's DOM representation is `div`. This can be
-  customized by setting the `tagName` property. The following view class:
 
-  ``` javascript
+  The default HTML tag name used for a view's DOM representation is `div`. This
+  can be customized by setting the `tagName` property. The following view
+class:
+
+  ```javascript
   ParagraphView = Ember.View.extend({
     tagName: 'em'
   });
@@ -245,15 +247,16 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Would result in instances with the following HTML:
 
-  ``` html
+  ```html
   <em id="ember1" class="ember-view"></em>
   ```
 
   ## HTML `class` Attribute
-  The HTML `class` attribute of a view's tag can be set by providing a `classNames` property
-  that is set to an array of strings:
 
-  ``` javascript
+  The HTML `class` attribute of a view's tag can be set by providing a
+  `classNames` property that is set to an array of strings:
+
+  ```javascript
   MyView = Ember.View.extend({
     classNames: ['my-class', 'my-other-class']
   });
@@ -261,16 +264,16 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view my-class my-other-class"></div>
   ```
 
-  `class` attribute values can also be set by providing a `classNameBindings` property
-  set to an array of properties names for the view. The return value of these properties
-  will be added as part of the value for the view's `class` attribute. These properties
-  can be computed properties:
+  `class` attribute values can also be set by providing a `classNameBindings`
+  property set to an array of properties names for the view. The return value
+  of these properties will be added as part of the value for the view's `class`
+  attribute. These properties can be computed properties:
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['propertyA', 'propertyB'],
     propertyA: 'from-a',
@@ -282,15 +285,15 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view from-a from-b"></div>
   ```
 
-  If the value of a class name binding returns a boolean the property name itself
-  will be used as the class name if the property is true. The class name will
-  not be added if the value is `false` or `undefined`.
+  If the value of a class name binding returns a boolean the property name
+  itself will be used as the class name if the property is true. The class name
+  will not be added if the value is `false` or `undefined`.
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['hovered'],
     hovered: true
@@ -299,15 +302,15 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view hovered"></div>
   ```
 
-  When using boolean class name bindings you can supply a string value other than the
-  property name for use as the `class` HTML attribute by appending the preferred value after
-  a ":" character when defining the binding:
+  When using boolean class name bindings you can supply a string value other
+  than the property name for use as the `class` HTML attribute by appending the
+  preferred value after a ":" character when defining the binding:
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['awesome:so-very-cool'],
     awesome: true
@@ -316,15 +319,14 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view so-very-cool"></div>
   ```
 
+  Boolean value class name bindings whose property names are in a
+  camelCase-style format will be converted to a dasherized format:
 
-  Boolean value class name bindings whose property names are in a camelCase-style
-  format will be converted to a dasherized format:
-
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['isUrgent'],
     isUrgent: true
@@ -333,15 +335,14 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view is-urgent"></div>
   ```
-
 
   Class name bindings can also refer to object values that are found by
   traversing a path relative to the view itself:
 
-  ``` javascript
+  ```javascript
   MyView = Ember.View.extend({
     classNameBindings: ['messages.empty']
     messages: Ember.Object.create({
@@ -352,16 +353,15 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view empty"></div>
   ```
-
 
   If you want to add a class name for a property which evaluates to true and
   and a different class name if it evaluates to false, you can pass a binding
   like this:
 
-  ```
+  ```javascript
   // Applies 'enabled' class when isEnabled is true and 'disabled' when isEnabled is false
   Ember.View.create({
     classNameBindings: ['isEnabled:enabled:disabled']
@@ -371,19 +371,20 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view enabled"></div>
   ```
 
-  When isEnabled is `false`, the resulting HTML reprensentation looks like this:
+  When isEnabled is `false`, the resulting HTML reprensentation looks like
+  this:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view disabled"></div>
   ```
 
   This syntax offers the convenience to add a class if a property is `false`:
 
-  ``` javascript
+  ```javascript
   // Applies no class when isEnabled is true and class 'disabled' when isEnabled is false
   Ember.View.create({
     classNameBindings: ['isEnabled::disabled']
@@ -393,31 +394,34 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view"></div>
   ```
 
   When the `isEnabled` property on the view is set to `false`, it will result
   in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view disabled"></div>
   ```
 
-  Updates to the the value of a class name binding will result in automatic update
-  of the  HTML `class` attribute in the view's rendered HTML representation.
-  If the value becomes  `false` or `undefined` the class name will be removed.
+  Updates to the the value of a class name binding will result in automatic
+  update of the  HTML `class` attribute in the view's rendered HTML
+  representation. If the value becomes `false` or `undefined` the class name
+  will be removed.
 
-  Both `classNames` and `classNameBindings` are concatenated properties.
-  See `Ember.Object` documentation for more information about concatenated properties.
+  Both `classNames` and `classNameBindings` are concatenated properties. See
+  `Ember.Object` documentation for more information about concatenated
+  properties.
 
   ## HTML Attributes
 
-  The HTML attribute section of a view's tag can be set by providing an `attributeBindings`
-  property set to an array of property names on the view. The return value of these properties
-  will be used as the value of the view's HTML associated attribute:
+  The HTML attribute section of a view's tag can be set by providing an
+  `attributeBindings` property set to an array of property names on the view.
+  The return value of these properties will be used as the value of the view's
+  HTML associated attribute:
 
-  ``` javascript
+  ```javascript
   AnchorView = Ember.View.extend({
     tagName: 'a',
     attributeBindings: ['href'],
@@ -427,7 +431,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <a id="ember1" class="ember-view" href="http://google.com"></a>
   ```
 
@@ -435,7 +439,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   the property will follow HTML's pattern of repeating the attribute's name as
   its value:
 
-  ``` javascript
+  ```javascript
   MyTextInput = Ember.View.extend({
     tagName: 'input',
     attributeBindings: ['disabled'],
@@ -445,13 +449,13 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <input id="ember1" class="ember-view" disabled="disabled" />
   ```
 
   `attributeBindings` can refer to computed properties:
 
-  ``` javascript
+  ```javascript
   MyTextInput = Ember.View.extend({
     tagName: 'input',
     attributeBindings: ['disabled'],
@@ -465,20 +469,21 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   });
   ```
 
-  Updates to the the property of an attribute binding will result in automatic update
-  of the  HTML attribute in the view's rendered HTML representation.
+  Updates to the the property of an attribute binding will result in automatic
+  update of the  HTML attribute in the view's rendered HTML representation.
 
-  `attributeBindings` is a concatenated property. See `Ember.Object` documentation
-  for more information about concatenated properties.
+  `attributeBindings` is a concatenated property. See `Ember.Object`
+  documentation for more information about concatenated properties.
 
   ## Templates
 
-  The HTML contents of a view's rendered representation are determined by its template.
-  Templates can be any function that accepts an optional context parameter and returns
-  a string of HTML that will be inserted within the view's tag. Most
-  typically in Ember this function will be a compiled Ember.Handlebars template.
+  The HTML contents of a view's rendered representation are determined by its
+  template. Templates can be any function that accepts an optional context
+  parameter and returns a string of HTML that will be inserted within the
+  view's tag. Most typically in Ember this function will be a compiled
+  `Ember.Handlebars` template.
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     template: Ember.Handlebars.compile('I am the template')
   });
@@ -486,14 +491,14 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">I am the template</div>
   ```
 
   Within an Ember application is more common to define a Handlebars templates as
   part of a page:
 
-  ``` handlebars
+  ```handlebars
   <script type='text/x-handlebars' data-template-name='some-template'>
     Hello
   </script>
@@ -501,23 +506,25 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   And associate it by name using a view's `templateName` property:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     templateName: 'some-template'
   });
   ```
 
-  Using a value for `templateName` that does not have a Handlebars template with a
-  matching `data-template-name` attribute will throw an error.
+  Using a value for `templateName` that does not have a Handlebars template
+  with a matching `data-template-name` attribute will throw an error.
 
-  Assigning a value to both `template` and `templateName` properties will throw an error.
+  Assigning a value to both `template` and `templateName` properties will throw
+  an error.
 
-  For views classes that may have a template later defined (e.g. as the block portion of a `{{view}}`
-  Handlebars helper call in another template or in a subclass), you can provide a `defaultTemplate`
-  property set to compiled template function. If a template is not later provided for the view
-  instance the `defaultTemplate` value will be used:
+  For views classes that may have a template later defined (e.g. as the block
+  portion of a `{{view}}` Handlebars helper call in another template or in
+  a subclass), you can provide a `defaultTemplate` property set to compiled
+  template function. If a template is not later provided for the view instance
+  the `defaultTemplate` value will be used:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     defaultTemplate: Ember.Handlebars.compile('I was the default'),
     template: null,
@@ -527,13 +534,14 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">I was the default</div>
   ```
 
-  If a `template` or `templateName` is provided it will take precedence over `defaultTemplate`:
+  If a `template` or `templateName` is provided it will take precedence over
+  `defaultTemplate`:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     defaultTemplate: Ember.Handlebars.compile('I was the default')
   });
@@ -545,7 +553,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in the following HTML representation when rendered:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">I was the template, not default</div>
   ```
 
@@ -553,7 +561,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   The default context of the compiled template is the view's controller:
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     template: Ember.Handlebars.compile('Hello {{excitedGreeting}}')
   });
@@ -572,30 +580,33 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">Hello Barry!!!</div>
   ```
 
-  A context can also be explicitly supplied through the view's `context` property.
-  If the view has neither `context` nor `controller` properties, the parentView's
-  context will be used.
+  A context can also be explicitly supplied through the view's `context`
+  property. If the view has neither `context` nor `controller` properties, the
+  `parentView`'s context will be used.
 
   ## Layouts
 
   Views can have a secondary template that wraps their main template. Like
-  primary templates, layouts can be any function that  accepts an optional context
-  parameter and returns a string of HTML that will be inserted inside view's tag. Views whose HTML
-  element is self closing (e.g. `<input />`) cannot have a layout and this property will be ignored.
+  primary templates, layouts can be any function that  accepts an optional
+  context parameter and returns a string of HTML that will be inserted inside
+  view's tag. Views whose HTML element is self closing (e.g. `<input />`)
+  cannot have a layout and this property will be ignored.
 
-  Most typically in Ember a layout will be a compiled Ember.Handlebars template.
+  Most typically in Ember a layout will be a compiled `Ember.Handlebars`
+  template.
 
-  A view's layout can be set directly with the `layout` property or reference an
-  existing Handlebars template by name with the `layoutName` property.
+  A view's layout can be set directly with the `layout` property or reference
+  an existing Handlebars template by name with the `layoutName` property.
 
-  A template used as a layout must contain a single use of the Handlebars `{{yield}}`
-  helper. The HTML contents of a view's rendered `template` will be inserted at this location:
+  A template used as a layout must contain a single use of the Handlebars
+  `{{yield}}` helper. The HTML contents of a view's rendered `template` will be
+  inserted at this location:
 
-  ``` javascript
+  ```javascript
   AViewWithLayout = Ember.View.extend({
     layout: Ember.Handlebars.compile("<div class='my-decorative-class'>{{yield}}</div>")
     template: Ember.Handlebars.compile("I got wrapped"),
@@ -604,7 +615,7 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   Will result in view instances with an HTML representation of:
 
-  ``` html
+  ```html
   <div id="ember1" class="ember-view">
     <div class="my-decorative-class">
       I got wrapped
@@ -616,15 +627,17 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   ## Responding to Browser Events
 
-  Views can respond to user-initiated events in one of three ways: method implementation,
-  through an event manager, and through `{{action}}` helper use in their template or layout.
+  Views can respond to user-initiated events in one of three ways: method
+  implementation, through an event manager, and through `{{action}}` helper use
+  in their template or layout.
 
   ### Method Implementation
 
-  Views can respond to user-initiated events by implementing a method that matches the
-  event name. A `jQuery.Event` object will be passed as the argument to this method.
+  Views can respond to user-initiated events by implementing a method that
+  matches the event name. A `jQuery.Event` object will be passed as the
+  argument to this method.
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     click: function(event){
       // will be called when when an instance's
@@ -635,15 +648,16 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   ### Event Managers
 
-  Views can define an object as their `eventManager` property. This object can then
-  implement methods that match the desired event names. Matching events that occur
-  on the view's rendered HTML or the rendered HTML of any of its DOM descendants
-  will trigger this method.  A `jQuery.Event` object will be passed as the first
-  argument to the method and an  `Ember.View` object as the second. The `Ember.View`
-  will be the view whose rendered HTML was interacted with. This may be the view with
-  the `eventManager` property or one of its descendent views.
+  Views can define an object as their `eventManager` property. This object can
+  then implement methods that match the desired event names. Matching events
+  that occur on the view's rendered HTML or the rendered HTML of any of its DOM
+  descendants will trigger this method. A `jQuery.Event` object will be passed
+  as the first argument to the method and an  `Ember.View` object as the
+  second. The `Ember.View` will be the view whose rendered HTML was interacted
+  with. This may be the view with the `eventManager` property or one of its
+  descendent views.
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     eventManager: Ember.Object.create({
       doubleClick: function(event, view){
@@ -656,10 +670,10 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   });
   ```
 
-  An event defined for an event manager takes precedence over events of the same
-  name handled through methods on the view.
+  An event defined for an event manager takes precedence over events of the
+  same name handled through methods on the view.
 
-  ``` javascript
+  ```javascript
   AView = Ember.View.extend({
     mouseEnter: function(event){
       // will never trigger.
@@ -673,12 +687,13 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   ```
 
   Similarly a view's event manager will take precedence for events of any views
-  rendered as a descendent. A method name that matches an event name will not be called
-  if the view instance was rendered inside the HTML representation of a view that has
-  an `eventManager` property defined that handles events of the name.  Events not handled
-  by the event manager will still trigger method calls on the descendent.
+  rendered as a descendent. A method name that matches an event name will not
+  be called if the view instance was rendered inside the HTML representation of
+  a view that has an `eventManager` property defined that handles events of the
+  name. Events not handled by the event manager will still trigger method calls
+  on the descendent.
 
-  ``` javascript
+  ```javascript
   OuterView = Ember.View.extend({
     template: Ember.Handlebars.compile("outer {{#view InnerView}}inner{{/view}} outer"),
     eventManager: Ember.Object.create({
@@ -709,23 +724,57 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
 
   ### Event Names
 
-  Possible events names for any of the responding approaches described above are:
+  Possible events names for any of the responding approaches described above
+  are:
 
-  Touch events: 'touchStart', 'touchMove', 'touchEnd', 'touchCancel'
+  Touch events:
 
-  Keyboard events: 'keyDown', 'keyUp', 'keyPress'
+  * `touchStart`
+  * `touchMove`
+  * `touchEnd`
+  * `touchCancel`
 
-  Mouse events: 'mouseDown', 'mouseUp', 'contextMenu', 'click', 'doubleClick', 'mouseMove',
-  'focusIn', 'focusOut', 'mouseEnter', 'mouseLeave'
+  Keyboard events
 
-  Form events: 'submit', 'change', 'focusIn', 'focusOut', 'input'
+  * `keyDown`
+  * `keyUp`
+  * `keyPress`
 
-  HTML5 drag and drop events: 'dragStart', 'drag', 'dragEnter', 'dragLeave', 'drop', 'dragEnd'
+  Mouse events
+
+  * `mouseDown`
+  * `mouseUp`
+  * `contextMenu`
+  * `click`
+  * `doubleClick`
+  * `mouseMove`
+  * `focusIn`
+  * `focusOut`
+  * `mouseEnter`
+  * `mouseLeave`
+
+  Form events: 
+
+  * `submit`
+  * `change`
+  * `focusIn`
+  * `focusOut`
+  * `input`
+
+  HTML5 drag and drop events: 
+
+  * `dragStart`
+  * `drag`
+  * `dragEnter`
+  * `dragLeave`
+  * `drop`
+  * `dragEnd`
 
   ## Handlebars `{{view}}` Helper
 
-  Other `Ember.View` instances can be included as part of a view's template by using the `{{view}}`
-  Handlebars helper. See `Handlebars.helpers.view` for additional information.
+  Other `Ember.View` instances can be included as part of a view's template by
+  using the `{{view}}` Handlebars helper. See `Handlebars.helpers.view` for
+  additional information.
 
   @class View
   @namespace Ember
@@ -752,7 +801,7 @@ Ember.View = Ember.CoreView.extend(
   /**
     The name of the template to lookup if no template is provided.
 
-    Ember.View will look for a template with this name in this view's
+    `Ember.View` will look for a template with this name in this view's
     `templates` object. By default, this will be a global object
     shared in `Ember.TEMPLATES`.
 
@@ -765,7 +814,7 @@ Ember.View = Ember.CoreView.extend(
   /**
     The name of the layout to lookup if no layout is provided.
 
-    Ember.View will look for a template with this name in this view's
+    `Ember.View` will look for a template with this name in this view's
     `templates` object. By default, this will be a global object
     shared in `Ember.TEMPLATES`.
 
@@ -932,7 +981,7 @@ Ember.View = Ember.CoreView.extend(
   }, 'context'),
 
   /**
-    If false, the view will appear hidden in DOM.
+    If `false`, the view will appear hidden in DOM.
 
     @property isVisible
     @type Boolean
@@ -944,7 +993,7 @@ Ember.View = Ember.CoreView.extend(
     @private
 
     Array of child views. You should never edit this array directly.
-    Instead, use appendChild and removeFromParent.
+    Instead, use `appendChild` and `removeFromParent`.
 
     @property childViews
     @type Array
@@ -1046,7 +1095,7 @@ Ember.View = Ember.CoreView.extend(
   },
 
   /**
-    Return the nearest ancestor that is an Ember.CollectionView
+    Return the nearest ancestor that is an `Ember.CollectionView`
 
     @property collectionView
     @return Ember.CollectionView
@@ -1057,7 +1106,7 @@ Ember.View = Ember.CoreView.extend(
 
   /**
     Return the nearest ancestor that is a direct child of
-    an Ember.CollectionView
+    an `Ember.CollectionView`
 
     @property itemView
     @return Ember.View
@@ -1081,7 +1130,7 @@ Ember.View = Ember.CoreView.extend(
     @private
 
     When the parent view changes, recursively invalidate
-    collectionView, itemView, and contentView
+    `collectionView`, `itemView,` and `contentView`.
 
     @method _parentViewDidChange
   */
@@ -1121,10 +1170,10 @@ Ember.View = Ember.CoreView.extend(
 
   /**
     Called on your view when it should push strings of HTML into a
-    Ember.RenderBuffer. Most users will want to override the `template`
+    `Ember.RenderBuffer`. Most users will want to override the `template`
     or `templateName` properties instead of this method.
 
-    By default, Ember.View will look for a function in the `template`
+    By default, `Ember.View` will look for a function in the `template`
     property and invoke it with the value of `context`. The value of
     `context` will be the view's controller unless you override it.
 
@@ -1452,11 +1501,11 @@ Ember.View = Ember.CoreView.extend(
     element will not be appended to the given element until all bindings have
     finished synchronizing.
 
-    This is not typically a function that you will need to call directly
-    when building your application. You might consider using Ember.ContainerView
-    instead. If you do need to use appendTo, be sure that the target element you
-    are providing is associated with an Ember.Application and does not have an
-    ancestor element that is associated with an Ember view.
+    This is not typically a function that you will need to call directly when
+    building your application. You might consider using `Ember.ContainerView`
+    instead. If you do need to use `appendTo`, be sure that the target element
+    you are providing is associated with an `Ember.Application` and does not
+    have an ancestor element that is associated with an Ember view.
 
     @method appendTo
     @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
@@ -1474,9 +1523,9 @@ Ember.View = Ember.CoreView.extend(
   },
 
   /**
-    Replaces the content of the specified parent element with this view's element.
-    If the view does not have an HTML representation yet, `createElement()`
-    will be called automatically.
+    Replaces the content of the specified parent element with this view's
+    element. If the view does not have an HTML representation yet,
+    `createElement()` will be called automatically.
 
     Note that this method just schedules the view to be appended; the DOM
     element will not be appended to the given element until all bindings have
@@ -1504,16 +1553,18 @@ Ember.View = Ember.CoreView.extend(
     ensures that all bindings have finished synchronizing before the view is
     rendered.
 
-    To use, pass a function that performs a DOM operation..
+    To use, pass a function that performs a DOM operation.
 
     Before your function is called, this view and all child views will receive
     the `willInsertElement` event. After your function is invoked, this view
     and all of its child views will receive the `didInsertElement` event.
 
-        view._insertElementLater(function() {
-          this.createElement();
-          this.$().appendTo('body');
-        });
+    ```javascript
+    view._insertElementLater(function() {
+      this.createElement();
+      this.$().appendTo('body');
+    });
+    ```
 
     @method _insertElementLater
     @param {Function} fn the function that inserts the element into the DOM
@@ -1583,10 +1634,10 @@ Ember.View = Ember.CoreView.extend(
 
   /**
     Attempts to discover the element in the parent element. The default
-    implementation looks for an element with an ID of elementId (or the view's
-    guid if elementId is null). You can override this method to provide your
-    own form of lookup. For example, if you want to discover your element
-    using a CSS class name instead of an ID.
+    implementation looks for an element with an ID of `elementId` (or the
+    view's guid if `elementId` is null). You can override this method to
+    provide your own form of lookup. For example, if you want to discover your
+    element using a CSS class name instead of an ID.
 
     @method findElementInParentElement
     @param {DOMElement} parentElement The parent's DOM element
@@ -1671,7 +1722,7 @@ Ember.View = Ember.CoreView.extend(
   /**
     @private
 
-    Invokes the receiver's willInsertElement() method if it exists and then
+    Invokes the receiver's `willInsertElement()` method if it exists and then
     invokes the same on all child views.
 
     NOTE: In some cases this was called when the element existed. This no longer
@@ -1688,7 +1739,7 @@ Ember.View = Ember.CoreView.extend(
   /**
     @private
 
-    Invokes the receiver's didInsertElement() method if it exists and then
+    Invokes the receiver's `didInsertElement()` method if it exists and then
     invokes the same on all child views.
 
     @method _notifyDidInsertElement
@@ -1718,12 +1769,12 @@ Ember.View = Ember.CoreView.extend(
     as well. If the view does not currently have a element, then this method
     will do nothing.
 
-    If you implement willDestroyElement() on your view, then this method will
+    If you implement `willDestroyElement()` on your view, then this method will
     be invoked on your view before your element is destroyed to give you a
     chance to clean up any event handlers, etc.
 
-    If you write a willDestroyElement() handler, you can assume that your
-    didInsertElement() handler was called earlier for the same element.
+    If you write a `willDestroyElement()` handler, you can assume that your
+    `didInsertElement()` handler was called earlier for the same element.
 
     Normally you will not call or override this method yourself, but you may
     want to implement the above callbacks when it is run.
@@ -1747,11 +1798,12 @@ Ember.View = Ember.CoreView.extend(
   /**
     @private
 
-    Triggers the `willDestroyElement` event (which invokes the `willDestroyElement()`
-    method if it exists) on this view and all child views.
+    Triggers the `willDestroyElement` event (which invokes the
+    `willDestroyElement()` method if it exists) on this view and all child
+    views.
 
-    Before triggering `willDestroyElement`, it first triggers the `willClearRender`
-    event recursively.
+    Before triggering `willDestroyElement`, it first triggers the
+    `willClearRender` event recursively.
 
     @method _notifyWillDestroyElement
   */
@@ -1845,8 +1897,8 @@ Ember.View = Ember.CoreView.extend(
   //
 
   /**
-    Tag name for the view's outer element. The tag name is only used when
-    an element is first created. If you change the tagName for an element, you
+    Tag name for the view's outer element. The tag name is only used when an
+    element is first created. If you change the `tagName` for an element, you
     must destroy and recreate the view element.
 
     By default, the render buffer will use a `<div>` tag for views.
@@ -1891,29 +1943,35 @@ Ember.View = Ember.CoreView.extend(
     is a string value, the value of that string will be applied as a class
     name.
 
-        // Applies the 'high' class to the view element
-        Ember.View.create({
-          classNameBindings: ['priority']
-          priority: 'high'
-        });
+    ```javascript
+    // Applies the 'high' class to the view element
+    Ember.View.create({
+      classNameBindings: ['priority']
+      priority: 'high'
+    });
+    ```
 
     If the value of the property is a Boolean, the name of that property is
     added as a dasherized class name.
 
-        // Applies the 'is-urgent' class to the view element
-        Ember.View.create({
-          classNameBindings: ['isUrgent']
-          isUrgent: true
-        });
+    ```javascript
+    // Applies the 'is-urgent' class to the view element
+    Ember.View.create({
+      classNameBindings: ['isUrgent']
+      isUrgent: true
+    });
+    ```
 
     If you would prefer to use a custom value instead of the dasherized
     property name, you can pass a binding like this:
 
-        // Applies the 'urgent' class to the view element
-        Ember.View.create({
-          classNameBindings: ['isUrgent:urgent']
-          isUrgent: true
-        });
+    ```javascript
+    // Applies the 'urgent' class to the view element
+    Ember.View.create({
+      classNameBindings: ['isUrgent:urgent']
+      isUrgent: true
+    });
+    ```
 
     This list of properties is inherited from the view's superclasses as well.
 
@@ -1927,21 +1985,25 @@ Ember.View = Ember.CoreView.extend(
     A list of properties of the view to apply as attributes. If the property is
     a string value, the value of that string will be applied as the attribute.
 
-        // Applies the type attribute to the element
-        // with the value "button", like <div type="button">
-        Ember.View.create({
-          attributeBindings: ['type'],
-          type: 'button'
-        });
+    ```javascript
+    // Applies the type attribute to the element
+    // with the value "button", like <div type="button">
+    Ember.View.create({
+      attributeBindings: ['type'],
+      type: 'button'
+    });
+    ```
 
     If the value of the property is a Boolean, the name of that property is
     added as an attribute.
 
-        // Renders something like <div enabled="enabled">
-        Ember.View.create({
-          attributeBindings: ['enabled'],
-          enabled: true
-        });
+    ```javascript
+    // Renders something like <div enabled="enabled">
+    Ember.View.create({
+      attributeBindings: ['enabled'],
+      enabled: true
+    });
+    ```
 
     @property attributeBindings
   */
@@ -1955,7 +2017,7 @@ Ember.View = Ember.CoreView.extend(
     @private
 
     Setup a view, but do not finish waking it up.
-    - configure childViews
+    - configure `childViews`
     - register the view with the global views hash, which is used for event
       dispatch
 
@@ -2013,7 +2075,7 @@ Ember.View = Ember.CoreView.extend(
   },
 
   /**
-    Removes all children from the parentView.
+    Removes all children from the `parentView`.
 
     @method removeAllChildren
     @return {Ember.View} receiver
@@ -2031,7 +2093,7 @@ Ember.View = Ember.CoreView.extend(
   },
 
   /**
-    Removes the view from its parentView, if one is found. Otherwise
+    Removes the view from its `parentView`, if one is found. Otherwise
     does nothing.
 
     @method removeFromParent
@@ -2094,7 +2156,7 @@ Ember.View = Ember.CoreView.extend(
   /**
     Instantiates a view to be added to the childViews array during view
     initialization. You generally will not call this method directly unless
-    you are overriding createChildViews(). Note that this method will
+    you are overriding `createChildViews()`. Note that this method will
     automatically configure the correct settings on the new view instance to
     act as a child of the parent.
 
@@ -2298,12 +2360,14 @@ Ember.View.reopenClass({
     For example a path like "content.isEnabled:enabled:disabled" wil return the
     following object:
 
-        {
-          path: "content.isEnabled",
-          className: "enabled",
-          falsyClassName: "disabled",
-          classNames: ":enabled:disabled"
-        }
+    ```javascript
+    {
+      path: "content.isEnabled",
+      className: "enabled",
+      falsyClassName: "disabled",
+      classNames: ":enabled:disabled"
+    }
+    ```
 
     @method _parsePropertyPath
     @static
@@ -2335,16 +2399,20 @@ Ember.View.reopenClass({
   /**
     @private
 
-    Get the class name for a given value, based on the path, optional className
-    and optional falsyClassName.
+    Get the class name for a given value, based on the path, optional
+    `className` and optional `falsyClassName`.
 
-    - if a className or falsyClassName has been specified:
-      - if the value is truthy and className has been specified, className is returned
-      - if the value is falsy and falsyClassName has been specified, falsyClassName is returned
-      - otherwise null is returned
-    - if the value is true, the dasherized last part of the supplied path is returned
-    - if the value is not false, undefined or null, the value is returned
-    - if none of the above rules apply, null is returned
+    - if a `className` or `falsyClassName` has been specified:
+      - if the value is truthy and `className` has been specified, 
+        `className` is returned
+      - if the value is falsy and `falsyClassName` has been specified, 
+        `falsyClassName` is returned
+      - otherwise `null` is returned
+    - if the value is `true`, the dasherized last part of the supplied path 
+      is returned
+    - if the value is not `false`, `undefined` or `null`, the `value` 
+      is returned
+    - if none of the above rules apply, `null` is returned
 
     @method _classStringForValue
     @param path


### PR DESCRIPTION
This PR focused on editing and formatting the inline documentation so it's easier to read online. The commits follows these rules:
1. All code blocks must be fenced
2. All code blocks must have a language declared
3. All code blocks must be valid code for syntax highlighting
4. All examples in code blocks must be aligned
5. All references to code words must be enclosed in ``
6. Prefer a single space between sentences
7. Reference Ember.js as Ember.
8. Wrap long markdown blocks > 80 characters

Misc updates:
1. Replace all instances handlebars script tags without declared template names.
