### PR TITLE
Added test to prove 3rd code block in Guides, section "Rendering a Template"

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -146,6 +146,30 @@ test("An alternate template will pull in an alternate controller", function() {
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from homepage)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
+test("The template will pull in an alternate controller via key/value", function() {
+  Router.map(function() {
+    this.route("homepage", { path: "/" });
+  });
+
+  App.HomepageRoute = Ember.Route.extend({
+    renderTemplate: function() {
+      this.render({controller: 'home'});
+    }
+  });
+
+  App.HomeController = Ember.Controller.extend({
+    home: "Comes from home."
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from home.)', '#qunit-fixture').length, 1, "The homepage template was rendered from data from the HomeController");
+});
+
 test("The Homepage with explicit template name in renderTemplate and controller", function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
I've been struggling with getting my code to work with the Guides section in the title.  Here's the code in the Guides itself:

``` js
    App.PostsRoute = Ember.Route.extend({
      renderTemplate: function() {
        this.render({ controller: 'favoritePost' });
      }
    });
```

I finally wrote a test (which I've adding here) to prove my understanding of it, and it now works.  Perhaps this would round out the test suite a bit more; I didn't see any other tests for this case.  It would certainly have helped me to find this test before.

Please reject this PR if this is a duplicate.

This is related to another issue, #2027.
