### PR TITLE
Improve Ember.inspect

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -197,6 +197,9 @@ Ember.copy = function(obj, deep) {
   @return {String} A description of the object
 */
 Ember.inspect = function(obj) {
+  if (Ember.typeOf(obj) === 'array') {
+    return '[' + obj + ']';
+  }
   if (typeof obj !== 'object' || obj === null) {
     return obj + '';
   }

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -197,10 +197,11 @@ Ember.copy = function(obj, deep) {
   @return {String} A description of the object
 */
 Ember.inspect = function(obj) {
-  if (Ember.typeOf(obj) === 'array') {
+  var type = Ember.typeOf(obj);
+  if (type === 'array') {
     return '[' + obj + ']';
   }
-  if (typeof obj !== 'object' || obj === null) {
+  if (type !== 'object') {
     return obj + '';
   }
 

--- a/packages/ember-runtime/tests/core/inspect_test.js
+++ b/packages/ember-runtime/tests/core/inspect_test.js
@@ -33,8 +33,5 @@ test("object", function() {
 });
 
 test("array", function() {
-  // this could be better, but let's not let this method get
-  // out of control unless we want to go all the way, a la
-  // JSDump
-  equal(inspect([1,2,3]), "{0: 1, 1: 2, 2: 3}");
+  equal(inspect([1,2,3]), "[1,2,3]");
 });

--- a/packages/ember-runtime/tests/core/inspect_test.js
+++ b/packages/ember-runtime/tests/core/inspect_test.js
@@ -35,3 +35,15 @@ test("object", function() {
 test("array", function() {
   equal(inspect([1,2,3]), "[1,2,3]");
 });
+
+test("regexp", function() {
+  equal(inspect(/regexp/), "/regexp/");
+});
+
+test("date", function() {
+  equal(inspect(new Date("Sat Apr 30 2011 13:24:11")).substring(0, 24), "Sat Apr 30 2011 13:24:11"); // Ignore assertion about timezone.
+});
+
+test("error", function() {
+  equal(inspect(new Error("Oops")), "Error: Oops");
+});


### PR DESCRIPTION
`Ember.inspect` couldn't inspect other than a direct instance of `Object`:

``` javascript
> Ember.inspect(/regexp/); //=> '{}'
```

So I fixed to support some objects to be inspected correctly.

For examples:

``` javascript
> Ember.inspect([1, 2, 3]); //=> '[1,2,3]'
> Ember.inspect(/regexp/); //=> '/regexp/'
> Ember.inspect(new Date("Sat Apr 30 2011 13:24:11")); //=> 'Sat Apr 30 2011 13:24:11 GMT+0900 (JST)'
> Ember.inspect(new Error("Oops"); //=> 'Error: Oops'
```
