### PR TITLE
[BUGFIX beta] Fix evaluateUnboundHelper properties

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -458,7 +458,7 @@ function evaluateUnboundHelper(context, fn, normalizedProperties, options) {
 
   for(loc = 0, len = normalizedProperties.length; loc < len; ++loc) {
     property = normalizedProperties[loc];
-    args.push(Ember.Handlebars.get(context, property.path, options));
+    args.push(Ember.Handlebars.get(property.root, property.path, options));
   }
   args.push(options);
   return fn.apply(context, args);

--- a/packages/ember-handlebars/tests/helpers/unbound_test.js
+++ b/packages/ember-handlebars/tests/helpers/unbound_test.js
@@ -156,6 +156,30 @@ test("should be able to render an unbound helper invocation for helpers with dep
 });
 
 
+test("should be able to render an unbound helper invocation in #each helper", function() {
+  view = Ember.View.create({
+    template: Ember.Handlebars.compile(
+      [ "{{#each person in people}}",
+        "{{capitalize person.firstName}} {{unbound capitalize person.firstName}}",
+        "{{/each}}"].join("")),
+    context: {
+      people: Ember.A([
+        {
+          firstName: 'shooby',
+          lastName:  'taylor'
+        },
+        {
+          firstName: 'cindy',
+          lastName:  'taylor'
+        }
+    ])}
+  });
+  appendView(view);
+
+  equal(view.$().text(), "SHOOBY SHOOBYCINDY CINDY", "unbound rendered correctly");
+});
+
+
 test("should be able to render an unbound helper invocation with bound hash options", function() {
   try {
     Ember.Handlebars.registerBoundHelper('repeat', function(value) {


### PR DESCRIPTION
There is an issues with evaluateUnboundHelper, it is getting properties of context instead of the root of the normalized property. This is resulting in undefined values for unbound bound helpers when inside of {{each}} templates.
