### PR TITLE
Fix to observe nested property at `Ember.TextField`

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -48,20 +48,5 @@ Ember.TextArea = Ember.View.extend(Ember.TextSupport, {
   tagName: "textarea",
   attributeBindings: ['rows', 'cols'],
   rows: null,
-  cols: null,
-
-  _updateElementValue: Ember.observer(function() {
-    // We do this check so cursor position doesn't get affected in IE
-    var value = get(this, 'value'),
-        $el = this.$();
-    if ($el && value !== $el.val()) {
-      $el.val(value);
-    }
-  }, 'value'),
-
-  init: function() {
-    this._super();
-    this.on("didInsertElement", this, this._updateElementValue);
-  }
-
+  cols: null
 });

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -35,6 +35,7 @@ Ember.TextSupport = Ember.Mixin.create({
     this.on("cut", this, this._elementValueDidChange);
     this.on("input", this, this._elementValueDidChange);
     this.on("keyUp", this, this.interpretKeyEvents);
+    this.on("didInsertElement", this, this._updateElementValue);
   },
 
   interpretKeyEvents: function(event) {
@@ -47,8 +48,16 @@ Ember.TextSupport = Ember.Mixin.create({
 
   _elementValueDidChange: function() {
     set(this, 'value', this.$().val());
-  }
+  },
 
+  _updateElementValue: Ember.observer(function() {
+    // We do this check so cursor position doesn't get affected in IE
+    var value = get(this, 'value'),
+        $el = this.$();
+    if ($el && value !== $el.val()) {
+      $el.val(value);
+    }
+  }, 'value')
 });
 
 Ember.TextSupport.KEY_EVENTS = {

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -146,6 +146,27 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textArea.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
+test("input value is updated when setting content property of view", function() {
+  Ember.run(function() {
+    textArea.destroy();
+    textArea = Ember.TextArea.createWithMixins({
+      valueBinding: 'TestObject.content.value'
+    });
+    set(TestObject, 'content', Ember.Object.create({
+      value: 'foo'
+    }));
+    textArea.append();
+  });
+
+  equal(textArea.$().val(), "foo", "renders text field with value");
+
+  Ember.run(function() {
+    set(TestObject, 'content', Ember.Object.create({}));
+  });
+
+  equal(textArea.$().val(), '', "updates text field after content changes without value property");
+});
+
 [ 'cut', 'paste', 'input' ].forEach(function(eventName) {
   test("should update the value on " + eventName + " events", function() {
 

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -142,6 +142,27 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textField.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
+test("input value is updated when setting content property of view", function() {
+  Ember.run(function() {
+    textField.destroy();
+    textField = Ember.TextField.createWithMixins({
+      valueBinding: 'TestObject.content.value'
+    });
+    set(TestObject, 'content', Ember.Object.create({
+      value: 'foo'
+    }));
+    textField.append();
+  });
+
+  equal(textField.$().val(), "foo", "renders text field with value");
+
+  Ember.run(function() {
+    set(TestObject, 'content', Ember.Object.create({}));
+  });
+
+  equal(textField.$().val(), '', "updates text field after content changes without value property");
+});
+
 test("value binding sets value on the element", function() {
   Ember.run(function() {
     textField.destroy(); // destroy existing textField


### PR DESCRIPTION
There is a case that the nested property observing doesn't work on `Ember.TextField`.
This case is that the content of observing property is updated _without value property_
(In this case, `Ember.TextArea` works.)

I think that the nested property should be observed not only `Ember.TextArea` but
also `Ember.TextField`.
