### PR TITLE
[FEATURE text input throttling]

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -86,9 +86,32 @@ Ember.TextSupport = Ember.Mixin.create({
   },
 
   _elementValueDidChange: function() {
-    set(this, 'value', this.$().val());
+    set(this, get(this, 'throttle') > 0 ? '_value' : 'value', this.$().val());
   },
 
+  /**
+    With throttling you can limit the update frequency of a text input. Default behaviour is immediate
+    updating of all dependent properties, which can have a performance impact.
+
+    By setting the throttle property to a higher number (like 300ms) you can limit the update rate of 
+    dependent properties, which can improve the performance and UX.
+
+    @property throttle Throttle time in ms
+    @type Integer
+    @default 0
+  */
+  throttle: 0,
+
+  _value: '',
+
+  _updateValueThrottled: function() {
+    set(this, 'value', get(this, '_value'));
+  },
+
+  _valueDidChange: Ember.observer(function() {
+    Ember.run.throttle(this, this._updateValueThrottled, get(this, 'throttle'));
+  }, '_value'),
+  
   /**
     The action to be sent when the user inserts a new line.
 


### PR DESCRIPTION
Having text fields bound to values quite often leads to a very jumpy UI, as dependent properties will immediately update with each keystroke. The faster you type, the more noise is seen.

This feature adds the `throttle` property to `input` and `textarea`, which limits (throttles) the update frequency. The frequency is expressed as an integer and refers to the number of milliseconds.

``` handlebars
{{textarea value=remarks throttle=500}}
```
