### PR TITLE
Fix indeterminate checkbox that is set on insert into dom

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -56,10 +56,16 @@ Ember.Checkbox = Ember.View.extend({
   type: "checkbox",
   checked: false,
   disabled: false,
+  indeterminate: false,
 
   init: function() {
     this._super();
     this.on("change", this, this._updateElementValue);
+  },
+
+  didInsertElement: function() {
+    this._super();
+    this.get('element').indeterminate = !!this.get('indeterminate');
   },
 
   _updateElementValue: function() {


### PR DESCRIPTION
Indeterminate is a property that can only be set via javascript, not as an attribute. For this reason, inserting a checkbox view with indeterminate already set causes it to not show the indeterminate state.

I tried for a while but I couldn't reproduce this in the test suite, but I can show it in a [jsfiddle](http://jsfiddle.net/alexspeller/NQKvy/37/). I'm not sure if the way the test suite appends the checkbox view to the dom is somehow working around the issue, but as you can see from the jsfiddle it's not working in real life - the tests that are already in the test suite for this look like they should be catching this problem.
