### PR TITLE
Don't use Ember.Error for needsFinallyFix.

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -445,7 +445,7 @@ var needsFinallyFix = (function() {
     try { }
     finally {
       count++;
-      throw new Ember.Error('needsFinallyFixTest');
+      throw new Error('needsFinallyFixTest');
     }
   } catch (e) {}
 


### PR DESCRIPTION
As mentioned in https://github.com/emberjs/ember.js/pull/3594/files#r7088644
this does not need to use `Ember.Error`.
