### PR TITLE
Fix event name in code comment for `Ember.TextSupport`

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -52,7 +52,7 @@ Ember.TextSupport = Ember.Mixin.create({
     Options are:
 
     * `enter`: the user pressed enter
-    * `keypress`: the user pressed a key
+    * `keyPress`: the user pressed a key
 
     @property onEvent
     @type String


### PR DESCRIPTION
`onEvent=keypress` wouldn't handled. this name should be `keyPress`.
