### PR TITLE
document that 'needs' is for singleton controllers only

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -66,6 +66,8 @@ Ember.ControllerMixin.reopen({
     this.get('controllers.post'); // instance of App.PostController
     ```
 
+    This is only available for singleton controllers.
+
     @property {Array} needs
     @default []
   */


### PR DESCRIPTION
question raised here on discuss.emberjs.com:

http://discuss.emberjs.com/t/documentation-needs-api-is-it-only-for-singleton-controllers/911/3

surprised me, surprised other people I'm working with, surprised other people on the internet. useful thing to have in the docs.
