### PR TITLE
Remove store property from ControllerMixin.

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -38,8 +38,6 @@ Ember.ControllerMixin = Ember.Mixin.create(Ember.ActionHandler, {
 
   parentController: null,
 
-  store: null,
-
   model: Ember.computed.alias('content'),
 
   deprecatedSendHandles: function(actionName) {


### PR DESCRIPTION
This is not used internally, and Ember Data injects `store` into controllers via an initializer (see [here](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/initializers.js#L76-L85)).
