### PR TITLE
Allow Route to render a View correctly when the View's Template is explicitly set.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -655,7 +655,7 @@ Ember.Route = Ember.Object.extend({
 
     var container = this.container,
         view = container.lookup('view:' + name),
-        template = container.lookup('template:' + name);
+        template = (view && get(view, 'template')) || container.lookup('template:' + name);
 
     if (!view && !template) {
       if (get(this.router, 'namespace.LOG_VIEW_LOOKUPS')) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -244,6 +244,26 @@ test('render does not replace templateName if user provided', function() {
   equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
 });
 
+test('render does not replace template if user provided', function () {
+  Router.map(function () {
+    this.route("home", { path: "/" });
+  });
+
+  App.HomeView = Ember.View.extend({
+    template: Ember.Handlebars.compile("<p>THIS IS THE REAL HOME</p>")
+  });
+  App.HomeController = Ember.Controller.extend();
+  App.HomeRoute = Ember.Route.extend();
+
+  bootApplication();
+
+  Ember.run(function () {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
+});
+
 test("The Homepage with a `setupController` hook", function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
If `template` is explicitly set on an `Ember.View`, I would expect the view to render with that template (as it would normally). However, a `template` explicitly set on an `Ember.View` that is obtained from the container in `Ember.Route.render` is ignored and the container is asked to provide the corresponding template. For view's that have simple one line templates (i.e. `template: Em.Handlebars.compile('My name is: {{name}}')`) it is desirable, from my perspective at least, that one should still be able to specify a `template` directly on a view and not be forced to use `defaultTemplate` or a separate file along with `templateName`.
