### PR TITLE
Adds support for on="eventType" attribute in linkTo helper

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -54,6 +54,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     replace: false,
     attributeBindings: ['href', 'title'],
     classNameBindings: ['active', 'disabled'],
+    eventName: 'click',
+
+    init: function() {
+      this._super();
+      // Map desired event name to invoke function
+      var eventName = get(this, 'eventName');
+      this.on(eventName, this, this._invoke);
+    },
 
     // Even though this isn't a virtual view, we want to treat it as if it is
     // so that you can access the parent with {{view.prop}}
@@ -81,7 +89,15 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       return this.get('controller').container.lookup('router:main');
     }),
 
-    click: function(event) {
+    /**
+      @private
+
+      Event handler that invokes the link, activating the associated route.
+
+      @method _invoke
+      @param {Event} event
+    */
+    _invoke: function(event) {
       if (!isSimpleClick(event)) { return true; }
 
       event.preventDefault();


### PR DESCRIPTION
Syntax of the `on` attribute is the same as in the `{{action}}` helper.

This is particularly useful on mobile when one wants to avoid the 300ms click delay using some sort of custom "tap" event. A global event type override can now be achieved like so:

```
Ember.LinkView.reopen({
  eventName: 'tap'
});
```
