### PR TITLE
TextSupport: listen to cut and paste events

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -33,6 +33,7 @@ Ember.TextSupport = Ember.Mixin.create({
     this.on("change", this, this._elementValueDidChange);
     this.on("paste", this, this._elementValueDidChange);
     this.on("cut", this, this._elementValueDidChange);
+    this.on("input", this, this._elementValueDidChange);
     this.on("keyUp", this, this.interpretKeyEvents);
   },
 

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -31,6 +31,8 @@ Ember.TextSupport = Ember.Mixin.create({
     this._super();
     this.on("focusOut", this, this._elementValueDidChange);
     this.on("change", this, this._elementValueDidChange);
+    this.on("paste", this, this._elementValueDidChange);
+    this.on("cut", this, this._elementValueDidChange);
     this.on("keyUp", this, this.interpretKeyEvents);
   },
 

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -145,7 +145,7 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textArea.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
-[ 'cut', 'paste' ].forEach(function(eventName) {
+[ 'cut', 'paste', 'input' ].forEach(function(eventName) {
   test("should update the value on " + eventName + " events", function() {
 
     Ember.run(function() {

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -145,6 +145,22 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textArea.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
+[ 'cut', 'paste' ].forEach(function(eventName) {
+  test("should update the value on " + eventName + " events", function() {
+
+    Ember.run(function() {
+      textArea.append();
+    });
+
+    textArea.$().val('new value');
+    textArea.trigger(eventName, Ember.Object.create({
+      type: eventName
+    }));
+
+    equal(textArea.get('value'), 'new value', 'value property updates on ' + eventName + ' events');
+  });
+});
+
 test("should call the insertNewline method when return key is pressed", function() {
   var wasCalled;
   var event = Ember.Object.create({


### PR DESCRIPTION
I think TextExpander must have changed what DOM events it fires. I just tried http://jsfiddle.net/KrEXM/5/ with TextExpander and both versions work fine. It might still be worth listening for the `cut`, `paste`, and `input` events in case some other client fires those.

Resolves #1717
