### PR TITLE
Ember testing update url in visit helper

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -19,6 +19,7 @@ Ember.Test.onInjectHelpers(function() {
 
 function visit(app, url) {
   Ember.run(app, app.handleURL, url);
+  app.__container__.lookup('router:main').location.setURL(url);
   return wait(app);
 }
 


### PR DESCRIPTION
It's good to keep the router's URL in sync with the current route, especially if some assertions depend on the router's URL, for example checking if redirection is working.
