### PR TITLE
Added `routeTo` for event-based transitions

### DIFF
--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -19,6 +19,7 @@ testing_suites:
     - "package=all&jquery=1.8.3&nojshint=true"
     - "package=all&jquery=git&nojshint=true"
     - "package=all&jquery=git2&nojshint=true"
+    - "package=all&enablerouteto&nojshint=true"
     - "package=all&extendprototypes=true&nojshint=true"
     - "package=all&extendprototypes=true&jquery=git&nojshint=true"
     - "package=all&extendprototypes=true&jquery=git2&nojshint=true"

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -81,10 +81,21 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
       var router = this.get('router');
 
-      if (this.get('replace')) {
-        router.replaceWith.apply(router, args(this, router));
+      if (Ember.ENV.ENABLE_ROUTE_TO) {
+
+        var routeArgs = args(this, router);
+
+        router.routeTo(Ember.TransitionEvent.create({
+          transitionMethod: this.get('replace') ? 'replaceWith' : 'transitionTo',
+          destinationRouteName: routeArgs[0],
+          contexts: routeArgs.slice(1)
+        }));
       } else {
-        router.transitionTo.apply(router, args(this, router));
+        if (this.get('replace')) {
+          router.replaceWith.apply(router, args(this, router));
+        } else {
+          router.transitionTo.apply(router, args(this, router));
+        }
       }
     },
 

--- a/packages/ember-routing/lib/system.js
+++ b/packages/ember-routing/lib/system.js
@@ -2,3 +2,4 @@ require('ember-routing/system/dsl');
 require('ember-routing/system/controller_for');
 require('ember-routing/system/router');
 require('ember-routing/system/route');
+require('ember-routing/system/transition_event');

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -72,6 +72,17 @@ Ember.Route = Ember.Object.extend({
   activate: Ember.K,
 
   /**
+    Transition to another route via the `routeTo` event which
+    will by default be handled by ApplicationRoute.
+   
+    @method routeTo
+    @param {TransitionEvent} transitionEvent 
+   */
+  routeTo: function(transitionEvent) {
+    this.router.routeTo(transitionEvent);
+  },
+
+  /**
     Transition into another route. Optionally supply a model for the
     route in question. The model will be serialized into the URL
     using the `serialize` hook.

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -84,6 +84,22 @@ Ember.Router = Ember.Object.extend({
     this.notifyPropertyChange('url');
   },
 
+  /**
+    Transition to another route via the `routeTo` event which
+    will by default be handled by ApplicationRoute.
+   
+    @method routeTo
+    @param {TransitionEvent} transitionEvent 
+   */
+  routeTo: function(transitionEvent) {
+    var handlerInfos = this.router.currentHandlerInfos;
+    if (handlerInfos) {
+      transitionEvent.sourceRoute = handlerInfos[handlerInfos.length - 1].handler;
+    }
+
+    this.send('routeTo', transitionEvent);
+  },
+
   transitionTo: function(name) {
     var args = [].slice.call(arguments);
     doTransition(this, 'transitionTo', args);
@@ -162,6 +178,12 @@ function getHandlerFunction(router) {
 
       container.register(routeName, DefaultRoute.extend());
       handler = container.lookup(routeName);
+    }
+
+    if (name === 'application') {
+      // Inject default `routeTo` handler.
+      handler.events = handler.events || {};
+      handler.events.routeTo = handler.events.routeTo || Ember.TransitionEvent.defaultHandler;
     }
 
     handler.routeName = name;

--- a/packages/ember-routing/lib/system/transition_event.js
+++ b/packages/ember-routing/lib/system/transition_event.js
@@ -1,0 +1,53 @@
+/**
+@module ember
+@submodule ember-routing
+*/
+
+
+/**
+  A TransitionEvent is passed as the argument for `transitionTo`
+  events and contains information about an attempted transition 
+  that can be modified or decorated by leafier `transitionTo` event
+  handlers before the actual transition is committed by ApplicationRoute.
+
+  @class TransitionEvent
+  @namespace Ember
+  @extends Ember.Deferred
+ */
+Ember.TransitionEvent = Ember.Object.extend({
+
+  /**
+    The Ember.Route method used to perform the transition.  Presently, 
+    the only valid values are 'transitionTo' and 'replaceWith'.
+   */
+  transitionMethod: 'transitionTo',
+  destinationRouteName: null,
+  sourceRoute: null,
+  contexts: null,
+
+  init: function() {
+    this._super();
+    this.contexts = this.contexts || [];
+  },
+
+  /**
+    Convenience method that returns an array that can be used for
+    legacy `transitionTo` and `replaceWith`.
+   */
+  transitionToArgs: function() {
+    return [this.destinationRouteName].concat(this.contexts);
+  }
+});
+
+
+Ember.TransitionEvent.reopenClass({
+  /**
+    This is the default transition event handler that will be injected
+    into ApplicationRoute. The context, like all route event handlers in
+    the events hash, will be an `Ember.Route`.
+   */
+  defaultHandler: function(transitionEvent) {
+    var router = this.router;
+    router[transitionEvent.transitionMethod].apply(router, transitionEvent.transitionToArgs());
+  }
+});

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -30,6 +30,10 @@
 
   ENV['EXPERIMENTAL_CONTROL_HELPER'] = true;
 
+  QUnit.config.urlConfig.push('enablerouteto');
+  var enableRouteTo = QUnit.urlParams.enablerouteto;
+  ENV['ENABLE_ROUTE_TO'] = !!enableRouteTo;
+
   EmberDev.distros = {
     spade:   'ember-spade.js',
     build:   'ember.js',


### PR DESCRIPTION
This a first step toward a more sound state-machine-based
approach to the router and transitions. Calls to `routeTo`
on `Route` or `Router` will convert to a

```
router.send('routeTo', transitionEvent);
```

where transitionEvent is an instance of a new class called
`Ember.TransitionEvent`, which contains all the information
about an attempted transition. Leafier routes can override
the 'routeTo' handler to halt the transition otherwise
committed by the default handler on ApplicationRoute.

The `linkTo` helper has been altered to make use of `routeTo`.

The main benefit to all of this is that all external transitions
are funneled through Route-interceptable events.

Note that the following functionality is missing and will
be addressed in future PR's:
- `handleURL` does not yet convert to `transitionTo` events.
- There's no way to bubble up a TransitionEvent up to the
  default handler, allowing for an opportunity to modify/
  decorate the TransitionEvent object passed to the
  handler without halting the transition. This will probably
  require a change to `router.js`.
