### PR TITLE
Use Ember.lookup as context for {{CONSTANT}}. Fixes #3098

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Add query params support to the ember router. You can now define which query params your routes respond to, use them in your route hooks to affect model loading or controller state, and transition query parameters with the link-to helper and the transitionTo method
 * Add named substates; e.g. when resolving a `loading` or `error` substate to enter, Ember will take into account the name of the immediate child route that the `error`/`loading` action originated from, e.g. 'foo' if `FooRoute`, and try and enter `foo_error` or `foo_loading` if it exists. This also adds the ability for a top-level `application_loading` or `application_error` state to be entered for `loading`/`error` events emitted from `ApplicationRoute`.
+* Ensure Handlebars values starting with capital letters are always looked up on `Ember.lookup`.
 
 ### Ember 1.2.0 _(TBD)_
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -94,9 +94,16 @@ for a detailed explanation.
 
   Add named substates; e.g. when resolving a `loading` or `error`
   substate to enter, Ember will take into account the name of the
-  immediate child route that the `error`/`loading` action originated 
-  from, e.g. 'foo' if `FooRoute`, and try and enter `foo_error` or 
-  `foo_loading` if it exists. This also adds the ability for a 
+  immediate child route that the `error`/`loading` action originated
+  from, e.g. 'foo' if `FooRoute`, and try and enter `foo_error` or
+  `foo_loading` if it exists. This also adds the ability for a
   top-level `application_loading` or `application_error` state to
-  be entered for `loading`/`error` events emitted from 
+  be entered for `loading`/`error` events emitted from
   `ApplicationRoute`.
+
+* `ember-handlebars-caps-lookup`
+  Forces Handlebars values starting with capital letters, like `{{CONSTANT}}`,
+  to always be looked up on `Ember.lookup`. Previously, these values would be
+  looked up on the controller in certain cases.
+
+  Added in [#3218](https://github.com/emberjs/ember.js/pull/3218)

--- a/features.json
+++ b/features.json
@@ -9,5 +9,6 @@
   "query-params": null,
   "string-humanize": null,
   "propertyBraceExpansion": null,
-  "ember-routing-named-substates": null
+  "ember-routing-named-substates": null,
+  "ember-handlebars-caps-lookup": null
 }

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -62,19 +62,31 @@ var handlebarsGet = Ember.Handlebars.get = function(root, path, options) {
       normalizedPath = normalizePath(root, path, data),
       value;
 
-  // In cases where the path begins with a keyword, change the
-  // root to the value represented by that keyword, and ensure
-  // the path is relative to it.
-  root = normalizedPath.root;
-  path = normalizedPath.path;
+  if (Ember.FEATURES.isEnabled("ember-handlebars-caps-lookup")) {
 
-  value = Ember.get(root, path);
+    // If the path starts with a capital letter, look it up on Ember.lookup,
+    // which defaults to the `window` object in browsers.
+    if (Ember.isGlobalPath(path)) {
+      value = Ember.get(Ember.lookup, path);
+    } else {
 
-  // If the path starts with a capital letter, look it up on Ember.lookup,
-  // which defaults to the `window` object in browsers.
-  if (value === undefined && root !== Ember.lookup && Ember.isGlobalPath(path)) {
-    value = Ember.get(Ember.lookup, path);
+      // In cases where the path begins with a keyword, change the
+      // root to the value represented by that keyword, and ensure
+      // the path is relative to it.
+      value = Ember.get(normalizedPath.root, normalizedPath.path);
+    }
+
+  } else {
+    root = normalizedPath.root;
+    path = normalizedPath.path;
+
+    value = Ember.get(root, path);
+
+    if (value === undefined && root !== Ember.lookup && Ember.isGlobalPath(path)) {
+      value = Ember.get(Ember.lookup, path);
+    }
   }
+
   return value;
 };
 

--- a/packages/ember-handlebars/tests/lookup_test.js
+++ b/packages/ember-handlebars/tests/lookup_test.js
@@ -28,6 +28,17 @@ test("ID parameters should be looked up on the context", function() {
   deepEqual(params, ["Mr", "Tom", "Dale"]);
 });
 
+if (Ember.FEATURES.isEnabled("ember-handlebars-caps-lookup")) {
+  test("ID parameters that start with capital letters use Ember.lookup as their context", function() {
+    Ember.lookup.FOO = "BAR";
+
+    var context = { FOO: "BAZ" };
+
+    var params = Ember.Handlebars.resolveParams(context, ["FOO"], { types: ["ID"] });
+    deepEqual(params, ["BAR"]);
+  });
+}
+
 test("ID parameters can look up keywords", function() {
   var controller = {
     salutation: "Mr"


### PR DESCRIPTION
This fixes the discrepancy in context between `{{CONSTANT}}` and `{{#each CONSTANT}}{{this}}{{/each}}` as described in #3098.

Is this the right way to fix this? I'm not sure if this change has unintended consequences.
