### PR TITLE
DI: App#inject and App#register

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -82,7 +82,8 @@ define("container",
       register: function(type, name, factory, options) {
         var fullName;
 
-        if (type.indexOf(':') !== -1 && arguments.length < 4) {
+
+        if (type.indexOf(':') !== -1){
           options = factory;
           factory = name;
           fullName = type;

--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -88,6 +88,7 @@ define("container",
           factory = name;
           fullName = type;
         } else {
+          Ember.deprecate('register("'+type +'", "'+ name+'") is now deprecated in-favour of register("'+type+':'+name+'");', true);
           fullName = type + ":" + name;
         }
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -32,7 +32,7 @@ test("A registered factory returns the same instance each time", function() {
   var container = new Container();
   var PostController = factory();
 
-  container.register('controller', 'post', PostController);
+  container.register('controller:post', PostController);
 
   var postController = container.lookup('controller:post');
 
@@ -45,7 +45,7 @@ test("A registered factory returns true for `has` if an item is registered", fun
   var container = new Container();
   var PostController = factory();
 
-  container.register('controller', 'post', PostController);
+  container.register('controller:post', PostController);
 
   equal(container.has('controller:post'), true, "The `has` method returned true for registered factories");
   equal(container.has('controller:posts'), false, "The `has` method returned false for unregistered factories");
@@ -55,7 +55,7 @@ test("A container lookup has access to the container", function() {
   var container = new Container();
   var PostController = factory();
 
-  container.register('controller', 'post', PostController);
+  container.register('controller:post', PostController);
 
   var postController = container.lookup('controller:post');
 
@@ -67,8 +67,8 @@ test("A factory type with a registered injection receives the injection", functi
   var PostController = factory();
   var Store = factory();
 
-  container.register('controller', 'post', PostController);
-  container.register('store', 'main', Store);
+  container.register('controller:post', PostController);
+  container.register('store:main', Store);
 
   container.typeInjection('controller', 'store', 'store:main');
 
@@ -83,8 +83,8 @@ test("An individual factory with a registered injection receives the injection",
   var PostController = factory();
   var Store = factory();
 
-  container.register('controller', 'post', PostController);
-  container.register('store', 'main', Store);
+  container.register('controller:post', PostController);
+  container.register('store:main', Store);
 
   container.injection('controller:post', 'store', 'store:main');
 
@@ -103,9 +103,9 @@ test("A factory with both type and individual injections", function() {
   var Store = factory();
   var Router = factory();
 
-  container.register('controller', 'post', PostController);
-  container.register('store', 'main', Store);
-  container.register('router', 'main', Router);
+  container.register('controller:post', PostController);
+  container.register('store:main', Store);
+  container.register('router:main', Router);
 
   container.injection('controller:post', 'store', 'store:main');
   container.typeInjection('controller', 'router', 'router:main');
@@ -122,7 +122,7 @@ test("A non-singleton factory is never cached", function() {
   var container = new Container();
   var PostView = factory();
 
-  container.register('view', 'post', PostView, { singleton: false });
+  container.register('view:post', PostView, { singleton: false });
 
   var postView1 = container.lookup('view:post');
   var postView2 = container.lookup('view:post');
@@ -134,7 +134,7 @@ test("A non-instantiated property is not instantiated", function() {
   var container = new Container();
 
   var template = function() {};
-  container.register('template', 'foo', template, { instantiate: false });
+  container.register('template:foo', template, { instantiate: false });
   equal(container.lookup('template:foo'), template);
 });
 
@@ -150,9 +150,9 @@ test("Destroying the container destroys any cached singletons", function() {
   var PostView = factory();
   var template = function() {};
 
-  container.register('controller', 'post', PostController);
-  container.register('view', 'post', PostView, { singleton: false });
-  container.register('template', 'post', template, { instantiate: false });
+  container.register('controller:post', PostController);
+  container.register('view:post', PostView, { singleton: false });
+  container.register('template:post', template, { instantiate: false });
 
   container.injection('controller:post', 'postView', 'view:post');
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -402,9 +402,9 @@ var Application = Ember.Application = Ember.Namespace.extend(
     @param  property {String}
     @param  injectionName {String}
   **/
-  inject: function(factoryNameOrType, property, injectionName){
+  inject: function(){
     var container = this.__container__;
-    container.typeInjection.apply(container, arguments);
+    container.injection.apply(container, arguments);
   },
 
   /**

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -363,6 +363,15 @@ var Application = Ember.Application = Ember.Namespace.extend(
     var container = this.__container__;
     container.register.apply(container, arguments);
   },
+  inject: function(factoryNameOrType, property, injectionName){
+    var container = this.__container__;
+
+    if (~factoryNameOrType.indexOf(':')) {
+      container.injection.apply(container, arguments);
+    } else {
+      container.typeInjection.apply(container, arguments);
+    }
+  },
 
   /**
     @private

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -359,10 +359,49 @@ var Application = Ember.Application = Ember.Namespace.extend(
     }
   },
 
+  /**
+    registers a factory for later injection
+
+    Example:
+
+    ```javascript
+    App = Ember.Application.create();
+
+    App.Person = Ember.Object.extend({});
+    App.Orange = Ember.Object.extend({});
+    App.Email  = Ember.Object.extend({});
+
+    App.register('model', 'user', App.Person, {singleton: false });
+    App.register('fruit', 'favorite', App.Orange);
+    App.register('communication', 'main', App.Email, {singleton: false});
+    ```
+
+    @method register
+    @param  type {String}
+    @param  name {String}
+    @param  factory {String}
+    @param  options {String} (optional)
+  **/
   register: function() {
     var container = this.__container__;
     container.register.apply(container, arguments);
   },
+  /**
+    defines an injection or typeInjection
+
+    Example:
+
+    ```javascript
+    App.inject(<full_name or type>, <property name>, <full_name>)
+    App.inject('model:user', 'email', 'model:email')
+    App.inject('model', 'source', 'source:main')
+    ```
+
+    @method inject
+    @param  factoryNameOrType {String}
+    @param  property {String}
+    @param  injectionName {String}
+  **/
   inject: function(factoryNameOrType, property, injectionName){
     var container = this.__container__;
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -361,7 +361,7 @@ var Application = Ember.Application = Ember.Namespace.extend(
 
   register: function() {
     var container = this.__container__;
-    return container.register.apply(container, arguments);
+    container.register.apply(container, arguments);
   },
 
   /**

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -371,9 +371,9 @@ var Application = Ember.Application = Ember.Namespace.extend(
     App.Orange = Ember.Object.extend({});
     App.Email  = Ember.Object.extend({});
 
-    App.register('model', 'user', App.Person, {singleton: false });
-    App.register('fruit', 'favorite', App.Orange);
-    App.register('communication', 'main', App.Email, {singleton: false});
+    App.register('model:user', App.Person, {singleton: false });
+    App.register('fruit:favorite', App.Orange);
+    App.register('communication:main', App.Email, {singleton: false});
     ```
 
     @method register

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -404,12 +404,7 @@ var Application = Ember.Application = Ember.Namespace.extend(
   **/
   inject: function(factoryNameOrType, property, injectionName){
     var container = this.__container__;
-
-    if (~factoryNameOrType.indexOf(':')) {
-      container.injection.apply(container, arguments);
-    } else {
-      container.typeInjection.apply(container, arguments);
-    }
+    container.typeInjection.apply(container, arguments);
   },
 
   /**

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -255,7 +255,6 @@ test('registered entities can be looked up later', function(){
 });
 
 test('injections', function(){
-
   application.inject('model', 'fruit', 'fruit:favorite');
   application.inject('model:user', 'communication', 'communication:main');
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -253,3 +253,18 @@ test('registered entities can be looked up later', function(){
   equal(locator.lookup('fruit:favorite'), locator.lookup('fruit:favorite'), 'singleton lookup worked');
   ok(locator.lookup('model:user') !== locator.lookup('model:user'), 'non-singleton lookup worked');
 });
+
+test('injections', function(){
+
+  application.inject('model', 'fruit', 'fruit:favorite');
+  application.inject('model:user', 'communication', 'communication:main');
+
+  var user = locator.lookup('model:user'),
+  person = locator.lookup('model:person'),
+  fruit = locator.lookup('fruit:favorite');
+
+  equal(user.get('fruit'), fruit);
+  equal(person.get('fruit'), fruit);
+
+  ok(application.Email.detectInstance(user.get('communication')));
+});

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -229,10 +229,10 @@ module("Ember.Application Depedency Injection", {
     application.Email  = Ember.Object.extend({});
     application.User   = Ember.Object.extend({});
 
-    application.register('model', 'person', application.Person, {singleton: false });
-    application.register('model', 'user', application.User, {singleton: false });
-    application.register('fruit', 'favorite', application.Orange);
-    application.register('communication', 'main', application.Email, {singleton: false});
+    application.register('model:person', application.Person, {singleton: false });
+    application.register('model:user', application.User, {singleton: false });
+    application.register('fruit:favorite', application.Orange);
+    application.register('communication:main', application.Email, {singleton: false});
 
     locator = application.__container__;
   },

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -216,3 +216,40 @@ test("Minimal Application initialized with just an application template", functi
 
   equal(trim(Ember.$('#qunit-fixture').text()), 'Hello World');
 });
+
+var locator;
+module("Ember.Application Depedency Injection", {
+  setup: function(){
+    Ember.run(function(){
+      application = Ember.Application.create();
+    });
+
+    application.Person = Ember.Object.extend({});
+    application.Orange = Ember.Object.extend({});
+    application.Email  = Ember.Object.extend({});
+    application.User   = Ember.Object.extend({});
+
+    application.register('model', 'person', application.Person, {singleton: false });
+    application.register('model', 'user', application.User, {singleton: false });
+    application.register('fruit', 'favorite', application.Orange);
+    application.register('communication', 'main', application.Email, {singleton: false});
+
+    locator = application.__container__;
+  },
+  teardown: function() {
+    Ember.run(function(){
+      application.destroy();
+    });
+    application = locator = null;
+  }
+});
+
+test('registered entities can be looked up later', function(){
+  equal(locator.resolve('model:person'), application.Person);
+  equal(locator.resolve('model:user'), application.User);
+  equal(locator.resolve('fruit:favorite'), application.Orange);
+  equal(locator.resolve('communication:main'), application.Email);
+
+  equal(locator.lookup('fruit:favorite'), locator.lookup('fruit:favorite'), 'singleton lookup worked');
+  ok(locator.lookup('model:user') !== locator.lookup('model:user'), 'non-singleton lookup worked');
+});


### PR DESCRIPTION
We now expose: `App.register` and `App.inject` on each application instance. This should eleviate the need to touch container from a global context and Yay for symmetry.

Docs for both `App.register` and `App.inject` have been added
## Some Api Changes:

``` javascript
App.register
```

now consumes

``` javascript
App.register(fullName, factory, options) // fullName -> '<type>:<name>'
```

and deprecates the old behaviour

``` javascript
App.register(type, name, factory, options)
```

So basically, rather then sometimes using fullName and sometimes type & name, we now use fullName everywhere. These changes go all the way down to the container.
