### PR TITLE
[WIP] Refresh href in linkTo when one of the params or properties change

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -86,7 +86,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
           self = this,
           path, paths = Ember.A([]), i, j,
           router = this.get('router'),
-          serializePaths = router.pathsForSerialize(this.namedRoute);
+          serializePaths = router.pathsForSerialize(fullRouteName(router, this.namedRoute));
 
       set(this, 'paramsContext', context);
 

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -38,6 +38,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     return ret.concat(resolvedPaths(linkView.parameters));
   }
 
+  function _createPath(path) {
+    var fullPath = 'paramsContext';
+    if(path !== '') {
+      fullPath += '.' + path;
+    }
+    return fullPath;
+  }
+
   /**
     Renders a link to the supplied route.
 
@@ -73,21 +81,28 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
           length = params.length,
           context = this.parameters.context,
           self = this,
-          path;
+          path, paths = Ember.A([]), i;
 
       set(this, 'paramsContext', context);
 
-      var observer = function() {
-        this.notifyPropertyChange('href');
+      for(i=0; i < length; i++) {
+        paths.pushObject(_createPath(params[i]));
+      }
+
+      var observer = function(object, path) {
+        var notify = true, i;
+        for(i=0; i < paths.length; i++) {
+          if(!get(this, paths[i])) {
+            notify = false;
+          }
+        }
+        if(notify) {
+          this.notifyPropertyChange('href');
+        }
       };
 
-      for(var i=0; i < length; i++) {
-        path = 'paramsContext';
-        if(params[i] !== '') {
-          path += '.' + params[i];
-        }
-
-        Ember.addObserver(this, path, this, observer);
+      for(i=0; i < length; i++) {
+        Ember.addObserver(this, paths[i], this, observer);
       }
     },
 

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -66,6 +66,31 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     attributeBindings: ['href', 'title'],
     classNameBindings: 'active',
 
+    init: function() {
+      this._super.apply(this, arguments);
+
+      var params = this.parameters.params,
+          length = params.length,
+          context = this.parameters.context,
+          self = this,
+          path;
+
+      set(this, 'paramsContext', context);
+
+      var observer = function() {
+        this.notifyPropertyChange('href');
+      };
+
+      for(var i=0; i < length; i++) {
+        path = 'paramsContext';
+        if(params[i] !== '') {
+          path += '.' + params[i];
+        }
+
+        Ember.addObserver(this, path, this, observer);
+      }
+    },
+
     // Even though this isn't a virtual view, we want to treat it as if it is
     // so that you can access the parent with {{view.prop}}
     concreteView: Ember.computed(function() {

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -38,10 +38,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     return ret.concat(resolvedPaths(linkView.parameters));
   }
 
-  function _createPath(path) {
+  function _createPath(path, property) {
     var fullPath = 'paramsContext';
     if(path !== '') {
       fullPath += '.' + path;
+    }
+    if(property && property !== '') {
+      fullPath += '.' + property;
     }
     return fullPath;
   }
@@ -81,12 +84,20 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
           length = params.length,
           context = this.parameters.context,
           self = this,
-          path, paths = Ember.A([]), i;
+          path, paths = Ember.A([]), i, j,
+          router = this.get('router'),
+          serializePaths = router.pathsForSerialize(this.namedRoute);
 
       set(this, 'paramsContext', context);
 
       for(i=0; i < length; i++) {
-        paths.pushObject(_createPath(params[i]));
+        if(serializePaths[i].length) {
+          for(j=0; j < serializePaths[i].length; j++) {
+            paths.pushObject(_createPath(params[i], serializePaths[i][j]));
+          }
+        } else {
+          paths.pushObject(_createPath(params[i]));
+        }
       }
 
       var observer = function(object, path) {

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -112,7 +112,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
         }
       };
 
-      for(i=0; i < length; i++) {
+      for(i=0, length=paths.length; i < length; i++) {
         Ember.addObserver(this, paths[i], this, observer);
       }
     },

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -55,6 +55,21 @@ Ember.Route = Ember.Object.extend({
   events: null,
 
   /**
+   The list of paths which are needed to serialize this route
+   and create the URL. It will be used in the places, where
+   the URL may need regeneration.
+
+   @property serializePaths
+   @type Array
+   @default: ['id']
+  */
+  serializePaths: ['id'],
+
+  _getSerializePaths: function() {
+    return this.get('serializePaths');
+  },
+
+  /**
     This hook is executed when the router completely exits this route. It is
     not executed when the model for the route changes.
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -103,6 +103,10 @@ Ember.Router = Ember.Object.extend({
     return this.location.formatURL(url);
   },
 
+  pathsForSerialize: function() {
+    return this.router.pathsForSerialize.apply(this.router, arguments);
+  },
+
   isActive: function(routeName) {
     var router = this.router;
     return router.isActive.apply(router, arguments);

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -155,6 +155,30 @@ define("router",
       },
 
       /**
+        Take a named route and context objects and return
+        an array of paths that would be used for URL generation.
+
+        @param {String} name the name of the route
+        @param {...Object} objects a list of objects to get serialize
+          paths for
+
+        @return {Array} a list of paths, each element is an Array itself
+      */
+      pathsForSerialize: function(handlerName) {
+        var handlers = this.recognizer.handlersFor(handlerName),
+            handler, i, paths = [], len;
+
+        for (i=0, len=handlers.length; i<len; i++) {
+          handler = this.getHandler(handlers[i].handler);
+          if(handlers[i].names.length) {
+            paths.push(handler._getSerializePaths());
+          }
+        }
+
+        return paths;
+      },
+
+      /**
         @private
 
         Used internally by `generate` and `transitionTo`.

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -150,6 +150,10 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
   indexController.set('post', secondPost);
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr was updated after one of the params had been changed');
+
+  indexController.set('post', null);
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr does not change when one of the arguments in nullified');
 });
 
 test("The {{linkTo}} helper supports a custom activeClass", function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -119,21 +119,21 @@ test("The {{linkTo}} helper supports URL replacement", function() {
 
 test("The {{linkTo}} helper refreshes href element when one of params changes", function() {
   Router.map(function() {
-    this.route('post', { path: '/posts/:post_slug' });
+    this.route('post', { path: '/posts/:post_id/:post_slug' });
   });
 
   var post = Ember.Object.create({id: '1', slug: 'post'}),
       secondPost = Ember.Object.create({id: '2', slug: 'second-post'});
 
   App.PostRoute = Ember.Route.extend({
-    serializePaths: ['slug'],
+    serializePaths: ['id', 'slug'],
 
     model: function(params) {
       return post;
     },
 
     serialize: function(post) {
-      return { post_slug: post.get('slug') };
+      return { post_id: post.get('id'), post_slug: post.get('slug') };
     }
   });
 
@@ -147,25 +147,25 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
 
   Ember.run(function() { router.handleURL("/"); });
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/post', 'precond - Link has rendered href attr properly');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/1/post', 'precond - Link has rendered href attr properly');
 
   Ember.run(function() {
     indexController.set('post', secondPost);
   });
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post', 'href attr was updated after one of the params had been changed');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2/second-post', 'href attr was updated after one of the params had been changed');
 
   Ember.run(function() {
     secondPost.set('slug', 'second-post-changed');
   });
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post-changed', 'href attr was updated after one of the properties needed to build URL had been changed');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2/second-post-changed', 'href attr was updated after one of the properties needed to build URL had been changed');
 
   Ember.run(function() {
     indexController.set('post', null);
   });
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post-changed', 'href attr does not change when one of the arguments in nullified');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2/second-post-changed', 'href attr does not change when one of the arguments in nullified');
 });
 
 test("The {{linkTo}} helper supports a custom activeClass", function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -117,6 +117,41 @@ test("The {{linkTo}} helper supports URL replacement", function() {
   equal(replaceCount, 1, 'replaceURL should be called once');
 });
 
+test("The {{linkTo}} helper refreshes href element when one of params changes", function() {
+  Router.map(function() {
+    this.route('post', { path: '/posts/:post_id' });
+  });
+
+  var post = Ember.Object.create({id: '1'}),
+      secondPost = Ember.Object.create({id: '2'});
+
+  App.PostRoute = Ember.Route.extend({
+    model: function(params) {
+      return post;
+    },
+
+    serialize: function(post) {
+      return { post_id: post.get('id') };
+    }
+  });
+
+  Ember.TEMPLATES.index = compile('{{#linkTo "post" post id="post"}}post{{/linkTo}}');
+
+  App.IndexController = Ember.Controller.extend();
+  var indexController = container.lookup('controller:index');
+  indexController.set('post', post);
+
+  bootApplication();
+
+  Ember.run(function() { router.handleURL("/"); });
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/1', 'precond - Link has rendered href attr properly');
+
+  indexController.set('post', secondPost);
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr was updated after one of the params had been changed');
+});
+
 test("The {{linkTo}} helper supports a custom activeClass", function() {
   Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo about id='about-link'}}About{{/linkTo}}{{#linkTo index id='self-link' activeClass='zomg-active'}}Self{{/linkTo}}");
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -119,19 +119,21 @@ test("The {{linkTo}} helper supports URL replacement", function() {
 
 test("The {{linkTo}} helper refreshes href element when one of params changes", function() {
   Router.map(function() {
-    this.route('post', { path: '/posts/:post_id' });
+    this.route('post', { path: '/posts/:post_slug' });
   });
 
-  var post = Ember.Object.create({id: '1'}),
-      secondPost = Ember.Object.create({id: '2'});
+  var post = Ember.Object.create({id: '1', slug: 'post'}),
+      secondPost = Ember.Object.create({id: '2', slug: 'second-post'});
 
   App.PostRoute = Ember.Route.extend({
+    serializePaths: ['slug'],
+
     model: function(params) {
       return post;
     },
 
     serialize: function(post) {
-      return { post_id: post.get('id') };
+      return { post_slug: post.get('slug') };
     }
   });
 
@@ -145,15 +147,19 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
 
   Ember.run(function() { router.handleURL("/"); });
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/1', 'precond - Link has rendered href attr properly');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/post', 'precond - Link has rendered href attr properly');
 
   indexController.set('post', secondPost);
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr was updated after one of the params had been changed');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post', 'href attr was updated after one of the params had been changed');
+
+  secondPost.set('slug', 'second-post-changed');
+
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post-changed', 'href attr was updated after one of the properties needed to build URL had been changed');
 
   indexController.set('post', null);
 
-  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/2', 'href attr does not change when one of the arguments in nullified');
+  equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post-changed', 'href attr does not change when one of the arguments in nullified');
 });
 
 test("The {{linkTo}} helper supports a custom activeClass", function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -149,15 +149,21 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/post', 'precond - Link has rendered href attr properly');
 
-  indexController.set('post', secondPost);
+  Ember.run(function() {
+    indexController.set('post', secondPost);
+  });
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post', 'href attr was updated after one of the params had been changed');
 
-  secondPost.set('slug', 'second-post-changed');
+  Ember.run(function() {
+    secondPost.set('slug', 'second-post-changed');
+  });
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post-changed', 'href attr was updated after one of the properties needed to build URL had been changed');
 
-  indexController.set('post', null);
+  Ember.run(function() {
+    indexController.set('post', null);
+  });
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '/posts/second-post-changed', 'href attr does not change when one of the arguments in nullified');
 });


### PR DESCRIPTION
I've already opened a similar pull request here #2181, but as I mentioned in the description there, it didn't handle the case when an attribute changes. This pull request is not technically ready, I would need to add more tests and I would need to make changes in `vendor/router.js` in the actual router repo, but I submit it for discussion (specifically, if this has chances to be merged in).

The problem, which this PR tries to resolve is described here:  #2241. To fix it, we need to refresh the href attribute whenever one of the properties used to generate it changes.

The idea behind this is that in most cases, when dynamic segments are used, serialize method needs an `id` to generate an URL. In the rare cases, when it needs something else, we could require a bit more declarative approach:

``` javascript
App.PostRoute = Ember.Route.extend({
  serializePaths: ['slug'], // I suck at naming, halp!
  serialize: function(post) {
    return { slug: post.get('slug'); }
  }
});
```

One more addition, which I would do on top of things already available in this PR is to set `#` as an URL if any of the params or properties is null. This would allow to just forget about problems in #2241.

Imagine the case where you display a list of posts (including links) and you insert a newly created post onto the list. Now you need to generate an URL for the new post, but id is obviously not available yet. You can do what I suggested in #2241 and just cover the link with `{{#if post.id}}`, but now you don't have the link at all. The ideal thing to do would be to render the link with `#` as a href and then update it as soon as record is saved and has an id.
