### PR TITLE
Make ember-testing click() more robust

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -31,7 +31,18 @@ function visit(app, url) {
 
 function click(app, selector, context) {
   var $el = findWithAssert(app, selector, context);
+  Ember.run($el, 'mousedown');
+
+  if ($el.is(':input')) {
+    var type = $el.prop('type');
+    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
+      Ember.run($el, 'focus');
+    }
+  }
+
+  Ember.run($el, 'mouseup');
   Ember.run($el, 'click');
+
   return wait(app);
 }
 

--- a/packages/ember-testing/lib/main.js
+++ b/packages/ember-testing/lib/main.js
@@ -1,4 +1,5 @@
 require('ember-application');
 require('ember-testing/test');
+require('ember-testing/support');
 require('ember-testing/adapters');
 require('ember-testing/helpers');

--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -1,0 +1,40 @@
+/**
+ * @module ember
+ * @sub-module ember-testing
+ */
+
+var $ = Ember.$;
+
+/**
+ * Determine whether a checkbox checked using jQuery's "click" method will have
+ * the correct value for its checked property. In some old versions of jQuery
+ * (e.g. 1.8.3) this does not behave correctly.
+ *
+ * If we determine that the current jQuery version exhibits this behavior,
+ * patch it to work correctly as in the commit for the actual fix:
+ * https://github.com/jquery/jquery/commit/1fb2f92.
+ */
+$('<input type="checkbox">')
+  .on('click', function() {
+    if (!this.checked && !$.event.special.click) {
+      $.event.special.click = {
+        // For checkbox, fire native event so checked state will be right
+        trigger: function() {
+          if ( $.nodeName( this, "input" ) && this.type === "checkbox" && this.click ) {
+            this.click();
+            return false;
+          }
+        }
+      };
+    }
+  })
+  .click();
+
+/**
+ * Try again to verify that the patch took effect or blow up.
+ */
+$('<input type="checkbox">')
+  .on('click', function() {
+    Ember.assert("clicked checkboxes should be checked! the jQuery patch didn't work", this.checked);
+  })
+  .click();


### PR DESCRIPTION
The current ember-testing `click()` helper only fires the `click` event on the given element. When a real click happens several other events might be fired depending on the type of element. This PR updates the `click()` helper to be a bit more realistic.
