### PR TITLE
Add assertion about setting the same current view to multiple container views

### DIFF
--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -223,6 +223,8 @@ Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
 
   replace: function(idx, removedCount, addedViews) {
     var addedCount = addedViews ? get(addedViews, 'length') : 0;
+    var self = this;
+    Ember.assert("You can't add a child to a container that is already a child of another view", Ember.A(addedViews).every(function(item) { return !get(item, '_parentView') || get(item, '_parentView') === self; }));
 
     this.arrayContentWillChange(idx, removedCount, addedCount);
     this.childViewsWillChange(this._childViews, idx, removedCount);
@@ -343,6 +345,7 @@ Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
   _currentViewDidChange: Ember.observer(function() {
     var currentView = get(this, 'currentView');
     if (currentView) {
+      Ember.assert("You tried to set a current view that already has a parent. Make sure you don't have multiple outlets in the same view.", !get(currentView, '_parentView'));
       this.pushObject(currentView);
     }
   }, 'currentView'),

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -564,3 +564,37 @@ test("should invalidate `element` on itself and childViews when being rendered b
     root.destroy();
   });
 });
+
+test("Child view can only be added to one container at a time", function () {
+  expect(2);
+
+  container = Ember.ContainerView.create();
+  var secondContainer = Ember.ContainerView.create();
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  var view = Ember.View.create();
+
+  Ember.run(function() {
+    container.set('currentView', view);
+  });
+
+  throws(function() {
+    Ember.run(function() {
+        secondContainer.set('currentView', view);
+    });
+  });
+
+  throws(function() {
+    Ember.run(function() {
+        secondContainer.pushObject(view);
+    });
+  });
+
+  Ember.run(function() {
+    secondContainer.destroy();
+  });
+
+});


### PR DESCRIPTION
Complain when the same view is being added twice as a child. This occurs when setting 2 outlets in the same view (see #2669)
