### PR TITLE
Fix an issue with concatenatedProperties.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -677,7 +677,7 @@ Ember.Application.reopenClass({
   initializer: function(initializer) {
     var initializers = get(this, 'initializers');
 
-    Ember.assert("The initializer '" + initializer.name + "' has already been registered", !initializers.findBy('name', initializers.name));
+    Ember.assert("The initializer '" + initializer.name + "' has already been registered", !Ember.A(initializers).findBy('name', initializers.name));
     Ember.assert("An initializer cannot be registered with both a before and an after", !(initializer.before && initializer.after));
     Ember.assert("An initializer cannot be registered without an initialize function", Ember.canInvoke(initializer, 'initialize'));
 

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -130,3 +130,37 @@ test("initializers can have multiple dependencies", function () {
   });
 });
 
+test("initializers set on Application subclasses should not be shared between apps", function(){
+  var firstInitializerRunCount = 0, secondInitializerRunCount = 0;
+  var FirstApp = Ember.Application.extend();
+  FirstApp.initializer({
+    name: 'first',
+    initialize: function(container) {
+      firstInitializerRunCount++;
+    }
+  });
+  var SecondApp = Ember.Application.extend();
+  SecondApp.initializer({
+    name: 'second',
+    initialize: function(container) {
+      secondInitializerRunCount++;
+    }
+  });
+  Ember.$('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
+  Ember.run(function() {
+    var firstApp = FirstApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #first'
+    });
+  });
+  equal(firstInitializerRunCount, 1, 'first initializer only was run');
+  equal(secondInitializerRunCount, 0, 'first initializer only was run');
+  Ember.run(function() {
+    var secondApp = SecondApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #second'
+    });
+  });
+  equal(firstInitializerRunCount, 1, 'second initializer only was run');
+  equal(secondInitializerRunCount, 1, 'second initializer only was run');
+});

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -137,7 +137,9 @@ function applyConcatenatedProperties(obj, key, value, values) {
       return Ember.makeArray(baseValue).concat(value);
     }
   } else {
-    return Ember.makeArray(value);
+    // Make sure this mixin has its own array so it is not
+    // accidentally mutated by another child's interactions
+    return Ember.makeArray(value).slice();
   }
 }
 


### PR DESCRIPTION
This commit fixes an issue with how contactedProperties are applied that
can result in subclasses sharing a reference to the same array, in a
surprising way. As an example, the failing test provided here shows
how two Ember.App subclasses shares were sharing inadvertently
sharing initializers.

Thanks to @kselden and @stefanpenner for code review.
