### PR TITLE
Ability to specify the view class used by the outlet Handlebars helper

### DIFF
--- a/packages/ember-routing/lib/helpers/outlet.js
+++ b/packages/ember-routing/lib/helpers/outlet.js
@@ -58,13 +58,27 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     });
     ```
 
+    You can specify the view class that the outlet uses to contain and manage the
+    templates rendered into it.
+
+    ``` handlebars
+    {{outlet viewClass=App.SectionContainer}}
+    ```
+
+    ``` javascript
+    App.SectionContainer = Ember.ContainerView.extend({
+      tagName: 'section',
+      classNames: ['special']
+    });
+    ```
+
     @method outlet
     @for Ember.Handlebars.helpers
     @param {String} property the property on the controller
       that holds the view for this outlet
   */
   Handlebars.registerHelper('outlet', function(property, options) {
-    var outletSource;
+    var outletSource, outletContainerClass;
 
     if (property && property.data && property.data.isRenderData) {
       options = property;
@@ -76,9 +90,11 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       outletSource = outletSource.get('_parentView');
     }
 
+    outletContainerClass = options.hash.viewClass || Handlebars.OutletView;
+
     options.data.view.set('outletSource', outletSource);
     options.hash.currentViewBinding = '_view.outletSource._outlets.' + property;
 
-    return Handlebars.helpers.view.call(this, Handlebars.OutletView, options);
+    return Handlebars.helpers.view.call(this, outletContainerClass, options);
   });
 });

--- a/packages/ember-routing/tests/helpers/outlet_test.js
+++ b/packages/ember-routing/tests/helpers/outlet_test.js
@@ -73,6 +73,33 @@ test("outlet should support an optional name", function() {
   equal(view.$().text().replace(/\s+/,''), 'HIBYE');
 });
 
+
+test("outlet should support an optional view class", function() {
+  var template = "<h1>HI</h1>{{outlet viewClass=view.outletView}}";
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(template),
+    outletView: Ember.ContainerView.extend()
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'HI');
+
+  var childView = Ember.View.create({
+    template: compile("<p>BYE</p>")
+  });
+
+  Ember.run(function() {
+    view.connectOutlet('main', childView);
+  });
+
+  ok(view.outletView.detectInstance(childView.get('_parentView')), "The custom view class should be used for the outlet");
+
+  // Replace whitespace for older IE
+  equal(view.$().text().replace(/\s+/,''), 'HIBYE');
+});
+
+
 test("Outlets bind to the current view, not the current concrete view", function() {
   var parentTemplate = "<h1>HI</h1>{{outlet}}";
   var middleTemplate = "<h2>MIDDLE</h2>{{outlet}}";


### PR DESCRIPTION
Currently, the `{{outlet}}` Handlebars helper always creates an "OutletView" (Metamorph extension of ContainerView) that manages the views rendered into the outlet.  While this handles simple view replacement on navigation (through connectOutlet class in routes, for example) it makes it difficult to animate between views since the outgoing view is immediately destroyed upon connecting the incoming view.

This change allows the view class used by the outlet to be set.  A simple use case is animating between views rendered into an outlet on a route change.  E.g. sliding (jQuery mobile-style) between master-detail views.  The pseudocode for a naive replacement outlet container view for this would be something like:

``` handlebars
{{outlet viewClass=App.SlideContainer}}
```

``` javascript
App.SlideContainer = Ember.ContainerView.extend({
  _currentViewWillChange: Ember.beforeObserver(function() {
    // Hold on to old view
  }, 'currentView'),

  _currentViewDidChange: Ember.observer(function() {
    // Append new current view to container
    // Slide all views in container to the left
    // When animation is complete, destroy old view
  }, 'currentView')
});
```

PR #1034 addressed a similar issue but in @c0urg3tt3's case the problem could be easily solved by specifying `tagName` and other general view properties in the outlet helper call (since it's an extension of the view helper).  The problem being addressed here involves the need for custom view lifecycle handling code that requires replacing, not adding bindings to a hardcoded `OutletView` class.

PR #1046 appears to be somewhat of a duplicate of #1034.  @wycats' [proposed solution](https://github.com/emberjs/ember.js/pull/1046#issuecomment-6497862) does allow a custom class to be used but no longer is a sufficient replacement for the role of an outlet since the base view helper does not find and set the `outletSource` property of the parent view.
