### PR TITLE
Begin Documenting Ember.CoreView

### DIFF
--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -124,7 +124,7 @@ Ember._MetamorphView = Ember.View.extend(Ember._Metamorph);
 /**
   @class _SimpleMetamorphView
   @namespace Ember
-  @extends Ember.View
+  @extends Ember.CoreView
   @uses Ember._Metamorph
   @private
 */

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -47,6 +47,15 @@ Ember.warn("The VIEW_PRESERVES_CONTEXT flag has been removed and the functionali
 */
 Ember.TEMPLATES = {};
 
+/**
+  `Ember.CoreView` is
+
+  @class CoreView
+  @namespace Ember
+  @extends Ember.Object
+  @uses Ember.Evented
+*/
+
 Ember.CoreView = Ember.Object.extend(Ember.Evented, {
   isView: true,
 
@@ -804,8 +813,7 @@ class:
 
   @class View
   @namespace Ember
-  @extends Ember.Object
-  @uses Ember.Evented
+  @extends Ember.CoreView
 */
 Ember.View = Ember.CoreView.extend(
 /** @scope Ember.View.prototype */ {


### PR DESCRIPTION
Change outdated documentation to reflect `Ember.CoreView`. I don't know enough about CoreView to add more context except that it acts as a base class, so this is preparing the way. See #2556.
