### PR TITLE
Bugfix in SortableMixin; sortProperty observers not being correctly removed

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -138,7 +138,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
         forEach(sortProperties, function(sortProperty) {
           Ember.removeObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
         }, this);
-      });
+      }, this);
     }
 
     return this._super(array, idx, removedCount, addedCount);

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -195,6 +195,15 @@ test("don't remove and insert if position didn't change", function() {
   ok(!insertItemSortedCalled, "insertItemSorted should not have been called");
 });
 
+test("sortProperties observers removed on content removal", function() {
+  var removedObject = unsortedArray.objectAt(2);
+  equal(Ember.listenersFor(removedObject, 'name:change').length, 1,
+    "Before removal, there should be one listener for sortProperty change.");
+  unsortedArray.replace(2, 1, []);
+  equal(Ember.listenersFor(removedObject, 'name:change').length, 0,
+    "After removal, there should be no listeners for sortProperty change.");
+});
+
 module("Ember.Sortable with sortProperties", {
   setup: function() {
     Ember.run(function() {


### PR DESCRIPTION
Hi all, long-time observer, first time submitter here. Found a small bug (missing 'this' context in a forEach iterator) that was causing the observer for item sortProperty changes (contentItemSortPropertyDidChange) not to be correctly removed.

This should be the fix. Hope this is helpful!
