### PR TITLE
[BUGFIX beta] Fix issue with Ember.Test.unregisterHelper.

### DIFF
--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -4,7 +4,6 @@
  */
 var slice = [].slice,
     helpers = {},
-    originalMethods = {},
     injectHelpersCallbacks = [];
 
 /**
@@ -114,10 +113,6 @@ Ember.Test = {
   */
   unregisterHelper: function(name) {
     delete helpers[name];
-    if (originalMethods[name]) {
-      this.helperContainer[name] = originalMethods[name];
-    }
-    delete originalMethods[name];
     delete Ember.Test.Promise.prototype[name];
   },
 
@@ -312,6 +307,21 @@ Ember.Application.reopen({
   testHelpers: {},
 
   /**
+   This property will contain the original methods that were registered
+   on the `helperContainer` before `injectTestHelpers` is called.
+
+   When `removeTestHelpers` is called, these methods are restored to the
+   `helperContainer`.
+
+    @property originalMethods
+    @type {Object}
+    @default {}
+    @private
+  */
+  originalMethods: {},
+
+
+  /**
   This property indicates whether or not this application is currently in
   testing mode. This is set when `setupForTesting` is called on the current
   application.
@@ -387,7 +397,7 @@ Ember.Application.reopen({
 
     this.testHelpers = {};
     for (var name in helpers) {
-      originalMethods[name] = this.helperContainer[name];
+      this.originalMethods[name] = this.helperContainer[name];
       this.testHelpers[name] = this.helperContainer[name] = helper(this, name);
       protoWrap(Ember.Test.Promise.prototype, name, helper(this, name), helpers[name].meta.wait);
     }
@@ -413,9 +423,9 @@ Ember.Application.reopen({
   */
   removeTestHelpers: function() {
     for (var name in helpers) {
-      this.helperContainer[name] = originalMethods[name];
+      this.helperContainer[name] = this.originalMethods[name];
       delete this.testHelpers[name];
-      delete originalMethods[name];
+      delete this.originalMethods[name];
     }
     Ember.RSVP.configure('onerror', null);
   }

--- a/packages/ember-testing/tests/helper_registration_test.js
+++ b/packages/ember-testing/tests/helper_registration_test.js
@@ -1,0 +1,76 @@
+var App, appBooted, helperContainer;
+
+function registerHelper(){
+  Ember.Test.registerHelper('boot', function(app) {
+    Ember.run(app, app.advanceReadiness);
+    appBooted = true;
+    return app.testHelpers.wait();
+  });
+}
+
+function unregisterHelper(){
+  Ember.Test.unregisterHelper('boot');
+}
+
+function setupApp(){
+  appBooted = false;
+  helperContainer = {};
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+    App.injectTestHelpers(helperContainer);
+  });
+}
+
+function destroyApp(){
+  if (App) {
+    Ember.run(App, 'destroy');
+    App = null;
+  }
+}
+
+module("Ember.Test - registerHelper/unregisterHelper", {
+  teardown: function(){
+    destroyApp();
+  }
+});
+
+test("Helper gets registered", function() {
+  expect(2);
+
+  registerHelper();
+  setupApp();
+
+  ok(App.testHelpers.boot);
+  ok(helperContainer.boot);
+});
+
+test("Helper is ran when called", function(){
+  expect(1);
+
+  registerHelper();
+  setupApp();
+
+  App.testHelpers.boot().then(function() {
+    ok(appBooted);
+  });
+});
+
+test("Helper can be unregistered", function(){
+  expect(4);
+
+  registerHelper();
+  setupApp();
+
+  ok(App.testHelpers.boot);
+  ok(helperContainer.boot);
+
+  unregisterHelper();
+
+  setupApp();
+
+  ok(!App.testHelpers.boot, "once unregistered the helper is not added to App.testHelpers");
+  ok(!helperContainer.boot, "once unregistered the helper is not added to the helperContainer");
+});
+

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -111,37 +111,6 @@ if (Ember.FEATURES.isEnabled('ember-testing-lazy-routing')){
   });
 }
 
-test("Ember.Test.registerHelper/unregisterHelper", function() {
-  expect(5);
-  var appBooted = false;
-
-  Ember.Test.registerHelper('boot', function(app) {
-    Ember.run(app, app.advanceReadiness);
-    appBooted = true;
-    return window.wait();
-  });
-
-  Ember.run(function() {
-    App = Ember.Application.create();
-    App.setupForTesting();
-    App.injectTestHelpers();
-  });
-
-  ok(App.testHelpers.boot);
-  ok(window.boot);
-
-  window.boot().then(function() {
-    ok(appBooted);
-
-    App.removeTestHelpers();
-    Ember.Test.unregisterHelper('boot');
-
-    ok(!App.testHelpers.boot);
-    ok(!window.boot);
-  });
-
-});
-
 test("`wait` helper can be passed a resolution value", function() {
   expect(4);
 
@@ -306,6 +275,22 @@ test("Ember.Application#injectTestHelpers adds helpers to provided object.", fun
 
   App.removeTestHelpers();
   assertNoHelpers(App, helpers);
+});
+
+test("Ember.Application#removeTestHelpers resets the helperContainer's original values", function(){
+  var helpers = {visit: 'snazzleflabber'};
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+  });
+
+  App.injectTestHelpers(helpers);
+
+  ok(helpers['visit'] !== 'snazzleflabber', "helper added to container");
+  App.removeTestHelpers();
+
+  ok(helpers['visit'] === 'snazzleflabber', "original value added back to container");
 });
 
 if (Ember.FEATURES.isEnabled("ember-testing-wait-hooks")) {


### PR DESCRIPTION
- `Ember.Test.unregisterHelper` will currently error if the helper being removed is found within `originalMethods`. The issue is that `this.helperContainer` is not available from `Ember.Test` (it is in `Ember.Application`).
- `orignalMethods` has been moved into a private property of the `Ember.Application` instance (so that we can properly restore the original value).
- Added a few tests for the behavior of `registerHelper` and `unregisterHelper`.

Fixes issue reported by @sly7-7 in IRC.
