### PR TITLE
Ember.Object.create now takes `undefined` as an argument.

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -70,12 +70,14 @@ function makeCtor() {
 
         Ember.assert("Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.", !(properties instanceof Ember.Mixin));
 
-        if (properties === null || typeof properties !== 'object') {
-          Ember.assert("Ember.Object.create only accepts objects.");
-          continue;
+        if (typeof properties !== 'object' && properties !== undefined) {
+          throw new Ember.Error("Ember.Object.create only accepts objects.");
         }
 
-        var keyNames = Ember.keys(properties);
+        var keyNames = [];
+        if (properties) {
+          keyNames = Ember.keys(properties);
+        }
         for (var j = 0, ll = keyNames.length; j < ll; j++) {
           var keyName = keyNames[j];
           if (!properties.hasOwnProperty(keyName)) { continue; }

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -111,16 +111,22 @@ test("inherits properties from passed in Ember.Object", function() {
   equal(secondaryObj.foo, baseObj.foo, "Em.O.create inherits properties from Ember.Object parameter");
 });
 
-test("throws if you try to pass anything other than an object or instance of Ember.Object", function(){
-  var expected = "Ember.Object.create only accepts objects.";
+test("throws if you try to pass anything a string as a parameter", function(){
+  var expected = "Ember.Object.create only accepts an objects.";
 
-  expectAssertion(function() {
+  throws(function() {
     var o = Ember.Object.create("some-string");
   }, expected);
+});
 
-  expectAssertion(function() {
-    var o = Ember.Object.create(null);
-  }, expected);
+test("Ember.Object.create can take undefined as a parameter", function(){
+  var o = Ember.Object.create(undefined);
+  deepEqual(Ember.Object.create(), o);
+});
+
+test("Ember.Object.create can take null as a parameter", function(){
+  var o = Ember.Object.create(null);
+  deepEqual(Ember.Object.create(), o);
 });
 
 module('Ember.Object.createWithMixins');


### PR DESCRIPTION
Fixes #3701.

/cc @stefanpenner @wagenet
