### PR TITLE
[FEATURE ember-testing-triggerEvent-helper]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -145,3 +145,10 @@ for a detailed explanation.
   Adds `currentRouteName`, `currentPath`, and `currentURL` testing helpers.
 
   Added in [#3711](https://github.com/emberjs/ember.js/pull/3711).
+
+* `ember-testing-triggerEvent-helper`
+
+  Adds `triggerEvent` testing helper to allow triggering of arbitrary events on an
+  element.
+
+  Added in [#3792](https://github.com/emberjs/ember.js/pull/3792).

--- a/features.json
+++ b/features.json
@@ -8,5 +8,6 @@
   "ember-testing-lazy-routing": null,
   "ember-handlebars-caps-lookup": null,
   "ember-testing-simple-setup": null,
-  "ember-testing-routing-helpers": null
+  "ember-testing-routing-helpers": null,
+  "ember-testing-triggerEvent-helper": null
 }

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -78,6 +78,19 @@ function click(app, selector, context) {
   return wait(app);
 }
 
+function triggerEvent(app, selector, context, event){
+  if (typeof method === 'undefined') {
+    event = context;
+    context = null;
+  }
+
+  var $el = findWithAssert(app, selector, context);
+
+  Ember.run($el, 'trigger', event);
+
+  return wait(app);
+}
+
 function keyEvent(app, selector, context, type, keyCode) {
   var $el;
   if (typeof keyCode === 'undefined') {
@@ -359,4 +372,22 @@ if (Ember.FEATURES.isEnabled('ember-testing-routing-helpers')){
     @return {Object} The currently active URL.
   */
   helper('currentURL', currentURL);
+}
+
+if (Ember.FEATURES.isEnabled('ember-testing-triggerEvent-helper')) {
+  /**
+    Triggers the given event on the element identified by the provided selector.
+
+    Example:
+
+    ```javascript
+    triggerEvent('#some-elem-id', 'blur');
+    ```
+
+   @method triggerEvent
+   @param {String} selector jQuery selector for finding element on the DOM
+   @param {String} event The event to be triggered.
+   @return {RSVP.Promise}
+  */
+  asyncHelper('triggerEvent', triggerEvent);
 }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -32,6 +32,10 @@ function assertHelpers(application, helperContainer, expected){
   checkHelperPresent('keyEvent', expected);
   checkHelperPresent('fillIn', expected);
   checkHelperPresent('wait', expected);
+
+  if (Ember.FEATURES.isEnabled("ember-testing-triggerEvent-helper")) {
+    checkHelperPresent('triggerEvent', expected);
+  }
 }
 
 function assertNoHelpers(application, helperContainer) {
@@ -494,3 +498,40 @@ test("it should raise an assertion error if ajaxStop is called without pendingAj
     });
   });
 });
+
+if (Ember.FEATURES.isEnabled("ember-testing-triggerEvent-helper")) {
+  test("`trigger` can be used to trigger arbitrary events", function() {
+    expect(2);
+
+    var triggerEvent, wait, event;
+
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.setupForTesting();
+    });
+
+    App.IndexView = Ember.View.extend({
+      template: Ember.Handlebars.compile('{{input type="text" id="foo"}}'),
+
+      didInsertElement: function() {
+        this.$('#foo').on('blur change', function(e) {
+          event = e;
+        });
+      }
+    });
+
+    App.injectTestHelpers();
+
+    Ember.run(App, App.advanceReadiness);
+
+    triggerEvent = App.testHelpers.triggerEvent;
+    wait         = App.testHelpers.wait;
+
+    wait().then(function() {
+      return triggerEvent('#foo', 'blur');
+    }).then(function() {
+      equal(event.type, 'blur', 'correct event was triggered');
+      equal(event.target.getAttribute('id'), 'foo', 'triggered on the correct element');
+    });
+  });
+}


### PR DESCRIPTION
Adds `triggerEvent` testing helper to allow triggering of arbitrary events on
an element.

/cc @stefanpenner
