### PR TITLE
Fixes to HistoryLocation

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -18,7 +18,6 @@ Ember.HistoryLocation = Ember.Object.extend({
 
   init: function() {
     set(this, 'location', get(this, 'location') || window.location);
-    this._initialUrl = this.getURL();
     this.initState();
   },
 
@@ -30,8 +29,8 @@ Ember.HistoryLocation = Ember.Object.extend({
     @method initState
   */
   initState: function() {
+    set(this, 'history', get(this, 'history') || window.history);
     this.replaceState(this.formatURL(this.getURL()));
-    set(this, 'history', window.history);
   },
 
   /**
@@ -112,7 +111,9 @@ Ember.HistoryLocation = Ember.Object.extend({
    @param path {String}
   */
   pushState: function(path) {
-    window.history.pushState({ path: path }, null, path);
+    get(this, 'history').pushState({ path: path }, null, path);
+    // used for webkit workaround
+    this._previousURL = this.getURL();
   },
 
   /**
@@ -124,7 +125,9 @@ Ember.HistoryLocation = Ember.Object.extend({
    @param path {String}
   */
   replaceState: function(path) {
-    window.history.replaceState({ path: path }, null, path);
+    get(this, 'history').replaceState({ path: path }, null, path);
+    // used for webkit workaround
+    this._previousURL = this.getURL();
   },
 
   /**
@@ -144,7 +147,7 @@ Ember.HistoryLocation = Ember.Object.extend({
       // Ignore initial page load popstate event in Chrome
       if(!popstateFired) {
         popstateFired = true;
-        if (self.formatURL(self.getURL()) === self._initialUrl) { return; }
+        if (self.getURL() === self._previousURL) { return; }
       }
       callback(self.getURL());
     });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -12,16 +12,17 @@ require("ember-routing/system/dsl");
 
 function setupLocation(router) {
   var location = get(router, 'location'),
-      rootURL = get(router, 'rootURL');
+      rootURL = get(router, 'rootURL'),
+      options = {};
+
+  if (typeof rootURL === 'string') {
+    options.rootURL = rootURL;
+  }
 
   if ('string' === typeof location) {
-    location = set(router, 'location', Ember.Location.create({
-      implementation: location
-    }));
+    options.implementation = location;
+    location = set(router, 'location', Ember.Location.create(options));
 
-    if (typeof rootURL === 'string') {
-      set(location, 'rootURL', rootURL);
-    }
   }
 }
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1464,6 +1464,39 @@ test("Router accounts for rootURL on page load when using history location", fun
   delete Ember.Location.implementations['historyTest'];
 });
 
+test("HistoryLocation has the correct rootURL on initState and webkit doesn't fire popstate on page load", function() {
+  expect(2);
+  var rootURL = window.location.pathname + 'app',
+      history,
+      HistoryTestLocation;
+
+  history = { replaceState: function() {} };
+
+  HistoryTestLocation = Ember.HistoryLocation.extend({
+    history: history,
+    initState: function() {
+      equal(this.get('rootURL'), rootURL);
+      this._super();
+      // these two should be equal to be able
+      // to successfully detect webkit initial popstate
+      equal(this._previousURL, this.getURL());
+    }
+  });
+
+  Ember.Location.registerImplementation('historyTest', HistoryTestLocation);
+
+  Router.reopen({
+    location: 'historyTest',
+    rootURL: rootURL
+  });
+
+  bootApplication();
+
+  // clean after test
+  delete Ember.Location.implementations['historyTest'];
+});
+
+
 test("Only use route rendered into main outlet for default into property on child", function() {
   Ember.TEMPLATES.application = compile("{{outlet menu}}{{outlet}}");
   Ember.TEMPLATES.posts = compile("{{outlet}}");


### PR DESCRIPTION
This PR fixes several issues with `Ember.HistoryLocation`:
1. `rootURL` was not handled correctly when page loads without the `rootURL` ( i.e. when the URL == '/' ).
2. In one rare case it was not handling `history#popstate` correctly for non-webkit browsers.
3. `history#popstate` fired on page load in webkit browsers when the index route contained a redirect.

This should fix all of the above issues.  It should also fix #2451
