### PR TITLE
Add title attribute binding to linkTo helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,10 @@ Syntax:
 * a = b and not a=b.
 * Follow the conventions you see used in the source already.
 
-Inline Documenation Guidelines:
+Inline Documentation Guidelines:
 
 All inline documentation is written using YUIDoc. Follow these rules when
-updating or writing new documenation:
+updating or writing new documentation:
 
 1. All code blocks must be fenced
 2. All code blocks must have a language declared

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -16,8 +16,9 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     tagName: 'a',
     namedRoute: null,
     currentWhen: null,
+    title: null,
     activeClass: 'active',
-    attributeBindings: 'href',
+    attributeBindings: ['href', 'title'],
     classNameBindings: 'active',
 
     active: Ember.computed(function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -181,3 +181,14 @@ test("The {{linkTo}} helper moves into the named route with context", function()
   equal(Ember.$('p', '#qunit-fixture').text(), "Erik Brynroflsson", "The name is correct");
 });
 
+test("The {{linkTo}} helper binds some anchor html tag common attributes", function() {
+  Router.map(function(match) {
+      match("/").to("home");
+  });
+   Ember.TEMPLATES.home = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo home id='self-link' title='title-attr'}}Self{{/linkTo}}");
+   bootApplication();
+   Ember.run(function() {
+      router.handleURL("/");
+  });
+   equal(Ember.$('#self-link', '#qunit-fixture').attr('title'), 'title-attr', "The self-link contains title attribute");
+});


### PR DESCRIPTION
HTML anchor tags often come with a title attribute.
This commit adds the "title" attribute binding to linkTo helper :

```
{{#linkTo home id='self-link' title='title-attr'}}Self{{/linkTo}}
```

A new test case covers this evolution.

I also fixed a little typo in contributing documentation.
