### PR TITLE
Strict Controller#needs

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -27,6 +27,7 @@ function verifyDependencies(controller) {
     // if needs then initialize controllers proxy
     get(controller, 'controllers');
   }
+
   return satisfied;
 }
 
@@ -99,9 +100,11 @@ Ember.ControllerMixin.reopen({
     @default null
   */
   controllers: Ember.computed(function() {
+    var controller = this;
+
     return {
-      needs: get(this, 'needs'),
-      container: get(this, 'container'),
+      needs: get(controller, 'needs'),
+      container: get(controller, 'container'),
       unknownProperty: function(controllerName) {
         var needs = this.needs,
           dependency, i, l;
@@ -111,6 +114,9 @@ Ember.ControllerMixin.reopen({
             return this.container.lookup('controller:' + controllerName);
           }
         }
+
+        var errorMessage = Ember.inspect(controller) + '#needs does not include `' + controllerName + '`. To access the ' + controllerName + ' controller from ' + Ember.inspect(controller) + ', ' + Ember.inspect(controller) + ' should have a `needs` property that is an array of the controllers it has access to.';
+        throw new ReferenceError(errorMessage);
       }
     };
   })

--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -119,5 +119,5 @@ Ember.ControllerMixin.reopen({
         throw new ReferenceError(errorMessage);
       }
     };
-  })
+  }).readOnly()
 });

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -71,3 +71,15 @@ test("raises if trying to get a controller that was not pre-defined in `needs`",
   }, /#needs does not include `baz`/,
   'should throw if no such controller was needed');
 });
+
+test("setting the controllers property directly, should not be possible", function(){
+  var controller = Ember.Controller.create();
+  var controllers = controller.get('controllers');
+
+  throws(function(){
+    controller.set('controllers', 'epic-self-troll');
+  }, /Cannot Set: controllers on:/,
+  'should raise when attempting to set to the controllers property');
+
+  equal(controller.get('controllers'), controllers, 'original controllers CP should have been unchanged');
+});

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -45,7 +45,29 @@ test("Mixin sets up controllers if there is needs before calling super", functio
   container.lookup('controller:posts').set('content', Ember.A(['a','b','c']));
 
   deepEqual(['a','b','c'], container.lookup('controller:other').toArray());
-
   deepEqual(['a','b','c'], container.lookup('controller:another').toArray());
+});
 
+test("raises if trying to get a controller that was not pre-defined in `needs`", function() {
+  var container = new Ember.Container();
+
+  container.register('controller:foo', Ember.Controller.extend());
+  container.register('controller:bar', Ember.Controller.extend({
+    needs: 'foo'
+  }));
+
+  var fooController = container.lookup('controller:foo');
+  var barController = container.lookup('controller:bar');
+
+  throws(function(){
+    fooController.get('controllers.bar');
+  }, /#needs does not include `bar`/,
+  'throws if controllers is accesed but needs not defined');
+
+  equal(barController.get('controllers.foo'), fooController, 'correctly needed controllers should continue to work');
+
+  throws(function(){
+    barController.get('controllers.baz');
+  }, /#needs does not include `baz`/,
+  'should throw if no such controller was needed');
 });


### PR DESCRIPTION
a stricter needs which should remove a whole class of self trolling.
1. attempting to access controllers which are not specified by needs, should behave like a ReferenceError
2. accidentally mutation of the controllers property itself should not be easily possible.
