### PR TITLE
WIP: Fixup app boot

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -295,7 +295,7 @@ var Application = Ember.Application = Ember.Namespace.extend({
     Automatically initialize the application once the DOM has
     become ready.
 
-    The initialization itself is deferred using Ember.run.once,
+    The initialization itself is scheduled on the actions queue
     which ensures that application loading finishes before
     booting.
 
@@ -309,8 +309,8 @@ var Application = Ember.Application = Ember.Namespace.extend({
   scheduleInitialize: function() {
     var self = this;
     this.$().ready(function() {
-      if (self.isDestroyed || self.isInitialized) return;
-      Ember.run(self, 'initialize');
+      if (self.isDestroyed || self.isInitialized) { return; }
+      Ember.run.schedule('actions', self, 'initialize');
     });
   },
 

--- a/packages/ember-application/tests/system/readiness_test.js
+++ b/packages/ember-application/tests/system/readiness_test.js
@@ -64,6 +64,7 @@ test("Ember.Application's ready event is called right away if jQuery is already 
 
   Ember.run(function() {
     application = Application.create({ router: false });
+    equal(readyWasCalled, 0, "ready is not called until later");
   });
 
   equal(readyWasCalled, 1, "ready was called");


### PR DESCRIPTION
Warning I am tired so this is still WIP.

So if domReady has already passed, jQuery.ready is synchronous. This means that if you create an Application after domReady and expect to defer its readiness, then you are going to have a bad time.

The general goal is to utilize the run loop correctly, allowing typical app boot to behave consistently, regardless of domReady.

Bonus: this makes ember work sanely again on jsfiddle.
