### PR TITLE
Don't allow registration of undefined factories.

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -268,6 +268,10 @@ define("container",
           fullName = type + ":" + name;
         }
 
+        if (factory === undefined) {
+          throw new TypeError('Attempting to register an unknown factory: `' + fullName + '`');
+        }
+
         var normalizedName = this.normalize(fullName);
 
         this.registry.set(normalizedName, factory);

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -456,3 +456,11 @@ test("The container can get options that should be applied to all factories for 
 
   ok(postView1 !== postView2, "The two lookups are different");
 });
+
+test("cannot register an `undefined` factory", function(){
+  var container = new Container();
+
+  throws(function(){
+    container.register('controller:apple', undefined);
+  }, '');
+});

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -677,7 +677,7 @@ Ember.Application.reopenClass({
   initializer: function(initializer) {
     var initializers = get(this, 'initializers');
 
-    Ember.assert("The initializer '" + initializer.name + "' has already been registered", !initializers.findBy('name', initializers.name));
+    Ember.assert("The initializer '" + initializer.name + "' has already been registered", !Ember.A(initializers).findBy('name', initializers.name));
     Ember.assert("An initializer cannot be registered with both a before and an after", !(initializer.before && initializer.after));
     Ember.assert("An initializer cannot be registered without an initialize function", Ember.canInvoke(initializer, 'initialize'));
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -454,7 +454,9 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     if (this.isDestroyed) { return; }
 
     // At this point, the App.Router must already be assigned
-    this.register('router:main', this.Router);
+    if (this.Router) {
+      this.register('router:main', this.Router);
+    }
 
     this.runInitializers();
     Ember.runLoadHooks('application', this);

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -130,3 +130,37 @@ test("initializers can have multiple dependencies", function () {
   });
 });
 
+test("initializers set on Application subclasses should not be shared between apps", function(){
+  var firstInitializerRunCount = 0, secondInitializerRunCount = 0;
+  var FirstApp = Ember.Application.extend();
+  FirstApp.initializer({
+    name: 'first',
+    initialize: function(container) {
+      firstInitializerRunCount++;
+    }
+  });
+  var SecondApp = Ember.Application.extend();
+  SecondApp.initializer({
+    name: 'second',
+    initialize: function(container) {
+      secondInitializerRunCount++;
+    }
+  });
+  Ember.$('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
+  Ember.run(function() {
+    var firstApp = FirstApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #first'
+    });
+  });
+  equal(firstInitializerRunCount, 1, 'first initializer only was run');
+  equal(secondInitializerRunCount, 0, 'first initializer only was run');
+  Ember.run(function() {
+    var secondApp = SecondApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #second'
+    });
+  });
+  equal(firstInitializerRunCount, 1, 'second initializer only was run');
+  equal(secondInitializerRunCount, 1, 'second initializer only was run');
+});

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -3,17 +3,17 @@ var get = Ember.get, set = Ember.set;
 var application;
 var Application;
 
-Application = Ember.Application.extend({
-  name: "App",
-  rootElement: "#qunit-fixture"
-});
-
 module("Ember.Application - resetting", {
+  setup: function() {
+    Application = Ember.Application.extend({
+      name: "App",
+      rootElement: "#qunit-fixture"
+    });
+  },
   teardown: function() {
+    Application = null;
     if (application) {
-      Ember.run(function() {
-        application.destroy();
-      });
+      Ember.run(application, 'destroy');
     }
   }
 });

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -137,7 +137,9 @@ function applyConcatenatedProperties(obj, key, value, values) {
       return Ember.makeArray(baseValue).concat(value);
     }
   } else {
-    return Ember.makeArray(value);
+    // Make sure this mixin has its own array so it is not
+    // accidentally mutated by another child's interactions
+    return Ember.makeArray(value).slice();
   }
 }
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -56,7 +56,7 @@ module("The {{link-to}} helper", {
 
       container = App.__container__;
 
-      container.register('view:app');
+      container.register('view:app', AppView);
       container.register('router:main', Router);
     });
   },


### PR DESCRIPTION
Don't allow registration of undefined factories.

container.register(fullName, undefined) now throws
an Exception. This is obviously much stricter then
the current approach, but an obvious win, as we
can detect obviously exceptional scenarios early.
- [x] add the assertion
- [x] fix the simple test failures
- [x] fix initializers leaking  (the huge number of test failures, is specific this point)
