### PR TITLE
Uncatchable assert

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,7 +25,8 @@
         "strictEqual",
         "module",
         "expect",
-        "minispade"
+        "minispade",
+        "expectAssertion"
     ],
 
     "node" : false,

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -31,27 +31,27 @@ test("you can make a new application in a non-overlapping element", function() {
 });
 
 test("you cannot make a new application that is a parent of an existing application", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.run(function() {
       Ember.Application.create({ rootElement: '#qunit-fixture' });
     });
-  }, Error);
+  });
 });
 
 test("you cannot make a new application that is a descendent of an existing application", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.run(function() {
       Ember.Application.create({ rootElement: '#one-child' });
     });
-  }, Error);
+  });
 });
 
 test("you cannot make a new application that is a duplicate of an existing application", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.run(function() {
       Ember.Application.create({ rootElement: '#one' });
     });
-  }, Error);
+  });
 });
 
 test("you cannot make two default applications without a rootElement error", function() {
@@ -63,11 +63,11 @@ test("you cannot make two default applications without a rootElement error", fun
   Ember.run(function() {
     application = Ember.Application.create({ router: false });
   });
-  raises(function() {
+  expectAssertion(function() {
     Ember.run(function() {
       Ember.Application.create({ router: false });
     });
-  }, Error);
+  });
 });
 
 test("acts like a namespace", function() {

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -22,7 +22,7 @@ test("If a controller specifies an unavailable dependency, it raises", function(
     needs: 'posts'
   }));
 
-  raises(function() {
+  expectAssertion(function() {
     container.lookup('controller:post');
   }, /controller:posts/);
 });

--- a/packages/ember-application/tests/system/readiness_test.js
+++ b/packages/ember-application/tests/system/readiness_test.js
@@ -151,7 +151,7 @@ test("Ember.Application's ready event can be deferred by other components", func
   equal(wasResolved, 1);
   equal(readyWasCalled, 1, "ready was called now all readiness deferrals are advanced");
 
-  raises(function() {
+  expectAssertion(function() {
     application.deferReadiness();
-  }, Error);
+  });
 });

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -45,6 +45,11 @@ if (!('MANDATORY_SETTER' in Ember.ENV)) {
 */
 Ember.assert = function(desc, test) {
   Ember.Logger.assert(test, desc);
+
+  if (Ember.testing && !test) {
+    // when testing, ensure test failures when assertions fail
+    throw new Error("Assertion Failed: " + desc);
+  }
 };
 
 

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -44,7 +44,7 @@ if (!('MANDATORY_SETTER' in Ember.ENV)) {
     falsy, an exception will be thrown.
 */
 Ember.assert = function(desc, test) {
-  if (!test) throw new Error("assertion failed: "+desc);
+  Ember.Logger.assert(test, desc);
 };
 
 

--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -1,5 +1,5 @@
-require("ember-handlebars-compiler");
 require("ember-runtime");
+require("ember-handlebars-compiler");
 require("ember-views");
 require("ember-handlebars/ext");
 require("ember-handlebars/string");

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -715,7 +715,7 @@ test("Template views return throw if their template cannot be found", function()
     templateName: 'cantBeFound'
   });
 
-  throws(function() {
+  expectAssertion(function() {
     get(view, 'template');
   }, /cantBeFound/);
 });
@@ -725,7 +725,7 @@ test("Layout views return throw if their layout cannot be found", function() {
     layoutName: 'cantBeFound'
   });
 
-  throws(function() {
+  expectAssertion(function() {
     get(view, 'layout');
   }, /cantBeFound/);
 });
@@ -835,9 +835,9 @@ test("should warn if setting a template on a view with a templateName already sp
     template: Ember.Handlebars.compile('{{#view childView}}test{{/view}}')
   });
 
-  raises(function() {
+  expectAssertion(function() {
     appendView();
-  }, Error, "raises if conflicting template and templateName are provided");
+  }, "Unable to find view at path 'childView'");
 
   Ember.run(function() {
     view.destroy();
@@ -848,9 +848,9 @@ test("should warn if setting a template on a view with a templateName already sp
     template: Ember.Handlebars.compile('{{#view childView templateName="foo"}}test{{/view}}')
   });
 
-  raises(function() {
+  expectAssertion(function() {
     appendView();
-  }, Error, "raises if conflicting template and templateName are provided via a Handlebars template");
+  }, "Unable to find view at path 'childView'");
 });
 
 test("Child views created using the view helper should have their parent view set properly", function() {
@@ -1115,12 +1115,12 @@ test("{{view}} class attribute should set class on layer", function() {
 });
 
 test("{{view}} should not allow attributeBindings to be set", function() {
-  raises(function() {
+  expectAssertion(function() {
     view = Ember.View.create({
       template: Ember.Handlebars.compile('{{view "Ember.View" attributeBindings="one two"}}')
     });
     appendView();
-  }, /Setting 'attributeBindings' via Handlebars is not allowed/, "should raise attributeBindings error");
+  }, /Setting 'attributeBindings' via Handlebars is not allowed/);
 });
 
 test("{{view}} should be able to point to a local view", function() {

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -248,8 +248,8 @@ test("bound helpers should not be invoked with blocks", function() {
     template: Ember.Handlebars.compile("{{#repeat}}Sorry, Charlie{{/repeat}}")
   });
 
-  raises(function() {
+  expectAssertion(function() {
     appendView();
-  }, Error, "raises error when using block helper with #block form");
+  }, /registerBoundHelper-generated helpers do not support use with Handlebars blocks/i);
 });
 

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -167,6 +167,19 @@ function consoleMethod(name) {
   }
 }
 
+function assertPolyfill(test, message) {
+  if (!test) {
+    try {
+      // attempt to preserve the stack
+      throw new Error("assertion failed: " + message);
+    } catch(error) {
+      setTimeout(function(){
+        throw error;
+      }, 0);
+    }
+  }
+}
+
 /**
   Inside Ember-Metal, simply uses the methods from `imports.console`.
   Override this to provide more robust logging functionality.
@@ -179,7 +192,8 @@ Ember.Logger = {
   warn:  consoleMethod('warn')  || Ember.K,
   error: consoleMethod('error') || Ember.K,
   info:  consoleMethod('info')  || Ember.K,
-  debug: consoleMethod('debug') || consoleMethod('info') || Ember.K
+  debug: consoleMethod('debug') || consoleMethod('info') || Ember.K,
+  assert: consoleMethod('assert') || assertPolyfill
 };
 
 

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -37,15 +37,15 @@ testBoth("should call unknownProperty on watched values if the value is undefine
 });
 
 test('warn on attempts to get a property of undefined', function(){
-  raises(function() {
+  expectAssertion(function() {
     Ember.get(undefined, 'aProperty');
-  });
+  }, /Cannot call get with 'aProperty' on an undefined object/i);
 });
 
 test('warn on attempts to get a property path of undefined', function(){
-  raises(function() {
+  expectAssertion(function(){
     Ember.get(undefined, 'aProperty.on.aPath');
-  });
+  }, /Cannot call get with 'aProperty.on.aPath' on an undefined object/);
 });
 
 // ..........................................................

--- a/packages/ember-metal/tests/mixin/apply_test.js
+++ b/packages/ember-metal/tests/mixin/apply_test.js
@@ -25,9 +25,9 @@ test('applying anonymous properties', function() {
 });
 
 test('applying null values', function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.mixin({}, null);
-  }, Error);
+  });
 });
 
 test('applying a property with an undefined value', function() {

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -739,9 +739,9 @@ testBoth("immediate observers should fire synchronously", function(get, set) {
 });
 
 testBoth("immediate observers are for internal properties only", function(get, set) {
-  raises(function() {
+  expectAssertion(function() {
     Ember.immediateObserver(Ember.K, 'foo.bar');
-  });
+  }, 'Immediate observers must observe internal properties only, not properties on other objects.');
 });
 
 module("Ember.changeProperties");

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -66,11 +66,12 @@ test('prior queues should be flushed before moving on to next queue', function()
 });
 
 test('makes sure it does not trigger an autorun during testing', function() {
-  throws(function() {
+  expectAssertion(function() {
     Ember.run.schedule('actions', function() {});
-  });
+  }, /wrap any code with asynchronous side-effects in an Ember.run/);
 
-  throws(function() {
-    Ember.run.scheduleOnce('actions', function() {});
-  });
+  // make sure not just the first violation is asserted.
+  expectAssertion(function() {
+    Ember.run.schedule('actions', function() {});
+  }, /wrap any code with asynchronous side-effects in an Ember.run/);
 });

--- a/packages/ember-old-router/tests/routable_test.js
+++ b/packages/ember-old-router/tests/routable_test.js
@@ -670,7 +670,7 @@ test("if a leaf state has a redirectsTo, it automatically transitions into that 
 });
 
 test("you cannot define connectOutlets AND redirectsTo", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.Router.create({
       location: 'none',
       root: Ember.Route.create({
@@ -685,7 +685,7 @@ test("you cannot define connectOutlets AND redirectsTo", function() {
 });
 
 test("you cannot have a redirectsTo in a non-leaf state", function () {
-  raises(function() {
+  expectAssertion(function() {
     Ember.Router.create({
       location: 'none',
       root: Ember.Route.create({
@@ -736,7 +736,7 @@ test("urlFor raises an error when route property is not defined", function() {
     })
   });
 
-  raises(function (){
+  expectAssertion(function (){
     router.urlFor('root.dashboard');
   });
 });

--- a/packages/ember-routing/tests/helpers/control_test.js
+++ b/packages/ember-routing/tests/helpers/control_test.js
@@ -46,7 +46,7 @@ if (Ember.ENV.EXPERIMENTAL_CONTROL_HELPER) {
     container.register('controller:widget', Ember.Controller.extend());
     container.register('template:widget', compile("Hello"));
 
-    throws(function() {
+    expectAssertion(function() {
       appendView({
         controller: container.lookup('controller:parent'),
         template: compile("{{control widget}}")
@@ -62,7 +62,7 @@ if (Ember.ENV.EXPERIMENTAL_CONTROL_HELPER) {
     container.register('view:widget', Ember.View.extend());
     container.register('template:widget', compile("Hello"));
 
-    throws(function() {
+    expectAssertion(function() {
       appendView({
         controller: container.lookup('controller:parent'),
         template: compile("{{control widget}}")

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -168,9 +168,9 @@ test("{{render}} helper should render a template without a model only once", fun
 
   Ember.TEMPLATES['home'] = compile("<p>BYE</p>");
 
-  raises(function() {
+  expectAssertion(function() {
     appendView(view);
-  }, 'should raise an exception');
+  }, /\{\{render\}\} helper once/i);
 });
 
 test("{{render}} helper should render templates with models multiple times", function() {

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -136,9 +136,9 @@ test("{{render}} helper should raise an error when a given controller name does 
 
   Ember.TEMPLATES['home'] = compile("<p>BYE</p>");
 
-  raises(function() {
+  expectAssertion(function(){
     appendView(view);
-  }, 'should raise an exception');
+  }, 'The controller name you supplied \'postss\' did not resolve to a controller.');
 });
 
 test("{{render}} helper should render with given controller", function() {

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -156,9 +156,9 @@ test("raise if the provided object is null", function() {
 */
 
 test("raise if the provided object is undefined", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.get(undefined, 'key');
-  });
+  }, /Cannot call get with 'key' on an undefined object/i);
 });
 
 test("should work when object is Ember (used in Ember.get)", function() {

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -144,13 +144,13 @@ test("can retrieve metadata for a computed property", function() {
 
   equal(typeof ClassWithNoMetadata.metaForProperty('computedProperty'), "object", "returns empty hash if no metadata has been saved");
 
-  raises(function() {
+  expectAssertion(function() {
     ClassWithNoMetadata.metaForProperty('nonexistentProperty');
-  }, Error, "throws an error if metadata for a non-existent property is requested");
+  }, "metaForProperty() could not find a computed property with key 'nonexistentProperty'.");
 
-  raises(function() {
+  expectAssertion(function() {
     ClassWithNoMetadata.metaForProperty('staticProperty');
-  }, Error, "throws an error if metadata for a non-computed property is requested");
+  }, "metaForProperty() could not find a computed property with key 'staticProperty'.");
 });
 
 testBoth("can iterate over a list of computed properties for a class", function(get, set) {

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -66,21 +66,21 @@ test("calls setUnknownProperty if defined", function() {
 });
 
 test("throws if you try to define a computed property", function() {
-  raises(function() {
-    var obj = Ember.Object.create({
+  expectAssertion(function() {
+    Ember.Object.create({
       foo: Ember.computed(function(){})
     });
-  }, 'should warn that a computed property was passed to create');
+  }, 'Ember.Object.create no longer supports defining computed properties.');
 });
 
 test("throws if you try to call _super in a method", function() {
-  raises(function() {
-    var obj = Ember.Object.create({
+  expectAssertion(function(){
+     Ember.Object.create({
       foo: function() {
         this._super();
       }
     });
-  }, 'should warn that a method that calls _super was passed to create');
+  }, 'Ember.Object.create no longer supports defining methods that call _super.');
 });
 
 test("throws if you try to 'mixin' a definition", function(){
@@ -90,9 +90,9 @@ test("throws if you try to 'mixin' a definition", function(){
     }
   });
 
-  raises(function(){
+  expectAssertion(function(){
     var o = Ember.Object.create(myMixin);
-  }, "should warn that you passed in a mixin");
+  }, "Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.");
 });
 
 module('Ember.Object.createWithMixins');
@@ -108,7 +108,6 @@ test("Creates a new object that contains passed properties", function() {
   equal(Ember.get(obj, 'prop'), 'FOO', 'obj.prop');
   obj.method();
   ok(called, 'method executed');
-
 });
 
 // ..........................................................

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -114,9 +114,9 @@ testBoth('observer should not fire after being destroyed', function(get, set) {
   Ember.run(function() { obj.destroy(); });
 
   if (Ember.assert) {
-    raises(function() {
+    expectAssertion(function() {
       set(obj, 'bar', "BAZ");
-    }, Error, "raises error when setting a property");
+    }, "calling set on destroyed object");
   } else {
     set(obj, 'bar', "BAZ");
   }

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -27,9 +27,9 @@ testBoth("should proxy properties to content", function(get, set) {
       proxy = Ember.ObjectProxy.create();
 
   equal(get(proxy, 'firstName'), undefined, 'get on proxy without content should return undefined');
-  raises(function () {
+  expectAssertion(function () {
     set(proxy, 'firstName', 'Foo');
-  }, 'set on proxy without content should raise');
+  }, /Cannot delegate set\('firstName', Foo\) to the 'content'/i);
 
   set(proxy, 'content', content);
 

--- a/packages/ember-states/tests/state_manager_test.js
+++ b/packages/ember-states/tests/state_manager_test.js
@@ -135,7 +135,7 @@ test("it does not enter an infinite loop in transitionTo", function() {
   stateManager.transitionTo('');
   ok(stateManager.get('currentState') === emptyState, "transitionTo does nothing when given empty name");
 
-  raises(function() {
+  expectAssertion(function() {
     stateManager.transitionTo('nonexistentState');
   }, 'Could not find state for path: "nonexistentState"');
 
@@ -288,12 +288,12 @@ test("it triggers setup on initialSubstate", function() {
 });
 
 test("it throws an assertion error when the initialState does not exist", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.StateManager.create({
       initialState: 'foo',
       bar: Ember.State.create()
     });
-  }, Error, 'raises an exception');
+  });
 });
 
 module("Ember.StateManager - Transitions on Complex State Managers");

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -581,20 +581,19 @@ test("Child view can only be added to one container at a time", function () {
     container.set('currentView', view);
   });
 
-  throws(function() {
+  expectAssertion(function(){
     Ember.run(function() {
-        secondContainer.set('currentView', view);
+      secondContainer.set('currentView', view);
     });
   });
 
-  throws(function() {
+  expectAssertion(function(){
     Ember.run(function() {
-        secondContainer.pushObject(view);
+      secondContainer.pushObject(view);
     });
   });
 
   Ember.run(function() {
     secondContainer.destroy();
   });
-
 });

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -38,23 +38,23 @@ test("registers itself with a controller if the viewController property is set",
 module("Ember.View.createWithMixins");
 
 test("should warn if a non-array is used for classNames", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.View.createWithMixins({
       elementId: 'test',
       classNames: Ember.computed(function() {
         return ['className'];
       }).volatile()
     });
-  }, /Only arrays are allowed/i, 'should warn that an array was not used');
+  }, /Only arrays are allowed/i);
 });
 
 test("should warn if a non-array is used for classNamesBindings", function() {
-  raises(function() {
+  expectAssertion(function() {
     Ember.View.createWithMixins({
       elementId: 'test',
       classNameBindings: Ember.computed(function() {
         return ['className'];
       }).volatile()
     });
-  }, /Only arrays are allowed/i, 'should warn that an array was not used');
+  }, /Only arrays are allowed/i);
 });

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -40,4 +40,59 @@
     prod:    'ember.prod.js',
     runtime: 'ember-runtime.js'
   };
+
+  function expectAssertion(fn, expectedMessage) {
+    var originalAssert = Ember.assert,
+      actualMessage, actualTest,
+      arity, sawAssertion;
+
+    var AssertionFailedError = new Error('AssertionFailed');
+
+    try {
+
+      Ember.assert = function(message, test) {
+        arity = arguments.length;
+        actualMessage = message;
+        actualTest = test;
+
+        if (!test) {
+          throw AssertionFailedError;
+        }
+      };
+
+      try {
+        fn();
+      } catch(error) {
+        if (error === AssertionFailedError) {
+          sawAssertion = true;
+        } else {
+          throw error;
+        }
+      }
+
+      if (!sawAssertion) {
+        ok(false, "Expected Ember.assert: '" + expectedMessage + "', but no assertions where run");
+      } else if (arity === 2) {
+
+        if (expectedMessage) {
+          if (expectedMessage instanceof RegExp) {
+            ok(expectedMessage.test(actualMessage), "Expected Ember.assert: '" + expectedMessage + "', but got '" + actualMessage + "'");
+          }else{
+            equal(actualMessage, expectedMessage, "Expected Ember.assert: '" + expectedMessage + "', but got '" + actualMessage + "'");
+          }
+        } else {
+          ok(!actualTest);
+        }
+      } else if (arity === 1) {
+        ok(!actualTest);
+      } else {
+        ok(false, 'Ember.assert was called without the assertion');
+      }
+
+    } finally {
+      Ember.assert = originalAssert;
+    }
+  }
+
+  window.expectAssertion = expectAssertion;
 })();

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -49,7 +49,6 @@
     var AssertionFailedError = new Error('AssertionFailed');
 
     try {
-
       Ember.assert = function(message, test) {
         arity = arguments.length;
         actualMessage = message;


### PR DESCRIPTION
an uncatchable assert.

The over arching idea is to mimc chromes `console.assert` which has some interesting properties.
1. uncatchable by user code (appealing)
2. does not block execution except in tests (I have mixed feelings)

This PR also adds an `expectAssertion` helper, and could likely lead to an additional  `expectAssertions` helper. I found that expectAssertions was a net benefit to the test suite,
and should likely remain in some form, even if we decide not to go with na uncatchable assert.

Caveats:
- some console.assert polyfils do not behave correctly
- the polyfill may be annoying to use with development tools

Glaring omission 
- make our friend ember-data work

I would like to hear your thoughts and concerns.
