### PR TITLE
Set actions as the default run loop queue

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -5,7 +5,8 @@ var Backburner = requireModule('backburner').Backburner,
       sync: {
         before: Ember.beginPropertyChanges,
         after: Ember.endPropertyChanges
-      }
+      },
+      defaultQueue: 'actions'
     }),
     slice = [].slice;
 


### PR DESCRIPTION
The default queue is currently `sync` (first queue in the array), it should be `actions`.
