### PR TITLE
Controls handle names with '/' correctly

### DIFF
--- a/packages/ember-routing/lib/helpers/control.js
+++ b/packages/ember-routing/lib/helpers/control.js
@@ -32,6 +32,10 @@ Ember.Handlebars.registerHelper('control', function(path, modelPath, options) {
       childController = subContainer.lookup('controller:' + normalizedPath),
       childTemplate = subContainer.lookup('template:' + path);
 
+  Ember.assert("Could not find controller for path: " + normalizedPath, childController);
+  Ember.assert("Could not find view for path: " + normalizedPath, childView);
+  Ember.assert("Could not find template for path: " + path, childTemplate);
+
   set(childController, 'target', controller);
   set(childController, 'model', model);
 

--- a/packages/ember-routing/lib/helpers/control.js
+++ b/packages/ember-routing/lib/helpers/control.js
@@ -26,8 +26,10 @@ Ember.Handlebars.registerHelper('control', function(path, modelPath, options) {
     children[controlID] = subContainer;
   }
 
-  var childView = subContainer.lookup('view:' + path),
-      childController = subContainer.lookup('controller:' + path),
+  var normalizedPath = path.replace(/\//g, '.');
+
+  var childView = subContainer.lookup('view:' + normalizedPath),
+      childController = subContainer.lookup('controller:' + normalizedPath),
       childTemplate = subContainer.lookup('template:' + path);
 
   set(childController, 'target', controller);

--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -37,6 +37,54 @@ function renderedText(expected, msg) {
   QUnit.push(actual === expected, actual, expected, msg);
 }
 
+test("A control raises an error when a view cannot be found", function() {
+  container = new Ember.Container();
+  container.options('template', { instantiate: false });
+  container.options('view', { singleton: false });
+  container.register('controller:parent', Ember.Controller.extend());
+  container.register('controller:widget', Ember.Controller.extend());
+  container.register('template:widget', compile("Hello"));
+
+  throws(function() {
+    appendView({
+      controller: container.lookup('controller:parent'),
+      template: compile("{{control widget}}")
+    });
+  }, /find view/, "Must raise an error if no view is defined");
+});
+
+test("A control raises an error when a controller cannot be found", function() {
+  container = new Ember.Container();
+  container.options('template', { instantiate: false });
+  container.options('view', { singleton: false });
+  container.register('controller:parent', Ember.Controller.extend());
+  container.register('view:widget', Ember.View.extend());
+  container.register('template:widget', compile("Hello"));
+
+  throws(function() {
+    appendView({
+      controller: container.lookup('controller:parent'),
+      template: compile("{{control widget}}")
+    });
+  }, /find controller/, "Must raise an error when no controller is defined");
+});
+
+test("A control raises an error when a template cannot be found", function() {
+  container = new Ember.Container();
+  container.options('template', { instantiate: false });
+  container.options('view', { singleton: false });
+  container.register('controller:parent', Ember.Controller.extend());
+  container.register('controller:widget', Ember.Controller.extend());
+  container.register('view:widget', Ember.View.extend());
+
+  throws(function() {
+    appendView({
+      controller: container.lookup('controller:parent'),
+      template: compile("{{control widget}}")
+    });
+  }, /find template/, "Must raise an error when no template is defined");
+});
+
 test("A control renders a template with a new instance of the named controller and view", function() {
   container.register('template:widget', compile("Hello"));
 

--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -48,6 +48,19 @@ test("A control renders a template with a new instance of the named controller a
   renderedText("Hello");
 });
 
+test("A control's controller and view are lookuped up via template name", function() {
+  container.register('template:widgets/foo', compile("Hello"));
+  container.register('controller:widgets.foo', Ember.Controller.extend());
+  container.register('view:widgets.foo', Ember.View.extend());
+
+  appendView({
+    controller: container.lookup('controller:parent'),
+    template: compile("{{control 'widgets/foo'}}")
+  });
+
+  renderedText("Hello");
+});
+
 test("A control can specify a model to use in its template", function() {
   container.register('template:widget', compile("{{model.name}}"));
 


### PR DESCRIPTION
Make `{{control 'emails/forms'}}` correctly lookup the controller and view using "." notation.

I've also added assertions that view, template, and controller are found.
