### PR TITLE
Fix failing test in older IE

### DIFF
--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -122,9 +122,9 @@ test("destroyed objects should not see each others changes during teardown but a
   var longLivedObject = new LongLivedObject();
 
   Ember.run(function () {
-    for (var key in objs) {
-      if (!objs.hasOwnProperty(key)) continue;
-      objs[key].destroy();
+    var keys = Ember.keys(objs);
+    for (var i = 0, l = keys.length; i < l; i++) {
+      objs[keys[i]].destroy();
     }
   });
 


### PR DESCRIPTION
In older IE, `for` enumerate internal properties.

After #2733 merged, this patch fixes failing test.
