### PR TITLE
Replace run loop instance with backburner's API

### DIFF
--- a/packages/ember-metal/tests/binding/connect_test.js
+++ b/packages/ember-metal/tests/binding/connect_test.js
@@ -5,7 +5,7 @@ require('ember-metal/~tests/props_helper');
 function performTest(binding, a, b, get, set, connect) {
   if (connect === undefined) connect = function(){binding.connect(a);};
 
-  ok(!Ember.run.backburner.currentInstance, 'performTest should not have a currentRunLoop');
+  ok(!Ember.run.backburner.currentInstance, 'performTest should not have a backburner\'s instance');
 
   equal(get(a, 'foo'), 'FOO', 'a should not have changed');
   equal(get(b, 'bar'), 'BAR', 'b should not have changed');

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -6,7 +6,7 @@ var wait = function(callback, maxWaitCount) {
   maxWaitCount = Ember.isNone(maxWaitCount) ? 100 : maxWaitCount;
 
   originalSetTimeout(function() {
-    if (maxWaitCount > 0 && (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop)) {
+    if (maxWaitCount > 0 && (Ember.run.hasScheduledTimers() || Ember.run.backburner.currentInstance)) {
       wait(callback, maxWaitCount - 1);
 
       return;


### PR DESCRIPTION
`Ember.run.currentRunLoop` is not exist anymore.
