### PR TITLE
Support namespaces in router definition map.

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -79,6 +79,20 @@ define("container",
         object[key] = value;
       },
 
+      registerNamespace: function(namespace) {
+        // register all 
+        if (namespace instanceof Ember.Namespace) {
+          var nameNS = namespace.toString().replace(/\./g, '::');
+          for (var key in namespace) {
+            var type = key.match(/(.*)(Route|Controller|View)$/), name;
+            if (type && type.length === 3) { // validate if is any of this types
+              name = type[1].toLowerCase(), type = type[2].toLowerCase();
+              this.register(type, nameNS + '::' + name, namespace.get(key));
+            }
+          }          
+        }
+      },
+
       register: function(type, name, factory, options) {
         var fullName;
 

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -3,12 +3,39 @@
 @submodule ember-routing
 */
 
-function DSL(name) {
+function DSL(name, namespace) {
   this.parent = name;
   this.matches = [];
+  this.ns = namespace;
 }
 
 DSL.prototype = {
+
+  namespace: function(object, callback) {
+    Ember.assert("You must send at least the callback", arguments.length > 0);
+
+    if (arguments.length === 1) {
+      callback = object;
+      object = null;
+    }
+
+    this.ns = object;
+    Ember.Container.defaultContainer.registerNamespace(this.ns);
+    callback.call(this);
+  },
+
+  normalizeName: function(name){
+    // never wrap application index child with other namespace
+    if (!(this.parent === 'application' && name === 'index'))
+      name = this.ns instanceof Ember.Namespace ? this.ns.toString().replace(/\./g, '::') + '::' + name : name;
+    return name;
+  },
+
+  getNamespace: function(name) {
+    // never wrap application index child with other namespace
+    return this.parent === 'application' && name === 'index' ? null : this.ns;
+  },
+
   resource: function(name, options, callback) {
     if (arguments.length === 2 && typeof options === 'function') {
       callback = options;
@@ -23,19 +50,22 @@ DSL.prototype = {
       options.path = "/" + name;
     }
 
+    name = this.normalizeName(name);
+    var ns = this.getNamespace(name);
+
     if (callback) {
-      var dsl = new DSL(name);
+      var dsl = new DSL(name, ns);
       callback.call(dsl);
-      this.push(options.path, name, dsl.generate());
+      this.push(options.path, name, ns, dsl.generate());
     } else {
-      this.push(options.path, name);
+      this.push(options.path, name, ns);
     }
   },
 
-  push: function(url, name, callback) {
+  push: function(url, name, namespace, callback) {
     if (url === "" || url === "/") { this.explicitIndex = true; }
 
-    this.matches.push([url, name, callback]);
+    this.matches.push([url, name, namespace, callback]);
   },
 
   route: function(name, options) {
@@ -47,11 +77,15 @@ DSL.prototype = {
       options.path = "/" + name;
     }
 
+    name = this.normalizeName(name);
+    var ns = this.getNamespace(name);
+
     if (this.parent && this.parent !== 'application') {
       name = this.parent + "." + name;
     }
 
-    this.push(options.path, name);
+    // send null as namespace for index in application index child
+    this.push(options.path, name, ns);
   },
 
   generate: function() {
@@ -64,7 +98,7 @@ DSL.prototype = {
     return function(match) {
       for (var i=0, l=dslMatches.length; i<l; i++) {
         var dslMatch = dslMatches[i];
-        match(dslMatch[0]).to(dslMatch[1], dslMatch[2]);
+        match(dslMatch[0]).to({ 'handler': dslMatch[1], 'namespace': dslMatch[2] }, dslMatch[3]);
       }
     };
   }

--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -317,7 +317,7 @@ define("route-recognizer",
             regex += segment.regex();
           }
 
-          handlers.push({ handler: route.handler, names: names });
+          handlers.push({ handler: route.handler, names: names, namespace: route.namespace });
         }
 
         if (isEmpty) {
@@ -467,14 +467,14 @@ define("route-recognizer",
       };
     }
 
-    function addRoute(routeArray, path, handler) {
+    function addRoute(routeArray, path, handler, namespace) {
       var len = 0;
       for (var i=0, l=routeArray.length; i<l; i++) {
         len += routeArray[i].path.length;
       }
 
       path = path.substr(len);
-      routeArray.push({ path: path, handler: handler });
+      routeArray.push({ path: path, handler: handler, namespace: namespace });
     }
 
     function eachRoute(baseRoute, matcher, callback, binding) {
@@ -483,7 +483,7 @@ define("route-recognizer",
       for (var path in routes) {
         if (routes.hasOwnProperty(path)) {
           var routeArray = baseRoute.slice();
-          addRoute(routeArray, path, routes[path]);
+          addRoute(routeArray, path, routes[path].handler, routes[path].namespace);
 
           if (matcher.children[path]) {
             eachRoute(routeArray, matcher.children[path], callback, binding);


### PR DESCRIPTION
Hi Guys,

From my previous PR https://github.com/emberjs/ember.js/pull/1895, suggestion from @wycats .and from @stefanpenner.

As many of developer using ember now use ruby I decided to user :: as a resolver of namespaces.

Here is a simple example how should work.

```
window.App = Em.Application.create({
  VERSION: '1.0.0',
  LOG_TRANSITIONS: true
});

App.ApplicationController = Em.Controller.extend({});
window.Beta = Em.Namespace.create({
  VERSION: '1.0.0'
});

Beta.RegistrationView = Em.View.extend({
  template: Em.TEMPLATES['beta.registration'],
  templateName: 'beta/registration'
});

Beta.RegistrationController = Em.ObjectController.extend({
  title: "Registra tu email"
});

Beta.RegistrationRoute = Em.Route.extend();

App.Router.map(function() {
  this.namespace(Beta, function() {
    this.route("registration", {
      path: "/beta/registration"
    });
  });
});

App.IndexRoute = Em.Route.extend({
  redirect: function() {
    this.transitionTo('Beta::registration');
  }
});
```

for transition we should use Namespace::name to avoid collapse with others. Namespaces is added in deep unless we call namespace with another namespace object or only the callback to user App object.

NOTE: Nested namespaces is not supported the reason is for nested namespace toString method returns undefined.
