### PR TITLE
Bypass default property setter for Ember.Select#value

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -326,7 +326,8 @@ Ember.Select = Ember.View.extend(
     @type String
     @default null
   */
-  value: Ember.computed(function(key) {
+  value: Ember.computed(function(key, value) {
+    if (arguments.length === 2) { return value; }
     var valuePath = get(this, 'optionValuePath').replace(/^content\.?/, '');
     return valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection');
   }).property('selection'),

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -565,7 +565,7 @@ test("upon content change, the DOM should reflect the selection (#481)", functio
   equal(selectEl.selectedIndex, 1, "The DOM reflects the correct selection");
 });
 
-test("select element should initialize with the correct selectedIndex when using valueBinding", function() {
+test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding", function() {
   var view = Ember.View.create({
     collection: Ember.A([{name: 'Wes', value: 'w'}, {name: 'Gordon', value: 'g'}]),
     val: 'g',
@@ -586,6 +586,15 @@ test("select element should initialize with the correct selectedIndex when using
   var select = view.get('select'),
       selectEl = select.$()[0];
 
+  equal(view.get('val'), 'g', "Precond: Initial bound property is correct");
   equal(select.get('value'), 'g', "Precond: Initial selection is correct");
   equal(selectEl.selectedIndex, 2, "Precond: The DOM reflects the correct selection");
+
+  select.$('option:eq(2)').removeAttr('selected');
+  select.$('option:eq(1)').attr('selected', true);
+  select.$().trigger('change');
+
+  equal(view.get('val'), 'w', "Updated bound property is correct");
+  equal(select.get('value'), 'w', "Updated selection is correct");
+  equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
 });


### PR DESCRIPTION
The default setter was preventing the selection and any bound properties from being updated when the user selected a different option.

Here's a demo of the issue: http://jsbin.com/ilasoz/1/edit
