### PR TITLE
Refactored promises usage:

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -67,8 +67,8 @@ function fillIn(app, selector, context, text) {
   }
   $el = findWithAssert(app, selector, context);
   Ember.run(function() {
-    $el.val(text).change();
   });
+    $el.val(text).change();
   return wait(app);
 }
 
@@ -86,6 +86,10 @@ function find(app, selector, context) {
   $el = app.$(selector, context);
 
   return $el;
+}
+
+function andThen(app, callback) {
+  return wait(app, callback(app));
 }
 
 function wait(app, value) {
@@ -231,3 +235,4 @@ helper('find', find);
 */
 helper('findWithAssert', findWithAssert);
 helper('wait', wait);
+helper('andThen', andThen);

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -159,6 +159,8 @@ Ember.Application.reopen({
     for(var i = 0, l = injectHelpersCallbacks.length; i < l; i++) {
       injectHelpersCallbacks[i](this);
     }
+
+    Ember.RSVP.configure('onerror', onerror);
   },
 
   removeTestHelpers: function() {
@@ -167,7 +169,9 @@ Ember.Application.reopen({
       delete this.testHelpers[name];
       delete originalMethods[name];
     }
+    Ember.RSVP.configure('onerror', null);
   }
+
 });
 
 function protoWrap(proto, name, callback) {
@@ -187,7 +191,6 @@ Ember.Test.Promise.prototype = Ember.create(Ember.RSVP.Promise.prototype);
 Ember.Test.Promise.prototype.constructor = Ember.Test.Promise;
 
 
-Ember.RSVP.configure('onerror', function(error) {
+function onerror(error) {
   Ember.Test.adapter.exception(error);
-});
-
+}

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -36,7 +36,6 @@ Ember.Test = {
       App.injectTestHelpers();
       boot();
     ```
-
     Whenever you register a helper that
     performs async operations,
     make sure you `return wait();` at the
@@ -46,12 +45,30 @@ Ember.Test = {
     pass it to the `wait` helper as a first argument:
     `return wait(val);`
 
+    If a helper is not async and needs to return
+    a value immediately (such as `find`), pass
+    `{ wait: false }` as an option parameter.
+    ```javascript
+    Ember.Test.registerHelper('findPost', function() {
+      return find('.post');
+    }, { wait: false });
+
+    ```
+
     @method registerHelper
     @param name {String}
     @param helperMethod {Function}
+    @param options {Object}
   */
-  registerHelper: function(name, helperMethod) {
-    helpers[name] = helperMethod;
+  registerHelper: function(name, helperMethod, meta) {
+    meta = meta || {};
+    if (meta.wait === undefined) {
+      meta.wait = true;
+    }
+    helpers[name] = {
+      method: helperMethod,
+      meta: meta
+    };
   },
   /**
     @public
@@ -103,6 +120,15 @@ Ember.Test = {
   },
 
   /**
+   Contains the last created
+   Ember.Test.Promise
+   The next helper will wait
+   for it to resolve before executing.
+
+  */
+  lastPromise: null,
+
+  /**
    @public
 
    Used to allow ember-testing
@@ -121,12 +147,47 @@ Ember.Test = {
   adapter: null
 };
 
-function curry(app, fn) {
+function helper(app, name) {
+  var fn = helpers[name].method,
+      meta = helpers[name].meta;
+
   return function() {
-    var args = slice.call(arguments);
+    var args = slice.call(arguments),
+        wait = app.testHelpers.wait,
+        lastPromise = Ember.Test.lastPromise;
+
     args.unshift(app);
-    return fn.apply(app, args);
+
+    // some helpers are not async and
+    // need to return a value immediately.
+    // example: `find`
+    if (!meta.wait) {
+      return fn.apply(app, args);
+    }
+
+    if (!lastPromise) {
+      // It's the first async helper in current context
+      lastPromise = fn.apply(app, args);
+    } else {
+      // wait for last helper's promise to resolve
+      // and then execute
+      run(function() {
+        lastPromise = lastPromise.then(function() {
+          return fn.apply(app, args);
+        });
+      });
+    }
+
+    return lastPromise;
   };
+}
+
+function run(fn) {
+  if (!Ember.run.currentRunLoop) {
+    Ember.run(fn);
+  } else {
+    fn();
+  }
 }
 
 Ember.Application.reopen({
@@ -141,7 +202,7 @@ Ember.Application.reopen({
       location: 'none'
     });
 
-   // if adapter is not manually set
+    // if adapter is not manually set
     // default to QUnit
     if (!Ember.Test.adapter) {
        Ember.Test.adapter = Ember.Test.QUnitAdapter.create();
@@ -152,8 +213,8 @@ Ember.Application.reopen({
     this.testHelpers = {};
     for (var name in helpers) {
       originalMethods[name] = window[name];
-      this.testHelpers[name] = window[name] = curry(this, helpers[name]);
-      protoWrap(Ember.Test.Promise.prototype, name, curry(this, helpers[name]));
+      this.testHelpers[name] = window[name] = helper(this, name);
+      protoWrap(Ember.Test.Promise.prototype, name, helper(this, name));
     }
 
     for(var i = 0, l = injectHelpersCallbacks.length; i < l; i++) {
@@ -174,22 +235,67 @@ Ember.Application.reopen({
 
 });
 
+// This method is no longer needed
+// But still here for backwards compatibility
 function protoWrap(proto, name, callback) {
   proto[name] = function() {
     var args = arguments;
-    return this.then(function() {
-      callback.apply(this, args);
-    });
+    return callback.apply(this, args);
   };
 }
 
 Ember.Test.Promise = function() {
   Ember.RSVP.Promise.apply(this, arguments);
+  Ember.Test.lastPromise = this;
 };
 
 Ember.Test.Promise.prototype = Ember.create(Ember.RSVP.Promise.prototype);
 Ember.Test.Promise.prototype.constructor = Ember.Test.Promise;
 
+// Patch `then` to isolate async methods
+// specifically `Ember.Test.lastPromise`
+var originalThen = Ember.RSVP.Promise.prototype.then;
+Ember.Test.Promise.prototype.then = function(onSuccess, onFailure) {
+  return originalThen.call(this, function(val) {
+    return isolate(onSuccess, val);
+  }, onFailure);
+};
+
+// This method isolates nested async methods
+// so that they don't conflict with other last promises.
+//
+// 1. Set `Ember.Test.lastPromise` to null
+// 2. Invoke method
+// 3. Return the last promise created during method
+// 4. Restore `Ember.Test.lastPromise` to original value
+function isolate(fn, val) {
+  var value, lastPromise,
+      prevPromise = Ember.Test.lastPromise;
+
+  // Reset lastPromise for nested helpers
+  Ember.Test.lastPromise = null;
+
+  value = fn.call(null, val);
+
+  lastPromise = Ember.Test.lastPromise;
+
+  // If the method returned a promise
+  // return that promise. If not,
+  // return the last async helper's promise
+  if ((value && value.then) || !lastPromise) {
+    return value;
+  } else {
+    run(function() {
+      lastPromise = lastPromise.then(function() {
+        return value;
+      });
+    });
+    return lastPromise;
+  }
+
+  // Reset last promise to what it was before the isolation
+  Ember.Test.lastPromise = prevPromise;
+}
 
 function onerror(error) {
   Ember.Test.adapter.exception(error);

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -64,6 +64,7 @@ Ember.Test = {
       window[name] = originalMethods[name];
     }
     delete originalMethods[name];
+    delete Ember.Test.Promise.prototype[name];
   },
 
   /**
@@ -98,30 +99,7 @@ Ember.Test = {
     @param resolver {Function}
   */
   promise: function(resolver) {
-    var promise = new Ember.RSVP.Promise(resolver);
-    var thenable = {
-      chained: false
-    };
-    thenable.then = function(onSuccess, onFailure) {
-      var thenPromise, nextPromise;
-      thenable.chained = true;
-      thenPromise = promise.then(onSuccess, onFailure);
-      // this is to ensure all downstream fulfillment
-      // handlers are wrapped in the error handling
-      nextPromise = Ember.Test.promise(function(resolve) {
-        resolve(thenPromise);
-      });
-      thenPromise.then(null, function(reason) {
-        // ensure this is the last promise in the chain
-        // if not, ignore and the exception will propagate
-        // this prevents the same error from being fired multiple times
-        if (!nextPromise.chained) {
-          Ember.Test.adapter.exception(reason);
-        }
-      });
-      return nextPromise;
-    };
-    return thenable;
+    return new Ember.Test.Promise(resolver);
   },
 
   /**
@@ -175,6 +153,7 @@ Ember.Application.reopen({
     for (var name in helpers) {
       originalMethods[name] = window[name];
       this.testHelpers[name] = window[name] = curry(this, helpers[name]);
+      protoWrap(Ember.Test.Promise.prototype, name, curry(this, helpers[name]));
     }
 
     for(var i = 0, l = injectHelpersCallbacks.length; i < l; i++) {
@@ -190,3 +169,25 @@ Ember.Application.reopen({
     }
   }
 });
+
+function protoWrap(proto, name, callback) {
+  proto[name] = function() {
+    var args = arguments;
+    return this.then(function() {
+      callback.apply(this, args);
+    });
+  };
+}
+
+Ember.Test.Promise = function() {
+  Ember.RSVP.Promise.apply(this, arguments);
+};
+
+Ember.Test.Promise.prototype = Ember.create(Ember.RSVP.Promise.prototype);
+Ember.Test.Promise.prototype.constructor = Ember.Test.Promise;
+
+
+Ember.RSVP.configure('onerror', function(error) {
+  Ember.Test.adapter.exception(error);
+});
+

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -1,4 +1,4 @@
-var App, find, click, fillIn, currentRoute, visit, originalAdapter;
+var App, find, click, fillIn, currentRoute, visit, originalAdapter, andThen;
 
 module("ember-testing Acceptance", {
   setup: function() {
@@ -50,6 +50,7 @@ module("ember-testing Acceptance", {
     click = window.click;
     fillIn = window.fillIn;
     visit = window.visit;
+    andThen = window.andThen;
 
     originalAdapter = Ember.Test.adapter;
   },
@@ -95,6 +96,8 @@ test("helpers can be chained with then", function() {
 
 
 
+// Keep this for backwards compatibility
+
 test("helpers can be chained to each other", function() {
   expect(4);
 
@@ -104,7 +107,7 @@ test("helpers can be chained to each other", function() {
   .click('a:first', '#comments-link')
   .fillIn('.ember-text-field', "hello")
   .then(function() {
-    equal(currentRoute, 'comments', "Successfully visited posts route");
+    equal(currentRoute, 'comments', "Successfully visited comments route");
     equal(Ember.$('.ember-text-field').val(), 'hello', "Fillin successfully works");
     find('.ember-text-field').one('keypress', function(e) {
       equal(e.keyCode, 13, "keyevent chained with correct keyCode.");
@@ -114,5 +117,78 @@ test("helpers can be chained to each other", function() {
   .visit('/posts')
   .then(function() {
     equal(currentRoute, 'posts', "Thens can also be chained to helpers");
+  });
+});
+
+test("helpers don't need to be chained", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts');
+
+  click('a:first', '#comments-link');
+
+  fillIn('.ember-text-field', "hello");
+
+  andThen(function() {
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  });
+
+  visit('/posts');
+
+  andThen(function() {
+    equal(currentRoute, 'posts');
+  });
+});
+
+test("Nested async helpers", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts');
+
+  andThen(function() {
+    click('a:first', '#comments-link');
+
+    fillIn('.ember-text-field', "hello");
+  });
+
+  andThen(function() {
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  });
+
+  visit('/posts');
+
+  andThen(function() {
+    equal(currentRoute, 'posts');
+  });
+});
+
+test("Helpers nested in thens", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts').then(function() {
+    click('a:first', '#comments-link');
+  });
+
+  andThen(function() {
+    fillIn('.ember-text-field', "hello");
+  });
+
+  andThen(function() {
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  });
+
+  visit('/posts');
+
+  andThen(function() {
+    equal(currentRoute, 'posts');
   });
 });

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -100,7 +100,8 @@ test("helpers can be chained to each other", function() {
 
   currentRoute = 'index';
 
-  visit('/posts').click('a:first', '#comments-link')
+  visit('/posts')
+  .click('a:first', '#comments-link')
   .fillIn('.ember-text-field', "hello")
   .then(function() {
     equal(currentRoute, 'comments', "Successfully visited posts route");

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -46,7 +46,7 @@ test("QUnitAdapter is used by default", function() {
 });
 
 test("Concurrent wait calls are supported", function() {
-  expect(4);
+  expect(2);
 
   var originalAdapter = Ember.Test.adapter,
       CustomAdapter,
@@ -78,14 +78,12 @@ test("Concurrent wait calls are supported", function() {
 
   Ember.run(App, App.advanceReadiness);
 
-  wait().then(function() {
-    equal(asyncStartCalled, 1, "asyncStart was called once");
-    equal(asyncEndCalled, 0, "asyncEnd hasn't been called yet");
-  });
-  wait().then(function() {
-    equal(asyncStartCalled, 1, "asyncStart was called once");
-    equal(asyncEndCalled, 1, "asyncEnd was called once");
+  var task1 = wait();
+  var task2 = wait();
+
+  Ember.RSVP.all([task1, task2]).then(function(){
+    equal(asyncStartCalled, 2);
+    equal(asyncEndCalled,   2);
     Ember.Test.adapter = originalAdapter;
   });
-
 });


### PR DESCRIPTION
1) Used a Promise subclass instead of patching and wrapping all the time
2) Updated RSVP to fix a subclassing bug
3) Updated RSVP to support a unified onerror callback that can be used
   instead of patching the `.then` on promises.

@stefanpenner @kselden @hjdivad please review :+1: 
