### PR TITLE
Fix Firefox <= 10 missing outerHTML

### DIFF
--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -450,7 +450,21 @@ Ember._RenderBuffer.prototype =
   */
   string: function() {
     if (this._element) {
-      return this.element().outerHTML;
+
+      // If there is no outerHTML (eg Firefox <= 10)
+      // use a fallback mechanism.
+      if(Ember.isNone(this.element().outerHTML)) {
+        
+        var div = document.createElement('div');
+          div.appendChild(this.element().cloneNode(true));
+          var contents = div.innerHTML;
+          div = null;
+          return contents;
+
+      } else {
+        return this.element().outerHTML;
+      }
+
     } else {
       return this.innerString();
     }


### PR DESCRIPTION
In Firefox <= 10 there is no outerHTML, as a workaround we wrap the element with a div and return the wrapped elements innerHTML.

It looks ugly to me and someone with more insight might find a better solution, but it works for me.

This fixes https://github.com/emberjs/ember.js/issues/1993 for me
