### PR TITLE
Improve the performance of `Ember.Object.create()`

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -294,13 +294,3 @@ ChainNodePrototype.didChange = function(suppressEvent) {
   // and finally tell parent about my path changing...
   if (this._parent) { this._parent.chainDidChange(this, this._key, 1); }
 };
-
-Ember.finishChains = function(obj) {
-  var m = metaFor(obj, false), chains = m.chains;
-  if (chains) {
-    if (chains.value() !== obj) {
-      m.chains = chains = chains.copy(obj);
-    }
-    chains.didChange(true);
-  }
-};

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -18,7 +18,6 @@ var set = Ember.set, get = Ember.get,
     generateGuid = Ember.generateGuid,
     meta = Ember.meta,
     rewatch = Ember.rewatch,
-    finishChains = Ember.finishChains,
     destroy = Ember.destroy,
     schedule = Ember.run.schedule,
     Mixin = Ember.Mixin,
@@ -119,8 +118,16 @@ function makeCtor() {
       }
     }
     finishPartial(this, m);
+    var hasChains = (typeof m.chains) !== "undefined";
     delete m.proto;
-    finishChains(this);
+
+    if (hasChains) {
+      if (m.chains.value() !== this) {
+        m.chains = m.chains.copy(this);
+      }
+      m.chains.didChange(true);
+    }
+
     this.init.apply(this, arguments);
   };
 


### PR DESCRIPTION
Reading the value of `chains` from an Object's metadata is significantly slower if done after the call to `delete m.proto`.

If the check for the existence of `chains` is done before the delete, you get a significant improvement in object creation speed. 

Additionally, I noticed that the `Ember.finishChains` is only used in core object. I decided to inline it in the same patch. I'm new to the internals of Ember so if this change is insane please let me know and I'll happily revise the patch.

Here are the results as measued in my new [https://github.com/eviltrout/ember-performance](ember-performance) suite:
### Before Patch

![before patch](https://f.cloud.github.com/assets/17538/911346/c44af228-fde9-11e2-838c-b077bf873173.png)
### After Patch

![after patch](https://f.cloud.github.com/assets/17538/911349/d0bc03b2-fde9-11e2-9a48-9dfa85133323.png)
