### PR TITLE
Making Router#url a property

### DIFF
--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -81,7 +81,9 @@ test("When an application is reset, the router URL is reset to `/`", function() 
   router = application.__container__.lookup('router:main');
 
   location = router.get('location');
-  location.handleURL('/one');
+  Ember.run(function() {
+    location.handleURL('/one');
+  });
 
   Ember.run(function() {
     application.reset();
@@ -96,7 +98,9 @@ test("When an application is reset, the router URL is reset to `/`", function() 
   equal(get(applicationController, 'currentPath'), "index");
 
   location = application.__container__.lookup('router:main').get('location');
-  location.handleURL('/one');
+  Ember.run(function() {
+    location.handleURL('/one');
+  });
 
   equal(get(applicationController, 'currentPath'), "one");
 });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -37,13 +37,15 @@ function setupLocation(router) {
 Ember.Router = Ember.Object.extend({
   location: 'hash',
 
-  url: null,
-
   init: function() {
     this.router = this.constructor.router;
     this._activeViews = {};
     setupLocation(this);
   },
+
+  url: Ember.computed(function() {
+    return get(this, 'location').getURL();
+  }),
 
   startRouting: function() {
     this.router = this.router || this.constructor.map(Ember.K);
@@ -82,8 +84,8 @@ Ember.Router = Ember.Object.extend({
   },
 
   handleURL: function(url) {
+    this.router.updateURL(url);
     this.router.handleURL(url);
-    set(this, 'url', url);
   },
 
   transitionTo: function(name) {
@@ -190,8 +192,9 @@ function setupRouter(emberRouter, router, location) {
   router.getHandler = getHandlerFunction(emberRouter);
 
   var doUpdateURL = function() {
+    emberRouter.propertyWillChange('url');
     location.setURL(lastURL);
-    set(emberRouter, 'url', location.getURL());
+    emberRouter.propertyDidChange('url');
   };
 
   router.updateURL = function(path) {
@@ -201,8 +204,9 @@ function setupRouter(emberRouter, router, location) {
 
   if (location.replaceURL) {
     var doReplaceURL = function() {
+      emberRouter.propertyWillChange('url');
       location.replaceURL(lastURL);
-      set(emberRouter, 'url', location.getURL());
+      emberRouter.propertyDidChange('url');
     };
 
     router.replaceURL = function(path) {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -37,15 +37,13 @@ function setupLocation(router) {
 Ember.Router = Ember.Object.extend({
   location: 'hash',
 
+  url: null,
+
   init: function() {
     this.router = this.constructor.router;
     this._activeViews = {};
     setupLocation(this);
   },
-
-  url: Ember.computed(function() {
-    return get(this, 'location').getURL();
-  }),
 
   startRouting: function() {
     this.router = this.router || this.constructor.map(Ember.K);
@@ -77,7 +75,6 @@ Ember.Router = Ember.Object.extend({
         path = routePath(infos);
 
     set(appController, 'currentPath', path);
-    this.notifyPropertyChange('url');
 
     if (get(this, 'namespace').LOG_TRANSITIONS) {
       Ember.Logger.log("Transitioned into '" + path + "'");
@@ -86,7 +83,7 @@ Ember.Router = Ember.Object.extend({
 
   handleURL: function(url) {
     this.router.handleURL(url);
-    this.notifyPropertyChange('url');
+    set(this, 'url', url);
   },
 
   transitionTo: function(name) {
@@ -194,6 +191,7 @@ function setupRouter(emberRouter, router, location) {
 
   var doUpdateURL = function() {
     location.setURL(lastURL);
+    set(emberRouter, 'url', location.getURL());
   };
 
   router.updateURL = function(path) {
@@ -204,6 +202,7 @@ function setupRouter(emberRouter, router, location) {
   if (location.replaceURL) {
     var doReplaceURL = function() {
       location.replaceURL(lastURL);
+      set(emberRouter, 'url', location.getURL());
     };
 
     router.replaceURL = function(path) {
@@ -229,7 +228,6 @@ function doTransition(router, method, args) {
   Ember.assert("The route " + passedName + " was not found", router.router.hasRoute(name));
 
   router.router[method].apply(router.router, args);
-  router.notifyPropertyChange('url');
 }
 
 Ember.Router.reopenClass({

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -106,14 +106,14 @@ test("The {{linkTo}} helper supports URL replacement", function() {
     router.handleURL("/");
   });
 
-  equal(setCount, 0, 'precond: setURL has not been called');
+  equal(setCount, 2, 'precond: setURL has been called twice');
   equal(replaceCount, 0, 'precond: replaceURL has not been called');
 
   Ember.run(function() {
     Ember.$('#about-link', '#qunit-fixture').click();
   });
 
-  equal(setCount, 0, 'setURL should not be called');
+  equal(setCount, 2, 'setURL should not be called');
   equal(replaceCount, 1, 'replaceURL should be called once');
 });
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -956,17 +956,47 @@ test('navigating away triggers a url property change', function() {
   Ember.run(function() {
     router.handleURL("/");
   });
+  equal(urlPropertyChangeCount, 1, 'triggered a single url property change');
 
-  equal(urlPropertyChangeCount, 2);
+  // Trigger the callback that would otherwise be triggered
+  // when a user clicks the back or forward button.
+  Ember.run(function() {
+    router.router.transitionTo('foo');
+  });
+  equal(urlPropertyChangeCount, 2, 'triggered url property change');
 
   Ember.run(function() {
-    // Trigger the callback that would otherwise be triggered
-    // when a user clicks the back or forward button.
-    router.router.transitionTo('foo');
+    router.router.transitionTo('bar');
+  });
+  equal(urlPropertyChangeCount, 3, 'triggered url property change');
+});
+
+test('the url property should be the current location url', function() {
+  Router.map(function() {
+    this.route('root', { path: '/' });
+    this.route('foo', { path: '/foo' });
+    this.route('bar', { path: '/bar-baz' });
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(get(router, 'url'), '/');
+
+  Ember.run(function() {
+    router.handleURL("/foo");
+  });
+
+  equal(get(router, 'url'), '/foo');
+
+  Ember.run(function() {
     router.router.transitionTo('bar');
   });
 
-  equal(urlPropertyChangeCount, 4, 'triggered url property change');
+  equal(get(router, 'url'), '/bar-baz');
 });
 
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -923,14 +923,14 @@ test("transitioning multiple times in a single run loop only sets the URL once",
     router.handleURL("/");
   });
 
-  equal(urlSetCount, 0);
+  equal(urlSetCount, 1);
 
   Ember.run(function() {
     router.transitionTo("foo");
     router.transitionTo("bar");
   });
 
-  equal(urlSetCount, 1);
+  equal(urlSetCount, 2);
   equal(router.get('location').getURL(), "/bar");
 });
 
@@ -1029,14 +1029,14 @@ test("using replaceWith calls location.replaceURL if available", function() {
     router.handleURL("/");
   });
 
-  equal(setCount, 0);
+  equal(setCount, 2);
   equal(replaceCount, 0);
 
   Ember.run(function() {
     router.replaceWith("foo");
   });
 
-  equal(setCount, 0, 'should not call setURL');
+  equal(setCount, 2, 'should not call setURL');
   equal(replaceCount, 1, 'should call replaceURL once');
   equal(router.get('location').getURL(), "/foo");
 });
@@ -1063,14 +1063,15 @@ test("using replaceWith calls setURL if location.replaceURL is not defined", fun
   Ember.run(function() {
     router.handleURL("/");
   });
+  equal(router.get('location').getURL(), "/");
 
-  equal(setCount, 0);
+  equal(setCount, 2);
 
   Ember.run(function() {
     router.replaceWith("foo");
   });
 
-  equal(setCount, 1, 'should call setURL once');
+  equal(setCount, 3, 'should call setURL once');
   equal(router.get('location').getURL(), "/foo");
 });
 


### PR DESCRIPTION
The motivation behind this change was to enable an easy way observe url changes for analytics.

The current implementation triggers two change events when the application boots.  This behavior seems incorrect.  In addition the change events would notify the observers before the url was actually changed.

I modified the "navigating away triggers url property change" test to reflect the fact that handleURL should only trigger one change event.  Also added test to ensure that the url property is set to the correct url provided by the location.

This pull request enables users to do simple things like this:

``` js
App.Router = Ember.Router.extend({
  urlChanged: function() {
    gaq.push(['_trackPageview', this.get('url')]);
  }.observes('url');
});
```
