### PR TITLE
reject and rejectProperty functions for Enumerable

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -329,6 +329,36 @@ Ember.Enumerable = Ember.Mixin.create(
   },
 
   /**
+    Returns an array with all of the items in the enumeration where the passed
+    function returns false for. This method is the inverse of filter().
+
+    The callback method you provide should have the following signature (all
+    parameters are optional):
+
+          function(item, index, enumerable);
+
+    - *item* is the current item in the iteration.
+    - *index* is the current index in the iteration
+    - *enumerable* is the enumerable object itself.
+
+    It should return the a falsey value to include the item in the results.
+
+    Note that in addition to a callback, you can also pass an optional target
+    object that will be set as "this" on the context. This is a good way
+    to give your iterator function access to the current object.
+
+    @method reject
+    @param {Function} callback The callback to execute
+    @param {Object} [target] The target object to use
+    @return {Array} A rejected array.
+   */
+  reject: function(callback, target) {
+    return this.filter(function() {
+      return !(callback.apply(target, arguments));
+    });
+  },
+
+  /**
     Returns an array with just the items with the matched property.  You
     can pass an optional second argument with the target value.  Otherwise
     this will match any property that evaluates to true.
@@ -340,6 +370,24 @@ Ember.Enumerable = Ember.Mixin.create(
   */
   filterProperty: function(key, value) {
     return this.filter(iter.apply(this, arguments));
+  },
+
+  /**
+    Returns an array with the items that do not have truthy values for
+    key.  You can pass an optional second argument with the target value.  Otherwise
+    this will match any property that evaluates to false.
+
+    @method rejectProperty
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against.
+    @return {Array} rejected array
+  */
+  rejectProperty: function(key, value) {
+    var exactValue = function(item) { return get(item, key) === value; },
+        hasValue = function(item) { return !!get(item, key); },
+        use = (arguments.length === 2 ? exactValue : hasValue);
+
+    return this.reject(use);
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -311,6 +311,7 @@ require('ember-runtime/~tests/suites/enumerable/invoke');
 require('ember-runtime/~tests/suites/enumerable/lastObject');
 require('ember-runtime/~tests/suites/enumerable/map');
 require('ember-runtime/~tests/suites/enumerable/reduce');
+require('ember-runtime/~tests/suites/enumerable/reject');
 require('ember-runtime/~tests/suites/enumerable/some');
 require('ember-runtime/~tests/suites/enumerable/toArray');
 require('ember-runtime/~tests/suites/enumerable/uniq');

--- a/packages/ember-runtime/tests/suites/enumerable/reject.js
+++ b/packages/ember-runtime/tests/suites/enumerable/reject.js
@@ -1,0 +1,144 @@
+require('ember-runtime/~tests/suites/enumerable');
+
+var suite = Ember.EnumerableTests;
+
+// ..........................................................
+// reject()
+//
+
+suite.module('reject');
+
+suite.test('should reject any item that does not meet the condition', function() {
+  var obj = this.newObject([1,2,3,4]),
+      result;
+
+  result = obj.reject(function(i) { return i < 3; });
+  deepEqual(result, [3,4], 'reject the correct items');
+});
+
+suite.test('should be the inverse of filter', function() {
+  var obj = this.newObject([1,2,3,4]),
+      isEven = function(i) { return i % 2 === 0; },
+      filtered, rejected;
+
+  filtered = obj.filter(isEven);
+  rejected = obj.reject(isEven);
+
+  deepEqual(filtered, [2,4], 'filtered evens');
+  deepEqual(rejected, [1,3], 'rejected evens'); 
+});
+
+// ..........................................................
+// rejectProperty()
+//
+
+suite.module('rejectProperty');
+
+suite.test('should reject based on object', function() {
+  var obj, ary;
+
+  ary = [
+    { foo: 'foo', bar: 'BAZ' },
+    Ember.Object.create({ foo: 'foo', bar: 'bar' })
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('foo', 'foo'), [], 'rejectProperty(foo)');
+  deepEqual(obj.rejectProperty('bar', 'bar'), [ary[0]], 'rejectProperty(bar)');
+});
+
+suite.test('should include in result if property is false', function() {
+  var obj, ary;
+
+  ary = [
+    { foo: false, bar: true },
+    Ember.Object.create({ foo: false, bar: false })
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('foo'), ary, 'rejectProperty(foo)');
+  deepEqual(obj.rejectProperty('bar'), [ary[1]], 'rejectProperty(bar)');
+});
+
+suite.test('should reject on second argument if provided', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 2}),
+    { name: 'obj3', foo: 2},
+    Ember.Object.create({ name: 'obj4', foo: 3})
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('foo', 3), [ary[1], ary[2]], "rejectProperty('foo', 3)')");
+});
+
+suite.test('should correctly reject null second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: null}),
+    { name: 'obj3', foo: null},
+    Ember.Object.create({ name: 'obj4', foo: 3})
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('foo', null), [ary[0], ary[3]], "rejectProperty('foo', null)')");
+});
+
+suite.test('should correctly reject undefined second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 2})
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('bar', undefined), [], "rejectProperty('bar', undefined)')");
+});
+
+suite.test('should correctly reject explicit undefined second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 3}),
+    { name: 'obj3', foo: undefined},
+    Ember.Object.create({ name: 'obj4', foo: undefined}),
+    { name: 'obj5'},
+    Ember.Object.create({ name: 'obj6'})
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('foo', undefined), ary.slice(0, 2), "rejectProperty('foo', undefined)')");
+});
+
+suite.test('should match undefined, null, or false properties without second argument', function() {
+  var obj, ary;
+
+  ary = [
+    { name: 'obj1', foo: 3},
+    Ember.Object.create({ name: 'obj2', foo: 3}),
+    { name: 'obj3', foo: undefined},
+    Ember.Object.create({ name: 'obj4', foo: undefined}),
+    { name: 'obj5'},
+    Ember.Object.create({ name: 'obj6'}),
+    { name: 'obj7', foo: null },
+    Ember.Object.create({ name: 'obj8', foo: null }),
+    { name: 'obj9', foo: false },
+    Ember.Object.create({ name: 'obj10', foo: false })
+  ];
+
+  obj = this.newObject(ary);
+
+  deepEqual(obj.rejectProperty('foo'), ary.slice(2), "rejectProperty('foo')')");
+});


### PR DESCRIPTION
rejects and rejectProperty for enumerable. This is the opposite of filter/filterProperty.

``` javascript
odds = [1,2,3,4].reject(function(i) { return i % 2 === 0 });
missingName = people.rejectProperty('name');
unresolved = tickets.rejectProperty('state', 'resolved');
```
