### PR TITLE
Decamelize handles strings with numbers

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -5,7 +5,7 @@
 
 var STRING_DASHERIZE_REGEXP = (/[ _]/g);
 var STRING_DASHERIZE_CACHE = {};
-var STRING_DECAMELIZE_REGEXP = (/([a-z])([A-Z])/g);
+var STRING_DECAMELIZE_REGEXP = (/([a-z\d])([A-Z])/g);
 var STRING_CAMELIZE_REGEXP = (/(\-|_|\.|\s)+(.)?/g);
 var STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
 var STRING_UNDERSCORE_REGEXP_2 = (/\-|\s+/g);

--- a/packages/ember-runtime/tests/system/string/decamelize.js
+++ b/packages/ember-runtime/tests/system/string/decamelize.js
@@ -27,3 +27,10 @@ test("converts a camelized string into all lower case separated by underscores."
     deepEqual('innerHTML'.decamelize(), 'inner_html');
   }
 });
+
+test("decamelizes strings with numbers", function() {
+  deepEqual(Ember.String.decamelize('size160Url'), 'size160_url');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('size160Url'.decamelize(), 'size160_url');
+  }
+});


### PR DESCRIPTION
Currently `Ember.String.decamelize` decamelizes strings with numbers surprisingly:

``` js
Ember.String.decamelize("size160Url") #=> "size160Url"
Ember.String.underscore("size160Url") #=> "size160_url"
```

With patch:

``` js
Ember.String.decamelize("size160Url") #=> "size160_url"
```

See https://github.com/emberjs/data/pull/1423

WDYT?
