### PR TITLE
Don't propagate the linkTo event if there is no href

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -235,6 +235,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     */
     _invoke: function(event) {
       if (!isSimpleClick(event)) { return true; }
+      if (get(this, 'href') === false) { return true; }
 
       event.preventDefault();
       if (this.bubbles === false) { event.stopPropagation(); }

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -140,6 +140,26 @@ test("the {{linkTo}} helper doesn't add an href when the tagName isn't 'a'", fun
   equal(Ember.$('#about-link').attr('href'), undefined, "there is no href attribute");
 });
 
+test("the {{linkTo}} helper doesn't propagate click event when there is no href", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#linkTo 'about' id='about-link' href=false}}About{{/linkTo}}");
+
+  Router.map(function() {
+    this.route("about");
+  });
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  Ember.run(function() {
+    Ember.$('#about-link', '#qunit-fixture').click();
+  });
+
+  equal(Ember.$('h3:contains(About)', '#qunit-fixture').length, 0, "Transitioning did not occur");
+});
+
 
 test("the {{linkTo}} applies a 'disabled' class when disabled", function () {
   Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo "about" id="about-link" disabledWhen="shouldDisable"}}About{{/linkTo}}');


### PR DESCRIPTION
For someone wanting to get an active class for an element other than a link, the currently recommended solution is the following:
http://stackoverflow.com/questions/14412073/assigning-active-class-to-selected-list-item-in-emberjs

However, it has a few problems, since the event will be bound to the non-link anyway.
I've fixed this with a [custom helper](http://dmathieu.com/articles/development/emberjs-twitter-bootstrap-active-li/) in my own applications.

This is a more clean and broad fix.
If `href=false` was provided (or the link isn't an `a`), we don't propagate any click event.
