### PR TITLE
Promises and the run-loop now behave well together.

### DIFF
--- a/packages/ember-runtime/lib/mixins/deferred.js
+++ b/packages/ember-runtime/lib/mixins/deferred.js
@@ -1,7 +1,7 @@
 var RSVP = requireModule("rsvp");
 
 RSVP.configure('async', function(callback, binding) {
-  Ember.run.schedule('actions', binding, callback);
+  Ember.run.join(binding, callback);
 });
 
 /**


### PR DESCRIPTION
When they occure outside of the run-loop, they create there
own run-loop. When they occure within a run-loop, they now
join the current run-loop and schedule themselves on the current
actions queue.

This should fix some extra autoruns causes by promises being resolve
async.
