### PR TITLE
Fix #2840 - textfield binding issue with null

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2452,8 +2452,8 @@ Ember.View.applyAttributeBindings = function(elem, name, value) {
       elem.attr(name, value);
     }
   } else if (name === 'value' || type === 'boolean') {
-    // We can't set properties to undefined
-    if (value === undefined) { value = null; }
+    // We can't set properties to undefined or null
+    if (!value) { value = ''; }
 
     if (value !== elem.prop(name)) {
       // value and booleans should always be properties

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -178,6 +178,25 @@ test("handles `undefined` value for properties", function() {
   equal(!!view.$().prop('value'), false, "value is not defined");
 });
 
+test("handles null value for attributes on text fields", function() {
+  view = Ember.View.create({
+    tagName: 'input',
+    attributeBindings: ['value']
+  });
+
+  appendView();
+
+  view.$().attr('value', 'test');
+
+  equal(view.$().attr('value'), "test", "value is defined");
+
+  Ember.run(function() {
+    view.set('value', null);
+  });
+
+  equal(!!view.$().prop('value'), false, "value is not defined");
+});
+
 test("attributeBindings should not fail if view has been removed", function(){
   Ember.run(function(){
     view = Ember.View.create({


### PR DESCRIPTION
Here is a fix for issue #2840 that I raised.  The issue seems to stem from the way jQuery handles "attributes" vs "properties".  This feels very quirky.
