### PR TITLE
[BUGFIX beta] Make flag LOG_TRANSITIONS_INTERNAL work again

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -26,6 +26,10 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     this.router = this.constructor.router || this.constructor.map(Ember.K);
     this._activeViews = {};
     this._setupLocation();
+
+    if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {
+      this.router.log = Ember.Logger.debug;
+    }
   },
 
   url: Ember.computed(function() {
@@ -470,10 +474,6 @@ Ember.Router.reopenClass({
       router.callbacks = [];
       router.triggerEvent = triggerEvent;
       this.reopenClass({ router: router });
-    }
-
-    if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {
-      router.log = Ember.Logger.debug;
     }
 
     var dsl = Ember.RouterDSL.map(function() {


### PR DESCRIPTION
The `router.log` method is set to `Ember.Logger.debug` when the
LOG_TRANSITIONS_INTERNAL flag on the application is set. Since the
`namespace` at the time of the check is `undefined`, this doesn't work.

This fix moves the check into the routers' `init` method.

@machty: should I add a regression test for this?
