### PR TITLE
Add `Ember.computed.join` shorthand method.

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -738,3 +738,25 @@ Ember.computed.defaultTo = function(defaultPath) {
     return newValue != null ? newValue : get(this, defaultPath);
   });
 };
+
+/**
+  @method computed.join
+  @for Ember
+  @param {String} separator
+  @param {String} dependentKey, [dependentKey...]
+  @return {Ember.ComputedProperty} computed property which returns
+  the each dependent property joined by the separator.
+*/
+Ember.computed.join = function(separator) {
+  var properties = a_slice.call(arguments, 1);
+
+  var computed = Ember.computed(function() {
+    var res = [];
+    for (var idx in properties) {
+      res.push(get(this, properties[idx]));
+    }
+    return res.join(separator);
+  });
+
+  return computed.property.apply(computed, properties);
+};

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -961,3 +961,13 @@ testBoth('Ember.computed.oneWay', function(get, set) {
 
   equal(get(obj, 'nickName'), 'TeddyBear');
 });
+
+testBoth('Ember.computed.join', function(get, set) {
+  var obj = { firstName: 'Jean-Luc', lastName: 'Picard' };
+  Ember.defineProperty(obj, 'fullName', Ember.computed.join(' ', 'firstName', 'lastName'));
+  equal(get(obj, 'fullName'), 'Jean-Luc Picard');
+
+  set(obj, 'firstName', 'Locutus');
+  set(obj, 'lastName', 'of Borg');
+  equal(get(obj, 'fullName'), 'Locutus of Borg');
+});


### PR DESCRIPTION
`Ember.computed.join` joins the result of each dependent property into a
single string, with the supplied separator.  This is analogous to
JavaScript's Array.join, which is used inside the implementation.

Example:

``` javascript
person = Ember.Object.create({
  firstName: 'Jean-Luc',
  lastName:  'Picard',
  fullName:  Ember.computed.join(' ', 'firstName', 'lastName')
});
```
