### PR TITLE
render helper: falsy contexts no longer treated as absent

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -36,7 +36,8 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   */
   Ember.Handlebars.registerHelper('render', function(name, contextString, options) {
     Ember.assert("You must pass a template to render", arguments.length >= 2);
-    var container, router, controller, view, context, lookupOptions;
+    var contextProvided = arguments.length === 3,
+        container, router, controller, view, context, lookupOptions;
 
     if (arguments.length === 2) {
       options = contextString;
@@ -52,7 +53,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     container = options.data.keywords.controller.container;
     router = container.lookup('router:main');
 
-    Ember.assert("You can only use the {{render}} helper once without a model object as its second argument, as in {{render \"post\" post}}.", context || !router || !router._lookupActiveView(name));
+    Ember.assert("You can only use the {{render}} helper once without a model object as its second argument, as in {{render \"post\" post}}.", contextProvided || !router || !router._lookupActiveView(name));
 
     view = container.lookup('view:' + name) || container.lookup('view:default');
 
@@ -67,7 +68,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
                       Ember.generateController(container, name, context);
     }
 
-    if (controller && context) {
+    if (controller && contextProvided) {
       controller.set('model', context);
     }
 

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -219,6 +219,32 @@ test("{{render}} helper should render templates with models multiple times", fun
   }
 });
 
+test("{{render}} helper should not treat invocations with falsy contexts as context-less", function() {
+  var template = "<h1>HI</h1> {{render 'post' zero}} {{render 'post' nonexistent}}";
+
+  view = Ember.View.create({
+    controller: Ember.Controller.createWithMixins({ 
+      container: container,
+      zero: false
+    }),
+    template: Ember.Handlebars.compile(template)
+  });
+
+  var PostController = Ember.ObjectController.extend();
+  container.register('controller:post', PostController, {singleton: false});
+
+  Ember.TEMPLATES['post'] = compile("<p>{{#unless content}}NOTHING{{/unless}}</p>");
+
+  appendView(view);
+
+  var postController1 = view.get('_childViews')[0].get('controller');
+  var postController2 = view.get('_childViews')[1].get('controller');
+
+  ok(view.$().text().match(/^HI ?NOTHING ?NOTHING$/));
+  equal(postController1.get('model'), 0);
+  equal(postController2.get('model'), undefined);
+});
+
 test("{{render}} helper should render templates both with and without models", function() {
   var template = "<h1>HI</h1> {{render 'post'}} {{render 'post' post}}";
   var post = {


### PR DESCRIPTION
```
{{render 'something' falsyValue1}} 
{{render 'something' falsyValue2}}
```

The above used to throw an error, treating the falsy values
as invocations of the `render` helper without 
a context, which you're not allowed to do if
rendering more than once. Now the above will not
throw, and the falsy context will be passed to
the generated controller as the model.
