### PR TITLE
Fix for using {{render}} with same template multiple times

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -44,7 +44,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     container = options.data.keywords.controller.container;
     router = container.lookup('router:main');
 
-    Ember.assert("This view is already rendered", !router || !router._lookupActiveView(name));
+    Ember.assert("You can only use the {{render}} helper once without a model object as its second argument, as in {{render \"post\" post}}.", context || !router || !router._lookupActiveView(name));
 
     view = container.lookup('view:' + name) || container.lookup('view:default');
 
@@ -72,7 +72,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     options.hash.template = container.lookup('template:' + name);
     options.hash.controller = controller;
 
-    if (router && !contextString) {
+    if (router && !context) {
       router._connectActiveView(name, view);
     }
 


### PR DESCRIPTION
Yehuda added support for using `{{render}}` with same template multiple times with different models in 47dfe5ed39bade9f261b9049e7e5636bf056d718. But when using it, Ember threw an assertion error, `"This view is already rendered"`, for everything but the first `{{render}}` call.

This should be fixed now, and I added a test for it and adjusted the assertion error message.
