### PR TITLE
View event handlers inside eventManager should be wrapped in run loop

### DIFF
--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -193,7 +193,9 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
 
     var handler = object[eventName];
     if (Ember.typeOf(handler) === 'function') {
-      result = handler.call(object, evt, view);
+      result = Ember.run(function() {
+        return handler.call(object, evt, view);
+      });
       // Do not preventDefault in eventManagers.
       evt.stopPropagation();
     }

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -257,3 +257,21 @@ test("event manager should be able to re-dispatch events to view", function() {
   Ember.$('#nestedView').trigger('mousedown');
   equal(receivedEvent, 2, "event should go to manager and not view");
 });
+
+test("event handlers should be wrapped in a run loop", function() {
+  expect(1);
+
+  view = Ember.View.createWithMixins({
+    elementId: 'test-view',
+
+    eventManager: Ember.Object.create({
+      mouseDown: function() {
+        ok(Ember.run.currentRunLoop, 'a run loop should have started');
+      }
+    })
+  });
+
+  Ember.run(function() { view.append(); });
+
+  Ember.$('#test-view').trigger('mousedown');
+});


### PR DESCRIPTION
When in test-mode a run loop doesn't automatically start, which makes simple things like this fail:

``` javascript
App.MyView = Ember.View.extend({
  eventManager: {
    click: function() {
      this.toggleProperty('isThingVisible');
    }
  }
});
```

With:

```
Assertion failed: You have turned on testing mode, which disabled the run-loop's autorun. You will need to wrap any code with asynchronous side-effects in an Ember.run
```

I don't see any reason why a run loop shouldn't start in these cases, and when bubbling an event the current behavior is also to wrap the handler in a run loop.
