### PR TITLE
Correctly handle a missing leading slash.

### DIFF
--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -377,9 +377,9 @@ define("route-recognizer",
 
         // DEBUG GROUP path
 
-        var pathLen = path.length;
-
         if (path.charAt(0) !== "/") { path = "/" + path; }
+
+        var pathLen = path.length;
 
         if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
           path = path.substr(0, pathLen - 1);


### PR DESCRIPTION
When recognizing a route, the existing code first calculates `pathLen`, then adds a leading slash, immediately making `pathLen` incorrect. This causes the next operation to trim too many characters in some corner cases (ie: in the case of a single character path, see below.)

This pull request fixes the problem by swapping the two lines of code. We add the leading slash first, and **then** calculate `pathLen`.

Fiddle it here: http://jsfiddle.net/3bGN4/67/
### Old Code

``` javascript

// Assume path set to "item/1"

var pathLen = path.length;

// pathLen now set to 6.

if (path.charAt(0) !== "/") { path = "/" + path; }

// path now set to "/item/1"

if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
  path = path.substr(0, pathLen - 1);
}

// path now incorrectly set to "/item" because pathLen is incorrect. 
// Where did our :item_id go? Note that this code works correctly when :item_id is 
// two or more digits, the bug only happens when :item_id is a single digit.
```
### New Code

``` javascript

// Assume path set to "item/1"

if (path.charAt(0) !== "/") { path = "/" + path; }

// path now set to "/item/1"

var pathLen = path.length;

// pathLen now set to 7.

if (pathLen > 1 && path.charAt(pathLen - 1) === "/") {
  path = path.substr(0, pathLen - 1);
}

// path now correctly set to "/item/1"
```
