### PR TITLE
Fix a bug with item controllers.

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -158,8 +158,6 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
   },
 
   arrayContentDidChange: function(idx, removedCnt, addedCnt) {
-    this._super(idx, removedCnt, addedCnt);
-
     var subContainers = get(this, 'subContainers'),
         subContainersToRemove = subContainers.slice(idx, idx+removedCnt);
 
@@ -168,6 +166,11 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
     });
 
     replace(subContainers, idx, removedCnt, new Array(addedCnt));
+
+    // The shadow array of subcontainers must be updated before we trigger
+    // observers, otherwise observers will get the wrong subcontainer when
+    // calling `objectAt`
+    this._super(idx, removedCnt, addedCnt);
   },
 
   init: function() {

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -223,3 +223,30 @@ test("if `lookupItemController` returns a string, it must be resolvable by the c
     /NonExistant/,
     "`lookupItemController` must return either null or a valid controller name");
 });
+
+test("array observers can invoke `objectAt` without overwriting existing item controllers", function() {
+  createArrayController();
+
+  var tywinController = arrayController.objectAtContent(0),
+      arrayObserverCalled = false;
+
+  arrayController.reopen({
+    lannistersWillChange: Ember.K,
+    lannistersDidChange: function(_, idx, removedAmt, addedAmt) {
+      arrayObserverCalled = true;
+      equal(this.objectAt(idx).get('name'), "Tyrion", "Array observers get the right object via `objectAt`");
+    }
+  });
+  arrayController.addArrayObserver(arrayController, {
+    willChange: 'lannistersWillChange',
+    didChange: 'lannistersDidChange'
+  });
+
+  Ember.run(function() {
+    lannisters.unshiftObject(tyrion);
+  });
+
+  equal(arrayObserverCalled, true, "Array observers are called normally");
+  equal(tywinController.get('name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' content");
+});
+


### PR DESCRIPTION
The shadow array of subcontainers was out of sync when array observers were 
fired.
