### PR TITLE
Add 'name' to attributeBinding for form controls

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -51,7 +51,7 @@ Ember.Checkbox = Ember.View.extend({
 
   tagName: 'input',
 
-  attributeBindings: ['type', 'checked', 'disabled', 'tabindex'],
+  attributeBindings: ['type', 'checked', 'disabled', 'tabindex', 'name'],
 
   type: "checkbox",
   checked: false,

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -266,7 +266,7 @@ Ember.Select = Ember.View.extend(
   tagName: 'select',
   classNames: ['ember-select'],
   defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#each view.content}}{{view Ember.SelectOption contentBinding="this"}}{{/each}}'),
-  attributeBindings: ['multiple', 'disabled', 'tabindex'],
+  attributeBindings: ['multiple', 'disabled', 'tabindex', 'name'],
 
   /**
     The `multiple` attribute of the select element. Indicates whether multiple

--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -46,7 +46,7 @@ Ember.TextArea = Ember.View.extend(Ember.TextSupport, {
   classNames: ['ember-text-area'],
 
   tagName: "textarea",
-  attributeBindings: ['rows', 'cols'],
+  attributeBindings: ['rows', 'cols', 'name'],
   rows: null,
   cols: null,
 

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -53,7 +53,7 @@ Ember.TextField = Ember.View.extend(Ember.TextSupport,
 
   classNames: ['ember-text-field'],
   tagName: "input",
-  attributeBindings: ['type', 'value', 'size', 'pattern'],
+  attributeBindings: ['type', 'value', 'size', 'pattern', 'name'],
 
   /**
     The `value` attribute of the input element. As the user inputs text, this

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -61,6 +61,18 @@ test("should support the tabindex property", function() {
   equal(checkboxView.$().prop('tabindex'), '3', 'the checkbox tabindex changes when it is changed in the view');
 });
 
+test("checkbox name is updated when setting name property of view", function() {
+  checkboxView = Ember.Checkbox.create({});
+
+  Ember.run(function() { checkboxView.set('name', 'foo'); });
+  append();
+
+  equal(checkboxView.$().attr('name'), "foo", "renders checkbox with the name");
+
+  Ember.run(function() { checkboxView.set('name', 'bar'); });
+
+  equal(checkboxView.$().attr('name'), "bar", "updates checkbox after name changes");
+});
 
 test("checked property mirrors input value", function() {
   checkboxView = Ember.Checkbox.create({});

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -84,6 +84,17 @@ test("select tabindex is updated when setting tabindex property of view", functi
   equal(select.$().attr('tabindex'), "1", "updates select after tabindex changes");
 });
 
+test("select name is updated when setting name property of view", function() {
+  Ember.run(function() { select.set('name', 'foo'); });
+  append();
+
+  equal(select.$().attr('name'), "foo", "renders select with the name");
+
+  Ember.run(function() { select.set('name', 'bar'); });
+
+  equal(select.$().attr('name'), "bar", "updates select after name changes");
+});
+
 test("can specify the property path for an option's label and value", function() {
   select.set('content', Ember.A([
     { id: 1, firstName: 'Yehuda' },

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -70,6 +70,19 @@ test("input placeholder is updated when setting placeholder property of view", f
   equal(textArea.$().attr('placeholder'), "bar", "updates text area after placeholder changes");
 });
 
+test("input name is updated when setting name property of view", function() {
+  Ember.run(function() {
+    set(textArea, 'name', 'foo');
+    textArea.append();
+  });
+
+  equal(textArea.$().attr('name'), "foo", "renders text area with name");
+
+  Ember.run(function() { set(textArea, 'name', 'bar'); });
+
+  equal(textArea.$().attr('name'), "bar", "updates text area after name changes");
+});
+
 test("input maxlength is updated when setting maxlength property of view", function() {
   Ember.run(function() {
     set(textArea, 'maxlength', '300');

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -70,6 +70,19 @@ test("input placeholder is updated when setting placeholder property of view", f
   equal(textField.$().attr('placeholder'), "bar", "updates text field after placeholder changes");
 });
 
+test("input name is updated when setting name property of view", function() {
+  Ember.run(function() {
+    set(textField, 'name', 'foo');
+    textField.append();
+  });
+
+  equal(textField.$().attr('name'), "foo", "renders text field with name");
+
+  Ember.run(function() { set(textField, 'name', 'bar'); });
+
+  equal(textField.$().attr('name'), "bar", "updates text field after name changes");
+});
+
 test("input maxlength is updated when setting maxlength property of view", function() {
   Ember.run(function() {
     set(textField, 'maxlength', '30');


### PR DESCRIPTION
I understand this idea was rejected a while ago: https://github.com/emberjs/ember.js/issues/794

However, the argument in that issue was over other JS libraries that rely on the `name` property.

I believe `name` should be added to the attributeBindings because browsers rely upon it being there to prefill data.
