### PR TITLE
If overriding tagName on linkTo helper, generate an inner A tag

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -33,14 +33,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     return ret.concat(resolvedPaths(linkView.parameters));
   }
 
-  var LinkView = Ember.View.extend({
+  var LinkViewMixin = Ember.Mixin.create({
     tagName: 'a',
     namedRoute: null,
     currentWhen: null,
     title: null,
     activeClass: 'active',
     replace: false,
-    attributeBindings: ['href', 'title'],
     classNameBindings: 'active',
 
     active: Ember.computed(function() {
@@ -78,7 +77,17 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     })
   });
 
+  var LinkView = Ember.View.extend(LinkViewMixin, {
+    attributeBindings: ['href', 'title']
+  });
+
   LinkView.toString = function() { return "LinkView"; };
+
+  var LinkContainerView = Ember.View.extend(LinkViewMixin, {
+    layout: Ember.Handlebars.compile('<a {{bindAttr href=view.href title=view.title}}>{{yield}}</a>')
+  });
+
+  LinkContainerView.toString = function() { return "LinkContainerView"; };
 
   Ember.Handlebars.registerHelper('linkTo', function(name) {
     var options = [].slice.call(arguments, -1)[0];
@@ -95,7 +104,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       params: params
     };
 
-    return Ember.Handlebars.helpers.view.call(this, LinkView, options);
+    var viewClass;
+    if (hash.tagName && hash.tagName !== 'a') {
+      viewClass = LinkContainerView;
+    } else {
+      viewClass = LinkView;
+    }
+
+    return Ember.Handlebars.helpers.view.call(this, viewClass, options);
   });
 
 });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -336,3 +336,27 @@ test("The {{linkTo}} helper accepts string arguments", function() {
 
   equal(Ember.$('#link', '#qunit-fixture').attr('href'), "/filters/unpopular");
 });
+
+test("The {{linkTo}} helper nests the A tag if a different tagName is given", function() {
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo about id='about-link' tagName='p' title='title-attr'}}About{{/linkTo}}{{#linkTo index id='self-link' activeClass='zomg-active' tagName='p'}}Self{{/linkTo}}");
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('h3:contains(Home)', '#qunit-fixture').length, 1, "The home template was rendered");
+  equal(Ember.$('#self-link.zomg-active', '#qunit-fixture').length, 1, "The self-link was rendered with active class");
+  equal(Ember.$('#about-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
+
+  equal(Ember.$('#self-link a', '#qunit-fixture').attr('href'), "/");
+  equal(Ember.$('#about-link a', '#qunit-fixture').attr('href'), "/about");
+
+  equal(Ember.$('#about-link a', '#qunit-fixture').attr('title'), 'title-attr', "The about-link contains title attribute");
+});


### PR DESCRIPTION
This has come up a fair bit on IRC and a [few](http://stackoverflow.com/questions/14328295/how-do-i-bind-to-the-active-class-of-a-link-using-the-new-ember-router) [times](http://stackoverflow.com/questions/14412073/assigning-active-class-to-selected-list-item-in-emberjs/14416595) on StackOverflow but none of the solutions seem particularly nice.

I've modified linkTo to detect if the `tagName` has been given and isn't 'a', then instead of generating invalid HTML (eg `<li href="/foo" class="active">...</li>`) then it will use a layout which contains the a tag (eg `<li class="active"><a href="/foo">...</a></li>`).

I'm not 100% on whether this is the correct implementation, especially if layout is going to go on the outside of the View in future, but hopefully good for some discussion.
