### PR TITLE
Add Route#viewFor

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -555,6 +555,16 @@ Ember.Route = Ember.Object.extend({
   },
 
   /**
+    Return a new view instance for the given name
+
+    @method viewFor
+    @param {String} name of the view
+    @return {Ember.View} instance of the view
+  */
+  viewFor: function(name) {
+    return this.container.lookup('view:' + name);
+  },
+  /**
     Returns the current model for a given route.
 
     This is the object returned by the `model` hook of the route

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -36,5 +36,21 @@ test("default model utilizes the container to acquire the model factory", functi
 
     return Post;
   }
+});
 
+test("Route#viewFor", function(){
+  ok(route.viewFor, 'function is present');
+
+  var lookup = {
+    'view:application': {}
+  };
+
+  route.container = {
+    lookup: function(fullName) {
+      return lookup[fullName];
+    }
+  };
+
+  equal(route.viewFor('unknown'), undefined, 'returns undefined for unknown for lookup');
+  equal(route.viewFor('application'), lookup['view:application'], 'return the correct view on valid lookup');
 });


### PR DESCRIPTION
This gives routes a first class way to access view instances.
For example creating a popup from the route as the result of an
event.

Although typically I use an specified popup outlet for popups,
I have seen the pattern of creating and instantiating view instances
for popups at both the controller and route. If this is going to
happen I would feel more comfortable with it happening at the route.

Views looked up via this abstraction:
- are automatically given a container
- are easily replaced for tests
- can now be registered on the container, providing a potential hook for 3rd part add-ons, such as a twitter bootstrap confirmation dialog, to register against.

Example:

``` javascript
Ember.Route.extend({
  // ...
  events: {
    confirm: function() {
      var view = this.viewfor('confirmation');
      // ...
    }
  }
})
```
