### PR TITLE
More accurate, helpful error message for handlebars version errors.

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -15,7 +15,8 @@ if(!Handlebars && typeof require === 'function') {
   Handlebars = require('handlebars');
 }
 
-Ember.assert("Ember Handlebars requires Handlebars 1.0.0-rc.3 or greater. Include a SCRIPT tag in the HTML HEAD linking to the Handlebars file before you link to Ember.", Handlebars && Handlebars.COMPILER_REVISION === 2);
+Ember.assert("Ember Handlebars requires Handlebars version 1.0.0-rc.3. Include a SCRIPT tag in the HTML HEAD linking to the Handlebars file before you link to Ember.", Handlebars)
+Ember.assert("Ember Handlebars requires Handlebars version 1.0.0-rc.3, COMPILER_REVISION 2. Builds of master may have other COMPILER_REVISION values.", Handlebars.COMPILER_REVISION === 2);
 
 /**
   Prepares the Handlebars templating library for use inside Ember's view


### PR DESCRIPTION
Makes the error messages regarding Handlebars versions more explicit and correct. Here is a new message for when Handlebars is missing, and a second for when the `COMPILER_REVISION` is incorrect.

![](http://cl.ly/image/0m3J2H0p220e/Screen%20Shot%202013-05-01%20at%2012.36.26%20AM.png)
![](http://cl.ly/image/3m311g2m0T3I/Screen%20Shot%202013-05-01%20at%2012.35.10%20AM.png)

The existing error of `Ember Handlebars requires Handlebars 1.0.0-rc.3 or greater` has been inaccurate since https://github.com/wycats/handlebars.js/commit/baccdb4cfc241cbcfd02d21aada56100c6c9c132 landed.
