### PR TITLE
[BUGFIX beta] Optimization: Clear the meta cache without using observers.

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -15,10 +15,18 @@ Ember.merge(preRender, {
     var viewCollection = view.viewHierarchyCollection();
 
     viewCollection.trigger('willInsertElement');
-    // after createElement, the view will be in the hasElement state.
+
     fn.call(view);
-    viewCollection.transitionTo('inDOM', false);
-    viewCollection.trigger('didInsertElement');
+
+    // We transition to `inDOM` if the element exists in the DOM
+    var element = view.get('element');
+    while (element = element.parentNode) {
+      if (element === document) {
+        viewCollection.transitionTo('inDOM', false);
+        viewCollection.trigger('didInsertElement');
+      }
+    }
+
   },
 
   renderToBufferIfNeeded: function(view, buffer) {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -11,6 +11,7 @@ var get = Ember.get, set = Ember.set;
 var guidFor = Ember.guidFor;
 var a_forEach = Ember.EnumerableUtils.forEach;
 var a_addObject = Ember.EnumerableUtils.addObject;
+var meta = Ember.meta;
 
 var childViewsProperty = Ember.computed(function() {
   var childViews = this._childViews, ret = Ember.A(), view = this;
@@ -1759,12 +1760,6 @@ Ember.View = Ember.CoreView.extend(
     return viewCollection;
   },
 
-  _elementWillChange: Ember.beforeObserver(function() {
-    this.forEachChildView(function(view) {
-      Ember.propertyWillChange(view, 'element');
-    });
-  }, 'element'),
-
   /**
     @private
 
@@ -1776,7 +1771,7 @@ Ember.View = Ember.CoreView.extend(
   */
   _elementDidChange: Ember.observer(function() {
     this.forEachChildView(function(view) {
-      Ember.propertyDidChange(view, 'element');
+      delete meta(view).cache.element;
     });
   }, 'element'),
 
@@ -2224,6 +2219,7 @@ Ember.View = Ember.CoreView.extend(
 
     if (priorState && priorState.exit) { priorState.exit(this); }
     if (currentState.enter) { currentState.enter(this); }
+    if (state === 'inDOM') { delete Ember.meta(this).cache.element; }
 
     if (children !== false) {
       this.forEachChildView(function(view) {

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -56,6 +56,17 @@ test("should remove previous elements when calling replaceIn()", function() {
 
 });
 
+test("should move the view to the inDOM state after replacing", function() {
+  Ember.$("#qunit-fixture").html('<div id="menu"></div>');
+  view = View.create();
+
+  Ember.run(function() {
+    view.replaceIn('#menu');
+  });
+
+  equal(view.currentState, Ember.View.states.inDOM, "the view is in the inDOM state");
+});
+
 module("Ember.View - replaceIn() in a view hierarchy", {
   setup: function() {
     View = Ember.ContainerView.extend({

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -151,6 +151,42 @@ test("rerender should throw inside a template", function() {
   }, /Something you did caused a view to re-render after it rendered but before it was inserted into the DOM./);
 });
 
+module("views/view/view_lifecycle_test - hasElement", {
+  teardown: function() {
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+    }
+  }
+});
+
+test("createElement puts the view into the hasElement state", function() {
+  view = Ember.View.create({
+    render: function(buffer) { buffer.push('hello'); }
+  });
+
+  Ember.run(function() {
+    view.createElement();
+  });
+
+  equal(view.currentState, Ember.View.states.hasElement, "the view is in the hasElement state");
+});
+
+test("trigger rerender on a view in the hasElement state doesn't change its state to inDOM", function() {
+  view = Ember.View.create({
+    render: function(buffer) { buffer.push('hello'); }
+  });
+
+  Ember.run(function() {
+    view.createElement();
+    view.rerender();
+  });
+
+  equal(view.currentState, Ember.View.states.hasElement, "the view is still in the hasElement state");
+});
+
+
 module("views/view/view_lifecycle_test - in DOM", {
   teardown: function() {
     if (view) {
@@ -315,5 +351,25 @@ test("should throw an exception when destroyElement is called after view is dest
   raises(function() {
     view.destroyElement();
   }, null, "throws an exception when calling destroyElement");
+});
+
+test("trigger rerender on a view in the inDOM state keeps its state as inDOM", function() {
+  Ember.run(function() {
+    view = Ember.View.create({
+      template: tmpl('foo')
+    });
+
+    view.append();
+  });
+
+  Ember.run(function() {
+    view.rerender();
+  });
+
+  equal(view.currentState, Ember.View.states.inDOM, "the view is still in the inDOM state");
+
+  Ember.run(function() {
+    view.destroy();
+  });
 });
 


### PR DESCRIPTION
Every `Ember.View` created creates an observer on an `element` property that contains a reference to the element in the DOM.

When changed, it calls `Ember.propertyWillChange` and `Ember.propertyDidChange` on all `childViews`. 

The purpose of this seems to be to invalidate the cached `element` value in the `metaData` so that references to DOM elements are cleared.

Creating all these observers just to clear a cache seems wasteful. This PR instead directly invalidates the cached value from the `metaData`.

Here are the results from a benchmark in my ember-performance suite, rendering a list of 1000 items.
### Before Patch

![before patch](https://f.cloud.github.com/assets/17538/913542/8cdc29e8-fe1a-11e2-9515-cde6562ee511.png)
### After Patch

 ![after patch](https://f.cloud.github.com/assets/17538/913544/a54bb5c0-fe1a-11e2-85ca-7bcd9d010e14.png)
