### PR TITLE
Document auto-initialization by default

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -27,8 +27,11 @@ var get = Ember.get, set = Ember.set;
   App.MyView = Ember.View.extend();
   ```
 
-  After all of your classes are defined, call `App.initialize()` to start the
-  application.
+  Calling `Ember.Application.create()` will automatically initialize your
+  application by calling the `Ember.Application.initialize()` method. If you
+  need to delay initialization, you can pass `{autoinit: false}` to the
+  `Ember.Application.create()` method, and call `App.initialize()`
+  later.
 
   Because `Ember.Application` inherits from `Ember.Namespace`, any classes
   you create will have useful string representations when calling `toString()`.


### PR DESCRIPTION
The docs lie! They say you must call `.create()` and then `.initialize()`, but by default `.create()` calls `.initialize()`.

This has already bitten someone on [StackOverflow](http://stackoverflow.com/questions/13599754/ember-js-how-to-set-up-application), and I could see it being a source of confusion going forward.
