### PR TITLE
remove redundant assignment of isDestroyed

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -703,7 +703,6 @@ define("container",
         @method destroy
       */
       destroy: function() {
-        this.isDestroyed = true;
 
         for (var i=0, l=this.children.length; i<l; i++) {
           this.children[i].destroy();


### PR DESCRIPTION
The object has its isDestroyed set at the end of the function.

I ran rake test[all] and they pass. 
