### PR TITLE
Reimplemented App.router as per documentation

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -443,8 +443,7 @@ var Application = Ember.Application = Ember.Namespace.extend(
     @method runInitializers
   */
   runInitializers: function() {
-    var router = this.__container__.lookup('router:main'),
-        initializers = get(this.constructor, 'initializers'),
+    var initializers = get(this.constructor, 'initializers'),
         container = this.__container__,
         graph = new Ember.DAG(),
         namespace = this,

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -149,6 +149,7 @@ test("initialize application via initialize call", function() {
   var router = app.__container__.lookup('router:main');
   equal(router instanceof Ember.Router, true, "Router was set from initialize call");
   equal(router.location instanceof Ember.NoneLocation, true, "Location was set from location implementation name");
+  equal(get(app, 'router'), router, 'App.router was set to the main instance of router');
 });
 
 test("initialize application with stateManager via initialize call from Router class", function() {

--- a/packages/ember-old-router/lib/application/system/application.js
+++ b/packages/ember-old-router/lib/application/system/application.js
@@ -254,7 +254,7 @@ Ember.Application = Ember.Namespace.extend(
 
   /**
     Should the application initialize itself after it's created. You can
-    set this to `false` if you'd like to choose when to initialize your 
+    set this to `false` if you'd like to choose when to initialize your
     application. This defaults to `!Ember.testing`
 
     @property autoinit

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -22,7 +22,8 @@ Ember.Router = Ember.Object.extend({
   location: 'hash',
 
   init: function() {
-    var router = this.router = new Router();
+    var router = this.router = new Router(),
+        application = this.container.lookup('application:main');
     this._activeViews = {};
 
     setupLocation(this);
@@ -32,6 +33,10 @@ Ember.Router = Ember.Object.extend({
     router.map(function(match) {
       match("/").to("application", callback);
     });
+
+    if (!get(application, 'router')) {
+      set(application, 'router', this);
+    }
   },
 
   startRouting: function() {


### PR DESCRIPTION
I know the router API is in flux, and the documentation probably hasn't been updated for a while, however I've added this back in as it is incredibly useful during development to be able to access the router in the console.

This PR makes `App.router` available as per documentation and the old router. This simply sets App.router to the instance of the first instantiated router, this is practice might not be the desired outcome and I'm sure @tomdale can weigh in on this.
