### PR TITLE
Fix docs to use extend instead of create when setting observers

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -40,7 +40,7 @@ var get = Ember.get, set = Ember.set;
   For example:
 
   ```javascript
-  Ember.Object.create({
+  Ember.Object.extend({
     valueObserver: function() {
       // Executes whenever the "value" property changes
     }.observes('value')
@@ -59,7 +59,7 @@ var get = Ember.get, set = Ember.set;
   object.addObserver('propertyKey', targetObject, targetAction)
   ```
 
-  This will call the `targetAction` method on the `targetObject` whenever 
+  This will call the `targetAction` method on the `targetObject` whenever
   the value of the `propertyKey` changes.
 
   Note that if `propertyKey` is a computed property, the observer will be


### PR DESCRIPTION
Since c1c720781c976f69fd4014ea50a1fee652286048 observers can't be set during `Ember.Object.create`
