### PR TITLE
Improve error message when action bubbles

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -329,7 +329,7 @@ function triggerEvent(handlerInfos, ignoreFailure, args) {
   }
 
   if (!eventWasHandled && !ignoreFailure) {
-    throw new Ember.Error("Nothing handled the event '" + name + "'.");
+    throw new Ember.Error("Nothing handled the action '" + name + "'. If you did handle the action, this error can be caused by returning true from an action handler, causing the action to bubble.");
   }
 }
 


### PR DESCRIPTION
This error is easy to trigger by returning true unintentionally from an action handler (coffeescript particularly exposes this problem).

A slight improvement of the error message makes it easier to see what the problem is.
