### PR TITLE
Fixes #3332 - Array computed properties should update synchronously

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -290,7 +290,7 @@ DependentArraysObserver.prototype = {
   },
 
   itemPropertyDidChange: function(obj, keyName, array, observerContext) {
-    Ember.run.once(this, 'flushChanges');
+    this.flushChanges();
   },
 
   flushChanges: function() {
@@ -571,7 +571,7 @@ ReduceComputedProperty.prototype.property = function () {
   If there are more than one arguments the first arguments are
   considered to be dependent property keys. The last argument is
   required to be an options object. The options object can have the
-  following four properties.
+  following four properties:
 
   `initialValue` - A value or function that will be used as the initial
   value for the computed. If this property is a function the result of calling

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -140,6 +140,19 @@ test("after first retrieval, array computed properties can observe properties on
   deepEqual(evenNestedNumbers, [2, 4, 6, 22], 'adds new number');
 });
 
+test("changes to array computed properties happen synchronously", function() {
+  var nestedNumbers = get(obj, 'nestedNumbers'),
+      evenNestedNumbers = get(obj, 'evenNestedNumbers');
+
+  deepEqual(evenNestedNumbers, [2, 4, 6], 'precond -- starts off with correct values');
+
+  Ember.run(function() {
+    nestedNumbers.objectAt(0).set('v', 22);
+    deepEqual(nestedNumbers.mapBy('v'), [22, 2, 3, 4, 5, 6], 'nested numbers is updated');
+    deepEqual(evenNestedNumbers, [2, 4, 6, 22], 'adds new number');
+  });
+});
+
 test("doubly nested item property keys (@each.foo.@each) are not supported", function() {
   Ember.run(function() {
     obj = Ember.Object.createWithMixins({


### PR DESCRIPTION
When an array changes, array computed properties that are dependent on it will now immediately reflect the correct value. Previously we would wait until the end of the run loop (via `Ember.run.once`) to flush the changes.

Note:
There is a performance consideration when flushing the changes. Specifically, if the length and offset of the dependent key array changes before the properties are modified, we want to avoid repeated runs of the [inner loop](https://github.com/hjdivad/ember.js/blob/d33e848cdbae0235a0e661119f50e5f3c525709c/packages/ember-runtime/lib/computed/reduce_computed.js#L212) of the `updateIndexes` method in `reduce_computed.js`. @mixonic @hjdivad and I  manually confirmed that the [early return](https://github.com/hjdivad/ember.js/blob/d33e848cdbae0235a0e661119f50e5f3c525709c/packages/ember-runtime/lib/computed/reduce_computed.js#L206) in `updateIndexes` is hit for RETAIN operations where the array index has not changed.
