### PR TITLE
Prevent race condition in Router

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -92,7 +92,9 @@ Ember.Router = Ember.Object.extend({
   _connectActiveView: function(templateName, view) {
     this._activeViews[templateName] = view;
     view.one('willDestroyElement', this, function() {
-      delete this._activeViews[templateName];
+      if (this._activeViews[templateName] === view){
+        delete this._activeViews[templateName];
+      }
     });
   }
 });


### PR DESCRIPTION
This defends against deleting the wrong view from the Router's activeViews when we have a newer view with the same template name.  It closes #1657.
