### PR TITLE
Added ability to customize generated controllers and routes

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -606,6 +606,12 @@ Ember.Application.reopenClass({
     container.optionsForType('view', { singleton: false });
     container.optionsForType('template', { instantiate: false });
     container.register('application', 'main', namespace, { instantiate: false });
+
+    container.register('controller:basic', Ember.Controller, { instantiate: false });
+    container.register('controller:object', Ember.ObjectController, { instantiate: false });
+    container.register('controller:array', Ember.ArrayController, { instantiate: false });
+    container.register('route:basic', Ember.Route, { instantiate: false });
+
     container.injection('router:main', 'namespace', 'application:main');
 
     container.typeInjection('controller', 'target', 'router:main');
@@ -654,6 +660,9 @@ function resolverFor(namespace) {
 
     if (type === 'controller' || type === 'route' || type === 'view') {
       name = name.replace(/\./g, '_');
+      if (name === 'basic') {
+        name = '';
+      }
     }
 
     if (type !== 'template' && name.indexOf('/') !== -1) {

--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -7,20 +7,28 @@ Ember.controllerFor = function(container, controllerName, context, lookupOptions
   return container.lookup('controller:' + controllerName, lookupOptions) ||
          Ember.generateController(container, controllerName, context);
 };
-
+/**
+  Generates a controller automatically if none was provided.
+  The type of generated controller depends on the context.
+  You can customize your generated controllers by defining
+  `App.ObjectController` and `App.ArrayController`
+*/
 Ember.generateController = function(container, controllerName, context) {
-  var controller;
+  var controller, DefaultController;
 
   if (context && Ember.isArray(context)) {
-    controller = Ember.ArrayController.extend({
+    DefaultController = container.resolve('controller:array');
+    controller = DefaultController.extend({
       content: context
     });
   } else if (context) {
-    controller = Ember.ObjectController.extend({
+    DefaultController = container.resolve('controller:object');
+    controller = DefaultController.extend({
       content: context
     });
   } else {
-    controller = Ember.Controller.extend();
+    DefaultController = container.resolve('controller:basic');
+    controller = DefaultController.extend();
   }
 
   controller.toString = function() {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -149,7 +149,8 @@ Ember.Router.reopenClass({
 });
 
 function getHandlerFunction(router) {
-  var seen = {}, container = router.container;
+  var seen = {}, container = router.container,
+      DefaultRoute = container.resolve('route:basic');
 
   return function(name) {
     var handler = container.lookup('route:' + name);
@@ -161,7 +162,7 @@ function getHandlerFunction(router) {
       if (name === 'loading') { return {}; }
       if (name === 'failure') { return router.constructor.defaultFailureHandler; }
 
-      container.register('route', name, Ember.Route.extend());
+      container.register('route', name, DefaultRoute.extend());
       handler = container.lookup('route:' + name);
     }
 

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -20,6 +20,10 @@ var buildContainer = function(namespace) {
   container.register('application', 'main', namespace, { instantiate: false });
   container.injection('router:main', 'namespace', 'application:main');
 
+  container.register('controller:basic', Ember.Controller, { instantiate: false });
+  container.register('controller:object', Ember.ObjectController, { instantiate: false });
+  container.register('controller:array', Ember.ArrayController, { instantiate: false });
+
   container.typeInjection('route', 'router', 'router:main');
 
   return container;

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -4,7 +4,12 @@ var buildContainer = function(namespace) {
   container.set = Ember.set;
   container.resolver = resolverFor(namespace);
   container.optionsForType('view', { singleton: false });
+
   container.register('application', 'main', namespace, { instantiate: false });
+
+  container.register('controller:basic', Ember.Controller, { instantiate: false });
+  container.register('controller:object', Ember.ObjectController, { instantiate: false });
+  container.register('controller:array', Ember.ArrayController, { instantiate: false });
 
   return container;
 };
@@ -14,18 +19,23 @@ function resolverFor(namespace) {
     var nameParts = fullName.split(":"),
         type = nameParts[0], name = nameParts[1];
 
+    if (name === 'basic') {
+      name = '';
+    }
     var className = Ember.String.classify(name) + Ember.String.classify(type);
     var factory = Ember.get(namespace, className);
+
+
 
     if (factory) { return factory; }
   };
 }
 
-var container, appController;
+var container, appController, namespace;
 
 module("Ember.controllerFor", {
   setup: function() {
-    var namespace = Ember.Namespace.create();
+    namespace = Ember.Namespace.create();
     container = buildContainer(namespace);
     container.register('controller', 'app', Ember.Controller.extend());
     appController = container.lookup('controller:app');
@@ -65,4 +75,35 @@ test("controllerFor should create Ember.ArrayController", function() {
 
   ok(controller instanceof Ember.ArrayController, 'should create controller');
   equal(controller.get('content'), context, 'should set content');
+});
+
+test("controllerFor should create App.Controller if provided", function() {
+  var controller;
+  namespace.Controller = Ember.Controller.extend();
+
+  controller = Ember.controllerFor(container, 'home');
+
+  ok(controller instanceof namespace.Controller, 'should create controller');
+});
+
+test("controllerFor should create App.ObjectController if provided", function() {
+  var context = {}, controller;
+  namespace.ObjectController = Ember.ObjectController.extend();
+
+  controller = Ember.controllerFor(container, 'home', context);
+
+  ok(controller instanceof namespace.ObjectController, 'should create controller');
+  equal(controller.get('content'), context, 'should set content');
+
+});
+
+test("controllerFor should create App.ArrayController if provided", function() {
+  var context = Ember.A(), controller;
+  namespace.ArrayController = Ember.ArrayController.extend();
+
+  controller = Ember.controllerFor(container, 'home', context);
+
+  ok(controller instanceof namespace.ArrayController, 'should create controller');
+  equal(controller.get('content'), context, 'should set content');
+
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1552,3 +1552,25 @@ test("Generating a URL should not affect currentModel", function() {
 
   equal(route.modelFor('post'), posts[1]);
 });
+
+
+test("Generated route should be an instance of App.Route if provided", function() {
+  var generatedRoute;
+
+  Router.map(function() {
+    this.route('posts');
+  });
+
+  App.Route = Ember.Route.extend();
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/posts");
+  });
+
+  generatedRoute = container.lookup('route:posts');
+
+  ok(generatedRoute instanceof App.Route, 'should extend the correct route');
+
+});


### PR DESCRIPTION
The problem with generated routes and controllers is that you cannot have a "rails-like" Base Controller and Base Route that all your controllers and routes can extend.

I am extending all my controllers from my defined `App.ObjectController` and `App.ArrayController`, and all my routes from my `App.Route`.  Problem is, I can no longer take advantage of Ember conventions, since generated controllers use the default `Ember.ObjectController`, `Ember.ArrayController`, `Ember.Route`.

This PR allows us to optionally define `App.ArrayController`, `App.ObjectController`, and `App.Route`.  All generated controllers and routes would extend them.

EDIT
I also added the ability to define `App.Controller`
