### PR TITLE
Improve error message for attempts to get a property of undefined

### DIFF
--- a/packages/ember-metal/lib/accessors.js
+++ b/packages/ember-metal/lib/accessors.js
@@ -37,8 +37,8 @@ var FIRST_KEY = /^([^\.\*]+)/;
   to respect the `unknownProperty` handler. Otherwise you can ignore this
   method.
 
-  Note that if the obj itself is `null`, this method will simply return
-  `undefined`.
+  Note that if the object itself is `undefined`, this method will throw
+  an error.
 
   @method get
   @for Ember
@@ -58,6 +58,7 @@ get = function get(obj, keyName) {
   }
 
   if (!obj || keyName.indexOf('.') !== -1) {
+    Ember.assert("Cannot call get with '"+ keyName +"' on an undefined object.", obj !== undefined);
     return getPath(obj, keyName);
   }
 

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -36,6 +36,18 @@ testBoth("should call unknownProperty on watched values if the value is undefine
   equal(get(obj, 'foo'), 'FOO', 'should return value from unknown');
 });
 
+test('warn on attempts to get a property of undefined', function(){
+  raises(function() {
+    Ember.get(undefined, 'aProperty');
+  });
+});
+
+test('warn on attempts to get a property path of undefined', function(){
+  raises(function() {
+    Ember.get(undefined, 'aProperty.on.aPath');
+  });
+});
+
 // ..........................................................
 // BUGS
 //


### PR DESCRIPTION
Currently attempts to get a property or property path on undefined
is not handled and instead throws "invalid path" (see #1612).

This warns and displays the attempted path name.
