### PR TITLE
StateManager and states now pass their `container` to child states.

### DIFF
--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -124,20 +124,24 @@ Ember.State = Ember.Object.extend(Ember.Evented,
 
   setupChild: function(states, name, value) {
     if (!value) { return false; }
+    var instance;
 
     if (value.isState) {
       set(value, 'name', name);
+      instance = value;
+      instance.container = this.container;
     } else if (Ember.State.detect(value)) {
-      value = value.create({
-        name: name
+      instance = value.create({
+        name: name,
+        container: this.container
       });
     }
 
-    if (value.isState) {
-      set(value, 'parentState', this);
-      get(this, 'childStates').pushObject(value);
-      states[name] = value;
-      return value;
+    if (instance && instance.isState) {
+      set(instance, 'parentState', this);
+      get(this, 'childStates').pushObject(instance);
+      states[name] = instance;
+      return instance;
     }
   },
 

--- a/packages/ember-states/tests/state_test.js
+++ b/packages/ember-states/tests/state_test.js
@@ -181,6 +181,27 @@ test("the isLeaf property is false when a state has child states", function() {
   equal(definitelyInside.get('isLeaf'), true);
 });
 
+test("propagates its container to its child states", function(){
+  var container = { lookup: Ember.K },
+      manager = Ember.StateManager.create({
+        container: container,
+        states: {
+          first: Ember.State.extend({
+            insideFirst: Ember.State.extend()
+          }),
+          second: Ember.State.create()
+        }
+      });
+
+  var first = manager.get('states.first'),
+      insideFirst = first.get('states.insideFirst'),
+      second = manager.get('states.second');
+
+  equal(first.container, container, 'container should be given to a `create`ed child state');
+  equal(insideFirst.container, container, 'container should be given to a nested child state');
+  equal(second.container, container, 'container should be given to a `extend`ed child state after creation');
+});
+
 module("Ember.State.transitionTo", {
   setup: function(){
     _$ = Ember.$;


### PR DESCRIPTION
This lets StateManagers participate in the container ecosystem more fully.
