### PR TITLE
Failing test: {{control}} helper test can be nested

### DIFF
--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -161,6 +161,23 @@ test("A control can be used multiple times", function() {
   renderedText("Tom DalePeter Wagenet");
 });
 
+test("A control can be nested", function() {
+  container.register('template:widget', compile("{{model.name}}{{#if model.submodel}}{{control 'widget' model.submodel}}{{/if}}"));
+
+  var controller = container.lookup('controller:parent');
+  controller.set('person', {
+    name: "Tom Dale",
+    submodel: { name: "Yehuda Katz" }
+  });
+
+  appendView({
+    controller: controller,
+    template: compile("{{control 'widget' person}}")
+  });
+
+  renderedText("TomDaleYehuda Katz");
+});
+
 test("A control's state is persisted if the view is destroyed and re-rendered", function() {
   container.register('template:widget', compile("{{randomValue}}{{model.name}}"));
 


### PR DESCRIPTION
Failing test for issue #1928.

After digging deeper into the `{{control}}` helper source code, I think I have found where the problem is.

First, a `child` is generated in the `container` [here](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/helpers/control.js#L25).

When the parent `{{control}}` is computed, it : 
- Generates a `child` in the `container` ([here](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/helpers/control.js#L25))
- Instantiate the controller and the view in this child by calling `lookup` ([here](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/helpers/control.js#L31-L33))

Then, when the nested `{{control}}` is computed, it:
- Generates a new `child`
- Lookups the `controller` and the `view` in this child. But, as the `cache` of this `child` is an `InheritingDict`, and since the parent container already has this kind of controller, it just return the existing parent `controller`.

Then, when setting the `model` of the `childController` ([here](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/helpers/control.js#L39)), it just removes the parent model add set the nested model instead.

The problem should not happen if the registered controller was not a singleton, but I am pretty sure this is not a solution...
