### PR TITLE
Set target of ArrayController generated by #each helper to current controller

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -18,6 +18,7 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
       var controller = Ember.ArrayController.create();
       set(controller, 'itemController', itemController);
       set(controller, 'container', get(this, 'controller.container'));
+      set(controller, 'target', get(this, 'controller'));
       set(controller, '_eachView', this);
       this.disableContentObservers(function() {
         set(this, 'content', controller);


### PR DESCRIPTION
This ensures action dispatch works as expected when specifying `itemController` via the `{{#each}}` helper.

In the current implementation, specifying `itemController` within the definition of an `ArrayController` works very differently than specifying it via a parameter to `{{#each}}`. In the former case, `{{action}}`s bubble up to the parent controller, route, etc. but in the latter stop at the `itemController`.

Fixes #1989
