### PR TITLE
A way to let users define custom made bound {{if}} statements

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -19,7 +19,7 @@ function exists(value) {
 
 // Binds a property into the DOM. This will create a hook in DOM that the
 // KVO system will look for and update if the property changes.
-function bind(property, options, preserveContext, shouldDisplay, valueNormalizer, childProperties) {
+helpers._bind = function(property, options, preserveContext, shouldDisplay, valueNormalizer, childProperties) {
   var data = options.data,
       fn = options.fn,
       inverse = options.inverse,
@@ -89,7 +89,7 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
     // be done with it.
     data.buffer.push(handlebarsGet(currentContext, property, options));
   }
-}
+};
 
 function simpleBind(property, options) {
   var data = options.data,
@@ -195,7 +195,7 @@ EmberHandlebars.registerHelper('bind', function(property, options) {
     return simpleBind.call(context, property, options);
   }
 
-  return bind.call(context, property, options, false, exists);
+  return helpers._bind.call(context, property, options, false, exists);
 });
 
 /**
@@ -229,7 +229,7 @@ EmberHandlebars.registerHelper('boundIf', function(property, fn) {
     }
   };
 
-  return bind.call(context, property, fn, true, func, func, ['isTruthy', 'length']);
+  return helpers._bind.call(context, property, fn, true, func, func, ['isTruthy', 'length']);
 });
 
 /**
@@ -267,7 +267,7 @@ EmberHandlebars.registerHelper('with', function(context, options) {
       Ember.bind(options.data.keywords, keywordName, contextPath);
     }
 
-    return bind.call(this, path, options, true, exists);
+    return helpers._bind.call(this, path, options, true, exists);
   } else {
     Ember.assert("You must pass exactly one argument to the with helper", arguments.length === 2);
     Ember.assert("You must pass a block to the with helper", options.fn && options.fn !== Handlebars.VM.noop);

--- a/packages/ember-handlebars/tests/helpers/custom_bounded_if_test.js
+++ b/packages/ember-handlebars/tests/helpers/custom_bounded_if_test.js
@@ -1,0 +1,116 @@
+/*globals TemplateTests*/
+
+var get = Ember.get, set = Ember.set;
+
+var view;
+
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+var registerRepeatHelper = function() {
+  Ember.Handlebars.helper('repeat', function(value, options) {
+    var count = options.hash.count;
+    var a = [];
+    while(a.length < count) {
+        a.push(value);
+    }
+    return a.join('');
+  });
+};
+
+module("Handlebars bounded if helpers", {
+  setup: function() {
+    window.TemplateTests = Ember.Namespace.create();
+  },
+  teardown: function() {
+    Ember.run(function() {
+      if (view) {
+        view.destroy();
+      }
+    });
+    window.TemplateTests = undefined;
+  }
+});
+
+test("should be able to register ifData", function() {
+
+  Ember.Handlebars.registerHelper("ifData", function(property, fn){
+    var context = (fn.contexts && fn.contexts[0]) || this;
+
+    var func = function(result){
+      if (typeof result === 'boolean'){
+        return result;
+      }
+
+      return result !== undefined && result !== null;
+    };
+
+    return Ember.Handlebars.helpers._bind.call(context, property, fn, true, func, func);
+  });
+
+  view = Ember.View.create({
+    controller: Ember.Object.create({name: "Brogrammer"}),
+    template: Ember.Handlebars.compile("{{#ifData name}}{{name}}{{else}}No Data{{/ifData}}")
+  });
+
+  appendView();
+
+  equal(view.$().text(), 'Brogrammer', "helper output is correct");
+
+  Ember.run(function() {
+    set(view.controller, 'name', undefined);
+  });
+
+  equal(view.$().text(), 'No Data', "helper output updated");
+
+  Ember.run(function() {
+    set(view.controller, 'name', "Henry Gale");
+  });
+
+  equal(view.$().text(), 'Henry Gale', "helper output updated");
+
+  Ember.run(function() {
+    set(view.controller, 'name', null);
+  });
+
+  equal(view.$().text(), 'No Data', "helper output updated");
+
+  Ember.run(function() {
+    set(view.controller, 'name', 0);
+  });
+
+  equal(view.$().text(), '0', "helper output updated");
+});
+
+test("should be able to register ifPositive", function() {
+
+  Ember.Handlebars.registerHelper("ifPositive", function(property, fn){
+    var context = (fn.contexts && fn.contexts[0]) || this;
+
+    var func = function(result){
+      if (typeof result === 'boolean'){
+        return result;
+      }
+
+      return result > 0;
+    };
+
+    return Ember.Handlebars.helpers._bind.call(context, property, fn, true, func, func);
+  });
+
+  view = Ember.View.create({
+    controller: Ember.Object.create({age: 10}),
+    template: Ember.Handlebars.compile("{{#ifPositive age}}Welcome{{else}}Access Denied{{/ifPositive}}")
+  });
+
+  appendView();
+
+  equal(view.$().text(), 'Welcome', "helper output is correct");
+
+  Ember.run(function() {
+    set(view.controller, 'age', -100);
+  });
+
+  equal(view.$().text(), 'Access Denied', "helper output updated");
+});


### PR DESCRIPTION
This pull requests makes it possible to create bound {{if}} statements more easily.

Here's a use case:

I'm working on a project where I'm displaying amount of rain that fell within the last hour.
These rainmeters are very fickle however, and don't always send their data to my server.
So when the server doesn't have any data it sends back: {rainfall: null}

Now when the users rainmeter doesn't send data I want the user to know so I show a message:

``` handlebars
{{if rainmeter.rainfall}}
  {{rainmeter.rainfall}}mm
{{else}}
 No Data
{{/if}}
```

Now here comes the problem sometimes the weather outside is delightfull and no rain falls.
So the value {{rainfall: 0}} must still be displayed as rainfall: 0 mm.

So I created this helper which only says 'undefined' or 'null' is false but not the number zero:

``` javascript
Handlebars.registerHelper("ifData", function(property, fn)
{
    var context = (fn.contexts && fn.contexts[0]) || this;

    var func = function(result)
    {
        if (typeof result === 'boolean')
        {
            return result;
        }

        return result != undefined && result != null;
    };

    return Ember.Handlebars.helpers._bind.call(context, property, fn, true, func, func);
});
```

This didn't work because I cannot call the 'bind' function in Ember.Handlebars.helper.

This pull simply makes it available as _bind so other helpers can use it to.

Now I can use:

``` handlebars
{{ifData rainmeter.rainfall}}
  {{rainmeter.rainfall}}mm
{{else}}
 No Data
{{/ifData}}
```

And it is bindings aware so when rainfall changes so does the template.
