### PR TITLE
Deprecate Ember.run.next?

### DIFF
--- a/packages/ember-metal/tests/run_loop/next_test.js
+++ b/packages/ember-metal/tests/run_loop/next_test.js
@@ -45,3 +45,19 @@ asyncTest('multiple calls to Ember.run.next share coalesce callbacks into same r
     ok(secondRunLoop && secondRunLoop === thirdRunLoop, 'callbacks coalesced into same run loop');
   }, 20);
 });
+
+test('does not break with synchronous testing', function() {
+  var callbackHasBeenRun = false;
+
+  Ember.run(function() {
+    // This be the application's production code that is being exercised from
+    // a test suite, and it calls Ember.run.next. We'd like for the callback
+    // to have finished executing before Ember.run returns, or non-determinism
+    // happens.
+    Ember.run.next(function() {
+      callbackHasBeenRun = true;
+    });
+  });
+
+  ok(callbackHasBeenRun, 'callback is called before run loop finishes');
+});


### PR DESCRIPTION
It seems that `Ember.run.next` is mostly used to hack around ordering issues, e.g. to defer stuff until the DOM has updated.

`Ember.run.next` might be very tempting, because it's quick and easy and "basically works". But in reality, it's just `setTimeout(fn, 1)` with a lot of lipstick on it, which is to say it's non-deterministic. That's bad in many ways. In particular, it gives you lots of grief once you try to test your code.

We're not using `run.next` in Ember core at all (save for [one hackish instance in the test code](https://github.com/emberjs/ember.js/blob/1dc0735e54afdcacbc9b3da937d2ed27a90d9601/packages/ember-handlebars/tests/helpers/each_test.js#L345)).

I'm wondering if we should deprecate it. @machty suggests we should be encouraging people to use the `afterRender` queue. That seems much better.

What do you guys think?
