### PR TITLE
Normalized Ember.run.later and Ember.run.next behavior.

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -231,7 +231,7 @@ var run = Ember.run;
 /**
   Begins a new RunLoop. Any deferred actions invoked after the begin will
   be buffered until you invoke a matching call to `Ember.run.end()`. This is
-  an lower-level way to use a RunLoop instead of using `Ember.run()`.
+  a lower-level way to use a RunLoop instead of using `Ember.run()`.
 
   ```javascript
   Ember.run.begin();
@@ -277,9 +277,9 @@ Ember.run.end = function() {
 
   @property queues
   @type Array
-  @default ['sync', 'actions', 'destroy', 'timers']
+  @default ['sync', 'actions', 'destroy']
 */
-Ember.run.queues = ['sync', 'actions', 'destroy', 'timers'];
+Ember.run.queues = ['sync', 'actions', 'destroy'];
 
 /**
   Adds the passed target/method and any optional arguments to the named
@@ -292,19 +292,19 @@ Ember.run.queues = ['sync', 'actions', 'destroy', 'timers'];
   the `run.queues` property.
 
   ```javascript
-  Ember.run.schedule('timers', this, function(){
-    // this will be executed at the end of the RunLoop, when timers are run
-    console.log("scheduled on timers queue");
+  Ember.run.schedule('sync', this, function(){
+    // this will be executed in the first RunLoop queue, when bindings are synced
+    console.log("scheduled on sync queue");
   });
 
-  Ember.run.schedule('sync', this, function(){
-    // this will be executed at the end of the RunLoop, when bindings are synced
-    console.log("scheduled on sync queue");
+  Ember.run.schedule('actions', this, function(){
+    // this will be executed in the 'actions' queue, after bindings have synced.
+    console.log("scheduled on actions queue");
   });
 
   // Note the functions will be run in order based on the run queues order. Output would be:
   //   scheduled on sync queue
-  //   scheduled on timers queue
+  //   scheduled on actions queue
   ```
 
   @method schedule
@@ -330,7 +330,7 @@ function autorun() {
 
 // Used by global test teardown
 Ember.run.hasScheduledTimers = function() {
-  return !!(scheduledAutorun || scheduledLater || scheduledNext);
+  return !!(scheduledAutorun || scheduledLater);
 };
 
 // Used by global test teardown
@@ -342,10 +342,6 @@ Ember.run.cancelTimers = function () {
   if (scheduledLater) {
     clearTimeout(scheduledLater);
     scheduledLater = null;
-  }
-  if (scheduledNext) {
-    clearTimeout(scheduledNext);
-    scheduledNext = null;
   }
   timers = {};
 };
@@ -381,7 +377,8 @@ Ember.run.autorun = function() {
   bindings in the application to sync.
 
   You should call this method anytime you need any changed state to propagate
-  throughout the app immediately without repainting the UI.
+  throughout the app immediately without repainting the UI (which happens
+  in the later 'render' queue added by the `ember-views` package).
 
   ```javascript
   Ember.run.sync();
@@ -401,25 +398,30 @@ Ember.run.sync = function() {
 
 var timers = {}; // active timers...
 
-var scheduledLater;
+var scheduledLater, scheduledLaterExpires;
 function invokeLaterTimers() {
   scheduledLater = null;
-  var now = (+ new Date()), earliest = -1;
-  for (var key in timers) {
-    if (!timers.hasOwnProperty(key)) { continue; }
-    var timer = timers[key];
-    if (timer && timer.expires) {
-      if (now >= timer.expires) {
-        delete timers[key];
-        invoke(timer.target, timer.method, timer.args, 2);
-      } else {
-        if (earliest<0 || (timer.expires < earliest)) earliest=timer.expires;
+  run(function() {
+    var now = (+ new Date()), earliest = -1;
+    for (var key in timers) {
+      if (!timers.hasOwnProperty(key)) { continue; }
+      var timer = timers[key];
+      if (timer && timer.expires) {
+        if (now >= timer.expires) {
+          delete timers[key];
+          invoke(timer.target, timer.method, timer.args, 2);
+        } else {
+          if (earliest < 0 || (timer.expires < earliest)) { earliest = timer.expires; }
+        }
       }
     }
-  }
 
-  // schedule next timeout to fire...
-  if (earliest > 0) { scheduledLater = setTimeout(invokeLaterTimers, earliest-(+ new Date())); }
+    // schedule next timeout to fire when the earliest timer expires
+    if (earliest > 0) { 
+      scheduledLater = setTimeout(invokeLaterTimers, earliest - now); 
+      scheduledLaterExpires = earliest;
+    }
+  });
 }
 
 /**
@@ -467,7 +469,19 @@ Ember.run.later = function(target, method) {
   timer   = { target: target, method: method, expires: expires, args: args };
   guid    = Ember.guidFor(timer);
   timers[guid] = timer;
-  run.once(timers, invokeLaterTimers);
+    
+  if(scheduledLater && expires < scheduledLaterExpires) {
+    // Cancel later timer (then reschedule earlier timer below)
+    clearTimeout(scheduledLater);
+    scheduledLater = null;
+  }
+
+  if (!scheduledLater) { 
+    // Schedule later timers to be run.
+    scheduledLater = setTimeout(invokeLaterTimers, wait);
+    scheduledLaterExpires = expires;
+  } 
+
   return guid;
 };
 
@@ -539,22 +553,9 @@ Ember.run.scheduleOnce = function(queue, target, method, args) {
   return scheduleOnce(queue, target, method, slice.call(arguments, 3));
 };
 
-var scheduledNext;
-function invokeNextTimers() {
-  scheduledNext = null;
-  for(var key in timers) {
-    if (!timers.hasOwnProperty(key)) { continue; }
-    var timer = timers[key];
-    if (timer.next) {
-      delete timers[key];
-      invoke(timer.target, timer.method, timer.args, 2);
-    }
-  }
-}
-
 /**
   Schedules an item to run after control has been returned to the system.
-  This is often equivalent to calling `setTimeout(function() {}, 1)`.
+  This is equivalent to calling `Ember.run.later` with a wait time of 1ms. 
 
   ```javascript
   Ember.run.next(myContext, function(){
@@ -570,20 +571,10 @@ function invokeNextTimers() {
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @return {Object} timer
 */
-Ember.run.next = function(target, method) {
-  var guid,
-      timer = {
-        target: target,
-        method: method,
-        args: slice.call(arguments),
-        next: true
-      };
-
-  guid = Ember.guidFor(timer);
-  timers[guid] = timer;
-
-  if (!scheduledNext) { scheduledNext = setTimeout(invokeNextTimers, 1); }
-  return guid;
+Ember.run.next = function() {
+  var args = slice.call(arguments);
+  args.push(1); // 1 millisecond wait
+  return run.later.apply(this, args);
 };
 
 /**

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -1,14 +1,21 @@
+
+var originalSetTimeout = window.setTimeout;
+
+module('Ember.run.later', {
+  teardown: function() {
+    window.setTimeout = originalSetTimeout;
+  }
+});
+
 var previousPreventRunloop;
 
-test('should invoke after specified period of time - function only', function() {
+asyncTest('should invoke after specified period of time - function only', function() {
 
   var invoked = false;
 
   Ember.run(function() {
     Ember.run.later(function() { invoked = true; }, 100);
   });
-
-  stop();
 
   setTimeout(function() {
     start();
@@ -18,15 +25,13 @@ test('should invoke after specified period of time - function only', function() 
 });
 
 
-test('should invoke after specified period of time - target/method', function() {
+asyncTest('should invoke after specified period of time - target/method', function() {
 
   var obj = { invoked: false } ;
 
   Ember.run(function() {
     Ember.run.later(obj, function() { this.invoked = true; }, 100);
   });
-
-  stop();
 
   setTimeout(function() {
     start();
@@ -36,7 +41,7 @@ test('should invoke after specified period of time - target/method', function() 
 });
 
 
-test('should invoke after specified period of time - target/method/args', function() {
+asyncTest('should invoke after specified period of time - target/method/args', function() {
 
   var obj = { invoked: 0 } ;
 
@@ -44,11 +49,158 @@ test('should invoke after specified period of time - target/method/args', functi
     Ember.run.later(obj, function(amt) { this.invoked += amt; }, 10, 100);
   });
 
-  stop();
-
   setTimeout(function() {
     start();
     equal(obj.invoked, 10, 'should have invoked later item');
   }, 150);
 
+});
+
+asyncTest('should always invoke within a separate runloop', function() {
+  var obj = { invoked: 0 }, firstRunLoop, secondRunLoop;
+
+  Ember.run(function() {
+    firstRunLoop = Ember.run.currentRunLoop; 
+
+    Ember.run.later(obj, function(amt) { 
+      this.invoked += amt; 
+      secondRunLoop = Ember.run.currentRunLoop;
+    }, 10, 1);
+
+    // Synchronous "sleep". This simulates work being done
+    // after run.later was called but before the run loop
+    // has flushed. In previous versions, this would have
+    // caused the run.later callback to have run from
+    // within the run loop flush, since by the time the 
+    // run loop has to flush, it would have considered 
+    // the timer already expired.
+    var pauseUntil = +new Date() + 100;
+    while(+new Date() < pauseUntil) { /* do nothing - sleeping */ }
+  });
+
+  ok(firstRunLoop, "first run loop captured");
+  ok(!Ember.run.currentRunLoop, "shouldn't be in a run loop after flush");
+  equal(obj.invoked, 0, "shouldn't have invoked later item yet");
+
+  setTimeout(function() {
+    start();
+    equal(obj.invoked, 10, "should have invoked later item");
+    ok(secondRunLoop, "second run loop took place");
+    ok(secondRunLoop !== firstRunLoop, "two different run loops took place");
+  }, 150);
+});
+
+asyncTest('callback order', function() {
+
+  var array = [];
+  function fn(val) { array.push(val); }
+
+  Ember.run(function() {
+    Ember.run.later(this, fn, 4, 130);
+    Ember.run.later(this, fn, 1, 10);
+    Ember.run.later(this, fn, 5, 200);
+    Ember.run.later(this, fn, 2, 80);
+    Ember.run.later(this, fn, 3, 80);
+  });
+
+  deepEqual(array, []);
+
+  setTimeout(function() {
+    start();
+    deepEqual(array, [1,2,3,4,5], 'callbacks were called in expected order');
+  }, 250);
+});
+
+asyncTest('callbacks coalesce into same run loop if expiring at the same time', function() {
+
+  var array = [];
+  function fn(val) { array.push(Ember.run.currentRunLoop); }
+
+  Ember.run(function() {
+    Ember.run.later(this, fn, 10);
+    Ember.run.later(this, fn, 100);
+    Ember.run.later(this, fn, 100);
+  });
+
+  deepEqual(array, []);
+
+  setTimeout(function() {
+    start();
+    equal(array.length, 3, 'all callbacks called');
+    ok(array[0] !== array[1], 'first two callbacks have different run loops');
+    ok(array[0], 'first runloop present');
+    ok(array[1], 'second runloop present');
+    equal(array[1], array[2], 'last two callbacks got the same run loop');
+  }, 200);
+});
+
+asyncTest('inception calls to run.later should run callbacks in separate run loops', function() {
+
+  var runLoop, finished;
+
+  Ember.run(function() {
+    runLoop = Ember.run.currentRunLoop;
+    ok(runLoop);
+
+    Ember.run.later(function() {
+      ok(Ember.run.currentRunLoop && Ember.run.currentRunLoop !== runLoop, 
+         'first later callback has own run loop');
+      runLoop = Ember.run.currentRunLoop;
+
+      Ember.run.later(function() {
+        ok(Ember.run.currentRunLoop && Ember.run.currentRunLoop !== runLoop, 
+           'second later callback has own run loop');
+        finished = true;
+      }, 40);
+    }, 40);
+  });
+
+  setTimeout(function() {
+    start();
+    ok(finished, 'all .later callbacks run');
+  }, 150);
+});
+
+asyncTest('setTimeout should never run with a negative wait', function() {
+
+  // Rationale: The old run loop code was susceptible to an occasional
+  // bug where invokeLaterTimers would be scheduled with a setTimeout
+  // with a negative wait. Modern browsers normalize this to 0, but
+  // older browsers (IE <= 8) break with a negative wait, which
+  // happens when an expired timer callback takes a while to run,
+  // which is what we simulate here.
+  var newSetTimeoutUsed;
+  window.setTimeout = function() {
+    var wait = arguments[arguments.length - 1];
+    newSetTimeoutUsed = true;
+    ok(!isNaN(wait) && wait >= 0, 'wait is a non-negative number');
+    originalSetTimeout.apply(this, arguments);
+  };
+
+  var count = 0;
+  Ember.run(function() {
+
+    Ember.run.later(function() {
+      count++;
+
+      // This will get run first. Waste some time.
+      // This is intended to break invokeLaterTimers code by taking a
+      // long enough time that other timers should technically expire. It's
+      // fine that they're not called in this run loop; just need to
+      // make sure that invokeLaterTimers doesn't end up scheduling
+      // a negative setTimeout.
+      var pauseUntil = +new Date() + 60;
+      while(+new Date() < pauseUntil) { /* do nothing - sleeping */ }
+    }, 1);
+
+    Ember.run.later(function() {
+      equal(count, 1, 'callbacks called in order');
+    }, 50);
+  });
+
+  originalSetTimeout(function() {
+    window.setTimeout = originalSetTimeout;
+    start();
+    ok(newSetTimeoutUsed, 'stub setTimeout was used');
+  }, 200);
 });

--- a/packages/ember-metal/tests/run_loop/next_test.js
+++ b/packages/ember-metal/tests/run_loop/next_test.js
@@ -1,10 +1,8 @@
-module('system/run_loop/next_test');
+module('Ember.run.next');
 
-test('should invoke immediately on next timeout', function() {
+asyncTest('should invoke immediately on next timeout', function() {
 
   var invoked = false;
-
-  stop();
 
   Ember.run(function() {
     Ember.run.next(function() { invoked = true; });
@@ -18,4 +16,32 @@ test('should invoke immediately on next timeout', function() {
     equal(invoked, true, 'should have invoked later item');
   }, 20);
 
+});
+
+asyncTest('callback should be called from within separate loop', function() {
+  var firstRunLoop, secondRunLoop;
+  Ember.run(function() {
+    firstRunLoop = Ember.run.currentRunLoop;
+    Ember.run.next(function() { secondRunLoop = Ember.run.currentRunLoop; });
+  });
+
+  setTimeout(function() {
+    start();
+    ok(secondRunLoop, 'callback was called from within run loop');
+    ok(firstRunLoop && secondRunLoop !== firstRunLoop, 'two seperate run loops were invoked');
+  }, 20);
+});
+
+asyncTest('multiple calls to Ember.run.next share coalesce callbacks into same run loop', function() {
+  var firstRunLoop, secondRunLoop, thirdRunLoop;
+  Ember.run(function() {
+    firstRunLoop = Ember.run.currentRunLoop;
+    Ember.run.next(function() { secondRunLoop = Ember.run.currentRunLoop; });
+    Ember.run.next(function() { thirdRunLoop  = Ember.run.currentRunLoop; });
+  });
+
+  setTimeout(function() {
+    start();
+    ok(secondRunLoop && secondRunLoop === thirdRunLoop, 'callbacks coalesced into same run loop');
+  }, 20);
 });

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -35,22 +35,32 @@ test('prior queues should be flushed before moving on to next queue', function()
   var order = [];
 
   Ember.run(function() {
+    var runLoop = Ember.run.currentRunLoop;
+    ok(runLoop, 'run loop present');
+
     Ember.run.schedule('sync', function() {
       order.push('sync');
+      equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
     });
     Ember.run.schedule('actions', function() {
       order.push('actions');
+      equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
+
       Ember.run.schedule('actions', function() {
         order.push('actions');
+        equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
       });
+
       Ember.run.schedule('sync', function() {
         order.push('sync');
+        equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
       });
     });
-    Ember.run.schedule('timers', function() {
-      order.push('timers');
+    Ember.run.schedule('destroy', function() {
+      order.push('destroy');
+      equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
     });
   });
 
-  deepEqual(order, ['sync', 'actions', 'sync', 'actions', 'timers']);
+  deepEqual(order, ['sync', 'actions', 'sync', 'actions', 'destroy']);
 });


### PR DESCRIPTION
In particular, callbacks for both are now guaranteed to be run from
within a totally separate run loop; previously, though the docs
suggested so, there was no guarantee the code would be run from
within a run loop at all, much less a separate one.

Ember.run.next is now shorthand for Ember.run.later with
1ms wait, as a result, there was a chunk of `next` code
that could be removed/consolidated in to `later`.

Fixes #913
