### PR TITLE
Added .inRunLoop to Function prototype extensions

### DIFF
--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -124,5 +124,49 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
     return this;
   };
 
+  /**
+    The `inRunLoop` extension of Javascript's Function prototype is
+    available when `Ember.EXTEND_PROTOTYPES` or
+    `Ember.EXTEND_PROTOTYPES.Function` is true, which is the default.
+
+    Adding a call to `inRunLoop` at the end of a function will return
+    a version of that function that gets called within an Ember
+    Run Loop. This is useful when you need to provide a callback
+    to $.ajax queries or third party plugins that won't automatically
+    wrap your callback in an Ember Run Loop.
+
+    ```javascript
+    Ember.$.ajax("/some_url", "GET", {
+      context: this,
+      success: function(json) {
+        this.set('value', json.value);
+      }.inRunLoop()
+    });
+
+    // This expands to:
+    Ember.$.ajax("/some_url", "GET", {
+      context: this,
+      success: function(json) {
+        Ember.run(this, function() { 
+          this.set('value', json.value); 
+        });
+      }
+    });
+    ```
+
+    See {{#crossLink "Ember.run"}}{{/crossLink}}
+
+    @method inRunLoop
+    @for Function
+  */
+  Function.prototype.inRunLoop = function() {
+    var fn = this;
+    return function() {
+      var args = arguments;
+      return Ember.run(this, function() {
+        return fn.apply(this, args);
+      });
+    };
+  };
 }
 

--- a/packages/ember-runtime/tests/ext/function_test.js
+++ b/packages/ember-runtime/tests/ext/function_test.js
@@ -29,3 +29,49 @@ testBoth('global observer helper takes multiple params', function(get, set) {
   equal(get(obj, 'count'), 2, 'should invoke observer after change');
 });
 
+
+module('Function.prototype.inRunLoop() helper');
+
+test('wraps function in run loop', function() {
+
+  if (Ember.EXTEND_PROTOTYPES === false) {
+    ok('Function.prototype helper disabled');
+    return ;
+  }
+
+  function fn() {
+    return Ember.run.currentRunLoop;
+  }
+
+  ok(!fn(), "vanilla fn() runs outside of run loop");
+
+  var fnWrapped = fn.inRunLoop();
+
+  var runLoop1 = fnWrapped(), runLoop2 = fnWrapped();
+  ok(runLoop1, "fn.inRunLoop() runs within run loop");
+  ok(runLoop2 && runLoop1 !== runLoop2, "additional calls to wrapped fn run within different run loops");
+});
+
+test('forwards arguments and context', function() {
+
+  if (Ember.EXTEND_PROTOTYPES === false) {
+    ok('Function.prototype helper disabled');
+    return ;
+  }
+
+  var obj = {};
+
+  function sum(a, b) {
+    this.result = a + b;
+    return this.result;
+  }
+
+  equal(sum.call(obj, 4, 3), 7, "vanilla sum function returns sum of args");
+  equal(obj.result, 7, "vanilla sum function stores result in context");
+
+  var sumWrapped = sum.inRunLoop();
+
+  equal(sumWrapped.call(obj, 5, 7), 12, "wrapped sum function returns sum of args");
+  equal(obj.result, 12, "wrapped sum function stores result in context");
+});
+


### PR DESCRIPTION
This change adds `inRunLoop` to the Function prototype to relieve you of the duty of wrapping all your callback code in `Ember.run`. 

``` javascript
Ember.$.ajax("/url", "GET", {
  success: function(result) {
    obj.set('foo', result);
  }.inRunLoop()
});
```

which is shorthand for 

``` javascript
Ember.$.ajax("/url", "GET", {
  success: function(result) {
    Ember.run(function() {
      obj.set('foo', result);
    });
  }
});
```
