### PR TITLE
Close #3307 – Fix unexpected behavior with functions in concatenated properties

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ a test!
 4. Make the test pass.
 
 5. Commit your changes. If your pull request fixes an issue specify it in the commit message.
-Here's an example: `git commit -m "Close #52 - Fix controller and viewbindings"`
+Here's an example: `git commit -m "Close #52 – Fix controller and viewbindings"`
 
 6. Push to your fork and submit a pull request. Please provide us with some
 explanation of why you made the changes you made. For new features make sure to

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -175,15 +175,14 @@ function addNormalizedProperty(base, key, value, meta, descs, values, concats, m
     descs[key]  = value;
     values[key] = undefined;
   } else {
-    // impl super if needed...
-    if (isMethod(value)) {
-      value = giveMethodSuper(base, key, value, values, descs);
-    } else if ((concats && a_indexOf.call(concats, key) >= 0) ||
+    if ((concats && a_indexOf.call(concats, key) >= 0) ||
                 key === 'concatenatedProperties' ||
                 key === 'mergedProperties') {
       value = applyConcatenatedProperties(base, key, value, values);
     } else if ((mergings && a_indexOf.call(mergings, key) >= 0)) {
       value = applyMergedProperties(base, key, value, values);
+    } else if (isMethod(value)) {
+      value = giveMethodSuper(base, key, value, values, descs);
     }
 
     descs[key] = undefined;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -256,7 +256,10 @@ CoreObject.PrototypeMixin = Mixin.create({
     are also concatenated, in addition to `classNames`.
 
     This feature is available for you to use throughout the Ember object model,
-    although typical app developers are likely to use it infrequently.
+    although typical app developers are likely to use it infrequently. Since
+    it changes expectations about behavior of properties, you should properly
+    document its usage in each individual concatenated property (to not 
+    mislead your users to think they can override the property in a subclass).
 
     @property concatenatedProperties
     @type Array

--- a/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -17,8 +17,9 @@
   module("Ember.Object Concatenated Properties", {
     setup: function() {
       klass = Ember.Object.extend({
-        concatenatedProperties: ['values'],
-        values: ['a', 'b', 'c']
+        concatenatedProperties: ['values', 'functions'],
+        values: ['a', 'b', 'c'],
+        functions: [Ember.K]
       });
     }
   });
@@ -77,6 +78,17 @@
     var values = get(obj, 'values'),
         expected = ['a', 'b', 'c', 'd', 'e', 'f'];
     deepEqual(values, expected, Ember.String.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
+  });
+
+  test("concatenates subclasses when the values are functions", function() {
+    var subKlass = klass.extend({
+      functions: Ember.K
+    });
+    var obj = subKlass.create();
+
+    var values = get(obj, 'functions'),
+        expected = [Ember.K, Ember.K];
+    deepEqual(values, expected, Ember.String.fmt("should concatenate functions property (expected: %@, got: %@)", [expected, values]));
   });
 
 


### PR DESCRIPTION
Two remarks:
- The bug was caused by wrong order of two conditions in `addNormalizedProperty` in `mixin.js`. Seeing the history of that file, I was surprised how few bugs it caused, so hats off to core developers.
- Why are concatenated (and merged) properties not implemented using `@_super` and computed properties? Seems so straightforward:

``` coffeescript
  ConcatenatedProperty = (value, opts = {}) ->
      @func = (key, newValue, cachedValue) ->
        if arguments.length is 1
          cachedValue ? do =>
            previous = if opts.isBaseValue then [] else @_super()
            previous.concat Ember.makeArray value
        else
          previous = if opts.isBaseValue then [] else @_super key
          previous.concat Ember.makeArray newValue

  ConcatenatedProperty.prototype = ComputedProperty

  M = Ember.Object.extend
      # concatenatedProperties: ['shared']
      shared: new ConcatenatedProperty Ember.K, isBaseValue: yes
  N = M.extend
      shared: new ConcatenatedProperty Ember.K

  shared = N.create().get 'shared'
  expect(shared).to.have.members [Ember.K, Ember.K]
```
