### PR TITLE
Add "navigates" flag to linkTo helper

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -92,6 +92,8 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       event.preventDefault();
       if (this.bubbles === false) { event.stopPropagation(); }
 
+      if (this.navigates === false) { return false; }
+
       var router = this.get('router');
 
       if (this.get('replace')) {


### PR DESCRIPTION
My use case is that I have a link on a page, but I don't want it to actually navigate; rather, I need it to navigate after an analytics request is made. This might not be solving the root of the problem, so I'll submit another PR with option B, performing the transitionTo _after_ a provided function is run. If nothing else, I hope this spurs up a discussion.
