### PR TITLE
Fix to keep timers order

### DIFF
--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -93,16 +93,15 @@ asyncTest('should always invoke within a separate runloop', function() {
 });
 
 asyncTest('callback order', function() {
-
   var array = [];
   function fn(val) { array.push(val); }
 
   Ember.run(function() {
-    Ember.run.later(this, fn, 4, 130);
-    Ember.run.later(this, fn, 1, 10);
-    Ember.run.later(this, fn, 5, 200);
-    Ember.run.later(this, fn, 2, 80);
-    Ember.run.later(this, fn, 3, 80);
+    Ember.run.later(this, fn, 4, 5);
+    Ember.run.later(this, fn, 1, 1);
+    Ember.run.later(this, fn, 5, 10);
+    Ember.run.later(this, fn, 2, 3);
+    Ember.run.later(this, fn, 3, 3);
   });
 
   deepEqual(array, []);
@@ -110,12 +109,10 @@ asyncTest('callback order', function() {
   setTimeout(function() {
     start();
     deepEqual(array, [1,2,3,4,5], 'callbacks were called in expected order');
-  }, 250);
+  }, 100);
 });
 
 asyncTest('callbacks coalesce into same run loop if expiring at the same time', function() {
-
-
   var array = [];
   function fn(val) { array.push(Ember.run.currentRunLoop); }
 


### PR DESCRIPTION
When the `Ember.run.later`'s callbacks are given wait-time less than resolution capability of `setTimeout`, they run incorrect order.

My test environment: Opera(12.15) - Mac OS X

Example code:

``` javascript
Ember.run.later(function() {
  console.log(2);
}, 3);
Ember.run.later(function() {
  console.log(3);
}, 5);
Ember.run.later(function() {
  console.log(1);
}, 1);
```

Expected:

```
1
2
3
```

But actual:

```
2
3
1
```

This reason is that  expired callbacks run in order by set order (not expires order) in Ember's run loop.

So I modified to sort expired callbacks in order by their expires.
