### PR TITLE
Ember.AutoLocation support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -133,3 +133,21 @@ for a detailed explanation.
   the transition was aborted/redirected within the same run loop.
 
   Added in [#4122](https://github.com/emberjs/ember.js/pull/4122).
+
+* `ember-routing-auto-location`
+
+  Adds `auto` as a `location` option for the app's `Router`.
+
+  ```javascript
+  App.Router.reopen({
+    location: 'auto'
+  });
+  ```
+
+  When used, Ember will select the best location option based off browser
+  support with the priority order: history, hash, none.
+
+  Clean pushState paths accessed by hashchange-only browsers will be redirected
+  to the hash-equivalent and vice versa so future transitions look consistent.
+
+  Added in [#3725](https://github.com/emberjs/ember.js/pull/3725).

--- a/features.json
+++ b/features.json
@@ -15,7 +15,8 @@
     "composable-computed-properties": null,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-metal-is-blank": true,
-    "ember-eager-url-update": true
+    "ember-eager-url-update": true,
+    "ember-routing-auto-location": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -747,6 +747,10 @@ Ember.Application.reopenClass({
     container.register('router:main',  Ember.Router);
     container.injection('router:main', 'namespace', 'application:main');
 
+    if (Ember.FEATURES.isEnabled("ember-routing-auto-location")) {
+      container.register('location:auto', Ember.AutoLocation);
+    }
+    
     container.register('location:hash', Ember.HashLocation);
     container.register('location:history', Ember.HistoryLocation);
     container.register('location:none', Ember.NoneLocation);

--- a/packages/ember-routing/lib/location.js
+++ b/packages/ember-routing/lib/location.js
@@ -3,3 +3,4 @@ require('ember-routing/location/api');
 require('ember-routing/location/none_location');
 require('ember-routing/location/hash_location');
 require('ember-routing/location/history_location');
+require('ember-routing/location/auto_location');

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -1,0 +1,183 @@
+if (Ember.FEATURES.isEnabled("ember-routing-auto-location")) {
+  /**
+  @module ember
+  @submodule ember-routing
+  */
+
+  var get = Ember.get, set = Ember.set;
+  var documentMode = document.documentMode,
+      history = window.history,
+      location = window.location;
+
+  /**
+    Ember.AutoLocation will select the best location option based off browser
+    support with the priority order: history, hash, none.
+
+    Clean pushState paths accessed by hashchange-only browsers will be redirected
+    to the hash-equivalent and vice versa so future transitions look consistent.
+
+    @class AutoLocation
+    @namespace Ember
+    @static
+  */
+  var AutoLocation = Ember.AutoLocation = {
+
+    /**
+      Will be pre-pended to path upon state change.
+
+      @property rootURL
+      @default '/'
+    */
+    rootURL: '/',
+
+    /**
+      @private
+
+      We assume that if the history object has a pushState method, the host should
+      support HistoryLocation.
+
+      @property supportsHistory
+    */
+    supportsHistory: (function () {
+      // Boosted from Modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
+      // The stock browser on Android 2.2 & 2.3 returns positive on history support
+      // Unfortunately support is really buggy and there is no clean way to detect
+      // these bugs, so we fall back to a user agent sniff :(
+      var userAgent = window.navigator.userAgent;
+
+      // We only want Android 2, stock browser, and not Chrome which identifies
+      // itself as 'Mobile Safari' as well
+      if (userAgent.indexOf('Android 2') !== -1 &&
+          userAgent.indexOf('Mobile Safari') !== -1 &&
+          userAgent.indexOf('Chrome') === -1) {
+        return false;
+      }
+
+      return !!(history && 'pushState' in history);
+    })(),
+
+    /**
+      @private
+
+      IE8 running in IE7 compatibility mode gives false positive, so we must also
+      check documentMode.
+
+      @property supportsHashChange
+    */
+    supportsHashChange: ('onhashchange' in window && (documentMode === undefined || documentMode > 7 )),
+
+    create: function (options) {
+      if (options && options.rootURL) {
+        this.rootURL = options.rootURL;
+      }
+
+      var implementationClass, historyPath, hashPath,
+          cancelRouterSetup = false,
+          currentPath = this.getFullPath();
+
+      if (this.supportsHistory) {
+        historyPath = this.getHistoryPath();
+
+        // Since we support history paths, let's be sure we're using them else 
+        // switch the location over to it.
+        if (currentPath === historyPath) {
+          implementationClass = Ember.HistoryLocation;
+        } else {
+          cancelRouterSetup = true;
+          location.replace(historyPath);
+        }
+
+      } else if (this.supportsHashChange) {
+        hashPath = this.getHashPath();
+
+        // Be sure we're using a hashed path, otherwise let's switch over it to so
+        // we start off clean and consistent.
+        if (currentPath === hashPath) {
+          implementationClass = Ember.HashLocation;
+        } else {
+          cancelRouterSetup = true;
+          location.replace(hashPath);
+        }
+      }
+
+      // If none has been set
+      if (!implementationClass) {
+        implementationClass = Ember.NoneLocation;
+      }
+
+      var implementation = implementationClass.create.apply(implementationClass, arguments);
+
+      if (cancelRouterSetup) {
+        set(implementation, 'cancelRouterSetup', true);
+      }
+      
+      return implementation;
+    },
+
+    /**
+      @private
+
+      Returns the current `location.pathname`, normalized for IE inconsistencies.
+
+      @method getPath
+    */
+    getPath: function () {
+      var pathname = location.pathname;
+      // Various versions of IE/Opera don't always return a leading slash
+      if (pathname.charAt(0) !== '/') {
+        pathname = '/' + pathname;
+      }
+
+      return pathname;
+    },
+
+    /**
+      @private
+
+      Returns the full pathname including the hash string.
+
+      @method getFullPath
+    */
+    getFullPath: function () {
+      return this.getPath() + location.hash;
+    },
+
+    /**
+      @private
+
+      Returns the current path as it should appear for HistoryLocation supported
+      browsers. This may very well differ from the real current path (e.g. if it 
+      starts off as a hashed URL)
+
+      @method getHistoryPath
+    */
+    getHistoryPath: function () {
+      var path = this.getPath(),  
+          hashPath = location.hash.substr(1),
+          url = path + hashPath;
+
+      // Removes any stacked double stashes
+      return url.replace(/\/\//, '/');
+    },
+
+    /**
+      @private
+
+      Returns the current path as it should appear for HashLocation supported
+      browsers. This may very well differ from the real current path.
+
+      @method getHashPath
+    */
+    getHashPath: function () {
+      var historyPath = this.getHistoryPath(),
+          exp = new RegExp('(' + this.rootURL + ')(.+)'),
+          url = historyPath.replace(exp, '$1#/$2');
+
+      // Remove any stacked double stashes
+      url = url.replace(/\/\//, '/');
+
+      return url;
+    }
+
+  };
+}

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -75,6 +75,14 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
         container = this.container,
         self = this;
 
+    if (Ember.FEATURES.isEnabled("ember-routing-auto-location")) {
+      // Allow the Location class to cancel the router setup while it refreshes
+      // the page
+      if (get(location, 'cancelRouterSetup')) {
+        return;
+      }
+    }
+
     this._setupRouter(router, location);
 
     container.register('view:default', DefaultView);


### PR DESCRIPTION
The original PR is here https://github.com/emberjs/ember.js/pull/2685.
- [x] Initial implementation
- [x] Consensus on halting Router setup 
- [x] FEATURE flagged
- [x] Unit tests - 1. how do we reliably test this since we can't actually redirect the test host environment? Mock the window.location object to override .replace()? 2. The only current Location class testing is in `/ember/tests/routing/basic_testing.js`, but it's only testing HistoryLocation and not much coverage. I think a separate PR is needed to add coverage to all Location classes..Thoughts?

Some people would like to support the history API but auto fallback to hashchanges in older browsers. The current way they could do that is check for support themselves and dynamically set the location property when they reopen the Router, but this makes it easy for them to not need that boilerplate code and also will transform between the two URL forms for sharing compatibility.

With the AutoLocation class, users can now just use:

``` javascript
App.Router.reopen({
  location: 'auto'
});
```

Let's discuss.

![image](https://f.cloud.github.com/assets/762949/1517912/91c75956-4b2b-11e3-87dc-8cd2b21f3b5a.png)
