### PR TITLE
Make Ember.Object.createWithMixins behave like extend().create().

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -27,7 +27,8 @@ var set = Ember.set, get = Ember.get,
     finishPartial = Mixin.finishPartial,
     reopen = Mixin.prototype.reopen,
     MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER,
-    indexOf = Ember.EnumerableUtils.indexOf;
+    indexOf = Ember.EnumerableUtils.indexOf,
+    a_slice = [].slice;
 
 var undefinedDescriptor = {
   configurable: true,
@@ -517,7 +518,15 @@ var ClassMixin = Mixin.create({
   */
   createWithMixins: function() {
     var C = this;
-    if (arguments.length>0) { this._initMixins(arguments); }
+    if (arguments.length>0) {
+      if (!(arguments[arguments.length - 1] instanceof Mixin)) {
+        this._initMixins(a_slice.call(arguments, 0, arguments.length - 1));
+        this._initProperties(a_slice.call(arguments, arguments.length - 1));
+      } else {
+        this._initMixins(arguments);
+      }
+    }
+
     return new C();
   },
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -10,7 +10,7 @@ module('Ember.computed.map', {
   setup: function() {
     Ember.run(function() {
       userFnCalls = 0;
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
 
         mapped: Ember.computed.map('array.@each.v', function(item) {
@@ -26,7 +26,7 @@ module('Ember.computed.map', {
             name: item.v.name
           };
         })
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -73,10 +73,10 @@ test("it maps simple unshifted properties", function() {
   var array = Ember.A([]);
 
   Ember.run(function() {
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       array: array,
       mapped: Ember.computed.map('array', function (item) { return item.toUpperCase(); })
-    });
+    }).create();
     get(obj, 'mapped');
   });
 
@@ -118,12 +118,12 @@ test("it maps unshifted objects with property observers", function() {
       cObj = { v: 'c' };
 
   Ember.run(function() {
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       array: array,
       mapped: Ember.computed.map('array.@each.v', function (item) {
         return get(item, 'v').toUpperCase();
       })
-    });
+    }).create();
     get(obj, 'mapped');
   });
 
@@ -142,10 +142,10 @@ test("it maps unshifted objects with property observers", function() {
 module('Ember.computed.mapBy', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
         mapped: Ember.computed.mapBy('array', 'v')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -195,13 +195,13 @@ module('Ember.computed.filter', {
   setup: function() {
     Ember.run(function() {
       userFnCalls = 0;
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         array: Ember.A([1, 2, 3, 4, 5, 6, 7, 8]),
         filtered: Ember.computed.filter('array', function(item) {
           ++userFnCalls;
           return item % 2 === 0;
         })
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -305,7 +305,7 @@ test("it updates as the array is replaced", function() {
 
 module('Ember.computed.filterBy', {
   setup: function() {
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       array: Ember.A([
         {name: "one", a:1, b:false},
         {name: "two", a:2, b:false},
@@ -315,7 +315,7 @@ module('Ember.computed.filterBy', {
       a1s: Ember.computed.filterBy('array', 'a', 1),
       as: Ember.computed.filterBy('array', 'a'),
       bs: Ember.computed.filterBy('array', 'b')
-    });
+    }).create();
   },
   teardown: function() {
     Ember.run(function() {
@@ -388,12 +388,12 @@ a_forEach.call(['uniq', 'union'], function (alias) {
   module('Ember.computed.' + alias, {
     setup: function() {
       Ember.run(function() {
-        obj = Ember.Object.createWithMixins({
+        obj = Ember.Object.extend({
           array: Ember.A([1,2,3,4,5,6]),
           array2: Ember.A([4,5,6,7,8,9,4,5,6,7,8,9]),
           array3: Ember.A([1,8,10]),
           union: Ember.computed[alias]('array', 'array2', 'array3')
-        });
+        }).create();
       });
     },
     teardown: function() {
@@ -461,12 +461,12 @@ a_forEach.call(['uniq', 'union'], function (alias) {
 module('Ember.computed.intersect', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         array: Ember.A([1,2,3,4,5,6]),
         array2: Ember.A([3,3,3,4,5]),
         array3: Ember.A([3,5,6,7,8]),
         intersection: Ember.computed.intersect('array', 'array2', 'array3')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -514,11 +514,11 @@ test("it has set-intersection semantics", function() {
 module('Ember.computed.setDiff', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         array: Ember.A([1,2,3,4,5,6,7]),
         array2: Ember.A([3,4,5,10]),
         diff: Ember.computed.setDiff('array', 'array2')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -530,20 +530,20 @@ module('Ember.computed.setDiff', {
 
 test("it throws an error if given fewer or more than two dependent properties", function() {
   throws(function () {
-    Ember.Object.createWithMixins({
+    Ember.Object.extend({
         array: Ember.A([1,2,3,4,5,6,7]),
         array2: Ember.A([3,4,5]),
         diff: Ember.computed.setDiff('array')
-    });
+    }).create();
   }, /requires exactly two dependent arrays/, "setDiff requires two dependent arrays");
 
   throws(function () {
-    Ember.Object.createWithMixins({
+    Ember.Object.extend({
         array: Ember.A([1,2,3,4,5,6,7]),
         array2: Ember.A([3,4,5]),
         array3: Ember.A([7]),
         diff: Ember.computed.setDiff('array', 'array2', 'array3')
-    });
+    }).create();
   }, /requires exactly two dependent arrays/, "setDiff requires two dependent arrays");
 });
 
@@ -709,7 +709,7 @@ function commonSortTests() {
 module('Ember.computed.sort - sortProperties', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         itemSorting: Ember.A(['lname', 'fname']),
         items: Ember.A([{
           fname: "Jaime", lname: "Lannister", age: 34
@@ -722,7 +722,7 @@ module('Ember.computed.sort - sortProperties', {
         }]),
 
         sortedItems: Ember.computed.sort('items', 'itemSorting')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -855,11 +855,11 @@ test("updating an item's sort properties does not error when binary search does 
       status: 2
     });
 
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       people: Ember.A([jaime, cersei]),
       sortProps: Ember.A(['status']),
       sortedPeople: Ember.computed.sort('people', 'sortProps')
-    });
+    }).create();
   });
 
   deepEqual(get(obj, 'sortedPeople'), [jaime, cersei], "precond - array is initially sorted");
@@ -906,7 +906,7 @@ function sortByFnameDesc(a, b) {
 module('Ember.computed.sort - sort function', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         items: Ember.A([{
           fname: "Jaime", lname: "Lannister", age: 34
         }, {
@@ -918,7 +918,7 @@ module('Ember.computed.sort - sort function', {
         }]),
 
         sortedItems: Ember.computed.sort('items.@each.fname', sortByLnameFname)
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -974,10 +974,10 @@ test("changing item properties not specified via @each does not trigger a resort
 module('Ember.computed.max', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         items: Ember.A([1,2,3]),
         max: Ember.computed.max('items')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -1027,10 +1027,10 @@ test("max recomputes when the current max is removed", function() {
 module('Ember.computed.min', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         items: Ember.A([1,2,3]),
         min: Ember.computed.min('items')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -1080,7 +1080,7 @@ test("min recomputes when the current min is removed", function() {
 module('Ember.arrayComputed - mixed sugar', {
   setup: function() {
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         items: Ember.A([{
           fname: "Jaime", lname: "Lannister", age: 34
         }, {
@@ -1099,7 +1099,7 @@ module('Ember.arrayComputed - mixed sugar', {
         starks: Ember.computed.filterBy('items', 'lname', 'Stark'),
         starkAges: Ember.computed.mapBy('starks', 'age'),
         oldestStarkAge: Ember.computed.max('starkAges')
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -1165,11 +1165,11 @@ function evenPriorities(todo) {
 
 module('Ember.arrayComputed - chains', {
   setup: function() {
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       todos: Ember.A([todo('E', 4), todo('D', 3), todo('C', 2), todo('B', 1), todo('A', 0)]),
       sorted: Ember.computed.sort('todos.@each.priority', priorityComparator),
       filtered: Ember.computed.filter('sorted.@each.priority', evenPriorities)
-    });
+    }).create();
   },
   teardown: function() {
     Ember.run(function() {
@@ -1210,14 +1210,14 @@ module('Chaining array and reduced CPs', {
   setup: function() {
     Ember.run(function() {
       userFnCalls = 0;
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
         mapped: Ember.computed.mapBy('array', 'v'),
         max: Ember.computed.max('mapped'),
         maxDidChange: Ember.observer('max', function(){
           userFnCalls++;
         })
-      });
+      }).create();
     });
   },
   teardown: function() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -4,7 +4,7 @@ module('Ember.arrayComputed', {
   setup: function () {
     addCalls = removeCalls = 0;
 
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       numbers:  Ember.A([ 1, 2, 3, 4, 5, 6 ]),
       otherNumbers: Ember.A([ 7, 8, 9 ]),
 
@@ -52,7 +52,7 @@ module('Ember.arrayComputed', {
           return array;
         }
       }).property('nestedNumbers.@each.v')
-    });
+    }).create();
   },
 
   teardown: function() {
@@ -68,7 +68,7 @@ test("array computed properties are instances of Ember.ComputedProperty", functi
 });
 
 test("when the dependent array is null or undefined, `addedItem` is not called and only the initial value is returned", function() {
-  obj = Ember.Object.createWithMixins({
+  obj = Ember.Object.extend({
     numbers: null,
     doubledNumbers: Ember.arrayComputed('numbers', {
       addedItem: function (array, n) {
@@ -77,7 +77,7 @@ test("when the dependent array is null or undefined, `addedItem` is not called a
         return array;
       }
     })
-  });
+  }).create();
 
   deepEqual(get(obj, 'doubledNumbers'), [], "When the dependent array is null, the initial value is returned");
   equal(addCalls, 0,  "`addedItem` is not called when the dependent array is null");
@@ -155,7 +155,7 @@ test("changes to array computed properties happen synchronously", function() {
 
 if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
   test("multiple dependent keys can be specified via brace expansion", function() {
-    var obj = Ember.Object.createWithMixins({
+    var obj = Ember.Object.extend({
           bar: Ember.A(),
           baz: Ember.A(),
           foo: Ember.reduceComputed({
@@ -163,7 +163,7 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
             addedItem: function(array, item) { array.pushObject('a:' + item); return array; },
             removedItem: function(array, item) { array.pushObject('r:' + item); return array; }
           }).property('{bar,baz}')
-        });
+        }).create();
 
     deepEqual(get(obj, 'foo'), [], "initially empty");
 
@@ -189,7 +189,7 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
         removedCalls = 0,
         expected = Ember.A(),
         item = { propA: 'A', propB: 'B', propC: 'C' },
-        obj = Ember.Object.createWithMixins({
+        obj = Ember.Object.extend({
           bar: Ember.A([item]),
           foo: Ember.reduceComputed({
             initialValue: Ember.A(),
@@ -202,7 +202,7 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
               return array;
             }
           }).property('bar.@each.{propA,propB}')
-        });
+        }).create();
 
     expected.pushObjects(['a:A:B:C']);
     deepEqual(get(obj, 'foo'), expected, "initially added dependent item");
@@ -225,7 +225,7 @@ if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
 
 test("doubly nested item property keys (@each.foo.@each) are not supported", function() {
   Ember.run(function() {
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       peopleByOrdinalPosition: Ember.A([{ first: Ember.A([Ember.Object.create({ name: "Jaime Lannister" })])}]),
       people: Ember.arrayComputed({
         addedItem: function (array, item) {
@@ -240,13 +240,13 @@ test("doubly nested item property keys (@each.foo.@each) are not supported", fun
           return array;
         }
       }).property('people.@each.name')
-    });
+    }).create();
   });
 
   equal(obj.get('names.firstObject'), 'Jaime Lannister', "Doubly nested item properties can be retrieved manually");
 
   throws(function() {
-    obj = Ember.Object.createWithMixins({
+    obj = Ember.Object.extend({
       people: [{ first: Ember.A([Ember.Object.create({ name: "Jaime Lannister" })])}],
       names: Ember.arrayComputed({
         addedItem: function (array, item) {
@@ -254,7 +254,7 @@ test("doubly nested item property keys (@each.foo.@each) are not supported", fun
           return array;
         }
       }).property('people.@each.first.@each.name')
-    });
+    }).create();
   }, /Nested @each/, "doubly nested item property keys are not supported");
 });
 
@@ -325,7 +325,7 @@ test("multiple array computed properties on the same object can observe dependen
 
 test("an error is thrown when a reduceComputed is defined without an initialValue property", function() {
   var defineExploder = function() {
-    Ember.Object.createWithMixins({
+    Ember.Object.extend({
       collection: Ember.A(),
       exploder: Ember.reduceComputed('collection', {
         initialize: function(initialValue, changeMeta, instanceMeta) {},
@@ -338,7 +338,7 @@ test("an error is thrown when a reduceComputed is defined without an initialValu
           return item;
         }
       })
-    });
+    }).create();
   };
 
   throws(defineExploder, /declared\ without\ an\ initial\ value/, "an error is thrown when the reduceComputed is defined without an initialValue");
@@ -500,7 +500,7 @@ if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
       var a = Ember.Object.create({ name: 'a' }),
           b = Ember.Object.create({ name: 'b' });
 
-      obj = Ember.ArrayProxy.createWithMixins({
+      obj = Ember.ArrayProxy.extend({
         content: Ember.A([a, b]),
         names: Ember.arrayComputed('@this.@each.name', {
           addedItem: function (array, item, changeMeta, instanceMeta) {
@@ -513,7 +513,7 @@ if (Ember.FEATURES.isEnabled('reduceComputedSelf')) {
             return array;
           }
         })
-      });
+      }).create();
     },
     teardown: function() {
       Ember.run(function() {
@@ -545,7 +545,7 @@ module('Ember.arrayComputed - changeMeta property observers', {
   setup: function() {
     callbackItems = [];
     Ember.run(function() {
-      obj = Ember.Object.createWithMixins({
+      obj = Ember.Object.extend({
         items: Ember.A([Ember.Object.create({ n: 'zero' }), Ember.Object.create({ n: 'one' })]),
         itemsN: Ember.arrayComputed('items.@each.n', {
           addedItem: function (array, item, changeMeta, instanceMeta) {
@@ -555,7 +555,7 @@ module('Ember.arrayComputed - changeMeta property observers', {
             callbackItems.push('remove:' + changeMeta.index + ":" + get(changeMeta.item, 'n'));
           }
         })
-      });
+      }).create();
     });
   },
   teardown: function() {
@@ -645,7 +645,7 @@ test("changeMeta includes item and index", function() {
 });
 
 test("when initialValue is undefined, everything works as advertised", function() {
-  var chars = Ember.Object.createWithMixins({
+  var chars = Ember.Object.extend({
     letters: Ember.A(),
     firstUpper: Ember.reduceComputed('letters', {
       initialValue: undefined,
@@ -675,7 +675,7 @@ test("when initialValue is undefined, everything works as advertised", function(
         return instanceMeta.firstMatch();
       }
     })
-  });
+  }).create();
   equal(get(chars, 'firstUpper'), undefined, "initialValue is undefined");
 
   get(chars, 'letters').pushObjects(['a', 'b', 'c']);

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -176,3 +176,22 @@ test("unhandled rejects still propogate to RSVP.configure('onerror', ...) ", fun
   Ember.run(deferred, 'reject', expectedReason);
 });
 
+test("Resolves properly with Ember.ObjectProxy.extend(Ember.PromiseProxyMixin).create()", function(){
+  var proxy = Ember.run(function(){
+    return Ember.ObjectProxy.extend(Ember.PromiseProxyMixin).create({
+        promise: Ember.RSVP.resolve(1)
+    })
+  });
+
+  equal(proxy.get('content'), 1, 'Should resolve');
+});
+
+test("Can be mixed into Ember.ObjectProxy via .createWithMixins", function(){
+  var proxy = Ember.run(function(){
+    return Ember.ObjectProxy.createWithMixins(Ember.PromiseProxyMixin, {
+      promise: Ember.RSVP.resolve(1)
+    })
+  });
+
+  equal(proxy.get('content'), 1, 'Should resolve');
+});


### PR DESCRIPTION
`Ember.Object.createWithMixins(SomeMixin, {foo: bar})` is supposed to emulate `Ember.Object.extend(SomeMixin).create({foo: bar})`, but since it interpreted all arguments as a Mixin it causes many small inconsistencies (including the error reported in #3713).

Once the issue reported in #3713 was handled, I began reviewing the remaining failing tests. The majority of them were related to `ReducedComputed` which was using `createWithMixins` to handle computed properties, but that is explicitly forbidden with `Ember.Object.create` (see [here](https://github.com/emberjs/ember.js/blob/8a10e4f284508239772067a37d726991bbc2e36c/packages/ember-runtime/lib/system/core_object.js#L98)).

There are many other failures in the `packages/ember-runtime/tests/legacy_1x/` directory that I am still working through.
