### PR TITLE
[BUGFIX beta] Don't use incompatible array methods

### DIFF
--- a/packages/ember-metal/lib/libraries.js
+++ b/packages/ember-metal/lib/libraries.js
@@ -1,4 +1,6 @@
 // Provides a way to register library versions with ember.
+var forEach = Ember.EnumerableUtils.forEach,
+    indexOf = Ember.EnumerableUtils.indexOf;
 
 Ember.libraries = function() {
   var libraries    = [];
@@ -26,14 +28,15 @@ Ember.libraries = function() {
 
   libraries.deRegister = function(name) {
     var lib = getLibrary(name);
-    if (lib) libraries.splice(libraries.indexOf(lib), 1);
+    if (lib) libraries.splice(indexOf(libraries, lib), 1);
   };
 
   libraries.each = function (callback) {
-    libraries.forEach(function(lib) {
+    forEach(libraries, function(lib) {
       callback(lib.name, lib.version);
     });
   };
+
   return libraries;
 }();
 


### PR DESCRIPTION
The old IE doesn't have some `Array` methods.
