### PR TITLE
viewName is a property

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2036,7 +2036,7 @@ Ember.View = Ember.CoreView.extend(
 
     // remove from non-virtual parent view if viewName was specified
     if (viewName && nonVirtualParentView) {
-      nonVirtualParentView[viewName] = null;
+      nonVirtualParentView.set(viewName, null);
     }
 
     childLen = childViews.length;


### PR DESCRIPTION
With latest ember master, all views I created manually specifying a `viewName` were complaining on `destroy`:

```
assertion failed: You must use Ember.set() to access this property
```

This patch fixes this bug.
