### PR TITLE
Proper labeling of html vs handlebars code blocks in comments

### DIFF
--- a/packages/ember-handlebars/lib/helpers/action.js
+++ b/packages/ember-handlebars/lib/helpers/action.js
@@ -71,7 +71,7 @@ ActionHelper.registerAction = function(actionName, options) {
 
   Given the following Handlebars template on the page
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="view"}}>
       click me
@@ -122,7 +122,7 @@ ActionHelper.registerAction = function(actionName, options) {
   By default the `{{action}}` helper registers for DOM `click` events. You can
   supply an `on` option to the helper to specify a different DOM event name:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName on="doubleClick"}}>
       click me
@@ -161,7 +161,7 @@ ActionHelper.registerAction = function(actionName, options) {
   object will receive the method call. This option must be a string
   representing a path to an object:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="MyApplication.someObject"}}>
       click me
@@ -177,7 +177,7 @@ ActionHelper.registerAction = function(actionName, options) {
   A path relative to the template's `Ember.View` instance can also be used as
   a target:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action anActionName target="parentView"}}>
       click me
@@ -196,7 +196,7 @@ ActionHelper.registerAction = function(actionName, options) {
   If an action's target does not implement a method that matches the supplied
   action name an error will be thrown.
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name='a-template'>
     <div {{action aMethodNameThatIsMissing}}>
       click me
@@ -227,7 +227,7 @@ ActionHelper.registerAction = function(actionName, options) {
   objects are made available as the `contexts` (also `context` if there is only
   one) properties in the `jQuery.Event` object:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name='a-template'>
     {{#each person in people}}
       <div {{action edit person}}>

--- a/packages/ember-handlebars/lib/helpers/template.js
+++ b/packages/ember-handlebars/lib/helpers/template.js
@@ -9,7 +9,7 @@ require('ember-handlebars/ext');
   `template` allows you to render a template from inside another template.
   This allows you to re-use the same template in multiple places. For example:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name="logged_in_user">
     {{#with loggedInUser}}
       Last Login: {{lastLogin}}
@@ -18,7 +18,7 @@ require('ember-handlebars/ext');
   </script>
   ```
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name="user_info">
     Name: <em>{{name}}</em>
     Karma: <em>{{karma}}</em>

--- a/packages/ember-old-router/lib/router.js
+++ b/packages/ember-old-router/lib/router.js
@@ -422,7 +422,7 @@ var merge = function(original, hash) {
 
   The following template:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name="aView">
       <h1><a {{action anActionOnTheRouter}}>{{title}}</a></h1>
   </script>
@@ -437,7 +437,7 @@ var merge = function(original, hash) {
   Different `context` can be supplied from within the `{{action}}` helper,
   allowing specific context passing between application states:
 
-  ```handlebars
+  ```html
   <script type="text/x-handlebars" data-template-name="photos">
     {{#each photo in controller}}
       <h1><a {{action showPhoto photo}}>{{title}}</a></h1>

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -467,7 +467,7 @@ class:
   Within an Ember application is more common to define a Handlebars templates as
   part of a page:
 
-  ```handlebars
+  ```html
   <script type='text/x-handlebars' data-template-name='some-template'>
     Hello
   </script>


### PR DESCRIPTION
Code blocks in which templates are embedded in `<script>` tags should be marked as `html`, not `handlebars`. This will correct display glitches in the API docs.
