### PR TITLE
Trigger parentViewDidChange event. Fixes #2423

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1116,6 +1116,8 @@ Ember.View = Ember.CoreView.extend(
   _parentViewDidChange: Ember.observer(function() {
     if (this.isDestroying) { return; }
 
+    this.trigger('parentViewDidChange');
+
     if (get(this, 'parentView.controller') && !get(this, 'controller')) {
       this.notifyPropertyChange('controller');
     }

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -111,6 +111,29 @@ test("should set the parentView property on views that are added to the child vi
   });
 });
 
+test("should trigger parentViewDidChange when parentView is changed", function() {
+  container = Ember.ContainerView.create();
+
+  var secondContainer = Ember.ContainerView.create();
+  var parentViewChanged = 0;
+
+  var View = Ember.View.extend({
+    parentViewDidChange: function() { parentViewChanged++; }
+  });
+
+  view = View.create();
+
+  container.pushObject(view);
+  container.removeChild(view);
+  secondContainer.pushObject(view);
+
+  equal(parentViewChanged, 3);
+
+  Ember.run(function() {
+    secondContainer.destroy();
+  });
+});
+
 test("views that are removed from a ContainerView should have their child views cleared", function() {
   container = Ember.ContainerView.create();
   view = Ember.View.createWithMixins({


### PR DESCRIPTION
This fixes #2423 where `parentViewDidChange` was never fired when a child view was transferred from one `ContainerView` to another.
