### PR TITLE
keyEvent integration test helper to simulate keydown, keypress etc.

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -46,6 +46,19 @@ function click(app, selector, context) {
   return wait(app);
 }
 
+function keyEvent(app, selector, context, type, keyCode) {
+  var $el;
+  if(typeof keyCode === 'undefined'){
+    keyCode = type;
+    type = context;
+    context = null;
+  }
+  $el = findWithAssert(app, selector, context);
+  var event = Ember.$.Event(type, { keyCode: keyCode });
+  Ember.run($el, 'trigger', event);
+  return wait(app);
+}
+
 function fillIn(app, selector, context, text) {
   var $el;
   if (typeof text === 'undefined') {
@@ -180,6 +193,25 @@ helper('visit', visit);
 * @returns {RSVP.Promise}
 */
 helper('click', click);
+
+/**
+* Simulates a key event, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode
+*
+* Example:
+*
+* ```
+* keyEvent('.some-jQuery-selector', 'keypress', 13).then(function(){
+*  // assert something
+* });
+* ```
+*
+* @method click
+* @param {String} selcetor jQuery selector for finding element on the DOM
+* @param {String} the type of key event, e.g. `keypress`, `keydown`, `keyup`
+* @param {Number} the keyCode of the simulated key event
+* @returns {RSVP.Promise}
+*/
+helper('keyEvent', keyEvent);
 
 /**
 * Fills in an input element with some text.

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -96,7 +96,7 @@ test("helpers can be chained with then", function() {
 
 
 test("helpers can be chained to each other", function() {
-  expect(3);
+  expect(4);
 
   currentRoute = 'index';
 
@@ -105,7 +105,11 @@ test("helpers can be chained to each other", function() {
   .then(function() {
     equal(currentRoute, 'comments', "Successfully visited posts route");
     equal(Ember.$('.ember-text-field').val(), 'hello', "Fillin successfully works");
+    find('.ember-text-field').one('keypress', function(e){
+      equal(e.keyCode, 13, "keyevent chained with correct keyCode.");
+    });
   })
+  .keyEvent('.ember-text-field', 'keypress', 13)
   .visit('/posts')
   .then(function() {
     equal(currentRoute, 'posts', "Thens can also be chained to helpers");

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -14,6 +14,8 @@ test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
   ok(!App.testHelpers.visit);
   ok(!window.click);
   ok(!App.testHelpers.click);
+  ok(!window.keyEvent);
+  ok(!App.testHelpers.keyEvent);
   ok(!window.fillIn);
   ok(!App.testHelpers.fillIn);
   ok(!window.wait);
@@ -25,6 +27,8 @@ test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
   ok(App.testHelpers.visit);
   ok(window.click);
   ok(App.testHelpers.click);
+  ok(window.keyEvent);
+  ok(App.testHelpers.keyEvent);
   ok(window.fillIn);
   ok(App.testHelpers.fillIn);
   ok(window.wait);
@@ -36,6 +40,8 @@ test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
   ok(!App.testHelpers.visit);
   ok(!window.click);
   ok(!App.testHelpers.click);
+  ok(!window.keyEvent);
+  ok(!App.testHelpers.keyEvent);
   ok(!window.fillIn);
   ok(!App.testHelpers.fillIn);
   ok(!window.wait);


### PR DESCRIPTION
keyEvent integration test helper in a similar vein to click, fillIn etc. to simulate keydown, keypress etc.

Example usage:

```
  visit('/posts').click('a:first', '#comments-link')
  .fillIn('.ember-text-field', "hello")
  .then(function() {
    equal(currentRoute, 'comments', "Successfully visited posts route");
    equal(Ember.$('.ember-text-field').val(), 'hello', "Fillin successfully works");
    find('.ember-text-field').one('keypress', function(e){
      equal(e.keyCode, 13, "keyevent chained with correct keyCode.");
    });
  })
  .keyEvent('.ember-text-field', 'keypress', 13)
  .visit('/posts')
  .then(function() {
    equal(currentRoute, 'posts', "Thens can also be chained to helpers");
  });
```
