### PR TITLE
Application Route model can return a promise

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -532,9 +532,10 @@ Ember.Route = Ember.Object.extend({
 });
 
 function parentRoute(route) {
-  var handlerInfos = route.router.router.targetHandlerInfos;
+  var handlerInfos = route.router.router.targetHandlerInfos,
+      parent, current;
 
-  var parent, current;
+  if (!handlerInfos) { return; }
 
   for (var i=0, l=handlerInfos.length; i<l; i++) {
     current = handlerInfos[i].handler;

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -621,6 +621,32 @@ test("The Special page returning an error puts the app into a default failure st
   equal(lastFailure, 'Setup error');
 });
 
+
+test("The application route model function will move into the loading state if it exists", function() {
+  var promise = new Ember.RSVP.Promise(function() { });
+
+  App.ApplicationRoute = Ember.Route.extend({
+    model: function() {
+      return promise;
+    }
+  });
+
+  App.LoadingRoute = Ember.Route.extend({});
+
+  Ember.TEMPLATES.loading = Ember.Handlebars.compile(
+    "<p>LOADING!</p>"
+  );
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "LOADING!", "The app is in the loading state");
+});
+
+
 test("Moving from one page to another triggers the correct callbacks", function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
If application route model function returns a promise and there is a loading state we get an error. Here is a failing jsbin case: http://jsbin.com/alicow/2/edit

This PR fixes that by having parentRoute return undefined if there is no targetHandlerInfo. There is also a failing/fixed test case.
