### PR TITLE
Update #each docs for groupedRows

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -315,6 +315,7 @@ GroupedEach.prototype = {
   @param [options] {Object} Handlebars key/value pairs of options
   @param [options.itemViewClass] {String} a path to a view class used for each item
   @param [options.itemController] {String} name of a controller to be created for each item
+  @param [options.groupedRows] {boolean} something about grouping ... rows?
 */
 Ember.Handlebars.registerHelper('each', function(path, options) {
   if (arguments.length === 4) {


### PR DESCRIPTION
Good news: I added a line that mentions the last undocumented option
that is used in #each helper.

Bad news: I have no idea what the groupedRows boolean is supposed to
accomplish. Something about metamorphs maybe? Also what is a metamorph?

It seems that if `groupedRows` is true or if an `itemViewClass` is
supplied, then it wil use EachView instead of `GroupedEach`. Strange to me
that `groupedRows=true` will result in _not_ using `GroupedEach`.

That is to say that using `GroupedEach` is default and if you supply
either `groupedRows=true` or `itemViewClass=App.FooView`, then it will
use EachView instead.
