### PR TITLE
Allow 0 as the value of a tag

### DIFF
--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -352,7 +352,7 @@ Ember._RenderBuffer.prototype =
       for (prop in props) {
         if (props.hasOwnProperty(prop)) {
           var value = props[prop];
-          if (value) {
+          if (value || typeof(value) === 'number') {
             if (value === true) {
               buffer.push(' ' + prop + '="' + prop + '"');
             } else {

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -15,6 +15,26 @@ test("RenderBuffers combine strings", function() {
   equal("<div>ab</div>", buffer.string(), "Multiple pushes should concatenate");
 });
 
+test("value of 0 is included in output", function() {
+  var buffer, $el;
+
+  buffer = new Ember.RenderBuffer('input');
+  buffer.prop('value', 0);
+  buffer.pushOpeningTag();
+  $el = buffer.element();
+
+  strictEqual($el.value, '0', "generated element has value of '0'");
+
+  buffer = new Ember.RenderBuffer('input');
+  buffer.prop('value', 0);
+  buffer.push('<div>');
+  buffer.pushOpeningTag();
+  buffer.push('</div>');
+  $el = Ember.$(buffer.innerString());
+
+  strictEqual($el.find('input').val(), '0', "raw tag has value of '0'");
+});
+
 test("prevents XSS injection via `id`", function() {
   var buffer = new Ember.RenderBuffer('div');
 


### PR DESCRIPTION
The fix for this was re-broken in 079630b.

We added the test back and updated it to work with the newer RenderBuffer
