### PR TITLE
Adding before and after filters to help debugging and do pre/post processing when needed

### DIFF
--- a/packages/ember-old-router/lib/controller_ext.js
+++ b/packages/ember-old-router/lib/controller_ext.js
@@ -11,7 +11,7 @@ Additional methods for the ControllerMixin
 @class ControllerMixin
 @namespace Ember
 */
-Ember.ControllerMixin.reopen({
+Ember.ControllerMixin.reopen(Ember.Filters, {
   controllers: null,
 
   /**
@@ -115,6 +115,8 @@ Ember.ControllerMixin.reopen({
     //     controller's `content` and thus the
     //     template's context.
 
+    this.fbefore('connectOutlet', arguments);
+
     var outletName, viewClass, view, controller, options;
 
     if (Ember.typeOf(context) === 'string') {
@@ -179,6 +181,8 @@ Ember.ControllerMixin.reopen({
     @param {String...} controllerNames the controllers to make available
   */
   connectControllers: function() {
+    this.fbefore('connectControllers', this, arguments);
+
     var controllers = get(this, 'controllers'),
         controllerNames = Array.prototype.slice.apply(arguments),
         controllerName;
@@ -196,6 +200,8 @@ Ember.ControllerMixin.reopen({
     @param  {String} outletName the outlet name. (optional)
    */
   disconnectOutlet: function(outletName) {
+    this.fbefore('disconnectOutlet', this, arguments);
+    
     outletName = outletName || 'view';
 
     set(this, outletName, null);

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -5,8 +5,10 @@
 
 var get = Ember.get, set = Ember.set;
 
-Ember.ControllerMixin.reopen({
+Ember.ControllerMixin.reopen(Ember.Filters, {
   transitionToRoute: function() {
+    this.fbefore('transitionToRoute', this);
+
     // target may be either another controller or a router
     var target = get(this, 'target'),
         method = target.transitionToRoute || target.transitionTo;
@@ -19,6 +21,8 @@ Ember.ControllerMixin.reopen({
   },
 
   replaceRoute: function() {
+    this.fbefore('replaceRoute', this, arguments);
+    
     // target may be either another controller or a router
     var target = get(this, 'target'),
         method = target.replaceRoute || target.replaceWith;
@@ -30,3 +34,5 @@ Ember.ControllerMixin.reopen({
     return this.replaceRoute.apply(this, arguments);
   }
 });
+
+

--- a/packages/ember-routing/lib/ext/view.js
+++ b/packages/ember-routing/lib/ext/view.js
@@ -5,13 +5,15 @@
 
 var get = Ember.get, set = Ember.set;
 
-Ember.View.reopen({
+Ember.View.reopen(Ember.Filters, {
   init: function() {
     set(this, '_outlets', {});
     this._super();
   },
 
   connectOutlet: function(outletName, view) {
+    this.fbefore('connectOutlet', this, arguments);
+
     var outlets = get(this, '_outlets'),
         container = get(this, 'container'),
         router = container && container.lookup('router:main'),
@@ -22,9 +24,13 @@ Ember.View.reopen({
     if (router && renderedName) {
       router._connectActiveView(renderedName, view);
     }
+
+    this.fafter('connectOutlet', this, arguments);
   },
 
   disconnectOutlet: function(outletName) {
+    this.fbefore('disconnectOutlet', this, arguments);
+    
     var outlets = get(this, '_outlets');
 
     set(outlets, outletName, null);

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -14,13 +14,14 @@ var get = Ember.get, set = Ember.set,
   @namespace Ember
   @extends Ember.Object
 */
-Ember.Route = Ember.Object.extend({
+Ember.Route = Ember.Object.extend(Ember.Filters, {
   /**
     @private
 
     @method exit
   */
   exit: function() {
+    this.fbefore('exit', this);
     this.deactivate();
     teardownView(this);
   },
@@ -31,6 +32,7 @@ Ember.Route = Ember.Object.extend({
     @method enter
   */
   enter: function() {
+    this.fbefore('enter', this);
     this.activate();
   },
 
@@ -80,6 +82,7 @@ Ember.Route = Ember.Object.extend({
     @param {...Object} models the
   */
   transitionTo: function() {
+    this.fbefore('transitionTo', this, arguments);
     if (this._checkingRedirect) { this.redirected = true; }
     return this.router.transitionTo.apply(this.router, arguments);
   },
@@ -93,6 +96,7 @@ Ember.Route = Ember.Object.extend({
     @param {...Object} models the
   */
   replaceWith: function() {
+    this.fbefore('replaceWith', this, arguments);
     if (this._checkingRedirect) { this.redirected = true; }
     return this.router.replaceWith.apply(this.router, arguments);
   },
@@ -109,6 +113,8 @@ Ember.Route = Ember.Object.extend({
     @method setup
   */
   setup: function(context) {
+    this.fbefore('setup', this, arguments);
+
     this.redirected = false;
     this._checkingRedirect = true;
 
@@ -141,6 +147,8 @@ Ember.Route = Ember.Object.extend({
     } else {
       this.renderTemplate(controller, context);
     }
+    
+    this.fafter('setup', this, arguments);
   },
 
   /**
@@ -163,6 +171,8 @@ Ember.Route = Ember.Object.extend({
     @method deserialize
   */
   deserialize: function(params) {
+    this.fbefore('deserialize', this, arguments);
+
     var model = this.model(params);
     return this.currentModel = model;
   },
@@ -173,6 +183,8 @@ Ember.Route = Ember.Object.extend({
     Called when the context is changed by router.js.
   */
   contextDidChange: function() {
+    this.fbefore('contextDidChange', this, arguments);
+
     this.currentModel = this.context;
   },
 
@@ -206,6 +218,8 @@ Ember.Route = Ember.Object.extend({
     @param {Object} params the parameters extracted from the URL
   */
   model: function(params) {
+    this.fbefore('model', this, arguments);
+
     var match, name, sawParams, value;
 
     for (var prop in params) {
@@ -262,6 +276,8 @@ Ember.Route = Ember.Object.extend({
     @return {Object} the serialized parameters
   */
   serialize: function(model, params) {
+    this.fbefore('serialize', this, arguments);
+
     if (params.length !== 1) { return; }
 
     var name = params[0], object = {};
@@ -327,6 +343,8 @@ Ember.Route = Ember.Object.extend({
     @return {Ember.Controller}
   */
   controllerFor: function(name, model) {
+    this.fbefore('controllerFor', this, arguments);
+
     var container = this.router.container,
         controller = container.lookup('controller:' + name);
 
@@ -352,6 +370,8 @@ Ember.Route = Ember.Object.extend({
     @return {Object} the model object
   */
   modelFor: function(name) {
+    this.fbefore('modelFor', this, arguments);
+
     var route = this.container.lookup('route:' + name);
     return route && route.currentModel;
   },
@@ -371,6 +391,8 @@ Ember.Route = Ember.Object.extend({
     @param {Object} model the route's model
   */
   renderTemplate: function(controller, model) {
+    this.fbefore('renderTemplate', this, arguments);
+
     this.render();
   },
 
@@ -426,6 +448,8 @@ Ember.Route = Ember.Object.extend({
     @param {Object} options the options
   */
   render: function(name, options) {
+    this.fbefore('render', this, arguments);
+
     Ember.assert("The name in the given arguments is undefined", arguments.length > 0 ? !Ember.isNone(arguments[0]) : true);
 
     if (typeof name === 'object' && !options) {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -33,7 +33,7 @@ function setupLocation(router) {
   @namespace Ember
   @extends Ember.Object
 */
-Ember.Router = Ember.Object.extend({
+Ember.Router = Ember.Object.extend(Ember.Filters, {
   location: 'hash',
 
   init: function() {
@@ -47,6 +47,8 @@ Ember.Router = Ember.Object.extend({
   }),
 
   startRouting: function() {
+    this.fbefore('startRouting', this, arguments);
+
     this.router = this.router || this.constructor.map(Ember.K);
 
     var router = this.router,
@@ -67,6 +69,8 @@ Ember.Router = Ember.Object.extend({
   },
 
   didTransition: function(infos) {
+    this.fbefore('didTransition', this, arguments);
+
     // Don't do any further action here if we redirected
     for (var i=0, l=infos.length; i<l; i++) {
       if (infos[i].handler.redirected) { return; }
@@ -84,26 +88,36 @@ Ember.Router = Ember.Object.extend({
   },
 
   handleURL: function(url) {
+    this.fbefore('handleURL', this, arguments);
+
     this.router.handleURL(url);
     this.notifyPropertyChange('url');
   },
 
   transitionTo: function(name) {
+    this.fbefore('transitionTo', this, arguments);
+
     var args = [].slice.call(arguments);
     doTransition(this, 'transitionTo', args);
   },
 
   replaceWith: function() {
+    this.fbefore('replaceWith', this, arguments);
+
     var args = [].slice.call(arguments);
     doTransition(this, 'replaceWith', args);
   },
 
   generate: function() {
+    this.fbefore('generate', this, arguments);
+
     var url = this.router.generate.apply(this.router, arguments);
     return this.location.formatURL(url);
   },
 
   isActive: function(routeName) {
+    this.fbefore('isActive', this, arguments);
+
     var router = this.router;
     return router.isActive.apply(router, arguments);
   },

--- a/packages/ember-runtime/lib/mixins.js
+++ b/packages/ember-runtime/lib/mixins.js
@@ -9,3 +9,4 @@ require('ember-runtime/mixins/observable');
 require('ember-runtime/mixins/target_action_support');
 require('ember-runtime/mixins/evented');
 require('ember-runtime/mixins/deferred');
+require('ember-runtime/mixins/filters');

--- a/packages/ember-runtime/lib/mixins/filters.js
+++ b/packages/ember-runtime/lib/mixins/filters.js
@@ -1,0 +1,121 @@
+/*
+  Use this to introduce filters to your ember objects in order to do interesting things before or after
+  key methods are called. This is often a better option than extending and monkeypatching a method
+  to introduce your behaviour. 
+
+  You should use the filters like this:
+
+      setup: function(context) {
+        this.fbefore('setup', this, arguments)
+
+        // do the setup
+
+        // optionally call after, in case this method doesn't return a value
+        this.fafter('setup', this, arguments)          
+      }
+
+  A typical use case would be to log the state at that point without having to set break points or
+  monkey-patching with `console.logs` directly into the ember code.
+
+  For the use case where you want to log a particular aspect of Ember, f.ex the Ember.Router, 
+  you can add a `beforeAnyMethod` function to Ember.Router like this:
+
+  Ember.Router.reopen({
+    fbeforeAnyMethod: function(args) {
+      var funName = args[0];
+      console.log "before:" + funName, args.slice(1)
+    },
+
+    fafterAnyMethod: function(args) {
+      var funName = args[0];
+      console.log "after:" + funName, args.slice(1)
+    },    
+  })
+
+  Then you will have complete output of what goes on internally in Ember.
+  You can then further make switch statements here, in order to control for which functions you want
+  to do something (such as logging). Powerful stuff!
+
+  Another typical use case, is when you want to wrap/convert the state of the object (or arguments) 
+  before a particular method is called. It could f.x be that you want to wrap the context object
+  with `R` (from the RubyJS project), in order to always add the R API to your models or array 
+  of models. You might also want to change how Ember resolves its naming convention magic, 
+  in order to add specific namespaces in some cases to better suit your needs. 
+  There are many possibilities. Use your imagination ;)
+
+  @class Filters
+  @namespace Ember
+  @extends Ember.Mixin      
+*/
+Ember.Filters = Ember.Mixin.create({
+  /*
+    Takes the method, f.ex `setup` and tries to execute `beforeSetup`
+    if such a method exists in the current context, with the arguments given
+    The convention is to call before like this:
+
+        setup: function(context) {
+          this.fbefore('setup', this, arguments)
+        }
+
+   @param {String} name The name of the function that called `before`
+  */
+  fbefore: function(methodName) {
+    var filterName = 'fbefore' + methodName.camelize;
+    this._callFilter(filterName, arguments);
+    this._filterAny('fbefore', methodName, arguments);
+  },
+
+  /*
+    Takes the method, f.ex `setup` and tries to execute `afterSetup`
+    if such a method exists in the current context, with the arguments given
+    The convention is to call after like this:
+
+        setup: function(context) {
+          // do the setup
+
+          // call after in case this method doesn't return a value
+          // Note: In some cases you might want to call `after` just before 
+          // the method returns a value
+          this.fafter('setup', this, arguments)          
+        }
+    @param {String} name The name of the function that called `after`
+  */
+  fafter: function(methodName) {
+    var filterName = 'fafter' + methodName.camelize;
+    this._callFilter(filterName, arguments);
+    this._filterAny('fafter', methodName, arguments);
+  },
+
+  /*
+    Check to see if a filter function exists in the current context
+    Executes the filter if it does exist.
+
+    @private
+    @param {String} filterName The name of filter function to call, f.ex `beforeSetup`
+  */
+  _callFilter: function(filterName, args) {
+    if (this[filterName])
+      this[filterName].apply(args);    
+  },
+
+  /*
+    Called from either `before` or `after` with a where argument (that equalt 'befor' or 'after')
+
+    When where = 'before'
+    Checks to see if a `beforeAnyMethod` filter function exists in the current context
+    Executes the `beforeAnyMethod` filter with arguments, that include the name 
+    of the original function that called the before or after filter.
+
+    When where = 'after'
+    Same as before.
+
+    @private
+    @param {String} where Either 'fbefore' or 'fafter'
+    @param {String} methName The original name of the function that called before or after
+    @param {String} args The arguments sent to before or after
+  */
+  _filterAny: function(where, methName, args) {
+    var filterName = where + 'AnyMethod';
+    this._callFilter(filterName, [methName, args]);
+  }
+});

--- a/packages/ember-runtime/tests/mixins/filters_test.js
+++ b/packages/ember-runtime/tests/mixins/filters_test.js
@@ -1,0 +1,140 @@
+module('mixins/filters');
+
+var FilterTestResults = Ember.Mixin.create({
+  beforeArgs: null,
+  afterArgs: null,
+  beforeAnyArgs: null,
+  afterAnyArgs: null
+});
+
+var TestFiltersWithBefore = Ember.Object.extend(Ember.Filters, FilterTestResults, {
+  setup: function(opts) {
+    this.fbefore('setup', this, arguments);
+    return this;
+  },
+  fbeforeSetup: function(args) {
+    console.log('beforeSetup called with', args);
+    this.set('beforeArgs', args);
+  }
+});
+
+var TestFiltersWithoutBefore = Ember.Object.extend(Ember.Filters, FilterTestResults, {
+  setup: function(opts) {
+    this.fbefore('setup', this, arguments);
+    return this;
+  }
+});
+
+var TestFiltersWithAfter = Ember.Object.extend(Ember.Filters, FilterTestResults, {
+  setup: function(opts) {
+    this.fafter('setup', this, arguments);
+    return this;
+  },
+  fafterSetup: function(args) {
+    console.log('afterSetup called with', args);
+    this.set('afterArgs', args);
+  }
+});
+
+var TestFiltersWithoutAfter = Ember.Object.extend(Ember.Filters, FilterTestResults, {
+  setup: function(opts) {
+    this.fafter('setup', this, arguments);
+    return this;
+  }
+});
+
+var TestFiltersWithAnyAfter = Ember.Object.extend(Ember.Filters, FilterTestResults, {
+  setup: function(opts) {
+    this.fafter('setup', this, arguments);
+    return this;
+  },
+
+  fafterAnyMethod: function(args) {
+    console.log('fafterAnyMethod called with', args);
+    this.set('afterAnyArgs', args);
+  }
+});
+
+var TestFiltersWithAnyBefore = Ember.Object.extend(Ember.Filters, FilterTestResults, {
+  setup: function(opts) {
+    this.fbefore('setup', this, arguments);
+    return this;
+  },
+
+  fbeforeAnyMethod: function(args) {
+    console.log('fbeforeAnyMethod called with', args);
+    this.set('beforeAnyArgs', args);
+  }
+});
+
+
+test('should filter before when it has matching before filter', function() {
+  var filterer   = TestFiltersWithBefore.create();
+  filterer.setup('hello');
+
+  notEqual(filterer.get('beforeArgs'), null, 'beforeArgs should be set by beforeSetup filter' );
+
+  var beforeArgs = filterer.get('beforeArgs');
+
+  if (beforeArgs) {
+    equal("hello", beforeArgs[0]);
+  }
+});
+
+test('should not filter before when it has no matching before filter', function() {
+  var filterer   = TestFiltersWithoutBefore.create();
+  filterer.setup('hello');
+
+  equal(null, filterer.get('beforeArgs'), 'beforeArgs should not be set since no beforeSetup filter defined' );
+});
+
+test('should filter after when it has matching after filter', function() {
+  var filterer   = TestFiltersWithAfter.create();
+  filterer.setup('bye');
+
+  notEqual(null, filterer.get('afterArgs'), 'afterArgs should be set by afterSetup filter' );
+
+  var afterArgs = filterer.get('afterArgs');
+
+  if (afterArgs) {  
+    equal("bye", afterArgs[0], 'should set afterArgs to bye');
+  }
+});
+
+test('should not filter after when it has no matching after filter', function() {
+  var filterer   = TestFiltersWithoutAfter.create();
+  filterer.setup('bye');
+
+  equal(null, filterer.get('afterArgs'), 'afterArgs should not be set since no afterSetup filter defined' );
+});
+
+// AnyMethod filters
+
+test('should filter after when it has an afterAnyMethod filter', function() {
+  var filterer   = TestFiltersWithAnyAfter.create();
+  filterer.setup('bye');
+
+  equal(null, filterer.get('afterArgs'), 'afterArgs should not be set by afterSetup filter' );
+
+  var afterAnyArgs = filterer.get('afterAnyArgs');
+
+  if (afterAnyArgs) {  
+    equal("setup", afterAnyArgs[0], 'should set afterAnyArgs[0] to setup');
+    equal("bye", afterAnyArgs[0], 'should set afterAnyArgs[1] to bye');
+  }
+});
+
+
+test('should filter after when it has matching after filter', function() {
+  var filterer   = TestFiltersWithAnyBefore.create();
+  filterer.setup('hello');
+
+  equal(null, filterer.get('beforeArgs'), 'beforeArgs should not be set by beforeSetup filter' );
+
+  var beforeAnyArgs = filterer.get('beforeAnyArgs');
+
+  if (beforeAnyArgs) {  
+    equal("setup", beforeAnyArgs[0], 'should set beforeAnyArgs[0] to setup');
+    equal("hello", beforeAnyArgs[1], 'should set beforeAnyArgs[1] to hello');
+  }
+});


### PR DESCRIPTION
Use this to introduce filters to your ember objects in order to do interesting things before or after key methods are called. This is often a better option than extending and monkey-patching a method to introduce your own behaviour. 

You should use the filters like this:

```
      setup: function(context) {
        this.fbefore('setup', this, arguments)

        // do the setup

        // optionally call after, in case this method doesn't return a value
        this.fafter('setup', this, arguments)          
      }
```

Note: `fbefore` and `fafter` were chosen in order to ensure they don't conflict with `before` and `after` from observable mixin (or some other mixin).

A typical use case would be to log the state at that point without having to set break points or monkey-patching with `console.logs` directly into the ember code base. Not very nice!

For the use case where you want to log a particular aspect of Ember, f.ex the Ember.Router, you can add a `beforeAnyMethod` function to Ember.Router like this:

```
  Ember.Router.reopen({
    fbeforeAnyMethod: function(args) {
      var funName = args[0];
      console.log "before:" + funName, args.slice(1)
    },

    fafterAnyMethod: function(args) {
      var funName = args[0];
      console.log "after:" + funName, args.slice(1)
    },    
  })
```

Then you will have complete output of what goes on internally in Ember (for any method with before or after filters). You can then further make switch statements in the `xxxAnyMethod` function, in order to control for which functions you want to do something (such as logging). Powerful stuff!

Another typical use case, is when you want to wrap/convert the state of the object (or arguments) before a particular method is called. It could f.x be that you want to wrap the context object with `R` (from the RubyJS project), in order to always add the `R` API to your models or array of models. You might also want to change how Ember resolves its naming convention magic, in order to f.ex use specific namespaces in some cases to better suit your needs. 
There are many possibilities. Use your imagination ;)

_Current problem! I have problem defining a decent set of tests :(_

**The current code additions don't break anything in Ember however. All existing test pass :)**

Please help me fix the tests at:

https://github.com/kristianmandrup/ember.js/blob/after-before-filters/packages/ember-runtime/tests/mixins/filters_test.js

Thanks :)

```
Module Failed: mixins/filters
  Test Failed: should filter before when it has matching before filter
    Assertion Failed: beforeArgs should be set by beforeSetup filter
  Test Failed: should filter after when it has matching after filter
    Assertion Failed: afterArgs should be set by afterSetup filter
  Test Failed: should filter after when it has an afterAnyMethod filter
    Assertion Failed: Died on test #1     at http://localhost:9999/qunit/qunit.js:412
    at :125
    at :142: 'undefined' is not a function (evaluating 'this.set('afterAnyArgs', args)')
  Test Failed: should filter after when it has matching after filter
    Assertion Failed: Died on test #1     at http://localhost:9999/qunit/qunit.js:412
    at :140
    at :142: 'undefined' is not a function (evaluating 'this.set('beforeAnyArgs', args)')
```

Please let me know what you think about this feature. Thanks!
