### PR TITLE
Ember.get of any property of a false value should return undefined

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -56,12 +56,11 @@ get = function get(obj, keyName) {
     obj = null;
   }
 
-  if (!obj || keyName.indexOf('.') !== -1) {
-    Ember.assert("Cannot call get with '"+ keyName +"' on an undefined object.", obj !== undefined);
+  Ember.assert("Cannot call get with '"+ keyName +"' on an undefined object.", obj !== undefined);
+
+  if (obj === null || keyName.indexOf('.') !== -1) {
     return getPath(obj, keyName);
   }
-
-  Ember.assert("You need to provide an object and key to `get`.", !!obj && keyName);
 
   var meta = obj[META_KEY], desc = meta && meta.descs[keyName], ret;
   if (desc) {
@@ -134,7 +133,7 @@ var getPath = Ember._getPath = function(root, path) {
 
   parts = path.split(".");
   len = parts.length;
-  for (idx=0; root && idx<len; idx++) {
+  for (idx=0; root !== undefined && root !== null && idx<len; idx++) {
     root = get(root, parts[idx], true);
     if (root && root.isDestroyed) { return undefined; }
   }

--- a/packages/ember-metal/tests/accessors/getPath_test.js
+++ b/packages/ember-metal/tests/accessors/getPath_test.js
@@ -7,8 +7,8 @@ var obj, moduleOpts = {
         bar: {
           baz: { biff: 'BIFF' }
         }
-      }
-
+      },
+      falseValue: false
     };
 
     window.Foo = {
@@ -55,6 +55,10 @@ test('[obj, this.foo.bar] -> obj.foo.bar', function() {
 
 test('[obj, this.Foo.bar] -> (null)', function() {
   deepEqual(Ember.get(obj, 'this.Foo.bar'), undefined);
+});
+
+test('[obj, falseValue.notDefined] -> (null)', function() {
+  deepEqual(Ember.get(obj, 'falseValue.notDefined'), undefined);
 });
 
 // ..........................................................


### PR DESCRIPTION
`Ember.get( { a: false }, 'a.someUndefinedProperty' )` should return `undefined`.  It currently returns `false`.

Fixes #2540
