### PR TITLE
Exiting loading state when transition is aborted.

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -213,7 +213,7 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
 
   ```javascript
   Ember.Handlebars.registerBoundHelper('concatenate', function() {
-    var values = arguments[arguments.length - 1];
+    var values = Array.prototype.slice.call(arguments, 0, -1);
     return values.join('||');
   });
   ```

--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -41,6 +41,6 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
   @for Ember.Handlebars.helpers
   @param {String} property
 */
-Ember.Handlebars.registerHelper('debugger', function() {
+Ember.Handlebars.registerHelper('debugger', function(options) {
   debugger;
 });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -261,6 +261,8 @@ function doTransition(router, method, args) {
   var transitionPromise = router.router[method].apply(router.router, args);
   transitionPromise.then(function() {
     transitionCompleted(router);
+  }, function() {
+    exitLoadingState(router);
   });
 
   // We want to return the configurable promise object

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -255,7 +255,11 @@ function doTransition(router, method, args) {
   scheduleLoadingStateEntry(router);
 
   var transitionPromise = router.router[method].apply(router.router, args);
-  transitionPromise.then(transitionCompleted);
+  transitionPromise.then(function() {
+    transitionCompleted(router);
+  }, function() {
+    exitLoadingState(router);
+  });
 
   // We want to return the configurable promise object
   // so that callers of this function can use `.method()` on it,


### PR DESCRIPTION
When aborting a transition in `willTransition`, the Ember Router incorrectly enters the `LoadingRoute` when it is specified. This is because exiting the loading state (or never entering it) is done in `transitionCompleted` when the transition promise has been resolved. When the transition is cancelled this promise doesn't successfully resolve, so the loading state is never exited or cancelled.

This change exits the loading state on transition failure.
