### PR TITLE
Avoid parent's implicit index route clobbering child's explicit index.

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -33,7 +33,8 @@ DSL.prototype = {
   },
 
   push: function(url, name, callback) {
-    if (url === "" || url === "/") { this.explicitIndex = true; }
+    var parts = name.split('.');
+    if (url === "" || url === "/" || parts[parts.length-1] === "index") { this.explicitIndex = true; }
 
     this.matches.push([url, name, callback]);
   },

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1572,3 +1572,25 @@ test("Generated route should be an instance of App.Route if provided", function(
   ok(generatedRoute instanceof App.Route, 'should extend the correct route');
 
 });
+
+test("Nested index route is not overriden by parent's implicit index route", function() {
+  Router.map(function() {
+    this.resource('posts', function() {
+      this.route('index', { path: ':category' } );
+    });
+  });
+
+  App.Route = Ember.Route.extend({
+    serialize: function(model) {
+      return { category: model.category };
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.transitionTo('posts', { category: 'emberjs' });
+  });
+
+  deepEqual(router.location.path, '/posts/emberjs');
+});


### PR DESCRIPTION
Fixes emberjs/ember.js#2318.
