### PR TITLE
More elastic Handlebars.VERSION check

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -11,7 +11,7 @@ var objectCreate = Object.create || function(parent) {
 };
 
 var Handlebars = this.Handlebars || Ember.imports.Handlebars;
-Ember.assert("Ember Handlebars requires Handlebars 1.0.rc.2 or greater", Handlebars && Handlebars.VERSION.match(/^1\.0\.rc\.[23456789]+/));
+Ember.assert("Ember Handlebars requires Handlebars 1.0.rc.2 or greater", Handlebars && Handlebars.VERSION.match(/^1\.0(\.0)?(\.|-)rc\.[23456789]+/));
 
 /**
   Prepares the Handlebars templating library for use inside Ember's view


### PR DESCRIPTION
Handlebars version changed format a bit, from `1.0.rc2` to `1.0.0-rc3`, which causes an error on version check, even though `1.0.0-rc3` is newest version. I made the regexp more flexible, to handle both versioning formats.
