### PR TITLE
Add `debounce` to Ember.run. Uses `backburner.debounce`

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -431,6 +431,38 @@ Ember.run.cancel = function(timer) {
   return backburner.cancel(timer);
 };
 
+/**
+  Execute the passed method in a specified amount of time, reset timer
+  upon additional calls.
+
+  ```javascript
+    var myFunc = function() { console.log(this.name + ' ran.'); };
+    var myContext = {name: 'debounce'};
+
+    Ember.run.debounce(myContext, myFunc, 150);
+
+    // less than 150ms passes
+
+    Ember.run.debounce(myContext, myFunc, 150);
+
+    // 150ms passes
+    // myFunc is invoked with context myContext
+    // console logs 'debounce ran.' one time.
+  ```
+
+  @method debounce
+  @param {Object} [target] target of method to invoke
+  @param {Function|String} method The method to invoke.
+    May be a function or a string. If you pass a string
+    then it will be looked up on the passed target.
+  @param {Object} [args*] Optional arguments to pass to the timeout.
+  @param {Number} wait Number of milliseconds to wait.
+  @return {void}
+*/
+Ember.run.debounce = function() {
+  return backburner.debounce.apply(backburner, arguments);
+};
+
 // Make sure it's not an autorun during testing
 function checkAutoRun() {
   if (!Ember.run.currentRunLoop) {

--- a/packages/ember-metal/tests/run_loop/debounce_test.js
+++ b/packages/ember-metal/tests/run_loop/debounce_test.js
@@ -1,0 +1,135 @@
+var originalSetTimeout = window.setTimeout;
+
+var wait = function(callback, maxWaitCount) {
+  maxWaitCount = Ember.isNone(maxWaitCount) ? 100 : maxWaitCount;
+
+  originalSetTimeout(function() {
+    if (maxWaitCount > 0 && (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop)) {
+      wait(callback, maxWaitCount - 1);
+
+      return;
+    }
+
+    callback();
+  }, 10);
+};
+
+module('Ember.run.debounce', {
+  teardown: function() {
+    window.setTimeout = originalSetTimeout;
+  }
+});
+
+asyncTest('should invoke only once after specified period of time - function only', function() {
+
+  var invokeCount = 0;
+  var myFunc = function() { invokeCount += 1; };
+  var myContext = null;
+
+  Ember.run(function() {
+    Ember.run.debounce(myContext, myFunc, 10);
+    Ember.run.debounce(myContext, myFunc, 10);
+  });
+
+  wait(function() {
+    start();
+    equal(invokeCount, 1, 'should have invoked only once');
+  });
+});
+
+asyncTest('should invoke only once after specified period of time - target/method', function() {
+
+  var obj = { invokeCount: 0 } ;
+  var myFunc = function() { this.invokeCount += 1; };
+
+  Ember.run(function() {
+    Ember.run.debounce(obj, myFunc, 10);
+    Ember.run.debounce(obj, myFunc, 10);
+  });
+
+  wait(function() {
+    start();
+    equal(obj.invokeCount, 1, 'should have invoked only once');
+  });
+});
+
+asyncTest('should invoke only once after specified period of time - target/method as string', function() {
+
+  var obj = {
+    myFunc: function() {this.invokeCount += 1; },
+    invokeCount: 0
+  };
+
+  Ember.run(function() {
+    Ember.run.debounce(obj, 'myFunc', 10);
+    Ember.run.debounce(obj, 'myFunc', 10);
+  });
+
+  wait(function() {
+    start();
+    equal(obj.invokeCount, 1, 'should have invoked only once');
+  });
+});
+
+asyncTest('should invoke only once after specified period of time - target/method/args', function() {
+
+  var obj = { invokeArg: null } ;
+  var myFunc = function(arg) { this.invokeArg = arg; };
+
+  Ember.run(function() {
+    Ember.run.debounce(obj, myFunc, 5, 10);
+    Ember.run.debounce(obj, myFunc, 7, 10);
+  });
+
+  wait(function() {
+    start();
+    equal(obj.invokeArg, 5, 'should have invoked item with first args');
+  });
+});
+
+asyncTest('should invoke again after timer has reset', function() {
+  var invokeCount = 0;
+  var myContext = null;
+  var myFunc = function() { invokeCount += 1; };
+
+  Ember.run(function() {
+    Ember.run.debounce(myContext, myFunc, 10);
+  });
+
+  wait( function() {
+    start();
+    equal(invokeCount, 1, 'should have invoked once');
+    stop();
+
+    Ember.run(function() {
+      Ember.run.debounce(myContext, myFunc, 10);
+    });
+
+    wait( function() {
+      start();
+      equal(invokeCount, 2, 'should have invoked a second time');
+    });
+  });
+});
+
+asyncTest('should not invoke before timer', function() {
+  var invokeCount = 0;
+  var myContext = null;
+  var myFunc = function() { invokeCount += 1; };
+
+  Ember.run(function() {
+    Ember.run.debounce(myContext, myFunc, 15);
+  });
+
+  originalSetTimeout( function() {
+    start();
+    equal(invokeCount, 0, 'should not invoke before timer');
+    stop();
+
+    originalSetTimeout( function() {
+      start();
+      equal(invokeCount, 1, 'should invoke after timer');
+    }, 10);
+  }, 10);
+
+});


### PR DESCRIPTION
This puts `debounce` onto `Ember.run`, so you don't have to contort through `Ember.run.backburner.debounce`.

Usage:

``` javascript
   var myFunc = function() { console.log(this.name + ' ran.'); };
   var myContext = {name: 'debounce'};

   Ember.run.debounce(myContext, myFunc, 150);
   // less than 150ms passes
   Ember.run.debounce(myContext, myFunc, 150);

   // 150ms passes
   // myFunc is invoked with context myContext
   // console logs 'debounce ran.' one time.
```

Added documentation along with the method in `run_loop.js` and tests in `tests/run_loop/debounce_test.js`

cc @mixonic
