### PR TITLE
Fix typo in route.js

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -845,6 +845,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     instance would be used.
 
     Example
+    
     ```js
     App.PostRoute = Ember.Route.extend({
       setupController: function(controller, model) {


### PR DESCRIPTION
Add an extra newline to one of the examples in setupController API docs to make sample JS code appear as code block.

![no newline](http://f.cl.ly/items/2C1C2V321H352Q2I2E2c/route_js_sans_newline.png)
