### PR TITLE
Idempotent render

### DIFF
--- a/packages/ember-routing/lib/ext/view.js
+++ b/packages/ember-routing/lib/ext/view.js
@@ -50,7 +50,10 @@ Ember.View.reopen({
 
   _finishDisconnections: function() {
     var outlets = get(this, '_outlets');
-    for (var outletName in this._pendingDisconnections) {
+    var pendingDisconnections = this._pendingDisconnections;
+    this._pendingDisconnections = null;
+
+    for (var outletName in pendingDisconnections) {
       set(outlets, outletName, null);
     }
   }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1773,3 +1773,51 @@ test("Child routes should render inside the application template if the applicat
 
   equal(Ember.$('#qunit-fixture > div').text(), "App posts");
 });
+
+test("The template is not re-rendered when the route's context changes", function() {
+  Router.map(function() {
+    this.route("page", { path: "/page/:name" });
+  });
+
+  App.PageRoute = Ember.Route.extend({
+    model: function(params) {
+      return Ember.Object.create({name: params.name});
+    }
+  });
+
+  var insertionCount = 0;
+  App.PageView = Ember.View.extend({
+    didInsertElement: function() {
+      insertionCount += 1;
+    }
+  });
+
+  Ember.TEMPLATES.page = Ember.Handlebars.compile(
+    "<p>{{name}}</p>"
+  );
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/page/first");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "first");
+  equal(insertionCount, 1);
+
+  Ember.run(function() {
+    router.handleURL("/page/second");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "second");
+  equal(insertionCount, 1, "view should have inserted only once");
+
+  Ember.run(function() {
+    router.transitionTo('page', Ember.Object.create({name: 'third'}));
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "third");
+  equal(insertionCount, 1, "view should still have inserted only once");
+});
+
+


### PR DESCRIPTION
This change prevents us from tearing down and recreating a view when
the new view is functionally identical to the old view.

This has important benefits:
- when you're changing context within a route, the view itself
  remains stable, and the controller has full control over how and
  when to update the data it's presenting to the view
  layer. (Previously, you got a forced re-render immediately whether
  you were ready for it or not.)
- when you're changing between routes, you can decide to keep the
  prior view in place, and replace it later when you're ready. (Think
  animated transitions between routes.)

This supercedes the proposed changes in PR #2563 (which has already
been reverted).

Views are "functionally identical" if they have the same prototype, the same context, and the same template. 
