### PR TITLE
Simplifying / correcting the observable "get" example

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -93,7 +93,7 @@ Ember.Observable = Ember.Mixin.create({
 
     ```javascript
     fullName: function() {
-      return this.getEach('firstName', 'lastName').compact().join(' ');
+      return this.get('firstName') + ' ' + this.get('lastName');
     }.property('firstName', 'lastName')
     ```
 


### PR DESCRIPTION
As a new user I do not understand the example for "get" in observable and I believe there may be an error.

This example references a method on "this" called "getEach".  Although I realize this is not necessarily true, I tend to assume this example is on Ember.Object as there are similar examples in the guides that are on Ember.Object.

Ember.Object does not have a method "getEach", but more critically I can not find any method "getEach" in Ember that matches the signature and expectations here.

This call to "getEach" each expects multiple arguments of properties and returns an array of the values for those properties.

When searching the documentation the only "getEach" I found is an alias to "mapBy" that takes a single argument which is a property.  It plucks the value from each object in the enumeration and returns it as an array.

This pull request simplifies the example.  The "getEach" does not seem critical to what the example is trying to show.

I am new, so I apologize if I am missing something obvious.

Thank you.
