### PR TITLE
`ReduceComputed` groups changed properties.

### DIFF
--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -109,15 +109,15 @@ ArrayComputedProperty.prototype.resetValue = function (array) {
 
   For property changes triggered on an item property change (when
   depKey is something like `someArray.@each.someProperty`),
-  `changeMeta` may also contain the followng properties:
+  `changeMeta` will also contain the followng property:
 
-    - `keyChanged` the name of the property on the item that changed
-    - `previousValue` the previous value of item.get(keyChanged)
+    - `previousValues` an object whose keys are the properties that changed on
+    the item, and whose values are the item's previous values.
 
-  These properties are important because Ember coalesces item
-  property changes via Ember.run.once. This means that by the time
-  removedItem gets called, item has the new value, but you may need
-  the previous value (eg for sorting & filtering).
+  `previousValues` is important Ember coalesces item property changes via
+  Ember.run.once. This means that by the time removedItem gets called, item has
+  the new values, but you may need the previous value (eg for sorting &
+  filtering).
 
   `instanceMeta` - An object that can be used to store meta
   information needed for calculating your computed. For example a

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -8,6 +8,7 @@ require('ember-runtime/computed/array_computed');
 var get = Ember.get,
     set = Ember.set,
     guidFor = Ember.guidFor,
+    merge = Ember.merge,
     a_slice = [].slice,
     forEach = Ember.EnumerableUtils.forEach,
     map = Ember.EnumerableUtils.map;
@@ -684,9 +685,8 @@ Ember.computed.sort = function (itemsKey, sortDefinition) {
     removedItem: function (array, item, changeMeta, instanceMeta) {
       var proxyProperties, index, searchItem;
 
-      if (changeMeta.keyChanged) {
-        proxyProperties = { content: item };
-        proxyProperties[changeMeta.keyChanged] = changeMeta.previousValue;
+      if (changeMeta.previousValues) {
+        proxyProperties = merge({ content: item }, changeMeta.previousValues);
 
         searchItem = Ember.ObjectProxy.create(proxyProperties);
      } else {

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1,4 +1,4 @@
-var map = Ember.EnumerableUtils.map, a_forEach = Ember.ArrayPolyfills.forEach, get = Ember.get, set = Ember.set,
+var map = Ember.EnumerableUtils.map, a_forEach = Ember.ArrayPolyfills.forEach, get = Ember.get, set = Ember.set, setProperties = Ember.setProperties,
     obj, sorted, sortProps, items, userFnCalls;
 
 module('Ember.computed.map', {
@@ -772,6 +772,28 @@ test("updating an item's sort properties updates the sorted array", function() {
   });
 
   deepEqual(sorted.mapBy('fname'), ['Jaime', 'Tyrion', 'Bran', 'Robb'], "updating an item's sort properties updates the sorted array");
+});
+
+test("updating several of an item's sort properties updated the sorted array", function() {
+  var sansaInDisguise;
+
+  Ember.run(function() {
+    sorted = get(obj, 'sortedItems');
+    items = get(obj, 'items');
+  });
+
+  sansaInDisguise = items.objectAt(1);
+
+  deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "precond - array is initially sorted");
+
+  Ember.run(function() {
+    setProperties(sansaInDisguise, {
+      fname: 'Sansa',
+      lname: 'Stark'
+    });
+  });
+
+  deepEqual(sorted.mapBy('fname'), ['Jaime', 'Bran', 'Robb', 'Sansa'], "updating an item's sort properties updates the sorted array");
 });
 
 test("updating an item's sort properties does not error when binary search does a self compare (#3273)", function() {


### PR DESCRIPTION
This is mostly important for sorting when items are changed via
`setProperties` instead of a sequence of `set`s.
