### PR TITLE
Fix bug when setting both sortProperties and sortAscending in SortableMixin

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -153,6 +153,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
       content.sort(function(item1, item2) {
         return self.orderBy(item1, item2);
       });
+      this._lastSortAscending = get(this, 'sortAscending');
       forEach(content, function(item) {
         forEach(sortProperties, function(sortProperty) {
           Ember.addObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -79,6 +79,24 @@ test("changing sort order triggers observers", function() {
   Ember.run(function() { observer.destroy(); });
 });
 
+test("changing sortProperties and sortAscending at the same time", function() {
+  sortedArrayController.set('sortProperties', ['name']);
+  sortedArrayController.set('sortAscending', false);
+
+  equal(sortedArrayController.objectAt(0).name, 'Scumbag Katz', 'array is sorted by name in DESC order');
+  equal(sortedArrayController.objectAt(2).name, 'Scumbag Bryn', 'array is sorted by name in DESC order');
+
+  sortedArrayController.setProperties({ sortProperties: ['id'], sortAscending: true});
+
+  equal(sortedArrayController.objectAt(0).id, 1, 'array is sorted by id in ASC order after setting sortAscending and sortProperties');
+  equal(sortedArrayController.objectAt(2).id, 3, 'array is sorted by id in ASC order after setting sortAscending and sortProperties');
+
+  sortedArrayController.setProperties({ sortProperties: ['name'], sortAscending: false});
+  
+  equal(sortedArrayController.objectAt(0).name, 'Scumbag Katz', 'array is sorted by name in DESC order after setting sortAscending and sortProperties');
+  equal(sortedArrayController.objectAt(2).name, 'Scumbag Bryn', 'array is sorted by name in DESC order after setting sortAscending and sortProperties');
+});
+
 module("Ember.Sortable with content and sortProperties", {
   setup: function() {
     Ember.run(function() {


### PR DESCRIPTION
I'm setting both sortProperties and sortAscending using one call

``` js
sortedArrayController.setProperties({ sortProperties: ['id'], sortAscending: true});
```

The arrangedContent gets sorted with new value for sortAscending, and then gets reversed, when the sortAscendingDidChange observer kicks in. To prevent this, _lastSortAscending needs to be set when the array is sorted

<!---
@huboard:{"order":4708.0,"custom_state":"blocked"}
-->
