### PR TITLE
[Fixes #1621] CoffeeScript _super var conflicts with assertion

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -85,7 +85,7 @@ function makeCtor() {
           var desc = m.descs[keyName];
 
           Ember.assert("Ember.Object.create no longer supports defining computed properties.", !(value instanceof Ember.ComputedProperty));
-          Ember.assert("Ember.Object.create no longer supports defining methods that call _super.", !(typeof value === 'function' && value.toString().indexOf('_super') !== -1));
+          Ember.assert("Ember.Object.create no longer supports defining methods that call _super.", !(typeof value === 'function' && value.toString().indexOf('._super') !== -1));
 
           if (concatenatedProperties && indexOf(concatenatedProperties, keyName) >= 0) {
             var baseValue = this[keyName];


### PR DESCRIPTION
Since Ember.Object.create no longer supports _super() calls, we have an assertion which prevents accidental calls. This sometimes overzealous assertion can cause CoffeeScript users some headaches.
