### PR TITLE
Add shortcut for whitelisting all modifier keys

### DIFF
--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -39,6 +39,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       return isSimpleClick(event);
     }
 
+    if (allowedKeys.indexOf("any") >= 0) {
+      return true;
+    }
+
     var allowed = true;
 
     forEach.call(keys, function(key) {
@@ -199,6 +203,16 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ```
 
     This way the `{{action}}` will fire when clicking with the alt key pressed down.
+
+    Alternatively, supply "any" to the `allowedKeys` option to accept any combination of modifier keys.
+
+    ```handlebars
+    <script type="text/x-handlebars" data-template-name='a-template'>
+      <div {{action 'anActionName' allowedKeys="any"}}>
+        click me with any key pressed
+      </div>
+    </script>
+    ```
 
     ### Specifying a Target
 

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -244,15 +244,18 @@ test("should register an event handler", function() {
 });
 
 test("handles whitelisted modifier keys", function() {
-  var eventHandlerWasCalled = false;
+  var eventHandlerWasCalled = false, shortcutHandlerWasCalled = false;
 
   var controller = Ember.Controller.extend({
-    actions: { edit: function() { eventHandlerWasCalled = true; } }
+    actions: {
+      edit: function() { eventHandlerWasCalled = true; },
+      shortcut: function() { shortcutHandlerWasCalled = true; }
+    }
   }).create();
 
   view = Ember.View.create({
     controller: controller,
-    template: Ember.Handlebars.compile('<a href="#" {{action "edit" allowedKeys="alt"}}>click me</a>')
+    template: Ember.Handlebars.compile('<a href="#" {{action "edit" allowedKeys="alt"}}>click me</a> <div {{action "shortcut" allowedKeys="any"}}>click me too</div>')
   });
 
   appendView();
@@ -266,8 +269,13 @@ test("handles whitelisted modifier keys", function() {
   view.$('a').trigger(e);
 
   ok(eventHandlerWasCalled, "The event handler was called");
-});
 
+  e = Ember.$.Event('click');
+  e.ctrlKey = true;
+  view.$('div').trigger(e);
+
+  ok(shortcutHandlerWasCalled, "The \"any\" shortcut's event handler was called");
+});
 
 test("should be able to use action more than once for the same event within a view", function() {
   var editWasCalled = false,


### PR DESCRIPTION
For an action subscribing to an event regardless of modifier keys, the template

``` handlebars
<a href="#" {{action "edit" allowedKeys="alt shift meta ctrl"}}>click me</a>
```

becomes

``` handlebars
<a href="#" {{action "edit" allowedKeys="any"}}>click me</a>
```

This lends itself to a cleaner and more future-proof template. Thoughts?
