### PR TITLE
FEATURE: Application Can Ignore Specified Events

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -222,6 +222,21 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   */
   customEvents: null,
 
+  /**
+    DOM events you don't want to listen to. This is often done for performance
+    reasons.
+
+    ```javascript
+    App = Ember.Application.create({
+      ignoredEvents: ['mouseenter']
+    });
+
+    @property ignoredEvents
+    @type Array
+    @default null
+  */
+  ignoredEvents: null,
+
   // Start off the number of deferrals at 1. This will be
   // decremented by the Application's own `initialize` method.
   _readinessDeferrals: 1,
@@ -612,11 +627,12 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
   */
   setupEventDispatcher: function() {
     var customEvents = get(this, 'customEvents'),
+        ignoredEvents = get(this, 'ignoredEvents'),
         rootElement = get(this, 'rootElement'),
         dispatcher = this.__container__.lookup('event_dispatcher:main');
 
     set(this, 'eventDispatcher', dispatcher);
-    dispatcher.setup(customEvents, rootElement);
+    dispatcher.setup(customEvents, rootElement, ignoredEvents);
   },
 
   /**

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -88,9 +88,12 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
 
     @method setup
     @param addedEvents {Hash}
+    @param ignoredEvents {Array}
   */
-  setup: function(addedEvents, rootElement) {
+  setup: function(addedEvents, rootElement, ignoredEvents) {
     var event, events = get(this, 'events');
+
+    ignoredEvents = ignoredEvents || [];
 
     Ember.$.extend(events, addedEvents || {});
 
@@ -110,7 +113,7 @@ Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.pro
     Ember.assert('Unable to add "ember-application" class to rootElement. Make sure you set rootElement to the body or an element in the body.', rootElement.is('.ember-application'));
 
     for (event in events) {
-      if (events.hasOwnProperty(event)) {
+      if (events.hasOwnProperty(event) && ignoredEvents.indexOf(event) === -1) {
         this.setupHandler(rootElement, event, events[event]);
       }
     }

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -331,3 +331,26 @@ test("additional events and rootElement can be specified", function () {
 
   Ember.$("#leView").trigger("myevent");
 });
+
+test("should ignore events not of interest", function () {
+  var ignoredEvent = 'keydown',
+      keyDownCount = 0;
+
+  expect(1);
+
+  Ember.run(function () {
+    dispatcher.setup({}, null, [ignoredEvent]);
+
+    view = Ember.View.create({
+      elementId: 'leView',
+
+      keyDown: function () {
+        keyDownCount++;
+      }
+    }).appendTo(dispatcher.get('rootElement'));
+  });
+
+  Ember.$('#leView').trigger(ignoredEvent);
+
+  equal(keyDownCount, 0, 'does not ignore event');
+});


### PR DESCRIPTION
Rob Harper pointed out in his talk on performance with Ember on mobile
devices, Ember listens to a large number of events, some of which we may
not be interested in.

This pull request introduces a property on Ember.Application that allows
us to ignore certain events without having to fiddle with, and reopen
the Ember.EventDispatcher class.

References:
- http://www.robharper.ca/ember-on-mobile/performance.html

(This my first pull request to this project. Please be gentle :heart:.)
