### PR TITLE
Redirect preserves resolved models from active transition

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -343,15 +343,16 @@ define("router",
      */
     function getMatchPoint(router, handlers, objects, inputParams) {
 
-      var objectsToMatch = objects.length, 
-          matchPoint = handlers.length, 
+      var matchPoint = handlers.length, 
           providedModels = {}, i,
           currentHandlerInfos = router.currentHandlerInfos || [],
           params = {},
           oldParams = router.currentParams || {},
           activeTransition = router.activeTransition,
-          handlerParams = {};
+          handlerParams = {},
+          obj;
 
+      objects = slice.call(objects);
       merge(params, inputParams);
    
       for (i = handlers.length - 1; i >= 0; i--) {
@@ -366,9 +367,9 @@ define("router",
         if (handlerObj.isDynamic) {
           // URL transition.
 
-          if (objectsToMatch > 0) {
+          if (obj = getMatchPointObject(objects, handlerName, activeTransition, true)) {
             hasChanged = true;
-            providedModels[handlerName] = objects[--objectsToMatch];
+            providedModels[handlerName] = obj;
           } else {
             handlerParams[handlerName] = {};
             for (var prop in handlerObj.params) {
@@ -378,18 +379,12 @@ define("router",
               handlerParams[handlerName][prop] = params[prop] = newParam;
             }
           }
-        } else if (handlerObj.hasOwnProperty('names') && handlerObj.names.length) {
+        } else if (handlerObj.hasOwnProperty('names')) {
           // Named transition.
 
-          if (objectsToMatch > 0) {
+          if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names.length)) {
             hasChanged = true;
-            providedModels[handlerName] = objects[--objectsToMatch];
-          } else if (activeTransition && activeTransition.providedModels[handlerName]) {
-
-            // Use model from previous transition attempt, preferably the resolved one.
-            hasChanged = true;
-            providedModels[handlerName] = activeTransition.providedModels[handlerName] ||
-                                          activeTransition.resolvedModels[handlerName];
+            providedModels[handlerName] = obj;
           } else {
             var names = handlerObj.names;
             handlerParams[handlerName] = {};
@@ -403,11 +398,21 @@ define("router",
         if (hasChanged) { matchPoint = i; }
       }
 
-      if (objectsToMatch > 0) {
+      if (objects.length > 0) {
         throw "More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler;
       }
 
       return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+    }
+
+    function getMatchPointObject(objects, handlerName, activeTransition, canUseProvidedObject) {
+      if (objects.length && canUseProvidedObject) {
+        return objects.pop();
+      } else if (activeTransition) {
+        // Use model from previous transition attempt, preferably the resolved one.
+        return (canUseProvidedObject && activeTransition.providedModels[handlerName]) ||
+               activeTransition.resolvedModels[handlerName];
+      } 
     }
 
     /**
@@ -882,15 +887,14 @@ define("router",
           handler = handlerInfo.handler,
           handlerName = handlerInfo.name,
           seq = transition.sequence,
-          errorAlreadyHandled = false,
-          resolvedModel;
+          errorAlreadyHandled = false;
 
       if (index < matchPoint) {
         log(router, seq, handlerName + ": using context from already-active handler");
 
         // We're before the match point, so don't run any hooks,
         // just use the already resolved context from the handler.
-        resolvedModel = handlerInfo.handler.context;
+        transition.resolvedModels[handlerInfo.name] = handlerInfo.handler.context;
         return proceed();
       }
 
@@ -930,8 +934,8 @@ define("router",
         trigger(handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
 
         if (handler.error) { 
-          handler.error(reason, transition); }
-
+          handler.error(reason, transition); 
+        }
 
         // Propagate the original error.
         return RSVP.reject(reason);
@@ -958,14 +962,14 @@ define("router",
         // want to use the value returned from `afterModel` in any way, but rather
         // always resolve with the original `context` object.
 
-        resolvedModel = context;
-        return handler.afterModel && handler.afterModel(resolvedModel, transition);
+        transition.resolvedModels[handlerInfo.name] = context;
+        return handler.afterModel && handler.afterModel(context, transition);
       }
 
       function proceed() {
         log(router, seq, handlerName + ": validation succeeded, proceeding");
 
-        handlerInfo.context = transition.resolvedModels[handlerInfo.name] = resolvedModel;
+        handlerInfo.context = transition.resolvedModels[handlerInfo.name];
         return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
       }
     }
@@ -997,7 +1001,7 @@ define("router",
         return handler.context;
       }
 
-      if (handlerInfo.isDynamic && transition.providedModels.hasOwnProperty(handlerName)) {
+      if (transition.providedModels.hasOwnProperty(handlerName)) {
         var providedModel = transition.providedModels[handlerName];
         return typeof providedModel === 'function' ? providedModel() : providedModel;
       }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2065,4 +2065,36 @@ test("Route should tear down multiple outlets.", function() {
    
 });
 
+test("Internal redirects do not call model hook of parent route", function() {
 
+  var modelCalled = 0;
+
+  Router.map(function() {
+    this.resource('post', function() {
+      this.route('index', { path: '/' });
+      this.route('new');
+    });
+  });
+
+  App.PostRoute = Ember.Route.extend({
+    model: function() {
+      modelCalled++;
+      return { title: 'Hello world' };
+    }
+  });
+
+  App.PostIndexRoute = Ember.Route.extend({
+    redirect: function() {
+      this.transitionTo('post.new');
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/post");
+  });
+
+  equal(modelCalled, 1, "model hook was called only once");
+
+});


### PR DESCRIPTION
Closes #2874.

Merges in latest router.js, in particular
https://github.com/tildeio/router.js/pull/27

This restores pre-facelift behavior where a redirect on a dynamic route
to another child route will 'soak up' the resolved model and
not require that it be passed as a context object in the
redirecting `transitionTo`.

Thanks to @teddyzeenny for the failing test case.

Also, this allows `afterModel` to swap out the resolved model
of the present route by setting
`transition.resolvedModels[routeName]`. The use case is not
super common afaik, so this approach is better than making it
so that the return value of `afterModel` replaces the resolved
model that'll end up getting passed to the controller.

/cc @ghempton and @ebryn
