### PR TITLE
Allow reduceComputed to have an initial value of 0.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -661,7 +661,7 @@ Ember.reduceComputed = function (options) {
     throw new Error("Reduce Computed Property declared without an options hash");
   }
 
-  if (!options.initialValue) {
+  if (Ember.isNone(options.initialValue)) {
     throw new Error("Reduce Computed Property declared without an initial value");
   }
 


### PR DESCRIPTION
This is necessary to get something like the following computed macro working:

```
Ember.computed.sum = function (dependentKey) {
  return Ember.reduceComputed.call(null, dependentKey, {
    initialValue: 0,

    addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
      return accumulatedValue + item;
    },

    removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
      return accumulatedValue - item;
    }
  });
};
```
