### PR TITLE
Failing test: derived `model` hooks are not re-invoked when the parent c...

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -913,7 +913,9 @@ test("Child routes render into their parent route's template by default", functi
 
 
 test("Parent route context change", function() {
-  var editCount = 0;
+  var editCount = 0,
+      postModelCount = 0,
+      editedPostIds = Ember.A();
 
   Ember.TEMPLATES.application = compile("{{outlet}}");
   Ember.TEMPLATES.posts = compile("{{outlet}}");
@@ -939,6 +941,7 @@ test("Parent route context change", function() {
 
   App.PostsPostRoute = Ember.Route.extend({
     model: function(params) {
+      postModelCount++;
       return {id: params.postId};
     },
 
@@ -950,6 +953,11 @@ test("Parent route context change", function() {
   });
 
   App.PostEditRoute = Ember.Route.extend({
+    model: function(params) {
+      var postId = this.modelFor("posts.post").id;
+      editedPostIds.push(postId);
+      return null;
+    },
     setup: function() {
       this._super.apply(this, arguments);
       editCount++;
@@ -975,4 +983,6 @@ test("Parent route context change", function() {
   });
 
   equal(editCount, 2, 'set up the edit route twice without failure');
+  equal(postModelCount, 2, 'invoke the posts.post model hook twice');
+  equal(editedPostIds, [1, 2], 'modelFor posts.post returns the right context');
 });


### PR DESCRIPTION
...hanges

This is the failing test for the issue #1733. 
It also looks related to #1736.

I just add some assertions on an existing test, tell me if you wants it in a single test.
