### PR TITLE
Close #1543 - uglify filter skips files named ".min.js"

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -159,11 +159,11 @@ distros.each do |name, modules|
 
     # Strip dev code
     match "#{name}.prod.js" do
-      filter(EmberProductionFilter) { ["#{name}.prod.js", "#{name}.min.js"] }
+      filter(EmberProductionFilter) { ["#{name}.prod.js", "min/#{name}.js"] }
     end
 
     # Minify
-    match "#{name}.min.js" do
+    match "min/#{name}.js" do
       uglify{ "#{name}.min.js" }
       filter VersionInfo
       filter EmberLicenseFilter


### PR DESCRIPTION
Avoid this by putting it in a "min" directory then uglify it as ".min.js"
