### PR TITLE
Document that registerBoundHelper doesn't support blocks

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -236,6 +236,10 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   In this example, if the name property changes, the helper
   will not re-render.
 
+  ## Use with blocks not supported
+
+  Bound helpers do not support use with Handlebars blocks or
+  the addition of child views of any kind.
 
   @method registerBoundHelper
   @for Ember.Handlebars
@@ -258,6 +262,8 @@ Ember.Handlebars.registerBoundHelper = function(name, fn) {
       normalized,
       pathRoot, path,
       loc, hashOption;
+
+    Ember.assert("registerBoundHelper-generated helpers do not support use with Handlebars blocks.", !options.fn);
 
     // Detect bound options (e.g. countBinding="otherCount")
     hash.boundOptions = {};

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -241,3 +241,15 @@ test("bound helpers can be invoked with zero args", function() {
   equal(view.$().text(), 'TROLOLOL and bork', "helper output is correct");
 });
 
+test("bound helpers should not be invoked with blocks", function() {
+  registerRepeatHelper();
+  view = Ember.View.create({
+    controller: Ember.Object.create({}),
+    template: Ember.Handlebars.compile("{{#repeat}}Sorry, Charlie{{/repeat}}")
+  });
+
+  raises(function() {
+    appendView();
+  }, Error, "raises error when using block helper with #block form");
+});
+


### PR DESCRIPTION
Document and add assertion reflecting that helpers created with registerBoundHelper don't support invocation with Handlebars blocks.

Fixes #2655
