### PR TITLE
Update ember-dev to allow for stable builds.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 7d511cb7db4b66c342bf5f4cd19d3a2666730b6a
+  revision: bc00ea0660b07744067f05d2e12354b183ae4cb1
   branch: master
   specs:
     ember-dev (0.1)
@@ -67,7 +67,7 @@ GEM
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
     thor (0.18.1)
-    uglifier (2.1.2)
+    uglifier (2.2.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
     uuidtools (2.1.4)


### PR DESCRIPTION
Updates `ember-dev` with https://github.com/emberjs/ember-dev/pull/30.

Details from https://github.com/emberjs/ember-dev/pull/30:

```
# Stable commit:

stable/ember.js
stable/daily/20130826/ember.js
stable/shas/3385bffee116a97c555b9672b64297fe283cfa5b/ember.js

# Master Commit:

ember-latest.js
latest/ember.js
daily/20130826/ember.js
shas/3385bffee116a97c555b9672b64297fe283cfa5b/ember.js

# Tagged commits:

tags/v999/ember.js
```
