### PR TITLE
Documentation: fix code block for Ember.String.capitalize

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -231,10 +231,12 @@ Ember.String = {
   /**
     Returns the Capitalized form of a string
 
-       'innerHTML'.capitalize()         // 'InnerHTML'
-       'action_name'.capitalize()       // 'Action_name'
-       'css-class-name'.capitalize()    // 'Css-class-name'
-       'my favorite items'.capitalize() // 'My favorite items'
+    ```javascript
+    'innerHTML'.capitalize()         // 'InnerHTML'
+    'action_name'.capitalize()       // 'Action_name'
+    'css-class-name'.capitalize()    // 'Css-class-name'
+    'my favorite items'.capitalize() // 'My favorite items'
+    ```
 
     @method capitalize
     @param {String} str


### PR DESCRIPTION
Code examples were not displayed in block code.
