### PR TITLE
Alias link-to and bind-attr to linkTo and bindAttr

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -312,11 +312,11 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
 });
 
 /**
-  `bindAttr` allows you to create a binding between DOM element attributes and
+  `bind-attr` allows you to create a binding between DOM element attributes and
   Ember objects. For example:
 
   ```handlebars
-  <img {{bindAttr src="imageUrl" alt="imageTitle"}}>
+  <img {{bind-attr src="imageUrl" alt="imageTitle"}}>
   ```
 
   The above handlebars template will fill the `<img>`'s `src` attribute will
@@ -338,17 +338,17 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   <img src="http://lolcats.info/haz-a-funny" alt="A humorous image of a cat">
   ```
 
-  `bindAttr` cannot redeclare existing DOM element attributes. The use of `src`
-  in the following `bindAttr` example will be ignored and the hard coded value
+  `bind-attr` cannot redeclare existing DOM element attributes. The use of `src`
+  in the following `bind-attr` example will be ignored and the hard coded value
   of `src="/failwhale.gif"` will take precedence:
 
   ```handlebars
-  <img src="/failwhale.gif" {{bindAttr src="imageUrl" alt="imageTitle"}}>
+  <img src="/failwhale.gif" {{bind-attr src="imageUrl" alt="imageTitle"}}>
   ```
 
-  ### `bindAttr` and the `class` attribute
+  ### `bind-attr` and the `class` attribute
 
-  `bindAttr` supports a special syntax for handling a number of cases unique
+  `bind-attr` supports a special syntax for handling a number of cases unique
   to the `class` DOM element attribute. The `class` attribute combines
   multiple discreet values into a single attribute as a space-delimited
   list of strings. Each string can be:
@@ -357,7 +357,7 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   * a boolean return value of an object's property
   * a hard-coded value
 
-  A string return value works identically to other uses of `bindAttr`. The
+  A string return value works identically to other uses of `bind-attr`. The
   return value of the property will become the value of the attribute. For
   example, the following view and template:
 
@@ -370,7 +370,7 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   ```
 
   ```handlebars
-  <img {{bindAttr class="view.someProperty}}>
+  <img {{bind-attr class="view.someProperty}}>
   ```
 
   Result in the following rendered output:
@@ -392,7 +392,7 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   ```
 
   ```handlebars
-  <img {{bindAttr class="view.someBool:class-name-if-true"}}>
+  <img {{bind-attr class="view.someBool:class-name-if-true"}}>
   ```
 
   Result in the following rendered output:
@@ -406,14 +406,14 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   value changes:
 
   ```handlebars
-  <img {{bindAttr class="view.someBool:class-name-if-true:class-name-if-false"}}>
+  <img {{bind-attr class="view.someBool:class-name-if-true:class-name-if-false"}}>
   ```
 
   A hard-coded value can be used by prepending `:` to the desired
   class name: `:class-name-to-always-apply`.
 
   ```handlebars
-  <img {{bindAttr class=":class-name-to-always-apply"}}>
+  <img {{bind-attr class=":class-name-to-always-apply"}}>
   ```
 
   Results in the following rendered output:
@@ -426,19 +426,19 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
   hard-coded value – can be combined in a single declaration:
 
   ```handlebars
-  <img {{bindAttr class=":class-name-to-always-apply view.someBool:class-name-if-true view.someProperty"}}>
+  <img {{bind-attr class=":class-name-to-always-apply view.someBool:class-name-if-true view.someProperty"}}>
   ```
 
-  @method bindAttr
+  @method bind-attr
   @for Ember.Handlebars.helpers
   @param {Hash} options
   @return {String} HTML string
 */
-EmberHandlebars.registerHelper('bindAttr', function(options) {
+EmberHandlebars.registerHelper('bind-attr', function(options) {
 
   var attrs = options.hash;
 
-  Ember.assert("You must specify at least one hash argument to bindAttr", !!Ember.keys(attrs).length);
+  Ember.assert("You must specify at least one hash argument to bind-attr", !!Ember.keys(attrs).length);
 
   var view = options.data.view;
   var ret = [];
@@ -500,7 +500,7 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
     // When the observer fires, find the element using the
     // unique data id and update the attribute to the new value.
     // Note: don't add observer when path is 'this' or path
-    // is whole keyword e.g. {{#each x in list}} ... {{bindAttr attr="x"}}
+    // is whole keyword e.g. {{#each x in list}} ... {{bind-attr attr="x"}}
     if (path !== 'this' && !(normalized.isKeyword && normalized.path === '' )) {
       view.registerObserver(normalized.root, normalized.path, observer);
     }
@@ -519,6 +519,17 @@ EmberHandlebars.registerHelper('bindAttr', function(options) {
   ret.push('data-bindattr-' + dataId + '="' + dataId + '"');
   return new EmberHandlebars.SafeString(ret.join(' '));
 });
+
+/**
+  See `bind-attr`
+
+  @method bindAttr
+  @for Ember.Handlebars.helpers
+  @param {Function} context
+  @param {Hash} options
+  @return {String} HTML string
+*/
+EmberHandlebars.registerHelper('bindAttr', EmberHandlebars.helpers['bind-attr']);
 
 /**
   @private

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1320,8 +1320,8 @@ test("{{view}} should be able to bind class names to truthy or falsy properties"
   equal(view.$('.is-falsy').length, 1, "sets class name to falsy value");
 });
 
-test("should be able to bind element attributes using {{bindAttr}}", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr src="view.content.url" alt="view.content.title"}}>');
+test("should be able to bind element attributes using {{bind-attr}}", function() {
+  var template = Ember.Handlebars.compile('<img {{bind-attr src="view.content.url" alt="view.content.title"}}>');
 
   view = Ember.View.create({
     template: template,
@@ -1372,10 +1372,10 @@ test("should be able to bind element attributes using {{bindAttr}}", function() 
   equal(view.$('img').attr('alt'), "Nanananana Ember!", "updates alt attribute when title property is computed");
 });
 
-test("should be able to bind to view attributes with {{bindAttr}}", function() {
+test("should be able to bind to view attributes with {{bind-attr}}", function() {
   view = Ember.View.create({
     value: 'Test',
-    template: Ember.Handlebars.compile('<img src="test.jpg" {{bindAttr alt="view.value"}}>')
+    template: Ember.Handlebars.compile('<img src="test.jpg" {{bind-attr alt="view.value"}}>')
   });
 
   appendView();
@@ -1389,11 +1389,11 @@ test("should be able to bind to view attributes with {{bindAttr}}", function() {
   equal(view.$('img').attr('alt'), "Updated", "updates value");
 });
 
-test("should be able to bind to globals with {{bindAttr}}", function() {
+test("should be able to bind to globals with {{bind-attr}}", function() {
   TemplateTests.set('value', 'Test');
 
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('<img src="test.jpg" {{bindAttr alt="TemplateTests.value"}}>')
+    template: Ember.Handlebars.compile('<img src="test.jpg" {{bind-attr alt="TemplateTests.value"}}>')
   });
 
   appendView();
@@ -1407,9 +1407,9 @@ test("should be able to bind to globals with {{bindAttr}}", function() {
   equal(view.$('img').attr('alt'), "Updated", "updates value");
 });
 
-test("should not allow XSS injection via {{bindAttr}}", function() {
+test("should not allow XSS injection via {{bind-attr}}", function() {
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('<img src="test.jpg" {{bindAttr alt="view.content.value"}}>'),
+    template: Ember.Handlebars.compile('<img src="test.jpg" {{bind-attr alt="view.content.value"}}>'),
     content: {
       value: 'Trololol" onmouseover="alert(\'HAX!\');'
     }
@@ -1422,8 +1422,8 @@ test("should not allow XSS injection via {{bindAttr}}", function() {
   equal(view.$('img').attr('alt'), 'Trololol" onmouseover="alert(\'HAX!\');');
 });
 
-test("should be able to bind use {{bindAttr}} more than once on an element", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr src="view.content.url"}} {{bindAttr alt="view.content.title"}}>');
+test("should be able to bind use {{bind-attr}} more than once on an element", function() {
+  var template = Ember.Handlebars.compile('<img {{bind-attr src="view.content.url"}} {{bind-attr alt="view.content.title"}}>');
 
   view = Ember.View.create({
     template: template,
@@ -1473,6 +1473,10 @@ test("should be able to bind use {{bindAttr}} more than once on an element", fun
 
   equal(view.$('img').attr('alt'), "Nanananana Ember!", "updates alt attribute when title property is computed");
 
+});
+
+test("{{bindAttr}} is aliased to {{bind-attr}}", function() {
+  equal(Ember.Handlebars.helpers.bindAttr, Ember.Handlebars.helpers['bind-attr']);
 });
 
 test("should not reset cursor position when text field receives keyUp event", function() {
@@ -1491,15 +1495,15 @@ test("should not reset cursor position when text field receives keyUp event", fu
     view.trigger('keyUp', {});
   });
 
-  equal(caretPosition(view.$()), 5, "The keyUp event should not result in the cursor being reset due to the bindAttr observers");
+  equal(caretPosition(view.$()), 5, "The keyUp event should not result in the cursor being reset due to the bind-attr observers");
 
   Ember.run(function() {
     view.destroy();
   });
 });
 
-test("should be able to bind element attributes using {{bindAttr}} inside a block", function() {
-  var template = Ember.Handlebars.compile('{{#with view.content}}<img {{bindAttr src="url" alt="title"}}>{{/with}}');
+test("should be able to bind element attributes using {{bind-attr}} inside a block", function() {
+  var template = Ember.Handlebars.compile('{{#with view.content}}<img {{bind-attr src="url" alt="title"}}>{{/with}}');
 
   view = Ember.View.create({
     template: template,
@@ -1521,8 +1525,8 @@ test("should be able to bind element attributes using {{bindAttr}} inside a bloc
   equal(view.$('img').attr('alt'), "El logo de Eember", "updates alt attribute when content's title attribute changes");
 });
 
-test("should be able to bind class attribute with {{bindAttr}}", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr class="view.foo"}}>');
+test("should be able to bind class attribute with {{bind-attr}}", function() {
+  var template = Ember.Handlebars.compile('<img {{bind-attr class="view.foo"}}>');
 
   view = Ember.View.create({
     template: template,
@@ -1540,8 +1544,8 @@ test("should be able to bind class attribute with {{bindAttr}}", function() {
   equal(view.$('img').attr('class'), 'baz', "updates class");
 });
 
-test("should be able to bind class attribute via a truthy property with {{bindAttr}}", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr class="view.isNumber:is-truthy"}}>');
+test("should be able to bind class attribute via a truthy property with {{bind-attr}}", function() {
+  var template = Ember.Handlebars.compile('<img {{bind-attr class="view.isNumber:is-truthy"}}>');
 
   view = Ember.View.create({
     template: template,
@@ -1559,8 +1563,8 @@ test("should be able to bind class attribute via a truthy property with {{bindAt
   equal(view.$('.is-truthy').length, 0, "removes class name if bound property is set to something non-truthy");
 });
 
-test("should be able to bind class to view attribute with {{bindAttr}}", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr class="view.foo"}}>');
+test("should be able to bind class to view attribute with {{bind-attr}}", function() {
+  var template = Ember.Handlebars.compile('<img {{bind-attr class="view.foo"}}>');
 
   view = Ember.View.create({
     template: template,
@@ -1578,9 +1582,9 @@ test("should be able to bind class to view attribute with {{bindAttr}}", functio
   equal(view.$('img').attr('class'), 'baz', "updates class");
 });
 
-test("should not allow XSS injection via {{bindAttr}} with class", function() {
+test("should not allow XSS injection via {{bind-attr}} with class", function() {
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('<img {{bindAttr class="view.foo"}}>'),
+    template: Ember.Handlebars.compile('<img {{bind-attr class="view.foo"}}>'),
     foo: '" onmouseover="alert(\'I am in your classes hacking your app\');'
   });
 
@@ -1591,8 +1595,8 @@ test("should not allow XSS injection via {{bindAttr}} with class", function() {
   equal(view.$('img').attr('class'), '" onmouseover="alert(\'I am in your classes hacking your app\');');
 });
 
-test("should be able to bind class attribute using ternary operator in {{bindAttr}}", function() {
-  var template = Ember.Handlebars.compile('<img {{bindAttr class="view.content.isDisabled:disabled:enabled"}} />');
+test("should be able to bind class attribute using ternary operator in {{bind-attr}}", function() {
+  var template = Ember.Handlebars.compile('<img {{bind-attr class="view.content.isDisabled:disabled:enabled"}} />');
   var content = Ember.Object.create({
     isDisabled: true
   });
@@ -1615,8 +1619,8 @@ test("should be able to bind class attribute using ternary operator in {{bindAtt
   ok(view.$('img').hasClass('enabled'), 'enabled class is rendered');
 });
 
-test("should be able to add multiple classes using {{bindAttr class}}", function() {
-  var template = Ember.Handlebars.compile('<div {{bindAttr class="view.content.isAwesomeSauce view.content.isAlsoCool view.content.isAmazing:amazing :is-super-duper view.content.isEnabled:enabled:disabled"}}></div>');
+test("should be able to add multiple classes using {{bind-attr class}}", function() {
+  var template = Ember.Handlebars.compile('<div {{bind-attr class="view.content.isAwesomeSauce view.content.isAlsoCool view.content.isAmazing:amazing :is-super-duper view.content.isEnabled:enabled:disabled"}}></div>');
   var content = Ember.Object.create({
     isAwesomeSauce: true,
     isAlsoCool: true,
@@ -1651,11 +1655,11 @@ test("should be able to add multiple classes using {{bindAttr class}}", function
   ok(view.$('div').hasClass('disabled'), "falsy class in ternary classname definition is rendered");
 });
 
-test("should be able to bind classes to globals with {{bindAttr class}}", function() {
+test("should be able to bind classes to globals with {{bind-attr class}}", function() {
   TemplateTests.set('isOpen', true);
 
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('<img src="test.jpg" {{bindAttr class="TemplateTests.isOpen"}}>')
+    template: Ember.Handlebars.compile('<img src="test.jpg" {{bind-attr class="TemplateTests.isOpen"}}>')
   });
 
   appendView();
@@ -1669,9 +1673,9 @@ test("should be able to bind classes to globals with {{bindAttr class}}", functi
   ok(!view.$('img').hasClass('is-open'), "removes the classname when the global property has changed");
 });
 
-test("should be able to bindAttr to 'this' in an {{#each}} block", function() {
+test("should be able to bind-attr to 'this' in an {{#each}} block", function() {
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{#each view.images}}<img {{bindAttr src="this"}}>{{/each}}'),
+    template: Ember.Handlebars.compile('{{#each view.images}}<img {{bind-attr src="this"}}>{{/each}}'),
     images: Ember.A(['one.png', 'two.jpg', 'three.gif'])
   });
 
@@ -1683,9 +1687,9 @@ test("should be able to bindAttr to 'this' in an {{#each}} block", function() {
   ok(/three\.gif$/.test(images[2].src));
 });
 
-test("should be able to bind classes to 'this' in an {{#each}} block with {{bindAttr class}}", function() {
+test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}}", function() {
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{#each view.items}}<li {{bindAttr class="this"}}>Item</li>{{/each}}'),
+    template: Ember.Handlebars.compile('{{#each view.items}}<li {{bind-attr class="this"}}>Item</li>{{/each}}'),
     items: Ember.A(['a', 'b', 'c'])
   });
 
@@ -1696,9 +1700,9 @@ test("should be able to bind classes to 'this' in an {{#each}} block with {{bind
   ok(view.$('li').eq(2).hasClass('c'), "sets classname to the value of the third item");
 });
 
-test("should be able to bindAttr to var in {{#each var in list}} block", function() {
+test("should be able to bind-attr to var in {{#each var in list}} block", function() {
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{#each image in view.images}}<img {{bindAttr src="image"}}>{{/each}}'),
+    template: Ember.Handlebars.compile('{{#each image in view.images}}<img {{bind-attr src="image"}}>{{/each}}'),
     images: Ember.A(['one.png', 'two.jpg', 'three.gif'])
   });
 
@@ -2393,9 +2397,9 @@ test("should teardown observers from bound properties on rerender", function() {
   equal(Ember.observersFor(view, 'foo').length, 1);
 });
 
-test("should teardown observers from bindAttr on rerender", function() {
+test("should teardown observers from bind-attr on rerender", function() {
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('<span {{bindAttr class="view.foo" name="view.foo"}}>wat</span>'),
+    template: Ember.Handlebars.compile('<span {{bind-attr class="view.foo" name="view.foo"}}>wat</span>'),
     foo: 'bar'
   });
 

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -41,13 +41,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     a supplied route by name.
 
     Instances of `LinkView` will most likely be created through
-    the `linkTo` Handlebars helper, but properties of this class
+    the `link-to` Handlebars helper, but properties of this class
     can be overridden to customize application-wide behavior.
 
     @class LinkView
     @namespace Ember
     @extends Ember.View
-    @see {Handlebars.helpers.linkTo}
+    @see {Handlebars.helpers.link-to}
   **/
   var LinkView = Ember.LinkView = Ember.View.extend({
     tagName: 'a',
@@ -114,7 +114,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     classNameBindings: ['active', 'loading', 'disabled'],
 
     /**
-      By default the `{{linkTo}}` helper responds to the `click` event. You
+      By default the `{{link-to}}` helper responds to the `click` event. You
       can override this globally by setting this property to your custom
       event name.
 
@@ -250,7 +250,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       if (get(this, '_isDisabled')) { return false; }
 
       if (get(this, 'loading')) {
-        Ember.Logger.warn("This linkTo is in an inactive loading state because at least one of its parameters' presently has a null/undefined value, or the provided route name is invalid.");
+        Ember.Logger.warn("This link-to is in an inactive loading state because at least one of its parameters' presently has a null/undefined value, or the provided route name is invalid.");
         return false;
       }
 
@@ -276,7 +276,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       }
       namedRoute = fullRouteName(router, namedRoute);
 
-      Ember.assert(fmt("The attempt to linkTo route '%@' failed. The router did not find '%@' in its possible routes: '%@'", [namedRoute, namedRoute, Ember.keys(router.router.recognizer.names).join("', '")]), router.hasRoute(namedRoute));
+      Ember.assert(fmt("The attempt to link-to route '%@' failed. The router did not find '%@' in its possible routes: '%@'", [namedRoute, namedRoute, Ember.keys(router.router.recognizer.names).join("', '")]), router.hasRoute(namedRoute));
 
       var resolvedContexts = resolvedPaths(this.parameters), paramsPresent = true;
       for (var i = 0, l = resolvedContexts.length; i < l; ++i) {
@@ -308,7 +308,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     }).property('routeArgs'),
 
     /**
-      The default href value to use while a linkTo is loading.
+      The default href value to use while a link-to is loading.
       Only applies when tagName is 'a'
 
       @property loadingHref
@@ -321,16 +321,16 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   LinkView.toString = function() { return "LinkView"; };
 
   /**
-    The `{{linkTo}}` helper renders a link to the supplied
+    The `{{link-to}}` helper renders a link to the supplied
     `routeName` passing an optionally supplied model to the
     route as its `model` context of the route. The block
-    for `{{linkTo}}` becomes the innerHTML of the rendered
+    for `{{link-to}}` becomes the innerHTML of the rendered
     element:
 
     ```handlebars
-    {{#linkTo 'photoGallery'}}
+    {{#link-to 'photoGallery'}}
       Great Hamster Photos
-    {{/linkTo}}
+    {{/link-to}}
     ```
 
     ```html
@@ -340,14 +340,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ```
 
     ### Supplying a tagName
-    By default `{{linkTo}}` renders an `<a>` element. This can
-    be overridden for a single use of `{{linkTo}}` by supplying
+    By default `{{link-to}}` renders an `<a>` element. This can
+    be overridden for a single use of `{{link-to}}` by supplying
     a `tagName` option:
 
     ```handlebars
-    {{#linkTo 'photoGallery' tagName="li"}}
+    {{#link-to 'photoGallery' tagName="li"}}
       Great Hamster Photos
-    {{/linkTo}}
+    {{/link-to}}
     ```
 
     ```html
@@ -360,23 +360,23 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     "Overriding Application-wide Defaults".
 
     ### Handling `href`
-    `{{linkTo}}` will use your application's Router to
+    `{{link-to}}` will use your application's Router to
     fill the element's `href` property with a url that
     matches the path to the supplied `routeName` for your
     routers's configured `Location` scheme, which defaults
     to Ember.HashLocation.
 
     ### Handling current route
-    `{{linkTo}}` will apply a CSS class name of 'active'
+    `{{link-to}}` will apply a CSS class name of 'active'
     when the application's current route matches
     the supplied routeName. For example, if the application's
     current route is 'photoGallery.recent' the following
-    use of `{{linkTo}}`:
+    use of `{{link-to}}`:
 
     ```handlebars
-    {{#linkTo 'photoGallery.recent'}}
+    {{#link-to 'photoGallery.recent'}}
       Great Hamster Photos from the last week
-    {{/linkTo}}
+    {{/link-to}}
     ```
 
     will result in
@@ -388,13 +388,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ```
 
     The CSS class name used for active classes can be customized
-    for a single use of `{{linkTo}}` by passing an `activeClass`
+    for a single use of `{{link-to}}` by passing an `activeClass`
     option:
 
     ```handlebars
-    {{#linkTo 'photoGallery.recent' activeClass="current-url"}}
+    {{#link-to 'photoGallery.recent' activeClass="current-url"}}
       Great Hamster Photos from the last week
-    {{/linkTo}}
+    {{/link-to}}
     ```
 
     ```html
@@ -418,9 +418,9 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ```
 
     ```handlebars
-    {{#linkTo 'photoGallery' aPhoto}}
+    {{#link-to 'photoGallery' aPhoto}}
       {{aPhoto.title}}
-    {{/linkTo}}
+    {{/link-to}}
     ```
 
     ```html
@@ -446,9 +446,9 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     This argument will become the model context of the linked route:
 
     ```handlebars
-    {{#linkTo 'photoGallery.comment' aPhoto comment}}
+    {{#link-to 'photoGallery.comment' aPhoto comment}}
       {{comment.body}}
-    {{/linkTo}}
+    {{/link-to}}
     ```
 
     ```html
@@ -458,7 +458,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ```
 
     ### Overriding Application-wide Defaults
-    ``{{linkTo}}`` creates an instance of Ember.LinkView
+    ``{{link-to}}`` creates an instance of Ember.LinkView
     for rendering. To override options for your entire
     application, reopen Ember.LinkView and supply the
     desired values:
@@ -479,13 +479,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     });
     ```
 
-    @method linkTo
+    @method link-to
     @for Ember.Handlebars.helpers
     @param {String} routeName
     @param {Object} [context]*
     @return {String} HTML string
   */
-  Ember.Handlebars.registerHelper('linkTo', function(name) {
+  Ember.Handlebars.registerHelper('link-to', function(name) {
     var options = [].slice.call(arguments, -1)[0],
         params = [].slice.call(arguments, 1, -1);
 
@@ -495,7 +495,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       if (Ember.ENV.HELPER_PARAM_LOOKUPS) {
         hash.namedRouteBinding = name;
       } else {
-        Ember.deprecate("You provided a quoteless destination route parameter of " + name + " to the linkTo helper. Soon, this will perform a property lookup, rather than be treated as a string. To get rid of this warning, wrap " + name + " in quotes. To opt in to this new behavior, set ENV.HELPER_PARAM_LOOKUPS = true");
+        Ember.deprecate("You provided a quoteless destination route parameter of " + name + " to the link-to helper. Soon, this will perform a property lookup, rather than be treated as a string. To get rid of this warning, wrap " + name + " in quotes. To opt in to this new behavior, set ENV.HELPER_PARAM_LOOKUPS = true");
         hash.namedRoute = name;
       }
     } else {
@@ -512,6 +512,17 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
     return Ember.Handlebars.helpers.view.call(this, LinkView, options);
   });
+
+  /**
+    See `link-to`
+
+    @method linkTo
+    @for Ember.Handlebars.helpers
+    @param {String} routeName
+    @param {Object} [context]*
+    @return {String} HTML string
+  */
+  Ember.Handlebars.registerHelper('linkTo', Ember.Handlebars.helpers['link-to']);
 });
 
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -16,7 +16,7 @@ function compile(template) {
   return Ember.Handlebars.compile(template);
 }
 
-module("The {{linkTo}} helper", {
+module("The {{link-to}} helper", {
   setup: function() {
     oldParamFlagValue = Ember.ENV.HELPER_PARAM_LOOKUPS;
     Ember.ENV.HELPER_PARAM_LOOKUPS = true;
@@ -37,9 +37,9 @@ module("The {{linkTo}} helper", {
 
       originalTemplates = Ember.$.extend({}, Ember.TEMPLATES);
       Ember.TEMPLATES.app = Ember.Handlebars.compile("{{outlet}}");
-      Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'about' id='about-link'}}About{{/linkTo}}{{#linkTo 'index' id='self-link'}}Self{{/linkTo}}");
-      Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>About</h3>{{#linkTo 'index' id='home-link'}}Home{{/linkTo}}{{#linkTo 'about' id='self-link'}}Self{{/linkTo}}");
-      Ember.TEMPLATES.item = Ember.Handlebars.compile("<h3>Item</h3><p>{{name}}</p>{{#linkTo 'index' id='home-link'}}Home{{/linkTo}}");
+      Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'about' id='about-link'}}About{{/link-to}}{{#link-to 'index' id='self-link'}}Self{{/link-to}}");
+      Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>About</h3>{{#link-to 'index' id='home-link'}}Home{{/link-to}}{{#link-to 'about' id='self-link'}}Self{{/link-to}}");
+      Ember.TEMPLATES.item = Ember.Handlebars.compile("<h3>Item</h3><p>{{name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
       AppView = Ember.View.extend({
         templateName: 'app'
@@ -59,7 +59,7 @@ module("The {{linkTo}} helper", {
   }
 });
 
-test("The {{linkTo}} helper moves into the named route", function() {
+test("The {{link-to}} helper moves into the named route", function() {
   Router.map(function(match) {
     this.route("about");
   });
@@ -83,11 +83,11 @@ test("The {{linkTo}} helper moves into the named route", function() {
   equal(Ember.$('#home-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
 });
 
-test("The {{linkTo}} helper supports URL replacement", function() {
+test("The {{link-to}} helper supports URL replacement", function() {
   var setCount = 0,
       replaceCount = 0;
 
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'about' id='about-link' replace=true}}About{{/linkTo}}");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'about' id='about-link' replace=true}}About{{/link-to}}");
 
   Router.reopen({
     location: Ember.NoneLocation.createWithMixins({
@@ -124,8 +124,8 @@ test("The {{linkTo}} helper supports URL replacement", function() {
   equal(replaceCount, 1, 'replaceURL should be called once');
 });
 
-test("the {{linkTo}} helper doesn't add an href when the tagName isn't 'a'", function() {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#linkTo 'about' id='about-link' tagName='div'}}About{{/linkTo}}");
+test("the {{link-to}} helper doesn't add an href when the tagName isn't 'a'", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#link-to 'about' id='about-link' tagName='div'}}About{{/link-to}}");
 
   Router.map(function() {
     this.route("about");
@@ -141,8 +141,8 @@ test("the {{linkTo}} helper doesn't add an href when the tagName isn't 'a'", fun
 });
 
 
-test("the {{linkTo}} applies a 'disabled' class when disabled", function () {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo "about" id="about-link" disabledWhen="shouldDisable"}}About{{/linkTo}}');
+test("the {{link-to}} applies a 'disabled' class when disabled", function () {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#link-to "about" id="about-link" disabledWhen="shouldDisable"}}About{{/link-to}}');
   App.IndexController = Ember.Controller.extend({
     shouldDisable: true
   });
@@ -160,8 +160,8 @@ test("the {{linkTo}} applies a 'disabled' class when disabled", function () {
   equal(Ember.$('#about-link.disabled', '#qunit-fixture').length, 1, "The link is disabled when its disabledWhen is true");
 });
 
-test("the {{linkTo}} doesn't apply a 'disabled' class if disabledWhen is not provided", function () {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo "about" id="about-link"}}About{{/linkTo}}');
+test("the {{link-to}} doesn't apply a 'disabled' class if disabledWhen is not provided", function () {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#link-to "about" id="about-link"}}About{{/link-to}}');
 
   Router.map(function() {
     this.route("about");
@@ -176,8 +176,8 @@ test("the {{linkTo}} doesn't apply a 'disabled' class if disabledWhen is not pro
   ok(!Ember.$('#about-link', '#qunit-fixture').hasClass("disabled"), "The link is not disabled if disabledWhen not provided");
 });
 
-test("the {{linkTo}} helper supports a custom disabledClass", function () {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo "about" id="about-link" disabledWhen="shouldDisable" disabledClass="do-not-want"}}About{{/linkTo}}');
+test("the {{link-to}} helper supports a custom disabledClass", function () {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#link-to "about" id="about-link" disabledWhen="shouldDisable" disabledClass="do-not-want"}}About{{/link-to}}');
   App.IndexController = Ember.Controller.extend({
     shouldDisable: true
   });
@@ -196,8 +196,8 @@ test("the {{linkTo}} helper supports a custom disabledClass", function () {
 
 });
 
-test("the {{linkTo}} helper does not respond to clicks when disabled", function () {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#linkTo "about" id="about-link" disabledWhen="shouldDisable"}}About{{/linkTo}}');
+test("the {{link-to}} helper does not respond to clicks when disabled", function () {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{#link-to "about" id="about-link" disabledWhen="shouldDisable"}}About{{/link-to}}');
   App.IndexController = Ember.Controller.extend({
     shouldDisable: true
   });
@@ -219,8 +219,8 @@ test("the {{linkTo}} helper does not respond to clicks when disabled", function 
   equal(Ember.$('h3:contains(About)', '#qunit-fixture').length, 0, "Transitioning did not occur");
 });
 
-test("The {{linkTo}} helper supports a custom activeClass", function() {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'about' id='about-link'}}About{{/linkTo}}{{#linkTo 'index' id='self-link' activeClass='zomg-active'}}Self{{/linkTo}}");
+test("The {{link-to}} helper supports a custom activeClass", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'about' id='about-link'}}About{{/link-to}}{{#link-to 'index' id='self-link' activeClass='zomg-active'}}Self{{/link-to}}");
 
   Router.map(function() {
     this.route("about");
@@ -237,7 +237,7 @@ test("The {{linkTo}} helper supports a custom activeClass", function() {
   equal(Ember.$('#about-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
 });
 
-test("The {{linkTo}} helper supports leaving off .index for nested routes", function() {
+test("The {{link-to}} helper supports leaving off .index for nested routes", function() {
   Router.map(function() {
     this.resource("about", function() {
       this.route("item");
@@ -246,7 +246,7 @@ test("The {{linkTo}} helper supports leaving off .index for nested routes", func
 
   Ember.TEMPLATES.about = compile("<h1>About</h1>{{outlet}}");
   Ember.TEMPLATES['about/index'] = compile("<div id='index'>Index</div>");
-  Ember.TEMPLATES['about/item'] = compile("<div id='item'>{{#linkTo 'about'}}About{{/linkTo}}</div>");
+  Ember.TEMPLATES['about/item'] = compile("<div id='item'>{{#link-to 'about'}}About{{/link-to}}</div>");
 
   bootApplication();
 
@@ -257,7 +257,7 @@ test("The {{linkTo}} helper supports leaving off .index for nested routes", func
   equal(normalizeUrl(Ember.$('#item a', '#qunit-fixture').attr('href')), '/about');
 });
 
-test("The {{linkTo}} helper supports custom, nested, currentWhen", function() {
+test("The {{link-to}} helper supports custom, nested, currentWhen", function() {
   Router.map(function(match) {
     this.resource("index", { path: "/" }, function() {
       this.route("about");
@@ -267,7 +267,7 @@ test("The {{linkTo}} helper supports custom, nested, currentWhen", function() {
   });
 
   Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{outlet}}");
-  Ember.TEMPLATES['index/about'] = Ember.Handlebars.compile("{{#linkTo 'item' id='other-link' currentWhen='index'}}ITEM{{/linkTo}}");
+  Ember.TEMPLATES['index/about'] = Ember.Handlebars.compile("{{#link-to 'item' id='other-link' currentWhen='index'}}ITEM{{/link-to}}");
 
   bootApplication();
 
@@ -278,8 +278,8 @@ test("The {{linkTo}} helper supports custom, nested, currentWhen", function() {
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active since currentWhen is a parent route");
 });
 
-test("The {{linkTo}} helper defaults to bubbling", function() {
-  Ember.TEMPLATES.about = Ember.Handlebars.compile("<div {{action 'hide'}}>{{#linkTo 'about.contact' id='about-contact'}}About{{/linkTo}}</div>{{outlet}}");
+test("The {{link-to}} helper defaults to bubbling", function() {
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<div {{action 'hide'}}>{{#link-to 'about.contact' id='about-contact'}}About{{/link-to}}</div>{{outlet}}");
   Ember.TEMPLATES['about/contact'] = Ember.Handlebars.compile("<h1 id='contact'>Contact</h1>");
 
   Router.map(function() {
@@ -313,8 +313,8 @@ test("The {{linkTo}} helper defaults to bubbling", function() {
   equal(hidden, 1, "The link bubbles");
 });
 
-test("The {{linkTo}} helper supports bubbles=false", function() {
-  Ember.TEMPLATES.about = Ember.Handlebars.compile("<div {{action 'hide'}}>{{#linkTo 'about.contact' id='about-contact' bubbles=false}}About{{/linkTo}}</div>{{outlet}}");
+test("The {{link-to}} helper supports bubbles=false", function() {
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<div {{action 'hide'}}>{{#link-to 'about.contact' id='about-contact' bubbles=false}}About{{/link-to}}</div>{{outlet}}");
   Ember.TEMPLATES['about/contact'] = Ember.Handlebars.compile("<h1 id='contact'>Contact</h1>");
 
   Router.map(function() {
@@ -348,13 +348,13 @@ test("The {{linkTo}} helper supports bubbles=false", function() {
   equal(hidden, 0, "The link didn't bubble");
 });
 
-test("The {{linkTo}} helper moves into the named route with context", function() {
+test("The {{link-to}} helper moves into the named route with context", function() {
   Router.map(function(match) {
     this.route("about");
     this.resource("item", { path: "/item/:id" });
   });
 
-  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each controller}}<li>{{#linkTo 'item' this}}{{name}}{{/linkTo}}<li>{{/each}}</ul>{{#linkTo 'index' id='home-link'}}Home{{/linkTo}}");
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each controller}}<li>{{#link-to 'item' this}}{{name}}{{/link-to}}<li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
   var people = {
     yehuda: "Yehuda Katz",
@@ -409,8 +409,8 @@ test("The {{linkTo}} helper moves into the named route with context", function()
   equal(Ember.$('p', '#qunit-fixture').text(), "Erik Brynroflsson", "The name is correct");
 });
 
-test("The {{linkTo}} helper binds some anchor html tag common attributes", function() {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'index' id='self-link' title='title-attr' rel='rel-attr'}}Self{{/linkTo}}");
+test("The {{link-to}} helper binds some anchor html tag common attributes", function() {
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'index' id='self-link' title='title-attr' rel='rel-attr'}}Self{{/link-to}}");
   bootApplication();
 
   Ember.run(function() {
@@ -422,7 +422,7 @@ test("The {{linkTo}} helper binds some anchor html tag common attributes", funct
   equal(link.attr('rel'), 'rel-attr', "The self-link contains rel attribute");
 });
 
-test("The {{linkTo}} helper accepts string/numeric arguments", function() {
+test("The {{link-to}} helper accepts string/numeric arguments", function() {
   Router.map(function() {
     this.route('filter', { path: '/filters/:filter' });
     this.route('post',   { path: '/post/:post_id' });
@@ -433,7 +433,7 @@ test("The {{linkTo}} helper accepts string/numeric arguments", function() {
     post_id: 123
   });
 
-  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>{{#linkTo "filter" "unpopular" id="link"}}Unpopular{{/linkTo}}{{#linkTo "filter" filter id="path-link"}}Unpopular{{/linkTo}}{{#linkTo "post" post_id id="post-path-link"}}Post{{/linkTo}}{{#linkTo "post" 123 id="post-number-link"}}Post{{/linkTo}}');
+  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>{{#link-to "filter" "unpopular" id="link"}}Unpopular{{/link-to}}{{#link-to "filter" filter id="path-link"}}Unpopular{{/link-to}}{{#link-to "post" post_id id="post-path-link"}}Post{{/link-to}}{{#link-to "post" 123 id="post-number-link"}}Post{{/link-to}}');
 
   Ember.TEMPLATES.index = compile('');
 
@@ -447,7 +447,7 @@ test("The {{linkTo}} helper accepts string/numeric arguments", function() {
   equal(normalizeUrl(Ember.$('#post-number-link', '#qunit-fixture').attr('href')), "/post/123");
 });
 
-test("The {{linkTo}} helper unwraps controllers", function() {
+test("The {{link-to}} helper unwraps controllers", function() {
   // The serialize hook is called twice: once to generate the href for the
   // link and once to generate the URL when the link is clicked.
   expect(2);
@@ -476,7 +476,7 @@ test("The {{linkTo}} helper unwraps controllers", function() {
   });
 
   Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>');
-  Ember.TEMPLATES.index = compile('{{#linkTo "filter" this id="link"}}Filter{{/linkTo}}');
+  Ember.TEMPLATES.index = compile('{{#link-to "filter" this id="link"}}Filter{{/link-to}}');
 
   bootApplication();
 
@@ -485,13 +485,13 @@ test("The {{linkTo}} helper unwraps controllers", function() {
   Ember.$('#link', '#qunit-fixture').trigger('click');
 });
 
-test("The {{linkTo}} helper doesn't change view context", function() {
+test("The {{link-to}} helper doesn't change view context", function() {
   App.IndexView = Ember.View.extend({
     elementId: 'index',
     name: 'test'
   });
 
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{view.name}}-{{#linkTo 'index' id='self-link'}}Link: {{view.name}}{{/linkTo}}");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{view.name}}-{{#link-to 'index' id='self-link'}}Link: {{view.name}}{{/link-to}}");
 
   bootApplication();
 
@@ -503,7 +503,7 @@ test("The {{linkTo}} helper doesn't change view context", function() {
 });
 
 test("Quoteless route param performs property lookup", function() {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#linkTo 'index' id='string-link'}}string{{/linkTo}}{{#linkTo foo id='path-link'}}path{{/linkTo}}{{#linkTo view.foo id='view-link'}}{{view.foo}}{{/linkTo}}");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#link-to 'index' id='string-link'}}string{{/link-to}}{{#link-to foo id='path-link'}}path{{/link-to}}{{#link-to view.foo id='view-link'}}{{view.foo}}{{/link-to}}");
 
   Ember.ENV.HELPER_PARAM_LOOKUPS = true;
 
@@ -544,13 +544,13 @@ test("Quoteless route param performs property lookup", function() {
   assertEquality('/about');
 });
 
-test("linkTo with null/undefined dynamic parameters are put in a loading state", function() {
+test("link-to with null/undefined dynamic parameters are put in a loading state", function() {
 
   expect(19);
 
   var oldWarn = Ember.Logger.warn, warnCalled = false;
   Ember.Logger.warn = function() { warnCalled = true; };
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#linkTo destinationRoute routeContext loadingClass='i-am-loading' id='context-link'}}string{{/linkTo}}{{#linkTo secondRoute loadingClass='i-am-loading' id='static-link'}}string{{/linkTo}}");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#link-to destinationRoute routeContext loadingClass='i-am-loading' id='context-link'}}string{{/link-to}}{{#link-to secondRoute loadingClass='i-am-loading' id='static-link'}}string{{/link-to}}");
 
   Ember.ENV.HELPER_PARAM_LOOKUPS = true;
 
@@ -580,10 +580,10 @@ test("linkTo with null/undefined dynamic parameters are put in a loading state",
 
   function assertLinkStatus($link, url) {
     if (url) {
-      equal(normalizeUrl($link.attr('href')), url, "loaded linkTo has expected href");
+      equal(normalizeUrl($link.attr('href')), url, "loaded link-to has expected href");
       ok(!$link.hasClass('i-am-loading'), "loaded linkView has no loadingClass");
     } else {
-      equal(normalizeUrl($link.attr('href')), '#', "unloaded linkTo has href='#'");
+      equal(normalizeUrl($link.attr('href')), '#', "unloaded link-to has href='#'");
       ok($link.hasClass('i-am-loading'), "loading linkView has loadingClass");
     }
   }
@@ -636,7 +636,7 @@ test("linkTo with null/undefined dynamic parameters are put in a loading state",
   Ember.Logger.warn = oldWarn;
 });
 
-test("The {{linkTo}} helper refreshes href element when one of params changes", function() {
+test("The {{link-to}} helper refreshes href element when one of params changes", function() {
   Router.map(function() {
     this.route('post', { path: '/posts/:post_id' });
   });
@@ -654,7 +654,7 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
     }
   });
 
-  Ember.TEMPLATES.index = compile('{{#linkTo "post" post id="post"}}post{{/linkTo}}');
+  Ember.TEMPLATES.index = compile('{{#link-to "post" post id="post"}}post{{/link-to}}');
 
   App.IndexController = Ember.Controller.extend();
   var indexController = container.lookup('controller:index');
@@ -674,4 +674,8 @@ test("The {{linkTo}} helper refreshes href element when one of params changes", 
   Ember.run(function() { indexController.set('post', null); });
 
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '#', 'href attr becomes # when one of the arguments in nullified');
+});
+
+test("{{linkTo}} is aliased", function() {
+  equal(Ember.Handlebars.helpers.linkTo, Ember.Handlebars.helpers['link-to']);
 });


### PR DESCRIPTION
Not sure if we want to just alias these for now, or completely rename and alias the camelized versions.

//cc @wagenet @stefanpenner @wycats @tomdale @kselden @trek
