### PR TITLE
Added Ember.getProperties

### DIFF
--- a/packages/ember-metal/lib/get_properties.js
+++ b/packages/ember-metal/lib/get_properties.js
@@ -1,0 +1,38 @@
+require('ember-metal/property_get');
+require('ember-metal/utils');
+
+var get = Ember.get;
+
+/**
+  To get multiple properties at once, call `Ember.getProperties`
+  with an object followed by a list of strings or an array:
+
+  ```javascript
+  Ember.getProperties(record, 'firstName', 'lastName', 'zipCode');  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+  ```
+
+  is equivalent to:
+
+  ```javascript
+  Ember.getProperties(record, ['firstName', 'lastName', 'zipCode']);  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+  ```
+
+  @method getProperties
+  @param obj
+  @param {String...|Array} list of keys to get
+  @return {Hash}
+*/
+Ember.getProperties = function(obj) {
+  var ret = {},
+      propertyNames = arguments,
+      i = 1;
+
+  if (arguments.length === 2 && Ember.typeOf(arguments[1]) === 'array') {
+    i = 0;
+    propertyNames = arguments[1];
+  }
+  for(var len = propertyNames.length; i < len; i++) {
+    ret[propertyNames[i]] = get(obj, propertyNames[i]);
+  }
+  return ret;
+};

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -14,6 +14,7 @@ require('ember-metal/property_get');
 require('ember-metal/property_set');
 require('ember-metal/properties');
 require('ember-metal/property_events');
+require('ember-metal/get_properties');
 require('ember-metal/set_properties');
 require('ember-metal/chains');
 require('ember-metal/computed');

--- a/packages/ember-metal/tests/accessors/getProperties_test.js
+++ b/packages/ember-metal/tests/accessors/getProperties_test.js
@@ -1,0 +1,18 @@
+module('Ember.getProperties');
+
+test('can retrieve a hash of properties from an object via an argument list or array of property names', function() {
+  var obj = {
+    firstName: "Steve",
+    lastName: "Jobs",
+    companyName: "Apple, Inc."
+  };
+
+  var getProperties = Ember.getProperties;
+  deepEqual(getProperties(obj, "firstName", "lastName"), { firstName: 'Steve', lastName: 'Jobs' });
+  deepEqual(getProperties(obj, "firstName", "lastName"), { firstName: 'Steve', lastName: 'Jobs' });
+  deepEqual(getProperties(obj, "lastName"), { lastName: 'Jobs' });
+  deepEqual(getProperties(obj), {});
+  deepEqual(getProperties(obj, ["firstName", "lastName"]), { firstName: 'Steve', lastName: 'Jobs' });
+  deepEqual(getProperties(obj, ["firstName"]), { firstName: 'Steve' });
+  deepEqual(getProperties(obj, []), {});
+});

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -3,7 +3,10 @@
 @submodule ember-runtime
 */
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get,
+    set = Ember.set,
+    slice = Array.prototype.slice,
+    getProperties = Ember.getProperties;
 
 /**
   ## Overview
@@ -133,15 +136,7 @@ Ember.Observable = Ember.Mixin.create({
     @return {Hash}
   */
   getProperties: function() {
-    var ret = {};
-    var propertyNames = arguments;
-    if (arguments.length === 1 && Ember.typeOf(arguments[0]) === 'array') {
-      propertyNames = arguments[0];
-    }
-    for(var i = 0; i < propertyNames.length; i++) {
-      ret[propertyNames[i]] = get(this, propertyNames[i]);
-    }
-    return ret;
+    return getProperties.apply(null, [this].concat(slice.call(arguments)));
   },
 
   /**


### PR DESCRIPTION
`getProperties` has always existed on `Ember.Object`'s prototype, but
it's been unavailable as a utility function to use on POJO's.
Now `Ember.getProperties` can be used with non `Ember.Object`s, e.g.

```
var obj = { foo: 5, bar: 6, baz: 7 };
Ember.getProperties(obj, 'foo', 'bar'); // => { foo: 5, bar: 6 }
// equivalent to
Ember.getProperties(obj, ['foo', 'bar']); // => { foo: 5, bar: 6 }
```
