### PR TITLE
Keep ember-testing framework agnostic

### DIFF
--- a/packages/ember-testing/lib/adapters.js
+++ b/packages/ember-testing/lib/adapters.js
@@ -1,0 +1,77 @@
+require('ember-testing/test');
+
+var Test = Ember.Test;
+
+/**
+  @class Adapter
+  @namespace Ember.Test
+*/
+Test.Adapter = Ember.Object.extend({
+  /**
+    @public
+
+    This callback will be called
+    whenever an async operation
+    is about to start.
+
+    Override this to call your
+    framework's methods
+    that handle async operations
+
+    @method asyncStart
+  */
+  asyncStart: Ember.K,
+
+  /**
+    @public
+
+    This callback will be called
+    whenever an async operation
+    has completed.
+
+    @method asyncStart
+  */
+  asyncEnd: Ember.K,
+
+  /**
+   @public
+
+    Override this method with your
+    testing framework's false assertion
+    This function is called whenever
+    an exception occurs causing the testing
+    promise to fail.
+
+    QUnit example:
+
+    ```javascript
+    exception: function(error) {
+      ok(false, error);
+    }
+    ```
+
+    @method exception
+    @param reason {String}
+  */
+  exception: function(error) {
+    setTimeout(function() {
+      throw error;
+    });
+  }
+});
+
+/**
+  @class QUnitAdapter
+  @namespace Ember.Test
+*/
+Test.QUnitAdapter = Test.Adapter.extend({
+  asyncStart: function() {
+    stop();
+  },
+  asyncEnd: function() {
+    start();
+  },
+  exception: function(error) {
+    ok(false, error);
+  }
+});

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -55,14 +55,14 @@ function find(app, selector, context) {
 
 function wait(app, value) {
   return Ember.Test.promise(function(resolve) {
-    stop();
+    Ember.Test.adapter.asyncStart();
     var watcher = setInterval(function() {
       var routerIsLoading = app.__container__.lookup('router:main').router.isLoading;
       if (routerIsLoading) { return; }
       if (pendingAjaxRequests) { return; }
       if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) { return; }
       clearInterval(watcher);
-      start();
+      Ember.Test.adapter.asyncEnd();
       Ember.run(function() {
         resolve(value);
       });

--- a/packages/ember-testing/lib/main.js
+++ b/packages/ember-testing/lib/main.js
@@ -1,3 +1,4 @@
 require('ember-application');
 require('ember-testing/test');
+require('ember-testing/adapters');
 require('ember-testing/helpers');

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -1,4 +1,4 @@
-var App, find, click, fillIn, currentRoute, visit, originalFailure;
+var App, find, click, fillIn, currentRoute, visit, originalAdapter;
 
 module("ember-testing Acceptance", {
   setup: function(){
@@ -50,7 +50,7 @@ module("ember-testing Acceptance", {
     fillIn = window.fillIn;
     visit = window.visit;
 
-    originalFailure = Ember.Test.failure;
+    originalAdapter = Ember.Test.adapter;
   },
 
   teardown: function(){
@@ -58,16 +58,17 @@ module("ember-testing Acceptance", {
     Ember.$('#ember-testing-container, #ember-testing').remove();
     Ember.run(App, App.destroy);
     App = null;
-    Ember.Test.failure = originalFailure;
+    Ember.Test.adapter = originalAdapter;
   }
 });
 
 test("helpers can be chained", function() {
   expect(5);
-
-  Ember.Test.failure = function(error) {
-    equal(error, "Element .does-not-exist not found.", "Exception successfully caught and passed to Ember.test.failure");
-  };
+  Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
+    exception: function(error) {
+      equal(error, "Element .does-not-exist not found.", "Exception successfully caught and passed to Ember.Test.adapter.exception");
+    }
+  });
 
   currentRoute = 'index';
 
@@ -84,7 +85,7 @@ test("helpers can be chained", function() {
     equal(Ember.$('.ember-text-field').val(), 'context working', "chained with fillIn");
     click(".does-not-exist");
   }).then(function() {
-    // This is needed in this test
+    // This redundant `then` is needed in this test
     // so we can assert that thrown exceptions
     // do not fire multiple times
   });

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -81,3 +81,40 @@ test("Ember.Test.registerHelper/unregisterHelper", function() {
   });
 
 });
+
+test("Setting a test adapter manually", function() {
+  expect(1);
+  var originalAdapter = Ember.Test.adapter, CustomAdapter;
+
+  CustomAdapter = Ember.Test.Adapter.extend({
+    asyncStart: function() {
+      ok(true, "Correct adapter was used");
+    }
+  });
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    Ember.Test.adapter = CustomAdapter.create();
+    App.setupForTesting();
+  });
+
+  Ember.Test.adapter.asyncStart();
+
+  Ember.Test.adapter = originalAdapter;
+});
+
+test("QUnitAdapter is used by default", function() {
+  expect(1);
+  var originalAdapter = Ember.Test.adapter, CustomAdapter;
+
+  Ember.Test.adapter = null;
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+  });
+
+  ok(Ember.Test.adapter instanceof Ember.Test.QUnitAdapter);
+
+  Ember.Test.adapter = originalAdapter;
+});


### PR DESCRIPTION
`stop()` and `start()` assume QUnit.  Not relying on them makes ember testing framework agnostic.
