### PR TITLE
Remove unreferenced property `Ember.Comparable#isComparable`

### DIFF
--- a/packages/ember-runtime/lib/mixins/comparable.js
+++ b/packages/ember-runtime/lib/mixins/comparable.js
@@ -20,15 +20,6 @@ require('ember-runtime/core');
 Ember.Comparable = Ember.Mixin.create( /** @scope Ember.Comparable.prototype */{
 
   /**
-    walk like a duck. Indicates that the object can be compared.
-
-    @property isComparable
-    @type Boolean
-    @default true
-  */
-  isComparable: true,
-
-  /**
     Override to return the result of the comparison of the two parameters. The
     compare method should return:
 


### PR DESCRIPTION
`Ember.Comparable#isComparable` is not referenced from anywhere.
