### PR TITLE
Fixed StarSegment route matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.bpkg
 *.gem
 *.rbc
+*.swp
 .DS_Store
 .bpm
 .bundle

--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -186,9 +186,9 @@ define("route-recognizer",
 
           charSpec = child.charSpec;
 
-          if (chars = charSpec.validChars) {
+          if (typeof (chars = charSpec.validChars) !== 'undefined') {
             if (chars.indexOf(char) !== -1) { returned.push(child); }
-          } else if (chars = charSpec.invalidChars) {
+          } else if (typeof (chars = charSpec.invalidChars) !== 'undefined') {
             if (chars.indexOf(char) === -1) { returned.push(child); }
           }
         }

--- a/packages/ember-routing/tests/integration/basic_test.js
+++ b/packages/ember-routing/tests/integration/basic_test.js
@@ -672,4 +672,28 @@ test("A redirection hook is provided", function() {
   equal(Ember.$("h3:contains(Hours)", "#qunit-fixture").length, 1, "The home template was rendered");
 });
 
+test("Star matching works correctly", function()
+{
+  Router.map(function(match) {
+    match("/").to("home");
+    match("/*blah").to("star");
+  });
+
+  var chooseFollowed = 0;
+
+  App.StarRoute = Ember.Route.extend({
+    setupControllers: function() {
+      chooseFollowed++;
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/" + String(Math.random()).substr(2));
+  });
+
+  equal(chooseFollowed, 1, "The 404 route was followed");
+});
+
 // TODO: Parent context change


### PR DESCRIPTION
The StarSegment segment type defined it's charSpec as `{invalidChars: ''}`, however the route matching logic checked for falsiness rather than undefined, so this spec was always skipped.

This commit fixes this and adds a basic test.
