### PR TITLE
Create a new promise on App.reset() w/ test

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -445,7 +445,15 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     return this;
   },
 
-  reset: function() {
+  /**
+   * Reset the application by destroying the main container and rebuilding
+   * the application.
+   *
+   * @returns {Ember.RSVP.Promise} which you can wait on until the reset
+   *                               has completed.
+   */
+  reset: function(){
+    this.set('promise', new Ember.RSVP.Promise());
     get(this, '__container__').destroy();
     this.buildContainer();
 
@@ -453,6 +461,8 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
       this._initialize();
       this.startRouting();
     });
+    
+    return this;
   },
 
   /**

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -18,6 +18,18 @@ module("Ember.Application - resetting", {
   }
 });
 
+test("When an application is reset, a new promise is created", function() {
+  Ember.run(function() {
+    application = Application.create();
+  });
+  var promise1 = get(application, 'promise');
+  Ember.run(function(){
+    application.reset();
+  });
+  var promise2 = get(application, 'promise');
+  notStrictEqual(promise1, promise2, "application reset replaces the existing promise with a new promise");
+});
+
 test("When an application is reset, new instances of controllers are generated", function() {
   Ember.run(function() {
     application = Application.create();


### PR DESCRIPTION
Application now has the deferred mixin that allow you to add functions to be called when your app is initialized.  Calling App.reset() should give you a new promise to allow to do the same thing when your app is reset.
