### PR TITLE
Support for Android Browser and Chrome Mobile

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -63,7 +63,7 @@ Ember.HistoryLocation = Ember.Object.extend({
   setURL: function(path) {
     path = this.formatURL(path);
 
-    if (this.getState().path !== path) {
+    if (this.getState() && this.getState().path !== path) {
       popstateReady = true;
       this.pushState(path);
     }


### PR DESCRIPTION
In Android Browser and Chrome Mobile this.getState() is null, so it throws error "Uncaught TypeError: Cannot read property 'path' of undefined".
So I added in if statement "this.getState() &&". Everything else works as expected.
