### PR TITLE
Adding "By" method aliases

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -386,6 +386,18 @@ Ember.Enumerable = Ember.Mixin.create({
   },
 
   /**
+    Alias for filterProperty
+
+    @method filterByProperty
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against.
+    @return {Array} filtered array
+  */
+  filterByProperty: function(key, value) {
+    return this.filterProperty.apply(this, arguments);
+  },
+
+  /**
     Returns an array with the items that do not have truthy values for
     key.  You can pass an optional second argument with the target value.  Otherwise
     this will match any property that evaluates to false.

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -26,7 +26,15 @@ suite.test('filter should invoke on each item', function() {
 
 suite.module('filterProperty');
 
-suite.test('should filter based on object', function() {
+function withMethods(methodNames, testFunc) {
+  return function() {
+    methodNames.forEach(function(methodName) {
+      testFunc.call(this, methodName);
+    }, this);
+  };
+}
+
+suite.test('should filter based on object', withMethods(['filterProperty', 'filterByProperty'], function(methodName) {
   var obj, ary;
 
   ary = [
@@ -36,9 +44,9 @@ suite.test('should filter based on object', function() {
 
   obj = this.newObject(ary);
 
-  deepEqual(obj.filterProperty('foo', 'foo'), ary, 'filterProperty(foo)');
-  deepEqual(obj.filterProperty('bar', 'bar'), [ary[1]], 'filterProperty(bar)');
-});
+  deepEqual(obj[methodName]('foo', 'foo'), ary, methodName + '(foo)');
+  deepEqual(obj[methodName]('bar', 'bar'), [ary[1]],  methodName + '(bar)');
+}));
 
 suite.test('should include in result if property is true', function() {
   var obj, ary;


### PR DESCRIPTION
This PR is to add "By" method aliases to many methods in Ember Enumerables.  

I've worked through one example of adding aliases to Enumerable mixin. I'd like feedback on how these additions should be tested. 

Currently, I am passing both method names to a utility function that just runs the test twice, once with each name.  I can't tell if wrapping every test in something like this is the correct amount of coverage, or overkill. 
