### PR TITLE
ArrayController#lookupItemController was called when `idx` was negative

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -138,7 +138,7 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
     var length = get(this, 'length'),
         object = get(this,'arrangedContent').objectAt(idx);
 
-    if (idx < length) {
+    if (idx >= 0 && idx < length) {
       var controllerClass = this.lookupItemController(object);
       if (controllerClass) {
         return this.controllerAt(idx, object, controllerClass);

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -230,7 +230,8 @@ test("when `idx` is out of range, `lookupItemController` is not called", functio
     content: lannisters
   });
 
-  strictEqual(arrayController.objectAtContent(50), undefined, "no controllers are created for out of range indexes");
+  strictEqual(arrayController.objectAtContent(50), undefined, "no controllers are created for indexes that are superior to the length");
+  strictEqual(arrayController.objectAtContent(-1), undefined, "no controllers are created for indexes less than zero");
 });
 
 test("if `lookupItemController` returns a string, it must be resolvable by the container", function() {
@@ -274,4 +275,3 @@ test("array observers can invoke `objectAt` without overwriting existing item co
   equal(arrayObserverCalled, true, "Array observers are called normally");
   equal(tywinController.get('name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' content");
 });
-


### PR DESCRIPTION
I recently fixed out of range indexes (see #1983), but do not check negatives.
The reason is the same as #1982, [`objectAt` is called with `-1`](https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/mixins/array.js#L380) when setting its content as an empty array.
