### PR TITLE
Close #1870 - Warn on missing layout

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -860,6 +860,8 @@ Ember.View = Ember.CoreView.extend(
     var layoutName = get(this, 'layoutName'),
         layout = this.templateForName(layoutName, 'layout');
 
+    Ember.warn("Could not find layout named '" + layoutName + "'. Check for typos. Using the default layout instead.", !layoutName || layout);
+
     return layout || get(this, 'defaultLayout');
   }).property('layoutName'),
 

--- a/packages/ember-views/tests/views/view/layout_test.js
+++ b/packages/ember-views/tests/views/view/layout_test.js
@@ -88,6 +88,24 @@ test("should not use defaultLayout if layout is provided", function() {
   equal("foo", view.$().text(), "default layout was not printed");
 });
 
+test("should warn if provided layout doesn't exist", function() {
+  var originalWarn = Ember.warn;
+  var warnCalled = false;
+  Ember.warn = function(message, test) { warnCalled = true; };
+
+  var view = Ember.View.create({
+    container: container,
+    layoutName: 'santa clause'
+  });
+  Ember.run(function(){
+    view.createElement();
+  });
+
+  ok(warnCalled, "warning is displayed when the layout doesn't exist");
+
+  Ember.warn = originalWarn;
+});
+
 test("the template property is available to the layout template", function() {
   var view = Ember.View.create({
     template: function(context, options) {


### PR DESCRIPTION
I couldn't find a good way to verify that a warning was displayed, so I replaced the original Ember.warn. Let me know if there's a better way to test this that I didn't see.
