### PR TITLE
Remove defined global property

### DIFF
--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -1,7 +1,8 @@
 var slice = [].slice,
     helpers = {},
     originalMethods = {},
-    injectHelpersCallbacks = [];
+    injectHelpersCallbacks = [],
+    has = {}.hasOwnProperty;
 
 /**
   @class Test
@@ -60,7 +61,7 @@ Ember.Test = {
   */
   unregisterHelper: function(name) {
     delete helpers[name];
-    if (originalMethods[name]) {
+    if (has.call(originalMethods, name)) {
       window[name] = originalMethods[name];
     }
     delete originalMethods[name];
@@ -107,7 +108,9 @@ Ember.Application.reopen({
   injectTestHelpers: function() {
     this.testHelpers = {};
     for (var name in helpers) {
-      originalMethods[name] = window[name];
+      if (has.call(window, name)) {
+        originalMethods[name] = window[name];
+      }
       this.testHelpers[name] = window[name] = curry(this, helpers[name]);
     }
 
@@ -118,7 +121,11 @@ Ember.Application.reopen({
 
   removeTestHelpers: function() {
     for (var name in helpers) {
-      window[name] = originalMethods[name];
+      if (has.call(originalMethods, name)) {
+        window[name] = originalMethods[name];
+      } else {
+        delete window[name];
+      }
       delete this.testHelpers[name];
       delete originalMethods[name];
     }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,4 +1,5 @@
-var App;
+var App,
+    has = {}.hasOwnProperty;
 
 module("ember-testing", {
   teardown: function() {
@@ -32,14 +33,14 @@ test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
 
   App.removeTestHelpers();
 
-  ok(!window.visit);
-  ok(!App.testHelpers.visit);
-  ok(!window.click);
-  ok(!App.testHelpers.click);
-  ok(!window.fillIn);
-  ok(!App.testHelpers.fillIn);
-  ok(!window.wait);
-  ok(!App.testHelpers.wait);
+  ok(!has.call(window, 'visit'));
+  ok(!has.call(App.testHelpers, 'visit'));
+  ok(!has.call(window, 'click'));
+  ok(!has.call(App.testHelpers, 'click'));
+  ok(!has.call(window, 'fillIn'));
+  ok(!has.call(App.testHelpers, 'fillIn'));
+  ok(!has.call(window, 'wait'));
+  ok(!has.call(App.testHelpers, 'wait'));
 });
 
 test("Ember.Application#setupForTesting", function() {
@@ -76,5 +77,5 @@ test("Ember.Test.registerHelper/unregisterHelper", function() {
   App.removeTestHelpers();
   Ember.Test.unregisterHelper('boot');
 
-  ok(!window.boot);
+  ok(!has.call(window, 'boot'));
 });


### PR DESCRIPTION
I think that `App.removeTestHelpers()` should remove global property defined by `App.injectTestHelpers()`.

``` javascript
window.hasOwnProperty('click'); //=> false

App.injectTestHelpers();
App.removeTestHelpers();

window.hasOwnProperty('click'); //=> true
```

I expect that the above of last line returns `false`.
