### PR TITLE
`Ember.TargetActionSupport`'s `sendAction` should support `null` as context

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -102,9 +102,13 @@ Ember.TargetActionSupport = Ember.Mixin.create({
   */
   triggerAction: function(opts) {
     opts = opts || {};
-    var action = opts['action'] || get(this, 'action'),
-        target = opts['target'] || get(this, 'targetObject'),
-        actionContext = opts['actionContext'] || get(this, 'actionContextObject') || this;
+    var action = opts.action || get(this, 'action'),
+        target = opts.target || get(this, 'targetObject'),
+        actionContext = opts.actionContext;
+
+    if (typeof actionContext === 'undefined') {
+      actionContext = get(this, 'actionContextObject') || this;
+    }
 
     if (target && action) {
       var ret;

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -144,3 +144,16 @@ test("it should use the actionContext specified in the argument", function() {
   });
   ok(true === obj.triggerAction({actionContext: context}), "a valid target and action were specified");
 });
+
+test("it should use a null value specified in the actionContext argument", function() {
+  expect(2);
+  var obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+    target: Ember.Object.create({
+      anEvent: function(ctx) {
+        ok(null === ctx, "anEvent method was called with the expected context (null)");
+      }
+    }),
+    action: 'anEvent'
+  });
+  ok(true === obj.triggerAction({actionContext: null}), "a valid target and action were specified");
+});


### PR DESCRIPTION
Doing:

``` javascript
this.sendAction('someAction', null);
```

in e.g. components do not have the expected behavior = that `null` is received as the context in the other end. Instead, since `opts['actionContext']` is not truthy, the `actionContextObject` property or `this` would be used as a default.

I also shaved off a few bytes by using `.property` instead of `['property']`.
