### PR TITLE
Added support for jQuery as a `require` module

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -3,7 +3,11 @@
 @submodule ember-views
 */
 
-var jQuery = Ember.imports.jQuery;
+var jQuery = this.jQuery || (Ember.imports && Ember.imports.jQuery);
+if (!jQuery && typeof require === 'function') {
+  jQuery = require('jquery');
+}
+
 Ember.assert("Ember Views require jQuery 1.7, 1.8, 1.9, 1.10, or 2.0", jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10))|2.0)(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
 
 /**


### PR DESCRIPTION
Currently Ember can only be used if `jQuery` is available on the `window` object. With AMD, ES6 module transpiled modules etc. it won't necessarily be there.

I changed it to use the same logic as https://github.com/emberjs/ember.js/blob/master/packages/ember-handlebars-compiler/lib/main.js#L13-L16
