### PR TITLE
Fix bug where link-to wouldn't be active even if resource is active

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -206,7 +206,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       whenever the helpers
      */
     _paramsChanged: function() {
-      this.notifyPropertyChange('routeArgs');
+      this.notifyPropertyChange('resolvedParams');
     },
 
     /**
@@ -251,13 +251,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       var router = get(this, 'router'),
           routeArgs = get(this, 'routeArgs'),
           contexts = routeArgs.slice(1),
-          currentWhen = this.currentWhen || routeArgs[0],
+          resolvedParams = get(this, 'resolvedParams'),
+          currentWhen = this.currentWhen || resolvedParams[0],
           currentWithIndex = currentWhen + '.index',
           isActive = router.isActive.apply(router, [currentWhen].concat(contexts)) ||
                      router.isActive.apply(router, [currentWithIndex].concat(contexts));
 
       if (isActive) { return get(this, 'activeClass'); }
-    }).property('routeArgs', 'router.url'),
+    }).property('resolvedParams', 'routeArgs', 'router.url'),
 
     /**
       Accessed as a classname binding to apply the `LinkView`'s `loadingClass`
@@ -319,6 +320,23 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     /**
       @private
 
+      Computed property that returns the resolved parameters.
+
+      @property
+      @return {Array}
+     */
+    resolvedParams: Ember.computed(function() {
+      var parameters = this.parameters,
+          options = parameters.options,
+          types = options.types,
+          data = options.data;
+
+      return resolveParams(parameters.context, parameters.params, { types: types, data: data });
+    }).property(),
+
+    /**
+      @private
+
       Computed property that returns the current route name and
       any dynamic segments.
 
@@ -327,11 +345,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
      */
     routeArgs: Ember.computed(function() {
 
-      var parameters = this.parameters,
-          options = parameters.options,
-          types = options.types,
-          data = options.data,
-          resolvedParams = resolveParams(parameters.context, parameters.params, { types: types, data: data }),
+      var resolvedParams = get(this, 'resolvedParams').slice(0),
           router = get(this, 'router'),
           namedRoute = resolvedParams[0];
 
@@ -351,7 +365,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       }
 
       return resolvedParams;
-    }).property(),
+    }).property('resolvedParams'),
 
     /**
       Sets the element's `href` attribute to the url for

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -685,3 +685,28 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
 test("{{linkTo}} is aliased", function() {
   equal(Ember.Handlebars.helpers.linkTo, Ember.Handlebars.helpers['link-to']);
 });
+
+test("The {{link-to}} helper is active when a resource is active", function() {
+  Router.map(function() {
+    this.resource("about", function() {
+      this.route("item");
+    });
+  });
+
+  Ember.TEMPLATES.about = compile("<div id='about'>{{#link-to 'about' id='about-link'}}About{{/link-to}} {{#link-to 'about.item' id='item-link'}}Item{{/link-to}} {{outlet}}</div>");
+  Ember.TEMPLATES['about/item'] = compile("");
+  Ember.TEMPLATES['about/index'] = compile("");
+
+  bootApplication();
+
+  Ember.run(router, 'handleURL', '/about');
+
+  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, "The about resource link is active");
+  equal(Ember.$('#item-link.active', '#qunit-fixture').length, 0, "The item route link is inactive");
+
+  Ember.run(router, 'handleURL', '/about/item');
+
+  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, "The about resource link is active");
+  equal(Ember.$('#item-link.active', '#qunit-fixture').length, 1, "The item route link is active");
+
+});


### PR DESCRIPTION
There's a regression in 4cacc46308086cec8db724713befc370ba1383bb where a `link-to 'resource'` would be inactive when the current child route isn't `resource.index`.

For example `{{link-to 'post'}}` would not be active when current route is `post.new` route.
