### PR TITLE
[BUGFIX beta] Use RegExp.test() for Ember.computed.match.

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -742,7 +742,7 @@ registerComputed('bool', function(dependentKey) {
 */
 registerComputed('match', function(dependentKey, regexp) {
   var value = get(this, dependentKey);
-  return typeof value === 'string' ? !!value.match(regexp) : false;
+  return typeof value === 'string' ? regexp.test(value) : false;
 });
 
 /**


### PR DESCRIPTION
After a bit of research I believe that `RegExp.test` is quite a bit faster and results in clearer code (as it returns a boolean instead of a match array).

Quote from the MDN article on `String.match`:

```
If you need to know if a string matches a regular expression regexp, use
regexp.test(string).
```

Supporting research:

http://jsperf.com/test-vs-match-regex 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test 
ttp://stackoverflow.com/a/10940138/1157494

Resolves #3746.
