### PR TITLE
Add Ember.DataAdapter in ember-extension-support

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -4,7 +4,7 @@ distros = {
   "runtime"           => %w(ember-metal rsvp container ember-runtime),
   "template-compiler" => %w(ember-handlebars-compiler),
   "data-deps"         => %w(ember-metal rsvp container ember-runtime ember-states),
-  "full"              => %w(ember-metal rsvp container ember-runtime ember-views metamorph handlebars ember-handlebars-compiler ember-handlebars ember-routing ember-application ember-states)
+  "full"              => %w(ember-metal rsvp container ember-runtime ember-views metamorph handlebars ember-handlebars-compiler ember-handlebars ember-routing ember-application ember-states ember-extension-support)
 }
 
 class AddMicroLoader < Rake::Pipeline::Filter

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -34,6 +34,7 @@ testing_packages:
   - ember-routing
   - ember-application
   - ember
+  - ember-extension-support
   - ember-testing
 testing_additional_requires:
   - ember-debug

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -1,0 +1,424 @@
+/**
+@module ember
+@submodule ember-extension-support
+*/
+
+require('ember-application');
+
+/**
+  The `DataAdapter` helps a data persistence library
+  interface with tools that debug Ember such
+  as the Chrome Ember Extension.
+
+  This class will be extended by a persistence library
+  which will override some of the methods with
+  library-specific code.
+
+  The methods likely to be overriden are
+  `getFilters`, `detect`, `columnsForType`,
+  `getRecords`, `getRecordColumnValues`,
+  `getRecordKeywords`, `getRecordFilterValues`,
+  `getRecordColor`, `observeRecord`
+
+  The adapter will need to be registered
+  in the application's container as `dataAdapter:main`
+
+  Example:
+  ```javascript
+  Application.initializer({
+    name: "dataAdapter",
+
+    initialize: function(container, application) {
+      application.register('dataAdapter:main', DS.DataAdapter);
+    }
+  });
+  ```
+
+  @class DataAdapter
+  @namespace Ember
+  @extends Ember.Object
+*/
+Ember.DataAdapter = Ember.Object.extend({
+  init: function() {
+    this._super();
+    this.releaseMethods = Ember.A();
+  },
+
+  /**
+    The container of the application being debugged.
+    This property will be injected
+    on creation.
+  */
+  container: null,
+
+  /**
+    @private
+
+    Number of attributes to send
+    as columns. (Enough to make the record
+    identifiable).
+  */
+  attributeLimit: 3,
+
+  /**
+    @private
+
+    Stores all methods that clear observers.
+    These methods will be called on destruction.
+  */
+  releaseMethods: Ember.A(),
+
+  /**
+    @public
+
+    Specifies how records can be filtered.
+    Records returned will need to have a `filterValues`
+    property with a key for every name in the returned array.
+
+    @method getFilters
+    @return {Array} List of objects defining filters.
+     The object should have a `name` and `desc` property.
+  */
+  getFilters: function() {
+    return Ember.A();
+  },
+
+  /**
+    @public
+
+    Fetch the model types and observe them for changes.
+
+    @method watchModelTypes
+
+    @param {Function} typesAdded Callback to call to add types.
+    Takes an array of objects containing wrapped types (returned from `wrapModelType`).
+
+    @param {Function} typesUpdated Callback to call when a type has changed.
+    Takes an array of objects containing wrapped types.
+
+    @return {Function} Method to call to remove all observers
+  */
+  watchModelTypes: function(typesAdded, typesUpdated) {
+    var modelTypes = this.getModelTypes(),
+        self = this, typesToSend, releaseMethods = Ember.A();
+
+    typesToSend = modelTypes.map(function(type) {
+      var wrapped = self.wrapModelType(type);
+      releaseMethods.push(self.observeModelType(type, typesUpdated));
+      return wrapped;
+    });
+
+    typesAdded(typesToSend);
+
+    var release = function() {
+      releaseMethods.forEach(function(fn) { fn(); });
+      self.releaseMethods.removeObject(release);
+    };
+    this.releaseMethods.pushObject(release);
+    return release;
+  },
+
+  /**
+    @public
+
+    Fetch the records of a given type and observe them for changes.
+
+    @method watchRecords
+
+    @param {Function} recordsAdded Callback to call to add records.
+    Takes an array of objects containing wrapped records.
+    The object should have the following properties:
+      columnValues: {Object} key and value of a table cell
+      object: {Object} the actual record object
+
+    @param {Function} recordsUpdated Callback to call when a record has changed.
+    Takes an array of objects containing wrapped records.
+
+    @param {Function} recordsRemoved Callback to call when a record has removed.
+    Takes the following parameters:
+      index: the array index where the records were removed
+      count: the number of records removed
+
+    @return {Function} Method to call to remove all observers
+  */
+  watchRecords: function(type, recordsAdded, recordsUpdated, recordsRemoved) {
+    var self = this, releaseMethods = Ember.A(), records = this.getRecords(type), release;
+
+    var recordUpdated = function(updatedRecord) {
+      recordsUpdated([updatedRecord]);
+    };
+
+    var recordsToSend = records.map(function(record) {
+      releaseMethods.push(self.observeRecord(record, recordUpdated));
+      return self.wrapRecord(record);
+    });
+
+
+    var contentDidChange = function(array, idx, removedCount, addedCount) {
+      for (var i = idx; i < idx + addedCount; i++) {
+        var record = array.objectAt(i);
+        var wrapped = self.wrapRecord(record);
+        releaseMethods.push(self.observeRecord(record, recordUpdated));
+        recordsAdded([wrapped]);
+      }
+
+      if (removedCount) {
+        recordsRemoved(idx, removedCount);
+      }
+    };
+
+    var observer = { didChange: contentDidChange, willChange: Ember.K };
+    records.addArrayObserver(self, observer);
+
+    release = function() {
+      releaseMethods.forEach(function(fn) { fn(); });
+      records.removeArrayObserver(self, observer);
+      self.releaseMethods.removeObject(release);
+    };
+
+    recordsAdded(recordsToSend);
+
+    this.releaseMethods.pushObject(release);
+    return release;
+  },
+
+  /**
+    @private
+
+    Clear all observers before destruction
+  */
+  willDestroy: function() {
+    this._super();
+    this.releaseMethods.forEach(function(fn) {
+      fn();
+    });
+  },
+
+  /**
+    @private
+
+    Detect whether a class is a model.
+
+    Test that against the model class
+    of your persistence library
+
+    @method detect
+    @param {Class} klass The class to test
+    @return boolean Whether the class is a model class or not
+  */
+  detect: function(klass) {
+    return false;
+  },
+
+  /**
+    @private
+
+    Get the columns for a given model type.
+
+    @method columnsForType
+    @param {Class} type The model type
+    @return {Array} An array of columns of the following format:
+     name: {String} name of the column
+     desc: {String} Humanized description (what would show in a table column name)
+  */
+  columnsForType: function(type) {
+    return Ember.A();
+  },
+
+  /**
+    @private
+
+    Adds observers to a model type class.
+
+    @method observeModelType
+    @param {Class} type The model type class
+    @param {Function} typesUpdated Called when a type is modified.
+    @return {Function} The function to call to remove observers
+  */
+
+  observeModelType: function(type, typesUpdated) {
+    var self = this, records = this.getRecords(type);
+
+    var onChange = function() {
+      typesUpdated([self.wrapModelType(type)]);
+    };
+    var observer = {
+      didChange: function() {
+        Ember.run.scheduleOnce('actions', this, onChange);
+      },
+      willChange: Ember.K
+    };
+
+    records.addArrayObserver(this, observer);
+
+    var release = function() {
+      records.removeArrayObserver(self, observer);
+    };
+
+    return release;
+  },
+
+
+  /**
+    @private
+
+    Wraps a given model type and observes changes to it.
+
+    @method wrapModelType
+    @param {Class} type A model class
+    @param {Function} typesUpdated callback to call when the type changes
+    @return {Object} contains the wrapped type and the function to remove observers
+    Format:
+      type: {Object} the wrapped type
+        The wrapped type has the following format:
+          name: {String} name of the type
+          count: {Integer} number of records available
+          columns: {Columns} array of columns to describe the record
+          object: {Class} the actual Model type class
+      release: {Function} The function to remove observers
+  */
+  wrapModelType: function(type, typesUpdated) {
+    var release, records = this.getRecords(type),
+        typeToSend, self = this;
+
+    typeToSend = {
+      name: type.toString(),
+      count: Ember.get(records, 'length'),
+      columns: this.columnsForType(type),
+      object: type
+    };
+
+
+    return typeToSend;
+  },
+
+
+  /**
+    @private
+
+    Fetches all models defined in the application.
+    TODO: Use the resolver instead of looping over namespaces.
+
+    @method getModelTypes
+    @return {Array} Array of model types
+  */
+  getModelTypes: function() {
+    var namespaces = Ember.A(Ember.Namespace.NAMESPACES), types = Ember.A(), self = this;
+
+    namespaces.forEach(function(namespace) {
+      for (var key in namespace) {
+        if (!namespace.hasOwnProperty(key)) { continue; }
+        var klass = namespace[key];
+        if (self.detect(klass)) {
+          types.push(klass);
+        }
+      }
+    });
+    return types;
+  },
+
+  /**
+    @private
+
+    Fetches all loaded records for a given type.
+
+    @method getRecords
+    @return {Array} array of records.
+     This array will be observed for changes,
+     so it should update when new records are added/removed.
+  */
+  getRecords: function(type) {
+    return Ember.A();
+  },
+
+  /**
+    @private
+
+    Wraps a record and observers changes to it
+
+    @method wrapRecord
+    @param {Object} record The record instance
+    @return {Object} the wrapped record. Format:
+    columnValues: {Array}
+    searchKeywords: {Array}
+  */
+  wrapRecord: function(record) {
+    var recordToSend = { object: record }, columnValues = {}, self = this;
+
+    recordToSend.columnValues = this.getRecordColumnValues(record);
+    recordToSend.searchKeywords = this.getRecordKeywords(record);
+    recordToSend.filterValues = this.getRecordFilterValues(record);
+    recordToSend.color = this.getRecordColor(record);
+
+    return recordToSend;
+  },
+
+  /**
+    @private
+
+    Gets the values for each column.
+
+    @method getRecordColumnValues
+    @return {Object} Keys should match column names defined
+    by the model type.
+  */
+  getRecordColumnValues: function(record) {
+    return {};
+  },
+
+  /**
+    @private
+
+    Returns keywords to match when searching records.
+
+    @method getRecordKeywords
+    @return {Array} Relevant keywords for search.
+  */
+  getRecordKeywords: function(record) {
+    return Ember.A();
+  },
+
+  /**
+    @private
+
+    Returns the values of filters defined by `getFilters`.
+
+    @method getRecordFilterValues
+    @param {Object} record The record instance
+    @return {Object} The filter values
+  */
+  getRecordFilterValues: function(record) {
+    return {};
+  },
+
+  /**
+    @private
+
+    Each record can have a color that represents its state.
+
+    @method getRecordColor
+    @param {Object} record The record instance
+    @return {String} The record's color
+      Possible options: black, red, blue, green
+  */
+  getRecordColor: function(record) {
+    return null;
+  },
+
+  /**
+    @private
+
+    Observes all relevant properties and re-sends the wrapped record
+    when a change occurs.
+
+    @method observerRecord
+    @param {Object} record The record instance
+    @param {Function} recordUpdated The callback to call when a record is updated.
+    @return {Function} The function to call to remove all observers.
+  */
+  observeRecord: function(record, recordUpdated) {
+    return function(){};
+  }
+
+});
+

--- a/packages/ember-extension-support/lib/main.js
+++ b/packages/ember-extension-support/lib/main.js
@@ -1,0 +1,9 @@
+/**
+Ember Extension Support
+
+@module ember
+@submodule ember-extension-support
+@requires ember-application
+*/
+
+require('ember-extension-support/data_adapter');

--- a/packages/ember-extension-support/package.json
+++ b/packages/ember-extension-support/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ember-extension-support",
+  "summary": "Ember Extension Support",
+  "description": "API for external tools such as the Chrome Ember Extension",
+  "homepage": "http://emberjs.com",
+  "authors": ["Teddy Zeenny"],
+  "version": "1.0.0-rc.6",
+  "dependencies": {
+    "ember-application": "1.0.0-rc.6"
+  },
+
+  "directories": {
+    "lib": "lib"
+  },
+
+  "dependencies:development": {
+    "spade-qunit": "~> 1.0.0"
+  },
+
+  "bpm:build": {
+
+    "bpm_libs.js": {
+      "files": ["lib"],
+      "modes": "*"
+    }
+  }
+
+}

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -1,0 +1,161 @@
+var adapter, App, get = Ember.get,
+    set = Ember.set, Model = Ember.Object.extend();
+
+var DataAdapter = Ember.DataAdapter.extend({
+  detect: function(klass) {
+    return klass !== Model && Model.detect(klass);
+  }
+});
+
+module("Data Adapter", {
+  setup:function() {
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.toString = function() { return 'App'; };
+      App.deferReadiness();
+      App.__container__.register('dataAdapter:main', DataAdapter);
+      adapter = App.__container__.lookup('dataAdapter:main');
+    });
+  },
+  teardown: function() {
+    Ember.run(function() {
+      adapter.destroy();
+      App.destroy();
+    });
+  }
+});
+
+test("Model Types Added", function() {
+  App.Post = Model.extend();
+
+  adapter.reopen({
+    getRecords: function() {
+      return Ember.A([1,2,3]);
+    },
+    columnsForType: function() {
+      return [ { name: 'title', desc: 'Title'} ];
+    }
+  });
+
+  Ember.run(App, 'advanceReadiness');
+
+  var modelTypesAdded = function(types) {
+
+    equal(types.length, 1);
+    var postType = types[0];
+    equal(postType.name, 'App.Post', 'Correctly sets the name');
+    equal(postType.count, 3, 'Correctly sets the record count');
+    strictEqual(postType.object, App.Post, 'Correctly sets the object');
+    deepEqual(postType.columns, [ {name: 'title', desc: 'Title'} ], 'Correctly sets the columns');
+  };
+
+  adapter.watchModelTypes(modelTypesAdded);
+
+});
+
+test("Model Types Updated", function() {
+  App.Post = Model.extend();
+
+  var records = Ember.A([1,2,3]);
+  adapter.reopen({
+    getRecords: function() {
+      return records;
+    }
+  });
+
+  Ember.run(App, 'advanceReadiness');
+
+  var modelTypesAdded = function() {
+    Ember.run(function() {
+      records.pushObject(4);
+    });
+  };
+
+  var modelTypesUpdated = function(types) {
+
+    var postType = types[0];
+    equal(postType.count, 4, 'Correctly updates the count');
+  };
+
+  adapter.watchModelTypes(modelTypesAdded, modelTypesUpdated);
+
+});
+
+test("Records Added", function() {
+  expect(8);
+  var countAdded = 1;
+
+  App.Post = Model.extend();
+
+  var post = App.Post.create();
+  var recordList = Ember.A([post]);
+
+  adapter.reopen({
+    getRecords: function() {
+      return recordList;
+    },
+    getRecordColor: function() {
+      return 'blue';
+    },
+    getRecordColumnValues: function() {
+      return { title: 'Post ' + countAdded };
+    },
+    getRecordKeywords: function() {
+      return ['Post ' + countAdded];
+    }
+  });
+
+  var recordsAdded = function(records) {
+    var record = records[0];
+    equal(record.color, 'blue', 'Sets the color correctly');
+    deepEqual(record.columnValues, { title: 'Post ' + countAdded }, 'Sets the column values correctly');
+    deepEqual(record.searchKeywords, ['Post ' + countAdded], 'Sets search keywords correctly');
+    strictEqual(record.object, post, 'Sets the object to the record instance');
+  };
+
+  adapter.watchRecords(App.Post, recordsAdded);
+  countAdded++;
+  post = App.Post.create();
+  recordList.pushObject(post);
+});
+
+test("Observes and releases a record correctly", function() {
+  var updatesCalled = 0;
+  App.Post = Model.extend();
+
+  var post = App.Post.create({ title: 'Post' });
+  var recordList = Ember.A([post]);
+
+  adapter.reopen({
+    getRecords: function() {
+      return recordList;
+    },
+    observeRecord: function(record, recordUpdated) {
+      var self = this;
+      var callback = function() {
+        recordUpdated(self.wrapRecord(record));
+      };
+      Ember.addObserver(record, 'title', callback);
+      return function() {
+        Ember.removeObserver(record, 'title', callback);
+      };
+    },
+    getRecordColumnValues: function(record) {
+      return { title: get(record, 'title') };
+    }
+  });
+
+  var recordsAdded = function() {
+    set(post, 'title', 'Post Modified');
+  };
+
+  var recordsUpdated = function(records) {
+    updatesCalled++;
+    equal(records[0].columnValues.title, 'Post Modified');
+  };
+
+  var release = adapter.watchRecords(App.Post, recordsAdded, recordsUpdated);
+  release();
+  set(post, 'title', 'New Title');
+  equal(updatesCalled, 1, 'Release function removes observers');
+});


### PR DESCRIPTION
I added a package called `ember-extension-support`.

In that package I defined `Ember.DataAdapter` which will be extended by data libraries, allowing their models to be inspected in the Chrome Extension's Data tab.

Next I will submit a PR to ED that will extend this class with ED specific code.
