### PR TITLE
[BUGFIX beta] reduceComputed handle out-of-range index.

### DIFF
--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -420,15 +420,13 @@ test("dependent arrays can use `replace` with a negative index to remove items i
 });
 
 test("dependent arrays that call `replace` with an out of bounds index to remove items is a no-op", function() {
-  var dependentArray = Ember.A(),
+  var dependentArray = Ember.A([1, 2]),
       array;
 
   obj = Ember.Object.extend({
     dependentArray: dependentArray,
     computed: Ember.arrayComputed('dependentArray', {
-      addedItem: function (acc, item, changeMeta) {
-        ok(false, "no items have been added");
-      },
+      addedItem: function (acc, item, changeMeta) { return acc; },
       removedItem: function (acc) {
         ok(false, "no items have been removed");
       }
@@ -440,6 +438,27 @@ test("dependent arrays that call `replace` with an out of bounds index to remove
   deepEqual(array, [], "precond - computed array is initially empty");
 
   dependentArray.replace(100, 2);
+});
+
+test("dependent arrays that call `replace` with a too-large removedCount a) works and b) still right-truncates", function() {
+  var dependentArray = Ember.A([1, 2]),
+      array;
+
+  obj = Ember.Object.extend({
+    dependentArray: dependentArray,
+    computed: Ember.arrayComputed('dependentArray', {
+      addedItem: function (acc, item) { return acc; },
+      removedItem: function (acc, item) { acc.pushObject(item); return acc; }
+    })
+  }).create();
+
+  array = get(obj, 'computed');
+
+  deepEqual(array, [], "precond - computed array is initially empty");
+
+  dependentArray.replace(1, 200);
+
+  deepEqual(array, [2], "array was correctly right-truncated");
 });
 
 


### PR DESCRIPTION
f3aa4a2d0854395e1f8158a74d1810c290a75139 added support for `replace`s on 
dependent arrays with out of range indexes, similar to what `[].splice` 
supports.  However, it had two errors that are corrected in this commit.
1.  An off by one error when determining the normalized index for removal 
2.  It did not limit the removed count by the number of items that could possibly
   be removed.

Change `normalizeIndex` to the more natural signature of `index, length,
count`. This has no effect on any public API.

Big thanks to @Cyril-sf for pairing on this fix.

Fix #3586 (again).

f3aa4a2d0854395e1f8158a74d1810c290a75139 fixed several bugs, but missed a couple
cases relevant to @gavinwahl's jsbin.  That jsbin passes for me with this PR.
