### PR TITLE
[BUGFIX release] Fix Ember.Object.extend for old IE

### DIFF
--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -268,16 +268,39 @@ Ember.ORDER_DEFINITION = Ember.ENV.ORDER_DEFINITION || [
 Ember.keys = Object.keys;
 
 if (!Ember.keys || Ember.create.isSimulated) {
-  Ember.keys = function(obj) {
-    var ret = [];
-    for(var key in obj) {
-      // Prevents browsers that don't respect non-enumerability from
-      // copying internal Ember properties
-      if (key.substring(0,2) === '__') continue;
-      if (key === '_super') continue;
+  var prototypeProperties = [
+    'constructor',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+    'valueOf',
+    'toLocaleString',
+    'toString'
+  ],
+  pushPropertyName = function(obj, array, key) {
+    // Prevents browsers that don't respect non-enumerability from
+    // copying internal Ember properties
+    if (key.substring(0,2) === '__') return;
+    if (key === '_super') return;
+    if (indexOf(array, key) >= 0) return;
+    if (!obj.hasOwnProperty(key)) return;
 
-      if (obj.hasOwnProperty(key)) { ret.push(key); }
+    array.push(key);
+  };
+
+  Ember.keys = function(obj) {
+    var ret = [], key;
+    for (key in obj) {
+      pushPropertyName(obj, ret, key);
     }
+
+    // IE8 doesn't enumerate property that named the same as prototype properties.
+    for (var i = 0, l = prototypeProperties.length; i < l; i++) {
+      key = prototypeProperties[i];
+
+      pushPropertyName(obj, ret, key);
+    }
+
     return ret;
   };
 }

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -70,7 +70,11 @@ function makeCtor() {
 
         Ember.assert("Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.", !(properties instanceof Ember.Mixin));
 
-        for (var keyName in properties) {
+        if (Ember.typeOf(properties) !== 'object') { continue; }
+
+        var keyNames = Ember.keys(properties);
+        for (var j = 0, ll = keyNames.length; j < ll; j++) {
+          var keyName = keyNames[j];
           if (!properties.hasOwnProperty(keyName)) { continue; }
 
           var value = properties[keyName],

--- a/packages/ember-runtime/tests/core/keys_test.js
+++ b/packages/ember-runtime/tests/core/keys_test.js
@@ -28,3 +28,14 @@ test("should get a key array for a specified Ember.Object", function() {
 
   deepEqual(object2, ['names','age','place']);
 });
+
+// This test is for IE8.
+test("should get a key array for property that is named the same as prototype property", function() {
+  var object1 = {
+    toString: function() {}
+  };
+
+  var object2 = Ember.keys(object1);
+
+  deepEqual(object2, ['toString']);
+});

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -95,6 +95,15 @@ test("throws if you try to 'mixin' a definition", function() {
   }, "Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.");
 });
 
+// This test is for IE8.
+test("property name is the same as own prototype property", function() {
+  var MyClass = Ember.Object.extend({
+    toString: function() { return 'MyClass'; }
+  });
+
+  equal(MyClass.create().toString(), 'MyClass', "should inherit property from the arguments of `Ember.Object.create`");
+});
+
 module('Ember.Object.createWithMixins');
 
 test("Creates a new object that contains passed properties", function() {


### PR DESCRIPTION
In old IE, `Ember.Object.extend` couldn't extend property that is named the same as a property of `Object.prototype`.

``` javascript

MyClass = Ember.Object.extend({
  toString: function() {
    return 'MyClass'
  }
});

var object = MyClass.create();

// The following should return `'MyClass'`.
object.toString(); //=> '<(unknown mixin):ember123>'
```

The cause is that `for ~ in` loop doesn't enumerate a property of `Object.prototype` in old IE.
To fix this issue, I fixed `Ember.keys` to return its own properties and I used it for `Ember.Object.extend`.
