### PR TITLE
WIP: Reopened the `Ember.View` class to add `registerHelper`

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2408,6 +2408,30 @@ Ember.View.reopenClass({
     } else {
       return null;
     }
+  },
+  
+  /**
+    @private
+
+    Registers this view class as a handlebars helper.
+
+    ```javascript
+      App.UserControlView = Ember.View.extend({
+        templateName: 'user-control',
+        user: null
+      }).registerHelper('userControl')
+    ```
+  
+    ```handlebars
+      {{userControl userBinding="createdBy"}}
+    ```
+
+    @method registerHelper
+    @static
+  */
+  registerHelper: function(name) {
+    Ember.Handlebars.helper(name, this);
+    return this;
   }
 });
 


### PR DESCRIPTION
This is a convenience function for creating handlebars helpers from view classes. We've had it in our app for a long time. I thought about submitting this a while ago, but I was under the impression that arbitrarily creating handlebars helpers would be discouraged. However, the addition of `{{input}}` and `{{textarea}}` made me think this might be worth discussing.

Here's the basic idea:

``` javascript
  App.UserControlView = Ember.View.extend({
    templateName: 'user-control',
    user: null
  }).registerHelper('userControl')
```

``` handlebars
  {{userControl userBinding="createdBy"}}
```

Clearly this is a WIP as there are no tests and crappy docs. I wanted to submit this idea to get general feedback. If others like this idea I'd be happy to finish it off and optionally convert `{{input}}` and `{{textarea}}` to follow this pattern.
