### PR TITLE
Don't add disabled class if disabledWhen not provided

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -64,7 +64,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     disabled: Ember.computed(function(key, value) {
       if (value !== undefined) { this.set('_isDisabled', value); }
       
-      return value === false ? false : this.get('disabledClass');
+      return value ? this.get('disabledClass') : false;
     }),
 
     active: Ember.computed(function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -153,6 +153,22 @@ test("the {{linkTo}} applies a 'disabled' class when disabled", function () {
   equal(Ember.$('#about-link.disabled', '#qunit-fixture').length, 1, "The link is disabled when its disabledWhen is true");
 });
 
+test("the {{linkTo}} doesn't apply a 'disabled' class if disabledWhen is not provided", function () {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo about id="about-link"}}About{{/linkTo}}');
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  ok(!Ember.$('#about-link', '#qunit-fixture').hasClass("disabled"), "The link is not disabled if disabledWhen not provided");
+});
+
 test("the {{linkTo}} helper supports a custom disabledClass", function () {
   Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo about id="about-link" disabledWhen="shouldDisable" disabledClass="do-not-want"}}About{{/linkTo}}');
   App.IndexController = Ember.Controller.extend({


### PR DESCRIPTION
With the addition of #2436 any `linkTo` helper without `disabledWhen` provided will be disabled by default.

I'm not sure what the `=== false` check was for, so this might not be the best solution.

cc @trek
