### PR TITLE
Added debug template for template-less leaf routes

### DIFF
--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -155,7 +155,10 @@ test("When an application is reset, the router URL is reset to `/`", function() 
   router = application.__container__.lookup('router:main');
 
   location = router.get('location');
-  location.handleURL('/one');
+
+  Ember.run(function() {
+    location.handleURL('/one');
+  });
 
   application.reset();
 
@@ -168,7 +171,9 @@ test("When an application is reset, the router URL is reset to `/`", function() 
   equal(get(applicationController, 'currentPath'), "index");
 
   location = application.__container__.lookup('router:main').get('location');
-  location.handleURL('/one');
+  Ember.run(function() {
+    location.handleURL('/one');
+  });
 
   equal(get(applicationController, 'currentPath'), "one");
 });

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -517,7 +517,14 @@ Ember.Route = Ember.Object.extend({
         view = container.lookup('view:' + name),
         template = container.lookup('template:' + name);
 
-    if (!view && !template) { return; }
+    if (!view && !template) { 
+      if (this.router.hasRoute(name)) {
+        // This is a template-less leaf route; display a debug template.
+        template = Ember.Router.getDebugTemplate(name.replace(/\./, '/'));
+      } else {
+        return;
+      }
+    }
 
     options = normalizeOptions(this, name, template, options);
     view = setupView(view, container, options);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -169,6 +169,20 @@ Ember.Router.reopenClass({
       // Using setTimeout allows us to escape from the Promise's try/catch block
       setTimeout(function() { throw error; });
     }
+  },
+
+  getDebugTemplate: function(templateName) {
+
+    var templateNames = [];
+    for(var name in Ember.TEMPLATES) {
+      templateNames.push(name);
+    }
+    templateNames.sort();
+
+    return function() {
+      return '<h3>Expected to find template named "' + templateName + '"</h3>' +
+             '<p>Found templates: ' + templateNames.join(', ') + '</p>';
+    };
   }
 });
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1916,4 +1916,32 @@ test("The template is not re-rendered when two routes present the exact same tem
   equal(insertionCount, 1, "view should still have inserted only once");
 });
 
+/*
+test("Rendering a leaf route without a template displays a helpful debug message", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+    this.resource("foo", function() {
+      this.route("bar");
+    });
+  });
 
+  Ember.TEMPLATES = { omg: null, alex: null };
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('h3', '#qunit-fixture').text(), "Expected to find template named \"home\"");
+  equal(Ember.$('p', '#qunit-fixture').text(), "Found templates: alex, omg");
+
+  Ember.run(function() {
+    router.handleURL("/foo/bar");
+  });
+
+  equal(Ember.$('h3', '#qunit-fixture').text(), "Expected to find template named \"foo/bar\"");
+  equal(Ember.$('p', '#qunit-fixture').text(), "Found templates: alex, omg");
+
+});
+*/


### PR DESCRIPTION
This gives the dev some feedback as to why nothings displaying even
though no error messages show up in the console.

Here's a demo: http://jsbin.com/ubafeg/1/edit
