### PR TITLE
Update link-to to allow using in non-block form

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -567,9 +567,28 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   Ember.Handlebars.registerHelper('link-to', function(name) {
     var options = [].slice.call(arguments, -1)[0],
         params = [].slice.call(arguments, 0, -1),
+        linkTitle = [].slice.call(params, 0, 1)[0],
         hash = options.hash;
 
     hash.disabledBinding = hash.disabledWhen;
+
+    if(!options.fn) {
+      name = arguments[1];
+
+      if(options.types[0] === "ID") {
+        linkTitle = get(this, linkTitle);
+      }
+
+      if(options.types.length > 2) {
+        options.types = [].slice.call(options.types, 1);
+      }
+
+      options.fn = function() {
+        return linkTitle;
+      };
+
+      params = [].slice.call(params, 1);
+    }
 
     hash.parameters = {
       context: this,

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -685,3 +685,52 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
 test("{{linkTo}} is aliased", function() {
   equal(Ember.Handlebars.helpers.linkTo, Ember.Handlebars.helpers['link-to']);
 });
+
+test("The {{link-to}} helper uses first argument as title if a block is not provided", function() {
+  Router.map(function() {
+    this.route("about");
+  });
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('<h3>Home</h3>{{linkTo "About Page" "about" id="about-link"}}');
+
+  bootApplication();
+
+  Ember.run(function() {
+    router.handleURL("/");
+  });
+
+  equal(Ember.$('#about-link', '#qunit-fixture').attr('href'), '/about', "href attr rendered properly");
+  equal(Ember.$('#about-link', '#qunit-fixture').text(), 'About Page', "first argument is used as link title");
+});
+
+test("The {{link-to}} helper treats first argument as a bound path if it is not a quoted string", function() {
+  Router.map(function() {
+    this.resource("posts", function() {
+      this.route("show", { path: '/:post_id' });
+    });
+  });
+ 
+  var posts = Ember.A([
+    {id: 1, title: "post1"},
+    {id: 2, title: "post2"}
+  ]);
+ 
+  App.IndexController = Ember.Controller.extend();
+  var indexController = container.lookup('controller:index');
+ 
+  Ember.run(function() { indexController.set('posts', posts); });
+ 
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('<h3>Home</h3><ul>{{#each posts}}<li class="post{{unbound id}}">{{linkTo title "posts.show" this}}</li>{{/each}}</ul>');
+ 
+  bootApplication();
+ 
+  Ember.run(function() { router.handleURL("/"); });
+ 
+  var titles = indexController.get('posts').mapProperty('title');
+ 
+  equal(Ember.$('li.post1 a', '#qunit-fixture').text(), titles[0]); 
+  equal(Ember.$('li.post2 a', '#qunit-fixture').text(), titles[1]);
+ 
+  equal(Ember.$('li.post1 a', '#qunit-fixture').attr('href'), '/posts/1');
+  equal(Ember.$('li.post2 a', '#qunit-fixture').attr('href'), '/posts/2');
+});


### PR DESCRIPTION
This PR adds the ability to use `link-to` helper in non-block form. It checks if a block is not provided, and if so, uses the first argument passed as the link title. If the first argument is not a quoted string, the helper looks it up on the current context.

Below are some examples:

``` handlebars
{{link-to 'About Page' 'about}}
```

``` handlebars
{{#each posts}}
  {{link-to title 'posts.show' this}}
{{/each}}
```

I have been working on this with a lot of guidance from @machty (thanks!), and the following discourse topic describes almost all of the process: http://discuss.emberjs.com/t/help-contribute-to-ember-non-block-form-linkto/2039.
