### PR TITLE
[BUGFIX beta] Publish ember-handlebars-compiler along with builds.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -166,7 +166,8 @@ task :publish_build => [:dist, :docs, 'ember:generate_static_test_site'] do
                dist_dir.join('ember-docs.json')
 
   files = %w{ember.js ember-runtime.js ember-docs.json
-             ember-spade.js ember-tests.js ember-tests.html}
+             ember-spade.js ember-tests.js ember-tests.html
+             ember-template-compiler.js}
 
   EmberDev::Publish.to_s3({
     :access_key_id => ENV['S3_ACCESS_KEY_ID'],


### PR DESCRIPTION
The compiler has been under some flux lately, and 1.2.0-beta.3's compiler is
not compatible with 1.1.2's.

This change will allow the `ember-handlebars-compiler` to be published to the
same `builds.emberjs.com` hierarchy as the rest of the assets.
