### PR TITLE
[BUGFIX beta] Calling `replaceIn` would incorrectly move views from the `hasElement` state to `inDOM`

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -15,10 +15,18 @@ Ember.merge(preRender, {
     var viewCollection = view.viewHierarchyCollection();
 
     viewCollection.trigger('willInsertElement');
-    // after createElement, the view will be in the hasElement state.
+
     fn.call(view);
-    viewCollection.transitionTo('inDOM', false);
-    viewCollection.trigger('didInsertElement');
+
+    // We transition to `inDOM` if the element exists in the DOM
+    var element = view.get('element');
+    while (element = element.parentNode) {
+      if (element === document) {
+        viewCollection.transitionTo('inDOM', false);
+        viewCollection.trigger('didInsertElement');
+      }
+    }
+
   },
 
   renderToBufferIfNeeded: function(view, buffer) {

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -56,6 +56,17 @@ test("should remove previous elements when calling replaceIn()", function() {
 
 });
 
+test("should move the view to the inDOM state after replacing", function() {
+  Ember.$("#qunit-fixture").html('<div id="menu"></div>');
+  view = View.create();
+
+  Ember.run(function() {
+    view.replaceIn('#menu');
+  });
+
+  equal(view.currentState, Ember.View.states.inDOM, "the view is in the inDOM state");
+});
+
 module("Ember.View - replaceIn() in a view hierarchy", {
   setup: function() {
     View = Ember.ContainerView.extend({

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -151,6 +151,42 @@ test("rerender should throw inside a template", function() {
   }, /Something you did caused a view to re-render after it rendered but before it was inserted into the DOM./);
 });
 
+module("views/view/view_lifecycle_test - hasElement", {
+  teardown: function() {
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+    }
+  }
+});
+
+test("createElement puts the view into the hasElement state", function() {
+  view = Ember.View.create({
+    render: function(buffer) { buffer.push('hello'); }
+  });
+
+  Ember.run(function() {
+    view.createElement();
+  });
+
+  equal(view.currentState, Ember.View.states.hasElement, "the view is in the hasElement state");
+});
+
+test("trigger rerender on a view in the hasElement state doesn't change its state to inDOM", function() {
+  view = Ember.View.create({
+    render: function(buffer) { buffer.push('hello'); }
+  });
+
+  Ember.run(function() {
+    view.createElement();
+    view.rerender();
+  });
+
+  equal(view.currentState, Ember.View.states.hasElement, "the view is still in the hasElement state");
+});
+
+
 module("views/view/view_lifecycle_test - in DOM", {
   teardown: function() {
     if (view) {
@@ -315,5 +351,25 @@ test("should throw an exception when destroyElement is called after view is dest
   raises(function() {
     view.destroyElement();
   }, null, "throws an exception when calling destroyElement");
+});
+
+test("trigger rerender on a view in the inDOM state keeps its state as inDOM", function() {
+  Ember.run(function() {
+    view = Ember.View.create({
+      template: tmpl('foo')
+    });
+
+    view.append();
+  });
+
+  Ember.run(function() {
+    view.rerender();
+  });
+
+  equal(view.currentState, Ember.View.states.inDOM, "the view is still in the inDOM state");
+
+  Ember.run(function() {
+    view.destroy();
+  });
 });
 


### PR DESCRIPTION
If you have a `Ember.View` that is currently in the `hasElement` state and called `rerender` on it, it would incorrectly transition the state to `inDOM`.

This patch respects the initial state of the view when `rerender` is called and puts it back in that state once rendering completes. It also includes additional tests to ensure things stay in the states they should.
