### PR TITLE
Deprecate `template` in favor of `partial`

### DIFF
--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -42,7 +42,6 @@ Ember.Handlebars.registerHelper('partial', function(name, options) {
       template = view.templateForName(underscoredName),
       deprecatedTemplate = !template && view.templateForName(name);
 
-  Ember.deprecate("You tried to render the partial " + name + ", which should be at '" + underscoredName + "', but Ember found '" + name + "'. Please use a leading underscore in your partials", template);
   Ember.assert("Unable to find partial with name '"+name+"'.", template || deprecatedTemplate);
 
   template = template || deprecatedTemplate;

--- a/packages/ember-handlebars/lib/helpers/template.js
+++ b/packages/ember-handlebars/lib/helpers/template.js
@@ -43,16 +43,13 @@ require('ember-handlebars/ext');
   Ember.TEMPLATES["my_cool_template"] = Ember.Handlebars.compile('<b>{{user}}</b>');
   ```
 
+  @deprecated
   @method template
   @for Ember.Handlebars.helpers
   @param {String} templateName the template to render
 */
 
 Ember.Handlebars.registerHelper('template', function(name, options) {
-  var view = options.data.view,
-      template = view.templateForName(name);
-
-  Ember.assert("Unable to find template with name '"+name+"'.", !!template);
-
-  template(this, { data: options.data });
+  Ember.deprecate("The `template` helper has been deprecated in favor of the `partial` helper. Please use `partial` instead, which will work the same way.");
+  return Ember.Handlebars.helpers.partial.apply(this, arguments);
 });


### PR DESCRIPTION
Also, don't emit a warning if you use the de-underscored
template name with the `partial` helper.

This is a step in the direction if simplifying all the
different ways to insert a template.
