### PR TITLE
Ember.Route refactor

### DIFF
--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -1,23 +1,23 @@
-
 Ember.controllerFor = function(container, controllerName, context) {
-  var controller = container.lookup('controller:' + controllerName);
+  return container.lookup('controller:' + controllerName) ||
+         Ember.generateController(container, controllerName, context);
+};
 
-  if (!controller) {
-    if (context && Ember.isArray(context)) {
-      controller = Ember.ArrayController.extend({content: context});
-    } else if (context) {
-      controller = Ember.ObjectController.extend({content: context});
-    } else {
-      controller = Ember.Controller.extend();
-    }
+Ember.generateController = function(container, controllerName, context) {
+  var controller;
 
-    controller.toString = function() {
-      return "(generated " + controllerName + " controller)";
-    };
-
-    container.register('controller', controllerName, controller);
-    controller = container.lookup('controller:' + controllerName);
+  if (context && Ember.isArray(context)) {
+    controller = Ember.ArrayController.extend({content: context});
+  } else if (context) {
+    controller = Ember.ObjectController.extend({content: context});
+  } else {
+    controller = Ember.Controller.extend();
   }
 
-  return controller;
+  controller.toString = function() {
+    return "(generated " + controllerName + " controller)";
+  };
+
+  container.register('controller', controllerName, controller);
+  return container.lookup('controller:' + controllerName);
 };

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -39,8 +39,7 @@ Ember.Route = Ember.Object.extend({
 
     if (this.transitioned) { return; }
 
-    var controller = this.lookupController(context);
-
+    var controller = this.controllerFor(this.templateName, context);
     this.setupController(controller, context);
     this.renderTemplates(context);
   },
@@ -155,23 +154,6 @@ Ember.Route = Ember.Object.extend({
   },
 
   /**
-    A hook you can use to lookup the controller used to render current route.
-
-    By default, the `lookupController` hook try to find a controller by route name.
-    If no controller is found, a default controller will be registered.
-    Based on context presence and type, the method will return an
-    Ember.ObjectController, Ember.ArrayController or an Ember.Controller.
-
-    @param {Object} context the context for this controller
-    @param {String} controllerName the name of the controller to lookup
-    @return {Ember.Controller}
-  */
-  lookupController: function(context, controllerName) {
-    controllerName = controllerName || this.templateName;
-    return Ember.controllerFor(this.router.container, controllerName, context);
-  },
-
-  /**
     A hook you can use to setup the controller for the current route.
 
     This method is called with the controller for the current route and the
@@ -223,10 +205,19 @@ Ember.Route = Ember.Object.extend({
 
     @method controllerFor
     @param {String} name the name of the route
+    @param {Object} model the model associated with the route (optional)
     @return {Ember.Controller}
   */
-  controllerFor: function(name) {
-    return this.container.lookup('controller:' + name);
+  controllerFor: function(name, model) {
+    var container = this.router.container,
+        controller = container.lookup('controller:' + name);
+
+    if (!controller) {
+      model = model || this.modelFor(name);
+      controller = Ember.generateController(container, name, model);
+    }
+
+    return controller;
   },
 
   /**

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -40,7 +40,8 @@ Ember.Route = Ember.Object.extend({
     if (this.transitioned) { return; }
 
     var controller = this.lookupController(context);
-    this.setupControllers(controller, context);
+
+    this.setupController(controller, context);
     this.renderTemplates(context);
   },
 
@@ -171,8 +172,7 @@ Ember.Route = Ember.Object.extend({
   },
 
   /**
-    A hook you can use to setup the necessary controllers for the current
-    route.
+    A hook you can use to setup the controller for the current route.
 
     This method is called with the controller for the current route and the
     model supplied by the `model` hook.
@@ -198,9 +198,9 @@ Ember.Route = Ember.Object.extend({
     This means that your template will get a proxy for the model as its
     context, and you can act as though the model itself was the context.
 
-    @method setupControllers
+    @method setupController
   */
-  setupControllers: function(controller, model) {
+  setupController: function(controller, model) {
     if (controller) {
       controller.set('content', model);
     }
@@ -211,7 +211,7 @@ Ember.Route = Ember.Object.extend({
 
     ```js
     App.PostRoute = Ember.Route.extend({
-      setupControllers: function(controller, post) {
+      setupController: function(controller, post) {
         this._super(controller, post);
         this.controllerFor('posts').set('currentPost', post);
       }

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -40,8 +40,20 @@ Ember.Route = Ember.Object.extend({
     if (this.transitioned) { return; }
 
     var controller = this.controllerFor(this.templateName, context);
-    this.setupController(controller, context);
-    this.renderTemplate(controller, context);
+
+    if (this.setupControllers) {
+      Ember.deprecate("Ember.Route.setupControllers is deprecated. Please use Ember.Route.setupController(controller, model) instead.");
+      this.setupControllers(controller, context);
+    } else {
+      this.setupController(controller, context);
+    }
+
+    if (this.renderTemplates) {
+      Ember.deprecate("Ember.Route.renderTemplates is deprecated. Please use Ember.Route.renderTemplate(controller, model) instead.");
+      this.renderTemplates(context);
+    } else {
+      this.renderTemplate(controller, context);
+    }
   },
 
   /**

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -41,7 +41,7 @@ Ember.Route = Ember.Object.extend({
 
     var controller = this.controllerFor(this.templateName, context);
     this.setupController(controller, context);
-    this.renderTemplates(context);
+    this.renderTemplate(controller, context);
   },
 
   /**
@@ -234,7 +234,21 @@ Ember.Route = Ember.Object.extend({
     return this.container.lookup('route:' + name).currentModel;
   },
 
-  renderTemplates: function(context) {
+  /**
+    A hook you can use to render the template for the current route.
+
+    This method is called with the controller for the current route and the
+    model supplied by the `model` hook. By default, it renders the route's
+    template, configured with the controller for the route.
+
+    This method can be overridden to set up and render additional or
+    alternative templates.
+
+    @method renderTemplate
+    @param {Object} controller the route's controller
+    @param {Object} model the route's model
+  */
+  renderTemplate: function(controller, model) {
     this.render();
   },
 
@@ -253,7 +267,7 @@ Ember.Route = Ember.Object.extend({
     });
 
     App.PostRoute = App.Route.extend({
-      renderTemplates: function() {
+      renderTemplate: function() {
         this.render();
       }
     });
@@ -272,7 +286,7 @@ Ember.Route = Ember.Object.extend({
 
     ```js
     App.PostRoute = App.Route.extend({
-      renderTemplates: function() {
+      renderTemplate: function() {
         this.render('myPost', {   // the template to render
           into: 'index',          // the template to render into
           outlet: 'detail',       // the name of the outlet in that template

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -84,13 +84,13 @@ test("The Homepage register as activeView", function() {
   equal(router._lookupActiveView('home'), undefined, '`home` active view is disconnected');
 });
 
-test("The Homepage with explicit template name in renderTemplates", function() {
+test("The Homepage with explicit template name in renderTemplate", function() {
   Router.map(function(match) {
     match("/").to("home");
   });
 
   App.HomeRoute = Ember.Route.extend({
-    renderTemplates: function() {
+    renderTemplate: function() {
       this.render('homepage');
     }
   });
@@ -104,7 +104,7 @@ test("The Homepage with explicit template name in renderTemplates", function() {
   equal(Ember.$('h3:contains(Megatroll)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("The Homepage with explicit template name in renderTemplates", function() {
+test("The Homepage with explicit template name in renderTemplate", function() {
   Router.map(function(match) {
     match("/").to("home");
   });
@@ -114,7 +114,7 @@ test("The Homepage with explicit template name in renderTemplates", function() {
   });
 
   App.HomeRoute = Ember.Route.extend({
-    renderTemplates: function() {
+    renderTemplate: function() {
       this.render('homepage');
     }
   });
@@ -437,7 +437,7 @@ test("Nested callbacks are not exited when moving to siblings", function() {
       rootSetup++;
     },
 
-    renderTemplates: function() {
+    renderTemplate: function() {
       rootRender++;
     }
   });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -128,13 +128,13 @@ test("The Homepage with explicit template name in renderTemplates", function() {
   equal(Ember.$('h3:contains(Megatroll) + p:contains(YES I AM HOME)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("The Homepage with a `setupControllers` hook", function() {
+test("The Homepage with a `setupController` hook", function() {
   Router.map(function(match) {
     match("/").to("home");
   });
 
   App.HomeRoute = Ember.Route.extend({
-    setupControllers: function(controller) {
+    setupController: function(controller) {
       set(controller, 'hours', Ember.A([
         "Monday through Friday: 9am to 5pm",
         "Saturday: Noon to Midnight",
@@ -158,13 +158,13 @@ test("The Homepage with a `setupControllers` hook", function() {
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
 
-test("The Homepage with a `setupControllers` hook modifying other controllers", function() {
+test("The Homepage with a `setupController` hook modifying other controllers", function() {
   Router.map(function(match) {
     match("/").to("home");
   });
 
   App.HomeRoute = Ember.Route.extend({
-    setupControllers: function(controller) {
+    setupController: function(controller) {
       set(this.controllerFor('home'), 'hours', Ember.A([
         "Monday through Friday: 9am to 5pm",
         "Saturday: Noon to Midnight",
@@ -202,7 +202,7 @@ test("The Homepage getting its controller context via model", function() {
       ]);
     },
 
-    setupControllers: function(controller, model) {
+    setupController: function(controller, model) {
       equal(this.controllerFor('home'), controller);
 
       set(this.controllerFor('home'), 'hours', model);
@@ -237,7 +237,7 @@ test("The Specials Page getting its controller context by deserializing the para
       });
     },
 
-    setupControllers: function(controller, model) {
+    setupController: function(controller, model) {
       set(controller, 'content', model);
     }
   });
@@ -271,7 +271,7 @@ test("The Specials Page defaults to looking models up via `find`", function() {
   };
 
   App.SpecialRoute = Ember.Route.extend({
-    setupControllers: function(controller, model) {
+    setupController: function(controller, model) {
       set(controller, 'content', model);
     }
   });
@@ -312,7 +312,7 @@ test("The Special Page returning a promise puts the app into a loading state unt
   });
 
   App.SpecialRoute = Ember.Route.extend({
-    setupControllers: function(controller, model) {
+    setupController: function(controller, model) {
       set(controller, 'content', model);
     }
   });
@@ -368,7 +368,7 @@ test("Moving from one page to another triggers the correct callbacks", function(
   });
 
   App.SpecialRoute = Ember.Route.extend({
-    setupControllers: function(controller, model) {
+    setupController: function(controller, model) {
       set(controller, 'content', model);
     }
   });
@@ -433,7 +433,7 @@ test("Nested callbacks are not exited when moving to siblings", function() {
       return this._super.apply(this, arguments);
     },
 
-    setupControllers: function() {
+    setupController: function() {
       rootSetup++;
     },
 
@@ -447,7 +447,7 @@ test("Nested callbacks are not exited when moving to siblings", function() {
   });
 
   App.SpecialRoute = Ember.Route.extend({
-    setupControllers: function(controller, model) {
+    setupController: function(controller, model) {
       set(controller, 'content', model);
     }
   });
@@ -713,7 +713,7 @@ test("A redirection hook is provided", function() {
       }
     },
 
-    setupControllers: function() {
+    setupController: function() {
       chooseFollowed++;
     }
   });


### PR DESCRIPTION
This PR includes a number of tweaks and breaking changes to Ember.Route:
- BREAKING: `setupControllers()` has been renamed `setupController()`. This method should be used to set up the route's default controller, not additional controllers used to render templates (which could be done in `renderTemplate()`). Therefore, there was no reason for the plural/singular mismatch between the method name and its arguments.
- BREAKING: `renderTemplates()` has been renamed `renderTemplate()` to match the default scenario of rendering a single template. The arguments (`controller, model`) now match those of `setupController()`. Docs were also added.
- `Ember.generateController()` has been extracted from `Ember.controllerFor()`, so that `generateController()` can be called independently.
- `Ember.Route.lookupController()` has been merged with `Ember.Route.controllerFor()`, which should be used for controller lookups.

This PR originally contained a method to override `controller` dynamically for a `Route`. However, after discussion with @wycats, we decided it would be best to encourage custom controllers to be registered. For example, if you want to use the `EditContactController` for your `AddContactRoute`, you should register it with your route's container:

```
App.AddContactRoute = Ember.Route.extend({
  init: function() {
    this._super();
    this.container.register('controller', 'addContact', App.EditContactController);
  }
});
```

NOTE (Jan. 6): improved the example for clarity
