### PR TITLE
[DOC] Add link to Handlebars.helpers

### DIFF
--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -12,7 +12,8 @@ var set = Ember.set, get = Ember.get;
   The internal class used to create text inputs when the `{{input}}`
   helper is used with `type` of `checkbox`.
 
-  See Handlebars.helpers.input for usage details.
+  See [Handlebars.helpers.input](/api/classes/Ember.Handlebars.helpers.html#method_input)
+  for usage details.
 
   ## Direct manipulation of `checked`
 


### PR DESCRIPTION
In the explanation of Ember.Checkbox, it says, "See
Handlebars.helpers.input for usage details." This commit adds
a link to that text to the appropriate method.
