### PR TITLE
Use plain ASCII for License.

### DIFF
--- a/generators/license.js
+++ b/generators/license.js
@@ -1,8 +1,8 @@
 // ==========================================================================
 // Project:   Ember - JavaScript Application Framework
-// Copyright: ©2011-2013 Tilde Inc. and contributors
-//            Portions ©2006-2011 Strobe Inc.
-//            Portions ©2008-2011 Apple Inc. All rights reserved.
+// Copyright: Copyright 2011-2013 Tilde Inc. and contributors
+//            Portions Copyright 2006-2011 Strobe Inc.
+//            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
 // License:   Licensed under MIT license
 //            See https://raw.github.com/emberjs/ember.js/master/LICENSE
 // ==========================================================================


### PR DESCRIPTION
The current file uses © (correct UTF copyright symbol), but when generated into the build artifacts (as ASCII text) it looks garbled (`// Copyright: Â©2011-2013`).

Resolves #3541.

References: 
- http://www.copyright.gov/circs/circ01.pdf
- http://stackoverflow.com/questions/221376/putting-copyright-symbol-into-a-python-file#221380
