### PR TITLE
[FEATURE ember-testing-lazy-routing]

### DIFF
--- a/features.json
+++ b/features.json
@@ -9,5 +9,6 @@
   "query-params": null,
   "string-humanize": null,
   "propertyBraceExpansion": null,
-  "ember-routing-named-substates": null
+  "ember-routing-named-substates": null,
+  "ember-testing-lazy-routing": null
 }

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -26,6 +26,10 @@ Test.onInjectHelpers(function() {
 
 
 function visit(app, url) {
+  if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+    Ember.run(app, 'advanceReadiness');
+  }
+
   app.__container__.lookup('router:main').location.setURL(url);
   Ember.run(app, app.handleURL, url);
   return wait(app);

--- a/packages/ember-testing/lib/initializers.js
+++ b/packages/ember-testing/lib/initializers.js
@@ -1,0 +1,13 @@
+Ember.onLoad('Ember.Application', function(Application) {
+  if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+    Application.initializer({
+      name: 'deferReadiness in `testing` mode',
+
+      initialize: function(container, application){
+        if (application.testing) {
+          application.deferReadiness();
+        }
+      }
+    });
+  }
+});

--- a/packages/ember-testing/lib/main.js
+++ b/packages/ember-testing/lib/main.js
@@ -1,6 +1,7 @@
 require('ember-application');
 require('ember-routing');
 require('ember-testing/test');
+require('ember-testing/initializers');
 require('ember-testing/support');
 require('ember-testing/adapters');
 require('ember-testing/helpers');

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -308,6 +308,17 @@ Ember.Application.reopen({
   testHelpers: {},
 
   /**
+  This property indicates whether or not this application is currently in
+  testing mode. This is set when `setupForTesting` is called on the current
+  application.
+
+  @property testing
+  @type {Boolean}
+  @default false
+  */
+  testing: false,
+
+  /**
    This hook defers the readiness of the application, so that you can start
    the app when your tests are ready to run. It also sets the router's
    location to 'none', so that the window's location will not be modified
@@ -324,7 +335,11 @@ Ember.Application.reopen({
   setupForTesting: function() {
     Ember.testing = true;
 
-    this.deferReadiness();
+    if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+      this.testing = true;
+    } else {
+      this.deferReadiness();
+    }
 
     this.Router.reopen({
       location: 'none'

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -40,9 +40,13 @@ module("ember-testing Acceptance", {
       App.setupForTesting();
     });
 
-    Ember.run(function() {
-      App.advanceReadiness();
-    });
+    if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+      // readiness is advanced upon first visit
+    } else {
+      Ember.run(function() {
+        App.advanceReadiness();
+      });
+    }
 
     App.injectTestHelpers();
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -63,6 +63,54 @@ test("Ember.Application#setupForTesting", function() {
   equal(App.__container__.lookup('router:main').location.implementation, 'none');
 });
 
+if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+  test("Ember.Application.setupForTesting sets the application to `testing`.", function(){
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+    });
+
+    equal(App.testing, true, "Application instance is set to testing.");
+  });
+
+  test("Ember.Application.setupForTesting leaves the system in a deferred state.", function(){
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+    });
+
+    equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
+  });
+
+  test("App.reset() after Application.setupForTesting leaves the system in a deferred state.", function(){
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+    });
+
+    equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
+
+    App.reset();
+    equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
+  });
+
+  test("`visit` advances readiness.", function(){
+    expect(2);
+
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+      App.injectTestHelpers();
+    });
+
+    equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
+
+    App.testHelpers.visit('/').then(function(){
+      equal(App._readinessDeferrals, 0, "App's readiness was advanced by visit.");
+    });
+  });
+}
+
 test("Ember.Test.registerHelper/unregisterHelper", function() {
   expect(5);
   var appBooted = false;

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -43,7 +43,11 @@ module("ember-testing Integration", {
 
     Ember.run(function() {
       App.reset();
-      App.deferReadiness();
+      if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+        // no need to deferReadiness as it is done via an initializer
+      } else {
+        App.deferReadiness();
+      }
     });
 
     App.injectTestHelpers();
@@ -100,3 +104,16 @@ test("template is again bound to empty array of people", function() {
     equal(rows, 0, "successfully stubbed another empty array of people");
   });
 });
+
+if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
+  test("`visit` can be called without advancedReadiness.", function(){
+    App.Person.find = function() {
+      return Ember.A();
+    };
+
+    visit("/").then(function() {
+      var rows = find(".name").length;
+      equal(rows, 0, "stubbed an empty array of people without calling advancedReadiness.");
+    });
+  });
+}


### PR DESCRIPTION
- `setupForTesting` sets the application into testing mode (which is used to defer readiness).
- Adds an initializer that defers readiness if the application is in testing mode.
- `visit` helper has been updated to advance readiness upon first call.
- `App.reset()` now behaves the same after `setupForTesting` (in a deferred state).
