### PR TITLE
Fix ClassNameBinding to work in a  removed view

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1239,6 +1239,15 @@ Ember.View = Ember.CoreView.extend(
       }
 
       this.registerObserver(this, parsedPath.path, observer);
+      // Remove className so when the view is rerendered,
+      // the className is added based on binding reevaluation
+      this.one('willClearRender', function() {
+        if (oldClass) {
+          classNames.removeObject(oldClass);
+          oldClass = null;
+        }
+      });
+
     }, this);
   },
 

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -124,6 +124,37 @@ test("classNames should not be duplicated on rerender", function(){
   equal(view.$().attr('class'), 'ember-view high');
 });
 
+test("classNameBindings should work when the binding property is updated and the view has been removed of the DOM", function(){
+  var view;
+
+  Ember.run(function(){
+    view = Ember.View.create({
+      classNameBindings: ['priority'],
+      priority: 'high'
+    });
+  });
+
+
+  Ember.run(function(){
+    view.createElement();
+  });
+
+  equal(view.$().attr('class'), 'ember-view high');
+
+  Ember.run(function(){
+    view.remove();
+  });
+
+  view.set('priority', 'low');
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  equal(view.$().attr('class'), 'ember-view low');
+
+});
+
 test("classNames removed by a classNameBindings observer should not re-appear on rerender", function(){
   var view = Ember.View.create({
     classNameBindings: ['isUrgent'],


### PR DESCRIPTION
ClassNameBinding did not work when a binding property was updated in a removed view, so the className did not apply as expected when the view was rerendered
