### PR TITLE
[BUGFIX beta] Fix import of Router module in ember-testing package

### DIFF
--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -5,8 +5,7 @@
 var slice = [].slice,
     helpers = {},
     originalMethods = {},
-    injectHelpersCallbacks = [],
-    Router = requireModule('router');
+    injectHelpersCallbacks = [];
 
 /**
   This is a container for an assortment of testing related functionality:
@@ -488,9 +487,6 @@ function isolate(fn, val) {
   }
 }
 
-
 function onerror(error) {
-  if (!(error instanceof Router.TransitionAborted)) {
-    Ember.Test.adapter.exception(error);
-  }
+  Ember.Test.adapter.exception(error);
 }

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -12,6 +12,8 @@ module("ember-testing Acceptance", {
       App.Router.map(function() {
         this.route('posts');
         this.route('comments');
+
+        this.route('abort_transition');
       });
 
       App.PostsRoute = Ember.Route.extend({
@@ -35,6 +37,12 @@ module("ember-testing Acceptance", {
 
       App.CommentsView = Ember.View.extend({
         defaultTemplate: Ember.Handlebars.compile("{{input type=text}}")
+      });
+
+      App.AbortTransitionRoute = Ember.Route.extend({
+        beforeModel: function(transition) {
+          transition.abort();
+        }
       });
 
       App.setupForTesting();
@@ -192,4 +200,16 @@ test("Helpers nested in thens", function() {
   andThen(function() {
     equal(currentRoute, 'posts');
   });
+});
+
+test("Aborted transitions are not logged via Ember.Test.adapter#exception", function () {
+  expect(0);
+
+  Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
+    exception: function(error) {
+      ok(false, "aborted transitions are not logged");
+    }
+  });
+
+  visit("/abort_transition");
 });


### PR DESCRIPTION
Since the router.js sync in cf0caa04f625067ec3b4629acdec12c8517df94e (which is already in beta branch), the Router is now stored in the "default" property.

Without this change the `instanceof` check in [ember-testing/lib/test.js#L493](https://github.com/pangratz/ember.js/blob/63376ed8b9e02181c4d0bba9303725b32fd0c13c/packages/ember-testing/lib/test.js#L493) fails - since `Router.TransitionAborted` is undefined - and an error is thrown: **TypeError: undefined' is not a valid argument for 'instanceof' (evaluating 'error instanceof Router.TransitionAborted'**.

This happens here:

``` javascript
function onerror(error) {
  if (!(error instanceof Router.TransitionAborted)) {
    Ember.Test.adapter.exception(error);
  }
}
```

There is currently no spec for this, so no tests were failing. I thought about adding a regression test for this; while reading through the code, the check for for the error being `Router.TransitionAborted` was added by @teddyzeenny in [526bb0cd - Ember-testing should not cause a test failure when aborting transitions](https://github.com/emberjs/ember.js/blob/526bb0cddf9479085fa4b8d7bc9d924c20870426). The added test in this PR also succeeds when the function in [ember-testing/lib/test.js#L493](https://github.com/pangratz/ember.js/blob/8fa02a9/packages/ember-testing/lib/test.js#L493) is changed to

``` javascript
function onerror(error) {
  Ember.Test.adapter.exception(error);
}
```

so the test is somewhat wrong, since with this change the test should fail. I don't have too much insight in the recent router.js / RSVP.js / ember-testing changes, but is it possible that the "ember-testing fails when a router transition is aborted" thing has already been resolved and the custom check in the `onerror` function is not needed anymore?

//cc @machty @teddyzeenny
