### PR TITLE
cleanup needs CP

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -8,7 +8,6 @@ var get = Ember.get, set = Ember.set;
 function verifyDependencies(controller) {
   var needs = get(controller, 'needs'),
       container = get(controller, 'container'),
-      satisfied = true,
       dependency, i, l;
 
   for (i=0, l=needs.length; i<l; i++) {
@@ -18,8 +17,7 @@ function verifyDependencies(controller) {
     }
 
     if (!container.has(dependency)) {
-      satisfied = false;
-      Ember.assert(controller + " needs " + dependency + " but it does not exist", false);
+      Ember.assert(Ember.inspect(controller) + " needs " + dependency + " but it does not exist", false);
     }
   }
 
@@ -27,8 +25,6 @@ function verifyDependencies(controller) {
     // if needs then initialize controllers proxy
     get(controller, 'controllers');
   }
-
-  return satisfied;
 }
 
 /**
@@ -68,9 +64,7 @@ Ember.ControllerMixin.reopen({
 
   init: function() {
     // Structure asserts to still do verification but not string concat in production
-    if (!verifyDependencies(this)) {
-      Ember.assert("Missing dependencies", false);
-    }
+    verifyDependencies(this);
 
     this._super.apply(this, arguments);
   },

--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -5,7 +5,7 @@
 
 var get = Ember.get, set = Ember.set;
 
-function verifyDependencies(controller) {
+function verifyNeedsDependencies(controller) {
   var needs = get(controller, 'needs'),
       container = get(controller, 'container'),
       dependency, i, l;
@@ -20,8 +20,12 @@ function verifyDependencies(controller) {
       Ember.assert(Ember.inspect(controller) + " needs " + dependency + " but it does not exist", false);
     }
   }
+}
 
-  if (l > 0) {
+function initilizeControllersProxy(controller) {
+  var length = get(controller, 'needs.length');
+
+  if (length > 0) {
     // if needs then initialize controllers proxy
     get(controller, 'controllers');
   }
@@ -64,7 +68,8 @@ Ember.ControllerMixin.reopen({
 
   init: function() {
     // Structure asserts to still do verification but not string concat in production
-    verifyDependencies(this);
+    verifyNeedsDependencies(this);
+    initilizeControllersProxy(this);
 
     this._super.apply(this, arguments);
   },


### PR DESCRIPTION
- remove un-needed double assertion
- improve assertion message
- extract controllers CP kick into into to improve readbility.
