### PR TITLE
Fix typos in the inline testing package docs

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -189,7 +189,7 @@ helper('visit', visit);
 * ```
 *
 * @method click
-* @param {String} selcetor jQuery selector for finding element on the DOM
+* @param {String} selector jQuery selector for finding element on the DOM
 * @returns {RSVP.Promise}
 */
 helper('click', click);
@@ -205,8 +205,8 @@ helper('click', click);
 * });
 * ```
 *
-* @method click
-* @param {String} selcetor jQuery selector for finding element on the DOM
+* @method keyEvent
+* @param {String} selector jQuery selector for finding element on the DOM
 * @param {String} the type of key event, e.g. `keypress`, `keydown`, `keyup`
 * @param {Number} the keyCode of the simulated key event
 * @returns {RSVP.Promise}

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -22,9 +22,9 @@ Ember.Test = {
 
     For example:
     ```javascript
-    Ember.Test.registerHelper('boot', function(app)) {
+    Ember.Test.registerHelper('boot', function(app) {
       Ember.run(app, app.deferReadiness);
-    }
+    });
     ```
 
     This helper can later be called without arguments


### PR DESCRIPTION
Just fixes small typos in the inline docs in the testing package.
