### PR TITLE
[BUGFIX beta] Adds preserveContext option for #each helper

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -8,12 +8,13 @@ require("ember-handlebars/views/metamorph_view");
 */
 
 var get = Ember.get, set = Ember.set;
-var fmt = Ember.String.fmt;
 
 Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
   init: function() {
     var itemController = get(this, 'itemController');
     var binding;
+
+    this._preserveContext = true;
 
     if (itemController) {
       var controller = get(this, 'controller.container').lookupFactory('controller:array').create({
@@ -41,8 +42,8 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
   },
 
   _assertArrayLike: function(content) {
-    Ember.assert(fmt("The value that #each loops over must be an Array. You passed %@, but it should have been an ArrayController", [content.constructor]), !Ember.ControllerMixin.detect(content) || (content && content.isGenerated) || content instanceof Ember.ArrayController);
-    Ember.assert(fmt("The value that #each loops over must be an Array. You passed %@", [(Ember.ControllerMixin.detect(content) && content.get('model') !== undefined) ? fmt("'%@' (wrapped in %@)", [content.get('model'), content]) : content]), Ember.Array.detect(content));
+    Ember.assert("The value that #each loops over must be an Array. You passed " + content.constructor + ", but it should have been an ArrayController", !Ember.ControllerMixin.detect(content) || (content && content.isGenerated) || content instanceof Ember.ArrayController);
+    Ember.assert("The value that #each loops over must be an Array. You passed " + ((Ember.ControllerMixin.detect(content) && content.get('model') !== undefined) ? ("" + content.get('model') + " (wrapped in " + content + ")") : ("" + content)), Ember.Array.detect(content));
   },
 
   disableContentObservers: function(callback) {

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -194,6 +194,8 @@ Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionVie
   */
   itemViewClass: Ember.View,
 
+  _preserveContext: false,
+
   /**
     Setup a CollectionView
 
@@ -331,7 +333,8 @@ Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionVie
   */
   arrayDidChange: function(content, start, removed, added) {
     var addedViews = [], view, item, idx, len, itemViewClass,
-      emptyView;
+        attrs,
+        emptyView;
 
     len = content ? get(content, 'length') : 0;
 
@@ -347,10 +350,17 @@ Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionVie
       for (idx = start; idx < start+added; idx++) {
         item = content.objectAt(idx);
 
-        view = this.createChildView(itemViewClass, {
+        attrs = {
           content: item,
           contentIndex: idx
-        });
+        };
+
+        if (!this._preserveContext) {
+          attrs.context = item;
+          attrs.controller = item;
+        }
+
+        view = this.createChildView(itemViewClass, attrs);
 
         addedViews.push(view);
       }

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -509,6 +509,35 @@ test("should not render the emptyView if content is emptied and refilled in the 
   equal(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, 0);
 });
 
+test("item view class template should be executed in the context of array item when using collection view with array controller", function() {
+  var array = Ember.A([{ name: "Other Katz" }]);
+
+  var controller = Ember.ArrayController.create({
+    content: array
+  });
+
+  var ContainerClass = Ember.CollectionView.extend({
+    tagName: 'ul',
+    content: controller,
+    itemViewClass: Ember.View.extend({
+      template: Handlebars.compile('{{name}}')
+    })
+  });
+
+  var container = ContainerClass.create();
+
+  Ember.run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  equal(container.$('li').length, 1, '1 list element should be in the DOM');
+  equal(container.$('li').text(), 'Other Katz', 'text of item view class\' template should be "Other Katz"');
+
+  Ember.run(function() {
+    container.destroy();
+  });
+});
+
 test("a array_proxy that backs an sorted array_controller that backs a collection view functions properly", function() {
 
   var array = Ember.A([{ name: "Other Katz" }]);


### PR DESCRIPTION
Since [3100](https://github.com/emberjs/ember.js/pull/3100) is kinda stale, I decided to take another stab at it.

It adds `preserveContext` property to `CollectionView` to fix problems `each` helper and makes `itemViewClass` property work with `ArrayController`.

Fixes #3086.

/cc @stefanpenner @wagenet @kselden @jvdneut @rjackson 
