### PR TITLE
Render values with val. Fixes #1828

### DIFF
--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -141,6 +141,35 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textField.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
+test("value binding sets value on the element", function() {
+  Ember.run(function() {
+    textField = Ember.TextField.createWithMixins({
+      valueBinding: 'TestObject.value'
+    });
+    textField.append();
+  });
+
+  // Set the value via the DOM
+  Ember.run(function() {
+    textField.$().val('via dom');
+    // Trigger lets the view know we changed this value (like a real user editing)
+    textField.trigger('input', Ember.Object.create({
+      type: 'input'
+    }));
+  });
+
+  equal(get(textField, 'value'), 'via dom', "value property was properly updated via dom");
+  equal(textField.$().val(), 'via dom', "dom property was properly updated via dom");
+
+  // Now, set it via the binding
+  Ember.run(function() {
+    set(TestObject, 'value', 'via view');
+  });
+
+  equal(get(textField, 'value'), 'via view', "value property was properly updated via view");
+  equal(textField.$().val(), 'via view', "dom property was properly updated via view");
+});
+
 test("should call the insertNewline method when return key is pressed", function() {
   var wasCalled;
   var event = Ember.Object.create({

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -105,6 +105,19 @@ Ember._RenderBuffer.prototype =
   elementAttributes: null,
 
   /**
+    The value for this attribute. Values cannot be set via attr after
+    jQuery 1.9, they need to be set with val() instead.
+
+    You should not maintain this value yourself, rather, you should use
+    the `val()` method of `Ember.RenderBuffer`.
+
+    @property elementValue
+    @type String
+    @default null
+  */
+  elementValue: null,
+
+  /**
     The tagname of the element an instance of `Ember.RenderBuffer` represents.
 
     Usually, this gets set as the first parameter to `Ember.RenderBuffer`. For
@@ -213,6 +226,26 @@ Ember._RenderBuffer.prototype =
   },
 
   /**
+    Adds an value which will be rendered to the element.
+
+    @method val
+    @param {String} value The value to set
+    @chainable
+    @return {Ember.RenderBuffer|String} this or the current value
+  */
+  val: function(value) {
+    var elementValue = this.elementValue;
+
+    if (arguments.length === 0) {
+      return elementValue;
+    } else {
+      this.elementValue = value;
+    }
+
+    return this;
+  },
+
+  /**
     Remove an attribute from the list of attributes to render.
 
     @method removeAttr
@@ -259,6 +292,7 @@ Ember._RenderBuffer.prototype =
         id = this.elementId,
         classes = this.classes,
         attrs = this.elementAttributes,
+        value = this.elementValue,
         style = this.elementStyle,
         prop;
 
@@ -297,6 +331,12 @@ Ember._RenderBuffer.prototype =
       this.elementAttributes = null;
     }
 
+    if (value) {
+      buffer.push(' value="' + this._escapeAttribute(value) + '"');
+
+      this.elementValue = null;
+    }
+
     buffer.push('>');
   },
 
@@ -316,6 +356,7 @@ Ember._RenderBuffer.prototype =
         id = this.elementId,
         classes = this.classes,
         attrs = this.elementAttributes,
+        value = this.elementValue,
         style = this.elementStyle,
         styleBuffer = '', prop;
 
@@ -348,6 +389,12 @@ Ember._RenderBuffer.prototype =
       }
 
       this.elementAttributes = null;
+    }
+
+    if (value) {
+      $element.val(value);
+
+      this.elementValue = null;
     }
 
     return element;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2321,16 +2321,56 @@ Ember.View.views = {};
 Ember.View.childViewsProperty = childViewsProperty;
 
 Ember.View.applyAttributeBindings = function(elem, name, value) {
+  if (name === 'value') {
+    Ember.View.applyValueBinding(elem, value);
+  } else {
+    Ember.View.applyAttributeBinding(elem, name, value);
+  }
+};
+
+Ember.View.applyAttributeBinding = function(elem, name, value) {
   var type = Ember.typeOf(value);
   var currentValue = elem.attr(name);
 
   // if this changes, also change the logic in ember-handlebars/lib/helpers/binding.js
-  if ((type === 'string' || (type === 'number' && !isNaN(value))) && value !== currentValue) {
+  if (
+    (
+      ( type === 'string' ) ||
+      ( type === 'number' && !isNaN(value) ) ||
+      ( type === 'boolean' && value )
+    ) && (
+      value !== currentValue
+    )
+  ) {
     elem.attr(name, value);
-  } else if (value && type === 'boolean') {
-    elem.attr(name, name);
   } else if (!value) {
     elem.removeAttr(name);
+  }
+};
+
+Ember.View.applyValueBinding = function(elem, value) {
+  var type = Ember.typeOf(value);
+  var currentValue = elem.val();
+
+  // if this changes, also change the logic in ember-handlebars/lib/helpers/binding.js
+  if (
+    (
+      ( type === 'string' ) ||
+      ( type === 'number' && !isNaN(value) ) ||
+      ( type === 'boolean' && value )
+    ) && (
+      value !== currentValue
+    )
+  ) {
+    if (elem.caretPosition) {
+      var caretPosition = elem.caretPosition();
+      elem.val(value);
+      elem.setCaretPosition(caretPosition);
+    } else {
+      elem.val(value);
+    }
+  } else if (!value) {
+    elem.val('');
   }
 };
 

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -48,6 +48,20 @@ test("prevents XSS injection via `attr`", function() {
   equal(el.childNodes.length, 0, 'should not have children');
 });
 
+test("prevents XSS injection via `val`", function() {
+  var buffer = new Ember.RenderBuffer('input');
+
+  buffer.val('trololol" onmouseover="pwn()');
+  buffer.pushOpeningTag();
+
+  var el = buffer.element(),
+      elValue = el.value,
+      elOnmouseover = el.getAttribute('onmouseover');
+
+  equal(elValue, 'trololol" onmouseover="pwn()', 'value should be escaped');
+  equal(elOnmouseover, undefined, 'should not have onmouseover');
+});
+
 test("prevents XSS injection via `addClass`", function() {
   var buffer = new Ember.RenderBuffer('div');
 


### PR DESCRIPTION
In jQuery 1.9, setting the value of an input with `attr` is no longer supported. Here we explode `applyAttributeBindings` to handle value properties with `val` instead of `attr`. This required adding a duck of value handling in jQuery to `RenderBuffer`.

One test explicitly handles the case of #1828, another the `val` function on `RenderBuffer`.

I'd like some feedback on the carot management. `val` blows the position away, so maybe we should be writing a replacement.

This could probably use some testing on a live app. A fixed version of the example gist for #1828 is here: http://jsfiddle.net/6P99H/.
