### PR TITLE
Include `Ember::VERSION` in 'ember-source' gem

### DIFF
--- a/ember-source.gemspec
+++ b/ember-source.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |gem|
   # so long as we're referencing pre-release versions.
   gem.add_dependency "handlebars-source", [">= 1.0.0.rc3", "< 1.0.0.rc4"]
 
-  gem.files = Dir['dist/*.js']
-  gem.files << 'lib/ember/source.rb'
+  gem.files = %w(VERSION) + Dir['dist/*.js', 'lib/ember/*.rb']
 end

--- a/lib/ember/source.rb
+++ b/lib/ember/source.rb
@@ -1,3 +1,5 @@
+require 'ember/version'
+
 module Ember
   module Source
     def self.bundled_path_for(distro)

--- a/lib/ember/version.rb
+++ b/lib/ember/version.rb
@@ -1,3 +1,3 @@
 module Ember
-  VERSION = File.read("VERSION").strip
+  VERSION = File.read(File.expand_path('../../../VERSION', __FILE__)).strip
 end


### PR DESCRIPTION
For examples:

``` ruby
require 'ember/source'

Ember::VERSION #=> "1.0.0-rc3"
```
