### PR TITLE
`Ember.computed.sort` fallback to guids.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -505,7 +505,7 @@ Ember.computed.setDiff = function (setAProperty, setBProperty) {
 };
 
 function binarySearch(array, item, low, high) {
-  var mid, midItem, res;
+  var mid, midItem, res, guidMid, guidItem;
 
   if (arguments.length < 4) { high = get(array, 'length'); }
   if (arguments.length < 3) { low = 0; }
@@ -517,10 +517,18 @@ function binarySearch(array, item, low, high) {
   mid = low + Math.floor((high - low) / 2);
   midItem = array.objectAt(mid);
 
-  if (isProxyContent(item, midItem)) {
+  guidMid = _guidFor(midItem);
+  guidItem = _guidFor(item);
+
+  if (guidMid === guidItem) {
     return mid;
   }
+
   res = this.order(midItem, item);
+  if (res === 0) {
+    res = guidMid < guidItem ? -1 : 1;
+  }
+
 
   if (res < 0) {
     return this.binarySearch(array, item, mid+1, high);
@@ -530,13 +538,11 @@ function binarySearch(array, item, low, high) {
 
   return mid;
 
-
-  function isProxyContent(searchItem, item) {
-    if (Ember.ObjectProxy.detectInstance(searchItem)) {
-      return guidFor(get(searchItem, 'content')) === guidFor(item);
+  function _guidFor(item) {
+    if (Ember.ObjectProxy.detectInstance(item)) {
+      return guidFor(get(item, 'content'));
     }
-
-    return false;
+    return guidFor(item);
   }
 }
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -620,6 +620,44 @@ function commonSortTests() {
 
     deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Robb'], "Removing from the dependent array updates the sorted array");
   });
+
+  test("distinct items may be sort-equal, although their relative order will not be guaranteed", function() {
+    var jaime, jaimeInDisguise;
+
+    Ember.run(function() {
+      // We recreate jaime and "Cersei" here only for test stability: we want
+      // their guid-ordering to be deterministic
+      jaimeInDisguise = Ember.Object.create({
+        fname: 'Cersei', lname: 'Lannister', age: 34
+      });
+      jaime = Ember.Object.create({
+        fname: 'Jaime', lname: 'Lannister', age: 34
+      });
+      items = get(obj, 'items');
+
+      items.replace(0, 1, jaime);
+      items.replace(1, 1, jaimeInDisguise);
+      sorted = get(obj, 'sortedItems');
+    });
+
+    deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "precond - array is initially sorted");
+
+    Ember.run(function() {
+      // comparator will now return 0.
+      // Apparently it wasn't a very good disguise.
+      jaimeInDisguise.set('fname', 'Jaime');
+    });
+
+    deepEqual(sorted.mapBy('fname'), ['Jaime', 'Jaime', 'Bran', 'Robb'], "sorted array is updated");
+
+    Ember.run(function() {
+      // comparator will again return non-zero
+      jaimeInDisguise.set('fname', 'Cersei');
+    });
+
+
+    deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "sorted array is updated");
+  });
 }
 
 module('Ember.computed.sort - sortProperties', {
@@ -802,13 +840,13 @@ module('Ember.computed.sort - sort function', {
     Ember.run(function() {
       obj = Ember.Object.createWithMixins({
         items: Ember.A([{
-          fname: "Jaime", lname: "Lannister"
+          fname: "Jaime", lname: "Lannister", age: 34
         }, {
-          fname: "Cersei", lname: "Lannister"
+          fname: "Cersei", lname: "Lannister", age: 34
         }, {
-          fname: "Robb", lname: "Stark"
+          fname: "Robb", lname: "Stark", age: 16
         }, {
-          fname: "Bran", lname: "Stark"
+          fname: "Bran", lname: "Stark", age: 8
         }]),
 
         sortedItems: Ember.computed.sort('items.@each.fname', sortByLnameFname)


### PR DESCRIPTION
It is now legal for a user's sorting to result in different items counted as 
equal for purposes of sorting.  Obviously the relative order of items that
are sort-equal is not guaranteed.

The implementation simply uses guids as a deterministic tie-breaker.

This addresses one of the bugs demonstrated by issue 2 in #3273.
