### PR TITLE
Added 'pattern' attribute to text field for iOS

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -53,7 +53,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
 
   classNames: ['ember-text-field'],
   tagName: "input",
-  attributeBindings: ['type', 'value', 'size'],
+  attributeBindings: ['type', 'value', 'size', 'pattern'],
 
   /**
     The `value` attribute of the input element. As the user inputs text, this
@@ -82,6 +82,15 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
     @default null
   */
   size: null,
+
+  /**
+    The `pattern` the pattern attribute of input element.
+
+    @property pattern
+    @type String
+    @default null
+  */
+  pattern: null,
 
   /**
     The action to be sent when the user presses the return key.


### PR DESCRIPTION
The keyboard shown for a text field can be affected by its pattern
attribute on iOS. See Apple's documentation for more details.

http://developer.apple.com/library/ios/#documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html
