### PR TITLE
Add document.title integration to Ember

### DIFF
--- a/features.json
+++ b/features.json
@@ -12,5 +12,6 @@
   "propertyBraceExpansion": null,
   "ember-routing-named-substates": null,
   "ember-testing-lazy-routing": null,
-  "ember-handlebars-caps-lookup": null
+  "ember-handlebars-caps-lookup": null,
+  "ember-document-title": null
 }

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -22,6 +22,38 @@ var get = Ember.get, set = Ember.set,
 Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
 
   /**
+    The partial title of the route, used for constructing
+    the document.title.
+
+    Setting this as a computed property will make the document
+    title dynamically update. Titles cascade, so any nesting
+    done in route form will be reflected in the construction
+    of the document title.
+
+    If you choose to exclude the route from the document title,
+    simply don't define it.
+
+    A simple case would be updating the title of the document to
+    reflect the user's name. In your route for the `user` model,
+    all that would have to be done would be to set up a `oneWay`
+    computed property to the name of the user:
+
+    ```javascript
+    App.UserRoute = Ember.Route.extend({
+      title: Ember.computed.oneWay('controller.name')
+    });
+    ```
+
+    When the user's name is changed, the title will automatically
+    change to reflect the changes on the model.
+
+    @property title
+    @type String
+    @default null
+   */
+  title: null,
+
+  /**
     @private
 
     @method exit
@@ -447,7 +479,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
 
     // Assign the route's controller so that it can more easily be
     // referenced in action handlers
-    this.controller = controller;
+    set(this, 'controller', controller);
 
     var args = [controller, context];
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -67,67 +67,6 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     return tokens;
   }),
 
-  /**
-    The title divider to use between each route `title`.
-
-    @property titleDivider
-    @type String
-    @default ' - '
-   */
-  titleDivider: ' - ',
-
-  /**
-    A flag to indicate whether the document title should
-    sort the route `title`s from most general to most
-    specific:
-
-    ```
-    Ember.js - About
-    ```
-
-    or most specific to most general:
-
-    ```
-    About - Ember.js
-    ```
-
-    @property titleSpecificityIncreases
-    @type Boolean
-    @default false
-   */
-  titleSpecificityIncreases: false,
-
-  /**
-    The title to be used to control the `document.title`.
-
-    Override this property to fully customize how the
-    `document.title` is computed. When overriding this
-    property, use the `titleTokens` property to get all
-    of the tokens that are active in order of most general
-    to most specific.
-
-    @property type
-    @type String
-    @default ''
-   */
-  title: Ember.computed('titleTokens', 'titleDivider', 'titleSpecificityIncreases', function() {
-    var tokens  = get(this, 'titleTokens'),
-        divider = get(this, 'titleDivider');
-
-    if (!get(this, 'titleSpecificityIncreases')) {
-      tokens = Ember.copy(tokens).reverse();
-    }
-
-    return tokens.join(divider);
-  }),
-
-  titleDidChange: Ember.observer(function() {
-    var title = get(this, 'title');
-    if (title) {
-      document.title = title;
-    }
-  }, 'title'),
-
   url: Ember.computed(function() {
     return get(this, 'location').getURL();
   }),

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -114,10 +114,6 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     var tokens  = get(this, 'titleTokens'),
         divider = get(this, 'titleDivider');
 
-    // Add spaces to the divider; it's more intuitive
-    // and a common practice across sites.
-    divider = divider;
-
     if (!get(this, 'titleSpecificityIncreases')) {
       tokens = Ember.copy(tokens).reverse();
     }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -26,7 +26,111 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     this.router = this.constructor.router || this.constructor.map(Ember.K);
     this._activeViews = {};
     this._setupLocation();
+
+    // Activate observers on `title`
+    if (Ember.FEATURES.isEnabled("ember-document-title")) {
+      this.get('title');
+    }
   },
+
+  /**
+    @private
+
+    Trigger the `titleTokens` property to change to cause
+    a cascade of changes down to the `title`.
+   */
+  titleTokensDidChange: function() {
+    this.notifyPropertyChange('titleTokens');
+  },
+
+  /**
+    The series of `title`s that compromise the active routes.
+
+    @property titleTokens
+    @type String[]
+    @default []
+   */
+  titleTokens: Ember.computed(function() {
+    var currentHandlerInfos = get(this, 'router.currentHandlerInfos'),
+        tokens = [],
+        token;
+
+    if (currentHandlerInfos) {
+      for (var i = 0, len = currentHandlerInfos.length; i < len; i++) {
+        token = get(currentHandlerInfos[i], 'handler.title');
+        if (token) {
+          tokens.push(token);
+        }
+      }
+    }
+
+    return tokens;
+  }),
+
+  /**
+    The title divider to use between each route `title`.
+
+    @property titleDivider
+    @type String
+    @default '|'
+   */
+  titleDivider: '|',
+
+  /**
+    A flag to indicate whether the document title should
+    sort the route `title`s from most general to most
+    specific:
+
+    ```
+    Ember.js | About
+    ```
+
+    or most specific to most general:
+
+    ```
+    About | Ember.js
+    ```
+
+    @property titleSpecificityIncreases
+    @type Boolean
+    @default false
+   */
+  titleSpecificityIncreases: false,
+
+  /**
+    The title to be used to control the `document.title`.
+
+    Override this property to fully customize how the
+    `document.title` is computed. When overriding this
+    property, use the `titleTokens` property to get all
+    of the tokens that are active in order of most general
+    to most specific.
+
+    @property type
+    @type String
+    @default ''
+   */
+  title: Ember.computed('titleTokens', 'titleDivider', 'titleSpecificityIncreases', function() {
+    var tokens  = get(this, 'titleTokens'),
+        divider = get(this, 'titleDivider');
+
+    // Add spaces to the divider; it's more intuitive
+    // and a common practice across sites.
+    divider = ' ' + divider + ' ';
+
+    if (!get(this, 'titleSpecificityIncreases')) {
+      tokens = Ember.copy(tokens).reverse();
+    }
+
+    return tokens.join(divider);
+  }),
+
+  titleDidChange: Ember.observer(function() {
+    var title = get(this, 'title');
+    if (title) {
+      document.title = title;
+    }
+  }, 'title'),
 
   url: Ember.computed(function() {
     return get(this, 'location').getURL();
@@ -52,6 +156,18 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     this.handleURL(location.getURL());
   },
 
+  willTransition: function(infos) {
+    var activeHandlers = get(this, 'router.currentHandlerInfos');
+
+    if (Ember.FEATURES.isEnabled("ember-document-title")) {
+      if (activeHandlers) {
+        for (var i = 0, len = activeHandlers.length; i < len; i++) {
+          Ember.removeObserver(activeHandlers[i].handler, 'title', this, this.titleTokensDidChange);
+        }
+      }
+    }
+  },
+
   didTransition: function(infos) {
     updatePaths(this);
 
@@ -59,6 +175,14 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
       this._cancelLoadingEvent();
     } else {
       exitLegacyLoadingRoute(this);
+    }
+
+    if (Ember.FEATURES.isEnabled("ember-document-title")) {
+      for (var i = 0, len = infos.length; i < len; i++) {
+        Ember.addObserver(infos[i].handler, 'title', this, this.titleTokensDidChange);
+      }
+
+      this.notifyPropertyChange('titleTokens');
     }
 
     this.notifyPropertyChange('url');
@@ -228,6 +352,10 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
     router.didTransition = function(infos) {
       emberRouter.didTransition(infos);
+    };
+
+    router.willTransition = function(infos) {
+      emberRouter.willTransition(infos);
     };
   },
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -72,9 +72,9 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
     @property titleDivider
     @type String
-    @default '|'
+    @default ' - '
    */
-  titleDivider: '|',
+  titleDivider: ' - ',
 
   /**
     A flag to indicate whether the document title should
@@ -82,13 +82,13 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     specific:
 
     ```
-    Ember.js | About
+    Ember.js - About
     ```
 
     or most specific to most general:
 
     ```
-    About | Ember.js
+    About - Ember.js
     ```
 
     @property titleSpecificityIncreases
@@ -116,7 +116,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
     // Add spaces to the divider; it's more intuitive
     // and a common practice across sites.
-    divider = ' ' + divider + ' ';
+    divider = divider;
 
     if (!get(this, 'titleSpecificityIncreases')) {
       tokens = Ember.copy(tokens).reverse();

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -44,7 +44,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
   },
 
   /**
-    The series of `title`s that compromise the active routes.
+    The series of `title`s that comprise the active routes.
 
     @property titleTokens
     @type String[]

--- a/packages/ember/tests/routing/document_title_test.js
+++ b/packages/ember/tests/routing/document_title_test.js
@@ -60,7 +60,7 @@ if (Ember.FEATURES.isEnabled("ember-document-title")) {
 
         App.Router.reopen({
           location: 'none',
-          titleDivider: '|',
+          titleDivider: ' | ',
           titleSpecificityIncreases: false
         });
 
@@ -202,9 +202,9 @@ if (Ember.FEATURES.isEnabled("ember-document-title")) {
       }, shouldNotHappen).then(function(result) {
         equal(document.title, "Ministry of Silly Walks | British Government");
 
-        set(router, 'titleDivider', '-');
+        set(router, 'titleDivider', ': ');
         Ember.run.next(function () {
-          equal(document.title, "Ministry of Silly Walks - British Government");
+          equal(document.title, "Ministry of Silly Walks: British Government");
           start();
         });
       }, shouldNotHappen);

--- a/packages/ember/tests/routing/document_title_test.js
+++ b/packages/ember/tests/routing/document_title_test.js
@@ -1,0 +1,250 @@
+var Router, App, AppView, templates, router, container, originalTemplates;
+var get = Ember.get, set = Ember.set;
+
+function bootApplication(url) {
+  router = container.lookup('router:main');
+  if(url) { router.location.setURL(url); }
+  Ember.run(App, 'advanceReadiness');
+}
+
+function compile(string) {
+  return Ember.Handlebars.compile(string);
+}
+
+function handleURL(path) {
+  return Ember.run(function() {
+    return router.handleURL(path).then(function(value) {
+      ok(true, 'url: `' + path + '` was handled');
+      return value;
+    }, function(reason) {
+      ok(false, 'failed to visit:`' + path + '` reason: `' + QUnit.jsDump.parse(reason));
+      throw reason;
+    });
+  });
+}
+
+function handleURLAborts(path) {
+  Ember.run(function() {
+    router.handleURL(path).then(function(value) {
+      ok(false, 'url: `' + path + '` was NOT to be handled');
+    }, function(reason) {
+      ok(reason && reason.message === "TransitionAborted",  'url: `' + path + '` was to be aborted');
+    });
+  });
+}
+
+function shouldNotHappen(error) {
+  console.error(error.stack);
+  ok(false, "this .then handler should not be called: " + error.message);
+}
+
+function handleURLRejectsWith(path, expectedReason) {
+  Ember.run(function() {
+    router.handleURL(path).then(function(value) {
+      ok(false, 'expected handleURLing: `' + path + '` to fail');
+    }, function(reason) {
+      equal(expectedReason, reason);
+    });
+  });
+}
+if (Ember.FEATURES.isEnabled("ember-document-title")) {
+  module("Routing document.title integration", {
+    setup: function() {
+      Ember.run(function() {
+        App = Ember.Application.create({
+          name: "App",
+          rootElement: '#qunit-fixture'
+        });
+
+        App.deferReadiness();
+
+        App.Router.reopen({
+          location: 'none',
+          titleDivider: '|',
+          titleSpecificityIncreases: false
+        });
+
+        Router = App.Router;
+
+        App.LoadingRoute = Ember.Route.extend();
+
+        container = App.__container__;
+
+        originalTemplates = Ember.$.extend({}, Ember.TEMPLATES);
+        Ember.TEMPLATES.application = compile("{{outlet}}");
+        Ember.TEMPLATES.ministries = compile("<h3>Ministries</h3>");
+        Ember.TEMPLATES.ministry = compile("<h3>{{name}}</h3>");
+        Ember.TEMPLATES.employee = compile("<h3>{{name}}</h3>");
+      });
+    },
+
+    teardown: function() {
+      Ember.run(function() {
+        App.destroy();
+        App = null;
+
+        Ember.TEMPLATES = originalTemplates;
+      });
+    }
+  });
+
+  test("The document.title is updated upon booting the app", function() {
+    expect(1);
+
+    Router.map(function() {
+      this.route("index", { path: "/" });
+    });
+
+    App.IndexRoute = Ember.Route.extend({
+      title: "British Government"
+    });
+
+    bootApplication("/");
+    equal(document.title, "British Government");
+  });
+
+
+  asyncTest("Transitioning will update the title of the document", function() {
+    expect(8);
+
+    Router.map(function() {
+      this.route("ministries", { path: "/ministries" });
+      this.resource("ministry", { path: "/ministries/:ministry_id" });
+      this.resource("employee", { path: "/employee/:employee_id" });
+    });
+
+    App.MinistriesRoute = Ember.Route.extend({
+      title: "Ministries"
+    });
+
+    App.MinistryRoute = Ember.Route.extend({
+      title: Ember.computed.oneWay("controller.name")
+    });
+
+    App.EmployeeRoute = Ember.Route.extend({
+      title: Ember.computed("controller.id", function () {
+        return "Employee #" + get(this, "controller.id");
+      })
+    });
+
+    var originalTitle = document.title;
+    bootApplication();
+
+    var transition = handleURL('/'),
+        ministry = Ember.Object.create({
+          name: "Ministry of Silly Walks"
+        });
+
+    Ember.run(function () {
+      transition.then(function () {
+        equal(document.title, originalTitle);
+        return router.transitionTo('ministries');
+      }, shouldNotHappen).then(function(result) {
+        equal(document.title, "Ministries");
+
+        return router.transitionTo('ministry', ministry);
+      }, shouldNotHappen).then(function (result) {
+        equal(document.title, "Ministry of Silly Walks");
+
+        set(ministry, 'name', "Ministry of Pointless Arguments");
+        equal(document.title, "Ministry of Pointless Arguments");
+
+        return router.transitionTo('ministries');
+      }, shouldNotHappen).then(function (result) {
+        equal(document.title, "Ministries");
+
+        set(ministry, 'name', "Ministry of Silly Walks");
+
+        return new Ember.RSVP.Promise(function (resolve) {
+          Ember.run.next(resolve);
+        });
+      }).then(function () {
+        equal(document.title, "Ministries");
+
+        return router.transitionTo("employee", Ember.Object.create({
+          id: 5,
+          name: "Mr. Teabag"
+        }));
+      }, shouldNotHappen).then(function (result) {
+        equal(document.title, "Employee #5");
+
+        start();
+      }, shouldNotHappen);
+    });
+  });
+
+
+  asyncTest("specifying the titleDivider property", function() {
+    expect(3);
+
+    Router.map(function() {
+      this.resource("ministry", { path: "/ministry/:ministry_id" });
+    });
+
+    App.ApplicationRoute = Ember.Route.extend({
+      title: "British Government"
+    });
+
+    App.MinistryRoute = Ember.Route.extend({
+      title: Ember.computed.oneWay("controller.name")
+    });
+
+    bootApplication();
+
+    var transition = handleURL('/'),
+        ministry = Ember.Object.create({
+          name: "Ministry of Silly Walks"
+        });
+
+    Ember.run(function() {
+      transition.then(function() {
+        return router.transitionTo('ministry', ministry);
+      }, shouldNotHappen).then(function(result) {
+        equal(document.title, "Ministry of Silly Walks | British Government");
+
+        set(router, 'titleDivider', '-');
+        Ember.run.next(function () {
+          equal(document.title, "Ministry of Silly Walks - British Government");
+          start();
+        });
+      }, shouldNotHappen);
+    });
+  });
+
+  asyncTest("specifying the titleSpecificityIncreases property", function() {
+    expect(3);
+
+    Router.map(function() {
+      this.resource("ministry", { path: "/ministry/:ministry_id" });
+    });
+
+    App.ApplicationRoute = Ember.Route.extend({
+      title: "British Government"
+    });
+
+    App.MinistryRoute = Ember.Route.extend({
+      title: Ember.computed.oneWay("controller.name")
+    });
+
+    bootApplication();
+
+    var transition = handleURL('/'),
+        ministry = Ember.Object.create({
+          name: "Ministry of Silly Walks"
+        });
+
+    Ember.run(function() {
+      transition.then(function() {
+        return router.transitionTo('ministry', ministry);
+      }, shouldNotHappen).then(function(result) {
+        equal(document.title, "Ministry of Silly Walks | British Government");
+
+        set(router, 'titleSpecificityIncreases', true);
+        Ember.run.next(function () {
+          equal(document.title, "British Government | Ministry of Silly Walks");
+          start();
+        });
+      }, shouldNotHappen);
+    });
+  });
+}


### PR DESCRIPTION
This is a copy over of #2757 with a few modifications. I've added feature flagging and layering to expose the ability to override how the document.title is created.

To enable this feature set the flag `"ember-document-title"` to `true`.

A typical example for an application would be the following:

``` javascript
App = Ember.Application.create();

App.Router = Ember.Router.extend({
  titleDivider: ': ',
  titleSpecificityIncreases: true
});

App.Router.map(function () {
  this.resource('users');
  this.resource('user', { path: '/users/:user_id' });
});

App.ApplicationRoute = Ember.Route.extend({
  title: "MyApp"
});

App.UsersRoute.extend({
  title: "Users"
});

App.UserRoute.extend({
  title: Ember.computed.oneWay('controller.name')
});
```

This structure will update the title of the document to `MyApp` when the app loads; `MyApp: Users` after transitioning to /users; and `MyApp: Finn the Human` upon loading the user for Finn the Human.

If you would like to override how the title property is displayed, simply override the `title` property on `App.Router`. When the `title` property becomes invalidated, the document title updates. That is the only contract you must satisfy. To get the tokens that the title is composed of, look at the `titleTokens` property. If overriding the `title`, you should make the `title` dependent on title tokens.

Side question:
The tests are passing, but the observers aren't getting removed. This needs a patch in tildeio/router in setupContexts to call willTransition to ensure that observers are getting torn down. I'm not sure, but are the observers getting removed upon transitioning away from a route, or do I have to remove them myself?
