### PR TITLE
[BUGFIX beta] Support for mock dates in `Ember.typeOf`.

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -9,9 +9,9 @@ require('ember-metal/error');
 
 /**
   @private
-  
+
   Prefix used for guids through out Ember.
-  
+
 */
 Ember.GUID_PREFIX = 'ember';
 
@@ -619,6 +619,8 @@ var toString = Object.prototype.toString;
       | 'undefined'   | Undefined value                                      |
       | 'function'    | A function                                           |
       | 'array'       | An instance of Array                                 |
+      | 'regexp'      | An instance of RegExp                                |
+      | 'date'        | An instance of Date                                  |
       | 'class'       | An Ember class (created using Ember.Object.extend()) |
       | 'instance'    | An Ember object instance                             |
       | 'error'       | An instance of the Error object                      |
@@ -635,6 +637,8 @@ var toString = Object.prototype.toString;
   Ember.typeOf(true);                   // 'boolean'
   Ember.typeOf(Ember.makeArray);        // 'function'
   Ember.typeOf([1,2,90]);               // 'array'
+  Ember.typeOf(/abc/);                  // 'regexp'
+  Ember.typeOf(new Date());             // 'date'
   Ember.typeOf(Ember.Object.extend());  // 'class'
   Ember.typeOf(Ember.Object.create());  // 'instance'
   Ember.typeOf(new Error('teamocil'));  // 'error'
@@ -658,7 +662,7 @@ Ember.typeOf = function(item) {
   } else if (ret === 'object') {
     if (item instanceof Error) ret = 'error';
     else if (Ember.Object && item instanceof Ember.Object) ret = 'instance';
-    else ret = 'object';
+    else if (item instanceof Date) ret = 'date';
   }
 
   return ret;

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -1,0 +1,31 @@
+module("Ember Type Checking");
+
+test("Ember.typeOf", function() {
+  var MockedDate = function() { };
+  MockedDate.prototype = new Date();
+
+  var mockedDate  = new MockedDate(),
+      date        = new Date(),
+      error       = new Error('boum'),
+      object      = {a: 'b'};
+
+  equal( Ember.typeOf(),            'undefined',  "undefined");
+  equal( Ember.typeOf(null),        'null',       "null");
+  equal( Ember.typeOf('Cyril'),     'string',     "Cyril");
+  equal( Ember.typeOf(101),         'number',     "101");
+  equal( Ember.typeOf(true),        'boolean',    "true");
+  equal( Ember.typeOf([1,2,90]),    'array',      "[1,2,90]");
+  equal( Ember.typeOf(/abc/),       'regexp',     "/abc/");
+  equal( Ember.typeOf(date),        'date',       "new Date()");
+  equal( Ember.typeOf(mockedDate),  'date',       "mocked date");
+  equal( Ember.typeOf(error),       'error',      "error");
+  equal( Ember.typeOf(object),      'object',     "object");
+
+  if(Ember.Object) {
+    var klass       = Ember.Object.extend(),
+        instance    = Ember.Object.create();
+
+    equal( Ember.typeOf(klass),     'class',      "class");
+    equal( Ember.typeOf(instance),  'instance',   "instance");
+  }
+});


### PR DESCRIPTION
When mocking `Date` (using [Timecop.js](https://github.com/jamesarosen/Timecop.js) for example),
`Ember.Enumerable.sortBy` fails because of the type detection (`object` instead of `date`).
