### PR TITLE
Deactivate route handlers before destroying container in App.reset()

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -463,7 +463,13 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   },
 
   /**
-    Reset the application. This is typically used only in tests.
+    Reset the application. This is typically used only in tests. It cleans up
+    the application in the following order:
+
+    1. Deactivate existing routes
+    2. Destroy all objects in the container
+    3. Create a new application container
+    4. Re-route to the existing url
 
     Typical Example:
 
@@ -527,6 +533,9 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   **/
   reset: function() {
     function handleReset() {
+      var router = this.__container__.lookup('router:main');
+      router.reset();
+
       Ember.run(this.__container__, 'destroy');
 
       this.buildContainer();

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -128,6 +128,18 @@ Ember.Router = Ember.Object.extend({
     return this.router.hasRoute(route);
   },
 
+  /**
+    @private
+
+    Resets the state of the router by clearing the current route
+    handlers and deactivating them.
+
+    @method reset
+   */
+  reset: function() {
+    this.router.reset();
+  },
+
   _lookupActiveView: function(templateName) {
     var active = this._activeViews[templateName];
     return active && active[0];

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -51,6 +51,21 @@ define("router",
       },
 
       /**
+        Clears the current and target route handlers and triggers exit
+        on each of them starting at the leaf and traversing up through
+        its ancestors.
+      */
+      reset: function() {
+        eachHandler(this.currentHandlerInfos, function(handler) {
+          if (handler.exit) {
+            handler.exit();
+          }
+        });
+        this.currentHandlerInfos = null;
+        this.targetHandlerInfos = null;
+      },
+
+      /**
         The entry point for handling a change to the URL (usually
         via the back and forward button).
 

--- a/packages/ember/tests/application_lifecycle.js
+++ b/packages/ember/tests/application_lifecycle.js
@@ -1,0 +1,59 @@
+var App, container;
+
+module("Application Lifecycle", {
+  setup: function() {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        rootElement: '#qunit-fixture'
+      });
+      App.deferReadiness();
+
+      App.Router = Ember.Router.extend({
+        location: 'none'
+      });
+
+      container = App.__container__;
+    });
+  },
+
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test("Resetting the application allows controller properties to be set when a route deactivates", function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+  App.HomeRoute = Ember.Route.extend({
+    activate: function() {
+      this.controllerFor('home').set('selectedMenuItem', 'home');
+    },
+    deactivate: function() {
+      this.controllerFor('home').set('selectedMenuItem', null);
+    }
+  });
+  App.ApplicationRoute = Ember.Route.extend({
+    activate: function() {
+      this.controllerFor('application').set('selectedMenuItem', 'home');
+    },
+    deactivate: function() {
+      this.controllerFor('application').set('selectedMenuItem', null);
+    }
+  });
+
+  var homeController = Ember.controllerFor(container, 'home');
+  var applicationController = Ember.controllerFor(container, 'application');
+  var router = container.lookup('router:main');
+
+  Ember.run(App, 'advanceReadiness');
+  Ember.run(function() {
+    router.handleURL('/');
+  });
+  equal(homeController.get('selectedMenuItem'), 'home');
+  equal(applicationController.get('selectedMenuItem'), 'home');
+
+  App.reset();
+  equal(homeController.get('selectedMenuItem'), null);
+  equal(applicationController.get('selectedMenuItem'), null);
+});


### PR DESCRIPTION
This patch fixes issue #2649. When an application is reset it ensures that the current route handlers are deactivated before destroying the container. This allows properties to be set on objects in the container on route deactivation.
