### PR TITLE
fix docs for helpers

### DIFF
--- a/packages/ember-handlebars/lib/helpers/yield.js
+++ b/packages/ember-handlebars/lib/helpers/yield.js
@@ -6,7 +6,6 @@
 var get = Ember.get, set = Ember.set;
 
 /**
-
   `{{yield}}` denotes an area of a template that will be rendered inside
   of another template. It has two main uses:
 

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -576,7 +576,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     @for Ember.Handlebars.helpers
     @param {String} routeName
     @param {Object} [context]*
-    @param [options] {Object} Handlebars key/value pairs of options, you can over-ride any property of {{#crossLink "Ember.LinkView"}}{{/crossLink}}
+    @param [options] {Object} Handlebars key/value pairs of options, you can override any property of Ember.LinkView
     @return {String} HTML string
     @see {Ember.LinkView}
   */


### PR DESCRIPTION
fix yield documentation so it is generated properly and
remove crossLink from linkTo @params as it's not supported
