### PR TITLE
Make parentController available from an itemController

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -20,6 +20,7 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
       set(controller, 'container', get(this, 'controller.container'));
       set(controller, '_eachView', this);
       set(controller, 'target', get(this, 'controller'));
+      set(controller, 'parentController', get(this, 'controller'));
 
       this.disableContentObservers(function() {
         set(this, 'content', controller);
@@ -292,6 +293,9 @@ GroupedEach.prototype = {
     {{person.name}} {{#if person.isAvailableForHire}}Hire me!{{/if}}
   {{/each}}
   ```
+
+  Each itemController will receive a reference to the current controller as
+  a `parentController` property.
 
   @method each
   @for Ember.Handlebars.helpers

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -241,6 +241,35 @@ test("it supports itemController", function() {
   strictEqual(view.get('_childViews')[0].get('_arrayController.target'), parentController, "the target property of the child controllers are set correctly");
 });
 
+test("itemController gets a parentController property", function() {
+  // using an ObjectController for this test to verify that parentController does accidentally get set
+  // on the proxied model.
+  var Controller = Ember.ObjectController.extend({
+        controllerName: Ember.computed(function() {
+          return "controller:"+this.get('content.name') + ' of ' + this.get('parentController.company');
+        })
+      }),
+      container = new Ember.Container(),
+      parentController = {
+        container: container,
+        company: 'Yapp'
+      };
+
+  Ember.run(function() { view.destroy(); }); // destroy existing view
+
+  view = Ember.View.create({
+    template: templateFor('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
+    people: people,
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  append(view);
+
+  equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
+});
+
 test("it supports itemController when using a custom keyword", function() {
   var Controller = Ember.Controller.extend({
     controllerName: Ember.computed(function() {

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -87,6 +87,10 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach,
   });
   ```
 
+  The itemController instances will have a `parentController` property set to
+  either the the `parentController` property of the `ArrayController`
+  or to the `ArrayController` instance itself.
+
   @class ArrayController
   @namespace Ember
   @extends Ember.ArrayProxy
@@ -197,6 +201,7 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
     }
 
     subController.set('target', this);
+    subController.set('parentController', get(this, 'parentController') || this);
     subController.set('content', object);
 
     return subController;

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -58,6 +58,8 @@ Ember.ControllerMixin = Ember.Mixin.create({
 
   container: null,
 
+  parentController: null,
+
   store: null,
 
   model: Ember.computed.alias('content'),

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -110,6 +110,14 @@ test("the target of item controllers is the parent controller", function() {
   equal(jaimeController.get('target'), arrayController, "Item controllers' targets are their parent controller");
 });
 
+test("the parentController property of item controllers is set to the parent controller", function() {
+  createArrayController();
+
+  var jaimeController = arrayController.objectAtContent(1);
+
+  equal(jaimeController.get('parentController'), arrayController, "Item controllers' targets are their parent controller");
+});
+
 test("when the underlying object has not changed, `objectAtContent` always returns the same instance", function() {
   createArrayController();
 


### PR DESCRIPTION
When using the `{{#each}}` helper with itemController specified,
the itemController instances will now have the parentController
set on them. The parentController is the value of the `controller`
keyword when the #each helper executes.

In the case of using ArrayController with itemController directly, the
ArrayController instance is set as the itemController's parentController.
