### PR TITLE
Point to updated preconfigured starting points for JSFiddle/JSBin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ this bug already.
 3. Provide JSFiddle or JSBin demo that specifically shows the problem. This
 demo should be fully operational with the exception of the bug you want to
 demonstrate. The more pared down, the better.
-Preconfigured starting points for the latest Ember: [JSFiddle](http://jsfiddle.net/mHYh5/) | [JSBin](http://jsbin.com/igawaq/1/edit) (may not work with older IE versions due to MIME type isses).
+Preconfigured starting points for the latest Ember: [JSFiddle](http://jsfiddle.net/DCrHG/) | [JSBin](http://jsbin.com/ucanam/1/edit) (may not work with older IE versions due to MIME type isses).
 Preconfigured starting points for 1.0.0-rc.2: [JSFiddle](http://jsfiddle.net/3bGN4/188/) | [JSBin](http://jsbin.com/ixupad/340/edit).
 Issues with fiddles are prioritized.
 


### PR DESCRIPTION
Point to updated preconfigured starting points for JSFiddle/JSBin with latest Ember build that is now being auto-posted to builds.emberjs.com.

Thanks to @fivetanley, @tomdale, and @ebryn for the legwork today to make this happen. Team work makes the dream work.
