### PR TITLE
Added deprecated flag for 'controllerFor' method on the 'ControllerMixin'

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -70,6 +70,11 @@ Ember.ControllerMixin.reopen({
     this._super.apply(this, arguments);
   },
 
+  /**
+    @method controllerFor
+    @see {Ember.Route#controllerFor}
+    @deprecated Use `needs` instead
+  */
   controllerFor: function(controllerName) {
     Ember.deprecate("Controller#controllerFor is deprecated, please use Controller#needs instead");
     return Ember.controllerFor(get(this, 'container'), controllerName);


### PR DESCRIPTION
`controllerFor` was deprecated for controllers in Ember 1.0 and had a `Ember.deprecate` function in place, but this wasn't reflected in the docs.
