### PR TITLE
Allow to inject falsy values like 'false' and 'null'

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -421,7 +421,7 @@ define("container",
 
         var value = instantiate(this, fullName);
 
-        if (!value) { return; }
+        if (value === undefined) { return; }
 
         if (isSingleton(this, fullName) && options.singleton !== false) {
           this.cache.set(fullName, value);
@@ -747,7 +747,7 @@ define("container",
         injection = injections[i];
         lookup = container.lookup(injection.fullName);
 
-        if (lookup) {
+        if (lookup !== undefined) {
           hash[injection.property] = lookup;
         } else {
           throw new Error('Attempting to inject an unknown injection: `' + injection.fullName + '`');
@@ -779,13 +779,13 @@ define("container",
       var cache = container.factoryCache;
       var type = fullName.split(":")[0];
 
-      if (!factory) { return; }
+      if (factory === undefined) { return; }
 
       if (cache.has(fullName)) {
         return cache.get(fullName);
       }
 
-      if (typeof factory.extend !== 'function' || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
+      if (!factory || typeof factory.extend !== 'function' || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
         // TODO: think about a 'safe' merge style extension
         // for now just fallback to create time injection
         return factory;

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -360,6 +360,17 @@ test("Injecting a failed lookup raises an error", function() {
   });
 });
 
+test("Injecting a falsy value does not raise an error", function() {
+  var container = new Container();
+  var ApplicationController = factory();
+
+  container.register('controller:application', ApplicationController);
+  container.register('user:current', null, { instantiate: false });
+  container.injection('controller:application', 'currentUser', 'user:current');
+
+  equal(container.lookup('controller:application').currentUser, null);
+});
+
 test("Destroying the container destroys any cached singletons", function() {
   var container = new Container();
   var PostController = factory();


### PR DESCRIPTION
Only `undefined` should signify that there is nothing to inject (i.e. nothing was registered) and hence to throw an error; injecting `false` and `null` should be working though.

One of the use cases is to be able to inject `currentUser` into controllers and routes. If the user isn't signed in, it'd be `null`. Currently it throws an error but I actually expected it to work properly (i.e. set `currentUser` on controllers and routes to `null` without throwing anything).
