### PR TITLE
Change Ember.observer and friends to take function as the final argument

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -42,7 +42,7 @@ Ember.SelectOption = Ember.View.extend({
     }
   }).property('content', 'parentView.selection'),
 
-  labelPathDidChange: Ember.observer(function() {
+  labelPathDidChange: Ember.observer('parentView.optionLabelPath', function() {
     var labelPath = get(this, 'parentView.optionLabelPath');
 
     if (!labelPath) { return; }
@@ -50,9 +50,9 @@ Ember.SelectOption = Ember.View.extend({
     Ember.defineProperty(this, 'label', Ember.computed(function() {
       return get(this, labelPath);
     }).property(labelPath));
-  }, 'parentView.optionLabelPath'),
+  }),
 
-  valuePathDidChange: Ember.observer(function() {
+  valuePathDidChange: Ember.observer('parentView.optionValuePath', function() {
     var valuePath = get(this, 'parentView.optionValuePath');
 
     if (!valuePath) { return; }
@@ -60,7 +60,7 @@ Ember.SelectOption = Ember.View.extend({
     Ember.defineProperty(this, 'value', Ember.computed(function() {
       return get(this, valuePath);
     }).property(valuePath));
-  }, 'parentView.optionValuePath')
+  })
 });
 
 Ember.SelectOptgroup = Ember.CollectionView.extend({
@@ -489,7 +489,7 @@ Ember.Select = Ember.View.extend(
     }
   },
 
-  selectionDidChange: Ember.observer(function() {
+  selectionDidChange: Ember.observer('selection.@each', function() {
     var selection = get(this, 'selection');
     if (get(this, 'multiple')) {
       if (!isArray(selection)) {
@@ -500,9 +500,9 @@ Ember.Select = Ember.View.extend(
     } else {
       this._selectionDidChangeSingle();
     }
-  }, 'selection.@each'),
+  }),
 
-  valueDidChange: Ember.observer(function() {
+  valueDidChange: Ember.observer('value', function() {
     var content = get(this, 'content'),
         value = get(this, 'value'),
         valuePath = get(this, 'optionValuePath').replace(/^content\.?/, ''),
@@ -516,7 +516,7 @@ Ember.Select = Ember.View.extend(
 
       this.set('selection', selection);
     }
-  }, 'value'),
+  }),
 
 
   _triggerChange: function() {

--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -34,14 +34,14 @@ Ember.TextArea = Ember.Component.extend(Ember.TextSupport, {
   rows: null,
   cols: null,
 
-  _updateElementValue: Ember.observer(function() {
+  _updateElementValue: Ember.observer('value', function() {
     // We do this check so cursor position doesn't get affected in IE
     var value = get(this, 'value'),
         $el = this.$();
     if ($el && value !== $el.val()) {
       $el.val(value);
     }
-  }, 'value'),
+  }),
 
   init: function() {
     this._super();

--- a/packages/ember-handlebars/tests/views/metamorph_view_test.js
+++ b/packages/ember-handlebars/tests/views/metamorph_view_test.js
@@ -169,9 +169,9 @@ test("replacing a Metamorph should invalidate childView elements", function() {
         this.get('element');
       },
 
-      elementDidChange: Ember.observer(function() {
+      elementDidChange: Ember.observer('element', function() {
         elementOnDidChange = this.get('element');
-      }, 'element'),
+      }),
 
       didInsertElement: function() {
         elementOnDidInsert = this.get('element');

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -677,7 +677,7 @@ Ember.observer = function() {
   var paths = a_slice.call(arguments, 0, -1);
 
   if (typeof func !== "function") {
-    Ember.deprecate("Ember.observer should be called with the function as the last argument after the property names.");
+    // revert to old, soft-deprecated argument ordering
 
     func  = arguments[0];
     paths = a_slice.call(arguments, 1);
@@ -771,7 +771,7 @@ Ember.beforeObserver = function() {
   var paths = a_slice.call(arguments, 0, -1);
 
   if (typeof func !== "function") {
-    Ember.deprecate("Ember.beforeObserver should be called with the function as the last argument after the property names.");
+    // revert to old, soft-deprecated argument ordering
 
     func  = arguments[0];
     paths = a_slice.call(arguments, 1);

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -696,9 +696,9 @@ Ember.observer = function() {
 
   ```javascript
   Ember.Object.extend({
-    valueObserver: Ember.immediateObserver(function() {
+    valueObserver: Ember.immediateObserver('value', function() {
       // Executes whenever the "value" property changes
-    }, 'value')
+    })
   });
   ```
 
@@ -710,8 +710,8 @@ Ember.observer = function() {
 
   @method immediateObserver
   @for Ember
-  @param {Function} func
   @param {String} propertyNames*
+  @param {Function} func
   @return func
 */
 Ember.immediateObserver = function() {
@@ -738,22 +738,22 @@ Ember.immediateObserver = function() {
 
     friends: [{ name: 'Tom' }, { name: 'Stefan' }, { name: 'Kris' }],
 
-    valueWillChange: Ember.beforeObserver(function(obj, keyName) {
+    valueWillChange: Ember.beforeObserver('content.value', function(obj, keyName) {
       this.changingFrom = obj.get(keyName);
-    }, 'content.value'),
+    }),
 
-    valueDidChange: Ember.observer(function(obj, keyName) {
+    valueDidChange: Ember.observer('content.value', function(obj, keyName) {
         // only run if updating a value already in the DOM
         if (this.get('state') === 'inDOM') {
           var color = obj.get(keyName) > this.changingFrom ? 'green' : 'red';
           // logic
         }
-    }, 'content.value'),
+    }),
 
-    friendsDidChange: Ember.observer(function(obj, keyName) {
+    friendsDidChange: Ember.observer('friends.@each.name', function(obj, keyName) {
       // some logic
       // obj.get(keyName) returns friends array
-    }, 'friends.@each.name')
+    })
   });
   ```
 
@@ -762,12 +762,25 @@ Ember.immediateObserver = function() {
 
   @method beforeObserver
   @for Ember
-  @param {Function} func
   @param {String} propertyNames*
+  @param {Function} func
   @return func
 */
-Ember.beforeObserver = function(func) {
-  var paths = a_slice.call(arguments, 1);
+Ember.beforeObserver = function() {
+  var func  = a_slice.call(arguments, -1)[0];
+  var paths = a_slice.call(arguments, 0, -1);
+
+  if (typeof func !== "function") {
+    Ember.deprecate("Ember.beforeObserver should be called with the function as the last argument after the property names.");
+
+    func  = arguments[0];
+    paths = a_slice.call(arguments, 1);
+  }
+
+  if (typeof func !== "function") {
+    throw new Error("Ember.beforeObserver called without a function");
+  }
+
   func.__ember_observesBefore__ = paths;
   return func;
 };

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -654,9 +654,9 @@ Ember.aliasMethod = function(methodName) {
 
   ```javascript
   Ember.Object.extend({
-    valueObserver: Ember.observer(function() {
+    valueObserver: Ember.observer('value', function() {
       // Executes whenever the "value" property changes
-    }, 'value')
+    })
   });
   ```
 
@@ -668,12 +668,25 @@ Ember.aliasMethod = function(methodName) {
 
   @method observer
   @for Ember
-  @param {Function} func
   @param {String} propertyNames*
+  @param {Function} func
   @return func
 */
-Ember.observer = function(func) {
-  var paths = a_slice.call(arguments, 1);
+Ember.observer = function() {
+  var func  = a_slice.call(arguments, -1)[0];
+  var paths = a_slice.call(arguments, 0, -1);
+
+  if (typeof func !== "function") {
+    Ember.deprecate("Ember.observer should be called with the function as the last argument after the property names.");
+
+    func  = arguments[0];
+    paths = a_slice.call(arguments, 1);
+  }
+
+  if (typeof func !== "function") {
+    throw new Error("Ember.observer called without a function");
+  }
+
   func.__ember_observes__ = paths;
   return func;
 };

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -684,7 +684,7 @@ Ember.observer = function() {
   }
 
   if (typeof func !== "function") {
-    throw new Error("Ember.observer called without a function");
+    throw new Ember.Error("Ember.observer called without a function");
   }
 
   func.__ember_observes__ = paths;
@@ -778,7 +778,7 @@ Ember.beforeObserver = function() {
   }
 
   if (typeof func !== "function") {
-    throw new Error("Ember.beforeObserver called without a function");
+    throw new Ember.Error("Ember.beforeObserver called without a function");
   }
 
   func.__ember_observesBefore__ = paths;

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -72,9 +72,9 @@ test('(regression) watched properties on unmodified inherited objects should sti
 
   var MyMixin = Ember.Mixin.create({
     someProperty: 'foo',
-    propertyDidChange: Ember.observer(function() {
+    propertyDidChange: Ember.observer('someProperty', function() {
       // NOTHING TO DO
-    }, 'someProperty')
+    })
   });
 
   var baseObject = MyMixin.apply({});
@@ -151,9 +151,9 @@ test('(regression) watched properties on unmodified inherited objects should sti
 
   var MyMixin = Ember.Mixin.create({
     someProperty: 'foo',
-    propertyDidChange: Ember.observer(function() {
+    propertyDidChange: Ember.observer('someProperty', function() {
       // NOTHING TO DO
-    }, 'someProperty')
+    })
   });
 
   var baseObject = MyMixin.apply({});

--- a/packages/ember-metal/tests/mixin/observer_test.js
+++ b/packages/ember-metal/tests/mixin/observer_test.js
@@ -10,9 +10,9 @@ testBoth('global observer helper', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
 
   });
 
@@ -29,9 +29,9 @@ testBoth('global observer helper takes multiple params', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', 'baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar', 'baz')
+    })
 
   });
 
@@ -50,16 +50,16 @@ testBoth('replacing observer should remove old observer', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
 
   });
 
   var Mixin2 = Ember.Mixin.create({
-    foo: Ember.observer(function() {
+    foo: Ember.observer('baz', function() {
       set(this, 'count', get(this, 'count')+10);
-    }, 'baz')
+    })
   });
 
   var obj = Ember.mixin({}, MyMixin, Mixin2);
@@ -79,9 +79,9 @@ testBoth('observing chain with property before', function(get, set) {
   var MyMixin = Ember.Mixin.create({
     count: 0,
     bar: obj2,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj = Ember.mixin({}, MyMixin);
@@ -96,9 +96,9 @@ testBoth('observing chain with property after', function(get, set) {
 
   var MyMixin = Ember.Mixin.create({
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz'),
+    }),
     bar: obj2
   });
 
@@ -115,9 +115,9 @@ testBoth('observing chain with property in mixin applied later', function(get, s
   var MyMixin = Ember.Mixin.create({
 
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var MyMixin2 = Ember.Mixin.create({bar: obj2});
@@ -137,9 +137,9 @@ testBoth('observing chain with existing property', function(get, set) {
 
   var MyMixin = Ember.Mixin.create({
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj = Ember.mixin({bar: obj2}, MyMixin);
@@ -155,9 +155,9 @@ testBoth('observing chain with property in mixin before', function(get, set) {
 
   var MyMixin = Ember.Mixin.create({
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj = Ember.mixin({}, MyMixin2, MyMixin);
@@ -173,9 +173,9 @@ testBoth('observing chain with property in mixin after', function(get, set) {
 
   var MyMixin = Ember.Mixin.create({
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj = Ember.mixin({}, MyMixin, MyMixin2);
@@ -193,9 +193,9 @@ testBoth('observing chain with overriden property', function(get, set) {
 
   var MyMixin = Ember.Mixin.create({
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj = Ember.mixin({bar: obj2}, MyMixin, MyMixin2);

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -960,10 +960,10 @@ testBoth("immediate observers should fire synchronously", function(get, set) {
   // trigger deferred behavior
   Ember.run(function() {
     mixin = Ember.Mixin.create({
-      fooDidChange: Ember.immediateObserver(function() {
+      fooDidChange: Ember.immediateObserver('foo', function() {
         observerCalled++;
         equal(get(this, 'foo'), "barbaz", "newly set value is immediately available");
-      }, 'foo')
+      })
     });
 
     mixin.apply(obj);
@@ -986,7 +986,7 @@ testBoth("immediate observers should fire synchronously", function(get, set) {
 
 testBoth("immediate observers are for internal properties only", function(get, set) {
   expectAssertion(function() {
-    Ember.immediateObserver(Ember.K, 'foo.bar');
+    Ember.immediateObserver('foo.bar', Ember.K);
   }, 'Immediate observers must observe internal properties only, not properties on other objects.');
 });
 

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -527,13 +527,13 @@ testBoth('local observers can be removed', function(get, set) {
   var barObserved = 0;
 
   var MyMixin = Ember.Mixin.create({
-    foo1: Ember.observer(function() {
+    foo1: Ember.observer('bar', function() {
       barObserved++;
-    }, 'bar'),
+    }),
 
-    foo2: Ember.observer(function() {
+    foo2: Ember.observer('bar', function() {
       barObserved++;
-    }, 'bar')
+    })
   });
 
   var obj = {};

--- a/packages/ember-metal/tests/watching/isWatching_test.js
+++ b/packages/ember-metal/tests/watching/isWatching_test.js
@@ -14,7 +14,7 @@ var testObserver = function(setup, teardown, key) {
 test("isWatching is true for regular local observers", function() {
   testObserver(function(obj, key, fn) {
     Ember.Mixin.create({
-      didChange: Ember.observer(fn, key)
+      didChange: Ember.observer(key, fn)
     }).apply(obj);
   }, function(obj, key, fn) {
     Ember.removeObserver(obj, key, obj, fn);

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -164,7 +164,7 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
     return content;
   }),
 
-  _contentWillChange: Ember.beforeObserver(function() {
+  _contentWillChange: Ember.beforeObserver('content', function() {
     var content = get(this, 'content'),
         sortProperties = get(this, 'sortProperties');
 
@@ -177,11 +177,11 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
     }
 
     this._super();
-  }, 'content'),
+  }),
 
-  sortAscendingWillChange: Ember.beforeObserver(function() {
+  sortAscendingWillChange: Ember.beforeObserver('sortAscending', function() {
     this._lastSortAscending = get(this, 'sortAscending');
-  }, 'sortAscending'),
+  }),
 
   sortAscendingDidChange: Ember.observer('sortAscending', function() {
     if (get(this, 'sortAscending') !== this._lastSortAscending) {

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -183,12 +183,12 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
     this._lastSortAscending = get(this, 'sortAscending');
   }, 'sortAscending'),
 
-  sortAscendingDidChange: Ember.observer(function() {
+  sortAscendingDidChange: Ember.observer('sortAscending', function() {
     if (get(this, 'sortAscending') !== this._lastSortAscending) {
       var arrangedContent = get(this, 'arrangedContent');
       arrangedContent.reverseObjects();
     }
-  }, 'sortAscending'),
+  }),
 
   contentArrayWillChange: function(array, idx, removedCount, addedCount) {
     var isSorted = get(this, 'isSorted');

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -136,13 +136,13 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
 
     @method _contentDidChange
   */
-  _contentDidChange: Ember.observer(function() {
+  _contentDidChange: Ember.observer('content', function() {
     var content = get(this, 'content');
 
     Ember.assert("Can't set ArrayProxy's content to itself", content !== this);
 
     this._setupContent();
-  }, 'content'),
+  }),
 
   _setupContent: function() {
     var content = get(this, 'content');
@@ -165,7 +165,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
     this._teardownArrangedContent(arrangedContent);
   }, 'arrangedContent'),
 
-  _arrangedContentDidChange: Ember.observer(function() {
+  _arrangedContentDidChange: Ember.observer('arrangedContent', function() {
     var arrangedContent = get(this, 'arrangedContent'),
         len = arrangedContent ? get(arrangedContent, 'length') : 0;
 
@@ -175,7 +175,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
 
     this.arrangedContentDidChange(this);
     this.arrangedContentArrayDidChange(this, 0, undefined, len);
-  }, 'arrangedContent'),
+  }),
 
   _setupArrangedContent: function() {
     var arrangedContent = get(this, 'arrangedContent');

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -110,9 +110,9 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
 
     @method _contentWillChange
   */
-  _contentWillChange: Ember.beforeObserver(function() {
+  _contentWillChange: Ember.beforeObserver('content', function() {
     this._teardownContent();
-  }, 'content'),
+  }),
 
   _teardownContent: function() {
     var content = get(this, 'content');
@@ -155,7 +155,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
     }
   },
 
-  _arrangedContentWillChange: Ember.beforeObserver(function() {
+  _arrangedContentWillChange: Ember.beforeObserver('arrangedContent', function() {
     var arrangedContent = get(this, 'arrangedContent'),
         len = arrangedContent ? get(arrangedContent, 'length') : 0;
 
@@ -163,7 +163,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
     this.arrangedContentWillChange(this);
 
     this._teardownArrangedContent(arrangedContent);
-  }, 'arrangedContent'),
+  }),
 
   _arrangedContentDidChange: Ember.observer('arrangedContent', function() {
     var arrangedContent = get(this, 'arrangedContent'),

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -105,9 +105,9 @@ Ember.ObjectProxy = Ember.Object.extend(/** @scope Ember.ObjectProxy.prototype *
     @default null
   */
   content: null,
-  _contentDidChange: Ember.observer(function() {
+  _contentDidChange: Ember.observer('content', function() {
     Ember.assert("Can't set ObjectProxy's content to itself", this.get('content') !== this);
-  }, 'content'),
+  }),
 
   isTruthy: Ember.computed.bool('content'),
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1185,9 +1185,9 @@ module('Chaining array and reduced CPs', {
         array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
         mapped: Ember.computed.mapBy('array', 'v'),
         max: Ember.computed.max('mapped'),
-        maxDidChange: Ember.observer(function(){
+        maxDidChange: Ember.observer('max', function(){
           userFnCalls++;
-        },'max')
+        })
       });
     });
   },

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -660,13 +660,13 @@ module("Observable objects & object properties ", {
         this.abnormal = 'changedValueObserved';
       },
 
-      testObserver: Ember.observer(function() {
+      testObserver: Ember.observer('normal', function() {
         this.abnormal = 'removedObserver';
-      }, 'normal'),
+      }),
 
-      testArrayObserver: Ember.observer(function() {
+      testArrayObserver: Ember.observer('normalArray.[]', function() {
         this.abnormal = 'notifiedObserver';
-      }, 'normalArray.[]')
+      })
 
     });
   }

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -28,20 +28,20 @@ module("object.propertyChanges", {
       foo  : 'fooValue',
       prop : 'propValue',
 
-      action: Ember.observer(function() {
+      action: Ember.observer('foo', function() {
         this.set('prop', 'changedPropValue');
-      }, 'foo'),
+      }),
 
       newFoo : 'newFooValue',
       newProp: 'newPropValue',
 
-      notifyAction: Ember.observer(function() {
+      notifyAction: Ember.observer('newFoo', function() {
         this.set('newProp', 'changedNewPropValue');
-      }, 'newFoo'),
+      }),
 
-      notifyAllAction: Ember.observer(function() {
+      notifyAllAction: Ember.observer('prop', function() {
         this.set('newFoo', 'changedNewFooValue');
-      }, 'prop'),
+      }),
 
       starProp: null,
       starObserver: function(target, key, value, rev) {

--- a/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -86,11 +86,11 @@ test("deferred observing during bindings", function() {
 
     callCount: 0,
 
-    observer: Ember.observer(function() {
+    observer: Ember.observer('value1', 'value2', function() {
       equal(get(this, 'value1'), 'CHANGED', 'value1 when observer fires');
       equal(get(this, 'value2'), 'CHANGED', 'value2 when observer fires');
       this.callCount++;
-    }, 'value1', 'value2')
+    })
   });
 
   var root = { fromObject: fromObject, toObject: toObject };
@@ -166,9 +166,9 @@ module("chained binding", {
         input: 'second',
         output: 'second',
 
-        inputDidChange: Ember.observer(function() {
+        inputDidChange: Ember.observer("input", function() {
           set(this, "output", get(this, "input")) ;
-        }, "input")
+        })
       }) ;
 
       third = Ember.Object.create({ input: "third" }) ;

--- a/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -76,17 +76,17 @@ module("Ember.Object observers", {
       prop1: null,
 
       // normal observer
-      observer: Ember.observer(function() {
+      observer: Ember.observer("prop1", function() {
         this._normal = true;
-      }, "prop1"),
+      }),
 
-      globalObserver: Ember.observer(function() {
+      globalObserver: Ember.observer("TestNamespace.obj.value", function() {
         this._global = true;
-      }, "TestNamespace.obj.value"),
+      }),
 
-      bothObserver: Ember.observer(function() {
+      bothObserver: Ember.observer("prop1", "TestNamespace.obj.value", function() {
         this._both = true;
-      }, "prop1", "TestNamespace.obj.value")
+      })
     });
 
   }

--- a/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -25,9 +25,9 @@ module("System:run_loop() - chained binding", {
       input: 'MyApp.second',
       output: 'MyApp.second',
 
-      inputDidChange: Ember.observer(function() {
+      inputDidChange: Ember.observer("input", function() {
         this.set("output", this.get("input")) ;
-      }, "input")
+      })
 
     }) ;
 

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -110,9 +110,9 @@ test('should notify observers of []', function() {
 
   obj = DummyArray.createWithMixins({
     _count: 0,
-    enumerablePropertyDidChange: Ember.observer(function() {
+    enumerablePropertyDidChange: Ember.observer('[]', function() {
       this._count++;
-    }, '[]')
+    })
   });
 
   equal(obj._count, 0, 'should not have invoked yet');
@@ -132,9 +132,9 @@ module('notify observers of length', {
   setup: function() {
     obj = DummyArray.createWithMixins({
       _after: 0,
-      lengthDidChange: Ember.observer(function() {
+      lengthDidChange: Ember.observer('length', function() {
         this._after++;
-      }, 'length')
+      })
 
     });
 
@@ -443,9 +443,9 @@ testBoth("observers that contain @each in the path should fire only once the fir
       set(this, 'resources', Ember.A());
     },
 
-    commonDidChange: Ember.observer(function() {
+    commonDidChange: Ember.observer('resources.@each.common', function() {
       count++;
-    }, 'resources.@each.common')
+    })
   });
 
   // Observer fires second time when new object is added

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -120,9 +120,9 @@ test('should notify observers of []', function() {
     nextObject: function() {}, // avoid exceptions
 
     _count: 0,
-    enumerablePropertyDidChange: Ember.observer(function() {
+    enumerablePropertyDidChange: Ember.observer('[]', function() {
       this._count++;
-    }, '[]')
+    })
   });
 
   equal(obj._count, 0, 'should not have invoked yet');
@@ -140,9 +140,9 @@ module('notify observers of length', {
   setup: function() {
     obj = DummyEnum.createWithMixins({
       _after: 0,
-      lengthDidChange: Ember.observer(function() {
+      lengthDidChange: Ember.observer('length', function() {
         this._after++;
-      }, 'length')
+      })
 
     });
 

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -57,9 +57,9 @@ test("changing sort order triggers observers", function() {
   var observer, changeCount = 0;
   observer = Ember.Object.createWithMixins({
     array: sortedArrayController,
-    arrangedDidChange: Ember.observer(function() {
+    arrangedDidChange: Ember.observer('array.[]', function() {
       changeCount++;
-    }, 'array.[]')
+    })
   });
 
   equal(changeCount, 0, 'precond - changeCount starts at 0');

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -159,9 +159,9 @@ testBoth("can iterate over a list of computed properties for a class", function(
 
     }),
 
-    fooDidChange: Ember.observer(function() {
+    fooDidChange: Ember.observer('foo', function() {
 
-    }, 'foo'),
+    }),
 
     bar: Ember.computed(function() {
 

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -23,7 +23,7 @@ test("sets up mandatory setters for watched simple properties", function() {
   var MyClass = Ember.Object.extend({
     foo: null,
     bar: null,
-    fooDidChange: Ember.observer(function() {}, 'foo')
+    fooDidChange: Ember.observer('foo', function() {})
   });
 
   var o = MyClass.create({foo: 'bar', bar: 'baz'});
@@ -213,9 +213,9 @@ test('create should not break observed values', function() {
       return this;
     },
 
-    valueDidChange: Ember.observer(function() {
+    valueDidChange: Ember.observer('value', function() {
       this._count++;
-    }, 'value')
+    })
   });
 
   var obj = CountObject.createWithMixins({ value: 'foo' });

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -22,7 +22,7 @@ test("should raise an exception when modifying watched properties on a destroyed
   if (Ember.platform.hasAccessors) {
     var obj = Ember.Object.createWithMixins({
       foo: "bar",
-      fooDidChange: Ember.observer(function() { }, 'foo')
+      fooDidChange: Ember.observer('foo', function() { })
     });
 
     Ember.run(function() {
@@ -40,9 +40,9 @@ test("should raise an exception when modifying watched properties on a destroyed
 test("observers should not fire after an object has been destroyed", function() {
   var count = 0;
   var obj = Ember.Object.createWithMixins({
-    fooDidChange: Ember.observer(function() {
+    fooDidChange: Ember.observer('foo', function() {
       count++;
-    }, 'foo')
+    })
   });
 
   obj.set('foo', 'bar');
@@ -70,12 +70,12 @@ test("destroyed objects should not see each others changes during teardown but a
     willDestroy: function () {
       this.set('isAlive', false);
     },
-    bDidChange: Ember.observer(function () {
+    bDidChange: Ember.observer('objs.b.isAlive', function () {
       shouldNotChange++;
-    }, 'objs.b.isAlive'),
-    cDidChange: Ember.observer(function () {
+    }),
+    cDidChange: Ember.observer('objs.c.isAlive', function () {
       shouldNotChange++;
-    }, 'objs.c.isAlive')
+    })
   });
 
   var B = Ember.Object.extend({
@@ -84,12 +84,12 @@ test("destroyed objects should not see each others changes during teardown but a
     willDestroy: function () {
       this.set('isAlive', false);
     },
-    aDidChange: Ember.observer(function () {
+    aDidChange: Ember.observer('objs.a.isAlive', function () {
       shouldNotChange++;
-    }, 'objs.a.isAlive'),
-    cDidChange: Ember.observer(function () {
+    }),
+    cDidChange: Ember.observer('objs.c.isAlive', function () {
       shouldNotChange++;
-    }, 'objs.c.isAlive')
+    })
   });
 
   var C = Ember.Object.extend({
@@ -98,19 +98,19 @@ test("destroyed objects should not see each others changes during teardown but a
     willDestroy: function () {
       this.set('isAlive', false);
     },
-    aDidChange: Ember.observer(function () {
+    aDidChange: Ember.observer('objs.a.isAlive', function () {
       shouldNotChange++;
-    }, 'objs.a.isAlive'),
-    bDidChange: Ember.observer(function () {
+    }),
+    bDidChange: Ember.observer('objs.b.isAlive', function () {
       shouldNotChange++;
-    }, 'objs.b.isAlive')
+    })
   });
 
   var LongLivedObject =  Ember.Object.extend({
     objs: objs,
-    isAliveDidChange: Ember.observer(function () {
+    isAliveDidChange: Ember.observer('objs.a.isAlive', function () {
       shouldChange++;
-    }, 'objs.a.isAlive')
+    })
   });
 
   objs.a = new A();

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -10,9 +10,9 @@ testBoth('observer on class', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
 
   });
 
@@ -30,16 +30,16 @@ testBoth('observer on subclass', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
 
   });
 
   var Subclass = MyClass.extend({
-    foo: Ember.observer(function() {
+    foo: Ember.observer('baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'baz')
+    })
   });
 
   var obj = new Subclass();
@@ -59,9 +59,9 @@ testBoth('observer on instance', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
 
   });
 
@@ -78,16 +78,16 @@ testBoth('observer on instance overridding class', function(get, set) {
 
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
 
   });
 
   var obj = MyClass.createWithMixins({
-    foo: Ember.observer(function() {
+    foo: Ember.observer('baz', function() { // <-- change property we observe
       set(this, 'count', get(this, 'count')+1);
-    }, 'baz') // <-- change property we observe
+    })
   });
 
   equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
@@ -104,9 +104,9 @@ testBoth('observer should not fire after being destroyed', function(get, set) {
 
   var obj = Ember.Object.createWithMixins({
     count: 0,
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar')
+    })
   });
 
   equal(get(obj, 'count'), 0, 'precond - should not invoke observer immediately');
@@ -133,9 +133,9 @@ testBoth('chain observer on class', function(get, set) {
   var MyClass = Ember.Object.extend({
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj1 = MyClass.create({
@@ -164,9 +164,9 @@ testBoth('chain observer on class', function(get, set) {
   var MyClass = Ember.Object.extend({
     count: 0,
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar.baz')
+    })
   });
 
   var obj1 = MyClass.createWithMixins({
@@ -177,9 +177,9 @@ testBoth('chain observer on class', function(get, set) {
     bar: { baz: 'biff2' },
     bar2: { baz: 'biff3' },
 
-    foo: Ember.observer(function() {
+    foo: Ember.observer('bar2.baz', function() {
       set(this, 'count', get(this, 'count')+1);
-    }, 'bar2.baz')
+    })
   });
 
   equal(get(obj1, 'count'), 0, 'should not invoke yet');

--- a/packages/ember-views/lib/system/controller.js
+++ b/packages/ember-views/lib/system/controller.js
@@ -26,7 +26,7 @@ Ember.ControllerMixin.reopen({
     set(this, '_childContainers', {});
   },
 
-  _modelDidChange: Ember.observer(function() {
+  _modelDidChange: Ember.observer('model', function() {
     var containers = get(this, '_childContainers');
 
     for (var prop in containers) {
@@ -35,5 +35,5 @@ Ember.ControllerMixin.reopen({
     }
 
     set(this, '_childContainers', {});
-  }, 'model')
+  })
 });

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -231,7 +231,7 @@ Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionVie
 
     @method _contentDidChange
   */
-  _contentDidChange: Ember.observer(function() {
+  _contentDidChange: Ember.observer('content', function() {
     var content = get(this, 'content');
 
     if (content) {
@@ -241,7 +241,7 @@ Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionVie
 
     var len = content ? get(content, 'length') : 0;
     this.arrayDidChange(content, 0, null, len);
-  }, 'content'),
+  }),
 
   /**
     @private

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -213,13 +213,13 @@ Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionVie
 
     @method _contentWillChange
   */
-  _contentWillChange: Ember.beforeObserver(function() {
+  _contentWillChange: Ember.beforeObserver('content', function() {
     var content = this.get('content');
 
     if (content) { content.removeArrayObserver(this); }
     var len = content ? get(content, 'length') : 0;
     this.arrayWillChange(content, 0, len);
-  }, 'content'),
+  }),
 
   /**
     @private

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -315,12 +315,12 @@ Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
 
   currentView: null,
 
-  _currentViewWillChange: Ember.beforeObserver(function() {
+  _currentViewWillChange: Ember.beforeObserver('currentView', function() {
     var currentView = get(this, 'currentView');
     if (currentView) {
       currentView.destroy();
     }
-  }, 'currentView'),
+  }),
 
   _currentViewDidChange: Ember.observer('currentView', function() {
     var currentView = get(this, 'currentView');

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -322,13 +322,13 @@ Ember.ContainerView = Ember.View.extend(Ember.MutableArray, {
     }
   }, 'currentView'),
 
-  _currentViewDidChange: Ember.observer(function() {
+  _currentViewDidChange: Ember.observer('currentView', function() {
     var currentView = get(this, 'currentView');
     if (currentView) {
       Ember.assert("You tried to set a current view that already has a parent. Make sure you don't have multiple outlets in the same view.", !get(currentView, '_parentView'));
       this.pushObject(currentView);
     }
-  }, 'currentView'),
+  }),
 
   _ensureChildrenAreInDOM: function () {
     this.currentState.ensureChildrenAreInDOM(this);

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1023,9 +1023,9 @@ Ember.View = Ember.CoreView.extend(
 
     @method _contextDidChange
   */
-  _contextDidChange: Ember.observer(function() {
+  _contextDidChange: Ember.observer('context', function() {
     this.rerender();
-  }, 'context'),
+  }),
 
   /**
     If `false`, the view will appear hidden in DOM.
@@ -1061,12 +1061,12 @@ Ember.View = Ember.CoreView.extend(
 
   // When it's a virtual view, we need to notify the parent that their
   // childViews did change.
-  _childViewsDidChange: Ember.observer(function() {
+  _childViewsDidChange: Ember.observer('childViews', function() {
     if (this.isVirtual) {
       var parentView = get(this, 'parentView');
       if (parentView) { Ember.propertyDidChange(parentView, 'childViews'); }
     }
-  }, 'childViews'),
+  }),
 
   /**
     Return the nearest ancestor that is an instance of the provided
@@ -1148,7 +1148,7 @@ Ember.View = Ember.CoreView.extend(
 
     @method _parentViewDidChange
   */
-  _parentViewDidChange: Ember.observer(function() {
+  _parentViewDidChange: Ember.observer('_parentView', function() {
     if (this.isDestroying) { return; }
 
     this.trigger('parentViewDidChange');
@@ -1156,9 +1156,9 @@ Ember.View = Ember.CoreView.extend(
     if (get(this, 'parentView.controller') && !get(this, 'controller')) {
       this.notifyPropertyChange('controller');
     }
-  }, '_parentView'),
+  }),
 
-  _controllerDidChange: Ember.observer(function() {
+  _controllerDidChange: Ember.observer('controller', function() {
     if (this.isDestroying) { return; }
 
     this.rerender();
@@ -1166,7 +1166,7 @@ Ember.View = Ember.CoreView.extend(
     this.forEachChildView(function(view) {
       view.propertyDidChange('controller');
     });
-  }, 'controller'),
+  }),
 
   cloneKeywords: function() {
     var templateData = get(this, 'templateData');
@@ -1769,11 +1769,11 @@ Ember.View = Ember.CoreView.extend(
 
     @method _elementDidChange
   */
-  _elementDidChange: Ember.observer(function() {
+  _elementDidChange: Ember.observer('element', function() {
     this.forEachChildView(function(view) {
       delete meta(view).cache.element;
     });
-  }, 'element'),
+  }),
 
   /**
     Called when the parentView property has changed.
@@ -2154,7 +2154,7 @@ Ember.View = Ember.CoreView.extend(
 
     @method _isVisibleDidChange
   */
-  _isVisibleDidChange: Ember.observer(function() {
+  _isVisibleDidChange: Ember.observer('isVisible', function() {
     var $el = this.$();
     if (!$el) { return; }
 
@@ -2169,7 +2169,7 @@ Ember.View = Ember.CoreView.extend(
     } else {
       this._notifyBecameHidden();
     }
-  }, 'isVisible'),
+  }),
 
   _notifyBecameVisible: function() {
     this.trigger('becameVisible');

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1052,12 +1052,12 @@ Ember.View = Ember.CoreView.extend(
 
   // When it's a virtual view, we need to notify the parent that their
   // childViews will change.
-  _childViewsWillChange: Ember.beforeObserver(function() {
+  _childViewsWillChange: Ember.beforeObserver('childViews', function() {
     if (this.isVirtual) {
       var parentView = get(this, 'parentView');
       if (parentView) { Ember.propertyWillChange(parentView, 'childViews'); }
     }
-  }, 'childViews'),
+  }),
 
   // When it's a virtual view, we need to notify the parent that their
   // childViews did change.

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -115,9 +115,9 @@ test("The Homepage", function() {
   var currentPath;
 
   App.ApplicationController = Ember.Controller.extend({
-    currentPathDidChange: Ember.observer(function() {
+    currentPathDidChange: Ember.observer('currentPath', function() {
       currentPath = get(this, 'currentPath');
-    }, 'currentPath')
+    })
   });
 
   bootApplication();
@@ -144,15 +144,15 @@ test("The Home page and the Camelot page with multiple Router.map calls", functi
   var currentPath;
 
   App.ApplicationController = Ember.Controller.extend({
-    currentPathDidChange: Ember.observer(function() {
+    currentPathDidChange: Ember.observer('currentPath', function() {
       currentPath = get(this, 'currentPath');
-    }, 'currentPath')
+    })
   });
 
   App.CamelotController = Ember.Controller.extend({
-    currentPathDidChange: Ember.observer(function() {
+    currentPathDidChange: Ember.observer('currentPath', function() {
       currentPath = get(this, 'currentPath');
-    }, 'currentPath')
+    })
   });
 
   bootApplication();
@@ -855,9 +855,9 @@ asyncTest("Nested callbacks are not exited when moving to siblings", function() 
   var currentPath;
 
   App.ApplicationController = Ember.Controller.extend({
-    currentPathDidChange: Ember.observer(function() {
+    currentPathDidChange: Ember.observer('currentPath', function() {
       currentPath = get(this, 'currentPath');
-    }, 'currentPath')
+    })
   });
 
   var menuItem;
@@ -2174,9 +2174,9 @@ test("ApplicationRoute with model does not proxy the currentPath", function() {
   });
 
   App.ApplicationController = Ember.ObjectController.extend({
-    currentPathDidChange: Ember.observer(function() {
+    currentPathDidChange: Ember.observer('currentPath', function() {
       currentPath = get(this, 'currentPath');
-    }, 'currentPath')
+    })
   });
 
   bootApplication();


### PR DESCRIPTION
Changes `Ember.observer`, `Ember.immediateObserver`, and `Ember.beforeObserver` to take propertyNames before the function like `Ember.computed` and `Ember.on` do.

It also allows for nicer coffeescript:

``` coffeescript
valueObserver: Em.observer "value", ->
  # function body...
```

The old style still works but with a deprecation notice.
