### PR TITLE
Tweak htmlSafe docs

### DIFF
--- a/packages/ember-handlebars/lib/string.js
+++ b/packages/ember-handlebars/lib/string.js
@@ -1,9 +1,11 @@
 /**
- * Mark a string as safe for raw output with Handlebars. If you
+ * Mark a string as safe for unescaped output with Handlebars. If you
  * return HTML from a Handlebars helper, use this function to
  * ensure Handlebars does not escape the HTML.
  *
- * `Ember.String.htmlSafe('<div>someString</div>')`
+ * ```javascript
+ * Ember.String.htmlSafe('<div>someString</div>')
+ * ```
  *
  * @method htmlSafe
  * @for Ember.String
@@ -19,8 +21,11 @@ var htmlSafe = Ember.String.htmlSafe;
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
-   * Use `'<div>someString</div>'.htmlSafe()` to mark a string as being
-   * safe for raw output with Handlebars.
+   * Mark a string as being safe for unescaped output with Handlebars.
+   *
+   * ```javascript
+   * '<div>someString</div>'.htmlSafe()
+   * ```
    *
    * See `Ember.String.htmlSafe`.
    *


### PR DESCRIPTION
@stefanpenner I missed a commit on my last docs PR. Whoooops. Sorry about that.

Better formatting and specific language for htmlSafe docs.
