### PR TITLE
cleanup promise proxy

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -1,5 +1,6 @@
 var set = Ember.set, get = Ember.get,
     resolve = Ember.RSVP.resolve,
+    rethrow = Ember.RSVP.rethrow,
     not = Ember.computed.not,
     or = Ember.computed.or;
 
@@ -7,14 +8,6 @@ var set = Ember.set, get = Ember.get,
   @module ember
   @submodule ember-runtime
  */
-
-function rethrow(reason) {
-  setTimeout(function(){
-    throw reason;
-  }, 0);
-
-  throw reason;
-}
 
 function installPromise(proxy, promise) {
   promise.then(function(value) {
@@ -25,7 +18,7 @@ function installPromise(proxy, promise) {
   }, function(reason) {
     set(proxy, 'isRejected', true);
     set(proxy, 'reason', reason);
-  }).then(null, rethrow);
+  }).fail(rethrow);
 }
 
 /**
@@ -50,7 +43,7 @@ function installPromise(proxy, promise) {
 
   ```javascript
   controller.get('isPending')   //=> true
-  controller.get('isResolved')  //=> false
+  controller.get('isSettled')  //=> false
   controller.get('isRejected')  //=> false
   controller.get('isFulfilled') //=> false
   ```
@@ -60,7 +53,7 @@ function installPromise(proxy, promise) {
 
   ```javascript
   controller.get('isPending')   //=> false
-  controller.get('isResolved')  //=> true
+  controller.get('isSettled')   //=> true
   controller.get('isRejected')  //=> false
   controller.get('isFulfilled') //=> true
   ```
@@ -94,8 +87,8 @@ function installPromise(proxy, promise) {
 */
 Ember.PromiseProxyMixin = Ember.Mixin.create({
   reason:    null,
-  isPending:   not('isResolved').readOnly(),
-  isResolved:  or('isRejected', 'isFulfilled').readOnly(),
+  isPending:  not('isSettled').readOnly(),
+  isSettled:  or('isRejected', 'isFulfilled').readOnly(),
   isRejected:  false,
   isFulfilled: false,
 

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -55,7 +55,7 @@ test("fulfillment", function(){
   equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
   equal(get(proxy, 'reason'),      undefined, 'expects the proxy to have no reason');
   equal(get(proxy, 'isPending'),   true,  'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isResolved'),  false, 'expects the proxy to indicate that it is not resolved');
+  equal(get(proxy, 'isSettled'),   false, 'expects the proxy to indicate that it is not settled');
   equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
   equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
@@ -70,7 +70,7 @@ test("fulfillment", function(){
   equal(get(proxy, 'content'),     value, 'expects the proxy to have content');
   equal(get(proxy, 'reason'),      undefined, 'expects the proxy to still have no reason');
   equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is no longer loading');
-  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isSettled'),   true,  'expects the proxy to indicate that it is settled');
   equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
   equal(get(proxy, 'isFulfilled'), true,  'expects the proxy to indicate that it is fulfilled');
 
@@ -87,7 +87,7 @@ test("fulfillment", function(){
   equal(get(proxy, 'content'),     value, 'expects the proxy to have still have same content');
   equal(get(proxy, 'reason'),      undefined, 'expects the proxy still to have no reason');
   equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is no longer loading');
-  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isSettled'),   true,  'expects the proxy to indicate that it is settled');
   equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
   equal(get(proxy, 'isFulfilled'), true,  'expects the proxy to indicate that it is fulfilled');
 
@@ -113,7 +113,7 @@ test("rejection", function(){
   equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
   equal(get(proxy, 'reason'),      undefined, 'expects the proxy to have no reason');
   equal(get(proxy, 'isPending'),   true,  'expects the proxy to indicate that it is loading');
-  equal(get(proxy, 'isResolved'),  false, 'expects the proxy to indicate that it is not resolved');
+  equal(get(proxy, 'isSettled'),   false, 'expects the proxy to indicate that it is not settled');
   equal(get(proxy, 'isRejected'),  false, 'expects the proxy to indicate that it is not rejected');
   equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 
@@ -128,7 +128,7 @@ test("rejection", function(){
   equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
   equal(get(proxy, 'reason'),      reason, 'expects the proxy to have a reason');
   equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is not longer loading');
-  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isSettled'),   true,  'expects the proxy to indicate that it is settled');
   equal(get(proxy, 'isRejected'),  true, 'expects the proxy to indicate that it is  rejected');
   equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
 
@@ -145,7 +145,7 @@ test("rejection", function(){
   equal(get(proxy, 'content'),     undefined, 'expects the proxy to have no content');
   equal(get(proxy, 'reason'),      reason, 'expects the proxy to have a reason');
   equal(get(proxy, 'isPending'),   false, 'expects the proxy to indicate that it is not longer loading');
-  equal(get(proxy, 'isResolved'),  true,  'expects the proxy to indicate that it is resolved');
+  equal(get(proxy, 'isSettled'),   true,  'expects the proxy to indicate that it is settled');
   equal(get(proxy, 'isRejected'),  true, 'expects the proxy to indicate that it is  rejected');
   equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
 });


### PR DESCRIPTION
- utilize RSVP.rethrow + Promise.fail
- update isResolved -> isSettled, to comply with promise/a+ naming conventions
  (cc @domenic)
