### PR TITLE
Rename _displayPropertyDidChange to _contextDidChange in comment

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -986,7 +986,7 @@ Ember.View = Ember.CoreView.extend(
     If a value that affects template rendering changes, the view should be
     re-rendered to reflect the new value.
 
-    @method _displayPropertyDidChange
+    @method _contextDidChange
   */
   _contextDidChange: Ember.observer(function() {
     this.rerender();


### PR DESCRIPTION
It's just a tiny change to have the generated api reflect the correct method name
