### PR TITLE
[BUGFIX beta] {{partial}} helper now works with bound params

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -91,6 +91,8 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
   }
 }
 
+EmberHandlebars.bind = bind;
+
 function simpleBind(currentContext, property, options) {
   var data = options.data,
       view = data.view,

--- a/packages/ember-handlebars/tests/helpers/partial_test.js
+++ b/packages/ember-handlebars/tests/helpers/partial_test.js
@@ -66,3 +66,33 @@ test("should use the current view's context", function() {
 
   equal(Ember.$.trim(view.$().text()), "Who is Kris Selden?");
 });
+
+test("Quoteless parameters passed to {{template}} perform a bound property lookup of the partial name", function() {
+  container.register('template:_subTemplate', Ember.Handlebars.compile("sub-template"));
+  container.register('template:_otherTemplate', Ember.Handlebars.compile("other-template"));
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('This {{partial view.partialName}} is pretty {{partial nonexistent}}great.'),
+    partialName: 'subTemplate'
+  });
+
+  Ember.run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
+
+  Ember.run(function() {
+    view.set('partialName', 'otherTemplate');
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This other-template is pretty great.");
+
+  Ember.run(function() {
+    view.set('partialName', null);
+  });
+
+  equal(Ember.$.trim(view.$().text()), "This  is pretty great.");
+});
+


### PR DESCRIPTION
{{partial name}} will look up `name` on
the present template context and render the partial
whose name is the present value of `name`. If `name`
changes, the partial gets re-rendered. If name is
falsy, nothing gets rendered. If name refers to a
non-existent template/partial, the same assertion you'd
see if you'd explicitly passed in an invalid template/partial
name in string form will fire.
