### PR TITLE
Remove unused Ember.metaPath

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -241,60 +241,6 @@ Ember.setMeta = function setMeta(obj, property, value) {
 /**
   @private
 
-  In order to store defaults for a class, a prototype may need to create
-  a default meta object, which will be inherited by any objects instantiated
-  from the class's constructor.
-
-  However, the properties of that meta object are only shallow-cloned,
-  so if a property is a hash (like the event system's `listeners` hash),
-  it will by default be shared across all instances of that class.
-
-  This method allows extensions to deeply clone a series of nested hashes or
-  other complex objects. For instance, the event system might pass
-  `['listeners', 'foo:change', 'ember157']` to `prepareMetaPath`, which will
-  walk down the keys provided.
-
-  For each key, if the key does not exist, it is created. If it already
-  exists and it was inherited from its constructor, the constructor's
-  key is cloned.
-
-  You can also pass false for `writable`, which will simply return
-  undefined if `prepareMetaPath` discovers any part of the path that
-  shared or undefined.
-
-  @method metaPath
-  @for Ember
-  @param {Object} obj The object whose meta we are examining
-  @param {Array} path An array of keys to walk down
-  @param {Boolean} writable whether or not to create a new meta
-    (or meta property) if one does not already exist or if it's
-    shared with its constructor
-*/
-Ember.metaPath = function metaPath(obj, path, writable) {
-  var meta = Ember.meta(obj, writable), keyName, value;
-
-  for (var i=0, l=path.length; i<l; i++) {
-    keyName = path[i];
-    value = meta[keyName];
-
-    if (!value) {
-      if (!writable) { return undefined; }
-      value = meta[keyName] = { __ember_source__: obj };
-    } else if (value.__ember_source__ !== obj) {
-      if (!writable) { return undefined; }
-      value = meta[keyName] = o_create(value);
-      value.__ember_source__ = obj;
-    }
-
-    meta = value;
-  }
-
-  return value;
-};
-
-/**
-  @private
-
   Wraps the passed function so that `this._super` will point to the superFunc
   when the function is invoked. This is the primitive we use to implement
   calls to super.

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -10,25 +10,6 @@ test("should return the same hash for an object", function() {
   equal(Ember.meta(obj).foo, "bar", "returns same hash with multiple calls to Ember.meta()");
 });
 
-module("Ember.metaPath");
-
-test("should not create nested objects if writable is false", function() {
-  var obj = {};
-
-  ok(!Ember.meta(obj).foo, "precond - foo property on meta does not yet exist");
-  equal(Ember.metaPath(obj, ['foo', 'bar', 'baz'], false), undefined, "should return undefined when writable is false and doesn't already exist") ;
-  equal(Ember.meta(obj).foo, undefined, "foo property is not created");
-});
-
-test("should create nested objects if writable is true", function() {
-  var obj = {};
-
-  ok(!Ember.meta(obj).foo, "precond - foo property on meta does not yet exist");
-
-  equal(typeof Ember.metaPath(obj, ['foo', 'bar', 'baz'], true), "object", "should return hash when writable is true and doesn't already exist") ;
-  ok(Ember.meta(obj).foo.bar.baz['bat'] = true, "can set a property on the newly created hash");
-});
-
 test("getMeta and setMeta", function() {
   var obj = {};
 


### PR DESCRIPTION
This method was once used to resolve issues with shallow
cloning the meta hash, but it hasn't been used for a while
and it's private API, so: removing.
