### PR TITLE
Ember.Application instances are now Deferreds. 

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -152,7 +152,8 @@ var get = Ember.get, set = Ember.set,
   @namespace Ember
   @extends Ember.Namespace
 */
-var Application = Ember.Application = Ember.Namespace.extend({
+
+var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin, {
 
   /**
     The root DOM element of the Application. This can be specified as an
@@ -486,6 +487,8 @@ var Application = Ember.Application = Ember.Namespace.extend({
       Ember.Namespace.processAll();
       Ember.BOOTED = true;
     }
+
+    this.resolve(this);
   },
 
   /**

--- a/packages/ember-application/tests/system/readiness_test.js
+++ b/packages/ember-application/tests/system/readiness_test.js
@@ -56,80 +56,120 @@ module("Application readiness", {
 // it was triggered after initialization.
 
 test("Ember.Application's ready event is called right away if jQuery is already ready", function() {
+  var wasResolved = 0;
   jQuery.isReady = true;
 
   Ember.run(function() {
     application = Application.create({ router: false });
+    application.then(function(){
+      wasResolved++;
+    });
+
     equal(readyWasCalled, 0, "ready is not called until later");
+    equal(wasResolved, 0);
   });
 
+  equal(wasResolved, 1);
   equal(readyWasCalled, 1, "ready was called");
 
   Ember.run(function() {
     domReady();
   });
 
+  equal(wasResolved, 1);
   equal(readyWasCalled, 1, "application's ready was not called again");
 });
 
 test("Ember.Application's ready event is called after the document becomes ready", function() {
+  var wasResolved = 0;
   Ember.run(function() {
     application = Application.create({ router: false });
+    application.then(function(){
+      wasResolved++;
+    });
+    equal(wasResolved, 0);
   });
 
   equal(readyWasCalled, 0, "ready wasn't called yet");
+  equal(wasResolved, 0);
 
   Ember.run(function() {
     domReady();
+    equal(wasResolved, 0);
   });
 
+  equal(wasResolved, 1);
   equal(readyWasCalled, 1, "ready was called now that DOM is ready");
 });
 
 test("Ember.Application's ready event is called after the document becomes ready without initialize if autoinit is set", function() {
+  var wasResolved = 0;
   Ember.run(function() {
     application = Application.create({
       router: false,
       autoinit: true
     });
+    application.then(function(){
+      wasResolved++;
+    });
+    equal(wasResolved, 0);
   });
 
   equal(readyWasCalled, 0, "ready wasn't called yet");
+  equal(wasResolved, 0);
 
   Ember.run(function() {
     domReady();
+    equal(wasResolved, 0);
   });
 
+  equal(wasResolved, 1);
   equal(readyWasCalled, 1, "ready was called now that DOM is ready");
 });
 
 test("Ember.Application's ready event can be deferred by other components", function() {
+  var wasResolved = 0;
+
   Ember.run(function() {
     application = Application.create({ router: false });
+    application.then(function(){
+      wasResolved++;
+    });
     application.deferReadiness();
+    equal(wasResolved, 0);
   });
 
   equal(readyWasCalled, 0, "ready wasn't called yet");
 
   Ember.run(function() {
     domReady();
+    equal(wasResolved, 0);
   });
 
   equal(readyWasCalled, 0, "ready wasn't called yet");
+  equal(wasResolved, 0);
 
   Ember.run(function() {
     application.advanceReadiness();
+    equal(readyWasCalled, 0);
+    equal(wasResolved, 0);
   });
 
+  equal(wasResolved, 1);
   equal(readyWasCalled, 1, "ready was called now all readiness deferrals are advanced");
 });
 
 test("Ember.Application's ready event can be deferred by other components", function() {
+  var wasResolved = 0;
   jQuery.isReady = false;
 
   Ember.run(function() {
     application = Application.create({ router: false });
     application.deferReadiness();
+    application.then(function(){
+      wasResolved++;
+    });
+    equal(wasResolved, 0);
   });
 
   Ember.run(function() {
@@ -140,8 +180,10 @@ test("Ember.Application's ready event can be deferred by other components", func
 
   Ember.run(function() {
     application.advanceReadiness();
+    equal(wasResolved, 0);
   });
 
+  equal(wasResolved, 1);
   equal(readyWasCalled, 1, "ready was called now all readiness deferrals are advanced");
 
   raises(function() {


### PR DESCRIPTION
``` javascript
app = Ember.Application.create()
app.then(function(){
  // will fire when the appDidBoot
  // very similar to #ready
});
```

can be used to prevent test runs
before the app is ready.

``` javascript
before(function(done){
  app.then(done);
});
```
