### PR TITLE
Close #1869 - Warn on missing template

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -819,6 +819,8 @@ Ember.View = Ember.CoreView.extend(
     var templateName = get(this, 'templateName'),
         template = this.templateForName(templateName, 'template');
 
+    Ember.warn("Could not find template named '" + templateName + "'. Check for typos. Using the default template instead.", !templateName || template);
+
     return template || get(this, 'defaultTemplate');
   }).property('templateName'),
 

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -104,6 +104,24 @@ test("should not use defaultTemplate if template is provided", function() {
   equal("foo", view.$().text(), "default template was not printed");
 });
 
+test("should warn if provided template doesn't exist", function() {
+  var originalWarn = Ember.warn;
+  var warnCalled = false;
+  Ember.warn = function(message, test) { warnCalled = true; };
+
+  var view = Ember.View.create({
+    container: container,
+    templateName: 'santa clause'
+  });
+  Ember.run(function(){
+    view.createElement();
+  });
+
+  ok(warnCalled, "warning is displayed when the template doesn't exist");
+
+  Ember.warn = originalWarn;
+});
+
 test("should render an empty element if no template is specified", function() {
   var view;
 


### PR DESCRIPTION
Same fix as #1870. Ember will warn if a template is specified that doesn't exist.
