### PR TITLE
Added isDestroying/isDestroyed flags meaning and invariants docs.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -259,12 +259,22 @@ CoreObject.PrototypeMixin = Mixin.create({
   concatenatedProperties: null,
 
   /**
+    Destroyed object property flag.
+
+    if this property is `true` the observers and bindings were already
+    removed by the effect of calling the `destroy()` method.
+
     @property isDestroyed
     @default false
   */
   isDestroyed: false,
 
   /**
+    Destruction scheduled flag. The `destroy()` method has been called.
+
+    The object stays intact until the end of the run loop at which point
+    the `isDestroyed` flag is set.
+
     @property isDestroying
     @default false
   */


### PR DESCRIPTION
Could you please have a look if I described the flags correctly? I think it would be good to have this documented.

In the process of integrating Ember and 3rd parties we found the need to track whether the object is in the destruction process and wanted to have a single flag check. From the source I found the `isDestroying` the right thing to check. It stays `true` ever since the `destroy()` method has been called.
