### PR TITLE
stop morph.html being called from a bound view in a destroying state

### DIFF
--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -106,6 +106,10 @@ SimpleHandlebarsView.prototype = {
 
   update: function () {
     this.updateId = null;
+    // FIXME: Update should not be called on a view with a state of destroying
+    if(!this.morph){
+      return;
+    }
     this.morph.html(this.render());
   },
 


### PR DESCRIPTION
I've been experiencing this bug where update is being called of a bound view in a destroying state:

Here is update:

```
update: function () {
  this.updateId = null;
  this.morph.html(this.render());
},
```

If update is called on a view in this state, `this.moprh` is null so a call to html will obviously blow up.

My naive fix just checks for this.morph to be truthy:

```
update: function () {
  this.updateId = null;
  // FIXME: Update should not be called on a view with a state of destroying
  if(!this.morph){
    return;
  }
  this.morph.html(this.render());
},
```

I think something more sinister is wrong in that update should not be called in this scenario.  

I created an issue for this a couple of days ago #2815.

Maybe somebody can comment on this, it is happening with more than one bound helper I have.
