### PR TITLE
Em String dasherize should remove special characters

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-var STRING_DASHERIZE_REGEXP = (/[ _]/g);
+var STRING_DASHERIZE_REGEXP = (/[^a-z0-9\-]+/g);
 var STRING_DASHERIZE_CACHE = {};
 var STRING_DECAMELIZE_REGEXP = (/([a-z])([A-Z])/g);
 var STRING_CAMELIZE_REGEXP = (/(\-|_|\.|\s)+(.)?/g);
@@ -144,16 +144,18 @@ Ember.String = {
     @return {String} the dasherized string.
   */
   dasherize: function(str) {
-    var cache = STRING_DASHERIZE_CACHE,
-        hit   = cache.hasOwnProperty(str),
-        ret;
+    var ret = Ember.String.decamelize(str),
+        sep = '-';
 
-    if (hit) {
-      return cache[str];
-    } else {
-      ret = Ember.String.decamelize(str).replace(STRING_DASHERIZE_REGEXP,'-');
-      cache[str] = ret;
-    }
+    var ret = Ember.String.decamelize(str)
+    // replace all unwanted chars into the separator
+    ret = ret.replace(STRING_DASHERIZE_REGEXP, sep);
+    // No more than one separator in a row
+    var dupePatt = new RegExp(sep + '{2,}');
+    ret = ret.replace(dupePatt, sep);
+    // remove leading/trailing separator
+    var trimPatt = new RegExp('^' + sep + '|' + sep + '$');
+    ret = ret.replace(trimPatt, '');
 
     return ret;
   },

--- a/packages/ember-runtime/tests/system/string/dasherize.js
+++ b/packages/ember-runtime/tests/system/string/dasherize.js
@@ -21,6 +21,14 @@ test("dasherize underscored string", function() {
   }
 });
 
+test("dasherize string with special chars", function() {
+  deepEqual(Ember.String.dasherize('A Cool String; no really it is'), 'a-cool-string-no-really-it-is');
+});
+
+test("dasherize string with repeated separators", function() {
+  deepEqual(Ember.String.dasherize('A Cool--://String; no really it is'), 'a-cool-string-no-really-it-is');
+});
+
 test("dasherize camelcased string", function() {
   deepEqual(Ember.String.dasherize('innerHTML'), 'inner-html');
   if (Ember.EXTEND_PROTOTYPES) {


### PR DESCRIPTION
This implementation is basically the same as [`parameterize`](http://apidock.com/rails/ActiveSupport/Inflector/parameterize) in Rails. 

The last [caching test](https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/tests/system/string/dasherize.js#L38-L54) is currently failing in this implementation, but I'm not sure how to fix it. 

My use case for this implementation is because I'm using dasherize to build URLs. Not sure if `dasherize` is the appropriate function or not. 

Feedback welcome. 
