### PR TITLE
Proposal - route mounting so you can build up a router in distinct chunks

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -67,6 +67,13 @@ DSL.prototype = {
         match(dslMatch[0]).to(dslMatch[1], dslMatch[2]);
       }
     };
+  },
+
+  mount: function(name, options) {
+    options = options || {};
+    var definition = definitions[name];
+    Ember.assert("The route definition " + name + " was not found", definition);
+    this.resource(name, options, definition);
   }
 };
 
@@ -74,6 +81,11 @@ DSL.map = function(callback) {
   var dsl = new DSL();
   callback.call(dsl);
   return dsl;
+};
+
+var definitions = {};
+DSL.define = function(name, callback) {
+  definitions[name] = callback;
 };
 
 Ember.RouterDSL = DSL;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -244,5 +244,8 @@ Ember.Router.reopenClass({
 
     router.map(dsl.generate());
     return router;
+  },
+  define: function(name, callback) {
+    Ember.RouterDSL.define(name, callback);
   }
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1401,3 +1401,72 @@ test("Only use route rendered into main outlet for default into property on chil
   equal(Ember.$('div.posts-menu:contains(postsMenu)', '#qunit-fixture').length, 1, "The posts/menu template was rendered");
   equal(Ember.$('section.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, "The posts/index template was rendered");
 });
+
+
+test("Defined routes can be mounted", function() {
+  Ember.TEMPLATES['post/edit'] = compile("<p>postsEdit</p>");
+
+  Router.define("posts", function() {
+    this.resource("post", { path: "/:postId" }, function() {
+      this.route("edit");
+    });
+  });
+
+  Router.map(function(){
+    this.mount("posts");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/posts/1/edit");
+  });
+
+  equal(Ember.$('#qunit-fixture:contains(postsEdit)').length, 1, "The templates were rendered");
+});
+
+test("Defined routes can be mounted under other resources", function() {
+  Ember.TEMPLATES['post/edit'] = compile("<p>postsEdit</p>");
+
+  Router.define("posts", function() {
+    this.resource("post", { path: "/:postId" }, function() {
+      this.route("edit");
+    });
+  });
+
+  Router.map(function(){
+    this.resource("blog", function(){
+      this.mount("posts");
+    });
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/blog/posts/1/edit");
+  });
+
+  equal(Ember.$('#qunit-fixture:contains(postsEdit)').length, 1, "The templates were rendered");
+});
+
+test("Defined routes can be mounted with custom options", function() {
+  Ember.TEMPLATES['post/edit'] = compile("<p>postsEdit</p>");
+
+  Router.define("posts", function() {
+    this.resource("post", { path: "/:postId" }, function() {
+      this.route("edit");
+    });
+  });
+
+  Router.map(function(){
+    this.mount("posts", { path: "/articles" });
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/articles/1/edit");
+  });
+
+  equal(Ember.$('#qunit-fixture:contains(postsEdit)').length, 1, "The templates were rendered");
+});


### PR DESCRIPTION
This has come up a few times (eg #1847, #1888) where people want to define their router in chunks.

This adds in `Router.define` to define a set of routes which can be mounted in your router with `this.mount('name')` like so:

```
App.Router.define("blog", function() {
  this.route("post", {path: "/:post_id"});
});

App.Router.map(function() {
  this.mount("blog");
});
```

is the equivalent to:

```
App.Router.map(function() {
  this.resource("blog", function() {
    this.route("post", {path: "/:post_id"});
  });
});
```

As it's basically just syntactic sugar for a resource you can mount it anywhere in your router and set the options, eg:

```
App.Router.map(function() {
  this.resource("stuff", function() {
    this.mount("blog", {path: '/news');
  });
});
```

I'm not 100% sure on the implementation, but hopefully will kick off a discussion at least.
