### PR TITLE
add Ember.computed.defaultTo

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -467,3 +467,21 @@ Ember.computed.alias = function(dependentKey) {
     }
   });
 };
+
+/**
+  Creates a computed property that acts like a standard getter and setter,
+  but defaults to the value from `defaultPath`.
+
+  @method computed.defaultTo
+  @for Ember
+  @param {String} defaultPath
+*/
+Ember.computed.defaultTo = function(defaultPath) {
+  return Ember.computed(function(key, newValue, cachedValue) {
+    var result;
+    if (arguments.length === 1) {
+      return cachedValue != null ? cachedValue : get(this, defaultPath);
+    }
+    return newValue != null ? newValue : get(this, defaultPath);
+  });
+};

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -744,3 +744,20 @@ testBoth('Ember.computed.alias', function(get, set) {
   equal(get(obj, 'baz'), 'newBaz');
   equal(get(obj, 'quz'), null);
 });
+
+testBoth('Ember.computed.defaultTo', function(get, set) {
+  var obj = { source: 'original source value' };
+  Ember.defineProperty(obj, 'copy', Ember.computed.defaultTo('source'));
+
+  equal(get(obj, 'copy'), 'original source value');
+
+  set(obj, 'copy', 'new copy value');
+  equal(get(obj, 'source'), 'original source value');
+  equal(get(obj, 'copy'), 'new copy value');
+
+  set(obj, 'source', 'new source value');
+  equal(get(obj, 'copy'), 'new copy value');
+
+  set(obj, 'copy', null);
+  equal(get(obj, 'copy'), 'new source value');
+});


### PR DESCRIPTION
`Ember.computed.defaultTo('foo.bar')` creates a getter/setter property that defaults to `get(this, 'foo.bar')`. Writes don't pass through to `foo.bar`. That is, it behaves much like a one-way binding that can be overridden.
