### PR TITLE
Less confusing failure message for jQuery 1.7 rejection

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -4,7 +4,7 @@
 */
 
 var jQuery = Ember.imports.jQuery;
-Ember.assert("Ember Views require jQuery 1.7 or 1.8", jQuery && (jQuery().jquery.match(/^1\.(7(?!$)(?!\.[01])|8)(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
+Ember.assert("Ember Views require jQuery 1.7 (>= 1.7.2) or 1.8", jQuery && (jQuery().jquery.match(/^1\.(7(?!$)(?!\.[01])|8)(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
 
 /**
   Alias for jQuery


### PR DESCRIPTION
Ember rejects jQuery 1.7 with the message "Ember Views require jQuery 1.7 or 1.8". 

I had to reverse-engineer the RegExp to see that it really requires jQuery1.7 >= 1.7.2. This will save someone else that trouble.

(See #1448 for why we require 1.7.2.)
