### PR TITLE
Fix undefined error when promise rejected on startup

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -245,6 +245,8 @@ define("router",
         var targetHandlerInfos = this.targetHandlerInfos,
             found = false, names, object, handlerInfo, handlerObj;
 
+        if (!targetHandlerInfos) { return; }
+
         for (var i=targetHandlerInfos.length-1; i>=0; i--) {
           handlerInfo = targetHandlerInfos[i];
           if (handlerInfo.name === handlerName) { found = true; }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -581,6 +581,38 @@ test("The Special page returning an error invokes the failure state's enter hand
   equal(Ember.$('p', '#qunit-fixture').text(), "FAILURE!", "The failure state was properly activated");
 });
 
+test("The home page returning an error puts the app into the failure state and redirect", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+    this.route("redirected", { path: "/redirected" });
+  });
+
+  var deferredObject = Ember.Object.createWithMixins(Ember.DeferredMixin);
+
+  App.HomeRoute = Ember.Route.extend({
+    model: function() {
+      return deferredObject;
+    }
+  });
+
+  App.FailureRoute = Ember.Route.extend({
+    redirect: function() {
+      this.transitionTo("redirected");
+    }
+  });
+
+  Ember.TEMPLATES.redirected = Ember.Handlebars.compile(
+    "<p>FAILURE!</p>"
+  );
+
+  bootApplication();
+
+  Ember.run(function() {
+    deferredObject.reject(deferredObject);
+  });
+
+  equal(Ember.$('p', '#qunit-fixture').text(), "FAILURE!", "The app had redirected from failure state");
+});
 
 test("The Special page returning an error puts the app into a default failure state if none provided", function() {
   Router.map(function() {


### PR DESCRIPTION
Router#targetHandlerInfos is not initialized when a
promise is rejected on startup, causing error
in Router#isActive

This replaces https://github.com/emberjs/ember.js/pull/2640
(this bug was thwarting an Embercast, needed it in a hurry
and that PR was encumbered by merge wackness). 
