### PR TITLE
Specify controller of a route via controllerName

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -214,7 +214,7 @@ Ember.Route = Ember.Object.extend({
     @method setup
   */
   setup: function(context) {
-    var controller = this.controllerFor(this.routeName, context);
+    var controller = this.controllerFor(this.controllerName || this.routeName, context);
 
     // Assign the route's controller so that it can more easily be
     // referenced in event handlers

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -341,6 +341,22 @@ test("The route controller is still set when overriding the setupController hook
   deepEqual(container.lookup('route:home').controller, container.lookup('controller:home'), "route controller is the home controller");
 });
 
+test("The route controller can be specified via controllerName", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+    controllerName: 'myController'
+  });
+
+  container.register('controller:myController', Ember.Controller.extend());
+
+  bootApplication();
+
+  deepEqual(container.lookup('route:home').controller, container.lookup('controller:myController'), "route controller is set by controllerName");
+});
+
 test("The Homepage with a `setupController` hook modifying other controllers", function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
This commit adds the possibility to specify the controller a route shall use via a `controllerName` property.

Given the following app

``` javascript
App.Router.map(function() {
  this.resource('team', function() {
    this.route('overview');
    this.route('detail');
  });
});

App.TeamController = Ember.ObjectController.extend({ ... });

App.TeamOverviewRoute = Ember.Route.extend({ controllerName: 'team' });
```

the controller in the `team/overview` template is the `App.TeamController` instead of the generated `App.TeamOverviewController`. Since the `controllerName` isn't set on the `App.TeamDetailRoute`, in this
template the generated `App.TeamDetailController` is used.

This addresses #1872.
