### PR TITLE
Add transitionToURL method

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -18,7 +18,7 @@ Ember.ControllerMixin.reopen({
     Optionally supply a model for the route in question. The model
     will be serialized into the URL using the `serialize` hook of
     the route:
-    
+
     ```javascript
       aController.transitionToRoute('blogPost', aPost);
     ```
@@ -60,5 +60,14 @@ Ember.ControllerMixin.reopen({
   replaceWith: function() {
     Ember.deprecate("replaceWith is deprecated. Please use replaceRoute.");
     return this.replaceRoute.apply(this, arguments);
+  },
+
+  /**
+    @param {String} URL to transition to
+    @for Ember.ControllerMixin
+    @method transitionToURL
+  */
+  transitionToURL: function(url) {
+    get(this, 'target').transitionToURL(url);
   }
 });

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -74,9 +74,9 @@ Ember.Route = Ember.Object.extend({
   /**
     Transition to another route via the `routeTo` event which
     will by default be handled by ApplicationRoute.
-   
+
     @method routeTo
-    @param {TransitionEvent} transitionEvent 
+    @param {TransitionEvent} transitionEvent
    */
   routeTo: function(transitionEvent) {
     this.router.routeTo(transitionEvent);
@@ -121,6 +121,19 @@ Ember.Route = Ember.Object.extend({
 
     if (this._checkingRedirect) { this._redirected[this._redirectDepth] = true; }
     return this.router.replaceWith.apply(this.router, arguments);
+  },
+
+  /**
+    Transition into a URL.  This is used if we have
+    the final URL to transition to, but don't know the
+    exact route and models.
+
+    @method transitionToURL
+    @param {String} url
+  */
+  transitionToURL: function(url) {
+    if (this._checkingRedirect) { this.redirected = true; }
+    return this.router.transitionToURL(url);
   },
 
   send: function() {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -87,9 +87,9 @@ Ember.Router = Ember.Object.extend({
   /**
     Transition to another route via the `routeTo` event which
     will by default be handled by ApplicationRoute.
-   
+
     @method routeTo
-    @param {TransitionEvent} transitionEvent 
+    @param {TransitionEvent} transitionEvent
    */
   routeTo: function(transitionEvent) {
     var handlerInfos = this.router.currentHandlerInfos;
@@ -109,6 +109,16 @@ Ember.Router = Ember.Object.extend({
     var args = [].slice.call(arguments);
     doTransition(this, 'replaceWith', args);
   },
+
+  transitionToURL: function(url) {
+    var self = this;
+    Ember.run.once(function() {
+      self.get('location').setURL(url);
+      self.notifyPropertyChange('url');
+    });
+    this.router.handleURL(url);
+  },
+
 
   generate: function() {
     var url = this.router.generate.apply(this.router, arguments);


### PR DESCRIPTION
This allows us to transition to a specific URL without necessarily knowing  the routes and models involved.

I found myself needing this several times when I need to save a specific route in order to transition to it later.

This comes in really handy when doing a login redirect on initial page load.  We can now save the initial URL, and after signing in, we redirect the user to where they wanted to go in the first place.

``` javascript
if (!signedIn) {
  initialURL = this.router.get('url');
  this.transitionTo('login');
}
```

And after logging in:

``` javascript
this.transitionToURL(initialURL);
```

`transitionToURL` can be accessed from `Ember.Router`, `Ember.Route`, and `Ember.Controller`.
