### PR TITLE
Avoids Ember.Logger.assert unless needed

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -44,7 +44,9 @@ if (!('MANDATORY_SETTER' in Ember.ENV)) {
     falsy, an exception will be thrown.
 */
 Ember.assert = function(desc, test) {
-  Ember.Logger.assert(test, desc);
+  if (!test) {
+    Ember.Logger.assert(test, desc);
+  }
 
   if (Ember.testing && !test) {
     // when testing, ensure test failures when assertions fail


### PR DESCRIPTION
It seems console.assert tends to cause some deoptimizations, leading to
some poor performance in development ment. So lets just avoid that
code path unless needed.
