### PR TITLE
In mid-transition, `modelFor` accepts both camelCase and underscore naming

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -563,14 +563,18 @@ Ember.Route = Ember.Object.extend({
   */
   modelFor: function(name) {
 
+    var route = this.container.lookup('route:' + name),
+        transition = this.router.router.activeTransition;
+
     // If we are mid-transition, we want to try and look up
     // resolved parent contexts on the current transitionEvent.
-    var transition = this.router.router.activeTransition;
     if (transition) {
-      return transition.resolvedModels[name];
+      var modelLookupName = (route && route.routeName) || name;
+      if (transition.resolvedModels.hasOwnProperty(modelLookupName)) {
+        return transition.resolvedModels[modelLookupName];
+      }
     }
 
-    var route = this.container.lookup('route:' + name);
     return route && route.currentModel;
   },
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1121,10 +1121,10 @@ test("using replaceWith calls setURL if location.replaceURL is not defined", fun
 });
 
 test("It is possible to get the model from a parent route", function() {
-  expect(3);
+  expect(6);
 
   Router.map(function() {
-    this.resource("post", { path: "/posts/:post_id" }, function() {
+    this.resource("the_post", { path: "/posts/:post_id" }, function() {
       this.resource("comments");
     });
   });
@@ -1137,7 +1137,7 @@ test("It is possible to get the model from a parent route", function() {
     3: post3
   };
 
-  App.PostRoute = Ember.Route.extend({
+  App.ThePostRoute = Ember.Route.extend({
     model: function(params) {
       return posts[params.post_id];
     }
@@ -1145,7 +1145,9 @@ test("It is possible to get the model from a parent route", function() {
 
   App.CommentsRoute = Ember.Route.extend({
     model: function() {
-      equal(this.modelFor('post'), currentPost);
+      // Allow both underscore / camelCase format.
+      equal(this.modelFor('thePost'), currentPost);
+      equal(this.modelFor('the_post'), currentPost);
     }
   });
 


### PR DESCRIPTION
With facelift router, `modelFor` maintains backwards compatibility
to return a resolved model on a parent route even in mid-transition.
This PR fixes a bug where only the underscore version of a route name
yielded a value in mid transition.
