### PR TITLE
Move /** @scope */ comments up a line

### DIFF
--- a/packages/ember-old-router/lib/application/system/application.js
+++ b/packages/ember-old-router/lib/application/system/application.js
@@ -189,8 +189,7 @@ var get = Ember.get, set = Ember.set;
   @namespace Ember
   @extends Ember.Namespace
 */
-Ember.Application = Ember.Namespace.extend(
-/** @scope Ember.Application.prototype */{
+Ember.Application = Ember.Namespace.extend(/** @scope Ember.Application.prototype */{
 
   /**
     The root DOM element of the Application. This can be specified as an
@@ -538,4 +537,3 @@ Ember.Application.registerInjection({
 });
 
 Ember.runLoadHooks('Ember.Application', Ember.Application);
-

--- a/packages/ember-old-router/lib/router.js
+++ b/packages/ember-old-router/lib/router.js
@@ -483,8 +483,7 @@ var get = Ember.get, set = Ember.set;
   @namespace Ember
   @extends Ember.StateManager
 */
-Ember.Router = Ember.StateManager.extend(
-/** @scope Ember.Router.prototype */ {
+Ember.Router = Ember.StateManager.extend(/** @scope Ember.Router.prototype */ {
 
   /**
     @property initialState

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -25,8 +25,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Mixin
   @since Ember 0.9
 */
-Ember.Copyable = Ember.Mixin.create(
-/** @scope Ember.Copyable.prototype */ {
+Ember.Copyable = Ember.Mixin.create(/** @scope Ember.Copyable.prototype */ {
 
   /**
     Override to return a copy of the receiver. Default implementation raises

--- a/packages/ember-runtime/lib/mixins/freezable.js
+++ b/packages/ember-runtime/lib/mixins/freezable.js
@@ -63,8 +63,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Mixin
   @since Ember 0.9
 */
-Ember.Freezable = Ember.Mixin.create(
-/** @scope Ember.Freezable.prototype */ {
+Ember.Freezable = Ember.Mixin.create(/** @scope Ember.Freezable.prototype */ {
 
   /**
     Set to `true` when the object is frozen. Use this property to detect

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -34,8 +34,7 @@ var get = Ember.get, set = Ember.set;
   @uses Ember.Array
   @uses Ember.MutableEnumerable
 */
-Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
-  /** @scope Ember.MutableArray.prototype */ {
+Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/** @scope Ember.MutableArray.prototype */ {
 
   /**
     __Required.__ You must implement this method to apply this mixin.
@@ -305,4 +304,3 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,
   }
 
 });
-

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -49,8 +49,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Object
   @uses Ember.MutableArray
 */
-Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
-/** @scope Ember.ArrayProxy.prototype */ {
+Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.ArrayProxy.prototype */ {
 
   /**
     The content array. Must be an object that implements `Ember.Array` and/or
@@ -325,4 +324,3 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,
     this._teardownContent();
   }
 });
-

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -94,8 +94,7 @@ function contentPropertyDidChange(content, contentKey) {
   @namespace Ember
   @extends Ember.Object
 */
-Ember.ObjectProxy = Ember.Object.extend(
-/** @scope Ember.ObjectProxy.prototype */ {
+Ember.ObjectProxy = Ember.Object.extend(/** @scope Ember.ObjectProxy.prototype */ {
   /**
     The object whose properties will be forwarded.
 

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -30,8 +30,7 @@
   @extends Ember.Object
   @private
 */
-Ember.Suite = Ember.Object.extend(
-  /** @scope Ember.Suite.prototype */ {
+Ember.Suite = Ember.Object.extend(/** @scope Ember.Suite.prototype */ {
 
   /**
     Define a name for these tests - all modules are prefixed w/ it.

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -16,8 +16,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   @private
   @extends Ember.Object
 */
-Ember.EventDispatcher = Ember.Object.extend(
-/** @scope Ember.EventDispatcher.prototype */{
+Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.prototype */{
 
   /**
     @private

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -161,8 +161,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   @extends Ember.ContainerView
   @since Ember 0.9
 */
-Ember.CollectionView = Ember.ContainerView.extend(
-/** @scope Ember.CollectionView.prototype */ {
+Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionView.prototype */ {
 
   /**
     A list of items to be displayed by the `Ember.CollectionView`.


### PR DESCRIPTION
Fixes weirdness in the docs where the following piece of documentation will be prefixed with /**
