### PR TITLE
Updated JSBin And JSFiddle links to point to working fiddle/bin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ this bug already.
 3. Provide JSFiddle or JSBin demo that specifically shows the problem. This
 demo should be fully operational with the exception of the bug you want to
 demonstrate. The more pared down, the better.
-Preconfigured starting points for the latest Ember: [JSFiddle](http://jsfiddle.net/DCrHG/) | [JSBin](http://jsbin.com/ucanam/54/edit) (may not work with older IE versions due to MIME type isses).
+Preconfigured starting points for the latest Ember: [JSFiddle](http://jsfiddle.net/NQKvy/) | [JSBin](http://jsbin.com/ucanam/239/edit) (may not work with older IE versions due to MIME type isses).
 Issues with fiddles are prioritized.
 
 4. Your issue will be verified. The provided fiddle will be tested for


### PR DESCRIPTION
The fiddle and the bin were both broken because they were using handlebars-1.0.0-rc.4.js with ember-latest.js

ember-latest.js requires handlebars-1.0.0.js

I update the fiddle and bin to use handlebars-1.0.0.js and also update to jquery-2.0.2.js

The linked to fiddle and bin now use  
- jquery-2.0.2.js
- handlebars-1.0.0.js
- ember-latest.js
