### PR TITLE
assertion to catch mixins being passed to Object.create

### DIFF
--- a/packages/ember-old-router/tests/helpers/action_url_test.js
+++ b/packages/ember-old-router/tests/helpers/action_url_test.js
@@ -50,7 +50,7 @@ test("it does not generate the URL when href property is not specified", functio
     template: compile("<a {{action show}}>Hi</a>")
   });
 
-  var controller = Ember.Object.create(Ember.ControllerMixin, {
+  var controller = Ember.Object.createWithMixins(Ember.ControllerMixin, {
     target: {
       urlForEvent: function(event, context) {
         return "/foo/bar";

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -66,6 +66,9 @@ function makeCtor() {
 
       for (var i = 0, l = props.length; i < l; i++) {
         var properties = props[i];
+
+        Ember.assert("Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.", !(properties instanceof Ember.Mixin));
+
         for (var keyName in properties) {
           if (!properties.hasOwnProperty(keyName)) { continue; }
 

--- a/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -17,7 +17,7 @@ var MyApp, binding1, binding2, previousPreventRunloop;
 module("System:run_loop() - chained binding", {
   setup: function() {
     MyApp = {};
-    MyApp.first = Ember.Object.create(Ember.Observable, {
+    MyApp.first = Ember.Object.createWithMixins(Ember.Observable, {
       output: 'MyApp.first'
     }) ;
 
@@ -31,7 +31,7 @@ module("System:run_loop() - chained binding", {
 
     }) ;
 
-    MyApp.third = Ember.Object.create(Ember.Observable, {
+    MyApp.third = Ember.Object.createWithMixins(Ember.Observable, {
       input: "MyApp.third"
     }) ;
   }

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -76,6 +76,18 @@ test("throws if you try to call _super in a method", function() {
   }, 'should warn that a method that calls _super was passed to create');
 });
 
+test("throws if you try to 'mixin' a definition", function(){
+  var myMixin = Ember.Mixin.create({
+    adder: function(arg1, arg2){
+      return arg1 + arg2;
+    }
+  });
+
+  raises(function(){
+    var o = Ember.Object.create(myMixin);
+  }, "should warn that you passed in a mixin");
+});
+
 module('Ember.Object.createWithMixins');
 
 test("Creates a new object that contains passed properties", function() {


### PR DESCRIPTION
I've added an assertion to stop stupid developers (like myself) trying to mix in definitions via Object create, e.g:

```
var o = Ember.Object.create(App.MyMixin);
```

The assertion will instruct the user to use createWithMixins instead.
