### PR TITLE
Make Chrome initial popstate workaround account for rootURL

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -144,7 +144,7 @@ Ember.HistoryLocation = Ember.Object.extend({
       // Ignore initial page load popstate event in Chrome
       if(!popstateFired) {
         popstateFired = true;
-        if (self.getURL() === self._initialUrl) { return; }
+        if (self.formatURL(self.getURL()) === self._initialUrl) { return; }
       }
       callback(self.getURL());
     });


### PR DESCRIPTION
The Router's `handleURL` fires twice in Chrome on page load when using `HistoryLocation` with `rootURL`.  There's already a workaround, but it didn't account for `rootURL`.
