### PR TITLE
Implemented Ember.control

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -515,6 +515,13 @@ Ember.Route = Ember.Object.extend({
     appendView(this, view, options);
   },
 
+  /**
+    @see {Ember#control}
+  */
+  control: function(name, model, properties) {
+    return Ember.control(this, name, model, properties);
+  },
+
   willDestroy: function() {
     teardownView(this);
   }

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -72,6 +72,13 @@ Ember.ControllerMixin = Ember.Mixin.create({
       Ember.assert("The target for controller " + this + " (" + target + ") did not define a `send` method", typeof target.send === 'function');
       target.send.apply(target, arguments);
     }
+  },
+
+  /**
+    @see {Ember#control} 
+  */
+  control: function(name, model, properties) {
+    return Ember.control(this, name, model, properties);
   }
 });
 

--- a/packages/ember-runtime/lib/system.js
+++ b/packages/ember-runtime/lib/system.js
@@ -13,3 +13,5 @@ require('ember-runtime/system/string');
 require('ember-runtime/system/deferred');
 
 require('ember-runtime/system/lazy_load');
+
+require('ember-runtime/system/control');

--- a/packages/ember-runtime/lib/system/control.js
+++ b/packages/ember-runtime/lib/system/control.js
@@ -1,0 +1,151 @@
+var get = Ember.get, set = Ember.set;
+
+
+
+
+
+/**
+  `Ember.control` lets you instantiate a controller + view pair that is not part of your normal routing flow.
+ 
+  This is very useful for programmatically creating views such as modals and popover menus that you want to use
+  controller logic for, but don't represent a route.
+
+  The `target` parameter should be a controller or a route. Ember uses this parameter to something...
+  Normally you would call `Ember.control` from within a [route]{@link Ember.Route#control} or a
+  [controller]{@link Ember.ControllerMixin#control}. To make that easier, you can just call `this.control` directly from
+  within routes and controllers, and thereby omit the `target` parameter.
+ 
+  Here is an example of using `this.control` from within a controller:
+ 
+  ```javascript
+  App.PostsShowController = Ember.ObjectController.extend({
+    edit: function() {
+      var controller = this.control('posts.edit', this.get('model'));
+    }
+  });
+  ```
+  
+  Ember will, based on the `name` parameter, create a controller from the class `App.PostsEditController` (not a singleton),
+  a view from the class `App.PostsEditView`, and use the template `posts.edit` (normalized to `posts/edit`).
+  The naming convention works just like everything else in Ember, e.g. route names.
+ 
+  The second argument to `Ember.control` is an optional `model`. This will be set as the `model` property on your controller. 
+ 
+  `Ember.control` returns the created controller. You can access the view through the controller with
+  `controller.get('view')`.
+ 
+  In the above example the modal controller and view could be defined like this:
+ 
+  ```javascript
+  App.PostsEditController = Ember.ObjectController.extend({
+    save: function() {
+      //...commit model, and close when successful
+      this.close();
+    },
+    cancel: function() {
+      //...rollback any changes
+      this.close();
+    },
+    close: function() {
+      this.get('view').destroy(); //Or fade it out first, if you're really fancy
+      this.destroy();
+    }
+  });
+ 
+  App.PostsEditView = Ember.View.extend({
+    classNames: ['modal']
+  });
+  ```
+ 
+  And the `posts/edit` template:
+ 
+  ```handlebars
+  <h1>Edit post</h1>
+  {{input valueBinding="title"}}<br>
+  <button {{action save}}>Save</button> <button {{action cancel}}>Cancel</button>
+  ```
+ 
+  `Ember.control` also supports specifying an object with `controllerClass`, `viewClass`, `template` and `templateName`
+  properties instead of a string in the `name` parameter. You can use this feature if your controller or view don't
+  adhere to the naming conventions (which they should!). The following is equivalent to our example above:
+
+  ```javascript
+  App.PostsShowController = Ember.ObjectController.extend({
+    edit: function() {
+      var controller = this.control({
+        controllerClass: App.PostsEditController,
+        viewClass: App.PostsEditView,
+        templateName: 'posts/edit',
+        template: Ember.Handlebars.compile('...')
+      }, this.get('model');
+    }
+  });
+  ```
+  
+  `controllerClass` is required. Either `viewClass` or one of `templateName` and `template` is required. If `viewClass`
+  is not set, a simple `Ember.View` will be used. You should only specify either `templateName` (the name of a template)
+  or `template` (a compiled template). If you don't set a template, the `viewClass`' template will be used.
+ 
+  From within the instantiated controller you can call `transitionToRoute`, use `needs` and anything else that a normal
+  controller supports.
+ 
+  @param {Ember.ControllerMixin|Ember.Route} target Will be set as the `target` on your controller, which makes it
+    possible to use `transitionToRoute` and other normal controller behavior.
+  @param {String|Object} name Either the name of your controller, view and/or template. Or an object with a
+    `controllerClass` property, and at least one of the following properties: `viewClass`, `template`, `templateName`. 
+  @param {Object} [model] An optional object to set as the `model` property on your controller.
+  @param {Object} [properties] Optional extra properties that should be set on the controller.
+  @returns Ember.Controller The instantiated controller. You can access the view via the controller through the
+    controller's `view` property.
+*/
+Ember.control = function(target, name, model, properties) {
+  var container = get(target, 'container'),
+    normalizedName,
+    childControllerClass,
+    childController,
+    childViewClass,
+    childView,
+    template,
+    templateName;
+  if (Ember.typeOf(name) === 'object') {
+    //Setup controller
+    childControllerClass = name.controllerClass;
+    Ember.assert("No `controllerClass` supplied to Ember.control", childControllerClass);
+    childController = childControllerClass.create();
+    //Find view and template
+    childViewClass = name.viewClass;
+    template = name.template;
+    templateName = name.templateName;
+    Ember.assert("No `viewClass`, `template` or `templateName` supplied to Ember.control", childViewClass || template || templateName);
+    Ember.assert("You can't set both `template` and `templateName` with Ember.control", !template || !templateName);
+    if (templateName) {
+      template = container.lookup('template:' + container.normalize(templateName));
+    }
+  } else {
+    normalizedName = container.normalize(name);
+    //Setup controller
+    childController = container.lookup('controller:' + normalizedName, {singleton: false});
+    Ember.assert("No controller for `" + name + "` found", childController);
+    //Setup view and template
+    childViewClass = container.resolve('view:' + normalizedName);
+    template = container.lookup('template:' + normalizedName);
+    Ember.assert("No view or template found for `" + name + "`", childViewClass || template);
+  }
+  //Set controller properties
+  set(childController, 'target', target);
+  if (model) {
+    set(childController, 'model', model);
+  }
+  if (properties) {
+    childController.setProperties(properties);
+  }
+  //Instantiate view
+  childViewClass = childViewClass || container.resolve('view:default');
+  childView = childViewClass.create();
+  if (template && !get(childView, 'template')) {
+    set(childView, 'template', template);
+  }
+  set(childView, 'controller', childController);
+  set(childController, 'view', childView);
+  return childController;
+};

--- a/packages/ember-runtime/tests/controllers/control_test.js
+++ b/packages/ember-runtime/tests/controllers/control_test.js
@@ -1,0 +1,347 @@
+var container,
+  TargetController,
+  AbstractControlView,
+  CarController,
+  CarView,
+  DefaultView,
+  lamborghini;
+
+function destroyControl(controller) {
+  controller.get('view').destroy();
+  controller.destroy();
+}
+
+module("Ember.control", {
+  setup: function() {
+    container = new Ember.Container();
+    container.options('template', {instantiate: false});
+    container.options('view', {singleton: false});
+    TargetController = Ember.Controller.extend();
+    container.register('controller:target', TargetController);
+    DefaultView = Ember.View.extend();
+    container.register('view:default', DefaultView);
+    CarController = Ember.ObjectController.extend();
+    container.register('controller:car', CarController);
+    AbstractControlView = Ember.View.extend({
+      init: function() {
+        this._super();
+        this.appendTo('#qunit-fixtures');
+      }
+    });
+    CarView = AbstractControlView.extend({
+      template: Ember.Handlebars.compile('{{name}} ({{#if isFast}}fast{{else}}slow{{/if}})')
+    });
+    container.register('view:car', CarView);
+    lamborghini = Ember.Object.create({
+      name: 'Lamborghini',
+      isFast: true
+    });
+  },
+  teardown: function() {
+    Ember.run(function() {
+      lamborghini.destroy();
+      container.destroy();
+    });
+  }
+
+});
+
+test("With model", function() {
+  var controller;
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller = Ember.control(targetController, 'car', lamborghini, {
+      isCheap: false
+    });
+  });
+
+  ok(controller instanceof CarController, "Correct controller instance was returned");
+  equal(controller.get('target'), targetController, "Property `target` was set on controller");
+  equal(controller.get('model'), lamborghini, "Property `model` was set on controller");
+  equal(controller.get('isCheap'), false, "Custom property was set on controller");
+  var view = controller.get('view');
+  ok(view instanceof CarView, "Correct view class was instantiated");
+  equal(view.get('controller'), controller, "Property `controller` was set on view");
+
+  equal(view.$().text(), 'Lamborghini (fast)', "View rendered correct content");
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller);
+  });
+});
+
+test("Without model", function() {
+  var controller1,
+    controller2;
+  CarController = Ember.Controller.extend(); //This test needs the CarController not to be an ObjectController
+  container.register('controller:car', CarController);
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller1 = Ember.control(targetController, 'car', null, {
+      name: 'Ford T',
+      isFast: false
+    });
+  });
+
+  ok(controller1 instanceof CarController, "Correct controller instance was returned");
+  equal(controller1.get('target'), targetController, "Property `target` was set on controller");
+  equal(controller1.get('model'), null, "Property `model` was set to null on controller");
+  equal(controller1.get('name'), 'Ford T', "Custom property was set on controller");
+  equal(controller1.get('isFast'), false, "Custom property was set on controller");
+  var view1 = controller1.get('view');
+  ok(view1 instanceof CarView, "Correct view class was instantiated");
+  equal(view1.get('controller'), controller1, "Controller property was set on view");
+
+  equal(view1.$().text(), 'Ford T (slow)', "View rendered correct content");
+
+  Ember.run(function() {
+    controller2 = Ember.control(targetController, 'car', null, {
+      name: 'Ford T',
+      isFast: false
+    });
+  });
+
+  notEqual(controller1, controller2, "Two non-identical controller instances was created");
+  notEqual(controller2.get('view'), view1, "Two non-identical view instances was created");
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller1);
+    destroyControl(controller2);
+  });
+});
+
+test("Unknown controller raises an error", function() {
+  var controller;
+  var JokerView = AbstractControlView.extend();
+  container.register('view:joker', JokerView);
+  var targetController = container.lookup('controller:target');
+
+  throws(function() {
+    Ember.run(function() {
+      controller = Ember.control(targetController, 'joker');
+    });
+  }, /No controller for `joker` found/);
+});
+
+test("Unknown view should use default view and a named template", function() {
+  var controller;
+  var JokerController = Ember.Controller.extend();
+  container.register('controller:joker', JokerController);
+  container.register('template:joker', Ember.Handlebars.compile('What is an Eskimo cow called? An eskimoo'));
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller = Ember.control(targetController, 'joker');
+  });
+
+  var view = controller.get('view');
+  ok(view instanceof DefaultView, "View was created");
+  equal(view.get('controller'), controller, "Controller property was set on view");
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixtures');
+  });
+  
+  equal(view.$().text(), 'What is an Eskimo cow called? An eskimoo');
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller);
+  });
+});
+
+test("Unknown view and template raises an error", function() {
+  var controller;
+  var JokerController = Ember.Controller.extend();
+  container.register('controller:joker', JokerController);
+  var targetController = container.lookup('controller:target');
+
+  throws(function() {
+    Ember.run(function() {
+      controller = Ember.control(targetController, 'joker');
+    });
+  }, /No view or template found for `joker`/);
+
+  Ember.run(function() {
+    targetController.destroy();
+  });
+});
+
+test("Known view with a defined template should not use named template", function() {
+  var controller;
+  var JokerController = Ember.Controller.extend();
+  container.register('controller:joker', JokerController);
+  var JokerView = AbstractControlView.extend({
+    template: Ember.Handlebars.compile('Which bees produce milk? Boo-bees.')
+  });
+  container.register('view:joker', JokerView);
+  container.register('template:joker', Ember.Handlebars.compile('What is an Eskimo cow called? An eskimoo'));
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller = Ember.control(targetController, 'joker');
+  });
+
+  var view = controller.get('view');
+  ok(view instanceof JokerView, "View was created");
+  equal(view.get('controller'), controller, "Controller property was set on view");
+
+  equal(view.$().text(), 'Which bees produce milk? Boo-bees.');
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller);
+  });
+});
+
+test("Using an object", function() {
+  var controller;
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller = Ember.control(targetController, {controllerClass: CarController, viewClass: CarView}, lamborghini, {
+      isCheap: false
+    });
+  });
+
+  ok(controller instanceof CarController, "Correct controller instance was returned");
+  equal(controller.get('target'), targetController, "Property `target` was set on controller");
+  equal(controller.get('model'), lamborghini, "Property `model` was set on controller");
+  equal(controller.get('isCheap'), false, "Custom property was set on controller");
+  var view = controller.get('view');
+  ok(view instanceof CarView, "Correct view class was instantiated");
+  equal(view.get('controller'), controller, "Property `controller` was set on view");
+
+  equal(view.$().text(), 'Lamborghini (fast)', "View rendered correct content");
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller);
+  });
+});
+
+test("Using an object without a viewClass should use default view and a named template", function() {
+  var controller;
+  var JokerController = Ember.Controller.extend();
+  container.register('controller:joker', JokerController);
+  container.register('template:joker', Ember.Handlebars.compile('Why does a TV have buttons? Because it would look weird with a zipper'));
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller = Ember.control(targetController, {controllerClass: JokerController, templateName: 'joker'});
+  });
+
+  var view = controller.get('view');
+  ok(view instanceof DefaultView, "View was created");
+  equal(view.get('controller'), controller, "Controller property was set on view");
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixtures');
+  });
+  
+  equal(view.$().text(), 'Why does a TV have buttons? Because it would look weird with a zipper');
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller);
+  });
+});
+
+test("Using an object without specifying `controllerClass` should raise an error", function() {
+  var controller;
+  var targetController = container.lookup('controller:target');
+
+  throws(function() {
+    Ember.run(function() {
+      controller = Ember.control(targetController, {viewClass: CarView}, lamborghini);
+    });
+  }, /No `controllerClass` supplied to Ember.control/);
+
+  Ember.run(function() {
+    targetController.destroy();
+  });
+});
+
+
+test("Using an object without specifying `viewClass` or `template` should raise an error", function() {
+  var controller;
+  var targetController = container.lookup('controller:target');
+
+  throws(function() {
+    Ember.run(function() {
+      controller = Ember.control(targetController, {controllerClass: CarController}, lamborghini);
+    });
+  }, /No `viewClass`, `template` or `templateName` supplied to Ember.control/);
+
+  Ember.run(function() {
+    targetController.destroy();
+  });
+});
+
+test("Call through a controller", function() {
+  var controller;
+  var TargetController = Ember.Controller.extend({
+    createCarControl: function() {
+      return this.control('car', lamborghini, {
+        isCheap: false
+      });
+    }
+  });
+  container.register('controller:target', TargetController);
+  var targetController = container.lookup('controller:target');
+
+  Ember.run(function() {
+    controller = targetController.createCarControl();
+  });
+
+  ok(controller instanceof CarController, "Correct controller instance was returned");
+  equal(controller.get('target'), targetController, "Property `target` was set on controller");
+  equal(controller.get('model'), lamborghini, "Property `model` was set on controller");
+  equal(controller.get('isCheap'), false, "Custom property was set on controller");
+  var view = controller.get('view');
+  ok(view instanceof CarView, "Correct view class was instantiated");
+  equal(view.get('controller'), controller, "Property `controller` was set on view");
+
+  equal(view.$().text(), 'Lamborghini (fast)', "View rendered correct content");
+
+  Ember.run(function() {
+    targetController.destroy();
+    destroyControl(controller);
+  });
+});
+
+test("Call through a route", function() {
+  var controller;
+  var TargetRoute = Ember.Route.extend({
+    createCarControl: function() {
+      return this.control('car', lamborghini, {
+        isCheap: false
+      });
+    }
+  });
+  container.register('route:target', TargetRoute);
+  var targetRoute = container.lookup('route:target');
+
+  Ember.run(function() {
+    controller = targetRoute.createCarControl();
+  });
+
+  ok(controller instanceof CarController, "Correct controller instance was returned");
+  equal(controller.get('target'), targetRoute, "Property `target` was set on controller");
+  equal(controller.get('model'), lamborghini, "Property `model` was set on controller");
+  equal(controller.get('isCheap'), false, "Custom property was set on controller");
+  var view = controller.get('view');
+  ok(view instanceof CarView, "Correct view class was instantiated");
+  equal(view.get('controller'), controller, "Property `controller` was set on view");
+
+  equal(view.$().text(), 'Lamborghini (fast)', "View rendered correct content");
+
+  Ember.run(function() {
+    targetRoute.destroy();
+    destroyControl(controller);
+  });
+});


### PR DESCRIPTION
This is a concrete implementation proposal of the `Ember.control` feature I suggested in the [Modal Views - can we agree on a best practice?](http://discuss.emberjs.com/t/modal-views-can-we-agree-on-a-best-practice/707/6) post on discuss.emberjs.com.

I think this is a very vital feature, which is missing in Ember right now. It makes it so elegant to programmatically create for example modal views. Something that requires a lot of boilerplate code to do today if you want your modal view to be controlled by a controller.
## Description

`Ember.control` lets you instantiate a controller + view pair that is not part of your normal routing flow.

This is very useful for programmatically creating views such as modals and popover menus that you want to use controller logic for, but don't represent a route.

You can call `this.control` from within controllers and routes.

Here is an example of using `this.control` from within a controller:

``` javascript
App.PostsShowController = Ember.ObjectController.extend({
  edit: function() {
    var controller = this.control('posts.edit', this.get('model'));
  }
});
```

Ember will, based on the `name` parameter, create a controller from the class `App.PostsEditController` (not a singleton),
a view from the class `App.PostsEditView`, and use the template `posts.edit` (normalized to `posts/edit`).
The naming convention works just like everything else in Ember, e.g. route names.

The second argument to `Ember.control` is an optional `model`. This will be set as the `model` property on your controller. 

`Ember.control` returns the created controller. You can access the view through the controller with
`controller.get('view')`.

In the above example the modal controller and view could be defined like this:

``` javascript
App.PostsEditController = Ember.ObjectController.extend({
  save: function() {
    //...commit model, and close when successful
    this.close();
  },
  cancel: function() {
    //...rollback any changes
    this.close();
  },
  close: function() {
    this.get('view').destroy(); //Or fade it out first, if you're really fancy
    this.destroy();
  }
});

App.PostsEditView = Ember.View.extend({
  classNames: ['modal']
});
```

And the `posts/edit` template:

``` handlebars
<h1>Edit post</h1>
{{input valueBinding="title"}}<br>
<button {{action save}}>Save</button> <button {{action cancel}}>Cancel</button>
```

`Ember.control` also supports specifying an object with `controllerClass`, `viewClass`, `template` and `templateName` properties instead of a string in the `name` parameter. You can use this feature if your controller or view don't adhere to the naming conventions (which they should!). The following is equivalent to our example above:

``` javascript
App.PostsShowController = Ember.ObjectController.extend({
  edit: function() {
    var controller = this.control({
      controllerClass: App.PostsEditController,
      viewClass: App.PostsEditView,
      templateName: 'posts/edit',
      template: Ember.Handlebars.compile('...')
    }, this.get('model');
  }
});
```

`controllerClass` is required. Either `viewClass` or one of `templateName` and `template` is required. If `viewClass`
is not set, a simple `Ember.View` will be used. You should only specify either `templateName` (the name of a template)
or `template` (a compiled template). If you don't set a template, the `viewClass`' template will be used.

From within the instantiated controller you can call `transitionToRoute`, use `needs` and anything else that a normal
controller supports.

---

Let's do this! What do people think?
