### PR TITLE
Improvements to route serialize hook.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -465,14 +465,16 @@ Ember.Route = Ember.Object.extend({
     @return {Object} the serialized parameters
   */
   serialize: function(model, params) {
-    if (params.length !== 1) { return; }
+    if (params.length === 0) { return; }
 
     var name = params[0], object = {};
 
     if (/_id$/.test(name)) {
       object[name] = get(model, 'id');
     } else {
-      object[name] = model;
+      for (var segment in params) {
+        object[segment] = get(model, segment);
+      }
     }
 
     return object;


### PR DESCRIPTION
It seems to me that we could make the default serialize hook smarter about how it gets information from the model. Consider the following (slightly simplified) code extracted from my own app that browses a list of Github repos:

``` javascript
Github.Router.map(function() {
  this.resource('repo', { path: '/:owner/:name' });
});

Github.RepoRoute = Ember.Route.extend({
  model: function(params) {
    return Github.Repo.find(params);
  },
  serialize: function(model, params) {
    return { owner: model.get('owner'), name: model.get('name') };
  }
});
```

Template:

```
{{#linkTo 'repo' repo}}{{repo.full_name}}{{/linkTo}}
```

The serialize hook could be intelligent in cases where the data and URLs are not structured around IDs but other properties on the model. If I define my path as `/:owner/:name` it would try and construct the URL using `model.get('owner')` and `model.get('name')`. Does that make sense?

This PR is just a starting point for discussion that covers my own use case. I would still like to add a test, get some feedback on the general idea, and hear any other cases that might make sense to be handled by the default serialize hook.
