### PR TITLE
Fix documentation error in Binding

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -335,7 +335,7 @@ mixinProperties(Binding, {
   Properties ending in a `Binding` suffix will be converted to `Ember.Binding`
   instances. The value of this property should be a string representing a path
   to another object or a custom binding instanced created using Binding helpers
-  (see "Customizing Your Bindings"):
+  (see "One Way Bindings"):
 
   ```
   valueBinding: "MyApp.someController.title"


### PR DESCRIPTION
The documentation reads:
`The value of this property should be a string representing a path
 to another object or a custom binding instanced created using Binding helpers
 (see "Customizing Your Bindings"):`
but the section "Customizing Your Bindings" no longer exists. Updated to oneWay helper section.
