### PR TITLE
Refactor `Ember.Application.initializer` to fix initializers bleeding or not running

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -569,10 +569,10 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
         container = this.__container__,
         graph = new Ember.DAG(),
         namespace = this,
-        i, initializer;
+        name, initializer;
 
-    for (i=0; i<initializers.length; i++) {
-      initializer = initializers[i];
+    for (name in initializers) {
+      initializer = initializers[name];
       graph.addEdges(initializer.name, initializer.initialize, initializer.before, initializer.after);
     }
 
@@ -677,16 +677,23 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 });
 
 Ember.Application.reopenClass({
-  concatenatedProperties: ['initializers'],
-  initializers: Ember.A(),
+  initializers: {},
   initializer: function(initializer) {
-    var initializers = get(this, 'initializers');
+    // If this is the first initializer being added to a subclass, we are going to reopen the class
+    // to make sure we have a new `initializers` object, which extends from the parent class' using
+    // prototypal inheritance. Without this, attempting to add initializers to the subclass would
+    // pollute the parent class as well as other subclasses.
+    if (this.superclass.initializers !== undefined && this.superclass.initializers === this.initializers) {
+      this.reopenClass({
+        initializers: Ember.create(this.initializers)
+      });
+    }
 
-    Ember.assert("The initializer '" + initializer.name + "' has already been registered", !Ember.A(initializers).findBy('name', initializers.name));
+    Ember.assert("The initializer '" + initializer.name + "' has already been registered", !this.initializers[initializer.name]);
     Ember.assert("An initializer cannot be registered with both a before and an after", !(initializer.before && initializer.after));
     Ember.assert("An initializer cannot be registered without an initialize function", Ember.canInvoke(initializer, 'initialize'));
 
-    initializers.push(initializer);
+    this.initializers[initializer.name] = initializer;
   },
 
   /**

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -137,9 +137,7 @@ function applyConcatenatedProperties(obj, key, value, values) {
       return Ember.makeArray(baseValue).concat(value);
     }
   } else {
-    // Make sure this mixin has its own array so it is not
-    // accidentally mutated by another child's interactions
-    return Ember.makeArray(value).slice();
+    return Ember.makeArray(value);
   }
 }
 

--- a/packages/ember-runtime/tests/system/object/extend_test.js
+++ b/packages/ember-runtime/tests/system/object/extend_test.js
@@ -1,3 +1,5 @@
+var get = Ember.get;
+
 module('Ember.Object.extend');
 
 test('Basic extend', function() {
@@ -51,4 +53,33 @@ test('Overriding a method several layers deep', function() {
   equal(obj.barCnt, 2, 'should invoke both');
 });
 
+test('With concatenatedProperties', function(){
+  var SomeClass = Ember.Object.extend({ things: 'foo', concatenatedProperties: ['things'] });
+  var AnotherClass = SomeClass.extend({ things: 'bar' });
+  var YetAnotherClass = SomeClass.extend({ things: 'baz' });
+  var some = new SomeClass();
+  var another = new AnotherClass();
+  var yetAnother = new YetAnotherClass();
+  deepEqual(some.get('things'), ['foo'], 'base class should have just its value');
+  deepEqual(another.get('things'), ['foo', 'bar'], "subclass should have base class' and it's own");
+  deepEqual(yetAnother.get('things'), ['foo', 'baz'], "subclass should have base class' and it's own");
+});
+
+test('With concatenatedProperties class properties', function(){
+  var SomeClass = Ember.Object.extend();
+  SomeClass.reopenClass({
+    concatenatedProperties: ['things'],
+    things: 'foo'
+  });
+  var AnotherClass = SomeClass.extend();
+  AnotherClass.reopenClass({ things: 'bar' });
+  var YetAnotherClass = SomeClass.extend();
+  YetAnotherClass.reopenClass({ things: 'baz' });
+  var some = new SomeClass();
+  var another = new AnotherClass();
+  var yetAnother = new YetAnotherClass();
+  deepEqual(get(some.constructor, 'things'), ['foo'], 'base class should have just its value');
+  deepEqual(get(another.constructor, 'things'), ['foo', 'bar'], "subclass should have base class' and it's own");
+  deepEqual(get(yetAnother.constructor, 'things'), ['foo', 'baz'], "subclass should have base class' and it's own");
+});
 


### PR DESCRIPTION
Previously, `Ember.Application.initializers` was implemented as a
concatenated property, which is works at class definition and instance
creation time, but not when the field is mutated, which is what
`Ember.Application.initializer` was doing prior to this commit.

Also reverted concatenatedProperties change, which had been added to try
unsuccessfully to address this issue.
