### PR TITLE
Remove obsolete paragraph from ObjectController comments

### DIFF
--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -7,10 +7,7 @@ require('ember-runtime/controllers/controller');
 */
 
 /**
-  `Ember.ObjectController` is part of Ember's Controller layer. A single shared
-  instance of each `Ember.ObjectController` subclass in your application's
-  namespace will be created at application initialization and be stored on your
-  application's `Ember.Router` instance.
+  `Ember.ObjectController` is part of Ember's Controller layer.
 
   `Ember.ObjectController` derives its functionality from its superclass
   `Ember.ObjectProxy` and the `Ember.ControllerMixin` mixin.


### PR DESCRIPTION
I don't think this is true anymore, right?
