### PR TITLE
Make jQuery version check less restrictive.

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -8,7 +8,7 @@ if (!jQuery && typeof require === 'function') {
   jQuery = require('jquery');
 }
 
-Ember.assert("Ember Views require jQuery 1.7, 1.8, 1.9, 1.10, or 2.0", jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10))|2.0)(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
+Ember.assert("Ember Views require jQuery >= 1.7", jQuery && (jQuery().jquery.match(/(^1\.[7-9]\.)|(^1\.\d{2,})|(^2\.\d+)/) || Ember.ENV.FORCE_JQUERY));
 
 /**
   Alias for jQuery


### PR DESCRIPTION
I had an issue with this check when loading Ember with the jQuery 2.1 beta.

It seems to me that it should only define a minimum version.
