### PR TITLE
[FEATURE ember-routing-didTransition-hook] Add a `didTransition` hook to the router.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -19,7 +19,7 @@ require("ember-routing/system/dsl");
   @namespace Ember
   @extends Ember.Object
 */
-Ember.Router = Ember.Object.extend({
+Ember.Router = Ember.Object.extend(Ember.Evented, {
   location: 'hash',
 
   init: function() {
@@ -63,6 +63,12 @@ Ember.Router = Ember.Object.extend({
     set(appController, 'currentRouteName', infos[infos.length - 1].name);
 
     this.notifyPropertyChange('url');
+
+    if (Ember.FEATURES.isEnabled("ember-routing-didTransition-hook")) {
+      // Put this in the runloop so url will be accurate. Seems
+      // less surprising than didTransition being out of sync.
+      Ember.run.once(this, this.trigger, 'didTransition');
+    }
 
     if (get(this, 'namespace').LOG_TRANSITIONS) {
       Ember.Logger.log("Transitioned into '" + path + "'");

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2441,6 +2441,47 @@ test("Aborting/redirecting the transition in `willTransition` prevents LoadingRo
   Ember.run(deferred.resolve);
 });
 
+if (Ember.FEATURES.isEnabled("ember-routing-didTransition-hook")) {
+  test("`didTransition` event fires on the router", function() {
+    expect(3);
+
+    Router.map(function(){
+      this.route("nork");
+    });
+
+    router = container.lookup('router:main');
+
+    router.one('didTransition', function(){
+      ok(true, 'didTransition fired on initial routing');
+    });
+
+    bootApplication();
+
+    router.one('didTransition', function(){
+      ok(true, 'didTransition fired on the router');
+      equal(router.get('url'), "/nork", 'The url property is updated by the time didTransition fires');
+    });
+
+    Ember.run(router, 'transitionTo', 'nork');
+  });
+  test("`didTransition` can be reopened", function() {
+    expect(1);
+
+    Router.map(function(){
+      this.route("nork");
+    });
+
+    Router.reopen({
+      didTransition: function(){
+        this._super.apply(this, arguments);
+        ok(true, 'reopened didTransition was called');
+      }
+    });
+
+    bootApplication();
+  });
+}
+
 test("Actions can be handled by inherited action handlers", function() {
 
   expect(4);


### PR DESCRIPTION
For use in analytics and such, you may listen to this hook.

``` JavaScript
Ember.Application.initializer({
  name: 'analytics',
  initialize: function(container, application){
    var router = container.lookup('router:main');
    router.on('didTransition', function(){
      _gaq.push(['_trackPageview', router.get('url')]);
    });
  }
});
```

Seems good for analytics, though perhaps you could just observe `url` directly? I imagine there are other use-cases.
