### PR TITLE
Should allow numbers in tagNames i.e. h1-6

### DIFF
--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -23,8 +23,8 @@ ClassSet.prototype = {
   }
 };
 
-var BAD_TAG_NAME_TEST_REGEXP = /[^a-zA-Z\-]/;
-var BAD_TAG_NAME_REPLACE_REGEXP = /[^a-zA-Z\-]/g;
+var BAD_TAG_NAME_TEST_REGEXP = /[^a-zA-Z0-9\-]/;
+var BAD_TAG_NAME_REPLACE_REGEXP = /[^a-zA-Z0-9\-]/g;
 
 function stripTagName(tagName) {
   if (!tagName) {

--- a/packages/ember-views/tests/views/view/render_test.js
+++ b/packages/ember-views/tests/views/view/render_test.js
@@ -109,6 +109,23 @@ test("should add ember-view to views", function() {
   ok(view.$().hasClass('ember-view'), "the view has ember-view");
 });
 
+test("should allow hX tags as tagName", function() {
+
+  view = Ember.ContainerView.create({
+    childViews: ["child"],
+
+    child: Ember.View.create({
+      tagName: 'h3'
+    })
+  });
+
+  Ember.run(function() {
+    view.createElement();
+  });
+
+  ok(view.$('h3').length, "does not render the h3 tag correctly");
+});
+
 test("should not add role attribute unless one is specified", function() {
   view = Ember.View.create();
 


### PR DESCRIPTION
The latest security update seems to have disallowed h1-6 as tagName, I have a series of `<h>` tags now.
