### PR TITLE
Tests for Ember metal watch/unwatch on "length" properties

### DIFF
--- a/packages/ember-metal/tests/watching/isWatching_test.js
+++ b/packages/ember-metal/tests/watching/isWatching_test.js
@@ -1,13 +1,14 @@
 module('Ember.isWatching');
 
-var testObserver = function(setup, teardown) {
-  var obj = {}, key = 'foo', fn = function() {};
+var testObserver = function(setup, teardown, key) {
+  var obj = {}, fn = function() {};
+  key = key || 'foo';
 
-  equal(Ember.isWatching(obj, 'foo'), false, "precond - isWatching is false by default");
+  equal(Ember.isWatching(obj, key), false, "precond - isWatching is false by default");
   setup(obj, key, fn);
-  equal(Ember.isWatching(obj, 'foo'), true, "isWatching is true when observers are added");
+  equal(Ember.isWatching(obj, key), true, "isWatching is true when observers are added");
   teardown(obj, key, fn);
-  equal(Ember.isWatching(obj, 'foo'), false, "isWatching is false after observers are removed");
+  equal(Ember.isWatching(obj, key), false, "isWatching is false after observers are removed");
 };
 
 test("isWatching is true for regular local observers", function() {
@@ -52,4 +53,15 @@ test("isWatching is true for chained computed properties", function() {
   }, function(obj, key, fn) {
     Ember.defineProperty(obj, 'computed', null);
   });
+});
+
+// can't watch length on Array - it is special...
+// But you should be able to watch a length property of an object
+test("isWatching is true for 'length' property on object", function() {
+  testObserver(function(obj, key, fn) {
+    Ember.defineProperty(obj, 'length', null, '26.2 miles');
+    Ember.addObserver(obj, 'length', obj, fn);
+  }, function(obj, key, fn) {
+    Ember.removeObserver(obj, 'length', obj, fn);
+  }, 'length');
 });

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -85,3 +85,22 @@ test('unwatching should be nested', function() {
   equal(willCount, 0, 'should NOT have invoked willCount');
   equal(didCount, 0, 'should NOT have invoked didCount');
 });
+
+testBoth('unwatching "length" property on an object', function(get, set) {
+
+  var obj = { foo: 'RUN' };
+
+  // Can watch length when it is undefined
+  Ember.watch(obj, 'length');
+  set(obj, 'length', '10k');
+  equal(willCount, 1, 'should have invoked willCount');
+  equal(didCount, 1, 'should have invoked didCount');
+
+  // Should stop watching despite length now being defined (making object 'array-like')
+  Ember.unwatch(obj, 'length');
+  willCount = didCount = 0;
+  set(obj, 'length', '5k');
+  equal(willCount, 0, 'should NOT have invoked willCount');
+  equal(didCount, 0, 'should NOT have invoked didCount');
+
+});

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -229,3 +229,37 @@ test('when watching another object, destroy should remove chain watchers from th
   equal(meta_objB.watching.foo, 0, 'should not be watching foo');
   equal(index, -1, 'should not have chain watcher');
 });
+
+// TESTS for length property
+
+testBoth('watching "length" property on an object', function(get, set) {
+
+  var obj = { length: '26.2 miles' };
+  addListeners(obj, 'length');
+
+  Ember.watch(obj, 'length');
+  equal(get(obj, 'length'), '26.2 miles', 'should have original prop');
+
+  set(obj, 'length', '10k');
+  equal(willCount, 1, 'should have invoked willCount');
+  equal(didCount, 1, 'should have invoked didCount');
+
+  equal(get(obj, 'length'), '10k', 'should get new value');
+  equal(obj.length, '10k', 'property should be accessible on obj');
+});
+
+testBoth('watching "length" property on an array', function(get, set) {
+
+  var arr = [];
+  addListeners(arr, 'length');
+
+  Ember.watch(arr, 'length');
+  equal(get(arr, 'length'), 0, 'should have original prop');
+
+  set(arr, 'length', '10');
+  equal(willCount, 0, 'should NOT have invoked willCount');
+  equal(didCount, 0, 'should NOT have invoked didCount');
+
+  equal(get(arr, 'length'), 10, 'should get new value');
+  equal(arr.length, 10, 'property should be accessible on arr');
+});


### PR DESCRIPTION
Tests address TODO in commit @49e90832ac28d5e14aa3cdc0353e9ad9f3772757

Watching the 'length' property on an object should work like any other property. However, the 'length' property of an array is special and cannot be correctly observed like an object property.

These new tests fail prior to the fixes implemented in @49e90832ac28d5e14aa3cdc0353e9ad9f3772757 and pass with the fixes in place.
