### PR TITLE
[BUGFIX beta] reduceComputed supports non-array dependencies.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,6 +24,22 @@ Ember.FEATURES['link-to'] = true;
 
 ## Feature Flags
 
+* `reduceComputed-non-array-dependencies`
+
+  `ReduceComputedProperty`s may have non-array dependent keys.  When a non-array
+  dependent key changes, the entire property is invalidated.
+
+  Array dependent keys may be specified with either one-at-a-time semantics or
+  total invalidation semantics.  Property names like `'dependentArray'` use
+  one-at-a-time semantics; property names like `'dependentArray.[]'` use total
+  invalidation semantics.
+
+  This can be useful for example, for filtering.  The items to be filtered
+  should use one-a-time semantics, but the properties to filter by should use
+  total invalidation semantics.
+
+  Added in [#3614](https://github.com/emberjs/ember.js/pull/3614).
+
 * `container-renderables`
 
   Components and helpers registered on the container can be rendered in templates

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -640,3 +640,89 @@ test("when initialValue is undefined, everything works as advertised", function(
   equal(get(chars, 'firstUpper'), 'B', "result is the next match when the first matching object is removed");
 });
 
+if (Ember.FEATURES.isEnabled('reduceComputed-non-array-dependencies')) {
+  module('Ember.arrayComputed - completely invalidating dependencies', {
+    setup: function () {
+      addCalls = removeCalls = 0;
+    }
+  });
+
+  test("non-array dependencies completely invalidate a reduceComputed CP", function() {
+    var dependentArray = Ember.A();
+
+    obj = Ember.Object.extend({
+      nonArray: 'v0',
+      dependentArray: dependentArray,
+
+      computed: Ember.arrayComputed('dependentArray', 'nonArray', {
+        addedItem: function (array) {
+          ++addCalls;
+          return array;
+        },
+
+        removedItem: function (array) {
+          --removeCalls;
+          return array;
+        }
+      })
+    }).create();
+
+    get(obj, 'computed');
+
+    equal(addCalls, 0, "precond - add has not initially been called");
+    equal(removeCalls, 0, "precond - remove has not initially been called");
+
+    dependentArray.pushObjects([1, 2]);
+
+    equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
+    equal(removeCalls, 0, "remove not called");
+
+    Ember.run(function() {
+      set(obj, 'nonArray', 'v1');
+    });
+
+    equal(addCalls, 4, "array completely recomputed when non-array dependency changed");
+    equal(removeCalls, 0, "remove not called");
+  });
+
+  test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
+    var dependentArray = Ember.A(),
+        totallyInvalidatingDependentArray = Ember.A();
+
+    obj = Ember.Object.extend({
+      totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+      dependentArray: dependentArray,
+
+      computed: Ember.arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+        addedItem: function (array, item) {
+          ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+          ++addCalls;
+          return array;
+        },
+
+        removedItem: function (array, item) {
+          ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+          --removeCalls;
+          return array;
+        }
+      })
+    }).create();
+
+    get(obj, 'computed');
+
+    equal(addCalls, 0, "precond - add has not initially been called");
+    equal(removeCalls, 0, "precond - remove has not initially been called");
+
+    dependentArray.pushObjects([1, 2]);
+
+    equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
+    equal(removeCalls, 0, "remove not called");
+
+    Ember.run(function() {
+      totallyInvalidatingDependentArray.pushObject(3);
+    });
+
+    equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
+    equal(removeCalls, 0, "remove not called");
+  });
+}


### PR DESCRIPTION
`ReduceComputedProperty`s want 3 kinds of dependencies.
1. non-array dependencies 
2. array dependencies with normal (total
   invalidation) CP semantics 
3. array dependencies with one-at-a-time semantics

It was previously only possible to create `reduceComputed`s with 3.  Macros 
could be written that would manually handle 1. and 2.  For example,
`Ember.computed.sort` does this.

This commit makes possible all three cases.

``` js
Ember.Object.extend({
 nonArray: 'string',
 totallyInvalidatingArray: [],
 oneAtATimeArray: [],

  computed: Ember.reduceComputed( 'nonArray',
                                 'totallyInvalidatingArray.[]',
                                 'oneAtATimeArray', {
   addedItem: function () { /* ... */ },
   removedItem: function () { /* ... */ }
 });
})
```

Arrays whose individual mutations should completely invalidate a
`reduceComputed` are specified by adding the `.[]` suffix to the dependent
key. Note that the items for this array are never passed to the `addedItem`
and
`removedItem` callbacks: they should be treated much like non-array
properties.

A straightforward motivating example is `Ember.computed.sort` - the items to
be sorted should be handled one-at-a-time, but the properties to sort by
should require a complete resort.

Fix #3600.
