### PR TITLE
[FEATURE query-params] Allow link-to helper to work without route

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -353,6 +353,16 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
           types = options.types,
           data = options.data;
 
+      if (Ember.FEATURES.isEnabled("query-params")) {
+        if (parameters.params.length === 0) {
+          var appController = this.container.lookup('controller:application');
+          return [get(appController, 'currentRouteName')];
+        } else {
+          return resolveParams(parameters.context, parameters.params, { types: types, data: data });
+        }
+      }
+
+      // Original implementation if query params not enabled
       return resolveParams(parameters.context, parameters.params, { types: types, data: data });
     }).property(),
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -865,6 +865,35 @@ if (Ember.FEATURES.isEnabled("query-params")) {
       promise.then(next, shouldNotHappen);
     });
   });
+
+
+
+  test("The {{linkTo}} can work without a route name if query params are supplied", function() {
+    expect(4);
+
+    Router.map(function() {
+      this.route("items", { queryParams: ['page'] });
+      this.route('about');
+    });
+
+    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#linkTo page=2 id='next-page'}}Next Page{{/linkTo}}");
+
+    bootApplication();
+
+    Ember.run(function() {
+      router.handleURL("/items");
+    });
+
+    equal(normalizeUrl(Ember.$('#next-page').attr('href')), '/items?page=2', "The link-to works without a routename");
+    shouldNotBeActive('#next-page');
+
+    Ember.run(function() {
+      Ember.$('#next-page', '#qunit-fixture').click();
+    });
+
+    equal(router.get('url'), "/items?page=2", "Clicking the link updates the url");
+    shouldBeActive('#next-page');
+  });
 }
 
 test("The {{link-to}} helper's bound parameter functionality works as expected in conjunction with an ObjectProxy/Controller", function() {


### PR DESCRIPTION
Someone asked in IRC and I've been meaning to implement for a while anyway, this allows:

``` javascript
App.Router.map(function() {
  this.route('index', {queryParams: ['page']});
});
```

``` handlebars
{{#link-to page=2}}Next Page{{/link-to}}
```

This is useful for example in components that can be used on multiple routes (a pagination component would be a good example) that want to change the query params but don't care about the actual route that is active.
