### PR TITLE
Fix rake dist (ember-metal/accessors.js)

### DIFF
--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -25,7 +25,6 @@
 require('ember-metal/enumerable_utils');
 require('ember-metal/utils');
 require('ember-metal/core');
-require('ember-metal/accessors');
 
 var get = Ember.get,
     set = Ember.set,


### PR DESCRIPTION
accessors.js does no longer exist, so don't require it.
requiring accessors.js currently breaks ember-rails:

```
  https://gist.github.com/schmidp/5608614
```
