### PR TITLE
Drop .cacheable documentation

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -117,24 +117,28 @@ ComputedProperty.prototype = new Ember.Descriptor();
 
 var ComputedPropertyPrototype = ComputedProperty.prototype;
 
-/**
-  Call on a computed property to set it into cacheable mode. When in this
-  mode the computed property will automatically cache the return value of
-  your function until one of the dependent keys changes.
+/*
+  Call on a computed property to explicitly change it's cacheable mode.
+
+  Please use `.volatile` over this method.
 
   ```javascript
   MyApp.president = Ember.Object.create({
     fullName: function() {
       return this.get('firstName') + ' ' + this.get('lastName');
 
-      // After calculating the value of this function, Ember will
-      // return that value without re-executing this function until
-      // one of the dependent properties change.
+      // By default, Ember will return the value of this property
+      // without re-executing this function.
     }.property('firstName', 'lastName')
+
+    initials: function() {
+      return this.get('firstName')[0] + this.get('lastName')[0];
+
+      // This function will be executed every time this property
+      // is requested.
+    }.property('firstName', 'lastName').cacheable(false)
   });
   ```
-
-  Properties are cacheable by default.
 
   @method cacheable
   @param {Boolean} aFlag optional set to `false` to disable caching

--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -7,7 +7,7 @@ Ember.controllerFor = function(container, controllerName, context, lookupOptions
   return container.lookup('controller:' + controllerName, lookupOptions) ||
          Ember.generateController(container, controllerName, context);
 };
-/**
+/*
   Generates a controller automatically if none was provided.
   The type of generated controller depends on the context.
   You can customize your generated controllers by defining

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -17,7 +17,7 @@ test("The `contentArrayDidChange` method is invoked after `content` is updated."
       // setup arrangedContent as a different object than content,
       // which is the default
       return Ember.A(this.get('content').slice());
-    }).cacheable(),
+    }),
 
     contentArrayDidChange: function(array, idx, removedCount, addedCount) {
       observerCalled = true;


### PR DESCRIPTION
Some small changes to the docs:
- Drop cacheable documentation. Defer to `.volatile`.
- Drop the last lingering used of `.cacheable` in a test.
- Drop the `/**` preamble for controller generator documentation. Quiets a warning.

Tom Dale sez "confirm, we should document volatile()" which I presume means not document cacheable.

:cake: 
