### PR TITLE
Remove meta objects from JSON output on IE7/8.

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -169,6 +169,10 @@ if (isDefinePropertySimulated) {
   // jQuery.extend() by having a property that fails
   // hasOwnProperty check.
   Meta.prototype.__preventPlainObject__ = true;
+
+  // Without non-enumerable properties, meta objects will be output in JSON
+  // unless explicitly suppressed
+  Meta.prototype.toJSON = function () { };
 }
 
 /**


### PR DESCRIPTION
Define a non-op Meta.toJSON() function on Meta objects to supress them from JSON output on IE7/8. This fixes a circular reference error that prevented EmberJS Objects from being output as JSON on these browsers.
