### PR TITLE
patch for url encoding/decoding issue (#3263)

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -63,7 +63,7 @@ Ember.HistoryLocation = Ember.Object.extend({
       url += search;
     }
 
-    return url;
+    return decodeURIComponent(url);
   },
 
   /**
@@ -134,7 +134,7 @@ Ember.HistoryLocation = Ember.Object.extend({
     }
 
     // used for webkit workaround
-    this._previousURL = this.getURL();
+    this._previousURL = this.formatURL(this.getURL());
   },
 
   /**
@@ -156,7 +156,7 @@ Ember.HistoryLocation = Ember.Object.extend({
     }
 
     // used for webkit workaround
-    this._previousURL = this.getURL();
+    this._previousURL = this.formatURL(this.getURL());
   },
 
   /**
@@ -174,11 +174,12 @@ Ember.HistoryLocation = Ember.Object.extend({
 
     Ember.$(window).on('popstate.ember-location-'+guid, function(e) {
       // Ignore initial page load popstate event in Chrome
+      var url = self.formatURL(self.getURL());
       if (!popstateFired) {
         popstateFired = true;
-        if (self.getURL() === self._previousURL) { return; }
+        if (url === self._previousURL) { return; }
       }
-      callback(self.getURL());
+      callback(url);
     });
   },
 
@@ -198,7 +199,7 @@ Ember.HistoryLocation = Ember.Object.extend({
       rootURL = rootURL.replace(/\/$/, '');
     }
 
-    return rootURL + url;
+    return encodeURIComponent(rootURL + url);
   },
 
   /**

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1878,7 +1878,7 @@ test("HistoryLocation has the correct rootURL on initState and webkit doesn't fi
       this._super();
       // these two should be equal to be able
       // to successfully detect webkit initial popstate
-      equal(this._previousURL, this.getURL());
+      equal(this._previousURL, encodeURIComponent(this.getURL()));
     }
   });
 


### PR DESCRIPTION
This PR normalizes browser inconsistencies regarding the encoded / decoded properties on the `window.location` object. As discussed in #3263, it force-url-decodes all properties prior to using them, and force-url-encodes all properties prior to setting them, and prior to using them for internal comparison.

The edge case that this PR cannot solve is the literal `%25`. Given an unknown browser behavior on the input being url encoded or decoded, we have no way of knowing, for sure, whether it means `%` (originall encoded) or `%25` (originally decoded). There is no behavior-sniffing method, that I know of, to check whether a browser would url-encode / url-decode the entry URL itself, and @wagenet has expressed a desire not to use browser-sniffing code in the ember code base with regards to this issue. ([here](https://github.com/emberjs/ember.js/issues/3263#issuecomment-25736757))

Tests: none for now. The code needs review to check for expected correct API, i.e. where to return a url encoded/decoded strings.

This PR might also necessitate changes in downstream code that consumes the location api, e.g. it should render #3396 obsolete.

This PR _might_ cause BC-breaks to apps that rely on some location-derived apis, e.g. the `params` hash in routes' `model` hook, being at the current form (undefined behavior depending on browser).
