### PR TITLE
[BUGFIX beta] Fix edge case in `TrackedArray`.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -178,14 +178,14 @@ DependentArraysObserver.prototype = {
     this.trackedArraysByGuid[dependentKey] = new Ember.TrackedArray(observerContexts);
   },
 
-  addTransformation: function (dependentKey, index, newItems) {
+  trackAdd: function (dependentKey, index, newItems) {
     var trackedArray = this.trackedArraysByGuid[dependentKey];
     if (trackedArray) {
       trackedArray.addItems(index, newItems);
     }
   },
 
-  removeTransformation: function (dependentKey, index, removedCount) {
+  trackRemove: function (dependentKey, index, removedCount) {
     var trackedArray = this.trackedArraysByGuid[dependentKey];
 
     if (trackedArray) {
@@ -226,7 +226,7 @@ DependentArraysObserver.prototype = {
         sliceIndex,
         observerContexts;
 
-    observerContexts = this.removeTransformation(dependentKey, index, removedCount);
+    observerContexts = this.trackRemove(dependentKey, index, removedCount);
 
     function removeObservers(propertyKey) {
       observerContexts[sliceIndex].destroyed = true;
@@ -271,7 +271,7 @@ DependentArraysObserver.prototype = {
         this.instanceMeta.context, this.getValue(), item, changeMeta, this.instanceMeta.sugarMeta));
     }, this);
 
-    this.addTransformation(dependentKey, index, observerContexts);
+    this.trackAdd(dependentKey, index, observerContexts);
   },
 
   itemPropertyWillChange: function (obj, keyName, array, observerContext) {

--- a/packages/ember-runtime/lib/system/tracked_array.js
+++ b/packages/ember-runtime/lib/system/tracked_array.js
@@ -20,9 +20,9 @@ Ember.TrackedArray = function (items) {
   var length = get(items, 'length');
 
   if (length) {
-    this._content = [new ArrayOperation(RETAIN, length, items)];
+    this._operations = [new ArrayOperation(RETAIN, length, items)];
   } else {
-    this._content = [];
+    this._operations = [];
   }
 };
 
@@ -56,7 +56,7 @@ Ember.TrackedArray.prototype = {
     if (arrayOperation) {
       if (!match.split) {
         // insert left of arrayOperation
-        this._content.splice(arrayOperationIndex, 0, newArrayOperation);
+        this._operations.splice(arrayOperationIndex, 0, newArrayOperation);
         composeIndex = arrayOperationIndex;
       } else {
         this._split(arrayOperationIndex, index - arrayOperationRangeStart, newArrayOperation);
@@ -64,7 +64,7 @@ Ember.TrackedArray.prototype = {
       }
     } else {
       // insert at end
-      this._content.push(newArrayOperation);
+      this._operations.push(newArrayOperation);
       composeIndex = arrayOperationIndex;
     }
 
@@ -89,7 +89,7 @@ Ember.TrackedArray.prototype = {
     newArrayOperation = new ArrayOperation(DELETE, count);
     if (!match.split) {
       // insert left of arrayOperation
-      this._content.splice(arrayOperationIndex, 0, newArrayOperation);
+      this._operations.splice(arrayOperationIndex, 0, newArrayOperation);
       composeIndex = arrayOperationIndex;
     } else {
       this._split(arrayOperationIndex, index - arrayOperationRangeStart, newArrayOperation);
@@ -104,12 +104,11 @@ Ember.TrackedArray.prototype = {
     items in the array.
 
     `callback` will be called for each operation and will be passed the following arguments:
-
-* {array} items The items for the given operation
-* {number} offset The computed offset of the items, ie the index in the
-array of the first item for this operation.
-* {string} operation The type of the operation.  One of `Ember.TrackedArray.{RETAIN, DELETE, INSERT}`
-*
+      * {array} items The items for the given operation
+      * {number} offset The computed offset of the items, ie the index in the
+      array of the first item for this operation.
+      * {string} operation The type of the operation.  One of
+      `Ember.TrackedArray.{RETAIN, DELETE, INSERT}`
 
     @method apply
     @param {function} callback
@@ -118,16 +117,16 @@ array of the first item for this operation.
     var items = [],
         offset = 0;
 
-    forEach(this._content, function (arrayOperation) {
-      callback(arrayOperation.items, offset, arrayOperation.operation);
+    forEach(this._operations, function (arrayOperation) {
+      callback(arrayOperation.items, offset, arrayOperation.type);
 
-      if (arrayOperation.operation !== DELETE) {
+      if (arrayOperation.type !== DELETE) {
         offset += arrayOperation.count;
         items = items.concat(arrayOperation.items);
       }
     });
 
-    this._content = [new ArrayOperation(RETAIN, items.length, items)];
+    this._operations = [new ArrayOperation(RETAIN, items.length, items)];
   },
 
   /**
@@ -149,10 +148,10 @@ array of the first item for this operation.
 
     // OPTIMIZE: we could search these faster if we kept a balanced tree.
     // find leftmost arrayOperation to the right of `index`
-    for (arrayOperationIndex = arrayOperationRangeStart = 0, len = this._content.length; arrayOperationIndex < len; ++arrayOperationIndex) {
-      arrayOperation = this._content[arrayOperationIndex];
+    for (arrayOperationIndex = arrayOperationRangeStart = 0, len = this._operations.length; arrayOperationIndex < len; ++arrayOperationIndex) {
+      arrayOperation = this._operations[arrayOperationIndex];
 
-      if (arrayOperation.operation === DELETE) { continue; }
+      if (arrayOperation.type === DELETE) { continue; }
 
       arrayOperationRangeEnd = arrayOperationRangeStart + arrayOperation.count - 1;
 
@@ -170,25 +169,24 @@ array of the first item for this operation.
   },
 
   _split: function (arrayOperationIndex, splitIndex, newArrayOperation) {
-    var arrayOperation = this._content[arrayOperationIndex],
+    var arrayOperation = this._operations[arrayOperationIndex],
         splitItems = arrayOperation.items.slice(splitIndex),
-        splitArrayOperation = new ArrayOperation(arrayOperation.operation, splitItems.length, splitItems);
+        splitArrayOperation = new ArrayOperation(arrayOperation.type, splitItems.length, splitItems);
 
     // truncate LHS
     arrayOperation.count = splitIndex;
     arrayOperation.items = arrayOperation.items.slice(0, splitIndex);
 
-    this._content.splice(arrayOperationIndex + 1, 0, newArrayOperation, splitArrayOperation);
+    this._operations.splice(arrayOperationIndex + 1, 0, newArrayOperation, splitArrayOperation);
   },
 
-  // TODO: unify _composeInsert, _composeDelete
   // see SubArray for a better implementation.
   _composeInsert: function (index) {
-    var newArrayOperation = this._content[index],
-        leftArrayOperation = this._content[index-1], // may be undefined
-        rightArrayOperation = this._content[index+1], // may be undefined
-        leftOp = leftArrayOperation && leftArrayOperation.operation,
-        rightOp = rightArrayOperation && rightArrayOperation.operation;
+    var newArrayOperation = this._operations[index],
+        leftArrayOperation = this._operations[index-1], // may be undefined
+        rightArrayOperation = this._operations[index+1], // may be undefined
+        leftOp = leftArrayOperation && leftArrayOperation.type,
+        rightOp = rightArrayOperation && rightArrayOperation.type;
 
     if (leftOp === INSERT) {
         // merge left
@@ -196,27 +194,27 @@ array of the first item for this operation.
         leftArrayOperation.items = leftArrayOperation.items.concat(newArrayOperation.items);
 
       if (rightOp === INSERT) {
-        // also merge right
+        // also merge right (we have split an insert with an insert)
         leftArrayOperation.count += rightArrayOperation.count;
         leftArrayOperation.items = leftArrayOperation.items.concat(rightArrayOperation.items);
-        this._content.splice(index, 2);
+        this._operations.splice(index, 2);
       } else {
         // only merge left
-        this._content.splice(index, 1);
+        this._operations.splice(index, 1);
       }
     } else if (rightOp === INSERT) {
       // merge right
       newArrayOperation.count += rightArrayOperation.count;
       newArrayOperation.items = newArrayOperation.items.concat(rightArrayOperation.items);
-      this._content.splice(index + 1, 1);
+      this._operations.splice(index + 1, 1);
     }
   },
 
   _composeDelete: function (index) {
-    var arrayOperation = this._content[index],
+    var arrayOperation = this._operations[index],
         deletesToGo = arrayOperation.count,
-        leftArrayOperation = this._content[index-1], // may be undefined
-        leftOp = leftArrayOperation && leftArrayOperation.operation,
+        leftArrayOperation = this._operations[index-1], // may be undefined
+        leftOp = leftArrayOperation && leftArrayOperation.type,
         nextArrayOperation,
         nextOp,
         nextCount,
@@ -228,8 +226,8 @@ array of the first item for this operation.
     }
 
     for (var i = index + 1; deletesToGo > 0; ++i) {
-      nextArrayOperation = this._content[i];
-      nextOp = nextArrayOperation.operation;
+      nextArrayOperation = this._operations[i];
+      nextOp = nextArrayOperation.type;
       nextCount = nextArrayOperation.count;
 
       if (nextOp === DELETE) {
@@ -259,19 +257,38 @@ array of the first item for this operation.
     }
 
     if (arrayOperation.count > 0) {
-      this._content.splice(index+1, i-1-index);
+      this._operations.splice(index+1, i-1-index);
     } else {
       // The delete operation can go away; it has merely reduced some other
       // operation, as in D:3 I:4
-      this._content.splice(index, 1);
+      this._operations.splice(index, removeNewAndNextOp ? 2 : 1);
     }
 
     return removedItems;
+  },
+
+  toString: function () {
+    var str = "";
+    forEach(this._operations, function (operation) {
+      str += " " + operation.type + ":" + operation.count;
+    });
+    return str.substring(1);
   }
 };
 
+/**
+  Internal data structure to represent an array operation.
+
+  @method ArrayOperation
+  @private
+  @property {string} type The type of the operation.  One of
+  `Ember.TrackedArray.{RETAIN, INSERT, DELETE}`
+  @property {number} count The number of items in this operation.
+  @property {array} items The items of the operation, if included.  RETAIN and
+  INSERT include their items, DELETE does not.
+*/
 function ArrayOperation (operation, count, items) {
-  this.operation = operation; // RETAIN | INSERT | DELETE
+  this.type = operation; // RETAIN | INSERT | DELETE
   this.count = count;
   this.items = items;
 }

--- a/packages/ember-runtime/tests/system/tracked_array_test.js
+++ b/packages/ember-runtime/tests/system/tracked_array_test.js
@@ -5,18 +5,10 @@ var forEach = Ember.EnumerableUtils.forEach, trackedArray,
 
 module('Ember.TrackedArray');
 
-function arrayOperationsString() {
-  var str = "";
-  forEach(trackedArray._content, function (mutation) {
-    str += " " + mutation.operation + ":" + mutation.count;
-  });
-  return str.substring(1);
-}
-
 test("operations for a tracked array of length n are initially retain:n", function() {
   trackedArray = new Ember.TrackedArray([1,2,3,4]);
 
-  equal("r:4", arrayOperationsString(), "initial mutation is retain n");
+  equal("r:4", trackedArray.toString(), "initial mutation is retain n");
 });
 
 test("inserts can split retains", function() {
@@ -24,11 +16,11 @@ test("inserts can split retains", function() {
 
   trackedArray.addItems(2, ['a']);
 
-  equal(arrayOperationsString(), "r:2 i:1 r:2", "inserts can split retains");
+  equal(trackedArray.toString(), "r:2 i:1 r:2", "inserts can split retains");
 
-  deepEqual(trackedArray._content[0].items, [1,2], "split retains have the right items");
-  deepEqual(trackedArray._content[1].items, ['a'], "inserts have the right items");
-  deepEqual(trackedArray._content[2].items, [3,4], "split retains have the right items");
+  deepEqual(trackedArray._operations[0].items, [1,2], "split retains have the right items");
+  deepEqual(trackedArray._operations[1].items, ['a'], "inserts have the right items");
+  deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
 });
 
 test("inserts can expand (split/compose) inserts", function() {
@@ -37,9 +29,9 @@ test("inserts can expand (split/compose) inserts", function() {
   trackedArray.addItems(0, [1,2,3,4]);
   trackedArray.addItems(2, ['a']);
 
-  equal(arrayOperationsString(), "i:5", "inserts can expand inserts");
+  equal(trackedArray.toString(), "i:5", "inserts can expand inserts");
 
-  deepEqual(trackedArray._content[0].items, [1,2,'a',3,4], "expanded inserts have the right items");
+  deepEqual(trackedArray._operations[0].items, [1,2,'a',3,4], "expanded inserts have the right items");
 });
 
 test("inserts left of inserts compose", function() {
@@ -48,11 +40,11 @@ test("inserts left of inserts compose", function() {
   trackedArray.addItems(2, ['b']);
   trackedArray.addItems(2, ['a']);
 
-  equal(arrayOperationsString(), "r:2 i:2 r:2", "inserts left of inserts compose");
+  equal(trackedArray.toString(), "r:2 i:2 r:2", "inserts left of inserts compose");
 
-  deepEqual(trackedArray._content[0].items, [1,2], "split retains have the right items");
-  deepEqual(trackedArray._content[1].items, ['a', 'b'], "composed inserts have the right items");
-  deepEqual(trackedArray._content[2].items, [3,4], "split retains have the right items");
+  deepEqual(trackedArray._operations[0].items, [1,2], "split retains have the right items");
+  deepEqual(trackedArray._operations[1].items, ['a', 'b'], "composed inserts have the right items");
+  deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
 });
 
 test("inserts right of inserts compose", function() {
@@ -61,11 +53,11 @@ test("inserts right of inserts compose", function() {
   trackedArray.addItems(2, ['a']);
   trackedArray.addItems(3, ['b']);
 
-  equal(arrayOperationsString(), "r:2 i:2 r:2", "inserts right of inserts compose");
+  equal(trackedArray.toString(), "r:2 i:2 r:2", "inserts right of inserts compose");
 
-  deepEqual(trackedArray._content[0].items, [1,2], "split retains have the right items");
-  deepEqual(trackedArray._content[1].items, ['a', 'b'], "composed inserts have the right items");
-  deepEqual(trackedArray._content[2].items, [3,4], "split retains have the right items");
+  deepEqual(trackedArray._operations[0].items, [1,2], "split retains have the right items");
+  deepEqual(trackedArray._operations[1].items, ['a', 'b'], "composed inserts have the right items");
+  deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
 });
 
 test("deletes compose with several inserts and retains", function() {
@@ -78,7 +70,7 @@ test("deletes compose with several inserts and retains", function() {
   trackedArray.addItems(0, ['a']); // a1b2c3d4e i1r1i1r1i1r1i1r1i1
 
   trackedArray.removeItems(0, 9);
-  equal(arrayOperationsString(), "d:4", "deletes compose with several inserts and retains");
+  equal(trackedArray.toString(), "d:4", "deletes compose with several inserts and retains");
 });
 
 test("deletes compose with several inserts and retains and an adjacent delete", function() {
@@ -92,7 +84,7 @@ test("deletes compose with several inserts and retains and an adjacent delete", 
   trackedArray.addItems(0, ['a']); // a2b3c4d5e d1i1r1i1r1i1r1i1r1i1
 
   trackedArray.removeItems(0, 9);
-  equal(arrayOperationsString(), "d:5", "deletes compose with several inserts, retains, and a single prior delete");
+  equal(trackedArray.toString(), "d:5", "deletes compose with several inserts, retains, and a single prior delete");
 });
 
 test("deletes compose with several inserts and retains and can reduce the last one", function() {
@@ -105,16 +97,16 @@ test("deletes compose with several inserts and retains and can reduce the last o
   trackedArray.addItems(0, ['a']); // a1b2c3d4e i1r1i1r1i1r1i1r1i2
 
   trackedArray.removeItems(0, 9);
-  equal(arrayOperationsString(), "d:4 i:1", "deletes compose with several inserts and retains, reducing the last one");
-  deepEqual(trackedArray._content[1].items, ['f'], "last mutation's items is correct");
+  equal(trackedArray.toString(), "d:4 i:1", "deletes compose with several inserts and retains, reducing the last one");
+  deepEqual(trackedArray._operations[1].items, ['f'], "last mutation's items is correct");
 });
 
 test("deletes can split retains", function() {
   trackedArray = new Ember.TrackedArray([1,2,3,4]);
   trackedArray.removeItems(0, 2);
 
-  equal(arrayOperationsString(), "d:2 r:2", "deletes can split retains");
-  deepEqual(trackedArray._content[1].items, [3,4], "retains reduced by delete have the right items");
+  equal(trackedArray.toString(), "d:2 r:2", "deletes can split retains");
+  deepEqual(trackedArray._operations[1].items, [3,4], "retains reduced by delete have the right items");
 });
 
 test("deletes can split inserts", function() {
@@ -122,8 +114,8 @@ test("deletes can split inserts", function() {
   trackedArray.addItems(0, ['a','b','c']);
   trackedArray.removeItems(0, 1);
 
-  equal(arrayOperationsString(), "i:2", "deletes can split inserts");
-  deepEqual(trackedArray._content[0].items, ['b', 'c'], "inserts reduced by delete have the right items");
+  equal(trackedArray.toString(), "i:2", "deletes can split inserts");
+  deepEqual(trackedArray._operations[0].items, ['b', 'c'], "inserts reduced by delete have the right items");
 });
 
 test("deletes can reduce an insert or retain, compose with several mutations of different types and reduce the last mutation if it is non-delete", function() {
@@ -136,9 +128,9 @@ test("deletes can reduce an insert or retain, compose with several mutations of 
   trackedArray.addItems(0, ['a','a','a']); // aaa1b2c3d4ef i3r1i1r1i1r1i1r1i2
 
   trackedArray.removeItems(1, 10);
-  equal(arrayOperationsString(), "i:1 d:4 i:1", "deletes reduce an insert, compose with several inserts and retains, reducing the last one");
-  deepEqual(trackedArray._content[0].items, ['a'], "first reduced mutation's items is correct");
-  deepEqual(trackedArray._content[2].items, ['f'], "last reduced mutation's items is correct");
+  equal(trackedArray.toString(), "i:1 d:4 i:1", "deletes reduce an insert, compose with several inserts and retains, reducing the last one");
+  deepEqual(trackedArray._operations[0].items, ['a'], "first reduced mutation's items is correct");
+  deepEqual(trackedArray._operations[2].items, ['f'], "last reduced mutation's items is correct");
 });
 
 test("removeItems returns the removed items", function() {
@@ -154,7 +146,7 @@ test("apply invokes the callback with each group of items and the mutation's cal
   trackedArray.removeItems(4, 2);          // 12ab4
   trackedArray.addItems(1, ['d']);         // 1d2ab4 r1 i1 r1 i2 d1 r1
 
-  equal(arrayOperationsString(), "r:1 i:1 r:1 i:2 d:1 r:1", "precond - trackedArray is in expected state");
+  equal(trackedArray.toString(), "r:1 i:1 r:1 i:2 d:1 r:1", "precond - trackedArray is in expected state");
 
   trackedArray.apply(function (items, offset, operation) {
     switch (i++) {
@@ -193,5 +185,5 @@ test("apply invokes the callback with each group of items and the mutation's cal
   });
   equal(i, 6, "`apply` invoked callback right number of times");
 
-  equal(arrayOperationsString(), "r:6", "after `apply` operations become retain:n");
+  equal(trackedArray.toString(), "r:6", "after `apply` operations become retain:n");
 });

--- a/packages/ember-runtime/tests/system/tracked_array_test.js
+++ b/packages/ember-runtime/tests/system/tracked_array_test.js
@@ -11,6 +11,16 @@ test("operations for a tracked array of length n are initially retain:n", functi
   equal("r:4", trackedArray.toString(), "initial mutation is retain n");
 });
 
+test("insert zero items is a no-op", function() {
+  trackedArray = new Ember.TrackedArray([1,2,3,4]);
+
+  trackedArray.addItems(2, []);
+
+  equal(trackedArray.toString(), "r:4", "insert:0 is a no-op");
+
+  deepEqual(trackedArray._operations[0].items, [1,2,3,4], "after a no-op, existing operation has right items");
+});
+
 test("inserts can split retains", function() {
   trackedArray = new Ember.TrackedArray([1,2,3,4]);
 
@@ -58,6 +68,16 @@ test("inserts right of inserts compose", function() {
   deepEqual(trackedArray._operations[0].items, [1,2], "split retains have the right items");
   deepEqual(trackedArray._operations[1].items, ['a', 'b'], "composed inserts have the right items");
   deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
+});
+
+test("delete zero items is a no-op", function() {
+  trackedArray = new Ember.TrackedArray([1,2,3,4]);
+
+  trackedArray.addItems(2, []);
+
+  equal(trackedArray.toString(), "r:4", "insert:0 is a no-op");
+
+  deepEqual(trackedArray._operations[0].items, [1,2,3,4], "after a no-op, existing operation has right items");
 });
 
 test("deletes compose with several inserts and retains", function() {
@@ -109,6 +129,22 @@ test("deletes can split retains", function() {
   deepEqual(trackedArray._operations[1].items, [3,4], "retains reduced by delete have the right items");
 });
 
+test("deletes can trim retains on the right", function() {
+  trackedArray = new Ember.TrackedArray([1,2,3]);
+  trackedArray.removeItems(2, 1);
+
+  equal(trackedArray.toString(), "r:2 d:1", "deletes can trim retains on the right");
+  deepEqual(trackedArray._operations[0].items, [1,2], "retains reduced by delete have the right items");
+});
+
+test("deletes can trim retains on the left", function() {
+  trackedArray = new Ember.TrackedArray([1,2,3]);
+  trackedArray.removeItems(0, 1);
+
+  equal(trackedArray.toString(), "d:1 r:2", "deletes can trim retains on the left");
+  deepEqual(trackedArray._operations[1].items, [2,3], "retains reduced by delete have the right items");
+});
+
 test("deletes can split inserts", function() {
   trackedArray = new Ember.TrackedArray([]);
   trackedArray.addItems(0, ['a','b','c']);
@@ -116,6 +152,34 @@ test("deletes can split inserts", function() {
 
   equal(trackedArray.toString(), "i:2", "deletes can split inserts");
   deepEqual(trackedArray._operations[0].items, ['b', 'c'], "inserts reduced by delete have the right items");
+});
+
+test("deletes can trim inserts on the right", function() {
+  trackedArray = new Ember.TrackedArray([]);
+  trackedArray.addItems(0, ['a','b','c']);
+  trackedArray.removeItems(2, 1);
+
+  equal(trackedArray.toString(), "i:2", "deletes can trim inserts on the right");
+  deepEqual(trackedArray._operations[0].items, ['a', 'b'], "inserts reduced by delete have the right items");
+});
+
+test("deletes can trim inserts on the left", function() {
+  trackedArray = new Ember.TrackedArray([]);
+  trackedArray.addItems(0, ['a','b','c']);
+  trackedArray.removeItems(0, 1);
+
+  equal(trackedArray.toString(), "i:2", "deletes can trim inserts on the right");
+  deepEqual(trackedArray._operations[0].items, ['b', 'c'], "inserts reduced by delete have the right items");
+});
+
+test("deletes can trim inserts on the left while composing with a delete on the left", function() {
+  trackedArray = new Ember.TrackedArray(['a']);
+  trackedArray.removeItems(0, 1);
+  trackedArray.addItems(0, ['b', 'c']);
+  trackedArray.removeItems(0, 1);
+
+  equal(trackedArray.toString(), "d:1 i:1", "deletes can trim inserts and compose with a delete on the left");
+  deepEqual(trackedArray._operations[1].items, ['c'], "inserts reduced by delete have the right items");
 });
 
 test("deletes can reduce an insert or retain, compose with several mutations of different types and reduce the last mutation if it is non-delete", function() {


### PR DESCRIPTION
Fix an edge case in delete composition for a delete that right-trims an insert.
This results in a delete followed by an insert that should both compose to a
no-op, but the insert was being erroneously left behind.

see http://jsbin.com/EFezAP/2

Also ignore no-op adds and deletes (ie add 0 items, delete 0 items).
