### PR TITLE
Ember.Test Helpers no longer need to be chained

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -59,6 +59,10 @@ function find(app, selector, context) {
   return $el;
 }
 
+function andThen(app, callback) {
+  return wait(app, callback(app));
+}
+
 function wait(app, value) {
   return Test.promise(function(resolve) {
     // If this is the first async promise, kick off the async test
@@ -97,6 +101,8 @@ function wait(app, value) {
 helper('visit', visit);
 helper('click', click);
 helper('fillIn', fillIn);
-helper('find', find);
-helper('findWithAssert', findWithAssert);
-helper('wait', wait);
+helper('andThen', andThen);
+
+helper('find', find, { wait: false });
+helper('findWithAssert', findWithAssert, { wait: false});
+helper('wait', wait, { wait: false });

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -1,4 +1,4 @@
-var App, find, click, fillIn, currentRoute, visit, originalAdapter;
+var App, find, click, fillIn, currentRoute, visit, originalAdapter, andThen;
 
 module("ember-testing Acceptance", {
   setup: function(){
@@ -50,6 +50,7 @@ module("ember-testing Acceptance", {
     click = window.click;
     fillIn = window.fillIn;
     visit = window.visit;
+    andThen = window.andThen;
 
     originalAdapter = Ember.Test.adapter;
   },
@@ -95,6 +96,8 @@ test("helpers can be chained with then", function() {
 
 
 
+// Keep this for backwards compatibility
+
 test("helpers can be chained to each other", function() {
   expect(3);
 
@@ -104,11 +107,84 @@ test("helpers can be chained to each other", function() {
   .click('a:first', '#comments-link')
   .fillIn('.ember-text-field', "hello")
   .then(function() {
-    equal(currentRoute, 'comments', "Successfully visited posts route");
+    equal(currentRoute, 'comments', "Successfully visited comments route");
     equal(Ember.$('.ember-text-field').val(), 'hello', "Fillin successfully works");
   })
   .visit('/posts')
   .then(function() {
     equal(currentRoute, 'posts', "Thens can also be chained to helpers");
+  });
+});
+
+test("helpers don't need to be chained", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts');
+
+  click('a:first', '#comments-link');
+
+  fillIn('.ember-text-field', "hello");
+
+  andThen(function() {
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  });
+
+  visit('/posts');
+
+  andThen(function() {
+    equal(currentRoute, 'posts');
+  });
+});
+
+test("Nested async helpers", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts');
+
+  andThen(function() {
+    click('a:first', '#comments-link');
+
+    fillIn('.ember-text-field', "hello");
+  });
+
+  andThen(function() {
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  });
+
+  visit('/posts');
+
+  andThen(function() {
+    equal(currentRoute, 'posts');
+  });
+});
+
+test("Helpers nested in thens", function() {
+  expect(3);
+
+  currentRoute = 'index';
+
+  visit('/posts').then(function() {
+    click('a:first', '#comments-link');
+  });
+
+  andThen(function() {
+    fillIn('.ember-text-field', "hello");
+  });
+
+  andThen(function() {
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
+  });
+
+  visit('/posts');
+
+  andThen(function() {
+    equal(currentRoute, 'posts');
   });
 });


### PR DESCRIPTION
Removes the need for ember-testing helpers to be chained.  Based on the proposal in [Discourse](http://discuss.emberjs.com/t/ember-testing-improvements/1652)

``` javascript

visit('posts/new');
click('.add-btn');
fillIn('.title', 'Post');
click('.submit');

andThen(function() {
  equal(find('.post-title'), 'Post');
});

visit('comments');

andThen(function() {
  equal(find('.comments').length, 0);
});
```

The PR also allows custom helpers to use async helpers without chaining:

``` javascript
Ember.Test.registerHelper('deletePost', function(app, postId) {
  visit('/post/' + postId);
  click('.delete-btn');
});
```

Then in your test:

``` javascript
deletePost(1);

andThen(function() {
  equal(find('.post').length, 0);
});
```

This commit keeps the chaining for backwards compatibility.

**Breaking Change**:

Helpers that are not async and need to return an immediate value (such as `find`) 
should have the option `{ wait: false }` passed on registration.

``` javascript
function findPost() {
  return find('.post');
}

Ember.Test.registerHelper('findPost', findPost, { wait: false });
```

cc @stefanpenner, @wycats
