### PR TITLE
Makes partial helper only lookup the deprecated template name if the first try is unsuccessful.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -40,7 +40,7 @@ Ember.Handlebars.registerHelper('partial', function(name, options) {
   var view = options.data.view,
       underscoredName = nameParts.join("/"),
       template = view.templateForName(underscoredName),
-      deprecatedTemplate = view.templateForName(name);
+      deprecatedTemplate = !template && view.templateForName(name);
 
   Ember.deprecate("You tried to render the partial " + name + ", which should be at '" + underscoredName + "', but Ember found '" + name + "'. Please use a leading underscore in your partials", template);
   Ember.assert("Unable to find partial with name '"+name+"'.", template || deprecatedTemplate);


### PR DESCRIPTION
Ember has changed partials to require an underscore in their name but still has support for the older, deprecated way. In doing so, it currently looks up both templates regardless of whether the first one is found or not.

For users who load their templates in via AJAX for dev purposes, this causes an unnecessary ajax request that likely 404's. Not the end of the world, but there's no sense looking up the deprecated template if the correct one is found.

This pull requests changes that behavior.
