### PR TITLE
Scope state transition cache to the state manager class

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -100,8 +100,26 @@ Ember.State = Ember.Object.extend(Ember.Evented,
       }
     }
 
-    set(this, 'pathsCache', {});
-    set(this, 'pathsCacheNoContext', {});
+    // pathsCaches is a nested hash of the form:
+    //   pathsCaches[stateManagerTypeGuid][path] == transitions_hash
+    set(this, 'pathsCaches', {});
+  },
+
+  setPathsCache: function(stateManager, path, transitions) {
+    var stateManagerTypeGuid = Ember.guidFor(stateManager.constructor),
+      pathsCaches = get(this, 'pathsCaches'),
+      pathsCacheForManager = pathsCaches[stateManagerTypeGuid] || {};
+
+    pathsCacheForManager[path] = transitions;
+    pathsCaches[stateManagerTypeGuid] = pathsCacheForManager;
+  },
+
+  getPathsCache: function(stateManager, path) {
+    var stateManagerTypeGuid = Ember.guidFor(stateManager.constructor),
+      pathsCaches = get(this, 'pathsCaches'),
+      pathsCacheForManager = pathsCaches[stateManagerTypeGuid] || {};
+
+    return pathsCacheForManager[path];
   },
 
   setupChild: function(states, name, value) {

--- a/packages/ember-states/lib/state_manager.js
+++ b/packages/ember-states/lib/state_manager.js
@@ -846,7 +846,7 @@ Ember.StateManager = Ember.State.extend({
   },
 
   contextFreeTransition: function(currentState, path) {
-    var cache = currentState.pathsCache[path];
+    var cache = currentState.getPathsCache(this, path);
     if (cache) { return cache; }
 
     var enterStates = this.getStatesInPath(currentState, path),
@@ -932,11 +932,13 @@ Ember.StateManager = Ember.State.extend({
 
     // Cache the enterStates, exitStates, and resolveState for the
     // current state and the `path`.
-    var transitions = currentState.pathsCache[path] = {
+    var transitions = {
       exitStates: exitStates,
       enterStates: enterStates,
       resolveState: resolveState
     };
+
+    currentState.setPathsCache(this, path, transitions);
 
     return transitions;
   },

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -810,3 +810,41 @@ test("nothing happens if transitioning to a parent state when the current state 
   equal(stateManager.get('currentState.path'), 'start.first', 'does not change state');
 
 });
+
+test("StateManagers can use `create`d states from mixins", function() {
+  var statesMixin,
+    firstManagerClass, secondManagerClass,
+    firstManager, secondManager,
+    firstCount = 0, secondCount = 0;
+
+  statesMixin = Ember.Mixin.create({
+    initialState: 'ready',
+    ready: Ember.State.create({
+      startUpload: function(manager) {
+        manager.transitionTo('uploading');
+      }
+    })
+  });
+
+  firstManagerClass = Ember.StateManager.extend(statesMixin, {
+    uploading: Ember.State.create({
+      enter: function() { firstCount++; }
+    })
+  });
+
+  secondManagerClass = Ember.StateManager.extend(statesMixin, {
+    uploading: Ember.State.create({
+      enter: function() { secondCount++; }
+    })
+  });
+
+  firstManager  = firstManagerClass.create();
+  firstManager.send('startUpload');
+
+  secondManager = secondManagerClass.create();
+  secondManager.send('startUpload');
+
+  equal(firstCount, 1, "The first state manager's uploading state was entered once");
+  equal(secondCount, 1, "The second state manager's uploading state was entered once");
+});
+


### PR DESCRIPTION
The `pathsCache` currently does not allow a state to be shared between multiple state managers.  If you have a mixin or base state manager class that specifies one state "ready", and then two subclasses that specify another state "uploading", the cache will result in only one of the "uploading" states being reachable.

See the failing spec for a better explanation.

Proposed solution takes into account the current stateManager's constructor when looking up the cached values.  Hopefully no-one is reopening state manager classes and overwriting states after they have been transitioned to.
