### PR TITLE
Make Ember.ContainerView implement Ember.MutableArray

### DIFF
--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -31,11 +31,7 @@ function append() {
 }
 
 function selectedOptions() {
-  var rv = [];
-  for(var i=0, len = select.get('content.length'); i < len; ++i) {
-    rv.push(select.get('childViews.' + i + '.childViews.0.selected'));
-  }
-  return rv;
+  return select.get('childViews').mapProperty('selected');
 }
 
 test("has 'ember-view' and 'ember-select' CSS classes", function() {

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1856,7 +1856,7 @@ test("should expose a controller keyword that persists through Ember.ContainerVi
   });
 
   Ember.run(function() {
-    get(containerView, 'childViews').pushObject(viewInstanceToBeInserted);
+    containerView.pushObject(viewInstanceToBeInserted);
   });
 
   equal(trim(viewInstanceToBeInserted.$().text()), "bar", "renders value from parent's controller");

--- a/packages/ember-old-router/tests/controller_test.js
+++ b/packages/ember-old-router/tests/controller_test.js
@@ -143,7 +143,7 @@ test("if the controller is explicitly set to null while connecting an outlet, th
     controller: postController
   });
 
-  containerView.get('childViews').pushObject(view);
+  containerView.pushObject(view);
   equal(view.get('controller'), postController, "the controller was inherited from the parent");
 });
 
@@ -165,7 +165,7 @@ test("if the controller is not given while connecting an outlet, the instantiate
     controller: postController
   });
 
-  containerView.get('childViews').pushObject(view);
+  containerView.pushObject(view);
   equal(view.get('controller'), postController, "the controller was inherited from the parent");
 });
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -254,9 +254,9 @@ Ember.CollectionView = Ember.ContainerView.extend(
     // Loop through child views that correspond with the removed items.
     // Note that we loop from the end of the array to the beginning because
     // we are mutating it as we go.
-    var childViews = get(this, 'childViews'), childView, idx, len;
+    var childViews = this._childViews, childView, idx, len;
 
-    len = get(childViews, 'length');
+    len = this._childViews.length;
 
     var removingAll = removedCount === len;
 
@@ -286,7 +286,6 @@ Ember.CollectionView = Ember.ContainerView.extend(
   */
   arrayDidChange: function(content, start, removed, added) {
     var itemViewClass = get(this, 'itemViewClass'),
-        childViews = get(this, 'childViews'),
         addedViews = [], view, item, idx, len, itemTagName;
 
     if ('string' === typeof itemViewClass) {
@@ -315,7 +314,7 @@ Ember.CollectionView = Ember.ContainerView.extend(
       addedViews.push(emptyView);
       set(this, 'emptyView', emptyView);
     }
-    childViews.replace(start, 0, addedViews);
+    this.replace(start, 0, addedViews);
   },
 
   createChildView: function(view, attrs) {

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -1,5 +1,6 @@
 require('ember-views/views/view');
 require('ember-views/views/states');
+require('ember-runtime/mixins/mutable_array');
 
 var states = Ember.View.cloneStates(Ember.View.states);
 
@@ -11,12 +12,9 @@ var states = Ember.View.cloneStates(Ember.View.states);
 var get = Ember.get, set = Ember.set, meta = Ember.meta;
 var forEach = Ember.EnumerableUtils.forEach;
 
-var childViewsProperty = Ember.computed.alias('_childViews');
-
 /**
-  A `ContainerView` is an `Ember.View` subclass that allows for manual or
-  programatic management of a view's `childViews` array that will correctly
-  update the `ContainerView` instance's rendered DOM representation.
+  A `ContainerView` is an `Ember.View` subclass that implements `Ember.MutableArray`
+  allowing programatic management of its child views.
 
   ## Setting Initial Child Views
 
@@ -56,11 +54,9 @@ var childViewsProperty = Ember.computed.alias('_childViews');
 
   ## Adding and Removing Child Views
 
-  The views in a container's `childViews` array should be added and removed by
-  manipulating the `childViews` property directly.
+  The container view implements `Ember.MutableArray` allowing programatic management of its child views.
 
-  To remove a view pass that view into a `removeObject` call on the container's
-  `childViews` property.
+  To remove a view, pass that view into a `removeObject` call on the container view.
 
   Given an empty `<body>` the following code
 
@@ -91,9 +87,9 @@ var childViewsProperty = Ember.computed.alias('_childViews');
   Removing a view
 
   ```javascript
-  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView]
-  aContainer.get('childViews').removeObject(aContainer.get('bView'));
-  aContainer.get('childViews');  // [aContainer.aView]
+  aContainer.toArray();  // [aContainer.aView, aContainer.bView]
+  aContainer.removeObject(aContainer.get('bView'));
+  aContainer.toArray();  // [aContainer.aView]
   ```
 
   Will result in the following HTML
@@ -105,7 +101,7 @@ var childViewsProperty = Ember.computed.alias('_childViews');
   ```
 
   Similarly, adding a child view is accomplished by adding `Ember.View` instances to the
-  container's `childViews` property.
+  container view.
 
   Given an empty `<body>` the following code
 
@@ -140,9 +136,9 @@ var childViewsProperty = Ember.computed.alias('_childViews');
     template: Ember.Handlebars.compile("Another view")
   });
 
-  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView]
-  aContainer.get('childViews').pushObject(AnotherViewClass.create());
-  aContainer.get('childViews');  // [aContainer.aView, aContainer.bView, <AnotherViewClass instance>]
+  aContainer.toArray();  // [aContainer.aView, aContainer.bView]
+  aContainer.pushObject(AnotherViewClass.create());
+  aContainer.toArray(); // [aContainer.aView, aContainer.bView, <AnotherViewClass instance>]
   ```
 
   Will result in the following HTML
@@ -167,7 +163,7 @@ var childViewsProperty = Ember.computed.alias('_childViews');
   rendered view.
 
   Calling `removeFromParent()` behaves as expected but should be avoided in
-  favor of direct manipulation of a container's `childViews` property.
+  favor of direct manipulation of a container as an array.
 
   ```javascript
   aContainer = Ember.ContainerView.create({
@@ -216,10 +212,9 @@ var childViewsProperty = Ember.computed.alias('_childViews');
 
   If you would like to display a single view in your ContainerView, you can set
   its `currentView` property. When the `currentView` property is set to a view
-  instance, it will be added to the ContainerView's `childViews` array. If the
-  `currentView` property is later changed to a different view, the new view
-  will replace the old view. If `currentView` is set to `null`, the last
-  `currentView` will be removed.
+  instance, it will be added to the ContainerView. If the `currentView` property
+  is later changed to a different view, the new view will replace the old view.
+  If `currentView` is set to `null`, the last `currentView` will be removed.
 
   This functionality is useful for cases where you want to bind the display of
   a ContainerView to a controller or state manager. For example, you can bind
@@ -241,15 +236,16 @@ var childViewsProperty = Ember.computed.alias('_childViews');
   @namespace Ember
   @extends Ember.View
 */
-
-Ember.ContainerView = Ember.View.extend({
+Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
   states: states,
 
   init: function() {
     this._super();
 
     var childViews = get(this, 'childViews');
-    Ember.defineProperty(this, 'childViews', childViewsProperty);
+
+    // redefine view's childViews property that was obliterated
+    Ember.defineProperty(this, 'childViews', Ember.View.childViewsProperty);
 
     var _childViews = this._childViews;
 
@@ -268,19 +264,37 @@ Ember.ContainerView = Ember.View.extend({
     }, this);
 
     var currentView = get(this, 'currentView');
-    if (currentView) _childViews.push(this.createChildView(currentView));
-
-    // Make the _childViews array observable
-    Ember.A(_childViews);
-
-    // Sets up an array observer on the child views array. This
-    // observer will detect when child views are added or removed
-    // and update the DOM to reflect the mutation.
-    get(this, 'childViews').addArrayObserver(this, {
-      willChange: 'childViewsWillChange',
-      didChange: 'childViewsDidChange'
-    });
+    if (currentView) {
+      _childViews.push(this.createChildView(currentView));
+    }
   },
+
+  replace: function(idx, removedCount, addedViews) {
+    var addedCount = addedViews ? get(addedViews, 'length') : 0;
+
+    this.arrayContentWillChange(idx, removedCount, addedCount);
+    this.childViewsWillChange(this._childViews, idx, removedCount);
+
+    if (addedCount === 0) {
+      this._childViews.splice(idx, removedCount) ;
+    } else {
+      var args = [idx, removedCount].concat(addedViews);
+      this._childViews.splice.apply(this._childViews, args);
+    }
+
+    this.arrayContentDidChange(idx, removedCount, addedCount);
+    this.childViewsDidChange(this._childViews, idx, removedCount, addedCount);
+
+    return this;
+  },
+
+  objectAt: function(idx) {
+    return this._childViews[idx];
+  },
+
+  length: Ember.computed(function () {
+    return this._childViews.length;
+  }),
 
   /**
     @private
@@ -301,23 +315,6 @@ Ember.ContainerView = Ember.View.extend({
   /**
     @private
 
-    When the container view is destroyed, tear down the child views
-    array observer.
-
-    @method willDestroy
-  */
-  willDestroy: function() {
-    get(this, 'childViews').removeArrayObserver(this, {
-      willChange: 'childViewsWillChange',
-      didChange: 'childViewsDidChange'
-    });
-
-    this._super();
-  },
-
-  /**
-    @private
-
     When a child view is removed, destroy its element so that
     it is removed from the DOM.
 
@@ -330,12 +327,13 @@ Ember.ContainerView = Ember.View.extend({
     @param {Number} removed the number of child views removed
   **/
   childViewsWillChange: function(views, start, removed) {
-    if (removed === 0) { return; }
+    this.propertyWillChange('childViews');
 
-    var changedViews = views.slice(start, start+removed);
-    this.initializeViews(changedViews, null, null);
-
-    this.currentState.childViewsWillChange(this, views, start, removed);
+    if (removed > 0) {
+      var changedViews = views.slice(start, start+removed);
+      this.initializeViews(changedViews, null, null);
+      this.currentState.childViewsWillChange(this, views, start, removed);
+    }
   },
 
   /**
@@ -356,16 +354,12 @@ Ember.ContainerView = Ember.View.extend({
     @param {Number} the number of child views added
   */
   childViewsDidChange: function(views, start, removed, added) {
-    var len = get(views, 'length');
-
-    // No new child views were added; bail out.
-    if (added === 0) return;
-
-    var changedViews = views.slice(start, start+added);
-    this.initializeViews(changedViews, this, get(this, 'templateData'));
-
-    // Let the current state handle the changes
-    this.currentState.childViewsDidChange(this, views, start, added);
+    if (added > 0) {
+      var changedViews = views.slice(start, start+added);
+      this.initializeViews(changedViews, this, get(this, 'templateData'));
+      this.currentState.childViewsDidChange(this, views, start, added);
+    }
+    this.propertyDidChange('childViews');
   },
 
   initializeViews: function(views, parentView, templateData) {
@@ -381,21 +375,17 @@ Ember.ContainerView = Ember.View.extend({
   currentView: null,
 
   _currentViewWillChange: Ember.beforeObserver(function() {
-    var childViews = get(this, 'childViews'),
-        currentView = get(this, 'currentView');
-
+    var currentView = get(this, 'currentView');
     if (currentView) {
       currentView.destroy();
-      childViews.removeObject(currentView);
+      this.removeObject(currentView);
     }
   }, 'currentView'),
 
   _currentViewDidChange: Ember.observer(function() {
-    var childViews = get(this, 'childViews'),
-        currentView = get(this, 'currentView');
-
+    var currentView = get(this, 'currentView');
     if (currentView) {
-      childViews.pushObject(currentView);
+      this.pushObject(currentView);
     }
   }, 'currentView'),
 
@@ -428,7 +418,7 @@ Ember.merge(states.hasElement, {
   },
 
   ensureChildrenAreInDOM: function(view) {
-    var childViews = view.get('childViews'), i, len, childView, previous, buffer;
+    var childViews = view._childViews, i, len, childView, previous, buffer;
     for (i = 0, len = childViews.length; i < len; i++) {
       childView = childViews[i];
       buffer = childView.renderToBufferIfNeeded();

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -14,9 +14,7 @@ var a_forEach = Ember.EnumerableUtils.forEach;
 var a_addObject = Ember.EnumerableUtils.addObject;
 
 var childViewsProperty = Ember.computed(function() {
-  var childViews = this._childViews;
-
-  var ret = Ember.A();
+  var childViews = this._childViews, ret = Ember.A(), view = this;
 
   a_forEach(childViews, function(view) {
     if (view.isVirtual) {
@@ -25,6 +23,14 @@ var childViewsProperty = Ember.computed(function() {
       ret.push(view);
     }
   });
+
+  ret.replace = function (idx, removedCount, addedViews) {
+    if (view instanceof Ember.ContainerView) {
+      Ember.deprecate("Manipulating a Ember.ContainerView through its childViews property is deprecated. Please use the ContainerView instance itself as an Ember.MutableArray.");
+      return view.replace(idx, removedCount, addedViews);
+    }
+    throw new Error("childViews is immutable");
+  };
 
   return ret;
 });

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -158,7 +158,7 @@ test("events should stop propagating if the view is destroyed", function() {
     }
   });
 
-  Ember.get(parentView, 'childViews').pushObject(view);
+  parentView.pushObject(view);
 
   Ember.run(function() {
     parentView.append();

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -19,7 +19,7 @@ test("should be able to insert views after the DOM representation is created", f
   });
 
   Ember.run(function() {
-    container.get('childViews').pushObject(view);
+    container.pushObject(view);
   });
 
   equal(Ember.$.trim(container.$().text()), "This is my moment");
@@ -34,7 +34,7 @@ test("should be able to observe properties that contain child views", function()
   var container;
 
   Ember.run(function() {
-    container = Ember.ContainerView.createWithMixins({
+    container = Ember.ContainerView.create({
       childViews: ['displayView'],
       displayIsDisplayedBinding: 'displayView.isDisplayed',
 
@@ -45,7 +45,6 @@ test("should be able to observe properties that contain child views", function()
 
     container.appendTo('#qunit-fixture');
   });
-
   ok(container.get('displayIsDisplayed'), "can bind to child view");
 });
 
@@ -56,14 +55,13 @@ test("should set the parentView property on views that are added to the child vi
           return "This is my moment";
         }
       }),
-      view = View.create(),
-      childViews = get(container, 'childViews');
+      view = View.create();
 
-  childViews.pushObject(view);
+  container.pushObject(view);
   equal(view.get('parentView'), container, "sets the parent view after the childView is appended");
 
   Ember.run(function() {
-    childViews.removeObject(view);
+    container.removeObject(view);
   });
   equal(get(view, 'parentView'), null, "sets parentView to null when a view is removed");
 
@@ -72,7 +70,7 @@ test("should set the parentView property on views that are added to the child vi
   });
 
   Ember.run(function(){
-    childViews.pushObject(view);
+    container.pushObject(view);
   });
 
   equal(get(view, 'parentView'), container, "sets the parent view after the childView is appended");
@@ -82,8 +80,8 @@ test("should set the parentView property on views that are added to the child vi
       fourthView = View.create();
 
   Ember.run(function(){
-    childViews.pushObject(secondView);
-    childViews.replace(1, 0, [thirdView, fourthView]);
+    container.pushObject(secondView);
+    container.replace(1, 0, [thirdView, fourthView]);
   });
 
   equal(get(secondView, 'parentView'), container, "sets the parent view of the second view");
@@ -91,7 +89,7 @@ test("should set the parentView property on views that are added to the child vi
   equal(get(fourthView, 'parentView'), container, "sets the parent view of the fourth view");
 
   Ember.run(function() {
-    childViews.replace(2, 2);
+    container.replace(2, 2);
   });
 
   equal(get(view, 'parentView'), container, "doesn't change non-removed view");
@@ -111,7 +109,7 @@ test("views that are removed from a ContainerView should have their child views 
     }
   });
 
-  get(container, 'childViews').pushObject(view);
+  container.pushObject(view);
 
   Ember.run(function() {
     container.appendTo('#qunit-fixture');
@@ -119,7 +117,7 @@ test("views that are removed from a ContainerView should have their child views 
 
   equal(get(view, 'childViews.length'), 1, "precond - renders one child view");
   Ember.run(function() {
-    get(container, 'childViews').removeObject(view);
+    container.removeObject(view);
   });
   equal(get(view, 'childViews.length'), 0, "child views are cleared when removed from container view");
 });
@@ -333,14 +331,12 @@ test("should be able to modify childViews many times during an run loop", functi
     }
   });
 
-  var childViews = container.get('childViews');
-
   Ember.run(function() {
     // initial order
-    childViews.pushObjects([three, one, two]);
+    container.pushObjects([three, one, two]);
     // sort
-    childViews.removeObject(three);
-    childViews.pushObject(three);
+    container.removeObject(three);
+    container.pushObject(three);
   });
 
   // Remove whitespace added by IE 8
@@ -354,14 +350,13 @@ test("should be able to modify childViews then remove the ContainerView in same 
     container.appendTo('#qunit-fixture');
   });
 
-  var childViews = container.get('childViews');
   var count = 0;
   var child = Ember.View.create({
     template: function () { count++; return 'child'; }
   });
 
   Ember.run(function() {
-    childViews.pushObject(child);
+    container.pushObject(child);
     container.remove();
   });
 
@@ -375,14 +370,13 @@ test("should be able to modify childViews then destroy the ContainerView in same
     container.appendTo('#qunit-fixture');
   });
 
-  var childViews = container.get('childViews');
   var count = 0;
   var child = Ember.View.create({
     template: function () { count++; return 'child'; }
   });
 
   Ember.run(function() {
-    childViews.pushObject(child);
+    container.pushObject(child);
     container.destroy();
   });
 
@@ -397,14 +391,13 @@ test("should be able to modify childViews then rerender the ContainerView in sam
     container.appendTo('#qunit-fixture');
   });
 
-  var childViews = container.get('childViews');
   var count = 0;
   var child = Ember.View.create({
     template: function () { count++; return 'child'; }
   });
 
   Ember.run(function() {
-    childViews.pushObject(child);
+    container.pushObject(child);
     container.rerender();
   });
 
@@ -418,7 +411,6 @@ test("should be able to modify childViews then rerender then modify again the Co
     container.appendTo('#qunit-fixture');
   });
 
-  var childViews = container.get('childViews');
   var Child = Ember.View.extend({
     count: 0,
     render: function (buffer) {
@@ -430,8 +422,8 @@ test("should be able to modify childViews then rerender then modify again the Co
   var two = Child.create({label: 'two'});
 
   Ember.run(function() {
-    childViews.pushObject(one);
-    childViews.pushObject(two);
+    container.pushObject(one);
+    container.pushObject(two);
   });
 
   equal(one.count, 1, 'rendered child only once');
@@ -447,7 +439,6 @@ test("should be able to modify childViews then rerender again the ContainerView 
     container.appendTo('#qunit-fixture');
   });
 
-  var childViews = container.get('childViews');
   var Child = Ember.View.extend({
     count: 0,
     render: function (buffer) {
@@ -459,7 +450,7 @@ test("should be able to modify childViews then rerender again the ContainerView 
   var two = Child.create({label: 'two'});
 
   Ember.run(function() {
-    childViews.pushObject(one);
+    container.pushObject(one);
     container.rerender();
   });
 
@@ -467,7 +458,7 @@ test("should be able to modify childViews then rerender again the ContainerView 
   equal(container.$().text(), 'one');
 
   Ember.run(function () {
-    childViews.pushObject(two);
+    container.pushObject(two);
   });
 
   equal(one.count, 1, 'rendered child only once');
@@ -486,7 +477,7 @@ test("should invalidate `element` on itself and childViews when being rendered b
   });
 
   Ember.run(function() {
-    root.get('childViews').pushObject(container);
+    root.pushObject(container);
 
     // Get the parent and child's elements to cause them to be cached as null
     container.get('element');

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -103,7 +103,7 @@ test("should update attribute bindings", function() {
 });
 
 test("should throw if attributes are changed in the inBuffer state", function() {
-  var parentView, childViews, Test;
+  var parentView, Test;
   Ember.run(function() {
     lookup.Test = Test = Ember.Namespace.create();
     Test.controller = Ember.Object.create({
@@ -112,8 +112,7 @@ test("should throw if attributes are changed in the inBuffer state", function() 
 
     parentView = Ember.ContainerView.create();
 
-    childViews = parentView.get('childViews');
-    childViews.pushObject(parentView.createChildView(Ember.View, {
+    parentView.pushObject(parentView.createChildView(Ember.View, {
       template: function() {
         return "foo";
       },
@@ -122,14 +121,14 @@ test("should throw if attributes are changed in the inBuffer state", function() 
       attributeBindings: ['foo']
     }));
 
-    childViews.pushObject(parentView.createChildView(Ember.View, {
+    parentView.pushObject(parentView.createChildView(Ember.View, {
       template: function() {
         Test.controller.set('foo', 'baz');
         return "bar";
       }
     }));
 
-    childViews.pushObject(parentView.createChildView(Ember.View, {
+    parentView.pushObject(parentView.createChildView(Ember.View, {
       template: function() {
         return "bat";
       }

--- a/packages/ember-views/tests/views/view/controller_test.js
+++ b/packages/ember-views/tests/views/view/controller_test.js
@@ -13,15 +13,15 @@ test("controller property should be inherited from nearest ancestor with control
     grandparent.set('controller', grandparentController);
     parent.set('controller', parentController);
 
-    grandparent.get('childViews').pushObject(parent);
-    parent.get('childViews').pushObject(child);
+    grandparent.pushObject(parent);
+    parent.pushObject(child);
 
     strictEqual(grandparent.get('controller'), grandparentController);
     strictEqual(parent.get('controller'), parentController);
     strictEqual(child.get('controller'), parentController);
     strictEqual(grandchild.get('controller'), null);
 
-    child.get('childViews').pushObject(grandchild);
+    child.pushObject(grandchild);
     strictEqual(grandchild.get('controller'), parentController);
 
     var newController = {};


### PR DESCRIPTION
BREAKING CHANGE
containerView.get('childViews').pushObject(childView)
becomes
containerView.pushObject(childView)

Ember.ContainerView's childViews is not a mutable
array and only reflects non virtual views like
Ember.View's childViews
