### PR TITLE
Improve Ember.Array slice implementation

### DIFF
--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -160,6 +160,10 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     var length = get(this, 'length') ;
     if (none(beginIndex)) beginIndex = 0 ;
     if (none(endIndex) || (endIndex > length)) endIndex = length ;
+
+    if (beginIndex < 0) beginIndex = length + beginIndex;
+    if (endIndex < 0) endIndex = length + endIndex;
+
     while(beginIndex < endIndex) {
       ret[ret.length] = this.objectAt(beginIndex++) ;
     }

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -37,12 +37,7 @@ var TestArray = Ember.Object.extend(Ember.Array, {
 
   length: Ember.computed(function() {
     return this._content.length;
-  }),
-
-  slice: function() {
-    return this._content.slice();
-  }
-
+  })
 });
 
 
@@ -72,6 +67,24 @@ test("the return value of slice has Ember.Array applied", function(){
   });
   var y = x.slice(1);
   equal(Ember.Array.detect(y), true, "mixin should be applied");
+});
+
+test("slice supports negative index arguments", function(){
+  var testArray = new TestArray([1,2,3,4]);
+
+  deepEqual(testArray.slice(-2),      [3, 4],     'slice(-2)');
+  deepEqual(testArray.slice(-2, -1),  [3],        'slice(-2, -1');
+  deepEqual(testArray.slice(-2, -2),  [],         'slice(-2, -2)');
+  deepEqual(testArray.slice(-1, -2),  [],         'slice(-1, -2)');
+
+  deepEqual(testArray.slice(-4, 1),   [1],        'slice(-4, 1)');
+  deepEqual(testArray.slice(-4, 5),   [1,2,3,4],  'slice(-4, 5)');
+  deepEqual(testArray.slice(-4),      [1,2,3,4],  'slice(-4)');
+
+  deepEqual(testArray.slice(0, -1),   [1,2,3],    'slice(0, -1)');
+  deepEqual(testArray.slice(0, -4),   [],         'slice(0, -4)');
+  deepEqual(testArray.slice(0, -3),   [1],        'slice(0, -3)');
+
 });
 
 // ..........................................................


### PR DESCRIPTION
Add support for negative index arguments.
Still doesn't behave as native slice in edge cases.

The easiest way to reproduce is to create an ArrayProxy

``` javascript
Ember.ArrayProxy.create({ content: Ember.A(['foo', 'bar']) }).slice(-2)
// => [undefined, undefined, "foo", "bar"]
```

Or if the array is empty

``` javascript
Ember.ArrayProxy.create({ content: Ember.A([]) }).slice(-2)
// => [undefined, undefined]
```

There may be some edge cases still not mimicked, but this should improve experience for sane users of slice :)

I'm happy to separate out assertions into there own tests if that's desired.
