### PR TITLE
Ember.Route.transitionTo macro

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -482,6 +482,24 @@ Ember.Route.reopenClass({
       args.unshift(path);
       this.transitionTo.apply(this, args);
     };
+  },
+
+  /**
+    Transition into another route while replacing the current URL if
+    possible. Identical to `transitionTo` in all other respects.
+
+    ```javascript
+    App.PostsIndexRoute = Ember.Route.extend({
+      redirect: Ember.Route.replaceWith('posts.all')
+    });
+    ```
+  */
+  replaceWith: function(path) {
+    return function() {
+      var args = slice.call(arguments);
+      args.unshift(path);
+      this.replaceWith.apply(this, args);
+    };
   }
 });
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -4,7 +4,8 @@
 */
 
 var get = Ember.get, set = Ember.set,
-    classify = Ember.String.classify;
+    classify = Ember.String.classify,
+    slice = [].slice;
 
 /**
   The `Ember.Route` class is used to define individual routes. Refer to
@@ -447,6 +448,40 @@ Ember.Route = Ember.Object.extend({
 
   willDestroy: function() {
     teardownView(this);
+  }
+});
+
+Ember.Route.reopenClass({
+  /**
+    Transition into another route.
+
+    ```javascript
+    App.PostNewRoute = Ember.Route.extend({
+      events: {
+        didSave: Ember.Route.transitionTo("post.show")
+      }
+    });
+
+    // or a more concise DSL
+
+    transitionTo = Ember.Route.transitionTo;
+
+    App.PostEditRoute = Ember.Route.extend({
+      events: {
+        didSave: transitionTo("post.show")
+      }
+    });
+    ```
+
+    @method transitionTo
+    @param {String} name the name of the route
+  */
+  transitionTo: function(path){
+    return function() {
+      var args = slice.call(arguments);
+      args.unshift(path);
+      this.transitionTo.apply(this, args);
+    };
   }
 });
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -5,7 +5,7 @@
 
 var Router = requireModule("router");
 var get = Ember.get, set = Ember.set;
-
+var slice = [].slice;
 var DefaultView = Ember._MetamorphView;
 
 require("ember-routing/system/dsl");
@@ -89,12 +89,12 @@ Ember.Router = Ember.Object.extend({
   },
 
   transitionTo: function(name) {
-    var args = [].slice.call(arguments);
+    var args = slice.call(arguments);
     doTransition(this, 'transitionTo', args);
   },
 
   replaceWith: function() {
-    var args = [].slice.call(arguments);
+    var args = slice.call(arguments);
     doTransition(this, 'replaceWith', args);
   },
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1135,6 +1135,44 @@ test("A redirection hook is provided", function() {
   equal(router.container.lookup('controller:application').get('currentPath'), 'home');
 });
 
+test("Ember.Route.transitionTo works as shorthand for this.transitionTo", function() {
+  expect(1);
+
+  Router.map(function() {
+    this.route("choose", { path: "/" });
+    this.route("home");
+  });
+
+  App.ChooseRoute = Ember.Route.extend({
+    redirect: Ember.Route.transitionTo('home'),
+
+    transitionTo: function(destination) {
+      equal("home", destination, "transitionTo has been invoked on the route");
+    }
+  });
+
+  bootApplication();
+});
+
+test("Ember.Route.transitionTo works as shorthand for this.replaceWith", function() {
+  expect(1);
+
+  Router.map(function() {
+    this.route("choose", { path: "/" });
+    this.route("home");
+  });
+
+  App.ChooseRoute = Ember.Route.extend({
+    redirect: Ember.Route.replaceWith('home'),
+
+    replaceWith: function(destination) {
+      equal("home", destination, "replaceWith has been invoked on the route");
+    }
+  });
+
+  bootApplication();
+});
+
 test("Redirecting from the middle of a route aborts the remainder of the routes", function() {
   expect(2);
 


### PR DESCRIPTION
add helper macro Ember.Route.transitionTo
I've found I use this all the time. any downside to adding it to the actual api?

``` javascript
App.IndexRoute = Ember.Route.extend({
  events: {
    didSave: Ember.Route.transitionTo("post.show")
  }
});

// or short

transitionTo = Ember.Route.transitionTo;

App.IndexRoute = Ember.Route.extend({
  events: {
    didSave: transitionTo("post.show")
  }
});

```
