### PR TITLE
Add rel attribute binding to linkTo helper

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -63,6 +63,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     title: null,
 
     /**
+      Sets the `rel` attribute of the `LinkView`'s HTML element.
+
+      @property rel
+      @default null
+    **/
+    rel: null,
+
+    /**
       The CSS class to apply to `LinkView`'s element when its `active`
       property is `true`.
 
@@ -102,7 +110,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       @default false
     **/
     replace: false,
-    attributeBindings: ['href', 'title'],
+    attributeBindings: ['href', 'title', 'rel'],
     classNameBindings: ['active', 'loading', 'disabled'],
 
     /**

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -414,14 +414,16 @@ test("The {{linkTo}} helper moves into the named route with context", function()
 });
 
 test("The {{linkTo}} helper binds some anchor html tag common attributes", function() {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'index' id='self-link' title='title-attr'}}Self{{/linkTo}}");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'index' id='self-link' title='title-attr' rel='rel-attr'}}Self{{/linkTo}}");
   bootApplication();
 
   Ember.run(function() {
     router.handleURL("/");
   });
-
-  equal(Ember.$('#self-link', '#qunit-fixture').attr('title'), 'title-attr', "The self-link contains title attribute");
+  
+  var link = Ember.$('#self-link', '#qunit-fixture');
+  equal(link.attr('title'), 'title-attr', "The self-link contains title attribute");
+  equal(link.attr('rel'), 'rel-attr', "The self-link contains rel attribute");
 });
 
 test("The {{linkTo}} helper accepts string/numeric arguments", function() {


### PR DESCRIPTION
Adding support for the 'rel' attribute on linkTo anchor tags:

``` handlebars
{{#linkTo 'authors' author rel='author'}}Tom Dale{{/linkTo}}
{{#linkTo 'contact' rel='nofollow'}}Contact{{/linkTo}}
```

Useful for seo, and meta info.
