### PR TITLE
Proper namespace lookup from render helper

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -48,7 +48,6 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       lookupOptions = { singleton: false };
     }
 
-    name = name.replace(/\//g, '.');
     container = options.data.keywords.controller.container;
     router = container.lookup('router:main');
 


### PR DESCRIPTION
With the addition of namespaces, slashes should not longer be treated the same as dot notation. This pull request makes the render helper work properly as discussed on the emberjs.com blog:

"If you want to use an alternative namespace, you can use a /-separated path.
    {{render 'blog/posts'}}
This will render the blog/posts template with the controller Blog.PostsController."
