### PR TITLE
Assert null and undefined keyName in get() and set()

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -56,6 +56,7 @@ get = function get(obj, keyName) {
     obj = null;
   }
 
+  Ember.assert("Cannot call get with "+ keyName +" key.", !!keyName);
   Ember.assert("Cannot call get with '"+ keyName +"' on an undefined object.", obj !== undefined);
 
   if (obj === null || keyName.indexOf('.') !== -1) {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -38,6 +38,8 @@ var set = function set(obj, keyName, value, tolerant) {
     obj = null;
   }
 
+  Ember.assert("Cannot call set with "+ keyName +" key.", !!keyName);
+
   if (!obj || keyName.indexOf('.') !== -1) {
     return setPath(obj, keyName, value, tolerant);
   }


### PR DESCRIPTION
I had piece of code something like this one

``` javascript
function(param) {
  obj.get(param);
}
```

So key was dynamic, and it worked ok with old ember version, but with new version of ember (when become possible to pass paths to get() and set()) this code started to throw exceptions. And I spent some time debugging to figure out what is wrong (it wasn't easy). I think it would be nice to warn user  if he passes null or undefined so he get instead of

``` javascript
obj = Ember.Object.create()
Class {constructor: function, toString: function, reopen: function, isInstance: true, init: function…}
obj.set(null)
TypeError: Cannot call method 'indexOf' of null
obj.set(undefined)
TypeError: Cannot call method 'indexOf' of undefined
obj.get(null)
TypeError: Cannot call method 'indexOf' of null
obj.get(undefined)
TypeError: Cannot call method 'indexOf' of undefined
```

these nice assertions:

``` javascript
obj = Ember.Object.create()
Class {constructor: function, toString: function, reopen: function, isInstance: true, init: function…}
obj.set(null)
Error: assertion failed: Cannot call set with null key.
obj.set(undefined)
Error: assertion failed: Cannot call set with undefined key.
obj.get(null)
Error: assertion failed: Cannot call get with null key.
obj.get(undefined)
Error: assertion failed: Cannot call get with undefined key.
```
