### PR TITLE
[BUGFIX beta] Allow features to be consistent across channels.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 737468731328fe13e695bd67405d98a96f9ab5e4
+  revision: 353847a384c64ed7662419136a7aaaf39e9e7aa5
   branch: master
   specs:
     ember-dev (0.1)

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -11,9 +11,9 @@ testing_suites:
   standard:
     - "EACH_PACKAGE"
     - "package=all&jquery=1.7.2&nojshint=true"
-    - "package=all&jquery=1.7.2&nojshint=true&enableallfeatures=true"
+    - "package=all&jquery=1.7.2&nojshint=true&enableoptionalfeatures=true"
     - "package=all&extendprototypes=true&nojshint=true"
-    - "package=all&extendprototypes=true&nojshint=true&enableallfeatures=true"
+    - "package=all&extendprototypes=true&nojshint=true&enableoptionalfeatures=true"
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
   all:
     - "EACH_PACKAGE"

--- a/features.json
+++ b/features.json
@@ -1,0 +1,14 @@
+{
+  "ember-routing-didTransition-hook": true,
+  "ember-routing-loading-error-substates": true,
+  "ember-runtime-sortBy": true,
+  "container-renderables": true,
+  "link-to-non-block": true,
+  "reduceComputedSelf": true,
+  "ember-testing-wait-hooks": null,
+  "query-params": null,
+  "string-humanize": null,
+  "propertyBraceExpansion": null,
+  "ember-runtime-sortBy": null,
+  "ember-routing-loading-error-substates": null
+}

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -92,15 +92,28 @@ Ember.FEATURES = Ember.ENV.FEATURES || {};
   Test that a feature is enabled. Parsed by Ember's build tools to leave
   experimental features out of beta/stable builds.
 
-  You can define an `ENV.ENABLE_ALL_FEATURES` config to force all features to
-  be enabled.
+  You can define the following configuration options:
+
+  * `ENV.ENABLE_ALL_FEATURES` - force all features to be enabled.
+  * `ENV.ENABLE_OPTIONAL_FEATURES` - enable any features that have not been explicitly
+    enabled/disabled.
 
   @method isEnabled
   @param {string} feature
 */
 
 Ember.FEATURES.isEnabled = function(feature) {
-  return Ember.ENV.ENABLE_ALL_FEATURES || Ember.FEATURES[feature];
+  var featureValue = Ember.FEATURES[feature];
+
+  if (Ember.ENV.ENABLE_ALL_FEATURES) {
+    return true;
+  } else if (featureValue === true || featureValue === false || featureValue === undefined) {
+    return featureValue;
+  } else if (Ember.ENV.ENABLE_OPTIONAL_FEATURES) {
+    return true;
+  } else {
+    return false;
+  }
 };
 
 // ..........................................................

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -1,0 +1,52 @@
+var isEnabled = Ember.FEATURES.isEnabled,
+    origFeatures, origEnableAll, origEnableOptional;
+
+module("Ember.FEATURES.isEnabled", {
+  setup: function(){
+    origFeatures       = Ember.FEATURES;
+    origEnableAll      = Ember.ENV.ENABLE_ALL_FEATURES;
+    origEnableOptional = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
+  },
+
+  teardown: function(){
+    Ember.FEATURES                     = origFeatures;
+    Ember.ENV.ENABLE_ALL_FEATURES      = origEnableAll;
+    Ember.ENV.ENABLE_OPTIONAL_FEATURES = origEnableOptional;
+  }
+});
+
+test("ENV.ENABLE_ALL_FEATURES", function() {
+  Ember.ENV.ENABLE_ALL_FEATURES = true;
+  Ember.FEATURES['fred'] = false;
+  Ember.FEATURES['wilma'] = null;
+
+  equal(isEnabled('fred'),  true, "overrides features set to false");
+  equal(isEnabled('wilma'), true, "enables optional features");
+  equal(isEnabled('betty'), true, "enables non-specified features");
+});
+
+test("ENV.ENABLE_OPTIONAL_FEATURES", function() {
+  Ember.ENV.ENABLE_OPTIONAL_FEATURES = true;
+  Ember.FEATURES['fred'] = false;
+  Ember.FEATURES['barney'] = true;
+  Ember.FEATURES['wilma'] = null;
+
+  equal(isEnabled('fred'),   false, "returns flag value if false");
+  equal(isEnabled('barney'), true,  "returns flag value if true");
+  equal(isEnabled('wilma'),  true,  "returns true if flag is not true|false|undefined");
+  equal(isEnabled('betty'),  undefined, "returns flag value if undefined");
+});
+
+test("isEnabled without ENV options", function(){
+  Ember.ENV.ENABLE_ALL_FEATURES = false;
+  Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
+
+  Ember.FEATURES['fred'] = false;
+  Ember.FEATURES['barney'] = true;
+  Ember.FEATURES['wilma'] = null;
+
+  equal(isEnabled('fred'),   false, "returns flag value if false");
+  equal(isEnabled('barney'), true,  "returns flag value if true");
+  equal(isEnabled('wilma'),  false, "returns false if flag is not set");
+  equal(isEnabled('betty'),  undefined, "returns flag value if undefined");
+});

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -19,11 +19,6 @@
   var extendPrototypes  = QUnit.urlParams.extendprototypes;
   ENV['EXTEND_PROTOTYPES'] = !!extendPrototypes;
 
-  // Handle testing feature flags
-  QUnit.config.urlConfig.push({ id: 'enableallfeatures', label: "Enable All Features"});
-  var enableAllFeatures = QUnit.urlParams.enableallfeatures;
-  ENV['ENABLE_ALL_FEATURES'] = !!enableAllFeatures;
-
   // Don't worry about jQuery version
   ENV['FORCE_JQUERY'] = true;
 


### PR DESCRIPTION
In order to ensure that all feature flags that have been enabled on the
beta branch are always enabled on master the following changes have been
made:
- Make `defeatureify` able to leave feature flagged items in the build output for values other than `true`, `false`, or `undefined`. Changes made in [thomasboyt/defeatureify#3](https://github.com/thomasboyt/defeatureify/pull/3) (and published as version 0.1.4).
- Add a `features.json` file with all beta enabled features set to `true`, and any other features set to `null` (thus leaving the feature flagged source in the build output).
- Add `ENV.ENABLE_OPTIONAL_FEATURES` flag to enable any features that are not explicitly set to 'false' or `undefined`. This will be used from the test harness in `ember-dev`.
- Add tests detailing the expected output from `Ember.FEATURES.isEnabled` in all scenarios.

I have manually tested this against beta (without modifying the `features.json`): all tests pass and no feature flagged items are included in the build.

/cc @machty @wagenet
