### PR TITLE
Ember testing capture exceptions thrown in promises

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -1,7 +1,6 @@
 require('ember-testing/test');
 
-var Promise = Ember.RSVP.Promise,
-    get = Ember.get,
+var get = Ember.get,
     helper = Ember.Test.registerHelper,
     pendingAjaxRequests = 0;
 
@@ -43,7 +42,7 @@ function find(app, selector) {
 }
 
 function wait(app, value) {
-  return new Promise(function(resolve) {
+  return Ember.Test.promise(function(resolve) {
     stop();
     var watcher = setInterval(function() {
       var routerIsLoading = app.__container__.lookup('router:main').router.isLoading;

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -1,4 +1,4 @@
-var App, find, click, fillIn, currentRoute, visit;
+var App, find, click, fillIn, currentRoute, visit, originalFailure;
 
 module("ember-testing Acceptance", {
   setup: function(){
@@ -49,6 +49,8 @@ module("ember-testing Acceptance", {
     click = window.click;
     fillIn = window.fillIn;
     visit = window.visit;
+
+    originalFailure = Ember.Test.failure;
   },
 
   teardown: function(){
@@ -56,15 +58,16 @@ module("ember-testing Acceptance", {
     Ember.$('#ember-testing-container, #ember-testing').remove();
     Ember.run(App, App.destroy);
     App = null;
+    Ember.Test.failure = originalFailure;
   }
 });
 
-function fail(error) {
-  ok(false, error);
-}
-
 test("helpers can be chained", function() {
-  expect(3);
+  expect(4);
+
+  Ember.Test.failure = function(error) {
+    equal(error, "exception", "Exception successfully caught and passed to Ember.test.failure");
+  };
 
   currentRoute = 'index';
 
@@ -76,5 +79,11 @@ test("helpers can be chained", function() {
     return fillIn('.ember-text-field', "yeah");
   }).then(function(){
     equal(Ember.$('.ember-text-field').val(), 'yeah', "chained with fillIn");
-  }).then(null, fail);
+    throw "exception";
+  }).then(function() {
+    // This is needed in this test
+    // so we can assert that thrown exceptions
+    // do not fire multiple times
+  });
+
 });


### PR DESCRIPTION
This allows us to capture exceptions thrown inside the `onSuccess` handlers.

The rejection handler can be customized based on the testing framework by overriding `Ember.Test.failure`. Example:

``` javascript
Ember.Test.failure = function(error) {
  ok(false, error);
});
```
