### PR TITLE
Fixes #1540

### DIFF
--- a/packages/ember-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-handlebars/tests/helpers/action_test.js
@@ -235,6 +235,25 @@ test("should unregister event handlers on rerender", function() {
   ok(Ember.Handlebars.ActionHelper.registeredActions[newActionId], "After rerender completes, a new event handler was added");
 });
 
+test("should gracefully ignore actions that have been removed", function() {
+  var editHandlerWasCalled = false;
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('<div {{action edit}}>click me</div>'),
+    edit: function() {
+      editHandlerWasCalled = true;
+    }
+  });
+
+  appendView();
+  view._notifyWillDestroyElement();
+
+  view.$("div").trigger("click");
+
+  ok(!editHandlerWasCalled, "gracefully ignored a removed action handler");
+});
+
+
 test("should properly capture events on child elements of a container with an action", function() {
   var eventHandlerWasCalled = false;
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -144,11 +144,10 @@ Ember.EventDispatcher = Ember.Object.extend(
     rootElement.delegate('[data-ember-action]', event + '.ember', function(evt) {
       return Ember.handleErrors(function() {
         var actionId = Ember.$(evt.currentTarget).attr('data-ember-action'),
-            action   = Ember.Handlebars.ActionHelper.registeredActions[actionId],
-            handler  = action.handler;
+            action   = Ember.Handlebars.ActionHelper.registeredActions[actionId];
 
-        if (action.eventName === eventName) {
-          return handler(evt);
+        if (action && action.eventName === eventName) {
+          return action.handler(evt);
         }
       }, this);
     });


### PR DESCRIPTION
As said in #1540, things like hitting enter on a form that cause a submit that destroy a view remove the handler for the actionId of things like "focusIn".

When the action is triggered and the handler has already been removed it should just be ignored since it's been intentionally removed.

I tested it with rake test[all], and everything was peachy.

I hope you guys pull this, because the error messages are filling up my logs, Thanks!
