### PR TITLE
Asserts that a target element is in the DOM on `appendTo` and `replaceIn`

### DIFF
--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -392,7 +392,7 @@ test("select tagName on collection helper automatically sets child tagName to op
   });
 
   Ember.run(function() {
-    view.appendTo('qunit-fixture');
+    view.appendTo('#qunit-fixture');
   });
 
   equal(view.$('option').length, 1, "renders the correct child tag name");

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1478,6 +1478,7 @@ Ember.View = Ember.CoreView.extend(
     // Schedule the DOM element to be created and appended to the given
     // element after bindings have synchronized.
     this._insertElementLater(function() {
+      Ember.assert("You tried to append to (" + target + ") but that isn't in the DOM", Ember.$(target).length > 0);
       Ember.assert("You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.", !Ember.$(target).is('.ember-view') && !Ember.$(target).parents().is('.ember-view'));
       this.$().appendTo(target);
     });
@@ -1499,6 +1500,7 @@ Ember.View = Ember.CoreView.extend(
     @return {Ember.View} received
   */
   replaceIn: function(target) {
+    Ember.assert("You tried to replace in (" + target + ") but that isn't in the DOM", Ember.$(target).length > 0);
     Ember.assert("You cannot replace an existing Ember.View. Consider using Ember.ContainerView instead.", !Ember.$(target).is('.ember-view') && !Ember.$(target).parents().is('.ember-view'));
 
     this._insertElementLater(function() {

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -46,6 +46,16 @@ test("should be added to the document body when calling append()", function() {
   ok(viewElem.length > 0, "creates and appends the view's element");
 });
 
+test("raises an assert when a target does not exist in the DOM", function() {
+  view = View.create();
+
+  expectAssertion(function() {
+    Ember.run(function() {
+      view.appendTo('does-not-exist-in-dom');
+    });
+  });
+});
+
 test("append calls willInsertElement and didInsertElement callbacks", function() {
   var willInsertElementCalled = false;
   var willInsertElementCalledInChild = false;

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -29,6 +29,17 @@ test("should be added to the specified element when calling replaceIn()", functi
   ok(viewElem.length > 0, "creates and replaces the view's element");
 });
 
+test("raises an assert when a target does not exist in the DOM", function() {
+  view = View.create();
+
+  expectAssertion(function() {
+    Ember.run(function() {
+      view.replaceIn('made-up-target');
+    });
+  });
+});
+
+
 test("should remove previous elements when calling replaceIn()", function() {
   Ember.$("#qunit-fixture").html('<div id="menu"><p>Foo</p></div>');
   var viewElem = Ember.$('#menu').children();


### PR DESCRIPTION
The behavior of `appendTo` and `replaceIn` are unexpected if the target you supply them with does not exist in the DOM.

In that case, the view will transition to the `inDOM` state even though it's not in the DOM, which is inconsistent.

I believe that if people use `appendTo` with a missing target it is almost certainly programmer error and you are doing something wrong. This patch includes an assertion to ensure that targets are actually present. 

Note one of the unit tests appends to 'qunit-fixture' instead of '#qunit-fixture' so I already found one bug as a result!
