### PR TITLE
Do not hook up mouse move and touch move events by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tmp.spade
 tests/source
 node_modules
 .vagrant
+*.swp

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -214,6 +214,14 @@ var Application = Ember.Application = Ember.Namespace.extend({
   */
   customEvents: null,
 
+  /**
+   For performance reasons move events are not delegated 
+   (touchmove and mousemove).
+
+   If you would like to enable move event delegation, set this to true
+   */
+  moveEvents: false,
+
   isInitialized: false,
 
   // Start off the number of deferrals at 1. This will be
@@ -488,6 +496,14 @@ var Application = Ember.Application = Ember.Namespace.extend({
   setupEventDispatcher: function() {
     var eventDispatcher = this.createEventDispatcher(),
         customEvents    = get(this, 'customEvents');
+
+    if(get(this, 'moveEvents')) {
+      customEvents = Ember.$.extend({
+        mousemove: 'mouseMove',
+        touchmove: 'touchMove'
+      } ,customEvents || {});
+
+    }
 
     eventDispatcher.setup(customEvents);
   },

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -88,6 +88,37 @@ test("acts like a namespace", function() {
   }
 });
 
+test("move events are not delegated", function(){
+
+  var receivedEvent = 0;
+
+  var view = Ember.View.createWithMixins({
+    elementId: 'myView',
+    mouseMove: function(evt) {
+      receivedEvent++;
+    },
+    touchMove: function(evt) {
+      receivedEvent++;
+    }
+  });
+
+  
+  Ember.run(function(){
+    view.appendTo('#one');
+  });
+
+  Ember.$('#myView')
+    .trigger('mousemove')
+    .trigger('touchmove');
+
+  Ember.run(function(){
+    view.destroy();
+  });
+
+  equal(receivedEvent, 0, "mouse move and touch move should not fire");
+
+});
+
 var app;
 
 module("Ember.Application initialization", {
@@ -296,4 +327,52 @@ test('the default resolver hook can look things up in other namespaces', functio
   var nav = locator.lookup('controller:userInterface/navigation');
 
   ok(nav instanceof UserInterface.NavigationController, "the result should be an instance of the specified class");
+});
+
+
+module("Ember.Application with move", {
+  setup: function() {
+    Ember.$("#qunit-fixture").html("<div id='one'><div id='one-child'>HI</div></div><div id='two'>HI</div>");
+    Ember.run(function() {
+      application = Ember.Application.create({ moveEvents: true, rootElement: '#one', router: null }).initialize();
+    });
+  },
+
+  teardown: function() {
+    if (application) {
+      Ember.run(function(){ application.destroy(); });
+    }
+  }
+});
+
+
+test("move events are delegated", function(){
+
+  var receivedEvent = 0;
+
+  var view = Ember.View.createWithMixins({
+    elementId: 'myView',
+    mouseMove: function(evt) {
+      receivedEvent++;
+    },
+    touchMove: function(evt) {
+      receivedEvent++;
+    }
+  });
+
+  
+  Ember.run(function(){
+    view.appendTo('#one');
+  });
+
+  Ember.$('#myView')
+    .trigger('mousemove')
+    .trigger('touchmove');
+
+  Ember.run(function(){
+    view.destroy();
+  });
+
+  equal(receivedEvent, 2, "mouse move and touch move should fire");
+
 });

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -52,7 +52,6 @@ Ember.EventDispatcher = Ember.Object.extend(
   setup: function(addedEvents) {
     var event, events = {
       touchstart  : 'touchStart',
-      touchmove   : 'touchMove',
       touchend    : 'touchEnd',
       touchcancel : 'touchCancel',
       keydown     : 'keyDown',
@@ -63,7 +62,6 @@ Ember.EventDispatcher = Ember.Object.extend(
       contextmenu : 'contextMenu',
       click       : 'click',
       dblclick    : 'doubleClick',
-      mousemove   : 'mouseMove',
       focusin     : 'focusIn',
       focusout    : 'focusOut',
       mouseenter  : 'mouseEnter',

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -257,3 +257,69 @@ test("event manager should be able to re-dispatch events to view", function() {
   Ember.$('#nestedView').trigger('mousedown');
   equal(receivedEvent, 2, "event should go to manager and not view");
 });
+
+
+test("Should not delegate move events by defaults", function(){
+  var receivedEvent=0;
+  view = Ember.View.createWithMixins({
+    elementId: 'myView',
+    mouseMove: function(evt) {
+      receivedEvent++;
+    },
+    touchMove: function(evt) {
+      receivedEvent++;
+    }
+  });
+
+  Ember.run(function() { view.append(); });
+
+  Ember.$('#myView')
+    .trigger('mousemove')
+    .trigger('touchmove');
+
+  equal(receivedEvent, 0, "mouse move and touch move should not fire");
+});
+
+
+
+module("Ember.EventDispatcher custom", {
+  setup: function() {
+    Ember.run(function() {
+      dispatcher = Ember.EventDispatcher.create({});
+      dispatcher.setup({
+        mousemove: 'mouseMove',
+        touchmove: 'touchMove'
+      });
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      if (view) { view.destroy(); }
+      dispatcher.destroy();
+    });
+  }
+});
+
+
+test("Should delegate move events if enabled", function(){
+  var receivedEvent=0;
+  view = Ember.View.createWithMixins({
+    elementId: 'myView',
+    mouseMove: function(evt) {
+      receivedEvent++;
+    },
+    touchMove: function(evt) {
+      receivedEvent++;
+    }
+  });
+
+  Ember.run(function() { view.append(); });
+
+  Ember.$('#myView')
+    .trigger('mousemove')
+    .trigger('touchmove');
+
+  equal(receivedEvent, 2, "mouse move and touch move should fire");
+});
+


### PR DESCRIPTION
Do not hook move events by default, allow applications to opt-in if needed. 

Seeing some perf issues at Discourse this should help address. 
