### PR TITLE
nested ember apps with proper event dispatching

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -366,7 +366,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     Call `advanceReadiness` after any asynchronous setup logic has completed.
     Each call to `deferReadiness` must be matched by a call to `advanceReadiness`
     or the application will never become ready and routing will not begin.
-    
+
     @method advanceReadiness
     @see {Ember.Application#deferReadiness}
   */
@@ -677,6 +677,25 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     this.constructor.initializer(options);
   }
 });
+
+if (Ember.FEATURES.isEnabled('nested-apps')) {
+  Ember.Application.reopen({
+    init: function() {
+      this._super();
+      this.set('childApps', Ember.A());
+    },
+    registerChildApp: function(childApp) {
+      this.get('childApps').pushObject(childApp);
+      this.get('eventDispatcher')._hasChildren = true;
+    },
+    unregisterChildApp: function(childApp) {
+      this.get('childApps').removeObject(childApp);
+      if (this.get('childApps.length') === 0) {
+        this.get('eventDispatcher')._hasChildren = false;
+      }
+    }
+  });
+}
 
 Ember.Application.reopenClass({
   concatenatedProperties: ['initializers'],

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -51,6 +51,16 @@ test("you cannot make a new application that is a parent of an existing applicat
   });
 });
 
+if (!Ember.FEATURES.isEnabled('nested-apps')) {
+  test("you cannot make a new application that is a descendent of an existing application", function() {
+    expectAssertion(function() {
+      Ember.run(function() {
+        Ember.Application.create({ rootElement: '#one-child' });
+      });
+    });
+  });
+}
+
 test("you cannot make a new application that is a duplicate of an existing application", function() {
   expectAssertion(function() {
     Ember.run(function() {

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -51,14 +51,6 @@ test("you cannot make a new application that is a parent of an existing applicat
   });
 });
 
-test("you cannot make a new application that is a descendent of an existing application", function() {
-  expectAssertion(function() {
-    Ember.run(function() {
-      Ember.Application.create({ rootElement: '#one-child' });
-    });
-  });
-});
-
 test("you cannot make a new application that is a duplicate of an existing application", function() {
   expectAssertion(function() {
     Ember.run(function() {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -116,7 +116,7 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     rootElement = Ember.$(get(this, 'rootElement'));
 
     Ember.assert(fmt('You cannot use the same root element (%@) multiple times in an Ember.Application', [rootElement.selector || rootElement[0].tagName]), !rootElement.is('.ember-application'));
-    Ember.assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest('.ember-application').length && !Ember.FEATURES.isEnabled('nested-apps'));
+    Ember.assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest('.ember-application').length || Ember.FEATURES.isEnabled('nested-apps'));
     Ember.assert('You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application', !rootElement.find('.ember-application').length);
 
     rootElement.addClass('ember-application');

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -5,6 +5,20 @@
 
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
+
+var appRegex = /\bember-application\b/;
+
+function closestRootElement(target) {
+  var node = target;
+  while(node) {
+    if (node.nodeType === 1 && appRegex.test(node.className)) {
+      break;
+    }
+    node = node.parentNode;
+  }
+  return node;
+}
+
 /**
   `Ember.EventDispatcher` handles delegating browser events to their
   corresponding `Ember.Views.` For example, when you click on a view,
@@ -102,7 +116,6 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     rootElement = Ember.$(get(this, 'rootElement'));
 
     Ember.assert(fmt('You cannot use the same root element (%@) multiple times in an Ember.Application', [rootElement.selector || rootElement[0].tagName]), !rootElement.is('.ember-application'));
-    Ember.assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest('.ember-application').length);
     Ember.assert('You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application', !rootElement.find('.ember-application').length);
 
     rootElement.addClass('ember-application');
@@ -142,6 +155,12 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     var self = this;
 
     rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {
+
+      // we could skip this if we know there are no nested ember apps
+      if (closestRootElement(this) !== rootElement[0]) {
+        return;
+      }
+
       return Ember.handleErrors(function() {
         var view = Ember.View.views[this.id],
             result = true, manager = null;

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -158,8 +158,7 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {
 
       if (Ember.FEATURES.isEnabled("nested-apps")) {
-        // we could skip this if we know there are no nested ember apps
-        if (closestRootElement(this) !== rootElement[0]) {
+        if (self._hasChildren && closestRootElement(this) !== rootElement[0]) {
           return;
         }
       }

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -116,6 +116,7 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     rootElement = Ember.$(get(this, 'rootElement'));
 
     Ember.assert(fmt('You cannot use the same root element (%@) multiple times in an Ember.Application', [rootElement.selector || rootElement[0].tagName]), !rootElement.is('.ember-application'));
+    Ember.assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest('.ember-application').length && !Ember.FEATURES.isEnabled('nested-apps'));
     Ember.assert('You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application', !rootElement.find('.ember-application').length);
 
     rootElement.addClass('ember-application');
@@ -156,9 +157,11 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
 
     rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {
 
-      // we could skip this if we know there are no nested ember apps
-      if (closestRootElement(this) !== rootElement[0]) {
-        return;
+      if (Ember.FEATURES.isEnabled("nested-apps")) {
+        // we could skip this if we know there are no nested ember apps
+        if (closestRootElement(this) !== rootElement[0]) {
+          return;
+        }
       }
 
       return Ember.handleErrors(function() {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -5,9 +5,12 @@
 
 var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
 
-
 var appRegex = /\bember-application\b/;
 
+/**
+  This method is *significantly* faster than jQuery's `closest`.
+  It gets run for every mouse event, so speed is important here.
+*/
 function closestRootElement(target) {
   var node = target;
   while(node) {

--- a/packages/ember-views/lib/views.js
+++ b/packages/ember-views/lib/views.js
@@ -3,3 +3,4 @@ require("ember-views/views/states");
 require("ember-views/views/container_view");
 require("ember-views/views/collection_view");
 require("ember-views/views/component");
+require("ember-views/views/nested_application_view");

--- a/packages/ember-views/lib/views/nested_application_view.js
+++ b/packages/ember-views/lib/views/nested_application_view.js
@@ -1,0 +1,16 @@
+
+if (Ember.FEATURES.isEnabled('nested-app')) {
+
+  Ember.NestedApplicationView = Ember.View.extend({
+    NestedApplication: null,
+    setupApplication: Ember.on("didInsertElement", function() {
+      this.app = this.NestedApplication.create({
+        rootElement: this.get('element')
+      });
+    }),
+    teardownApplication: Ember.on("willDestroyElement", function() {
+      this.app.destroy();
+    })
+  });
+
+}

--- a/packages/ember-views/lib/views/nested_application_view.js
+++ b/packages/ember-views/lib/views/nested_application_view.js
@@ -3,13 +3,18 @@ if (Ember.FEATURES.isEnabled('nested-app')) {
 
   Ember.NestedApplicationView = Ember.View.extend({
     NestedApplication: null,
+    application: Ember.computed(function() {
+      return this.container.lookup('application:main');
+    }),
     setupApplication: Ember.on("didInsertElement", function() {
       this.app = this.NestedApplication.create({
         rootElement: this.get('element')
       });
+      this.get('application').registerChildApp(this.app);
     }),
     teardownApplication: Ember.on("willDestroyElement", function() {
       this.app.destroy();
+      this.get('application').unregisterChildApp(this.app);
     })
   });
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1488,7 +1488,7 @@ Ember.View = Ember.CoreView.extend(
       Ember.assert("You tried to append to (" + target + ") but that isn't in the DOM", Ember.$(target).length > 0);
 
       // we will want to find a better way to keep this assert and allow nesting
-      Ember.assert("You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.", Ember.$(target).hasClass('ember-application') || !Ember.$(target).is('.ember-view') && !Ember.$(target).parents().is('.ember-view'));
+      Ember.assert("You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.", (Ember.FEATURES.isEnabled("nested-apps") && Ember.$(target).hasClass('ember-application')) || !Ember.$(target).is('.ember-view') && !Ember.$(target).parents().is('.ember-view'));
 
       this.$().appendTo(target);
     });

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1486,7 +1486,10 @@ Ember.View = Ember.CoreView.extend(
     // element after bindings have synchronized.
     this._insertElementLater(function() {
       Ember.assert("You tried to append to (" + target + ") but that isn't in the DOM", Ember.$(target).length > 0);
-      Ember.assert("You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.", !Ember.$(target).is('.ember-view') && !Ember.$(target).parents().is('.ember-view'));
+
+      // we will want to find a better way to keep this assert and allow nesting
+      Ember.assert("You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.", Ember.$(target).hasClass('ember-application') || !Ember.$(target).is('.ember-view') && !Ember.$(target).parents().is('.ember-view'));
+
       this.$().appendTo(target);
     });
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2649,6 +2649,7 @@ if (Ember.FEATURES.isEnabled("nested-apps")) {
     handleURL('/');
 
     equal(Ember.$('#qunit-fixture button.inner').length, 1, "Inner button was rendered");
+    ok(App.get('eventDispatcher')._hasChildren, "event dispatcher knows about nested apps");
   });
 
   test("event handlers on views in the InnerApp fire exactly once", function() {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2586,7 +2586,7 @@ test("Route model hook finds the same model as a manual find", function() {
 if (Ember.FEATURES.isEnabled("nested-apps")) {
   var InnerApp, OuterIndexView, InnerIndexView, innerContainer, innerClicks;
 
-  module("Nested Ember Apps", {
+  module("Ember.NestedApplicationView", {
     setup: function() {
       Ember.run(function() {
         App = Ember.Application.create({
@@ -2594,34 +2594,7 @@ if (Ember.FEATURES.isEnabled("nested-apps")) {
           rootElement: '#qunit-fixture'
         });
 
-        InnerApp = Ember.Application.extend({
-          name: "InnerApp"
-        });
-
-        App.deferReadiness();
-
-        App.Router.reopen({
-          location: 'none'
-        });
-
-        App.LoadingRoute = Ember.Route.extend();
-
-        OuterIndexView = Ember.View.extend({
-          templateName: "outer_index",
-          didInsertElement: function() {
-            this._app = InnerApp.create({
-              rootElement: this.$('.inner-root')[0]
-            });
-            innerContainer = this._app.__container__;
-            innerContainer.register('view:index', InnerIndexView);
-          },
-          willDestroyElement: function() {
-            this._app.destroy();
-          }
-        });
-
-        container = App.__container__;
-        container.register('view:index', OuterIndexView);
+        InnerApp = Ember.Application.extend();
 
         innerClicks = 0;
 
@@ -2632,8 +2605,28 @@ if (Ember.FEATURES.isEnabled("nested-apps")) {
           }
         });
 
-        // Ember.TEMPLATES.application = compile("{{outlet}}"); // Kris is POSITIVE this is generated. ;)
-        Ember.TEMPLATES.outer_index = compile("<div class='inner-root'></div>");
+        InnerApp.initializer({
+          name: "setupInnerIndexView",
+          initialize: function(innerContainer, application) {
+            innerContainer.register('view:index', InnerIndexView);
+          }
+        });
+
+        App.deferReadiness();
+
+        App.Router.reopen({
+          location: 'none'
+        });
+
+        App.LoadingRoute = Ember.Route.extend();
+
+        OuterIndexView = Ember.NestedApplicationView.extend({
+          NestedApplication: InnerApp
+        });
+
+        container = App.__container__;
+        container.register('view:index', OuterIndexView);
+
         Ember.TEMPLATES.inner_index = compile("I AM THE INNER<button class='inner'>BUTTON</button>");
       });
     },

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2582,3 +2582,88 @@ test("Route model hook finds the same model as a manual find", function() {
 
   equal(App.Post, Post);
 });
+
+var InnerApp, OuterIndexView, InnerIndexView, innerContainer, innerClicks;
+
+module("Nested Ember Apps", {
+  setup: function() {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        name: "App",
+        rootElement: '#qunit-fixture'
+      });
+
+      InnerApp = Ember.Application.extend({
+        name: "InnerApp"
+      });
+
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+
+      App.LoadingRoute = Ember.Route.extend();
+
+      OuterIndexView = Ember.View.extend({
+        templateName: "outer_index",
+        didInsertElement: function() {
+          this._app = InnerApp.create({
+            rootElement: this.$('.inner-root')[0]
+          });
+          innerContainer = this._app.__container__;
+          innerContainer.register('view:index', InnerIndexView);
+        },
+        willDestroyElement: function() {
+          this._app.destroy();
+        }
+      });
+
+      container = App.__container__;
+      container.register('view:index', OuterIndexView);
+
+      innerClicks = 0;
+
+      InnerIndexView = Ember.View.extend({
+        templateName: "inner_index",
+        click: function() {
+          innerClicks = innerClicks + 1;
+        }
+      });
+
+      // Ember.TEMPLATES.application = compile("{{outlet}}"); // Kris is POSITIVE this is generated. ;)
+      Ember.TEMPLATES.outer_index = compile("<div class='inner-root'></div>");
+      Ember.TEMPLATES.inner_index = compile("I AM THE INNER<button class='inner'>BUTTON</button>");
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      InnerApp = null;
+      App.destroy(); // App is an instance, InnerApp is not
+      App = null;
+
+      Ember.TEMPLATES = {};
+    });
+    Ember.TESTING_DEPRECATION = false;
+  }
+});
+
+test("InnerApp's index view is rendered", function() {
+  bootApplication();
+
+  handleURL('/');
+
+  equal(Ember.$('#qunit-fixture button.inner').length, 1, "Inner button was rendered");
+});
+
+test("event handlers on views in the InnerApp fire exactly once", function() {
+  bootApplication();
+
+  handleURL('/');
+
+  Ember.$('button.inner').trigger('click');
+
+  equal(innerClicks, 1, "inner view click handler was called one time");
+});
+


### PR DESCRIPTION
- removes asserts preventing app nesting
- removes test for one of removed asserts
- adds test showing a nested app rendering in basic_test.js
- update event dispatching to not dispatch when closest `.ember-application`is not rootElement 
- adds test showing that a click handler in a nested app's view gets hit exactly one time

cc: @kselden
