### PR TITLE
Initial QueryParams implementation

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -26,17 +26,17 @@ DSL.prototype = {
     if (callback) {
       var dsl = new DSL(name);
       callback.call(dsl);
-      this.push(options.path, name, dsl.generate());
+      this.push(options.path, name, dsl.generate(), options.queryParams);
     } else {
-      this.push(options.path, name);
+      this.push(options.path, name, null, options.queryParams);
     }
   },
 
-  push: function(url, name, callback) {
+  push: function(url, name, callback, queryParams) {
     var parts = name.split('.');
     if (url === "" || url === "/" || parts[parts.length-1] === "index") { this.explicitIndex = true; }
 
-    this.matches.push([url, name, callback]);
+    this.matches.push([url, name, callback, queryParams]);
   },
 
   route: function(name, options) {
@@ -52,7 +52,7 @@ DSL.prototype = {
       name = this.parent + "." + name;
     }
 
-    this.push(options.path, name);
+    this.push(options.path, name, null, options.queryParams);
   },
 
   generate: function() {
@@ -65,7 +65,12 @@ DSL.prototype = {
     return function(match) {
       for (var i=0, l=dslMatches.length; i<l; i++) {
         var dslMatch = dslMatches[i];
-        match(dslMatch[0]).to(dslMatch[1], dslMatch[2]);
+        var matchObj = match(dslMatch[0]).to(dslMatch[1], dslMatch[2]);
+        if (Ember.FEATURES.isEnabled("query-params")) {
+          if(dslMatch[3]) {
+            matchObj.withQueryParams.apply(matchObj, dslMatch[3]);
+          }
+        }
       }
     };
   }

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -389,7 +389,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
 
     @method setup
   */
-  setup: function(context) {
+  setup: function(context, queryParams) {
     var controllerName = this.controllerName || this.routeName,
         controller = this.controllerFor(controllerName, true);
     if (!controller) {
@@ -400,18 +400,24 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     // referenced in action handlers
     this.controller = controller;
 
+    var args = [controller, context];
+
+    if (Ember.FEATURES.isEnabled("query-params")) {
+      args.push(queryParams);
+    }
+
     if (this.setupControllers) {
       Ember.deprecate("Ember.Route.setupControllers is deprecated. Please use Ember.Route.setupController(controller, model) instead.");
       this.setupControllers(controller, context);
     } else {
-      this.setupController(controller, context);
+      this.setupController.apply(this, args);
     }
 
     if (this.renderTemplates) {
       Ember.deprecate("Ember.Route.renderTemplates is deprecated. Please use Ember.Route.renderTemplate(controller, model) instead.");
       this.renderTemplates(context);
     } else {
-      this.renderTemplate(controller, context);
+      this.renderTemplate.apply(this, args);
     }
   },
 
@@ -502,6 +508,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
 
     @method beforeModel
     @param {Transition} transition
+    @param {Object} queryParams the active query params for this route
     @return {Promise} if the value returned from this hook is
       a promise, the transition will pause until the transition
       resolves. Otherwise, non-promise return values are not
@@ -535,12 +542,13 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     @param {Object} resolvedModel the value returned from `model`,
       or its resolved value if it was a promise
     @param {Transition} transition
+    @param {Object} queryParams the active query params for this handler
     @return {Promise} if the value returned from this hook is
       a promise, the transition will pause until the transition
       resolves. Otherwise, non-promise return values are not
       utilized in any way.
    */
-  afterModel: function(resolvedModel, transition) {
+  afterModel: function(resolvedModel, transition, queryParams) {
     this.redirect(resolvedModel, transition);
   },
 
@@ -600,6 +608,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     @method model
     @param {Object} params the parameters extracted from the URL
     @param {Transition} transition
+    @param {Object} queryParams the query params for this route
     @return {Object|Promise} the model for this route. If
       a promise is returned, the transition will pause until
       the promise resolves, and the resolved value of the promise

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -220,12 +220,16 @@ Ember.Router = Ember.Object.extend({
     args = [].slice.call(args);
     args[0] = args[0] || '/';
 
-    var passedName = args[0], name, self = this;
+    var passedName = args[0], name, self = this,
+      isQueryParamsOnly = false;
 
-    if (passedName.charAt(0) === '/') {
+    if (Ember.FEATURES.isEnabled("query-params")) {
+      isQueryParamsOnly = (args.length === 1 && args[0].hasOwnProperty('queryParams'));
+    }
+
+    if (!isQueryParamsOnly && passedName.charAt(0) === '/') {
       name = passedName;
-    } else {
-
+    } else if (!isQueryParamsOnly) {
       if (!this.router.hasRoute(passedName)) {
         name = args[0] = passedName + '.index';
       } else {

--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -101,7 +101,7 @@ define("route-recognizer",
           results.push(new StarSegment(match[1]));
           names.push(match[1]);
           types.stars++;
-        } else if (segment === "") {
+        } else if(segment === "") {
           results.push(new EpsilonSegment());
         } else {
           results.push(new StaticSegment(segment));
@@ -250,19 +250,31 @@ define("route-recognizer",
       return nextStates;
     }
 
-    function findHandler(state, path) {
+    function findHandler(state, path, queryParams) {
       var handlers = state.handlers, regex = state.regex;
       var captures = path.match(regex), currentCapture = 1;
       var result = [];
 
       for (var i=0, l=handlers.length; i<l; i++) {
-        var handler = handlers[i], names = handler.names, params = {};
+        var handler = handlers[i], names = handler.names, params = {},
+          watchedQueryParams = handler.queryParams || [],
+          activeQueryParams = {},
+          j, m;
 
-        for (var j=0, m=names.length; j<m; j++) {
+        for (j=0, m=names.length; j<m; j++) {
           params[names[j]] = captures[currentCapture++];
         }
-
-        result.push({ handler: handler.handler, params: params, isDynamic: !!names.length });
+        for (j=0, m=watchedQueryParams.length; j < m; j++) {
+          var key = watchedQueryParams[j];
+          if(queryParams[key]){
+            activeQueryParams[key] = queryParams[key];
+          }
+        }
+        var currentResult = { handler: handler.handler, params: params, isDynamic: !!names.length };
+        if(watchedQueryParams && watchedQueryParams.length > 0) {
+          currentResult.queryParams = activeQueryParams;
+        }
+        result.push(currentResult);
       }
 
       return result;
@@ -317,7 +329,11 @@ define("route-recognizer",
             regex += segment.regex();
           }
 
-          handlers.push({ handler: route.handler, names: names });
+          var handler = { handler: route.handler, names: names };
+          if(route.queryParams) {
+            handler.queryParams = route.queryParams;
+          }
+          handlers.push(handler);
         }
 
         if (isEmpty) {
@@ -369,12 +385,61 @@ define("route-recognizer",
 
         if (output.charAt(0) !== '/') { output = '/' + output; }
 
+        if (params && params.queryParams) {
+          output += this.generateQueryString(params.queryParams, route.handlers);
+        }
+
         return output;
+      },
+
+      generateQueryString: function(params, handlers) {
+        var pairs = [], allowedParams = [];
+        for(var i=0; i < handlers.length; i++) {
+          var currentParamList = handlers[i].queryParams;
+          if(currentParamList) {
+            allowedParams.push.apply(allowedParams, currentParamList);
+          }
+        }
+        for(var key in params) {
+          if (params.hasOwnProperty(key)) {
+            if(!~allowedParams.indexOf(key)) {
+              throw 'Query param "' + key + '" is not specified as a valid param for this route';
+            }
+            var value = params[key];
+            var pair = encodeURIComponent(key);
+            if(value !== true) {
+              pair += "=" + encodeURIComponent(value);
+            }
+            pairs.push(pair);
+          }
+        }
+
+        if (pairs.length === 0) { return ''; }
+
+        return "?" + pairs.join("&");
+      },
+
+      parseQueryString: function(queryString) {
+        var pairs = queryString.split("&"), queryParams = {};
+        for(var i=0; i < pairs.length; i++) {
+          var pair      = pairs[i].split('='),
+              key       = decodeURIComponent(pair[0]),
+              value     = pair[1] ? decodeURIComponent(pair[1]) : true;
+          queryParams[key] = value;
+        }
+        return queryParams;
       },
 
       recognize: function(path) {
         var states = [ this.rootState ],
-            pathLen, i, l;
+            pathLen, i, l, queryStart, queryParams = {};
+
+        queryStart = path.indexOf('?');
+        if (~queryStart) {
+          var queryString = path.substr(queryStart + 1, path.length);
+          path = path.substr(0, queryStart);
+          queryParams = this.parseQueryString(queryString);
+        }
 
         // DEBUG GROUP path
 
@@ -402,7 +467,7 @@ define("route-recognizer",
         var state = solutions[0];
 
         if (state && state.handlers) {
-          return findHandler(state, path);
+          return findHandler(state, path, queryParams);
         }
       }
     };
@@ -427,18 +492,35 @@ define("route-recognizer",
           if (callback.length === 0) { throw new Error("You must have an argument in the function passed to `to`"); }
           this.matcher.addChild(this.path, target, callback, this.delegate);
         }
+        return this;
+      },
+
+      withQueryParams: function() {
+        if (arguments.length === 0) { throw new Error("you must provide arguments to the withQueryParams method"); }
+        for (var i = 0; i < arguments.length; i++) {
+          if (typeof arguments[i] !== "string") {
+            throw new Error('you should call withQueryParams with a list of strings, e.g. withQueryParams("foo", "bar")');
+          }
+        }
+        var queryParams = [].slice.call(arguments);
+        this.matcher.addQueryParams(this.path, queryParams);
       }
     };
 
     function Matcher(target) {
       this.routes = {};
       this.children = {};
+      this.queryParams = {};
       this.target = target;
     }
 
     Matcher.prototype = {
       add: function(path, handler) {
         this.routes[path] = handler;
+      },
+
+      addQueryParams: function(path, params) {
+        this.queryParams[path] = params;
       },
 
       addChild: function(path, target, callback, delegate) {
@@ -467,23 +549,26 @@ define("route-recognizer",
       };
     }
 
-    function addRoute(routeArray, path, handler) {
+    function addRoute(routeArray, path, handler, queryParams) {
       var len = 0;
       for (var i=0, l=routeArray.length; i<l; i++) {
         len += routeArray[i].path.length;
       }
 
       path = path.substr(len);
-      routeArray.push({ path: path, handler: handler });
+      var route = { path: path, handler: handler };
+      if(queryParams) { route.queryParams = queryParams; }
+      routeArray.push(route);
     }
 
     function eachRoute(baseRoute, matcher, callback, binding) {
       var routes = matcher.routes;
+      var queryParams = matcher.queryParams;
 
       for (var path in routes) {
         if (routes.hasOwnProperty(path)) {
           var routeArray = baseRoute.slice();
-          addRoute(routeArray, path, routes[path]);
+          addRoute(routeArray, path, routes[path], queryParams[path]);
 
           if (matcher.children[path]) {
             eachRoute(routeArray, matcher.children[path], callback, binding);

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -108,9 +108,9 @@ define("router",
        */
       retry: function() {
         this.abort();
-
         var recogHandlers = this.router.recognizer.handlersFor(this.targetName),
-            newTransition = performTransition(this.router, recogHandlers, this.providedModelsArray, this.params, this.data);
+            handlerInfos  = generateHandlerInfosWithQueryParams(this.router, recogHandlers, this.queryParams),
+            newTransition = performTransition(this.router, handlerInfos, this.providedModelsArray, this.params, this.queryParams, this.data);
 
         return newTransition;
       },
@@ -135,6 +135,10 @@ define("router",
       method: function(method) {
         this.urlMethod = method;
         return this;
+      },
+
+      toString: function() {
+        return "Transition (sequence " + this.sequence + ")";
       }
     };
 
@@ -279,8 +283,21 @@ define("router",
         @param {Array[Object]} contexts
         @return {Object} a serialized parameter hash
       */
+
       paramsForHandler: function(handlerName, contexts) {
-        return paramsForHandler(this, handlerName, slice.call(arguments, 1));
+        var partitionedArgs = extractQueryParams(slice.call(arguments, 1));
+        return paramsForHandler(this, handlerName, partitionedArgs[0], partitionedArgs[1]);
+      },
+
+      /**
+        This method takes a handler name and returns a list of query params
+        that are valid to pass to the handler or its parents
+
+        @param {String} handlerName
+        @return {Array[String]} a list of query parameters
+      */
+      queryParamsForHandler: function (handlerName) {
+        return queryParamsForHandler(this, handlerName);
       },
 
       /**
@@ -294,12 +311,41 @@ define("router",
         @return {String} a URL
       */
       generate: function(handlerName) {
-        var params = paramsForHandler(this, handlerName, slice.call(arguments, 1));
+        var partitionedArgs = extractQueryParams(slice.call(arguments, 1)),
+          suppliedParams = partitionedArgs[0],
+          queryParams = partitionedArgs[1];
+
+        var params = paramsForHandler(this, handlerName, suppliedParams, queryParams),
+          validQueryParams = queryParamsForHandler(this, handlerName);
+
+        var missingParams = [];
+
+        for (var key in queryParams) {
+          if (queryParams.hasOwnProperty(key) && !~validQueryParams.indexOf(key)) {
+            missingParams.push(key);
+          }
+        }
+
+        if (missingParams.length > 0) {
+          var err = 'You supplied the params ';
+          err += missingParams.map(function(param) {
+            return '"' + param + "=" + queryParams[param] + '"';
+          }).join(' and ');
+
+          err += ' which are not valid for the "' + handlerName + '" handler or its parents';
+
+          throw new Error(err);
+        }
+
         return this.recognizer.generate(handlerName, params);
       },
 
       isActive: function(handlerName) {
-        var contexts = slice.call(arguments, 1);
+        var partitionedArgs   = extractQueryParams(slice.call(arguments, 1)),
+            contexts          = partitionedArgs[0],
+            queryParams       = partitionedArgs[1],
+            activeQueryParams  = {},
+            effectiveQueryParams = {};
 
         var targetHandlerInfos = this.targetHandlerInfos,
             found = false, names, object, handlerInfo, handlerObj;
@@ -307,19 +353,24 @@ define("router",
         if (!targetHandlerInfos) { return false; }
 
         var recogHandlers = this.recognizer.handlersFor(targetHandlerInfos[targetHandlerInfos.length - 1].name);
-
         for (var i=targetHandlerInfos.length-1; i>=0; i--) {
           handlerInfo = targetHandlerInfos[i];
           if (handlerInfo.name === handlerName) { found = true; }
 
           if (found) {
-            if (contexts.length === 0) { break; }
+            var recogHandler = recogHandlers[i];
 
-            if (handlerInfo.isDynamic) {
+            merge(activeQueryParams, handlerInfo.queryParams);
+            if (queryParams !== false) {
+              merge(effectiveQueryParams, handlerInfo.queryParams);
+              mergeSomeKeys(effectiveQueryParams, queryParams, recogHandler.queryParams);
+            }
+
+            if (handlerInfo.isDynamic && contexts.length > 0) {
               object = contexts.pop();
 
               if (isParam(object)) {
-                var recogHandler = recogHandlers[i], name = recogHandler.names[0];
+                var name = recogHandler.names[0];
                 if ("" + object !== this.currentParams[name]) { return false; }
               } else if (handlerInfo.context !== object) {
                 return false;
@@ -328,7 +379,8 @@ define("router",
           }
         }
 
-        return contexts.length === 0 && found;
+
+        return contexts.length === 0 && found && queryParamsEqual(activeQueryParams, effectiveQueryParams);
       },
 
       trigger: function(name) {
@@ -351,7 +403,7 @@ define("router",
       a shared pivot parent route and other data necessary to perform
       a transition.
      */
-    function getMatchPoint(router, handlers, objects, inputParams) {
+    function getMatchPoint(router, handlers, objects, inputParams, queryParams) {
 
       var matchPoint = handlers.length,
           providedModels = {}, i,
@@ -406,6 +458,12 @@ define("router",
           }
         }
 
+        // If there is an old handler, see if query params are the same. If there isn't an old handler,
+        // hasChanged will already be true here
+        if(oldHandlerInfo && !queryParamsEqual(oldHandlerInfo.queryParams, handlerObj.queryParams)) {
+            hasChanged = true;
+        }
+
         if (hasChanged) { matchPoint = i; }
       }
 
@@ -439,6 +497,28 @@ define("router",
       return (typeof object === "string" || object instanceof String || !isNaN(object));
     }
 
+
+
+    /**
+      @private
+
+      This method takes a handler name and returns a list of query params
+      that are valid to pass to the handler or its parents
+
+      @param {Router} router
+      @param {String} handlerName
+      @return {Array[String]} a list of query parameters
+    */
+    function queryParamsForHandler(router, handlerName) {
+      var handlers = router.recognizer.handlersFor(handlerName),
+        queryParams = [];
+
+      for (var i = 0; i < handlers.length; i++) {
+        queryParams.push.apply(queryParams, handlers[i].queryParams || []);
+      }
+
+      return queryParams;
+    }
     /**
       @private
 
@@ -450,12 +530,16 @@ define("router",
       @param {Array[Object]} objects
       @return {Object} a serialized parameter hash
     */
-    function paramsForHandler(router, handlerName, objects) {
+    function paramsForHandler(router, handlerName, objects, queryParams) {
 
       var handlers = router.recognizer.handlersFor(handlerName),
           params = {},
-          matchPoint = getMatchPoint(router, handlers, objects).matchPoint,
+          handlerInfos = generateHandlerInfosWithQueryParams(router, handlers, queryParams),
+          matchPoint = getMatchPoint(router, handlerInfos, objects).matchPoint,
+          mergedQueryParams = {},
           object, handlerObj, handler, names, i;
+
+      params.queryParams = {};
 
       for (i=0; i<handlers.length; i++) {
         handlerObj = handlers[i];
@@ -475,7 +559,13 @@ define("router",
           // Serialize to generate params
           merge(params, serialize(handler, object, names));
         }
+        if (queryParams !== false) {
+          mergeSomeKeys(params.queryParams, router.currentQueryParams, handlerObj.queryParams);
+          mergeSomeKeys(params.queryParams, queryParams, handlerObj.queryParams);
+        }
       }
+
+      if (queryParamsEqual(params.queryParams, {})) { delete params.queryParams; }
       return params;
     }
 
@@ -485,24 +575,84 @@ define("router",
       }
     }
 
+    function mergeSomeKeys(hash, other, keys) {
+      if (!other || !keys) { return; }
+      for(var i = 0; i < keys.length; i++) {
+        var key = keys[i], value;
+        if(other.hasOwnProperty(key)) {
+          value = other[key];
+          if(value === null || value === false || typeof value === "undefined") {
+            delete hash[key];
+          } else {
+            hash[key] = other[key];
+          }
+        }
+      }
+    }
+
+    /**
+      @private
+    */
+
+    function generateHandlerInfosWithQueryParams(router, handlers, queryParams) {
+      var handlerInfos = [];
+
+      for (var i = 0; i < handlers.length; i++) {
+        var handler = handlers[i],
+          handlerInfo = { handler: handler.handler, names: handler.names, context: handler.context, isDynamic: handler.isDynamic },
+          activeQueryParams = {};
+
+        if (queryParams !== false) {
+          mergeSomeKeys(activeQueryParams, router.currentQueryParams, handler.queryParams);
+          mergeSomeKeys(activeQueryParams, queryParams, handler.queryParams);
+        }
+
+        if (handler.queryParams && handler.queryParams.length > 0) {
+          handlerInfo.queryParams = activeQueryParams;
+        }
+
+        handlerInfos.push(handlerInfo);
+      }
+
+      return handlerInfos;
+    }
+
+    /**
+      @private
+    */
+    function createQueryParamTransition(router, queryParams) {
+      var currentHandlers = router.currentHandlerInfos,
+          currentHandler = currentHandlers[currentHandlers.length - 1],
+          name = currentHandler.name;
+
+      log(router, "Attempting query param transition");
+
+      return createNamedTransition(router, [name, queryParams]);
+    }
+
     /**
       @private
     */
     function createNamedTransition(router, args) {
-      var handlers = router.recognizer.handlersFor(args[0]);
+      var partitionedArgs     = extractQueryParams(args),
+        pureArgs              = partitionedArgs[0],
+        queryParams           = partitionedArgs[1],
+        handlers              = router.recognizer.handlersFor(pureArgs[0]),
+        handlerInfos          = generateHandlerInfosWithQueryParams(router, handlers, queryParams);
 
-      log(router, "Attempting transition to " + args[0]);
 
-      return performTransition(router, handlers, slice.call(args, 1), router.currentParams);
+      log(router, "Attempting transition to " + pureArgs[0]);
+
+      return performTransition(router, handlerInfos, slice.call(pureArgs, 1), router.currentParams, queryParams);
     }
 
     /**
       @private
     */
     function createURLTransition(router, url) {
-
       var results = router.recognizer.recognize(url),
-          currentHandlerInfos = router.currentHandlerInfos;
+          currentHandlerInfos = router.currentHandlerInfos,
+          queryParams = {};
 
       log(router, "Attempting URL transition to " + url);
 
@@ -510,7 +660,11 @@ define("router",
         return errorTransition(router, new Router.UnrecognizedURLError(url));
       }
 
-      return performTransition(router, results, [], {});
+      for(var i = 0; i < results.length; i++) {
+        merge(queryParams, results[i].queryParams);
+      }
+
+      return performTransition(router, results, [], {}, queryParams);
     }
 
 
@@ -594,8 +748,9 @@ define("router",
         checkAbort(transition);
 
         setContext(handler, context);
+        setQueryParams(handler, handlerInfo.queryParams);
 
-        if (handler.setup) { handler.setup(context); }
+        if (handler.setup) { handler.setup(context, handlerInfo.queryParams); }
         checkAbort(transition);
       } catch(e) {
         if (!(e instanceof Router.TransitionAborted)) {
@@ -624,6 +779,29 @@ define("router",
       for (var i=0, l=handlerInfos.length; i<l; i++) {
         callback(handlerInfos[i]);
       }
+    }
+
+    /**
+      @private
+
+      determines if two queryparam objects are the same or not
+    **/
+    function queryParamsEqual(a, b) {
+      a = a || {};
+      b = b || {};
+      var checkedKeys = [], key;
+      for(key in a) {
+        if (!a.hasOwnProperty(key)) { continue; }
+        if(b[key] !== a[key]) { return false; }
+        checkedKeys.push(key);
+      }
+      for(key in b) {
+        if (!b.hasOwnProperty(key)) { continue; }
+        if (~checkedKeys.indexOf(key)) { continue; }
+        // b has a key not in a
+        return false;
+      }
+      return true;
     }
 
     /**
@@ -675,19 +853,21 @@ define("router",
             unchanged: []
           };
 
-      var handlerChanged, contextChanged, i, l;
+      var handlerChanged, contextChanged, queryParamsChanged, i, l;
 
       for (i=0, l=newHandlers.length; i<l; i++) {
         var oldHandler = oldHandlers[i], newHandler = newHandlers[i];
 
         if (!oldHandler || oldHandler.handler !== newHandler.handler) {
           handlerChanged = true;
+        } else if (!queryParamsEqual(oldHandler.queryParams, newHandler.queryParams)) {
+          queryParamsChanged = true;
         }
 
         if (handlerChanged) {
           handlers.entered.push(newHandler);
           if (oldHandler) { handlers.exited.unshift(oldHandler); }
-        } else if (contextChanged || oldHandler.context !== newHandler.context) {
+        } else if (contextChanged || oldHandler.context !== newHandler.context || queryParamsChanged) {
           contextChanged = true;
           handlers.updatedContext.push(newHandler);
         } else {
@@ -740,21 +920,45 @@ define("router",
       if (handler.contextDidChange) { handler.contextDidChange(); }
     }
 
+    function setQueryParams(handler, queryParams) {
+      handler.queryParams = queryParams;
+      if (handler.queryParamsDidChange) { handler.queryParamsDidChange(); }
+    }
+
+
+    /**
+      @private
+
+      Extracts query params from the end of an array
+    **/
+
+    function extractQueryParams(array) {
+      var len = (array && array.length), head, queryParams;
+
+      if(len && len > 0 && array[len - 1] && array[len - 1].hasOwnProperty('queryParams')) {
+        queryParams = array[len - 1].queryParams;
+        head = slice.call(array, 0, len - 1);
+        return [head, queryParams];
+      } else {
+        return [array, null];
+      }
+    }
+
     /**
       @private
 
       Creates, begins, and returns a Transition.
      */
-    function performTransition(router, recogHandlers, providedModelsArray, params, data) {
+    function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data) {
 
-      var matchPointResults = getMatchPoint(router, recogHandlers, providedModelsArray, params),
+      var matchPointResults = getMatchPoint(router, recogHandlers, providedModelsArray, params, queryParams),
           targetName = recogHandlers[recogHandlers.length - 1].handler,
           wasTransitioning = false,
           currentHandlerInfos = router.currentHandlerInfos;
 
       // Check if there's already a transition underway.
       if (router.activeTransition) {
-        if (transitionsIdentical(router.activeTransition, targetName, providedModelsArray)) {
+        if (transitionsIdentical(router.activeTransition, targetName, providedModelsArray, queryParams)) {
           return router.activeTransition;
         }
         router.activeTransition.abort();
@@ -769,6 +973,7 @@ define("router",
       transition.providedModelsArray = providedModelsArray;
       transition.params = matchPointResults.params;
       transition.data = data || {};
+      transition.queryParams = queryParams;
       router.activeTransition = transition;
 
       var handlerInfos = generateHandlerInfos(router, recogHandlers);
@@ -835,11 +1040,16 @@ define("router",
         var handlerObj = recogHandlers[i],
             isDynamic = handlerObj.isDynamic || (handlerObj.names && handlerObj.names.length);
 
-        handlerInfos.push({
+
+        var handlerInfo = {
           isDynamic: !!isDynamic,
           name: handlerObj.handler,
           handler: router.getHandler(handlerObj.handler)
-        });
+        };
+        if(handlerObj.queryParams) {
+          handlerInfo.queryParams = handlerObj.queryParams;
+        }
+        handlerInfos.push(handlerInfo);
       }
       return handlerInfos;
     }
@@ -847,7 +1057,7 @@ define("router",
     /**
       @private
      */
-    function transitionsIdentical(oldTransition, targetName, providedModelsArray) {
+    function transitionsIdentical(oldTransition, targetName, providedModelsArray, queryParams) {
 
       if (oldTransition.targetName !== targetName) { return false; }
 
@@ -857,6 +1067,11 @@ define("router",
       for (var i = 0, len = oldModels.length; i < len; ++i) {
         if (oldModels[i] !== providedModelsArray[i]) { return false; }
       }
+
+      if(!queryParamsEqual(oldTransition.queryParams, queryParams)) {
+        return false;
+      }
+
       return true;
     }
 
@@ -870,11 +1085,12 @@ define("router",
 
       var router = transition.router,
           seq = transition.sequence,
-          handlerName = handlerInfos[handlerInfos.length - 1].name;
+          handlerName = handlerInfos[handlerInfos.length - 1].name,
+          i;
 
       // Collect params for URL.
       var objects = [], providedModels = transition.providedModelsArray.slice();
-      for (var i = handlerInfos.length - 1; i>=0; --i) {
+      for (i = handlerInfos.length - 1; i>=0; --i) {
         var handlerInfo = handlerInfos[i];
         if (handlerInfo.isDynamic) {
           var providedModel = providedModels.pop();
@@ -882,9 +1098,17 @@ define("router",
         }
       }
 
-      var params = paramsForHandler(router, handlerName, objects);
+      var newQueryParams = {};
+      for (i = handlerInfos.length - 1; i>=0; --i) {
+        merge(newQueryParams, handlerInfos[i].queryParams);
+      }
+      router.currentQueryParams = newQueryParams;
+
+
+      var params = paramsForHandler(router, handlerName, objects, transition.queryParams);
 
       router.currentParams = params;
+
 
       var urlMethod = transition.urlMethod;
       if (urlMethod) {
@@ -976,13 +1200,13 @@ define("router",
 
         log(router, seq, handlerName + ": calling beforeModel hook");
 
-        var p = handler.beforeModel && handler.beforeModel(transition);
+        var args = [transition, handlerInfo.queryParams],
+          p = handler.beforeModel && handler.beforeModel.apply(handler, args);
         return (p instanceof Transition) ? null : p;
       }
 
       function model() {
         log(router, seq, handlerName + ": resolving model");
-
         var p = getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
         return (p instanceof Transition) ? null : p;
       }
@@ -997,7 +1221,8 @@ define("router",
 
         transition.resolvedModels[handlerInfo.name] = context;
 
-        var p = handler.afterModel && handler.afterModel(context, transition);
+        var args= [context, transition, handlerInfo.queryParams],
+          p = handler.afterModel && handler.afterModel.apply(handler, args);
         return (p instanceof Transition) ? null : p;
       }
 
@@ -1028,9 +1253,8 @@ define("router",
       or use one of the models provided to `transitionTo`.
      */
     function getModel(handlerInfo, transition, handlerParams, needsUpdate) {
-
       var handler = handlerInfo.handler,
-          handlerName = handlerInfo.name;
+          handlerName = handlerInfo.name, args;
 
       if (!needsUpdate && handler.hasOwnProperty('context')) {
         return handler.context;
@@ -1041,7 +1265,9 @@ define("router",
         return typeof providedModel === 'function' ? providedModel() : providedModel;
       }
 
-      return handler.model && handler.model(handlerParams || {}, transition);
+      args = [handlerParams || {}, transition, handlerInfo.queryParams];
+
+      return handler.model && handler.model.apply(handler, args);
     }
 
     /**
@@ -1074,10 +1300,12 @@ define("router",
       // Normalize blank transitions to root URL transitions.
       var name = args[0] || '/';
 
-      if (name.charAt(0) === '/') {
+      if(args.length === 1 && args[0].hasOwnProperty('queryParams')) {
+        return createQueryParamTransition(router, args[0]);
+      } else if (name.charAt(0) === '/') {
         return createURLTransition(router, name);
       } else {
-        return createNamedTransition(router, args);
+        return createNamedTransition(router, slice.call(args));
       }
     }
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,0 +1,449 @@
+var Router, App, AppView, templates, router, container, originalTemplates;
+var get = Ember.get, set = Ember.set;
+
+function bootApplication(url) {
+  router = container.lookup('router:main');
+  if(url) { router.location.setURL(url); }
+  Ember.run(App, 'advanceReadiness');
+}
+
+function compile(string) {
+  return Ember.Handlebars.compile(string);
+}
+
+function handleURL(path) {
+  return Ember.run(function() {
+    return router.handleURL(path).then(function(value) {
+      ok(true, 'url: `' + path + '` was handled');
+      return value;
+    }, function(reason) {
+      ok(false, 'failed to visit:`' + path + '` reason: `' + QUnit.jsDump.parse(reason));
+      throw reason;
+    });
+  });
+}
+
+function handleURLAborts(path) {
+  Ember.run(function() {
+    router.handleURL(path).then(function(value) {
+      ok(false, 'url: `' + path + '` was NOT to be handled');
+    }, function(reason) {
+      ok(reason && reason.message === "TransitionAborted",  'url: `' + path + '` was to be aborted');
+    });
+  });
+}
+
+function shouldNotHappen(error) {
+  console.error(error.stack);
+  ok(false, "this .then handler should not be called: " + error.message);
+}
+
+function handleURLRejectsWith(path, expectedReason) {
+  Ember.run(function() {
+    router.handleURL(path).then(function(value) {
+      ok(false, 'expected handleURLing: `' + path + '` to fail');
+    }, function(reason) {
+      equal(expectedReason, reason);
+    });
+  });
+}
+if (Ember.FEATURES.isEnabled("query-params")) {
+  module("Routing with Query Params", {
+    setup: function() {
+      Ember.run(function() {
+        App = Ember.Application.create({
+          name: "App",
+          rootElement: '#qunit-fixture'
+        });
+
+        App.deferReadiness();
+
+        App.Router.reopen({
+          location: 'none'
+        });
+
+        Router = App.Router;
+
+        App.LoadingRoute = Ember.Route.extend({
+        });
+
+        container = App.__container__;
+
+        originalTemplates = Ember.$.extend({}, Ember.TEMPLATES);
+        Ember.TEMPLATES.application = compile("{{outlet}}");
+        Ember.TEMPLATES.home = compile("<h3>Hours</h3>");
+        Ember.TEMPLATES.homepage = compile("<h3>Megatroll</h3><p>{{home}}</p>");
+        Ember.TEMPLATES.camelot = compile('<section><h3>Is a silly place</h3></section>');
+      });
+    },
+
+    teardown: function() {
+      Ember.run(function() {
+        App.destroy();
+        App = null;
+
+        Ember.TEMPLATES = originalTemplates;
+      });
+    }
+  });
+
+  test("The Homepage with Query Params", function() {
+    expect(5);
+
+    Router.map(function() {
+      this.route("index", { path: "/", queryParams: ['foo', 'baz'] });
+    });
+
+    App.IndexRoute = Ember.Route.extend({
+      beforeModel: function(transition, queryParams) {
+        deepEqual(queryParams, {foo: 'bar', baz: true}, "beforeModel hook is called with query params");
+      },
+
+      model: function(params, transition, queryParams) {
+        deepEqual(queryParams, {foo: 'bar', baz: true}, "Model hook is called with query params");
+      },
+
+      afterModel: function(resolvedModel, transition, queryParams) {
+        deepEqual(queryParams, {foo: 'bar', baz: true}, "afterModel hook is called with query params");
+      },
+
+      setupController: function (controller, context, queryParams) {
+        deepEqual(queryParams, {foo: 'bar', baz: true}, "setupController hook is called with query params");
+      },
+
+      renderTemplate: function (controller, context, queryParams) {
+        deepEqual(queryParams, {foo: 'bar', baz: true}, "renderTemplates hook is called with query params");
+      }
+
+    });
+
+
+    bootApplication("/?foo=bar&baz");
+  });
+
+
+  asyncTest("Transitioning query params works on the same route", function() {
+    expect(25);
+
+    var expectedQueryParams;
+
+    Router.map(function() {
+      this.route("home", { path: "/" });
+      this.resource("special", { path: "/specials/:menu_item_id", queryParams: ['view'] });
+    });
+
+    App.SpecialRoute = Ember.Route.extend({
+      beforeModel: function (transition, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
+      },
+
+      model: function(params, transition, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the model hook");
+        return {id: params.menu_item_id};
+      },
+
+      afterModel: function (resolvedModel, transition, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
+      },
+
+      setupController: function (controller, context, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the setupController hook");
+      },
+
+      renderTemplate: function (controller, context, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the renderTemplates hook");
+      },
+
+      serialize: function (obj) {
+        return {menu_item_id: obj.id};
+      }
+    });
+
+
+    Ember.TEMPLATES.home = Ember.Handlebars.compile(
+      "<h3>Home</h3>"
+    );
+
+
+    Ember.TEMPLATES.special = Ember.Handlebars.compile(
+      "<p>{{content.id}}</p>"
+    );
+
+    bootApplication();
+
+    var transition = handleURL('/');
+
+    Ember.run(function() {
+      transition.then(function() {
+        equal(Ember.$('h3', '#qunit-fixture').text(), "Home", "The app is now in the initial state");
+
+        expectedQueryParams = {};
+        return router.transitionTo('special', {id: 1});
+      }, shouldNotHappen).then(function(result) {
+        deepEqual(router.location.path, '/specials/1', "Correct URL after transitioning");
+
+        expectedQueryParams = {view: 'details'};
+        return router.transitionTo('special', {queryParams: {view: 'details'}});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/1?view=details', "Correct URL after transitioning with route name and query params");
+
+        expectedQueryParams = {view: 'other'};
+        return router.transitionTo({queryParams: {view: 'other'}});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/1?view=other', "Correct URL after transitioning with query params only");
+
+        expectedQueryParams = {view: 'three'};
+        return router.transitionTo("/specials/1?view=three");
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/1?view=three', "Correct URL after transitioning with url");
+
+        start();
+      }, shouldNotHappen);
+    });
+  });
+
+
+  asyncTest("Transitioning query params works on a different route", function() {
+    expect(46);
+
+    var expectedQueryParams, expectedOtherQueryParams;
+
+    Router.map(function() {
+      this.route("home", { path: "/" });
+      this.resource("special", { path: "/specials/:menu_item_id", queryParams: ['view'] });
+      this.resource("other", { path: "/others/:menu_item_id", queryParams: ['view', 'lang'] });
+    });
+
+    App.SpecialRoute = Ember.Route.extend({
+      beforeModel: function (transition, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
+      },
+
+      model: function(params, transition, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the model hook");
+        return {id: params.menu_item_id};
+      },
+
+      afterModel: function (resolvedModel, transition, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
+      },
+
+      setupController: function (controller, context, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the setupController hook");
+      },
+
+      renderTemplate: function (controller, context, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "The query params are correct in the renderTemplates hook");
+      },
+
+      serialize: function (obj) {
+        return {menu_item_id: obj.id};
+      }
+    });
+
+    App.OtherRoute = Ember.Route.extend({
+      beforeModel: function (transition, queryParams) {
+        deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the beforeModel hook");
+      },
+
+      model: function(params, transition, queryParams) {
+        deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the model hook");
+        return {id: params.menu_item_id};
+      },
+
+      afterModel: function (resolvedModel, transition, queryParams) {
+        deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the beforeModel hook");
+      },
+
+      setupController: function (controller, context, queryParams) {
+        deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the setupController hook");
+      },
+
+      renderTemplate: function (controller, context, queryParams) {
+        deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the renderTemplates hook");
+      },
+
+      serialize: function (obj) {
+        return {menu_item_id: obj.id};
+      }
+    });
+
+
+
+    Ember.TEMPLATES.home = Ember.Handlebars.compile(
+      "<h3>Home</h3>"
+    );
+
+
+    Ember.TEMPLATES.special = Ember.Handlebars.compile(
+      "<p>{{content.id}}</p>"
+    );
+
+    bootApplication();
+
+    var transition = handleURL('/');
+
+    Ember.run(function() {
+      transition.then(function() {
+        equal(Ember.$('h3', '#qunit-fixture').text(), "Home", "The app is now in the initial state");
+
+        expectedQueryParams = {};
+
+        return router.transitionTo('special', {id: 1});
+      }, shouldNotHappen).then(function(result) {
+        deepEqual(router.location.path, '/specials/1', "Correct URL after transitioning");
+
+        expectedQueryParams = {view: 'details'};
+        return router.transitionTo('special', {queryParams: {view: 'details'}});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/1?view=details', "Correct URL after transitioning with route name and query params");
+
+        expectedOtherQueryParams = {view: 'details'};
+
+        return router.transitionTo('other', {id: 2});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/others/2?view=details', "Correct URL after transitioning to other route");
+
+        expectedOtherQueryParams = {view: 'details', lang: 'en'};
+        return router.transitionTo({queryParams: {lang: 'en'}});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/others/2?view=details&lang=en', "Correct URL after transitioning to other route");
+
+        expectedQueryParams = {view: 'details'};
+
+        return router.transitionTo("special", {id: 2});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/2?view=details', "Correct URL after back to special route");
+
+        expectedQueryParams = {};
+
+        return router.transitionTo({queryParams: false});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/2', "queryParams: false clears queryParams");
+
+        expectedQueryParams = {view: 'details'};
+
+       return router.transitionTo("special", {id: 2}, {queryParams: {view: 'details'}});
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/2?view=details', "Correct URL after back to special route");
+
+        expectedQueryParams = {};
+
+        return router.transitionTo("/specials/2");
+      }, shouldNotHappen).then(function (result) {
+        deepEqual(router.location.path, '/specials/2', "url transition clears queryParams");
+
+        start();
+      }, shouldNotHappen);
+    });
+  });
+
+
+
+  test("Redirecting to the current target with a different query param aborts the remainder of the routes", function() {
+    expect(4);
+
+    Router.map(function() {
+      this.route("home");
+      this.resource("foo", function() {
+        this.resource("bar", { path: "bar/:id" }, function() {
+          this.route("baz", { queryParams: ['foo']});
+        });
+      });
+    });
+
+    var model = { id: 2 };
+
+    var count = 0;
+
+    App.BarRoute = Ember.Route.extend({
+      afterModel: function(context) {
+        if (count++ > 10) {
+          ok(false, 'infinite loop');
+        } else {
+          this.transitionTo("bar.baz", {queryParams: {foo: 'bar'}});
+        }
+      },
+
+      serialize: function(params) {
+        return params;
+      }
+    });
+
+    App.BarBazRoute = Ember.Route.extend({
+      setupController: function() {
+        ok(true, "Should still invoke setupController");
+      }
+    });
+
+    bootApplication();
+
+    handleURLAborts("/foo/bar/2/baz");
+
+    equal(router.container.lookup('controller:application').get('currentPath'), 'foo.bar.baz');
+    equal(router.get('location').getURL(), "/foo/bar/2/baz?foo=bar");
+  });
+
+  test("Parent route query params change", function() {
+    expect(4);
+
+    var editCount = 0,
+        expectedQueryParams = {};
+
+    Ember.TEMPLATES.application = compile("{{outlet}}");
+    Ember.TEMPLATES.posts = compile("{{outlet}}");
+    Ember.TEMPLATES.post = compile("{{outlet}}");
+    Ember.TEMPLATES['post/index'] = compile("showing");
+    Ember.TEMPLATES['post/edit'] = compile("editing");
+
+    Router.map(function() {
+      this.resource("posts", {queryParams: ['sort']}, function() {
+        this.resource("post", { path: "/:postId" }, function() {
+          this.route("edit");
+        });
+      });
+    });
+
+    App.PostsRoute = Ember.Route.extend({
+      events: {
+        sort: function(dir) {
+          this.transitionTo({queryParams: {sort: dir}});
+        }
+      },
+
+      setupController: function(controller, context, queryParams) {
+        deepEqual(queryParams, expectedQueryParams, "Posts route has correct query params");
+      }
+    });
+
+    App.PostRoute = Ember.Route.extend({
+      events: {
+        editPost: function(context) {
+          this.transitionTo('post.edit');
+        }
+      }
+    });
+
+    App.PostEditRoute = Ember.Route.extend({
+      setup: function() {
+        editCount++;
+      }
+    });
+
+    bootApplication();
+
+    handleURL("/posts/1");
+
+    Ember.run(function() {
+      router.send('editPost');
+    });
+
+    expectedQueryParams = {sort: 'desc'};
+
+    Ember.run(function() {
+      router.send('sort', 'desc');
+    });
+
+    equal(editCount, 2, 'set up the edit route twice without failure');
+  });
+}


### PR DESCRIPTION
It's finally here. It works well. There are lots of tests. It makes sense. The API is as nice as possible whilst not introducing any backwards-incompatible changes. It works with all location implementations. There are nice, verbose error messages. It is, in general, super-awesome.

[Live JSFiddle demo](http://jsfiddle.net/alexspeller/K9xUP/)
## Defining your query params

Query params are baked right into the routes. This is essential so that the router and helpers can know what valid transitions and query parameter states are.

``` javascript
App.Router.map(function() {
  this.resource('posts', {queryParams: ['sort', 'direction']}, function() {
    this.resource('post', {path: "/:id", queryParams: ['showDetails']});
  });
});
```
## Model hooks

**Note: Please see if #3383 has been merged yet to determine if the param order described here is still accurate**

Query params are passed into all the relevant model hooks now. Only query params that have been registered to apply to the route in the router.map call will be passed in. If no query params are active for this route,
an empty object `{}` is passed in. 

``` javascript
App.IndexRoute = Ember.Route.extend({
    beforeModel:      function( transition, queryParams ) {},
    model:            function( params, transition, queryParams ) {},
    afterModel:       function( resolvedModel, transition, queryParams ) {},
    setupController:  function( controller, context, queryParams ) {},
    renderTemplate:   function( controller, context, queryParams ) {}
});
```
## Transitioning Query Params

`transitionTo` now will accept a final argument, which must be an object with the key `queryParams`.

``` javascript
this.transitionTo('post', object, {queryParams: {showDetails: true}});
this.transitionTo('posts', {queryParams: {sort: 'title'}});
this.transitionTo({queryParams: {direction: 'asc'}});
```

You can also use add query params to URL transitions as you would expect:

``` javascript
this.transitionTo("/posts/1?sort=date&showDetails=true");
```
## linkTo Helper

The linkTo helper supports queryParams as well.

``` handlebars
{{#linkTo 'posts' direction=asc}}Sort{{/linkTo}}
{{#linkTo 'posts' directionBinding=otherDirection}}Sort{{/linkTo}}
```

The linkTo helper now takes into account query parameters when determining its "active" state, and will set the class appropriately. The active state is determined by working out if you clicked on the link, would the query params end up the same? You don't have to supply all of the current, active query params for this to be true.
## Stickiness

By default, query params are "sticky". This means that if you are on a url like `/posts?sort=name`, and you executed `transitionTo({queryParams: {direction: 'desc'}})` or clicked `{{#linkTo 'posts' direction=desc}}`, the resulting url will be `/posts?sort=name&direction=desc`. This is true whilst you are linking to a route in the currently active tree.

To clear query params, give a falsy value (but **not** `undefined`), e.g.
`transitionTo({queryParams: {direction: null}})` or `{{#linkTo 'posts' direction=false}}`

It's also possible to clear all query params by passing false, e.g. `transitionTo({queryParams: false})` or `{{#linkTo 'posts' queryParams=false}}`
## Boolean Query params

Boolean query params are serialised without the truth value, e.g. `transitionTo('posts', {queryParams: {sort: true}})` would result in the url `/posts?sort`
## TODO

Query param changes always hit the model hook. This is not always necessary. There should be a way to specify that query params don't affect the model.
Slightly more automatic way to observe controller params and serialise to url
## Microlib PRs

tildeio/router.js#47
tildeio/route-recognizer#9
