### PR TITLE
Avoid 'already initialized constant' warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,6 @@ require "ember-dev/tasks"
 
 ### RELEASE TASKS ###
 
-EMBER_VERSION = File.read("VERSION").strip
-
 namespace :release do
 
   def pretend?


### PR DESCRIPTION
Avoid Rakefile:6: warning: already initialized constant EMBER_VERSION
