### PR TITLE
Error replaced with warning in router.js

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -608,7 +608,7 @@ define("router",
         }
       }
 
-      throw new Error("Nothing handled the event '" + name + "'.");
+      Ember.warn("Nothing handled the event '" + name + "'.");
     }
 
     function setContext(handler, context) {


### PR DESCRIPTION
Rather than throwing an error, the router prints a console warning if a triggered event is unhandled. Fixes #2123
