### PR TITLE
[BUGFIX release] Update to Handlebars 1.1.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
   remote: .
   specs:
     ember-source (1.3.0.beta.1.canary)
-      handlebars-source (= 1.1.1)
+      handlebars-source (~> 1.1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -47,7 +47,7 @@ GEM
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
-    handlebars-source (1.1.1)
+    handlebars-source (1.1.2)
     json (1.8.1)
     kicker (2.6.1)
       listen

--- a/ember-source.gemspec
+++ b/ember-source.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.version       = Ember.rubygems_version_string
 
-  gem.add_dependency "handlebars-source", ["1.1.1"]
+  gem.add_dependency "handlebars-source", ["~> 1.1.2"]
 
   gem.files = %w(VERSION) + Dir['dist/*.js', 'lib/ember/*.rb']
 end


### PR DESCRIPTION
Handlebars 1.1.2 allows compiling empty templates (which doesn't work under 1.1.1).

Since this only affects the tooling, we don't need to republish a 1.2.1 for this, but I tagged it with `[BUGFIX release]` so that we can get the stable branch `.gemspec` updated. Once merged, I can publish an updated gem as 1.2.0.1.

Also, uses allows future point releases to be allowed for consumer projects (ember-rails, ember-appkit-rails, etc).
