### PR TITLE
fix chrome "unsafe javascript" error in framed or sandboxed windows

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -511,15 +511,13 @@ function processNames(paths, root, seen) {
 }
 
 function findNamespaces() {
-  var Namespace = Ember.Namespace, lookup = Ember.lookup, obj, isNamespace, isFramed;
+  var Namespace = Ember.Namespace, lookup = Ember.lookup, obj, isNamespace;
 
   if (Namespace.PROCESSED) { return; }
 
-  if (lookup.top !== lookup.self) { isFramed = true; }
-
   for (var prop in lookup) {
     // prevent console errors complaining of "unsafe javascript" in framed (like jsfiddle) or sandboxed/CSP (like chrome extensions) environments
-    if (isFramed && Ember.A(["parent", "top", "frameElement"]).indexOf(prop) > -1) { continue; }
+    if (Ember.A(["parent", "top", "frameElement"]).indexOf(prop) > -1) { continue; }
     //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
     // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage
     if (prop === "globalStorage" && lookup.StorageList && lookup.globalStorage instanceof lookup.StorageList) { continue; }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -511,11 +511,15 @@ function processNames(paths, root, seen) {
 }
 
 function findNamespaces() {
-  var Namespace = Ember.Namespace, lookup = Ember.lookup, obj, isNamespace;
+  var Namespace = Ember.Namespace, lookup = Ember.lookup, obj, isNamespace, isFramed;
 
   if (Namespace.PROCESSED) { return; }
 
+  if (lookup.top !== lookup.self) { isFramed = true; }
+
   for (var prop in lookup) {
+    // prevent console errors complaining of "unsafe javascript" in framed (like jsfiddle) or sandboxed/CSP (like chrome extensions) environments
+    if (isFramed && Ember.A(["parent", "top", "frameElement"]).indexOf(prop) > -1) { continue; }
     //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
     // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage
     if (prop === "globalStorage" && lookup.StorageList && lookup.globalStorage instanceof lookup.StorageList) { continue; }


### PR DESCRIPTION
Prevent Chrome from complaining about unsafe javascript in framed (like jsFiddle) or sandboxed (like Chrome extension) windows ... mostly harmless but who likes seeing streams of red in the console...

this along and the removal of Handlebars.compile from Ember.Select  (#1443 fixes when/if that ever gets pulled/resolved/whatever) -- then Ember + Handlebars-runtime + precompiled templates will work in the default CSP policy enforced by Chrome for extensions and apps
