### PR TITLE
Add documentation stub for Ember.Router

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -25,6 +25,14 @@ function setupLocation(router) {
   }
 }
 
+/**
+  The `Ember.Router` class manages the application state and URLs. Refer to
+  the [routing guide](http://emberjs.com/guides/routing/) for documentation.
+
+  @class Router
+  @namespace Ember
+  @extends Ember.Object
+*/
 Ember.Router = Ember.Object.extend({
   location: 'hash',
 


### PR DESCRIPTION
Adding `/** @scope Ember.Router.prototype */` makes YUIdoc print out the
entire router definition, without any error message. It doesn't actually
blow up, it just prints source. It's strange.

The method listing don't seem right yet -- it contains methods like
Ember.Route#controllerFor. But it's a start.
