### PR TITLE
better connectOutlet

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -284,10 +284,6 @@ var Application = Ember.Application = Ember.Namespace.extend(
   buildContainer: function() {
     var container = this.container = Application.buildContainer(this);
 
-    // Register a fallback application view. App.ApplicationView will
-    // take precedence.
-    container.register('view', 'application', Ember.View.extend());
-
     return container;
   },
 
@@ -500,7 +496,7 @@ var Application = Ember.Application = Ember.Namespace.extend(
         applicationView = this.container.lookup('view:application');
 
     if (router) {
-      router._activeViews.application = applicationView;
+      router._connectActiveView('application', applicationView);
     }
 
     applicationView.appendTo(rootElement);
@@ -590,6 +586,8 @@ Ember.Application.reopenClass({
   */
   buildContainer: function(namespace) {
     var container = new Ember.Container();
+    var ApplicationView = Ember.View.extend();
+
     container.set = Ember.set;
     container.resolve = resolveFor(namespace);
     container.optionsForType('view', { singleton: false });
@@ -605,6 +603,10 @@ Ember.Application.reopenClass({
 
     container.injection('view:application', 'controller', 'controller:application');
     container.injection('view:application', 'defaultTemplate', 'template:application');
+
+    // Register a fallback application view. App.ApplicationView will
+    // take precedence.
+    container.register('view', 'application', ApplicationView);
 
     return container;
   }

--- a/packages/ember-routing/lib/handlebars_ext.js
+++ b/packages/ember-routing/lib/handlebars_ext.js
@@ -66,8 +66,35 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     },
 
     connectOutlet: function(outletName, view) {
-      var outlets = get(this, '_outlets');
+      var outlets = get(this, '_outlets'),
+          container = get(this, 'container'),
+          router = container && container.lookup('router:main'),
+          oldView = get(outlets, outletName),
+          viewName = get(view, 'viewName');
+
       set(outlets, outletName, view);
+
+      if (router) {
+        if (oldView) {
+          router._disconnectActiveView(oldView);
+        }
+        if (viewName) {
+          router._connectActiveView(viewName, view);
+        }
+      }
+    },
+
+    disconnectOutlet: function(outletName) {
+      var outlets = get(this, '_outlets'),
+          container = get(this, 'container'),
+          router = container && container.lookup('router:main'),
+          view = get(outlets, outletName);
+
+      set(outlets, outletName, null);
+
+      if (router && view) {
+        router._disconnectActiveView(view);
+      }
     }
   });
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1,7 +1,5 @@
 var get = Ember.get, set = Ember.set, classify = Ember.String.classify;
 
-var DefaultView = Ember.View.extend(Ember._Metamorph);
-
 Ember.Route = Ember.Object.extend({
   /**
     @private
@@ -88,11 +86,10 @@ Ember.Route = Ember.Object.extend({
     var templateName = name || this.templateName,
         container = this.router.container,
         className = classify(templateName),
-        view = container.lookup('view:' + templateName) || DefaultView.create();
-
-    this.router._activeViews[templateName] = view;
+        view = container.lookup('view:' + templateName) || container.lookup('view:default');
 
     set(view, 'template', container.lookup('template:' + templateName));
+    set(view, 'viewName', templateName);
 
     options = options || {};
     var into = options.into || 'application';
@@ -105,7 +102,7 @@ Ember.Route = Ember.Object.extend({
 
     set(view, 'controller', controller);
 
-    var parentView = this.router._activeViews[into];
+    var parentView = this.router._lookupActiveView(into);
     parentView.connectOutlet(outlet, view);
   }
 });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -20,7 +20,7 @@ Ember.Router = Ember.Object.extend({
 
   init: function() {
     var router = this.router = new Router();
-    var activeViews = this._activeViews = {};
+    this._activeViews = {};
 
     setupLocation(this);
 
@@ -45,11 +45,7 @@ Ember.Router = Ember.Object.extend({
       Ember.run.once(updateURL);
     };
 
-    if (!container.lookup('view:application')) {
-      container.register('view', 'application', DefaultView.create({
-        templateName: 'application'
-      }));
-    }
+    container.register('view', 'default', DefaultView);
 
     router.handleURL(location.getURL());
     location.onUpdateURL(function(url) {
@@ -75,6 +71,26 @@ Ember.Router = Ember.Object.extend({
     }
 
     this.router.trigger(name, context);
+  },
+
+  _lookupActiveView: function(templateName) {
+    return this._activeViews[templateName];
+  },
+
+  _connectActiveView: function(templateName, view) {
+    this._activeViews[templateName] = view;
+  },
+
+  _disconnectActiveView: function(view) {
+    var activeViews = this._activeViews,
+        templateName;
+    for (templateName in activeViews) {
+      if (!activeViews.hasOwnProperty(templateName)) { continue; }
+      if (activeViews[templateName] === view) {
+        delete activeViews[templateName];
+        break;
+      }
+    }
   }
 });
 

--- a/packages/ember-routing/tests/helpers/outlet_test.js
+++ b/packages/ember-routing/tests/helpers/outlet_test.js
@@ -101,3 +101,28 @@ test("Outlets bind to the current view, not the current concrete view", function
   var output = Ember.$('#qunit-fixture h1 ~ h2 ~ h3').text();
   equal(output, "BOTTOM", "all templates were rendered");
 });
+
+test("view should support disconnectOutlet for the main outlet", function() {
+  var template = "<h1>HI</h1>{{outlet}}";
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(template)
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'HI');
+
+  Ember.run(function() {
+    view.connectOutlet('main', Ember.View.create({
+      template: compile("<p>BYE</p>")
+    }));
+  });
+
+  equal(view.$().text(), 'HIBYE');
+
+  Ember.run(function() {
+    view.disconnectOutlet('main');
+  });
+
+  equal(view.$().text(), 'HI');
+});

--- a/packages/ember-routing/tests/integration/basic_test.js
+++ b/packages/ember-routing/tests/integration/basic_test.js
@@ -5,7 +5,7 @@ function bootApplication() {
   router = container.lookup('router:main');
 
   Ember.run(function() {
-    router._activeViews.application = AppView.create().appendTo('#qunit-fixture');
+    router._activeViews.application = container.lookup('view:application').appendTo('#qunit-fixture');
     router.startRouting();
   });
 }
@@ -34,7 +34,7 @@ module("Basic Routing", {
         template: Ember.TEMPLATES.app
       });
 
-      container.register('view', 'app');
+      container.register('view', 'application', AppView);
       container.register('router', 'main', Router);
     });
   }
@@ -55,6 +55,34 @@ test("The Homepage", function() {
   });
 
   equal(Ember.$('h3:contains(Hours)', '#qunit-fixture').length, 1, "The home template was rendered");
+});
+
+test("The Homepage register as activeView", function() {
+  Router.map(function(match) {
+    match("/").to("home");
+    match("/homepage").to("homepage");
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+  });
+
+  App.HomepageRoute = Ember.Route.extend({
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  ok(router._lookupActiveView('home'), '`home` active view is connected');
+
+  Ember.run(function() {
+    router.handleURL("/homepage");
+  });
+
+  ok(router._lookupActiveView('homepage'), '`homepage` active view is connected');
+  equal(router._lookupActiveView('home'), undefined, '`home` active view is disconnected');
 });
 
 test("The Homepage with explicit template name in renderTemplates", function() {


### PR DESCRIPTION
- ensure we do not keep references to destroyed activeView on the router
- ensure all views are created through container api in order to ensure that all view have a container
- do all the book-keeping inside connectOutlet/disconnectOutlet, it allow to use thous methods reliably outside of route#render
- add disconnectOutlet
