### PR TITLE
Stop using extended method

### DIFF
--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -9,7 +9,7 @@ require('ember-runtime/mixins/freezable');
 @submodule ember-runtime
 */
 
-var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.isNone;
+var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, none = Ember.isNone, fmt = Ember.String.fmt;
 
 /**
   An unordered collection of objects.
@@ -451,7 +451,7 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
     for(idx = 0; idx < len; idx++) {
       array[idx] = this[idx];
     }
-    return "Ember.Set<%@>".fmt(array.join(','));
+    return fmt("Ember.Set<%@>", [array.join(',')]);
   }
 
 });


### PR DESCRIPTION
I used `Ember.String.fmt` instead of `String#fmt`.
Because the latter may be undefined.
