### PR TITLE
Router should notify url property change on navigate events

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -51,6 +51,7 @@ Ember.Router = Ember.Object.extend({
         path = routePath(infos);
 
     set(appController, 'currentPath', path);
+    this.notifyPropertyChange('url');
 
     if (get(this, 'namespace').LOG_TRANSITIONS) {
       Ember.Logger.log("Transitioned into '" + path + "'");

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -763,6 +763,42 @@ test("transitioning multiple times in a single run loop only sets the URL once",
   equal(router.get('location').getURL(), "/bar");
 });
 
+test('navigating away triggers a url property change', function() {
+  var urlPropertyChangeCount = 0;
+
+  Router.map(function(match) {
+    match("/").to("root");
+    match("/foo").to("foo");
+    match("/bar").to("bar");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    Ember.addObserver(router, 'url', function() {
+      urlPropertyChangeCount++;
+    });
+  });
+
+  equal(urlPropertyChangeCount, 0);
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(urlPropertyChangeCount, 2);
+
+  Ember.run(function() {
+    // Trigger the callback that would otherwise be triggered
+    // when a user clicks the back or forward button.
+    router.router.transitionTo('foo');
+    router.router.transitionTo('bar');
+  });
+
+  equal(urlPropertyChangeCount, 4, 'triggered url property change');
+});
+
+
 test("using replaceWith calls location.replaceURL if available", function() {
   var setCount = 0,
       replaceCount = 0;


### PR DESCRIPTION
This fixes an issue where observers on the `router.url` property (used by `LinkTo` helper) are not updated if the user clicks the back or forward buttons, thus the active state for this view would not be removed.
