### PR TITLE
Update ember-dev gem to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 2f17d36959adb2dc7b172fe9c8b34a4b99725507
+  revision: 7f6f0e546de58533b187fa9d3a1ad662d8d8715c
   branch: master
   specs:
     ember-dev (0.1)
@@ -28,8 +28,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     colored (1.2)
-    diff-lcs (1.2.1)
-    ember-source (0.0.1)
+    diff-lcs (1.2.2)
+    ember-source (0.0.4)
       handlebars-source (>= 1.0.0.rc3, < 1.0.0.rc4)
     execjs (1.4.0)
       multi_json (~> 1.0)
@@ -42,15 +42,15 @@ GEM
     kicker (2.6.1)
       listen
     listen (0.7.3)
-    mime-types (1.21)
-    multi_json (1.6.1)
+    mime-types (1.22)
+    multi_json (1.7.2)
     posix-spawn (0.3.6)
     rack (1.5.2)
-    rake (10.0.3)
+    rake (10.0.4)
     rake-pipeline-web-filters (0.7.0)
       rack
       rake-pipeline (~> 0.6)
-    thor (0.17.0)
+    thor (0.18.1)
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)


### PR DESCRIPTION
I ran `bundle update ember-dev` so the gem is updated to the latest version, 
which upgraded QUnit to v1.11.0, see
https://github.com/emberjs/ember-dev/commit/806acd126dbf46253500222fd5f47e156899bbf0
