### PR TITLE
Store Router.location in container.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -749,6 +749,10 @@ Ember.Application.reopenClass({
     container.register('router:main',  Ember.Router);
     container.injection('router:main', 'namespace', 'application:main');
 
+    container.register('location:hash', Ember.HashLocation);
+    container.register('location:history', Ember.HistoryLocation);
+    container.register('location:none', Ember.NoneLocation);
+
     container.injection('controller', 'target', 'router:main');
     container.injection('controller', 'namespace', 'application:main');
 

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -79,6 +79,8 @@ Ember.Location = {
     @param {Object} implementation of the `location` API
   */
   registerImplementation: function(name, implementation) {
+    Ember.deprecate('Using the Ember.Location.registerImplementation is no longer supported. Register your custom location implementation with the container instead.', false);
+
     this.implementations[name] = implementation;
   },
 

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -15,6 +15,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Object
 */
 Ember.HashLocation = Ember.Object.extend({
+  implementation: 'hash',
 
   init: function() {
     set(this, 'location', get(this, 'location') || window.location);
@@ -127,5 +128,3 @@ Ember.HashLocation = Ember.Object.extend({
     Ember.$(window).off('hashchange.ember-location-'+guid);
   }
 });
-
-Ember.Location.registerImplementation('hash', Ember.HashLocation);

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -16,6 +16,7 @@ var supportsHistoryState = window.history && 'state' in window.history;
   @extends Ember.Object
 */
 Ember.HistoryLocation = Ember.Object.extend({
+  implementation: 'history',
 
   init: function() {
     set(this, 'location', get(this, 'location') || window.location);
@@ -214,5 +215,3 @@ Ember.HistoryLocation = Ember.Object.extend({
     Ember.$(window).off('popstate.ember-location-'+guid);
   }
 });
-
-Ember.Location.registerImplementation('history', Ember.HistoryLocation);

--- a/packages/ember-routing/lib/location/none_location.js
+++ b/packages/ember-routing/lib/location/none_location.js
@@ -16,6 +16,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Object
 */
 Ember.NoneLocation = Ember.Object.extend({
+  implementation: 'none',
   path: '',
 
   /**
@@ -90,5 +91,3 @@ Ember.NoneLocation = Ember.Object.extend({
     return url;
   }
 });
-
-Ember.Location.registerImplementation('none', Ember.NoneLocation);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -121,13 +121,6 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     this.router.reset();
   },
 
-  willDestroy: function(){
-    var location = get(this, 'location');
-    location.destroy();
-
-    this._super.apply(this, arguments);
-  },
-
   _lookupActiveView: function(templateName) {
     var active = this._activeViews[templateName];
     return active && active[0];
@@ -150,16 +143,23 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
   _setupLocation: function() {
     var location = get(this, 'location'),
-        rootURL = get(this, 'rootURL'),
-        options = {};
+        rootURL = get(this, 'rootURL');
 
-    if (typeof rootURL === 'string') {
-      options.rootURL = rootURL;
+    if ('string' === typeof location && this.container) {
+      var resolvedLocation = this.container.lookup('location:' + location);
+
+      if ('undefined' !== typeof resolvedLocation) {
+        location = set(this, 'location', resolvedLocation);
+      } else {
+        // Allow for deprecated registration of custom location API's
+        var options = {implementation: location};
+
+        location = set(this, 'location', Ember.Location.create(options));
+      }
     }
 
-    if ('string' === typeof location) {
-      options.implementation = location;
-      location = set(this, 'location', Ember.Location.create(options));
+    if (typeof rootURL === 'string') {
+      location.rootURL = rootURL;
     }
   },
 

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -20,6 +20,8 @@ var buildContainer = function(namespace) {
   container.register('application:main', namespace, { instantiate: false });
   container.injection('router:main', 'namespace', 'application:main');
 
+  container.register('location:hash', Ember.HashLocation);
+
   container.register('controller:basic', Ember.Controller, { instantiate: false });
   container.register('controller:object', Ember.ObjectController, { instantiate: false });
   container.register('controller:array', Ember.ArrayController, { instantiate: false });

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -1,8 +1,15 @@
-var Router;
+var Router, container, router;
 
 module("Ember Router", {
   setup: function() {
+    container = new Ember.Container();
+
+    //register the HashLocation (the default)
+    container.register('location:hash', Ember.HashLocation);
+
     Router = Ember.Router.extend();
+
+    router = Router.create({container: container});
   },
   teardown: function() {
     Router = null;
@@ -10,16 +17,13 @@ module("Ember Router", {
 });
 
 test("should create a router if one does not exist on the constructor", function() {
-  var router = Router.create();
   ok(router.router);
 });
 
-test("should destroy its location upon Router.destroy.", function(){
-  var router = Router.create(),
-      location = router.get('location');
+test("should destroy its location upon destroying the routers container.", function(){
+  var location = router.get('location');
 
-  Ember.run(router, 'destroy');
+  Ember.run(container, 'destroy');
 
-  ok(router.isDestroyed, "router should be destroyed");
   ok(location.isDestroyed, "location should be destroyed");
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1880,7 +1880,8 @@ test("Router accounts for rootURL on page load when using history location", fun
     }
   });
 
-  Ember.Location.registerImplementation('historyTest', HistoryTestLocation);
+
+  container.register('location:historyTest', HistoryTestLocation);
 
   Router.reopen({
     location: 'historyTest',
@@ -1901,9 +1902,6 @@ test("Router accounts for rootURL on page load when using history location", fun
   bootApplication();
 
   ok(postsTemplateRendered, "Posts route successfully stripped from rootURL");
-
-  // clean after test
-  delete Ember.Location.implementations['historyTest'];
 });
 
 test("HistoryLocation has the correct rootURL on initState and webkit doesn't fire popstate on page load", function() {
@@ -1925,7 +1923,7 @@ test("HistoryLocation has the correct rootURL on initState and webkit doesn't fi
     }
   });
 
-  Ember.Location.registerImplementation('historyTest', HistoryTestLocation);
+  container.register('location:historyTest', HistoryTestLocation);
 
   Router.reopen({
     location: 'historyTest',
@@ -1933,9 +1931,6 @@ test("HistoryLocation has the correct rootURL on initState and webkit doesn't fi
   });
 
   bootApplication();
-
-  // clean after test
-  delete Ember.Location.implementations['historyTest'];
 });
 
 
@@ -2604,4 +2599,40 @@ test("Route model hook finds the same model as a manual find", function() {
   handleURL('/post/1');
 
   equal(App.Post, Post);
+});
+
+test("Can register an implementation via Ember.Location.registerImplementation", function(){
+  Ember.TESTING_DEPRECATION = true;
+
+  var TestLocation = Ember.NoneLocation.extend({
+    implementation: 'test'
+  });
+
+  Ember.Location.registerImplementation('test', TestLocation);
+
+  Router.reopen({
+    location: 'test'
+  });
+
+  bootApplication();
+
+  equal(router.get('location.implementation'), 'test', 'custom location implementation can be registered with registerImplementation');
+
+  Ember.TESTING_DEPRECATION = false;
+});
+
+test("Ember.Location.registerImplementation is deprecated", function(){
+  Ember.ENV.RAISE_ON_DEPRECATION = true;
+
+  var TestLocation = Ember.NoneLocation.extend({
+    implementation: 'test'
+  });
+
+  try{
+    Ember.Location.registerImplementation('test', TestLocation);
+  } catch(e) {
+    equal(e.message, "Using the Ember.Location.registerImplementation is no longer supported. Register your custom location implementation with the container instead.", "deprecation warning is present");
+  }
+
+  Ember.ENV.RAISE_ON_DEPRECATION = false;
 });


### PR DESCRIPTION
This was suggested in #3702, but since that PR targeted the beta branch we decided not to make significant structural changes.

This enables the location to be looked up from the container (instead of manually created).

Deprecates usage of `Ember.Location.registerImplementation`.

Resolves #3803.
