### PR TITLE
["BUGFIX" beta] Improve unhandled action error messages

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -302,12 +302,12 @@ function triggerEvent(handlerInfos, ignoreFailure, args) {
 
   if (!handlerInfos) {
     if (ignoreFailure) { return; }
-    throw new Ember.Error("Could not trigger event '" + name + "'. There are no active handlers");
+    throw new Ember.Error("Can't trigger action '" + name + "' because your app hasn't finished transitioning into its first route. To trigger an action on destination routes during a transition, you can call `.send()` on the `Transition` object passed to the `model/beforeModel/afterModel` hooks.");
   }
 
   var eventWasHandled = false;
 
-  for (var i=handlerInfos.length-1; i>=0; i--) {
+  for (var i = handlerInfos.length - 1; i >= 0; i--) {
     var handlerInfo = handlerInfos[i],
         handler = handlerInfo.handler;
 
@@ -321,7 +321,7 @@ function triggerEvent(handlerInfos, ignoreFailure, args) {
   }
 
   if (!eventWasHandled && !ignoreFailure) {
-    throw new Ember.Error("Nothing handled the action '" + name + "'. If you did handle the action, this error can be caused by returning true from an action handler, causing the action to bubble.");
+    throw new Ember.Error("Nothing handled the action '" + name + "'.");
   }
 }
 


### PR DESCRIPTION
1) The comment about `return true` being a possible source of error
   is incorrect; even if an action handler returns true, the action
   is considered handled and it won't cause an error even if parent
   routes don't handle the event.
2) 99% of the time, the only time people see the error about no
   active handlers is when they try to call `Route#send` within
   `model`, `beforeModel`, or `afterModel`. Most likely the solution
   is to call `Transition#send` on the transition object passed into
   the various model hooks, so I've updated the error message
   to suggest using `Transition#send` instead.

edit: the only other time I can think of that you'd see the error from (2) is if you were doing some `controllerFor` stuff within the `model` hooks before a route's actually been entered, and something you did with those controllers tried to call `.send()`; even if my suggested new error message doesn't make perfect sense in that case, it seems that the user would know enough about `.send()` to benefit from the error message
