### PR TITLE
The View helper learns about the container

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -10,6 +10,8 @@ require("ember-handlebars");
 
 var get = Ember.get, set = Ember.set;
 var EmberHandlebars = Ember.Handlebars;
+var LOWERCASE_A_Z = /^[a-z]/;
+var VIEW_PREFIX = /^view\./;
 
 EmberHandlebars.ViewHelper = Ember.Object.create({
 
@@ -121,7 +123,18 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
         newView;
 
     if ('string' === typeof path) {
-      newView = EmberHandlebars.get(thisContext, path, options);
+
+      // TODO: this is a lame conditional, this should likely change
+      // but something along these lines will likely need to be added
+      // as deprecation warnings
+      //
+      if (options.types[0] === 'STRING' && LOWERCASE_A_Z.test(path) && !VIEW_PREFIX.test(path)) {
+        Ember.assert("View requires a container", !!data.view.container);
+        newView = data.view.container.lookupFactory('view:' + path);
+      } else {
+        newView = EmberHandlebars.get(thisContext, path, options);
+      }
+
       Ember.assert("Unable to find view at path '" + path + "'", !!newView);
     } else {
       newView = path;

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -1,0 +1,87 @@
+var view, originalLookup;
+
+var container = {
+  lookupFactory: function(){ }
+};
+
+function viewClass(options){
+  options.container = options.container || container;
+  return Ember.View.extend(options);
+}
+
+module("Handlebars {{#view}} helper", {
+  setup: function() {
+    originalLookup = Ember.lookup;
+
+  },
+
+  teardown: function() {
+    Ember.lookup = originalLookup;
+    Ember.run(view, 'destroy');
+  }
+});
+
+
+test("View lookup - App.FuView", function(){
+  Ember.lookup = {
+    App: {
+      FuView: viewClass({
+        elementId: "fu",
+        template: Ember.Handlebars.compile("bro")
+      })
+    }
+  };
+
+  view = viewClass({
+    template: Ember.Handlebars.compile("{{view App.FuView}}")
+  }).create();
+
+  Ember.run(view, 'appendTo', '#qunit-fixture');
+
+  equal(Ember.$('#fu').text(), 'bro');
+});
+
+test("View lookup - 'App.FuView'", function(){
+  Ember.lookup = {
+    App: {
+      FuView: viewClass({
+        elementId: "fu",
+        template: Ember.Handlebars.compile("bro")
+      })
+    }
+  };
+
+  view = viewClass({
+    template: Ember.Handlebars.compile("{{view 'App.FuView'}}")
+  }).create();
+
+  Ember.run(view, 'appendTo', '#qunit-fixture');
+
+  equal(Ember.$('#fu').text(), 'bro');
+});
+
+test("View lookup - 'fu'", function(){
+  var FuView = viewClass({
+    elementId: "fu",
+    template: Ember.Handlebars.compile("bro")
+  });
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = Ember.View.extend({
+    template: Ember.Handlebars.compile("{{view 'fu'}}"),
+    container: container
+  }).create();
+
+  Ember.run(view, 'appendTo', '#qunit-fixture');
+
+  equal(Ember.$('#fu').text(), 'bro');
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
+});


### PR DESCRIPTION
This provides more options to allow for a global free code base.

``` javascript
// stays the same
{{view App.FuView}}

// uses the container
{{view 'fu'}}
```

The following continues to work as it does today, looking directly up on the view, rather then via the container. but leads to some annoying internal conditionals, and maybe ambiguity

``` javascript
{{view 'view.someOtherView'}}
```

To deal with this, i believe the forward moving goal is as follows:

``` javascript
// current
{{view 'view.someOtherView'}}
// future
{{view view.someOtherView}}
```

The question is how do we move forward.
1. support both string and non-string lookups, detect 'view.' and spew deprecation warnings
2. error hard on string lookups that prefix with 'view:'
3. don't detect the view case, merely allow the existing "your view is missing error" to handle it.

Let the discussion begin.
