### PR TITLE
Use the original arg length of wrapped CP funcs, still call the wrapper

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -303,7 +303,7 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
       oldSuspended = this._suspended,
       hadCachedValue = false,
       cache = meta.cache,
-      cachedValue, ret;
+      funcArgLength, cachedValue, ret;
 
   if (this._readOnly) {
     throw new Error('Cannot Set: ' + keyName + ' on: ' + obj.toString() );
@@ -318,17 +318,18 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
       hadCachedValue = true;
     }
 
-    // Check if the CP has been wrapped
-    if (func.wrappedFunction) { func = func.wrappedFunction; }
+    // Check if the CP has been wrapped. If if has, use the
+    // length from the wrapped function.
+    funcArgLength = (func.wrappedFunction ? func.wrappedFunction.length : func.length);
 
     // For backwards-compatibility with computed properties
     // that check for arguments.length === 2 to determine if
     // they are being get or set, only pass the old cached
     // value if the computed property opts into a third
     // argument.
-    if (func.length === 3) {
+    if (funcArgLength === 3) {
       ret = func.call(obj, keyName, value, cachedValue);
-    } else if (func.length === 2) {
+    } else if (funcArgLength === 2) {
       ret = func.call(obj, keyName, value);
     } else {
       Ember.defineProperty(obj, keyName, null, cachedValue);

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -1,4 +1,5 @@
-var get = Ember.get;
+var get = Ember.get,
+    set = Ember.set;
 
 module('Ember.Mixin Computed Properties');
 
@@ -52,6 +53,48 @@ test('overriding computed properties', function() {
   equal(get(obj, 'aProp'), "objD", "should preserve original computed property");
 });
 
+test('calling set on overridden computed properties', function() {
+  var SuperMixin, SubMixin;
+  var obj;
+
+  var superGetOccurred = false,
+      superSetOccurred = false;
+
+  SuperMixin = Ember.Mixin.create({
+    aProp: Ember.computed(function(key, val) {
+      if (arguments.length === 1) {
+        superGetOccurred = true;
+      } else {
+        superSetOccurred = true;
+      }
+      return true;
+    })
+  });
+
+  SubMixin = Ember.Mixin.create(SuperMixin, {
+    aProp: Ember.computed(function(key, val) {
+      return this._super.apply(this, arguments);
+    })
+  });
+
+  obj = {};
+  SubMixin.apply(obj);
+
+  set(obj, 'aProp', 'set thyself');
+  ok(superSetOccurred, 'should pass set to _super');
+
+  superSetOccurred = false; // reset the set assertion
+
+  obj = {};
+  SubMixin.apply(obj);
+
+  get(obj, 'aProp');
+  ok(superGetOccurred, 'should pass get to _super');
+
+  set(obj, 'aProp', 'set thyself');
+  ok(superSetOccurred, 'should pass set to _super after getting');
+});
+
 test('setter behavior works properly when overriding computed properties', function() {
   var obj = {};
 
@@ -80,15 +123,15 @@ test('setter behavior works properly when overriding computed properties', funct
   MixinA.apply(obj);
   MixinB.apply(obj);
 
-  Ember.set(obj, 'cpWithSetter2', 'test');
+  set(obj, 'cpWithSetter2', 'test');
   ok(cpWasCalled, "The computed property setter was called when defined with two args");
   cpWasCalled = false;
 
-  Ember.set(obj, 'cpWithSetter3', 'test');
+  set(obj, 'cpWithSetter3', 'test');
   ok(cpWasCalled, "The computed property setter was called when defined with three args");
   cpWasCalled = false;
 
-  Ember.set(obj, 'cpWithoutSetter', 'test');
+  set(obj, 'cpWithoutSetter', 'test');
   equal(Ember.get(obj, 'cpWithoutSetter'), 'test', "The default setter was called, the value is correct");
   ok(!cpWasCalled, "The default setter was called, not the CP itself");
 });


### PR DESCRIPTION
`ComputedPropertyPrototype.set` analyzes the length of CP arguments to decide how the CP function should be called. Since the wrapper (which sets up `_super`) handles arbitrary arguments, the original function (at `wrappedFunction`) should be inspected for `.length`. The wrapper, however, should still be called when performing the set (ensuring that `_super` is present).

Fixes #2890
