### PR TITLE
Make {{partial}} and {{template}} helpers lookup templates using templateForName

### DIFF
--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -7,7 +7,7 @@ require('ember-handlebars/ext');
 
 /**
   `partial` renders a template directly using the current context.
-  If needed the context can be set using the `{{#with foo}}` helper. 
+  If needed the context can be set using the `{{#with foo}}` helper.
 
   ```html
   <script type="text/x-handlebars" data-template-name="header_bar">
@@ -36,10 +36,10 @@ Ember.Handlebars.registerHelper('partial', function(name, options) {
 
   nameParts[nameParts.length - 1] = "_" + lastPart;
 
-  var underscoredName = nameParts.join("/");
-
-  var template = Ember.TEMPLATES[underscoredName],
-      deprecatedTemplate = Ember.TEMPLATES[name];
+  var view = options.data.view,
+      underscoredName = nameParts.join("/"),
+      template = view.templateForName(underscoredName),
+      deprecatedTemplate = view.templateForName(name);
 
   Ember.deprecate("You tried to render the partial " + name + ", which should be at '" + underscoredName + "', but Ember found '" + name + "'. Please use a leading underscore in your partials", template);
   Ember.assert("Unable to find partial with name '"+name+"'.", template || deprecatedTemplate);

--- a/packages/ember-handlebars/lib/helpers/template.js
+++ b/packages/ember-handlebars/lib/helpers/template.js
@@ -49,9 +49,10 @@ require('ember-handlebars/ext');
 */
 
 Ember.Handlebars.registerHelper('template', function(name, options) {
-  var template = Ember.TEMPLATES[name];
+  var view = options.data.view,
+      template = view.templateForName(name);
 
   Ember.assert("Unable to find template with name '"+name+"'.", !!template);
 
-  Ember.TEMPLATES[name](this, { data: options.data });
+  template(this, { data: options.data });
 });

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -2276,48 +2276,6 @@ test("should not enter an infinite loop when binding an attribute in Handlebars"
   });
 });
 
-test("should render other templates using the {{template}} helper", function() {
-  Ember.TEMPLATES.sub_template = Ember.Handlebars.compile("sub-template");
-
-  view = Ember.View.create({
-    template: Ember.Handlebars.compile('This {{template "sub_template"}} is pretty great.')
-  });
-
-  Ember.run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-
-  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
-});
-
-test("should render other templates using the {{partial}} helper", function() {
-  Ember.TEMPLATES._subTemplate = Ember.Handlebars.compile("sub-template");
-
-  view = Ember.View.create({
-    template: Ember.Handlebars.compile('This {{partial "subTemplate"}} is pretty great.')
-  });
-
-  Ember.run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-
-  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
-});
-
-test("should render other slash-separated templates using the {{partial}} helper", function() {
-  Ember.TEMPLATES["child/_subTemplate"] = Ember.Handlebars.compile("sub-template");
-
-  view = Ember.View.create({
-    template: Ember.Handlebars.compile('This {{partial "child/subTemplate"}} is pretty great.')
-  });
-
-  Ember.run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-
-  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
-});
-
 test("should update bound values after the view is removed and then re-appended", function() {
   view = Ember.View.create({
     template: Ember.Handlebars.compile("{{#if view.showStuff}}{{view.boundValue}}{{else}}Not true.{{/if}}"),

--- a/packages/ember-handlebars/tests/helpers/partial_test.js
+++ b/packages/ember-handlebars/tests/helpers/partial_test.js
@@ -1,0 +1,68 @@
+var MyApp;
+var originalLookup = Ember.lookup, lookup, TemplateTests, view, container;
+
+module("Support for {{partial}} helper", {
+  setup: function(){
+    Ember.lookup = lookup = { Ember: Ember };
+    MyApp = lookup.MyApp = Ember.Object.create({});
+    container = new Ember.Container();
+    container.optionsForType('template', { instantiate: false });
+  },
+  teardown: function(){
+    Ember.run(function() {
+      if (view) {
+        view.destroy();
+      }
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("should render other templates registered with the container", function() {
+  container.register('template:_subTemplateFromContainer', Ember.Handlebars.compile('sub-template'));
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('This {{partial "subTemplateFromContainer"}} is pretty great.')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
+});
+
+test("should render other slash-separated templates registered with the container", function() {
+  container.register('template:child/_subTemplateFromContainer', Ember.Handlebars.compile("sub-template"));
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('This {{partial "child/subTemplateFromContainer"}} is pretty great.')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
+});
+
+test("should use the current view's context", function(){
+  container.register('template:_person_name', Ember.Handlebars.compile("{{{firstName}} {{lastName}}"));
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('Who is {{partial "person_name"}}?')
+  });
+  view.set('controller', Ember.Object.create({
+    firstName: 'Kris',
+    lastName: 'Selden'
+  }));
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "Who is Kris Selden?");
+});

--- a/packages/ember-handlebars/tests/helpers/template_test.js
+++ b/packages/ember-handlebars/tests/helpers/template_test.js
@@ -1,0 +1,53 @@
+var MyApp;
+var originalLookup = Ember.lookup, lookup, TemplateTests, view, container;
+
+module("Support for {{template}} helper", {
+  setup: function(){
+    Ember.lookup = lookup = { Ember: Ember };
+    MyApp = lookup.MyApp = Ember.Object.create({});
+    container = new Ember.Container();
+    container.optionsForType('template', { instantiate: false });
+  },
+  teardown: function(){
+    Ember.run(function() {
+      if (view) {
+        view.destroy();
+      }
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("should render other templates via the container", function() {
+  container.register('template:sub_template_from_container', Ember.Handlebars.compile('sub-template'));
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('This {{template "sub_template_from_container"}} is pretty great.')
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
+});
+
+test("should use the current view's context", function(){
+  container.register('template:person_name', Ember.Handlebars.compile("{{{firstName}} {{lastName}}"));
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('Who is {{template "person_name"}}?')
+  });
+  view.set('controller', Ember.Object.create({
+    firstName: 'Kris',
+    lastName: 'Selden'
+  }));
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "Who is Kris Selden?");
+});


### PR DESCRIPTION
This commit changes the implementation of the `{{partial}}` and `{{template}}` helpers to lookup templates using the view's `templateForName` method, like other template lookups, rather than directly from `Ember.TEMPLATES`. This will make it play nicely with container-registered templates.

Fixes #2295
