### PR TITLE
make handlebars compilation output repeatable

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -183,7 +183,7 @@ Ember.Handlebars.JavaScriptCompiler.prototype.appendToBuffer = function(string) 
   return "data.buffer.push("+string+");";
 };
 
-var prefix = "ember" + (+new Date()), incr = 1;
+var prefix = "ember_control_id_", incr = 1;
 
 /**
   @private


### PR DESCRIPTION
Handlebars compilation when run twice produced different result because identifier was generated with current timestamp as a base. 
