### PR TITLE
[BUGFIX beta] Add context property to itemViews created by collection view

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -70,7 +70,7 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
       if (options.hash.controller) {
         bindView.set('_contextController', this.container.lookupFactory('controller:'+options.hash.controller).create({
           container: currentContext.container,
-          parentController: currentContext,
+          parentController: get(currentContext, 'parentController') || currentContext,
           target: currentContext
         }));
       }

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -15,7 +15,11 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
     var itemController = get(this, 'itemController');
     var binding;
 
-    this._preserveContext = true;
+    var keyword = get(this, 'keyword');
+
+    if (keyword) {
+      this._preserveContext = true;
+    }
 
     if (itemController) {
       var controller = get(this, 'controller.container').lookupFactory('controller:array').create({

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -15,6 +15,8 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
     var itemController = get(this, 'itemController');
     var binding;
 
+    this._preserveContext = true;
+
     if (itemController) {
       var controller = get(this, 'controller.container').lookupFactory('controller:array').create({
         _isVirtual: true,

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -193,6 +193,8 @@ Ember.CollectionView = Ember.ContainerView.extend({
   */
   itemViewClass: Ember.View,
 
+  _preserveContext: false,
+
   /**
     Setup a CollectionView
 
@@ -327,7 +329,8 @@ Ember.CollectionView = Ember.ContainerView.extend({
   */
   arrayDidChange: function(content, start, removed, added) {
     var addedViews = [], view, item, idx, len, itemViewClass,
-      emptyView;
+        attrs,
+        emptyView;
 
     len = content ? get(content, 'length') : 0;
 
@@ -345,10 +348,17 @@ Ember.CollectionView = Ember.ContainerView.extend({
       for (idx = start; idx < start+added; idx++) {
         item = content.objectAt(idx);
 
-        view = this.createChildView(itemViewClass, {
+        attrs = {
           content: item,
           contentIndex: idx
-        });
+        };
+
+        if (!this._preserveContext) {
+          attrs.context = item;
+          attrs.controller = item;
+        }
+
+        view = this.createChildView(itemViewClass, attrs);
 
         addedViews.push(view);
       }

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -353,9 +353,13 @@ Ember.CollectionView = Ember.ContainerView.extend({
           contentIndex: idx
         };
 
-        if (!this._preserveContext) {
+        if (this._preserveContext) {
+          set(get(this, 'context'), 'container', get(this, 'container'));
+          set(get(this, 'context'), 'parentController', get(this, 'controller'));
+          attrs.context = get(this, 'context');
+        }
+        else {
           attrs.context = item;
-          attrs.controller = item;
         }
 
         view = this.createChildView(itemViewClass, attrs);

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -510,6 +510,36 @@ test("should not render the emptyView if content is emptied and refilled in the 
   equal(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, 0);
 });
 
+test("item view class template should be executed in the context of array item when using collection view with array controller", function() {
+
+  var array = Ember.A([{ name: "Other Katz" }]);
+
+  var controller = Ember.ArrayController.create({
+    content: array
+  });
+
+  var ContainerClass = Ember.CollectionView.extend({
+    tagName: 'ul',
+    content: controller,
+    itemViewClass: Ember.View.extend({
+      template: Handlebars.compile('{{name}}')
+    })
+  });
+
+  var container = ContainerClass.create();
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  equal(container.$('li').length, 1, '1 list element should be in the DOM');
+  equal(container.$('li').text(), 'Other Katz', 'text of item view class\' template should be "Other Katz"');
+
+  Ember.run(function() {
+    container.destroy();
+  });
+});
+
 test("a array_proxy that backs an sorted array_controller that backs a collection view functions properly", function() {
 
   var array = Ember.A([{ name: "Other Katz" }]);


### PR DESCRIPTION
This partially addresses #3086.

I've conditionally added the context property to each of the childViews created by a collection view. After adding this property, one test was breaking. 

This test was `#each accepts a name binding and does not change the context` and I fixed that by adding the conditional around the addition of context to the itemView. 

<!---
@huboard:{"order":3100.0,"custom_state":""}
-->
