### PR TITLE
[FEATURE container-renderables] ComponentLookup uses child container

### DIFF
--- a/packages/ember-handlebars/lib/component_lookup.js
+++ b/packages/ember-handlebars/lib/component_lookup.js
@@ -1,7 +1,9 @@
 Ember.ComponentLookup = Ember.Object.extend({
-  lookupFactory: function(name) {
-    var container = this.container,
-        fullName = 'component:' + name,
+  lookupFactory: function(name, container) {
+
+    container = container || this.container;
+
+    var fullName = 'component:' + name,
         templateFullName = 'template:components/' + name,
         templateRegistered = container && container.has(templateFullName);
 

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -178,7 +178,10 @@ Ember.Handlebars.resolveHelper = function(container, name) {
 
   var helper = container.lookup('helper:' + name);
   if (!helper) {
-    var Component = container.lookup('component-lookup:main').lookupFactory(name);
+    var componentLookup = container.lookup('component-lookup:main');
+    Ember.assert("Could not find 'component-lookup:main' on the provided container, which is necessary for performing component lookups", componentLookup);
+
+    var Component = componentLookup.lookupFactory(name, container);
     if (Component) {
       helper = EmberHandlebars.makeViewHelper(Component);
       container.register('helper:' + name, helper);

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -118,4 +118,25 @@ if (Ember.FEATURES.isEnabled('container-renderables')) {
 
     equal(Ember.$('#wrapper').text(), "machty hello  world", "The component is composed correctly");
   });
+
+  test("Component lookups should take place on components' subcontainers", function() {
+
+    expect(1);
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#sally-rutherford}}{{mach-ty}}{{/sally-rutherford}}</div>");
+
+    boot(function() {
+      container.register('component:sally-rutherford', Ember.Component.extend({
+        init: function() {
+          this._super();
+          this.container = new Ember.Container(this.container);
+          this.container.register('component:mach-ty', Ember.Component.extend({
+            didInsertElement: function() {
+              ok(true, "mach-ty was rendered");
+            }
+          }));
+        }
+      }));
+    });
+  });
 }


### PR DESCRIPTION
If currently rendering a view/component that has a child container
inheriting from the global container, the lookup for a Component
should occur on that child container, not the global container.
