### PR TITLE
Notify of _subController property change

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -211,6 +211,7 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
     });
 
     subControllers[idx] = subController;
+    this.notifyPropertyChange('_subControllers');
 
     return subController;
   },


### PR DESCRIPTION
When ArrayControllers instantiate an itemController and insert into the
_subControllers array the member it replaces is `undefined`. This fix
will push a notification for property change when the actual
itemController replaces the `undefined` item.
