### PR TITLE
[BUGFIX beta] Fixes issue when content is undefined for Ember.Select wit...

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -455,8 +455,9 @@ Ember.Select = Ember.View.extend(
   groupedContent: Ember.computed(function() {
     var groupPath = get(this, 'optionGroupPath');
     var groupedContent = Ember.A();
+    var content = get(this, 'content') || [];
 
-    forEach(get(this, 'content'), function(item) {
+    forEach(content, function(item) {
       var label = get(item, groupPath);
 
       if (get(groupedContent, 'lastObject.label') !== label) {

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -393,7 +393,19 @@ test("select with group observes its content", function() {
   });
   equal(labels.join(''), 'YehudaKeith');
 });
+test("select with group whose content is undefined doesn't breaks", function() {
+  
+		var content;
+  Ember.run(function() {
+    select.set('content', content),
+    select.set('optionGroupPath', 'organization');
+    select.set('optionLabelPath', 'content.firstName');
+  });
 
+  append();
+
+  equal(select.$('optgroup').length, 0);
+});
 test("selection uses the same array when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' },
       tom = { id: 2, firstName: 'Tom' },


### PR DESCRIPTION
...h optgroup

If the content given is undefined at the time of initialization, and
later changed,
`Ember.Select` correctly renders an empty select and then updates the content.   [Example](http://jsbin.com/epodAwU/14/edit),
But `Ember.Select` with `optgroup` breaks. [Example](http://jsbin.com/IJaToVO/1/edit).

This breakage may happen, when the content for the select is fetched
via an ajax call to the server.

This PR fixes it.
