### PR TITLE
Don't try to destroy an element that's already destroying.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1674,6 +1674,8 @@ Ember.View = Ember.CoreView.extend(
     @return {Ember.View} receiver
   */
   destroyElement: function() {
+    if(this.isDestroyed || this.isDestroying) { return; }
+
     return this.currentState.destroyElement(this);
   },
 


### PR DESCRIPTION
When I call `clear()` on a certain controller's content, I get a DOM exception 8, because Ember is attempting to remove an element that's already been removed. 

There's probably a more fundamental issue that's causing this that I will look into when I have time, but this stops an element from being removed that's already being removed. There is similar code is in other places in the deletion cycle but it's not catching whatever edge-case is causing my problem.

Thanks for all your hard work on Ember.
