### PR TITLE
Bring back Ember.run.currentRunLoop and Ember.run.queues

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -548,7 +548,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
       });
     }
 
-    if (Ember.run.backburner.currentInstance) {
+    if (Ember.run.currentRunLoop) {
       handleReset.call(this);
     } else {
       Ember.run(this, handleReset);

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,12 +1,22 @@
 require('ember-metal/vendor/backburner');
 
+var onBegin = function(current) {
+  Ember.run.currentRunLoop = current;
+};
+
+var onEnd = function(current, next) {
+  Ember.run.currentRunLoop = next;
+};
+
 var Backburner = requireModule('backburner').Backburner,
     backburner = new Backburner(['sync', 'actions', 'destroy'], {
       sync: {
         before: Ember.beginPropertyChanges,
         after: Ember.endPropertyChanges
       },
-      defaultQueue: 'actions'
+      defaultQueue: 'actions',
+      onBegin: onBegin,
+      onEnd: onEnd
     }),
     slice = [].slice;
 
@@ -58,6 +68,10 @@ Ember.run = function(target, method) {
 Ember.run.backburner = backburner;
 
 var run = Ember.run;
+
+Ember.run.currentRunLoop = null;
+
+Ember.run.queues = backburner.queueNames;
 
 /**
   Begins a new RunLoop. Any deferred actions invoked after the begin will

--- a/packages/ember-metal/tests/binding/connect_test.js
+++ b/packages/ember-metal/tests/binding/connect_test.js
@@ -5,7 +5,7 @@ require('ember-metal/~tests/props_helper');
 function performTest(binding, a, b, get, set, connect) {
   if (connect === undefined) connect = function(){binding.connect(a);};
 
-  ok(!Ember.run.backburner.currentInstance, 'performTest should not have a currentRunLoop');
+  ok(!Ember.run.currentRunLoop, 'performTest should not have a currentRunLoop');
 
   equal(get(a, 'foo'), 'FOO', 'a should not have changed');
   equal(get(b, 'bar'), 'BAR', 'b should not have changed');

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -69,11 +69,11 @@ asyncTest('should always invoke within a separate runloop', function() {
   var obj = { invoked: 0 }, firstRunLoop, secondRunLoop;
 
   Ember.run(function() {
-    firstRunLoop = Ember.run.backburner.currentInstance;
+    firstRunLoop = Ember.run.currentRunLoop;
 
     Ember.run.later(obj, function(amt) {
       this.invoked += amt;
-      secondRunLoop = Ember.run.backburner.currentInstance;
+      secondRunLoop = Ember.run.currentRunLoop;
     }, 10, 1);
 
     // Synchronous "sleep". This simulates work being done
@@ -88,7 +88,7 @@ asyncTest('should always invoke within a separate runloop', function() {
   });
 
   ok(firstRunLoop, "first run loop captured");
-  ok(!Ember.run.backburner.currentInstance, "shouldn't be in a run loop after flush");
+  ok(!Ember.run.currentRunLoop, "shouldn't be in a run loop after flush");
   equal(obj.invoked, 0, "shouldn't have invoked later item yet");
 
   wait(function() {
@@ -121,7 +121,7 @@ asyncTest('callback order', function() {
 
 asyncTest('callbacks coalesce into same run loop if expiring at the same time', function() {
   var array = [];
-  function fn(val) { array.push(Ember.run.backburner.currentInstance); }
+  function fn(val) { array.push(Ember.run.currentRunLoop); }
 
   Ember.run(function() {
 
@@ -154,16 +154,16 @@ asyncTest('inception calls to run.later should run callbacks in separate run loo
   var runLoop, finished;
 
   Ember.run(function() {
-    runLoop = Ember.run.backburner.currentInstance;
+    runLoop = Ember.run.currentRunLoop;
     ok(runLoop);
 
     Ember.run.later(function() {
-      ok(Ember.run.backburner.currentInstance && Ember.run.backburner.currentInstance !== runLoop,
+      ok(Ember.run.currentRunLoop && Ember.run.currentRunLoop !== runLoop,
          'first later callback has own run loop');
-      runLoop = Ember.run.backburner.currentInstance;
+      runLoop = Ember.run.currentRunLoop;
 
       Ember.run.later(function() {
-        ok(Ember.run.backburner.currentInstance && Ember.run.backburner.currentInstance !== runLoop,
+        ok(Ember.run.currentRunLoop && Ember.run.currentRunLoop !== runLoop,
            'second later callback has own run loop');
         finished = true;
       }, 40);

--- a/packages/ember-metal/tests/run_loop/next_test.js
+++ b/packages/ember-metal/tests/run_loop/next_test.js
@@ -21,8 +21,8 @@ asyncTest('should invoke immediately on next timeout', function() {
 asyncTest('callback should be called from within separate loop', function() {
   var firstRunLoop, secondRunLoop;
   Ember.run(function() {
-    firstRunLoop = Ember.run.backburner.currentInstance;
-    Ember.run.next(function() { secondRunLoop = Ember.run.backburner.currentInstance; });
+    firstRunLoop = Ember.run.currentRunLoop;
+    Ember.run.next(function() { secondRunLoop = Ember.run.currentRunLoop; });
   });
 
   setTimeout(function() {
@@ -35,9 +35,9 @@ asyncTest('callback should be called from within separate loop', function() {
 asyncTest('multiple calls to Ember.run.next share coalesce callbacks into same run loop', function() {
   var firstRunLoop, secondRunLoop, thirdRunLoop;
   Ember.run(function() {
-    firstRunLoop = Ember.run.backburner.currentInstance;
-    Ember.run.next(function() { secondRunLoop = Ember.run.backburner.currentInstance; });
-    Ember.run.next(function() { thirdRunLoop  = Ember.run.backburner.currentInstance; });
+    firstRunLoop = Ember.run.currentRunLoop;
+    Ember.run.next(function() { secondRunLoop = Ember.run.currentRunLoop; });
+    Ember.run.next(function() { thirdRunLoop  = Ember.run.currentRunLoop; });
   });
 
   setTimeout(function() {

--- a/packages/ember-metal/tests/run_loop/once_test.js
+++ b/packages/ember-metal/tests/run_loop/once_test.js
@@ -48,7 +48,7 @@ test('should be inside of a runloop when running', function() {
 
   Ember.run(function() {
     Ember.run.once(function() {
-      ok(!!Ember.run.backburner.currentInstance, 'should have a runloop');
+      ok(!!Ember.run.currentRunLoop, 'should have a runloop');
     });
   });
 });

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -35,30 +35,30 @@ test('prior queues should be flushed before moving on to next queue', function()
   var order = [];
 
   Ember.run(function() {
-    var runLoop = Ember.run.backburner.currentInstance;
+    var runLoop = Ember.run.currentRunLoop;
     ok(runLoop, 'run loop present');
 
     Ember.run.schedule('sync', function() {
       order.push('sync');
-      equal(runLoop, Ember.run.backburner.currentInstance, 'same run loop used');
+      equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
     });
     Ember.run.schedule('actions', function() {
       order.push('actions');
-      equal(runLoop, Ember.run.backburner.currentInstance, 'same run loop used');
+      equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
 
       Ember.run.schedule('actions', function() {
         order.push('actions');
-        equal(runLoop, Ember.run.backburner.currentInstance, 'same run loop used');
+        equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
       });
 
       Ember.run.schedule('sync', function() {
         order.push('sync');
-        equal(runLoop, Ember.run.backburner.currentInstance, 'same run loop used');
+        equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
       });
     });
     Ember.run.schedule('destroy', function() {
       order.push('destroy');
-      equal(runLoop, Ember.run.backburner.currentInstance, 'same run loop used');
+      equal(runLoop, Ember.run.currentRunLoop, 'same run loop used');
     });
   });
 

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -1,7 +1,7 @@
 module('system/run_loop/unwind_test');
 
 test('RunLoop unwinds despite unhandled exception', function() {
-  var initialRunLoop = Ember.run.backburner.currentInstance;
+  var initialRunLoop = Ember.run.currentRunLoop;
 
   raises(function(){
     Ember.run(function() {
@@ -13,15 +13,15 @@ test('RunLoop unwinds despite unhandled exception', function() {
   // tasks into the already-dead runloop, which will never get
   // flushed. I can't easily demonstrate this in a unit test because
   // autorun explicitly doesn't work in test mode. - ef4
-  equal(Ember.run.backburner.currentInstance, initialRunLoop, "Previous run loop should be cleaned up despite exception");
+  equal(Ember.run.currentRunLoop, initialRunLoop, "Previous run loop should be cleaned up despite exception");
 
   // Prevent a failure in this test from breaking subsequent tests.
-  Ember.run.backburner.currentInstance = initialRunLoop;
+  Ember.run.currentRunLoop = initialRunLoop;
 
 });
 
 test('Ember.run unwinds despite unhandled exception', function() {
-  var initialRunLoop = Ember.run.backburner.currentInstance;
+  var initialRunLoop = Ember.run.currentRunLoop;
 
   raises(function(){
     Ember.run(function() {
@@ -29,10 +29,10 @@ test('Ember.run unwinds despite unhandled exception', function() {
     });
   }, Error, "boom!");
 
-  equal(Ember.run.backburner.currentInstance, initialRunLoop, "Previous run loop should be cleaned up despite exception");
+  equal(Ember.run.currentRunLoop, initialRunLoop, "Previous run loop should be cleaned up despite exception");
 
   // Prevent a failure in this test from breaking subsequent tests.
-  Ember.run.backburner.currentInstance = initialRunLoop;
+  Ember.run.currentRunLoop = initialRunLoop;
 
 });
 

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -60,7 +60,7 @@ function wait(app, value) {
       var routerIsLoading = app.__container__.lookup('router:main').router.isLoading;
       if (routerIsLoading) { return; }
       if (pendingAjaxRequests) { return; }
-      if (Ember.run.hasScheduledTimers() || Ember.run.backburner.currentInstance) { return; }
+      if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) { return; }
       clearInterval(watcher);
       Ember.Test.adapter.asyncEnd();
       Ember.run(function() {

--- a/packages/ember-views/lib/system/ext.js
+++ b/packages/ember-views/lib/system/ext.js
@@ -6,6 +6,6 @@
 // Add a new named queue for rendering views that happens
 // after bindings have synced, and a queue for scheduling actions
 // that that should occur after view rendering.
-var queues = Ember.run.backburner.queueNames,
+var queues = Ember.run.queues,
     indexOf = Ember.ArrayPolyfills.indexOf;
 queues.splice(indexOf.call(queues, 'actions')+1, 0, 'render', 'afterRender');


### PR DESCRIPTION
Keeping the Ember run loop API non-breaking.

It's now possible to unset `Ember.run.backburner` (which I think we should do). Hiding backburner would give Backburner room to have breaking changes without being tied up by Ember's stability requirement.

cc: @stefanpenner , @ebryn
