### PR TITLE
failing test for control with model change

### DIFF
--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -199,7 +199,6 @@ if (Ember.ENV.EXPERIMENTAL_CONTROL_HELPER) {
     container.register('template:widget', compile("{{randomValue}}{{model.name}}"));
 
     var controller = container.lookup('controller:parent');
-    controller.set('model', { name: "Tom Dale" });
 
     container.register('controller:widget', Ember.Controller.extend({
       randomValue: Ember.computed(function() {
@@ -210,6 +209,10 @@ if (Ember.ENV.EXPERIMENTAL_CONTROL_HELPER) {
     appendView({
       controller: controller,
       template: compile("{{control 'widget' model}}")
+    });
+
+    Ember.run(function() {
+      controller.set('model', { name: "Tom Dale" });
     });
 
     var childController = view.get('childViews').objectAt(0).get('controller');


### PR DESCRIPTION
There is currently a timing issue with the controller destroying it's sub containers when the model changes. It can currently be hacked around using something like the following:

```
{{#with model}}{{control 'widget' controller.model}}{{/with}}
```

`render` and `control` should probably be metamorph views.
