### PR TITLE
App#reset now triggers a eventDispatcher teardown

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -450,7 +450,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
       this.buildContainer();
 
       this._readinessDeferrals = 1;
-      this.$(this.rootElement).removeClass('ember-application');
+      this.teardownEventDispatcher();
 
       Ember.run.schedule('actions', this, function(){
         this._initialize();
@@ -514,6 +514,19 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
         customEvents    = get(this, 'customEvents');
 
     eventDispatcher.setup(customEvents);
+  },
+
+  /**
+    @private
+
+    Teardown the eventDispatcher
+
+    @method teardownEventDispatcher
+  */
+  teardownEventDispatcher: function() {
+    var eventDispatcher = get(this, 'eventDispatcher');
+
+    eventDispatcher.destroy();
   },
 
   /**

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -38,6 +38,43 @@ test("When an application is reset, new instances of controllers are generated",
   notStrictEqual(firstController, thirdController, "controllers looked up after the application is reset should not be the same instance");
 });
 
+test("When an application is reset, the eventDispatcher is destroyed and recreated", function() {
+  var eventDispatcherWasSetup, eventDispatcherWasDestroyed,
+  stubEventDispatcher;
+
+  eventDispatcherWasSetup = 0;
+  eventDispatcherWasDestroyed = 0;
+
+  stubEventDispatcher = {
+    setup: function(){
+      eventDispatcherWasSetup++;
+    },
+    destroy: function(){
+      eventDispatcherWasDestroyed++;
+    }
+  };
+
+  Ember.run(function() {
+    application = Application.create();
+
+    application.createEventDispatcher = function (){
+      set(this, 'eventDispatcher', stubEventDispatcher);
+      return stubEventDispatcher;
+    };
+
+    equal(eventDispatcherWasSetup, 0);
+    equal(eventDispatcherWasDestroyed, 0);
+  });
+
+  equal(eventDispatcherWasSetup, 1);
+  equal(eventDispatcherWasDestroyed, 0);
+
+  application.reset();
+
+  equal(eventDispatcherWasSetup, 2);
+  equal(eventDispatcherWasDestroyed, 1);
+});
+
 test("When an application is reset, the ApplicationView is torn down", function() {
   Ember.run(function() {
     application = Application.create();


### PR DESCRIPTION
this might have been causing duplicate event dispatches in tests after app#reset's
