### PR TITLE
Fixes {{control}} rerendering when destroyed

### DIFF
--- a/packages/ember-routing/lib/helpers/control.js
+++ b/packages/ember-routing/lib/helpers/control.js
@@ -60,8 +60,12 @@ if (Ember.ENV.EXPERIMENTAL_CONTROL_HELPER) {
 
     function observer() {
       var model = Ember.Handlebars.get(this, modelPath, options);
-      set(childController, 'model', model);
-      childView.rerender();
+      if (!get(childController, "isDestroyed")) {
+        set(childController, 'model', model);
+      }
+      if (!get(childView, "isDestroyed")) {
+        childView.rerender();
+      }
     }
 
     Ember.addObserver(this, modelPath, observer);


### PR DESCRIPTION
I'm sure there's a larger problem here. As far as I can tell, {{control}}s don't register with the parentView, causing them to not be properly destroyed.  This is just a hack to keep it from crashing my app.
