### PR TITLE
[BUGFIX release] Fix to return `undefined` for `href` of {{link-to}}

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -450,7 +450,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       @property href
     **/
     href: Ember.computed(function() {
-      if (get(this, 'tagName') !== 'a') { return false; }
+      if (get(this, 'tagName') !== 'a') { return; }
 
       var router = get(this, 'router'),
           routeArgs = get(this, 'routeArgs');


### PR DESCRIPTION
The old IE renders `false` to `href="false"` against my expectation.
