### PR TITLE
.jshintrc: set browser:false

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,11 +26,15 @@
         "module",
         "expect",
         "minispade",
-        "expectAssertion"
+        "expectAssertion",
+
+        // A safe subset of "browser:true":
+        "window", "location", "document", "XMLSerializer",
+        "setTimeout", "clearTimeout", "setInterval", "clearInterval"
     ],
 
     "node" : false,
-    "browser" : true,
+    "browser" : false,
 
     "boss" : true,
     "curly": false,


### PR DESCRIPTION
Setting `browser:true` predefines a large list of globals. Some of these, like `window`, `location`, and `setTimeout`, are really useful. Some of them, like `name`, `event`, and `status` are really dangerous to have available as globals. They invite code errors.

This PR
- sets `browser: false`
- predefines `window`, `location`, `setTimeout` and the other "normal" globals
