### PR TITLE
Support namespaced references in resolver

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -637,7 +637,18 @@ function resolveFor(namespace) {
       }
     }
 
-    var className = classify(name) + classify(type);
+    var components = name.split("/");
+
+    var classifiedComponents =
+      components.map(function(component){
+        return classify(component);
+      });
+
+    var className = classifiedComponents.length > 1 ?
+      classifiedComponents.join(".") : classifiedComponents[0];
+
+    className = className + classify(type);
+
     var factory = get(namespace, className);
 
     if (factory) { return factory; }


### PR DESCRIPTION
- Requires separating namespace components with "/"
- Assumes it can access all components using normal "." notation

This enables us to reference namespaced routes using the new routing syntax. So we can support all of:

App.IndexRoute => match("/").to("index")
App.Users.IndexRoute => match("/users").to("users/index")
