### PR TITLE
Adds the ability to specify viewClass for render

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1021,6 +1021,11 @@ function setupView(view, container, options) {
     if (options.LOG_VIEW_LOOKUPS) {
       Ember.Logger.info("Rendering " + options.name + " with " + view, { fullName: 'view:' + options.name });
     }
+  } else if(options.viewClass && typeof options.viewClass === 'string') {
+    view = container.lookup('view:'+options.viewClass);
+    if (options.LOG_VIEW_LOOKUPS) {
+      Ember.Logger.info("Rendering " + options.name + " with " + view, { fullName: 'view:' + options.viewClass });
+    }
   } else {
     var defaultView = options.into ? 'view:default' : 'view:toplevel';
     view = container.lookup(defaultView);

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -288,6 +288,28 @@ test("Renders correct view with slash notation", function() {
   equal(Ember.$('p:contains(Home/Page)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
+test("Renders the view given in viewClass", function() {
+  Ember.TEMPLATES['home'] = compile("<p>{{view.name}}</p>");
+
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+    renderTemplate: function() {
+      this.render({viewClass: 'homePage'});
+    }
+  });
+
+  App.HomePageView = Ember.View.extend({
+    name: "Home/Page"
+  });
+
+  bootApplication();
+
+  equal(Ember.$('p:contains(Home/Page)', '#qunit-fixture').length, 1, "The homepage view was rendered");
+});
+
 test('render does not replace templateName if user provided', function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
Right now templateName, controller, outlet and into can be passed to the render helper.
This adds the ability to pass viewClass also while rendering a template.  

This will be useful in implementing modal views.  

One fine example for modal views is @ahawkins [implementation](http://jsbin.com/elenaz/1/edit).
But here the problem is when to have more no.of modals in the application, then a dummy view have to be defined which has no specific logic, just extending the Modal view for the sake of template name alone, as in this
[example](http://jsbin.com/oPIMALo/2/edit).

Before this change,

``` javascript
   App.ApplicationRoute = Ember.Route.extend({
    actions: {
      open: function(name) {
        this.render(name, { into: 'application', outlet: 'modal' });
      },
      open1: function() {
        this.send('open','modal1');
      },
      open2: function() {
        this.send('open','modal2');
      },
      open3: function() {
        this.send('open','modal3');
      },

      close: function() {
        this.render('nothing', { into: 'application', outlet: 'modal'});
      },

      save: function() {
        alert('actions work like normal!');
      }
  }
});
App.ModalView = Ember.View.extend({  
//Modal view logic here
});
App.Modal1View = App.ModalView.extend({});
App.Modal2View = App.ModalView.extend({});
App.Modal3View = App.ModalView.extend({});

```

  After this change

``` javascript
       App.ApplicationRoute = Ember.Route.extend({
        actions: {
          open: function(name) {
            this.render(name, { into: 'application', outlet: 'modal', viewClass:'modal' });
          },
          open1: function() {
            this.send('open','modal1');
          },
          open2: function() {
            this.send('open','modal2');
          },
          open3: function() {
            this.send('open','modal3');
          },

          close: function() {
            this.render('nothing', { into: 'application', outlet:'modal' });
          },

          save: function() {
            alert('actions work like normal!');
          }
        }
        });

```

No more need to create those dummy views
