### PR TITLE
Add readonly attribute support to textarea helper

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -30,7 +30,7 @@ Ember.TextArea = Ember.Component.extend(Ember.TextSupport, {
   classNames: ['ember-text-area'],
 
   tagName: "textarea",
-  attributeBindings: ['rows', 'cols', 'name'],
+  attributeBindings: ['rows', 'cols', 'name', 'readonly'],
   rows: null,
   cols: null,
 

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -90,6 +90,24 @@ test("should become disabled if the disabled attribute is true", function() {
   ok(textArea.$().is(":not(:disabled)"));
 });
 
+test("should become readonly if the readonly attribute is true", function() {
+  textArea.set('readonly', true);
+  append();
+
+  ok(textArea.$().is(":read-only"));
+});
+
+test("should become readonly if the readonly attribute is true", function() {
+  append();
+  ok(textArea.$().is(":not(:read-only)"));
+
+  Ember.run(function() { textArea.set('readonly', true); });
+  ok(textArea.$().is(":read-only"));
+
+  Ember.run(function() { textArea.set('readonly', false); });
+  ok(textArea.$().is(":not(:read-only)"));
+});
+
 test("input value is updated when setting value property of view", function() {
   Ember.run(function() {
     set(textArea, 'value', 'foo');


### PR DESCRIPTION
Support for readonly attribute in {{textarea}} and tests.
