### PR TITLE
Make controllers handle events defined on their prototypes

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -58,7 +58,7 @@ Ember.ControllerMixin = Ember.Mixin.create({
   send: function(actionName, event) {
     var target;
 
-    if (this.hasOwnProperty(actionName)) {
+    if (typeof(this[actionName])==='function') {
       this[actionName](event);
     } else if(target = get(this, 'target')) {
       target.send(actionName, event);

--- a/packages/ember-runtime/tests/controllers/controller_tests.js
+++ b/packages/ember-runtime/tests/controllers/controller_tests.js
@@ -1,0 +1,14 @@
+module("Ember.Controller");
+
+
+test("should respond to events defined in its prototype", function() {
+  var controller = Ember.Controller.extend({
+    actionFired: false,
+    myAction: function(){
+      this.set('actionFired', true);
+    }
+  }).create();
+
+  controller.send('myAction');
+  equal(controller.get('actionFired'), true, "action fired");
+});


### PR DESCRIPTION
The following very simple use of `action` doesn't work:

```
<script type="text/x-handlebars" data-template-name="application">
<div {{action "myAction"}}>Action</div>    
</script>​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​​
```

``` javascript
App = Ember.Application.create();

App.ApplicationController = Ember.Controller.extend({
    myAction: function(){ alert("it worked")}
});
```

(Runnable version here: http://jsfiddle.net/AMLf4/)

The event fails to fire because `ControllerMixin.send` uses `hasOwnProperty` to determine if the controller can handle the event. In this case (and most cases), the property is defined higher up the prototype chain.
