### PR TITLE
[FEATURE ember-testing-remove-helpers] Add onRemoveHelpers callback queue.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -116,3 +116,11 @@ for a detailed explanation.
   Enables `{{#with}}` to take a `controller=` option for wrapping the context.
 
   Added in [#3722](https://github.com/emberjs/ember.js/pull/3722)
+* `ember-testing-remove-helpers`
+
+  Adds a callback queue (`onRemoveHelpers`) that fires upon `App.removeTestHelpers`. This
+  allows any custom cleanup from the `onInjectHelpers` callbacks to be done.
+
+  For example removing the handlers for `ajaxStart` and `ajaxStop`.
+
+  Added in [#3567](https://github.com/emberjs/ember.js/pull/3567)

--- a/features.json
+++ b/features.json
@@ -10,5 +10,6 @@
   "ember-testing-simple-setup": null,
   "ember-testing-routing-helpers": null,
   "ember-testing-triggerEvent-helper": null,
-  "with-controller": null
+  "with-controller": null,
+  "ember-testing-remove-helpers": null
 }

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -24,6 +24,13 @@ Test.onInjectHelpers(function() {
   });
 });
 
+if (Ember.FEATURES.isEnabled("ember-testing-remove-helpers")) {
+  Test.onRemoveHelpers(function() {
+    Ember.$(document).off('ajaxStart');
+    Ember.$(document).off('ajaxStop');
+  });
+}
+
 function currentRouteName(app){
   var appController = app.__container__.lookup('controller:application');
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -377,6 +377,51 @@ if (Ember.FEATURES.isEnabled("ember-testing-wait-hooks")) {
   });
 }
 
+if (Ember.FEATURES.isEnabled("ember-testing-remove-helpers")) {
+  test("Ember.Application#removeTestHelpers", function() {
+    var documentEvents;
+
+    Ember.run(function(){
+      Ember.$(document).off('ajaxStart');
+      Ember.$(document).off('ajaxStop');
+    });
+
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+    });
+
+    App.injectTestHelpers();
+    App.removeTestHelpers();
+
+    documentEvents = Ember.$._data(document, 'events');
+
+    if (!documentEvents) {
+      documentEvents = {};
+    }
+
+    ok(documentEvents['ajaxStart'] === undefined, 'there are no ajaxStart listers setup after calling removeTestHelpers');
+    ok(documentEvents['ajaxStop'] === undefined, 'there are no ajaxStop listers setup after calling removeTestHelpers');
+  });
+
+  test("Ember.Application#removeTestHelpers calls any callbacks registered with onRemoveHelpers", function(){
+    var called = 0;
+
+    Ember.Test.onRemoveHelpers(function(){
+      called++;
+    });
+
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+    });
+
+    App.removeTestHelpers();
+
+    equal(called, 1, 'onRemoveHelpers are called after removeTestHelpers');
+  });
+}
+
 if (Ember.FEATURES.isEnabled('ember-testing-routing-helpers')){
 
   module("ember-testing routing helpers", {


### PR DESCRIPTION
This adds a callback queue that fires upon removeTestHelpers. The main reason for this change was to allow any cleanup from the `onInjectHelpers` callbacks to be done.

For example removing the handlers for `ajaxStart` and `ajaxStop`.
