### PR TITLE
[FEATURE container-renderables] lookup/render templates as well

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -178,17 +178,24 @@ Ember.Handlebars.resolveHelper = function(container, name) {
   }
 
   var helper = container.lookup('helper:' + name);
-  if (!helper) {
-    var componentLookup = container.lookup('component-lookup:main');
-    Ember.assert("Could not find 'component-lookup:main' on the provided container, which is necessary for performing component lookups", componentLookup);
-
-    var Component = componentLookup.lookupFactory(name, container);
-    if (Component) {
-      helper = EmberHandlebars.makeViewHelper(Component);
-      container.register('helper:' + name, helper);
-    }
+  if (helper) {
+    return helper;
   }
-  return helper;
+
+  var componentLookup = container.lookup('component-lookup:main');
+  Ember.assert("Could not find 'component-lookup:main' on the provided container, which is necessary for performing component lookups", componentLookup);
+
+  var Component = componentLookup.lookupFactory(name, container);
+  if (Component) {
+    helper = EmberHandlebars.makeViewHelper(Component);
+    container.register('helper:' + name, helper);
+    return helper;
+  }
+
+  var template = container.lookup('template:' + name);
+  return template && function(options) {
+    template(this, { data: options.data });
+  };
 };
 
 /**

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -98,4 +98,22 @@ if (Ember.FEATURES.isEnabled('container-renderables')) {
 
     Ember.Handlebars.helpers.helperMissing = realHelperMissing;
   });
+
+  test("Dasherized mustaches can render templates", function() {
+
+    Ember.TEMPLATES.application = compile("<div id='wrapper'>!{{some-template}}{{other-template}}{{dashed-thing}}!</div>");
+    Ember.TEMPLATES['some-template'] = compile("LOL");
+
+    boot(function() {
+      container.register('template:other-template', compile("ROFL"));
+      container.register('template:dashed-thing', compile("I AM SHADOWED"));
+
+      // This should be prioritized over the template.
+      container.register('helper:dashed-thing', function() {
+        return "OMG";
+      });
+    });
+
+    equal(Ember.$('#wrapper').text(), "!LOLROFLOMG!", "Dasherized mustache successfully rendered templates");
+  });
 }


### PR DESCRIPTION
{{some-template}} will now attempt to resolve 
'template:some-template' and render it if it exists,
as if {{partial 'some-template'}} had been written instead.
