### PR TITLE
Guard against undefined variables

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -112,7 +112,11 @@ Ember.Route = Ember.Object.extend({
     this.redirected = false;
     this._checkingRedirect = true;
 
-    this.redirect(context);
+    if (context === undefined) {
+      this.redirect();
+    } else {
+      this.redirect(context);
+    }
 
     this._checkingRedirect = false;
     if (this.redirected) { return false; }


### PR DESCRIPTION
Under no circumstances do you want an undefined
value entering your system here. Turns out that under 
normal flows the framework may subject you to an
unwanted undefined and this just leads to many sad
pandas.
