### PR TITLE
typeInjections for Ember.View

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -118,10 +118,21 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
   helper: function(thisContext, path, options) {
     var data = options.data,
         fn = options.fn,
+        currentView = data.view,
         newView;
 
     if ('string' === typeof path) {
       newView = EmberHandlebars.get(thisContext, path, options);
+
+      if (!Ember.View.detect(newView) && !Ember.View.detectInstance(newView)) {
+
+        // Context lookup failed. Try container lookup.
+        var container = currentView.get('container');
+        if (container) {
+          newView = container.lookup('view:' + path) || container.lookup(path);
+        }
+      }
+
       Ember.assert("Unable to find view at path '" + path + "'", !!newView);
     } else {
       newView = path;
@@ -130,7 +141,6 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
     Ember.assert(Ember.String.fmt('You must pass a view to the #view helper, not %@ (%@)', [path, newView]), Ember.View.detect(newView) || Ember.View.detectInstance(newView));
 
     var viewOptions = this.propertiesFromHTMLOptions(options, thisContext);
-    var currentView = data.view;
     viewOptions.templateData = data;
     var newViewProto = newView.proto ? newView.proto() : newView;
 

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1988,6 +1988,31 @@ test("should be able to explicitly set a view's context", function() {
   equal(view.$().text(), "test");
 });
 
+test("should perform container lookup is context lookup fails", function() {
+
+  TemplateTests.WidgetView = Ember.View.extend({
+    template: Ember.Handlebars.compile("woot")
+  });
+
+  TemplateTests.MainView = Ember.View.extend({
+    template: Ember.Handlebars.compile("{{view widget}}{{view 'view:widget'}}"),
+    context: Ember.Object.create({
+      widget: "I am not a view! Ignore me!"
+    })
+  });
+
+  container.register('view:main', TemplateTests.MainView);
+  container.register('view:widget', TemplateTests.WidgetView);
+
+  view = container.lookup('view:main');
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$().text(), "wootwoot");
+});
+
 module("Ember.View - handlebars integration", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };


### PR DESCRIPTION
This change makes it possible for Ember.View's instantiated in templates
and other Ember core code to run type injections through the container,
even if they're anonymous `Ember.View.extend` classes. This works by
performing a reverse lookup on the container on all parent classes of
the view and running any typeInjections that match registered parent
classes. But the algorithm is generalized to all classes, and not
just Views, though it seems that this problem of type injections not
running is unique to Views and the way they were being directly
`.create()`d by Ember core code.

Just to be clear, beforehand, if you registered a type injection on a `view`, views inserted via templates would not receive those type injections. 

edit:
## 4/16: the above description is out of date. present PR doesn't rely on changes to container.
