### PR TITLE
Add container as a dependency in the old-router package.

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -132,7 +132,7 @@ distros = {
   "template-compiler" => %w(handlebars ember-handlebars-compiler),
   "data-deps"         => %w(ember-metal ember-runtime ember-states),
   "full"              => %w(ember-metal rsvp container ember-runtime ember-views metamorph ember-handlebars-compiler ember-handlebars ember-routing ember-application ember-states),
-  "old-router"        => %w(ember-metal rsvp ember-runtime ember-views ember-states ember-viewstates metamorph ember-handlebars-compiler ember-handlebars ember-old-router )
+  "old-router"        => %w(ember-metal rsvp container ember-runtime ember-views ember-states ember-viewstates metamorph ember-handlebars-compiler ember-handlebars ember-old-router )
 }
 
 output "dist"


### PR DESCRIPTION
The ember-old-router build does not work because ember-runtime tries
to load the container module.  I tried moving the container module
to be a dependency of the new router but this broke a lot of things.
It seems a lot easier to ust add container to old-router.
