### PR TITLE
Remove unused argument

### DIFF
--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -559,7 +559,7 @@ Ember.finishChains = function(obj) {
   @param {String} keyName The property key (or path) that will change.
   @return {void}
 */
-function propertyWillChange(obj, keyName, value) {
+function propertyWillChange(obj, keyName) {
   var m = metaFor(obj, false),
       watching = m.watching[keyName] > 0 || keyName === 'length',
       proto = m.proto,


### PR DESCRIPTION
This argument `value` is not used and not referenced anywhere.
