### PR TITLE
Fix `Ember.keys` to ignore internal properties for IE8

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -263,7 +263,7 @@ Ember.ORDER_DEFINITION = Ember.ENV.ORDER_DEFINITION || [
 */
 Ember.keys = Object.keys;
 
-if (!Ember.keys) {
+if (!Ember.keys || Ember.create.isSimulated) {
   Ember.keys = function(obj) {
     var ret = [];
     for(var key in obj) {

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -267,6 +267,11 @@ if (!Ember.keys) {
   Ember.keys = function(obj) {
     var ret = [];
     for(var key in obj) {
+      // Prevents browsers that don't respect non-enumerability from
+      // copying internal Ember properties
+      if (key.substring(0,2) === '__') continue;
+      if (key === '_super') continue;
+
       if (obj.hasOwnProperty(key)) { ret.push(key); }
     }
     return ret;

--- a/packages/ember-runtime/tests/core/keys_test.js
+++ b/packages/ember-runtime/tests/core/keys_test.js
@@ -12,7 +12,19 @@ test("should get a key array for a specified object", function() {
   object1.age = "23";
   object1.place = "Mangalore";
 
-  var object2 = [];
-  object2 = Ember.keys(object1);
-  deepEqual(object2,['names','age','place']);
+  var object2 = Ember.keys(object1);
+
+  deepEqual(object2, ['names','age','place']);
+});
+
+test("should get a key array for a specified Ember.Object", function() {
+  var object1 = Ember.Object.create({
+    names: "Rahul",
+    age: "23",
+    place: "Mangalore"
+  });
+
+  var object2 = Ember.keys(object1);
+
+  deepEqual(object2, ['names','age','place']);
 });

--- a/packages/ember-runtime/tests/core/keys_test.js
+++ b/packages/ember-runtime/tests/core/keys_test.js
@@ -5,16 +5,14 @@
 
 module("Fetch Keys ");
 
-test("should get a key array for a specified object ",function(){
-	var object1 = {};
+test("should get a key array for a specified object", function() {
+  var object1 = {};
 
-	object1.names = "Rahul";
-	object1.age = "23";
-	object1.place = "Mangalore";
+  object1.names = "Rahul";
+  object1.age = "23";
+  object1.place = "Mangalore";
 
-	var object2 = [];
-	object2 = Ember.keys(object1);
-	deepEqual(object2,['names','age','place']);
+  var object2 = [];
+  object2 = Ember.keys(object1);
+  deepEqual(object2,['names','age','place']);
 });
-
-


### PR DESCRIPTION
`Ember.keys` should not return internal properties.
But `Ember.keys` returns it when `Ember.create` is a simulated method.

This unexpected behavior has occurred in IE8.
