### PR TITLE
Renaming everyBy and anyBy to isEvery and isAny

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -551,29 +551,35 @@ Ember.Enumerable = Ember.Mixin.create({
   },
 
   /**
-    Returns `true` if the passed property resolves to `true` for all items in
-    the enumerable. This method is often simpler/faster than using a callback.
-
     @method everyBy
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
+    @deprecated Use `isEvery` instead
     @return {Boolean}
   */
-  everyBy: function(key, value) {
-    return this.every(iter.apply(this, arguments));
-  },
+  everyBy: Ember.aliasMethod('isEvery'),
+
+  /**
+    @method everyProperty
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against.
+    @deprecated Use `isEvery` instead
+    @return {Boolean}
+  */
+  everyProperty: Ember.aliasMethod('isEvery'),
 
   /**
     Returns `true` if the passed property resolves to `true` for all items in
     the enumerable. This method is often simpler/faster than using a callback.
 
-    @method everyProperty
+    @method isEvery
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
     @return {Boolean}
-    @deprecated Use `everyBy` instead
   */
-  everyProperty: Ember.aliasMethod('everyBy'),
+  isEvery: function(key, value) {
+    return this.every(iter.apply(this, arguments));
+  },
 
   /**
     Returns `true` if the passed function returns true for any item in the
@@ -659,21 +665,27 @@ Ember.Enumerable = Ember.Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Boolean} `true` if the passed function returns `true` for any item
   */
-  anyBy: function(key, value) {
+  isAny: function(key, value) {
     return this.any(iter.apply(this, arguments));
   },
 
   /**
-    Returns `true` if the passed property resolves to `true` for any item in
-    the enumerable. This method is often simpler/faster than using a callback.
-
     @method someProperty
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
     @return {Boolean} `true` if the passed function returns `true` for any item
-    @deprecated Use `anyBy` instead
+    @deprecated Use `isAny` instead
   */
-  someProperty: Ember.aliasMethod('anyBy'),
+  anyBy: Ember.aliasMethod('isAny'),
+
+  /**
+    @method someProperty
+    @param {String} key the property to test
+    @param {String} [value] optional value to test against.
+    @return {Boolean} `true` if the passed function returns `true` for any item
+    @deprecated Use `isAny` instead
+  */
+  someProperty: Ember.aliasMethod('isAny'),
 
   /**
     This will combine the values of the enumerator into a single value. It

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -55,6 +55,8 @@ Ember.EnumerableTests.extend({
 
 }).run();
 
+module('Ember.Enumerable');
+
 test("should apply Ember.Array to return value of map", function() {
   var x = Ember.Object.createWithMixins(Ember.Enumerable);
   var y = x.map(Ember.K);
@@ -95,7 +97,51 @@ test("should apply Ember.Array to return value of uniq", function() {
   equal(Ember.Array.detect(y), true, "should have mixin applied");
 });
 
+test('any', function() {
+  var kittens = Ember.A([{
+    color: 'white'
+  }, {
+    color: 'black'
+  }, {
+    color: 'white'
+  }]),
+  foundWhite = kittens.any(function(kitten) { return kitten.color === 'white'; }),
+  foundWhite2 = kittens.isAny('color', 'white');
 
+  equal(foundWhite, true);
+  equal(foundWhite2, true);
+});
+
+test('every', function() {
+  var allColorsKittens = Ember.A([{
+    color: 'white'
+  }, {
+    color: 'black'
+  }, {
+    color: 'white'
+  }]),
+  allWhiteKittens = Ember.A([{
+    color: 'white'
+  }, {
+    color: 'white'
+  }, {
+    color: 'white'
+  }]),
+  allWhite = false,
+  whiteKittenPredicate = function(kitten) { return kitten.color === 'white'; };
+
+  allWhite = allColorsKittens.every(whiteKittenPredicate);
+  equal(allWhite, false);
+
+  allWhite = allWhiteKittens.every(whiteKittenPredicate);
+  equal(allWhite, true);
+
+  allWhite = allColorsKittens.isEvery('color', 'white');
+  equal(allWhite, false);
+
+  allWhite = allWhiteKittens.isEvery('color', 'white');
+  equal(allWhite, true);
+});
 
 // ..........................................................
 // CONTENT DID CHANGE
@@ -273,7 +319,4 @@ test('removing enumerable observer should disable', function() {
   obj.enumerableContentDidChange();
   deepEqual(observer._after, null);
 });
-
-
-
 

--- a/packages/ember-runtime/tests/suites/enumerable/any.js
+++ b/packages/ember-runtime/tests/suites/enumerable/any.js
@@ -55,10 +55,10 @@ suite.test('any should be aliased to some', function() {
 });
 
 // ..........................................................
-// anyBy()
+// isAny()
 //
 
-suite.module('anyBy');
+suite.module('isAny');
 
 suite.test('should return true of any property matches', function() {
   var obj = this.newObject([
@@ -66,9 +66,9 @@ suite.test('should return true of any property matches', function() {
     Ember.Object.create({ foo: 'foo', bar: 'bar' })
   ]);
 
-  equal(obj.anyBy('foo', 'foo'), true, 'anyBy(foo)');
-  equal(obj.anyBy('bar', 'bar'), true, 'anyBy(bar)');
-  equal(obj.anyBy('bar', 'BIFF'), false, 'anyBy(BIFF)');
+  equal(obj.isAny('foo', 'foo'), true, 'isAny(foo)');
+  equal(obj.isAny('bar', 'bar'), true, 'isAny(bar)');
+  equal(obj.isAny('bar', 'BIFF'), false, 'isAny(BIFF)');
 });
 
 suite.test('should return true of any property is true', function() {
@@ -78,9 +78,9 @@ suite.test('should return true of any property is true', function() {
   ]);
 
   // different values - all eval to true
-  equal(obj.anyBy('foo'), true, 'anyBy(foo)');
-  equal(obj.anyBy('bar'), true, 'anyBy(bar)');
-  equal(obj.anyBy('BIFF'), false, 'anyBy(biff)');
+  equal(obj.isAny('foo'), true, 'isAny(foo)');
+  equal(obj.isAny('bar'), true, 'isAny(bar)');
+  equal(obj.isAny('BIFF'), false, 'isAny(biff)');
 });
 
 suite.test('should return true if any property matches null', function() {
@@ -89,8 +89,8 @@ suite.test('should return true if any property matches null', function() {
     Ember.Object.create({ foo: 'foo', bar: null })
   ]);
 
-  equal(obj.anyBy('foo', null), true, "anyBy('foo', null)");
-  equal(obj.anyBy('bar', null), true, "anyBy('bar', null)");
+  equal(obj.isAny('foo', null), true, "isAny('foo', null)");
+  equal(obj.isAny('bar', null), true, "isAny('bar', null)");
 });
 
 suite.test('should return true if any property is undefined', function() {
@@ -99,8 +99,8 @@ suite.test('should return true if any property is undefined', function() {
     Ember.Object.create({ foo: 'foo' })
   ]);
 
-  equal(obj.anyBy('foo', undefined), true, "anyBy('foo', undefined)");
-  equal(obj.anyBy('bar', undefined), true, "anyBy('bar', undefined)");
+  equal(obj.isAny('foo', undefined), true, "isAny('foo', undefined)");
+  equal(obj.isAny('bar', undefined), true, "isAny('bar', undefined)");
 });
 
 suite.test('should not match undefined properties without second argument', function() {
@@ -109,10 +109,15 @@ suite.test('should not match undefined properties without second argument', func
     Ember.Object.create({ })
   ]);
 
-  equal(obj.anyBy('foo'), false, "anyBy('foo', undefined)");
+  equal(obj.isAny('foo'), false, "isAny('foo', undefined)");
 });
 
-suite.test('anyBy should be aliased to someProperty', function() {
+suite.test('anyBy should be aliased to isAny', function() {
   var obj = this.newObject();
-  equal(obj.someProperty, obj.anyBy);
+  equal(obj.isAny, obj.anyBy);
+});
+
+suite.test('isAny should be aliased to someProperty', function() {
+  var obj = this.newObject();
+  equal(obj.someProperty, obj.isAny);
 });

--- a/packages/ember-runtime/tests/suites/enumerable/every.js
+++ b/packages/ember-runtime/tests/suites/enumerable/every.js
@@ -32,10 +32,10 @@ suite.test('every should stop invoking when you return false', function() {
 });
 
 // ..........................................................
-// everyBy()
+// isEvery()
 //
 
-suite.module('everyBy');
+suite.module('isEvery');
 
 suite.test('should return true of every property matches', function() {
   var obj = this.newObject([
@@ -43,8 +43,8 @@ suite.test('should return true of every property matches', function() {
     Ember.Object.create({ foo: 'foo', bar: 'bar' })
   ]);
 
-  equal(obj.everyBy('foo', 'foo'), true, 'everyBy(foo)');
-  equal(obj.everyBy('bar', 'bar'), false, 'everyBy(bar)');
+  equal(obj.isEvery('foo', 'foo'), true, 'isEvery(foo)');
+  equal(obj.isEvery('bar', 'bar'), false, 'isEvery(bar)');
 });
 
 suite.test('should return true of every property is true', function() {
@@ -54,8 +54,8 @@ suite.test('should return true of every property is true', function() {
   ]);
 
   // different values - all eval to true
-  equal(obj.everyBy('foo'), true, 'everyBy(foo)');
-  equal(obj.everyBy('bar'), false, 'everyBy(bar)');
+  equal(obj.isEvery('foo'), true, 'isEvery(foo)');
+  equal(obj.isEvery('bar'), false, 'isEvery(bar)');
 });
 
 suite.test('should return true if every property matches null', function() {
@@ -64,8 +64,18 @@ suite.test('should return true if every property matches null', function() {
     Ember.Object.create({ foo: null, bar: null })
   ]);
 
-  equal(obj.everyBy('foo', null), true, "everyBy('foo', null)");
-  equal(obj.everyBy('bar', null), false, "everyBy('bar', null)");
+  equal(obj.isEvery('foo', null), true, "isEvery('foo', null)");
+  equal(obj.isEvery('bar', null), false, "isEvery('bar', null)");
+});
+
+suite.test('everyBy should be aliased to isEvery', function() {
+  var obj = this.newObject();
+  equal(obj.isEvery, obj.everyBy);
+});
+
+suite.test('everyProperty should be aliased to isEvery', function() {
+  var obj = this.newObject();
+  equal(obj.isEvery, obj.everyProperty);
 });
 
 suite.test('should return true if every property is undefined', function() {
@@ -74,6 +84,6 @@ suite.test('should return true if every property is undefined', function() {
     Ember.Object.create({ bar: undefined })
   ]);
 
-  equal(obj.everyBy('foo', undefined), true, "everyBy('foo', undefined)");
-  equal(obj.everyBy('bar', undefined), false, "everyBy('bar', undefined)");
+  equal(obj.isEvery('foo', undefined), true, "isEvery('foo', undefined)");
+  equal(obj.isEvery('bar', undefined), false, "isEvery('bar', undefined)");
 });


### PR DESCRIPTION
- [x] hide `everyBy` and `everyProperty` from public API (use YUI doc `@deprecated` attribute)
- [x] replace `everyBy` with `isEvery` with new syntax
- [x] hide `anyBy` from public API and replace it with `isAny`
- [x] add tests for new changes
- [x] updates docs

New syntax:

``` javascript
any(fn)
isAny(propName, value) // uses any

every(fn)
isEvery(propName, value) // uses every

filter(fn)
filterBy(propName, value) // uses filter

find(fn)
findBy(propName, value) // uses find

map(fn) 
mapBy(propName, value) // uses map

reject(fn)
rejectBy(propName, value) //uses reject
```
