### PR TITLE
Only use valueNormalizer if one is present insideGroup. Fixes #2809

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -38,7 +38,7 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
 
       var template, context, result = handlebarsGet(currentContext, property, options);
 
-      result = valueNormalizer(result);
+      result = valueNormalizer ? valueNormalizer(result) : result;
 
       context = preserveContext ? currentContext : result;
       if (shouldDisplay(result)) {

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -153,3 +153,32 @@ test("it should support #with this as qux", function() {
     view.destroy();
   });
 });
+
+module("Handlebars {{#with foo}} insideGroup");
+
+test("it should render without fail", function() {
+  var View = Ember.View.extend({
+    template: Ember.Handlebars.compile("{{#view view.childView}}{{#with person}}{{name}}{{/with}}{{/view}}"),
+    controller: Ember.Object.create({ person: { name: "Ivan IV Vasilyevich" } }),
+    childView: Ember.View.extend({
+      render: function(){
+        this.set('templateData.insideGroup', true);
+        return this._super.apply(this, arguments);
+      }
+    })
+  });
+
+  var view = View.create();
+  appendView(view);
+  equal(view.$().text(), "Ivan IV Vasilyevich", "should be properly scoped");
+
+  Ember.run(function() {
+    Ember.set(view, 'controller.person.name', "Ivan the Terrible");
+  });
+
+  equal(view.$().text(), "Ivan the Terrible", "should update");
+
+  Ember.run(function() {
+    view.destroy();
+  });
+});


### PR DESCRIPTION
The `valueNormalizer` function is optional in `_HandlebarsBoundView`, see:

  https://github.com/emberjs/ember.js/blob/master/packages/ember-handlebars/lib/views/handlebars_bound_view.js#L246

It should be the same inside of bind's alternative logic for when insideGroup. bind is called without `valueNormalizer` twice, see:

  https://github.com/emberjs/ember.js/blob/master/packages/ember-handlebars/lib/helpers/binding.js#L198
  https://github.com/emberjs/ember.js/blob/master/packages/ember-handlebars/lib/helpers/binding.js#L270

Line 270 is for the `#with` helper, fixing #2809.
