### PR TITLE
Prevent unnecessary re-rendering when only route context has changed

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -198,14 +198,25 @@ Ember.Route = Ember.Object.extend({
     } else {
       this.setupController(controller, context);
     }
+  },
 
+  /**
+    @private
+
+    This hook is an entry point for router.js. It is invoked when
+    we're entering a route, after the route's context has been setup.
+
+    @method setupTemplate
+  */
+  setupTemplate: function(context) {
     if (this.renderTemplates) {
       Ember.deprecate("Ember.Route.renderTemplates is deprecated. Please use Ember.Route.renderTemplate(controller, model) instead.");
       this.renderTemplates(context);
     } else {
-      this.renderTemplate(controller, context);
+      this.renderTemplate(this.controller, context);
     }
   },
+
 
   /**
     A hook you can implement to optionally redirect to another route.

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -298,6 +298,7 @@ define("router",
         if (handler) {
           if (handler.enter) { handler.enter(); }
           if (handler.setup) { handler.setup(); }
+          if (handler.setupTemplate) { handler.setupTemplate(); }
         }
       }
     }
@@ -340,6 +341,7 @@ define("router",
       if (handler){
         if (handler.enter) { handler.enter(); }
         if (handler.setup) { handler.setup(error); }
+        if (handler.setupTemplate) { handler.setupTemplate(error); }
       }
     }
 
@@ -495,10 +497,12 @@ define("router",
             aborted = true;
           }
         }
-
         if (!aborted) {
+          if (handler.setupTemplate) {
+            handler.setupTemplate(context);
+          }
           currentHandlerInfos.push(handlerInfo);
-        }
+	}
       });
 
       if (!aborted && router.didTransition) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1773,3 +1773,51 @@ test("Child routes should render inside the application template if the applicat
 
   equal(Ember.$('#qunit-fixture > div').text(), "App posts");
 });
+
+test("The template is not re-rendered when the route's context changes", function() {
+  Router.map(function() {
+    this.route("page", { path: "/page/:name" });
+  });
+
+  App.PageRoute = Ember.Route.extend({
+    model: function(params) {
+      return Ember.Object.create({name: params.name});
+    }
+  });
+
+  var insertionCount = 0;
+  App.PageView = Ember.View.extend({
+    didInsertElement: function() {
+      insertionCount += 1;
+    }
+  });
+
+  Ember.TEMPLATES.page = Ember.Handlebars.compile(
+    "<p>{{name}}</p>"
+  );
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/page/first");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "first");
+  equal(insertionCount, 1);
+
+  Ember.run(function() {
+    router.handleURL("/page/second");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "second");
+  equal(insertionCount, 1, "view should have inserted only once");
+
+  Ember.run(function() {
+    router.transitionTo('page', Ember.Object.create({name: 'third'}));
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "third");
+  equal(insertionCount, 1, "view should still have inserted only once");
+});
+
+


### PR DESCRIPTION
It should only be necessary to run `renderTemplate` when a route is
entered. Subsequent changes to a route's context Just Work(tm) thanks
to the usual magic of bindings.

In addition to a theoretical performance benefit, this change gives
the controller more control over precisely when and how the view will
transition from model-to-model. (In my case, I'm using this capability
to nicely animate the transition.)

This change doesn't break any unit tests or change the API. But if
someone is doing something weird in `renderTemplate` (like choosing
their template based on the model, or doing something else with
side-effects), they will get breakage. I think those cases are
sufficiently pathological not to worry about.
