### PR TITLE
App router should always have internal router

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -39,7 +39,7 @@ Ember.Router = Ember.Object.extend({
   location: 'hash',
 
   init: function() {
-    this.router = this.constructor.router;
+    this.router = this.constructor.router || this.constructor.map(Ember.K);
     this._activeViews = {};
     setupLocation(this);
   },

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -1,0 +1,15 @@
+var Router;
+
+module("Ember Router", {
+  setup: function() {
+    Router = Ember.Router.extend();
+  },
+  teardown: function() {
+    Router = null;
+  }
+});
+
+test("should create a router if one does not exist on the consturctor", function() {
+  var router = Router.create();
+  ok(router.router);
+});

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -9,7 +9,7 @@ module("Ember Router", {
   }
 });
 
-test("should create a router if one does not exist on the consturctor", function() {
+test("should create a router if one does not exist on the constructor", function() {
   var router = Router.create();
   ok(router.router);
 });


### PR DESCRIPTION
Currently the router's internal router is only created during
`Router.map`.  If the application only has an Index then it is
reasonable that `App.Router.map` would never be called.

This ensures that the `Router.map` has been called when 
creating the router.

cc @stefanpenner
