### PR TITLE
Fix typo in {{partial}} docs.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -15,6 +15,7 @@ require('ember-handlebars/ext');
       {{partial user_info}}
     {{/with}}
   </script>
+  ```
 
   The `data-template-name` attribute of a partial template
   is prefixed with an underscore.


### PR DESCRIPTION
Related: #2253
