### PR TITLE
Debugger keyword in HB debug helper confuses yui-compressor

### DIFF
--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -42,5 +42,5 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
   @param {String} property
 */
 Ember.Handlebars.registerHelper('debugger', function() {
-  debugger;
+  eval('debugger');
 });


### PR DESCRIPTION
Also both jslint and jshint are unhappy with `debugger` keyword with default options.
