### PR TITLE
Mixin.prototype.reopen calls didApply if available

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -363,6 +363,15 @@ Ember.mixin = function(obj) {
   commentView.edit(); // outputs 'starting to edit'
   ```
 
+  // If a Mixin has a didApply property, it will be called after it is mixed
+  // in:
+  App.Editable.didApply = function(object) {
+    console.log("Editable applied to " + object.ownerConstructor);
+  };
+
+  App.CommentView = Ember.View.extend(App.Editable);
+  // logs "Editable applied to App.CommentView"
+
   Note that Mixins are created with `Ember.Mixin.create`, not
   `Ember.Mixin.extend`.
 
@@ -425,6 +434,10 @@ MixinPrototype.reopen = function() {
       tmp = Mixin.create();
       tmp.properties = mixin;
       mixins.push(tmp);
+    }
+
+    if (mixin.didApply != null) {
+      mixin.didApply(this);
     }
   }
 

--- a/packages/ember-metal/tests/mixin/did_apply_test.js
+++ b/packages/ember-metal/tests/mixin/did_apply_test.js
@@ -1,0 +1,28 @@
+module('Ember.Mixin.prototype.didApply');
+
+test('is called with the recipient after reopen', function() {
+  var MixinA = Ember.Mixin.create({ foo: 'foo' }),
+      appliedTo;
+
+  MixinA.didApply = function(object) {
+    appliedTo = object;
+  };
+
+  var obj = {};
+  MixinA.reopen.call(obj, MixinA);
+
+  equal(appliedTo, obj, 'didApply called with recipient of reopen');
+});
+
+test('is called in order, left to right', function() {
+  var Foo = Ember.Mixin.create(),
+      Bar = Ember.Mixin.create();
+
+  Foo.didApply = function(object) { object.value = 'foo'; };
+  Bar.didApply = function(object) { object.value = 'bar'; };
+
+  var obj = {};
+  Foo.reopen.call(obj, Foo, Bar);
+
+  equal(Ember.get(obj, 'value'), 'bar', 'later mixins win over earlier');
+});


### PR DESCRIPTION
My use-case:

``` javascript
var Singleton = Ember.Mixin.create({
  init: function() {
    if (this.constructor.instance !== undefined) {
      throw "Cannot create a second instance of " + this.constructor;
    }
    this.constructor.instance = this;
    return this._super.apply(this, arguments);
  },

  willDestroy: function() {
    this.constructor.instance = undefined;
    if (this._super) { this._super.apply(this, arguments); }
  }
});

Singleton.didApply = function(obj) {
  var klass = obj.ownerConstructor,
      originalCreate = klass.create;
  klass.create = function(properties) {
    return this.instance !== undefined ? this.instance : originalCreate.call(this, properties);
  };
};

var Foo = Ember.Object.extend(Singleton),
    foo = Foo.create({ bar: 'baz' });

foo === Foo.create(); // true
foo === Foo.create(); // true
```

<!---
@huboard:{"custom_state":"","order":0.07928466796875}
-->
