### PR TITLE
Control defaults to using the default view

### DIFF
--- a/packages/ember-routing/lib/helpers/control.js
+++ b/packages/ember-routing/lib/helpers/control.js
@@ -28,13 +28,12 @@ Ember.Handlebars.registerHelper('control', function(path, modelPath, options) {
 
   var normalizedPath = path.replace(/\//g, '.');
 
-  var childView = subContainer.lookup('view:' + normalizedPath),
+  var childView = subContainer.lookup('view:' + normalizedPath) || container.lookup('view:default'),
       childController = subContainer.lookup('controller:' + normalizedPath),
       childTemplate = subContainer.lookup('template:' + path);
 
   Ember.assert("Could not find controller for path: " + normalizedPath, childController);
   Ember.assert("Could not find view for path: " + normalizedPath, childView);
-  Ember.assert("Could not find template for path: " + path, childTemplate);
 
   set(childController, 'target', controller);
   set(childController, 'model', model);

--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -69,22 +69,6 @@ test("A control raises an error when a controller cannot be found", function() {
   }, /find controller/, "Must raise an error when no controller is defined");
 });
 
-test("A control raises an error when a template cannot be found", function() {
-  container = new Ember.Container();
-  container.options('template', { instantiate: false });
-  container.options('view', { singleton: false });
-  container.register('controller:parent', Ember.Controller.extend());
-  container.register('controller:widget', Ember.Controller.extend());
-  container.register('view:widget', Ember.View.extend());
-
-  throws(function() {
-    appendView({
-      controller: container.lookup('controller:parent'),
-      template: compile("{{control widget}}")
-    });
-  }, /find template/, "Must raise an error when no template is defined");
-});
-
 test("A control renders a template with a new instance of the named controller and view", function() {
   container.register('template:widget', compile("Hello"));
 
@@ -100,6 +84,19 @@ test("A control's controller and view are lookuped up via template name", functi
   container.register('template:widgets/foo', compile("Hello"));
   container.register('controller:widgets.foo', Ember.Controller.extend());
   container.register('view:widgets.foo', Ember.View.extend());
+
+  appendView({
+    controller: container.lookup('controller:parent'),
+    template: compile("{{control 'widgets/foo'}}")
+  });
+
+  renderedText("Hello");
+});
+
+test("A control defaults to the default view", function() {
+  container.register('template:widgets/foo', compile("Hello"));
+  container.register('controller:widgets.foo', Ember.Controller.extend());
+  container.register('view:default', Ember.View.extend());
 
   appendView({
     controller: container.lookup('controller:parent'),


### PR DESCRIPTION
`{{control}}` should match `{{render}}` and router semantics when it comes to views. In the case where a control does not have a view, it now defaults to the default view.

This PR also removes the error when no template exists since the view itself could specify the template (as will often be the case such as if you want control templates to live in a `control/` directory).
