### PR TITLE
method for filter property starts with the passed value

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -32,6 +32,17 @@ function iter(key, value) {
   return i ;
 }
 
+iterForStartWith: function(key, value) {
+  Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
+  Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
+  var valueProvided = arguments.length === 2;
+  function i(item) {
+    var cur = Ember.get(item, key);
+    return valueProvided ? (cur.indexOf(value) == 0) : !!cur;
+    }
+  return i ;
+}
+
 /**
   This mixin defines the common interface implemented by enumerable objects
   in Ember.  Most of these methods follow the standard Array iteration
@@ -342,6 +353,18 @@ Ember.Enumerable = Ember.Mixin.create(
     return this.filter(iter.apply(this, arguments));
   },
 
+  /**
+    Returns an array with just the items with the property start with the value.
+    @param {String} key the property to test. It must be a valid string.
+    @param {String} value to test against. It must be a valid string.
+    @returns {Array} filtered array
+  */
+  filterPropertyStartWith: function(key, value) {
+    Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
+    Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
+    return this.filter(this.iterForStartWith.apply(this, arguments));
+  },
+  
   /**
     Returns the first item in the array for which the callback returns true.
     This method works similar to the filter() method defined in JavaScript 1.6

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -362,7 +362,7 @@ Ember.Enumerable = Ember.Mixin.create(
   filterPropertyStartWith: function(key, value) {
     Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
     Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
-    return this.filter(iterForStartWith.apply(this, arguments));
+    return this.filter(this.iterForStartWith.apply(this, arguments));
   },
   
   /**

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -33,9 +33,15 @@ function iter(key, value) {
 }
 
 function iterForStartWith(key, value) {
-  Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
-  Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
   var valueProvided = arguments.length === 2;
+  if("string" !== typeof key) {
+	  console.error("Key must be a valid string.")
+	  valueProvided = false;
+  }
+  if("string" !== typeof value) {
+	  console.error("Value must be a valid string.")
+	  valueProvided = false;
+  }
   function i(item) {
     var cur = Ember.get(item, key);
     return valueProvided ? (cur.indexOf(value) == 0) : !!cur;
@@ -360,9 +366,7 @@ Ember.Enumerable = Ember.Mixin.create(
     @returns {Array} filtered array
   */
   filterPropertyStartWith: function(key, value) {
-    Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
-    Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
-    return this.filter(this.iterForStartWith.apply(this, arguments));
+    return this.filter(iterForStartWith.apply(this, arguments));
   },
   
   /**

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -32,7 +32,7 @@ function iter(key, value) {
   return i ;
 }
 
-iterForStartWith: function(key, value) {
+function iterForStartWith(key, value) {
   Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
   Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
   var valueProvided = arguments.length === 2;
@@ -362,7 +362,7 @@ Ember.Enumerable = Ember.Mixin.create(
   filterPropertyStartWith: function(key, value) {
     Ember.assert("Key must be a valid string.", (Ember.typeOf(key) === "string"));
     Ember.assert("Value must be a valid string.", (Ember.typeOf(value) === "string"));
-    return this.filter(this.iterForStartWith.apply(this, arguments));
+    return this.filter(iterForStartWith.apply(this, arguments));
   },
   
   /**


### PR DESCRIPTION
Hi,

I have added a method which return the array having property starts with the passed value.

For Ex:

var myArray = [
 Ember.Object.create(firstName: "abcde", lastName: "fghij"),
 Ember.Object.create(firstName: "ab678878", lastName: "djsfhk"),
 Ember.Object.create(firstName: "abbgd",lastName: "cxgd"),
 Ember.Object.create(firstName: "dsgf",lastName: "sdfs")
]

Ember.Object.create(myArray).filterPropertyStartWith("firstname","ab")

will return array of 3 items
