### PR TITLE
Fixes incorrect truncation

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -100,7 +100,7 @@ function setPath(root, path, value, tolerant) {
   keyName = path.slice(path.lastIndexOf('.') + 1);
 
   // get the first part of the part
-  path    = path.slice(0, path.length-(keyName.length+1));
+  path    = (path === keyName) ? keyName : path.slice(0, path.length-(keyName.length+1));
 
   // unless the path is this, look up the first part to
   // get the root


### PR DESCRIPTION
![ember benchmarks 2013-11-26 22-13-07](https://f.cloud.github.com/assets/1131196/1628450/d7993890-5711-11e3-8a5e-1ee1efc1d38d.jpg)

Should be `name` instead of `nam`.
