### PR TITLE
Treat {{#each}} as {{#each this}}

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -318,6 +318,11 @@ Ember.Handlebars.registerHelper('each', function(path, options) {
     options.hash.keyword = keywordName;
   }
 
+  if (arguments.length === 1) {
+    options = path;
+    path = 'this';
+  }
+
   options.hash.dataSourceBinding = path;
   // Set up emptyView as a metamorph with no tag
   //options.hash.emptyViewClass = Ember._MetamorphView;

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -484,3 +484,26 @@ test("controller is assignable inside an #each", function() {
 
   equal(view.$().text(), "AdamSteve");
 });
+
+test("single-arg each defaults to current context", function() {
+  view = Ember.View.create({
+    context: Ember.A([ { name: "Adam" }, { name: "Steve" } ]),
+    template: templateFor('{{#each}}{{name}}{{/each}}')
+  });
+
+  append(view);
+
+  equal(view.$().text(), "AdamSteve");
+});
+
+test("single-arg each will iterate over controller if present", function() {
+  view = Ember.View.create({
+    controller: Ember.A([ { name: "Adam" }, { name: "Steve" } ]),
+    template: templateFor('{{#each}}{{name}}{{/each}}')
+  });
+
+  append(view);
+
+  equal(view.$().text(), "AdamSteve");
+});
+


### PR DESCRIPTION
Now the following is supported:

```
{{#each}}Hello, {{name}}{{/each}}
```

This should alleviate the silliness that all of the following are
(often) the same:

```
{{#each this}}...{{/each}}
{{#each controller}}...{{/each}}
{{#each content}}...{{/each}}
```
