### PR TITLE
[BUGFIX] Register a default RSVP error handler.

### DIFF
--- a/packages/ember-runtime/lib/ext/ember.js
+++ b/packages/ember-runtime/lib/ext/ember.js
@@ -8,3 +8,19 @@
   @constructor
 */
 Ember.RSVP = requireModule('rsvp');
+
+Ember.RSVP.onerrorDefault = function(event) {
+  var error = event.detail;
+
+  if (error instanceof Error) {
+    Ember.Logger.error(error.stack);
+
+    if (Ember.testing) {
+      throw error;
+    } else {
+      Ember.assert(error, false);
+    }
+  }
+};
+
+Ember.RSVP.on('error', Ember.RSVP.onerrorDefault);

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -1,0 +1,15 @@
+module('Ember.RSVP');
+
+test('Ensure that errors thrown from within a promise are sent to the console', function(){
+  var error = new Error('Error thrown in a promise for testing purposes.');
+
+  try {
+    Ember.run(function(){
+      new Ember.RSVP.Promise(function(resolve, reject){
+        throw error;
+      });
+    });
+  } catch (e) {
+    equal(e, error, "error was re-thrown");
+  }
+});

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -18,9 +18,13 @@ module("Ember.PromiseProxy - ObjectProxy", {
     proxy = ObjectPromiseProxy.create({
       promise: deferred.promise
     });
+
+    Ember.RSVP.off('error', Ember.RSVP.onerrorDefault);
   },
   teardown: function() {
     proxy = deferred = null;
+
+    Ember.RSVP.on('error', Ember.RSVP.onerrorDefault);
   }
 });
 

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -401,6 +401,7 @@ Ember.Application.reopen({
     }
 
     Ember.RSVP.on('error', onerror);
+    Ember.RSVP.off('error', Ember.RSVP.onerrorDefault);
   },
 
   /**
@@ -422,6 +423,7 @@ Ember.Application.reopen({
       delete originalMethods[name];
     }
     Ember.RSVP.off('error', onerror);
+    Ember.RSVP.on('error', Ember.RSVP.onerrorDefault);
   }
 
 });


### PR DESCRIPTION
This will significantly improve the users experience when debugging errors
thrown in promises as they will now be logged to the console in development.

This could easily be made into a feature, but in my opinion the sad state of
promise errors is a significant bug (hence the `[BUGFIX beta]` tag).
