### PR TITLE
Simplify rubygems version string.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 PATH
   remote: .
   specs:
-    ember-source (1.2.0.betabeta)
+    ember-source (1.2.0.beta.1.canary)
       handlebars-source (= 1.0.12)
 
 GEM

--- a/lib/ember/version.rb
+++ b/lib/ember/version.rb
@@ -6,12 +6,6 @@ module Ember
   # we might want to unify this with the ember version string,
   # but consistency?
   def rubygems_version_string
-    if VERSION =~ /rc|beta/
-      major, rc = VERSION.sub('-','.').scan(/(\d+\.\d+\.\d+\.(rc|beta))\.(\d+)/).first
-
-      "#{major}#{rc}"
-    else
-      VERSION
-    end
+    VERSION.gsub(/[-\+]/,'.')
   end
 end


### PR DESCRIPTION
Rubygems only supports letters, numbers, and period as part of the version string. This uses the new structure implemented in https://github.com/emberjs/ember.js/commit/3d8d23af6d9f1387ee37d9588bd567704730ee21 and simplifies the generated rubygems_version_string for non-published versions.
