### PR TITLE
Components should not be singletons (just like views)

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -697,6 +697,7 @@ Ember.Application.reopenClass({
     container.normalize = normalize;
     container.resolver = resolverFor(namespace);
     container.describe = container.resolver.describe;
+    container.optionsForType('component', { singleton: false });
     container.optionsForType('view', { singleton: false });
     container.optionsForType('template', { instantiate: false });
     container.register('application:main', namespace, { instantiate: false });


### PR DESCRIPTION
I guess components should not be singletons. That's the same behavior with views at least.

I had trouble with code like this:

``` javascript
var c1 = container.lookup('component:popover');
var c2 = container.lookup('component:popover');
notStrictEqual(c1, c2); //Fails
```
