### PR TITLE
Hook to override default toggle visibility in _isVisibleDidChange

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 *Ember 1.0.0-pre.2 (October 25, 2012)*
 
+* Hook to override default toggle visibility in _isVisibleDidChange
 * Ember.SortableMixin: don't remove and reinsert items when their sort order doesn't change.  Fixes #1486.
 * Fix edge cases with adding/removing observers
 * Added 'disabled' attribute binding to Select

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2141,9 +2141,9 @@ Ember.View = Ember.CoreView.extend(
     var $el = this.$();
     if (!$el) { return; }
 
-    var isVisible = get(this, 'isVisible');
+    this.toggleVisibility();
 
-    $el.toggle(isVisible);
+    var isVisible = get(this, 'isVisible');
 
     if (this._isAncestorHidden()) { return; }
 
@@ -2153,6 +2153,16 @@ Ember.View = Ember.CoreView.extend(
       this._notifyBecameHidden();
     }
   }, 'isVisible'),
+
+
+  /**
+    Override to provide different toggle visibility behaviour
+   **/
+  toggleVisibility: function(){
+    var isVisible = get(this, 'isVisible');
+
+    this.$().toggle(isVisible);
+  },
 
   _notifyBecameVisible: function() {
     this.trigger('becameVisible');

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2141,27 +2141,36 @@ Ember.View = Ember.CoreView.extend(
     var $el = this.$();
     if (!$el) { return; }
 
-    this.toggleVisibility();
+    var self = this;
 
-    var isVisible = get(this, 'isVisible');
+    this.toggleVisibility(function(){
+      if (self._isAncestorHidden()) { return; }
 
-    if (this._isAncestorHidden()) { return; }
+      self._notifyVisibilityChanged();
+    });
 
-    if (isVisible) {
-      this._notifyBecameVisible();
-    } else {
-      this._notifyBecameHidden();
-    }
   }, 'isVisible'),
 
 
   /**
     Override to provide different toggle visibility behaviour
    **/
-  toggleVisibility: function(){
+  toggleVisibility: function(callback){
     var isVisible = get(this, 'isVisible');
 
     this.$().toggle(isVisible);
+
+    callback();
+  },
+
+  _notifyVisibilityChanged: function(){
+    var isVisible = get(this, 'isVisible');
+
+    if (isVisible) {
+      this._notifyBecameVisible();
+    } else {
+      this._notifyBecameHidden();
+    }
   },
 
   _notifyBecameVisible: function() {

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -200,3 +200,28 @@ test("if a child view becomes visible while its parent is hidden, if its parent 
   equal(childBecameVisible, 1);
   equal(grandchildBecameVisible, 1);
 });
+
+test("the default toggle visibility can be overriden", function(){
+  var visibilityChanged = 0;
+  view = View.create({ 
+    toggleVisibility: function(){
+      visibilityChanged++;
+      this.$().hide();
+    }
+  });
+
+  Ember.run(function() {
+    view.append();
+  });
+  
+  equal(visibilityChanged, 0, "precond - toggleVisibility not triggered on creation");
+
+  ok(view.$().is(':visible'), "precond - view is visible when appended");
+
+  Ember.run(function(){
+    view.set('isVisible', false);
+  });
+
+  equal(visibilityChanged, 1);
+  ok(view.$().is(':hidden'), "view is now hidden");
+});

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -201,27 +201,29 @@ test("if a child view becomes visible while its parent is hidden, if its parent 
   equal(grandchildBecameVisible, 1);
 });
 
-test("the default toggle visibility can be overriden", function(){
-  var visibilityChanged = 0;
-  view = View.create({ 
-    toggleVisibility: function(){
-      visibilityChanged++;
-      this.$().hide();
+test("the default toggle visibility can be overriden and notifications delayed until animation has completed", function(){
+  view = View.create({
+    becameHidden: function() { parentBecameHidden++; },
+
+    toggleVisibility: function(callback){
+      this.$().hide('fast', function(){
+        start();
+        callback();
+
+        ok(view.$().is(':hidden'), "view is now hidden");
+        equal(parentBecameHidden, 1);
+      });
     }
   });
 
   Ember.run(function() {
     view.append();
   });
-  
-  equal(visibilityChanged, 0, "precond - toggleVisibility not triggered on creation");
 
   ok(view.$().is(':visible'), "precond - view is visible when appended");
 
+  stop();
   Ember.run(function(){
     view.set('isVisible', false);
   });
-
-  equal(visibilityChanged, 1);
-  ok(view.$().is(':hidden'), "view is now hidden");
 });


### PR DESCRIPTION
At the moment there is no way apart from overriding the whole of _isVisibleDidChange to supply your own custom animations for when the view's isVisible property changes:

```
  _isVisibleDidChange: Ember.observer(function() {
    var $el = this.$();
    if (!$el) { return; }

    var isVisible = get(this, 'isVisible');

    $el.toggle(isVisible);

    if (this._isAncestorHidden()) { return; }

    if (isVisible) {
      this._notifyBecameVisible();
    } else {
      this._notifyBecameHidden();
    }
  }, 'isVisible'),
```

This PR gives the user a chance to supply their own slideUp/slideDown, fadeIn/fadeOut etc. functionality when the isVisible property changes.
