### PR TITLE
Fix to update jQuery version for testing

### DIFF
--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -10,13 +10,13 @@ testing_suites:
     - "package=container,ember-views,ember-handlebars"
   standard:
     - "EACH_PACKAGE"
-    - "package=all&jquery=1.7.2&nojshint=true"
+    - "package=all&jquery=1.8.3&nojshint=true"
     - "package=all&extendprototypes=true&nojshint=true"
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
   all:
     - "EACH_PACKAGE"
-    - "package=all&jquery=1.7.2&nojshint=true"
     - "package=all&jquery=1.8.3&nojshint=true"
+    - "package=all&jquery=1.9.1&nojshint=true"
     - "package=all&jquery=git&nojshint=true"
     - "package=all&jquery=git2&nojshint=true"
     - "package=all&enablerouteto&nojshint=true"


### PR DESCRIPTION
I think jQuery 1.7 is no longer supported since 079630bce.
