### PR TITLE
Close #2043 - Remove last item in CollectionView containing metamorph view

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1987,6 +1987,7 @@ Ember.View = Ember.CoreView.extend(
     childLen = childViews.length;
     for (i=childLen-1; i>=0; i--) {
       childViews[i].removedFromDOM = true;
+      childViews[i].destroy();
     }
 
     // remove from non-virtual parent view if viewName was specified
@@ -2003,11 +2004,6 @@ Ember.View = Ember.CoreView.extend(
     if (parent) { parent.removeChild(this); }
 
     this.transitionTo('destroyed');
-
-    childLen = childViews.length;
-    for (i=childLen-1; i>=0; i--) {
-      childViews[i].destroy();
-    }
 
     // next remove view from global hash
     if (!this.isVirtual) delete Ember.View.views[get(this, 'elementId')];

--- a/packages/ember-views/package.json
+++ b/packages/ember-views/package.json
@@ -14,7 +14,8 @@
     "spade":              "~> 1.0",
     "jquery":             "~> 1.7",
     "ember-runtime": "1.0.0-rc.1",
-    "container": "1.0.0-pre.2"
+    "container": "1.0.0-pre.2",
+    "ember-handlebars": "1.0.0-rc.1"
   },
 
   "dependencies:development": {

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -2,6 +2,8 @@ var set = Ember.set, get = Ember.get;
 var forEach = Ember.EnumerableUtils.forEach;
 var view;
 
+require("ember-handlebars");
+
 module("Ember.CollectionView", {
   setup: function() {
     Ember.CollectionView.CONTAINER_MAP.del = 'em';
@@ -528,4 +530,37 @@ test("a array_proxy that backs an sorted array_controller that backs a collectio
   Ember.run(function() {
     container.destroy();
   });
+});
+
+test("should be able to clear all child views when the row view has metamorph grand children", function() {
+  var ItemView = Ember.View.extend(), RowView = Ember.ContainerView.extend(), CollectionView = Ember.CollectionView.extend();
+  var items = Ember.A(['A']);
+
+  ItemView.reopen({
+    template: Ember.Handlebars.compile('I am {{#if view.isAlive}}alive{{/if}}')
+  });
+  RowView.reopen({
+    init: function() {
+      this._super.apply(this, arguments);
+      this.set('currentView', ItemView.create());
+    }
+  });
+  CollectionView.reopen({
+    content: items,
+    itemViewClass: RowView
+  });
+
+  view = CollectionView.create();
+  Ember.run(function() {
+    view.appendTo('body');
+  });
+
+  try {
+    Ember.run(function() {
+      items.clear();
+    });
+    ok(true, "All items were cleared from the CollectionView");
+  } catch(ex) {
+    ok(false, "Removing the last item from a CollectionView should not throw an expection");
+  }
 });


### PR DESCRIPTION
This patch destroys child views using depth first traversal. It ensures that all descendants are marked as removedFromDOM when it is known that the parent view has already been removed.

This changes the behavior of view removal because it now
- Uses depth first instead of breadth first
- It does not rely on `clearRenderedChildren` to destroy child views. `clearRenderedChildren` is only responsible for cleaning up child views that were rendered since the last call to `render`.
