### PR TITLE
Smarter linkTo observers

### DIFF
--- a/packages/ember-routing/lib/helpers/shared.js
+++ b/packages/ember-routing/lib/helpers/shared.js
@@ -3,22 +3,43 @@ require('ember-routing/system/router');
 Ember.onLoad('Ember.Handlebars', function() {
   var handlebarsResolve = Ember.Handlebars.resolveParams,
       map = Ember.ArrayPolyfills.map,
-      get = Ember.get;
+      get = Ember.get,
+      handlebarsGet = Ember.Handlebars.get;
 
   function resolveParams(context, params, options) {
-    var resolved = handlebarsResolve(context, params, options);
-    return map.call(resolved, unwrap);
+    return resolvePaths(context, params, options).map(function(path, i) {
+      if (null === path) {
+        // Param was string/number, not a path, so just return raw string/number.
+        return params[i];
+      } else {
+        return handlebarsGet(context, path, options);
+      }
+    });
+  }
 
-    function unwrap(object, i) {
-      if (params[i] === 'controller') { return object; }
+  function resolvePaths(context, params, options) {
+    var resolved = handlebarsResolve(context, params, options),
+        types = options.types;
+
+    return map.call(resolved, function(object, i) {
+      if (types[i] === 'ID') {
+        return unwrap(object, params[i]);
+      } else {
+        return null;
+      }
+    });
+
+    function unwrap(object, path) {
+      if (path === 'controller') { return path; }
 
       if (Ember.ControllerMixin.detect(object)) {
-        return unwrap(get(object, 'model'));
+        return unwrap(get(object, 'model'), path ? path + '.model' : 'model');
       } else {
-        return object;
+        return path;
       }
     }
   }
 
   Ember.Router.resolveParams = resolveParams;
+  Ember.Router.resolvePaths = resolvePaths;
 });

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -630,7 +630,7 @@ test("should allow multiple contexts to be specified", function() {
   deepEqual(passedContexts, models, "the action was called with the passed contexts");
 });
 
-test("should allow multiple contexts to be specified", function() {
+test("should allow multiple contexts to be specified mixed with string args", function() {
   var passedParams,
       model = Ember.Object.create();
 


### PR DESCRIPTION
Minor refactor to clean up some linkTo code and fix an inconsistency
whereby `{{linkTo 'elsewhere' this}}` would not automatically update
when the present route's ObjectController's content would change,
since the `this` was only watching the ObjectController, and not its
proxied content object. There was already code that special cased
the resolution of ObjectControllers' content, but it was missing from
the code that sets up the observers; now the same code is shared between
both code paths. Hooray.

Also removed the short-lived and probably unnecessary flag
HELPER_PARAM_LOOKUPS, which was only used for the linkTo,
and enabled linkTo parameters, routeName included, to be
bound paths when unquoted.

Thanks to @abahdanovich for pointing this out.
