### PR TITLE
Pass through any extra .trigger params in the event dispatcher

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -125,16 +125,23 @@ Ember.EventDispatcher = Ember.Object.extend(
     var self = this;
 
     rootElement.delegate('.ember-view', event + '.ember', function(evt, triggeringManager) {
+      var delegateArguments = arguments;
       return Ember.handleErrors(function() {
         var view = Ember.View.views[this.id],
-            result = true, manager = null;
+            result = true, manager = null,
+            // If triggeringManager is actually a triggeringManager, we probably want to
+            // exclude it from the additional arguments array.
+            // BUT: How do we know if triggeringManager is a triggeringManager or
+            // just an additional argument?
+            // For now, it will just get passed on as an additional argument
+            additionalArguments = Array.prototype.slice.call(delegateArguments, 1);
 
         manager = self._findNearestEventManager(view,eventName);
 
         if (manager && manager !== triggeringManager) {
-          result = self._dispatchEvent(manager, evt, eventName, view);
+          result = self._dispatchEvent.apply(self, [manager, evt, eventName, view].concat(additionalArguments));
         } else if (view) {
-          result = self._bubbleEvent(view,evt,eventName);
+          result = self._bubbleEvent.apply(self, [view,evt,eventName].concat(additionalArguments));
         } else {
           evt.stopPropagation();
         }
@@ -172,24 +179,27 @@ Ember.EventDispatcher = Ember.Object.extend(
   },
 
   _dispatchEvent: function(object, evt, eventName, view) {
-    var result = true;
+    var result = true,
+        additionalArguments = Array.prototype.slice.call(arguments, 4);
 
     var handler = object[eventName];
     if (Ember.typeOf(handler) === 'function') {
-      result = handler.call(object, evt, view);
+      result = handler.apply(object, [evt, view].concat(additionalArguments));
       // Do not preventDefault in eventManagers.
       evt.stopPropagation();
     }
     else {
-      result = this._bubbleEvent(view, evt, eventName);
+      result = this._bubbleEvent.apply(this, [view,evt,eventName].concat(additionalArguments));
     }
 
     return result;
   },
 
   _bubbleEvent: function(view, evt, eventName) {
+    var additionalArguments = Array.prototype.slice.call(arguments, 3);
+
     return Ember.run(function() {
-      return view.handleEvent(eventName, evt);
+      return view.handleEvent.apply(view, [eventName, evt].concat(additionalArguments));
     });
   },
 

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -71,10 +71,12 @@ Ember.merge(hasElement, {
 
   // Handle events from `Ember.EventDispatcher`
   handleEvent: function(view, eventName, evt) {
+    var additionalArguments = Array.prototype.slice.call(arguments, 3);
+
     if (view.has(eventName)) {
       // Handler should be able to re-dispatch events, so we don't
       // preventDefault or stopPropagation.
-      return view.trigger(eventName, evt);
+      return view.trigger.apply(this, [eventName, evt].concat(additionalArguments));
     } else {
       return true; // continue event propagation
     }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -731,7 +731,7 @@ class:
   * `mouseEnter`
   * `mouseLeave`
 
-  Form events: 
+  Form events:
 
   * `submit`
   * `change`
@@ -739,7 +739,7 @@ class:
   * `focusOut`
   * `input`
 
-  HTML5 drag and drop events: 
+  HTML5 drag and drop events:
 
   * `dragStart`
   * `drag`
@@ -2148,7 +2148,9 @@ Ember.View = Ember.CoreView.extend(
     @param evt {Event}
   */
   handleEvent: function(eventName, evt) {
-    return this.currentState.handleEvent(this, eventName, evt);
+    var additionalArguments = Array.prototype.slice.call(arguments, 2);
+
+    return this.currentState.handleEvent.apply(this, [this, eventName, evt].concat(additionalArguments));
   },
 
   registerObserver: function(root, path, target, observer) {
@@ -2293,14 +2295,14 @@ Ember.View.reopenClass({
     `className` and optional `falsyClassName`.
 
     - if a `className` or `falsyClassName` has been specified:
-      - if the value is truthy and `className` has been specified, 
+      - if the value is truthy and `className` has been specified,
         `className` is returned
-      - if the value is falsy and `falsyClassName` has been specified, 
+      - if the value is falsy and `falsyClassName` has been specified,
         `falsyClassName` is returned
       - otherwise `null` is returned
-    - if the value is `true`, the dasherized last part of the supplied path 
+    - if the value is `true`, the dasherized last part of the supplied path
       is returned
-    - if the value is not `false`, `undefined` or `null`, the `value` 
+    - if the value is not `false`, `undefined` or `null`, the `value`
       is returned
     - if none of the above rules apply, `null` is returned
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -257,3 +257,39 @@ test("event manager should be able to re-dispatch events to view", function() {
   Ember.$('#nestedView').trigger('mousedown');
   equal(receivedEvent, 2, "event should go to manager and not view");
 });
+
+test("should pass along any additional arguments it receives", function() {
+  var viewString1 = "";
+  var viewString2 = "";
+  var managerString1 = "";
+  var managerString2 = "";
+
+  var messageArgument1 = "additional argument1";
+  var messageArgument2 = "additional argument2";
+
+  view = Ember.ContainerView.createWithMixins({
+    elementId: 'containerView',
+    mouseDown: function(evt, additionalArgument1, additionalArgument2) {
+      viewString1 = additionalArgument1;
+      viewString2 = additionalArgument2;
+    },
+    eventManager: Ember.Object.create({
+      click: function(event, view, additionalArgument1, additionalArgument2){
+        managerString1 = additionalArgument1;
+        managerString2 = additionalArgument2;
+      }
+    })
+  });
+
+  Ember.run(function() { view.append(); });
+
+  //Will set the view strings
+  Ember.$('#containerView').trigger('mousedown', [messageArgument1, messageArgument2]);
+  equal(viewString1, messageArgument1, "additional parameters should be passed on");
+  equal(viewString2, messageArgument2, "additional parameters should be passed on");
+
+  //Will set the manager strings
+  Ember.$('#containerView').trigger('click', [messageArgument1, messageArgument2]);
+  equal(managerString1, messageArgument1, "additional parameters should be passed on");
+  equal(managerString2, messageArgument2, "additional parameters should be passed on");
+});


### PR DESCRIPTION
jQuery.trigger lets you specify the event and an optional array of extra parameters.  Those extra parameters were not being passed through by the event-dispatcher.  

With this patch, you can now do:

``` javascript
App.view = Ember.View.extend({
  myCustomEvent: function(param1, param2, param3){
    ...
  }
});

Ember.$('#view').trigger('myCustomEvent', ["myArg1", "myArg2", "myArg3"]);
```
