### PR TITLE
Remove the .VERSION from library version logging.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -249,7 +249,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
       Ember.debug('-------------------------------');
       Ember.libraries.each(function(name, version) {
         var spaces = new Array(maxNameLength - name.length + 1).join(" ");
-        Ember.debug([name, '.VERSION', spaces, ' : ', version].join(""));
+        Ember.debug([name, spaces, ' : ', version].join(""));
       });
       Ember.debug('-------------------------------');
     }

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -209,10 +209,10 @@ test('enable log of libraries with an ENV var', function() {
     });
   });
 
-  equal(messages[1], "Ember.VERSION      : " + Ember.VERSION);
-  equal(messages[2], "Handlebars.VERSION : " + Handlebars.VERSION);
-  equal(messages[3], "jQuery.VERSION     : " + Ember.$().jquery);
-  equal(messages[4], "my-lib.VERSION     : " + "2.0.0a");
+  equal(messages[1], "Ember      : " + Ember.VERSION);
+  equal(messages[2], "Handlebars : " + Handlebars.VERSION);
+  equal(messages[3], "jQuery     : " + Ember.$().jquery);
+  equal(messages[4], "my-lib     : " + "2.0.0a");
 
   Ember.libraries.deRegister("my-lib");
   Ember.LOG_VERSION = false;


### PR DESCRIPTION
Makes sense for Ember and Handlebars but falls apart for `jQuery.VERSION`, `Ember Data.VERSION` and any library whose common name doesn't also happen to be its namespace.
