### PR TITLE
Update ember-dev to disable automatic asset compression.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: eb0bb8df47dc80f10ec210de0ad6b4d2528fb058
+  revision: 6d48dbd90d7ac41d836e8ffecfe8cdb9bf3a032f
   branch: master
   specs:
     ember-dev (0.1)


### PR DESCRIPTION
See details here: https://github.com/emberjs/ember-dev/pull/28.

tldr: We are serving compressed files to all clients whether they request (or support) compression or not. This is certainly not RFC compliant, and I don't see a way to make S3 take care of this automatically for us.
