### PR TITLE
Bootstrap DOM templates into the container instead of Ember.TEMPLATES

### DIFF
--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -10,9 +10,8 @@ require("ember-handlebars/ext");
 /**
   @private
 
-  Find templates stored in the head tag as script tags and make them available
-  to `Ember.CoreView` in the global `Ember.TEMPLATES` object. This will be run
-  as as jQuery DOM-ready callback.
+  Find templates stored in the document as script tags and make them available
+  via the container. This is run as part of application intialization.
 
   Script tags with `text/x-handlebars` will be compiled
   with Ember's Handlebars and are suitable for use as a view's template.
@@ -24,7 +23,7 @@ require("ember-handlebars/ext");
   @static
   @param ctx
 */
-Ember.Handlebars.bootstrap = function(ctx) {
+Ember.Handlebars.bootstrap = function(ctx, container) {
   var selectors = 'script[type="text/x-handlebars"], script[type="text/x-raw-handlebars"]';
 
   Ember.$(selectors, ctx)
@@ -41,21 +40,29 @@ Ember.Handlebars.bootstrap = function(ctx) {
       templateName = script.attr('data-template-name') || script.attr('id') || 'application',
       template = compile(script.html());
 
-    // Check if template of same name already exists
-    if (Ember.TEMPLATES[templateName] !== undefined) {
-      throw new Error('Template named "' + templateName  + '" already exists.');
-    }
+    if (container) {
+      var fullName = 'template:' + templateName;
+      if (container.has(fullName)) {
+        throw new Error('Template named "' + templateName  + '" already registered.');
+      }
+      container.register(fullName, template);
+    } else {
+      // Check if template of same name already exists
+      if (Ember.TEMPLATES[templateName] !== undefined) {
+        throw new Error('Template named "' + templateName  + '" already exists.');
+      }
 
-    // For templates which have a name, we save them and then remove them from the DOM
-    Ember.TEMPLATES[templateName] = template;
+      // For templates which have a name, we save them and then remove them from the DOM
+      Ember.TEMPLATES[templateName] = template;
+    }
 
     // Remove script tag from DOM
     script.remove();
   });
 };
 
-function bootstrap() {
-  Ember.Handlebars.bootstrap( Ember.$(document) );
+function bootstrap(container) {
+  Ember.Handlebars.bootstrap(Ember.$(document), container);
 }
 
 function registerComponents(container) {


### PR DESCRIPTION
This is almost certainly the direction we want to go.

But I am unsure about backward compatibility and whether we should feature flag this.

For normal usage, this change should be transparent. Not sure if people may be abusing this method in some way that requires leaving in the no container branch as I have here.

Feedback?

<!---
@huboard:{"order":0.039642333984375,"custom_state":""}
-->
