### PR TITLE
[BUGFIX beta] Make Ember.Handlebars.makeViewHelper warning useful.

### DIFF
--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -40,6 +40,7 @@ testing_packages:
   - ember-runtime
   - ember-views
   - ember-handlebars
+  - ember-handlebars-compiler
   - ember-routing
   - ember-application
   - ember

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -111,7 +111,7 @@ Ember.Handlebars.helper = function(name, value) {
 */
 Ember.Handlebars.makeViewHelper = function(ViewClass) {
   return function(options) {
-    Ember.assert("You can only pass attributes (such as name=value) not bare values to a helper for a View", arguments.length < 2);
+    Ember.assert("You can only pass attributes (such as name=value) not bare values to a helper for a View found in '" + ViewClass.toString() + "'", arguments.length < 2);
     return Ember.Handlebars.helpers.view.call(this, ViewClass, options);
   };
 };

--- a/packages/ember-handlebars-compiler/tests/make_view_helper_test.js
+++ b/packages/ember-handlebars-compiler/tests/make_view_helper_test.js
@@ -1,0 +1,11 @@
+module("Ember.Handlebars.makeViewHelper");
+
+test("makes helpful assertion when called with invalid arguments", function(){
+  var viewClass = {toString: function(){ return 'Some Random Class';}};
+
+  var helper = Ember.Handlebars.makeViewHelper(viewClass);
+
+  expectAssertion(function(){
+    helper({foo: 'bar'}, this);
+  }, "You can only pass attributes (such as name=value) not bare values to a helper for a View found in 'Some Random Class'");
+});


### PR DESCRIPTION
- Adds `ember-handlebars-compiler` to the list of packages that are tested.
- Uses `ViewClass.toString()` in the assertion thrown from `Ember.Handlebars.makeViewHelper`.

Example message before this change:

```
You can only pass attributes (such as name=value) not bare values to a helper for a View
```

And after (using EAK resolver):

```
You can only pass attributes (such as name=value) not bare values to a helper for a View 
found in 'appkit@component:api-file-link:'
```
