### PR TITLE
Route events don't need to be in events object and can be inherited

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -93,7 +93,7 @@ function giveDescriptorSuper(meta, key, property, values, descs) {
   // it on the original object.
   superProperty = superProperty || meta.descs[key];
 
-  if (!superProperty || !(superProperty instanceof Ember.ComputedProperty)) {
+  if (!superProperty || !(superProperty instanceof property.constructor)) {
     return property;
   }
 
@@ -387,7 +387,7 @@ Ember.anyUnprocessedMixins = false;
 /**
   Creates an instance of a class. Accepts either no arguments, or an object
   containing values to initialize the newly instantiated object with.
-  
+
   ```javascript
   App.Person = Ember.Object.extend({
     helloWorld: function() {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -35,6 +35,25 @@ Ember.Route = Ember.Object.extend({
     this.activate();
   },
 
+  init: function() {
+    this._super();
+
+    var proto = this.constructor.proto(),
+        descs = Ember.meta(proto).descs,
+        handler;
+
+    if (this.events === null) {
+      this.events = {};
+    }
+
+    for (var name in proto) {
+      handler = descs[name];
+      if (handler instanceof EventHandler) {
+        this.events[name] = handler.func;
+      }
+    }
+  },
+
   /**
     The collection of functions keyed by name available on this route as
     action targets.
@@ -541,4 +560,28 @@ function teardownView(route) {
 
   delete route.teardownView;
   delete route.lastRenderedTemplate;
+}
+
+/**
+  @class EventHandler
+  @namespace Ember
+  @extends Ember.Descriptor
+  @constructor
+*/
+function EventHandler(func) {
+  this.func = func;
+}
+
+EventHandler.prototype = new Ember.Descriptor();
+EventHandler.prototype.setup = Ember.K;
+EventHandler.prototype.teardown = Ember.K;
+
+Ember.Route.event = function(handler) {
+  return new EventHandler(handler);
+};
+
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
+  Function.prototype.event = function() {
+    return Ember.Route.event(this);
+  };
 }


### PR DESCRIPTION
WIP - probably needs some more tests and documentation once we're happy with the concept & implementation.

100% backwards compatible with existing events object so won't break anyones app, just gives new inheritable & composable goodness.

```
App.MyRoute = Ember.Route.extend({
  events: {
    someEvent: function(context) {
      // oh noes, can't call this._super() :o(
    }
  }
});
```

Is now:

```
App.MyRoute = Ember.Route.extend({
  someEvent: function(context) {
    // can call this._super()
  }.event()
});
```
