### PR TITLE
Support object with `Ember.String.fmt`

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -58,7 +58,7 @@ Ember.String = {
     return str.replace(/%@([0-9]+)?/g, function(s, argIndex) {
       argIndex = (argIndex) ? parseInt(argIndex, 10) - 1 : idx++;
       s = formats[argIndex];
-      return ((s === null) ? '(null)' : (s === undefined) ? '' : s).toString();
+      return (s === null) ? '(null)' : (s === undefined) ? '' : Ember.inspect(s);
     }) ;
   },
 

--- a/packages/ember-runtime/tests/system/string/fmt_string.js
+++ b/packages/ember-runtime/tests/system/string/fmt_string.js
@@ -21,3 +21,10 @@ test("'%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four
     equal('%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight'), 'Eight Seven Six Five Four Three Two One');
   }
 });
+
+test("'data: %@'.fmt({id: 3}) => 'data: {id: 3}'", function() {
+  equal(Ember.String.fmt('data: %@', [{id: 3}]), 'data: {id: 3}');
+  if (Ember.EXTEND_PROTOTYPES) {
+    equal('data: %@'.fmt({id: 3}), 'data: {id: 3}');
+  }
+});


### PR DESCRIPTION
- before:

``` javascript
'data: %@'.fmt({id: 3}); //=> 'data: [object Object]'
```
- after:

``` javascript
'data: %@'.fmt({id: 3}); //=> 'data: {a: 1}'
```

This commit improves assertion message such as the following:

``` javascript
Ember.assert('Your data must contain `id`. But actual: %@'.fmt(data), data.id);
```
