### PR TITLE
point to https rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
 gem "ember-dev", :git => "https://github.com/emberjs/ember-dev.git", :branch => "master"


### PR DESCRIPTION
Set `Gemfile` source to `https://rubygems.org`

Since the recent rubygems.org exploit the rubygems team have been recommending that everyone update their Gemfiles to have `source` point to `https`

From #Rubygems on Freenode

> over http, a man in the middle could provide you a malicious gem
