### PR TITLE
Close #2403 - Removing last item in CollectionView triggers removal of metamorph views that are not in the DOM

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -268,11 +268,9 @@ Ember.CollectionView = Ember.ContainerView.extend(
 
     if (removingAll) {
       this.currentState.empty(this);
-      var priorRemovedFromDOM = this.removedFromDOM;
       this.invokeRecursively(function(view) {
         view.removedFromDOM = true;
-      });
-      this.removedFromDOM = priorRemovedFromDOM;
+      }, false);
     }
 
     for (idx = start + removedCount - 1; idx >= start; idx--) {

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -268,11 +268,15 @@ Ember.CollectionView = Ember.ContainerView.extend(
 
     if (removingAll) {
       this.currentState.empty(this);
+      var priorRemovedFromDOM = this.removedFromDOM;
+      this.invokeRecursively(function(view) {
+        view.removedFromDOM = true;
+      });
+      this.removedFromDOM = priorRemovedFromDOM;
     }
 
     for (idx = start + removedCount - 1; idx >= start; idx--) {
       childView = childViews[idx];
-      if (removingAll) { childView.removedFromDOM = true; }
       childView.destroy();
     }
   },

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1603,13 +1603,15 @@ Ember.View = Ember.CoreView.extend(
   /**
     @private
 
-    Run this callback on the current view and recursively on child views.
+    Run this callback on the current view (unless includeSelf is false) and recursively on child views.
 
     @method invokeRecursively
     @param fn {Function}
+    @param includeSelf (optional, default true)
   */
-  invokeRecursively: function(fn) {
-    var childViews = [this], currentViews, view;
+  invokeRecursively: function(fn, includeSelf) {
+    var childViews = (includeSelf === false) ? this._childViews : [this];
+    var currentViews, view;
 
     while (childViews.length) {
       currentViews = childViews.slice();


### PR DESCRIPTION
This fixes issue #2403.

There had already been a PR (#2133) which hasn't been merged yet. This is an alternative fix with a test case that does not depend on handlebars.

It's possible that the `CollectionView` is not actually the right place to fix this (other parts of the code depend on views to propagate the `removedFromDOM` to their children), but since the `CollectionView` does something special here (with the .empty() call), I think this is okay. 

The reason why it is not propagated through the regular `view.destroy` is that the code only calls `.destroy()` on the innermost nested view, but not on its parent (which happens in `view.clearRenderedChildren`).
