### PR TITLE
[BUGFIX beta] Add spec for unhandled exception being logged by Test.adapter.exception

### DIFF
--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -78,11 +78,6 @@ module("ember-testing Acceptance", {
 
 test("helpers can be chained with then", function() {
   expect(5);
-  Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
-    exception: function(error) {
-      equal(error.message, "Element .does-not-exist not found.", "Exception successfully caught and passed to Ember.Test.adapter.exception");
-    }
-  });
 
   currentRoute = 'index';
 
@@ -212,4 +207,22 @@ test("Aborted transitions are not logged via Ember.Test.adapter#exception", func
   });
 
   visit("/abort_transition");
+});
+
+test("Unhandled exceptions are logged via Ember.Test.adapter#exception", function () {
+  expect(2);
+
+  Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
+    exception: function(error) {
+      equal(error.message, "Element .does-not-exist not found.", "Exception successfully caught and passed to Ember.Test.adapter.exception");
+    }
+  });
+
+  visit('/posts');
+
+  click(".invalid-element").then(null, function(error) {
+    equal(error.message, "Element .invalid-element not found.", "Exception successfully handled in the rejection handler");
+  });
+
+  click(".does-not-exist");
 });


### PR DESCRIPTION
The changes in exception handling introduced in cf0caa04f625067ec3b4629acdec12c8517df94e made a test assertion in an existing test obsolete, since it wasn't called anymore.

This commit adds a spec for Test.adapter.exception being invoked, when an exception is not handled.

This can be merged once #3704 is resolved.
