### PR TITLE
Add support unhandledEvent for unhandledEvent to StateManager

### DIFF
--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -466,6 +466,47 @@ test("it throws an exception if an event is dispatched that is unhandled", funct
   ok(true, "does not raise exception when errorOnUnhandledEvent is set to false");
 });
 
+test("it looks for unhandledEvent handler in the currentState if event is not handled by named handler", function() {
+  var wasCalled = 0,
+      evt = "foo",
+      calledWithOriginalEventName,
+      calledWithEvent;
+  stateManager = Ember.StateManager.create({
+    initialState: 'loading',
+    loading: Ember.State.create({
+      unhandledEvent: function(manager, originalEventName, event) {
+        wasCalled = true;
+        calledWithOriginalEventName = originalEventName;
+        calledWithEvent = event;
+      }
+    })
+  });
+  stateManager.send("somethingUnhandled", evt);
+  ok(wasCalled);
+  equal(calledWithOriginalEventName, 'somethingUnhandled');
+  equal(calledWithEvent, evt);
+});
+
+test("it looks for unhandledEvent handler in the stateManager if event is not handled by named handler", function() {
+  var wasCalled = 0,
+      evt = "foo",
+      calledWithOriginalEventName,
+      calledWithEvent;
+  stateManager = Ember.StateManager.create({
+    initialState: 'loading',
+    unhandledEvent: function(manager, originalEventName, event) {
+      wasCalled = true;
+      calledWithOriginalEventName = originalEventName;
+      calledWithEvent = event;
+    },
+    loading: Ember.State.create({})
+  });
+  stateManager.send("somethingUnhandled", evt);
+  ok(wasCalled);
+  equal(calledWithOriginalEventName, 'somethingUnhandled');
+  equal(calledWithEvent, evt);
+});
+
 module("Ember.Statemanager - Pivot states", {
   setup: function() {
     var State = Ember.State.extend(stateEventStub);


### PR DESCRIPTION
If an action is unhandled by the current state or any of its
parent states, the StateManager will now look for a method
named `unhandledEvent` in the current state, traversing up
through its parents until one is found. The method is called
with the manager, original event name and the context
argument(s) originally sent with the event. There is a default
implemenation of `unhandledEvent` on the StateManager itself,
which raises an Ember.Error unless `errorOnUnhandledEvent` is
false.

This flexibility may be useful for a variety of situations, but
it is specifically laying the groundwork for improved error
messages in Ember Data's DS.StateManager.

Luke Melia & Trek Glowacki
