### PR TITLE
fallback for browsers that don't support domElement.outerHTML

### DIFF
--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -450,7 +450,9 @@ Ember._RenderBuffer.prototype =
   */
   string: function() {
     if (this._element) {
-      return this.element().outerHTML;
+      // Firefox versions < 11 do not have support for element.outerHTML.
+      return this.element().outerHTML ||
+        new XMLSerializer().serializeToString(this.element());
     } else {
       return this.innerString();
     }

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -105,9 +105,11 @@ var setInnerHTML = function(element, html) {
   if (canSetInnerHTML(tagName)) {
     setInnerHTMLWithoutFix(element, html);
   } else {
-    Ember.assert("Can't set innerHTML on "+element.tagName+" in this browser", element.outerHTML);
+    // Firefox versions < 11 do not have support for element.outerHTML.
+    var outerHTML = element.outerHTML || new XMLSerializer().serializeToString(element);
+    Ember.assert("Can't set innerHTML on "+element.tagName+" in this browser", outerHTML);
 
-    var startTag = element.outerHTML.match(new RegExp("<"+tagName+"([^>]*)>", 'i'))[0],
+    var startTag = outerHTML.match(new RegExp("<"+tagName+"([^>]*)>", 'i'))[0],
         endTag = '</'+tagName+'>';
 
     var wrapper = document.createElement('div');

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -87,6 +87,15 @@ test("handles null props - Issue #2019", function() {
   equal('<span></span><div>', buffer.string());
 });
 
+test("handles browsers like Firefox < 11 that don't support outerHTML Issue #1952", function(){
+  var buffer = new Ember.RenderBuffer('div');
+  buffer.pushOpeningTag();
+  // Make sure element.outerHTML is falsy to trigger the fallback.
+  var elementStub = '<div></div>';
+  buffer.element = function(){ return elementStub; };
+  equal(new XMLSerializer().serializeToString(elementStub), buffer.string());
+});
+
 module("Ember.RenderBuffer - without tagName");
 
 test("It is possible to create a RenderBuffer without a tagName", function() {


### PR DESCRIPTION
If you look at the element.outerHTML page below, `outer.outerHTML` is available in most browsers, just not Firefox versions < 11. Even old IE has it. 

Also let me know if I can improve the test. I tried deleting the `outerHTML` property from the element, but that raised an exception. I tried also stubbing `XMLSerializer` by redefining it on `window`, which also threw an exception.

I know that the string I provide in the test is not **really** a DOM element, but I'm stuck on how to stub this out in a better way. Happy for suggestions.

Resources:

http://stackoverflow.com/questions/1700870/how-do-i-do-outerhtml-in-firefox
https://developer.mozilla.org/en-US/docs/XMLSerializer
https://developer.mozilla.org/en-US/docs/DOM/element.outerHTML

EDIT: http://jsfiddle.net/RCLd7/14/ <- This is the updated version of ember+handlebars from the original issue that I tested in Firefox 10.

fixes emberjs/ember.js#1952
