### PR TITLE
Ensure lookup returns same object when using different formats

### DIFF
--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -302,8 +302,13 @@ module("Ember.Application Depedency Injection", {
 });
 
 test('container lookup is normalized', function() {
+  var dotNotationController = locator.lookup('controller:post.index');
+  var camelCaseController = locator.lookup('controller:postIndex');
+
   ok(locator.lookup('controller:post.index') instanceof application.PostIndexController);
   ok(locator.lookup('controller:postIndex') instanceof application.PostIndexController);
+
+  equal(dotNotationController, camelCaseController);
 });
 
 test('registered entities can be looked up later', function(){


### PR DESCRIPTION
Regression test. Currently this is only tested with `instanceOf`. This test ensures that the container returns the same object and just one of the same type.
