### PR TITLE
[FEATURE with-controller]: {{#with}} can take a controller= option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Ember 1.4.0 _(TBD)_
 
 * In canary
+* {{#with}} can take a controller= option for wrapping the context. Must be an `Ember.ObjectController`
 
 ### Ember 1.3.0 _(TBD)_
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -110,3 +110,9 @@ for a detailed explanation.
   element.
 
   Added in [#3792](https://github.com/emberjs/ember.js/pull/3792).
+
+* `with-controller`
+
+  Enables `{{#with}}` to take a `controller=` option for wrapping the context.
+
+  Added in [#3722](https://github.com/emberjs/ember.js/pull/3722)

--- a/features.json
+++ b/features.json
@@ -9,5 +9,6 @@
   "ember-handlebars-caps-lookup": null,
   "ember-testing-simple-setup": null,
   "ember-testing-routing-helpers": null,
-  "ember-testing-triggerEvent-helper": null
+  "ember-testing-triggerEvent-helper": null,
+  "with-controller": null
 }

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -66,6 +66,14 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
         templateData: options.data
       });
 
+      if (Ember.FEATURES.isEnabled('with-controller'))  {
+        if (options.hash.controller) {
+          bindView.set('contextController', this.container.lookupFactory('controller:'+options.hash.controller).create({
+            container: currentContext
+          }));
+        }
+      }
+
       view.appendChild(bindView);
 
       observer = function() {

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -282,6 +282,12 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
         preserveContext = get(this, 'preserveContext'),
         context = get(this, 'previousContext');
 
+    var contextController;
+
+    if (Ember.FEATURES.isEnabled('with-controller')) {
+      contextController = get(this, 'contextController');
+    }
+
     var inverseTemplate = get(this, 'inverseTemplate'),
         displayTemplate = get(this, 'displayTemplate');
 
@@ -301,6 +307,12 @@ Ember._HandlebarsBoundView = Ember._MetamorphView.extend({
       // Otherwise, determine if this is a block bind or not.
       // If so, pass the specified object to the template
         if (displayTemplate) {
+          if (Ember.FEATURES.isEnabled('with-controller')) {
+            if (contextController) {
+              set(contextController, 'content', result);
+              result = contextController;
+            }
+          }
           set(this, '_context', result);
         } else {
         // This is not a bind block, just push the result of the

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -233,3 +233,49 @@ test("it should render without fail", function() {
     view.destroy();
   });
 });
+
+if (Ember.FEATURES.isEnabled('with-controller')) {
+  module("Handlebars {{#with foo}} with defined controller");
+
+  test("it should wrap context with object controller", function() {
+    var Controller = Ember.ObjectController.extend({
+      controllerName: Ember.computed(function() {
+        return "controller:"+this.get('content.name');
+      })
+    });
+
+    var person = Ember.Object.create({name: 'Steve Holt'});
+    var container = new Ember.Container();
+
+    var parentController = {
+      container: container
+    };
+
+    view = Ember.View.create({
+      container: container,
+      template: Ember.Handlebars.compile('{{#with view.person controller="person"}}{{controllerName}}{{/with}}'),
+      person: person,
+      controller: parentController
+    });
+
+    container.register('controller:person', Controller);
+
+    appendView(view);
+
+    equal(view.$().text(), "controller:Steve Holt");
+
+    Ember.run(function() {
+      view.rerender();
+    });
+
+    equal(view.$().text(), "controller:Steve Holt");
+
+    Ember.run(function() {
+      person.set('name', 'Gob');
+      view.rerender();
+    });
+
+    equal(view.$().text(), "controller:Gob");
+    Ember.run(function() { view.destroy(); }); // destroy existing view
+  });
+}


### PR DESCRIPTION
Wrap the context for with in an Ember.ObjectController

@stefanpenner and I discussed this feature already. Similar to `{{#each}}` where you can pass the `itemController` for each of the collection member models to be wrapped this PR will do the same but for `{{#with}}`.

I need this for `ember-easyForm`. I plan on adding support for a `{{#fieldsFor relation}}``helper that will take the block. The helper will check to see if the relation is an array. If it is it will call`{{#each}}`and attempt to attach an`itemController`automatically. This way`ember-validations` can be used to assign validations to that controller instead of on the model thus avoiding the need for global validations. This PR would allow me to add support for singular relationships.
