### PR TITLE
Add {{boundTemplate}} helper

### DIFF
--- a/packages/ember-handlebars/lib/helpers.js
+++ b/packages/ember-handlebars/lib/helpers.js
@@ -6,4 +6,5 @@ require("ember-handlebars/helpers/unbound");
 require("ember-handlebars/helpers/debug");
 require("ember-handlebars/helpers/each");
 require("ember-handlebars/helpers/template");
+require("ember-handlebars/helpers/bound_template");
 require("ember-handlebars/helpers/yield");

--- a/packages/ember-handlebars/lib/helpers/bound_template.js
+++ b/packages/ember-handlebars/lib/helpers/bound_template.js
@@ -1,0 +1,26 @@
+require('ember-handlebars/ext');
+
+/**
+@module ember
+@submodule ember-handlebars
+*/
+
+/**
+  `boundTemplate` same as the `template` helper, except that it takes the path to the template name.
+
+  @method boundTemplate
+  @for Ember.Handlebars.helpers
+  @param {String} path to templateName
+*/
+
+Ember.Handlebars.registerHelper('boundTemplate', function(path, options) {
+
+  var handlebarsGet = Ember.Handlebars.get, 
+      context = (options.contexts && options.contexts[0]) || this,
+      name =  handlebarsGet(context, path, options),
+      template = Ember.TEMPLATES[name];
+
+  Ember.assert("Unable to find template with name '"+name+"'.", !!template);
+
+  Ember.TEMPLATES[name](this, { data: options.data });
+});


### PR DESCRIPTION
It's simply the {{template}} helper, that's receive a path to templateName, instead of templateName.
For example it can be used for switch between present mode and edit mode for implement inline edit of model's attribute:

``` coffeescript
EditableBase = Ember.View.extend
  templateName:  'editable/base'
  isEditorState: false

EditableString = EditableBase.extend
  presentTemplateName: 'editable/string_present'
  editTemplateName: 'editable/string_edit'
```

editable/base.handlebars:

``` handlebars
{{#if isEditorState}}
  {{boundTemplate 'editTemplateName'}}
{{else}}
  {{boundTemplate 'presentTemplateName'}}
{{/if}}
```
