### PR TITLE
Remove documentation for this._super() within a route's event

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -76,18 +76,81 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     this.send('playMusic');
     ```
 
-    It is also possible to call `this._super()` from within an
-    action handler if it overrides a handle defined on a parent
-    class or mixin.
-
     Within a route's action handler, the value of the `this` context
-    is the Route object.
+    is the Route object:
+
+    ```js
+    App.SongRoute = Ember.Route.extend({
+      actions: {
+        myAction: function() {
+          this.controllerFor("song");
+          this.transitionTo("other.route");
+          ...
+        }
+      }
+    });
+    ```
+
+    It is also possible to call `this._super()` from within an
+    action handler if it overrides a handler defined on a parent
+    class or mixin:
+
+    Take for example the following routes:
+
+    ```js
+    App.DebugRoute = Ember.Mixin.create({
+      actions: {
+        debugRouteInformation: function() {
+          console.debug("trololo");
+        }
+      }
+    });
+
+    App.AnnoyingDebugRoute = Ember.Route.extend(App.DebugRoute, {
+      actions: {
+        debugRouteInformation: function() {
+          // also call the debugRouteInformation of mixed in App.DebugRoute
+          this._super();
+
+          // show additional annoyance
+          window.alert(...);
+        }
+      }
+    });
+    ```
 
     ## Bubbling
 
     By default, an action will stop bubbling once a handler defined
     on the `actions` hash handles it. To continue bubbling the action,
-    you must return `true` from the handler.
+    you must return `true` from the handler:
+
+    ```js
+    App.Router.map(function() {
+      this.resource("album", function() {
+        this.route("song");
+      });
+    });
+
+    App.AlbumRoute = Ember.Route.extend({
+      actions: {
+        startPlaying: function() {
+        }
+      }
+    });
+
+    App.AlbumSongRoute = Ember.Route.extend({
+      actions: {
+        startPlaying: function() {
+          // ...
+
+          if (actionShouldAlsoBeTriggeredOnParentRoute) {
+            return true;
+          }
+        }
+      }
+    });
+    ```
 
     ## Built-in actions
 


### PR DESCRIPTION
This doesn't seem to work, as demonstrated in http://jsbin.com/AliwOnI/1/edit, though it is documented.

@machty you introduced this in 065afc0c, do you know what's going on here?
