### PR TITLE
Fixes to GroupedEach

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -185,7 +185,13 @@ GroupedEach.prototype = {
   },
 
   rerenderContainingView: function() {
-    Ember.run.scheduleOnce('render', this.containingView, 'rerender');
+    var self = this;
+    Ember.run.scheduleOnce('render', this, function() {
+      // It's possible it's been destroyed after we enqueued a re-render call.
+      if (!self.destroyed) {
+        self.containingView.rerender();
+      }
+    });
   },
 
   destroy: function() {
@@ -193,6 +199,7 @@ GroupedEach.prototype = {
     if (this.content) {
       this.removeArrayObservers();
     }
+    this.destroyed = true;
   }
 };
 

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -143,6 +143,8 @@ GroupedEach.prototype = {
   },
 
   addArrayObservers: function() {
+    if (!this.content) { return; }
+
     this.content.addArrayObserver(this, {
       willChange: 'contentArrayWillChange',
       didChange: 'contentArrayDidChange'
@@ -150,6 +152,8 @@ GroupedEach.prototype = {
   },
 
   removeArrayObservers: function() {
+    if (!this.content) { return; }
+
     this.content.removeArrayObserver(this, {
       willChange: 'contentArrayWillChange',
       didChange: 'contentArrayDidChange'
@@ -167,6 +171,8 @@ GroupedEach.prototype = {
   },
 
   render: function() {
+    if (!this.content) { return; }
+
     var content = this.content,
         contentLength = get(content, 'length'),
         data = this.options.data,
@@ -184,7 +190,9 @@ GroupedEach.prototype = {
 
   destroy: function() {
     this.removeContentObservers();
-    this.removeArrayObservers();
+    if (this.content) {
+      this.removeArrayObservers();
+    }
   }
 };
 

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -114,6 +114,21 @@ test("#each with no content", function() {
   appendView();
 });
 
+test("#each's content can be changed right before a destroy", function() {
+  expect(0);
+
+  createGroupedView(
+    "{{#each numbers}}{{this}}{{/each}}",
+    {numbers: Ember.A([1,2,3])}
+  );
+  appendView();
+
+  Ember.run(function() {
+    view.set('context.numbers', Ember.A([3,2,1]));
+    view.destroy();
+  });
+});
+
 test("#each can be nested", function() {
   createGroupedView(
     "{{#each numbers}}{{this}}{{/each}}",

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -106,6 +106,14 @@ test("should work with the #if helper", function() {
   equal(trim(view.$().text()), 'boo', "The falsy value was rendered");
 });
 
+test("#each with no content", function() {
+  expect(0);
+  createGroupedView(
+    "{{#each missing}}{{this}}{{/each}}"
+  );
+  appendView();
+});
+
 test("#each can be nested", function() {
   createGroupedView(
     "{{#each numbers}}{{this}}{{/each}}",


### PR DESCRIPTION
The `GroupedEach` functionality is mostly hidden in Ember right now, but we are using it on Discourse for performance reasons. I discovered some issues within the `GroupedEach` helper in Ember and these commits address their behaviour, complete with tests.
1. If you created a `GroupedEach` with on a variable that's undefined, you would get a big nasty error. The first commit fixes that by checking that content is there before rendering and setting up observers.
2. If you changed the content of a `GroupedEach` right before it was destroyed, Ember would complain about "You can't call rerender on a view being destroyed". This is because `rerenderContainingView` was scheduling a render in the future, and a call to destroy could be made in the meantime. We actually encountered this on Discourse.

The fix was to track that an object was deleted in case a rerender was scheduled in the future after the `destroy` was called.
