### PR TITLE
Support grouping option for Ember.Select using optgroup

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -9,6 +9,7 @@ var set = Ember.set,
     get = Ember.get,
     indexOf = Ember.EnumerableUtils.indexOf,
     indexesOf = Ember.EnumerableUtils.indexesOf,
+    forEach = Ember.EnumerableUtils.forEach,
     replace = Ember.EnumerableUtils.replace,
     isArray = Ember.isArray,
     precompileTemplate = Ember.Handlebars.compile;
@@ -60,6 +61,18 @@ Ember.SelectOption = Ember.View.extend({
       return get(this, valuePath);
     }).property(valuePath));
   }, 'parentView.optionValuePath')
+});
+
+Ember.SelectOptgroup = Ember.CollectionView.extend({
+  tagName: 'optgroup',
+  attributeBindings: ['label'],
+
+  selectionBinding: 'parentView.selection',
+  multipleBinding: 'parentView.multiple',
+  optionLabelPathBinding: 'parentView.optionLabelPath',
+  optionValuePathBinding: 'parentView.optionValuePath',
+
+  itemViewClassBinding: 'parentView.optionView'
 });
 
 /**
@@ -311,7 +324,7 @@ Ember.Select = Ember.View.extend(
 
   tagName: 'select',
   classNames: ['ember-select'],
-  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#each view.content}}{{view view.optionView contentBinding="this"}}{{/each}}'),
+  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each view.groupedContent}}{{view view.groupView contentBinding=this.content labelBinding=this.label}}{{/each}}{{else}}{{#each view.content}}{{view view.optionView contentBinding="this"}}{{/each}}{{/if}}'),
   attributeBindings: ['multiple', 'disabled', 'tabindex', 'name'],
 
   /**
@@ -406,6 +419,45 @@ Ember.Select = Ember.View.extend(
     @default 'content'
   */
   optionValuePath: 'content',
+
+  /**
+    The path of the option group.
+    When this property is used, `content` should be sorted by `optionGroupPath`.
+
+    @property optionGroupPath
+    @type String
+    @default null
+  */
+  optionGroupPath: null,
+
+  /**
+    The view class for optgroup.
+
+    @property groupView
+    @type Ember.View
+    @default Ember.SelectOptgroup
+  */
+  groupView: Ember.SelectOptgroup,
+
+  groupedContent: Ember.computed(function() {
+    var groupPath = get(this, 'optionGroupPath');
+    var groupedContent = Ember.A([]);
+
+    forEach(get(this, 'content'), function(item) {
+      var label = get(item, groupPath);
+
+      if (get(groupedContent, 'lastObject.label') !== label) {
+        groupedContent.pushObject({
+          label: label,
+          content: Ember.A([])
+        });
+      }
+
+      get(groupedContent, 'lastObject.content').push(item);
+    });
+
+    return groupedContent;
+  }).property('optionGroupPath', 'content.@each'),
 
   /**
     The view class for option.

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -307,6 +307,93 @@ test("multiple selections can be set indirectly via bindings and in-place when m
   deepEqual(select.get('selection'), [cyril], "After updating bound selection, selection should be correct");
 });
 
+test("select with group can groupe options", function() {
+  var content = Ember.A([
+    { firstName: 'Yehuda', organization: 'Tilde' },
+    { firstName: 'Tom', organization: 'Tilde' },
+    { firstName: 'Keith', organization: 'Envato' }
+  ]);
+
+  Ember.run(function() {
+    select.set('content', content),
+    select.set('optionGroupPath', 'organization');
+    select.set('optionLabelPath', 'content.firstName');
+  });
+
+  append();
+
+  equal(select.$('optgroup').length, 2);
+
+  var labels = [];
+  select.$('optgroup').each(function() {
+    labels.push(this.label);
+  });
+  equal(labels.join(''), ['TildeEnvato']);
+
+  equal(select.$('optgroup').first().text().replace(/\s+/g,''), 'YehudaTom');
+  equal(select.$('optgroup').last().text().replace(/\s+/g,''), 'Keith');
+});
+
+test("select with group doesn't break options", function() {
+  var content = Ember.A([
+    { id: 1, firstName: 'Yehuda', organization: 'Tilde' },
+    { id: 2, firstName: 'Tom', organization: 'Tilde' },
+    { id: 3, firstName: 'Keith', organization: 'Envato' }
+  ]);
+
+  Ember.run(function() {
+    select.set('content', content),
+    select.set('optionGroupPath', 'organization');
+    select.set('optionLabelPath', 'content.firstName');
+    select.set('optionValuePath', 'content.id');
+  });
+
+  append();
+
+  equal(select.$('option').length, 3);
+  equal(select.$().text().replace(/\s+/g,''), 'YehudaTomKeith');
+
+  Ember.run(function() {
+    content.set('firstObject.firstName', 'Peter');
+  });
+  equal(select.$().text(), 'PeterTomKeith');
+
+  select.$('option').get(0).selected = true;
+  select.$().trigger('change');
+  deepEqual(select.get('selection'), content.get('firstObject'));
+});
+
+test("select with group observs its content", function() {
+  var wycats = { firstName: 'Yehuda', organization: 'Tilde' };
+  var content = Ember.A([
+    wycats
+  ]);
+
+  Ember.run(function() {
+    select.set('content', content),
+    select.set('optionGroupPath', 'organization');
+    select.set('optionLabelPath', 'content.firstName');
+  });
+
+  append();
+
+  Ember.run(function() {
+    content.pushObject({ firstName: 'Keith', organization: 'Envato' });
+  });
+
+  equal(select.$('optgroup').length, 2);
+  equal(select.$('optgroup[label=Envato]').length, 1);
+
+  Ember.run(function() {
+    select.set('optionGroupPath', 'firstName');
+  });
+  var labels = [];
+  select.$('optgroup').each(function() {
+    labels.push(this.label);
+  });
+  equal(labels.join(''), 'YehudaKeith');
+});
+
 test("selection uses the same array when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' },
       tom = { id: 2, firstName: 'Tom' },


### PR DESCRIPTION
I supported using `Ember.Select` with `optgroup`.
## Usage

To use `optgroup`, the `optionGroupPath` is required.
- Source

``` javascript
var content = Ember.A([
  { id: 1, firstName: 'Yehuda', organization: 'Tilde' },
  { id: 2, firstName: 'Tom', organization: 'Tilde' },
  { id: 3, firstName: 'Keith', organization: 'Envato' }
]);

var select = Ember.Select.create({
  content: content,
  optionGroupPath: 'organization',
  optionLabelPath: 'content.firstName',
  optionValuePath: 'content.id'
});

select.appendTo('body');
```
- Result

![ 2013-04-14 2 53 44](https://f.cloud.github.com/assets/290782/376916/2221c1b4-a463-11e2-9888-4ba501eb6004.png)

_caution: `content` should be sorted by `optionGroupPath`_.
