### PR TITLE
Fixes Ember-data-870 Lazy destruction + App#reset issues

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -443,7 +443,8 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   },
 
   reset: function() {
-    get(this, '__container__').destroy();
+    Ember.run(get(this,'__container__'), 'destroy');
+
     this.buildContainer();
 
     this._readinessDeferrals = 1;


### PR DESCRIPTION
Deleting the container during reset should complete before
we rebuild the container. This fixes an outstanding ember-data
issue -> https://github.com/emberjs/data/pull/870
