### PR TITLE
Create Ember.Test with registerHelper method

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -2,7 +2,20 @@ require('ember-testing/test');
 
 var Promise = Ember.RSVP.Promise,
     get = Ember.get,
-    helper = Ember.Test.registerHelper;
+    helper = Ember.Test.registerHelper,
+    pendingAjaxRequests = 0;
+
+
+Ember.Test.onInjectHelpers(function() {
+  Ember.$(document).ajaxStart(function() {
+    pendingAjaxRequests++;
+  });
+
+  Ember.$(document).ajaxStop(function() {
+    pendingAjaxRequests--;
+  });
+});
+
 
 function visit(app, url) {
   Ember.run(app, app.handleURL, url);
@@ -34,7 +47,7 @@ function wait(app, value) {
     var watcher = setInterval(function() {
       var routerIsLoading = app.__container__.lookup('router:main').router.isLoading;
       if (routerIsLoading) { return; }
-      if (Ember.Test.pendingAjaxRequests) { return; }
+      if (pendingAjaxRequests) { return; }
       if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) { return; }
       clearInterval(watcher);
       start();

--- a/packages/ember-testing/lib/main.js
+++ b/packages/ember-testing/lib/main.js
@@ -1,2 +1,3 @@
 require('ember-application');
+require('ember-testing/test');
 require('ember-testing/helpers');

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -1,0 +1,115 @@
+var slice = [].slice,
+    helpers = {},
+    originalMethods = {};
+
+/**
+  @class Test
+  @namespace Ember
+*/
+Ember.Test = {
+
+  /**
+    @public
+
+    `registerHelper` is used to register a
+    test helper that will be injected when
+    `App.injectTestHelpers` is called.
+
+    The helper method will always be called
+    with the current Application as the first
+    parameter.
+
+    For example:
+    ```javascript
+    Ember.Test.registerHelper('boot', function(app)) {
+      Ember.run(app, app.deferReadiness);
+    }
+    ```
+
+    This helper can later be called without arguments
+    because it will be called with `app` as the
+    first parameter.
+
+    ```javascript
+      App = Ember.Application.create();
+      App.injectTestHelpers();
+      boot();
+    ```
+
+    Whenever you register a helper that
+    performs async operations,
+    make sure you `return wait();` at the
+    end of the helper.
+
+    If an async helper also needs to return a value,
+    pass it to the `wait` helper as a first argument:
+    `return wait(val);`
+
+    @method registerHelper
+    @param name {String}
+    @param helperMethod {Function}
+  */
+  registerHelper: function(name, helperMethod) {
+    helpers[name] = helperMethod;
+  },
+  /**
+    @method unregisterHelper
+    @param name {String}
+  */
+  unregisterHelper: function(name) {
+    delete helpers[name];
+    if (originalMethods[name]) {
+      window[name] = originalMethods[name];
+    }
+    delete originalMethods[name];
+  },
+
+  pendingAjaxRequests: 0
+};
+
+
+function curry(app, fn) {
+  return function() {
+    var args = slice.call(arguments);
+    args.unshift(app);
+    return fn.apply(app, args);
+  };
+}
+
+
+Ember.Application.reopen({
+  testHelpers: {},
+
+  setupForTesting: function() {
+    this.deferReadiness();
+
+    this.Router.reopen({
+      location: 'none'
+    });
+  },
+
+  injectTestHelpers: function() {
+    this.testHelpers = {};
+
+    Ember.$(document).ajaxStart(function() {
+      Ember.Test.pendingAjaxRequests++;
+    });
+
+    Ember.$(document).ajaxStop(function() {
+      Ember.Test.pendingAjaxRequests--;
+    });
+
+    for (var name in helpers) {
+      originalMethods[name] = window[name];
+      this.testHelpers[name] = window[name] = curry(this, helpers[name]);
+    }
+  },
+
+  removeTestHelpers: function() {
+    for (var name in helpers) {
+      window[name] = originalMethods[name];
+      delete this.testHelpers[name];
+      delete originalMethods[name];
+    }
+  }
+});

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -11,24 +11,35 @@ module("ember-testing", {
 test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
   App = Ember.run(Ember.Application, Ember.Application.create);
   ok(!window.visit);
+  ok(!App.testHelpers.visit);
   ok(!window.click);
+  ok(!App.testHelpers.click);
   ok(!window.fillIn);
+  ok(!App.testHelpers.fillIn);
   ok(!window.wait);
+  ok(!App.testHelpers.wait);
 
   App.injectTestHelpers();
 
   ok(window.visit);
+  ok(App.testHelpers.visit);
   ok(window.click);
+  ok(App.testHelpers.click);
   ok(window.fillIn);
-  ok(window.find);
+  ok(App.testHelpers.fillIn);
   ok(window.wait);
+  ok(App.testHelpers.wait);
 
   App.removeTestHelpers();
 
   ok(!window.visit);
+  ok(!App.testHelpers.visit);
   ok(!window.click);
+  ok(!App.testHelpers.click);
   ok(!window.fillIn);
+  ok(!App.testHelpers.fillIn);
   ok(!window.wait);
+  ok(!App.testHelpers.wait);
 });
 
 test("Ember.Application#setupForTesting", function() {
@@ -38,4 +49,32 @@ test("Ember.Application#setupForTesting", function() {
   });
 
   equal(App.__container__.lookup('router:main').location.implementation, 'none');
+});
+
+test("Ember.Test.registerHelper/unregisterHelper", function() {
+  expect(3);
+  var appBooted = false;
+
+  Ember.Test.registerHelper('boot', function(app) {
+    Ember.run(app, app.advanceReadiness);
+    appBooted = true;
+    return window.wait();
+  });
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+    App.injectTestHelpers();
+  });
+
+  ok(window.boot);
+
+  window.boot().then(function() {
+    ok(appBooted);
+  });
+
+  App.removeTestHelpers();
+  Ember.Test.unregisterHelper('boot');
+
+  ok(!window.boot);
 });


### PR DESCRIPTION
This will expose an `Ember.Test` that will allow us to expose methods for users to customize their testing environment.

The first thing I added was `Ember.Test.registerHelper` method, which allows us to create our own custom helpers.

The helper will always get passed the current application as a first argument:

``` javascript
Em.Test.registerHelper('boot', function(app) {
  Em.run(app, app.advanceReadiness);
  return wait();
});

App = Em.Application.create();
App.setupForTesting();
App.injectTestHelpers();

boot().then(function() {
  return visit('/posts');
}).then(function() {
  // assertion
});
```

It's very easy to create async helpers, all they need to do is `return wait();` at the end of the helper.

The second thing I added is the ability to register callbacks that would be fired when `App.injectTestHelpers` is called.

``` javascript
Ember.Test.onInjectHelpers(function(app) {
  console.log('helpers where injected into ' + app);
});
```
