### PR TITLE
Improve error messages by quoting name of object that can't be found.

### DIFF
--- a/packages/ember-views/lib/system/controller.js
+++ b/packages/ember-views/lib/system/controller.js
@@ -156,8 +156,8 @@ Ember.ControllerMixin.reopen({
       viewClass = get(namespace, viewClassName);
       controller = get(controllers, name + 'Controller');
 
-      Ember.assert("The name you supplied " + name + " did not resolve to a view " + viewClassName, !!viewClass);
-      Ember.assert("The name you supplied " + name + " did not resolve to a controller " + name + 'Controller', (!!controller && !!context) || !context);
+      Ember.assert("The name you supplied '" + name + "' did not resolve to a view " + viewClassName, !!viewClass);
+      Ember.assert("The name you supplied '" + name + "' did not resolve to a controller " + name + 'Controller', (!!controller && !!context) || !context);
     }
 
     if (controller && context) { set(controller, 'content', context); }


### PR DESCRIPTION
Error messages are more readable when the string being reported on is quoted. This patch adds quotes to the error message when a view or controller can't be found.
