### PR TITLE
Assert controller's container in {{each}}

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -15,9 +15,13 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
     var binding;
 
     if (itemController) {
+      var container = get(this, 'controller.container');
+      
+      Ember.assert("Could not find container! This is most likely a problem with ember.", container);
+      
       var controller = Ember.ArrayController.create();
       set(controller, 'itemController', itemController);
-      set(controller, 'container', get(this, 'controller.container'));
+      set(controller, 'container', container);
       set(controller, '_eachView', this);
       this.disableContentObservers(function() {
         set(this, 'content', controller);


### PR DESCRIPTION
We found this issue building our application. The container is an
internal requirement, thusly it must be asserted. Otherwise you'll see errors
in seemingly unrelated places.
