### PR TITLE
Update beta changelog.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,66 @@
+* Ember 1.1.0-beta.2 (September 27, 2013)*
+
+  * Revert "[BUGFIX] Fix an issue with concatenatedProperties."
+  * Update to the latest ember-dev.
+  * [BUGFIX beta] Fixes #3332 - Array Computed Properties should update synchronously
+  * [BUGFIX beta] Fixes issue when content is undefined for Ember.Select with optgroup
+  * [BUGFIX] Fix an issue with concatenatedProperties.
+  * fix initializer assertion messages
+  * [BUGFIX release] `Ember.SubArray` operation composition fix.
+  * [BUGFIX beta] Fire observers for array computed changes.
+  * [BUGFIX beta] Added tests failing for issue #3331
+  * Adding comments for 'extend()' method
+  * Fix the second half of the bug in suspendListeners
+  * [BUGFIX beta] Optimization: Clear the meta cache without using observers.
+  * [BUGFIX beta] Calling `replaceIn` would incorrectly move views from the `hasElement` to `inDOM`
+
+* Ember 1.1.0-beta.1 (September 13, 2013)*
+
+  * [BUGFIX beta] ReduceComputedProperty ignore invalidated property observers.
+  * Update link_to.js
+  * Force a rebuild
+  * Set source object as context for callbacks in computed array property
+  * fix yield documentation so it is generated properly
+  * fix missing backquotes on link-to docs
+  * fix small typo
+  * allow to inject falsy values like 'false' and 'null'
+  * `Ember.TargetActionSupport`'s `sendAction` should support `null` as context.
+  * Fix some YUIDoc parsing
+  * Update ember-dev to fix broken builds
+  * Update ember-dev.
+  * Remove the .VERSION from library version logging.
+  * Update docs for App.register
+  * Use EmberDefeatureify
+  * Create Ember.libraries for keeping track of versions for debugging. emberjs/data#1051
+  * Update Ember.TextArea and Ember.TextField documentation
+  * components should declare actions in the actions hash
+  * Improve docs for CoreObject#concatenatedProperties
+  * Fix grammar in CONTRIBUTING.md
+  * Close #3307 – Fix unexpected behavior with functions in concatenated properties
+  * Add test for using concatenated properties with functions
+  * fixing grammer in computed property docs
+  * Add shortcut for whitelisting all modifier keys on {{action}} Modifier key-independent action helper use cases can be less verbose and more future-proof.
+  * Only throw an initialValue error if it is null or undefined (i.e. not 0 or some other falsy value)
+  * Improve message and logic around UnrecognizedURLError
+  * Incorrect error message in router.js
+  * Add defeatureify to Travis config.
+  * add inline doc for deprecated Ember.State/StateManager
+  * Fix Em.Computed.not example typo error
+  * As the container api is currently for internal use, and YUI doesn't seem to allow marking an entire class or module as private. Simply hide it for now. This will hopefully prevent some confusion, but power-users can still read the documention.
+  * Fix route name in code comment
+  * Use the declared variable
+  * TESTING_DEPRECATIONS refactor in various testcases
+  * Install default error handler on ApplicationRoute#actions, not #events
+  * fixup docs (mostly formatting)
+  * Reuse variable
+  * Fix typo in docstring
+  * update ember-source
+  * fixed duplicated @param
+  * reference CONTRIBUTING.md
+  * Contribution section added to README.md
+  * Fix size calculations on website
+  * Fix ember-source to handle non-RCs
+
 *Ember 1.0.0 (August 31, 2013)*
 
 * Fix nested `{{yield}}`


### PR DESCRIPTION
The CHANGELOG was not updated when 1.1.0-beta.1 and 1.1.0-beta.2 were tagged.

We are working in https://github.com/emberjs/ember-dev/issues/72 to update the release process to ensure that this happens properly going forward.

**NOTE: This PR targets the `beta` branch.**
