### PR TITLE
[FEATURE ember-testing-wait-hooks]

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -100,6 +100,13 @@ function wait(app, value) {
       if (routerIsLoading) { return; }
       if (Test.pendingAjaxRequests) { return; }
       if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) { return; }
+      if (Ember.FEATURES.isEnabled("ember-testing-wait-hooks")) {
+        if (Test.waiters && Test.waiters.any(function(waiter) {
+          var context = waiter[0];
+          var callback = waiter[1];
+          return !callback.apply(context);
+        })) { return; }
+      }
 
       clearInterval(watcher);
 


### PR DESCRIPTION
In integration testing, sometimes it's necessary to make `wait` respect
other kinds of pending actions that are not in its default
implementation. For example, if your application is waiting for a CSS3
transition or an IndexDB action, the default `wait` implementaiton will
ignore those things and move on with the test prematurely.

This change lets you register additional functions that `wait` will call
to see whether it's really time to move on.
