### PR TITLE
Use paths in Ember.Handlebars.TemplateHelper

### DIFF
--- a/packages/ember-handlebars/lib/helpers/template.js
+++ b/packages/ember-handlebars/lib/helpers/template.js
@@ -41,6 +41,9 @@ require('ember-handlebars/ext');
 */
 
 Ember.Handlebars.registerHelper('template', function(name, options) {
+  var handlebarsGet = Ember.Handlebars.get;
+  var context = (options.contexts && options.contexts[0]) || this;
+  name =  handlebarsGet(context, name, options) || name;
   var template = Ember.TEMPLATES[name];
 
   Ember.assert("Unable to find template with name '"+name+"'.", !!template);


### PR DESCRIPTION
Allows you to use path as parameter

```
{{template view.altTemplateName}}
```
