### PR TITLE
Optimization per @kselden

### DIFF
--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -9,7 +9,7 @@ require('ember-runtime/mixins/array');
 
 var set = Ember.set, get = Ember.get, guidFor = Ember.guidFor;
 var forEach = Ember.EnumerableUtils.forEach,
-    indexOf = Ember.EnumerableUtils.indexOf;
+    indexOf = Ember.ArrayPolyfills.indexOf;
 
 var EachArray = Ember.Object.extend(Ember.Array, {
 


### PR DESCRIPTION
indicies is only ever a native array, so the ArrayPolyfills.indexOf is more efficient than the one from EnumerableUtils
