### PR TITLE
Ember.ArrayProxy issue with `arrangedContent` not being initialized

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -144,7 +144,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
     this._setupContent();
   }, 'content'),
 
-  _setupContent: function() {
+  _setupContent: Ember.on('init', function() {
     var content = get(this, 'content');
 
     if (content) {
@@ -153,7 +153,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
         didChange: 'contentArrayDidChange'
       });
     }
-  },
+  }),
 
   _arrangedContentWillChange: Ember.beforeObserver(function() {
     var arrangedContent = get(this, 'arrangedContent'),
@@ -177,7 +177,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
     this.arrangedContentArrayDidChange(this, 0, undefined, len);
   }, 'arrangedContent'),
 
-  _setupArrangedContent: function() {
+  _setupArrangedContent: Ember.on('init', function() {
     var arrangedContent = get(this, 'arrangedContent');
 
     if (arrangedContent) {
@@ -186,7 +186,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
         didChange: 'arrangedContentArrayDidChange'
       });
     }
-  },
+  }),
 
   _teardownArrangedContent: function() {
     var arrangedContent = get(this, 'arrangedContent');
@@ -314,12 +314,6 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
 
   arrangedContentArrayDidChange: function(item, idx, removedCnt, addedCnt) {
     this.arrayContentDidChange(idx, removedCnt, addedCnt);
-  },
-
-  init: function() {
-    this._super();
-    this._setupContent();
-    this._setupArrangedContent();
   },
 
   willDestroy: function() {

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -61,3 +61,14 @@ test("The `arrangedContentDidChange` method is invoked after `content` is change
   proxy.set('content', Ember.A(['a', 'b']));
   equal(callCount, 1, "replacing the content array triggers the hook");
 });
+
+test("`arrangedContent` should be setup when `content` is set in `init` after `this._super()`.", function() {
+  var proxy = Ember.ArrayProxy.extend({
+    init: function() {
+      this._super();
+      this.set('content', Ember.A());
+    }
+  }).create();
+
+  ok(proxy.get('arrangedContent'), 'Arranged content should be set');
+});


### PR DESCRIPTION
`Ember.ArrayProxy` subclasses that sets its `content` property in `init` after `this._super()` stopped working with https://github.com/emberjs/ember.js/commit/d4fd799020c995e784944139c9fd61895d5b5c4f. The `_setupArrangedContent` is now not fired through the observer as it did before. Therefore the `arrangedContent` property will be `null` in examples like this:

Example:

``` javascript
App.MyCrazyArray = Ember.ArrayProxy.extend({
  init: function() {
    this._super();
    this.set('content', Em.A());
  }
});

var a = App.MyCrazyArray.create();
console.log(a.get('arrangedContent')); //`null`, the `content` value would be expected
//Therefore the `length` property is broken:
a.pushObject('John');
console.log(a.get('length')); //`0`, should be `1`
console.log(a.get('content.length')); //`1` (works)
```

So I changed the `_setupContent` and `_setupArrangedContent` to run after `init` using the new `on` feature.
