### PR TITLE
Don't push childViews if undefined/invalid (issue #2967)

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -16,9 +16,9 @@ var childViewsProperty = Ember.computed(function() {
   var childViews = this._childViews, ret = Ember.A(), view = this;
 
   a_forEach(childViews, function(view) {
-    var currentChildViews = get(view, 'childViews');
+    var currentChildViews;
     if (view.isVirtual) {
-      if(Ember.Enumerable.detect(currentChildViews) || Ember.isArray(currentChildViews)) {
+      if(currentChildViews = get(view, 'childViews')) {
         ret.pushObjects(currentChildViews);
       }
     } else {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -16,8 +16,11 @@ var childViewsProperty = Ember.computed(function() {
   var childViews = this._childViews, ret = Ember.A(), view = this;
 
   a_forEach(childViews, function(view) {
+    var currentChildViews = get(view, 'childViews');
     if (view.isVirtual) {
-      ret.pushObjects(get(view, 'childViews'));
+      if(Ember.Enumerable.detect(currentChildViews) || Ember.isArray(currentChildViews)) {
+        ret.pushObjects(currentChildViews);
+      }
     } else {
       ret.push(view);
     }


### PR DESCRIPTION
Since 3a16e2821d021a2c88ac290516825ca3b0cafa62, pushObjects throws an error when provided with null or undefined.

Checking the childViews property for compatibility with the pushObjects method prior to calling pushObjects. Will not attempt to push invalid objects.

This is an alternative fix for issue #2967 that leaves the exception in the pushObjects method intact.
