### PR TITLE
Simplify not-null-or-undefined checks

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -451,7 +451,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
 
   // Handle classes differently, as we can bind multiple classes
   var classBindings = attrs['class'];
-  if (classBindings !== null && classBindings !== undefined) {
+  if (classBindings != null) {
     var classResults = EmberHandlebars.bindClasses(this, classBindings, view, dataId, options);
 
     ret.push('class="' + Handlebars.Utils.escapeExpression(classResults.join(' ')) + '"');

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -133,7 +133,7 @@ var getPath = Ember._getPath = function(root, path) {
 
   parts = path.split(".");
   len = parts.length;
-  for (idx=0; root !== undefined && root !== null && idx<len; idx++) {
+  for (idx = 0; root != null && idx < len; idx++) {
     root = get(root, parts[idx], true);
     if (root && root.isDestroyed) { return undefined; }
   }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2391,7 +2391,7 @@ Ember.View.reopenClass({
 
     // If the value is not false, undefined, or null, return the current
     // value of the property.
-    } else if (val !== false && val !== undefined && val !== null) {
+    } else if (val !== false && val != null) {
       return val;
 
     // Nothing to display. Return null so that the old class is removed


### PR DESCRIPTION
Save ALL the bytes!

`a != null` is what the CoffeeScript compiler emits for `a?` -- it's a
cute idiom, and we use it in several places already.
