### PR TITLE
add Ember.create unit test, preventing parent object's pollute

### DIFF
--- a/packages/ember-metal/tests/platform/create_test.js
+++ b/packages/ember-metal/tests/platform/create_test.js
@@ -28,3 +28,13 @@ test("passing additional property descriptors should define", function() {
   equal(obj2.repl, 'obj2', 'should have replaced parent');
 });
 
+test("passing additional property descriptors should not pollute parent object", function() {
+  var obj = { foo: 'FOO', repl: 'obj' };
+  var obj2 = Ember.create(obj, {
+    repl: {
+      value: 'obj2'
+    }
+  });
+
+  notEqual(obj.repl, obj2.repl, 'should not pollute parent object');
+});


### PR DESCRIPTION
```
var K = function() {};

Ember.create = function(obj, props) {
  K.prototype = obj;
  obj = new K();
  if (props) {
    K.prototype = obj; // prevent pollute
    for (var prop in props) {
      K.prototype[prop] = props[prop].value;
    }
    obj = new K();
  }
  K.prototype = null;

  return obj;
};
```
