### PR TITLE
Document htmlSafe

### DIFF
--- a/packages/ember-handlebars/lib/string.js
+++ b/packages/ember-handlebars/lib/string.js
@@ -1,8 +1,15 @@
 /**
-  @method htmlSafe
-  @for Ember.String
-  @static
-*/
+ * Mark a string as safe for raw output with Handlebars. If you
+ * return HTML from a Handlebars helper, use this function to
+ * ensure Handlebars does not escape the HTML.
+ *
+ * `Ember.String.htmlSafe('<div>someString</div>')`
+ *
+ * @method htmlSafe
+ * @for Ember.String
+ * @static
+ * @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
+ */
 Ember.String.htmlSafe = function(str) {
   return new Handlebars.SafeString(str);
 };
@@ -12,11 +19,15 @@ var htmlSafe = Ember.String.htmlSafe;
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
-    See `Ember.String.htmlSafe`.
-
-    @method htmlSafe
-    @for String
-  */
+   * Use `'<div>someString</div>'.htmlSafe()` to mark a string as being
+   * safe for raw output with Handlebars.
+   *
+   * See `Ember.String.htmlSafe`.
+   *
+   * @method htmlSafe
+   * @for String
+   * @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
+   */
   String.prototype.htmlSafe = function() {
     return htmlSafe(this);
   };


### PR DESCRIPTION
`htmlSafe` is useful, but undocumented.

![String docs](http://f.cl.ly/items/2p2347391v3o3U1F0F00/Screen%20Shot%202013-07-19%20at%209.50.16%20AM.png)

![Static docs](http://f.cl.ly/items/1M1H0m362J2r0t2K1z0k/Screen%20Shot%202013-07-19%20at%209.49.27%20AM.png)
