### PR TITLE
Update accessors.js typo in comments

### DIFF
--- a/packages/ember-metal/lib/accessors.js
+++ b/packages/ember-metal/lib/accessors.js
@@ -18,7 +18,7 @@ var FIRST_KEY = /^([^\.\*]+)/;
 // ..........................................................
 // GET AND SET
 //
-// If we are on a platform that supports accessors we can get use those.
+// If we are on a platform that supports accessors we can use those.
 // Otherwise simulate accessors by looking up the property directly on the
 // object.
 


### PR DESCRIPTION
typo should be 'If we are on a platform that supports accessors we can use those' 
instead of 'If we are on a platform that supports accessors we can get use those.'
