### PR TITLE
Fix issue where classNameBindings can try to update removed DOM element.

### DIFF
--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -39,5 +39,6 @@ Ember.View.states._default = {
     return false;
   },
 
-  rerender: Ember.K
+  rerender: Ember.K,
+  invokeObserver: Ember.K
 };

--- a/packages/ember-views/lib/views/states/in_buffer.js
+++ b/packages/ember-views/lib/views/states/in_buffer.js
@@ -75,6 +75,10 @@ Ember.merge(inBuffer, {
     }
 
     return value;
+  },
+
+  invokeObserver: function(target, observer) {
+    observer.call(target);
   }
 });
 

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -78,6 +78,10 @@ Ember.merge(hasElement, {
     } else {
       return true; // continue event propagation
     }
+  },
+
+  invokeObserver: function(target, observer) {
+    observer.call(target);
   }
 });
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1285,7 +1285,6 @@ Ember.View = Ember.CoreView.extend(
       // JavaScript property changes.
       var observer = function() {
         elem = this.$();
-        if (!elem) { return; }
 
         attributeValue = get(this, property);
 
@@ -2153,10 +2152,18 @@ Ember.View = Ember.CoreView.extend(
   },
 
   registerObserver: function(root, path, target, observer) {
-    Ember.addObserver(root, path, target, observer);
+    if (!observer && 'function' === typeof target) {
+      observer = target;
+      target = null;
+    }
+    var view = this,
+        stateCheckedObserver = function(){
+          view.currentState.invokeObserver(this, observer);
+        };
+    Ember.addObserver(root, path, target, stateCheckedObserver);
 
     this.one('willClearRender', function() {
-      Ember.removeObserver(root, path, target, observer);
+      Ember.removeObserver(root, path, target, stateCheckedObserver);
     });
   }
 

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -206,3 +206,50 @@ test("handles attribute bindings for properties", function() {
 
   equal(view.$().prop('checked'), false, 'changes to unchecked');
 });
+test("attributeBindings should not fail if view has been removed", function(){
+  Ember.run(function(){
+    view = Ember.View.create({
+      attributeBindings: ['checked'],
+      checked: true
+    });
+  });
+  Ember.run(function(){
+    view.createElement();
+  });
+  var error;
+  try {
+    Ember.run(function(){
+      Ember.changeProperties(function(){
+        view.set('checked', false);
+        view.remove();
+      });
+    });
+  } catch(e) {
+    error = e;
+  }
+  ok(!error, error);
+});
+
+test("attributeBindings should not fail if view has been destroyed", function(){
+  Ember.run(function(){
+    view = Ember.View.create({
+      attributeBindings: ['checked'],
+      checked: true
+    });
+  });
+  Ember.run(function(){
+    view.createElement();
+  });
+  var error;
+  try {
+    Ember.run(function(){
+      Ember.changeProperties(function(){
+        view.set('checked', false);
+        view.destroy();
+      });
+    });
+  } catch(e) {
+    error = e;
+  }
+  ok(!error, error);
+});

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -206,3 +206,51 @@ test("classNameBindings lifecycle test", function(){
 
   equal(Ember.isWatching(view, 'priority'), false);
 });
+
+test("classNameBindings should not fail if view has been removed", function(){
+  Ember.run(function(){
+    view = Ember.View.create({
+      classNameBindings: ['priority'],
+      priority: 'high'
+    });
+  });
+  Ember.run(function(){
+    view.createElement();
+  });
+  var error;
+  try {
+    Ember.run(function(){
+      Ember.changeProperties(function(){
+        view.set('priority', 'low');
+        view.remove();
+      });
+    });
+  } catch(e) {
+    error = e;
+  }
+  ok(!error, error);
+});
+
+test("classNameBindings should not fail if view has been destroyed", function(){
+  Ember.run(function(){
+    view = Ember.View.create({
+      classNameBindings: ['priority'],
+      priority: 'high'
+    });
+  });
+  Ember.run(function(){
+    view.createElement();
+  });
+  var error;
+  try {
+    Ember.run(function(){
+      Ember.changeProperties(function(){
+        view.set('priority', 'low');
+        view.destroy();
+      });
+    });
+  } catch(e) {
+    error = e;
+  }
+  ok(!error, error);
+});


### PR DESCRIPTION
With this PR, Ember.View#registerObserver uses states to invoke observers only when there is an element for them to operate on. This avoids a class of issues that can arise when observers are triggered even though the element has been removed from the DOM. (with help from @stefanpenner and @kselden)
