### PR TITLE
Safari 5 should update URL when using History based location (pushState)

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -63,13 +63,16 @@ Ember.HistoryLocation = Ember.Object.extend({
 
     Uses `history.pushState` to update the url without a page reload.
 
+    `history.state` is not supported in safari <6, so instead use
+    get(this, 'location').pathname
+
     @method setURL
     @param path {String}
   */
   setURL: function(path) {
     path = this.formatURL(path);
 
-    if (this.getState() && this.getState().path !== path) {
+    if(get(this, 'location').pathname !== path) { //if(this.getState() && this.getState().path !== path) {
       this.pushState(path);
     }
   },
@@ -80,26 +83,18 @@ Ember.HistoryLocation = Ember.Object.extend({
     Uses `history.replaceState` to update the url without a page reload
     or history modification.
 
+    `history.state` is not supported in safari <6, so instead use
+    get(this, 'location').pathname
+
     @method replaceURL
     @param path {String}
   */
   replaceURL: function(path) {
     path = this.formatURL(path);
 
-    if (this.getState() && this.getState().path !== path) {
+    if(get(this, 'location').pathname !== path) { //if (this.getState() && this.getState().path !== path) {
       this.replaceState(path);
     }
-  },
-
-  /**
-   @private
-
-   Get the current `history.state`
-
-   @method getState
-  */
-  getState: function() {
-    return get(this, 'history').state;
   },
 
   /**
@@ -111,7 +106,7 @@ Ember.HistoryLocation = Ember.Object.extend({
    @param path {String}
   */
   pushState: function(path) {
-    get(this, 'history').pushState({ path: path }, null, path);
+    get(this, 'history').pushState({}, null, path);
     // used for webkit workaround
     this._previousURL = this.getURL();
   },
@@ -125,7 +120,7 @@ Ember.HistoryLocation = Ember.Object.extend({
    @param path {String}
   */
   replaceState: function(path) {
-    get(this, 'history').replaceState({ path: path }, null, path);
+    get(this, 'history').replaceState({}, null, path);
     // used for webkit workaround
     this._previousURL = this.getURL();
   },

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1491,7 +1491,11 @@ test("Router accounts for rootURL on page load when using history location", fun
       HistoryTestLocation;
 
   setHistory = function(obj, path) {
-    obj.set('history', { state: { path: path } });
+
+    //obj.set('history', { state: { path: path } });
+    obj.set('location', {
+      pathname: path
+    });
   };
 
   // Create new implementation that extends HistoryLocation
@@ -1500,7 +1504,6 @@ test("Router accounts for rootURL on page load when using history location", fun
     initState: function() {
       var path = rootURL + '/posts';
 
-      setHistory(this, path);
       this.set('location', {
         pathname: path
       });


### PR DESCRIPTION
Fixes #2365

`history.state` is [not supported in Safari 5](https://developer.mozilla.org/en/docs/DOM/Manipulating_the_browser_history) and the current implementation of `Ember.HistoryLocation` relies on it to check the current path before making a `pushState` or `replaceState`. This the reason why the URL is not updating in any Safari 5.

I fixed it by removing the references to `history.state` to get the current path and used `location.pathname` instead. I went ahead and removed the `HistoryLocation.getState` method as well since `history.state` can't be relied upon to store any data. I updated also the `HistoryTestLocation` to reflect these changes. 

All tests are passing correctly (including of course the modified `HistoryTestLocation`) but I am not sure if I should make any additional tests for this fix. If so, I'd really appreciate some advice on how to build a test for this browser-specific issue.
