### PR TITLE
Add template namespace

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -170,6 +170,19 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   */
   rootElement: 'body',
 
+
+  /**
+    The template namespace which will be used as a prefix to all template name lookups.
+
+    For example when templateNamespace is "foo", the application template will become
+    "foo/application".
+
+    @property templateNamespace
+    @type String
+    @default null
+  */
+  templateNamespace: null,
+
   /**
     The `Ember.EventDispatcher` responsible for delegating events to this
     application's views.

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -85,6 +85,7 @@ Ember.DefaultResolver = Ember.Object.extend({
     @property namespace
   */
   namespace: null,
+
   /**
     This method is called via the container's resolver method.
     It parses the provided `fullName` and then looks up and
@@ -145,6 +146,10 @@ Ember.DefaultResolver = Ember.Object.extend({
   resolveTemplate: function(parsedName) {
     var templateName = parsedName.fullNameWithoutType.replace(/\./g, '/');
 
+    if (this.namespace.templateNamespace) {
+      templateName = this.namespace.templateNamespace + '/' + templateName;
+    }
+
     if (Ember.TEMPLATES[templateName]) {
       return Ember.TEMPLATES[templateName];
     }
@@ -154,6 +159,7 @@ Ember.DefaultResolver = Ember.Object.extend({
       return Ember.TEMPLATES[templateName];
     }
   },
+
   /**
     Given a parseName object (output from `parseName`), apply
     the conventions expected by `Ember.Router`
@@ -167,6 +173,7 @@ Ember.DefaultResolver = Ember.Object.extend({
       parsedName.name = '';
     }
   },
+
   /**
     @protected
     @method resolveController
@@ -175,6 +182,7 @@ Ember.DefaultResolver = Ember.Object.extend({
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
   },
+
   /**
     @protected
     @method resolveRoute
@@ -183,6 +191,7 @@ Ember.DefaultResolver = Ember.Object.extend({
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
   },
+
   /**
     @protected
     @method resolveView
@@ -191,6 +200,7 @@ Ember.DefaultResolver = Ember.Object.extend({
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
   },
+
   /**
     Look up the specified object (from parsedName) on the appropriate
     namespace (usually on the Application)
@@ -203,4 +213,5 @@ Ember.DefaultResolver = Ember.Object.extend({
         factory = get(parsedName.root, className);
     if (factory) { return factory; }
   }
+
 });

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -410,3 +410,43 @@ test('normalization is indempotent', function() {
     equal(locator.normalize(locator.normalize(example)), locator.normalize(example));
   });
 });
+
+module("Ember.Application templateNamespace");
+
+test("you can specify a templateNamespace", function() {
+  var app;
+
+  Ember.run(function() {
+    app = Ember.Application.create({ rootElement: '#qunit-fixture', templateNamespace: 'foo' });
+    Ember.TEMPLATES["foo/application"] = Ember.Handlebars.compile("<h1>hello ember</h1>");
+  });
+
+  equal(Ember.$("#qunit-fixture h1").text(), "hello ember");
+
+  Ember.run(function() {
+    app.destroy();
+  });
+});
+
+test("two apps can co-exist with different templateNamespace", function() {
+  Ember.$('#qunit-fixture').append(Ember.$('<div id="app1"></div>'));
+  Ember.$('#qunit-fixture').append(Ember.$('<div id="app2"></div>'));
+
+  var app1, app2;
+
+  Ember.run(function() {
+    app1 = Ember.Application.create({ rootElement: '#app1', templateNamespace: 'app1' });
+    Ember.TEMPLATES['app1/application'] = Ember.Handlebars.compile('<h1>hello app1</h1>');
+
+    app2 = Ember.Application.create({ rootElement: '#app2', templateNamespace: 'app2' });
+    Ember.TEMPLATES['app2/application'] = Ember.Handlebars.compile('<h2>hello app2</h2>');
+  });
+
+  equal(Ember.$("#qunit-fixture h1").text(), "hello app1");
+  equal(Ember.$("#qunit-fixture h2").text(), "hello app2");
+
+  Ember.run(function() {
+    app1.destroy();
+    app2.destroy();
+  });
+});


### PR DESCRIPTION
This is mostly useful in the case when there are multiple Ember applications within a single Rails app. Right now the only way to solve this is by overriding `templateName` for every single view.
