### PR TITLE
{{each}} itemView option

### DIFF
--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -159,11 +159,24 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   var hash = options.hash, itemHash = {}, match;
 
   // Extract item view class if provided else default to the standard class
-  var itemViewClass, itemViewPath = hash.itemViewClass;
-  var collectionPrototype = collectionClass.proto();
+  var collectionPrototype = collectionClass.proto(),
+      itemViewClass;
+
+  if (hash.itemView) {
+    var controller = data.keywords.controller;
+    Ember.assert('itemView given, but no container is available', controller && controller.container);
+    var container = controller.container;
+    itemViewClass = container.resolve('view:' + hash.itemView) || container.resolve('view:default');
+  } else if (hash.itemViewClass) {
+    itemViewClass = handlebarsGet(collectionPrototype, hash.itemViewClass, options);
+  } else {
+    itemViewClass = collectionPrototype.itemViewClass;
+  }
+
+  Ember.assert(fmt("%@ #collection: Could not find itemViewClass %@", [data.view, itemViewClass]), !!itemViewClass);
+
   delete hash.itemViewClass;
-  itemViewClass = itemViewPath ? handlebarsGet(collectionPrototype, itemViewPath, options) : collectionPrototype.itemViewClass;
-  Ember.assert(fmt("%@ #collection: Could not find itemViewClass %@", [data.view, itemViewPath]), !!itemViewClass);
+  delete hash.itemView;
 
   // Go through options passed to the {{collection}} helper and extract options
   // that configure item views instead of the collection itself.

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -166,7 +166,8 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
     var controller = data.keywords.controller;
     Ember.assert('itemView given, but no container is available', controller && controller.container);
     var container = controller.container;
-    itemViewClass = container.resolve('view:' + hash.itemView) || container.resolve('view:default');
+    itemViewClass = container.resolve('view:' + Ember.String.camelize(hash.itemView));
+    Ember.assert('itemView not found in container', !!itemViewClass);
   } else if (hash.itemViewClass) {
     itemViewClass = handlebarsGet(collectionPrototype, hash.itemViewClass, options);
   } else {

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -317,7 +317,7 @@ test("it supports {{itemView=}}", function() {
     }
   });
 
-  container.register('view:AnItemView', itemView);
+  container.register('view:anItemView', itemView);
 
   append(view);
 

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -301,6 +301,29 @@ test("it supports itemController when using a custom keyword", function() {
   equal(view.$().text(), "controller:Steve Holtcontroller:Annabelle");
 });
 
+test("it supports {{itemView=}}", function() {
+  var container = new Ember.Container();
+
+  var itemView = Ember.View.extend({
+    template: templateFor('itemView:{{name}}')
+  });
+
+  Ember.run(function() { view.destroy(); }); // destroy existing view
+  view = Ember.View.create({
+    template: templateFor('{{each view.people itemView="AnItemView"}}'),
+    people: people,
+    controller: {
+      container: container
+    }
+  });
+
+  container.register('view:AnItemView', itemView);
+
+  append(view);
+
+  assertText(view, "itemView:Steve HoltitemView:Annabelle");
+});
+
 test("it supports {{itemViewClass=}}", function() {
   Ember.run(function() { view.destroy(); }); // destroy existing view
   view = Ember.View.create({
@@ -311,7 +334,6 @@ test("it supports {{itemViewClass=}}", function() {
   append(view);
 
   assertText(view, "Steve HoltAnnabelle");
-
 });
 
 test("it supports {{itemViewClass=}} with tagName", function() {


### PR DESCRIPTION
Allows `itemView` option into the each/collection helper. If itemView
exists and there is a controller container, then it will attempt to
resolve the view via the container.

Chose the name `itemView` because its API is similar to 
`itemController`.  It only takes a name, no namespace/type required.

The reason for this is so `{{each` can find its item view via the 
resolver.
