### PR TITLE
Use factory superclass in Route#model hook

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -547,7 +547,7 @@ Ember.Route = Ember.Object.extend({
     if (!name && sawParams) { return params; }
     else if (!name) { return; }
 
-    var modelClass = this.container.lookupFactory('model:' + name);
+    var modelClass = this.container.lookupFactory('model:' + name).superclass;
     var namespace = get(this, 'router.namespace');
 
     Ember.assert("You used the dynamic segment " + name + "_id in your router, but " + namespace + "." + classify(name) + " did not exist and you did not override your route's `model` hook.", modelClass);

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -17,11 +17,12 @@ test("default model utilizes the container to acquire the model factory", functi
 
   post = {};
 
-  Post = {
+  Post = Ember.Object.extend();
+  Post.reopenClass({
     find: function(id) {
       return post;
     }
-  };
+  });
 
   container = {
     lookupFactory: lookupFactory
@@ -34,7 +35,7 @@ test("default model utilizes the container to acquire the model factory", functi
   function lookupFactory(fullName) {
     equal(fullName, "model:post", "correct factory was looked up");
 
-    return Post;
+    return Post.extend();
   }
 
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2293,3 +2293,23 @@ test("currentRouteName is a property installed on ApplicationController that can
   transitionAndCheck('each.other', 'be.excellent.to.each.other', 'each.other');
 });
 
+test("Route model hook finds the same model as a manual find", function() {
+  var Post;
+  App.Post = Ember.Object.extend();
+  App.Post.reopenClass({
+    find: function() {
+      Post = this;
+      return {};
+    }
+  });
+
+  Router.map(function() {
+    this.route('post', { path: '/post/:post_id' });
+  });
+
+  bootApplication();
+
+  handleURL('/post/1');
+
+  equal(App.Post, Post);
+});


### PR DESCRIPTION
With factory injections, container objects are now extended when registered. 

This results in: `container.lookupFactory('model:post') !== App.Post`

Which in Ember Data, means:

``` javascript
var Post = container.lookupFactory('model:post');
Post === App.Post; // false
Post.find(1) === App.Post.find(1); // false
```

Since currently most Ember apps use `App.Post.find(1)` or `store.find(App.Post, 1)`, this will cause Ember RC8 to break all apps that use Ember Data or access models in a similar way.

This PR is a quick workaround that prevents the RC8 release from having this breaking change.  An Ember Data PR will also follow with a similar fix for internal lookup of models.

Any better ideas for a quick fix are welcome (I'm not very happy with this one).
### Issues with this fix
- It is obviously a hack that needs to be re-visited at a later stage.
- Model injections would no longer be possible.
