### PR TITLE
Property names that clash with Evented

### DIFF
--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -175,3 +175,16 @@ test("classNameBindings lifecycle test", function(){
 
   equal(Ember.isWatching(view, 'priority'), false);
 });
+
+test("class names can be bound to properties named 'one'", function() {
+  var view = Ember.View.create({
+    one: 'james',
+    classNameBindings: ['one']
+  });
+
+  Ember.run(function() {
+    view.createElement();
+  });
+
+  ok(view.$().hasClass('james'), "adds the class of the one property");
+});


### PR DESCRIPTION
What should the solution be to property names that clash with Ember Evented?

The attached test fails because the view has a property named `one` and the `one` function is provided by the Evented mixin.

``` .js
test("class names can be bound to properties named 'one'", function() {
  var view = Ember.View.create({
    one: 'james',
    classNameBindings: ['one']
  });

  Ember.run(function() {
    view.createElement();
  });

  ok(view.$().hasClass('james'), "adds the class of the one property");
});
```

Does the Ember Evented `one` function need to be part of the public API of the view?
