### PR TITLE
Enumerable#compact now removes undefined values

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -650,17 +650,19 @@ Ember.Enumerable = Ember.Mixin.create({
   },
 
   /**
-    Returns a copy of the array with all null elements removed.
+    Returns a copy of the array with all null and undefined elements removed.
 
     ```javascript
-    var arr = ["a", null, "c", null];
+    var arr = ["a", null, "c", undefined];
     arr.compact();  // ["a", "c"]
     ```
 
     @method compact
-    @return {Array} the array without null elements.
+    @return {Array} the array without null and undefined elements.
   */
-  compact: function() { return this.without(null); },
+  compact: function() {
+    return this.filter(function(value) { return value != null; });
+  },
 
   /**
     Returns a new enumerable that excludes the passed value. The default

--- a/packages/ember-runtime/tests/suites/enumerable/compact.js
+++ b/packages/ember-runtime/tests/suites/enumerable/compact.js
@@ -4,9 +4,8 @@ var suite = Ember.EnumerableTests;
 
 suite.module('compact');
 
-suite.test('removes null values from enumerable', function() {
-  var obj = this.newObject([null, 1, null]);
+suite.test('removes null and undefined values from enumerable', function() {
+  var obj = this.newObject([null, 1, false, '', undefined, 0, null]);
   var ary = obj.compact();
-  equal(ary[0], 1);
-  equal(ary.length, 1);
+  deepEqual(ary, [1, false, '', 0]);
 });

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -38,8 +38,8 @@ test("addObjects - adds to end of 'content' if not present", function() {
   deepEqual(array.get('arrangedContent'), [6,5,4,3,2,1], 'arrangedContent stays sorted');
 });
 
-test("compact - returns arrangedContent without nulls", function() {
-  Ember.run(function() { array.set('content', Ember.A([1,3,null,2])); });
+test("compact - returns arrangedContent without nulls and undefined", function() {
+  Ember.run(function() { array.set('content', Ember.A([1,3,null,2,undefined])); });
   deepEqual(array.compact(), [3,2,1]);
 });
 


### PR DESCRIPTION
`Enumerable#compact` removes only null values, leaving undefined values in the array.
It may be unexpected for someone (like it was for me), could lead to hard-to-debug bugs and generally reduces usefulness of this method.

I'm not sure what's the reason for this behavior, but if there is none, I hope nobody is relying on this and it could be changed without breaking anything.
