### PR TITLE
Add `bundle install` step to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ For new users, we recommend downloading the [Ember.js Starter Kit](https://githu
 
 NOTE: Due to the rename, these instructions may be in flux
 
-1. Run `rake dist` to build Ember.js. Two builds will be placed in the `dist/` directory.
+1. Run `bundle install` to fetch the necessary ruby gems.
+2. Run `rake dist` to build Ember.js. Two builds will be placed in the `dist/` directory.
   * `ember.js` and `ember.min.js` - unminified and minified
     builds of Ember.js
 


### PR DESCRIPTION
Not obvious to non-rubyists like me.

Wondering if it would be also useful to add `gem install rake` and `gem install bundler`.
