### PR TITLE
Allow less writing for setProperties with the same value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember.js [![Build Status](https://secure.travis-ci.org/emberjs/ember.js.png?branch=master)](http://travis-ci.org/emberjs/ember.js)
 
-Ember.js is a JavaScript framework that does all of the heavy lifting
+Ember.js is a JavaScript framework that does all of the heavy lifting 
 that you'd normally have to do by hand. There are tasks that are common
 to every web app; Ember.js does those things for you, so you can focus
 on building killer features and UI.

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -19,16 +19,14 @@ Ember.setProperties = function(self, hash, value) {
   changeProperties(function(){
    
    if(Array.isArray(hash) && value !== undefined){
-       for(var i = 0; i < hash.length; i++) {
+      for(var i = 0; i < hash.length; i++) {
    	    set(self, hash[i], value); 
    	  }
    }else{
-   
    	 for(var prop in hash) {
    	   if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
    	  }
    }
-    
   });
   return self;
 };

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -18,14 +18,14 @@ var changeProperties = Ember.changeProperties,
 Ember.setProperties = function(self, hash, value) {
   changeProperties(function(){
    
-   if(Array.isArray(hash) && value !== undefined){
-      for(var i = 0; i < hash.length; i++) {
-   	    set(self, hash[i], value); 
-   	  }
+    if(Array.isArray(hash) && value !== undefined){
+        for(var i = 0; i < hash.length; i++) {
+        set(self, hash[i], value); 
+    }
    }else{
-   	 for(var prop in hash) {
-   	   if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
-   	  }
+    for(var prop in hash) {
+        if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
+    }
    }
   });
   return self;

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -18,7 +18,7 @@ var changeProperties = Ember.changeProperties,
 Ember.setProperties = function(self, hash, value) {
   changeProperties(function(){
    
-    if(Array.isArray(hash) && value !== undefined){
+    if(Ember.isArray(hash) && value !== undefined){
         for(var i = 0; i < hash.length; i++) {
         set(self, hash[i], value); 
     }

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -14,11 +14,20 @@ var changeProperties = Ember.changeProperties,
   @param {Hash} properties
   @return target
 */
-Ember.setProperties = function(self, hash) {
+Ember.setProperties = function(self, hash, value) {
   changeProperties(function(){
-    for(var prop in hash) {
-      if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
-    }
+   
+   if(Array.isArray(hash) && value !== undefined){
+       for(var i = 0; i < hash.length; i++) {
+   	    set(self, hash[i], value); 
+   	  }
+   }else{
+   
+   	 for(var prop in hash) {
+   	   if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
+   	  }
+   }
+    
   });
   return self;
 };

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -12,6 +12,7 @@ var changeProperties = Ember.changeProperties,
   @method setProperties
   @param target
   @param {Hash} properties
+  @param {Object} value The value to set or `null`.
   @return target
 */
 Ember.setProperties = function(self, hash, value) {

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -204,14 +204,12 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
 
     ```javascript
     record.setProperties({ firstName: 'Charles', lastName: 'Jolley' });
+    record.setProperties(['prop1', 'prop2'], 'value');
     ```
-
-    record.setProperties(['prop1', 'prop2'], 'Same Value');
-
 
     @method setProperties
     @param {Hash} hash the hash of keys and values to set
-     @param {Object} value The value to set or `null`.
+    @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
   */
   setProperties: function(hash, value) {

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -206,12 +206,16 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     record.setProperties({ firstName: 'Charles', lastName: 'Jolley' });
     ```
 
+    record.setProperties(['prop1', 'prop2'], 'Same Value');
+
+
     @method setProperties
     @param {Hash} hash the hash of keys and values to set
+     @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
   */
-  setProperties: function(hash) {
-    return Ember.setProperties(this, hash);
+  setProperties: function(hash, value) {
+    return Ember.setProperties(this, hash, value);
   },
 
   /**


### PR DESCRIPTION
This change allows you to set multiple properties with the same value.

Old way:
`object.setProperties({'prop1': false, 'prop2': false});`

New way:
`object.setProperties(['prop1', 'prop2'], false);`
