### PR TITLE
Find helper now throws when element not found and added selector context

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -22,23 +22,35 @@ function visit(app, url) {
   return wait(app);
 }
 
-function click(app, selector) {
+function click(app, selector, context) {
+  var $el = find(app, selector, context);
   Ember.run(function() {
     app.$(selector).click();
   });
   return wait(app);
 }
 
-function fillIn(app, selector, text) {
-  var $el = find(app, selector);
+function fillIn(app, selector, context, text) {
+  var $el;
+  if (typeof text === 'undefined') {
+    text = context;
+    context = null;
+  }
+  $el = find(app, selector, context);
   Ember.run(function() {
     $el.val(text).change();
   });
   return wait(app);
 }
 
-function find(app, selector) {
-  return app.$(get(app, 'rootElement')).find(selector);
+function find(app, selector, context) {
+  var $el;
+  context = context || get(app, 'rootElement');
+  $el = app.$(selector, context);
+  if ($el.length === 0) {
+    throw("Element " + selector + " not found.");
+  }
+  return $el;
 }
 
 function wait(app, value) {

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -63,10 +63,10 @@ module("ember-testing Acceptance", {
 });
 
 test("helpers can be chained", function() {
-  expect(4);
+  expect(5);
 
   Ember.Test.failure = function(error) {
-    equal(error, "exception", "Exception successfully caught and passed to Ember.test.failure");
+    equal(error, "Element .does-not-exist not found.", "Exception successfully caught and passed to Ember.test.failure");
   };
 
   currentRoute = 'index';
@@ -77,9 +77,12 @@ test("helpers can be chained", function() {
   }).then(function() {
     equal(currentRoute, 'comments', "visit chained with click");
     return fillIn('.ember-text-field', "yeah");
-  }).then(function(){
+  }).then(function() {
     equal(Ember.$('.ember-text-field').val(), 'yeah', "chained with fillIn");
-    throw "exception";
+    return fillIn('.ember-text-field', '#ember-testing-container', "context working");
+  }).then(function(){
+    equal(Ember.$('.ember-text-field').val(), 'context working', "chained with fillIn");
+    click(".does-not-exist");
   }).then(function() {
     // This is needed in this test
     // so we can assert that thrown exceptions


### PR DESCRIPTION
Added selector context to `find`, `click`, and `fillIn`:

``` js
find('.element');
find('.element', '.parent');
click('.element');
click('.element', '.parent');
fillIn('.element', 'new val');
fillIn('.element', '.parent', 'new val');
```

Also `find`, `click`, and `fillIn` now cause a rejection when the element is not found.  (This results in a failed assertion with 'Element not found' as reason.)
