### PR TITLE
reduceComputed dependent keys may refer to @self.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -1,7 +1,7 @@
 require('ember-metal/computed');
 require('ember-runtime/mixins/array');
 
-var get = Ember.get,
+var e_get = Ember.get,
     set = Ember.set,
     guidFor = Ember.guidFor,
     metaFor = Ember.meta,
@@ -17,6 +17,16 @@ var get = Ember.get,
     // testing, but there's no particular reason why it should be disallowed.
     eachPropertyPattern = /^(.*)\.@each\.(.*)/,
     doubleEachPropertyPattern = /(.*\.@each){2,}/;
+
+function get(obj, key) {
+  if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
+    if (key === '@self') {
+      return obj;
+    }
+  }
+
+  return e_get(obj, key);
+}
 
 /*
   Tracks changes to dependent arrays, as well as to properties of items in
@@ -641,6 +651,37 @@ ReduceComputedProperty.prototype.property = function () {
       }
     });
   };
+  ```
+
+  Dependent keys may refer to `@self` to observe changes to the object itself,
+  which must be array-like, rather than a property of the object.  This is
+  mostly useful for array proxies, to ensure objects are retrieved via
+  `objectAtContent`.  This is how you could sort items by properties defined on an item controller.
+
+  Example
+
+  ```javascript
+  App.PeopleController = Ember.ArrayController.extend({
+    itemController: 'person',
+
+    sortedPeople: Ember.computed.sort('@self.@each.reversedName', function(personA, personB) {
+      // `reversedName` isn't defined on Person, but we have access to it via
+      // the item controller App.PersonController.  If we'd used
+      // `content.@each.reversedName` above, we would be getting the objects
+      // directly and not have access to `reversedName`.
+      //
+      var reversedNameA = get(personA, 'reversedName'),
+          reversedNameB = get(personB, 'reversedName');
+
+      return Ember.compare(reversedNameA, reversedNameB);
+    })
+  });
+
+  App.PersonController = Ember.ObjectController.extend({
+    reversedName: function () {
+      return reverse(get(this, 'name'));
+    }.property('name')
+  })
   ```
 
   @method reduceComputed

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -144,7 +144,7 @@ test("when the underlying array changes, old subcontainers are destroyed", funct
       cerseiController = subControllers[2];
 
   equal(!!jaimeController.isDestroying, false, "precond - nobody is destroyed yet");
-  equal(!!!!cerseiController.isDestroying, false, "precond - nobody is destroyed yet");
+  equal(!!cerseiController.isDestroying, false, "precond - nobody is destroyed yet");
 
   Ember.run(function() {
     arrayController.set('content', Ember.A());

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -279,3 +279,48 @@ test("array observers can invoke `objectAt` without overwriting existing item co
   equal(arrayObserverCalled, true, "Array observers are called normally");
   equal(tywinController.get('name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' content");
 });
+
+if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
+  module('Ember.ArrayController - itemController with arrayComputed', {
+    setup: function() {
+      container = new Ember.Container();
+
+      cersei = Ember.Object.create({ name: 'Cersei' });
+      jaime = Ember.Object.create({ name: 'Jaime' });
+      lannisters = Ember.A([ jaime, cersei ]);
+
+      controllerClass = Ember.ObjectController.extend({
+        title: Ember.computed(function () {
+          switch (get(this, 'name')) {
+            case 'Jaime':   return 'Kingsguard';
+            case 'Cersei':  return 'Queen';
+          }
+        }).property('name'),
+
+        toString: function() {
+          return "itemController for " + this.get('name');
+        }
+      });
+
+      container.register("controller:Item", controllerClass);
+    },
+    teardown: function() {
+      Ember.run(function() {
+        container.destroy();
+      });
+    }
+  });
+
+  test("item controllers can be used to provide properties for array computed macros", function() {
+    createArrayController();
+
+    ok(Ember.compare(Ember.guidFor(cersei), Ember.guidFor(jaime)) < 0, "precond - guid tiebreaker would fail test");
+
+    arrayController.reopen({
+      sortProperties: Ember.A(['title']),
+      sorted: Ember.computed.sort('@self', 'sortProperties')
+    });
+
+    deepEqual(arrayController.get('sorted').mapProperty('name'), ['Jaime', 'Cersei'], "ArrayController items can be sorted on itemController properties");
+  });
+}


### PR DESCRIPTION
This is mostly useful for array proxies, and in particular array
controllers that use item controllers.  This allows users to, for
instance, sort items according to properties specified on array
controllers.

@self is implemented only in reduceComputed because it doesn't really make
sense for non-reduceComputed CPs.

@tchak does this PR resolve your use case?
