### PR TITLE
Added `Em.O` (shorthand for `Ember.Object.create`)

### DIFF
--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -6,6 +6,34 @@ require('ember-runtime/system/core_object');
 @submodule ember-runtime
 */
 
+if (Ember.FEATURES.isEnabled("em-o")) {
+  /**
+    Shorthand for `Ember.Object.create(properties)`.
+
+    Wraps a vanilla/native object in an `Ember.Object` instance with the same
+    properties. The `properties` argument will not be altered.
+
+    If you pass an instance of `Ember.Object` as the `properties` argument, the
+    same object will be returned.
+ 
+    Example:
+ 
+    ```javascript
+    var john1 = Ember.O({name: 'John'});
+    //...has the same effect as:
+    var john2 = Ember.Object.create({name: 'John'});
+
+    console.log(john1 === Em.O(john1); //true
+    ```
+ 
+    @param {Object} [properties]
+    @returns Ember.Object
+  */
+  Ember.O = function(properties) {
+    return Ember.Object.detectInstance(properties) ? properties : Ember.Object.create(properties);
+  };
+}
+
 /**
   `Ember.Object` is the main base class for all Ember objects. It is a subclass
   of `Ember.CoreObject` with the `Ember.Observable` mixin applied. For details,

--- a/packages/ember-runtime/tests/system/object/o_test.js
+++ b/packages/ember-runtime/tests/system/object/o_test.js
@@ -1,0 +1,25 @@
+if (Ember.FEATURES.isEnabled("em-o")) {
+  module('Ember.O');
+    
+  test("wraps a native object", function() {
+    var o = Ember.O({ohai: 'there'});
+    ok(o instanceof Ember.Object, 'is an Ember.Object instance');
+    equal(o.get('ohai'), 'there', 'property was assigned');
+  });
+    
+  test("wraps null", function() {
+    var o = Ember.O(null);
+    ok(o instanceof Ember.Object, 'is an Ember.Object instance');
+  });
+    
+  test("wraps undefined", function() {
+    var o = Ember.O();
+    ok(o instanceof Ember.Object, 'is an Ember.Object instance');
+  });
+    
+  test("returns same Ember.Object", function() {
+    var o1 = Ember.Object.create({ohai: 'there'});
+    var o2 = Ember.O(o1);
+    strictEqual(o1, o2, 'are the same objects');
+  });
+}


### PR DESCRIPTION
I'm not sure if this is something you want in the framework, but I find this syntax a lot nicer when creating a lot of objects:

```
[
  Em.O({
    name: 'Tarzan'
  }),
  Em.O({
    name: 'Jane'
  }),
]
```

= :yum: 

vs.

``` javascript
[
  Em.Object.create({
    name: 'Tarzan'
  }),
  Em.Object.create(({
    name: 'Jane'
  }),
]
```

= :weary: 

It's like `Em.A`, but for objects.
