### PR TITLE
[BUGFIX] Ever-present _super, avoids infinite loop case

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -26,6 +26,16 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
   var expandProperties = Ember.expandProperties;
 }
 
+function superFunction(){
+  var ret, func = this.__nextSuper;
+  if (func) {
+    this.__nextSuper = null;
+    ret = func.apply(this, arguments);
+    this.__nextSuper = func;
+  }
+  return ret;
+}
+
 function mixinsMeta(obj) {
   var m = Ember.meta(obj, true), ret = m.mixins;
   if (!ret) {
@@ -151,17 +161,24 @@ function applyMergedProperties(obj, key, value, values) {
 
   if (!baseValue) { return value; }
 
-  var newBase = Ember.merge({}, baseValue);
+  var newBase = Ember.merge({}, baseValue),
+      hasFunction = false;
+
   for (var prop in value) {
     if (!value.hasOwnProperty(prop)) { continue; }
 
     var propValue = value[prop];
     if (isMethod(propValue)) {
       // TODO: support for Computed Properties, etc?
+      hasFunction = true;
       newBase[prop] = giveMethodSuper(obj, prop, propValue, baseValue, {});
     } else {
       newBase[prop] = propValue;
     }
+  }
+
+  if (hasFunction) {
+    newBase._super = superFunction;
   }
 
   return newBase;
@@ -172,7 +189,7 @@ function addNormalizedProperty(base, key, value, meta, descs, values, concats, m
     if (value === REQUIRED && descs[key]) { return CONTINUE; }
 
     // Wrap descriptor function to implement
-    // _super() if needed
+    // __nextSuper() if needed
     if (value.func) {
       value = giveDescriptorSuper(meta, key, value, values, descs);
     }
@@ -319,6 +336,8 @@ function replaceObserversAndListeners(obj, key, observerOrListener) {
 function applyMixin(obj, mixins, partial) {
   var descs = {}, values = {}, m = Ember.meta(obj),
       key, value, desc, keys = [];
+
+  obj._super = superFunction;
 
   // Go through all mixins and hashes passed in, and:
   //

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -321,13 +321,11 @@ Ember.metaPath = function metaPath(obj, path, writable) {
   @return {Function} wrapped function.
 */
 Ember.wrap = function(func, superFunc) {
-  function K() {}
-
   function superWrapper() {
-    var ret, sup = this._super;
-    this._super = superFunc || K;
+    var ret, sup = this.__nextSuper;
+    this.__nextSuper = superFunc;
     ret = func.apply(this, arguments);
-    this._super = sup;
+    this.__nextSuper = sup;
     return ret;
   }
 

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -112,6 +112,42 @@ test('Including the same mixin more than once will only run once', function() {
   equal(cnt, 1, 'should invoke MixinA.foo one time');
 });
 
+test('_super from a single mixin with no superclass does not error', function() {
+  var MixinA = Ember.Mixin.create({
+    foo: function() {
+      this._super();
+    }
+  });
+
+  var obj = {};
+  MixinA.apply(obj);
+
+  obj.foo();
+  ok(true);
+});
+
+test('_super from a first-of-two mixins with no superclass function does not error', function() {
+  // _super was previously calling itself in the second assertion.
+  // Use remaining count of calls to ensure it doesn't loop indefinitely.
+  var remaining = 3;
+  var MixinA = Ember.Mixin.create({
+    foo: function() {
+      if (remaining-- > 0) this._super();
+    }
+  });
+
+  var MixinB = Ember.Mixin.create({
+    foo: function() { this._super(); }
+  });
+
+  var obj = {};
+  MixinA.apply(obj);
+  MixinB.apply(obj);
+
+  obj.foo();
+  ok(true);
+});
+
 // ..........................................................
 // CONFLICTS
 //

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -49,7 +49,7 @@ function makeCtor() {
       Class.proto(); // prepare prototype...
     }
     o_defineProperty(this, GUID_KEY, undefinedDescriptor);
-    o_defineProperty(this, '_super', undefinedDescriptor);
+    o_defineProperty(this, '__nextSuper', undefinedDescriptor);
     var m = meta(this), proto = m.proto;
     m.proto = this;
     if (initMixins) {


### PR DESCRIPTION
This changes `_super` to be an omnipresent method on ember objects, and to have a `__nextSuper` that decides what is called next. This allows `_super` to be a noop when it has no parent.

Fixes #3523, but has one failing test I still need to address. Should have similar performance characteristics to the `_super` we know and love today.

![failing test](http://f.cl.ly/items/2X3h2G0u1Z220w0B2p0W/Screen%20Shot%202013-11-02%20at%2012.00.45%20AM.png)

I welcome feedback on this strategy.
