### PR TITLE
Various enhancements to bound helpers, closes #1665 #1768. 

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -1,5 +1,7 @@
 require('ember-handlebars-compiler');
 
+var slice = Array.prototype.slice;
+
 /**
   @private
 
@@ -180,6 +182,18 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   {{repeat text count=3}}
   ```
 
+  ## Example with bound options
+
+  Bound hash options are also supported. Example: 
+
+  ```handlebars
+  {{repeat text countBinding="numRepeats"}}
+  ```
+
+  In this example, count will be bound to the value of
+  the `numRepeats` property on the context. If that property
+  changes, the helper will be re-rendered.
+
   ## Example with extra dependencies
 
   The `Ember.Handlebars.registerBoundHelper` method takes a variable length
@@ -192,6 +206,37 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   }, 'name');
   ```
 
+  ## Example with multiple bound properties
+
+  `Ember.Handlebars.registerBoundHelper` supports binding to
+  multiple properties, e.g.:
+
+  ```javascript
+  Ember.Handlebars.registerBoundHelper('concatenate', function() {
+    var values = arguments[arguments.length - 1];
+    return values.join('||');
+  });
+  ```
+
+  Which allows for template syntax such as {{concatenate prop1 prop2}} or
+  {{concatenate prop1 prop2 prop3}}. If any of the properties change,
+  the helpr will re-render.  Note that dependency keys cannot be
+  using in conjunction with multi-property helpers, since it is ambiguous
+  which property the dependent keys would belong to. 
+  
+  ## Use with unbound helper
+
+  The {{unbound}} helper can be used with bound helper invocations 
+  to render them in their unbound form, e.g.
+
+  ```handlebars
+  {{unbound capitalize name}} 
+  ```
+
+  In this example, if the name property changes, the helper
+  will not re-render.
+
+
   @method registerBoundHelper
   @for Ember.Handlebars
   @param {String} name
@@ -199,15 +244,50 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   @param {String} dependentKeys*
 */
 Ember.Handlebars.registerBoundHelper = function(name, fn) {
-  var dependentKeys = Array.prototype.slice.call(arguments, 2);
-  Ember.Handlebars.registerHelper(name, function(property, options) {
-    var data = options.data,
+  var dependentKeys = slice.call(arguments, 2);
+
+  Ember.Handlebars.registerHelper(name, function() {
+    var properties = slice.call(arguments, 0, -1),
+      numProperties = properties.length,
+      options = arguments[arguments.length - 1],
+      normalizedProperties = [],
+      data = options.data,
+      hash = options.hash,
       view = data.view,
       currentContext = (options.contexts && options.contexts[0]) || this,
-      pathRoot, path, normalized,
-      observer, loc;
+      normalized,
+      pathRoot, path, 
+      loc, hashOption;
 
-    normalized = Ember.Handlebars.normalizePath(currentContext, property, data);
+    // Detect bound options (e.g. countBinding="otherCount")
+    hash.boundOptions = {};
+    for (hashOption in hash) {
+      if (!hash.hasOwnProperty(hashOption)) { continue; }
+
+      if (Ember.IS_BINDING.test(hashOption) && typeof hash[hashOption] === 'string') {
+        // Lop off 'Binding' suffix.
+        hash.boundOptions[hashOption.slice(0, -7)] = hash[hashOption];
+      }
+    }
+
+    // Expose property names on data.properties object.
+    data.properties = [];
+    for (loc = 0; loc < numProperties; ++loc) {
+      data.properties.push(properties[loc]);
+      normalizedProperties.push(normalizePath(currentContext, properties[loc], data));
+    }
+
+    if (data.isUnbound) {
+      return evaluateUnboundHelper(this, fn, normalizedProperties, options);
+    }
+
+    if (dependentKeys.length === 0) {
+      return evaluateMultiPropertyBoundHelper(currentContext, fn, normalizedProperties, options);
+    }
+
+    Ember.assert("Dependent keys can only be used with single-property helpers.", properties.length === 1);
+
+    normalized = normalizedProperties[0];
 
     pathRoot = normalized.root;
     path = normalized.path;
@@ -223,17 +303,112 @@ Ember.Handlebars.registerBoundHelper = function(name, fn) {
 
     view.appendChild(bindView);
 
-    observer = function() {
-      Ember.run.scheduleOnce('render', bindView, 'rerender');
-    };
-
-    view.registerObserver(pathRoot, path, observer);
+    view.registerObserver(pathRoot, path, bindView, rerenderBoundHelperView);
 
     for (var i=0, l=dependentKeys.length; i<l; i++) {
-      view.registerObserver(pathRoot, path + '.' + dependentKeys[i], observer);
+      view.registerObserver(pathRoot, path + '.' + dependentKeys[i], bindView, rerenderBoundHelperView);
     }
   });
 };
+
+/**
+  @private
+
+  Renders the unbound form of an otherwise bound helper function.
+
+  @param {Function} fn
+  @param {Object} context
+  @param {Array} normalizedProperties
+  @param {String} options
+*/
+function evaluateMultiPropertyBoundHelper(context, fn, normalizedProperties, options) {
+  var numProperties = normalizedProperties.length,
+      self = this,
+      data = options.data,
+      view = data.view,
+      hash = options.hash,
+      boundOptions = hash.boundOptions,
+      watchedProperties,
+      boundOption, bindView, loc, property, len;
+
+  bindView = new Ember._SimpleHandlebarsView(null, null, !hash.unescaped, data);
+  bindView.normalizedValue = function() {
+    var args = [], value, boundOption;
+
+    // Copy over bound options.
+    for (boundOption in boundOptions) {
+      if (!boundOptions.hasOwnProperty(boundOption)) { continue; }
+      property = normalizePath(context, boundOptions[boundOption], data);
+      bindView.path = property.path;
+      bindView.pathRoot = property.root;
+      hash[boundOption] = Ember._SimpleHandlebarsView.prototype.normalizedValue.call(bindView);
+    }
+
+    for (loc = 0; loc < numProperties; ++loc) {
+      property = normalizedProperties[loc];
+      bindView.path = property.path;
+      bindView.pathRoot = property.root;
+      args.push(Ember._SimpleHandlebarsView.prototype.normalizedValue.call(bindView));
+    }
+    args.push(options);
+    return fn.apply(context, args);
+  };
+
+  view.appendChild(bindView);
+
+  // Assemble liast of watched properties that'll re-render this helper.
+  watchedProperties = [];
+  for (boundOption in boundOptions) {
+    if (boundOptions.hasOwnProperty(boundOption)) { 
+      watchedProperties.push(normalizePath(context, boundOptions[boundOption], data));
+    }
+  }
+  watchedProperties = watchedProperties.concat(normalizedProperties);
+
+  // Observe each property.
+  for (loc = 0, len = watchedProperties.length; loc < len; ++loc) {
+    property = watchedProperties[loc];
+    view.registerObserver(property.root, property.path, bindView, rerenderBoundHelperView);
+  }
+
+}
+
+/**
+  @private
+
+  An observer function used with bound helpers which
+  will schedule a re-render of the _SimpleHandlebarsView
+  connected with the helper.
+*/
+function rerenderBoundHelperView() {
+  Ember.run.scheduleOnce('render', this, 'rerender');
+}
+
+/**
+  @private
+
+  Renders the unbound form of an otherwise bound helper function.
+
+  @param {Function} fn
+  @param {Object} context
+  @param {Array} normalizedProperties
+  @param {String} options
+*/
+function evaluateUnboundHelper(context, fn, normalizedProperties, options) {
+  var args = [], hash = options.hash, boundOptions = hash.boundOptions, loc, len, property, boundOption;
+
+  for (boundOption in boundOptions) {
+    if (!boundOptions.hasOwnProperty(boundOption)) { continue; }
+    hash[boundOption] = Ember.Handlebars.get(context, boundOptions[boundOption], options);
+  }
+
+  for(loc = 0, len = normalizedProperties.length; loc < len; ++loc) {
+    property = normalizedProperties[loc];
+    args.push(Ember.Handlebars.get(context, property.path, options));
+  }
+  args.push(options);
+  return fn.apply(context, args);
+}
 
 /**
   @private

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -17,12 +17,30 @@ var handlebarsGet = Ember.Handlebars.get;
   <div>{{unbound somePropertyThatDoesntChange}}</div>
   ```
 
+  `unbound` can also be used in conjunction with a bound helper to
+  render it in its unbound form:
+
+  ```handlebars
+  <div>{{unbound helperName somePropertyThatDoesntChange}}</div>
+  ```
+
   @method unbound
   @for Ember.Handlebars.helpers
   @param {String} property
   @return {String} HTML string
 */
 Ember.Handlebars.registerHelper('unbound', function(property, fn) {
-  var context = (fn.contexts && fn.contexts[0]) || this;
+  var options = arguments[arguments.length - 1], helper, context, out;
+
+  if(arguments.length > 2) {
+    // Unbound helper call.
+    options.data.isUnbound = true;
+    helper = Ember.Handlebars.helpers[arguments[0]] || Ember.Handlebars.helperMissing;
+    out = helper.apply(this, Array.prototype.slice.call(arguments, 1)); 
+    delete options.data.isUnbound;
+    return out;
+  }
+
+  context = (fn.contexts && fn.contexts[0]) || this;
   return handlebarsGet(context, property, fn);
 });

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -8,6 +8,17 @@ var appendView = function() {
   Ember.run(function() { view.appendTo('#qunit-fixture'); });
 };
 
+var registerRepeatHelper = function() {
+  Ember.Handlebars.registerBoundHelper('repeat', function(value, options) {
+    var count = options.hash.count;
+    var a = [];
+    while(a.length < count){
+        a.push(value);
+    }
+    return a.join('');
+  });
+};
+
 module("Handlebars bound helpers", {
   setup: function() {
     window.TemplateTests = Ember.Namespace.create();
@@ -69,14 +80,8 @@ test("should allow for computed properties with dependencies", function() {
 });
 
 test("bound helpers should support options", function() {
-  Ember.Handlebars.registerBoundHelper('repeat', function(value, options) {
-    var count = options.hash.count;
-    var a = [];
-    while(a.length < count){
-        a.push(value);
-    }
-    return a.join('');
-  });
+
+  registerRepeatHelper();
   
   view = Ember.View.create({
     controller: Ember.Object.create({text: 'ab'}),
@@ -133,3 +138,106 @@ test("bound helper should support this keyword", function() {
 
   ok(view.$().text() === 'AB', "helper output is correct");
 });
+
+test("bound helpers should support bound options", function() {
+
+  registerRepeatHelper();
+  
+  view = Ember.View.create({
+    controller: Ember.Object.create({text: 'ab', numRepeats: 3}),
+    template: Ember.Handlebars.compile('{{repeat text countBinding="numRepeats"}}')
+  });
+
+  appendView();
+  
+  equal(view.$().text(), 'ababab', "helper output is correct");
+
+  Ember.run(function() {
+    view.set('controller.numRepeats', 4);
+  });
+
+  equal(view.$().text(), 'abababab', "helper correctly re-rendered after bound option was changed");
+
+  Ember.run(function() {
+    view.set('controller.numRepeats', 2);
+    view.set('controller.text', "YES");
+  });
+
+  equal(view.$().text(), 'YESYES', "helper correctly re-rendered after both bound option and property changed");
+});
+
+
+test("bound helpers should support multiple bound properties", function() {
+
+  Ember.Handlebars.registerBoundHelper('concat', function() {
+    return [].slice.call(arguments, 0, -1).join('');
+  });
+  
+  view = Ember.View.create({
+    controller: Ember.Object.create({thing1: 'ZOID', thing2: 'BERG'}),
+    template: Ember.Handlebars.compile('{{concat thing1 thing2}}')
+  });
+
+  appendView();
+  
+  equal(view.$().text(), 'ZOIDBERG', "helper output is correct");
+
+  Ember.run(function() {
+    view.set('controller.thing2', "NERD");
+  });
+
+  equal(view.$().text(), 'ZOIDNERD', "helper correctly re-rendered after second bound helper property changed");
+
+  Ember.run(function() {
+    view.controller.setProperties({
+      thing1: "WOOT",
+      thing2: "YEAH"
+    });
+  });
+
+  equal(view.$().text(), 'WOOTYEAH', "helper correctly re-rendered after both bound helper properties changed");
+});
+
+test("bound helpers should expose property names in options.data.properties", function() {
+  Ember.Handlebars.registerBoundHelper('echo', function() {
+    var options = arguments[arguments.length - 1];
+    var values = [].slice.call(arguments, 0, -1);
+    var a = [];
+    for(var i = 0; i < values.length; ++i) {
+      var propertyName = options.data.properties[i];
+      a.push(propertyName);
+    }
+    return a.join(' ');
+  });
+  
+  view = Ember.View.create({
+    controller: Ember.Object.create({
+      thing1: 'ZOID', 
+      thing2: 'BERG', 
+      thing3: Ember.Object.create({ 
+        foo: 123 
+      })
+    }),
+    template: Ember.Handlebars.compile('{{echo thing1 thing2 thing3.foo}}')
+  });
+
+  appendView();
+  
+  equal(view.$().text(), 'thing1 thing2 thing3.foo', "helper output is correct");
+});
+
+test("bound helpers can be invoked with zero args", function() {
+  Ember.Handlebars.registerBoundHelper('troll', function(options) {
+    return options.hash.text || "TROLOLOL";
+  });
+  
+  view = Ember.View.create({
+    controller: Ember.Object.create({trollText: "yumad"}),
+    template: Ember.Handlebars.compile('{{troll}} and {{troll text="bork"}}')
+  });
+
+  appendView();
+  
+  equal(view.$().text(), 'TROLOLOL and bork', "helper output is correct");
+});
+

--- a/packages/ember-handlebars/tests/helpers/unbound_test.js
+++ b/packages/ember-handlebars/tests/helpers/unbound_test.js
@@ -1,0 +1,177 @@
+/*globals Foo */
+
+var get = Ember.get, set = Ember.set;
+
+var appendView = function(view) {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+var view;
+var originalLookup = Ember.lookup, lookup;
+
+module("Handlebars {{#unbound}} helper -- classic single-property usage", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    view = Ember.View.create({
+      template: Ember.Handlebars.compile("{{unbound foo}} {{unbound bar}}"),
+      context: Ember.Object.create({
+        foo: "BORK",
+        barBinding: 'foo'
+      })
+    });
+
+    appendView(view);
+  },
+
+  teardown: function() {
+    Ember.run(function(){
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("it should render the current value of a property on the context", function() {
+  equal(view.$().text(), "BORK BORK", "should render the current value of a property");
+});
+
+test("it should not re-render if the property changes", function() {
+  Ember.run(function() {
+    view.set('context.foo', 'OOF');
+  });
+  equal(view.$().text(), "BORK BORK", "should not re-render if the property changes");
+});
+
+
+module("Handlebars {{#unbound boundHelper arg1 arg2... argN}} form: render unbound helper invocations", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    Ember.Handlebars.registerBoundHelper('capitalize', function(value) {
+      return value.toUpperCase();
+    });
+
+    Ember.Handlebars.registerBoundHelper('capitalizeName', function(value) {
+      return get(value, 'firstName').toUpperCase();
+    }, 'firstName');
+
+    Ember.Handlebars.registerBoundHelper('concat', function(value) {
+      return [].slice.call(arguments, 0, -1).join('');
+    });
+
+    Ember.Handlebars.registerBoundHelper('concatNames', function(value) {
+      return get(value, 'firstName') + get(value, 'lastName');
+    }, 'firstName', 'lastName');
+  },
+
+  teardown: function() {
+    Ember.run(function(){
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+
+test("should be able to render an unbound helper invocation", function() {
+
+  Ember.Handlebars.registerBoundHelper('repeat', function(value, options) {
+    var count = options.hash.count;
+    var a = [];
+    while(a.length < count){
+        a.push(value);
+    }
+    return a.join('');
+  });
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{unbound repeat foo countBinding="bar"}} {{repeat foo countBinding="bar"}} {{unbound repeat foo count=2}} {{repeat foo count=4}}'),
+    context: Ember.Object.create({
+      foo: "X",
+      numRepeatsBinding: "bar",
+      bar: 5
+    })
+  });
+  appendView(view);
+
+  equal(view.$().text(), "XXXXX XXXXX XX XXXX", "first render is correct");
+
+  Ember.run(function() {
+    set(view, 'context.bar', 1);
+  });
+
+  equal(view.$().text(), "XXXXX X XX XXXX", "only unbound bound options changed");
+});
+
+
+test("should be able to render unbound forms of multi-arg helpers", function() {
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile("{{concat foo bar bing}} {{unbound concat foo bar bing}}"),
+    context: Ember.Object.create({
+      foo: "a",
+      bar: "b",
+      bing: "c"
+    })
+  });
+  appendView(view);
+
+  equal(view.$().text(), "abc abc", "first render is correct");
+
+  Ember.run(function() {
+    set(view, 'context.bar', 'X');
+  });
+
+  equal(view.$().text(), "aXc abc", "unbound helpers/properties stayed the same");
+});
+
+
+test("should be able to render an unbound helper invocation for helpers with dependent keys", function() {
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile("{{capitalizeName person}} {{unbound capitalizeName person}} {{concatNames person}} {{unbound concatNames person}}"),
+    context: Ember.Object.create({
+      person: Ember.Object.create({
+        firstName: 'shooby',
+        lastName:  'taylor'
+      })
+    })
+  });
+  appendView(view);
+
+  equal(view.$().text(), "SHOOBY SHOOBY shoobytaylor shoobytaylor", "first render is correct");
+
+  Ember.run(function() {
+    set(view, 'context.person.firstName', 'sally');
+  });
+
+  equal(view.$().text(), "SALLY SHOOBY sallytaylor shoobytaylor", "only bound values change");
+});
+
+
+test("should be able to render an unbound helper invocation with bound hash options", function() {
+
+  Ember.Handlebars.registerBoundHelper('repeat', function(value) {
+    return [].slice.call(arguments, 0, -1).join('');
+  });
+
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile("{{capitalizeName person}} {{unbound capitalizeName person}} {{concatNames person}} {{unbound concatNames person}}"),
+    context: Ember.Object.create({
+      person: Ember.Object.create({
+        firstName: 'shooby',
+        lastName:  'taylor'
+      })
+    })
+  });
+  appendView(view);
+
+  equal(view.$().text(), "SHOOBY SHOOBY shoobytaylor shoobytaylor", "first render is correct");
+
+  Ember.run(function() {
+    set(view, 'context.person.firstName', 'sally');
+  });
+
+  equal(view.$().text(), "SALLY SHOOBY sallytaylor shoobytaylor", "only bound values change");
+});
+

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2139,11 +2139,11 @@ Ember.View = Ember.CoreView.extend(
     return this.currentState.handleEvent(this, eventName, evt);
   },
 
-  registerObserver: function(root, path, observer) {
-    Ember.addObserver(root, path, observer);
+  registerObserver: function(root, path, target, observer) {
+    Ember.addObserver(root, path, target, observer);
 
     this.one('willClearRender', function() {
-      Ember.removeObserver(root, path, observer);
+      Ember.removeObserver(root, path, target, observer);
     });
   }
 


### PR DESCRIPTION
1. Bound helpers now support multiple properties `{{foo prop1 prop2}}` (previously only supported only 1)
2. Helpers declared as bound can be invoked by their unbound former via the `unbound` helper: `{{unbound foo prop1 prop2}}`
3. Hash parameters can now be bound via the `Binding` suffix: `{{foo prop1 thingBinding="whatever"}}`
4. Exposes an array of bound property names via `options.data.properties` (see #1665)
