### PR TITLE
Refresh href in linkTo when one of the params changes

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -38,6 +38,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     return ret.concat(resolvedPaths(linkView.parameters));
   }
 
+  var _createPath = function(path) {
+    var fullPath = 'paramsContext';
+    if(path !== '') {
+      fullPath += '.' + path;
+    }
+    return fullPath;
+  };
+
   var LinkView = Ember.View.extend({
     tagName: 'a',
     namedRoute: null,
@@ -55,21 +63,28 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
           length = params.length,
           context = this.parameters.context,
           self = this,
-          path;
+          path, paths = Ember.A([]), i;
 
       set(this, 'paramsContext', context);
 
-      var observer = function() {
-        this.notifyPropertyChange('href');
+      for(i=0; i < length; i++) {
+        paths.pushObject(_createPath(params[i]));
+      }
+
+      var observer = function(object, path) {
+        var notify = true, i;
+        for(i=0; i < paths.length; i++) {
+          if(!get(this, paths[i])) {
+            notify = false;
+          }
+        }
+        if(notify) {
+          this.notifyPropertyChange('href');
+        }
       };
 
-      for(var i=0; i < length; i++) {
-        path = 'paramsContext';
-        if(params[i] !== '') {
-          path += '.' + params[i];
-        }
-
-        Ember.addObserver(this, path, this, observer);
+      for(i=0; i < length; i++) {
+        Ember.addObserver(this, paths[i], this, observer);
       }
     },
 

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -48,6 +48,31 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     attributeBindings: ['href', 'title'],
     classNameBindings: 'active',
 
+    init: function() {
+      this._super.apply(this, arguments);
+
+      var params = this.parameters.params,
+          length = params.length,
+          context = this.parameters.context,
+          self = this,
+          path;
+
+      set(this, 'paramsContext', context);
+
+      var observer = function() {
+        this.notifyPropertyChange('href');
+      };
+
+      for(var i=0; i < length; i++) {
+        path = 'paramsContext';
+        if(params[i] !== '') {
+          path += '.' + params[i];
+        }
+
+        Ember.addObserver(this, path, this, observer);
+      }
+    },
+
     // Even though this isn't a virtual view, we want to treat it as if it is
     // so that you can access the parent with {{view.prop}}
     concreteView: Ember.computed(function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -152,6 +152,10 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
   indexController.set('post', secondPost);
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr was updated after one of the params had been changed');
+
+  indexController.set('post', null);
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr does not change when one of the arguments in nullified');
 });
 
 test("The {{linkTo}} helper supports a custom activeClass", function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -119,6 +119,41 @@ test("The {{linkTo}} helper supports URL replacement", function() {
   equal(replaceCount, 1, 'replaceURL should be called once');
 });
 
+test("The {{linkTo}} helper refreshes href element when one of params changes", function() {
+  Router.map(function() {
+    this.route('post', { path: '/posts/:post_id' });
+  });
+
+  var post = Ember.Object.create({id: '1'}),
+      secondPost = Ember.Object.create({id: '2'});
+
+  App.PostRoute = Ember.Route.extend({
+    model: function(params) {
+      return post;
+    },
+
+    serialize: function(post) {
+      return { post_id: post.get('id') };
+    }
+  });
+
+  Ember.TEMPLATES.index = compile('{{#linkTo "post" post id="post"}}post{{/linkTo}}');
+
+  App.IndexController = Ember.Controller.extend();
+  var indexController = container.lookup('controller:index');
+  indexController.set('post', post);
+
+  bootApplication();
+
+  Ember.run(function() { router.handleURL("/"); });
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/1', 'precond - Link has rendered href attr properly');
+
+  indexController.set('post', secondPost);
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr was updated after one of the params had been changed');
+});
+
 test("The {{linkTo}} helper supports a custom activeClass", function() {
   Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo about id='about-link'}}About{{/linkTo}}{{#linkTo index id='self-link' activeClass='zomg-active'}}Self{{/linkTo}}");
 


### PR DESCRIPTION
Currently `linkTo` helper is unbound when it comes to href attribute, which may be really annoying, because suddenly your pretty templates start to be full of `{{#with}}` helpers over every `linkTo`, which has the object that potentially can change.

This can be fixed rather easily by refreshing `href` attribute when one of the params changes.

This will of course not handle the case when the actual attribute, like an `id`, changes, but it will help in **most** cases. Most of the time you use `id` and most of the time `id` does not change.
