### PR TITLE
Add tests for Application#injectTestHelpers.

### DIFF
--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,12 +1,23 @@
 var App;
 
-module("ember-testing Helpers", {
-  teardown: function() {
+function cleanup(){
+  if (App) {
     Ember.run(App, App.destroy);
     App.removeTestHelpers();
     App = null;
-    Ember.TEMPLATES = {};
   }
+
+  Ember.run(function(){
+    Ember.$(document).off('ajaxStart');
+    Ember.$(document).off('ajaxStop');
+  });
+
+  Ember.TEMPLATES = {};
+}
+
+module("ember-testing Helpers", {
+  setup: function(){ cleanup(); },
+  teardown: function() { cleanup(); }
 });
 
 test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
@@ -197,6 +208,49 @@ test("`click` triggers appropriate events in order", function() {
   });
 });
 
+test("Ember.Application#injectTestHelpers", function() {
+  var documentEvents;
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+  });
+
+  documentEvents = Ember.$._data(document, 'events');
+
+  if (!documentEvents) {
+    documentEvents = {};
+  }
+
+  ok(documentEvents['ajaxStart'] === undefined, 'there are no ajaxStart listers setup prior to calling injectTestHelpers');
+  ok(documentEvents['ajaxStop'] === undefined, 'there are no ajaxStop listers setup prior to calling injectTestHelpers');
+
+  App.injectTestHelpers();
+  documentEvents = Ember.$._data(document, 'events');
+
+  equal(documentEvents['ajaxStart'].length, 1, 'calling injectTestHelpers registers an ajaxStart handler');
+  equal(documentEvents['ajaxStop'].length, 1, 'calling injectTestHelpers registers an ajaxStop handler');
+});
+
+test("Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers", function(){
+  var injected = 0;
+
+  Ember.Test.onInjectHelpers(function(){
+    injected++;
+  });
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+  });
+
+  equal(injected, 0, 'onInjectHelpers are not called before injectTestHelpers');
+
+  App.injectTestHelpers();
+
+  equal(injected, 1, 'onInjectHelpers are called after injectTestHelpers');
+});
+
 if (Ember.FEATURES.isEnabled("ember-testing-wait-hooks")) {
   test("`wait` respects registerWaiters", function() {
     expect(2);
@@ -255,10 +309,7 @@ if (Ember.FEATURES.isEnabled("ember-testing-wait-hooks")) {
 
 module("ember-testing pendingAjaxRequests", {
   setup: function(){
-    Ember.run(function(){
-      Ember.$(document).off('ajaxStart');
-      Ember.$(document).off('ajaxStop');
-    });
+    cleanup();
 
     Ember.run(function() {
       App = Ember.Application.create();
@@ -268,12 +319,7 @@ module("ember-testing pendingAjaxRequests", {
     App.injectTestHelpers();
   },
 
-  teardown: function() {
-    Ember.run(App, App.destroy);
-    App.removeTestHelpers();
-    App = null;
-    Ember.TEMPLATES = {};
-  }
+  teardown: function() { cleanup(); }
 });
 
 test("pendingAjaxRequests is incremented on each document ajaxStart event", function() {


### PR DESCRIPTION
Adds tests to ensure that the `onInjectHelpers` callbacks are ran, and ensures
that the tests are run in a consistent state (prior to the
`cleanup` changes here we would leak `ajaxStart` and `ajaxStop` event 
handlers).

These are tests for existing functionality (as mentioned in #3567).
