### PR TITLE
render action was declared as @method action

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -20,10 +20,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     The default target for `{{action}}`s in the rendered template is the
     named controller.
 
-    @method action
+    @method render
     @for Ember.Handlebars.helpers
-    @param {String} actionName
-    @param {Object?} model
+    @param {String} name
+    @param {Object?} contextString
     @param {Hash} options
   */
   Ember.Handlebars.registerHelper('render', function(name, contextString, options) {


### PR DESCRIPTION
fixes this typo for the 1.0 rc1 branch.

Not sure how to do a pull request for the tag, sorry.  I don't think I can.

This is just a pull of https://github.com/emberjs/ember.js/commit/5e55780ea577bdb1b3146e6711a4a241a87d5113#packages/ember-routing/lib/helpers/render.js to the rc1 commit. If you prefer that commit, it should cherry pick cleanly.

This one is just on top of the HEAD commit for the rc1 tag.

fixes emberjs/website#378
