### PR TITLE
Access __container__ directly, not via Ember.get.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -445,7 +445,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   reset: function() {
     Ember.assert('App#reset no longer needs to be wrapped in a run-loop', !Ember.run.currentRunLoop);
     Ember.run(this, function(){
-      Ember.run(get(this,'__container__'), 'destroy');
+      Ember.run(this.__container__, 'destroy');
 
       this.buildContainer();
 
@@ -557,7 +557,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   willDestroy: function() {
     Ember.BOOTED = false;
 
-    get(this, '__container__').destroy();
+    this.__container__.destroy();
   },
 
   initializer: function(options) {


### PR DESCRIPTION
This brings these two usages into alignment with the rest of the codebase which uses direct property access for this private property.
