### PR TITLE
[fixes #1571] Prevent simulated events from causing nested run-loops. 

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -521,6 +521,8 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     @method reset
   **/
   reset: function() {
+    this._readinessDeferrals = 1;
+
     function handleReset() {
       var router = this.__container__.lookup('router:main');
       router.reset();
@@ -529,19 +531,13 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
       this.buildContainer();
 
-      this._readinessDeferrals = 1;
-
       Ember.run.schedule('actions', this, function(){
         this._initialize();
         this.startRouting();
       });
     }
 
-    if (Ember.run.currentRunLoop) {
-      handleReset.call(this);
-    } else {
-      Ember.run(this, handleReset);
-    }
+    Ember.run.join(this, handleReset);
   },
 
   /**

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -65,6 +65,54 @@ Ember.run = function(target, method) {
   return ret;
 };
 
+/**
+
+  If no run-loop is present, it creates a new one. If a run loop is
+  present it will queue itself to run on the existing run-loops action
+  queue.
+
+  Please note: This is not for normal usage, and should be used sparingly.
+
+  If invoked when not within a run loop:
+
+  ```javascript
+  Ember.run.join(function(){
+    // creates a new run-loop
+  });
+  ```
+
+  Alternatively, if called within an existing run loop:
+
+  ```javascript
+  Ember.run(function(){
+    // creates a new run-loop
+    Ember.run.join(function(){
+      // joins with the existing run-loop, and queues for invocation on
+      // the existing run-loops action queue.
+    });
+  });
+  ```
+
+  @method join
+  @namespace Ember
+  @param {Object} [target] target of method to call
+  @param {Function|String} method Method to invoke.
+    May be a function or a string. If you pass a string
+    then it will be looked up on the passed target.
+  @param {Object} [args*] Any additional arguments you wish to pass to the method.
+  @return {Object} return value from invoking the passed function. Please note, 
+  when called within an existing loop, no return value is possible.
+*/
+Ember.run.join = function(target, method) {
+  if (!Ember.run.currentRunLoop) {
+    return Ember.run.apply(Ember.run, arguments);
+  }
+
+  var args = slice.call(arguments);
+  args.unshift('actions');
+  Ember.run.schedule.apply(Ember.run, args);
+};
+
 Ember.run.backburner = backburner;
 
 var run = Ember.run;

--- a/packages/ember-metal/tests/run_loop/join_test.js
+++ b/packages/ember-metal/tests/run_loop/join_test.js
@@ -1,0 +1,49 @@
+module('system/run_loop/join_test');
+
+test('Ember.run.join brings its own run loop if none provided', function() {
+  ok(!Ember.run.currentRunLoop, 'expects no existing run-loop');
+
+  Ember.run.join(function() {
+    ok(Ember.run.currentRunLoop, 'brings its own run loop');
+  });
+});
+
+test('Ember.run.join joins and existing run-loop, and fires its action queue.', function() {
+  var outerRunLoop, wasInvoked;
+
+  Ember.run(function() {
+    outerRunLoop = Ember.run.currentRunLoop;
+
+    Ember.run.join(function() {
+      wasInvoked = true;
+      deepEqual(outerRunLoop, Ember.run.currentRunLoop, 'joined the existing run-loop');
+    });
+
+    ok(!wasInvoked, 'expected the joined callback not be invoked yet');
+  });
+  ok(wasInvoked, 'expected the joined callback to have invoked');
+});
+
+test('Ember.run.join returns a value if creating a new run-loop', function() {
+  var value = 'returned value';
+
+  var result = Ember.run.join(function() {
+    return value;
+  });
+
+  equal(value, result, 'returns expected output');
+});
+
+test('Ember.run.join returns undefined if joining another run-loop', function() {
+  var value = 'returned value',
+  result;
+
+  Ember.run(function(){
+    var result = Ember.run.join(function() {
+      return value;
+    });
+  });
+
+  equal(result, undefined, 'returns nothing');
+});
+

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -152,10 +152,7 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
         var actionId = Ember.$(evt.currentTarget).attr('data-ember-action'),
             action   = Ember.Handlebars.ActionHelper.registeredActions[actionId];
 
-        // We have to check for action here since in some cases, jQuery will trigger
-        // an event on `removeChild` (i.e. focusout) after we've already torn down the
-        // action handlers for the view.
-        if (action && action.eventName === eventName) {
+        if (action.eventName === eventName) {
           return action.handler(evt);
         }
       }, this);
@@ -192,9 +189,22 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
   },
 
   _bubbleEvent: function(view, evt, eventName) {
-    return Ember.run(function() {
-      return view.handleEvent(eventName, evt);
-    });
+    if (Ember.run.currentRunLoop){
+      // this works around an issue caused when simulated events
+      // are triggerd. Simulated events occure synchronously rather
+      // then on next tick. This causes an unexpected nested run-loop,
+      // resulting in negative behaviour.
+      //
+      // for reference:
+      // https://github.com/emberjs/ember.js/commit/aafb5eb5693dccf04dd0951385b4c6bb6db7ae46
+      return Ember.run.schedule('actions', function(){
+        return view.handleEvent(eventName, evt);
+      });
+    } else {
+      return Ember.run(function() {
+        return view.handleEvent(eventName, evt);
+      });
+    }
   },
 
   destroy: function() {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -189,22 +189,14 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
   },
 
   _bubbleEvent: function(view, evt, eventName) {
-    if (Ember.run.currentRunLoop){
-      // this works around an issue caused when simulated events
-      // are triggerd. Simulated events occure synchronously rather
-      // then on next tick. This causes an unexpected nested run-loop,
-      // resulting in negative behaviour.
-      //
-      // for reference:
-      // https://github.com/emberjs/ember.js/commit/aafb5eb5693dccf04dd0951385b4c6bb6db7ae46
-      return Ember.run.schedule('actions', function(){
-        return view.handleEvent(eventName, evt);
-      });
-    } else {
-      return Ember.run(function() {
-        return view.handleEvent(eventName, evt);
-      });
-    }
+    // this works around an issue caused when simulated events
+    // are triggerd. Simulated events occure synchronously rather
+    // then on next tick. This causes an unexpected nested run-loop,
+    // resulting in negative behaviour.
+    //
+    // for reference:
+    // https://github.com/emberjs/ember.js/commit/aafb5eb5693dccf04dd0951385b4c6bb6db7ae46
+    return Ember.run.join(view, 'handleEvent', eventName, evt);
   },
 
   destroy: function() {

--- a/packages/ember-views/tests/views/view/destroy_test.js
+++ b/packages/ember-views/tests/views/view/destroy_test.js
@@ -20,3 +20,48 @@ test("should teardown viewName on parentView when childView is destroyed", funct
   });
 });
 
+module("Ember.View#destroy - synchronous synthesised event edge-case", {
+  setup: function() {
+    dispatcher = Ember.run(Ember.EventDispatcher, 'create');
+    dispatcher.setup({}, '#qunit-fixture');
+  },
+
+  teardown: function() {
+    Ember.run(dispatcher, 'destroy');
+
+    if (parentView) {
+      Ember.run(parentView, 'destroy');
+    }
+  }
+});
+
+var parentView, dispatcher;
+
+test("focusOut event caused by removal of an in-focus text field should fire on the actions queue", function() {
+  expect(3);
+
+  var focusOutCount = 0;
+
+  parentView = Ember.View.create({
+    focusOut: function(e) {
+      focusOutCount++;
+    },
+    render: function(buffer) {
+      buffer.push("<input>");
+    }
+  });
+
+  Ember.run(parentView, 'appendTo', '#qunit-fixture');
+
+  parentView.$('input').focus();
+
+  Ember.run(function(){
+    parentView.$('input').remove();
+    equal(focusOutCount, 0, 'focusOut was not called yet');
+  });
+
+  equal(focusOutCount, 1, 'focusOut event was fired once, on next tick');
+
+  equal(Ember.$(':focus')[0], undefined, 'nothing is in focus');
+});
+

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -332,9 +332,7 @@ test("The {{linkTo}} helper supports bubbles=false", function() {
     router.handleURL("/about");
   });
 
-  Ember.run(function() {
-    Ember.$('#about-contact', '#qunit-fixture').click();
-  });
+  Ember.$('#about-contact', '#qunit-fixture').click();
 
   equal(Ember.$("#contact", "#qunit-fixture").text(), "Contact", "precond - the link worked");
 


### PR DESCRIPTION
Fix #1571 with tests, and small run-loop addition to help with these scenarios. 
