### PR TITLE
Resolve initial RouterClass load.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -232,8 +232,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     if (!this.$) { this.$ = Ember.$; }
     this.__container__ = this.buildContainer();
 
-    this.Router = this.Router || this.defaultRouter();
-    if (this.Router) { this.Router.namespace = this; }
+    this.Router = this.defaultRouter();
 
     this._super();
 
@@ -292,13 +291,17 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     @method defaultRouter
     @return {Ember.Router} the default router
   */
+
   defaultRouter: function() {
-    // Create a default App.Router if one was not supplied to make
-    // it possible to do App.Router.map(...) without explicitly
-    // creating a router first.
-    if (this.router === undefined) {
-      return Ember.Router.extend();
+    if (this.Router === false) { return; }
+    var container = this.__container__;
+
+    if (this.Router) {
+      container.unregister('router:main');
+      container.register('router:main', this.Router);
     }
+
+    return container.lookupFactory('router:main');
   },
 
   /**
@@ -455,7 +458,9 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
     // At this point, the App.Router must already be assigned
     if (this.Router) {
-      this.register('router:main', this.Router);
+      var container = this.__container__;
+      container.unregister('router:main');
+      container.register('router:main', this.Router);
     }
 
     this.runInitializers();
@@ -734,6 +739,7 @@ Ember.Application.reopenClass({
     container.register('route:basic', Ember.Route, { instantiate: false });
     container.register('event_dispatcher:main', Ember.EventDispatcher);
 
+    container.register('router:main',  Ember.Router);
     container.injection('router:main', 'namespace', 'application:main');
 
     container.injection('controller', 'target', 'router:main');

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -242,3 +242,25 @@ test('disable log version of libraries with an ENV var', function() {
 
   ok(!logged, 'library version logging skipped');
 });
+
+test("can resolve custom router", function(){
+  var CustomRouter = Ember.Router.extend();
+
+  var CustomResolver = Ember.DefaultResolver.extend({
+    resolveOther: function(parsedName){
+      if (parsedName.type === "router") {
+        return CustomRouter;
+      } else {
+        return this._super(parsedName);
+      }
+    }
+  });
+
+  app = Ember.run(function(){
+    return Ember.Application.create({
+      Resolver: CustomResolver
+    });
+  });
+
+  ok(app.__container__.lookup('router:main') instanceof CustomRouter, 'application resolved the correct router');
+});

--- a/packages/ember/tests/application_lifecycle.js
+++ b/packages/ember/tests/application_lifecycle.js
@@ -7,11 +7,11 @@ module("Application Lifecycle", {
         rootElement: '#qunit-fixture'
       });
 
-      App.deferReadiness();
-
-      App.Router = Ember.Router.extend({
+      App.Router.extend({
         location: 'none'
       });
+
+      App.deferReadiness();
 
       container = App.__container__;
     });


### PR DESCRIPTION
This PR allows for a custom router to be resolved, before this was not possible.

seems to fix #3362

Some tricky bits, which resulted in mode codez, were that we allow post creation time Router swaps, and reopenings. 
