### PR TITLE
[BUGFIX beta] Added assert mismatched template compiler version.

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -182,6 +182,8 @@ Ember.Handlebars.registerHelper('blockHelperMissing', function(path) {
 
   if (Ember.FEATURES.isEnabled('container-renderables')) {
 
+    Ember.assert("`blockHelperMissing` was invoked without a helper name, which is most likely due to a mismatch between the version of Ember.js you're running now and the one used to precompile your templates. Please make sure the version of `ember-handlebars-compiler` you're using is up to date.", path);
+
     var helper = Ember.Handlebars.resolveHelper(options.data.view.container, path);
 
     if (helper) {


### PR DESCRIPTION
See #3728. Using an old version of Ember to precompile templates
can result in an unusual error when trying to render a component
in block form, e.g.

```
  {{#my-component}}Hello{{/my-component}}
```

This commit adds an assert to give the user more information
as to what's going on.
