### PR TITLE
[FEATURE propertyBraceExpansion]

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1,6 +1,7 @@
 require('ember-metal/core');
 require('ember-metal/platform');
 require('ember-metal/utils');
+require('ember-metal/expand_properties');
 require('ember-metal/property_get');
 require('ember-metal/property_set');
 require('ember-metal/properties');
@@ -17,6 +18,7 @@ Ember.warn("The CP_DEFAULT_CACHEABLE flag has been removed and computed properti
 var get = Ember.get,
     set = Ember.set,
     metaFor = Ember.meta,
+    expandProperties = Ember.expandProperties,
     a_slice = [].slice,
     o_create = Ember.create,
     META_KEY = Ember.META_KEY,
@@ -276,9 +278,13 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
   @chainable
 */
 ComputedPropertyPrototype.property = function() {
+  function addArg(arg) {
+    args.push(arg);
+  }
+
   var args = [];
   for (var i = 0, l = arguments.length; i < l; i++) {
-    args.push(arguments[i]);
+    expandProperties(arguments[i], addArg);
   }
   this._dependentKeys = args;
   return this;

--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -1,0 +1,42 @@
+require('ember-metal/core');
+require('ember-metal/utils');
+
+/**
+  @module ember-metal 
+*/
+
+var forEach = Ember.EnumerableUtils.forEach,
+    IS_BRACE_EXPANSION = /^\{([^.]*)\}$/;
+
+/**
+  Expands `pattern`, invoking `callback` for each expansion.
+
+  The only pattern supported is brace-expansion, anything else will be passed
+  once to `callback` directly.  Furthermore, brace-expansion is only applied to
+  the entire pattern, not to substrings.
+
+  Example
+  ```js
+  function echo(arg){ console.log(arg); }
+
+  Ember.expandProperties('foo.bar', echo);        //=> 'foo.bar'
+  Ember.expandProperties('{foo,bar}', echo);      //=> 'foo', 'bar'
+  Ember.expandProperties('foo.{bar,baz}', echo);  //=> 'foo.{bar,baz}'
+  ```
+
+  @method
+  @private
+  @param {string} pattern The property pattern to expand.
+  @param {function} callback The callback to invoke.  It is invoked once per
+  expansion, and is passed the expansion.
+*/
+Ember.expandProperties = function (pattern, callback) {
+  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+    if (IS_BRACE_EXPANSION.test(pattern)) {
+      forEach(pattern.substring(1, pattern.length-1).split(','), callback);
+      return;
+    }
+  }
+
+  callback(pattern);
+};

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -1,6 +1,7 @@
 require('ember-metal/core');
 require('ember-metal/platform');
 require('ember-metal/utils'); // Ember.tryFinally
+require('ember-metal/expand_properties');
 require('ember-metal/property_get');
 require('ember-metal/array');
 
@@ -8,8 +9,9 @@ require('ember-metal/array');
 @module ember-metal
 */
 
-var AFTER_OBSERVERS = ':change';
-var BEFORE_OBSERVERS = ':before';
+var AFTER_OBSERVERS = ':change',
+    BEFORE_OBSERVERS = ':before',
+    expandProperties = Ember.expandProperties;
 
 function changeEvent(keyName) {
   return keyName+AFTER_OBSERVERS;
@@ -26,9 +28,12 @@ function beforeEvent(keyName) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-Ember.addObserver = function(obj, path, target, method) {
-  Ember.addListener(obj, changeEvent(path), target, method);
-  Ember.watch(obj, path);
+Ember.addObserver = function(obj, _path, target, method) {
+  expandProperties(_path, function (path) {
+    Ember.addListener(obj, changeEvent(path), target, method);
+    Ember.watch(obj, path);
+  });
+
   return this;
 };
 
@@ -43,9 +48,11 @@ Ember.observersFor = function(obj, path) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-Ember.removeObserver = function(obj, path, target, method) {
-  Ember.unwatch(obj, path);
-  Ember.removeListener(obj, changeEvent(path), target, method);
+Ember.removeObserver = function(obj, _path, target, method) {
+  expandProperties(_path, function (path) {
+    Ember.unwatch(obj, path);
+    Ember.removeListener(obj, changeEvent(path), target, method);
+  });
   return this;
 };
 
@@ -56,9 +63,11 @@ Ember.removeObserver = function(obj, path, target, method) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-Ember.addBeforeObserver = function(obj, path, target, method) {
-  Ember.addListener(obj, beforeEvent(path), target, method);
-  Ember.watch(obj, path);
+Ember.addBeforeObserver = function(obj, _path, target, method) {
+  expandProperties(_path, function (path) {
+    Ember.addListener(obj, beforeEvent(path), target, method);
+    Ember.watch(obj, path);
+  });
   return this;
 };
 
@@ -97,8 +106,10 @@ Ember.beforeObserversFor = function(obj, path) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-Ember.removeBeforeObserver = function(obj, path, target, method) {
-  Ember.unwatch(obj, path);
-  Ember.removeListener(obj, beforeEvent(path), target, method);
+Ember.removeBeforeObserver = function(obj, _path, target, method) {
+  expandProperties(_path, function (path) {
+    Ember.unwatch(obj, path);
+    Ember.removeListener(obj, beforeEvent(path), target, method);
+  });
   return this;
 };

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -1,6 +1,7 @@
 require('ember-metal/core');
 require('ember-metal/platform');
 require('ember-metal/utils');
+require('ember-metal/expand_properties');
 require('ember-metal/property_get');
 require('ember-metal/properties');
 require('ember-metal/watch_key');
@@ -13,6 +14,7 @@ require('ember-metal/watch_path');
 var metaFor = Ember.meta, // utils.js
     GUID_KEY = Ember.GUID_KEY, // utils.js
     META_KEY = Ember.META_KEY, // utils.js
+    expandProperties = Ember.expandProperties,
     removeChainWatcher = Ember.removeChainWatcher,
     watchKey = Ember.watchKey, // watch_key.js
     unwatchKey = Ember.unwatchKey,
@@ -41,15 +43,17 @@ function isKeyName(path) {
   @param obj
   @param {String} keyName
 */
-Ember.watch = function(obj, keyPath) {
+Ember.watch = function(obj, _keyPath) {
   // can't watch length on Array - it is special...
-  if (keyPath === 'length' && typeOf(obj) === 'array') { return; }
+  if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  if (isKeyName(keyPath)) {
-    watchKey(obj, keyPath);
-  } else {
-    watchPath(obj, keyPath);
-  }
+  expandProperties(_keyPath, function (keyPath) {
+    if (isKeyName(keyPath)) {
+      watchKey(obj, keyPath);
+    } else {
+      watchPath(obj, keyPath);
+    }
+  });
 };
 
 Ember.isWatching = function isWatching(obj, key) {
@@ -59,15 +63,17 @@ Ember.isWatching = function isWatching(obj, key) {
 
 Ember.watch.flushPending = Ember.flushPendingChains;
 
-Ember.unwatch = function(obj, keyPath) {
+Ember.unwatch = function(obj, _keyPath) {
   // can't watch length on Array - it is special...
-  if (keyPath === 'length' && typeOf(obj) === 'array') { return; }
+  if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  if (isKeyName(keyPath)) {
-    unwatchKey(obj, keyPath);
-  } else {
-    unwatchPath(obj, keyPath);
-  }
+  expandProperties(_keyPath, function (keyPath) {
+    if (isKeyName(keyPath)) {
+      unwatchKey(obj, keyPath);
+    } else {
+      unwatchPath(obj, keyPath);
+    }
+  });
 };
 
 /**

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -393,6 +393,30 @@ testBoth('redefining a property should undo old depenent keys', function(get ,se
   equal(get(obj, 'foo'), 'baz 3');
 });
 
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth('can watch multiple dependent keys specified via brace expansion', function (get, set) {
+    Ember.defineProperty(obj, 'foo', Ember.computed(function(key, value) {
+      count++;
+      return 'foo '+count;
+    }).property('{bar,baz}'));
+
+    equal(get(obj, 'foo'), 'foo 1', "get once");
+    equal(get(obj, 'foo'), 'foo 1', "cached retrieve");
+
+    set(obj, 'bar', 'bar'); // invalidate foo
+
+    equal(get(obj, 'foo'), 'foo 2', "foo invalidated from bar");
+
+    set(obj, 'baz', 'baz'); // invalidate foo
+
+    equal(get(obj, 'foo'), 'foo 3', "foo invalidated from baz");
+
+    set(obj, 'quux', 'quux'); // do not invalidate foo
+
+    equal(get(obj, 'foo'), 'foo 3', "foo not invalidated by quux");
+  });
+}
+
 // ..........................................................
 // CHAINED DEPENDENT KEYS
 //

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -40,6 +40,51 @@ testBoth('observer should fire when dependent property is modified', function(ge
   equal(count, 1, 'should have invoked observer');
 });
 
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth('observer added via brace expansion should fire when property changes', function (get, set) {
+    var obj = {};
+    var count = 0;
+
+    Ember.addObserver(obj, '{foo,bar}', function() {
+      count++;
+    });
+
+    set(obj, 'foo', 'foo');
+    equal(count, 1, 'observer specified via brace expansion invoked on property change');
+
+    set(obj, 'bar', 'bar');
+    equal(count, 2, 'observer specified via brace expansion invoked on property change');
+
+    set(obj, 'baz', 'baz');
+    equal(count, 2, 'observer not invoked on unspecified property');
+  });
+
+  testBoth('observer specified via brace expansion should fire when dependent property changes', function (get, set) {
+    var obj = { baz: 'Initial' };
+    var count = 0;
+
+    Ember.defineProperty(obj, 'foo', Ember.computed(function() {
+      return get(this,'bar').toLowerCase();
+    }).property('bar'));
+
+    Ember.defineProperty(obj, 'bar', Ember.computed(function() {
+      return get(this,'baz').toUpperCase();
+    }).property('baz'));
+
+    Ember.addObserver(obj, '{foo,bar}', function() {
+      count++;
+    });
+
+    get(obj, 'foo');
+    set(obj, 'baz', 'Baz');
+    // fire once for foo, once for bar
+    equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
+
+    set(obj, 'quux', 'Quux');
+    equal(count, 2, 'observer not fired on unspecified property');
+  });
+}
+
 testBoth('nested observers should fire in order', function(get,set) {
   var obj = { foo: 'foo', bar: 'bar' };
   var fooCount = 0, barCount = 0;
@@ -439,6 +484,45 @@ testBoth('removing observer should stop firing', function(get,set) {
   equal(count, 1, "removed observer shouldn't fire");
 });
 
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth("observers removed via brace expansion should stop firing", function(get, set) {
+    function observer() { count++; }
+    function didRemoveListener(eventName) {
+      if (eventName === 'foo:change') {
+        fooListenerRemoved = true;
+      } else if (eventName === 'bar:change') {
+        barListenerRemoved = true;
+      } else {
+        ok(false, "Unexpected listener removed " + eventName);
+      }
+    }
+
+    var fooListenerRemoved = false,
+        barListenerRemoved = false,
+        obj = { didRemoveListener: didRemoveListener },
+        count = 0;
+
+    Ember.addObserver(obj, 'foo', observer);
+    Ember.addObserver(obj, 'bar', observer);
+
+    set(obj, 'foo', 'foo');
+    equal(count, 1, 'should have invoked observer');
+
+    set(obj, 'bar', 'bar');
+    equal(count, 2, 'should have invoked observer');
+
+    Ember.removeObserver(obj, '{foo,bar}', observer);
+    ok(fooListenerRemoved, 'listener was removed');
+    ok(barListenerRemoved, 'listener was removed');
+
+    set(obj, 'foo', 'foo2');
+    equal(count, 2, "removed observer shouldn't fire");
+
+    set(obj, 'bar', 'bar2');
+    equal(count, 2, "removed observer shouldn't fire");
+  });
+}
+
 testBoth('local observers can be removed', function(get, set) {
   var barObserved = 0;
 
@@ -538,6 +622,51 @@ testBoth('observer should fire before dependent property is modified', function(
   set(obj, 'bar', 'baz');
   equal(count, 1, 'should have invoked observer');
 });
+
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth('before observer added via brace expansion should fire when property changes', function (get, set) {
+    var obj = {};
+    var count = 0;
+
+    Ember.addBeforeObserver(obj, '{foo,bar}', function() {
+      count++;
+    });
+
+    set(obj, 'foo', 'foo');
+    equal(count, 1, 'observer specified via brace expansion invoked on property change');
+
+    set(obj, 'bar', 'bar');
+    equal(count, 2, 'observer specified via brace expansion invoked on property change');
+
+    set(obj, 'baz', 'baz');
+    equal(count, 2, 'observer not invoked on unspecified property');
+  });
+
+  testBoth('before observer specified via brace expansion should fire when dependent property changes', function (get, set) {
+    var obj = { baz: 'Initial' };
+    var count = 0;
+
+    Ember.defineProperty(obj, 'foo', Ember.computed(function() {
+      return get(this,'bar').toLowerCase();
+    }).property('bar'));
+
+    Ember.defineProperty(obj, 'bar', Ember.computed(function() {
+      return get(this,'baz').toUpperCase();
+    }).property('baz'));
+
+    Ember.addBeforeObserver(obj, '{foo,bar}', function() {
+      count++;
+    });
+
+    get(obj, 'foo');
+    set(obj, 'baz', 'Baz');
+    // fire once for foo, once for bar
+    equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
+
+    set(obj, 'quux', 'Quux');
+    equal(count, 2, 'observer not fired on unspecified property');
+  });
+}
 
 testBoth('addBeforeObserver should propagate through prototype', function(get,set) {
   var obj = { foo: 'foo', count: 0 }, obj2;
@@ -726,6 +855,47 @@ testBoth('depending on a Global chain', function(get, set) {
   set(foo.bar.baz, 'biff', "BOOM");
   equal(count, 6, 'should be not have invoked observer');
 });
+
+module('Ember.removeBeforeObserver');
+
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth("before observers removed via brace expansion should stop firing", function(get, set) {
+    function observer() { count++; }
+    function didRemoveListener(eventName) {
+      if (eventName === 'foo:before') {
+        fooListenerRemoved = true;
+      } else if (eventName === 'bar:before') {
+        barListenerRemoved = true;
+      } else {
+        ok(false, "Unexpected listener removed " + eventName);
+      }
+    }
+
+    var fooListenerRemoved = false,
+        barListenerRemoved = false,
+        obj = { didRemoveListener: didRemoveListener },
+        count = 0;
+
+    Ember.addBeforeObserver(obj, 'foo', observer);
+    Ember.addBeforeObserver(obj, 'bar', observer);
+
+    set(obj, 'foo', 'foo');
+    equal(count, 1, 'should have invoked observer');
+
+    set(obj, 'bar', 'bar');
+    equal(count, 2, 'should have invoked observer');
+
+    Ember.removeBeforeObserver(obj, '{foo,bar}', observer);
+    ok(fooListenerRemoved, 'listener was removed');
+    ok(barListenerRemoved, 'listener was removed');
+
+    set(obj, 'foo', 'foo2');
+    equal(count, 2, "removed observer shouldn't fire");
+
+    set(obj, 'bar', 'bar2');
+    equal(count, 2, "removed observer shouldn't fire");
+  });
+}
 
 // ..........................................................
 // SETTING IDENTICAL VALUES

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -26,6 +26,26 @@ module('Ember.unwatch', {
   }
 });
 
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth("unwatching multiple properties specified via brace expansion", function(get, set) {
+    var obj = { foo: null, bar: null, baz: null };
+
+    Ember.watch(obj, 'foo');
+    Ember.watch(obj, 'bar');
+    Ember.watch(obj, 'baz');
+    
+    equal(Ember.isWatching(obj, 'foo'), true, "precond - initially watching foo");
+    equal(Ember.isWatching(obj, 'bar'), true, "precond - initially watching bar");
+    equal(Ember.isWatching(obj, 'baz'), true, "precond - initially watching baz");
+
+    Ember.unwatch(obj, '{foo,bar,baz}');
+
+    equal(Ember.isWatching(obj, 'foo'), false, "unwatching foo from brace expansion");
+    equal(Ember.isWatching(obj, 'bar'), false, "unwatching bar from brace expansion");
+    equal(Ember.isWatching(obj, 'baz'), false, "unwatching baz from brace expansion");
+  });
+}
+
 testBoth('unwatching a computed property - regular get/set', function(get, set) {
 
   var obj = {};

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -25,6 +25,22 @@ function addListeners(obj, keyPath) {
   });
 }
 
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  testBoth("watching multiple properties specified via brace expansion", function(get, set) {
+    var obj = { foo: null, bar: null, baz: null };
+
+    equal(Ember.isWatching(obj, 'foo'), false, "precond - not initially watching foo");
+    equal(Ember.isWatching(obj, 'bar'), false, "precond - not initially watching bar");
+    equal(Ember.isWatching(obj, 'baz'), false, "precond - not initially watching baz");
+
+    Ember.watch(obj, '{foo,bar,baz}');
+
+    equal(Ember.isWatching(obj, 'foo'), true, "watching foo from brace expansion");
+    equal(Ember.isWatching(obj, 'bar'), true, "watching bar from brace expansion");
+    equal(Ember.isWatching(obj, 'baz'), true, "watching baz from brace expansion");
+  });
+}
+
 testBoth('watching a computed property', function(get, set) {
 
   var obj = {};

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -153,6 +153,76 @@ test("changes to array computed properties happen synchronously", function() {
   });
 });
 
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  test("multiple dependent keys can be specified via brace expansion", function() {
+    var obj = Ember.Object.createWithMixins({
+          bar: Ember.A(),
+          baz: Ember.A(),
+          foo: Ember.reduceComputed({
+            initialValue: Ember.A(),
+            addedItem: function(array, item) { array.pushObject('a:' + item); return array; },
+            removedItem: function(array, item) { array.pushObject('r:' + item); return array; }
+          }).property('{bar,baz}')
+        });
+
+    deepEqual(get(obj, 'foo'), [], "initially empty");
+
+    get(obj, 'bar').pushObject(1);
+
+    deepEqual(get(obj, 'foo'), ['a:1'], "added item from brace-expanded dependency");
+
+    get(obj, 'baz').pushObject(2);
+
+    deepEqual(get(obj, 'foo'), ['a:1', 'a:2'], "added item from brace-expanded dependency");
+
+    get(obj, 'bar').popObject();
+
+    deepEqual(get(obj, 'foo'), ['a:1', 'a:2', 'r:1'], "removed item from brace-expanded dependency");
+
+    get(obj, 'baz').popObject();
+
+    deepEqual(get(obj, 'foo'), ['a:1', 'a:2', 'r:1', 'r:2'], "removed item from brace-expanded dependency");
+  });
+
+  test("multiple item property keys can be specified via brace expansion", function() {
+    var addedCalls = 0,
+        removedCalls = 0,
+        expected = Ember.A(),
+        item = { propA: 'A', propB: 'B', propC: 'C' },
+        obj = Ember.Object.createWithMixins({
+          bar: Ember.A([item]),
+          foo: Ember.reduceComputed({
+            initialValue: Ember.A(),
+            addedItem: function(array, item, changeMeta) {
+              array.pushObject('a:' + get(item, 'propA') + ':' + get(item, 'propB') + ':' + get(item, 'propC'));
+              return array;
+            },
+            removedItem: function(array, item, changeMeta) {
+              array.pushObject('r:' + get(item, 'propA') + ':' + get(item, 'propB') + ':' + get(item, 'propC'));
+              return array;
+            }
+          }).property('bar.@each.{propA,propB}')
+        });
+
+    expected.pushObjects(['a:A:B:C']);
+    deepEqual(get(obj, 'foo'), expected, "initially added dependent item");
+
+    set(item, 'propA', 'AA');
+
+    expected.pushObjects(['r:AA:B:C', 'a:AA:B:C']);
+    deepEqual(get(obj, 'foo'), expected, "observing item property key specified via brace expansion");
+
+    set(item, 'propB', 'BB');
+
+    expected.pushObjects(['r:AA:BB:C', 'a:AA:BB:C']);
+    deepEqual(get(obj, 'foo'), expected, "observing item property key specified via brace expansion");
+
+    set(item, 'propC', 'CC');
+
+    deepEqual(get(obj, 'foo'), expected, "not observing unspecified item properties");
+  });
+}
+
 test("doubly nested item property keys (@each.foo.@each) are not supported", function() {
   Ember.run(function() {
     obj = Ember.Object.createWithMixins({


### PR DESCRIPTION
Add support for brace-expansion in dependent keys, observer and watch 
properties.  The complete list of methods with this support is as follows:
- computed
- reduceComputed
- addObserver
- removeObserver
- addBeforeObserver
- removeBeforeObserver
- watch
- unwatch

This is most useful with array computed properties, although it is supported
in other cases.

Example:

``` js
// The following two are equivalent Em.O({
 filtered: Em.computed.filter('list.@each.propA',
filterFn).property('list.@each.propB')
});

Em.O({
 filtered: Em.computed.filter('list.@each.{propA,propB}', filterFn)
});

// The following two are equivalent obj = {}; observer = function() {}; 
Ember.addObserver(obj, 'foo', observer); Ember.addObserver(obj, 'bar',
observer);

Ember.addobserver(obj, '{foo,bar}', observer);
```
