### PR TITLE
Added the ability to chain test helpers

### DIFF
--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -62,7 +62,7 @@ module("ember-testing Acceptance", {
   }
 });
 
-test("helpers can be chained", function() {
+test("helpers can be chained with then", function() {
   expect(5);
   Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
     exception: function(error) {
@@ -90,4 +90,23 @@ test("helpers can be chained", function() {
     // do not fire multiple times
   });
 
+});
+
+
+
+test("helpers can be chained to each other", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts').click('a:contains("Comments")')
+  .fillIn('.ember-text-field', "hello")
+  .then(function() {
+    equal(currentRoute, 'comments', "Successfully visited posts route");
+    equal(Ember.$('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  })
+  .visit('/posts')
+  .then(function() {
+    equal(currentRoute, 'posts', "Thens can also be chained to helpers");
+  });
 });


### PR DESCRIPTION
This gives us the ability to chain helpers:

``` javascript
test("Adding a post", function() {

  visit('posts/new')
  .fillIn('.txt-title', 'My Post')
  .fillIn('.txt-body', 'This is the body')
  .click('.btn-submit')
  .then(function() {
    equal(find('.post-title').text(), 'My Post');
    equal(find('.post-body').text(), 'This is the body');
  })
  .click('.post-title')
  .click('.btn-new-comment')
  .fillIn('.txt-comment-body', 'My Comment')
  .click('.submit')
  .then(function() {
    equal(find('.comment').length, 1);
  });

});
```

Any custom helpers added using `Ember.Test.registerHelper` method would also be chained:

``` javascript
Ember.Test.registerHelper('boot', function(app) {
  Em.run(app, app.advanceReadiness);
  return wait();
});

Ember.Test.registerHelper('reset', function(app) {
  app.reset();
  return wait();
});

// ... later in the test
boot().visit('posts').click('.post-name').reset();

```
