### PR TITLE
Remove unused property

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -165,8 +165,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     return this;
   },
 
-  isInstance: true,
-
   /**
     An overridable method called when objects are instantiated. By default,
     does nothing unless it is overridden during class definition.

--- a/packages/ember-runtime/tests/system/object/extend_test.js
+++ b/packages/ember-runtime/tests/system/object/extend_test.js
@@ -5,7 +5,6 @@ test('Basic extend', function() {
   ok(SomeClass.isClass, "A class has isClass of true");
   var obj = new SomeClass();
   equal(obj.foo, 'BAR');
-  ok(obj.isInstance, "An instance of a class has isInstance of true");
 });
 
 test('Sub-subclass', function() {


### PR DESCRIPTION
`Ember.CoreObject#isInstance` is referenced from only test code.
