### PR TITLE
Defeatureify

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -56,6 +56,9 @@ distros.each do |name, modules|
 
     match "{#{name}.js,#{name}.prod.js}" do
       filter HandlebarsPrecompiler
+      if File.exists?("features.json")
+        filter EmberDefeatureify
+      end
       filter AddMicroLoader unless name == "ember-template-compiler"
     end
 

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -77,6 +77,27 @@ Ember.ENV = Ember.ENV || ENV;
 
 Ember.config = Ember.config || {};
 
+/**
+  Hash of enabled Canary features. Add to before creating your application.
+
+  @property FEATURES
+  @type Hash
+*/
+
+Ember.FEATURES = {};
+
+/**
+  Test that a feature is enabled. Parsed by Ember's build tools to leave
+  experimental features out of beta/stable builds.
+
+  @method isEnabled
+  @param {string} feature
+*/
+
+Ember.FEATURES.isEnabled = function(feature) {
+  return Ember.FEATURES[feature];
+};
+
 // ..........................................................
 // BOOTSTRAP
 //


### PR DESCRIPTION
Per recent conversations in #ember-dev, this adds support for feature conditionals as described [here](https://gist.github.com/thomasboyt/a5f4e04e83365eb40afd).

It relies on the `defeatureify` NPM package, so to build a non-Canary build, you'll need to install it:

```
npm install -g defeatureify
```

(travis builds are dependent on #3322. Also builds appear to be breaking when using ember-dev from Git instead of a local directory, not sure what's going on there.)
