### PR TITLE
Adjust query params param order

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -1200,8 +1200,15 @@ define("router",
 
         log(router, seq, handlerName + ": calling beforeModel hook");
 
-        var args = [transition, handlerInfo.queryParams],
-          p = handler.beforeModel && handler.beforeModel.apply(handler, args);
+        var args;
+
+        if (handlerInfo.queryParams) {
+          args = [handlerInfo.queryParams, transition];
+        } else {
+          args = [transition];
+        }
+
+        var p = handler.beforeModel && handler.beforeModel.apply(handler, args);
         return (p instanceof Transition) ? null : p;
       }
 
@@ -1221,8 +1228,15 @@ define("router",
 
         transition.resolvedModels[handlerInfo.name] = context;
 
-        var args= [context, transition, handlerInfo.queryParams],
-          p = handler.afterModel && handler.afterModel.apply(handler, args);
+        var args;
+
+        if (handlerInfo.queryParams) {
+          args = [context, handlerInfo.queryParams, transition];
+        } else {
+          args = [context, transition];
+        }
+
+        var p = handler.afterModel && handler.afterModel.apply(handler, args);
         return (p instanceof Transition) ? null : p;
       }
 
@@ -1265,7 +1279,11 @@ define("router",
         return typeof providedModel === 'function' ? providedModel() : providedModel;
       }
 
-      args = [handlerParams || {}, transition, handlerInfo.queryParams];
+      if (handlerInfo.queryParams) {
+        args = [handlerParams || {}, handlerInfo.queryParams, transition];
+      } else {
+        args = [handlerParams || {}, transition, handlerInfo.queryParams];
+      }
 
       return handler.model && handler.model.apply(handler, args);
     }

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -95,15 +95,15 @@ if (Ember.FEATURES.isEnabled("query-params")) {
     });
 
     App.IndexRoute = Ember.Route.extend({
-      beforeModel: function(transition, queryParams) {
+      beforeModel: function(queryParams, transition) {
         deepEqual(queryParams, {foo: 'bar', baz: true}, "beforeModel hook is called with query params");
       },
 
-      model: function(params, transition, queryParams) {
+      model: function(params, queryParams, transition) {
         deepEqual(queryParams, {foo: 'bar', baz: true}, "Model hook is called with query params");
       },
 
-      afterModel: function(resolvedModel, transition, queryParams) {
+      afterModel: function(resolvedModel, queryParams, transition) {
         deepEqual(queryParams, {foo: 'bar', baz: true}, "afterModel hook is called with query params");
       },
 
@@ -133,16 +133,16 @@ if (Ember.FEATURES.isEnabled("query-params")) {
     });
 
     App.SpecialRoute = Ember.Route.extend({
-      beforeModel: function (transition, queryParams) {
+      beforeModel: function (queryParams, transition) {
         deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
       },
 
-      model: function(params, transition, queryParams) {
+      model: function(params, queryParams, transition) {
         deepEqual(queryParams, expectedQueryParams, "The query params are correct in the model hook");
         return {id: params.menu_item_id};
       },
 
-      afterModel: function (resolvedModel, transition, queryParams) {
+      afterModel: function (resolvedModel, queryParams, transition) {
         deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
       },
 
@@ -215,16 +215,16 @@ if (Ember.FEATURES.isEnabled("query-params")) {
     });
 
     App.SpecialRoute = Ember.Route.extend({
-      beforeModel: function (transition, queryParams) {
+      beforeModel: function (queryParams, transition) {
         deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
       },
 
-      model: function(params, transition, queryParams) {
+      model: function(params, queryParams, transition) {
         deepEqual(queryParams, expectedQueryParams, "The query params are correct in the model hook");
         return {id: params.menu_item_id};
       },
 
-      afterModel: function (resolvedModel, transition, queryParams) {
+      afterModel: function (resolvedModel, queryParams, transition) {
         deepEqual(queryParams, expectedQueryParams, "The query params are correct in the beforeModel hook");
       },
 
@@ -242,16 +242,16 @@ if (Ember.FEATURES.isEnabled("query-params")) {
     });
 
     App.OtherRoute = Ember.Route.extend({
-      beforeModel: function (transition, queryParams) {
+      beforeModel: function (queryParams, transition) {
         deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the beforeModel hook");
       },
 
-      model: function(params, transition, queryParams) {
+      model: function(params, queryParams, transition) {
         deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the model hook");
         return {id: params.menu_item_id};
       },
 
-      afterModel: function (resolvedModel, transition, queryParams) {
+      afterModel: function (resolvedModel, queryParams, transition) {
         deepEqual(queryParams, expectedOtherQueryParams, "The query params are correct in the beforeModel hook");
       },
 


### PR DESCRIPTION
This is what was discussed with @wycats on twitter and IRC. The summary is:

If your route has query params specified:

``` javascript
App.IndexRoute = Ember.Route.extend({
    beforeModel:      function( queryParams, transition ) {},
    model:            function( params, queryParams, transition ) {},
    afterModel:       function( resolvedModel, queryParams, transition ) {}
});
```

If your route does not have query params specified:

``` javascript
App.IndexRoute = Ember.Route.extend({
    beforeModel:      function( transition ) {},
    model:            function( params, transition ) {},
    afterModel:       function( resolvedModel, transition ) {}
});
```

This is backwards compatible, a better long term api, and needs no flag setting.

This PR really just updates the tests. The meat of this is in tildeio/router.js#50 (the updated router.js is included here).
