### PR TITLE
Events sent to controllers can bubble

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -63,12 +63,15 @@ Ember.ControllerMixin = Ember.Mixin.create({
   model: Ember.computed.alias('content'),
 
   send: function(actionName) {
-    var args = [].slice.call(arguments, 1), target;
+    var args = [].slice.call(arguments, 1), target,
+        bubble = true;
 
     if (this[actionName]) {
       Ember.assert("The controller " + this + " does not have the action " + actionName, typeof this[actionName] === 'function');
-      this[actionName].apply(this, args);
-    } else if(target = get(this, 'target')) {
+      bubble = this[actionName].apply(this, args) === true;
+    } 
+    
+    if (bubble && (target = get(this, 'target'))) {
       Ember.assert("The target for controller " + this + " (" + target + ") did not define a `send` method", typeof target.send === 'function');
       target.send.apply(target, arguments);
     }


### PR DESCRIPTION
If you return true from an event handler on a controller, it
will continue to bubble (presumably to the router).

This is part of `routeTo` work:
https://github.com/emberjs/ember.js/pull/2522

Also related, on the router.js side:
https://github.com/tildeio/router.js/pull/15
