### PR TITLE
[BUGFIX beta]  sort guid fallback unconfused by ObjectProxy.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -1,3 +1,6 @@
+require('ember-runtime/ext/string');
+require('ember-runtime/system/namespace');
+require('ember-runtime/system/object_proxy');
 require('ember-runtime/computed/array_computed');
 
 /**
@@ -11,7 +14,8 @@ var get = Ember.get,
     merge = Ember.merge,
     a_slice = [].slice,
     forEach = Ember.EnumerableUtils.forEach,
-    map = Ember.EnumerableUtils.map;
+    map = Ember.EnumerableUtils.map,
+    SearchProxy;
 
 /**
   A computed property that calculates the maximum value in the
@@ -539,12 +543,15 @@ function binarySearch(array, item, low, high) {
   return mid;
 
   function _guidFor(item) {
-    if (Ember.ObjectProxy.detectInstance(item)) {
+    if (SearchProxy.detectInstance(item)) {
       return guidFor(get(item, 'content'));
     }
     return guidFor(item);
   }
 }
+
+
+SearchProxy = Ember.ObjectProxy.extend();
 
 /**
   A computed property which returns a new array with all the
@@ -687,10 +694,10 @@ Ember.computed.sort = function (itemsKey, sortDefinition) {
       if (changeMeta.previousValues) {
         proxyProperties = merge({ content: item }, changeMeta.previousValues);
 
-        searchItem = Ember.ObjectProxy.create(proxyProperties);
-     } else {
-       searchItem = item;
-     }
+        searchItem = SearchProxy.create(proxyProperties);
+      } else {
+        searchItem = item;
+      }
 
       index = instanceMeta.binarySearch(array, searchItem);
       array.removeAt(index);

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1,4 +1,9 @@
-var map = Ember.EnumerableUtils.map, a_forEach = Ember.ArrayPolyfills.forEach, get = Ember.get, set = Ember.set, setProperties = Ember.setProperties,
+var map = Ember.EnumerableUtils.map,
+    a_forEach = Ember.ArrayPolyfills.forEach,
+    get = Ember.get,
+    set = Ember.set,
+    setProperties = Ember.setProperties,
+    ObjectProxy = Ember.ObjectProxy,
     obj, sorted, sortProps, items, userFnCalls, todos, filtered;
 
 module('Ember.computed.map', {
@@ -674,6 +679,30 @@ function commonSortTests() {
 
 
     deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "sorted array is updated");
+  });
+
+  test("guid sort-order fallback with a serach proxy is not confused by non-search ObjectProxys", function() {
+    var tyrion = { fname: "Tyrion", lname: "Lannister" },
+        tyrionInDisguise = ObjectProxy.create({
+          fname: "Yollo",
+          lname: "",
+          content: tyrion
+        });
+
+    items = get(obj, 'items');
+    sorted = get(obj, 'sortedItems');
+
+    Ember.run(function() {
+      items.pushObject(tyrion);
+    });
+
+    deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Tyrion', 'Bran', 'Robb']);
+
+    Ember.run(function() {
+      items.pushObject(tyrionInDisguise);
+    });
+
+    deepEqual(sorted.mapBy('fname'), ['Yollo', 'Cersei', 'Jaime', 'Tyrion', 'Bran', 'Robb']);
   });
 }
 


### PR DESCRIPTION
`Em.computed.sort` uses a guid check as a fallback comparator.  In order to 
search for items correctly, it also wraps items on removal in an object proxy
to shadow new values with the previous values.

This proxy needs to be sort-equal to the actual object.  To ensure the guid 
fallback check treated the item and the proxy as equal, it had a check
`ObjectProxy.detectInstance`.  This check is obviously deficient in the face
of items that might themselves be `ObjectProxy`s, such as `ObjectController`s
when using `@this` as the base array in an `ArrayController`.

This commit creates a local type of `ObjectProxy`, `SearchProxy`, to avoid
this confusion.
