### PR TITLE
Generate static site tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -158,14 +158,15 @@ namespace :release do
   task :deploy => ['ember:release:deploy', 'starter_kit:deploy', 'website:deploy']
 end
 
-task :publish_build => [:dist, :docs] do
+task :publish_build => [:dist, :docs, 'ember:generate_static_test_site'] do
   root_dir = Pathname.new(__FILE__).dirname
   dist_dir = root_dir.join('dist')
 
   FileUtils.cp root_dir.join('docs', 'build', 'data.json'),
                dist_dir.join('ember-docs.json')
 
-  files = %w{ember.js ember-runtime.js ember-docs.json}
+  files = %w{ember.js ember-runtime.js ember-docs.json
+             ember-spade.js ember-tests.js ember-tests.html}
 
   EmberDev::Publish.to_s3({
     :access_key_id => ENV['S3_ACCESS_KEY_ID'],


### PR DESCRIPTION
This will publish a ember-tests.html static test site along with the builds. This makes it extremely simple to test the latest canary/beta/release builds on various devices. It is also critical to the cross-browser testing that we have been working on.

This depends on changes in #3591.
