### PR TITLE
Fix {{yield}} helper to work with non Ember.Component views that have layouts

### DIFF
--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -57,7 +57,7 @@ var get = Ember.get, set = Ember.set;
   @return {String} HTML string
 */
 Ember.Handlebars.registerHelper('yield', function(options) {
-  var currentView = options.data.view, view = currentView, template;
+  var currentView = options.data.view, view = currentView, template, contextObject;
 
   while (view && !get(view, 'layout')) {
     view = get(view, 'parentView');
@@ -67,14 +67,17 @@ Ember.Handlebars.registerHelper('yield', function(options) {
 
   template = get(view, 'template');
 
-  var keywords = view._parentView.cloneKeywords();
+  contextObject = Ember.Component.detectInstance(view) ?
+    (view._parentView || view) : view;
+
+  var keywords = contextObject.cloneKeywords();
 
   currentView.appendChild(Ember.View, {
     isVirtual: true,
     tagName: '',
     template: template,
-    context: get(view._parentView, 'context'),
-    controller: get(view._parentView, 'controller'),
+    context: get(contextObject, 'context'),
+    controller: get(contextObject, 'controller'),
     templateData: {keywords: keywords}
   });
 });

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -180,3 +180,61 @@ test("yield view should be a virtual view", function() {
     view.appendTo('#qunit-fixture');
   });
 });
+
+test("adding a layout should not affect the context of normal views", function() {
+  var parentView = Ember.View.create({
+    context: "ParentContext"
+  });
+
+  view = Ember.View.create({
+    template:     Ember.Handlebars.compile("View context: {{this}}"),
+    context:      "ViewContext",
+    _parentView:  parentView
+  });
+
+  Ember.run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().text(), "View context: ViewContext");
+
+
+  set(view, 'layout', Ember.Handlebars.compile("Layout: {{yield}}"));
+
+  Ember.run(function() {
+    view.destroyElement();
+    view.createElement();
+  });
+
+  equal(view.$().text(), "Layout: View context: ViewContext");
+
+  Ember.run(function() {
+    parentView.destroy();
+  });
+});
+
+test("yield should work for views and components even if _parentView is null", function() {
+  view = Ember.View.create({
+    layout:   Ember.Handlebars.compile('Layout: {{yield}}'),
+    template: Ember.Handlebars.compile("View Content")
+  });
+
+  var component = Ember.Component.create({
+    boundText:  "Component Content",
+    layout:     Ember.Handlebars.compile("Layout: {{yield}}"),
+    template:   Ember.Handlebars.compile("{{boundText}}")
+  });
+
+  Ember.run(function() {
+    view.createElement();
+    component.createElement();
+  });
+
+  equal(view.$().text(), "Layout: View Content");
+  equal(component.$().text(), "Layout: Component Content");
+
+  Ember.run(function() {
+    component.destroy();
+  });
+
+});

--- a/packages/ember-views/tests/views/view/layout_test.js
+++ b/packages/ember-views/tests/views/view/layout_test.js
@@ -108,3 +108,4 @@ test("the template property is available to the layout template", function() {
 
   equal("Herp derp", view.$().text(), "the layout has access to the template");
 });
+


### PR DESCRIPTION
This adds a fix and test for #3075, which is actually a much worse bug than I thought - currently on master, layouts are entirely broken as they change the context of the child view to be the  context of the parent view. 

I also made another jsfiddle that's simpler: http://jsfiddle.net/6hWjz/5/
