### PR TITLE
Allow multiple calls to `App.Router.map`

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -234,15 +234,27 @@ function doTransition(router, method, args) {
 
 Ember.Router.reopenClass({
   map: function(callback) {
-    var router = this.router = new Router();
+      // Make sure the mapCallbacks exists
+      if (this.mapCallbacks == null) {
+          this.mapCallbacks = [];
+      }
+      this.mapCallbacks.push(callback);
 
-    var dsl = Ember.RouterDSL.map(function() {
-      this.resource('application', { path: "/" }, function() {
-        callback.call(this);
+      var router = this.router,
+          self = this;
+      if (this.router === undefined) {
+          router = this.router = new Router();
+      }
+
+      var dsl = Ember.RouterDSL.map(function() {
+          this.resource('application', { path: "/" }, function() {
+              for (var cb_i = 0, cb_l = self.mapCallbacks.length; cb_i < cb_l; cb_i++) {
+                  self.mapCallbacks[cb_i].call(this);
+              }
+          });
       });
-    });
 
-    router.map(dsl.generate());
-    return router;
+      router.map(dsl.generate());
+      return router;
   }
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -35,6 +35,7 @@ module("Basic Routing", {
       Ember.TEMPLATES.application = compile("{{outlet}}");
       Ember.TEMPLATES.home = compile("<h3>Hours</h3>");
       Ember.TEMPLATES.homepage = compile("<h3>Megatroll</h3><p>{{home}}</p>");
+      Ember.TEMPLATES.camelot = compile('<section><h3>Is a silly place</h3></section>');
     });
   },
 
@@ -65,6 +66,53 @@ test("The Homepage", function() {
   });
 
   bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(currentPath, 'home');
+  equal(Ember.$('h3:contains(Hours)', '#qunit-fixture').length, 1, "The home template was rendered");
+});
+
+test("The Home page and the Camelot page with multiple Router.map calls", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  Router.map(function() {
+    this.route("camelot", {path: "/camelot"});
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+  });
+
+  App.CamelotRoute = Ember.Route.extend({
+  });
+
+  var currentPath;
+
+  App.ApplicationController = Ember.Controller.extend({
+    currentPathDidChange: Ember.observer(function() {
+      currentPath = get(this, 'currentPath');
+    }, 'currentPath')
+  });
+
+  App.CamelotController = Ember.Controller.extend({
+    currentPathDidChange: Ember.observer(function() {
+      currentPath = get(this, 'currentPath');
+    }, 'currentPath')
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/camelot");
+  });
+
+  equal(currentPath, 'camelot');
+  equal(Ember.$('h3:contains(silly)', '#qunit-fixture').length, 1, "The camelot template was rendered");
+
 
   Ember.run(function() {
     router.handleURL("/");


### PR DESCRIPTION
I've found a need to be able to add new routes at runtime (one of my apps allows plugins). Upon looking through docs and API, I couldn't find a way to do this so I went to source and still didn't find anything.

Attached is code that allows you to call `App.Router.map` multiple times without overwriting the previous behavior.

I've written two tests for it because the change is minor. I'm happy to write additional tests or receive guidance from the team.
