### PR TITLE
Added default property rootURL in Ember.Router

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -17,6 +17,8 @@ function setupLocation(router) {
 
 Ember.Router = Ember.Object.extend({
   location: 'hash',
+  
+  rootURL: '/',
 
   init: function() {
     var router = this.router = new Router();


### PR DESCRIPTION
I added the default property `rootURL: '/'` to Ember.Router because in [`setupLocation()`](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/system/router.js#L6-L16), `rootURL` is `undefined` if there's no `routeURL` passed when extending Ember.Router.

This doesn't affect the app when the Router is used with `location: 'hash'`. However, when `location: 'history'` is set the error `Uncaught TypeError: Cannot call method 'replace' of undefined` is thrown in [`formatURL()`](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/location/history_location.js#L139) because `rootURL` is still `undefined`. 
