### PR TITLE
Trigger change in fillIn helper in ember testing

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -32,7 +32,7 @@ function click(app, selector) {
 function fillIn(app, selector, text) {
   var $el = find(app, selector);
   Ember.run(function() {
-    $el.val(text);
+    $el.val(text).change();
   });
   return wait(app);
 }


### PR DESCRIPTION
Bindings of Ember.TextField don't work if we don't trigger the `change` event after updating the value.
