### PR TITLE
Polyfill history.state for non-supporting browsers

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -5,9 +5,7 @@
 
 var get = Ember.get, set = Ember.set;
 var popstateFired = false;
-var supportsHistoryState = (function(){
-  return !!(window.history && history.hasOwnProperty('state'));
-})();
+var supportsHistoryState = window.history && 'state' in window.history;
 
 /**
   Ember.HistoryLocation implements the location API using the browser's


### PR DESCRIPTION
When using HistoryLocation, the url is not properly updated in browsers that don't support history.state (Safari 5, Mobile Safari iOS5, various Android).

Fixes #2365, #2551
