### PR TITLE
Only catch promise errors after injecting helpers

### DIFF
--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -157,6 +157,8 @@ Ember.Application.reopen({
     for(var i = 0, l = injectHelpersCallbacks.length; i < l; i++) {
       injectHelpersCallbacks[i](this);
     }
+
+    Ember.RSVP.configure('onerror', onerror);
   },
 
   removeTestHelpers: function() {
@@ -165,7 +167,9 @@ Ember.Application.reopen({
       delete this.testHelpers[name];
       delete originalMethods[name];
     }
+    Ember.RSVP.configure('onerror', null);
   }
+
 });
 
 function protoWrap(proto, name, callback) {
@@ -185,7 +189,6 @@ Ember.Test.Promise.prototype = Ember.create(Ember.RSVP.Promise.prototype);
 Ember.Test.Promise.prototype.constructor = Ember.Test.Promise;
 
 
-Ember.RSVP.configure('onerror', function(error) {
+function onerror(error) {
   Ember.Test.adapter.exception(error);
-});
-
+}


### PR DESCRIPTION
The ember-testing adapter should only handle promise exceptions when inside ember-testing tests, so to ensure that, I registered the `onerror` callback inside the `injectTestHelpers` method.

There also appears to be un-handled rejections throughout the Ember code. This can cause issues while testing because an expected rejection would cause a test failure.  So maybe the safest bet would be to check that the `onerror` event was triggered by an instance of `Ember.Test.Promise`.  This requires minor changes to RSVP to pass along the promise that triggered the error. If you think this is a good approach, I can implement it.

cc @stefanpenner , @wycats
