### PR TITLE
Assert a controller "needs" the controller its binding to

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -254,6 +254,7 @@ function connectBindings(obj, m) {
         } else { // binding is string path
           binding = new Ember.Binding(to, binding);
         }
+        Ember.assert('Expected controller ' + obj + 'to have "needs" property for source controller in binding ' + binding._from, !binding._from || binding._from.split('.').length < 2 || binding._from.split('.')[0] !== 'controllers' || obj.needs.contains(binding._from.split('.')[1]));
         binding.connect(obj);
         obj[key] = binding;
       }


### PR DESCRIPTION
Reading from this binding will fail silently if the controller containing the code does not "needs" the otherController

```
App.FirstController = Ember.Controller.extend({
    needs: [],
    myBinding: 'controllers.otherController.property'
})
```

I think it's very important to have good warnings for gotchas like this. It's just too easy for somebody unfamiliar with the framework to get stuck and not know why this property isn't exposed correctly.

I'm not really happy with my implementation of the assert - is there a better way to tell what type of object we're dealing with, rather than introspecting the string directly?
