### PR TITLE
Stop using cache for `Ember.String.dasherize`

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -145,13 +145,14 @@ Ember.String = {
   */
   dasherize: function(str) {
     var cache = STRING_DASHERIZE_CACHE,
-        ret   = cache[str];
+        key   = ':' + str,
+        ret   = cache[key];
 
     if (ret) {
       return ret;
     } else {
       ret = Ember.String.decamelize(str).replace(STRING_DASHERIZE_REGEXP,'-');
-      cache[str] = ret;
+      cache[key] = ret;
     }
 
     return ret;

--- a/packages/ember-runtime/tests/system/string/dasherize.js
+++ b/packages/ember-runtime/tests/system/string/dasherize.js
@@ -28,6 +28,13 @@ test("dasherize camelcased string", function() {
   }
 });
 
+test("dasherize string that is the property name of Object.prototype", function() {
+  deepEqual(Ember.String.dasherize('toString'), 'to-string');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('toString'.dasherize(), 'to-string');
+  }
+});
+
 test("after call with the same passed value take object from cache", function() {
   var res = Ember.String.dasherize('innerHTML');
 


### PR DESCRIPTION
The value that is contained as key of `Object.prototype` couldn't be dasherize.

For examples:

``` javascript
Ember.String.dasherize('toString'); // function toString() { [native code] }
```

This reason is that cache is object (not Hash or Map) inherited `Object.prototype` as its property.

`Object` should not be used as key of cache that accept any keys from user input.
I think there is no reason why `Ember.String.dasherize` should use cache.
