### PR TITLE
fixed duplicated @param

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -287,7 +287,7 @@ Ember.Logger = {
 
    @method assert
    @for Ember.Logger
-   @param @param {Boolean} bool Value to test
+   @param {Boolean} bool Value to test
   */
   assert: consoleMethod('assert') || assertPolyfill
 };


### PR DESCRIPTION
There was a duplicated `@param` in the docs for assert.
