### PR TITLE
Removed window dependancies

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -127,8 +127,9 @@ Ember.deprecateFunc = function(message, func) {
   };
 };
 
-
-window.ember_assert         = Ember.deprecateFunc("ember_assert is deprecated. Please use Ember.assert instead.",               Ember.assert);
-window.ember_warn           = Ember.deprecateFunc("ember_warn is deprecated. Please use Ember.warn instead.",                   Ember.warn);
-window.ember_deprecate      = Ember.deprecateFunc("ember_deprecate is deprecated. Please use Ember.deprecate instead.",         Ember.deprecate);
-window.ember_deprecateFunc  = Ember.deprecateFunc("ember_deprecateFunc is deprecated. Please use Ember.deprecateFunc instead.", Ember.deprecateFunc);
+if ('undefined' !== typeof window) {
+  window.ember_assert         = Ember.deprecateFunc("ember_assert is deprecated. Please use Ember.assert instead.",               Ember.assert);
+  window.ember_warn           = Ember.deprecateFunc("ember_warn is deprecated. Please use Ember.warn instead.",                   Ember.warn);
+  window.ember_deprecate      = Ember.deprecateFunc("ember_deprecate is deprecated. Please use Ember.deprecate instead.",         Ember.deprecate);
+  window.ember_deprecateFunc  = Ember.deprecateFunc("ember_deprecateFunc is deprecated. Please use Ember.deprecateFunc instead.", Ember.deprecateFunc);
+}

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -59,7 +59,7 @@ var populateListeners = function(name) {
 };
 
 var time = (function() {
-	var perf = window.performance || {};
+	var perf = 'undefined' !== typeof window ? window.performance || {} : {};
 	var fn = perf.now || perf.mozNow || perf.webkitNow || perf.msNow || perf.oNow;
 	// fn.bind will be available in all the browsers that support the advanced window.performance... ;-)
 	return fn ? fn.bind(perf) : function() { return +new Date(); };


### PR DESCRIPTION
- Deprecated debug functions are no longer assigned to window when there is no window
- Intrumentation time function now checks if window is defined
