### PR TITLE
Use a container form the controller given as context to a route

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -72,30 +72,35 @@ Ember.Route = Ember.Object.extend({
     this.redirected = false;
     this._checkingRedirect = true;
 
-    this.redirect(context);
+    var model = context;
+    if (model && get(model, 'isController')){
+      model = get(model, 'content');
+    }
+
+    this.redirect(model);
 
     this._checkingRedirect = false;
     if (this.redirected) { return false; }
 
-    var controller = this.controllerFor(this.routeName, context);
+    var controller = this.controllerFor(this.routeName, model);
 
     if (controller) {
       this.controller = controller;
-      set(controller, 'model', context);
+      set(controller, 'model', model);
     }
 
     if (this.setupControllers) {
       Ember.deprecate("Ember.Route.setupControllers is deprecated. Please use Ember.Route.setupController(controller, model) instead.");
-      this.setupControllers(controller, context);
+      this.setupControllers(controller, model);
     } else {
-      this.setupController(controller, context);
+      this.setupController(controller, model);
     }
 
     if (this.renderTemplates) {
       Ember.deprecate("Ember.Route.renderTemplates is deprecated. Please use Ember.Route.renderTemplate(controller, model) instead.");
-      this.renderTemplates(context);
+      this.renderTemplates(model);
     } else {
-      this.renderTemplate(controller, context);
+      this.renderTemplate(controller, model);
     }
   },
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -73,8 +73,11 @@ Ember.Route = Ember.Object.extend({
     this._checkingRedirect = true;
 
     var model = context;
-    if (model && get(model, 'isController')){
+    if (model && get(model, 'isController')) {
+      this.container = model.container;
       model = get(model, 'content');
+    } else {
+      this.container = this.router.container;
     }
 
     this.redirect(model);
@@ -281,7 +284,7 @@ Ember.Route = Ember.Object.extend({
     @return {Ember.Controller}
   */
   controllerFor: function(name, model) {
-    var container = this.router.container,
+    var container = this.container,
         controller = container.lookup('controller:' + name);
 
     if (!controller) {

--- a/packages/ember/tests/routing/route_test.js
+++ b/packages/ember/tests/routing/route_test.js
@@ -1,0 +1,90 @@
+var Router, App, router, container, originalTemplates,
+    things, thingController, thingsController, route;
+var get = Ember.get, set = Ember.set;
+
+function bootApplication() {
+  router = container.lookup('router:main');
+  Ember.run(App, 'advanceReadiness');
+}
+
+function compile(string) {
+  return Ember.Handlebars.compile(string);
+}
+
+module("Ember.Route", {
+  setup: function() {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        name: "App",
+        rootElement: '#qunit-fixture'
+      });
+
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+
+      Router = App.Router;
+
+      container = App.__container__;
+
+      originalTemplates = Ember.$.extend({}, Ember.TEMPLATES);
+      Ember.TEMPLATES.application = compile("{{outlet}}");
+      Ember.TEMPLATES.thing = compile("<h3>{{name}}</h3>");
+      Ember.TEMPLATES.things = compile("{{#each this}}{{name}}{{/each}}");
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      App.destroy();
+      App = null;
+
+      Ember.TEMPLATES = originalTemplates;
+    });
+  }
+});
+
+test("if a conroller is given as a route context, it's model should be used as context and it's container should be used for lookup", function() {
+  Router.map(function() {
+    this.route("things", { path: "/" });
+    this.route("thing", { path: "/:name" });
+  });
+
+  App.ThingsController = Ember.ArrayController.extend({
+    itemController: 'thing'
+  });
+
+  App.ThingController = Ember.ObjectController.extend();
+
+  things = Ember.A([{name: 'toto'}, {name: 'tata'}]);
+
+  App.ThingsRoute = Ember.Route.extend({
+    model: function() {
+      return things;
+    }
+  });
+
+  App.ThingRoute = Ember.Route.extend({
+    routeName: 'thing'
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  route = container.lookup('route:thing');
+  thingsController = container.lookup('controller:things');
+  thingController = thingsController.get('firstObject');
+
+  Ember.run(function() {
+    route.setup(thingController);
+  });
+  equal(route.controller, thingController);
+  equal(route.controller.get('model'), things[0]);
+  equal(route.container, thingController.container);
+  notEqual(thingController.container, route.router.container);
+});


### PR DESCRIPTION
it fix #2009 and #1998 

As it is explained in the corresponding issue, some times, it can be interesting to use the same controller for a item in the list and for it full representation. This PR makes the route use the container form the calling controller instead of the default `router.container`

If I have a positive feedback on it, I will add tests and docs
