### PR TITLE
Adjust wait time to tick next run loop for more browsers

### DIFF
--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -127,8 +127,8 @@ asyncTest('callbacks coalesce into same run loop if expiring at the same time', 
     Date.prototype.valueOf = function() { return now; };
 
     Ember.run.later(this, fn, 10);
-    Ember.run.later(this, fn, 100);
-    Ember.run.later(this, fn, 100);
+    Ember.run.later(this, fn, 200);
+    Ember.run.later(this, fn, 200);
 
     Date.prototype.valueOf = originalDateValueOf;
   });
@@ -142,7 +142,7 @@ asyncTest('callbacks coalesce into same run loop if expiring at the same time', 
     ok(array[0], 'first runloop present');
     ok(array[1], 'second runloop present');
     equal(array[1], array[2], 'last two callbacks got the same run loop');
-  }, 200);
+  }, 500);
 });
 
 asyncTest('inception calls to run.later should run callbacks in separate run loops', function() {
@@ -169,7 +169,7 @@ asyncTest('inception calls to run.later should run callbacks in separate run loo
   setTimeout(function() {
     start();
     ok(finished, 'all .later callbacks run');
-  }, 150);
+  }, 250);
 });
 
 asyncTest('setTimeout should never run with a negative wait', function() {


### PR DESCRIPTION
I set wait-time to long.

In some environments, when it is high-stressed, the resolution capability of `setTimeout` will get longer than wait-time for test.

My test environment: Opera(12.15) - Mac OS X
