### PR TITLE
Make Evented#on, #off, and #one chainable

### DIFF
--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -25,6 +25,16 @@
   // outputs: 'Our person has greeted'
   ```
 
+  You can also chain multiple event subscriptions:
+
+  ```javascript
+  person.on('greet', function() {
+    console.log('Our person has greeted');
+  }).one('greet', function() {
+    console.log('Offer one-time special');
+  }).off('event', this, forgetThis);
+  ```
+
   @class Evented
   @namespace Ember
   @extends Ember.Mixin
@@ -52,6 +62,7 @@ Ember.Evented = Ember.Mixin.create({
   */
   on: function(name, target, method) {
     Ember.addListener(this, name, target, method);
+    return this;
   },
 
   /**
@@ -75,6 +86,7 @@ Ember.Evented = Ember.Mixin.create({
     }
 
     Ember.addListener(this, name, target, method, true);
+    return this;
   },
 
   /**
@@ -118,6 +130,7 @@ Ember.Evented = Ember.Mixin.create({
   */
   off: function(name, target, method) {
     Ember.removeListener(this, name, target, method);
+    return this;
   },
 
   /**

--- a/packages/ember-runtime/tests/system/object/events_test.js
+++ b/packages/ember-runtime/tests/system/object/events_test.js
@@ -122,3 +122,17 @@ test("a listener registered with one can be removed with off", function() {
 
   equal(obj.has('event!'), false, 'has no more events');
 });
+
+test("adding and removing listeners should be chainable", function() {
+  var obj = Ember.Object.createWithMixins(Ember.Evented);
+  var F = function() {};
+
+  var ret = obj.on('event!', F);
+  equal(ret, obj, '#on returns self');
+
+  ret = obj.off('event!', F);
+  equal(ret, obj, '#off returns self');
+
+  ret = obj.one('event!', F);
+  equal(ret, obj, '#one returns self');
+});


### PR DESCRIPTION
Simple change to make Evented#on, #off, and #one chainable.

Comes in useful with `ember-data`:

```
record.one('didCreate', function() {
  ctrl.transitionToRoute('success');
}).one('becameError', function() {
  alert('Bad input');
}).get('transaction').commit();
```
