### PR TITLE
Added `mergedProperties` to ember-metal, Ember.Route's `events`

### DIFF
--- a/packages/ember-metal/tests/mixin/mergedProperties_test.js
+++ b/packages/ember-metal/tests/mixin/mergedProperties_test.js
@@ -1,0 +1,124 @@
+/*globals setup */
+
+module('Ember.Mixin mergedProperties');
+
+test('defining mergedProperties should merge future version', function() {
+
+  var MixinA = Ember.Mixin.create({
+    mergedProperties: ['foo'],
+    foo: { a: true, b: true, c: true }
+  });
+
+  var MixinB = Ember.Mixin.create({
+    foo: { d: true, e: true, f: true }
+  });
+
+  var obj = Ember.mixin({}, MixinA, MixinB);
+  deepEqual(Ember.get(obj, 'foo'), 
+    { a: true, b: true, c: true, d: true, e: true, f: true });
+});
+
+test('defining mergedProperties on future mixin should merged into past', function() {
+
+  var MixinA = Ember.Mixin.create({
+    foo: { a: true, b: true, c: true }
+  });
+
+  var MixinB = Ember.Mixin.create({
+    mergedProperties: ['foo'],
+    foo: { d: true, e: true, f: true }
+  });
+
+  var obj = Ember.mixin({}, MixinA, MixinB);
+  deepEqual(Ember.get(obj, 'foo'), 
+    { a: true, b: true, c: true, d: true, e: true, f: true });
+});
+
+test('defining mergedProperties with null properties should keep properties null', function() {
+
+  var MixinA = Ember.Mixin.create({
+    mergedProperties: ['foo'],
+    foo: null
+  });
+
+  var MixinB = Ember.Mixin.create({
+    foo: null
+  });
+
+  var obj = Ember.mixin({}, MixinA, MixinB);
+  equal(Ember.get(obj, 'foo'), null);
+});
+
+test("mergedProperties' properties can get overwritten", function() {
+
+  var MixinA = Ember.Mixin.create({
+    mergedProperties: ['foo'],
+    foo: { a: 1 }
+  });
+
+  var MixinB = Ember.Mixin.create({
+    foo: { a: 2 }
+  });
+
+  var obj = Ember.mixin({}, MixinA, MixinB);
+  deepEqual(Ember.get(obj, 'foo'), { a: 2 });
+});
+
+test('mergedProperties should be concatenated', function() {
+
+  var MixinA = Ember.Mixin.create({
+    mergedProperties: ['foo'],
+    foo: { a: true, b: true, c: true }
+  });
+
+  var MixinB = Ember.Mixin.create({
+    mergedProperties: 'bar',
+    foo: { d: true, e: true, f: true },
+    bar: { a: true, l: true }
+  });
+
+  var MixinC = Ember.Mixin.create({
+    bar: { e: true, x: true }
+  });
+
+  var obj = Ember.mixin({}, MixinA, MixinB, MixinC);
+  deepEqual(Ember.get(obj, 'mergedProperties'), ['foo', 'bar'], 'get mergedProperties');
+  deepEqual(Ember.get(obj, 'foo'), { a: true, b: true, c: true, d: true, e: true, f: true }, "get foo");
+  deepEqual(Ember.get(obj, 'bar'), { a: true, l: true, e: true, x: true }, "get bar");
+});
+
+test("mergedProperties' overwriting methods can call _super", function() {
+
+  expect(4);
+
+  var MixinA = Ember.Mixin.create({
+    mergedProperties: ['foo'],
+    foo: {
+      meth: function(a) {
+        equal(a, "WOOT", "_super successfully called MixinA's `foo.meth` method");
+        return "WAT";
+      }
+    }
+  });
+
+  var MixinB = Ember.Mixin.create({
+    foo: {
+      meth: function(a) {
+        ok(true, "MixinB's `foo.meth` method called");
+        return this._super.apply(this, arguments);
+      }
+    }
+  });
+
+  var MixinC = Ember.Mixin.create({
+    foo: {
+      meth: function(a) {
+        ok(true, "MixinC's `foo.meth` method called");
+        return this._super(a);
+      }
+    }
+  });
+
+  var obj = Ember.mixin({}, MixinA, MixinB, MixinC);
+  equal(obj.foo.meth("WOOT"), "WAT");
+});

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -45,9 +45,42 @@ Ember.Route = Ember.Object.extend({
     from within a template and the application's current route is this route.
 
     Events can also be invoked from other parts of your application via `Route#send`
-    or `Controller#send`.
+    or `Controller#send`. 
 
-    The context of the event will be this route.
+    The `events` hash will inherit event handlers from
+    the `events` hash defined on extended Route parent classes
+    or mixins rather than just replace the entire hash, e.g.:
+
+    ```js
+    App.CanDisplayBanner = Ember.Mixin.create({
+      events: {
+        displayBanner: function(msg) {
+          // ...
+        }
+      }
+    });
+
+    App.WelcomeRoute = Ember.Route.extend(App.CanDisplayBanner, {
+      events: {
+        playMusic: function() {
+          // ...
+        }
+      }
+    });
+
+    // `WelcomeRoute`, when active, will be able to respond
+    // to both events, since the events hash is merged rather
+    // then replaced when extending mixins / parent classes.
+    this.send('displayBanner');
+    this.send('playMusic');
+    ```
+
+    It is also possible to call `this._super()` from within an
+    event handler if it overrides a handle defined on a parent
+    class or mixin.
+
+    Within a route's event handler, the value of the `this` context 
+    is the Route object.
 
     ## Bubbling
 
@@ -155,6 +188,8 @@ Ember.Route = Ember.Object.extend({
     @default null
   */
   events: null,
+
+  mergedProperties: ['events'],
 
   /**
     This hook is executed when the router completely exits this route. It is

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2140,7 +2140,6 @@ test("Route supports clearing outlet explicitly", function() {
   equal(Ember.$('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 0, "The posts/extra template was removed");
 });
 
-
 test("Aborting/redirecting the transition in `willTransition` prevents LoadingRoute from being entered", function() {
 
   expect(8);
@@ -2209,5 +2208,44 @@ test("Aborting/redirecting the transition in `willTransition` prevents LoadingRo
   deferred = Ember.RSVP.defer();
   Ember.run(router, 'transitionTo', 'nork');
   Ember.run(deferred.resolve);
+});
+
+test("Events can be handled by inherited event handlers", function() {
+
+  expect(4);
+
+  App.SuperRoute = Ember.Route.extend({
+    events: {
+      foo: function() {
+        ok(true, 'foo');
+      },
+      bar: function(msg) {
+        equal(msg, "HELLO");
+      }
+    }
+  });
+
+  App.RouteMixin = Ember.Mixin.create({
+    events: {
+      bar: function(msg) {
+        equal(msg, "HELLO");
+        this._super(msg);
+      }
+    }
+  });
+
+  App.IndexRoute = App.SuperRoute.extend(App.RouteMixin, {
+    events: {
+      baz: function() {
+        ok(true, 'baz');
+      }
+    }
+  });
+
+  bootApplication();
+
+  router.send("foo");
+  router.send("bar", "HELLO");
+  router.send("baz");
 });
 


### PR DESCRIPTION
/cc @lukemelia, @kselden

Added `mergedProperties`, the object-merging sibling of
`concatenatedProperties`. Properties specified in the
`mergedProperties` array will not overwrite but rather
merge into such properties defined in extended parent
classes or mixins.

Also added it to the `events` hash in `Ember.Route`,
which is its most useful application at present.Will add it to
Controllers per #2884 in a separate PR once
this is merged.
