### PR TITLE
[FEATURE propertyBraceExpansion] Brace-expansion only in declarative form.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add query params support to the ember router. You can now define which query params your routes respond to, use them in your route hooks to affect model loading or controller state, and transition query parameters with the link-to helper and the transitionTo method
 * Add named substates; e.g. when resolving a `loading` or `error` substate to enter, Ember will take into account the name of the immediate child route that the `error`/`loading` action originated from, e.g. 'foo' if `FooRoute`, and try and enter `foo_error` or `foo_loading` if it exists. This also adds the ability for a top-level `application_loading` or `application_error` state to be entered for `loading`/`error` events emitted from `ApplicationRoute`.
 * Ensure Handlebars values starting with capital letters are always looked up on `Ember.lookup`.
+* Add simple brace expansion for dependent keys and watched properties specified declaratively.  This is primarily useful with reduce computed properties, for specifying dependencies on multiple item properties of a dependent array, as with `Ember.computed.sort('items.@each.{propertyA,propertyB}', userSortFn)`.
 
 ### Ember 1.2.0 _(TBD)_
 

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -281,21 +281,21 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
   @chainable
 */
 ComputedPropertyPrototype.property = function() {
-  var addArg;
+  var args;
 
   if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    // Slightly odd setup to keep JSHint happy
-    addArg = function(arg) { args.push(arg); };
+    var addArg = function (property) {
+      args.push(property); 
+    };
+
+    args = [];
+    for (var i = 0, l = arguments.length; i < l; i++) {
+      expandProperties(arguments[i], addArg);
+    }
+  } else {
+    args = a_slice.call(arguments);
   }
 
-  var args = [];
-  for (var i = 0, l = arguments.length; i < l; i++) {
-    if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-      expandProperties(arguments[i], addArg);
-    } else {
-      args.push(arguments[i]);
-    }
-  }
   this._dependentKeys = args;
   return this;
 };

--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -2,20 +2,20 @@ require('ember-metal/core');
 require('ember-metal/utils');
 
 
-/**
-  @module ember-metal
-*/
-
 if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  /**
+    @module ember-metal
+  */
+
   var forEach = Ember.EnumerableUtils.forEach,
-      IS_BRACE_EXPANSION = /^\{([^.]*)\}$/;
+      BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
 
   /**
     Expands `pattern`, invoking `callback` for each expansion.
 
     The only pattern supported is brace-expansion, anything else will be passed
-    once to `callback` directly.  Furthermore, brace-expansion is only applied to
-    the entire pattern, not to substrings.
+    once to `callback` directly. Brace expansion can only appear at the end of a
+    pattern, for example as the last item in a chain.
 
     Example
     ```js
@@ -23,7 +23,8 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
 
     Ember.expandProperties('foo.bar', echo);        //=> 'foo.bar'
     Ember.expandProperties('{foo,bar}', echo);      //=> 'foo', 'bar'
-    Ember.expandProperties('foo.{bar,baz}', echo);  //=> 'foo.{bar,baz}'
+    Ember.expandProperties('foo.{bar,baz}', echo);  //=> 'foo.bar', 'foo.baz'
+    Ember.expandProperties('{foo,bar}.baz', echo);  //=> '{foo,bar}.baz'
     ```
 
     @method
@@ -33,11 +34,17 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
     expansion, and is passed the expansion.
   */
   Ember.expandProperties = function (pattern, callback) {
-    if (IS_BRACE_EXPANSION.test(pattern)) {
-      forEach(pattern.substring(1, pattern.length-1).split(','), callback);
-      return;
-    }
+    var match, prefix, list;
 
-    callback(pattern);
+    if (match = BRACE_EXPANSION.exec(pattern)) {
+      prefix = match[1];
+      list = match[2];
+
+      forEach(list.split(','), function (suffix) {
+        callback(prefix + suffix);
+      });
+    } else {
+      callback(pattern);
+    }
   };
 }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -2,6 +2,7 @@ require('ember-metal/core');
 require('ember-metal/property_get');
 require('ember-metal/computed');
 require('ember-metal/properties');
+require('ember-metal/expand_properties');
 require('ember-metal/observer');
 require('ember-metal/utils');
 require('ember-metal/array');
@@ -20,6 +21,10 @@ var Mixin, REQUIRED, Alias,
     o_create = Ember.create,
     defineProperty = Ember.defineProperty,
     guidFor = Ember.guidFor;
+
+if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+  var expandProperties = Ember.expandProperties;
+}
 
 function mixinsMeta(obj) {
   var m = Ember.meta(obj, true), ret = m.mixins;
@@ -674,13 +679,33 @@ Ember.aliasMethod = function(methodName) {
 */
 Ember.observer = function() {
   var func  = a_slice.call(arguments, -1)[0];
-  var paths = a_slice.call(arguments, 0, -1);
+  var paths;
 
-  if (typeof func !== "function") {
-    // revert to old, soft-deprecated argument ordering
+  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+    var addWatchedProperty = function (path) { paths.push(path); };
+    var _paths = a_slice.call(arguments, 0, -1);
 
-    func  = arguments[0];
-    paths = a_slice.call(arguments, 1);
+    if (typeof func !== "function") {
+      // revert to old, soft-deprecated argument ordering
+
+      func  = arguments[0];
+      _paths = a_slice.call(arguments, 1);
+    }
+
+    paths = [];
+
+    for (var i=0; i<_paths.length; ++i) {
+      expandProperties(_paths[i], addWatchedProperty);
+    }
+  } else {
+    paths = a_slice.call(arguments, 0, -1);
+
+    if (typeof func !== "function") {
+      // revert to old, soft-deprecated argument ordering
+
+      func  = arguments[0];
+      paths = a_slice.call(arguments, 1);
+    }
   }
 
   if (typeof func !== "function") {
@@ -768,13 +793,34 @@ Ember.immediateObserver = function() {
 */
 Ember.beforeObserver = function() {
   var func  = a_slice.call(arguments, -1)[0];
-  var paths = a_slice.call(arguments, 0, -1);
+  var paths;
 
-  if (typeof func !== "function") {
-    // revert to old, soft-deprecated argument ordering
+  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
+    var addWatchedProperty = function(path) { paths.push(path); };
 
-    func  = arguments[0];
-    paths = a_slice.call(arguments, 1);
+    var _paths = a_slice.call(arguments, 0, -1);
+
+    if (typeof func !== "function") {
+      // revert to old, soft-deprecated argument ordering
+
+      func  = arguments[0];
+      _paths = a_slice.call(arguments, 1);
+    }
+
+    paths = [];
+
+    for (var i=0; i<_paths.length; ++i) {
+      expandProperties(_paths[i], addWatchedProperty);
+    }
+  } else {
+    paths = a_slice.call(arguments, 0, -1);
+
+    if (typeof func !== "function") {
+      // revert to old, soft-deprecated argument ordering
+
+      func  = arguments[0];
+      paths = a_slice.call(arguments, 1);
+    }
   }
 
   if (typeof func !== "function") {

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -1,7 +1,6 @@
 require('ember-metal/core');
 require('ember-metal/platform');
 require('ember-metal/utils'); // Ember.tryFinally
-require('ember-metal/expand_properties');
 require('ember-metal/property_get');
 require('ember-metal/array');
 
@@ -11,10 +10,6 @@ require('ember-metal/array');
 
 var AFTER_OBSERVERS = ':change',
     BEFORE_OBSERVERS = ':before';
-
-if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-  var expandProperties = Ember.expandProperties;
-}
 
 function changeEvent(keyName) {
   return keyName+AFTER_OBSERVERS;
@@ -32,15 +27,8 @@ function beforeEvent(keyName) {
   @param {Function|String} [method]
 */
 Ember.addObserver = function(obj, _path, target, method) {
-  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    expandProperties(_path, function (path) {
-      Ember.addListener(obj, changeEvent(path), target, method);
-      Ember.watch(obj, path);
-    });
-  } else {
-    Ember.addListener(obj, changeEvent(_path), target, method);
-    Ember.watch(obj, _path);
-  }
+  Ember.addListener(obj, changeEvent(_path), target, method);
+  Ember.watch(obj, _path);
 
   return this;
 };
@@ -57,15 +45,9 @@ Ember.observersFor = function(obj, path) {
   @param {Function|String} [method]
 */
 Ember.removeObserver = function(obj, _path, target, method) {
-  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    expandProperties(_path, function (path) {
-      Ember.unwatch(obj, path);
-      Ember.removeListener(obj, changeEvent(path), target, method);
-    });
-  } else {
-    Ember.unwatch(obj, _path);
-    Ember.removeListener(obj, changeEvent(_path), target, method);
-  }
+  Ember.unwatch(obj, _path);
+  Ember.removeListener(obj, changeEvent(_path), target, method);
+
   return this;
 };
 
@@ -77,15 +59,9 @@ Ember.removeObserver = function(obj, _path, target, method) {
   @param {Function|String} [method]
 */
 Ember.addBeforeObserver = function(obj, _path, target, method) {
-  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    expandProperties(_path, function (path) {
-      Ember.addListener(obj, beforeEvent(path), target, method);
-      Ember.watch(obj, path);
-    });
-  } else {
-    Ember.addListener(obj, beforeEvent(_path), target, method);
-    Ember.watch(obj, _path);
-  }
+  Ember.addListener(obj, beforeEvent(_path), target, method);
+  Ember.watch(obj, _path);
+
   return this;
 };
 
@@ -125,14 +101,8 @@ Ember.beforeObserversFor = function(obj, path) {
   @param {Function|String} [method]
 */
 Ember.removeBeforeObserver = function(obj, _path, target, method) {
-  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    expandProperties(_path, function (path) {
-      Ember.unwatch(obj, path);
-      Ember.removeListener(obj, beforeEvent(path), target, method);
-    });
-  } else {
-    Ember.unwatch(obj, _path);
-    Ember.removeListener(obj, beforeEvent(_path), target, method);
-  }
+  Ember.unwatch(obj, _path);
+  Ember.removeListener(obj, beforeEvent(_path), target, method);
+
   return this;
 };

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -1,7 +1,6 @@
 require('ember-metal/core');
 require('ember-metal/platform');
 require('ember-metal/utils');
-require('ember-metal/expand_properties');
 require('ember-metal/property_get');
 require('ember-metal/properties');
 require('ember-metal/watch_key');
@@ -22,10 +21,6 @@ var metaFor = Ember.meta, // utils.js
     typeOf = Ember.typeOf, // utils.js
     generateGuid = Ember.generateGuid,
     IS_PATH = /[\.\*]/;
-
-if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-  var expandProperties = Ember.expandProperties;
-}
 
 // returns true if the passed path is just a keyName
 function isKeyName(path) {
@@ -50,20 +45,10 @@ Ember.watch = function(obj, _keyPath) {
   // can't watch length on Array - it is special...
   if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    expandProperties(_keyPath, function (keyPath) {
-      if (isKeyName(keyPath)) {
-        watchKey(obj, keyPath);
-      } else {
-        watchPath(obj, keyPath);
-      }
-    });
+  if (isKeyName(_keyPath)) {
+    watchKey(obj, _keyPath);
   } else {
-    if (isKeyName(_keyPath)) {
-      watchKey(obj, _keyPath);
-    } else {
-      watchPath(obj, _keyPath);
-    }
+    watchPath(obj, _keyPath);
   }
 };
 
@@ -78,20 +63,10 @@ Ember.unwatch = function(obj, _keyPath) {
   // can't watch length on Array - it is special...
   if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-    expandProperties(_keyPath, function (keyPath) {
-      if (isKeyName(keyPath)) {
-        unwatchKey(obj, keyPath);
-      } else {
-        unwatchPath(obj, keyPath);
-      }
-    });
+  if (isKeyName(_keyPath)) {
+    unwatchKey(obj, _keyPath);
   } else {
-    if (isKeyName(_keyPath)) {
-      unwatchKey(obj, _keyPath);
-    } else {
-      unwatchPath(obj, _keyPath);
-    }
+    unwatchPath(obj, _keyPath);
   }
 };
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -394,24 +394,25 @@ testBoth('redefining a property should undo old depenent keys', function(get ,se
 });
 
 if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-  testBoth('can watch multiple dependent keys specified via brace expansion', function (get, set) {
+  testBoth('can watch multiple dependent keys specified declaratively via brace expansion', function (get, set) {
     Ember.defineProperty(obj, 'foo', Ember.computed(function(key, value) {
       count++;
       return 'foo '+count;
-    }).property('{bar,baz}'));
+    }).property('qux.{bar,baz}'));
 
     equal(get(obj, 'foo'), 'foo 1', "get once");
     equal(get(obj, 'foo'), 'foo 1', "cached retrieve");
 
-    set(obj, 'bar', 'bar'); // invalidate foo
+    set(obj, 'qux', {});
+    set(obj, 'qux.bar', 'bar'); // invalidate foo
 
     equal(get(obj, 'foo'), 'foo 2', "foo invalidated from bar");
 
-    set(obj, 'baz', 'baz'); // invalidate foo
+    set(obj, 'qux.baz', 'baz'); // invalidate foo
 
     equal(get(obj, 'foo'), 'foo 3', "foo invalidated from baz");
 
-    set(obj, 'quux', 'quux'); // do not invalidate foo
+    set(obj, 'qux.quux', 'quux'); // do not invalidate foo
 
     equal(get(obj, 'foo'), 'foo 3', "foo not invalidated by quux");
   });

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -26,26 +26,6 @@ module('Ember.unwatch', {
   }
 });
 
-if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-  testBoth("unwatching multiple properties specified via brace expansion", function(get, set) {
-    var obj = { foo: null, bar: null, baz: null };
-
-    Ember.watch(obj, 'foo');
-    Ember.watch(obj, 'bar');
-    Ember.watch(obj, 'baz');
-    
-    equal(Ember.isWatching(obj, 'foo'), true, "precond - initially watching foo");
-    equal(Ember.isWatching(obj, 'bar'), true, "precond - initially watching bar");
-    equal(Ember.isWatching(obj, 'baz'), true, "precond - initially watching baz");
-
-    Ember.unwatch(obj, '{foo,bar,baz}');
-
-    equal(Ember.isWatching(obj, 'foo'), false, "unwatching foo from brace expansion");
-    equal(Ember.isWatching(obj, 'bar'), false, "unwatching bar from brace expansion");
-    equal(Ember.isWatching(obj, 'baz'), false, "unwatching baz from brace expansion");
-  });
-}
-
 testBoth('unwatching a computed property - regular get/set', function(get, set) {
 
   var obj = {};

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -25,22 +25,6 @@ function addListeners(obj, keyPath) {
   });
 }
 
-if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
-  testBoth("watching multiple properties specified via brace expansion", function(get, set) {
-    var obj = { foo: null, bar: null, baz: null };
-
-    equal(Ember.isWatching(obj, 'foo'), false, "precond - not initially watching foo");
-    equal(Ember.isWatching(obj, 'bar'), false, "precond - not initially watching bar");
-    equal(Ember.isWatching(obj, 'baz'), false, "precond - not initially watching baz");
-
-    Ember.watch(obj, '{foo,bar,baz}');
-
-    equal(Ember.isWatching(obj, 'foo'), true, "watching foo from brace expansion");
-    equal(Ember.isWatching(obj, 'bar'), true, "watching bar from brace expansion");
-    equal(Ember.isWatching(obj, 'baz'), true, "watching baz from brace expansion");
-  });
-}
-
 testBoth('watching a computed property', function(get, set) {
 
   var obj = {};


### PR DESCRIPTION
For performance reasons, property brace expansion is now only supported in declarative form.  This is very unlikely to affect any users.

So the following works:

``` js
var obj = { name: 'Edmure Tully', title: 'Lord Paramount of the Trident' };
Ember.mixin(obj, {
  tridentObserver: function () {
  }.observes('{name,title}')
});
```

While the following does not:

``` js
var obj = { name: 'Edmure Tully', title: 'Lord Paramount of the Trident' };
Ember.addObserver(obj, '{name,title}', function () {});
```
## Moar
- [x] expand in function forms (`Ember.observer` &c.)
