### PR TITLE
Adds set (array) injection capability to Ember.Container

### DIFF
--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -127,6 +127,62 @@ test("An individual factory with a registered injection receives the injection",
   });
 });
 
+test("A factory type with registered array injections receives an array of injections", function() {
+  var container = new Container();
+  var PostController = factory();
+  var PluginA = factory();
+  var PluginB = factory();
+  var PluginC = factory();
+
+  container.register('controller:post', PostController);
+  container.register('plugin:a', PluginA);
+  container.register('plugin:b', PluginB);
+  container.register('plugin:c', PluginC);
+
+  container.typeInjection('controller', 'plugins', 'plugin:a', {array:true});
+  container.typeInjection('controller', 'plugins', 'plugin:b', {array:true});
+  container.typeInjection('controller', 'plugins', 'plugin:c', {array:true});
+
+  var postController = container.lookup('controller:post');
+  var pluginA = container.lookup('plugin:a');
+  var pluginB = container.lookup('plugin:b');
+  var pluginC = container.lookup('plugin:c');
+
+  ok(postController.plugins instanceof Array);
+  equal(postController.plugins.length, 3);
+  ok(postController.plugins.indexOf(pluginA) >= 0);
+  ok(postController.plugins.indexOf(pluginB) >= 0);
+  ok(postController.plugins.indexOf(pluginC) >= 0);
+});
+
+test("An individual factory with registered array injections receives an array of injections", function() {
+  var container = new Container();
+  var PostController = factory();
+  var PluginA = factory();
+  var PluginB = factory();
+  var PluginC = factory();
+
+  container.register('controller:post', PostController);
+  container.register('plugin:a', PluginA);
+  container.register('plugin:b', PluginB);
+  container.register('plugin:c', PluginC);
+
+  container.injection('controller:post', 'plugins', 'plugin:a', {array:true});
+  container.injection('controller:post', 'plugins', 'plugin:b', {array:true});
+  container.injection('controller:post', 'plugins', 'plugin:c', {array:true});
+
+  var postController = container.lookup('controller:post');
+  var pluginA = container.lookup('plugin:a');
+  var pluginB = container.lookup('plugin:b');
+  var pluginC = container.lookup('plugin:c');
+
+  ok(postController.plugins instanceof Array);
+  equal(postController.plugins.length, 3);
+  ok(postController.plugins.indexOf(pluginA) >= 0);
+  ok(postController.plugins.indexOf(pluginB) >= 0);
+  ok(postController.plugins.indexOf(pluginC) >= 0);
+});
+
 test("A factory with both type and individual injections", function() {
   var container = new Container();
   var PostController = factory();


### PR DESCRIPTION
I often find myself adding support for pluggable modules in my Ember apps: the application can be provided [0..N] modules that expose a common interface. For example, a set of "Sharing" plugins that cause a list of provider-specific share buttons to appear within the app with implementations for: 
- Facebook
- Pinterest
- Twitter
- LinkedIn
- Email
- etc

Dependency injection is a perfect match for handling this case but at the moment the Ember Container does not support a way to inject a collection of modules into a property as a set (array).

This PR adds support for controlling how objects are injected during instantiation within the container.  Specifically, it adds an `options` hash to the `injection` and `typeInjection` functions. The only supported option (other than no options) is `array:true` which causes thus-marked injections to be combined into an array of values. For example:

```
container.injection('model:sharing', 'plugins', 'plugin:one', {array:true});
container.injection('model:sharing', 'plugins', 'plugin:two', {array:true});

var model = container.lookup('model:sharing');
model.get('plugins').length === 2;  // true
```

Also, added documentation to `injection` and `typeInjection`.
