### PR TITLE
Ember.computed.notNone

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -645,6 +645,35 @@ registerComputed('none', function(dependentKey) {
 });
 
 /**
+  A computed property that returns true of the value of the dependent
+  property is NEITHER null NOR undefined.  This avoids errors from JSLint
+  complaining about use of ==, which can be technically confusing.
+
+  Example
+
+  ```javascript
+  var Hampster = Ember.Object.extend({
+    isHungry: Ember.computed.notNone('food')
+  });
+  var hampster = Hampster.create();
+  hampster.get('isHungry'); // false
+  hampster.set('food', 'Banana');
+  hampster.get('isHungry'); // true
+  hampster.set('food', null);
+  hampster.get('isHungry'); // false
+  ```
+
+  @method computed.notNone
+  @for Ember
+  @param {String} dependentKey
+  @return {Ember.ComputedProperty} computed property which returns true if
+  original value for property is not empty.
+*/
+registerComputed('notNone', function(dependentKey) {
+  return !Ember.isNone(get(this, dependentKey));
+});
+
+/**
   A computed property that returns the inverse boolean value
   of the original value for the dependent property.
 


### PR DESCRIPTION
This is simply a counterpart of `Ember.computed.none`, in line with `Ember.computed.empty` having an `Ember.computed.notEmpty` counterpart.

On a side note, it is rather cumbersome and inconsistent to declare an inverse for these computed properties. Do we declare more inverses for `equal`? Or `bool`? IMO the canonical way of writing these should be unified, and should probably go through the `not` helper. One idea is to allow chaining of computed properties helpers, such that devs can prepend `not` in front of other helpers - much like in programming languages.
