### PR TITLE
computed.alias gets optional readOnly flag

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -454,15 +454,25 @@ Ember.computed.bool = function(dependentKey) {
 /**
   @method computed.alias
   @for Ember
+
+  Available options:
+
+  * `readOnly`: `true`
+
   @param {String} dependentKey
+  @param {Object} options
 */
-Ember.computed.alias = function(dependentKey) {
+Ember.computed.alias = function(dependentKey, options) {
   return Ember.computed(dependentKey, function(key, value){
-    if (arguments.length === 1) {
-      return get(this, dependentKey);
+    if (arguments.length > 1) {
+      if (options && options.readOnly){
+        throw new Error('Cannot Set: ' + key + ' on: ' + this.toString() );
+      } else{
+        set(this, dependentKey, value);
+        return value;
+      }
     } else {
-      set(this, dependentKey, value);
-      return value;
+      return get(this, dependentKey);
     }
   });
 };

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -744,3 +744,40 @@ testBoth('Ember.computed.alias', function(get, set) {
   equal(get(obj, 'baz'), 'newBaz');
   equal(get(obj, 'quz'), null);
 });
+
+testBoth('Ember.computed.alias readOnly: true', function(get, set) {
+  var obj = { bar: 'asdf', baz: null, quz: false};
+  Ember.defineProperty(obj, 'bay', Ember.computed(function(key){
+    return 'apple';
+  }));
+
+  Ember.defineProperty(obj, 'barAlias', Ember.computed.alias('bar', { readOnly: true }));
+  Ember.defineProperty(obj, 'bazAlias', Ember.computed.alias('baz', { readOnly: true }));
+  Ember.defineProperty(obj, 'quzAlias', Ember.computed.alias('quz', { readOnly: true }));
+  Ember.defineProperty(obj, 'bayAlias', Ember.computed.alias('bay', { readOnly: true }));
+
+  equal(get(obj, 'barAlias'), 'asdf');
+  equal(get(obj, 'bazAlias'), null);
+  equal(get(obj, 'quzAlias'), false);
+  equal(get(obj, 'bayAlias'), 'apple');
+
+  raises(function(){
+    set(obj, 'barAlias', 'newBar');
+  }, /Cannot Set: barAlias on:/ );
+
+  raises(function(){
+    set(obj, 'bazAlias', 'newBaz');
+  }, /Cannot Set: bazAlias on:/ );
+ 
+  raises(function(){
+    set(obj, 'quzAlias', null);
+  }, /Cannot Set: quzAlias on:/ );
+
+  equal(get(obj, 'barAlias'), 'asdf');
+  equal(get(obj, 'bazAlias'), null);
+  equal(get(obj, 'quzAlias'), false);
+
+  equal(get(obj, 'bar'), 'asdf');
+  equal(get(obj, 'baz'), null);
+  equal(get(obj, 'quz'), false);
+});


### PR DESCRIPTION
Aliasing properties is powerful, to some peoples
surprise they alias in both direction (set and get).
Usually this is the behaviour one wants but sometimes,
as https://github.com/emberjs/data/commit/7b88a92c090dddf2d554fb4d4095322f9eef8a59 suggests, this behaviour
is not always wanted.

When the read only flag is flipped on, a set will
throw and Error. Preventing the set, and providing
useful feedback.
