### PR TITLE
[BUGFIX beta] The router should cleanup itself upon destroy.

### DIFF
--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -248,3 +248,21 @@ test("With ember-data like initializer and constant", function() {
   ok(DS.defaultStore, 'still has defaultStore');
   ok(application.__container__.lookup("store:main"), 'store is still present');
 });
+
+test("Ensure that the hashchange event listener is removed", function(){
+  var listeners;
+
+  Ember.$(window).off('hashchange'); // ensure that any previous listeners are cleared
+
+  Ember.run(function() {
+    application = Application.create();
+  });
+
+  listeners = Ember.$._data(Ember.$(window)[0], 'events');
+  equal(listeners['hashchange'].length, 1, 'hashchange event listener was setup');
+
+  application.reset();
+
+  listeners = Ember.$._data(Ember.$(window)[0], 'events');
+  equal(listeners['hashchange'].length, 1, 'hashchange event only exists once');
+});

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -127,6 +127,13 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     this.router.reset();
   },
 
+  willDestroy: function(){
+    var location = get(this, 'location');
+    location.destroy();
+
+    this._super.apply(this, arguments);
+  },
+
   _lookupActiveView: function(templateName) {
     var active = this._activeViews[templateName];
     return active && active[0];

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -13,3 +13,13 @@ test("should create a router if one does not exist on the constructor", function
   var router = Router.create();
   ok(router.router);
 });
+
+test("should destroy its location upon Router.destroy.", function(){
+  var router = Router.create(),
+      location = router.get('location');
+
+  Ember.run(router, 'destroy');
+
+  ok(router.isDestroyed, "router should be destroyed");
+  ok(location.isDestroyed, "location should be destroyed");
+});


### PR DESCRIPTION
Prior to this change the router did not cleanup its location object upon 
destroy. This caused multiple transitions to be triggered after an
`App.reset()` call.

Resolves #3669.

@twokul / @rjackson
