### PR TITLE
wip add an assert for non-existent templates

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -662,14 +662,10 @@ Ember.Route = Ember.Object.extend({
 
     var container = this.container,
         view = container.lookup('view:' + name),
-        template = container.lookup('template:' + name);
+        template = container.lookup('template:' + name),
+        hasTemplateAndView = !!(template && view);
 
-    if (!view && !template) {
-      if (get(this.router, 'namespace.LOG_VIEW_LOOKUPS')) {
-        Ember.Logger.info("Could not find \"" + name + "\" template or view. Nothing will be rendered", { fullName: 'template:' + name });
-      }
-      return;
-    }
+    Ember.assert("Could not find \"" + name + "\" template or view. Nothing will be rendered", hasTemplateAndView);
 
     options = normalizeOptions(this, name, template, options);
     view = setupView(view, container, options);

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -38,3 +38,4 @@ test("default model utilizes the container to acquire the model factory", functi
   }
 
 });
+


### PR DESCRIPTION
This is a work in progress, but it fails many tests that don't have a template/view.

Refs #2949

I'm not sure an assert is the right answer here. Not rendering anything (e.g. putting in a "blank" template) may be expected behavior. Perhaps just always warning in the console is more appropriate?

I know there will be failing tests for this one.
