### PR TITLE
Fix documentation for Ember.Select multiple and disabled attributes

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -346,7 +346,7 @@ Ember.Select = Ember.View.extend(
     The `disabled` attribute of the select element. Indicates whether
     the element is disabled from interactions.
 
-    @property multiple
+    @property disabled
     @type Boolean
     @default false
   */


### PR DESCRIPTION
This is preventing documentation from being generated for the `disabled` attribute and causing incorrect documentation for the `multiple` attribute.
