### PR TITLE
Add currentRouteName to ApplicationController

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -56,10 +56,12 @@ Ember.Router = Ember.Object.extend({
     var appController = this.container.lookup('controller:application'),
         path = Ember.Router._routePath(infos);
 
-    if (!('currentPath' in appController)) {
-      defineProperty(appController, 'currentPath');
-    }
+    if (!('currentPath' in appController)) { defineProperty(appController, 'currentPath'); }
     set(appController, 'currentPath', path);
+
+    if (!('currentRouteName' in appController)) { defineProperty(appController, 'currentRouteName'); }
+    set(appController, 'currentRouteName', infos[infos.length - 1].name);
+
     this.notifyPropertyChange('url');
 
     if (get(this, 'namespace').LOG_TRANSITIONS) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2252,3 +2252,44 @@ test("Events can be handled by inherited event handlers", function() {
   router.send("baz");
 });
 
+test("currentRouteName is a property installed on ApplicationController that can be used in transitionTo", function() {
+
+  expect(24);
+
+  Router.map(function() {
+    this.resource("be", function() {
+      this.resource("excellent", function() {
+        this.resource("to", function() {
+          this.resource("each", function() {
+            this.route("other");
+          });
+        });
+      });
+    });
+  });
+
+  bootApplication();
+
+  var appController = router.container.lookup('controller:application');
+
+  function transitionAndCheck(path, expectedPath, expectedRouteName) {
+    if (path) { Ember.run(router, 'transitionTo', path); }
+    equal(appController.get('currentPath'), expectedPath);
+    equal(appController.get('currentRouteName'), expectedRouteName);
+  }
+
+  transitionAndCheck(null, 'index', 'index');
+  transitionAndCheck('/be', 'be.index', 'be.index');
+  transitionAndCheck('/be/excellent', 'be.excellent.index', 'excellent.index');
+  transitionAndCheck('/be/excellent/to', 'be.excellent.to.index', 'to.index');
+  transitionAndCheck('/be/excellent/to/each', 'be.excellent.to.each.index', 'each.index');
+  transitionAndCheck('/be/excellent/to/each/other', 'be.excellent.to.each.other', 'each.other');
+
+  transitionAndCheck('index', 'index', 'index');
+  transitionAndCheck('be', 'be.index', 'be.index');
+  transitionAndCheck('excellent', 'be.excellent.index', 'excellent.index');
+  transitionAndCheck('to.index', 'be.excellent.to.index', 'to.index');
+  transitionAndCheck('each', 'be.excellent.to.each.index', 'each.index');
+  transitionAndCheck('each.other', 'be.excellent.to.each.other', 'each.other');
+});
+


### PR DESCRIPTION
`currentRouteName`, unlike `currentPath`, can always be used as a target route
name within `linkTo` and `transitionTo` even for nested routes.

Closes #2812
