### PR TITLE
add reset property to textfields

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -55,6 +55,12 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
   tagName: "input",
   attributeBindings: ['type', 'value', 'size', 'pattern'],
 
+  /** 
+    The `clearOnEnter` attribute of the input element. When `insertNewLine` is called, 
+    if this property is true, the text field will clear.
+  */
+  clearOnEnter: false,
+
   /**
     The `value` attribute of the input element. As the user inputs text, this
     property is updated live.
@@ -132,6 +138,10 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
       if (!get(this, 'bubbles')) {
         event.stopPropagation();
       }
+    }
+
+    if ( get(this, 'clearOnEnter') ) {
+      set(this, 'value', null);
     }
   }
 });

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -188,6 +188,25 @@ test("should call the insertNewline method when return key is pressed", function
   ok(wasCalled, "invokes insertNewline method");
 });
 
+test("should clear the text field when insertNewLine is called if clearOnEnter attribute is true", function() {
+
+  textField.set('value', "the glass is half full");
+  textField.set('clearOnEnter', true );
+
+  textField.insertNewline();
+
+  equal(get(textField, 'value'), null, "value was cleared sucesfully" );
+});
+
+test("should not clear the text field when insertNewLine is called if clearOnEnter attribute is false", function() {
+
+  textField.set('value', "the glass is half full");
+
+  textField.insertNewline();
+
+  equal(get(textField, 'value'), "the glass is half full", "value was cleared sucesfully" );
+});
+
 test("should call the cancel method when escape key is pressed", function() {
   var wasCalled;
   var event = Ember.Object.create({


### PR DESCRIPTION
I would use this all the time. 

`{{view Ember.TextField clearOnEnter=true}}`
