### PR TITLE
Update supported ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ you may have luck with another of the runtimes supported by
 
 ## Setup
 
-1. Install Ruby 1.9.2+. There are many resources on the web can help;
+1. Install Ruby 1.9.3+. There are many resources on the web can help;
 one of the best is [rvm](https://rvm.io/).
 
 2. Install Bundler: `gem install bundler`


### PR DESCRIPTION
Ruby 1.9.2 seems to be no longer supported.
Because the security patch has not been applied to 1.9.2:
- http://www.ruby-lang.org/en/news/2013/06/27/hostname-check-bypassing-vulnerability-in-openssl-client-cve-2013-4073/
