### PR TITLE
[BUGFIX beta] Make Component.sendAction behave the same as {{action}} helper.

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -106,6 +106,13 @@ Ember.TargetActionSupport = Ember.Mixin.create({
         target = opts.target || get(this, 'targetObject'),
         actionContext = opts.actionContext;
 
+    function args(options, actionName) {
+      var ret = [];
+      if (actionName) { ret.push(actionName); }
+
+      return ret.concat(options);
+    }
+
     if (typeof actionContext === 'undefined') {
       actionContext = get(this, 'actionContextObject') || this;
     }
@@ -114,10 +121,10 @@ Ember.TargetActionSupport = Ember.Mixin.create({
       var ret;
 
       if (target.send) {
-        ret = target.send.apply(target, [action, actionContext]);
+        ret = target.send.apply(target, args(actionContext, action));
       } else {
         Ember.assert("The action '" + action + "' did not exist on " + target, typeof target[action] === 'function');
-        ret = target[action].apply(target, [actionContext]);
+        ret = target[action].apply(target, args(actionContext));
       }
 
       if (ret !== false) ret = true;

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -145,6 +145,22 @@ test("it should use the actionContext specified in the argument", function() {
   ok(true === obj.triggerAction({actionContext: context}), "a valid target and action were specified");
 });
 
+test("it should allow multiple arguments from actionContext", function() {
+  expect(3);
+  var param1 = 'someParam',
+      param2 = 'someOtherParam',
+      obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{
+    target: Ember.Object.create({
+      anEvent: function(first, second) {
+        ok(first === param1, "anEvent method was called with the expected first argument");
+        ok(second === param2, "anEvent method was called with the expected second argument");
+      }
+    }),
+    action: 'anEvent'
+  });
+  ok(true === obj.triggerAction({actionContext: [param1, param2]}), "a valid target and action were specified");
+});
+
 test("it should use a null value specified in the actionContext argument", function() {
   expect(2);
   var obj = Ember.Object.createWithMixins(Ember.TargetActionSupport,{

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -1,6 +1,8 @@
 require("ember-views/views/view");
 
-var get = Ember.get, set = Ember.set, isNone = Ember.isNone;
+var get = Ember.get, set = Ember.set, isNone = Ember.isNone,
+    a_slice = Array.prototype.slice;
+
 
 /**
 @module ember
@@ -191,8 +193,9 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, {
     @param [action] {String} the action to trigger
     @param [context] {*} a context to send with the action
   */
-  sendAction: function(action, context) {
-    var actionName;
+  sendAction: function(action) {
+    var actionName,
+        contexts = a_slice.call(arguments, 1);
 
     // Send the default action
     if (action === undefined) {
@@ -208,7 +211,7 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, {
 
     this.triggerAction({
       action: actionName,
-      actionContext: context
+      actionContext: contexts
     });
   }
 });

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -1,4 +1,5 @@
-var get = Ember.get, set = Ember.set;
+var get = Ember.get, set = Ember.set,
+    a_slice = Array.prototype.slice;
 
 module("Ember.Component");
 
@@ -14,20 +15,20 @@ test("The controller (target of `action`) of an Ember.Component is itself", func
   strictEqual(control, control.get('controller'), "A control's controller is itself");
 });
 
-var component, controller, actionCounts, sendCount, actionContext;
+var component, controller, actionCounts, sendCount, actionArguments;
 
 module("Ember.Component - Actions", {
   setup: function() {
     actionCounts = {};
     sendCount = 0;
-    actionContext = null;
+    actionArguments = null;
 
     controller = Ember.Object.create({
-      send: function(actionName, context) {
+      send: function(actionName) {
         sendCount++;
         actionCounts[actionName] = actionCounts[actionName] || 0;
         actionCounts[actionName]++;
-        actionContext = context;
+        actionArguments = a_slice.call(arguments, 1);
       }
     });
 
@@ -100,5 +101,16 @@ test("Calling sendAction on a component with a context", function() {
 
   component.sendAction('playing', testContext);
 
-  strictEqual(actionContext, testContext, "context was sent with the action");
+  deepEqual(actionArguments, [testContext], "context was sent with the action");
+});
+
+test("Calling sendAction on a component with multiple parameters", function() {
+  set(component, 'playing', "didStartPlaying");
+
+  var firstContext  = {song: 'She Broke My Ember'},
+      secondContext = {song: 'My Achey Breaky Ember'};
+
+  component.sendAction('playing', firstContext, secondContext);
+
+  deepEqual(actionArguments, [firstContext, secondContext], "arguments were sent to the action");
 });


### PR DESCRIPTION
Currently, the `{{action}}` handlebars helper allows multiple parameters to be specified and are passed properly to the action's function, but `Component.sendAction` only passes a single parameter.

`ActionHelper.registerAction` (source [here](https://github.com/emberjs/ember.js/blob/99fea760c73a3e0264330debf81737b41f6e200c/packages/ember-routing/lib/helpers/action.js#L80-85)) converts the provided parameters into an array and calls the action's function with those arguments.

`Component.sendAction` (source [here](https://github.com/emberjs/ember.js/blob/99fea760c73a3e0264330debf81737b41f6e200c/packages/ember-views/lib/views/component.js#L194-213)) only passes the first argument to `TargetActionSupport.triggerAction` (in the `actionContext` property).

Regarding the BUGFIX tag, I personally thought this was a bug, but I would be happy to change the commit message if you'd prefer.

Also, `ember-dev` currently is having issues with multi-branch testing.  This does cherry-pick properly into `beta`, but has a minor conflict in `stable`.

Resolves https://github.com/emberjs/website/issues/985.
