### PR TITLE
[FEATURE __] Loading/error substates

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -25,6 +25,8 @@ DSL.prototype = {
 
     if (callback) {
       var dsl = new DSL(name);
+      dsl.route('loading');
+      dsl.route('error', { path: "/_unused_dummy_error_path/:error" });
       callback.call(dsl);
       this.push(options.path, name, dsl.generate(), options.queryParams);
     } else {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -53,14 +53,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
   },
 
   didTransition: function(infos) {
-    var appController = this.container.lookup('controller:application'),
-        path = Ember.Router._routePath(infos);
-
-    if (!('currentPath' in appController)) { defineProperty(appController, 'currentPath'); }
-    set(appController, 'currentPath', path);
-
-    if (!('currentRouteName' in appController)) { defineProperty(appController, 'currentRouteName'); }
-    set(appController, 'currentRouteName', infos[infos.length - 1].name);
+    updatePaths(this);
 
     this.notifyPropertyChange('url');
 
@@ -71,7 +64,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     }
 
     if (get(this, 'namespace').LOG_TRANSITIONS) {
-      Ember.Logger.log("Transitioned into '" + path + "'");
+      Ember.Logger.log("Transitioned into '" + Ember.Router._routePath(infos) + "'");
     }
   },
 
@@ -81,6 +74,17 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
   transitionTo: function() {
     return this._doTransition('transitionTo', arguments);
+  },
+
+  intermediateTransitionTo: function() {
+    this.router.intermediateTransitionTo.apply(this.router, arguments);
+
+    updatePaths(this);
+
+    var infos = this.router.currentHandlerInfos;
+    if (get(this, 'namespace').LOG_TRANSITIONS) {
+      Ember.Logger.log("Intermediate-transitioned into '" + Ember.Router._routePath(infos) + "'");
+    }
   },
 
   replaceWith: function() {
@@ -166,24 +170,12 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
       seen[name] = true;
 
       if (!handler) {
-        if (name === 'loading') { return {}; }
-
         container.register(routeName, DefaultRoute.extend());
         handler = container.lookup(routeName);
 
         if (get(self, 'namespace.LOG_ACTIVE_GENERATION')) {
           Ember.Logger.info("generated -> " + routeName, { fullName: routeName });
         }
-      }
-
-      if (name === 'application') {
-        // Inject default `error` handler.
-        // Note: `events` is deprecated, but we'll let the
-        // deprecation warnings be handled at event-handling time rather
-        // than duplicating that logic here.
-        var actions = handler._actions || handler.events;
-        if (!actions) { actions = handler._actions = {}; }
-        actions.error = actions.error || Ember.Router._defaultErrorHandler;
       }
 
       handler.routeName = name;
@@ -247,11 +239,6 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
     var transitionPromise = this.router[method].apply(this.router, args);
 
-    // Don't schedule loading state entry if user has already aborted the transition.
-    if (this.router.activeTransition) {
-      this._scheduleLoadingStateEntry();
-    }
-
     transitionPromise.then(function(route) {
       self._transitionCompleted(route);
     }, function(error) {
@@ -266,35 +253,34 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     return transitionPromise;
   },
 
-  _scheduleLoadingStateEntry: function() {
-    if (this._loadingStateActive) { return; }
-    this._shouldEnterLoadingState = true;
-    Ember.run.scheduleOnce('routerTransitions', this, this._enterLoadingState);
-  },
-
-  _enterLoadingState: function() {
-    if (this._loadingStateActive || !this._shouldEnterLoadingState) { return; }
-
-    var loadingRoute = this.router.getHandler('loading');
-    if (loadingRoute) {
-      if (loadingRoute.enter) { loadingRoute.enter(); }
-      if (loadingRoute.setup) { loadingRoute.setup(); }
-      this._loadingStateActive = true;
+  _scheduleLoadingEvent: function(transition, originRoute) {
+    if (this._loadingStateTimer) {
+      Ember.run.cancel(this._loadingStateTimer);
     }
+
+    this._loadingStateTimer = Ember.run.scheduleOnce('routerTransitions', this, '_fireLoadingEvent', transition, originRoute);
   },
 
-  _exitLoadingState: function () {
-    this._shouldEnterLoadingState = false;
-    if (!this._loadingStateActive) { return; }
+  _fireLoadingEvent: function(transition, originRoute) {
+    if (transition !== this.router.activeTransition) {
+      // Don't fire an event if we've since moved on from
+      // the transition that put us in a loading state.
+      return;
+    }
 
-    var loadingRoute = this.router.getHandler('loading');
-    if (loadingRoute && loadingRoute.exit) { loadingRoute.exit(); }
-    this._loadingStateActive = false;
+    transition.trigger(true, 'loading', transition, originRoute);
+  },
+
+  _cancelLoadingEvent: function () {
+    if (this._loadingStateTimer) {
+      Ember.run.cancel(this._loadingStateTimer);
+    }
+    this._loadingStateTimer = null;
   },
 
   _transitionCompleted: function(route) {
     this.notifyPropertyChange('url');
-    this._exitLoadingState();
+    this._cancelLoadingEvent();
   }
 });
 
@@ -318,19 +304,30 @@ function triggerEvent(handlerInfos, ignoreFailure, args) {
       } else {
         return;
       }
-    } else if (handler.events && handler.events[name]) {
-      Ember.deprecate('Action handlers contained in an `events` object are deprecated in favor of putting them in an `actions` object (' + name + ' on ' + handler + ')', false);
-      if (handler.events[name].apply(handler, args) === true) {
-        eventWasHandled = true;
-      } else {
-        return;
-      }
     }
   }
 
   if (!eventWasHandled && !ignoreFailure) {
     throw new Ember.Error("Nothing handled the action '" + name + "'. If you did handle the action, this error can be caused by returning true from an action handler, causing the action to bubble.");
   }
+}
+
+function updatePaths(router) {
+  var appController = router.container.lookup('controller:application'),
+      infos = router.router.currentHandlerInfos,
+      path = Ember.Router._routePath(infos);
+
+  if (!('currentPath' in appController)) {
+    defineProperty(appController, 'currentPath');
+  }
+
+  set(appController, 'currentPath', path);
+
+  if (!('currentRouteName' in appController)) {
+    defineProperty(appController, 'currentRouteName');
+  }
+
+  set(appController, 'currentRouteName', infos[infos.length - 1].name);
 }
 
 Ember.Router.reopenClass({
@@ -362,10 +359,6 @@ Ember.Router.reopenClass({
     return router;
   },
 
-  _defaultErrorHandler: function(error, transition) {
-    Ember.Logger.assert(false, 'Error while loading route: ' + Ember.inspect(error));
-  },
-
   _routePath: function(handlerInfos) {
     var path = [];
 
@@ -379,4 +372,7 @@ Ember.Router.reopenClass({
     return path.join(".");
   }
 });
+
+Router.Transition.prototype.send = Router.Transition.prototype.trigger;
+
 

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -54,6 +54,11 @@ define("router",
       providedModels: null,
       resolvedModels: null,
       params: null,
+      pivotHandler: null,
+      resolveIndex: 0,
+      handlerInfos: null,
+
+      isActive: true,
 
       /**
         The Transition's internal promise. Calling `.then` on this property
@@ -97,6 +102,7 @@ define("router",
         if (this.isAborted) { return this; }
         log(this.router, this.sequence, this.targetName + ": transition was aborted");
         this.isAborted = true;
+        this.isActive = false;
         this.router.activeTransition = null;
         return this;
       },
@@ -137,6 +143,25 @@ define("router",
         return this;
       },
 
+      /**
+        Fires an event on the current list of resolved/resolving
+        handlers within this transition. Useful for firing events
+        on route hierarchies that haven't fully been entered yet.
+
+        @param {Boolean} ignoreFailure the name of the event to fire
+        @param {String} name the name of the event to fire
+       */
+      trigger: function(ignoreFailure) {
+        var args = slice.call(arguments);
+        if (typeof ignoreFailure === 'boolean') {
+          args.shift();
+        } else {
+          // Throw errors on unhandled trigger events by default
+          ignoreFailure = false;
+        }
+        trigger(this.router, this.handlerInfos.slice(0, this.resolveIndex + 1), ignoreFailure, args);
+      },
+
       toString: function() {
         return "Transition (sequence " + this.sequence + ")";
       }
@@ -145,6 +170,9 @@ define("router",
     function Router() {
       this.recognizer = new RouteRecognizer();
     }
+
+    // TODO: separate into module?
+    Router.Transition = Transition;
 
 
 
@@ -259,6 +287,10 @@ define("router",
       */
       transitionTo: function(name) {
         return doTransition(this, arguments);
+      },
+
+      intermediateTransitionTo: function(name) {
+        doTransition(this, arguments, true);
       },
 
       /**
@@ -471,7 +503,10 @@ define("router",
         throw new Error("More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler);
       }
 
-      return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
+      var pivotHandlerInfo = currentHandlerInfos[matchPoint - 1],
+          pivotHandler = pivotHandlerInfo && pivotHandlerInfo.handler;
+
+      return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams, pivotHandler: pivotHandler };
     }
 
     function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
@@ -620,20 +655,20 @@ define("router",
     /**
       @private
     */
-    function createQueryParamTransition(router, queryParams) {
+    function createQueryParamTransition(router, queryParams, isIntermediate) {
       var currentHandlers = router.currentHandlerInfos,
           currentHandler = currentHandlers[currentHandlers.length - 1],
           name = currentHandler.name;
 
       log(router, "Attempting query param transition");
 
-      return createNamedTransition(router, [name, queryParams]);
+      return createNamedTransition(router, [name, queryParams], isIntermediate);
     }
 
     /**
       @private
     */
-    function createNamedTransition(router, args) {
+    function createNamedTransition(router, args, isIntermediate) {
       var partitionedArgs     = extractQueryParams(args),
         pureArgs              = partitionedArgs[0],
         queryParams           = partitionedArgs[1],
@@ -643,28 +678,46 @@ define("router",
 
       log(router, "Attempting transition to " + pureArgs[0]);
 
-      return performTransition(router, handlerInfos, slice.call(pureArgs, 1), router.currentParams, queryParams);
+      return performTransition(router,
+                               handlerInfos,
+                               slice.call(pureArgs, 1),
+                               router.currentParams,
+                               queryParams,
+                               null,
+                               isIntermediate);
     }
 
     /**
       @private
     */
-    function createURLTransition(router, url) {
+    function createURLTransition(router, url, isIntermediate) {
       var results = router.recognizer.recognize(url),
           currentHandlerInfos = router.currentHandlerInfos,
-          queryParams = {};
+          queryParams = {},
+          i, len;
 
       log(router, "Attempting URL transition to " + url);
+
+      if (results) {
+        // Make sure this route is actually accessible by URL.
+        for (i = 0, len = results.length; i < len; ++i) {
+
+          if (router.getHandler(results[i].handler).inaccessiblyByURL) {
+            results = null;
+            break;
+          }
+        }
+      }
 
       if (!results) {
         return errorTransition(router, new Router.UnrecognizedURLError(url));
       }
 
-      for(var i = 0; i < results.length; i++) {
+      for(i = 0, len = results.length; i < len; i++) {
         merge(queryParams, results[i].queryParams);
       }
 
-      return performTransition(router, results, [], {}, queryParams);
+      return performTransition(router, results, [], {}, queryParams, null, isIntermediate);
     }
 
 
@@ -755,7 +808,7 @@ define("router",
       } catch(e) {
         if (!(e instanceof Router.TransitionAborted)) {
           // Trigger the `error` event starting from this failed handler.
-          trigger(transition.router, currentHandlerInfos.concat(handlerInfo), true, ['error', e, transition]);
+          transition.trigger(true, 'error', e, transition, handler);
         }
 
         // Propagate the error so that the transition promise will reject.
@@ -944,17 +997,37 @@ define("router",
       }
     }
 
+    function performIntermediateTransition(router, recogHandlers, matchPointResults) {
+
+      var handlerInfos = generateHandlerInfos(router, recogHandlers);
+      for (var i = 0; i < handlerInfos.length; ++i) {
+        var handlerInfo = handlerInfos[i];
+        handlerInfo.context = matchPointResults.providedModels[handlerInfo.name];
+      }
+
+      var stubbedTransition = {
+        router: router,
+        isAborted: false
+      };
+
+      setupContexts(stubbedTransition, handlerInfos);
+    }
+
     /**
       @private
 
       Creates, begins, and returns a Transition.
      */
-    function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data) {
+    function performTransition(router, recogHandlers, providedModelsArray, params, queryParams, data, isIntermediate) {
 
       var matchPointResults = getMatchPoint(router, recogHandlers, providedModelsArray, params, queryParams),
           targetName = recogHandlers[recogHandlers.length - 1].handler,
           wasTransitioning = false,
           currentHandlerInfos = router.currentHandlerInfos;
+
+      if (isIntermediate) {
+        return performIntermediateTransition(router, recogHandlers, matchPointResults);
+      }
 
       // Check if there's already a transition underway.
       if (router.activeTransition) {
@@ -974,9 +1047,11 @@ define("router",
       transition.params = matchPointResults.params;
       transition.data = data || {};
       transition.queryParams = queryParams;
+      transition.pivotHandler = matchPointResults.pivotHandler;
       router.activeTransition = transition;
 
       var handlerInfos = generateHandlerInfos(router, recogHandlers);
+      transition.handlerInfos = handlerInfos;
 
       // Fire 'willTransition' event on current handlers, but don't fire it
       // if a transition was already underway.
@@ -985,7 +1060,7 @@ define("router",
       }
 
       log(router, transition.sequence, "Beginning validation for transition to " + transition.targetName);
-      validateEntry(transition, handlerInfos, 0, matchPointResults.matchPoint, matchPointResults.handlerParams)
+      validateEntry(transition, matchPointResults.matchPoint, matchPointResults.handlerParams)
                    .then(transitionSuccess, transitionFailure);
 
       return transition;
@@ -1013,6 +1088,7 @@ define("router",
           log(router, transition.sequence, "TRANSITION COMPLETE.");
 
           // Resolve with the final handler.
+          transition.isActive = false;
           deferred.resolve(handlerInfos[handlerInfos.length - 1].handler);
         } catch(e) {
           deferred.reject(e);
@@ -1042,7 +1118,6 @@ define("router",
       for (var i = 0, len = recogHandlers.length; i < len; ++i) {
         var handlerObj = recogHandlers[i],
             isDynamic = handlerObj.isDynamic || (handlerObj.names && handlerObj.names.length);
-
 
         var handlerInfo = {
           isDynamic: !!isDynamic,
@@ -1089,6 +1164,7 @@ define("router",
       var router = transition.router,
           seq = transition.sequence,
           handlerName = handlerInfos[handlerInfos.length - 1].name,
+          urlMethod = transition.urlMethod,
           i;
 
       // Collect params for URL.
@@ -1098,6 +1174,10 @@ define("router",
         if (handlerInfo.isDynamic) {
           var providedModel = providedModels.pop();
           objects.unshift(isParam(providedModel) ? providedModel.toString() : handlerInfo.context);
+        }
+
+        if (handlerInfo.handler.inaccessiblyByURL) {
+          urlMethod = null;
         }
       }
 
@@ -1112,8 +1192,6 @@ define("router",
 
       router.currentParams = params;
 
-
-      var urlMethod = transition.urlMethod;
       if (urlMethod) {
         var url = router.recognizer.generate(handlerName, params);
 
@@ -1136,7 +1214,10 @@ define("router",
       and `afterModel` in promises, and checks for redirects/aborts
       between each.
      */
-    function validateEntry(transition, handlerInfos, index, matchPoint, handlerParams) {
+    function validateEntry(transition, matchPoint, handlerParams) {
+
+      var handlerInfos = transition.handlerInfos,
+          index = transition.resolveIndex;
 
       if (index === handlerInfos.length) {
         // No more contexts to resolve.
@@ -1159,6 +1240,8 @@ define("router",
           handlerInfo.handler.context;
         return proceed();
       }
+
+      transition.trigger(true, 'willResolveModel', transition, handler);
 
       return RSVP.resolve().then(handleAbort)
                            .then(beforeModel)
@@ -1193,7 +1276,7 @@ define("router",
 
         // An error was thrown / promise rejected, so fire an
         // `error` event from this handler info up to root.
-        trigger(router, handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
+        transition.trigger(true, 'error', reason, transition, handlerInfo.handler);
 
         // Propagate the original error.
         return RSVP.reject(reason);
@@ -1247,7 +1330,8 @@ define("router",
         log(router, seq, handlerName + ": validation succeeded, proceeding");
 
         handlerInfo.context = transition.resolvedModels[handlerInfo.name];
-        return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
+        transition.resolveIndex++;
+        return validateEntry(transition, matchPoint, handlerParams);
       }
     }
 
@@ -1317,16 +1401,16 @@ define("router",
       @param {Array[Object]} args arguments passed to transitionTo,
         replaceWith, or handleURL
     */
-    function doTransition(router, args) {
+    function doTransition(router, args, isIntermediate) {
       // Normalize blank transitions to root URL transitions.
       var name = args[0] || '/';
 
       if(args.length === 1 && args[0].hasOwnProperty('queryParams')) {
-        return createQueryParamTransition(router, args[0]);
+        return createQueryParamTransition(router, args[0], isIntermediate);
       } else if (name.charAt(0) === '/') {
-        return createURLTransition(router, name);
+        return createURLTransition(router, name, isIntermediate);
       } else {
-        return createNamedTransition(router, slice.call(args));
+        return createNamedTransition(router, slice.call(args), isIntermediate);
       }
     }
 

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-var get = Ember.get;
+var get = Ember.get, typeOf = Ember.typeOf;
 
 /**
   The `Ember.ActionHandler` mixin implements support for moving an `actions`
@@ -29,9 +29,21 @@ Ember.ActionHandler = Ember.Mixin.create({
     @method willMergeMixin
   */
   willMergeMixin: function(props) {
-    if (props.actions && !props._actions) {
-      props._actions = Ember.merge(props._actions || {}, props.actions);
-      delete props.actions;
+    var hashName;
+
+    if (!props._actions) {
+      if (typeOf(props.actions) === 'object') {
+        hashName = 'actions';
+      } else if (typeOf(props.events) === 'object') {
+        Ember.deprecate('Action handlers contained in an `events` object are deprecated in favor of putting them in an `actions` object', false);
+        hashName = 'events';
+      }
+
+      if (hashName) {
+        props._actions = Ember.merge(props._actions || {}, props[hashName]);
+      }
+
+      delete props[hashName];
     }
   },
 

--- a/packages/ember/tests/routing/loading_substates_test.js
+++ b/packages/ember/tests/routing/loading_substates_test.js
@@ -1,0 +1,503 @@
+var Router, App, AppView, templates, router, container, counter;
+var get = Ember.get, set = Ember.set, compile = Ember.Handlebars.compile;
+
+function step(expectedValue, description) {
+  equal(counter, expectedValue, "Step " + expectedValue + ": " + description);
+  counter++;
+}
+
+function bootApplication(startingURL) {
+
+  for (var name in templates) {
+    Ember.TEMPLATES[name] = compile(templates[name]);
+  }
+
+  if (startingURL) {
+    Ember.NoneLocation.reopen({
+      path: startingURL
+    });
+  }
+
+  startingURL = startingURL || '';
+  router = container.lookup('router:main');
+  Ember.run(App, 'advanceReadiness');
+}
+
+function handleURL(path) {
+  return Ember.run(function() {
+    return router.handleURL(path).then(function(value) {
+      ok(true, 'url: `' + path + '` was handled');
+      return value;
+    }, function(reason) {
+      ok(false, 'failed to visit:`' + path + '` reason: `' + QUnit.jsDump.parse(reason));
+      throw reason;
+    });
+  });
+}
+
+module("Loading substates", {
+  setup: function() {
+    counter = 1;
+
+    Ember.run(function() {
+      App = Ember.Application.create({
+        name: "App",
+        rootElement: '#qunit-fixture'
+      });
+
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+
+      Router = App.Router;
+
+      //App.LoadingRoute = Ember.Route.extend({
+      //});
+
+      container = App.__container__;
+
+      templates = {
+        application: '<div id="app">{{outlet}}</div>',
+        index: 'INDEX',
+        loading: 'LOADING',
+        bro: 'BRO',
+        sis: 'SIS'
+      };
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      App.destroy();
+      App = null;
+
+      Ember.TEMPLATES = {};
+    });
+
+    Ember.NoneLocation.reopen({
+      path: ''
+    });
+  }
+});
+
+test("Slow promise from a child route of application enters nested loading state", function() {
+
+  var broModel = {}, broDeferred = Ember.RSVP.defer();
+
+  Router.map(function() {
+    this.route('bro');
+  });
+
+  App.ApplicationRoute = Ember.Route.extend({
+    setupController: function() {
+      step(2, "ApplicationRoute#setup");
+    }
+  });
+
+  App.BroRoute = Ember.Route.extend({
+    model: function() {
+      step(1, "BroRoute#model");
+      return broDeferred.promise;
+    }
+  });
+
+  bootApplication('/bro');
+
+  equal(Ember.$('#app', '#qunit-fixture').text(), "LOADING", "The Loading template is nested in application template's outlet");
+
+  Ember.run(broDeferred, 'resolve', broModel);
+
+  equal(Ember.$('#app', '#qunit-fixture').text(), "BRO", "bro template has loaded and replaced loading template");
+});
+
+test("Slow promises waterfall on startup", function() {
+
+  expect(7);
+
+  var grandmaDeferred = Ember.RSVP.defer(),
+      sallyDeferred = Ember.RSVP.defer();
+
+  Router.map(function() {
+    this.resource('grandma', function() {
+      this.resource('mom', function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  templates.grandma = "GRANDMA {{outlet}}";
+  templates.mom = "MOM {{outlet}}";
+  templates['mom/loading'] = "MOMLOADING";
+  templates['mom/sally'] = "SALLY";
+
+  App.GrandmaRoute = Ember.Route.extend({
+    model: function() {
+      step(1, "GrandmaRoute#model");
+      return grandmaDeferred.promise;
+    }
+  });
+
+  App.MomRoute = Ember.Route.extend({
+    model: function() {
+      step(2, "Mom#model");
+      return {};
+    }
+  });
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model: function() {
+      step(3, "SallyRoute#model");
+      return sallyDeferred.promise;
+    },
+    setupController: function() {
+      step(4, "SallyRoute#setupController");
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+
+  equal(Ember.$('#app', '#qunit-fixture').text(), "LOADING", "The Loading template is nested in application template's outlet");
+
+  Ember.run(grandmaDeferred, 'resolve', {});
+  equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA MOM MOMLOADING", "Mom's child loading route is displayed due to sally's slow promise");
+
+  Ember.run(sallyDeferred, 'resolve', {});
+  equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA MOM SALLY", "Sally template displayed");
+});
+
+test("ApplicationRoute#currentPath reflects loading state path", function() {
+
+  expect(4);
+
+  var momDeferred = Ember.RSVP.defer();
+
+  Router.map(function() {
+    this.resource('grandma', function() {
+      this.route('mom');
+    });
+  });
+
+  templates.grandma = "GRANDMA {{outlet}}";
+  templates['grandma/loading'] = "GRANDMALOADING";
+  templates['grandma/mom'] = "MOM";
+
+  App.GrandmaMomRoute = Ember.Route.extend({
+    model: function() {
+      return momDeferred.promise;
+    }
+  });
+
+  bootApplication('/grandma/mom');
+
+  equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA GRANDMALOADING");
+
+  var appController = container.lookup('controller:application');
+  equal(appController.get('currentPath'), "grandma.loading", "currentPath reflects loading state");
+
+  Ember.run(momDeferred, 'resolve', {});
+  equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA MOM");
+  equal(appController.get('currentPath'), "grandma.mom", "currentPath reflects final state");
+});
+
+test("Slow promises returned from ApplicationRoute#model enter NOTHING????", function() {
+
+  expect(2);
+
+  var appDeferred = Ember.RSVP.defer();
+
+  App.ApplicationRoute = Ember.Route.extend({
+    model: function() {
+      return appDeferred.promise;
+    }
+  });
+
+  App.LoadingRoute = Ember.Route.extend({
+    setupController: function() {
+      ok(false, "shouldn't get here");
+    }
+  });
+
+  bootApplication();
+
+  equal(Ember.$('#app', '#qunit-fixture').text(), "", "nothing has been rendered yet");
+
+  Ember.run(appDeferred, 'resolve', {});
+  equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
+});
+
+test("Don't enter loading route unless either route or template defined", function() {
+
+  delete templates.loading;
+
+  expect(2);
+
+  var indexDeferred = Ember.RSVP.defer();
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.IndexRoute = Ember.Route.extend({
+    model: function() {
+      return indexDeferred.promise;
+    }
+  });
+
+  bootApplication();
+
+  var appController = container.lookup('controller:application');
+  ok(appController.get('currentPath') !== "loading", "loading state not entered");
+
+  Ember.run(indexDeferred, 'resolve', {});
+  equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
+});
+
+test("Enter loading route if only LoadingRoute defined", function() {
+
+  delete templates.loading;
+
+  expect(4);
+
+  var indexDeferred = Ember.RSVP.defer();
+
+  App.IndexRoute = Ember.Route.extend({
+    model: function() {
+      step(1, "IndexRoute#model");
+      return indexDeferred.promise;
+    }
+  });
+
+  App.LoadingRoute = Ember.Route.extend({
+    setupController: function() {
+      step(2, "LoadingRoute#setupController");
+    }
+  });
+
+  bootApplication();
+
+  var appController = container.lookup('controller:application');
+  equal(appController.get('currentPath'), "loading", "loading state entered");
+
+  Ember.run(indexDeferred, 'resolve', {});
+  equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
+});
+
+test("Enter child loading state of pivot route", function() {
+
+  expect(4);
+
+  var deferred = Ember.RSVP.defer();
+
+  Router.map(function() {
+    this.resource('grandma', function() {
+      this.resource('mom', function() {
+        this.route('sally');
+      });
+      this.route('smells');
+    });
+  });
+
+  templates['grandma/loading'] = "GMONEYLOADING";
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    setupController: function() {
+      step(1, "SallyRoute#setupController");
+    }
+  });
+
+  App.GrandmaSmellsRoute = Ember.Route.extend({
+    model: function() {
+      return deferred.promise;
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+
+  var appController = container.lookup('controller:application');
+  equal(appController.get('currentPath'), "grandma.mom.sally", "Initial route fully loaded");
+
+  Ember.run(router, 'transitionTo', 'grandma.smells');
+  equal(appController.get('currentPath'), "grandma.loading", "in pivot route's child loading state");
+
+  Ember.run(deferred, 'resolve', {});
+
+  equal(appController.get('currentPath'), "grandma.smells", "Finished transition");
+});
+
+test("Don't bubble loading event above pivot route", function() {
+
+  expect(5);
+
+  delete templates.loading;
+
+  var sallyDeferred = Ember.RSVP.defer(),
+      smellsDeferred = Ember.RSVP.defer();
+
+  var shouldBubbleToApplication = true;
+
+  Router.map(function() {
+    this.resource('grandma', function() {
+      this.resource('mom', function() {
+        this.route('sally');
+      });
+      this.route('smells');
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.ApplicationRoute = Ember.Route.extend({
+    actions: {
+      loading: function(transition, route) {
+        equal(route, container.lookup('route:mom.sally'), "the only route whose loading event should bubble to app route is mom.sally");
+      }
+    }
+  });
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model: function() {
+      return sallyDeferred.promise;
+    }
+  });
+
+  App.GrandmaSmellsRoute = Ember.Route.extend({
+    model: function() {
+      return smellsDeferred.promise;
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+
+  var appController = container.lookup('controller:application');
+  ok(!appController.get('currentPath'), "Initial route fully loaded");
+  Ember.run(sallyDeferred, 'resolve', {});
+
+  equal(appController.get('currentPath'), "grandma.mom.sally", "transition completed");
+
+  Ember.run(router, 'transitionTo', 'grandma.smells');
+  equal(appController.get('currentPath'), "grandma.mom.sally", "still in initial state because loading event didn't bubble");
+
+  Ember.run(smellsDeferred, 'resolve', {});
+
+  equal(appController.get('currentPath'), "grandma.smells", "Finished transition");
+});
+
+
+/*
+
+test("Aborting/redirecting the transition in `willTransition` prevents LoadingRoute from being entered", function() {
+
+  expect(8);
+
+  Router.map(function() {
+    this.route("nork");
+    this.route("about");
+  });
+
+  var redirect = false;
+
+  App.IndexRoute = Ember.Route.extend({
+    actions: {
+      willTransition: function(transition) {
+        ok(true, "willTransition was called");
+        if (redirect) {
+          // router.js won't refire `willTransition` for this redirect
+          this.transitionTo('about');
+        } else {
+          transition.abort();
+        }
+      }
+    }
+  });
+
+  var deferred = null;
+
+  App.LoadingRoute = Ember.Route.extend({
+    activate: function() {
+      ok(deferred, "LoadingRoute should be entered at this time");
+    },
+    deactivate: function() {
+      ok(true, "LoadingRoute was exited");
+    }
+  });
+
+  App.NorkRoute = Ember.Route.extend({
+    activate: function() {
+      ok(true, "NorkRoute was entered");
+    }
+  });
+
+  App.AboutRoute = Ember.Route.extend({
+    activate: function() {
+      ok(true, "AboutRoute was entered");
+    },
+    model: function() {
+      if (deferred) { return deferred.promise; }
+    }
+  });
+
+  bootApplication();
+
+  // Attempted transitions out of index should abort.
+  Ember.run(router, 'transitionTo', 'nork');
+  Ember.run(router, 'handleURL', '/nork');
+
+  // Attempted transitions out of index should redirect to about
+  redirect = true;
+  Ember.run(router, 'transitionTo', 'nork');
+  Ember.run(router, 'transitionTo', 'index');
+
+  // Redirected transitions out of index to a route with a
+  // promise model should pause the transition and
+  // activate LoadingRoute
+  deferred = Ember.RSVP.defer();
+  Ember.run(router, 'transitionTo', 'nork');
+  Ember.run(deferred.resolve);
+});
+*/
+
+test("Default error event moves into nested route", function() {
+
+  expect(5);
+
+  templates['grandma'] = "GRANDMA {{outlet}}";
+  templates['grandma/error'] = "ERROR: {{msg}}";
+
+  Router.map(function() {
+    this.resource('grandma', function() {
+      this.resource('mom', function() {
+        this.route('sally');
+      });
+    });
+  });
+
+  App.ApplicationController = Ember.Controller.extend();
+
+  App.MomSallyRoute = Ember.Route.extend({
+    model: function() {
+      step(1, "MomSallyRoute#model");
+      throw {
+        msg: "did it broke?"
+      };
+    },
+    actions: {
+      error: function() {
+        step(2, "MomSallyRoute#actions.error");
+        return true;
+      }
+    }
+  });
+
+  bootApplication('/grandma/mom/sally');
+
+  step(3, "App finished booting");
+
+  equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA ERROR: did it broke?", "error bubbles");
+
+  var appController = container.lookup('controller:application');
+  equal(appController.get('currentPath'), 'grandma.error', "Initial route fully loaded");
+});
+
+


### PR DESCRIPTION
Proposal/Discussion:
http://discuss.emberjs.com/t/proposal-nested-loading-routes/2895

Possible doubts:
- Global `LoadingRoute` behavior has changed (though it's decently
  agreed upon that it was always mad broke). Instead of creating a
  top-level sibling view of `ApplicationView`, (sub) loading routes
  render into an outlet (unless you override `renderTemplate` to
  do otherwise). This will surprise avid users of `LoadingRoute`,
  wherever they are. There doesn't seem to be a clean way to preserve
  this behavior in a backwards compatible manner without putting
  mental/API hurdles in front of doing the likely more desirable
  new behavior of rendering loading templates into outlets,
  but I'm all ears.

TODO:
- [x] Extend this logic to `error` routes/templates
- [x] Make `loading` action support `_super`
- [x] Come up with more JSBin examples for everyone to grok.
## Demos
- [Basic Loading Substates Demo](http://jsbin.com/ucanam/1399#/foo/bar/woot)
- [Loading+Error Substates Demo](http://jsbin.com/ucanam/1406#/foo/bar/woot)
- [handling `error`, calling `_super`](http://jsbin.com/ucanam/1407/edit)
