### PR TITLE
{{action}} and {{linkTo}} now default to bubbles=false (stopPropagation)

### DIFF
--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -39,9 +39,9 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       eventName: options.eventName,
       handler: function(event) {
         if (!isSimpleClick(event)) { return true; }
-        event.preventDefault();
 
-        if (options.bubbles === false) {
+        event.preventDefault();
+        if (!options.bubbles) {
           event.stopPropagation();
         }
 
@@ -127,13 +127,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ### Event Propagation
 
     Events triggered through the action helper will automatically have
-    `.preventDefault()` called on them. You do not need to do so in your event
-    handlers.
+    `.preventDefault()` and `.stopPropagation()` called on them. You do not
+    need to do so in your event handlers.
 
-    To also disable bubbling, pass `bubbles=false` to the helper:
+    To suppress the `.stopPropagation()` call, pass `bubbles=true` to the
+    helper:
 
     ```handlebars
-    <button {{action 'edit' post bubbles=false}}>Edit</button>
+    <button {{action 'edit' post bubbles=true}}>Edit</button>
     ```
 
     If you need the default handler to trigger you should either register your

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -61,7 +61,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       if (!isSimpleClick(event)) { return true; }
 
       event.preventDefault();
-      if (this.bubbles === false) { event.stopPropagation(); }
+      if (!this.bubbles) { event.stopPropagation(); }
 
       var router = this.get('router');
 

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -169,49 +169,6 @@ test("should be able to use action more than once for the same event within a vi
   equal(deleteWasCalled, false, "The delete action was not called");
 });
 
-test("the event should not bubble if `bubbles=false` is passed", function() {
-  var editWasCalled = false,
-      deleteWasCalled = false,
-      originalEventHandlerWasCalled = false;
-
-  var controller = Ember.Controller.extend({
-    edit: function() { editWasCalled = true; },
-    "delete": function() { deleteWasCalled = true; }
-  }).create();
-
-  view = Ember.View.create({
-    controller: controller,
-    template: Ember.Handlebars.compile(
-      '<a id="edit" href="#" {{action "edit" bubbles=false}}>edit</a><a id="delete" href="#" {{action "delete" bubbles=false}}>delete</a>'
-    ),
-    click: function() { originalEventHandlerWasCalled = true; }
-  });
-
-  appendView();
-
-  view.$('#edit').trigger('click');
-
-  equal(editWasCalled, true, "The edit action was called");
-  equal(deleteWasCalled, false, "The delete action was not called");
-  equal(originalEventHandlerWasCalled, false, "The original event handler was not called");
-
-  editWasCalled = deleteWasCalled = originalEventHandlerWasCalled = false;
-
-  view.$('#delete').trigger('click');
-
-  equal(editWasCalled, false, "The edit action was not called");
-  equal(deleteWasCalled, true, "The delete action was called");
-  equal(originalEventHandlerWasCalled, false, "The original event handler was not called");
-
-  editWasCalled = deleteWasCalled = originalEventHandlerWasCalled = false;
-
-  view.$().trigger('click');
-
-  equal(editWasCalled, false, "The edit action was not called");
-  equal(deleteWasCalled, false, "The delete action was not called");
-  equal(originalEventHandlerWasCalled, true, "The original event handler was called");
-});
-
 test("should work properly in an #each block", function() {
   var eventHandlerWasCalled = false;
 
@@ -294,7 +251,7 @@ test("should properly capture events on child elements of a container with an ac
   ok(eventHandlerWasCalled, "Event on a child element triggered the action of it's parent");
 });
 
-test("should allow bubbling of events from action helper to original parent event", function() {
+test("should not bubble events from action helper to original parent event", function() {
   var eventHandlerWasCalled = false,
       originalEventHandlerWasCalled = false;
 
@@ -312,10 +269,11 @@ test("should allow bubbling of events from action helper to original parent even
 
   view.$('a').trigger('click');
 
-  ok(eventHandlerWasCalled && originalEventHandlerWasCalled, "Both event handlers were called");
+  ok(eventHandlerWasCalled, "The child handler was called");
+  ok(!originalEventHandlerWasCalled, "The parent handler was not called");
 });
 
-test("should not bubble an event from action helper to original parent event if `bubbles=false` is passed", function() {
+test("should bubble an event from action helper to original parent event if `bubbles=true` is passed", function() {
   var eventHandlerWasCalled = false,
       originalEventHandlerWasCalled = false;
 
@@ -325,7 +283,7 @@ test("should not bubble an event from action helper to original parent event if 
 
   view = Ember.View.create({
     controller: controller,
-    template: Ember.Handlebars.compile('<a href="#" {{action "edit" bubbles=false}}>click me</a>'),
+    template: Ember.Handlebars.compile('<a href="#" {{action "edit" bubbles=true}}>click me</a>'),
     click: function() { originalEventHandlerWasCalled = true; }
   });
 
@@ -333,8 +291,7 @@ test("should not bubble an event from action helper to original parent event if 
 
   view.$('a').trigger('click');
 
-  ok(eventHandlerWasCalled, "The child handler was called");
-  ok(!originalEventHandlerWasCalled, "The parent handler was not called");
+  ok(eventHandlerWasCalled && originalEventHandlerWasCalled, "Both event handlers were called");
 });
 
 test("should allow 'send' as action name (#594)", function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -176,7 +176,7 @@ test("The {{linkTo}} helper supports custom, nested, currentWhen", function() {
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active since currentWhen is a parent route");
 });
 
-test("The {{linkTo}} helper defaults to bubbling", function() {
+test("The {{linkTo}} helper defaults to not bubbling", function() {
   Ember.TEMPLATES.about = Ember.Handlebars.compile("<button {{action 'hide'}}>{{#linkTo 'about.contact' id='about-contact'}}About{{/linkTo}}</button>{{outlet}}");
   Ember.TEMPLATES['about/contact'] = Ember.Handlebars.compile("<h1 id='contact'>Contact</h1>");
 
@@ -208,11 +208,11 @@ test("The {{linkTo}} helper defaults to bubbling", function() {
 
   equal(Ember.$("#contact", "#qunit-fixture").text(), "Contact", "precond - the link worked");
 
-  equal(hidden, 1, "The link bubbles");
+  equal(hidden, 0, "The link does not bubble");
 });
 
-test("The {{linkTo}} helper supports bubbles=false", function() {
-  Ember.TEMPLATES.about = Ember.Handlebars.compile("<button {{action 'hide'}}>{{#linkTo 'about.contact' id='about-contact' bubbles=false}}About{{/linkTo}}</button>{{outlet}}");
+test("The {{linkTo}} helper supports bubbles=true", function() {
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<button {{action 'hide'}}>{{#linkTo 'about.contact' id='about-contact' bubbles=true}}About{{/linkTo}}</button>{{outlet}}");
   Ember.TEMPLATES['about/contact'] = Ember.Handlebars.compile("<h1 id='contact'>Contact</h1>");
 
   Router.map(function() {
@@ -243,7 +243,7 @@ test("The {{linkTo}} helper supports bubbles=false", function() {
 
   equal(Ember.$("#contact", "#qunit-fixture").text(), "Contact", "precond - the link worked");
 
-  equal(hidden, 0, "The link didn't bubble");
+  equal(hidden, 1, "The link bubbles");
 });
 
 test("The {{linkTo}} helper moves into the named route with context", function() {


### PR DESCRIPTION
/cc @devinus re 62d6c7220e55987127b19e6136b75e55a3e4a5d7

I claim that _not_ bubbling is the most common use case for action handlers, in particular having links/buttons inside a clickable area, like on Twitter:

![Screenshot 1:21:13 15:27-2](https://f.cloud.github.com/assets/524783/83234/c1c62f7a-63d6-11e2-8e61-fc16c5a34e4a.png)

Let's make it the default.

`old-router` still bubbles by default; it doesn't even have a `bubbles` option. I'm leaving it unchanged for simplicity and compatibility.
