### PR TITLE
Allow libraries loaded before ember to tie into ember load hooks

### DIFF
--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-var loadHooks = {};
+var loadHooks = Ember.ENV.EMBER_LOAD_HOOKS || {};
 var loaded = {};
 
 /**

--- a/packages/ember-runtime/tests/system/lazy_load_test.js
+++ b/packages/ember-runtime/tests/system/lazy_load_test.js
@@ -37,3 +37,15 @@ test("if runLoadHooks was already run, it executes newly added hooks immediately
 
   equal(count, 1, "the original object was passed into the load hook");
 });
+
+test("hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed", function() {
+
+  // Note that the necessary code to perform this test is run before
+  // the Ember lib is loaded in tests/index.html
+
+  Ember.run(function() {
+    Ember.runLoadHooks("__before_ember_test_hook__", 1);
+  });
+
+  equal(window.ENV.__test_hook_count__, 1, "the object was passed into the load hook");
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -67,6 +67,14 @@
     }
     window.ENV = window.ENV || {};
 
+    // Test for "hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed"
+    ENV.EMBER_LOAD_HOOKS = ENV.EMBER_LOAD_HOOKS || {};
+    ENV.EMBER_LOAD_HOOKS.__before_ember_test_hook__ = ENV.EMBER_LOAD_HOOKS.__before_ember_test_hook__ || [];
+    ENV.__test_hook_count__ = 0;
+    ENV.EMBER_LOAD_HOOKS.__before_ember_test_hook__.push(function(object) {
+      ENV.__test_hook_count__ += object;
+    });
+
     // Handle extending prototypes
     QUnit.config.urlConfig.push('extendprototypes');
 


### PR DESCRIPTION
The less abortive version of https://github.com/emberjs/ember.js/pull/1837
