### PR TITLE
Disabled model factory injections by default.

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -1,3 +1,10 @@
+/**
+ Flag to enable/disable model factory injections (disabled by default)
+ If model factory injections are enabled, models should not be
+ accessed globally (only through `container.lookupFactory('model:modelName'))`);
+*/
+Ember.MODEL_FACTORY_INJECTIONS = false || !!Ember.ENV.MODEL_FACTORY_INJECTIONS;
+
 define("container",
   [],
   function() {
@@ -359,7 +366,7 @@ define("container",
       */
       makeToString: function(factory, fullName) {
         return factory.toString();
-      }, 
+      },
 
       /**
         Given a fullName return a corresponding instance.
@@ -767,6 +774,7 @@ define("container",
       var factory = container.resolve(name);
       var injectedFactory;
       var cache = container.factoryCache;
+      var type = fullName.split(":")[0];
 
       if (!factory) { return; }
 
@@ -774,7 +782,7 @@ define("container",
         return cache.get(fullName);
       }
 
-      if (typeof factory.extend !== 'function') {
+      if (typeof factory.extend !== 'function' || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
         // TODO: think about a 'safe' merge style extension
         // for now just fallback to create time injection
         return factory;

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -21,7 +21,16 @@ var o_create = Object.create || (function(){
   };
 }());
 
-module("Container");
+var originalModelInjections;
+
+module("Container", {
+  setup: function() {
+    originalModelInjections = Ember.MODEL_FACTORY_INJECTIONS;
+  },
+  teardown: function() {
+    Ember.MODEL_FACTORY_INJECTIONS = originalModelInjections;
+  }
+});
 
 var guids = 0;
 
@@ -331,6 +340,8 @@ test("A failed lookup returns undefined", function() {
 });
 
 test("Injecting a failed lookup raises an error", function() {
+  Ember.MODEL_FACTORY_INJECTIONS = true;
+
   var container = new Container();
 
   var fooInstance = {};

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -1,7 +1,10 @@
-var originalLookup, App;
+var originalLookup, App, originalModelInjections;
 
-module("Ember.Application Depedency Injection – toString",{
+module("Ember.Application Dependency Injection – toString",{
   setup: function() {
+    originalModelInjections = Ember.MODEL_FACTORY_INJECTIONS;
+    Ember.MODEL_FACTORY_INJECTIONS = true;
+
     originalLookup = Ember.lookup;
 
     Ember.run(function(){
@@ -12,11 +15,13 @@ module("Ember.Application Depedency Injection – toString",{
     });
 
     App.Post = Ember.Object.extend();
+
   },
 
   teardown: function() {
     Ember.lookup = originalLookup;
     Ember.run(App, 'destroy');
+    Ember.MODEL_FACTORY_INJECTIONS = originalModelInjections;
   }
 });
 

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -1,9 +1,12 @@
 var locator, originalLookup = Ember.lookup, lookup,
     application, set = Ember.set, get = Ember.get,
-    forEach = Ember.ArrayPolyfills.forEach;
+    forEach = Ember.ArrayPolyfills.forEach, originalModelInjections;
 
-module("Ember.Application Depedency Injection", {
+module("Ember.Application Dependency Injection", {
   setup: function() {
+    originalModelInjections = Ember.MODEL_FACTORY_INJECTIONS;
+    Ember.MODEL_FACTORY_INJECTIONS = true;
+
     application = Ember.run(Ember.Application, 'create');
 
     application.Person              = Ember.Object.extend({});
@@ -26,6 +29,7 @@ module("Ember.Application Depedency Injection", {
     Ember.run(application, 'destroy');
     application = locator = null;
     Ember.lookup = originalLookup;
+    Ember.MODEL_FACTORY_INJECTIONS = originalModelInjections;
   }
 });
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -555,7 +555,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     if (!name && sawParams) { return params; }
     else if (!name) { return; }
 
-    var modelClass = this.container.lookupFactory('model:' + name).superclass;
+    var modelClass = this.container.lookupFactory('model:' + name);
     var namespace = get(this, 'router.namespace');
 
     Ember.assert("You used the dynamic segment " + name + "_id in your route, but " + namespace + "." + classify(name) + " did not exist and you did not override your route's `model` hook.", modelClass);
@@ -585,7 +585,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     ```
 
     The default `serialize` method will insert the model's `id` into the
-    route's dynamic segment (in this case, `:post_id`) if the segment contains '_id'. 
+    route's dynamic segment (in this case, `:post_id`) if the segment contains '_id'.
     If the route has multiple dynamic segments or does not contain '_id', `serialize`
     will return `Ember.getProperties(model, params)`
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -35,7 +35,7 @@ test("default model utilizes the container to acquire the model factory", functi
   function lookupFactory(fullName) {
     equal(fullName, "model:post", "correct factory was looked up");
 
-    return Post.extend();
+    return Post;
   }
 
 });


### PR DESCRIPTION
Given that it is currently very common to use models as globals, and that `App.Post !== lookupFactory('model:post')` when factory injections are enabled, it made sense to disable model factory injections by default.

With model injections disabled, `App.Post === lookupFactory('model:post')`.  This will allow for a smooth transition from globals to factory lookups without breaking any apps.

Added the flag `Ember.ENV.MODEL_FACTORY_INJECTIONS` to enable model injections.

Model factory injections will become the default when accessing global models is no longer a common pattern.
