### PR TITLE
use Ember.K for consistency

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1712,7 +1712,7 @@ Ember.View = Ember.CoreView.extend(
 
     @event willDestroyElement
   */
-  willDestroyElement: function() {},
+  willDestroyElement: Ember.K,
 
   /**
     @private


### PR DESCRIPTION
Unless there's a reason behind using just `function() {}`, it seems more reasonable to use Ember.K for consistency
