### PR TITLE
Added length property to Ember.Map

### DIFF
--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -25,8 +25,11 @@
 require('ember-metal/array');
 require('ember-metal/utils');
 require('ember-metal/core');
+require('ember-metal/accessors');
 
-var guidFor = Ember.guidFor,
+var get = Ember.get,
+    set = Ember.set,
+    guidFor = Ember.guidFor,
     indexOf = Ember.ArrayPolyfills.indexOf;
 
 var copy = function(obj) {
@@ -45,6 +48,7 @@ var copyMap = function(original, newObject) {
 
   newObject.keys = keys;
   newObject.values = values;
+  newObject.length = original.length;
 
   return newObject;
 };
@@ -205,6 +209,16 @@ Map.create = function() {
 
 Map.prototype = {
   /**
+    This property will change as the number of objects in the map changes.
+   
+    @property length
+    @type number
+    @default 0
+  */
+  length: 0,
+    
+    
+  /**
     Retrieve the value associated with a given key.
 
     @method get
@@ -233,6 +247,7 @@ Map.prototype = {
 
     keys.add(key);
     values[guid] = value;
+    set(this, 'length', keys.list.length);
   },
 
   /**
@@ -254,6 +269,7 @@ Map.prototype = {
       keys.remove(key);
       value = values[guid];
       delete values[guid];
+      set(this, 'length', keys.list.length);
       return true;
     } else {
       return false;

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -118,6 +118,39 @@ function testMap(variety) {
 
     mapHasEntries([ ], map2);
   });
+    
+  test("length", function() {
+    //Add a key twice
+    equal(map.length, 0);
+    map.set(string, "a string");
+    equal(map.length, 1);
+    map.set(string, "the same string");
+    equal(map.length, 1);
+    
+    //Add another
+    map.set(number, "a number");
+    equal(map.length, 2);
+    
+    //Remove one that doesn't exist
+    map.remove('does not exist');
+    equal(map.length, 2);
+    
+    //Check copy
+    var copy = map.copy();
+    equal(copy.length, 2);
+    
+    //Remove a key twice
+    map.remove(number);
+    equal(map.length, 1);
+    map.remove(number);
+    equal(map.length, 1);
+    
+    //Remove the last key
+    map.remove(string);
+    equal(map.length, 0);
+    map.remove(string);
+    equal(map.length, 0);
+  });
 }
 
 for (var i = 0;  i < varieties.length;  i++) {


### PR DESCRIPTION
When using `Ember.Map` in my own code, it would be very useful to have a `length` property.
