### PR TITLE
remove "~YUIDOC_LINE~!" from generated documentation

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -445,8 +445,7 @@ function invokeLaterTimers() {
     If you pass a string it will be resolved on the
     target at the time the method is invoked.
   @param {Object} [args*] Optional arguments to pass to the timeout.
-  @param {Number} wait
-    Number of milliseconds to wait.
+  @param {Number} wait Number of milliseconds to wait.
   @return {String} a string you can use to cancel the timer in
     {{#crossLink "Ember/run.cancel"}}{{/crossLink}} later.
 */


### PR DESCRIPTION
You can read the commit for a description of why the issue happened. Here's a screenshot of what it looks like now in my middleman local server: http://cl.ly/image/1K080O2H0r3k
