### PR TITLE
Give precedence to routes with more static segments. Fixes #3573

### DIFF
--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -232,7 +232,7 @@ define("route-recognizer",
       return states.sort(function(a, b) {
         if (a.types.stars !== b.types.stars) { return a.types.stars - b.types.stars; }
         if (a.types.dynamics !== b.types.dynamics) { return a.types.dynamics - b.types.dynamics; }
-        if (a.types.statics !== b.types.statics) { return a.types.statics - b.types.statics; }
+        if (a.types.statics !== b.types.statics) { return b.types.statics - a.types.statics; }
 
         return 0;
       });


### PR DESCRIPTION
This PR makes it so that the route recognizer prioritizes routes with the most static segments if both stars and dynamics are equal. It should fix #3573.

I'm not sure what the process is for updating tildeio/route-recognizer, so I submitted PRs here and [over there](https://github.com/tildeio/route-recognizer/pull/13). Let me know if I need to do it differently!
