### PR TITLE
Throw exception on invalid arguments for pushObjects method (issue #2848)

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -154,7 +154,7 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/**
 
     ```javascript
     var colors = ["red", "green", "blue"];
-    colors.pushObjects("black");               // ["red", "green", "blue", "black"]
+    colors.pushObjects(["black"]);               // ["red", "green", "blue", "black"]
     colors.pushObjects(["yellow", "orange"]);  // ["red", "green", "blue", "black", "yellow", "orange"]
     ```
 
@@ -163,6 +163,9 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/**
     @return {Ember.Array} receiver
   */
   pushObjects: function(objects) {
+    if(!(Ember.Enumerable.detect(objects) || Ember.isArray(objects))) {
+      throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
+    }
     this.replace(get(this, 'length'), 0, objects);
     return this;
   },

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -278,6 +278,9 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
   },
 
   pushObjects: function(objects) {
+    if(!(Ember.Enumerable.detect(objects) || Ember.isArray(objects))) {
+      throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
+    }
     this._replace(get(this, 'length'), 0, objects);
     return this;
   },

--- a/packages/ember-runtime/tests/suites/mutable_array.js
+++ b/packages/ember-runtime/tests/suites/mutable_array.js
@@ -5,6 +5,7 @@ Ember.MutableArrayTests = Ember.ArrayTests.extend();
 require('ember-runtime/~tests/suites/mutable_array/insertAt');
 require('ember-runtime/~tests/suites/mutable_array/popObject');
 require('ember-runtime/~tests/suites/mutable_array/pushObject');
+require('ember-runtime/~tests/suites/mutable_array/pushObjects');
 require('ember-runtime/~tests/suites/mutable_array/removeAt');
 require('ember-runtime/~tests/suites/mutable_array/replace');
 require('ember-runtime/~tests/suites/mutable_array/shiftObject');

--- a/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
@@ -1,0 +1,13 @@
+require('ember-runtime/~tests/suites/mutable_array');
+
+var suite = Ember.MutableArrayTests;
+
+suite.module('pushObjects');
+
+suite.test("should raise exception if not Ember.Enumerable is passed to pushObjects", function() {
+  var obj = this.newObject([]);
+
+  raises(function() {
+    obj.pushObjects( "string" );
+  });
+});


### PR DESCRIPTION
Ember.MutableArray and Ember.ArrayProxy method #pushObjects should accept only
Ember.Enumerable or Array as argument. In other case it throws an exception.

This is a bugfix for: https://github.com/emberjs/ember.js/issues/2848

Pull request consist of: bugfix, changes in documentation, tests.
