### PR TITLE
Guid prefix

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -6,6 +6,14 @@ require('ember-metal/array');
 @module ember-metal
 */
 
+/**
+  @private
+  
+  Prefix used for guids through out Ember.
+  
+*/
+Ember.GUID_PREFIX = 'ember';
+
 
 var o_defineProperty = Ember.platform.defineProperty,
     o_create = Ember.create,
@@ -60,13 +68,13 @@ var GUID_DESC = {
   @return {String} the guid
 */
 Ember.generateGuid = function generateGuid(obj, prefix) {
-  if (!prefix) prefix = 'ember';
+  if (!prefix) prefix = Ember.GUID_PREFIX;
   var ret = (prefix + (uuid++));
   if (obj) {
     GUID_DESC.value = ret;
     o_defineProperty(obj, GUID_KEY, GUID_DESC);
   }
-  return ret ;
+  return ret;
 };
 
 /**

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -86,7 +86,7 @@ Ember.rewatch = function(obj) {
 
   // make sure the object has its own guid.
   if (GUID_KEY in obj && !obj.hasOwnProperty(GUID_KEY)) {
-    generateGuid(obj, 'ember');
+    generateGuid(obj);
   }
 
   // make sure any chained watchers update.

--- a/packages/ember-metal/tests/utils/generate_guid_test.js
+++ b/packages/ember-metal/tests/utils/generate_guid_test.js
@@ -1,0 +1,7 @@
+module("Ember.generateGuid");
+
+test("Prefix", function() {
+  var a = {};
+  
+  ok( Ember.generateGuid(a, 'tyrell').indexOf('tyrell') > -1, "guid can be prefixed" );
+});

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -494,7 +494,7 @@ var ClassMixin = Mixin.create({
 
     proto = Class.prototype = o_create(this.prototype);
     proto.constructor = Class;
-    generateGuid(proto, 'ember');
+    generateGuid(proto);
     meta(proto).proto = proto; // this will disable observers on prototype
 
     Class.ClassMixin.apply(Class);


### PR DESCRIPTION
There are two changes:
1. Introduce a constant for guid prefix. Good because it's less prone to errors, and neat if one wants to change the prefix (writing _em123_ when debugging/developing is quicker than _ember123_, similar to the `Ember === Em` shortcut).
2. Reduces some repetition between `generateGuid` and `guidFor` (I'm unsure about this one). The current structure may be for performance, to skip an extra function call. Perhaps someone with more knowledge of JS performance can chip in?

(I'm happy to axe the second commit if it's more performant, and otherwise I'll squash them together)
