### PR TITLE
Replace crossLink with a markdown link.

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -629,7 +629,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     {{/link-to}}
     ```
 
-    See {{#crossLink "Ember.LinkView"}}{{/crossLink}} for a
+    See [Ember.LinkView](/api/classes/Ember.LinkView.html) for a
     complete list of overrideable properties. Be sure to also
     check out inherited properties of `LinkView`.
 
@@ -680,7 +680,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   });
 
   /**
-    See `link-to`
+    See [link-to](/api/classes/Ember.Handlebars.helpers.html#method_link-to)
 
     @method linkTo
     @for Ember.Handlebars.helpers


### PR DESCRIPTION
For some reason the crossLink helper is not rendering correctly.
![screen shot 2013-09-10 at 2 09 25 pm](https://f.cloud.github.com/assets/54056/1116897/3a27408e-1a44-11e3-88ec-c775f05069a0.png)

Link using markdown:
![screen shot 2013-09-10 at 2 07 07 pm](https://f.cloud.github.com/assets/54056/1116898/3a2fab0c-1a44-11e3-8646-0afd20543c4b.png)

I also added a link to the `link-to` docs from the `linkTo` docs.
