### PR TITLE
[FEATURE computed-controller] Add Ember.computed.controller

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * Add query params support to the ember router. You can now define which query params your routes respond to, use them in your route hooks to affect model loading or controller state, and transition query parameters with the link-to helper and the transitionTo method
 * Add a non-block form link-to helper. E.g {{link-to "About us" "about"}} will have "About us" as link text and will transition to the "about" route. Everything works as with the block form link-to.
 * Components and helpers registered on the container can be rendered in templates via their dasherized names. E.g. {{helper-name}} or {{component-name}}
+* Add Ember.computed.controller. This computed property generates a controller to decorate a model. It can be useful when dealing with hierarchical application states where global singleton controllers are not sufficient.
 
 *Ember 1.0.0 (August 31, 2013)*
 

--- a/packages/ember-runtime/lib/computed/computed_controller.js
+++ b/packages/ember-runtime/lib/computed/computed_controller.js
@@ -1,0 +1,41 @@
+var set = Ember.set,
+    get = Ember.get;
+
+if (Ember.FEATURES.isEnabled("computed-controller")) {
+  /**
+    A computed property that creates a controller. This computed property should
+    only be used on a controller. The controller class is specified by
+    `controllerName` and must be explicitly defined. The content of the
+    controller must be specified by the `contentPath` parameter. The generated
+    controller has access to the parent controller through its `parentController`
+    property. Any actions emitted from the generated controller will pass through
+    the parent controller.
+
+    ```javascript
+    App.PostController = Ember.ObjectController.extend({
+      comments: Ember.computed.controller('comments', 'model.comments');
+    });
+
+    // Must be defined
+    App.CommentsController = Ember.ArrayController.extend();
+    ```
+
+    @method computed.controller
+    @for Ember
+    @param {String} controllerName
+    @param {String} contentPath
+    @return {Ember.ComputedProperty} computed property which creates a
+    controller with content from `contentPath`.
+  */
+  Ember.computed.controller = function(controllerName, contentPath) {
+    return Ember.computed(contentPath, function() {
+      var fullName = 'controller:' + controllerName;
+      var controller = this.container.lookup(fullName, {singleton: false});
+
+      set(controller, 'content', get(this, contentPath));
+      set(controller, 'parentController', this);
+      set(controller, 'target', this);
+      return controller;
+    });
+  };
+}

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -10,6 +10,7 @@ require('container');
 require('ember-metal');
 require('ember-runtime/core');
 require('ember-runtime/computed/reduce_computed_macros');
+require('ember-runtime/computed/computed_controller');
 require('ember-runtime/ext');
 require('ember-runtime/mixins');
 require('ember-runtime/system');

--- a/packages/ember-runtime/tests/computed/computed_controller_test.js
+++ b/packages/ember-runtime/tests/computed/computed_controller_test.js
@@ -1,0 +1,96 @@
+var set = Ember.set,
+    get = Ember.get;
+
+if (Ember.FEATURES.isEnabled("computed-controller")) {
+  module('Ember.computed - controller');
+
+  test("Computed controllers should have correct types and references", function() {
+    var PostController = Ember.Controller.extend({
+      comments: Ember.computed.controller('comments', 'content.comments')
+    });
+    var CommentsController = Ember.ArrayController.extend({
+      itemController: 'comment'
+    });
+    var CommentController = Ember.ObjectController.extend();
+
+    var container = new Ember.Container();
+    container.register('controller:post', PostController);
+    container.register('controller:comments', CommentsController);
+    container.register('controller:comment', CommentController);
+
+    var postController = container.lookup('controller:post');
+    var comment1 = {}, comment2 = {};
+    set(postController, 'content', {comments: Ember.A([comment1, comment2])});
+    var commentsController = get(postController, 'comments');
+    var commentController = commentsController.objectAt(0);
+
+    ok(commentsController instanceof CommentsController);
+    ok(commentController instanceof CommentController);
+    equal(get(commentController, 'content'), comment1);
+
+    equal(get(commentController, 'parentController'), commentsController);
+    equal(get(commentsController, 'parentController'), postController);
+
+    equal(get(commentController, 'target'), commentsController);
+    equal(get(commentsController, 'target'), postController);
+
+    set(postController, 'content.comments', Ember.A());
+    notEqual(commentsController, get(postController, 'comments'), 'changing content generates new controller');
+  });
+
+  test("Computed controllers send actions to their parent", function() {
+    var actionsTriggered = 0;
+
+    var container = new Ember.Container();
+    container.register('controller:post', Ember.Controller.extend({
+      comments: Ember.computed.controller('comments', 'foo'),
+      foo: Ember.A([{}, {}]),
+      actions: {
+        test: function() {
+          actionsTriggered++;
+        }
+      }
+    }));
+    container.register('controller:comments', Ember.ArrayController.extend({
+      itemController: 'comment'
+    }));
+    container.register('controller:comment', Ember.ObjectController.extend());
+
+    var postController = container.lookup('controller:post');
+    var commentsController = get(postController, 'comments');
+    var commentController = commentsController.objectAt(0);
+
+    equal(actionsTriggered, 0);
+    commentController.send('test');
+    equal(actionsTriggered, 1);
+    commentsController.send('test');
+    equal(actionsTriggered, 2);
+    postController.send('test');
+    equal(actionsTriggered, 3);
+  });
+
+  test("Computed controllers should throw if controller is not defined", function() {
+    var BadPostController = Ember.Controller.extend({
+      comments: Ember.computed.controller('comments', 'missing')
+    });
+    var EvilPostController = Ember.Controller.extend({
+      comments: Ember.computed.controller('foo', 'content.missing')
+    });
+    var CommentsController = Ember.ArrayController.extend();
+
+    var container = new Ember.Container();
+    container.register('controller:badPost', BadPostController);
+    container.register('controller:evilPost', EvilPostController);
+    container.register('controller:comments', CommentsController);
+
+    var badPostController = container.lookup('controller:badPost');
+    var commentsController = get(badPostController, 'comments');
+    ok(commentsController instanceof CommentsController);
+    equal(get(commentsController, 'content'), undefined);
+
+    var evilPostController = container.lookup('controller:evilPost');
+    throws(function() {
+      get(evilPostController, 'comments');
+    }, /Invalid Path/);
+  });
+}


### PR DESCRIPTION
This is an idea for working with nested array controllers and for sharing array/item controllers between multiple views.

Usage:

``` javascript
property: Ember.computed.controller('controllerName','path.to.content')
```

Here is a demo in action: http://jsbin.com/ULuqIPe/1/edit

And here are the docs:

``````
A computed property that creates a controller. This computed property should
only be used on a controller. The controller class is specified by
`controllerName` and must be explicitly defined. The content of the
controller must be is specified by the `contentPath` parameter. The generated
controller has access to the parent controller through its `parentController`
property. Any actions emitted from the generated controller will pass through
the parent controller.

```javascript
App.PostController = Ember.ObjectController.extend({
  comments: Ember.computed.controller('comments', 'model.comments');
});

// Must be defined
App.CommentsController = Ember.ArrayController.extend();
```

@method computed.controller
@for Ember
@param {String} controllerName
@param {String} contentPath
@return {Ember.ComputedProperty} computed property which creates a
controller with content from `contentPath`.
``````
