### PR TITLE
Fix incrementProperty/decrementProperty to handle NaN

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -450,7 +450,8 @@ Ember.Observable = Ember.Mixin.create({
   */
   incrementProperty: function(keyName, increment) {
     if (Ember.isNone(increment)) { increment = 1; }
-    set(this, keyName, (get(this, keyName) || 0)+increment);
+    Ember.assert("Must pass a numeric value to incrementProperty", (!isNaN(parseFloat(increment)) && isFinite(increment)));
+    set(this, keyName, (get(this, keyName) || 0) + increment);
     return get(this, keyName);
   },
 
@@ -469,7 +470,8 @@ Ember.Observable = Ember.Mixin.create({
   */
   decrementProperty: function(keyName, decrement) {
     if (Ember.isNone(decrement)) { decrement = 1; }
-    set(this, keyName, (get(this, keyName) || 0)-decrement);
+    Ember.assert("Must pass a numeric value to decrementProperty", (!isNaN(parseFloat(decrement)) && isFinite(decrement)));
+    set(this, keyName, (get(this, keyName) || 0) - decrement);
     return get(this, keyName);
   },
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -678,6 +678,7 @@ module("Observable objects & object properties ", {
 
 test('incrementProperty and decrementProperty',function() {
   var newValue = object.incrementProperty('numberVal');
+
   equal(25,newValue,'numerical value incremented');
   object.numberVal = 24;
   newValue = object.decrementProperty('numberVal');
@@ -691,6 +692,21 @@ test('incrementProperty and decrementProperty',function() {
   object.numberVal = 25;
   newValue = object.incrementProperty('numberVal', 0);
   equal(25,newValue,'zero numerical value incremented by specified increment');
+
+  expectAssertion(function() {
+    newValue = object.incrementProperty('numberVal', (0 - void(0))); // Increment by NaN
+  }, /Must pass a numeric value to incrementProperty/i);
+
+  expectAssertion(function() {
+    newValue = object.incrementProperty('numberVal', 'Ember'); // Increment by non-numeric String
+  }, /Must pass a numeric value to incrementProperty/i);
+
+  expectAssertion(function() {
+    newValue = object.incrementProperty('numberVal', 1/0); // Increment by Infinity
+  }, /Must pass a numeric value to incrementProperty/i);
+
+  equal(25,newValue,'Attempting to increment by non-numeric values should not increment value');
+
   object.numberVal = 25;
   newValue = object.decrementProperty('numberVal',5);
   equal(20,newValue,'numerical value decremented by specified increment');
@@ -700,6 +716,20 @@ test('incrementProperty and decrementProperty',function() {
   object.numberVal = 25;
   newValue = object.decrementProperty('numberVal', 0);
   equal(25,newValue,'zero numerical value decremented by specified increment');
+
+  expectAssertion(function() {
+    newValue = object.decrementProperty('numberVal', (0 - void(0))); // Decrement by NaN
+  }, /Must pass a numeric value to decrementProperty/i);
+
+  expectAssertion(function() {
+    newValue = object.decrementProperty('numberVal', 'Ember'); // Decrement by non-numeric String
+  }, /Must pass a numeric value to decrementProperty/i);
+
+  expectAssertion(function() {
+    newValue = object.decrementProperty('numberVal', 1/0); // Decrement by Infinity
+  }, /Must pass a numeric value to decrementProperty/i);
+
+  equal(25,newValue,'Attempting to decrement by non-numeric values should not decrement value');
 });
 
 test('toggle function, should be boolean',function() {


### PR DESCRIPTION
Includes fixes for incrementProperty and decrementProperty.

incrementProperty and decrementProperty will now throw a TypeError if attempting to increment/decrement by a non-numeric value or Infinity.

Retains support for 0 increment

Added tests for NaN, non-numeric string, and Infinity
