### PR TITLE
Ember.Handlebars.collection is deprecated

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -150,10 +150,10 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   manipulated. Instead, add, remove, replace items from its `content` property.
   This will trigger appropriate changes to its rendered HTML.
 
-  ## Use in templates via the `{{collection}}` `Ember.Handlebars` helper
+  ## Use in templates via the `{{each}}` `Ember.Handlebars` helper
 
   `Ember.Handlebars` provides a helper specifically for adding
-  `CollectionView`s to templates. See `Ember.Handlebars.collection` for more
+  `CollectionView`s to templates. See `Ember.Handlebars.each` for more
   details
 
   @class CollectionView


### PR DESCRIPTION
Update the CollectionView documentation to reference `{{each}}` instead of the deprecated `{{collection}}`.
