### PR TITLE
Fix HistoryLocation test for static site testing.

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1875,7 +1875,7 @@ test("Router accounts for rootURL on page load when using history location", fun
 
 test("HistoryLocation has the correct rootURL on initState and webkit doesn't fire popstate on page load", function() {
   expect(2);
-  var rootURL = window.location.pathname + 'app',
+  var rootURL = window.location.pathname,
       history,
       HistoryTestLocation;
 


### PR DESCRIPTION
Before this change this test fails when running tests under a static
site (aka 'file://some/path/index.html').

I am not 100% sure that this is the correct way to fix this issue, but
tests pass under both scenarios with this change (static and `rackup`
tests).

Thanks to @alexspeller for pointing me in the right direction to start
tracking this issue down.
