### PR TITLE
Update to Handlebars 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
 gem "ember-dev", :git => "https://github.com/emberjs/ember-dev.git", :branch => "master"
+gem "handlebars-source", :git => "https://github.com/wycats/handlebars.js.git", :tag => "v1.0.12"
 
 # Require the specific version of handlebars-source that
 # we'll be precompiling and performing tests with.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,11 +23,18 @@ GIT
       rake (~> 10.0.0)
       thor
 
+GIT
+  remote: https://github.com/wycats/handlebars.js.git
+  revision: 1585f917498f47263f3cd6dc4343ac377e93ad22
+  tag: v1.0.12
+  specs:
+    handlebars-source (1.0.12)
+
 PATH
   remote: .
   specs:
     ember-source (1.0.0.rc5)
-      handlebars-source (= 1.0.0.rc4)
+      handlebars-source (= 1.0.12)
 
 GEM
   remote: https://rubygems.org/
@@ -45,7 +52,6 @@ GEM
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
-    handlebars-source (1.0.0.rc4)
     json (1.8.0)
     kicker (2.6.1)
       listen
@@ -79,4 +85,5 @@ PLATFORMS
 DEPENDENCIES
   ember-dev!
   ember-source!
+  handlebars-source!
   rake-pipeline!

--- a/ember-source.gemspec
+++ b/ember-source.gemspec
@@ -12,9 +12,7 @@ Gem::Specification.new do |gem|
 
   gem.version       = Ember.rubygems_version_string
 
-  # Note: can't use the squiggly ~> operator the way we'd expect
-  # so long as we're referencing pre-release versions.
-  gem.add_dependency "handlebars-source", ["1.0.0.rc4"]
+  gem.add_dependency "handlebars-source", ["1.0.12"]
 
   gem.files = %w(VERSION) + Dir['dist/*.js', 'lib/ember/*.rb']
 end

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -15,8 +15,8 @@ if(!Handlebars && typeof require === 'function') {
   Handlebars = require('handlebars');
 }
 
-Ember.assert("Ember Handlebars requires Handlebars version 1.0.0-rc.4. Include a SCRIPT tag in the HTML HEAD linking to the Handlebars file before you link to Ember.", Handlebars)
-Ember.assert("Ember Handlebars requires Handlebars version 1.0.0-rc.4, COMPILER_REVISION expected: 3, got: " +  Handlebars.COMPILER_REVISION + " – Please note: Builds of master may have other COMPILER_REVISION values.", Handlebars.COMPILER_REVISION === 3);
+Ember.assert("Ember Handlebars requires Handlebars version 1.0.0. Include a SCRIPT tag in the HTML HEAD linking to the Handlebars file before you link to Ember.", Handlebars)
+Ember.assert("Ember Handlebars requires Handlebars version 1.0.0, COMPILER_REVISION expected: 4, got: " +  Handlebars.COMPILER_REVISION + " – Please note: Builds of master may have other COMPILER_REVISION values.", Handlebars.COMPILER_REVISION === 4);
 
 /**
   Prepares the Handlebars templating library for use inside Ember's view
@@ -192,7 +192,7 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
   } else if (mustache.params.length || mustache.hash) {
     // no changes required
   } else {
-    var id = new Handlebars.AST.IdNode(['_triageMustache']);
+    var id = new Handlebars.AST.IdNode([{ part: '_triageMustache' }]);
 
     // Update the mustache node to include a hash value indicating whether the original node
     // was escaped. This will allow us to properly escape values when the underlying value

--- a/packages/ember-handlebars/tests/helpers/partial_test.js
+++ b/packages/ember-handlebars/tests/helpers/partial_test.js
@@ -49,7 +49,7 @@ test("should render other slash-separated templates registered with the containe
 });
 
 test("should use the current view's context", function(){
-  container.register('template:_person_name', Ember.Handlebars.compile("{{{firstName}} {{lastName}}"));
+  container.register('template:_person_name', Ember.Handlebars.compile("{{firstName}} {{lastName}}"));
 
   view = Ember.View.create({
     container: container,

--- a/packages/ember-handlebars/tests/helpers/template_test.js
+++ b/packages/ember-handlebars/tests/helpers/template_test.js
@@ -34,7 +34,7 @@ test("should render other templates via the container", function() {
 });
 
 test("should use the current view's context", function(){
-  container.register('template:person_name', Ember.Handlebars.compile("{{{firstName}} {{lastName}}"));
+  container.register('template:person_name', Ember.Handlebars.compile("{{firstName}} {{lastName}}"));
 
   view = Ember.View.create({
     container: container,


### PR DESCRIPTION
This updates Ember's Handlebars dependency to 1.0.0.

I had to use a git gem dependency because the handlebars-source gem hasn't been updated yet: https://github.com/wycats/handlebars.js/issues/548.
