### PR TITLE
child containers inherit type injections

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -62,7 +62,7 @@ define("container",
       this.resolver = parent && parent.resolver || function() {};
       this.registry = new InheritingDict(parent && parent.registry);
       this.cache = new InheritingDict(parent && parent.cache);
-      this.typeInjections = {};
+      this.typeInjections = new InheritingDict(parent && parent.typeInjections);
       this.injections = {};
       this._options = new InheritingDict(parent && parent._options);
       this._typeOptions = new InheritingDict(parent && parent._typeOptions);
@@ -137,7 +137,11 @@ define("container",
       typeInjection: function(type, property, fullName) {
         if (this.parent) { illegalChildOperation('typeInjection'); }
 
-        var injections = this.typeInjections[type] = this.typeInjections[type] || [];
+        var injections = this.typeInjections.get(type);
+        if (!injections) {
+          injections = [];
+          this.typeInjections.set(type, injections);
+        }
         injections.push({ property: property, fullName: fullName });
       },
 
@@ -239,7 +243,7 @@ define("container",
 
       if (factory) {
         var injections = [];
-        injections = injections.concat(container.typeInjections[type] || []);
+        injections = injections.concat(container.typeInjections.get(type) || []);
         injections = injections.concat(container.injections[fullName] || []);
 
         var hash = buildInjections(container, injections);

--- a/packages/container/tests/sub_container_test.js
+++ b/packages/container/tests/sub_container_test.js
@@ -91,3 +91,21 @@ test("Resolver is inherited from parent container", function() {
   equal(subContainer.resolve('controller:post'), otherController, 'should use parent resolver');
   equal(container.resolve('controller:post'), otherController, 'should use resolver');
 });
+
+test("Type injections should be inherited", function() {
+  var container = new Container();
+  var PostController = factory();
+  var Store = factory();
+
+  container.register('controller:post', PostController);
+  container.register('store:main', Store);
+
+  container.typeInjection('controller', 'store', 'store:main');
+
+  var store = container.lookup('store:main');
+
+  var childContainer = container.child();
+  var postController = childContainer.lookup('controller:post');
+
+  equal(postController.store, store);
+});


### PR DESCRIPTION
This PR makes type injections inherit to sub-containers. Setting _new_ type injections on child containers is still prevented. Reasoning below:

We would like to use the store and router inside of our controls. For instance, we currently have code such as the following:

```
{{view GT.HeaderView controllerBinding="controllers.header"}}
```

And instead would like to use:

```
{{control header}}
```

However, the header controller logic requires access to the store/router.
