### PR TITLE
Fix to use `Ember.ArrayPolyfills.forEach` for IE8

### DIFF
--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -5,7 +5,8 @@ var get = Ember.get, set = function(object, key, value) {
   Ember.run(function() { Ember.set(object, key, value); });
 };
 
-var compile = Ember.Handlebars.compile;
+var compile = Ember.Handlebars.compile,
+    forEach = Ember.ArrayPolyfills.forEach;
 
 function append() {
   Ember.run(function() {
@@ -204,7 +205,7 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textArea.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
-[ 'cut', 'paste', 'input' ].forEach(function(eventName) {
+forEach.call([ 'cut', 'paste', 'input' ], function(eventName) {
   test("should update the value on " + eventName + " events", function() {
 
     Ember.run(function() {

--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -4,7 +4,6 @@
 */
 
 require('ember-handlebars/ext');
-
 require('ember-handlebars/helpers/view');
 
 Ember.onLoad('Ember.Handlebars', function(Handlebars) {
@@ -15,6 +14,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   var EmberHandlebars = Ember.Handlebars,
       handlebarsGet = EmberHandlebars.get,
       SafeString = EmberHandlebars.SafeString,
+      forEach = Ember.ArrayPolyfills.forEach,
       get = Ember.get,
       a_slice = Array.prototype.slice;
 
@@ -41,7 +41,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
     var allowed = true;
 
-    keys.forEach(function(key) {
+    forEach.call(keys, function(key) {
       if (event[key + "Key"] && allowedKeys.indexOf(key) === -1) {
         allowed = false;
       }

--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -1,3 +1,5 @@
+var forEach = Ember.ArrayPolyfills.forEach;
+
 /**
 @module ember
 @submodule ember-runtime
@@ -30,12 +32,10 @@ Ember.onLoad = function(name, callback) {
 @param object {Object} object to pass to callbacks
 */
 Ember.runLoadHooks = function(name, object) {
-  var hooks;
-
   loaded[name] = object;
 
-  if (hooks = loadHooks[name]) {
-    loadHooks[name].forEach(function(callback) {
+  if (loadHooks[name]) {
+    forEach.call(loadHooks[name], function(callback) {
       callback(object);
     });
   }


### PR DESCRIPTION
IE8 has no method `Array.prototype.forEach`.
