### PR TITLE
Allow multiple dependent keys for `Ember.computed.filter`

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -217,13 +217,21 @@ Ember.computed.mapProperty = Ember.computed.mapBy;
   @return {Ember.ComputedProperty} the filtered array
 */
 Ember.computed.filter = function(dependentKey, callback) {
+
+  if (arguments.length < 2) {
+    throw new Error("Computed filter declared without a callback");
+  }
+  
+  var dependentKeys = a_slice.call(arguments, 0, -1);
+  callback = a_slice.call(arguments, -1)[0];
+  
   var options = {
     initialize: function (array, changeMeta, instanceMeta) {
       instanceMeta.filteredArrayIndexes = new Ember.SubArray();
     },
 
     addedItem: function(array, item, changeMeta, instanceMeta) {
-      var match = !!callback.call(this, item),
+      var match = !!callback(item),
           filterIndex = instanceMeta.filteredArrayIndexes.addItem(changeMeta.index, match);
 
       if (match) {
@@ -243,8 +251,10 @@ Ember.computed.filter = function(dependentKey, callback) {
       return array;
     }
   };
-
-  return Ember.arrayComputed(dependentKey, options);
+  
+  var args = dependentKeys;
+  args.push(options);
+  return Ember.arrayComputed.apply(this, args);
 };
 
 /**

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -231,7 +231,7 @@ Ember.computed.filter = function(dependentKey, callback) {
     },
 
     addedItem: function(array, item, changeMeta, instanceMeta) {
-      var match = !!callback(item),
+      var match = !!callback.call(this, item),
           filterIndex = instanceMeta.filteredArrayIndexes.addItem(changeMeta.index, match);
 
       if (match) {


### PR DESCRIPTION
It would be great if `Ember.computed.filter` could take multiple dependent keys. This is an example of how that could be achieved. Some questions:
- Should this be applied to other computed macros too?
- Are zero dependent keys allowed? (regular computed properties allow `.property()`)

(also, if anyone want's to grab this and have a go at it, feel free :)
