### PR TITLE
{{action}} will target a template's controller

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -58,7 +58,7 @@ Ember.ControllerMixin = Ember.Mixin.create({
   send: function(actionName, event) {
     var target;
 
-    if (this.hasOwnProperty(actionName)) {
+    if (this[actionName]) {
       this[actionName](event);
     } else if(target = get(this, 'target')) {
       target.send(actionName, event);


### PR DESCRIPTION
If a function whose name matches an an action is implemented on
a template's controller, that method will be called instead of
delegating the action to the application's current state.

Not sure why a check of `hasOwnProperty` was used, but
it prevented this new behavior from occurring.

@tomdale and I discussed this briefly last night.
