### PR TITLE
Update to latest RSVP (80cec268).

### DIFF
--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -154,8 +154,8 @@ test("rejection", function(){
   equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
 });
 
-test("unhandled rejects still propogate to RSVP.configure('onerror', ...) ", function(){
-  expect(2);
+test("unhandled rejects still propogate to RSVP.on('error', ...) ", function(){
+  expect(1);
 
   var expectedReason = new Error("failure");
   var deferred = Ember.RSVP.defer();
@@ -165,14 +165,16 @@ test("unhandled rejects still propogate to RSVP.configure('onerror', ...) ", fun
   });
 
   var promise = proxy.get('promise');
-  // # internal promise behaviour, not to be used elsewhere..
-  equal(1, promise._promiseCallbacks.error.length, '1 error handler should be subscirbed');
-  promise.on('error', function(reason) {
+
+  function onerror(reason){
     equal(reason.detail, expectedReason, 'expected reason');
-  });
-  // / internal promise behaviour, not to be used elsewhere..
+  }
+
+  Ember.RSVP.on('error', onerror);
 
   // force synchronous promise rejection
   Ember.run(deferred, 'reject', expectedReason);
+
+  Ember.RSVP.off('error', onerror);
 });
 

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -400,7 +400,7 @@ Ember.Application.reopen({
       injectHelpersCallbacks[i](this);
     }
 
-    Ember.RSVP.configure('onerror', onerror);
+    Ember.RSVP.on('error', onerror);
   },
 
   /**
@@ -421,7 +421,7 @@ Ember.Application.reopen({
       delete this.testHelpers[name];
       delete originalMethods[name];
     }
-    Ember.RSVP.configure('onerror', null);
+    Ember.RSVP.off('error', onerror);
   }
 
 });
@@ -491,6 +491,6 @@ function isolate(fn, val) {
   }
 }
 
-function onerror(error) {
-  Ember.Test.adapter.exception(error);
+function onerror(event) {
+  Ember.Test.adapter.exception(event.detail);
 }


### PR DESCRIPTION
A few of the changes:
- Added `Promise.cast`
- Added `Promise.finally`
- Added `RSVP.on('error', callback)`.

See full changes [here](https://github.com/tildeio/rsvp.js/compare/ae4abbccea971a7a7a0437d8275b6c5f1f21ff4c...80cec268a5ef91273b2dd6cd83c3d3d4f4d427df).

Once this is merged, I will update #3743 to use the new `RSVP.on('error', …)` syntax.
