### PR TITLE
Remove references to `autoinit: false` in ember-application

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -31,11 +31,11 @@ Ember.Container.set = Ember.set;
   App.MyView = Ember.View.extend();
   ```
 
-  Calling `Ember.Application.create()` will automatically initialize your
-  application by calling the `Ember.Application.initialize()` method. If you
-  need to delay initialization, you can pass `{autoinit: false}` to the
-  `Ember.Application.create()` method, and call `App.initialize()`
-  later.
+  By default, calling `Ember.Application.create()` will automatically initialize
+  your  application by calling the `Ember.Application.initialize()` method. If
+  you need to delay initialization, you can call your app's `deferReadiness()`
+  method. When you are ready for your app to be initialized, call its
+  `advanceReadiness()` method.
 
   Because `Ember.Application` inherits from `Ember.Namespace`, any classes
   you create will have useful string representations when calling `toString()`.


### PR DESCRIPTION
Remove reference to non-existent `autoinit: false` property passed in to
`Ember.Application.create` and add docs for `deferReadiness` and
`advanceReadiness`
