### PR TITLE
Added support for toStringExtension to augment toString

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -205,8 +205,40 @@ CoreObject.PrototypeMixin = Mixin.create({
     return from;
   },
 
+  /**
+    Returns a string representation which attempts to provide more information
+    than Javascript's `toString` typically does, in a generic way for all Ember
+    objects.
+
+        App.Person = Em.Object.extend()
+        person = App.Person.create()
+        person.toString() //=> "<App.Person:ember1024>"
+
+    If the object's class is not defined on an Ember namespace, it will
+    indicate it is a subclass of the registered superclass:
+
+        Student = App.Person.extend()
+        student = Student.create()
+        student.toString() //=> "<(subclass of App.Person):ember1025>"
+
+    If the method `toStringExtension` is defined, its return value will be
+    included in the output.
+
+        App.Teacher = App.Person.extend({
+          toStringExtension: function(){
+            return @get('fullName');
+          }
+        });
+        teacher = App.Teacher.create()
+        teacher.toString(); // #=> "<App.Teacher:ember1026:Tom Dale>"
+
+    @method toString
+    @return {String} string representation
+  */
   toString: function() {
-    return '<'+this.constructor.toString()+':'+guidFor(this)+'>';
+    var hasToStringExtension = Ember.typeOf(this.toStringExtension) === 'function',
+        extension = hasToStringExtension ? ":" + this.toStringExtension() : '';
+    return '<'+this.constructor.toString()+':'+guidFor(this)+extension+'>';
   }
 });
 

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -1,0 +1,19 @@
+module('system/object/toString');
+
+test('toString includes toStringExtension if defined', function() {
+
+  var Foo = Ember.Object.extend({
+        toStringExtension: function(){
+          return "fooey";
+        }
+      }),
+      foo = Foo.create(),
+      Bar = Ember.Object.extend({}),
+      bar = Bar.create();
+    // simulate these classes being defined on a Namespace
+    Foo[Ember.GUID_KEY+'_name'] = 'Foo';
+    Bar[Ember.GUID_KEY+'_name'] = 'Bar';
+
+  equal(bar.toString(), '<Bar:'+Ember.guidFor(bar)+'>', 'does not include toStringExtension part');
+  equal(foo.toString(), '<Foo:'+Ember.guidFor(foo)+':fooey>', 'Includes toStringExtension result');
+});


### PR DESCRIPTION
A class may now implements `toStringExtension()` to have the return value included in `toString()` output. This commit also adds docs for toString.
