### PR TITLE
Fixed setupView to avoid blowing away view template if router fails to lookup a template

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -398,9 +398,11 @@ function setupView(view, container, options) {
 
   view = view || container.lookup(defaultView);
 
-  if ('undefined' !== typeof options.template) {
+  if (!get(view, 'templateName')) {
+    Ember.assert('template should be set', options.template);
     set(view, 'template', options.template);
-  };
+  }
+
   set(view, 'renderedName', options.name);
   set(view, 'controller', options.controller);
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -399,7 +399,6 @@ function setupView(view, container, options) {
   view = view || container.lookup(defaultView);
 
   if (!get(view, 'templateName')) {
-    Ember.assert('template should be set', options.template);
     set(view, 'template', options.template);
   }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -398,7 +398,9 @@ function setupView(view, container, options) {
 
   view = view || container.lookup(defaultView);
 
-  set(view, 'template', options.template);
+  if ('undefined' !== typeof options.template) {
+    set(view, 'template', options.template);
+  };
   set(view, 'renderedName', options.name);
   set(view, 'controller', options.controller);
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -146,6 +146,30 @@ test("The Homepage with explicit template name in renderTemplate", function() {
   equal(Ember.$('h3:contains(Megatroll) + p:contains(YES I AM HOME)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
+test('render does not replace templateName if user provided', function() {
+  Router.map(function(match) {
+    match("/").to("home");
+  });
+
+  Ember.TEMPLATES.the_real_home_template = Ember.Handlebars.compile(
+    "<p>THIS IS THE REAL HOME</p>"
+  );
+
+  App.HomeView = Ember.View.extend({
+    templateName: 'the_real_home_template'
+  });
+  App.HomeController = Ember.Route.extend();
+  App.HomeRoute = Ember.Route.extend();
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
+});
+
 test("The Homepage with a `setupController` hook", function() {
   Router.map(function(match) {
     match("/").to("home");


### PR DESCRIPTION
Because it is possible to tell the route which view to render, we shouldn't blatantly try to set the template on this view, especially if we fail to find a template with the same name as the view.

Example:

``` js
App.PostSummaryView = Ember.View.extend({
  templateName: 'my_custom_post'
});

App.PostsPostRoute = Ember.Route.extend({
  renderTemplate: function(controller, model) {
    this.render('postSummary');
  }
});
```

Previously this would look for a template called `post_summary`, which would return undefined. `setupView` would then set `template` on `App.PostSummaryView` to `undefined`.
