### PR TITLE
`itemController` and `linkTo`

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -70,29 +70,35 @@ Ember.Route = Ember.Object.extend({
   */
   setup: function(context) {
     this.transitioned = false;
-    this.redirect(context);
+
+    var model = context;
+    if(model && get(model, 'isController')){
+      model = get(model, 'content');
+    }
+
+    this.redirect(model);
 
     if (this.transitioned) { return false; }
 
-    var controller = this.controllerFor(this.routeName, context);
+    var controller = this.controllerFor(this.routeName, model);
 
     if (controller) {
       this.controller = controller;
-      set(controller, 'model', context);
+      set(controller, 'model', model);
     }
 
     if (this.setupControllers) {
       Ember.deprecate("Ember.Route.setupControllers is deprecated. Please use Ember.Route.setupController(controller, model) instead.");
-      this.setupControllers(controller, context);
+      this.setupControllers(controller, model);
     } else {
-      this.setupController(controller, context);
+      this.setupController(controller, model);
     }
 
     if (this.renderTemplates) {
       Ember.deprecate("Ember.Route.renderTemplates is deprecated. Please use Ember.Route.renderTemplate(controller, model) instead.");
-      this.renderTemplates(context);
+      this.renderTemplates(model);
     } else {
-      this.renderTemplate(controller, context);
+      this.renderTemplate(controller, model);
     }
   },
 


### PR DESCRIPTION
I've found a use case with `itemController` that probably needs to be tackled.

I have the following controllers:

``` javascript
App.UsersController = Ember.ArrayController.extend({
  itemController: 'user'
});

App.UserController = Ember.ArrayController({
  someApplicationStateProperty: true,
  someAction: function(){}
});
```

And from the Users template:

``` html
{{#collection contentBinding="this"}}
  {{#linkTo user view.content}}{{view.content.name}}{{/linkTo}}
{{/collection}}
```

The this is; the `UserRoute` will receive an instance of the controller, and not the model itself. This effectively ends up as an infinite loop at some point.

The workaround I've found is to call the `linkTo` helper this way:

``` html
{{#linkTo user view.content.content}}...{{/linkTo}}
```

This looks rather verbose though.

My guess is that this should be either `linkTo`'s responibility or maybe `UserRoute`'s using the `isController` property.

What do you think?
