### PR TITLE
Automatically synthesize the controller 'needs' dependencies

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -1,4 +1,20 @@
 var get = Ember.get, set = Ember.set;
+var ControllersProxy = Ember.Object.extend({
+  controller: null,
+
+  unknownProperty: function(controllerName) {
+    var controller = get(this, 'controller'),
+      needs = get(controller, 'needs'),
+      dependency;
+
+    for (var i=0, l=needs.length; i<l; i++) {
+      dependency = needs[i];
+      if (dependency === controllerName) {
+        return controller.controllerFor(controllerName);
+      }
+    }
+  }
+});
 
 Ember.ControllerMixin.reopen({
   concatenatedProperties: ['needs'],
@@ -30,7 +46,11 @@ Ember.ControllerMixin.reopen({
     } else {
       return get(this, 'content');
     }
-  }).property('content')
+  }).property('content'),
+
+  controllers: Ember.computed(function() {
+    return ControllersProxy.create({ controller: this });
+  })
 });
 
 function verifyDependencies(controller) {
@@ -46,7 +66,7 @@ function verifyDependencies(controller) {
 
     if (!container.has(dependency)) {
       satisfied = false;
-      Ember.assert(this + " needs " + dependency + " but it does not exist", false);
+      Ember.assert(controller + " needs " + dependency + " but it does not exist", false);
     }
   }
 

--- a/packages/ember-routing/tests/system/controller_test.js
+++ b/packages/ember-routing/tests/system/controller_test.js
@@ -19,6 +19,21 @@ test("If a controller specifies a dependency, it is available to `controllerFor`
   equal(postsController, postController.get('postsController'), "Getting dependency controllers work");
 });
 
+test("If a controller specifies a dependency, it is accessible", function() {
+  var container = new Ember.Container();
+
+  container.register('controller', 'post', Ember.Controller.extend({
+    needs: 'posts'
+  }));
+
+  container.register('controller', 'posts', Ember.Controller.extend());
+
+  var postController = container.lookup('controller:post'),
+      postsController = container.lookup('controller:posts');
+
+  equal(postsController, postController.get('controllers.posts'), "controller.posts must be auto synthesized");
+});
+
 test("If a controller specifies an unavailable dependency, it raises", function() {
   var container = new Ember.Container();
 


### PR DESCRIPTION
Add a little bit of hidden magic that automatically synthesizes properties for dependencies specified using `needs` (issue #1713). The following:

```
App.PostController = Em.Controller.extend({})
App.CommentsController = Em.Controller.extend({
  needs: 'post'
})
```

would result in a controller that verifies that the post controller exists and exposes a `postController` property defined as:

```
postController: function() {
    this.controllerFor('post');
}.property();
```

I feel this would make the `needs` property work as expected. Without the pull request `needs` would only verify that the dependency exists in the container with no side effects if the controller does exist.

I don't consider this pull request complete but wanted to get it out there so we can have a public discussion about `needs` in general. I also feel that my current implementation isn't the best way of doing it so feedback on that is welcome too :)
