### PR TITLE
fix missing backquotes on link-to docs

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -544,6 +544,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     {{#link-to  aPhoto tagName='li' title='Following this link will change your life' classNames=['pic', 'sweet']}}
       Uh-mazing!
     {{/link-to}}
+    ```
 
     See {{#crossLink "Ember.LinkView"}}{{/crossLink}} for a
     complete list of overrideable properties. Be sure to also


### PR DESCRIPTION
link-to documentation is not rendering properly on the website
(see http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_link-to)
