### PR TITLE
Normalize controller lookup, fix #2025

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -76,7 +76,6 @@ define("container",
       register: function(type, name, factory, options) {
         var fullName;
 
-
         if (type.indexOf(':') !== -1){
           options = factory;
           factory = name;
@@ -86,12 +85,18 @@ define("container",
           fullName = type + ":" + name;
         }
 
-        this.registry.set(fullName, factory);
-        this._options.set(fullName, options || {});
+        var normalizedName = this.normalize(fullName);
+
+        this.registry.set(normalizedName, factory);
+        this._options.set(normalizedName, options || {});
       },
 
       resolve: function(fullName) {
         return this.resolver(fullName) || this.registry.get(fullName);
+      },
+
+      normalize: function(fullName) {
+        return fullName;
       },
 
       lookup: function(fullName, options) {
@@ -223,7 +228,8 @@ define("container",
     }
 
     function factoryFor(container, fullName) {
-      return container.resolve(fullName);
+      var name = container.normalize(fullName);
+      return container.resolve(name);
     }
 
     function instantiate(container, fullName) {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -225,6 +225,20 @@ test("The container respect the resolver hook for `has`", function() {
   ok(container.has('controller:post'), "the `has` method uses the resolver hook");
 });
 
+test("The container normalizes names before resolving", function() {
+  var container = new Container();
+  var PostController = factory();
+
+  container.normalize = function(fullName) {
+    return 'controller:post';
+  };
+
+  container.register('controller:post', PostController);
+  var postController = container.lookup('wycats');
+
+  ok(postController instanceof PostController, "Normalizes the name before resolving");
+});
+
 test("The container can get options that should be applied to all factories for a given type", function() {
   var container = new Container();
   var PostView = factory();

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -594,6 +594,7 @@ Ember.Application.reopenClass({
     Ember.Container.defaultContainer = Ember.Container.defaultContainer || container;
 
     container.set = Ember.set;
+    container.normalize = normalize;
     container.resolver = resolverFor(namespace);
     container.optionsForType('view', { singleton: false });
     container.optionsForType('template', { instantiate: false });
@@ -633,6 +634,7 @@ function resolverFor(namespace) {
 
     if (type === 'template') {
       var templateName = name.replace(/\./g, '/');
+
       if (Ember.TEMPLATES[templateName]) {
         return Ember.TEMPLATES[templateName];
       }
@@ -663,5 +665,16 @@ function resolverFor(namespace) {
   };
 }
 
-Ember.runLoadHooks('Ember.Application', Ember.Application);
+function normalize(fullName) {
+  var split = fullName.split(':'),
+      type = split[0],
+      name = split[1];
 
+  if (type !== 'template' && name.indexOf('.') > -1) {
+    return type + ':' + name.replace(/\.(.)/g, function(m) { return m[1].toUpperCase(); });
+  } else {
+    return fullName;
+  }
+}
+
+Ember.runLoadHooks('Ember.Application', Ember.Application);

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -233,15 +233,17 @@ module("Ember.Application Depedency Injection", {
       application = Ember.Application.create().initialize();
     });
 
-    application.Person = Ember.Object.extend({});
-    application.Orange = Ember.Object.extend({});
-    application.Email  = Ember.Object.extend({});
-    application.User   = Ember.Object.extend({});
+    application.Person              = Ember.Object.extend({});
+    application.Orange              = Ember.Object.extend({});
+    application.Email               = Ember.Object.extend({});
+    application.User                = Ember.Object.extend({});
+    application.PostIndexController = Ember.Object.extend({});
 
     application.register('model:person', application.Person, {singleton: false });
     application.register('model:user', application.User, {singleton: false });
     application.register('fruit:favorite', application.Orange);
     application.register('communication:main', application.Email, {singleton: false});
+    application.register('controller:postIndex', application.PostIndexController, {singleton: true});
 
     locator = application.__container__;
 
@@ -256,15 +258,22 @@ module("Ember.Application Depedency Injection", {
   }
 });
 
+test('container lookup is normalized', function() {
+  ok(locator.lookup('controller:post.index') instanceof application.PostIndexController);
+  ok(locator.lookup('controller:postIndex') instanceof application.PostIndexController);
+});
+
 test('registered entities can be looked up later', function(){
   equal(locator.resolve('model:person'), application.Person);
   equal(locator.resolve('model:user'), application.User);
   equal(locator.resolve('fruit:favorite'), application.Orange);
   equal(locator.resolve('communication:main'), application.Email);
+  equal(locator.resolve('controller:postIndex'), application.PostIndexController);
 
   equal(locator.lookup('fruit:favorite'), locator.lookup('fruit:favorite'), 'singleton lookup worked');
   ok(locator.lookup('model:user') !== locator.lookup('model:user'), 'non-singleton lookup worked');
 });
+
 
 test('injections', function(){
   application.inject('model', 'fruit', 'fruit:favorite');

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -26,4 +26,3 @@ test("If a controller specifies an unavailable dependency, it raises", function(
     container.lookup('controller:post');
   }, /controller:posts/);
 });
-


### PR DESCRIPTION
As suggested [here](https://github.com/emberjs/ember.js/issues/2025#issuecomment-13846776) this will normalize `postsIndex` to `posts.index` so that the container can lookup a correct controller instance.
