### PR TITLE
Allow nested route calls

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -40,8 +40,6 @@ DSL.prototype = {
   },
 
   route: function(name, options) {
-    Ember.assert("You must use `this.resource` to nest", typeof options !== 'function');
-
     options = options || {};
 
     if (typeof options.path !== 'string') {


### PR DESCRIPTION
There is no technical reason for this to exist. @wycats told me it was there to clarify the difference between `resource` and `route`. Nesting routes allows you to create more substates when needed. Nesting resources does not solve this problem.
