### PR TITLE
Added a "loader" method in Ember.Router to be used to load files async

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -65,7 +65,7 @@ Ember.Router = Ember.Object.extend({
     location.onUpdateURL(function(url) {
       self.handleURL(url);
     });
-debugger;
+    
     this.handleURL(location.getURL());
   },
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -239,9 +239,10 @@ function doTransition(router, method, args) {
   }
 
   Ember.assert("The route " + passedName + " was not found", router.router.hasRoute(name));
-
-  router.router[method].apply(router.router, args);
-  router.notifyPropertyChange('url');
+  router.loader(name, function() {
+    router.router[method].apply(router.router, args);
+    router.notifyPropertyChange('url');
+  });
 }
 
 Ember.Router.reopenClass({

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -38,7 +38,9 @@ Ember.Router = Ember.Object.extend({
 
   init: function() {
     this.router = this.constructor.router;
-    this.router.loader = this.loader || this.router.loader 
+    if (this.router) {
+      this.router.loader = this.loader || this.router.loader;
+    }
     this._activeViews = {};
     setupLocation(this);
   },
@@ -63,7 +65,7 @@ Ember.Router = Ember.Object.extend({
     location.onUpdateURL(function(url) {
       self.handleURL(url);
     });
-
+debugger;
     this.handleURL(location.getURL());
   },
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -38,6 +38,7 @@ Ember.Router = Ember.Object.extend({
 
   init: function() {
     this.router = this.constructor.router;
+    this.router.loader = this.loader || this.router.loader 
     this._activeViews = {};
     setupLocation(this);
   },

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -33,6 +33,9 @@ define("router",
 
 
     Router.prototype = {
+      loader: function(handler, done) {
+        done();
+      },
       /**
         The main entry point into the router. The API is essentially
         the same as the `map` method in `route-recognizer`.
@@ -397,7 +400,9 @@ define("router",
           handler: result.handler,
           isDynamic: result.isDynamic
         }]);
-        collectObjects(router, results, index + 1, updatedObjects);
+        router.loader(result, function() {
+          collectObjects(router, results, index + 1, updatedObjects);
+        });
       }
     }
 


### PR DESCRIPTION
Proposed fix for #2194

Use:

``` javascript
App.Router.reopen({
      loader: function(handler, done){
        var modules = moduleName(handler.handler); //or a JSON map, or another method, up to developer to decide
        require(modules, function(module) {
          done();
        });
      }
    });
```

By default, it will call done() directly. So it is backwards compatible.
