### PR TITLE
Calling this.render() in renderTemplate() more than once breaks default into value.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -367,10 +367,10 @@ Ember.Route = Ember.Object.extend({
 
     if (!view && !template) { return; }
 
-    this.lastRenderedTemplate = name;
-
     options = normalizeOptions(this, name, template, options);
     view = setupView(view, container, options);
+
+    if (options.outlet === 'main') { this.lastRenderedTemplate = name; }
 
     appendView(this, view, options);
   }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1360,3 +1360,44 @@ test("Router accounts for rootURL on page load when using history location", fun
   // clean after test
   delete Ember.Location.implementations['historyTest'];
 });
+
+test("Only use route rendered into main outlet for default into property on child", function() {
+  Ember.TEMPLATES.application = compile("{{outlet menu}}{{outlet}}");
+  Ember.TEMPLATES.posts = compile("{{outlet}}");
+  Ember.TEMPLATES['posts/index'] = compile("postsIndex");
+  Ember.TEMPLATES['posts/menu'] = compile("postsMenu");
+
+  Router.map(function() {
+    this.resource("posts", function() {});
+  });
+
+  App.PostsMenuView = Ember.View.extend({
+    tagName: 'div',
+    templateName: 'posts/menu',
+    classNames: ['posts-menu']
+  });
+
+  App.PostsIndexView = Ember.View.extend({
+    tagName: 'section',
+    classNames: ['posts-index']
+  });
+
+  App.PostsRoute = Ember.Route.extend({
+    renderTemplate: function() {
+      this.render();
+      this.render('postsMenu', {
+        into: 'application',
+        outlet: 'menu'
+      });
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/posts");
+  });
+
+  equal(Ember.$('div.posts-menu:contains(postsMenu)', '#qunit-fixture').length, 1, "The posts/menu template was rendered");
+  equal(Ember.$('section.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, "The posts/index template was rendered");
+});


### PR DESCRIPTION
In situations where you may want to call `this.render()` more than once within `renderTemplate()`, the default `into` option will get set to unexpected values depending on the order that `this.render()` is called. For this example, the application.handlebars will have two outlets, one with the name menu.

``` javascript
App.Router.map(function() {
  this.resource('posts', function() {});
});

App.PostsRoute = Ember.Route.extend({
  renderTemplate: function() {
    this.render();
    this.render('posts/menu', {
      into: 'application',
      outlet: 'menu'
      controller: 'postsMenu'
    });
  }
});
```

The fix is to only set lastRenderedTemplate to the template/view name if it is getting set to the `main` outlet.
