### PR TITLE
CoreObject.willDestroy is sync called and should be able to clean up bindings

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -297,6 +297,8 @@ CoreObject.PrototypeMixin = Mixin.create({
   destroy: function() {
     if (this._didCallDestroy) { return; }
 
+    if (this.willDestroy) { this.willDestroy(); }
+
     this.isDestroying = true;
     this._didCallDestroy = true;
 
@@ -304,6 +306,13 @@ CoreObject.PrototypeMixin = Mixin.create({
     return this;
   },
 
+  /**
+    Called before the object is destroyed, but before anything has
+    been torn down. This is a good opportunity to clean up manually
+    bindings.
+
+    @method willDestroy
+  */
   willDestroy: Ember.K,
 
   /**
@@ -315,7 +324,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     @method _scheduledDestroy
   */
   _scheduledDestroy: function() {
-    if (this.willDestroy) { this.willDestroy(); }
     destroy(this);
     this.isDestroyed = true;
     if (this.didDestroy) { this.didDestroy(); }

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -1,4 +1,5 @@
 /*globals raises TestObject */
+/*globals MyApp:true */
 
 module('ember-runtime/system/object/destroy_test');
 
@@ -57,3 +58,43 @@ test("observers should not fire after an object has been destroyed", function() 
 
   equal(count, 1, "observer was not called after object was destroyed");
 });
+
+test("bindings should be synced when are updated in the willDestroy hook", function() {
+
+  var foo = Ember.Object.create({
+    value: true
+  });
+
+  var bar = Ember.Object.create({
+    value: null,
+    willDestroy: function() {
+      this.set('value', true);
+    }
+  });
+
+  MyApp = {
+    foo: foo,
+    bar: bar
+  };
+
+  Ember.run(function(){
+    Ember.bind(bar, 'value', 'MyApp.foo.value');
+  });
+
+  ok(bar.get('value'), 'the initial value has been bound'); 
+
+  Ember.run(function(){
+    bar.set('value', false);
+  });
+
+
+  ok(!foo.get('value'), 'foo synced'); 
+
+  Ember.run(function() {
+    bar.destroy();
+  });
+
+  ok(foo.get('value'), 'foo is synced when the binding is updated in the willDestroy hook'); 
+  MyApp = null;
+});
+


### PR DESCRIPTION
The use case is to provide an object the ability to clean up any related two-way bindings during its `willDestroy` hook.

``` js
Em.View.extend({
  valueBinding: 'xxxx',

  willDestroy: function() {
     set(this, 'value', true);
  }
});
```

Maybe, this change affects some way to the current behavior which was introduced at this [commit](https://github.com/emberjs/ember.js/commit/604753e99bb9a24d12aba96f87f827b4365a47f0), but all the tests pass.

The binding is not applied because the current implementation of `notifyObservers` is skipped if the obj has enabled the `isDestroying` [flag](https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/property_events.js#L204).

In the case, this change cannot be applied:
- which is the common intention of the `willDestroy` hook?
- which is the recommended way to perform this use case?
