### PR TITLE
Test with all feature flags enabled.

### DIFF
--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -11,8 +11,11 @@ testing_suites:
   standard:
     - "EACH_PACKAGE"
     - "package=all&jquery=1.7.2&nojshint=true"
+    - "package=all&jquery=1.7.2&nojshint=true&enableallfeatures=true"
     - "package=all&extendprototypes=true&nojshint=true"
+    - "package=all&extendprototypes=true&nojshint=true&enableallfeatures=true"
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
+    - "package=all&skipPackage=container&dist=build&nojshint=true&enableallfeatures=true" # container isn't publicly available in the built version
   all:
     - "EACH_PACKAGE"
     - "package=all&jquery=1.7.2&nojshint=true"

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -90,12 +90,15 @@ Ember.FEATURES = {};
   Test that a feature is enabled. Parsed by Ember's build tools to leave
   experimental features out of beta/stable builds.
 
+  You can define an `ENV.ENABLE_ALL_FEATURES` config to force all features to
+  be enabled.
+
   @method isEnabled
   @param {string} feature
 */
 
 Ember.FEATURES.isEnabled = function(feature) {
-  return Ember.FEATURES[feature];
+  return Ember.ENV.ENABLE_ALL_FEATURES || Ember.FEATURES[feature];
 };
 
 // ..........................................................

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -15,10 +15,14 @@
   });
 
   // Handle extending prototypes
-  QUnit.config.urlConfig.push('extendprototypes');
-
-  var extendPrototypes = QUnit.urlParams.extendprototypes;
+  QUnit.config.urlConfig.push({ id: 'extendprototypes', label: 'Extend Prototypes'});
+  var extendPrototypes  = QUnit.urlParams.extendprototypes;
   ENV['EXTEND_PROTOTYPES'] = !!extendPrototypes;
+
+  // Handle testing feature flags
+  QUnit.config.urlConfig.push({ id: 'enableallfeatures', label: "Enable All Features"});
+  var enableAllFeatures = QUnit.urlParams.enableallfeatures;
+  ENV['ENABLE_ALL_FEATURES'] = !!enableAllFeatures;
 
   // Don't worry about jQuery version
   ENV['FORCE_JQUERY'] = true;


### PR DESCRIPTION
- Adds a new `Ember.ENV` param to force all feature flags on.
- Sets up a new option in QUnit to allow toggling the `ENV.ENABLE_ALL_FEATURES` option.
- Changes the standard test target to test with and without features enabled.
- Pretties up the Extend Prototype configuration in QUnit (giving a nicer display).

I also think we should be testing the individual packages with and without the feature flags so I have submitted https://github.com/emberjs/ember-dev/pull/51 to change `EACH_PACKAGE` to test with feature flags on and off.

This should resolve #3421.

/cc @thomasboyt
