### PR TITLE
Convert stray github urls into links in docs

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -189,7 +189,7 @@ Ember.copy = function(obj, deep) {
   convert the object into a useful string description.
 
   It is a pretty simple implementation. If you want something more robust,
-  use something like JSDump: https://github.com/NV/jsDump
+  use something like JSDump: [https://github.com/NV/jsDump](https://github.com/NV/jsDump)
 
   @method inspect
   @for Ember

--- a/packages/ember-runtime/lib/ext/ember.js
+++ b/packages/ember-runtime/lib/ext/ember.js
@@ -1,7 +1,7 @@
 /**
   Expose RSVP implementation
   
-  Documentation can be found here: https://github.com/tildeio/rsvp.js/blob/master/README.md
+  Documentation can be found here: [https://github.com/tildeio/rsvp.js/blob/master/README.md](https://github.com/tildeio/rsvp.js/blob/master/README.md)
 
   @class RSVP
   @namespace Ember


### PR DESCRIPTION
Before:
![screen shot 2013-09-13 at 5 10 38 pm](https://f.cloud.github.com/assets/54056/1141673/53930680-1cb9-11e3-8cd5-8c43ee3d1a2d.png)

After:
![screen shot 2013-09-13 at 5 10 18 pm](https://f.cloud.github.com/assets/54056/1141672/5388af1e-1cb9-11e3-87dd-0b7605e711d4.png)
