### PR TITLE
Add Ember.PromiseProxyMixin

### DIFF
--- a/packages/ember-runtime/lib/mixins.js
+++ b/packages/ember-runtime/lib/mixins.js
@@ -10,3 +10,4 @@ require('ember-runtime/mixins/target_action_support');
 require('ember-runtime/mixins/evented');
 require('ember-runtime/mixins/deferred');
 require('ember-runtime/mixins/action_handler');
+require('ember-runtime/mixins/promise_proxy');

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -1,0 +1,116 @@
+var set = Ember.set, get = Ember.get,
+    resolve = Ember.RSVP.resolve,
+    not = Ember.computed.not,
+    or = Ember.computed.or;
+
+/**
+  @module ember
+  @submodule ember-runtime
+ */
+
+function rethrow(reason) {
+  setTimeout(function(){
+    throw reason;
+  }, 0);
+
+  throw reason;
+}
+
+function installPromise(proxy, promise) {
+  promise.then(function(value) {
+    set(proxy, 'isFulfilled', true);
+    set(proxy, 'content', value);
+
+    return value;
+  }, function(reason) {
+    set(proxy, 'isRejected', true);
+    set(proxy, 'reason', reason);
+  }).then(null, rethrow);
+}
+
+/**
+  A low level mixin making ObjectProxy, ObjectController or ArrayController's promise aware.
+
+  ```javascript
+  var ObjectPromiseController = Ember.ObjectController.extend(Ember.PromiseProxyMixin);
+
+  var controller = ObjectPromiseController.create({
+    promise: $.getJSON('/some/remote/data.json')
+  });
+
+  controller.then(function(json){
+     // the json
+  }, function(reason) {
+     // the reason why you have no json
+  });
+  ```
+
+  the controller has bindable attributes which
+  track the promises life cycle
+
+  ```javascript
+  controller.get('isPending')   //=> true
+  controller.get('isResolved')  //=> false
+  controller.get('isRejected')  //=> false
+  controller.get('isFulfilled') //=> false
+  ```
+
+  When the the $.getJSON completes, and the promise is fulfilled
+  with json, the life cycle attributes will update accordingly.
+
+  ```javascript
+  controller.get('isPending')   //=> false
+  controller.get('isResolved')  //=> true
+  controller.get('isRejected')  //=> false
+  controller.get('isFulfilled') //=> true
+  ```
+
+  As the controller is an ObjectController, and the json now its content,
+  all the json properties will be available directly from the controller.
+
+  ```javascript
+  // Assuming the following json:
+  {
+    firstName: 'Stefan',
+    lastName: 'Penner'
+  }
+
+  // both properties will accessible on the controller
+  controller.get('firstName') //=> 'Stefan'
+  controller.get('lastName')  //=> 'Penner'
+  ```
+
+  If the controller is backing a template, the attributes are 
+  bindable from within that template
+  ```handlebars
+  {{#if isPending}}
+    loading...
+  {{else}}
+    firstName: {{firstName}}
+    lastName: {{lastName}}
+  {{/if}}
+  ```
+  @class Ember.PromiseProxyMixin
+*/
+Ember.PromiseProxyMixin = Ember.Mixin.create({
+  reason:    null,
+  isPending:   not('isResolved').readOnly(),
+  isResolved:  or('isRejected', 'isFulfilled').readOnly(),
+  isRejected:  false,
+  isFulfilled: false,
+
+  promise: Ember.computed(function(key, promise) {
+    if (arguments.length === 2) {
+      promise = resolve(promise);
+      installPromise(this, promise);
+      return promise;
+    } else {
+      throw new Error("PromiseProxy's promise must be set");
+    }
+  }),
+
+  then: function(fulfill, reject) {
+    return get(this, 'promise').then(fulfill, reject);
+  }
+});
+

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -1,0 +1,152 @@
+var proxy, deferred, ObjectPromiseProxy;
+var get = Ember.get;
+
+module("Ember.PromiseProxyMixin");
+
+test("present on ember namespace", function(){
+  ok(Ember.PromiseProxyMixin, "expected Ember.PromiseProxyMixin to exist");
+});
+
+module("Ember.PromiseProxy - ObjectProxy", {
+  setup: function() {
+    ObjectPromiseProxy = Ember.ObjectProxy.extend(Ember.PromiseProxyMixin);
+    deferred = Ember.RSVP.defer();
+    proxy = ObjectPromiseProxy.create({
+      promise: deferred.promise
+    });
+  },
+  teardown: function() {
+    proxy = deferred = null;
+  }
+});
+
+test("no promise, invoking then should raise", function(){
+  var value = {
+    firstName: 'stef',
+    lastName: 'penner'
+  };
+
+  var proxy = ObjectPromiseProxy.create();
+
+  raises(function(){
+    proxy.then(Ember.K, Ember.K);
+  }, new RegExp("PromiseProxy's promise must be set"));
+});
+
+test("fulfillment", function(){
+  var value = {
+    firstName: 'stef',
+    lastName: 'penner'
+  };
+
+  var proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  var didFulfillCount = 0;
+  var didRejectCount  = 0;
+
+  proxy.then(function(){
+    didFulfillCount++;
+  }, function(){
+    didRejectCount++;
+  });
+
+  equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
+  equal(get(proxy, 'reason'),      undefined, 'expects the proxy to have no reason');
+  equal(get(proxy, 'isPending'),   true,  'expects the proxy to indicate that it is loading');
+  equal(get(proxy, 'isResolved'),  false, 'expects the proxy to indicate that it is not resolved');
+  equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
+  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+
+  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  equal(didRejectCount, 0, 'should not yet have been rejected');
+
+  Ember.run(deferred, 'resolve', value);
+
+  equal(didFulfillCount, 1, 'should have been fulfilled');
+  equal(didRejectCount, 0, 'should not have been rejected');
+
+  equal(get(proxy, 'content'),     value, 'expects the proxy to have content');
+  equal(get(proxy, 'reason'),      undefined, 'expects the proxy to still have no reason');
+  equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is no longer loading');
+  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
+  equal(get(proxy, 'isFulfilled'), true,  'expects the proxy to indicate that it is fulfilled');
+
+  Ember.run(deferred, 'resolve', value);
+
+  equal(didFulfillCount, 1, 'should still have been only fulfilled once');
+  equal(didRejectCount,  0, 'should still not have been rejected');
+
+  Ember.run(deferred, 'reject', value);
+
+  equal(didFulfillCount, 1, 'should still have been only fulfilled once');
+  equal(didRejectCount,  0, 'should still not have been rejected');
+
+  equal(get(proxy, 'content'),     value, 'expects the proxy to have still have same content');
+  equal(get(proxy, 'reason'),      undefined, 'expects the proxy still to have no reason');
+  equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is no longer loading');
+  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
+  equal(get(proxy, 'isFulfilled'), true,  'expects the proxy to indicate that it is fulfilled');
+
+  // rest of the promise semantics are tested in directly in RSVP
+});
+
+test("rejection", function(){
+  var reason = new Error("failure");
+
+  var proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  var didFulfillCount = 0;
+  var didRejectCount  = 0;
+
+  proxy.then(function(){
+    didFulfillCount++;
+  }, function(){
+    didRejectCount++;
+  });
+
+  equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
+  equal(get(proxy, 'reason'),      undefined, 'expects the proxy to have no reason');
+  equal(get(proxy, 'isPending'),   true,  'expects the proxy to indicate that it is loading');
+  equal(get(proxy, 'isResolved'),  false, 'expects the proxy to indicate that it is not resolved');
+  equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
+  equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
+
+  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  equal(didRejectCount, 0, 'should not yet have been rejected');
+
+  Ember.run(deferred, 'reject', reason);
+
+  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  equal(didRejectCount, 1, 'should have been rejected');
+
+  equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
+  equal(get(proxy, 'reason'),      reason, 'expects the proxy to have a reason');
+  equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is not longer loading');
+  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isRejected'),  true, 'expects the proxy to indicate that it is  rejected');
+  equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
+
+  Ember.run(deferred, 'reject', reason);
+
+  equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
+  equal(didRejectCount, 1, 'should still remain rejected');
+
+  Ember.run(deferred, 'resolve', 1);
+
+  equal(didFulfillCount, 0, 'should stll not yet have been fulfilled');
+  equal(didRejectCount, 1, 'should still remain rejected');
+
+  equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
+  equal(get(proxy, 'reason'),      reason, 'expects the proxy to have a reason');
+  equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is not longer loading');
+  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isRejected'),  true, 'expects the proxy to indicate that it is  rejected');
+  equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
+});
+


### PR DESCRIPTION
  A low level mixin making ObjectProxy, ObjectController or ArrayController's promise aware.
  This is a tool we can use to deal with ember-data models currently also being promises.

``` javascript
  var ObjectPromiseController = Ember.ObjectController.extend(Ember.PromiseProxyMixin);

  var controller = ObjectPromiseController.create({
    // this isn't really a fantastic example,  as jQuery's Promises are strange, but its nice and short
    promise: $.getJSON('/some/remote/data.json')
  });

  controller.then(function(json){
     // the json
  }, function(reason) {
     // the reason why you have no json
  });
```

  the controller has bindable attributes which
  track the promises life cycle

``` javascript
  controller.get('isPending')   //=> true
  controller.get('isResolved')  //=> false
  controller.get('isRejected')  //=> false
  controller.get('isFulfilled') //=> false
```

  When the the $.getJSON completes, and the promise is fulfilled
  with json, the life cycle attributes will update accordingly.

``` javascript
  controller.get('isPending')   //=> false
  controller.get('isResolved')  //=> true
  controller.get('isRejected')  //=> false
  controller.get('isFulfilled') //=> true
```

  As the controller is an ObjectController, and the json now its content,
  all the json properties will be available directly from the controller.

``` javascript
  // Assuming the following json:
  {
    firstName: 'Stefan',
    lastName: 'Penner'
  }

  // both properties will accessible on the controller
  controller.get('firstName') //=> 'Stefan'
  controller.get('lastName')  //=> 'Penner'
```

  If the controller is backing a template, the attributes are 
  bindable from within that template

``` handlebars
    {{#if isPending}}
      loading...
    {{else}}
      firstName: {{firstName}}
      lastName: {{lastName}}
    {{/if}}
```
