### PR TITLE
Add documentation and test for Ember.Handlebars.helper

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -48,6 +48,59 @@ function makeBindings(options) {
   }
 }
 
+/**
+  Register a bound helper or custom view helper.
+
+  ## Simple bound helper example
+
+  ```javascript
+  Ember.Handlebars.helper('capitalize', function(value) {
+    return value.toUpperCase();
+  });
+  ```
+
+  The above bound helper can be used inside of templates as follows:
+
+  ```handlebars
+  {{capitalize name}}
+  ```
+
+  In this case, when the `name` property of the template's context changes,
+  the rendered value of the helper will update to reflect this change.
+
+  For more examples of bound helpers, see documentation for
+  `Ember.Handlebars.registerBoundHelper`.
+
+  ## Custom view helper example
+
+  Assuming a view subclass named `App.CalenderView` were defined, a helper
+  for rendering instances of this view could be registered as follows:
+
+  ```javascript
+  Ember.Handlebars.helper('calendar', App.CalendarView):
+  ```
+
+  The above bound helper can be used inside of templates as follows:
+
+  ```handlebars
+  {{calendar}}
+  ```
+
+  Which is functionally equivalent to:
+
+  ```handlebars
+  {{view App.CalendarView}}
+  ```
+
+  Options in the helper will be passed to the view in exactly the same
+  manner as with the `view` helper.
+
+  @method helper
+  @for Ember.Handlebars
+  @param {String} name
+  @param {Function|Ember.View} function or view class constructor
+  @param {String} dependentKeys*
+*/
 Ember.Handlebars.helper = function(name, value) {
   if (Ember.View.detect(value)) {
     Ember.Handlebars.registerHelper(name, function(options) {

--- a/packages/ember-handlebars/tests/helpers/custom_view_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/custom_view_helper_test.js
@@ -1,0 +1,40 @@
+/*globals TemplateTests*/
+
+var view;
+
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+module("Handlebars custom view helpers", {
+  setup: function() {
+    window.TemplateTests = Ember.Namespace.create();
+  },
+  teardown: function() {
+    Ember.run(function(){
+      if (view) {
+        view.destroy();
+      }
+    });
+    window.TemplateTests = undefined;
+  }
+});
+
+test("should render an instance of the specified view", function() {
+  TemplateTests.OceanView = Ember.View.extend({
+    template: Ember.Handlebars.compile('zomg, nice view')
+  });
+
+  Ember.Handlebars.helper('oceanView', TemplateTests.OceanView);
+
+  view = Ember.View.create({
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{oceanView tagName="strong"}}')
+  });
+
+  appendView();
+
+  var oceanViews = view.$().find("strong:contains('zomg, nice view')");
+
+  equal(oceanViews.length, 1, "helper rendered an instance of the view");
+});


### PR DESCRIPTION
This PR documents the method's behaviour as an alias for `registerBoundHelper` and as a method for registering custom shorthand view helpers.
