### PR TITLE
Possibility to specify string for Ember.Route#redirect

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -112,7 +112,9 @@ Ember.Route = Ember.Object.extend({
     this.redirected = false;
     this._checkingRedirect = true;
 
-    if (context === undefined) {
+    if (Ember.typeOf(this.redirect) === 'string') {
+      this.transitionTo(this.redirect);
+    } else if (context === undefined) {
       this.redirect();
     } else {
       this.redirect(context);
@@ -148,6 +150,9 @@ Ember.Route = Ember.Object.extend({
 
     If you call `this.transitionTo` from inside of this hook, this route
     will not be entered in favor of the other hook.
+
+    If redirect is a String it will be used as name of the route into which
+    it shall be transitioned into.
 
     @method redirect
     @param {Object} model the model for this route

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1135,6 +1135,29 @@ test("A redirection hook is provided", function() {
   equal(router.container.lookup('controller:application').get('currentPath'), 'home');
 });
 
+test("The redirection hook can be specified as string", function() {
+  Router.map(function() {
+    this.route("choose", { path: "/" });
+    this.route("home");
+  });
+
+  var chooseFollowed = 0, destination;
+
+  App.ChooseRoute = Ember.Route.extend({
+    redirect: 'home',
+
+    setupController: function() {
+      chooseFollowed++;
+    }
+  });
+
+  bootApplication();
+
+  equal(chooseFollowed, 0, "The choose route wasn't entered since a transition occurred");
+  equal(Ember.$("h3:contains(Hours)", "#qunit-fixture").length, 1, "The home template was rendered");
+  equal(router.container.lookup('controller:application').get('currentPath'), 'home');
+});
+
 test("Redirecting from the middle of a route aborts the remainder of the routes", function() {
   expect(2);
 


### PR DESCRIPTION
Now it is possible to specify a string for the redirect property on a route. The string specifies the name of the route into which it should be transitioned.

I also started a discussion about adding a `redirect` option to the router DSL http://discuss.emberjs.com/t/add-redirect-option-to-router/795
