### PR TITLE
Use `jQuery.is(':disabled')` instead of `jQuery(':disbled').length` for Opera

### DIFF
--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -40,9 +40,9 @@ test("should append a checkbox", function() {
 });
 
 test("should begin disabled if the disabled attribute is true", function() {
-  equal(checkboxView.$('input[type=checkbox]:disabled').length, 0, "The checkbox isn't disabled");
+  ok(checkboxView.$('input').is(':not(:disabled)'), "The checkbox isn't disabled");
   set(controller, 'disabled', true);
-  equal(checkboxView.$('input[type=checkbox]:disabled').length, 1, "The checkbox is now disabled");
+  ok(checkboxView.$('input').is(':disabled'), "The checkbox is now disabled");
 });
 
 test("should support the tabindex property", function() {
@@ -85,7 +85,7 @@ module("{{input type='checkbox'}} - static values", {
 });
 
 test("should begin disabled if the disabled attribute is true", function() {
-  equal(checkboxView.$('input[type=checkbox]:disabled').length, 1, "The checkbox isn't disabled");
+  ok(checkboxView.$().is(':not(:disabled)'), "The checkbox isn't disabled");
 });
 
 test("should support the tabindex property", function() {

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -43,9 +43,9 @@ test("Should insert a textarea", function() {
 });
 
 test("Should become disabled when the controller changes", function() {
-  equal(textArea.$('textarea:disabled').length, 0, "Nothing is disabled yet");
-  set(controller, 'disabled', true); 
-  equal(textArea.$('textarea:disabled').length, 1, "The disabled attribute is updated");
+  ok(textArea.$('textarea').is(':not(:disabled)'), "Nothing is disabled yet");
+  set(controller, 'disabled', true);
+  ok(textArea.$('textarea').is(':disabled'), "The disabled attribute is updated");
 });
 
 test("Should bind its contents to the specified value", function() {

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -50,13 +50,13 @@ test("should insert a text field into DOM", function() {
 });
 
 test("should become disabled if the disabled attribute is true", function() {
-  equal(textField.$('input:disabled').length, 0, "There are no disabled text fields");
+  ok(textField.$('input').is(':not(:disabled)'), "There are no disabled text fields");
 
   set(controller, 'disabled', true);
-  equal(textField.$('input:disabled').length, 1, "The text field is disabled");
+  ok(textField.$('input').is(':disabled'), "The text field is disabled");
 
   set(controller, 'disabled', false);
-  equal(textField.$('input:disabled').length, 0, "There are no disabled text fields");
+  ok(textField.$('input').is(':not(:disabled)'), "There are no disabled text fields");
 });
 
 test("input value is updated when setting value property of view", function() {
@@ -117,7 +117,7 @@ test("should insert a text field into DOM", function() {
 });
 
 test("should become disabled if the disabled attribute is true", function() {
-  equal(textField.$('input:disabled').length, 1, "The text field is disabled");
+  ok(textField.$('input').is(':disabled'), "The text field is disabled");
 });
 
 test("input value is updated when setting value property of view", function() {


### PR DESCRIPTION
Some tests are failed in Opera(12.15) - Mac OS X.

I fixed failing test by using `jQuery.is(':disable')` instead of `jQuery(':disable').length`.

In the case of `element.disabled = true;`, Opera has it as `<input  disabled="true"/>` (not `<input  disabled="disabled"/>`).
It is not match with `$(':disabled')` and returns always `[]`.
