### PR TITLE
Fixes: Safari's 'double finally on error bug'

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -211,11 +211,10 @@ function suspendListener(obj, eventName, target, method, callback) {
     actions[actionIndex] = action; // replace the shared object with our copy
   }
 
-  try {
-    return callback.call(target);
-  } finally {
-    if (action) { action[3] = undefined; }
-  }
+  function tryable()   { return callback.call(target); }
+  function finalizer() { if (action) { action[3] = undefined; } }
+
+  return Ember.tryFinally(tryable, finalizer);
 }
 
 /**
@@ -258,13 +257,15 @@ function suspendListeners(obj, eventNames, target, method, callback) {
     }
   }
 
-  try {
-    return callback.call(target);
-  } finally {
+  function tryable() { return callback.call(target); }
+
+  function finalizer() {
     for (i = 0, l = suspendedActions.length; i < l; i++) {
       suspendedActions[i][3] = undefined;
     }
   }
+
+  return Ember.tryFinally(tryable, finalizer);
 }
 
 /**

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -1,6 +1,6 @@
 require('ember-metal/core');
 require('ember-metal/platform');
-require('ember-metal/utils');
+require('ember-metal/utils'); // Ember.tryFinally
 require('ember-metal/accessors');
 require('ember-metal/array');
 
@@ -114,11 +114,7 @@ Ember.endPropertyChanges = function() {
 */
 Ember.changeProperties = function(cb, binding){
   Ember.beginPropertyChanges();
-  try {
-    cb.call(binding);
-  } finally {
-    Ember.endPropertyChanges();
-  }
+  Ember.tryFinally(cb, Ember.endPropertyChanges, binding);
 };
 
 /**

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -406,3 +406,121 @@ Ember.tryInvoke = function(obj, methodName, args) {
     return obj[methodName].apply(obj, args || []);
   }
 };
+
+// https://github.com/emberjs/ember.js/pull/1617
+var needsFinallyFix = (function() {
+  var count = 0;
+  try{
+    try { }
+    finally {
+      count++;
+      throw new Error('needsFinallyFixTest');
+    }
+  } catch (e) {}
+
+  return count !== 1;
+})();
+
+/**
+  Provides try { } finally { } functionality, while working
+  around Safari's double finally bug.
+
+  @method tryFinally
+  @for Ember
+  @param {Function} function The function to run the try callback
+  @param {Function} function The function to run the finally callback
+  @param [binding]
+  @return {anything} The return value is the that of the finalizer,
+  unless that valueis undefined, in which case it is the return value
+  of the tryable
+*/
+
+if (needsFinallyFix) {
+  Ember.tryFinally = function(tryable, finalizer, binding) {
+    var result, finalResult, finalError;
+
+    binding = binding || this;
+
+    try {
+      result = tryable.call(binding);
+    } finally {
+      try {
+        finalResult = finalizer.call(binding);
+      } catch (e){
+        finalError = e;
+      }
+    }
+
+    if (finalError) { throw finalError; }
+
+    return (finalResult === undefined) ? result : finalResult;
+  };
+} else {
+  Ember.tryFinally = function(tryable, finalizer, binding) {
+    var result, finalResult;
+
+    binding = binding || this;
+
+    try {
+      result = tryable.call(binding);
+    } finally {
+      finalResult = finalizer.call(binding);
+    }
+
+    return (finalResult === undefined) ? result : finalResult;
+  };
+}
+
+/**
+  Provides try { } catch finally { } functionality, while working
+  around Safari's double finally bug.
+
+  @method tryCatchFinally
+  @for Ember
+  @param {Function} function The function to run the try callback
+  @param {Function} function The function to run the catchable callback
+  @param {Function} function The function to run the finally callback
+  @param [binding]
+  @return {anything} The return value is the that of the finalizer,
+  unless that value is undefined, in which case it is the return value
+  of the tryable.
+*/
+if (needsFinallyFix) {
+  Ember.tryCatchFinally = function(tryable, catchable, finalizer, binding) {
+    var result, finalResult, finalError, finalReturn;
+
+    binding = binding || this;
+
+    try {
+      result = tryable.call(binding);
+    } catch(error) {
+      result = catchable.call(binding, error);
+    } finally {
+      try {
+        finalResult = finalizer.call(binding);
+      } catch (e){
+        finalError = e;
+      }
+    }
+
+    if (finalError) { throw finalError; }
+
+    return (finalResult === undefined) ? result : finalResult;
+  };
+} else {
+  Ember.tryCatchFinally = function(tryable, catchable, finalizer, binding) {
+    var result, finalResult;
+
+    binding = binding || this;
+
+    try {
+      result = tryable.call(binding);
+    } catch(error) {
+      result = catchable.call(binding, error);
+    } finally {
+      finalResult = finalizer.call(binding);
+    }
+
+    return (finalResult === undefined) ? result : finalResult;
+  };
+}

--- a/packages/ember-metal/tests/utils/try_catch_finally_test.js
+++ b/packages/ember-metal/tests/utils/try_catch_finally_test.js
@@ -1,0 +1,119 @@
+var tryCount, catchCount, finalizeCount, tryable, catchable, finalizer, error,
+tryableResult, catchableResult, finalizerResult;
+
+module("Ember.tryFinally", {
+  setup: function() {
+    error = new Error('Test Error');
+    tryCount = 0;
+    finalizeCount = 0;
+    catchCount = 0;
+    tryableResult = 'tryable return value';
+    catchableResult = 'catchable return value';
+    finalizerResult = undefined;
+
+    tryable   = function() { tryCount++;      return tryableResult;   };
+    catchable = function() { catchCount++;    return catchableResult; };
+    finalizer = function() { finalizeCount++; return finalizerResult; };
+  },
+
+  teardown: function() {
+    tryCount = catchCount, finalizeCount = tryable = catchable = finalizer =
+    finalizeCount =tryableResult = null;
+  }
+});
+
+function callTryCatchFinallyWithError(){
+  var errorWasThrown;
+  try {
+    Ember.tryCatchFinally(tryable, catchable, finalizer);
+  } catch(e) {
+    errorWasThrown = true;
+    equal(e, error, 'correct error was thrown');
+  }
+
+  equal(errorWasThrown, true,  'error was thrown');
+}
+
+test("no failure", function() {
+  equal(Ember.tryCatchFinally(tryable, catchable, finalizer), tryableResult, 'correct return value');
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    0, 'catchable was never called');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("no failure, return from finally", function() {
+  finalizerResult = 'finalizer return value';
+
+  equal(Ember.tryCatchFinally(tryable, catchable, finalizer), finalizerResult, 'correct return value');
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    0, 'catchable was never called');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("try failed", function() {
+  tryable = function() { tryCount++; throw error; };
+
+  var result = Ember.tryCatchFinally(tryable, catchable, finalizer);
+
+  equal(result, catchableResult, 'correct return value');
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    1, 'catchable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("catch failed", function() {
+  catchable = function() { catchCount++; throw error; };
+
+  Ember.tryCatchFinally(tryable, catchable, finalizer);
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    0, 'catchable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("try and catch failed", function() {
+  tryable = function() { tryCount++; throw error; };
+  catchable = function() { catchCount++; throw error; };
+
+  callTryCatchFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    1, 'catchable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("finally failed", function() {
+  finalizer = function() { finalizeCount++; throw error; };
+
+  callTryCatchFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    0, 'catchable was never called');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("finally and try failed", function() {
+  tryable   = function() { tryCount++;      throw error; };
+  finalizer = function() { finalizeCount++; throw error; };
+
+  callTryCatchFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    1, 'catchable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("finally, catch and try failed", function() {
+  tryable   = function() { tryCount++;      throw error; };
+  catchable = function() { catchCount++; throw error; };
+  finalizer = function() { finalizeCount++; throw error; };
+
+  callTryCatchFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(catchCount,    1, 'catchable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});

--- a/packages/ember-metal/tests/utils/try_finally_test.js
+++ b/packages/ember-metal/tests/utils/try_finally_test.js
@@ -1,0 +1,74 @@
+var tryCount, finalizeCount, tryable, finalizer, error, tryableResult, finalizerResult;
+
+module("Ember.tryFinally", {
+  setup: function() {
+    error = new Error('Test Error');
+    tryCount = 0;
+    finalizeCount = 0;
+    tryableResult = 'tryable return value';
+    finalizerResult = undefined;
+
+    tryable   = function() { tryCount++;      return tryableResult;   };
+    finalizer = function() { finalizeCount++; return finalizerResult; };
+  },
+
+  teardown: function() {
+    tryCount = finalizeCount = tryable = finalizer = finalizeCount, tryableResult = null;
+  }
+});
+
+function callTryFinallyWithError(){
+  var errorWasThrown;
+  try {
+    Ember.tryFinally(tryable, finalizer);
+  } catch(e) {
+    errorWasThrown = true;
+    equal(e, error, 'correct error was thrown');
+  }
+
+  equal(errorWasThrown, true,  'error was thrown');
+}
+
+test("no failure", function() {
+  equal(Ember.tryFinally(tryable, finalizer), tryableResult, 'correct return value');
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("no failure, return from finally", function() {
+  finalizerResult = 'finalizer return value';
+
+  equal(Ember.tryFinally(tryable, finalizer), finalizerResult, 'crrect return value');
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("try failed", function() {
+  tryable = function() { tryCount++; throw error; };
+
+  callTryFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("finally failed", function() {
+  finalizer = function() { finalizeCount++; throw error; };
+
+  callTryFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});
+
+test("finally and try failed", function() {
+  tryable   = function() { tryCount++;      throw error; };
+  finalizer = function() { finalizeCount++; throw error; };
+
+  callTryFinallyWithError();
+
+  equal(tryCount,      1, 'tryable was called once');
+  equal(finalizeCount, 1, 'finalize was called once');
+});

--- a/packages/ember-routing/lib/router.js
+++ b/packages/ember-routing/lib/router.js
@@ -1,6 +1,7 @@
 require('ember-routing/route_matcher');
 require('ember-routing/routable');
 require('ember-routing/location');
+require('ember-metal/utils'); // Ember.tryFinally
 
 /**
 @module ember
@@ -539,8 +540,7 @@ Ember.Router = Ember.StateManager.extend(
     set(this, 'isRouting', true);
 
     var routableState;
-
-    try {
+    function tryable() {
       path = path.replace(get(this, 'rootURL'), '');
       path = path.replace(/^(?=[^\/])/, "/");
 
@@ -555,9 +555,13 @@ Ember.Router = Ember.StateManager.extend(
       var rest = path.substr(currentURL.length);
 
       this.send('routePath', rest);
-    } finally {
+    }
+
+    function finalizer() {
       set(this, 'isRouting', false);
     }
+
+    Ember.tryFinally(tryable, finalizer, this);
 
     routableState = get(this, 'currentState');
     while (routableState && !routableState.get('isRoutable')) {


### PR DESCRIPTION
## Scumbag Safari

Turns out safari (6.0.2) and potentially other webkits,
will execute finally twice, if an error is thrown within the
finally block;

``` Javascript

count = 0;
try {

} finally {
  count ++;
  throw new Error('bromg');
}

count
> 2
```

Those who gained some extra gray hair debugging this one:
- @kselden
- @wagenet
- @stefanpenner

Bug Demo: http://jsbin.com/usoquy/1/edit
known to be an issue in:
- Safari 6.0.2 
- iOS 6 mobile safari
- maybe others

We also submitting a bug report to [apple](http://bugreport.apple.com/), and it is `Problem ID: #12929607`

Interestingly the error will only be thrown once, but the
code up until the error is thrown, will be executed twice.

Although strange, it is rare during normal ideal execution
that this causes real issues, but when it does, it
is quite frustrating to debug.

This bug manifested itself as an unrelated, error. Simply
telling us we must be in a runloop, when we actually were.

Turns out, the real error was occuring during a run.end()

``` Javascript
// https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/run_loop.js#L219
try {
  if (target || method) { ret = invoke(target, method, arguments, 2); }
} finally {
  run.end(); // <----- Error was raise here, causing this code block to be re-executed
}
```

Since `finally`` executes a second time in buggy versions of Safari,
we re-entered code, but lacking a proper run-loop.

Anyways, fun times.

To solve this problem, and keep dirty hacks contained, two new utility methods
provide the 'safe' workaround:

``` Javascript
Ember.tryFinally(tryable, finalizer);
Ember.tryCatchFinally(tryable, catchable, finalizer);
```

These helpers try to abide by the languages try/catch/finally semantics.

Happy Holidays.
