### PR TITLE
visit helper should update router url before handling it

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -18,8 +18,8 @@ Ember.Test.onInjectHelpers(function() {
 
 
 function visit(app, url) {
-  Ember.run(app, app.handleURL, url);
   app.__container__.lookup('router:main').location.setURL(url);
+  Ember.run(app, app.handleURL, url);
   return wait(app);
 }
 


### PR DESCRIPTION
Router URL should be set before handling it, otherwise if a redirect happens during handling, the router URL will end up with the wrong URL.
