### PR TITLE
Universalize {{view}} helper quoteless binding syntax, prevent id binding

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -34,20 +34,6 @@ Ember.assert("Ember Handlebars requires Handlebars version 1.0.0, COMPILER_REVIS
 */
 Ember.Handlebars = objectCreate(Handlebars);
 
-function makeBindings(options) {
-  var hash = options.hash,
-      hashType = options.hashTypes;
-
-  for (var prop in hash) {
-    if (hashType[prop] === 'ID') {
-      hash[prop + 'Binding'] = hash[prop];
-      hashType[prop + 'Binding'] = 'STRING';
-      delete hash[prop];
-      delete hashType[prop];
-    }
-  }
-}
-
 /**
   Register a bound helper or custom view helper.
 
@@ -107,7 +93,6 @@ Ember.Handlebars.helper = function(name, value) {
   if (Ember.View.detect(value)) {
     Ember.Handlebars.registerHelper(name, function(options) {
       Ember.assert("You can only pass attributes (such as name=value) not bare values to a helper for a View", arguments.length < 2);
-      makeBindings(options);
       return Ember.Handlebars.helpers.view.call(this, value, options);
     });
   } else {

--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -9,15 +9,6 @@ require("ember-handlebars/controls/select");
 @submodule ember-handlebars-compiler
 */
 
-function normalizeHash(hash, hashTypes) {
-  for (var prop in hash) {
-    if (hashTypes[prop] === 'ID') {
-      hash[prop + 'Binding'] = hash[prop];
-      delete hash[prop];
-    }
-  }
-}
-
 /**
 
   The `{{input}}` helper inserts an HTML `<input>` tag into the template,
@@ -166,8 +157,6 @@ Ember.Handlebars.registerHelper('input', function(options) {
 
   delete hash.type;
   delete hash.on;
-
-  normalizeHash(hash, types);
 
   if (inputType === 'checkbox') {
     return Ember.Handlebars.helpers.view.call(this, Ember.Checkbox, options);
@@ -331,6 +320,5 @@ Ember.Handlebars.registerHelper('textarea', function(options) {
   var hash = options.hash,
       types = options.hashTypes;
 
-  normalizeHash(hash, types);
   return Ember.Handlebars.helpers.view.call(this, Ember.TextArea, options);
 });

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -100,7 +100,7 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
   ```
 
   ```handlebars
-  {{view Ember.Select contentBinding="names"}}
+  {{view Ember.Select content=names}}
   ```
 
   Would result in the following HTML:
@@ -113,7 +113,7 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
   ```
 
   You can control which `<option>` is selected through the `Ember.Select`'s
-  `value` property directly or as a binding:
+  `value` property:
 
   ```javascript
   App.ApplicationController = Ember.Controller.extend({
@@ -124,8 +124,8 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
 
   ```handlebars
   {{view Ember.Select
-         contentBinding="names"
-         valueBinding="selectedName"
+         content=names
+         value=selectedName
   }}
   ```
 
@@ -166,7 +166,7 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
 
   ```handlebars
   {{view Ember.Select
-         contentBinding="programmers"
+         content=programmers
          optionValuePath="content.id"
          optionLabelPath="content.firstName"}}
   ```
@@ -181,8 +181,7 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
   ```
 
   The `value` attribute of the selected `<option>` within an `Ember.Select`
-  can be bound to a property on another object by providing a
-  `valueBinding` option:
+  can be bound to a property on another object:
 
   ```javascript
   App.ApplicationController = Ember.Controller.extend({
@@ -198,10 +197,10 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
 
   ```handlebars
   {{view Ember.Select
-         contentBinding="programmers"
+         content=programmers
          optionValuePath="content.id"
          optionLabelPath="content.firstName"
-         valueBinding="currentProgrammer.id"}}
+         value=currentProgrammer.id}}
   ```
 
   Would result in the following HTML with a selected option:
@@ -218,8 +217,8 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
   to match the `value` property of the newly selected `<option>`.
 
   Alternatively, you can control selection through the underlying objects
-  used to render each object providing a `selectionBinding`. When the selected
-  `<option>` is changed, the property path provided to `selectionBinding`
+  used to render each object by binding the `selection` option. When the selected
+  `<option>` is changed, the property path provided to `selection`
   will be updated to match the content object of the rendered `<option>`
   element:
 
@@ -235,10 +234,10 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
 
   ```handlebars
   {{view Ember.Select
-         contentBinding="programmers"
+         content=programmers
          optionValuePath="content.id"
          optionLabelPath="content.firstName"
-         selectionBinding="selectedPerson"}}
+         selection=selectedPerson}}
   ```
 
   Would result in the following HTML with a selected option:
@@ -251,7 +250,7 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
   ```
 
   Interacting with the rendered element by selecting the first option
-  ('Yehuda') will update the `selectedPerson` to match the object of 
+  ('Yehuda') will update the `selectedPerson` to match the object of
   the newly selected `<option>`. In this case it is the first object
   in the `programmers`
 
@@ -272,8 +271,8 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
 
   ``` handlebars
   {{view Ember.Select
-         contentBinding="programmers"
-         valueBinding="selectedProgrammer"
+         content=programmers
+         value=selectedProgrammer
   }}
   ```
 
@@ -304,8 +303,8 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
 
   ```handlebars
   {{view Ember.Select
-         contentBinding="programmers"
-         valueBinding="selectedProgrammer"
+         content=programmers
+         value=selectedProgrammer
          prompt="Please select a name"
   }}
   ```
@@ -329,7 +328,7 @@ Ember.Select = Ember.View.extend(
 
   tagName: 'select',
   classNames: ['ember-select'],
-  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each view.groupedContent}}{{view view.groupView contentBinding=this.content labelBinding=this.label}}{{/each}}{{else}}{{#each view.content}}{{view view.optionView contentBinding="this"}}{{/each}}{{/if}}'),
+  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each view.groupedContent}}{{view view.groupView content=content label=label}}{{/each}}{{else}}{{#each view.content}}{{view view.optionView content=this}}{{/each}}{{/if}}'),
   attributeBindings: ['multiple', 'disabled', 'tabindex', 'name'],
 
   /**

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -13,6 +13,28 @@ var EmberHandlebars = Ember.Handlebars;
 var LOWERCASE_A_Z = /^[a-z]/;
 var VIEW_PREFIX = /^view\./;
 
+function makeBindings(thisContext, options) {
+  var hash = options.hash,
+      hashType = options.hashTypes;
+
+  for (var prop in hash) {
+    if (hashType[prop] === 'ID') {
+      hash[prop + 'Binding'] = hash[prop];
+      hashType[prop + 'Binding'] = 'STRING';
+      delete hash[prop];
+      delete hashType[prop];
+    }
+  }
+
+  if (hash.hasOwnProperty('idBinding')) {
+    // id can't be bound, so just perform one-time lookup.
+    hash.id = EmberHandlebars.get(thisContext, hash.idBinding, options);
+    hashType.id = 'STRING';
+    delete hash.idBinding;
+    delete hashType.idBinding;
+  }
+}
+
 EmberHandlebars.ViewHelper = Ember.Object.create({
 
   propertiesFromHTMLOptions: function(options) {
@@ -121,6 +143,8 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
     var data = options.data,
         fn = options.fn,
         newView;
+
+    makeBindings(thisContext, options);
 
     if ('string' === typeof path) {
 

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -394,7 +394,7 @@ test("select with group observes its content", function() {
   equal(labels.join(''), 'YehudaKeith');
 });
 test("select with group whose content is undefined doesn't breaks", function() {
-  
+
 		var content;
   Ember.run(function() {
     select.set('content', content),
@@ -767,18 +767,11 @@ test("upon content change with Array-like content, the DOM should reflect the se
   equal(selectEl.selectedIndex, 1, "The DOM reflects the correct selection");
 });
 
-test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding", function() {
+function testValueBinding(templateString) {
   view = Ember.View.create({
     collection: Ember.A([{name: 'Wes', value: 'w'}, {name: 'Gordon', value: 'g'}]),
     val: 'g',
-    template: Ember.Handlebars.compile(
-      '{{view Ember.Select viewName="select"' +
-      '    contentBinding="view.collection"' +
-      '    optionLabelPath="content.name"' +
-      '    optionValuePath="content.value"' +
-      '    prompt="Please wait..."' +
-      '    valueBinding="view.val"}}'
-    )
+    template: Ember.Handlebars.compile(templateString)
   });
 
   Ember.run(function() {
@@ -799,4 +792,26 @@ test("select element should correctly initialize and update selectedIndex and bo
   equal(view.get('val'), 'w', "Updated bound property is correct");
   equal(select.get('value'), 'w', "Updated selection is correct");
   equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
+}
+
+test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (old xBinding='' syntax)", function() {
+  testValueBinding(
+    '{{view Ember.Select viewName="select"' +
+    '    contentBinding="view.collection"' +
+    '    optionLabelPath="content.name"' +
+    '    optionValuePath="content.value"' +
+    '    prompt="Please wait..."' +
+    '    valueBinding="view.val"}}'
+  );
+});
+
+test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (new quoteless binding shorthand)", function() {
+  testValueBinding(
+    '{{view Ember.Select viewName="select"' +
+    '    content=view.collection' +
+    '    optionLabelPath="content.name"' +
+    '    optionValuePath="content.value"' +
+    '    prompt="Please wait..."' +
+    '    value=view.val}}'
+  );
 });

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -85,3 +85,16 @@ test("View lookup - 'fu'", function() {
     return FuView;
   }
 });
+
+test("id bindings downgrade to one-time property lookup", function() {
+  view = Ember.View.extend({
+    template: Ember.Handlebars.compile("{{#view Ember.View id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}"),
+    meshuggah: 'stengah'
+  }).create();
+
+  Ember.run(view, 'appendTo', '#qunit-fixture');
+
+  equal(Ember.$('#stengah').text(), 'stengah', "id binding performed property lookup");
+  Ember.run(view, 'set', 'meshuggah', 'omg');
+  equal(Ember.$('#stengah').text(), 'omg', "id didn't change");
+});

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -677,7 +677,7 @@ if (Ember.FEATURES.isEnabled("query-params")) {
     });
 
     Ember.TEMPLATES.about = Ember.Handlebars.compile("<h1>About</h1> {{#linkTo 'about' id='about-link'}}About{{/linkTo}} {{#linkTo 'about' section='intro' id='about-link-with-qp'}}Intro{{/linkTo}}{{#linkTo 'about' section=false id='about-clear-qp'}}Intro{{/linkTo}}{{#if isIntro}} <p>Here is the intro</p>{{/if}}");
-    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#linkTo 'about' id='about-link'}}About{{/linkTo}} {{#linkTo 'items' id='items-link' directionBinding=otherDirection}}Sort{{/linkTo}} {{#linkTo 'items' id='items-sort-link' sort='name'}}Sort Ascending{{/linkTo}} {{#linkTo 'items' id='items-clear-link' queryParams=false}}Clear Query Params{{/linkTo}}");
+    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#linkTo 'about' id='about-link'}}About{{/linkTo}} {{#linkTo 'items' id='items-link' direction=otherDirection}}Sort{{/linkTo}} {{#linkTo 'items' id='items-sort-link' sort='name'}}Sort Ascending{{/linkTo}} {{#linkTo 'items' id='items-clear-link' queryParams=false}}Clear Query Params{{/linkTo}}");
 
     App.AboutRoute = Ember.Route.extend({
       setupController: function(controller, context, queryParams) {


### PR DESCRIPTION
The quoteless shorthand binding syntax, which you may
remember from the `{{input}}` helper or views/components
wrapped in `Ember.Handlebars.helper`, has been moved
into the `{{view}}` helper, which universalizes the syntax
for any helpers that eventually invoke the `{{view}}` helper.

So now you can do:

```
{{#view 'someView' foo=bar}}
  Bound foo property: {{view.foo}}
{{/view}}
```

Instead of having to do `fooBinding="bar"`

Furthermore, specifying `id=someProperty` will just perform a
one-time lookup for `someProperty`, rather than creating a binding.
Closes #3490.
