### PR TITLE
Fix incrementProperty/decrementProperty to be able to use with 0

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -450,7 +450,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @return {Object} The new property value
   */
   incrementProperty: function(keyName, increment) {
-    if (!increment) { increment = 1; }
+    if (Ember.isNone(increment)) { increment = 1; }
     set(this, keyName, (get(this, keyName) || 0)+increment);
     return get(this, keyName);
   },
@@ -469,7 +469,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @return {Object} The new property value
   */
   decrementProperty: function(keyName, increment) {
-    if (!increment) { increment = 1; }
+    if (Ember.isNone(increment)) { increment = 1; }
     set(this, keyName, (get(this, keyName) || 0)-increment);
     return get(this, keyName);
   },

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -686,8 +686,20 @@ test('incrementProperty and decrementProperty',function(){
   newValue = object.incrementProperty('numberVal', 5);
   equal(30,newValue,'numerical value incremented by specified increment');
   object.numberVal = 25;
+  newValue = object.incrementProperty('numberVal', -5);
+  equal(20,newValue,'minus numerical value incremented by specified increment');
+  object.numberVal = 25;
+  newValue = object.incrementProperty('numberVal', 0);
+  equal(25,newValue,'zero numerical value incremented by specified increment');
+  object.numberVal = 25;
   newValue = object.decrementProperty('numberVal',5);
   equal(20,newValue,'numerical value decremented by specified increment');
+  object.numberVal = 25;
+  newValue = object.decrementProperty('numberVal', -5);
+  equal(30,newValue,'minus numerical value decremented by specified increment');
+  object.numberVal = 25;
+  newValue = object.decrementProperty('numberVal', 0);
+  equal(25,newValue,'zero numerical value decremented by specified increment');
 });
 
 test('toggle function, should be boolean',function(){


### PR DESCRIPTION
Ember.Observable#incrementProperty and decrementProperty can't be able to use with 0.

// person.age = 25
person.incrementProperty('age',0);
// person.age -> 26 , not 25

http://jsfiddle.net/ZCxwH/
