### PR TITLE
Force downcase tag name for IE8

### DIFF
--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -12,7 +12,8 @@ test("RenderBuffers combine strings", function() {
   buffer.push('a');
   buffer.push('b');
 
-  equal("<div>ab</div>", buffer.string(), "Multiple pushes should concatenate");
+  // IE8 returns `element name as upper case with extra whitespace.
+  equal("<div>ab</div>", buffer.string().toLowerCase().replace(/\s+/g, ''), "Multiple pushes should concatenate");
 });
 
 test("value of 0 is included in output", function() {
@@ -93,7 +94,8 @@ test("handles browsers like Firefox < 11 that don't support outerHTML Issue #195
   // Make sure element.outerHTML is falsy to trigger the fallback.
   var elementStub = '<div></div>';
   buffer.element = function(){ return elementStub; };
-  equal(elementStub, buffer.string());
+  // IE8 returns `element name as upper case with extra whitespace.
+  equal(elementStub, buffer.string().toLowerCase().replace(/\s/g, ''));
 });
 
 module("Ember.RenderBuffer - without tagName");


### PR DESCRIPTION
In IE8, `buffer.string()` returns upper case with whitespace such as the following:

``` html
    <DIV></DIV>
```
