### PR TITLE
[BUGFIX] Allow keyboard events to work with the action helper

### DIFF
--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -34,9 +34,15 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
   var keys = ["alt", "shift", "meta", "ctrl"];
 
-  var isAllowedClick = function(event, allowedKeys) {
+  var POINTER_EVENT_TYPE_REGEX = /^click|mouse|touch/;
+
+  var isAllowedEvent = function(event, allowedKeys) {
     if (typeof allowedKeys === "undefined") {
-      return isSimpleClick(event);
+      if (POINTER_EVENT_TYPE_REGEX.test(event.type)) {
+        return isSimpleClick(event);
+      } else {
+        allowedKeys = [];
+      }
     }
 
     if (allowedKeys.indexOf("any") >= 0) {
@@ -60,7 +66,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ActionHelper.registeredActions[actionId] = {
       eventName: options.eventName,
       handler: function(event) {
-        if (!isAllowedClick(event, allowedKeys)) { return true; }
+        if (!isAllowedEvent(event, allowedKeys)) { return true; }
 
         event.preventDefault();
 

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -704,6 +704,33 @@ test("it does not trigger action with special clicks", function() {
   checkClick('which', undefined, true); // IE <9
 });
 
+test("it can trigger actions for keyboard events", function() {
+  var showCalled = false;
+
+  view = Ember.View.create({
+    template: compile("<input type='text' {{action show on='keyUp'}}>")
+  });
+
+  var controller = Ember.Controller.extend({
+    actions: {
+      show: function() {
+        showCalled = true;
+      }
+    }
+  }).create();
+
+  Ember.run(function() {
+    view.set('controller', controller);
+    view.appendTo('#qunit-fixture');
+  });
+
+  var event = Ember.$.Event("keyup");
+  event.char = 'a';
+  event.which = 65;
+  view.$('input').trigger(event);
+  ok(showCalled, "should call action with keyup");
+});
+
 module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
   setup: function() {
     dispatcher = Ember.EventDispatcher.create();


### PR DESCRIPTION
The way action helper was validating the modifier keys against the
helper's allowedKeys option assumed a mouse/touch event. This commit
changes that to treat mouse/touch events differently.

Fixes #3340
