### PR TITLE
Stop application template from duplicating on re-render

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -532,6 +532,10 @@ function appendView(route, view, options) {
     parentView.connectOutlet(options.outlet, view);
   } else {
     var rootElement = get(route, 'router.namespace.rootElement');
+    // tear down view if one is already rendered
+    if (route.teardownView) {
+      route.teardownView();
+    }
     route.router._connectActiveView(options.name, view);
     route.teardownView = teardownTopLevel(view);
     view.appendTo(rootElement);

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1579,3 +1579,27 @@ test("Nested index route is not overriden by parent's implicit index route", fun
 
   deepEqual(router.location.path, '/posts/emberjs');
 });
+
+test("Application template does not duplicate when re-rendered", function() {
+  Ember.TEMPLATES.application = compile("<h3>I Render Once</h3>{{outlet}}");
+
+  Router.map(function() {
+    this.route('posts');
+  });
+
+  App.ApplicationRoute = Ember.Route.extend({
+    model: function() {
+      return Ember.A();
+    }
+  });
+
+
+  bootApplication();
+
+  // should cause application template to re-render
+  Ember.run(function() {
+    router.handleURL('/posts');
+  });
+
+  equal(Ember.$('h3:contains(I Render Once)').size(), 1);
+});


### PR DESCRIPTION
Some cases might cause the `application` template to re-render (such as changing the context in the `ApplicationRoute#model` hook).

Currently the application template is duplicated.  This PR tears down the existing `application` view before re-rendering.
