### PR TITLE
Safe return on null/undefined arguments for pushObjects (issue #2967)

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -163,6 +163,8 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/**
     @return {Ember.Array} receiver
   */
   pushObjects: function(objects) {
+    // Return immediately if objects argument is equivalent to nothing (null/undefined)
+    if (objects === void 0 || objects === null) return this;
     if(!(Ember.Enumerable.detect(objects) || Ember.isArray(objects))) {
       throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
     }

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -278,6 +278,8 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
   },
 
   pushObjects: function(objects) {
+    // Return immediately if objects argument is equivalent to nothing (null/undefined)
+    if (objects === void 0 || objects === null) return this;
     if(!(Ember.Enumerable.detect(objects) || Ember.isArray(objects))) {
       throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
     }

--- a/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
@@ -11,3 +11,22 @@ suite.test("should raise exception if not Ember.Enumerable is passed to pushObje
     obj.pushObjects( "string" );
   });
 });
+
+suite.test("should return self immediately without error if nothing is passed to pushObjects", function() {
+  var mutable = Ember.Object.extend(Ember.MutableArray, {
+    content: [1,2,4]
+  });
+
+  var obj = mutable.create();
+
+  var a = obj.pushObjects();
+  var b = obj.pushObjects(void(0));
+  var c = obj.pushObjects(null);
+
+  equal(a, obj, 'pushObjects remains chainable when nothing passed');
+  equal(b, obj, 'pushObjects remains chainable when undefined passed');
+  equal(c, obj, 'pushObjects remains chainable when null passed');
+
+  deepEqual(obj.get('content'), [1,2,4], 'content un-altered when nothing passed to pushObjects');
+
+});


### PR DESCRIPTION
Ember.MutableArray and Ember.ArrayProxy method #pushObjects should accept only
Ember.Enumerable or Array as argument. In other cases it throws an exception.

However, if the equivalent of nothing (i.e. null/undefined) is passed to #pushObjects, then no exception should be thrown and the method should return immediately.

This is a bugfix for: #2967

Pull request contains: bugfix and tests.
