### PR TITLE
The Ember Handlebars precompiler throws an error when using variables beginning with '@'

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1808,6 +1808,20 @@ test("should work with precompiled templates", function() {
   equal(view.$().text(), "updated", "the precompiled template was updated");
 });
 
+test("should precompile with custom variables", function() {
+  var templateString = Ember.Handlebars.precompile("{{@customVar}}"),
+      compiledTemplate = Ember.Handlebars.template(eval(templateString));
+
+  view = Ember.View.create({
+    value: "rendered",
+    template: compiledTemplate
+  });
+
+  appendView();
+
+  equal(view.$().text(), "rendered", "the precompiled template was rendered");
+});
+
 test("should expose a controller keyword when present on the view", function() {
   var templateString = "{{controller.foo}}{{#view}}{{controller.baz}}{{/view}}";
   view = Ember.View.create({

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -507,6 +507,22 @@ test("controller is assignable inside an #each", function() {
   equal(view.$().text(), "AdamSteve");
 });
 
+test("the @index variable can be used inside an #each", function() {
+
+  var controller = Ember.ArrayController.create({
+    content: Ember.A(["foo", "bar", "baz"])
+  });
+
+  var view = Ember.View.create({
+    controller: controller,
+    template: templateFor("{{#each controller}}{{@index}}{{/each}}")
+  });
+
+  append(view);
+
+  equal(view.$().text(), "012");
+});
+
 test("single-arg each defaults to current context", function() {
   view = Ember.View.create({
     context: Ember.A([ { name: "Adam" }, { name: "Steve" } ]),


### PR DESCRIPTION
In Handlebars templates you should be able to use a variable beginning with `@`. Handlebars itself provides the `@index` variable inside an `#each` block. However, using any variable beginning with `@` such as `@index` or any other variable you might define using a Handlebars helper will throw an error:

```
SyntaxError: Unexpected token ,
at Object.Function (<anonymous>)
at Object.JavaScriptCompiler.createFunctionContext (http://localhost:9292/handlebars.js:1500:23)
at Object.JavaScriptCompiler.compile (http://localhost:9292/handlebars.js:1415:17)
at Object.Ember.Handlebars.precompile (ember-handlebars-compiler:247:52)
at Object.templateString (ember-handlebars/~tests/handlebars_test:1812:41)
at Object.Test.run (http://localhost:9292/qunit/qunit.js:190:18)
at http://localhost:9292/qunit/qunit.js:348:10
at process (http://localhost:9292/qunit/qunit.js:1420:24)
at http://localhost:9292/qunit/qunit.js:466:5
```

Using the ordinary Handlebars precompiler does not throw an error when you try to use an `@` variable. 

You can see the [`@index` error here](http://jsbin.com/ucanam/398/edit) and the [custom variable error here](http://jsbin.com/ucanam/399/edit). This pull request includes two failing unit tests.
