### PR TITLE
[FEATURE ember-testing-simple-setup]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -120,3 +120,22 @@ for a detailed explanation.
 
   Added in [#3218](https://github.com/emberjs/ember.js/pull/3218)
 
+* `ember-testing-simple-setup`
+  Removes the need for most of the ceremony of setting up an application for testing. The following
+  examples are equivalent:
+
+  Ember 1.0.0 testing setup:
+
+  ```javascript
+  App = Ember.Application.create();
+  App.setupForTesting();
+  App.injectTestHelpers();
+  ```
+
+  New simple setup:
+
+  ```javascript
+  App = Ember.Application.create({testing: true});
+  ```
+
+  Added in [#3785](https://github.com/emberjs/ember.js/pull/3785).

--- a/features.json
+++ b/features.json
@@ -12,5 +12,6 @@
   "propertyBraceExpansion": null,
   "ember-routing-named-substates": null,
   "ember-testing-lazy-routing": null,
-  "ember-handlebars-caps-lookup": null
+  "ember-handlebars-caps-lookup": null,
+  "ember-testing-simple-setup": null
 }

--- a/packages/ember-testing/lib/initializers.js
+++ b/packages/ember-testing/lib/initializers.js
@@ -10,4 +10,17 @@ Ember.onLoad('Ember.Application', function(Application) {
       }
     });
   }
+
+  if (Ember.FEATURES.isEnabled('ember-testing-simple-setup')){
+    Application.initializer({
+      name: 'setupForTesting and injectTestHelpers when created with testing = true',
+
+      initialize: function(container, application){
+        if (application.testing && !application.testingSetup) {
+          application.setupForTesting();
+          application.injectTestHelpers();
+        }
+      }
+    });
+  }
 });

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -353,6 +353,10 @@ Ember.Application.reopen({
     if (!Ember.Test.adapter) {
        Ember.Test.adapter = Ember.Test.QUnitAdapter.create();
     }
+
+    if (Ember.FEATURES.isEnabled('ember-testing-simple-setup')){
+      this.testingSetup = true;
+    }
   },
 
   /**

--- a/packages/ember-testing/tests/simple_setup.js
+++ b/packages/ember-testing/tests/simple_setup.js
@@ -1,0 +1,35 @@
+var App;
+
+module('Simple Testing Setup', {
+  teardown: function() {
+    if (App) {
+      App.removeTestHelpers();
+      Ember.$('#ember-testing-container, #ember-testing').remove();
+      Ember.run(App, 'destroy');
+      App = null;
+    }
+  }
+});
+
+if (Ember.FEATURES.isEnabled('ember-testing-simple-setup')){
+  test('testing is setup automatically, if the application is created with testing = true', function(){
+    Ember.run(function(){
+      App = Ember.Application.create({testing: true});
+    });
+
+    ok(Ember.keys(App.testHelpers).length > 0);
+  });
+
+  test('the test helper container can be supplied when creating the application', function(){
+    var container = {};
+
+    Ember.run(function(){
+      App = Ember.Application.create({
+        testing: true,
+        helperContainer: container
+      });
+    });
+
+    ok(Ember.keys(container).length > 0);
+  });
+}


### PR DESCRIPTION
Removes the need for most of the ceremony of setting up an application for
testing. The following examples are equivalent:

Ember 1.0.0 type testing setup:

``` javascript
App = Ember.Application.create();
App.setupForTesting(); 
App.injectTestHelpers();
```

New simple setup:

``` javascript
App = Ember.Application.create({testing: true});
```
