### PR TITLE
Wrap debugger statement in HB helper

### DIFF
--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -42,5 +42,9 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
   @param {String} property
 */
 Ember.Handlebars.registerHelper('debugger', function() {
-  eval('debugger');
+  if (window.execScript) {
+    window.execScript('debugger');
+  } else {
+    window['eval'].call(this, 'debugger');
+  }
 });

--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -42,5 +42,5 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
   @param {String} property
 */
 Ember.Handlebars.registerHelper('debugger', function() {
-  debugger;
+  eval('debugger');
 });


### PR DESCRIPTION
Relates to #1843, @wagenet pls review.

I've added version working in IE's and added context to eval call to preserve call stack in dev tools. Inspired by jQuerys `globalEval` function.
