### PR TITLE
Ember.String: Serialize objects with JSON.stringify in fmt()

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -57,7 +57,17 @@ Ember.String = {
     return str.replace(/%@([0-9]+)?/g, function(s, argIndex) {
       argIndex = (argIndex) ? parseInt(argIndex,0) - 1 : idx++ ;
       s = formats[argIndex];
-      return ((s === null) ? '(null)' : (s === undefined) ? '' : s).toString();
+      switch(s) {
+        case null:
+          return '(null)';
+        case undefined:
+          return '';
+        default:
+          if (Ember.typeOf(s) === 'object') {
+              return JSON.stringify(s);
+          }
+          return s.toString();
+      }
     }) ;
   },
 

--- a/packages/ember-runtime/tests/system/string/fmt_string.js
+++ b/packages/ember-runtime/tests/system/string/fmt_string.js
@@ -14,4 +14,23 @@ test("'Hello %@2 %@1'.fmt('John', 'Doe') => 'Hello Doe John'", function() {
   }
 });
 
+test("'Hello %@'.fmt({John: 'Doe') => 'Hello {\"John\":\"Doe\"}'", function() {
+  equal(Ember.String.fmt('Hello %@', [{John: 'Doe'}]), 'Hello {"John":"Doe"}');
+  if (Ember.EXTEND_PROTOTYPES) {
+    equal('Hello %@'.fmt({John: 'Doe'}), 'Hello {"John":"Doe"}');
+  }
+});
 
+test("'Hello %@'.fmt(null) => 'Hello (null)'", function() {
+  equal(Ember.String.fmt('Hello %@', [null]), 'Hello (null)');
+  if (Ember.EXTEND_PROTOTYPES) {
+    equal('Hello %@'.fmt(null), 'Hello (null)');
+  }
+});
+
+test("'Hello %@'.fmt(undefined) => 'Hello '", function() {
+  equal(Ember.String.fmt('Hello %@', [undefined]), 'Hello ');
+  if (Ember.EXTEND_PROTOTYPES) {
+    equal('Hello %@'.fmt(undefined), 'Hello ');
+  }
+});


### PR DESCRIPTION
If an argument of Ember.String.fmt() is an object, serialise it to
string with JSON.stringify() instead of .toString().

This commit also adds tests for the serialisation of `null` (to "(null"))
and `undefined` to an empty string.

I've made this change as a [recent commit on ember-data](https://github.com/emberjs/data/commit/b0be92515de73f5eca5a5412b3bdf690f1938b1a) only prints out [object Object], which is not that helpful.
