### PR TITLE
Fire observers for array computed changes.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -5,6 +5,8 @@ var e_get = Ember.get,
     set = Ember.set,
     guidFor = Ember.guidFor,
     metaFor = Ember.meta,
+    propertyWillChange = Ember.propertyWillChange,
+    propertyDidChange = Ember.propertyDidChange,
     addBeforeObserver = Ember.addBeforeObserver,
     removeBeforeObserver = Ember.removeBeforeObserver,
     addObserver = Ember.addObserver,
@@ -75,7 +77,7 @@ function ItemPropertyObserverContext (dependentArray, index, trackedArray) {
 
 DependentArraysObserver.prototype = {
   setValue: function (newValue) {
-    this.instanceMeta.setValue(newValue);
+    this.instanceMeta.setValue(newValue, true);
   },
   getValue: function () {
     return this.instanceMeta.getValue();
@@ -370,11 +372,21 @@ ReduceComputedPropertyInstanceMeta.prototype = {
     }
   },
 
-  setValue: function(newValue) {
+  setValue: function(newValue, triggerObservers) {
     // This lets sugars force a recomputation, handy for very simple
     // implementations of eg max.
     if (newValue !== undefined) {
+      var fireObservers = triggerObservers && (newValue !== this.cache[this.propertyName]);
+
+      if (fireObservers) {
+        propertyWillChange(this.context, this.propertyName);
+      }
+
       this.cache[this.propertyName] = newValue;
+
+      if (fireObservers) {
+        propertyDidChange(this.context, this.propertyName);
+      }
     } else {
       delete this.cache[this.propertyName];
     }
@@ -639,6 +651,12 @@ ReduceComputedProperty.prototype.property = function () {
   value. It is acceptable to not return anything (ie return undefined)
   to invalidate the computation. This is generally not a good idea for
   arrayComputed but it's used in eg max and min.
+
+  Note that observers will be fired if either of these functions return a value
+  that differs from the accumulated value.  When returning an object that
+  mutates in response to array changes, for example an array that maps
+  everything from some other array (see `Ember.computed.map`), it is usually
+  important that the *same* array be returned to avoid accidentally triggering observers.
 
   Example
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -168,6 +168,23 @@ test("it maps properties", function() {
   deepEqual(get(obj, 'mapped'), [1, 3, 2, 5]);
 });
 
+test("it is observerable", function() {
+  var mapped = get(obj, 'mapped'),
+      calls = 0;
+
+  deepEqual(get(obj, 'mapped'), [1, 3, 2, 1]);
+
+  Ember.addObserver(obj, 'mapped.@each', function() {
+    calls++;
+  });
+
+  Ember.run(function() {
+    obj.get('array').pushObject({ v: 5 });
+  });
+
+  equal(calls, 1, 'Ember.computed.mapBy is observerable');
+});
+
 
 module('Ember.computed.filter', {
   setup: function() {
@@ -1100,7 +1117,6 @@ test("filtering, sorting and reduce (max) can be combined", function() {
   equal(35, get(obj, 'oldestStarkAge'), "chain is updated correctly");
 });
 
-
 function todo(name, priority) {
   return Ember.Object.create({name: name, priority: priority});
 }
@@ -1160,3 +1176,43 @@ test("it can filter and sort when both depend on the same item property", functi
   deepEqual(sorted.mapProperty('name'), ['A', 'B', 'C', 'E', 'D'], "precond - sorted updated correctly");
   deepEqual(filtered.mapProperty('name'), ['A', 'C', 'E', 'D'], "filtered updated correctly");
 });
+
+module('Chaining array and reduced CPs', {
+  setup: function() {
+    Ember.run(function() {
+      userFnCalls = 0;
+      obj = Ember.Object.createWithMixins({
+        array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
+        mapped: Ember.computed.mapBy('array', 'v'),
+        max: Ember.computed.max('mapped'),
+        maxDidChange: Ember.observer(function(){
+          userFnCalls++;
+        },'max')
+      });
+    });
+  },
+  teardown: function() {
+    Ember.run(function() {
+      obj.destroy();
+    });
+  }
+});
+
+test("it computes interdependent array computed properties", function() {
+  var mapped = get(obj, 'mapped');
+
+  equal(get(obj, 'max'), 3, 'sanity - it properly computes the maximum value');
+  equal(userFnCalls, 0, 'observer is not called on initialisation');
+
+  var calls = 0;
+  Ember.addObserver(obj, 'max', function(){ calls++ });
+
+  Ember.run(function() {
+    obj.get('array').pushObject({ v: 5 });
+  });
+
+  equal(get(obj, 'max'), 5, 'maximum value is updated correctly');
+  equal(userFnCalls, 1, 'object defined observers fire');
+  equal(calls, 1, 'runtime created observers fire');
+});
+

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1205,7 +1205,7 @@ test("it computes interdependent array computed properties", function() {
   equal(userFnCalls, 0, 'observer is not called on initialisation');
 
   var calls = 0;
-  Ember.addObserver(obj, 'max', function(){ calls++ });
+  Ember.addObserver(obj, 'max', function(){ calls++; });
 
   Ember.run(function() {
     obj.get('array').pushObject({ v: 5 });


### PR DESCRIPTION
When dealing with chains of arrays, it is not necessary (or correct) to
fire non-array observers when array contents change, but the array itself
does not.

However, for other `ReduceComputedProperty`s, such as  
`Ember.computed.max`, it is necessary to fire observers in response to  
upstream array changes.                                                  

Thanks @ssured for pointing this out, and for providing tests!
