### PR TITLE
Handlebars template as properties should not be regarded as methods

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -266,7 +266,10 @@ if (Handlebars.compile) {
     var environment = new Ember.Handlebars.Compiler().compile(ast, options);
     var templateSpec = new Ember.Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
 
-    return Ember.Handlebars.template(templateSpec);
+    var template = Ember.Handlebars.template(templateSpec);
+    template.isMethod = false; //Make sure we don't wrap templates with ._super
+      
+    return template;
   };
 }
 


### PR DESCRIPTION
We're having issues when reopening views/components and overriding their `template` properties, if the views use `{{yield}}`.

Example:

``` javascript
App.TestThingView = Em.Component.extend({
  layout: Em.Handlebars.compile('<div class="test">{{yield}}</div>'),
  template: Em.Handlebars.compile('Hey')
});

App.TestThingView.reopen({
  template: Em.Handlebars.compile('Please don\'t super me.')
});
```

Will result in:

```
Assertion failed: Ember.Object.create no longer supports defining methods that call _super.
```

The problem is that yield views are created with the `template` property sent to `Ember.View.create` here: https://github.com/emberjs/ember.js/blob/master/packages/ember-handlebars/lib/helpers/yield.js#L75

The fix is to set `isMethod = false` on the compiled Handlebars templates, so that they are never regarded as class methods and therefore not wrapped with `_super` (https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/mixin.js#L50)
