### PR TITLE
Fix issue with Metamorph replace

### DIFF
--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -36,7 +36,7 @@ var DOMManager = {
     view.transitionTo('preRender');
 
     Ember.run.schedule('render', this, function() {
-      if (get(view, 'isDestroyed')) { return; }
+      if (view.isDestroying) { return; }
 
       view.clearRenderedChildren();
       var buffer = view.renderToBuffer();

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -664,6 +664,32 @@ test("should update the block when object passed to #if helper changes and an in
   });
 });
 
+test("edge case: child conditional should not render children if parent conditional becomes false", function() {
+  var childCreated = false;
+
+  view = Ember.View.create({
+    cond1: true,
+    cond2: false,
+    viewClass: Ember.View.extend({
+      init: function() {
+        this._super();
+        childCreated = true;
+      }
+    }),
+    template: Ember.Handlebars.compile('{{#if view.cond1}}{{#if view.cond2}}{{#view view.viewClass}}test{{/view}}{{/if}}{{/if}}')
+  });
+
+  appendView();
+
+  Ember.run(function() {
+    // The order of these sets is important for the test
+    view.set('cond2', true);
+    view.set('cond1', false);
+  });
+
+  ok(!childCreated, 'child should not be created');
+});
+
 // test("Should insert a localized string if the {{loc}} helper is used", function() {
 //   Ember.stringsFor('en', {
 //     'Brazil': 'Brasilia'


### PR DESCRIPTION
Scenario: Two nested {{if}}. Outer true, inner false.
Step 1: Set inner to true.
Step 2: Set outer to false in same runloop.
Result: Children of the inner conditional are created without being destroyed.
Expected: Children should not be created at all.
