### PR TITLE
Add failing test for observing @each.foo.bar

### DIFF
--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -346,6 +346,26 @@ test('adding an object should notify (@each)', function() {
 
 });
 
+test('changing a value of a nested property should notify (@each.isDone.maybe)', function() {
+  ary = new TestArray([
+    { isDone: { maybe: true },  desc: 'Todo 1' },
+    { isDone: { maybe: false }, desc: 'Todo 2' }
+  ]);
+
+  var called = 0;
+
+  var observerObject = Ember.Object.create({
+    wasCalled: function() {
+      called++;
+    }
+  });
+
+  Ember.addObserver(ary, '@each.isDone.maybe', observerObject, 'wasCalled');
+
+  ary.set("firstObject.isDone.maybe", false);
+  equal(called, 1, "calls observer when nested object is changed");
+});
+
 test('adding an object should notify (@each.isDone)', function() {
 
   var get = Ember.get, set = Ember.set;


### PR DESCRIPTION
I'm not sure if this is by design or a bug, but anyway here's a failing test :)
