### PR TITLE
Remove unused parameter in propertiesFromHTMLOptions

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -15,7 +15,7 @@ var VIEW_PREFIX = /^view\./;
 
 EmberHandlebars.ViewHelper = Ember.Object.create({
 
-  propertiesFromHTMLOptions: function(options, thisContext) {
+  propertiesFromHTMLOptions: function(options) {
     var hash = options.hash, data = options.data;
     var extensions = {},
         classes = hash['class'],


### PR DESCRIPTION
Just noticed a parameter that is not used anywhere inside `EmberHandlebars.ViewHelper`'s `propertiesFromHTMLOptions` method.
