### PR TITLE
Don't create namespaces for nested routes

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -203,7 +203,8 @@ function setupRouterDelegate(router, namespace) {
     contextEntered: function(target, match) {
       match('/').to('index');
 
-      namespace[classify(target)] = Ember.Namespace.create();
+      if (target === 'root')
+        namespace[classify(target)] = Ember.Namespace.create();
     }
   };
 }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -927,3 +927,13 @@ test("Parent route context change", function() {
 
   equal(editCount, 2, 'set up the edit route twice without failure');
 });
+
+test("Router does not create namespace for nested routes", function() {
+  Router.map(function(match) {
+    match("/posts").to("posts", function(match) {
+      match("/post").to("post");
+    });
+  });
+
+  equal(App.Posts, undefined, 'no namespace should exist');
+});


### PR DESCRIPTION
As of 027ae310ba457730143b62a0f265c3321f97003f the router isn't supposed to create namespaces anymore for nested routes. While the router was changed to not depend on it anymore it was actually still creating the namespace.
