### PR TITLE
[DOC] Add reference for ember-routing-named-substates.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -101,6 +101,8 @@ for a detailed explanation.
   be entered for `loading`/`error` events emitted from 
   `ApplicationRoute`.
 
+  Added in [#3655](https://github.com/emberjs/ember.js/pull/3655).
+
 * `ember-testing-lazy-routing`
 
   Uses an initializer to defer readiness while testing. Readiness is advanced upon the first


### PR DESCRIPTION
I noticed that this feature didn't have a reference to the PR that it
came from.  I think this is useful for people to figure out what exactly
is done by a given feature.

/cc @machty
