### PR TITLE
Updated documentation for Ember.Object init method

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -184,7 +184,6 @@ CoreObject.PrototypeMixin = Mixin.create({
     ```javascript
     App.Person = Ember.Object.extend({
       init: function() {
-        this._super();
         alert('Name is ' + this.get('name'));
       }
     });


### PR DESCRIPTION
No need to call `this._super()` when extending Ember.Object. Like it says in the "NOTE" :-)
