### PR TITLE
Don't trigger a property change unless the value changes

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -46,7 +46,10 @@ Ember.TextSupport = Ember.Mixin.create({
   },
 
   _elementValueDidChange: function() {
-    set(this, 'value', this.$().val());
+    var previousValue = get(this, 'value') || "";
+    var currentValue = this.$().val();
+    if(currentValue !== previousValue)
+      set(this, 'value', currentValue);
   }
 
 });

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -253,6 +253,26 @@ test("should call the cancel method when escape key is pressed", function() {
   ok(wasCalled, "invokes cancel method");
 });
 
+test("should not set the value property when the text is empty", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 9
+  });
+
+  Ember.run(function() { textArea.append(); });
+
+  set(textArea, 'value', null);
+
+  textArea.addObserver('value', textArea, function(){
+    wasCalled = true;
+  });
+
+  textArea.$().val('');
+  textArea.trigger('keyUp', event);
+
+  ok(!wasCalled, "doesn't change the value");
+});
+
 // test("listens for focus and blur events", function() {
 //   var focusCalled = 0;
 //   var blurCalled = 0;

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -449,6 +449,27 @@ test("bubbling of handled actions can be enabled via bubbles property", function
   equal(stopPropagationCount, 1, "propagation was prevented if bubbles is false");
 });
 
+test("should not set the value property when the text is empty", function() {
+  var wasCalled;
+  var event = Ember.Object.create({
+    keyCode: 9
+  });
+
+  Ember.run(function() { textField.append(); });
+
+  set(textField, 'value', null);
+
+  textField.addObserver('value', textField, function(){
+    wasCalled = true;
+  });
+
+  textField.$().val('');
+  textField.trigger('keyUp', event);
+
+  ok(!wasCalled, "doesn't change the value");
+});
+
+
 // test("listens for focus and blur events", function() {
 //   var focusCalled = 0;
 //   var blurCalled = 0;


### PR DESCRIPTION
This is particularly useful on scenarios where the user is switching from a form field to another using the TAB key, or just navigating through the text using the arrow keys.

There weren't any `Ember.TextSupport`-specific tests, so I added them in both `Ember.TextField` and `Ember.TextArea`.
