### PR TITLE
Require correct ember-handlebars version

### DIFF
--- a/ember-source.gemspec
+++ b/ember-source.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   # Note: can't use the squiggly ~> operator the way we'd expect
   # so long as we're referencing pre-release versions.
-  gem.add_dependency "handlebars-source", ["1.0.0.rc4"]
+  gem.add_dependency "handlebars-source", ["1.0.11"]
 
   gem.files = %w(VERSION) + Dir['dist/*.js', 'lib/ember/*.rb']
 end


### PR DESCRIPTION
It seems like it was recently bumped to `1.0.11`.

Related to: https://github.com/emberjs/ember-rails/pull/192
