### PR TITLE
{{control}} now correctly removes observers

### DIFF
--- a/packages/ember-routing/lib/helpers/control.js
+++ b/packages/ember-routing/lib/helpers/control.js
@@ -48,7 +48,7 @@ Ember.Handlebars.registerHelper('control', function(path, modelPath, options) {
   }
 
   Ember.addObserver(this, modelPath, observer);
-  childView.one('willDestroyElement', function() {
+  childView.one('willDestroyElement', this, function() {
     Ember.removeObserver(this, modelPath, observer);
   });
 

--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -204,3 +204,27 @@ test("if a controller's model changes, its child controllers are destroyed", fun
   equal(childController.isDestroying, true);
   ok(view.$().text().match(/^.*Yehuda Katz.*$/), "The view rendered");
 });
+
+test("A control should correctly remove model observers", function() {
+  var Controller = Ember.Controller.extend({
+    message: 'bro'
+  });
+
+  container.register('template:widget', compile("{{content}}"));
+  container.register('controller:bro', Controller);
+
+  appendView({
+    controller: container.lookup('controller:bro'),
+    template: compile("{{control widget message}}")
+  });
+
+  renderedText("bro");
+
+  Ember.run(function() {
+    view.destroy();
+  });
+
+  Ember.run(function() {
+    Ember.set(container.lookup('controller:bro'), 'message', 'grammer');
+  });
+});


### PR DESCRIPTION
The handler on the view's `willDestroyElement` handler did not have the correct context resulting in failed cleanup.
