### PR TITLE
Handle case where pendingAjaxRequests is negative

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -98,7 +98,7 @@ function wait(app, value) {
     var watcher = setInterval(function() {
       var routerIsLoading = app.__container__.lookup('router:main').router.isLoading;
       if (routerIsLoading) { return; }
-      if (Test.pendingAjaxRequests) { return; }
+      if (Test.pendingAjaxRequests > 0) { return; }
       if (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop) { return; }
       if (Ember.FEATURES.isEnabled("ember-testing-wait-hooks")) {
         if (Test.waiters && Test.waiters.any(function(waiter) {


### PR DESCRIPTION
Somehow the pendingAjaxrequests is sometimes negative. This causes the wait te wait forever. This fixes that problem
