### PR TITLE
Precompile defaultTemplate even in development versions.

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -3,23 +3,12 @@ require "json"
 require "uglifier"
 require "execjs"
 
-class EmberProductionFilter < Rake::Pipeline::Filter
-
-  def js_context
-    # We're using Ember to build Ember! Inception!
-    unless @context
-      headless = File.read("lib/headless-ember.js")
-      ember    = File.read("lib/ember.js")
-      @context = ExecJS.compile([headless, ember].join("\n"))
-    end
-    @context
-  end
-
+class EmberStripDebugMessagesFilter < Rake::Pipeline::Filter
   def strip_debug(data)
     # Strip debug code
     data.gsub!(%r{^(\s)*Ember\.(assert|deprecate|warn)\((.*)\).*$}, "")
   end
-
+  
   def add_localhost_warning(data)
     data << "\n\n" + <<END
 if (typeof location !== 'undefined' && (location.hostname === 'localhost' || location.hostname === '127.0.0.1')) {
@@ -29,18 +18,36 @@ if (typeof location !== 'undefined' && (location.hostname === 'localhost' || loc
 END
   end
 
-  def precompile_templates(data)
-    # Precompile defaultTemplates
-    data.gsub!(%r{(defaultTemplate(?:\s*=|:)\s*)Ember\.Handlebars\.compile\(['"](.*)['"]\)}) do
-      "#{$1}Ember.Handlebars.template(#{js_context.call("precompileEmberHandlebars", $2)})"
-    end
-  end
-
   def generate_output(inputs, output)
     inputs.each do |input|
       result = File.read(input.fullpath)
       strip_debug(result)
       add_localhost_warning(result)
+      output.write result
+    end
+  end
+end
+
+class HandlebarsPrecompiler < Rake::Pipeline::Filter
+  def js_context
+    # We're using Ember to build Ember! Inception!
+    unless @context
+      compiler = "exports={};#{File.read('dist/ember-template-compiler.js')}"
+      @context = ExecJS.compile(compiler)
+    end
+    @context
+  end
+
+  def precompile_templates(data)
+    # Precompile defaultTemplates
+   data.gsub!(%r{(defaultTemplate(?:\s*=|:)\s*)precompileTemplate\(['"](.*)['"]\)}) do
+     "#{$1}Ember.Handlebars.template(#{js_context.call("exports.precompile", $2)})"
+   end
+  end
+
+  def generate_output(inputs, output)
+    inputs.each do |input|
+      result = File.read(input.fullpath)
       precompile_templates(result)
       output.write result
     end
@@ -207,6 +214,7 @@ distros.each do |name, modules|
     module_paths = modules.map{|m| "#{m}.js" }
     match "{#{module_paths.join(',')}}" do
       concat(module_paths){ ["#{name}.js", "#{name}.prod.js"] }
+      filter HandlebarsPrecompiler
       filter AddMicroLoader unless name == "ember-template-compiler"
     end
 
@@ -219,7 +227,7 @@ distros.each do |name, modules|
 
     # Strip dev code
     match "#{name}.prod.js" do
-      filter(EmberProductionFilter) { ["#{name}.prod.js", "min/#{name}.js"] }
+      filter(EmberStripDebugMessagesFilter) { ["#{name}.prod.js", "min/#{name}.js"] }
     end
 
     # Minify

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -10,7 +10,8 @@ var set = Ember.set,
     indexOf = Ember.EnumerableUtils.indexOf,
     indexesOf = Ember.EnumerableUtils.indexesOf,
     replace = Ember.EnumerableUtils.replace,
-    isArray = Ember.isArray;
+    isArray = Ember.isArray,
+    precompileTemplate = Ember.Handlebars.compile;
 
 /**
   The `Ember.Select` view class renders a
@@ -264,7 +265,7 @@ Ember.Select = Ember.View.extend(
 
   tagName: 'select',
   classNames: ['ember-select'],
-  defaultTemplate: Ember.Handlebars.compile('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#each view.content}}{{view Ember.SelectOption contentBinding="this"}}{{/each}}'),
+  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#each view.content}}{{view Ember.SelectOption contentBinding="this"}}{{/each}}'),
   attributeBindings: ['multiple', 'disabled', 'tabindex'],
 
   /**


### PR DESCRIPTION
Currently Handlebars strings in Ember core are precompiled
into functions in `dist/ember.prod.js` and its derivatives.

Except for cases where ember itself uses these strings
developers using a build tool in development could use
handlebars-runtime as a dependency.

The only instance of Handlebars string templates in Ember
is the defaultTemplate for Ember.Select.

This moves the precompilation process earlier in the pipeline

One goofy side effect: documentation examples for defaultTemplate
will also be compiled.
