### PR TITLE
Actions warning

### DIFF
--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -32,6 +32,8 @@ Ember.ActionHandler = Ember.Mixin.create({
     var hashName;
 
     if (!props._actions) {
+      Ember.assert(this + " 'actions' should not be a function", typeof(props.actions) !== 'function');
+
       if (typeOf(props.actions) === 'object') {
         hashName = 'actions';
       } else if (typeOf(props.events) === 'object') {

--- a/packages/ember-runtime/tests/mixins/action_handler_test.js
+++ b/packages/ember-runtime/tests/mixins/action_handler_test.js
@@ -1,0 +1,13 @@
+test("passing a function for the actions hash triggers an assertion", function() {
+  expect(1);
+
+  var controller = Ember.Controller.extend({
+    actions: function(){}
+  });
+
+  expectAssertion(function(){
+    Ember.run(function(){
+      controller.create();
+    });
+  });
+});


### PR DESCRIPTION
Since almost every property on a class definition is a function, it's easy to accidentally say this out of habit:

``` javascript

App.MyController = Ember.Controller.extend({
  actions: function() {
    doThing: function() { ... }
  }
});

```

When you meant to say this:

``` javascript

App.MyController = Ember.Controller.extend({
  actions: {
    doThing: function() { ... }
  }
});

```

The above doesn't produce any error or warning, it just makes your handlers invisible. My change adds a warning.
