### PR TITLE
Enhance Ember.TargetActionSupport and introduce Ember.ViewTargetActionSupport

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -6,6 +6,15 @@
 var get = Ember.get, set = Ember.set;
 
 /**
+`Ember.TargetActionSupport` is a mixin that can be included in a class
+to add a `triggerAction` method with semantics similar to the Handlebars
+`{{action}}` helper. In normal Ember usage, the `{{action}}` helper is
+usually the best choice. This mixin is most often useful when you are
+doing more complex event handling in View objects.
+
+See also `Ember.ViewTargetActionSupport`, which has
+view-aware defaults for target and actionContext.
+
 @class TargetActionSupport
 @namespace Ember
 @extends Ember.Mixin
@@ -13,6 +22,7 @@ var get = Ember.get, set = Ember.set;
 Ember.TargetActionSupport = Ember.Mixin.create({
   target: null,
   action: null,
+  actionContext: null,
 
   targetObject: Ember.computed(function() {
     var target = get(this, 'target');
@@ -26,21 +36,86 @@ Ember.TargetActionSupport = Ember.Mixin.create({
     }
   }).property('target'),
 
-  triggerAction: function() {
-    var action = get(this, 'action'),
-        target = get(this, 'targetObject');
+  actionContextObject: Ember.computed(function() {
+    var actionContext = get(this, 'actionContext');
+
+    if (Ember.typeOf(actionContext) === "string") {
+      var value = get(this, actionContext);
+      if (value === undefined) { value = get(Ember.lookup, actionContext); }
+      return value;
+    } else {
+      return actionContext;
+    }
+  }).property('actionContext'),
+
+  /**
+  Send an "action" with an "actionContext" to a "target". The action, actionContext
+  and target will be retrieved from properties of the object. For example:
+
+  ```javascript
+  App.SaveButtonView = Ember.View.extend(Ember.TargetActionSupport, {
+    target: Ember.computed.alias('controller'),
+    action: 'save',
+    actionContext: Ember.computed.alias('context'),
+    click: function(){
+      this.triggerAction(); // Sends the `save` action, along with the current context
+                            // to the current controller
+    }
+  });
+  ```
+
+  The `target`, `action`, and `actionContext` can be provided as properties of
+  an optional object argument to `triggerAction` as well.
+
+  ```javascript
+  App.SaveButtonView = Ember.View.extend(Ember.TargetActionSupport, {
+    click: function(){
+      this.triggerAction({
+        action: 'save',
+        target: this.get('controller'),
+        actionContext: this.get('context'),
+      }); // Sends the `save` action, along with the current context
+          // to the current controller
+    }
+  });
+  ```
+
+  The `actionContext` defaults to the object you mixing `TargetActionSupport` into.
+  But `target` and `action` must be specified either as properties or with the argument
+  to `triggerAction`, or a combination:
+
+  ```javascript
+  App.SaveButtonView = Ember.View.extend(Ember.TargetActionSupport, {
+    target: Ember.computed.alias('controller'),
+    click: function(){
+      this.triggerAction({
+        action: 'save'
+      }); // Sends the `save` action, along with a reference to `this`,
+          // to the current controller
+    }
+  });
+  ```
+
+  @method triggerAction
+  @param opts {Hash} (optional, with the optional keys action, target and/or actionContext)
+  @return {Boolean} true if the action was sent successfully and did not return false
+  */
+  triggerAction: function(opts) {
+    opts = opts || {};
+    var action = opts['action'] || get(this, 'action'),
+        target = opts['target'] || get(this, 'targetObject'),
+        actionContext = opts['actionContext'] || get(this, 'actionContextObject') || this;
 
     if (target && action) {
       var ret;
 
-      if (typeof target.send === 'function') {
-        ret = target.send(action, this);
+      if (target.send) {
+        ret = target.send.apply(target, [action, actionContext]);
       } else {
-        if (typeof action === 'string') {
-          action = target[action];
-        }
-        ret = action.call(target, this);
+        Ember.assert("The action '" + action + "' did not exist on " + target, typeof target[action] === 'function');
+        ret = target[action].apply(target, [actionContext]);
       }
+
       if (ret !== false) ret = true;
 
       return ret;

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -36,12 +36,13 @@ test("it should support actions specified as strings", function() {
 });
 
 test("it should invoke the send() method on objects that implement it", function() {
-  expect(2);
+  expect(3);
 
   var obj = Ember.Object.createWithMixins(Ember.TargetActionSupport, {
     target: Ember.Object.create({
-      send: function(evt) {
+      send: function(evt, context) {
         equal(evt, 'anEvent', "send() method was invoked with correct event name");
+        equal(context, obj, "send() method was invoked with correct context");
       }
     }),
 
@@ -69,4 +70,77 @@ test("it should find targets specified using a property path", function() {
   });
 
   ok(true === myObj.triggerAction(), "a valid target and action were specified");
+});
+
+test("it should use an actionContext object specified as a property on the object", function(){
+  expect(2);
+  var obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+        action: 'anEvent',
+        actionContext: {},
+        target: Ember.Object.create({
+          anEvent: function(ctx) {
+            ok(obj.actionContext === ctx, "anEvent method was called with the expected context");
+          }
+        })
+      });
+  ok(true === obj.triggerAction(), "a valid target and action were specified");
+});
+
+test("it should find an actionContext specified as a property path", function(){
+  expect(2);
+
+  var Test = {};
+  Ember.lookup = { Test: Test };
+  Test.aContext = {};
+
+  var obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+        action: 'anEvent',
+        actionContext: 'Test.aContext',
+        target: Ember.Object.create({
+          anEvent: function(ctx) {
+            ok(Test.aContext === ctx, "anEvent method was called with the expected context");
+          }
+        })
+      });
+  ok(true === obj.triggerAction(), "a valid target and action were specified");
+});
+
+test("it should use the target specified in the argument", function(){
+  expect(2);
+  var targetObj = Ember.Object.create({
+        anEvent: function() {
+          ok(true, "anEvent method was called");
+        }
+      }),
+      obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+        action: 'anEvent'
+      });
+  ok(true === obj.triggerAction({target: targetObj}), "a valid target and action were specified");
+});
+
+test("it should use the action specified in the argument", function(){
+  expect(2);
+
+  var obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+    target: Ember.Object.create({
+      anEvent: function() {
+        ok(true, "anEvent method was called");
+      }
+    })
+  });
+  ok(true === obj.triggerAction({action: 'anEvent'}), "a valid target and action were specified");
+});
+
+test("it should use the actionContext specified in the argument", function(){
+  expect(2);
+  var context = {},
+      obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+    target: Ember.Object.create({
+      anEvent: function(ctx) {
+        ok(context === ctx, "anEvent method was called with the expected context");
+      }
+    }),
+    action: 'anEvent'
+  });
+  ok(true === obj.triggerAction({actionContext: context}), "a valid target and action were specified");
 });

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -15,3 +15,4 @@ Ember Views
 require("ember-views/core");
 require("ember-views/system");
 require("ember-views/views");
+require("ember-views/mixins");

--- a/packages/ember-views/lib/mixins.js
+++ b/packages/ember-views/lib/mixins.js
@@ -1,0 +1,1 @@
+require("ember-views/mixins/view_target_action_support");

--- a/packages/ember-views/lib/mixins/view_target_action_support.js
+++ b/packages/ember-views/lib/mixins/view_target_action_support.js
@@ -1,0 +1,51 @@
+/**
+`Ember.ViewTargetActionSupport` is a mixin that can be included in a
+view class to add a `triggerAction` method with semantics similar to
+the Handlebars `{{action}}` helper. It provides intelligent defaults
+for the action's target: the view's controller; and the context that is
+sent with the action: the view's context.
+
+Note: In normal Ember usage, the `{{action}}` helper is usually the best
+choice. This mixin is most often useful when you are doing more complex
+event handling in custom View subclasses.
+
+For example:
+
+```javascript
+App.SaveButtonView = Ember.View.extend(Ember.ViewTargetActionSupport, {
+  action: 'save',
+  click: function(){
+    this.triggerAction(); // Sends the `save` action, along with the current context
+                          // to the current controller
+  }
+});
+```
+
+The `action` can be provided as properties of an optional object argument
+to `triggerAction` as well.
+
+```javascript
+App.SaveButtonView = Ember.View.extend(Ember.ViewTargetActionSupport, {
+  click: function(){
+    this.triggerAction({
+      action: 'save'
+    }); // Sends the `save` action, along with the current context
+        // to the current controller
+  }
+});
+```
+
+@class ViewTargetActionSupport
+@namespace Ember
+@extends Ember.TargetActionSupport
+*/
+Ember.ViewTargetActionSupport = Ember.Mixin.create(Ember.TargetActionSupport, {
+  /**
+  @property target
+  */
+  target: Ember.computed.alias('controller'),
+  /**
+  @property actionContext
+  */
+  actionContext: Ember.computed.alias('context')
+});

--- a/packages/ember-views/tests/mixins/view_target_action_support_test.js
+++ b/packages/ember-views/tests/mixins/view_target_action_support_test.js
@@ -1,0 +1,54 @@
+/*global Test:true*/
+
+var originalLookup;
+
+module("Ember.ViewTargetActionSupport", {
+  setup: function() {
+    originalLookup = Ember.lookup;
+  },
+  teardown: function() {
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("it should return false if no action is specified", function() {
+  expect(1);
+
+  var view = Ember.View.createWithMixins(Ember.ViewTargetActionSupport, {
+    controller: Ember.Object.create()
+  });
+
+  ok(false === view.triggerAction(), "a valid target and action were specified");
+});
+
+test("it should support actions specified as strings", function() {
+  expect(2);
+
+  var view = Ember.View.createWithMixins(Ember.ViewTargetActionSupport, {
+    controller: Ember.Object.create({
+      anEvent: function() {
+        ok(true, "anEvent method was called");
+      }
+    }),
+    action: 'anEvent'
+  });
+
+  ok(true === view.triggerAction(), "a valid target and action were specified");
+});
+
+test("it should invoke the send() method on the controller with the view's context", function() {
+  expect(3);
+
+  var view = Ember.View.createWithMixins(Ember.ViewTargetActionSupport, {
+    context: {},
+    controller: Ember.Object.create({
+      send: function(evt, context) {
+        equal(evt, 'anEvent', "send() method was invoked with correct event name");
+        equal(context, view.context, "send() method was invoked with correct context");
+      }
+    }),
+    action: 'anEvent'
+  });
+
+  ok(true === view.triggerAction(), "a valid target and action were specified");
+});


### PR DESCRIPTION
Enhancements to `Ember.TargetActionSupport` now allow `triggerAction` to receive an object specifying the desired action name and target. A target and/or action provided in the function call take precedence over any target/action properties in the object.

`Ember.ViewTargetActionSupport` is a new mixin that encompasses `Ember.TargetActionSupport` and complements it by defining the default `target` as the view's `controller` and the default `actionContext` as the view's `context`.

This is an extraction from the approach we have used on a few Yapp projects in production and it has worked well for us. In particular, it is useful when you are handling multiple DOM events on a view class and want to dispatch different actions in response to them. 
