### PR TITLE
Support indeterminate property in checkboxes

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -51,7 +51,7 @@ Ember.Checkbox = Ember.View.extend({
 
   tagName: 'input',
 
-  attributeBindings: ['type', 'checked', 'disabled', 'tabindex', 'name'],
+  attributeBindings: ['type', 'checked', 'indeterminate', 'disabled', 'tabindex', 'name'],
 
   type: "checkbox",
   checked: false,

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -140,6 +140,29 @@ test("should become disabled if the disabled attribute is changed", function() {
   ok(checkboxView.$().is(":not(:disabled)"));
 });
 
+test("should begin indeterminate if the indeterminate attribute is true", function() {
+  checkboxView = Ember.Checkbox.create({});
+
+  checkboxView.set('indeterminate', true);
+  append();
+
+  equal(checkboxView.$().prop('indeterminate'), true, "Checkbox should be indeterminate");
+});
+
+test("should become indeterminate if the indeterminate attribute is changed", function() {
+  checkboxView = Ember.Checkbox.create({});
+
+  append();
+
+  equal(checkboxView.$().prop('indeterminate'), false, "Checkbox should not be indeterminate");
+
+  Ember.run(function() { checkboxView.set('indeterminate', true); });
+  equal(checkboxView.$().prop('indeterminate'), true, "Checkbox should be indeterminate");
+
+  Ember.run(function() { checkboxView.set('indeterminate', false); });
+  equal(checkboxView.$().prop('indeterminate'), false, "Checkbox should not be indeterminate");
+});
+
 test("should support the tabindex property", function() {
   checkboxView = Ember.Checkbox.create({});
 


### PR DESCRIPTION
Support the missing third checkbox state in attributeBindings:

![image](https://f.cloud.github.com/assets/1217/807316/27f61378-ee4c-11e2-92bd-5e84c441c203.png)
