### PR TITLE
[BUGFIX beta] uniq reduceComputed dependent keys.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -539,7 +539,7 @@ ReduceComputedProperty.prototype.clearItemPropertyKeys = function (dependentArra
 ReduceComputedProperty.prototype.property = function () {
   var cp = this,
       args = a_slice.call(arguments),
-      propertyArgs = [],
+      propertyArgs = new Ember.Set(),
       match,
       dependentArrayKey,
       itemPropertyKey;
@@ -551,13 +551,13 @@ ReduceComputedProperty.prototype.property = function () {
       dependentArrayKey = match[1];
       itemPropertyKey = match[2];
       cp.itemPropertyKey(dependentArrayKey, itemPropertyKey);
-      propertyArgs.push(dependentArrayKey);
+      propertyArgs.add(dependentArrayKey);
     } else {
-      propertyArgs.push(dependentKey);
+      propertyArgs.add(dependentKey);
     }
   });
 
-  return ComputedProperty.prototype.property.apply(this, propertyArgs);
+  return ComputedProperty.prototype.property.apply(this, propertyArgs.toArray());
 };
 
 /**

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -274,6 +274,32 @@ test("an error is thrown when a reduceComputed is defined without an initialValu
   throws(defineExploder, /declared\ without\ an\ initial\ value/, "an error is thrown when the reduceComputed is defined without an initialValue");
 });
 
+test("dependent arrays with multiple item properties are not double-counted", function() {
+  var obj = Ember.Object.extend({
+    items: Ember.A([{ foo: true }, { bar: false }, { bar: true }]),
+    countFooOrBar: Ember.reduceComputed({
+      initialValue: 0,
+      addedItem: function (acc) {
+        ++addCalls;
+        return acc;
+      },
+
+      removedItem: function (acc) {
+        ++removeCalls;
+        return acc;
+      }
+    }).property('items.@each.foo', 'items.@each.bar', 'items')
+  }).create();
+
+  equal(0, addCalls, "precond - no adds yet");
+  equal(0, removeCalls, "precond - no removes yet");
+
+  get(obj, 'countFooOrBar');
+
+  equal(3, addCalls, "all items added once");
+  equal(0, removeCalls, "no removes yet");
+});
+
 if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
   module('Ember.arryComputed - self chains', {
     setup: function() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -253,6 +253,27 @@ test("multiple array computed properties on the same object can observe dependen
   deepEqual(get(obj, 'evenNumbersMultiDep'), [2, 4, 6, 8, 12, 14], "evenNumbersMultiDep is updated");
 });
 
+test("an error is thrown when a reduceComputed is defined without an initialValue property", function() {
+  var defineExploder = function() {
+    Ember.Object.createWithMixins({
+      collection: Ember.A(),
+      exploder: Ember.reduceComputed('collection', {
+        initialize: function(initialValue, changeMeta, instanceMeta) {},
+
+        addedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
+          return item;
+        },
+
+        removedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
+          return item;
+        }
+      })
+    });
+  };
+
+  throws(defineExploder, /declared\ without\ an\ initial\ value/, "an error is thrown when the reduceComputed is defined without an initialValue");
+});
+
 if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
   module('Ember.arryComputed - self chains', {
     setup: function() {
@@ -448,25 +469,4 @@ test("when initialValue is undefined, everything works as advertised", function(
   get(chars, 'letters').removeAt(3);
 
   equal(get(chars, 'firstUpper'), 'B', "result is the next match when the first matching object is removed");
-});
-
-test("an error is thrown when a reduceComputed is defined without an initialValue property", function() {
-  var defineExploder = function() {
-    Ember.Object.createWithMixins({
-      collection: Ember.A(),
-      exploder: Ember.reduceComputed('collection', {
-        initialize: function(initialValue, changeMeta, instanceMeta) {},
-
-        addedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
-          return item;
-        },
-
-        removedItem: function(accumulatedValue,item,changeMeta,instanceMeta) {
-          return item;
-        }
-      })
-    });
-  };
-
-  throws(defineExploder, /declared\ without\ an\ initial\ value/, "an error is thrown when the reduceComputed is defined without an initialValue");
 });


### PR DESCRIPTION
If property brace expansion is enabled, there is never a need to have
duplicate dependent keys.  However, with proeprty brace expansion
disabled, it is the only way to specify multiple item property keys, as in
the following:

``` js

var obj = Em.Object.createWithMixins({
 items: Em.A([{ foo: true }, { bar: false }, { bar: true }]),
 countFooOrBar: Em.reduceComputed({
   initialValue: 0,
   addedItem: function (acc, item) {
     if ( get(item, 'foo') || get(item, 'bar')) {
       ++acc;
     }
     return acc;
   },

    removedItem: function (acc, item) {
     if ( get(item, 'foo') || get(item, 'bar')) {
       --acc;
     }
     return acc;
   }
 }).property('items.@each.foo', 'items.@each.bar')
});
```

Of course, with property brace expansion, it would be better to write the
dependency as `property('items.@each.{foo,bar}')`.

Fix #3554.
