### PR TITLE
router.js++: transitionTo/linkTo parameterize strings/numbers

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -229,7 +229,7 @@ define("router",
         @param {String} url a URL to update to
       */
       updateURL: function() {
-        throw "updateURL is not implemented";
+        throw new Error("updateURL is not implemented");
       },
 
       /**
@@ -367,7 +367,7 @@ define("router",
         if (handlerObj.isDynamic) {
           // URL transition.
 
-          if (obj = getMatchPointObject(objects, handlerName, activeTransition, true)) {
+          if (obj = getMatchPointObject(objects, handlerName, activeTransition, true, params)) {
             hasChanged = true;
             providedModels[handlerName] = obj;
           } else {
@@ -382,15 +382,16 @@ define("router",
         } else if (handlerObj.hasOwnProperty('names')) {
           // Named transition.
 
-          if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names.length)) {
-            hasChanged = true;
+          if (objects.length) { hasChanged = true; }
+
+          if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names[0], params)) {
             providedModels[handlerName] = obj;
           } else {
             var names = handlerObj.names;
             handlerParams[handlerName] = {};
             for (var j = 0, len = names.length; j < len; ++j) {
               var name = names[j];
-              handlerParams[handlerName][name] = params[name] = oldParams[name] || params[name];
+              handlerParams[handlerName][name] = params[name] = params[name] || oldParams[name];
             }
           }
         } 
@@ -399,20 +400,33 @@ define("router",
       }
 
       if (objects.length > 0) {
-        throw "More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler;
+        throw new Error("More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler);
       }
 
       return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
     }
 
-    function getMatchPointObject(objects, handlerName, activeTransition, canUseProvidedObject) {
-      if (objects.length && canUseProvidedObject) {
-        return objects.pop();
+    function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
+
+      if (objects.length && paramName) {
+
+        var object = objects.pop();
+
+        // If provided object is string or number, treat as param.
+        if (isParam(object)) {
+          params[paramName] = object.toString();
+        } else {
+          return object;
+        }
       } else if (activeTransition) {
         // Use model from previous transition attempt, preferably the resolved one.
-        return (canUseProvidedObject && activeTransition.providedModels[handlerName]) ||
+        return (paramName && activeTransition.providedModels[handlerName]) ||
                activeTransition.resolvedModels[handlerName];
       } 
+    }
+
+    function isParam(object) {
+      return object && (typeof object === "string" || object instanceof String || !isNaN(object));
     }
 
     /**
@@ -1060,6 +1074,12 @@ define("router",
     */
     function serialize(handler, model, names) {
 
+      var object = {};
+      if (isParam(model)) {
+        object[names[0]] = model;
+        return object;
+      }
+
       // Use custom serialize if it exists.
       if (handler.serialize) {
         return handler.serialize(model, names);
@@ -1067,7 +1087,7 @@ define("router",
 
       if (names.length !== 1) { return; }
 
-      var name = names[0], object = {};
+      var name = names[0];
 
       if (/_id$/.test(name)) {
         object[name] = model.id;

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -419,12 +419,19 @@ test("The {{linkTo}} helper binds some anchor html tag common attributes", funct
   equal(Ember.$('#self-link', '#qunit-fixture').attr('title'), 'title-attr', "The self-link contains title attribute");
 });
 
-test("The {{linkTo}} helper accepts string arguments", function() {
+test("The {{linkTo}} helper accepts string/numeric arguments", function() {
   Router.map(function() {
     this.route('filter', { path: '/filters/:filter' });
+    this.route('post',   { path: '/post/:post_id' });
   });
 
-  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>{{#linkTo "filter" "unpopular" id="link"}}Unpopular{{/linkTo}}');
+  App.FilterController = Ember.Controller.extend({
+    filter: "unpopular",
+    post_id: 123
+  });
+
+  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>{{#linkTo "filter" "unpopular" id="link"}}Unpopular{{/linkTo}}{{#linkTo "filter" filter id="path-link"}}Unpopular{{/linkTo}}{{#linkTo "post" post_id id="post-path-link"}}Post{{/linkTo}}{{#linkTo "post" 123 id="post-number-link"}}Post{{/linkTo}}');
+
   Ember.TEMPLATES.index = compile('');
 
   bootApplication();
@@ -432,6 +439,9 @@ test("The {{linkTo}} helper accepts string arguments", function() {
   Ember.run(function() { router.handleURL("/filters/popular"); });
 
   equal(normalizeUrl(Ember.$('#link', '#qunit-fixture').attr('href')), "/filters/unpopular");
+  equal(normalizeUrl(Ember.$('#path-link', '#qunit-fixture').attr('href')), "/filters/unpopular");
+  equal(normalizeUrl(Ember.$('#post-path-link', '#qunit-fixture').attr('href')), "/post/123");
+  equal(normalizeUrl(Ember.$('#post-number-link', '#qunit-fixture').attr('href')), "/post/123");
 });
 
 test("The {{linkTo}} helper unwraps controllers", function() {


### PR DESCRIPTION
This PR depends on https://github.com/tildeio/router.js/pull/32

This PR will convert string and number params of linkTo
and transitionTo into URL params that `model` will
use to fetch the model:

```
// Use posts.show's `model` hook to retrieve the model.
// 123 will be passed in as the post id
this.transitionTo('posts.show', 123);

{{linkTo 'posts.show' 123}}

{{#each relatedPosts}}
  {{linkTo 'posts.show' id}}
{{/each}}
```

This prevents you from needing an object in order to
linkTo a dynamic route. It's also a good way to unify
model-fetching behavior by always letting `model` do
the loading work, which prevents you from having to
keep your `transitionTo`'s in sync with whatever
`model` does if you want the model loading behavior
to be the same.

NOTE: possible breaking change, but probably only in 
really weird, likely misinformed, and totally avoidable
use cases: raw numbers and strings can't (easily)
be used as route models. You would need to wrap
them in an object.
