### PR TITLE
Add Ember.on, Function.prototype.on, and didInit event

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -9,6 +9,7 @@ require('ember-metal/utils');
 var o_create = Ember.create,
     metaFor = Ember.meta,
     META_KEY = Ember.META_KEY,
+    a_slice = [].slice,
     /* listener flags */
     ONCE = 1, SUSPENDED = 2;
 
@@ -367,6 +368,31 @@ function listenersFor(obj, eventName) {
 
   return ret;
 }
+
+/**
+  Define a property as a function that should be executed when
+  a specified event or events are triggered.
+
+      var Job = Ember.Object.extend({
+        logCompleted: Ember.on('completed', function(){
+          console.log('Job completed!');
+        })
+      });
+      var job = Job.create();
+      Ember.sendEvent(job, 'completed'); // Logs "Job completed!"
+
+  @method on
+  @for Ember
+  @param {String} eventNames*
+  @param {Function} func
+  @return func
+*/
+Ember.on = function(){
+  var func = a_slice.call(arguments, -1)[0],
+      events = a_slice.call(arguments, 0, -1);
+  func.__ember_listens__ = events;
+  return func;
+};
 
 Ember.addListener = addListener;
 Ember.removeListener = removeListener;

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -321,6 +321,7 @@ Ember.wrap = function(func, superFunc) {
   superWrapper.wrappedFunction = func;
   superWrapper.__ember_observes__ = func.__ember_observes__;
   superWrapper.__ember_observesBefore__ = func.__ember_observesBefore__;
+  superWrapper.__ember_listens__ = func.__ember_listens__;
 
   return superWrapper;
 };

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -211,3 +211,47 @@ test('while suspended, it should not be possible to add a duplicate listener', f
   equal(target.count, 2, 'should have invoked again');
   equal(Ember.meta(obj).listeners['event!'].length, 1, "a duplicate listener wasn't added");
 });
+
+test('a listener can be added as part of a mixin', function() {
+  var triggered = 0;
+  var MyMixin = Ember.Mixin.create({
+    foo1: Ember.on('bar', function() {
+      triggered++;
+    }),
+
+    foo2: Ember.on('bar', function() {
+      triggered++;
+    })
+  });
+
+  var obj = {};
+  MyMixin.apply(obj);
+
+  Ember.sendEvent(obj, 'bar');
+  equal(triggered, 2, 'should invoke listeners');
+});
+
+test('a listener added as part of a mixin may be overridden', function() {
+
+  var triggered = 0;
+  var FirstMixin = Ember.Mixin.create({
+    foo: Ember.on('bar', function() {
+      triggered++;
+    })
+  });
+  var SecondMixin = Ember.Mixin.create({
+    foo: Ember.on('baz', function() {
+      triggered++;
+    })
+  });
+
+  var obj = {};
+  FirstMixin.apply(obj);
+  SecondMixin.apply(obj);
+
+  Ember.sendEvent(obj, 'bar');
+  equal(triggered, 0, 'should not invoke from overriden property');
+
+  Ember.sendEvent(obj, 'baz');
+  equal(triggered, 1, 'should invoke from subclass property');
+});

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -86,7 +86,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
     });
     ```
 
-    See `Ember.Observable.observes`.
+    See `Ember.observes`.
 
     @method observes
     @for Function
@@ -113,7 +113,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
     });
     ```
 
-    See `Ember.Observable.observesBefore`.
+    See `Ember.observesBefore`.
 
     @method observesBefore
     @for Function
@@ -123,5 +123,31 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
     return this;
   };
 
+  /**
+    The `on` extension of Javascript's Function prototype is available
+    when `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Function` is
+    true, which is the default.
+
+    You can listen for events simply by adding the `on` call to the end of
+    your method declarations in classes or mixins that you write. For example:
+
+    ```javascript
+    Ember.Mixin.create({
+      doSomethingWithElement: function() {
+        // Executes whenever the "didInsertElement" event fires
+      }.on('didInsertElement')
+    });
+    ```
+
+    See `Ember.on`.
+
+    @method on
+    @for Function
+  */
+  Function.prototype.on = function() {
+    var events = a_slice.call(arguments);
+    this.__ember_listens__ = events;
+    return this;
+  };
 }
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -19,6 +19,7 @@ var set = Ember.set, get = Ember.get,
     meta = Ember.meta,
     rewatch = Ember.rewatch,
     finishChains = Ember.finishChains,
+    sendEvent = Ember.sendEvent,
     destroy = Ember.destroy,
     schedule = Ember.run.schedule,
     Mixin = Ember.Mixin,
@@ -122,6 +123,7 @@ function makeCtor() {
     delete m.proto;
     finishChains(this);
     this.init.apply(this, arguments);
+    sendEvent(this, "didInit");
   };
 
   Class.toString = Mixin.prototype.toString;

--- a/packages/ember-runtime/tests/ext/function_test.js
+++ b/packages/ember-runtime/tests/ext/function_test.js
@@ -29,3 +29,53 @@ testBoth('global observer helper takes multiple params', function(get, set) {
   equal(get(obj, 'count'), 2, 'should invoke observer after change');
 });
 
+module('Function.prototype.on() helper');
+
+testBoth('sets up an event listener, and can trigger the function on multiple events', function(get, set) {
+
+  if (Ember.EXTEND_PROTOTYPES === false) {
+    ok('Function.prototype helper disabled');
+    return ;
+  }
+
+  var MyMixin = Ember.Mixin.create({
+
+    count: 0,
+
+    foo: function() {
+      set(this, 'count', get(this, 'count')+1);
+    }.on('bar', 'baz')
+
+  });
+
+  var obj = Ember.mixin({}, Ember.Evented, MyMixin);
+  equal(get(obj, 'count'), 0, 'should not invoke listener immediately');
+
+  obj.trigger('bar');
+  obj.trigger('baz');
+  equal(get(obj, 'count'), 2, 'should invoke listeners when events trigger');
+});
+
+testBoth('can be chained with observes', function(get, set) {
+
+  if (Ember.EXTEND_PROTOTYPES === false) {
+    ok('Function.prototype helper disabled');
+    return ;
+  }
+
+  var MyMixin = Ember.Mixin.create({
+
+    count: 0,
+    bay: 'bay',
+    foo: function() {
+      set(this, 'count', get(this, 'count')+1);
+    }.observes('bay').on('bar')
+  });
+
+  var obj = Ember.mixin({}, Ember.Evented, MyMixin);
+  equal(get(obj, 'count'), 0, 'should not invoke listener immediately');
+
+  set(obj, 'bay', 'BAY');
+  obj.trigger('bar');
+  equal(get(obj, 'count'), 2, 'should invoke observer and listener');
+});

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -167,6 +167,17 @@ test("Calls all mixin inits if defined", function() {
   equal(completed, 2, 'should have called init for both mixins.');
 });
 
+test("Triggers didInit", function() {
+  var completed = false;
+  var obj = Ember.Object.createWithMixins({
+    markAsCompleted: Ember.on("didInit", function(){
+      completed = true;
+    })
+  });
+
+  ok(completed, 'should have triggered didInit which should have run markAsCompleted');
+});
+
 test('creating an object with required properties', function() {
   var ClassA = Ember.Object.extend({
     foo: Ember.required()


### PR DESCRIPTION
This PR adds `Ember.on(eventName, func)` and `Function.prototype.on`
as cousins to `Ember.observes` and `Function.prototype.observes`. This
provides a declarative form of marking methods to execute when an event
fires.

This is useful for mixins which need to do things on `didInsertElement` and `willDestroyElement`, but don't want to force a call to `super` from the classes that include it:

``` javascript
Ember.Mixin.create({
  doSomethingWithElement: function() {
    // Executes whenever the "didInsertElement" event fires, regardless of the presence of a method named `didInsertElement`
  }.on('didInsertElement')
});
```

In addition, this commit also makes Ember.Object send a `didInit` event after initializing. This provides for an elegant solution to a common need: marking a function as an observer and also executing it at creation time. e.g.

``` javascript
Ember.Object.extend({
  upateOptions: function(){
    var opts = this.get('controller.foo').importantTransform();
    this.set('options', opts);
  }.observes('controller.foo').on('didInit')
});
```
