### PR TITLE
Container Learns: Factory injections

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -125,8 +125,13 @@ define("container",
       this.resolver = parent && parent.resolver || function() {};
       this.registry = new InheritingDict(parent && parent.registry);
       this.cache = new InheritingDict(parent && parent.cache);
+      this.factoryCache = new InheritingDict(parent && parent.cache);
       this.typeInjections = new InheritingDict(parent && parent.typeInjections);
       this.injections = {};
+
+      this.factoryTypeInjections = new InheritingDict(parent && parent.factoryTypeInjections);
+      this.factoryInjections = {};
+
       this._options = new InheritingDict(parent && parent._options);
       this._typeOptions = new InheritingDict(parent && parent._typeOptions);
     }
@@ -348,7 +353,7 @@ define("container",
 
         The default behaviour is for lookup to return a singleton instance.
         The singleton is scoped to the container, allowing multiple containers
-        to all have there own locally scoped singletons.
+        to all have their own locally scoped singletons.
 
         ```javascript
         var container = new Container();
@@ -430,7 +435,7 @@ define("container",
       },
 
       /**
-        Allow registerying options for all factories of a type.
+        Allow registering options for all factories of a type.
 
         ```javascript
         var container = new Container();
@@ -510,17 +515,7 @@ define("container",
       typeInjection: function(type, property, fullName) {
         if (this.parent) { illegalChildOperation('typeInjection'); }
 
-        var injections = this.typeInjections.get(type);
-
-        if (!injections) {
-          injections = [];
-          this.typeInjections.set(type, injections);
-        }
-
-        injections.push({
-          property: property,
-          fullName: fullName
-        });
+        addTypeInjection(this.typeInjections, type, property, fullName);
       },
 
       /*
@@ -541,7 +536,7 @@ define("container",
 
         container.register('source:main', Source);
         container.register('model:user', User);
-        container.register('model:post', PostController);
+        container.register('model:post', Post);
 
         // injecting one fullName on another fullName
         // eg. each user model gets a post model
@@ -574,8 +569,104 @@ define("container",
           return this.typeInjection(factoryName, property, injectionName);
         }
 
-        var injections = this.injections[factoryName] = this.injections[factoryName] || [];
-        injections.push({ property: property, fullName: injectionName });
+        addInjection(this.injections, factoryName, property, injectionName);
+      },
+
+
+      /*
+        @private
+
+        Used only via `factoryInjection`.
+
+        Provides a specialized form of injection, specifically enabling
+        all factory of one type to be injected with a reference to another
+        object.
+
+        For example, provided each factory of type `model` needed a `store`.
+        one would do the following:
+
+        ```javascript
+        var container = new Container();
+
+        container.registerFactory('model:user', User);
+        container.register('store:main', SomeStore);
+
+        container.factoryTypeInjection('model', 'store', 'store:main');
+
+        var store = container.lookup('store:main');
+        var UserFactory = container.lookupFactory('model:user');
+
+        UserFactory.store instanceof SomeStore; //=> true
+        ```
+
+        @method factoryTypeInjection
+        @param {String} type
+        @param {String} property
+        @param {String} fullName
+      */
+      factoryTypeInjection: function(type, property, fullName) {
+        if (this.parent) { illegalChildOperation('factoryTypeInjection'); }
+
+        addTypeInjection(this.factoryTypeInjections, type, property, fullName);
+      },
+
+      /*
+        Defines factory injection rules.
+
+        Similar to regular injection rules, but are run against factories, via
+        `Container#lookupFactory`.
+
+        These rules are used to inject objects onto factories when they
+        are looked up.
+
+        Two forms of injections are possible:
+
+        * Injecting one fullName on another fullName
+        * Injecting one fullName on a type
+
+        Example:
+
+        ```javascript
+        var container = new Container();
+
+        container.register('store:main', Store);
+        container.register('store:secondary', OtherStore);
+        container.register('model:user', User);
+        container.register('model:post', Post);
+
+        // injecting one fullName on another type
+        container.factoryInjection('model', 'store', 'store:main');
+
+        // injecting one fullName on another fullName
+        container.factoryInjection('model:post', 'secondaryStore', 'store:secondary');
+
+        var UserFactory = container.lookupFactory('model:user');
+        var PostFactory = container.lookupFactory('model:post');
+        var store = container.lookup('store:main');
+
+        UserFactory.store instanceof Store; //=> true
+        UserFactory.secondaryStore instanceof OtherStore; //=> false
+
+        PostFactory.store instanceof Store; //=> true
+        PostFactory.secondaryStore instanceof OtherStore; //=> true
+
+        // and both models share the same source instance
+        UserFactory.store === PostFactory.store; //=> true
+        ```
+
+        @method factoryInjection
+        @param {String} factoryName
+        @param {String} property
+        @param {String} injectionName
+      */
+      factoryInjection: function(factoryName, property, injectionName) {
+        if (this.parent) { illegalChildOperation('injection'); }
+
+        if (factoryName.indexOf(':') === -1) {
+          return this.factoryTypeInjection(factoryName, property, injectionName);
+        }
+
+        addInjection(this.factoryInjections, factoryName, property, injectionName);
       },
 
       /**
@@ -597,7 +688,7 @@ define("container",
           item.destroy();
         });
 
-        delete this.parent;
+        this.parent = undefined;
         this.isDestroyed = true;
       },
 
@@ -660,32 +751,76 @@ define("container",
 
     function factoryFor(container, fullName) {
       var name = container.normalize(fullName);
-      return container.resolve(name);
+      var factory = container.resolve(name);
+      var injectedFactory;
+      var cache = container.factoryCache;
+
+      if (!factory) { return; }
+
+      if (cache.has(fullName)) {
+        return cache.get(fullName);
+      }
+
+      if (typeof factory.extend !== 'function') {
+        // TODO: think about a 'safe' merge style extension
+        // for now just fallback to create time injection
+        return factory;
+      } else {
+        injectedFactory = factory.extend(injectionsFor(container, fullName));
+        injectedFactory.reopenClass(factoryInjectionsFor(container, fullName));
+
+        cache.set(fullName, injectedFactory);
+
+        return injectedFactory;
+      }
+    }
+
+    function injectionsFor(container ,fullName) {
+      var splitName = fullName.split(":"),
+        type = splitName[0],
+        injections = [];
+
+      injections = injections.concat(container.typeInjections.get(type) || []);
+      injections = injections.concat(container.injections[fullName] || []);
+
+      injections = buildInjections(container, injections);
+      injections._debugContainerKey = fullName;
+      injections.container = container;
+
+      return injections;
+    }
+
+    function factoryInjectionsFor(container, fullName) {
+      var splitName = fullName.split(":"),
+        type = splitName[0],
+        factoryInjections = [];
+
+      factoryInjections = factoryInjections.concat(container.factoryTypeInjections.get(type) || []);
+      factoryInjections = factoryInjections.concat(container.factoryInjections[fullName] || []);
+
+      factoryInjections = buildInjections(container, factoryInjections);
+      factoryInjections._debugContainerKey = fullName;
+
+      return factoryInjections;
     }
 
     function instantiate(container, fullName) {
       var factory = factoryFor(container, fullName);
-
-      var splitName = fullName.split(":"),
-          type = splitName[0],
-          value;
 
       if (option(container, fullName, 'instantiate') === false) {
         return factory;
       }
 
       if (factory) {
-        var injections = [];
-        injections = injections.concat(container.typeInjections.get(type) || []);
-        injections = injections.concat(container.injections[fullName] || []);
-
-        var hash = buildInjections(container, injections);
-        hash.container = container;
-        hash._debugContainerKey = fullName;
-
-        value = factory.create(hash);
-
-        return value;
+        if (typeof factory.extend === 'function') {
+          // assume the factory was extendable and is already injected
+          return factory.create();
+        } else {
+          // assume the factory was extendable
+          // to create time injections
+          // TODO: support new'ing for instantiation and merge injections for pure JS Functions
+          return factory.create(injectionsFor(container, fullName));
+        }
       }
     }
 
@@ -702,6 +837,25 @@ define("container",
         value.destroy();
       });
       container.cache.dict = {};
+    }
+
+    function addTypeInjection(rules, type, property, fullName) {
+      var injections = rules.get(type);
+
+      if (!injections) {
+        injections = [];
+        rules.set(type, injections);
+      }
+
+      injections.push({
+        property: property,
+        fullName: fullName
+      });
+    }
+
+    function addInjection(rules, factoryName, property, injectionName) {
+      var injections = rules[factoryName] = rules[factoryName] || [];
+      injections.push({ property: property, fullName: injectionName });
     }
 
     return Container;

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,13 +1,25 @@
 var passedOptions;
 var Container = requireModule('container');
 
-var setProperties = function(object, properties) {
+function setProperties(object, properties) {
   for (var key in properties) {
     if (properties.hasOwnProperty(key)) {
       object[key] = properties[key];
     }
   }
-};
+}
+
+var o_create = Object.create || (function(){
+  function F(){}
+
+  return function(o) {
+    if (arguments.length !== 1) {
+      throw new Error('Object.create implementation only accepts one parameter.');
+    }
+    F.prototype = o;
+    return new F();
+  };
+}());
 
 module("Container");
 
@@ -19,6 +31,7 @@ function factory() {
     this._guid = guids++;
   };
 
+  Klass.prototype.constructor = Klass;
   Klass.prototype.destroy = function() {
     this.isDestroyed = true;
   };
@@ -27,12 +40,42 @@ function factory() {
     return "<Factory:" + this._guid + ">";
   };
 
-  Klass.create = function(options) {
-    passedOptions = options;
-    return new Klass(options);
-  };
+  Klass.create = create;
+  Klass.extend = extend;
+  Klass.reopen = extend;
+  Klass.reopenClass = reopenClass;
 
   return Klass;
+
+  function create(options) {
+    passedOptions = options;
+    return new this.prototype.constructor(options);
+  }
+
+  function reopenClass(options) {
+    setProperties(this, options);
+  }
+
+  function extend(options) {
+    var Child = function(options) {
+      Klass.call(this, options);
+    };
+
+    var Parent = this;
+
+    Child.prototype = new Parent();
+    Child.prototype.constructor = Child;
+
+    setProperties(Child.prototype, options);
+
+    Child.create = create;
+    Child.extend = extend;
+    Child.reopen = extend;
+
+    Child.reopenClass = reopenClass;
+
+    return Child;
+  }
 }
 
 test("A registered factory returns the same instance each time", function() {
@@ -54,7 +97,66 @@ test("A registered factory is returned from lookupFactory", function() {
 
   container.register('controller:post', PostController);
 
-  equal(container.lookupFactory('controller:post'), PostController, "The factory is returned from lookupFactory");
+  var PostControllerFactory = container.lookupFactory('controller:post');
+
+  ok(PostControllerFactory, 'factory is returned');
+  ok(PostControllerFactory.create() instanceof  PostController, "The return of factory.create is an instance of PostController");
+});
+
+test("A registered factory is returned from lookupFactory is the same factory each time", function() {
+  var container = new Container();
+  var PostController = factory();
+
+  container.register('controller:post', PostController);
+
+  deepEqual(container.lookupFactory('controller:post'), container.lookupFactory('controller:post'), 'The return of lookupFactory is always the same');
+});
+
+test("A factory returned from lookupFactory has a debugkey", function(){
+  var container = new Container();
+  var PostController = factory();
+  var instance;
+
+  container.register('controller:post', PostController);
+  var PostFactory = container.lookupFactory('controller:post');
+
+  ok(!PostFactory.container, 'factory instance receives a container');
+  equal(PostFactory._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
+});
+
+test("fallback for to create time injections if factory has no extend", function(){
+  var container = new Container();
+  var AppleController = factory();
+  var PostController = factory();
+
+  PostController.extend = undefined; // remove extend
+
+  var instance;
+
+  container.register('controller:apple', AppleController);
+  container.register('controller:post', PostController);
+  container.injection('controller:post', 'apple', 'controller:apple');
+
+  var postController = container.lookup('controller:post');
+
+  ok(postController.container, 'instance receives a container');
+  equal(postController.container, container, 'instance receives the correct container');
+  equal(postController._debugContainerKey, 'controller:post', 'instance receives _debugContainerKey');
+  ok(postController.apple instanceof AppleController, 'instance receives an apple of instance AppleController');
+});
+
+test("The descendants of a factory returned from lookupFactory have a container and debugkey", function(){
+  var container = new Container();
+  var PostController = factory();
+  var instance;
+
+  container.register('controller:post', PostController);
+  instance = container.lookupFactory('controller:post').create();
+
+  ok(instance.container, 'factory instance receives a container');
+  equal(instance._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
+
+  ok(instance instanceof PostController, 'factory instance is instance of factory');
 });
 
 test("A registered factory returns a fresh instance if singleton: false is passed as an option", function() {
@@ -123,7 +225,7 @@ test("A container lookup has access to the container", function() {
   equal(postController.container, container);
 });
 
-test("A factory type with a registered injection receives the injection", function() {
+test("A factory type with a registered injection's instances receive that injection", function() {
   var container = new Container();
   var PostController = factory();
   var Store = factory();
@@ -152,11 +254,12 @@ test("An individual factory with a registered injection receives the injection",
   var postController = container.lookup('controller:post');
   var store = container.lookup('store:main');
 
-  deepEqual(passedOptions, {
-    store: store,
-    container: container,
-    _debugContainerKey: 'controller:post'
-  });
+  equal(store.container, container);
+  equal(store._debugContainerKey, 'store:main');
+
+  equal(postController.container, container);
+  equal(postController._debugContainerKey, 'controller:post');
+  equal(postController.store, store, 'has the correct store injected');
 });
 
 test("A factory with both type and individual injections", function() {
@@ -180,7 +283,28 @@ test("A factory with both type and individual injections", function() {
   equal(postController.router, router);
 });
 
-test("A non-singleton factory is never cached", function() {
+test("A factory with both type and individual factoryInjections", function() {
+  var container = new Container();
+  var PostController = factory();
+  var Store = factory();
+  var Router = factory();
+
+  container.register('controller:post', PostController);
+  container.register('store:main', Store);
+  container.register('router:main', Router);
+
+  container.factoryInjection('controller:post', 'store', 'store:main');
+  container.factoryTypeInjection('controller', 'router', 'router:main');
+
+  var PostControllerFactory = container.lookupFactory('controller:post');
+  var store = container.lookup('store:main');
+  var router = container.lookup('router:main');
+
+  equal(PostControllerFactory.store, store, 'PostControllerFactory has the instance of store');
+  equal(PostControllerFactory.router, router, 'PostControllerFactory has the route instance');
+});
+
+test("A non-singleton instance is never cached", function() {
   var container = new Container();
   var PostView = factory();
 
@@ -208,10 +332,16 @@ test("A failed lookup returns undefined", function() {
 
 test("Injecting a failed lookup raises an error", function() {
   var container = new Container();
-  var Foo = { create: function() { }};
+
+  var fooInstance = {};
+  var fooFactory  = {};
+
+  var Foo = {
+    create: function(args) { return fooInstance; },
+    extend: function(args) { return fooFactory;  }
+  };
 
   container.register('model:foo', Foo);
-
   container.injection('model:foo', 'store', 'store:main');
 
   throws(function() {

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -38,23 +38,32 @@ test('the default resolver looks up templates in Ember.TEMPLATES', function() {
 });
 
 test('the default resolver looks up basic name as no prefix', function() {
-  equal(locator.lookup('controller:basic'), Ember.Controller);
+  ok(Ember.Controller.detect(locator.lookup('controller:basic')), 'locator looksup correct controller');
 });
+
+function detectEqual(first, second, message) {
+  ok(first.detect(second), message);
+}
 
 test('the default resolver looks up arbitrary types on the namespace', function() {
   application.FooManager = Ember.Object.extend({});
-  equal(locator.resolve('manager:foo'), application.FooManager, "looks up FooManager on application");
+
+  detectEqual(application.FooManager, locator.resolver('manager:foo'),"looks up FooManager on application");
 });
 
 test("the default resolver resolves models on the namespace", function() {
   application.Post = Ember.Object.extend({});
-  equal(locator.lookupFactory('model:post'), application.Post, "looks up Post model on application");
+
+  detectEqual(application.Post, locator.lookupFactory('model:post'), "looks up Post model on application");
 });
 
-test("the default resolver throws an error if the fullName to resolve is invalid", function() {
-  raises(function() { locator.resolve('');       }, TypeError, /Invalid fullName/ );
-  raises(function() { locator.resolve(':');      }, TypeError, /Invalid fullName/ );
-  raises(function() { locator.resolve('model');  }, TypeError, /Invalid fullName/ );
-  raises(function() { locator.resolve('model:'); }, TypeError, /Invalid fullName/ );
-  raises(function() { locator.resolve(':type');  }, TypeError, /Invalid fullName/ );
+test("the default resolver throws an error if the fullName to resolve is invalid", function(){
+  raises(function(){ locator.resolve(undefined);}, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve(null);     }, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve('');       }, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve('');       }, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve(':');      }, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve('model');  }, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve('model:'); }, TypeError, /Invalid fullName/ );
+  raises(function(){ locator.resolve(':type');  }, TypeError, /Invalid fullName/ );
 });

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -42,11 +42,11 @@ module("Ember.Application – logging of generated classes", {
 function visit(path) {
   stop();
 
-  var promise = Ember.run(function() {
-    return new Ember.RSVP.Promise(function(resolve, reject) {
+  var promise = Ember.run(function(){
+    return new Ember.RSVP.Promise(function(resolve, reject){
       var router = App.__container__.lookup('router:main');
 
-      resolve(router.handleURL(path).then(function(value) {
+      resolve(router.handleURL(path).then(function(value){
         start();
         ok(true, 'visited: `' + path + '`');
         return value;

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -15,12 +15,12 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
     var binding;
 
     if (itemController) {
-      var controller = Ember.ArrayController.create();
-      set(controller, 'itemController', itemController);
-      set(controller, 'container', get(this, 'controller.container'));
-      set(controller, '_eachView', this);
-      set(controller, 'target', get(this, 'controller'));
-      set(controller, 'parentController', get(this, 'controller'));
+      var controller = get(this, 'controller.container').lookupFactory('controller:array').create({
+        parentController: get(this, 'controller'),
+        itemController: itemController,
+        target: get(this, 'controller'),
+        _eachView: this
+      });
 
       this.disableContentObservers(function() {
         set(this, 'content', controller);

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -207,7 +207,10 @@ test("it supports itemController", function() {
     container: container
   };
 
+  container.register('controller:array', Ember.ArrayController.extend());
+
   view = Ember.View.create({
+    container: container,
     template: templateFor('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
     people: people,
     controller: parentController
@@ -255,9 +258,11 @@ test("itemController gets a parentController property", function() {
         company: 'Yapp'
       };
 
+  container.register('controller:array', Ember.ArrayController.extend());
   Ember.run(function() { view.destroy(); }); // destroy existing view
 
   view = Ember.View.create({
+    container: container,
     template: templateFor('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
     people: people,
     controller: parentController
@@ -278,9 +283,11 @@ test("it supports itemController when using a custom keyword", function() {
   });
 
   var container = new Ember.Container();
+  container.register('controller:array', Ember.ArrayController.extend());
 
   Ember.run(function() { view.destroy(); }); // destroy existing view
   view = Ember.View.create({
+    container: container,
     template: templateFor('{{#each person in view.people itemController="person"}}{{person.controllerName}}{{/each}}'),
     people: people,
     controller: {

--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -15,33 +15,28 @@ Ember.controllerFor = function(container, controllerName, lookupOptions) {
   `App.ObjectController` and `App.ArrayController`
 */
 Ember.generateController = function(container, controllerName, context) {
-  var controller, DefaultController, fullName, instance;
+  var ControllerFactory, fullName, instance, name, factoryName, controllerType;
 
   if (context && Ember.isArray(context)) {
-    DefaultController = container.resolve('controller:array');
-    controller = DefaultController.extend({
-      isGenerated: true
-    });
+    controllerType = 'array';
   } else if (context) {
-    DefaultController = container.resolve('controller:object');
-    controller = DefaultController.extend({
-      isGenerated: true
-    });
+    controllerType = 'object';
   } else {
-    DefaultController = container.resolve('controller:basic');
-    controller = DefaultController.extend({
-      isGenerated: true
-    });
+    controllerType = 'basic';
   }
 
-  controller.toString = function() {
-    return "(generated " + controllerName + " controller)";
-  };
+  factoryName = 'controller:' + controllerType;
 
-  controller.isGenerated = true;
+  ControllerFactory = container.lookupFactory(factoryName).extend({
+    isGenerated: true,
+    toString: function() {
+      return "(generated " + controllerName + " controller)";
+    }
+  });
 
   fullName = 'controller:' + controllerName;
-  container.register(fullName, controller);
+
+  container.register(fullName, ControllerFactory);
 
   instance = container.lookup(fullName);
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -728,10 +728,12 @@ Ember.Route = Ember.Object.extend({
     }
 
     name = name ? name.replace(/\//g, '.') : this.routeName;
+    var viewName = this.viewName || name;
+    var templateName = this.templateName || name;
 
     var container = this.container,
-        view = container.lookup('view:' + name),
-        template = container.lookup('template:' + name);
+        view = container.lookup('view:' + viewName),
+        template = container.lookup('template:' + templateName);
 
     if (!view && !template) {
       Ember.assert("Could not find \"" + name + "\" template or view.", !namePassed);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -146,7 +146,7 @@ Ember.Router = Ember.Object.extend({
 
   _getHandlerFunction: function() {
     var seen = {}, container = this.container,
-        DefaultRoute = container.resolve('route:basic'),
+        DefaultRoute = container.lookupFactory('route:basic'),
         self = this;
 
     return function(name) {
@@ -278,11 +278,13 @@ Ember.Router = Ember.Object.extend({
 });
 
 Ember.Router.reopenClass({
+  router: null,
   map: function(callback) {
     var router = this.router;
     if (!router) {
-      router = this.router = new Router();
+      router = new Router();
       router.callbacks = [];
+      this.reopenClass({ router: router });
     }
 
     if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -189,20 +189,24 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
   controllerAt: function(idx, object, controllerClass) {
     var container = get(this, 'container'),
         subControllers = get(this, '_subControllers'),
-        subController = subControllers[idx];
+        subController = subControllers[idx],
+        factory, fullName;
 
-    if (!subController) {
-      subController = container.lookup("controller:" + controllerClass, { singleton: false });
-      subControllers[idx] = subController;
-    }
+    if (subController) { return subController; }
 
-    if (!subController) {
+    fullName = "controller:" + controllerClass;
+
+    if (!container.has(fullName)) {
       throw new Error('Could not resolve itemController: "' + controllerClass + '"');
     }
 
-    subController.set('target', this);
-    subController.set('parentController', get(this, 'parentController') || this);
-    subController.set('content', object);
+    subController = container.lookupFactory(fullName).create({
+      target: this,
+      parentController: get(this, 'parentController') || this,
+      content: object
+    });
+
+    subControllers[idx] = subController;
 
     return subController;
   },


### PR DESCRIPTION
- [x] the hard work (make it all work)
- [x] improve commit messages
- [x] fall back to create time injections if no extend is present.
- [x] add examples to this PR

You are now able to inject on to factories:

``` javascript
container.register('model:user', User);
container.register('store:main', Store);
container.register('config:main', Config);

container.factoryInjection('model:user', 'store', 'store:main')
container.injection('model:user', 'config', 'config:main')
container.lookupFactory('model:user').store  instanceof Store; //=> true
```

Also the factory returned from `container.lookupFactory` can be used
to instantiate fully injected instances.

``` javascript
// assuming the above example

var UserFactory = container.lookupFactory('model:user');
var user = UserFactory.create({ name: 'stefan' })

user.container === container // => true
user.config instanceof Config // => true
user.name === 'stefan' // => true
```
