### PR TITLE
[BUGFIX] Correct type of variable initialization

### DIFF
--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -41,7 +41,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       if (POINTER_EVENT_TYPE_REGEX.test(event.type)) {
         return isSimpleClick(event);
       } else {
-        allowedKeys = [];
+        allowedKeys = '';
       }
     }
 


### PR DESCRIPTION
`allowedKeys` should be a string value because it will be passed from template.

Such as:

``` handlebars
<a href="#" {{action "edit" allowedKeys="alt"}}>click me</a>
```

If it is treated as an array, [`allowedKeys.indexOf`](https://github.com/emberjs/ember.js/blob/a51806a2cdc2fc93f8ed3fe6d0d53ab229c455d3/packages/ember-routing/lib/helpers/action.js#L48) doesn't work on old IE.
Because `Array#indexOf` is not defined in old IE.
