### PR TITLE
[BUGFIX release] Fix #3681.

### DIFF
--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -41,6 +41,11 @@ ArrayComputedProperty.prototype.resetValue = function (array) {
   return array;
 };
 
+// This is a stopgap to keep the reference counts correct with lazy CPs.
+ArrayComputedProperty.prototype.didChange = function (obj, keyName) {
+  return;
+};
+
 /**
   Creates a computed property which operates on dependent arrays and
   is updated with "one at a time" semantics. When items are added or

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -1,4 +1,9 @@
-var obj, addCalls, removeCalls, map = Ember.EnumerableUtils.map, get = Ember.get, set = Ember.set, callbackItems;
+var map = Ember.EnumerableUtils.map,
+    get = Ember.get,
+    set = Ember.set,
+    metaFor = Ember.meta,
+    keys = Ember.keys,
+    obj, addCalls, removeCalls, callbackItems;
 
 module('Ember.arrayComputed', {
   setup: function () {
@@ -493,6 +498,62 @@ test("removedItem is not erroneously called for dependent arrays during a recomp
   ok(true, "removedItem not invoked with invalid index");
 });
 
+module('Ember.arrayComputed - recomputation DKs', {
+  setup: function() {
+    obj = Ember.Object.extend({
+      people: Ember.A([{
+        name: 'Jaime Lannister',
+        title: 'Kingsguard'
+      }, {
+        name: 'Cersei Lannister',
+        title: 'Queen'
+      }]),
+
+      titles: Ember.arrayComputed('people', {
+        addedItem: function (acc, person) {
+          acc.pushObject(get(person, 'title'));
+          return acc;
+        }
+      })
+    }).create();
+  },
+  teardown: function() {
+    Ember.run(function() {
+      obj.destroy();
+    });
+  }
+});
+
+test("recomputations from `arrayComputed` observers add back dependent keys", function() {
+  var meta = metaFor(obj),
+      people = get(obj, 'people'),
+      titles;
+
+  equal(meta.deps, undefined, "precond - nobody depends on people'");
+  equal(meta.watching.people, undefined, "precond - nobody is watching people");
+
+  titles = get(obj, 'titles');
+
+  deepEqual(titles, ["Kingsguard", "Queen"], "precond - value is correct");
+
+  ok(meta.deps.people !== undefined, "people has dependencies");
+  deepEqual(keys(meta.deps.people), ["titles"], "only titles depends on people");
+  equal(meta.deps.people.titles, 1, "titles depends on people exactly once");
+  equal(meta.watching.people, 2, "people has two watchers: the array listener and titles");
+
+  Ember.run(function() {
+    set(obj, 'people', Ember.A());
+  });
+
+  // Regular CPs are invalidated when their dependent keys change, but array
+  // computeds keep refs up to date
+  deepEqual(titles, [], "value is correct");
+  equal(meta.cache.titles, titles, "value remains cached");
+  ok(meta.deps.people !== undefined, "people has dependencies");
+  deepEqual(keys(meta.deps.people), ["titles"], "meta.deps.people is unchanged");
+  equal(meta.deps.people.titles, 1, "deps.people.titles is unchanged");
+  equal(meta.watching.people, 2, "watching.people is unchanged");
+});
 
 if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
   module('Ember.arryComputed - self chains', {


### PR DESCRIPTION
`Em.arrayComputed` is not presently compatible with lazy CPs. There are a few 
issues.
1.  To keep refs up to date, observers stay around as long as the object does. 
2.  Those observers can repopulate the cache, but when they do so they fail to
   add dependent keys when the cache was empty.

This commit works around 2. by not removing them in the first place. 
Essentially the semantics for `ArrayComputedProperty`s differ from standard
`ComputedProperty`s with regards to laziness.

These observers need to be managed better.  Probably the right thing to do,
now that `recomputeOnce` is no longer necessary, is to:
1. Fix `Em.computed.sort` to not use `recomputeOnce`;
2. Fix `Em.arrayComputed` to return a proxy to the cached value;
3. Teardown array observers when the deps count hits 0.

This will give reduce computed properties semantics much closer to regular 
computed properties.  There are two important points to note about this 
suggestion:
1.  The cached values would still update synchronously.  This can be improved
   with a lazy array implementation and @wycats's skiplist strategy. 
2.  The semantics of an array computed would change such that existing refs
   would only be kept up to date as long as the cache had not been invalidated.
   This is probably fine: the current behaviour is not promised in the
   documentation anywhere and it would be pretty bad practice to keep references
   around rather than `Ember.get`ing them.
