### PR TITLE
Fix ArrayController#length when content is not explicitly set

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -177,8 +177,8 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
   },
 
   init: function() {
-    this._super();
     if (!this.get('content')) { Ember.defineProperty(this, 'content', undefined, Ember.A()); }
+    this._super();
     this.set('_subControllers', Ember.A());
   },
 

--- a/packages/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/array_controller_test.js
@@ -28,3 +28,10 @@ test("defaults it's `content` to an empty array", function () {
   equal(Controller.create().get('firstObject'), undefined, 'can fetch firstObject');
   equal(Controller.create().get('lastObject'), undefined, 'can fetch lastObject');
 });
+
+
+test("Ember.ArrayController length property works even if content was not set initially", function() {
+  var controller = Ember.ArrayController.create();
+  controller.pushObject('item');
+  equal(controller.get('length'), 1);
+});


### PR DESCRIPTION
Fixes #2416. If `content` is not set explicitly, `ArrayController#length` currently breaks.
