### PR TITLE
Revert "Merge pull request #2577 from machty/bubbling-controller-events"

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -65,15 +65,12 @@ Ember.ControllerMixin = Ember.Mixin.create({
   model: Ember.computed.alias('content'),
 
   send: function(actionName) {
-    var args = [].slice.call(arguments, 1), target,
-        bubble = true;
+    var args = [].slice.call(arguments, 1), target;
 
     if (this[actionName]) {
       Ember.assert("The controller " + this + " does not have the action " + actionName, typeof this[actionName] === 'function');
-      bubble = this[actionName].apply(this, args) === true;
-    } 
-    
-    if (bubble && (target = get(this, 'target'))) {
+      this[actionName].apply(this, args);
+    } else if(target = get(this, 'target')) {
       Ember.assert("The target for controller " + this + " (" + target + ") did not define a `send` method", typeof target.send === 'function');
       target.send.apply(target, arguments);
     }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -824,56 +824,6 @@ asyncTest("Events are triggered on the controller if a matching action name is i
   action.handler(event);
 });
 
-asyncTest("Events triggered on the controller can bubble up to routes if the controller handler returns true", function() {
-  expect(2);
-  Router.map(function() {
-    this.route("home", { path: "/" });
-  });
-
-  var model = { name: "Tom Dale" };
-
-  App.HomeRoute = Ember.Route.extend({
-    model: function() {
-      return model;
-    },
-
-    events: {
-      showStuff: function(obj) {
-        deepEqual(obj, { name: "Tom Dale" }, "context correctly bubbles up");
-        start();
-      }
-    }
-  });
-
-  Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action showStuff content}}>{{name}}</a>"
-  );
-
-  var controller = Ember.Controller.extend({
-    showStuff: function(context){
-      deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
-
-      // Bubble the event.
-      return true;
-    }
-  });
-
-  container.register('controller:home', controller);
-
-  bootApplication();
-
-
-  Ember.run(function() {
-    router.handleURL("/");
-  });
-
-  var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
-  var event = new Ember.$.Event("click");
-  action.handler(event);
-});
-
-
 asyncTest("Events are triggered on the current state", function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
This reverts commit 05686ccce26808da4a1e1247b131c68cfba15486, reversing
changes made to 7387d6723b5a20395dfd041a67633a6101c2259d.

This changed introduced a regression in #2636 and should be reverted until we can decide on a better/safer API. Note that we're preserving the bubbling function provided in router.js for event handlers in the `events` hash, which is far more important than bubbling within the controller.

The root of the regression is as follows: if you put `{{action toggleProperty 'foo'}}` in your template (a hack to some, sugar to others, but suggested in the docs at http://emberjs.com/guides/controllers/), the `action` helper will use `.send`, which will bubble if the result of the called function is true, and since `toggleProperty` returns true half the time, the event will bubble half the time. 
