### PR TITLE
View subclasses were instrumented as render.render.* (Fixes 2552)

### DIFF
--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -143,7 +143,7 @@ merge(states.inDOM, {
   @private
 */
 Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
-  instrumentName: 'render.boundHandlebars',
+  instrumentName: 'boundHandlebars',
   states: states,
 
   /**

--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -85,7 +85,7 @@ Ember._Metamorph = Ember.Mixin.create({
   isVirtual: true,
   tagName: '',
 
-  instrumentName: 'render.metamorph',
+  instrumentName: 'metamorph',
 
   init: function() {
     this._super();

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -263,7 +263,7 @@ Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
     });
   },
 
-  instrumentName: 'render.container',
+  instrumentName: 'container',
 
   /**
     @private


### PR DESCRIPTION
After digging through the commit history, I believe this is just a oversight when previous changes were made to the instrumentation system (f310d7, 9d13b7, 299cdf and friends), so I fixed it. Before this change, container view (for example) was instrumented under the name "render.render.container", now it's just "render.container".
