### PR TITLE
method for filter property starts with the passed value

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -32,6 +32,17 @@ function iter(key, value) {
   return i ;
 }
 
+iterForStartWith: function(key, value) {
+  Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
+  Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
+  var valueProvided = arguments.length === 2;
+  function i(item) {
+    var cur = Ember.get(item, key);
+    return valueProvided ? (cur.indexOf(value) == 0) : !!cur;
+  }
+  return i ;
+}
+
 /**
   This mixin defines the common interface implemented by enumerable objects
   in Ember.  Most of these methods follow the standard Array iteration
@@ -340,6 +351,20 @@ Ember.Enumerable = Ember.Mixin.create(
   */
   filterProperty: function(key, value) {
     return this.filter(iter.apply(this, arguments));
+  },
+  
+  /**
+    Returns an array with just the items with the property start with the value.
+
+    @param {String} key the property to test. It must be a valid string.
+    @param {String} value to test against. It must be a valid string.
+    @returns {Array} filtered array
+  */
+
+  filterPropertyStartWith: function(key, value) {
+    Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
+	Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
+	return this.filter(this.iterForStartWith.apply(this, arguments));
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -131,3 +131,24 @@ suite.test('should not match undefined properties without second argument', func
 
   deepEqual(obj.filterProperty('foo'), ary.slice(0, 2), "filterProperty('foo', 3)')");
 });
+
+
+//..........................................................
+//filterPropertyStartWith()
+//
+
+suite.module('filterPropertyStartWith');
+
+suite.test('should filter based on object', function() {
+var obj, ary;
+
+ary = [
+ { foo: 'foo', bar: 'BAZ' },
+ Ember.Object.create({ foo: 'foo', bar: 'bar' })
+];
+
+obj = this.newObject(ary);
+
+deepEqual(obj.filterPropertyStartWith('foo', 'fo'), ary, 'filterPropertyStartWith(foo)');
+deepEqual(obj.filterPropertyStartWith('bar', 'ba'), [ary[1]], 'filterPropertyStartWith(bar)');
+});


### PR DESCRIPTION
Hi,

I have added a method which return the array having property starts with the passed value.

For Ex:

var myArray = [
 Ember.Object.create(firstName: "abcde", lastName: "fghij"),
 Ember.Object.create(firstName: "ab678878", lastName: "djsfhk"),
 Ember.Object.create(firstName: "abbgd",lastName: "cxgd"),
 Ember.Object.create(firstName: "dsgf",lastName: "sdfs")
]

Ember.Object.create(myArray).filterPropertyStartWith("firstname","ab")

will return array of 3 items
