### PR TITLE
Em.Components typo fix - fixes #3118

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -155,7 +155,7 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, {
 
     ```handlebars
     {{! categories.hbs}}
-    {{my-tree didClickTreeNode=didClickCategory}}
+    {{my-tree didClickTreeNode='didClickCategory'}}
     ```
 
     @method sendAction


### PR DESCRIPTION
It seems to be a typo in Em.Components in the following line https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/views/component.js#LC158

```
  {{my-tree didClickTreeNode=didClickCategory}} 
```

and it should be stringified as

```
   {{my-tree didClickTreeNode='didClickCategory'}} 
```

since 'didClickCategory' is a method in the example.

https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/views/component.js#L150-152
