### PR TITLE
Quoteless route param in linkTo performs lookup

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -365,7 +365,7 @@ function evaluateMultiPropertyBoundHelper(context, fn, normalizedProperties, opt
 
   view.appendChild(bindView);
 
-  // Assemble liast of watched properties that'll re-render this helper.
+  // Assemble list of watched properties that'll re-render this helper.
   watchedProperties = [];
   for (boundOption in boundOptions) {
     if (boundOptions.hasOwnProperty(boundOption)) {


### PR DESCRIPTION
See: http://discuss.emberjs.com/t/upcoming-linkto-changes-ideas/1635

New behavior is wrapped in ENV.HELPER_PARAM_LOOKUPS flag,
named that way since the behavior will likely be applied to
actions as well.

Closes #2462 
