### PR TITLE
[BUGFIX beta] Increase precedence of route.controllerName

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1458,10 +1458,12 @@ function normalizeOptions(route, name, template, options) {
 
   if (options.controller) {
     controller = options.controller;
+  } else if (route.controllerName) {
+    controller = route.controllerName;
   } else if (namedController = route.container.lookup('controller:' + name)) {
     controller = namedController;
   } else {
-    controller = route.controllerName || route.routeName;
+    controller = route.routeName;
   }
 
   if (typeof controller === 'string') {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -452,6 +452,7 @@ test("The route controller can be specified via controllerName", function() {
     controllerName: 'myController'
   });
 
+  container.register('controller:home', Ember.Controller.extend());
   container.register('controller:myController', Ember.Controller.extend({
     myValue: "foo"
   }));


### PR DESCRIPTION
Currently a controller specified for a route via the `controllerName`
property is considered too late when the controller for the route is
determined: when a controller with the routeName already exists - for
example it has been used elsewhere in the app before - then it is used,
regardless of `controllerName` being present on the route.

This fix moves the check for a specified `controllerName` before the
route-name-controller-lookup.
