### PR TITLE
Fix test for setTimeout with negative wait for older IE

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -427,7 +427,10 @@ function invokeLaterTimers() {
 
     // schedule next timeout to fire when the earliest timer expires
     if (earliest > 0) {
-      scheduledLater = setTimeout(invokeLaterTimers, earliest - now);
+      // To allow overwrite `setTimeout` as stub from test code.
+      // The assignment to `window.setTimeout` doesn't equal to `setTimeout` in older IE.
+      // So `window` is required.
+      scheduledLater = window.setTimeout(invokeLaterTimers, earliest - now);
       scheduledLaterExpires = earliest;
     }
   });

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -182,7 +182,9 @@ asyncTest('setTimeout should never run with a negative wait', function() {
     var wait = arguments[arguments.length - 1];
     newSetTimeoutUsed = true;
     ok(!isNaN(wait) && wait >= 0, 'wait is a non-negative number');
-    originalSetTimeout.apply(this, arguments);
+    // In IE8, `setTimeout.apply` is `undefined`.
+    var apply = Function.prototype.apply;
+    return apply.apply(originalSetTimeout, [this, arguments]);
   };
 
   var count = 0;


### PR DESCRIPTION
I used `window.setTimeout` instead of `setTimeout`.
This reason is that the assignment to `window.setTimeout` doesn't equal to `setTimeout` in older IE.
But test code want to overwrite `setTimeout`.

If this PR is landed, I think all tests are passed on IE8.
