### PR TITLE
Updated the docs for Ember.Route.activate()

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -317,8 +317,8 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
   deactivate: Ember.K,
 
   /**
-    This hook is executed when the router enters the route for the first time.
-    It is not executed when the model for the route changes.
+    This hook is executed when the router enters the route. It is not executed
+    when the model for the route changes.
 
     @method activate
   */


### PR DESCRIPTION
Docs currently state that `.activate()` is only fired the first time the route is entered when it is, in fact, fired on every entry.
