### PR TITLE
Use preventDefault in linkTo helper

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -56,9 +56,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     click: function(event) {
       if (!isSimpleClick(event)) { return true; }
 
+      event.preventDefault();
+
       var router = this.get('router');
       router.transitionTo.apply(router, args(this, router));
-      return false;
     },
 
     href: Ember.computed(function() {

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -34,6 +34,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     tagName: 'a',
     namedRoute: null,
     currentWhen: null,
+    bubbles: true,
     title: null,
     activeClass: 'active',
     attributeBindings: ['href', 'title'],
@@ -57,6 +58,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       if (!isSimpleClick(event)) { return true; }
 
       event.preventDefault();
+
+      if (this.bubbles === false) {
+        event.stopPropagation();
+      }
 
       var router = this.get('router');
       router.transitionTo.apply(router, args(this, router));


### PR DESCRIPTION
Returning false will stop propagation of the event. As far as I can see all we actually want to do here is prevent the default and allow the event to bubble up.

Note that tests on master are currently failing so the travis will fail for this PR.
