### PR TITLE
ApplicationView with template set and templateName unset fails to render

### DIFF
--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -191,6 +191,28 @@ test("ApplicationView is inserted into the page", function() {
   equal(Ember.$("#qunit-fixture").text(), "Hello!");
 });
 
+test("ApplicationView template without templateName set", function() {
+  Ember.$("#qunit-fixture").empty();
+
+  Ember.run(function() {
+    app = Ember.Application.create({
+      rootElement: "#qunit-fixture"
+    });
+
+    app.Router.reopen({
+      location: "none"
+    });
+
+    app.ApplicationView = Ember.View.extend({
+      template: function() {
+        return "<h1>DOM DOM DOM DOM</h1>";
+      }
+    });
+  });
+
+  equal(Ember.$("#qunit-fixture h1").text(), "DOM DOM DOM DOM");
+});
+
 test("Application initialized twice raises error", function() {
   Ember.run(function() {
     app = Ember.Application.create({


### PR DESCRIPTION
If desired, I can wip up a jsfiddle/jsbin for this as well, but I figured the test would be sufficient to illustrate the point.

In short, when an ApplicationView has a template function set - and that alone - the view fails to render. However, if you set `templateName` to any random string - doesn't have to map to a template -, the view will render.

From [a comment in the annotated source](https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/views/view.js#L818-819), I know it's suggested to use `templateName` over `template`. I can certainly work around it. Worth noting, all the same.
