### PR TITLE
Actions should be unregistered when destroying virtual views

### DIFF
--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -282,7 +282,6 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
         contexts = a_slice.call(arguments, 1, -1);
 
     var hash = options.hash,
-        view = options.data.view,
         controller;
 
     // create a hash to pass along to registerAction
@@ -296,7 +295,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       params: contexts
     };
 
-    action.view = view = get(view, 'concreteView');
+    action.view = options.data.view;
 
     var root, target;
 

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -380,6 +380,28 @@ test("should unregister event handlers on rerender", function() {
   ok(Ember.Handlebars.ActionHelper.registeredActions[newActionId], "After rerender completes, a new event handler was added");
 });
 
+test("should unregister event handlers on inside virtual views", function() {
+  var things = Ember.A([
+    {
+      name: 'Thingy'
+    }
+  ]);
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#each view.things}}<a href="#" {{action "edit"}}>click me</a>{{/each}}'),
+    things: things
+  });
+
+  appendView();
+
+  var actionId = view.$('a[data-ember-action]').attr('data-ember-action');
+
+  Ember.run(function() {
+    things.removeAt(0);
+  });
+
+  ok(!Ember.Handlebars.ActionHelper.registeredActions[actionId], "After the virtual view was destroyed, the action was unregistered");
+});
+
 test("should properly capture events on child elements of a container with an action", function() {
   var eventHandlerWasCalled = false;
 


### PR DESCRIPTION
With a template like:

``` handlebars
{{#each view.things}}
  <a href="#" {{action "edit"}}>click me</a>
{{/each}}
```

When an item was removed from `things`, its action wasn't removed from `Ember.Handlebars.ActionHelper.registeredActions`.
