### PR TITLE
Enhancements to Ember.TargetActionSupport

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -11,24 +11,9 @@ var get = Ember.get, set = Ember.set;
 @extends Ember.Mixin
 */
 Ember.TargetActionSupport = Ember.Mixin.create({
-  target: null,
-  action: null,
-
-  targetObject: Ember.computed(function() {
-    var target = get(this, 'target');
-
-    if (Ember.typeOf(target) === "string") {
-      var value = get(this, target);
-      if (value === undefined) { value = get(Ember.lookup, target); }
-      return value;
-    } else {
-      return target || get(this, 'controller');
-    }
-  }).property('target'),
-
-  triggerAction: function() {
-    var action = get(this, 'action'),
-        target = get(this, 'targetObject');
+  triggerAction: function(name) {
+    var action = getAction.call(this, name),
+        target = getTarget.call(this, name);
 
     if (target && action) {
       var ret;
@@ -49,3 +34,17 @@ Ember.TargetActionSupport = Ember.Mixin.create({
     }
   }
 });
+
+function getAction(name) {
+  var propName = name ? name+'Action' : 'action';
+  return get(this, propName);
+}
+
+function getTarget(name) {
+  var propName = name ? name+'Target' : 'target';
+  var target = get(this, propName);
+  if (Ember.typeOf(target) === "string") {
+    return get(this, target) || get(Ember.lookup, target);
+  }
+  return target || get(this, 'controller');
+}

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -22,7 +22,7 @@ Ember.TargetActionSupport = Ember.Mixin.create({
       if (value === undefined) { value = get(Ember.lookup, target); }
       return value;
     } else {
-      return target;
+      return target || get(this, 'controller');
     }
   }).property('target'),
 

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -70,3 +70,18 @@ test("it should find targets specified using a property path", function() {
 
   ok(true === myObj.triggerAction(), "a valid target and action were specified");
 });
+
+test("if no target is specified, actions should be sent to the controller", function() {
+  expect(2);
+
+  var myObj = Ember.Object.createWithMixins(Ember.TargetActionSupport, {
+    controller: {
+      send: function(evt) {
+        equal(evt, 'anEvent', "send() method was invoked with correct event name");
+      }
+    },
+    action: 'anEvent'
+  });
+
+  ok(true === myObj.triggerAction(), "a valid controller and action were specified");
+});

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -85,3 +85,18 @@ test("if no target is specified, actions should be sent to the controller", func
 
   ok(true === myObj.triggerAction(), "a valid controller and action were specified");
 });
+
+test("namespaced targets and actions can be specified", function() {
+  expect(2);
+  var myObj = Ember.Object.createWithMixins(Ember.TargetActionSupport, {
+    controller: {
+      anEvent: function() {
+        ok(true, "anEvent method was called");
+      }
+    },
+    mouseEnterTarget: 'controller',
+    mouseEnterAction: 'anEvent'
+  });
+
+  ok(true === myObj.triggerAction('mouseEnter'), "a valid controller and action were specified");
+});


### PR DESCRIPTION
Two changes here...

First, `this.get('controller')` will be considered a valid target if no target is specified.

Second, multiple actions can be triggered by passing an argument to `triggerAction`.  Example:

```
{{view App.HoverableView
  mouseEnterAction="handleMouseEnter"
  mouseLeaveAction="handleMouseLeave"}}
```

```
App.HoverableView = Ember.View.extend(Ember.TargetActionSupport, {
    mouseEnter : function(){
        this.triggerAction('mouseEnter');
    },
    mouseLeave : function(){
        this.triggerAction('mouseLeave');
    }
});
```
