### PR TITLE
CollectionView no longer respects emptyView defined on the View.

### DIFF
--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -93,6 +93,8 @@ test("empty views should be removed when content is added to the collection (reg
     view.appendTo('#qunit-fixture');
   });
 
+  equal(view.$('tr').length, 1, 'Make sure the empty view is there (regression)');
+
   Ember.run(function() {
     App.ListController.pushObject({title : "Go Away, Placeholder Row!"});
   });

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -86,7 +86,7 @@ test("empty views should be removed when content is added to the collection (reg
   });
 
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{#collection App.ListView contentBinding="App.ListController" tagName="table"}} <td>{{content.title}}</td> {{/collection}}')
+    template: Ember.Handlebars.compile('{{#collection App.ListView contentBinding="App.ListController" tagName="table"}} <td>{{view.content.title}}</td> {{/collection}}')
   });
 
   Ember.run(function() {
@@ -100,6 +100,7 @@ test("empty views should be removed when content is added to the collection (reg
   });
 
   equal(view.$('tr').length, 1, 'has one row');
+  equal(view.$('tr:nth-child(1) td').text(), 'Go Away, Placeholder Row!', 'The content is the updated data.');
 
   Ember.run(function(){ App.destroy(); });
 });


### PR DESCRIPTION
This breaks the documented functionality http://emberjs.com/api/classes/Ember.CollectionView.html :

``` js
App.ListWithNothing = Ember.CollectionView.extend({
  classNames: ['nothing']
  content: null,
  emptyView: Ember.View.extend({
    template: Ember.Handlebars.compile("The collection is empty")
  })
});
```

This does still work if you pass the `emptyView` as an argument via handlebars collection helper

```
{{#collection App.ListView emptyViewClass="App.EmptyView"}} ... {{/collection}}
```

And the `{{else}}` still works.

This updates the unit test to show the failure.
