### PR TITLE
Use tag name supported by html 4

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1591,7 +1591,7 @@ test("Only use route rendered into main outlet for default into property on chil
   });
 
   App.PostsIndexView = Ember.View.extend({
-    tagName: 'section',
+    tagName: 'p',
     classNames: ['posts-index']
   });
 
@@ -1612,7 +1612,7 @@ test("Only use route rendered into main outlet for default into property on chil
   });
 
   equal(Ember.$('div.posts-menu:contains(postsMenu)', '#qunit-fixture').length, 1, "The posts/menu template was rendered");
-  equal(Ember.$('section.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, "The posts/index template was rendered");
+  equal(Ember.$('p.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, "The posts/index template was rendered");
 });
 
 test("Generating a URL should not affect currentModel", function() {


### PR DESCRIPTION
Some browsers that not supported html 5 (such as IE8) couldn't render 'section' tag.
This test doesn't have to use 'section'.
