### PR TITLE
Guard against render(undefined)

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -372,6 +372,8 @@ Ember.Route = Ember.Object.extend({
     @param {Object} options the options
   */
   render: function(name, options) {
+    Ember.assert("The name in the given arguments is undefined", arguments.length > 0 ? !Ember.isNone(arguments[0]) : true);
+
     if (typeof name === 'object' && !options) {
       options = name;
       name = this.routeName;


### PR DESCRIPTION
render(undefined) was doing absolutely horrible things. I found this
problem because I passed an undefined variable as the first argument.
This ended up changing containers on controllers and doing other
absolutely horrible things.

I don't even know how the consequences happened, but they took forever to debug and it was absolute hell.
