### PR TITLE
Allow render template name to be a reference.

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -40,6 +40,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       lookupOptions = { singleton: false };
     }
 
+    if (options.types[0] === "ID") {
+      var newName = Ember.Handlebars.get(options.contexts[0], name, options);
+      if (newName) {
+        Ember.assert("Path must refer to a string to render. The path " + name + " refers to a " + newName.toString(), typeof(newName) === 'string');
+        name = newName;
+      }
+    }
+
     name = name.replace(/\//g, '.');
     container = options.data.keywords.controller.container;
     router = container.lookup('router:main');


### PR DESCRIPTION
This is a very incomplete pull request, but I wanted to see whether this idea was sensible before I fleshed out the docs / tests.

I love the render helper. It's great for creating reusable components, especially when working with routerless applications. I want `render` to be able to look up the template / controller name from a variable, like I can with the `view` helper. This will let me replace my reusable view components with a view / controller pair.

Here's a contrived example of how I am currently using it:

``` javascript
App.inputs = [
  Ember.Object.create({ label: 'name', renderTemplate: 'textfield' }),
  Ember.Object.create({ label: 'email', renderTemplate: 'textfield' }),
  Ember.Object.create({ label: 'name', renderTemplate: 'hideable' })
];
```

```
# application.js.handlebars
{{#each input in App.inputs}}
  {{render input.renderTemplate input}}
{{/each}}

# textfield.js.handlebars
<label>{{label}}</label>
{{view Ember.TextField}}

# hideable.js.handlebars
<a href="javascript:;" {{action "show"}} />I want to enter a value for {{name}}</a>
{{#if visible}} {{view Ember.TextField}} {{/if}}
```

This is my first contribution to ember, and I'm still trying to work my way around the code base, so please let me know if this is completely on the wrong track.

david

<!---
@huboard:{"order":1302.0,"custom_state":""}
-->
