### PR TITLE
Don't set context in Ember.controllerFor

### DIFF
--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -21,14 +21,12 @@ Ember.generateController = function(container, controllerName, context) {
   if (context && Ember.isArray(context)) {
     DefaultController = container.resolve('controller:array');
     controller = DefaultController.extend({
-      isGenerated: true,
-      content: context
+      isGenerated: true
     });
   } else if (context) {
     DefaultController = container.resolve('controller:object');
     controller = DefaultController.extend({
-      isGenerated: true,
-      content: context
+      isGenerated: true
     });
   } else {
     DefaultController = container.resolve('controller:basic');

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -66,7 +66,6 @@ test("controllerFor should create Ember.ObjectController", function() {
   var controller = Ember.controllerFor(container, 'home', context);
 
   ok(controller instanceof Ember.ObjectController, 'should create controller');
-  equal(controller.get('content'), context, 'should set content');
 });
 
 test("controllerFor should create Ember.ArrayController", function() {
@@ -74,7 +73,6 @@ test("controllerFor should create Ember.ArrayController", function() {
   var controller = Ember.controllerFor(container, 'home', context);
 
   ok(controller instanceof Ember.ArrayController, 'should create controller');
-  equal(controller.get('content'), context, 'should set content');
 });
 
 test("controllerFor should create App.Controller if provided", function() {
@@ -93,7 +91,6 @@ test("controllerFor should create App.ObjectController if provided", function() 
   controller = Ember.controllerFor(container, 'home', context);
 
   ok(controller instanceof namespace.ObjectController, 'should create controller');
-  equal(controller.get('content'), context, 'should set content');
 
 });
 
@@ -104,6 +101,5 @@ test("controllerFor should create App.ArrayController if provided", function() {
   controller = Ember.controllerFor(container, 'home', context);
 
   ok(controller instanceof namespace.ArrayController, 'should create controller');
-  equal(controller.get('content'), context, 'should set content');
 
 });


### PR DESCRIPTION
`Ember.controllerFor` shouldn't set the controller's context.  Setting the context should only be done in the route's `setupController`.

Fixes #3033
