### PR TITLE
Fixed bug in Ember.Application#reset that calls `startRouting` twice.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -536,7 +536,6 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
       Ember.run.schedule('actions', this, function(){
         this._initialize();
-        this.startRouting();
       });
     }
 


### PR DESCRIPTION
The `_initialize` method internally calls `startRouting`.
