### PR TITLE
fix a typo in {{bindAttr}} doc

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -419,7 +419,7 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   Results in the following rendered output:
 
   ```html
-  <img class=":class-name-to-always-apply">
+  <img class="class-name-to-always-apply">
   ```
 
   All three strategies - string return value, boolean return value, and


### PR DESCRIPTION
small typo fix in docs.

``` handlebars
<img {{bindAttr class=":class-name-to-always-apply"}}>
```

should generate

``` html
<img class="class-name-to-always-apply">
```

not

``` html
<img class=":class-name-to-always-apply">
```
