### PR TITLE
Ignore webkitStorageInfo during namespace lookup to avoid warning

### DIFF
--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -116,7 +116,7 @@ function findNamespaces() {
 
   for (var prop in lookup) {
     // These don't raise exceptions but can cause warnings
-    if (prop === "parent" || prop === "top" || prop === "frameElement") { continue; }
+    if (prop === "parent" || prop === "top" || prop === "frameElement" || prop === "webkitStorageInfo") { continue; }
 
     //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
     // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage


### PR DESCRIPTION
Fixes #2366
