### PR TITLE
Use matrix builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - "npm install -g yuidocjs"
 - "bundle install --deployment"
 after_success: bundle exec rake publish_build
-script: rake test\[standard]
+script: rake test\[$TEST_SUITE]
 notifications:
   campfire:
     rooms:
@@ -32,3 +32,8 @@ env:
       PZ8DNTxX0zsp2jjY8NwTR5MC8NBH+J5VjuTSGv82t5sm0i0jzaBmOOSLbKqH
 
       I/BFT0MbnR6JVCZiPV7TCWPgY1gvgZ6TEEIKGqauDMUBdL8ZK6I='
+  matrix:
+    - TEST_SUITE=packages
+    - TEST_SUITE=old_jquery
+    - TEST_SUITE=extend_prototypes
+    - TEST_SUITE=built

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -2,6 +2,14 @@
 name: Ember
 assetfile: 'Assetfile'
 testing_suites:
+  packages:
+    - "EACH_PACKAGE"
+  old_jquery:
+    - "package=all&jquery=1.7.2&nojshint=true"
+    - "package=all&jquery=1.7.2&nojshint=true&enableallfeatures=true"
+  extend_prototypes:
+    - "package=all&extendprototypes=true&nojshint=true"
+    - "package=all&extendprototypes=true&nojshint=true&enableallfeatures=true"
   built:
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
   runtime:


### PR DESCRIPTION
This breaks down the previous `standard` test run into four smaller test
runs. In tests on my branch this cut the total build time in half.
