### PR TITLE
Control should lookup default view on subContainer

### DIFF
--- a/packages/ember-routing/lib/helpers/control.js
+++ b/packages/ember-routing/lib/helpers/control.js
@@ -28,7 +28,7 @@ Ember.Handlebars.registerHelper('control', function(path, modelPath, options) {
 
   var normalizedPath = path.replace(/\//g, '.');
 
-  var childView = subContainer.lookup('view:' + normalizedPath) || container.lookup('view:default'),
+  var childView = subContainer.lookup('view:' + normalizedPath) || subContainer.lookup('view:default'),
       childController = subContainer.lookup('controller:' + normalizedPath),
       childTemplate = subContainer.lookup('template:' + path);
 

--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -106,6 +106,25 @@ test("A control defaults to the default view", function() {
   renderedText("Hello");
 });
 
+test("A control with a default view survives re-render", function() {
+  container.register('template:widgets/foo', compile("Hello"));
+  container.register('controller:widgets.foo', Ember.Controller.extend());
+  container.register('view:default', Ember.View.extend());
+
+  appendView({
+    controller: container.lookup('controller:parent'),
+    template: compile("{{control 'widgets/foo'}}")
+  });
+
+  renderedText("Hello");
+
+  Ember.run(function() {
+    view.rerender();
+  });
+
+  renderedText("Hello");
+});
+
 test("A control can specify a model to use in its template", function() {
   container.register('template:widget', compile("{{model.name}}"));
 


### PR DESCRIPTION
Currently, controls that use the default view will error on re-render.
