### PR TITLE
Make sets during init behave the same as create(props)

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -120,9 +120,9 @@ function makeCtor() {
       }
     }
     finishPartial(this, m);
+    this.init.apply(this, arguments);
     m.proto = proto;
     finishChains(this);
-    this.init.apply(this, arguments);
     sendEvent(this, "init");
   };
 

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -439,7 +439,7 @@ testBoth("observers that contain @each in the path should fire only once the fir
 
   var obj = Ember.Object.createWithMixins({
     init: function() {
-      // Observer fires once when resources changes
+      // Observer does not fire on init
       set(this, 'resources', Ember.A());
     },
 
@@ -453,5 +453,5 @@ testBoth("observers that contain @each in the path should fire only once the fir
   // Observer fires third time when property on an object is changed
   set(get(obj, 'resources').objectAt(0), 'common', "BYE!");
 
-  equal(count, 3, "observers should only be called once");
+  equal(count, 2, "observers should only be called once");
 });

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -43,18 +43,25 @@ test("should be able to insert views after the DOM representation is created", f
 
 test("should be able to observe properties that contain child views", function() {
   Ember.run(function() {
-    container = Ember.ContainerView.create({
+    var Container = Ember.ContainerView.extend({
       childViews: ['displayView'],
-      displayIsDisplayedBinding: 'displayView.isDisplayed',
+      displayIsDisplayed: Ember.computed.alias('displayView.isDisplayed'),
 
       displayView: Ember.View.extend({
         isDisplayed: true
       })
     });
 
+    container = Container.create();
     container.appendTo('#qunit-fixture');
   });
-  ok(container.get('displayIsDisplayed'), "can bind to child view");
+  equal(container.get('displayIsDisplayed'), true, "can bind to child view");
+
+  Ember.run(function () {
+    container.set('displayView.isDisplayed', false);
+  });
+
+  equal(container.get('displayIsDisplayed'), false, "can bind to child view");
 });
 
 test("childViews inherit their parents iocContainer, and retain the original container even when moved", function() {


### PR DESCRIPTION
If you were relying on set during init to trigger
an observer please move it to an on('init') function
which runs after the object is fully initialized.
