### PR TITLE
Fix git submodule plural mistake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ Using Vagrant to buid latest version of Ember.js is quite simple. Just follow ne
 2. Retrieve chef cookbooks
 
 ~~~
-git submodules init
-git submodules update
+git submodule init
+git submodule update
 ~~~
 3. Lauch your vagrant virtual machine
 


### PR DESCRIPTION
I made a typo while updating contributing.md file in my previous PR.
git submodule command is back in singular form as it should have always been.
