### PR TITLE
[BUG] Failing test for the (handlebars) partial helper using properties

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -2243,6 +2243,21 @@ test("should render other templates using the {{partial}} helper", function() {
   equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
 });
 
+test("should render other templates using the {{partial}} helper by name referenced in view property", function() {
+  Ember.TEMPLATES._subTemplate = Ember.Handlebars.compile("sub-template");
+
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('This {{partial view.partialName}} is pretty great.'),
+    partialName: 'subTemplate'
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
+});
+
 test("should render other slash-separated templates using the {{partial}} helper", function() {
   Ember.TEMPLATES["child/_subTemplate"] = Ember.Handlebars.compile("sub-template");
 


### PR DESCRIPTION
I'm trying to set the name of a partial as a property on a view, so that I can extend that view changing the name of the partial (thus rendering a different one) and there seems to be a bug on the partial helper by which the helper is trying to render a partial with the path of the property.

I think this isn't expected behaviour because you can use properties on other helpers like the view helper and they are accessed correctly. 
