### PR TITLE
Apply "actions" hash to View, Controller & Route action handling

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -208,6 +208,7 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
 
     if (props) {
       meta = Ember.meta(base);
+      if (base.willMergeMixin) { base.willMergeMixin(props); }
       concats = concatenatedMixinProperties('concatenatedProperties', props, values, base);
       mergings = concatenatedMixinProperties('mergedProperties', props, values, base);
 

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -333,7 +333,7 @@ define("router",
 
       trigger: function(name) {
         var args = slice.call(arguments);
-        trigger(this.currentHandlerInfos, false, args);
+        trigger(this, this.currentHandlerInfos, false, args);
       },
 
       /**
@@ -600,7 +600,7 @@ define("router",
       } catch(e) {
         if (!(e instanceof Router.TransitionAborted)) {
           // Trigger the `error` event starting from this failed handler.
-          trigger(currentHandlerInfos.concat(handlerInfo), true, ['error', e, transition]);
+          trigger(transition.router, currentHandlerInfos.concat(handlerInfo), true, ['error', e, transition]);
         }
 
         // Propagate the error so that the transition promise will reject.
@@ -702,7 +702,11 @@ define("router",
       return handlers;
     }
 
-    function trigger(handlerInfos, ignoreFailure, args) {
+    function trigger(router, handlerInfos, ignoreFailure, args) {
+      if (router.triggerEvent) {
+        router.triggerEvent(handlerInfos, ignoreFailure, args);
+        return;
+      }
 
       var name = args.shift();
 
@@ -772,7 +776,7 @@ define("router",
       // Fire 'willTransition' event on current handlers, but don't fire it
       // if a transition was already underway.
       if (!wasTransitioning) {
-        trigger(currentHandlerInfos, true, ['willTransition', transition]);
+        trigger(router, currentHandlerInfos, true, ['willTransition', transition]);
       }
 
       log(router, transition.sequence, "Beginning validation for transition to " + transition.targetName);
@@ -964,7 +968,7 @@ define("router",
 
         // An error was thrown / promise rejected, so fire an
         // `error` event from this handler info up to root.
-        trigger(handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
+        trigger(router, handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
 
         // Propagate the original error.
         return RSVP.reject(reason);

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -224,7 +224,7 @@ test("should register an event handler", function() {
   var eventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -247,7 +247,7 @@ test("handles whitelisted modifier keys", function() {
   var eventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -275,8 +275,10 @@ test("should be able to use action more than once for the same event within a vi
       originalEventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { editWasCalled = true; },
-    "delete": function() { deleteWasCalled = true; }
+    actions: {
+      edit: function() { editWasCalled = true; },
+      "delete": function() { deleteWasCalled = true; }
+    }
   }).create();
 
   view = Ember.View.create({
@@ -315,8 +317,10 @@ test("the event should not bubble if `bubbles=false` is passed", function() {
       originalEventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { editWasCalled = true; },
-    "delete": function() { deleteWasCalled = true; }
+    actions: {
+      edit: function() { editWasCalled = true; },
+      "delete": function() { deleteWasCalled = true; }
+    }
   }).create();
 
   view = Ember.View.create({
@@ -356,7 +360,7 @@ test("should work properly in an #each block", function() {
   var eventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -376,7 +380,7 @@ test("should work properly in a #with block", function() {
   var eventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -395,10 +399,10 @@ test("should work properly in a #with block", function() {
 test("should unregister event handlers on rerender", function() {
   var eventHandlerWasCalled = false;
 
-  view = Ember.View.create({
+  view = Ember.View.extend({
     template: Ember.Handlebars.compile('<a href="#" {{action "edit"}}>click me</a>'),
-    edit: function() { eventHandlerWasCalled = true; }
-  });
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
+  }).create();
 
   appendView();
 
@@ -441,7 +445,7 @@ test("should properly capture events on child elements of a container with an ac
   var eventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -461,7 +465,7 @@ test("should allow bubbling of events from action helper to original parent even
       originalEventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -482,7 +486,7 @@ test("should not bubble an event from action helper to original parent event if 
       originalEventHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    edit: function() { eventHandlerWasCalled = true; }
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
   }).create();
 
   view = Ember.View.create({
@@ -525,9 +529,11 @@ test("should send the view, event and current Handlebars context to the action",
   var passedContext;
 
   var aTarget = Ember.Controller.extend({
-    edit: function(context) {
-      passedTarget = this;
-      passedContext = context;
+    actions: {
+      edit: function(context) {
+        passedTarget = this;
+        passedContext = context;
+      }
     }
   }).create();
 
@@ -549,10 +555,10 @@ test("should send the view, event and current Handlebars context to the action",
 test("should only trigger actions for the event they were registered on", function() {
   var editWasCalled = false;
 
-  view = Ember.View.create({
+  view = Ember.View.extend({
     template: Ember.Handlebars.compile('<a href="#" {{action "edit"}}>edit</a>'),
-    edit: function() { editWasCalled = true; }
-  });
+    actions: { edit: function() { editWasCalled = true; } }
+  }).create();
 
   appendView();
 
@@ -561,36 +567,15 @@ test("should only trigger actions for the event they were registered on", functi
   ok(!editWasCalled, "The action wasn't called");
 });
 
-test("should allow a context to be specified", function() {
-  var passedContext,
-      model = Ember.Object.create();
-
-  var controller = Ember.Controller.extend({
-    edit: function(context) {
-      passedContext = context;
-    }
-  }).create();
-
-  view = Ember.View.create({
-    controller: controller,
-    people: Ember.A([model]),
-    template: Ember.Handlebars.compile('{{#each person in view.people}}<button {{action edit person}}>edit</button>{{/each}}')
-  });
-
-  appendView();
-
-  view.$('button').trigger('click');
-
-  equal(passedContext, model, "the action was called with the passed context");
-});
-
 test("should unwrap controllers passed as a context", function() {
   var passedContext,
       model = Ember.Object.create(),
       controller = Ember.ObjectController.extend({
         model: model,
-        edit: function(context) {
-          passedContext = context;
+        actions: {
+          edit: function(context) {
+            passedContext = context;
+          }
         }
       }).create();
 
@@ -611,8 +596,10 @@ test("should allow multiple contexts to be specified", function() {
       models = [Ember.Object.create(), Ember.Object.create()];
 
   var controller = Ember.Controller.extend({
-    edit: function() {
-      passedContexts = [].slice.call(arguments);
+    actions: {
+      edit: function() {
+        passedContexts = [].slice.call(arguments);
+      }
     }
   }).create();
 
@@ -635,8 +622,10 @@ test("should allow multiple contexts to be specified mixed with string args", fu
       model = Ember.Object.create();
 
   var controller = Ember.Controller.extend({
-    edit: function() {
-      passedParams = [].slice.call(arguments);
+    actions: {
+      edit: function() {
+        passedParams = [].slice.call(arguments);
+      }
     }
   }).create();
 
@@ -671,21 +660,13 @@ test("it does not trigger action with special clicks", function() {
     template: compile("<a {{action show href=true}}>Hi</a>")
   });
 
-  var controller = Ember.Controller.create({
-    target: {
-      urlForEvent: function(event, context) {
-        return "/foo/bar";
-      },
-
-      send: function(event, context) {
-        this[event](context);
-      },
-
+  var controller = Ember.Controller.extend({
+    actions: {
       show: function() {
         showCalled = true;
       }
     }
-  });
+  }).create();
 
   Ember.run(function() {
     view.set('controller', controller);
@@ -715,4 +696,41 @@ test("it does not trigger action with special clicks", function() {
   checkClick('which', undefined, true); // IE <9
 });
 
+module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
+  setup: function() {
+    dispatcher = Ember.EventDispatcher.create();
+    dispatcher.setup();
+    Ember.TESTING_DEPRECATION = true;
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      dispatcher.destroy();
+      if (view) { view.destroy(); }
+    });
+    Ember.TESTING_DEPRECATION = false;
+  }
+});
+
+test("should invoke a handler defined directly on the target (DEPRECATED)", function() {
+  var eventHandlerWasCalled,
+      model = Ember.Object.create();
+
+  var controller = Ember.Controller.extend({
+    edit: function() {
+      eventHandlerWasCalled = true;
+    }
+  }).create();
+
+  view = Ember.View.create({
+    controller: controller,
+    template: Ember.Handlebars.compile('<button {{action edit}}>edit</button>')
+  });
+
+  appendView();
+
+  view.$('button').trigger('click');
+
+  ok(eventHandlerWasCalled, "the action was called");
+});
 

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -223,7 +223,7 @@ test("{{render}} helper should not treat invocations with falsy contexts as cont
   var template = "<h1>HI</h1> {{render 'post' zero}} {{render 'post' nonexistent}}";
 
   view = Ember.View.create({
-    controller: Ember.Controller.createWithMixins({ 
+    controller: Ember.Controller.createWithMixins({
       container: container,
       zero: false
     }),
@@ -293,9 +293,10 @@ test("{{render}} helper should link child controllers to the parent controller",
   var template = '<h1>HI</h1>{{render "posts"}}';
   var controller = Ember.Controller.extend({
     container: container,
-
-    parentPlease: function() {
-      parentTriggered++;
+    actions: {
+      parentPlease: function() {
+        parentTriggered++;
+      }
     }
   });
 

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -16,15 +16,15 @@ var get = Ember.get;
   @class ControllerMixin
   @namespace Ember
 */
-Ember.ControllerMixin = Ember.Mixin.create({
+Ember.ControllerMixin = Ember.Mixin.create(Ember.ActionHandler, {
   /* ducktype as a controller */
   isController: true,
 
   /**
-    The object to which events from the view should be sent.
+    The object to which actions from the view should be sent.
 
     For example, when a Handlebars template uses the `{{action}}` helper,
-    it will attempt to send the event to the view's controller's `target`.
+    it will attempt to send the action to the view's controller's `target`.
 
     By default, a controller's `target` is set to the router after it is
     instantiated by `Ember.Application#initialize`.
@@ -42,16 +42,16 @@ Ember.ControllerMixin = Ember.Mixin.create({
 
   model: Ember.computed.alias('content'),
 
-  send: function(actionName) {
-    var args = [].slice.call(arguments, 1), target;
+  deprecatedSendHandles: function(actionName) {
+    return !!this[actionName];
+  },
 
-    if (this[actionName]) {
-      Ember.assert("The controller " + this + " does not have the action " + actionName, typeof this[actionName] === 'function');
-      this[actionName].apply(this, args);
-    } else if (target = get(this, 'target')) {
-      Ember.assert("The target for controller " + this + " (" + target + ") did not define a `send` method", typeof target.send === 'function');
-      target.send.apply(target, arguments);
-    }
+  deprecatedSend: function(actionName) {
+    var args = [].slice.call(arguments, 1);
+    Ember.assert('' + this + " has the action " + actionName + " but it is not a function", typeof this[actionName] === 'function');
+    Ember.deprecate('Action handlers implemented directly on controllers are deprecated in favor of action handlers on an `actions` object', false);
+    this[actionName].apply(this, args);
+    return;
   }
 });
 

--- a/packages/ember-runtime/lib/mixins.js
+++ b/packages/ember-runtime/lib/mixins.js
@@ -9,3 +9,4 @@ require('ember-runtime/mixins/observable');
 require('ember-runtime/mixins/target_action_support');
 require('ember-runtime/mixins/evented');
 require('ember-runtime/mixins/deferred');
+require('ember-runtime/mixins/action_handler');

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -1,0 +1,61 @@
+/**
+@module ember
+@submodule ember-runtime
+*/
+
+var get = Ember.get;
+
+/**
+  The `Ember.ActionHandler` mixin implements support for moving an `actions`
+  property to an `_actions` property at extend time, and adding `_actions`
+  to the object's mergedProperties list.
+
+  `Ember.ActionHandler` is used internally by Ember in  `Ember.View`,
+  `Ember.Controller`, and `Ember.Route`.
+
+  @class ActionHandler
+  @namespace Ember
+*/
+Ember.ActionHandler = Ember.Mixin.create({
+  mergedProperties: ['_actions'],
+
+  /**
+    @private
+
+    Moves `actions` to `_actions` at extend time. Note that this currently
+    modifies the mixin themselves, which is technically dubious but
+    is practically of little consequence. This may change in the future.
+
+    @method willMergeMixin
+  */
+  willMergeMixin: function(props) {
+    if (props.actions && !props._actions) {
+      props._actions = Ember.merge(props._actions || {}, props.actions);
+      delete props.actions;
+    }
+  },
+
+  send: function(actionName) {
+    var args = [].slice.call(arguments, 1), target;
+
+    if (this._actions && this._actions[actionName]) {
+      if (this._actions[actionName].apply(this, args) === true) {
+        // handler returned true, so this action will bubble
+      } else {
+        return;
+      }
+    } else if (this.deprecatedSend && this.deprecatedSendHandles && this.deprecatedSendHandles(actionName)) {
+      if (this.deprecatedSend.apply(this, [].slice.call(arguments)) === true) {
+        // handler return true, so this action will bubble
+      } else {
+        return;
+      }
+    }
+
+    if (target = get(this, 'target')) {
+      Ember.assert("The `target` for " + this + " (" + target + ") does not have a `send` method", typeof target.send === 'function');
+      target.send.apply(target, arguments);
+    }
+  }
+
+});

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -90,6 +90,7 @@ function makeCtor() {
 
           Ember.assert("Ember.Object.create no longer supports defining computed properties.", !(value instanceof Ember.ComputedProperty));
           Ember.assert("Ember.Object.create no longer supports defining methods that call _super.", !(typeof value === 'function' && value.toString().indexOf('._super') !== -1));
+          Ember.assert("`actions` must be provided at extend time, not at create time, when Ember.ActionHandler is used (i.e. views, controllers & routes).", !((keyName === 'actions') && Ember.ActionHandler.detect(this)));
 
           if (concatenatedProperties && indexOf(concatenatedProperties, keyName) >= 0) {
             var baseValue = this[keyName];

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -1,0 +1,139 @@
+module('Ember.Controller event handling');
+
+test("Action can be handled by a function on actions object", function() {
+  expect(1);
+  var TestController = Ember.Controller.extend({
+    actions: {
+      poke: function() {
+        ok(true, 'poked');
+      }
+    }
+  });
+  var controller = TestController.create({});
+  controller.send("poke");
+});
+
+// TODO: Can we support this?
+// test("Actions handlers can be configured to use another name", function() {
+//   expect(1);
+//   var TestController = Ember.Controller.extend({
+//     actionsProperty: 'actionHandlers',
+//     actionHandlers: {
+//       poke: function() {
+//         ok(true, 'poked');
+//       }
+//     }
+//   });
+//   var controller = TestController.create({});
+//   controller.send("poke");
+// });
+
+test("When `_actions` is provided, `actions` is left alone", function() {
+  expect(2);
+  var TestController = Ember.Controller.extend({
+    actions: ['foo', 'bar'],
+    _actions: {
+      poke: function() {
+        ok(true, 'poked');
+      }
+    }
+  });
+  var controller = TestController.create({});
+  controller.send("poke");
+  equal('foo', controller.get("actions")[0], 'actions property is not untouched');
+});
+
+test("Actions object doesn't shadow a proxied object's 'actions' property", function() {
+  var TestController = Ember.ObjectController.extend({
+    content: {
+      actions: 'foo'
+    },
+    actions: {
+      poke: function() {
+        console.log('ouch');
+      }
+    }
+  });
+  var controller = TestController.create({});
+  equal(controller.get("actions"), 'foo', "doesn't shadow the content's actions property");
+});
+
+test("A handled action can be bubbled to the target for continued processing", function() {
+  expect(2);
+  var TestController = Ember.Controller.extend({
+    actions: {
+      poke: function() {
+        ok(true, 'poked 1');
+        return true;
+      }
+    }
+  });
+
+  var controller = TestController.create({
+    target: Ember.Controller.extend({
+      actions: {
+        poke: function() {
+          ok(true, 'poked 2');
+        }
+      }
+    }).create()
+  });
+  controller.send("poke");
+});
+
+test("Action can be handled by a superclass' actions object", function() {
+  expect(4);
+
+  var SuperController = Ember.Controller.extend({
+    actions: {
+      foo: function() {
+        ok(true, 'foo');
+      },
+      bar: function(msg) {
+        equal(msg, "HELLO");
+      }
+    }
+  });
+
+  var BarControllerMixin = Ember.Mixin.create({
+    actions: {
+      bar: function(msg) {
+        equal(msg, "HELLO");
+        this._super(msg);
+      }
+    }
+  });
+
+  var IndexController = SuperController.extend(BarControllerMixin, {
+    actions: {
+      baz: function() {
+        ok(true, 'baz');
+      }
+    }
+  });
+
+  var controller = IndexController.create({});
+  controller.send("foo");
+  controller.send("bar", "HELLO");
+  controller.send("baz");
+});
+
+module('Ember.Controller deprecations',{
+  setup: function() {
+    Ember.TESTING_DEPRECATION = true;
+  },
+  teardown: function() {
+    Ember.TESTING_DEPRECATION = false;
+  }
+});
+
+test("Action can be handled by method directly on controller (DEPRECATED)", function() {
+  expect(1);
+  var TestController = Ember.Controller.extend({
+    poke: function() {
+      ok(true, 'poked');
+    }
+  });
+  var controller = TestController.create({});
+  controller.send("poke");
+});

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -52,12 +52,12 @@ Ember.TEMPLATES = {};
 
 /**
   `Ember.CoreView` is an abstract class that exists to give view-like behavior
-  to both Ember's main view class `Ember.View` and other classes like 
+  to both Ember's main view class `Ember.View` and other classes like
   `Ember._SimpleMetamorphView` that don't need the fully functionaltiy of
   `Ember.View`.
 
   Unless you have specific needs for `CoreView`, you will use `Ember.View`
-  in your applications. 
+  in your applications.
 
   @class CoreView
   @namespace Ember
@@ -65,7 +65,7 @@ Ember.TEMPLATES = {};
   @uses Ember.Evented
 */
 
-Ember.CoreView = Ember.Object.extend(Ember.Evented, {
+Ember.CoreView = Ember.Object.extend(Ember.Evented, Ember.ActionHandler, {
   isView: true,
 
   states: states,
@@ -178,6 +178,18 @@ Ember.CoreView = Ember.Object.extend(Ember.Evented, {
       }
       return method.apply(this, args);
     }
+  },
+
+  deprecatedSendHandles: function(actionName) {
+    return !!this[actionName];
+  },
+
+  deprecatedSend: function(actionName) {
+    var args = [].slice.call(arguments, 1);
+    Ember.assert('' + this + " has the action " + actionName + " but it is not a function", typeof this[actionName] === 'function');
+    Ember.deprecate('Action handlers implemented directly on views are deprecated in favor of action handlers on an `actions` object', false);
+    this[actionName].apply(this, args);
+    return;
   },
 
   has: function(name) {

--- a/packages/ember-views/tests/views/view/actions_test.js
+++ b/packages/ember-views/tests/views/view/actions_test.js
@@ -1,0 +1,108 @@
+var set = Ember.set, get = Ember.get, view;
+
+module("Ember.View action handling", {
+  teardown: function() {
+    Ember.run(function() {
+      if (view) { view.destroy(); }
+    });
+  }
+});
+
+test("Action can be handled by a function on actions object", function() {
+  expect(1);
+  view = Ember.View.extend({
+    actions: {
+      poke: function() {
+        ok(true, 'poked');
+      }
+    }
+  }).create();
+  view.send("poke");
+});
+
+test("Action can be handled by a function on the view (DEPRECATED)", function() {
+  Ember.TESTING_DEPRECATION = true;
+  expect(1);
+  view = Ember.View.extend({
+    poke: function() {
+      ok(true, 'poked');
+      Ember.TESTING_DEPRECATION = true;
+    }
+  }).create();
+  view.send("poke");
+});
+
+test("A handled action can be bubbled to the target for continued processing", function() {
+  expect(2);
+  view = Ember.View.extend({
+    actions: {
+      poke: function() {
+        ok(true, 'poked 1');
+        return true;
+      }
+    },
+    target: Ember.Controller.extend({
+      actions: {
+        poke: function() {
+          ok(true, 'poked 2');
+        }
+      }
+    }).create()
+  }).create();
+  view.send("poke");
+});
+
+test("Action can be handled by a superclass' actions object", function() {
+  expect(4);
+
+  var SuperView = Ember.View.extend({
+    actions: {
+      foo: function() {
+        ok(true, 'foo');
+      },
+      bar: function(msg) {
+        equal(msg, "HELLO");
+      }
+    }
+  });
+
+  var BarViewMixin = Ember.Mixin.create({
+    actions: {
+      bar: function(msg) {
+        equal(msg, "HELLO");
+        this._super(msg);
+      }
+    }
+  });
+
+  var IndexView = SuperView.extend(BarViewMixin, {
+    actions: {
+      baz: function() {
+        ok(true, 'baz');
+      }
+    }
+  });
+
+  view = IndexView.create();
+  view.send("foo");
+  view.send("bar", "HELLO");
+  view.send("baz");
+});
+
+test("Actions cannot be provided at create time", function() {
+  expectAssertion(function() {
+    view = Ember.View.create({
+      actions: {
+        foo: function() {
+          ok(true, 'foo');
+        }
+      }
+    });
+  });
+  // but should be OK on an object that doesn't mix in Ember.ActionHandler
+  var obj = Ember.Object.create({
+    actions: ['foo']
+  });
+});
+
+

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -284,7 +284,7 @@ test("The {{link-to}} helper defaults to bubbling", function() {
   var hidden = 0;
 
   App.AboutRoute = Ember.Route.extend({
-    events: {
+    actions: {
       hide: function() {
         hidden++;
       }
@@ -319,7 +319,7 @@ test("The {{link-to}} helper supports bubbles=false", function() {
   var hidden = 0;
 
   App.AboutRoute = Ember.Route.extend({
-    events: {
+    actions: {
       hide: function() {
         hidden++;
       }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -99,8 +99,6 @@ test("The Homepage", function() {
 
   bootApplication();
 
-  handleURL('/');
-
   equal(currentPath, 'home');
   equal(Ember.$('h3:contains(Hours)', '#qunit-fixture').length, 1, "The home template was rendered");
 });
@@ -161,8 +159,6 @@ test("The Homepage register as activeView", function() {
 
   bootApplication();
 
-  handleURL('/');
-
   ok(router._lookupActiveView('home'), '`home` active view is connected');
 
   handleURL('/homepage');
@@ -184,8 +180,6 @@ test("The Homepage with explicit template name in renderTemplate", function() {
 
   bootApplication();
 
-  handleURL('/');
-
   equal(Ember.$('h3:contains(Megatroll)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
@@ -205,8 +199,6 @@ test("An alternate template will pull in an alternate controller", function() {
   });
 
   bootApplication();
-
-  handleURL('/');
 
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from homepage)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
@@ -228,8 +220,6 @@ test("The template will pull in an alternate controller via key/value", function
 
   bootApplication();
 
-  handleURL('/');
-
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from home.)', '#qunit-fixture').length, 1, "The homepage template was rendered from data from the HomeController");
 });
 
@@ -249,8 +239,6 @@ test("The Homepage with explicit template name in renderTemplate and controller"
   });
 
   bootApplication();
-
-  handleURL('/');
 
   equal(Ember.$('h3:contains(Megatroll) + p:contains(YES I AM HOME)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
@@ -274,8 +262,6 @@ test("Renders correct view with slash notation", function() {
 
   bootApplication();
 
-  handleURL('/');
-
   equal(Ember.$('p:contains(Home/Page)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
@@ -295,8 +281,6 @@ test('render does not replace templateName if user provided', function() {
   App.HomeRoute = Ember.Route.extend();
 
   bootApplication();
-
-  handleURL('/');
 
   equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
 });
@@ -323,8 +307,6 @@ test("The Homepage with a `setupController` hook", function() {
   bootApplication();
 
   container.register('controller:home', Ember.Controller.extend());
-
-  handleURL('/');
 
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
@@ -387,8 +369,6 @@ test("The Homepage with a `setupController` hook modifying other controllers", f
 
   container.register('controller:home', Ember.Controller.extend());
 
-  handleURL('/');
-
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
 
@@ -412,8 +392,6 @@ test("The Homepage with a computed context that does not get overridden", functi
   );
 
   bootApplication();
-
-  handleURL('/');
 
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the context intact");
 });
@@ -446,8 +424,6 @@ test("The Homepage getting its controller context via model", function() {
   bootApplication();
 
   container.register('controller:home', Ember.Controller.extend());
-
-  handleURL('/');
 
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
@@ -632,7 +608,7 @@ asyncTest("The Special page returning an error fires the error hook on SpecialRo
     setup: function() {
       throw 'Setup error';
     },
-    events: {
+    actions: {
       error: function(reason) {
         equal(reason, 'Setup error');
         start();
@@ -668,7 +644,7 @@ asyncTest("The Special page returning an error invokes SpecialRoute's error hand
     setup: function() {
       throw 'Setup error';
     },
-    events: {
+    actions: {
       error: function(reason) {
         equal(reason, 'Setup error', 'SpecialRoute#error received the error thrown from setup');
         start();
@@ -701,7 +677,7 @@ asyncTest("ApplicationRoute's default error handler can be overridden", function
   });
 
   App.ApplicationRoute = Ember.Route.extend({
-    events: {
+    actions: {
       error: function(reason) {
         equal(reason, 'Setup error', "error was correctly passed to custom ApplicationRoute handler");
         start();
@@ -885,7 +861,7 @@ asyncTest("Events are triggered on the controller if a matching action name is i
       return model;
     },
 
-    events: {
+    actions: {
       showStuff: function(obj) {
         stateIsNotCalled = false;
       }
@@ -897,10 +873,12 @@ asyncTest("Events are triggered on the controller if a matching action name is i
   );
 
   var controller = Ember.Controller.extend({
-    showStuff: function(context) {
-      ok (stateIsNotCalled, "an event on the state is not triggered");
-      deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
-      start();
+    actions: {
+      showStuff: function(context) {
+        ok (stateIsNotCalled, "an event on the state is not triggered");
+        deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
+        start();
+      }
     }
   });
 
@@ -908,15 +886,13 @@ asyncTest("Events are triggered on the controller if a matching action name is i
 
   bootApplication();
 
-  handleURL('/');
-
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
   var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
 
-asyncTest("Events are triggered on the current state", function() {
+asyncTest("Events are triggered on the current state when defined in `actions` object", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -928,7 +904,7 @@ asyncTest("Events are triggered on the current state", function() {
       return model;
     },
 
-    events: {
+    actions: {
       showStuff: function(obj) {
         ok(this instanceof App.HomeRoute, "the handler is an App.HomeRoute");
         // Using Ember.copy removes any private Ember vars which older IE would be confused by
@@ -946,18 +922,13 @@ asyncTest("Events are triggered on the current state", function() {
 
   container.register('controller:home', Ember.Controller.extend());
 
-  //var controller = router._container.controller.home = Ember.Controller.create();
-  //controller.target = router;
-
-  handleURL('/');
-
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
   var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
 
-asyncTest("Events are triggered on the current state when routes are nested", function() {
+asyncTest("Events defined in `actions` object are triggered on the current state when routes are nested", function() {
   Router.map(function() {
     this.resource("root", { path: "/" }, function() {
       this.route("index", { path: "/" });
@@ -967,7 +938,7 @@ asyncTest("Events are triggered on the current state when routes are nested", fu
   var model = { name: "Tom Dale" };
 
   App.RootRoute = Ember.Route.extend({
-    events: {
+    actions: {
       showStuff: function(obj) {
         ok(this instanceof App.RootRoute, "the handler is an App.HomeRoute");
         // Using Ember.copy removes any private Ember vars which older IE would be confused by
@@ -995,6 +966,168 @@ asyncTest("Events are triggered on the current state when routes are nested", fu
   action.handler(event);
 });
 
+asyncTest("Events are triggered on the current state when defined in `events` object (DEPRECATED)", function() {
+  Ember.TESTING_DEPRECATION = true;
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  var model = { name: "Tom Dale" };
+
+  App.HomeRoute = Ember.Route.extend({
+    model: function() {
+      return model;
+    },
+
+    events: {
+      showStuff: function(obj) {
+        ok(this instanceof App.HomeRoute, "the handler is an App.HomeRoute");
+        // Using Ember.copy removes any private Ember vars which older IE would be confused by
+        deepEqual(Ember.copy(obj, true), { name: "Tom Dale" }, "the context is correct");
+        start();
+        Ember.TESTING_DEPRECATION = false;
+      }
+    }
+  });
+
+  Ember.TEMPLATES.home = Ember.Handlebars.compile(
+    "<a {{action showStuff content}}>{{name}}</a>"
+  );
+
+  bootApplication();
+
+  container.register('controller:home', Ember.Controller.extend());
+
+  var actionId = Ember.$("#qunit-fixture a").data("ember-action");
+  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var event = new Ember.$.Event("click");
+  action.handler(event);
+});
+
+asyncTest("Events defined in `events` object are triggered on the current state when routes are nested (DEPRECATED)", function() {
+  Ember.TESTING_DEPRECATION = true;
+  Router.map(function() {
+    this.resource("root", { path: "/" }, function() {
+      this.route("index", { path: "/" });
+    });
+  });
+
+  var model = { name: "Tom Dale" };
+
+  App.RootRoute = Ember.Route.extend({
+    events: {
+      showStuff: function(obj) {
+        ok(this instanceof App.RootRoute, "the handler is an App.HomeRoute");
+        // Using Ember.copy removes any private Ember vars which older IE would be confused by
+        deepEqual(Ember.copy(obj, true), { name: "Tom Dale" }, "the context is correct");
+        start();
+        Ember.TESTING_DEPRECATION = false;
+      }
+    }
+  });
+
+  App.RootIndexRoute = Ember.Route.extend({
+    model: function() {
+      return model;
+    }
+  });
+
+  Ember.TEMPLATES['root/index'] = Ember.Handlebars.compile(
+    "<a {{action showStuff content}}>{{name}}</a>"
+  );
+
+  bootApplication();
+
+  var actionId = Ember.$("#qunit-fixture a").data("ember-action");
+  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var event = new Ember.$.Event("click");
+  action.handler(event);
+});
+
+test("Events can be handled by inherited event handlers", function() {
+
+  expect(4);
+
+  App.SuperRoute = Ember.Route.extend({
+    actions: {
+      foo: function() {
+        ok(true, 'foo');
+      },
+      bar: function(msg) {
+        equal(msg, "HELLO");
+      }
+    }
+  });
+
+  App.RouteMixin = Ember.Mixin.create({
+    actions: {
+      bar: function(msg) {
+        equal(msg, "HELLO");
+        this._super(msg);
+      }
+    }
+  });
+
+  App.IndexRoute = App.SuperRoute.extend(App.RouteMixin, {
+    actions: {
+      baz: function() {
+        ok(true, 'baz');
+      }
+    }
+  });
+
+  bootApplication();
+
+  router.send("foo");
+  router.send("bar", "HELLO");
+  router.send("baz");
+});
+
+asyncTest("Events are triggered on the controller if a matching action name is implemented as a method (DEPRECATED)", function() {
+  Ember.TESTING_DEPRECATION = true;
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  var model = { name: "Tom Dale" };
+  var stateIsNotCalled = true;
+
+  App.HomeRoute = Ember.Route.extend({
+    model: function() {
+      return model;
+    },
+
+    events: {
+      showStuff: function(obj) {
+        stateIsNotCalled = false;
+      }
+    }
+  });
+
+  Ember.TEMPLATES.home = Ember.Handlebars.compile(
+    "<a {{action showStuff content}}>{{name}}</a>"
+  );
+
+  var controller = Ember.Controller.extend({
+    showStuff: function(context) {
+      ok (stateIsNotCalled, "an event on the state is not triggered");
+      deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
+      start();
+      Ember.TESTING_DEPRECATION = false;
+    }
+  });
+
+  container.register('controller:home', controller);
+
+  bootApplication();
+
+  var actionId = Ember.$("#qunit-fixture a").data("ember-action");
+  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var event = new Ember.$.Event("click");
+  action.handler(event);
+});
+
+
 asyncTest("actions can be triggered with multiple arguments", function() {
   Router.map(function() {
     this.resource("root", { path: "/" }, function() {
@@ -1006,7 +1139,7 @@ asyncTest("actions can be triggered with multiple arguments", function() {
       model2 = { name: "Tom Dale" };
 
   App.RootRoute = Ember.Route.extend({
-    events: {
+    actions: {
       showStuff: function(obj1, obj2) {
         ok(this instanceof App.RootRoute, "the handler is an App.HomeRoute");
         // Using Ember.copy removes any private Ember vars which older IE would be confused by
@@ -1049,8 +1182,6 @@ test("transitioning multiple times in a single run loop only sets the URL once",
     urlSetCount++;
     set(this, 'path', path);
   };
-
-  handleURL('/');
 
   equal(urlSetCount, 0);
 
@@ -1126,8 +1257,6 @@ test("using replaceWith calls location.replaceURL if available", function() {
 
   bootApplication();
 
-  handleURL('/');
-
   equal(setCount, 0);
   equal(replaceCount, 0);
 
@@ -1158,8 +1287,6 @@ test("using replaceWith calls setURL if location.replaceURL is not defined", fun
   });
 
   bootApplication();
-
-  handleURL('/');
 
   equal(setCount, 0);
 
@@ -1373,7 +1500,7 @@ test("Transitioning from a parent event does not prevent currentPath from being 
   });
 
   App.FooRoute = Ember.Route.extend({
-    events: {
+    actions: {
       goToQux: function() {
         this.transitionTo('foo.qux');
       }
@@ -1510,8 +1637,6 @@ test("Rendering into specified template with slash notation", function() {
 
   bootApplication();
 
-  handleURL("/");
-
   equal(Ember.$('#qunit-fixture:contains(profile details!)').length, 1, "The templates were rendered");
 });
 
@@ -1535,7 +1660,7 @@ test("Parent route context change", function() {
   });
 
   App.PostsRoute = Ember.Route.extend({
-    events: {
+    actions: {
       showPost: function(context) {
         this.transitionTo('post', context);
       }
@@ -1547,7 +1672,7 @@ test("Parent route context change", function() {
       return {id: params.postId};
     },
 
-    events: {
+    actions: {
       editPost: function(context) {
         this.transitionTo('post.edit');
       }
@@ -1961,8 +2086,6 @@ test("ApplicationRoute with model does not proxy the currentPath", function() {
 
   bootApplication();
 
-  handleURL("/");
-
   equal(currentPath, 'index', 'currentPath is index');
   equal('currentPath' in model, false, 'should have defined currentPath on controller');
 });
@@ -2088,7 +2211,7 @@ test("Route supports clearing outlet explicitly", function() {
   });
 
   App.PostsRoute = Ember.Route.extend({
-    events: {
+    actions: {
       showModal: function() {
         this.render('postsModal', {
           into: 'application',
@@ -2102,7 +2225,7 @@ test("Route supports clearing outlet explicitly", function() {
   });
 
   App.PostsIndexRoute = Ember.Route.extend({
-    events: {
+    actions: {
       showExtra: function() {
         this.render('postsExtra', {
           into: 'posts/index'
@@ -2155,7 +2278,7 @@ test("Aborting/redirecting the transition in `willTransition` prevents LoadingRo
   var redirect = false;
 
   App.IndexRoute = Ember.Route.extend({
-    events: {
+    actions: {
       willTransition: function(transition) {
         ok(true, "willTransition was called");
         if (redirect) {
@@ -2213,12 +2336,12 @@ test("Aborting/redirecting the transition in `willTransition` prevents LoadingRo
   Ember.run(deferred.resolve);
 });
 
-test("Events can be handled by inherited event handlers", function() {
+test("Actions can be handled by inherited action handlers", function() {
 
   expect(4);
 
   App.SuperRoute = Ember.Route.extend({
-    events: {
+    actions: {
       foo: function() {
         ok(true, 'foo');
       },
@@ -2229,7 +2352,7 @@ test("Events can be handled by inherited event handlers", function() {
   });
 
   App.RouteMixin = Ember.Mixin.create({
-    events: {
+    actions: {
       bar: function(msg) {
         equal(msg, "HELLO");
         this._super(msg);
@@ -2238,7 +2361,7 @@ test("Events can be handled by inherited event handlers", function() {
   });
 
   App.IndexRoute = App.SuperRoute.extend(App.RouteMixin, {
-    events: {
+    actions: {
       baz: function() {
         ok(true, 'baz');
       }


### PR DESCRIPTION
WIP

This PR makes view, controller & route action handlers expected to be defined on an `actions` object.

The previous locations are deprecated (i.e. defining action handler functions directly on the view, directly on the controller, and in an `events` object on the route).

This makes action-handling consistent across Ember.

Some developers expressed concern that "actions" was a part of the domain language of their app. To mitigate the impact on these apps, this PR makes Ember will automatically rename `actions` to `_actions` behind the scenes. This allows an ObjectController to proxy to a model with an `actions` attribute, even if you have an `actions` object defined on the controller.

Note: this PR relies on a change to tildeio/router.js, which I have included in this PR as a separate commit for discussion purposes. When this PR is ready, I will make a separate PR for the router.js project, to be applied first. I have a already prepared a test for the new functionality. 

Specific comments on the code in this PR can go here. The general discussion about action handling in Ember here: http://discuss.emberjs.com/t/the-future-of-the-events-hash/1630/26
