### PR TITLE
Optimization: Disable W3C Range API by default

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -62,7 +62,18 @@ Ember.VERSION = '1.0.0-rc.6.1';
   @property ENV
   @type Hash
 */
-Ember.ENV = Ember.ENV || ('undefined' === typeof ENV ? {} : ENV);
+
+if ('undefined' === typeof ENV) {
+  exports.ENV = {};
+}
+
+// We disable the RANGE API by default for performance reasons
+if ('undefined' === typeof ENV.DISABLE_RANGE_API) {
+  ENV.DISABLE_RANGE_API = true;
+}
+
+
+Ember.ENV = Ember.ENV || ENV;
 
 Ember.config = Ember.config || {};
 

--- a/packages/metamorph/lib/main.js
+++ b/packages/metamorph/lib/main.js
@@ -10,9 +10,10 @@ define("metamorph",
     var K = function() {},
         guid = 0,
         document = this.document,
+        disableRange = ('undefined' === typeof ENV ? {} : ENV).DISABLE_RANGE_API,
 
         // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
-        supportsRange = document && ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,
+        supportsRange = (!disableRange) && document && ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,
 
         // Internet Explorer prior to 9 does not allow setting innerHTML if the first element
         // is a "zero-scope" element. This problem can be worked around by making


### PR DESCRIPTION
Ember.js will use the W3C Range API for updating the contents of templates when bindings change. However, not all browsers support the range API and Ember.js provides an alternate way of updating the DOM in this case.

It seems the W3C range API is significantly slower than using the alternate path. I've tested in Chrome, Firefox, Safari and Chrome on Android. All are much faster without using the API. I've also added a Template Bindings test to the ember-performance suite. 

**This patch disables the range API by default**. It can be re-enabled using a new environment variable, `ENV. ENABLE_RANGE_API`. Here are the results in Chrome 23:
### Before

![before](https://f.cloud.github.com/assets/17538/919037/ef2e909e-fec0-11e2-867f-a0dfecf60c54.png)
### After

![after](https://f.cloud.github.com/assets/17538/919035/e0666cf8-fec0-11e2-8fd8-20a6c887bc33.png)
