### PR TITLE
App.reset does not handle readiness correctly

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -346,6 +346,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   */
   advanceReadiness: function() {
     this._readinessDeferrals--;
+    Ember.assert('_readinessDeferrals is ' + this._readinessDeferrals + ' (must be >= 0); was advanceReadiness() called without a matching deferReadiness()?', this._readinessDeferrals >= 0);
 
     if (this._readinessDeferrals === 0) {
       Ember.run.once(this, this.didBecomeReady);


### PR DESCRIPTION
`_readinessDeferrals` [starts off at 1](https://github.com/emberjs/ember.js/blob/508563931a5532290421b41ea1f17f77ac32d3af/packages/ember-application/lib/system/application.js#L215), but `App.reset()` never sets it back to 1. So when `App.reset()` calls `advanceReadiness` through `_initialize`, `_readinessDeferrals` becomes negative.

The attached patch exposes this issue. `rake test[ember-application]` yields three failures:

```
Module Failed: Ember.Application - resetting
  Test Failed: When an application is reset, new instances of controllers are generated
    Assertion Failed: Died on test #1     at http://localhost:9999/qunit/qunit.js:412
    at :41
    at :104: assertion failed: _readinessDeferrals is -1 (must be >= 0); was advanceReadiness() called without a matching deferReadiness()?
  Test Failed: When an application is reset, the ApplicationView is torn down
    Assertion Failed: Died on test #2     at http://localhost:9999/qunit/qunit.js:412
    at :64
    at :104: assertion failed: _readinessDeferrals is -1 (must be >= 0); was advanceReadiness() called without a matching deferReadiness()?
    Assertion Failed: Ember.View.views should be empty
      Expected: , Actual: application-view
  Test Failed: When an application is reset, the router URL is reset to `/`
    Assertion Failed: Died on test #1     at http://localhost:9999/qunit/qunit.js:412
    at :102
    at :104: assertion failed: _readinessDeferrals is -1 (must be >= 0); was advanceReadiness() called without a matching deferReadiness()?
```
