### PR TITLE
Remove unnecessary assertion for `Ember.inspect`

### DIFF
--- a/packages/ember-runtime/tests/core/inspect_test.js
+++ b/packages/ember-runtime/tests/core/inspect_test.js
@@ -46,7 +46,3 @@ test("date", function() {
   ok(inspected.match(/2011/), "The inspected date has its year");
   ok(inspected.match(/13:24:11/), "The inspected date has its time");
 });
-
-test("error", function() {
-  equal(inspect(new Error("Oops")), "Error: Oops");
-});


### PR DESCRIPTION
The assertion for `Ember.inspect` with error object depends on `Error#toString`.

It returns the value that provided by each environments.

Fix #3039.
