### PR TITLE
Outlet helper allows to define its own view class

### DIFF
--- a/packages/ember-routing/lib/helpers/outlet.js
+++ b/packages/ember-routing/lib/helpers/outlet.js
@@ -13,8 +13,6 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   @submodule ember-routing
   */
 
-  Handlebars.OutletView = Ember.ContainerView.extend(Ember._Metamorph);
-
   /**
     The `outlet` helper is a placeholder that the router will fill in with
     the appropriate template based on the current state of the application.
@@ -58,6 +56,28 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     });
     ```
 
+
+    By default, outlet will create an `Ember.OutletView` instance to show the
+    view content based on the route state.
+
+    But you can also define how this content can be shown based on the view property.
+
+    ``` handlebars
+      {{outlet view="App.NavigationView"}}
+    ```
+
+    ``` handlebars
+
+    App.NavigationView = Em.View.extend({
+
+      // you can observe `outletContent` changes to represent
+      // as you desire the new route content
+      outletContent: null
+
+    });
+
+    ```
+
     @method outlet
     @for Ember.Handlebars.helpers
     @param {String} property the property on the controller
@@ -65,10 +85,17 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   */
   Handlebars.registerHelper('outlet', function(property, options) {
     var outletSource;
-
     if (property && property.data && property.data.isRenderData) {
       options = property;
       property = 'main';
+    }
+    
+    var viewClass = options.hash.view; 
+    if ( viewClass ) {
+      viewClass = Ember.get(viewClass);
+      delete options.hash.view;
+    } else {
+      viewClass = Ember.OutletView;
     }
 
     outletSource = options.data.view;
@@ -77,8 +104,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     }
 
     options.data.view.set('outletSource', outletSource);
-    options.hash.currentViewBinding = '_view.outletSource._outlets.' + property;
 
-    return Handlebars.helpers.view.call(this, Handlebars.OutletView, options);
+    options.hash.outletName = property;
+    options.hash.outletContentBinding = '_view.outletSource._outlets.' + property;
+
+    return Handlebars.helpers.view.call(this, viewClass, options);
   });
 });

--- a/packages/ember-routing/lib/main.js
+++ b/packages/ember-routing/lib/main.js
@@ -3,6 +3,7 @@ require('ember-views');
 require('ember-handlebars');
 require('ember-routing/vendor/route-recognizer');
 require('ember-routing/vendor/router');
+require('ember-routing/views');
 require('ember-routing/system');
 require('ember-routing/helpers');
 require('ember-routing/ext');

--- a/packages/ember-routing/lib/views.js
+++ b/packages/ember-routing/lib/views.js
@@ -1,0 +1,1 @@
+require('ember-routing/views/outlet_view');

--- a/packages/ember-routing/lib/views/outlet_view.js
+++ b/packages/ember-routing/lib/views/outlet_view.js
@@ -1,0 +1,41 @@
+var get = Ember.get, set = Ember.set;
+
+/**
+@module ember
+@submodule ember-routing
+*/
+
+/**
+  An `Ember.OutletView` instance will be inserted by the `outlet` helper when
+  a view type is not specified.
+
+  This view will define how to show the view content of the outlet 
+  based on the current route state.
+
+  The implementation of the `Ember.OutletView` binds its `currentView` content 
+  to the value of its outlet in the '`outletSource` view which is setup in 
+  the `connectOutlet` call.
+
+  ``` handlebars
+    {{outlet}}
+  ```
+
+  On the other hand, you can also define your own view to show the content 
+  based on your UI requirements:
+
+  ``` handlebars
+    {{outlet view=App.NavigationView}}
+  ```
+
+*/
+Ember.OutletView = Ember.ContainerView.extend(Ember._Metamorph,{
+  
+  outletName: null,
+  outletContent: null,
+
+  init: function () {
+    this._super();
+    this.bind('currentView', 'outletContent');
+  }
+                                                  
+});

--- a/packages/ember-routing/tests/helpers/outlet_test.js
+++ b/packages/ember-routing/tests/helpers/outlet_test.js
@@ -73,6 +73,37 @@ test("outlet should support an optional name", function() {
   equal(view.$().text().replace(/\s+/,''), 'HIBYE');
 });
 
+test("by default, outlet should insert an instance of Ember.OutletView", function() {
+
+  var template = "<h1>HI</h1>{{outlet}}";
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(template)
+  });
+
+  appendView(view);
+  var outletView = view._childViews[0];
+
+  ok(outletView instanceof Ember.OutletView, 'the outletView is instance of Ember.OutletView' );
+
+});
+
+test("outlet should insert an instance of view whose type is based on the view property", function() {
+
+  var template = "<h1>HI</h1>{{outlet view=Ember.View}}";
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(template)
+  });
+
+  appendView(view);
+  var outletView = view._childViews[0];
+
+  ok(!Ember._Metamorph.detect(outletView), 'the outletView has not _Metamorph mixin' );
+
+  ok(outletView instanceof Ember.View, 'the outletView is an instance of the view type defined in view option' );
+  ok(!(outletView instanceof Ember.ContainerView), 'the outletView is an instance of the view type defined in view option' );
+
+});
+
 test("Outlets bind to the current view, not the current concrete view", function() {
   var parentTemplate = "<h1>HI</h1>{{outlet}}";
   var middleTemplate = "<h2>MIDDLE</h2>{{outlet}}";


### PR DESCRIPTION
```
{{outlet view=App.NavigationView}}
```

The outlet view property allows to setup a view class to define how the route view content will be shown.

When omitted, the outlet helper will use a Ember.OutletView
