### PR TITLE
Better error message for developers upgrading Ember apps

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -420,7 +420,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     @method initialize
   */
   initialize: function() {
-    Ember.assert("Application initialize may only be called once", !this.isInitialized);
+    Ember.assert("Application initialize may only be called once. Note: calling initialize in application code is no longer required.", !this.isInitialized);
     Ember.assert("Cannot initialize a destroyed application", !this.isDestroyed);
     this.isInitialized = true;
 


### PR DESCRIPTION
Since calling .initialize() is no longer required, the error
message makes more sense when you explain to them that they
should remove their explicit call to .initialize() to fix it,
rather than looking for a second call.
