### PR TITLE
Change docs to mention `setUnknownProperty`

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -10,7 +10,7 @@ var META_KEY = Ember.META_KEY,
 /**
   Sets the value of a property on an object, respecting computed properties
   and notifying observers and other listeners of the change. If the
-  property is not defined but the object implements the `unknownProperty`
+  property is not defined but the object implements the `setUnknownProperty`
   method then that will be invoked as well.
 
   If you plan to run on IE8 and older browsers then you should use this
@@ -20,7 +20,7 @@ var META_KEY = Ember.META_KEY,
 
   On all newer browsers, you only need to use this method to set
   properties if the property might not be defined on the object and you want
-  to respect the `unknownProperty` handler. Otherwise you can ignore this
+  to respect the `setUnknownProperty` handler. Otherwise you can ignore this
   method.
 
   @method set

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -25,7 +25,7 @@ test('should call setUnknownProperty if defined and value is undefined', functio
     count: 0,
 
     unknownProperty: function(key, value) {
-      ok(false, 'should not invoke unknownProperty is setUnknownProperty is defined');
+      ok(false, 'should not invoke unknownProperty if setUnknownProperty is defined');
     },
 
     setUnknownProperty: function(key, value) {

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -149,7 +149,7 @@ Ember.Observable = Ember.Mixin.create({
 
     This method is generally very similar to calling `object[key] = value` or
     `object.key = value`, except that it provides support for computed
-    properties, the `unknownProperty()` method and property observers.
+    properties, the `setUnknownProperty()` method and property observers.
 
     ### Computed Properties
 
@@ -163,9 +163,9 @@ Ember.Observable = Ember.Mixin.create({
     ### Unknown Properties
 
     If you try to set a value on a key that is undefined in the target
-    object, then the `unknownProperty()` handler will be called instead. This
+    object, then the `setUnknownProperty()` handler will be called instead. This
     gives you an opportunity to implement complex "virtual" properties that
-    are not predefined on the object. If `unknownProperty()` returns
+    are not predefined on the object. If `setUnknownProperty()` returns
     undefined, then `set()` will simply set the value on the object.
 
     ### Property Observers


### PR DESCRIPTION
The docs incorrectly said that `unknownProperty` would be called when setting an unknown property.

This causes the current docs at emberjs.com for the observable mixin to be incorrect: ( http://emberjs.com/api/classes/Ember.Observable.html#method_set ).
