### PR TITLE
Update to latest ember-dev so that publish task can work properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 7f6f0e546de58533b187fa9d3a1ad662d8d8715c
+  revision: 8b71f1fc01acb3ec61d34ea6410b9296475b781d
   branch: master
   specs:
     ember-dev (0.1)
+      aws-sdk
       colored
       ember-source
       execjs
@@ -27,9 +28,13 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aws-sdk (1.8.5)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+      uuidtools (~> 2.1)
     colored (1.2)
-    diff-lcs (1.2.2)
-    ember-source (0.0.4)
+    diff-lcs (1.2.3)
+    ember-source (0.0.5)
       handlebars-source (>= 1.0.0.rc3, < 1.0.0.rc4)
     execjs (1.4.0)
       multi_json (~> 1.0)
@@ -44,6 +49,7 @@ GEM
     listen (0.7.3)
     mime-types (1.22)
     multi_json (1.7.2)
+    nokogiri (1.5.9)
     posix-spawn (0.3.6)
     rack (1.5.2)
     rake (10.0.4)
@@ -51,9 +57,10 @@ GEM
       rack
       rake-pipeline (~> 0.6)
     thor (0.18.1)
-    uglifier (1.3.0)
+    uglifier (2.0.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    uuidtools (2.1.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
The recent merge of Stanley Stuart's build publishing work requires a newer build of ember-dev. This commit bumps the dependency.
