### PR TITLE
Removed dependency on a global Handlebars instance

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -399,8 +399,10 @@ function evaluateUnboundHelper(context, fn, normalizedProperties, options) {
   @for Ember.Handlebars
   @param {String} template spec
 */
-Ember.Handlebars.template = function(spec) {
-  var t = Handlebars.template(spec);
-  t.isTop = true;
-  return t;
-};
+Ember.Handlebars.template = (function(template) {
+  return function(spec) {
+    var t = template(spec);
+    t.isTop = true;
+    return t;
+  };
+})(Ember.Handlebars.template);


### PR DESCRIPTION
A local instance of Handlebars can be passed to Ember by defining an Ember.imports object before requiring/loading ember.  Doing so was causing an exception to be thrown by a file that was assuming that Handlebars existed globally.  This fixes that.
