### PR TITLE
Create Ember.libraries for keeping track of versions for debugging.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -239,12 +239,18 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
     this.scheduleInitialize();
 
-    if (Ember.LOG_VERSION) {
+    Ember.libraries.registerCoreLibrary('Handlebars', Ember.Handlebars.VERSION);
+    Ember.libraries.registerCoreLibrary('jQuery', Ember.$().jquery);
+
+    if ( Ember.LOG_VERSION ) {
       Ember.LOG_VERSION = false; // we only need to see this once per Application#init
+      var maxNameLength = Math.max.apply(this, Ember.A(Ember.libraries).mapBy("name.length"));
+
       Ember.debug('-------------------------------');
-      Ember.debug('Ember.VERSION : ' + Ember.VERSION);
-      Ember.debug('Handlebars.VERSION : ' + Ember.Handlebars.VERSION);
-      Ember.debug('jQuery.VERSION : ' + Ember.$().jquery);
+      Ember.libraries.each(function(name, version) {
+        var spaces = new Array(maxNameLength - name.length + 1).join(" ");
+        Ember.debug([name, '.VERSION', spaces, ' : ', version].join(""));
+      });
       Ember.debug('-------------------------------');
     }
   },

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -1,4 +1,5 @@
 var view;
+var app;
 var application;
 var set = Ember.set, get = Ember.get;
 var forEach = Ember.ArrayPolyfills.forEach;
@@ -34,8 +35,6 @@ module("Ember.Application", {
 });
 
 test("you can make a new application in a non-overlapping element", function() {
-  var app;
-
   Ember.run(function() {
     app = Ember.Application.create({ rootElement: '#two', router: null });
   });
@@ -87,8 +86,6 @@ test("acts like a namespace", function() {
   app.Foo = Ember.Object.extend();
   equal(app.Foo.toString(), "TestApp.Foo", "Classes pick up their parent namespace");
 });
-
-var app;
 
 module("Ember.Application initialization", {
   teardown: function() {
@@ -194,26 +191,30 @@ test("Minimal Application initialized with just an application template", functi
   equal(trim(Ember.$('#qunit-fixture').text()), 'Hello World');
 });
 
-test('enable log  of libraries with an ENV var', function() {
+test('enable log of libraries with an ENV var', function() {
   var debug = Ember.debug;
+  var messages = [];
+
   Ember.LOG_VERSION = true;
 
   Ember.debug = function(message) {
-    ok(true, 'libraries versions logged');
+    messages.push(message);
   };
 
-  Ember.$("#qunit-fixture").empty();
+  Ember.libraries.register("my-lib", "2.0.0a");
 
   Ember.run(function() {
     app = Ember.Application.create({
       rootElement: '#qunit-fixture'
     });
-
-    app.Router.reopen({
-      location: 'none'
-    });
   });
 
+  equal(messages[1], "Ember.VERSION      : " + Ember.VERSION);
+  equal(messages[2], "Handlebars.VERSION : " + Handlebars.VERSION);
+  equal(messages[3], "jQuery.VERSION     : " + Ember.$().jquery);
+  equal(messages[4], "my-lib.VERSION     : " + "2.0.0a");
+
+  Ember.libraries.deRegister("my-lib");
   Ember.LOG_VERSION = false;
   Ember.debug = debug;
 });
@@ -239,5 +240,5 @@ test('disable log version of libraries with an ENV var', function() {
     });
   });
 
-  ok(!logged, 'libraries versions logged');
+  ok(!logged, 'library version logging skipped');
 });

--- a/packages/ember-metal/lib/libraries.js
+++ b/packages/ember-metal/lib/libraries.js
@@ -1,0 +1,40 @@
+// Provides a way to register library versions with ember.
+
+Ember.libraries = function() {
+  var libraries    = [];
+  var coreLibIndex = 0;
+
+  var getLibrary = function(name) {
+    for (var i = 0; i < libraries.length; i++) {
+      if (libraries[i].name === name) {
+        return libraries[i];
+      }
+    }
+  };
+
+  libraries.register = function(name, version) {
+    if (!getLibrary(name)) {
+      libraries.push({name: name, version: version});
+    }
+  };
+
+  libraries.registerCoreLibrary = function(name, version) {
+    if (!getLibrary(name)) {
+      libraries.splice(coreLibIndex++, 0, {name: name, version: version});
+    }
+  };
+
+  libraries.deRegister = function(name) {
+    var lib = getLibrary(name);
+    if (lib) libraries.splice(libraries.indexOf(lib), 1);
+  };
+
+  libraries.each = function (callback) {
+    libraries.forEach(function(lib) {
+      callback(lib.name, lib.version);
+    });
+  };
+  return libraries;
+}();
+
+Ember.libraries.registerCoreLibrary('Ember', Ember.VERSION);

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -26,3 +26,4 @@ require('ember-metal/observer');
 require('ember-metal/mixin');
 require('ember-metal/binding');
 require('ember-metal/run_loop');
+require('ember-metal/libraries');

--- a/packages/ember-metal/tests/libraries_test.js
+++ b/packages/ember-metal/tests/libraries_test.js
@@ -1,0 +1,48 @@
+var libs = Ember.libraries;
+
+test('Ember registers itself', function() {
+  equal(libs[0].name, "Ember");
+});
+
+test('core libraries come before other libraries', function() {
+  var l = libs.length;
+
+  libs.register("my-lib", "2.0.0a");
+  libs.registerCoreLibrary("DS", "1.0.0-beta.2");
+
+  equal(libs[l].name, "DS");
+  equal(libs[l+1].name, "my-lib");
+
+  libs.deRegister("my-lib");
+  libs.deRegister("DS");
+});
+
+test('only the first registration of a library is stored', function() {
+  var l = libs.length;
+
+  libs.register("magic", 1.23);
+  libs.register("magic", 2.23);
+  libs.register("magic", 3.23);
+
+  equal(libs[l].name, "magic");
+  equal(libs[l].version, 1.23);
+  equal(libs.length, l+1);
+
+  libs.deRegister("magic");
+});
+
+test('libraries can be de-registered', function() {
+  var l = libs.length;
+
+  libs.register("lib1", "1.0.0b");
+  libs.register("lib2", "1.0.0b");
+  libs.register("lib3", "1.0.0b");
+
+  libs.deRegister("lib1");
+  libs.deRegister("lib3");
+
+  equal(libs[l].name, "lib2");
+  equal(libs.length, l+1);
+
+  libs.deRegister("lib2");
+});


### PR DESCRIPTION
Ember registers its libraries and external libraries can register themselves, so given:

``` javascript
Ember.libraries.register("Emberella", "0.0.1");
```

We get:

``` text
DEBUG: -------------------------------
DEBUG: Ember.VERSION      : 1.0.0
DEBUG: Handlebars.VERSION : 1.0.0
DEBUG: jQuery.VERSION     : 1.10.2
DEBUG: Emberella.VERSION  : 0.0.1
DEBUG: ------------------------------- 
```
