### PR TITLE
Remove redundant calls to ComputedProperty#property()

### DIFF
--- a/packages/ember-handlebars/lib/controls/button.js
+++ b/packages/ember-handlebars/lib/controls/button.js
@@ -46,14 +46,14 @@ Ember.Button = Ember.View.extend(Ember.TargetActionSupport, {
   type: Ember.computed(function(key) {
     var tagName = this.tagName;
     if (tagName === 'input' || tagName === 'button') { return 'button'; }
-  }).property(),
+  }),
 
   disabled: false,
 
   // Allow 'a' tags to act like buttons
   href: Ember.computed(function() {
     return this.tagName === 'a' ? '#' : null;
-  }).property(),
+  }),
 
   mouseDown: function() {
     if (!get(this, 'disabled')) {

--- a/packages/ember-handlebars/lib/controls/tabs/tab_pane_view.js
+++ b/packages/ember-handlebars/lib/controls/tabs/tab_pane_view.js
@@ -14,7 +14,7 @@ var get = Ember.get;
 Ember.TabPaneView = Ember.View.extend({
   tabsContainer: Ember.computed(function() {
     return this.nearestOfType(Ember.TabContainerView);
-  }).property().volatile(),
+  }).volatile(),
 
   isVisible: Ember.computed(function() {
     return get(this, 'viewName') === get(this, 'tabsContainer.currentView');

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -70,7 +70,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
         indexArray[i] = i;
       }
       return indexArray;
-    }).property()
+    })
   });
 
   view = Ember.View.create({

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -159,7 +159,6 @@ module('Ember.computed - metadata');
 
 test("can set metadata on a computed property", function() {
   var computedProperty = Ember.computed(function() { });
-  computedProperty.property();
   computedProperty.meta({ key: 'keyValue' });
 
   equal(computedProperty.meta().key, 'keyValue', "saves passed meta hash to the _meta property");
@@ -533,7 +532,7 @@ testBoth('depending on Global chain', function(get, set) {
 });
 
 testBoth('chained dependent keys should evaluate computed properties lazily', function(get,set){
-  Ember.defineProperty(obj.foo.bar, 'b', Ember.computed(func).property());
+  Ember.defineProperty(obj.foo.bar, 'b', Ember.computed(func));
   Ember.defineProperty(obj.foo, 'c', Ember.computed(function(){}).property('bar.b'));
   equal(count, 0, 'b should not run');
 });

--- a/packages/ember-metal/tests/performance_test.js
+++ b/packages/ember-metal/tests/performance_test.js
@@ -58,7 +58,7 @@ test("computed properties are not executed if they are the last segment of an ob
 
   Ember.defineProperty(foo.bar.baz, 'bam', Ember.computed(function() {
     count++;
-  }).property());
+  }));
 
   Ember.addObserver(foo, 'bar.baz.bam', function() {});
 

--- a/packages/ember-old-router/lib/resolved_state.js
+++ b/packages/ember-old-router/lib/resolved_state.js
@@ -14,7 +14,7 @@ Ember._ResolvedState = Ember.Object.extend({
           manager = get(this, 'manager');
       return state.deserialize(manager, match.hash);
     }
-  }).property(),
+  }),
 
   hasPromise: Ember.computed(function() {
     return Ember.canInvoke(get(this, 'object'), 'then');

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -122,15 +122,15 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   '[]': Ember.computed(function(key, value) {
     if (value !== undefined) this.replace(0, get(this, 'length'), value) ;
     return this ;
-  }).property(),
+  }),
 
   firstObject: Ember.computed(function() {
     return this.objectAt(0);
-  }).property(),
+  }),
 
   lastObject: Ember.computed(function() {
     return this.objectAt(get(this, 'length')-1);
-  }).property(),
+  }),
 
   // optimized version from Enumerable
   contains: function(obj){
@@ -301,7 +301,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   */
   hasArrayObservers: Ember.computed(function() {
     return Ember.hasListeners(this, '@array:change') || Ember.hasListeners(this, '@array:before');
-  }).property(),
+  }),
 
   /**
     If you are implementing an object that supports `Ember.Array`, call this
@@ -400,6 +400,6 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   '@each': Ember.computed(function() {
     if (!this.__each) this.__each = new Ember.EachProxy(this);
     return this.__each;
-  }).property()
+  })
 
 }) ;

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -719,7 +719,7 @@ Ember.Enumerable = Ember.Mixin.create(
   */
   '[]': Ember.computed(function(key, value) {
     return this;
-  }).property(),
+  }),
 
   // ..........................................................
   // ENUMERABLE OBSERVERS
@@ -773,7 +773,7 @@ Ember.Enumerable = Ember.Mixin.create(
   */
   hasEnumerableObservers: Ember.computed(function() {
     return Ember.hasListeners(this, '@enumerable:change') || Ember.hasListeners(this, '@enumerable:before');
-  }).property(),
+  }),
 
 
   /**

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -211,7 +211,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     var arrangedContent = get(this, 'arrangedContent');
     return arrangedContent ? get(arrangedContent, 'length') : 0;
     // No dependencies since Enumerable notifies length of change
-  }).property(),
+  }),
 
   replace: function(idx, amt, objects) {
     Ember.assert('The content property of '+ this.constructor + ' should be set before modifying it', this.get('content'));

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -27,7 +27,7 @@ var EachArray = Ember.Object.extend(Ember.Array, {
   length: Ember.computed(function() {
     var content = this._content;
     return content ? get(content, 'length') : 0;
-  }).property()
+  })
 
 });
 

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -355,12 +355,12 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
   // more optimized version
   firstObject: Ember.computed(function() {
     return this.length > 0 ? this[0] : undefined;
-  }).property(),
+  }),
 
   // more optimized version
   lastObject: Ember.computed(function() {
     return this.length > 0 ? this[this.length-1] : undefined;
-  }).property(),
+  }),
 
   // implements Ember.MutableEnumerable
   addObject: function(obj) {

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -47,7 +47,7 @@ module("object.get()", {
       numberVal: 24,
       toggleVal: true,
 
-      computed: Ember.computed(function() { return 'value'; }).property().volatile(),
+      computed: Ember.computed(function() { return 'value'; }).volatile(),
 
       method: function() { return "value"; },
 
@@ -96,7 +96,7 @@ module("Ember.get()", {
       numberVal: 24,
       toggleVal: true,
 
-      computed: Ember.computed(function() { return 'value'; }).property().volatile(),
+      computed: Ember.computed(function() { return 'value'; }).volatile(),
 
       method: function() { return "value"; },
 
@@ -179,7 +179,7 @@ module("Ember.get() with paths", {
 test("should return a property at a given path relative to the lookup", function() {
   lookup.Foo = ObservableObject.create({
     Bar: ObservableObject.createWithMixins({
-      Baz: Ember.computed(function() { return "blargh"; }).property().volatile()
+      Baz: Ember.computed(function() { return "blargh"; }).volatile()
     })
   });
 
@@ -189,7 +189,7 @@ test("should return a property at a given path relative to the lookup", function
 test("should return a property at a given path relative to the passed object", function() {
   var foo = ObservableObject.create({
     bar: ObservableObject.createWithMixins({
-      baz: Ember.computed(function() { return "blargh"; }).property().volatile()
+      baz: Ember.computed(function() { return "blargh"; }).volatile()
     })
   });
 
@@ -235,7 +235,7 @@ module("object.set()", {
           this._computed = value ;
         }
         return this._computed ;
-      }).property().volatile(),
+      }).volatile(),
 
       // method, but not a property
       _method: "method",
@@ -321,13 +321,13 @@ module("Computed properties", {
       computed: Ember.computed(function(key, value) {
         this.computedCalls.push(value);
         return 'computed';
-      }).property().volatile(),
+      }).volatile(),
 
       computedCachedCalls: [],
       computedCached: Ember.computed(function(key, value) {
         this.computedCachedCalls.push(value);
         return 'computedCached';
-      }).property(),
+      }),
 
 
       // DEPENDENT KEYS

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -37,7 +37,7 @@ var TestArray = Ember.Object.extend(Ember.Array, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property(),
+  }),
 
   slice: function() {
     return this._content.slice();

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -26,7 +26,7 @@ var TestEnumerable = Ember.Object.extend(Ember.Enumerable, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property(),
+  }),
 
   slice: function() {
     return this._content.slice();

--- a/packages/ember-runtime/tests/mixins/mutable_array_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_array_test.js
@@ -33,7 +33,7 @@ var TestMutableArray = Ember.Object.extend(Ember.MutableArray, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property(),
+  }),
 
   slice: function() {
     return this._content.slice();

--- a/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
@@ -37,7 +37,7 @@ var TestMutableEnumerable = Ember.Object.extend(Ember.MutableEnumerable, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }).property(),
+  }),
 
   slice: function() {
     return this._content.slice();

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -219,7 +219,7 @@ var EnumerableTests = Ember.Object.extend({
   */
   canTestMutation: Ember.computed(function() {
     return this.mutate !== EnumerableTests.prototype.mutate;
-  }).property(),
+  }),
 
   /**
     Invoked to actually run the test - overridden by mixins

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -130,14 +130,14 @@ test("can retrieve metadata for a computed property", function() {
 
   var MyClass = Ember.Object.extend({
     computedProperty: Ember.computed(function() {
-    }).property().meta({ key: 'keyValue' })
+    }).meta({ key: 'keyValue' })
   });
 
   equal(get(MyClass.metaForProperty('computedProperty'), 'key'), 'keyValue', "metadata saved on the computed property can be retrieved");
 
   var ClassWithNoMetadata = Ember.Object.extend({
     computedProperty: Ember.computed(function() {
-    }).property().volatile(),
+    }).volatile(),
 
     staticProperty: 12
   });

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -47,7 +47,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
     }
 
     return path;
-  }).property(),
+  }),
 
   /**
     @private

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -27,7 +27,7 @@ var childViewsProperty = Ember.computed(function() {
   });
 
   return ret;
-}).property();
+});
 
 Ember.warn("The VIEW_PRESERVES_CONTEXT flag has been removed and the functionality can no longer be disabled.", Ember.ENV.VIEW_PRESERVES_CONTEXT !== false);
 

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -35,7 +35,7 @@ test("should warn if a non-array is used for classNames", function() {
     Ember.View.createWithMixins({
       classNames: Ember.computed(function() {
         return ['className'];
-      }).property().volatile()
+      }).volatile()
     });
   }, /Only arrays are allowed/i, 'should warn that an array was not used');
 });
@@ -45,7 +45,7 @@ test("should warn if a non-array is used for classNamesBindings", function() {
     Ember.View.createWithMixins({
       classNameBindings: Ember.computed(function() {
         return ['className'];
-      }).property().volatile()
+      }).volatile()
     });
   }, /Only arrays are allowed/i, 'should warn that an array was not used');
 });


### PR DESCRIPTION
With no dependent keys, there is no reason to call `property()` on the `ComputedProperty` returned by `Ember.computed()`.

This of course is harmless but having many instances of it in the codebase cause people to cargo cult it.
