### PR TITLE
Close #2056 - Sync first/lastObject of array on computed property chainWatcher

### DIFF
--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -217,3 +217,22 @@ test('when watching another object, destroy should remove chain watchers from th
   equal(meta_objB.watching.foo, 0, 'should not be watching foo');
   equal(index, -1, 'should not have chain watcher');
 });
+
+module('Ember.watch.array');
+
+testBoth('watching a chained computed property that depends on array.@each should sync firstObject and lastObject', function(get, set) {
+  var firstObject, lastObject;
+  var obj = { items: Ember.A([]) };
+  var computedProperty = Ember.computed('items.@each', function(keyName, value) {
+    firstObject = get(this, 'items.firstObject');
+    lastObject = get(this, 'items.lastObject');
+  });
+  Ember.defineProperty(obj, 'hasItems', computedProperty);
+
+  Ember.watch(obj, 'hasItems.foo');
+  obj.items.pushObject("A");
+
+  equal(firstObject, "A", 'There should be an item in firstObject');
+  equal(lastObject, "A", 'There should be an item in lastObject');
+});
+

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -368,7 +368,6 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     }
 
     this.enumerableContentDidChange(removeAmt, adding);
-    Ember.sendEvent(this, '@array:change', [this, startIdx, removeAmt, addAmt]);
 
     var length      = get(this, 'length'),
         cachedFirst = cacheFor(this, 'firstObject'),
@@ -381,6 +380,8 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
       Ember.propertyWillChange(this, 'lastObject');
       Ember.propertyDidChange(this, 'lastObject');
     }
+
+    Ember.sendEvent(this, '@array:change', [this, startIdx, removeAmt, addAmt]);
 
     return this;
   },


### PR DESCRIPTION
This fixes a bug (#2056) with the first/last object computed properties of an array. It occurs within computed properties that (1) have an `array.@each` dependent key and (2) are being watched via a chain.

This patch ensures the following are true before any such computed properties are re-calculated:
- `firstObject` points to `array.objectAt(0)`
- `lastObject` points to `array.objectAt(array.length-1)`
