### PR TITLE
improve Ember.View#createChildView container support

### DIFF
--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -326,6 +326,7 @@ Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
   initializeViews: function(views, parentView, templateData) {
     forEach(views, function(view) {
       set(view, '_parentView', parentView);
+      set(view, 'container', parentView && parentView.container);
 
       if (!get(view, 'templateData')) {
         set(view, 'templateData', templateData);

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2078,31 +2078,32 @@ Ember.View = Ember.CoreView.extend(
     @return {Ember.View} new instance
   */
   createChildView: function(view, attrs) {
-    if (view.isView && view._parentView === this) { return view; }
+    if (view.isView && view._parentView === this && view.container === this.container) {
+      return view;
+    }
+
+    attrs = attrs || {};
+    attrs._parentView = this;
+    attrs.container = this.container;
 
     if (Ember.CoreView.detect(view)) {
-      attrs = attrs || {};
-      attrs._parentView = this;
-      attrs.container = this.container;
       attrs.templateData = attrs.templateData || get(this, 'templateData');
 
       view = view.create(attrs);
 
       // don't set the property on a virtual view, as they are invisible to
       // consumers of the view API
-      if (view.viewName) { set(get(this, 'concreteView'), view.viewName, view); }
+      if (view.viewName) {
+        set(get(this, 'concreteView'), view.viewName, view);
+      }
     } else {
       Ember.assert('You must pass instance or subclass of View', view.isView);
 
-      if (attrs) {
-        view.setProperties(attrs);
-      }
+      Ember.setProperties(view, attrs);
 
       if (!get(view, 'templateData')) {
         set(view, 'templateData', get(this, 'templateData'));
       }
-
-      set(view, '_parentView', this);
     }
 
     return view;

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -12,7 +12,8 @@ module("ember-views/views/container_view_test", {
 test("should be able to insert views after the DOM representation is created", function() {
   container = Ember.ContainerView.create({
     classNameBindings: ['name'],
-    name: 'foo'
+    name: 'foo',
+    container: {}
   });
 
   Ember.run(function() {
@@ -29,6 +30,8 @@ test("should be able to insert views after the DOM representation is created", f
     container.pushObject(view);
   });
 
+  equal(view.container, container.container, 'view gains its containerViews container');
+  equal(view._parentView, container, 'view\'s _parentView is the container');
   equal(Ember.$.trim(container.$().text()), "This is my moment");
 
   Ember.run(function(){

--- a/packages/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages/ember-views/tests/views/view/create_child_view_test.js
@@ -1,10 +1,15 @@
 var set = Ember.set, get = Ember.get;
 
-var view, myViewClass, newView;
+var view, myViewClass, newView, container;
 
 module("Ember.View#createChildView", {
   setup: function() {
-    view = Ember.View.create();
+    container = { };
+
+    view = Ember.View.create({
+      container: container
+    });
+
     myViewClass = Ember.View.extend({ isMyView: true, foo: 'bar' });
   },
 
@@ -17,8 +22,13 @@ module("Ember.View#createChildView", {
 });
 
 test("should create view from class with any passed attributes", function() {
-  var attrs = { foo: "baz" };
+  var attrs = {
+    foo: "baz"
+  };
+
   newView = view.createChildView(myViewClass, attrs);
+
+  equal(newView.container, container, 'expects to share container with parent');
   ok(get(newView, 'isMyView'), 'newView is instance of myView');
   equal(get(newView, 'foo'), 'baz', 'view did get custom attributes');
   ok(!attrs.parentView, "the original attributes hash was not mutated");
@@ -26,12 +36,34 @@ test("should create view from class with any passed attributes", function() {
 
 test("should set newView.parentView to receiver", function() {
   newView = view.createChildView(myViewClass) ;
+
+  equal(newView.container, container, 'expects to share container with parent');
   equal(get(newView, 'parentView'), view, 'newView.parentView == view');
 });
 
 test("should create property on parentView to a childView instance if provided a viewName", function() {
-  var attrs = { viewName: "someChildView" };
+  var attrs = {
+    viewName: "someChildView"
+  };
+
   newView = view.createChildView(myViewClass, attrs);
+  equal(newView.container, container, 'expects to share container with parent');
 
   equal(get(view, 'someChildView'), newView);
 });
+
+test("should update a view instances attributes, including the _parentView and container properties", function() {
+  var attrs = {
+    foo: "baz"
+  };
+
+  var myView = myViewClass.create();
+  newView = view.createChildView(myView, attrs);
+
+  equal(newView.container,  container, 'expects to share container with parent');
+  equal(newView._parentView, view, 'expects to have the correct parent');
+  equal(get(newView, 'foo'), 'baz', 'view did get custom attributes');
+
+  deepEqual(newView, myView);
+});
+


### PR DESCRIPTION
Now view instances passed to `View#createChildView`
should get both `parentView` and `container` properties
updated.

Also, when views are added to a `ContainerView` its container
is now passed to the child.

This should improve some scenarios brought up [here](https://gist.github.com/stefanpenner/5627411)
