### PR TITLE
Suppress warning by using local ember-source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
 gem "ember-dev", :git => "https://github.com/emberjs/ember-dev.git", :branch => "master"
+gem "ember-source", :path => File.dirname(__FILE__)
 
 # Require the specific version of handlebars-source that
 # we'll be precompiling and performing tests with.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,12 @@ GIT
       rake (~> 10.0.0)
       thor
 
+PATH
+  remote: ./
+  specs:
+    ember-source (1.0.0.rc3)
+      handlebars-source (>= 1.0.0.rc3, < 1.0.0.rc4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -33,8 +39,6 @@ GEM
       uuidtools (~> 2.1)
     colored (1.2)
     diff-lcs (1.2.4)
-    ember-source (0.0.8)
-      handlebars-source (>= 1.0.0.rc3, < 1.0.0.rc4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.8.1)
@@ -75,5 +79,6 @@ PLATFORMS
 
 DEPENDENCIES
   ember-dev!
+  ember-source!
   handlebars-source (= 1.0.0.rc3)
   rake-pipeline!


### PR DESCRIPTION
When running `bundle exec rake`, the following warning is shown:

```
/Users/tricknotes/.rbenv/versions/2.0.0-dev/lib/ruby/gems/2.0.0/gems/ember-source-0.0.8/lib/ember/version.rb:2: warning: already initialized constant Ember::VERSION
/Users/tricknotes/Documents/dev/ember.js/lib/ember/version.rb:2: warning: previous definition of VERSION was here
```

This cause is that `ember-source` is already required before [`require './lib/ember/version.rb'`](https://github.com/emberjs/ember.js/blob/master/Rakefile#L3).
To avoid this, I used locale `ember-source` as dependency gem.
