### PR TITLE
Add an extra space to fix the list formatting in the input helper docs

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -105,6 +105,7 @@ function normalizeHash(hash, hashTypes) {
 * `indeterminate`
 * `name`
 
+
   When set to a quoted string, these values will be directly applied to the HTML
   element. When left unquoted, these values will be bound to a property on the
   template's current rendering context (most typically a controller instance).


### PR DESCRIPTION
It looks like the list markdown in YUI docs needs to have 2 blank lines at the end to get the correct formatting.

[Current Ember docs site](http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_input):
![screen shot 2013-09-13 at 11 52 29 am](https://f.cloud.github.com/assets/54056/1139466/955a0a0a-1c8c-11e3-8dad-563086fdf6f3.png)
## Ember docs site with 2 spaces after the checkbox properties list:

![screen shot 2013-09-13 at 11 52 39 am](https://f.cloud.github.com/assets/54056/1139467/96cb24a0-1c8c-11e3-83d1-0126e39b31a2.png)
