### PR TITLE
Removing childViews in a containerView doesn't update DOM

### DIFF
--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -122,6 +122,7 @@ test("views that are removed from a ContainerView should have their child views 
     get(container, 'childViews').removeObject(view);
   });
   equal(get(view, 'childViews.length'), 0, "child views are cleared when removed from container view");
+  equal(container.$().html(),'', "the child view is removed from the DOM")
 });
 
 test("if a ContainerView starts with an empy currentView, nothing is displayed", function() {


### PR DESCRIPTION
In a containerView , I'm trying to remove a childView like this https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/views/container_view.js#L91. The view isn't re-rendered after the call to removeObject() , I added an assertion in the related spec in the PR (container_view_test.js:125) which demonstrate the bug . 
