### PR TITLE
[BUGFIX release] Allow Ember.Object.create to accept an Ember.Object.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -70,7 +70,12 @@ function makeCtor() {
 
         Ember.assert("Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.", !(properties instanceof Ember.Mixin));
 
-        if (Ember.typeOf(properties) !== 'object') { continue; }
+        var propertyType = Ember.typeOf(properties);
+        if (propertyType !== 'object' && propertyType !== 'instance') {
+          Ember.assert("Ember.Object.create will only accept an object or an instance of Ember.Object.", false);
+
+          continue;
+        }
 
         var keyNames = Ember.keys(properties);
         for (var j = 0, ll = keyNames.length; j < ll; j++) {

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -104,6 +104,25 @@ test("property name is the same as own prototype property", function() {
   equal(MyClass.create().toString(), 'MyClass', "should inherit property from the arguments of `Ember.Object.create`");
 });
 
+test("inherits properties from passed in Ember.Object", function() {
+  var baseObj = Ember.Object.create({ foo: 'bar' }),
+      secondaryObj = Ember.Object.create(baseObj);
+
+  equal(secondaryObj.foo, baseObj.foo, "Em.O.create inherits properties from Ember.Object parameter");
+});
+
+test("throws if you try to pass anything other than an object or instance of Ember.Object", function(){
+  var expected = "Ember.Object.create will only accept an object or an instance of Ember.Object.";
+
+  expectAssertion(function() {
+    var o = Ember.Object.create("some-string");
+  }, expected);
+
+  expectAssertion(function() {
+    var o = Ember.Object.create(['foo','bar']);
+  }, expected);
+});
+
 module('Ember.Object.createWithMixins');
 
 test("Creates a new object that contains passed properties", function() {


### PR DESCRIPTION
Also, adds an assertion if the passed in value is not an object or instance of `Ember.Object`.

Resolves #3596.
