### PR TITLE
Add placeholder container module description

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -1,4 +1,6 @@
 /**
+Container
+
 @module container
 */
 


### PR DESCRIPTION
/api/modules/container.html can't build without a description (you can see the page [currently 404s](http://emberjs.com/api/modules/container.html))
