### PR TITLE
Fix CollectionView docs to use extend rather than create

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -21,7 +21,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   instance's `content` property.
 
   ```javascript
-  someItemsView = Ember.CollectionView.create({
+  someItemsView = Ember.CollectionView.extend({
     content: ['A', 'B','C']
   })
   ```
@@ -38,7 +38,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   Given an empty `<body>` and the following code:
 
   ```javascript
-  someItemsView = Ember.CollectionView.create({
+  someItemsView = Ember.CollectionView.extend({
     classNames: ['a-collection'],
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
@@ -68,7 +68,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   Given an empty `<body>` and the following code:
 
   ```javascript
-  anUndorderedListView = Ember.CollectionView.create({
+  anUndorderedListView = Ember.CollectionView.extend({
     tagName: 'ul',
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
@@ -123,7 +123,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   will be the `CollectionView`s only child.
 
   ```javascript
-  aListWithNothing = Ember.CollectionView.create({
+  aListWithNothing = Ember.CollectionView.extend({
     classNames: ['nothing']
     content: null,
     emptyView: Ember.View.extend({

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -21,7 +21,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   instance's `content` property.
 
   ```javascript
-  someItemsView = Ember.CollectionView.extend({
+  SomeItemsView = Ember.CollectionView.extend({
     content: ['A', 'B','C']
   })
   ```
@@ -38,7 +38,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   Given an empty `<body>` and the following code:
 
   ```javascript
-  someItemsView = Ember.CollectionView.extend({
+  SomeItemsView = Ember.CollectionView.extend({
     classNames: ['a-collection'],
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
@@ -46,7 +46,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
     })
   });
 
-  someItemsView.appendTo('body');
+  SomeItemsView.appendTo('body');
   ```
 
   Will result in the following HTML structure
@@ -68,7 +68,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   Given an empty `<body>` and the following code:
 
   ```javascript
-  anUndorderedListView = Ember.CollectionView.extend({
+  AnUnorderedListView = Ember.CollectionView.extend({
     tagName: 'ul',
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
@@ -123,7 +123,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   will be the `CollectionView`s only child.
 
   ```javascript
-  aListWithNothing = Ember.CollectionView.extend({
+  AListWithNothing = Ember.CollectionView.extend({
     classNames: ['nothing']
     content: null,
     emptyView: Ember.View.extend({


### PR DESCRIPTION
https://github.com/emberjs/ember.js/blob/v1.0.0-rc.6.1/packages/ember-views/lib/views/collection_view.js#L106 specifies to use `extend`, and in my brief attempt to use this class, using `create` yields

```
Uncaught TypeError: Object [object Object] has no method 'create' 
```
