### PR TITLE
Ember.GroupableMixin

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -1,6 +1,7 @@
 require('ember-runtime/system/array_proxy');
 require('ember-runtime/controllers/controller');
 require('ember-runtime/mixins/sortable');
+require('ember-runtime/mixins/groupable');
 
 /**
 @module ember

--- a/packages/ember-runtime/lib/mixins/groupable.js
+++ b/packages/ember-runtime/lib/mixins/groupable.js
@@ -15,6 +15,8 @@ Ember.GroupableMixin = Ember.Mixin.create({
 
       this.insertItemGrouped(object);
     }, this);
+
+    this._super.apply(this, array, idx, removedCount, addedCount);
   },
 
   contentArrayWillChange: function(array, idx, removedCount, addedCount) {
@@ -26,6 +28,8 @@ Ember.GroupableMixin = Ember.Mixin.create({
 
       this.removeItemGrouped(object);
     }, this);
+
+    this._super.apply(this, array, idx, removedCount, addedCount);
   },
 
   insertItemGrouped: function(object) {

--- a/packages/ember-runtime/lib/mixins/groupable.js
+++ b/packages/ember-runtime/lib/mixins/groupable.js
@@ -1,0 +1,63 @@
+/**
+@module ember
+@submodule ember-runtime
+*/
+
+var get = Ember.get, set = Ember.set;
+
+Ember.GroupableMixin = Ember.Mixin.create({
+  groupedContent: Ember.computed('arrangedContent', 'groupBy', function() {
+    var content = get(this, 'arrangedContent');
+    if (!content) return;
+
+    return this.group(content);
+  }),
+
+  group: function(collection) {
+    var groupsMap = {};
+    var groups = Ember.A([]);
+
+    set(this, 'groupsMap', groupsMap);
+    set(this, 'groups', groups);
+
+    collection.forEach((function(object) {
+      var group = this.groupFor(object);
+
+      if (!group) return;
+
+      group.get("content").pushObject(object);
+    }), this);
+
+    return groups;
+  },
+
+  groupFor: function(object) {
+    var group, groupName, groupType, groups, groupsMap;
+
+    groupsMap = this.get('groupsMap');
+    groups = this.get('groups');
+    groupName = this.extractGroup(object);
+
+    if (!groupName) return;
+
+    group = groupsMap[groupName];
+
+    if (!group) {
+      groupType = this.get('groupType');
+
+      group = Ember.ArrayProxy.create({
+        content: Ember.A([]),
+        name: groupName
+      })
+
+      groupsMap[groupName] = group;
+      groups.pushObject(group);
+    }
+
+    return group;
+  },
+
+  extractGroup: function(object) {
+    return get(object, get(this, 'groupBy'));
+  }
+});

--- a/packages/ember-runtime/lib/mixins/groupable.js
+++ b/packages/ember-runtime/lib/mixins/groupable.js
@@ -48,7 +48,7 @@ Ember.GroupableMixin = Ember.Mixin.create({
       group = Ember.ArrayProxy.create({
         content: Ember.A([]),
         name: groupName
-      })
+      });
 
       groupsMap[groupName] = group;
       groups.pushObject(group);
@@ -58,6 +58,10 @@ Ember.GroupableMixin = Ember.Mixin.create({
   },
 
   extractGroup: function(object) {
-    return get(object, get(this, 'groupBy'));
+    var propertyName = get(this, 'groupBy');
+
+    if (!propertyName) return;
+
+    return get(object, propertyName);
   }
 });

--- a/packages/ember-runtime/tests/mixins/groupable_test.js
+++ b/packages/ember-runtime/tests/mixins/groupable_test.js
@@ -1,0 +1,47 @@
+var get = Ember.get, set = Ember.set;
+
+module("Ember.Groupable");
+
+test("has no groups when there is no content", function() {
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+  });
+
+  var groups = get(groupedArray, 'groupedContent');
+
+  ok(!groups, "Groups empty");
+});
+
+test("groups an array according to property", function() {
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+    content: Ember.A([
+      Ember.Object.create({kind: "car", name: "Mustang"}),
+      Ember.Object.create({kind: "car", name: "Corvette"}),
+      Ember.Object.create({kind: "fruit", name: "Apple"}),
+      Ember.Object.create({kind: "fruit", name: "Orange"})
+    ])
+  });
+
+  var groups = get(groupedArray, 'groupedContent');
+
+  ok(groups, "Groups generated");
+
+  var carGroup = groups.find(function(item) {
+    return item.get('name') === 'car';
+  });
+
+  ok(carGroup, "Group generated from groupBy attribute");
+  equal("Mustang", get(carGroup, 'firstObject.name'));
+
+  equal(2, carGroup.get('length'));
+
+  var fruitGroup = groups.find(function(item) {
+    return item.get('name') === 'fruit';
+  });
+
+  ok(fruitGroup, "Group generated from groupBy attribute");
+  equal("Apple", get(fruitGroup, 'firstObject.name'));
+
+  equal(2, carGroup.get('length'));
+});

--- a/packages/ember-runtime/tests/mixins/groupable_test.js
+++ b/packages/ember-runtime/tests/mixins/groupable_test.js
@@ -1,38 +1,65 @@
 var get = Ember.get, set = Ember.set;
 
-module("Ember.Groupable");
+module('Ember.Groupable');
 
-test("has no groups when there is no content", function() {
+test('has no groups when there is no content', function() {
   var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
-    groupBy: 'kind',
+    groupBy: 'kind'
   });
 
   var groups = get(groupedArray, 'groupedContent');
 
-  ok(!groups, "Groups empty");
+  ok(Ember.isEmpty(groups), 'Groups empty');
 });
 
-test("groups an array according to property", function() {
+test('does not blow up when there is no group property', function() {
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    content: Ember.A([
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'})
+    ])
+  });
+
+  ok(Ember.isEmpty(get(groupedArray, 'groupedContent')), 'No groups');
+});
+
+test('when the group property is null', function() {
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'foo',
+    content: Ember.A([
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'})
+    ])
+  });
+
+  ok(Ember.isEmpty(get(groupedArray, 'groupedContent')), 'No groups');
+});
+
+test('groups an array according to property', function() {
   var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
     groupBy: 'kind',
     content: Ember.A([
-      Ember.Object.create({kind: "car", name: "Mustang"}),
-      Ember.Object.create({kind: "car", name: "Corvette"}),
-      Ember.Object.create({kind: "fruit", name: "Apple"}),
-      Ember.Object.create({kind: "fruit", name: "Orange"})
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'})
     ])
   });
 
   var groups = get(groupedArray, 'groupedContent');
 
-  ok(groups, "Groups generated");
+  ok(groups, 'Groups generated');
 
   var carGroup = groups.find(function(item) {
     return item.get('name') === 'car';
   });
 
-  ok(carGroup, "Group generated from groupBy attribute");
-  equal("Mustang", get(carGroup, 'firstObject.name'));
+  ok(carGroup, 'Group generated from groupBy attribute');
+  equal('Mustang', get(carGroup, 'firstObject.name'));
 
   equal(2, carGroup.get('length'));
 
@@ -40,28 +67,27 @@ test("groups an array according to property", function() {
     return item.get('name') === 'fruit';
   });
 
-  ok(fruitGroup, "Group generated from groupBy attribute");
-  equal("Apple", get(fruitGroup, 'firstObject.name'));
+  ok(fruitGroup, 'Group generated from groupBy attribute');
+  equal('Apple', get(fruitGroup, 'firstObject.name'));
 
   equal(2, carGroup.get('length'));
 });
 
-test("regenerates groups when group property changes", function() {
+test('regenerates groups when group property changes', function() {
   var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
     groupBy: 'kind',
     content: Ember.A([
-      Ember.Object.create({kind: "car", name: "Mustang"}),
-      Ember.Object.create({kind: "car", name: "Corvette"}),
-      Ember.Object.create({kind: "fruit", name: "Apple"}),
-      Ember.Object.create({kind: "fruit", name: "Orange"})
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'})
     ])
   });
 
-  var groups = get(groupedArray, 'groupedContent');
 
-  equal(2, get(groups, 'length'));
+  equal(2, get(groupedArray, 'groupedContent.length'));
 
   set(groupedArray, 'groupBy', 'name');
 
-  equal(4, get(groups, 'length'), "Groups updated by property change");
+  equal(4, get(groupedArray, 'groupedContent.length'), 'Groups updated by property change');
 });

--- a/packages/ember-runtime/tests/mixins/groupable_test.js
+++ b/packages/ember-runtime/tests/mixins/groupable_test.js
@@ -45,3 +45,23 @@ test("groups an array according to property", function() {
 
   equal(2, carGroup.get('length'));
 });
+
+test("regenerates groups when group property changes", function() {
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+    content: Ember.A([
+      Ember.Object.create({kind: "car", name: "Mustang"}),
+      Ember.Object.create({kind: "car", name: "Corvette"}),
+      Ember.Object.create({kind: "fruit", name: "Apple"}),
+      Ember.Object.create({kind: "fruit", name: "Orange"})
+    ])
+  });
+
+  var groups = get(groupedArray, 'groupedContent');
+
+  equal(2, get(groups, 'length'));
+
+  set(groupedArray, 'groupBy', 'name');
+
+  equal(4, get(groups, 'length'), "Groups updated by property change");
+});

--- a/packages/ember-runtime/tests/mixins/groupable_test.js
+++ b/packages/ember-runtime/tests/mixins/groupable_test.js
@@ -61,7 +61,7 @@ test('groups an array according to property', function() {
   ok(carGroup, 'Group generated from groupBy attribute');
   equal('Mustang', get(carGroup, 'firstObject.name'));
 
-  equal(2, carGroup.get('length'));
+  equal(carGroup.get('length'), 2);
 
   var fruitGroup = groups.find(function(item) {
     return item.get('name') === 'fruit';
@@ -70,7 +70,7 @@ test('groups an array according to property', function() {
   ok(fruitGroup, 'Group generated from groupBy attribute');
   equal('Apple', get(fruitGroup, 'firstObject.name'));
 
-  equal(2, carGroup.get('length'));
+  equal(carGroup.get('length'), 2);
 });
 
 test('regenerates groups when group property changes', function() {
@@ -84,10 +84,96 @@ test('regenerates groups when group property changes', function() {
     ])
   });
 
-
-  equal(2, get(groupedArray, 'groupedContent.length'));
+  equal(get(groupedArray, 'groupedContent.length'), 2);
 
   set(groupedArray, 'groupBy', 'name');
 
-  equal(4, get(groupedArray, 'groupedContent.length'), 'Groups updated by property change');
+  equal(get(groupedArray, 'groupedContent.length'), 4, 'Groups updated by property change');
+});
+
+test('updates groups when an object is added', function() {
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+    content: Ember.A([
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'})
+    ])
+  });
+
+  var beer = Ember.Object.create({kind: 'drink', name: 'Beer'});
+
+  equal(get(groupedArray, 'groupedContent.length'), 2);
+
+  groupedArray.pushObject(beer);
+
+  equal(get(groupedArray, 'groupedContent.length'), 3, 'Groups changed when adding');
+});
+
+test('updates groups when an object is removed', function() {
+  var beer = Ember.Object.create({kind: 'drink', name: 'Beer'});
+
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+    content: Ember.A([
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'}),
+      beer
+    ])
+  });
+
+  equal(get(groupedArray, 'groupedContent.length'), 3);
+
+  groupedArray.removeObject(beer);
+
+  equal(get(groupedArray, 'groupedContent.length'), 2, 'Groups changed when removing');
+});
+
+test('updates groups when content itself changes', function() {
+  var beer = Ember.Object.create({kind: 'drink', name: 'Beer'});
+
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+    content: Ember.A([
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'})
+    ])
+  });
+
+  equal(get(groupedArray, 'groupedContent.length'), 2);
+
+  set(groupedArray, 'content', Ember.A([beer]));
+  equal(get(groupedArray, 'groupedContent.length'), 1, 'Groups changed when content changed');
+});
+
+test('updates groups when underlying property changes', function() {
+  var beer = Ember.Object.create({kind: 'drink', name: 'Beer'});
+  var music = Ember.Object.create({kind: 'music', name: 'Trance'});
+
+  var groupedArray = Ember.ArrayProxy.createWithMixins(Ember.GroupableMixin,{
+    groupBy: 'kind',
+    content: Ember.A([
+      Ember.Object.create({kind: 'car', name: 'Mustang'}),
+      Ember.Object.create({kind: 'car', name: 'Corvette'}),
+      Ember.Object.create({kind: 'fruit', name: 'Apple'}),
+      Ember.Object.create({kind: 'fruit', name: 'Orange'}),
+      beer
+    ])
+  });
+
+  equal(get(groupedArray, 'groupedContent.length'), 3);
+
+  set(beer, 'kind', 'car');
+  equal(get(groupedArray, 'groupedContent.length'), 2, 'Groups changed when the property changes');
+
+  groupedArray.pushObject(music);
+  equal(get(groupedArray, 'groupedContent.length'), 3);
+
+  set(music, 'kind', 'car');
+  equal(get(groupedArray, 'groupedContent.length'), 2, 'Groups changed when the property changes');
 });


### PR DESCRIPTION
I've extract this from our app and added some more tests and functionality. Our initial use case was taking an array of notifications and splitting them in groups (ie: meetings, reminders, emails) for display ala  OSX notification center. Since then I've used it quite extensively in our app. I use to generate calendars and other split sections. I think other people would find this useful so I've open this PR.

`Ember.GroupableMixin` is notable because it does not implement the `arrangedContent` property. This is because it would probably screw up other things. Instead it implements `groupedContent`. This way you can use the `Ember.GroupableMixin` with `Ember.SortableMixin` or anything else.

If the core team wants this code, I'll add documentation and examples.
