### PR TITLE
Ember.Select breaks when content has changed and value hasn't

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -398,6 +398,19 @@ Ember.Select = Ember.View.extend(
     }
   }, 'value'),
 
+  contentDidChange: Ember.observer(function() {
+    if (get(this, 'multiple')) { return; }
+    var content = get(this, 'content'),
+        value = get(this, 'value'),
+        valuePath = get(this, 'optionValuePath').replace(/^content\.?/, ''),
+        selection = get(this, 'selection');
+    if (content && selection != null && content.indexOf(selection)===-1) {
+      selection = content.find(function(obj) {
+        return value === (valuePath ? get(obj, valuePath) : obj);
+      });
+      this.set('selection', selection);
+    }
+  }, 'content.@each'),
 
   _triggerChange: function() {
     var selection = get(this, 'selection');

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -410,7 +410,7 @@ Ember.Select = Ember.View.extend(
       });
       this.set('selection', selection);
     }
-  }, 'content.@each'),
+  }, 'content.[]'),
 
   _triggerChange: function() {
     var selection = get(this, 'selection');

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -362,6 +362,36 @@ test("Ember.SelectedOption knows when it is selected when multiple=false", funct
   deepEqual(selectedOptions(), [false, false, false, true], "After changing it, selection should be correct");
 });
 
+test("Ember.SelectedOption knows when it is selected when content has changed and value is reused", function() {
+  var a = Ember.Object.create({
+    value: 2,
+    choices: Ember.A([{id: 1, label: 'One'}, {id: 2, label: 'Two'}])
+  }),
+  b = Ember.Object.create({
+    value: 2,
+    choices: Ember.A([{id: 1, label: 'First'}, {id: 2, label: 'Second'}])
+  });
+
+  select = Ember.Select.create({
+    target: a,
+    contentBinding: 'target.choices',
+    valueBinding: 'target.value',
+    optionLabelPath: 'content.label',
+    optionValuePath: 'content.id'
+  });
+
+  append();
+
+  deepEqual(selectedOptions(), [false, true], "Initial selection should be correct");
+
+  Ember.run(function() { 
+    select.set('target', b);
+  });
+
+  deepEqual(selectedOptions(), [false, true], "After changing it, selection should be correct");
+});
+
+
 test("Ember.SelectedOption knows when it is selected when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' },
       tom = { id: 2, firstName: 'Tom' },


### PR DESCRIPTION
Changing `Ember.Select`'s `content` should invalidate the `selection` property. Otherwise, you can end up with a stale `selection` that is not in `content`, which causes the SelectedOptions to fail to match.

The included unit test demonstrates one way this bug can strike in practice: swapping out models that each contain their own selection choices, with overlapping values.
