### PR TITLE
In StateManager, use instanceof check instead old isState attribute. Thi...

### DIFF
--- a/packages/ember-old-router/tests/helpers/action_test.js
+++ b/packages/ember-old-router/tests/helpers/action_test.js
@@ -92,7 +92,6 @@ test("should by default target the state manager on the controller if it exists"
   view = Ember.View.create({
     controller: Ember.Controller.create({
       target: Ember.Object.create({
-        isState: true,
         send: function(context) {
           sent++;
         }
@@ -291,7 +290,6 @@ test("should be compatible with sending events to a state manager", function() {
   var eventNameCalled,
       eventObjectSent,
       manager = {
-        isState: true,
         send: function(eventName, eventObject) { eventNameCalled = eventName; eventObjectSent = eventObject; }
       };
 

--- a/packages/ember-states/lib/state.js
+++ b/packages/ember-states/lib/state.js
@@ -13,8 +13,6 @@ var get = Ember.get, set = Ember.set;
 */
 Ember.State = Ember.Object.extend(Ember.Evented,
 /** @scope Ember.State.prototype */{
-  isState: true,
-
   /**
     A reference to the parent state.
 
@@ -126,7 +124,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
     if (!value) { return false; }
     var instance;
 
-    if (value.isState) {
+    if (value instanceof Ember.State) {
       set(value, 'name', name);
       instance = value;
       instance.container = this.container;
@@ -137,7 +135,7 @@ Ember.State = Ember.Object.extend(Ember.Evented,
       });
     }
 
-    if (instance && instance.isState) {
+    if (instance instanceof Ember.State) {
       set(instance, 'parentState', this);
       get(this, 'childStates').pushObject(instance);
       states[name] = instance;


### PR DESCRIPTION
In StateManager, use instanceof check instead old isState attribute, which dates to the Sproutcore days. This is potentially breaking, but very unlikely to affect real-world code.

@lukemelia/@stefanpenner
