### PR TITLE
Allow base set of events to listen on to be customized in EventDispatcher (for performance)

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -19,6 +19,47 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.prototype */{
 
   /**
+    The set of events names (and associated handler function names) to be setup
+    and dispatched by the `EventDispatcher`. Custom events can added to this list at setup
+    time, generally via the `Ember.Application.customEvents` hash. Only override this
+    default set to prevent the EventDispatcher from listening on some events all together.
+
+    This set will be modified by `setup` to also include any events added at that time.
+
+    @property events
+    @type Object
+  */
+  events: {
+    touchstart  : 'touchStart',
+    touchmove   : 'touchMove',
+    touchend    : 'touchEnd',
+    touchcancel : 'touchCancel',
+    keydown     : 'keyDown',
+    keyup       : 'keyUp',
+    keypress    : 'keyPress',
+    mousedown   : 'mouseDown',
+    mouseup     : 'mouseUp',
+    contextmenu : 'contextMenu',
+    click       : 'click',
+    dblclick    : 'doubleClick',
+    mousemove   : 'mouseMove',
+    focusin     : 'focusIn',
+    focusout    : 'focusOut',
+    mouseenter  : 'mouseEnter',
+    mouseleave  : 'mouseLeave',
+    submit      : 'submit',
+    input       : 'input',
+    change      : 'change',
+    dragstart   : 'dragStart',
+    drag        : 'drag',
+    dragenter   : 'dragEnter',
+    dragleave   : 'dragLeave',
+    dragover    : 'dragOver',
+    drop        : 'drop',
+    dragend     : 'dragEnd'
+  },
+
+  /**
     @private
 
     The root DOM element to which event listeners should be attached. Event
@@ -49,35 +90,7 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     @param addedEvents {Hash}
   */
   setup: function(addedEvents, rootElement) {
-    var event, events = {
-      touchstart  : 'touchStart',
-      touchmove   : 'touchMove',
-      touchend    : 'touchEnd',
-      touchcancel : 'touchCancel',
-      keydown     : 'keyDown',
-      keyup       : 'keyUp',
-      keypress    : 'keyPress',
-      mousedown   : 'mouseDown',
-      mouseup     : 'mouseUp',
-      contextmenu : 'contextMenu',
-      click       : 'click',
-      dblclick    : 'doubleClick',
-      mousemove   : 'mouseMove',
-      focusin     : 'focusIn',
-      focusout    : 'focusOut',
-      mouseenter  : 'mouseEnter',
-      mouseleave  : 'mouseLeave',
-      submit      : 'submit',
-      input       : 'input',
-      change      : 'change',
-      dragstart   : 'dragStart',
-      drag        : 'drag',
-      dragenter   : 'dragEnter',
-      dragleave   : 'dragLeave',
-      dragover    : 'dragOver',
-      drop        : 'drop',
-      dragend     : 'dragEnd'
-    };
+    var event, events = get(this, 'events');
 
     Ember.$.extend(events, addedEvents || {});
 


### PR DESCRIPTION
Moves the hash of events -> handler names from a hash defined within the `setup` function of EventDispatcher to an overridable property on the class.

The motivation for this PR is to be able to turn off dispatcher handling of unused events, specifically `mousemove`/`touchmove`/`drag` due to high heap thrashing.

Below are two screenshots of memory heap usage of an application taken while holding down the mouse button and dragging the cursor back and forth over the app.

_With all default events registered:_
![screen shot 2013-06-07 at 3 14 20 pm](https://f.cloud.github.com/assets/900789/625669/530e57be-cfa7-11e2-94a7-d4cafbebd6ce.png)
Observe how 8MB of memory is used and then gc'd  every ~4 seconds (2 MB/s)

_With mousemove/touchmove/drag and other high rate events commented out:_
![screen shot 2013-06-07 at 3 11 27 pm](https://f.cloud.github.com/assets/900789/625675/65f3b356-cfa7-11e2-8b92-6f14d10c2560.png)
Observe how 6MB of memory is used and gc'd over ~8 seconds (.75 MB/s).

Note that in both cases no views are actually registered for any of the events - this is just the cost of the event listeners + delegation to nowhere.

This PR would allow performance sensitive apps stop Ember from registering costly listeners on unused events.
