### PR TITLE
Observer targetActions follow paths

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -2,6 +2,8 @@ require('ember-metal/core');
 require('ember-metal/platform');
 require('ember-metal/utils');
 
+var get = Ember.get;
+
 /**
 @module ember-metal
 */
@@ -319,7 +321,9 @@ function sendEvent(obj, eventName, params, actions) {
 
     if (once) { removeListener(obj, eventName, target, method); }
     if (!target) { target = obj; }
-    if ('string' === typeof method) { method = target[method]; }
+    if ('string' === typeof method) {
+      method = get(target, method);
+    }
     if (params) {
       method.apply(target, params);
     } else {

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -85,3 +85,21 @@ testBoth("should be able to retrieve cached values of computed properties withou
 
   equal(obj.cacheFor('bar'), undefined, "returns undefined if the value is not a computed property");
 });
+
+test('should be able to follow path for targetAction', function() {
+  var model = Ember.Object.create();
+  var Route = Ember.Object.extend({
+    events: {
+      action1: function() {
+        model.addObserver('id', this, 'events.action2');
+        model.set('id', 1);
+      },
+      action2: function() {
+        model.set('id', 2);
+      }
+    }
+  });
+  var route = Route.create();
+  route.events.action1.call(route);
+  equal(model.get('id'), 2, 'Observer should have followed path');
+});


### PR DESCRIPTION
When setting observers with targetActions inside a Route's event hash
the targetAction function was not being properly called.

example:

``` js
App.NewRecordRoute = Ember.Route.extend({
  events: {
    submit: function() {
      this.controller.get('content').addObserver('id', this, 'afterCreate');
      this.controller.get('strore').commit();
    },
    afterCreate: function() {
      this.controller.get('content').removeObserver('id', this, 'afterCreate');
    }
  }
});
```

because `this` is the scope of the instance of `NewRecordRoute` the `afterCreate` function is actually under `this.events`. So we should properly write it as:

``` js
App.NewRecordRoute = Ember.Route.extend({
  events: {
    submit: function() {
      this.controller.get('content').addObserver('id', this, 'events.afterCreate');
      this.controller.get('strore').commit();
    },
    afterCreate: function() {
      this.controller.get('content').removeObserver('id', this, 'events.afterCreate');
    }
  }
});
```

However currently this doesn't work. This PR will allow the paths to be followed.
