### PR TITLE
Use Ember setter to set Ember.Route controller

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -124,7 +124,7 @@ Ember.Route = Ember.Object.extend({
     var controller = this.controllerFor(this.routeName, context);
 
     if (controller) {
-      this.controller = controller;
+      set(this, 'controller', controller);
       set(controller, 'model', context);
     }
 


### PR DESCRIPTION
Minor change to use the Ember setter function. Error is only going to arise when `Ember.ENV.MANDATORY_SETTER` is set to true (so, in debug builds, for example), but seems worthwhile to do, even if only for the sake of consistency.
