### PR TITLE
[FEATURE container-renderables] Late-registered components, helpers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 * Add query params support to the ember router. You can now define which query params your routes respond to, use them in your route hooks to affect model loading or controller state, and transition query parameters with the link-to helper and the transitionTo method
 * Add a non-block form link-to helper. E.g {{link-to "About us" "about"}} will have "About us" as link text and will transition to the "about" route. Everything works as with the block form link-to.
+* Components and helpers registered on the container can be rendered in templates via their dasherized names. E.g. {{helper-name}} or {{component-name}}
 
 *Ember 1.0.0 (August 31, 2013)*
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -366,7 +366,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     Call `advanceReadiness` after any asynchronous setup logic has completed.
     Each call to `deferReadiness` must be matched by a call to `advanceReadiness`
     or the application will never become ready and routing will not begin.
-    
+
     @method advanceReadiness
     @see {Ember.Application#deferReadiness}
   */
@@ -731,6 +731,11 @@ Ember.Application.reopenClass({
     container.optionsForType('component', { singleton: false });
     container.optionsForType('view', { singleton: false });
     container.optionsForType('template', { instantiate: false });
+
+    if (Ember.FEATURES.isEnabled('container-renderables')) {
+      container.optionsForType('helper', { instantiate: false });
+    }
+
     container.register('application:main', namespace, { instantiate: false });
 
     container.register('controller:basic', Ember.Controller, { instantiate: false });

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -241,6 +241,10 @@ Ember.DefaultResolver = Ember.Object.extend({
     return this.resolveOther(parsedName);
   },
 
+  resolveHelper: function(parsedName) {
+    return this.resolveOther(parsedName) || Ember.Handlebars.helpers[parsedName.fullNameWithoutType];
+  },
+
   /**
     Lookup the model on the Application namespace
 

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -58,6 +58,26 @@ test("the default resolver resolves models on the namespace", function() {
   detectEqual(application.Post, locator.lookupFactory('model:post'), "looks up Post model on application");
 });
 
+if (Ember.FEATURES.isEnabled('container-renderables')) {
+  test("the default resolver resolves helpers from Ember.Handlebars.helpers", function(){
+    function fooresolvertestHelper(){ return 'FOO'; }
+    function barBazResolverTestHelper(){ return 'BAZ'; }
+    Ember.Handlebars.registerHelper('fooresolvertest', fooresolvertestHelper);
+    Ember.Handlebars.registerHelper('bar-baz-resolver-test', barBazResolverTestHelper);
+    equal(fooresolvertestHelper, locator.lookup('helper:fooresolvertest'), "looks up fooresolvertestHelper helper");
+    equal(barBazResolverTestHelper, locator.lookup('helper:bar-baz-resolver-test'), "looks up barBazResolverTestHelper helper");
+  });
+
+  test("the default resolver resolves container-registered helpers", function(){
+    function gooresolvertestHelper(){ return 'GOO'; }
+    function gooGazResolverTestHelper(){ return 'GAZ'; }
+    application.register('helper:gooresolvertest', gooresolvertestHelper);
+    application.register('helper:goo-baz-resolver-test', gooGazResolverTestHelper);
+    equal(gooresolvertestHelper, locator.lookup('helper:gooresolvertest'), "looks up gooresolvertest helper");
+    equal(gooGazResolverTestHelper, locator.lookup('helper:goo-baz-resolver-test'), "looks up gooGazResolverTestHelper helper");
+  });
+}
+
 test("the default resolver throws an error if the fullName to resolve is invalid", function(){
   raises(function(){ locator.resolve(undefined);}, TypeError, /Invalid fullName/ );
   raises(function(){ locator.resolve(null);     }, TypeError, /Invalid fullName/ );

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -91,13 +91,29 @@ Ember.Handlebars.helper = function(name, value) {
   Ember.assert("You tried to register a component named '" + name + "', but component names must include a '-'", !Ember.Component.detect(value) || name.match(/-/));
 
   if (Ember.View.detect(value)) {
-    Ember.Handlebars.registerHelper(name, function(options) {
-      Ember.assert("You can only pass attributes (such as name=value) not bare values to a helper for a View", arguments.length < 2);
-      return Ember.Handlebars.helpers.view.call(this, value, options);
-    });
+    Ember.Handlebars.registerHelper(name, Ember.Handlebars.makeViewHelper(value));
   } else {
     Ember.Handlebars.registerBoundHelper.apply(null, arguments);
   }
+};
+
+/**
+  @private
+
+  Returns a helper function that renders the provided ViewClass.
+
+  Used internally by Ember.Handlebars.helper and other methods
+  involving helper/component registration.
+
+  @method helper
+  @for Ember.Handlebars
+  @param {Function} ViewClass view class constructor
+*/
+Ember.Handlebars.makeViewHelper = function(ViewClass) {
+  return function(options) {
+    Ember.assert("You can only pass attributes (such as name=value) not bare values to a helper for a View", arguments.length < 2);
+    return Ember.Handlebars.helpers.view.call(this, ViewClass, options);
+  };
 };
 
 /**
@@ -156,6 +172,43 @@ Ember.Handlebars.JavaScriptCompiler.prototype.initializeBuffer = function() {
 */
 Ember.Handlebars.JavaScriptCompiler.prototype.appendToBuffer = function(string) {
   return "data.buffer.push("+string+");";
+};
+
+// Hacks ahead:
+// Handlebars presently has a bug where the `blockHelperMissing` hook
+// doesn't get passed the name of the missing helper name, but rather
+// gets passed the value of that missing helper evaluated on the current
+// context, which is most likely `undefined` and totally useless.
+//
+// So we alter the compiled template function to pass the name of the helper
+// instead, as expected.
+//
+// This can go away once the following is closed:
+// https://github.com/wycats/handlebars.js/issues/617
+
+var DOT_LOOKUP_REGEX = /helpers\.(.*?)\)/,
+    BRACKET_STRING_LOOKUP_REGEX = /helpers\['(.*?)'/,
+    INVOCATION_SPLITTING_REGEX = /(.*blockHelperMissing\.call\(.*)(stack[0-9]+)(,.*)/;
+
+Ember.Handlebars.JavaScriptCompiler.stringifyLastBlockHelperMissingInvocation = function(source) {
+  var helperInvocation = source[source.length - 1],
+      helperName = (DOT_LOOKUP_REGEX.exec(helperInvocation) || BRACKET_STRING_LOOKUP_REGEX.exec(helperInvocation))[1],
+      matches = INVOCATION_SPLITTING_REGEX.exec(helperInvocation);
+
+  source[source.length - 1] = matches[1] + "'" + helperName + "'" + matches[3];
+}
+var stringifyBlockHelperMissing = Ember.Handlebars.JavaScriptCompiler.stringifyLastBlockHelperMissingInvocation;
+
+var originalBlockValue = Ember.Handlebars.JavaScriptCompiler.prototype.blockValue;
+Ember.Handlebars.JavaScriptCompiler.prototype.blockValue = function() {
+  originalBlockValue.apply(this, arguments);
+  stringifyBlockHelperMissing(this.source);
+};
+
+var originalAmbiguousBlockValue = Ember.Handlebars.JavaScriptCompiler.prototype.ambiguousBlockValue;
+Ember.Handlebars.JavaScriptCompiler.prototype.ambiguousBlockValue = function() {
+  originalAmbiguousBlockValue.apply(this, arguments);
+  stringifyBlockHelperMissing(this.source);
 };
 
 var prefix = "ember" + (+new Date()), incr = 1;

--- a/packages/ember-handlebars-compiler/tests/block_helper_missing_test.js
+++ b/packages/ember-handlebars-compiler/tests/block_helper_missing_test.js
@@ -1,0 +1,47 @@
+var stringify = Ember.Handlebars.JavaScriptCompiler.stringifyLastBlockHelperMissingInvocation,
+    s;
+
+module("stringifyLastBlockHelperMissingInvocation", {
+  setup: function() {
+  },
+
+  teardown: function() {
+  }
+});
+
+function shouldBecome(expected) {
+  var source = [s];
+  stringify(source);
+  equal(source[0], expected);
+}
+
+test('basic', function() {
+  s = "if (!helpers['expand']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }";
+  shouldBecome("if (!helpers['expand']) { stack1 = blockHelperMissing.call(depth0, 'expand', options); }");
+});
+
+test('dot lookup', function() {
+  s = "if (!helpers.expand) { stack1 = blockHelperMissing.call(depth0, stack1, options); }";
+  shouldBecome("if (!helpers.expand) { stack1 = blockHelperMissing.call(depth0, 'expand', options); }");
+});
+
+test('dot lookup', function() {
+  s = "if (!helpers.view) { stack1 = blockHelperMissing.call(depth0, stack1, options); }";
+  shouldBecome("if (!helpers.view) { stack1 = blockHelperMissing.call(depth0, 'view', options); }");
+});
+
+test('dashed helper invocation', function() {
+  s = "if (!helpers['expand-it']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }";
+  shouldBecome("if (!helpers['expand-it']) { stack1 = blockHelperMissing.call(depth0, 'expand-it', options); }");
+});
+
+test('weird chars invocation', function() {
+  s = "if (!helpers['blorg/snork']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }";
+  shouldBecome("if (!helpers['blorg/snork']) { stack1 = blockHelperMissing.call(depth0, 'blorg/snork', options); }");
+});
+
+test('large stack/depth numbers', function() {
+  s = "if (!helpers['blorg/snork']) { stack6236 = blockHelperMissing.call(depth512, stack6129, options); }";
+  shouldBecome("if (!helpers['blorg/snork']) { stack6236 = blockHelperMissing.call(depth512, 'blorg/snork', options); }");
+});
+

--- a/packages/ember-handlebars/lib/component_lookup.js
+++ b/packages/ember-handlebars/lib/component_lookup.js
@@ -1,0 +1,24 @@
+Ember.ComponentLookup = Ember.Object.extend({
+  lookupFactory: function(name) {
+    var container = this.container,
+        fullName = 'component:' + name,
+        templateFullName = 'template:components/' + name,
+        templateRegistered = container && container.has(templateFullName);
+
+    if (templateRegistered) {
+      container.injection(fullName, 'layout', templateFullName);
+    }
+
+    var Component = container.lookupFactory(fullName);
+
+    // Only treat as a component if either the component
+    // or a template has been registered.
+    if (templateRegistered || Component) {
+      if (!Component) {
+        container.register(fullName, Ember.Component);
+        Component = container.lookupFactory(fullName);
+      }
+      return Component;
+    }
+  }
+});

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -127,14 +127,56 @@ Ember.Handlebars.resolveHash = function(context, hash, options) {
   @param {String} path
   @param {Hash} options
 */
-Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
+Ember.Handlebars.registerHelper('helperMissing', function(path) {
   var error, view = "";
+
+  var options = arguments[arguments.length - 1];
+
+  if (Ember.FEATURES.isEnabled('container-renderables')) {
+
+    var helper = Ember.Handlebars.resolveHelper(options.data.view.container, path);
+
+    if (helper) {
+      return helper.apply(this, slice.call(arguments, 1));
+    }
+  }
 
   error = "%@ Handlebars error: Could not find property '%@' on object %@.";
   if (options.data) {
     view = options.data.view;
   }
   throw new Ember.Error(Ember.String.fmt(error, [view, path, this]));
+});
+
+/**
+  @private
+
+  Registers a helper in Handlebars that will be called if no property with the
+  given name can be found on the current context object, and no helper with
+  that name is registered.
+
+  This throws an exception with a more helpful error message so the user can
+  track down where the problem is happening.
+
+  @method helperMissing
+  @for Ember.Handlebars.helpers
+  @param {String} path
+  @param {Hash} options
+*/
+Ember.Handlebars.registerHelper('blockHelperMissing', function(path) {
+
+  var options = arguments[arguments.length - 1];
+
+  if (Ember.FEATURES.isEnabled('container-renderables')) {
+
+    var helper = Ember.Handlebars.resolveHelper(options.data.view.container, path);
+
+    if (helper) {
+      return helper.apply(this, slice.call(arguments, 1));
+    }
+  }
+
+  return Handlebars.helpers.blockHelperMissing.apply(this, arguments);
 });
 
 /**
@@ -247,7 +289,39 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   @param {String} dependentKeys*
 */
 Ember.Handlebars.registerBoundHelper = function(name, fn) {
-  var dependentKeys = slice.call(arguments, 2);
+  var boundHelperArgs = slice.call(arguments, 1),
+      boundFn = Ember.Handlebars.makeBoundHelper.apply(this, boundHelperArgs);
+  Ember.Handlebars.registerHelper(name, boundFn);
+};
+
+/**
+  @private
+
+  A (mostly) private helper function to `registerBoundHelper`. Takes the
+  provided Handlebars helper function fn and returns it in wrapped
+  bound helper form.
+
+  The main use case for using this outside of `registerBoundHelper`
+  is for registering helpers on the container:
+
+  ```js
+  var boundHelperFn = Ember.Handlebars.makeBoundHelper(function(word) {
+    return word.toUpperCase();
+  });
+
+  container.register('helper:my-bound-helper', boundHelperFn);
+  ```
+
+  In the above example, if the helper function hadn't been wrapped in
+  `makeBoundHelper`, the registered helper would be unbound.
+
+  @method makeBoundHelper
+  @for Ember.Handlebars
+  @param {Function} function
+  @param {String} dependentKeys*
+*/
+Ember.Handlebars.makeBoundHelper = function(fn) {
+  var dependentKeys = slice.call(arguments, 1);
 
   function helper() {
     var properties = slice.call(arguments, 0, -1),
@@ -359,7 +433,7 @@ Ember.Handlebars.registerBoundHelper = function(name, fn) {
   }
 
   helper._rawFunction = fn;
-  Ember.Handlebars.registerHelper(name, helper);
+  return helper;
 };
 
 /**

--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -1,6 +1,7 @@
 /*globals Handlebars */
 
 require("ember-handlebars/ext");
+require("ember-handlebars/component_lookup");
 
 /**
 @module ember
@@ -87,6 +88,10 @@ function registerComponent(container, name) {
   Ember.Handlebars.helper(name, Component);
 }
 
+function registerComponentLookup(container) {
+  container.register('component-lookup:main', Ember.ComponentLookup);
+}
+
 /*
   We tie this to application.load to ensure that we've at least
   attempted to bootstrap at the point that the application is loaded.
@@ -104,9 +109,22 @@ Ember.onLoad('Ember.Application', function(Application) {
     initialize: bootstrap
   });
 
-  Application.initializer({
-    name: 'registerComponents',
-    after: 'domTemplates',
-    initialize: registerComponents
-  });
+  var useNewComponentLookup = false;
+  if (Ember.FEATURES.isEnabled('container-renderables')) {
+    useNewComponentLookup = true;
+  }
+
+  if (useNewComponentLookup) {
+    Application.initializer({
+      name: 'registerComponentLookup',
+      after: 'domTemplates',
+      initialize: registerComponentLookup
+    });
+  } else {
+    Application.initializer({
+      name: 'registerComponents',
+      after: 'domTemplates',
+      initialize: registerComponents
+    });
+  }
 });

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -42,10 +42,12 @@ function boot(callback) {
   });
 }
 
-test("A helper is registered for templates under the components/ directory", function() {
-  boot();
-  ok(Ember.Handlebars.helpers['expand-it'], "The helper is registered");
-});
+if (!Ember.FEATURES.isEnabled('container-renderables')) {
+  test("A helper is registered for templates under the components/ directory", function() {
+    boot();
+    ok(Ember.Handlebars.helpers['expand-it'], "The helper is registered");
+  });
+}
 
 test("The helper becomes the body of the component", function() {
   boot();
@@ -61,3 +63,59 @@ test("If a component is registered, it is used", function() {
 
   equal(Ember.$('div.testing123', '#qunit-fixture').text(), "hello world", "The component is composed correctly");
 });
+
+if (Ember.FEATURES.isEnabled('container-renderables')) {
+
+  test("Late-registered components can be rendered with custom `template` property", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>there goes {{my-hero}}</div>");
+
+    boot(function() {
+      container.register('component:my-hero', Ember.Component.extend({
+        classNames: 'testing123',
+        template: function() { return "watch him as he GOES"; }
+      }));
+    });
+
+    equal(Ember.$('#wrapper').text(), "there goes watch him as he GOES", "The component is composed correctly");
+    ok(!Ember.Handlebars.helpers['my-hero'], "Component wasn't saved to global Handlebars.helpers hash");
+  });
+
+  test("Late-registered components can be rendered with template registered on the container", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{sally-rutherford}} {{#sally-rutherford}}!!!{{/sally-rutherford}}</div>");
+
+    boot(function() {
+      container.register('template:components/sally-rutherford', compile("funkytowny{{yield}}"));
+      container.register('component:sally-rutherford', Ember.Component);
+    });
+
+    equal(Ember.$('#wrapper').text(), "hello world funkytowny funkytowny!!!", "The component is composed correctly");
+    ok(!Ember.Handlebars.helpers['sally-rutherford'], "Component wasn't saved to global Handlebars.helpers hash");
+  });
+
+  test("Late-registered components can be rendered with ONLY the template registered on the container", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{borf-snorlax}} {{#borf-snorlax}}!!!{{/borf-snorlax}}</div>");
+
+    boot(function() {
+      container.register('template:components/borf-snorlax', compile("goodfreakingTIMES{{yield}}"));
+    });
+
+    equal(Ember.$('#wrapper').text(), "hello world goodfreakingTIMES goodfreakingTIMES!!!", "The component is composed correctly");
+    ok(!Ember.Handlebars.helpers['borf-snorlax'], "Component wasn't saved to global Handlebars.helpers hash");
+  });
+
+  test("Component-like invocations are treated as bound paths if neither template nor component are registered on the container", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>{{user-name}} hello {{api-key}} world</div>");
+
+    boot(function() {
+      container.register('controller:application', Ember.Controller.extend({
+        'user-name': 'machty'
+      }));
+    });
+
+    equal(Ember.$('#wrapper').text(), "machty hello  world", "The component is composed correctly");
+  });
+}

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -1,0 +1,101 @@
+var App, container;
+var compile = Ember.Handlebars.compile;
+
+function reverseHelper(value) {
+  return arguments.length > 1 ? value.split('').reverse().join('') : "--";
+}
+
+if (Ember.FEATURES.isEnabled('container-renderables')) {
+
+  module("Application Lifecycle - Helper Registration", {
+    teardown: function() {
+      Ember.run(function() {
+        App.destroy();
+        App = null;
+        Ember.TEMPLATES = {};
+      });
+    }
+  });
+
+  var boot = function(callback) {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        name: 'App',
+        rootElement: '#qunit-fixture'
+      });
+
+      App.deferReadiness();
+
+      App.Router = Ember.Router.extend({
+        location: 'none'
+      });
+
+      container = App.__container__;
+
+      if (callback) { callback(); }
+    });
+
+    var router = container.lookup('router:main');
+
+    Ember.run(App, 'advanceReadiness');
+    Ember.run(function() {
+      router.handleURL('/');
+    });
+  };
+
+  test("Unbound dashed helpers registered on the container can be late-invoked", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf YES}}</div>");
+
+    boot(function() {
+      container.register('helper:x-borf', function(val) {
+        return arguments.length > 1 ? val : "BORF";
+      });
+    });
+
+    equal(Ember.$('#wrapper').text(), "BORF YES", "The helper was invoked from the container");
+    ok(!Ember.Handlebars.helpers['x-borf'], "Container-registered helper doesn't wind up on global helpers hash");
+  });
+
+  test("Bound helpers registered on the container can be late-invoked", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-reverse}} {{x-reverse foo}}</div>");
+
+    boot(function() {
+      container.register('controller:application', Ember.Controller.extend({
+        foo: "alex"
+      }));
+      container.register('helper:x-reverse', Ember.Handlebars.makeBoundHelper(reverseHelper));
+    });
+
+    equal(Ember.$('#wrapper').text(), "-- xela", "The bound helper was invoked from the container");
+    ok(!Ember.Handlebars.helpers['x-reverse'], "Container-registered helper doesn't wind up on global helpers hash");
+  });
+
+  test("Undashed helpers registered on the container can not (presently) be invoked", function() {
+
+    var realHelperMissing = Ember.Handlebars.helpers.helperMissing;
+    Ember.Handlebars.helpers.helperMissing = function() {
+      return "NOHALPER";
+    };
+
+    // Note: the reason we're not allowing undashed helpers is to avoid
+    // a possible perf hit in hot code paths, i.e. _triageMustache.
+    // We only presently perform container lookups if prop.indexOf('-') >= 0
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>{{omg}}|{{omg 'GRRR'}}|{{yorp}}|{{yorp 'ahh'}}</div>");
+
+    boot(function() {
+      container.register('helper:omg', function() {
+        return "OMG";
+      });
+      container.register('helper:yorp', Ember.Handlebars.makeBoundHelper(function() {
+        return "YORP";
+      }));
+    });
+
+    equal(Ember.$('#wrapper').text(), "|NOHALPER||NOHALPER", "The undashed helper was invoked from the container");
+
+    Ember.Handlebars.helpers.helperMissing = realHelperMissing;
+  });
+}


### PR DESCRIPTION
Previously, you couldn't register components without their
templates being on `Ember.TEMPLATES`. Now, any dasherized
handlebars invocation will check to see if a component
or template has been registered under that name, and if so,
render the component. Otherwise, if neither template nor
component are registered on the container, treat the dasherized
HB invocation as a bound property path.

On the helpers side of things, we're making it possible to invoke
helpers registered on the container. Helpers will be registered as plain
ol functions on the container; bound helpers can be stored on the
container by making use of the new `makeBoundHelper` to convert a raw
helper function into a bound helper function. Ember-app-kit and the like
will need to distinguish between raw and bound helpers and decide
whether to store raw functions vs `makeBoundHelper`-wrapped functions on
the container as 'helper:xxxxxx'
- [x] Modify Handlebars to pass string path into `blockHelperMissing`
- [x] Support block invocations of Components
- [x] Move component resolution logic from Handlebars to default Resolver
