### PR TITLE
Injections define a property, fixes #2022

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -53,6 +53,7 @@ define("container",
       this.parent = parent;
       this.children = [];
 
+      this.injectProperty = injectProperty;
       this.resolver = parent && parent.resolver || function() {};
       this.registry = new InheritingDict(parent && parent.registry);
       this.cache = new InheritingDict(parent && parent.cache);
@@ -239,7 +240,7 @@ define("container",
 
       var splitName = fullName.split(":"),
           type = splitName[0], name = splitName[1],
-          value;
+          instance;
 
       if (option(container, fullName, 'instantiate') === false) {
         return factory;
@@ -254,11 +255,19 @@ define("container",
         hash.container = container;
         hash._debugContainerKey = fullName;
 
-        value = factory.create(hash);
+        for (var key in hash) {
+          if (hash.hasOwnProperty(key)) {
+            container.injectProperty(factory, key);
+          }
+        }
 
-        return value;
+        instance = factory.create(hash);
+
+        return instance;
       }
     }
+
+    function injectProperty(factory, property) { }
 
     function eachDestroyable(container, callback) {
       container.cache.eachLocal(function(key, value) {

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -599,6 +599,7 @@ Ember.Application.reopenClass({
     container.set = Ember.set;
     container.normalize = normalize;
     container.resolver = resolverFor(namespace);
+    container.injectProperty = injectProperty;
     container.optionsForType('view', { singleton: false });
     container.optionsForType('template', { instantiate: false });
     container.register('application', 'main', namespace, { instantiate: false });
@@ -666,6 +667,10 @@ function resolverFor(namespace) {
 
     if (factory) { return factory; }
   };
+}
+
+function injectProperty(factory, property) {
+  Ember.defineProperty(factory.prototype, property);
 }
 
 function normalize(fullName) {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -237,7 +237,7 @@ module("Ember.Application Depedency Injection", {
     application.Orange              = Ember.Object.extend({});
     application.Email               = Ember.Object.extend({});
     application.User                = Ember.Object.extend({});
-    application.PostIndexController = Ember.Object.extend({});
+    application.PostIndexController = Ember.ObjectController.extend({});
 
     application.register('model:person', application.Person, {singleton: false });
     application.register('model:user', application.User, {singleton: false });
@@ -289,6 +289,15 @@ test('injections', function() {
   ok(application.Email.detectInstance(user.get('communication')));
 });
 
+test('injection defines a property on ObjectController', function() {
+  application.inject('controller:postIndex', 'fruit', 'fruit:favorite');
+
+  var controller = locator.lookup('controller:postIndex'),
+      fruit = locator.lookup('fruit:favorite');
+
+  equal(controller.get('fruit'), fruit);
+});
+
 test('the default resolver hook can look things up in other namespaces', function() {
   var UserInterface = lookup.UserInterface = Ember.Namespace.create();
   UserInterface.NavigationController = Ember.Controller.extend();
@@ -323,3 +332,4 @@ test('normalization is indempotent', function() {
     equal(locator.normalize(locator.normalize(example)), locator.normalize(example));
   });
 });
+


### PR DESCRIPTION
Prior to this PR if we define an injection on any controller which might become `ObjectController`, the injection will be delegated onto it's content, even though we're actually injecting the controller.

This PR introduces a hook which allows us to define a property prior to the injection, which solves the issue, because `ObjectController` doesn't delegate properties which are already defined on it. See #2022 for the issue discussion.
## [Detailed explanation](https://gist.github.com/darthdeus/5025249)
