### PR TITLE
Remove reduceComputed's requirement that initialValue not be undefined.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -512,13 +512,11 @@ ReduceComputedProperty.prototype._instanceMeta = function (context, propertyName
 };
 
 ReduceComputedProperty.prototype.initialValue = function () {
-  switch (typeof this.options.initialValue) {
-    case 'undefined':
-      throw new Error("reduce computed properties require an initial value: did you forget to pass one to Ember.reduceComputed?");
-    case  'function':
-      return this.options.initialValue();
-    default:
-      return this.options.initialValue;
+  if (typeof this.options.initialValue === 'function') {
+    return this.options.initialValue();
+  }
+  else {
+    return this.options.initialValue;
   }
 };
 
@@ -727,7 +725,7 @@ Ember.reduceComputed = function (options) {
     throw new Error("Reduce Computed Property declared without an options hash");
   }
 
-  if (Ember.isNone(options.initialValue)) {
+  if (!('initialValue' in options)) {
     throw new Error("Reduce Computed Property declared without an initial value");
   }
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -402,3 +402,71 @@ test("changeMeta includes item and index", function() {
 
   deepEqual(callbackItems, expected, "items removed from the array had observers removed");
 });
+
+test("when initialValue is undefined, everything works as advertised", function() {
+  var chars = Ember.Object.createWithMixins({
+    letters: Ember.A(),
+    firstUpper: Ember.reduceComputed('letters', {
+      initialValue: undefined,
+
+      initialize: function(initialValue, changeMeta, instanceMeta) {
+        instanceMeta.matchingItems = Ember.A();
+        instanceMeta.subArray = new Ember.SubArray();
+        instanceMeta.firstMatch = function() {
+          return Ember.getWithDefault(instanceMeta.matchingItems, 'firstObject', initialValue);
+        };
+      },
+
+      addedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
+        var filterIndex;
+        filterIndex = instanceMeta.subArray.addItem(changeMeta.index, item.toUpperCase() === item);
+        if (filterIndex > -1) {
+          instanceMeta.matchingItems.insertAt(filterIndex, item);
+        }
+        return instanceMeta.firstMatch();
+      },
+
+      removedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
+        var filterIndex = instanceMeta.subArray.removeItem(changeMeta.index);
+        if (filterIndex > -1) {
+          instanceMeta.matchingItems.removeAt(filterIndex);
+        }
+        return instanceMeta.firstMatch();
+      }
+    })
+  });
+  equal(get(chars, 'firstUpper'), undefined, "initialValue is undefined");
+
+  get(chars, 'letters').pushObjects(['a', 'b', 'c']);
+
+  equal(get(chars, 'firstUpper'), undefined, "result is undefined when no matches are present");
+
+  get(chars, 'letters').pushObjects(['A', 'B', 'C']);
+
+  equal(get(chars, 'firstUpper'), 'A', "result is the first match when matching objects are present");
+
+  get(chars, 'letters').removeAt(3);
+
+  equal(get(chars, 'firstUpper'), 'B', "result is the next match when the first matching object is removed");
+});
+
+test("an error is thrown when a reduceComputed is defined without an initialValue property", function() {
+  var defineExploder = function() {
+    Ember.Object.createWithMixins({
+      collection: Ember.A(),
+      exploder: Ember.reduceComputed('collection', {
+        initialize: function(initialValue, changeMeta, instanceMeta) {},
+
+        addedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
+          return item;
+        },
+
+        removedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
+          return item;
+        }
+      })
+    });
+  };
+
+  throws(defineExploder, /declared\ without\ an\ initial\ value/, "an error is thrown when the reduceComputed is defined without an initialValue");
+});


### PR DESCRIPTION
I'm implementing `Em.Enumerable#find` as a `Em.reduceComputed` and it's
requirement that `initialValue` not be `undefined` causes us not to be
able to implement the default behaviour of `find` (ie that it returns
the first matching item, or `undefined`).

/cc @hjdivad.
