### PR TITLE
Use local npm packages for defeatureify.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ rvm:
 node_js:
 - "0.10"
 install:
-- "npm install -g defeatureify"
-- "npm install -g yuidocjs"
+- "npm install"
 - "bundle install --deployment"
 after_success: bundle exec rake publish_build
 script: rake test\[$TEST_SUITE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ building Ember is quite simple.
 ```sh
 cd ember.js
 bundle install
-npm install -g defeatureify
+npm install
 rake
 ```
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 353847a384c64ed7662419136a7aaaf39e9e7aa5
+  revision: 81d5486f625051710682711de177056885e64fce
   branch: master
   specs:
     ember-dev (0.1)
@@ -33,7 +33,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.22.1)
+    aws-sdk (1.24.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4, < 1.6.0)
       uuidtools (~> 2.1)
@@ -42,7 +42,7 @@ GEM
     colored (1.2)
     diff-lcs (1.2.4)
     execjs (2.0.2)
-    ffi (1.9.0)
+    ffi (1.9.3)
     grit (2.5.0)
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
@@ -51,12 +51,11 @@ GEM
     json (1.8.1)
     kicker (2.6.1)
       listen
-    listen (2.1.1)
+    listen (2.2.0)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mime-types (1.25)
-    multi_json (1.8.2)
     nokogiri (1.5.10)
     posix-spawn (0.3.6)
     puma (2.6.0)
@@ -71,9 +70,9 @@ GEM
       ffi (>= 0.5.0)
     thor (0.18.1)
     timers (1.1.0)
-    uglifier (2.2.1)
+    uglifier (2.3.0)
       execjs (>= 0.3.0)
-      multi_json (~> 1.0, >= 1.0.2)
+      json (>= 1.8.0)
     uuidtools (2.1.4)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ everything you need to get started.
 2. Ensure that [Bundler](http://bundler.io/) is installed (`gem install bundler`).
 3. Ensure that [Node.js](http://nodejs.org/) is installed.
 4. Run `bundle install` to install the necessary ruby gems.
-5. Run `npm install -g defeatureify`.
+5. Run `npm install`.
 6. Run `rake dist` to build Ember.js. The builds will be placed in the `dist/` directory.
 
 # Contribution

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "defeatureify": "~0.1.4",
+    "yuidocjs": "~0.3.46"
+  }
+}


### PR DESCRIPTION
Update to the latest `ember-dev` which requires `defeatureify` and `yuidocjs` to be installed locally (previously these were required to be global).

Also, adds a `package.json` to make installing as simple as `npm install`.
