### PR TITLE
[Fail at async, please advise ] Add assertion test

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -590,6 +590,29 @@ test("The Specials Page defaults to looking models up via `find`", function() {
   equal(Ember.$('p', '#qunit-fixture').text(), "1", "The model was used to render the template");
 });
 
+
+test("The Specials Page returns an assertion if model is not defined", function(){
+  Router.map(function() {
+    this.resource("special", { path: "/specials/:menu_item_id" });
+  });
+
+  bootApplication();
+
+  var oldAssert = Ember.assert;
+
+  Ember.assert = function(msg, test){
+    if(!test){
+      equal(msg, "You used the dynamic segment menu_item_id in your route special, but App.MenuItem did not exist and you did not override your route's `model` hook.");
+    }
+  };
+
+  Ember.run(function(){
+    router.handleURL("/specials/1");
+  });
+
+  Ember.assert = oldAssert;
+});
+
 test("The Special Page returning a promise puts the app into a loading state until the promise is resolved", function() {
   Router.map(function() {
     this.route("home", { path: "/" });


### PR DESCRIPTION
Hi:

Add an assertion test for Ember.assert when model is not defined for route with dynamic segment.

Although this test passes, it pollutes other async integration tests in `basic-test`:

> Uncaught TypeError: Cannot call method 'find' of undefined
> Source:  
> http://localhost:9292/?package=ember:352

I believe the cause of the error are:
- Even though `Ember.assert` is triggered, the flow continues to `return modelClass.find(value)` with modelClass is nil. 
- store computed property didn't return right away. 

Please advise how to tackle the test pollution? Much appreciated!

Below is what I'm trying to test:

```
 store: Ember.computed(function(){
    var container = this.container;
    var routeName = this.routeName;
    var namespace = get(this, 'router.namespace');

    return {
      find: function(name, value) {
        var modelClass = container.lookupFactory('model:' + name);

        Ember.assert("You used the dynamic segment " + name + "_id in your route "+ routeName + ", but " + namespace + "." + classify(name) + " did not exist and you did not override your route's `model` hook.", modelClass);

        return modelClass.find(value);
      }
    };
```
