### PR TITLE
Added warning when using deprecated helpers and removed bindAttr/linkTo references

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -262,7 +262,7 @@ Ember.Handlebars.precompile = function(string) {
     knownHelpers: {
       action: true,
       unbound: true,
-      bindAttr: true,
+      'bind-attr': true,
       template: true,
       view: true,
       _triageMustache: true

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -571,7 +571,10 @@ EmberHandlebars.registerHelper('bind-attr', function(options) {
   @param {Hash} options
   @return {String} HTML string
 */
-EmberHandlebars.registerHelper('bindAttr', EmberHandlebars.helpers['bind-attr']);
+EmberHandlebars.registerHelper('bindAttr', function() {
+  Ember.warn("The 'bindAttr' view helper is deprecated in favor of 'bind-attr'");
+  return EmberHandlebars.helpers['bind-attr'].apply(this, arguments);
+});
 
 /**
   @private

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1456,7 +1456,24 @@ test("should be able to bind use {{bind-attr}} more than once on an element", fu
 });
 
 test("{{bindAttr}} is aliased to {{bind-attr}}", function() {
-  equal(Ember.Handlebars.helpers.bindAttr, Ember.Handlebars.helpers['bind-attr']);
+
+  var originalBindAttr = Ember.Handlebars.helpers['bind-attr'],
+    originalWarn = Ember.warn;
+
+  Ember.warn = function(msg) {
+    equal(msg, "The 'bindAttr' view helper is deprecated in favor of 'bind-attr'", 'Warning called');
+  };
+
+  Ember.Handlebars.helpers['bind-attr'] = function() {
+    equal(arguments[0], 'foo', 'First arg match');
+    equal(arguments[1], 'bar', 'Second arg match');
+    return 'result';
+  };
+  var result = Ember.Handlebars.helpers.bindAttr('foo', 'bar');
+  equal(result, 'result', 'Result match');
+
+  Ember.Handlebars.helpers['bind-attr'] = originalBindAttr;
+  Ember.warn = originalWarn;
 });
 
 test("should not reset cursor position when text field receives keyUp event", function() {

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -71,9 +71,9 @@ test("property changes inside views should only rerender their view", function()
   equal(trim(view.$().text()), 'ohbai', "The updated value was rendered");
 });
 
-test("should work with bindAttr", function() {
+test("should work with bind-attr", function() {
   createGroupedView(
-    '<button {{bindAttr class="innerClass"}}>ohai</button>',
+    '<button {{bind-attr class="innerClass"}}>ohai</button>',
     {innerClass: 'magic'}
   );
   appendView();

--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -507,44 +507,44 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
     To override this option for your entire application, see
     "Overriding Application-wide Defaults".
-    
+
     ### Disabling the `link-to` helper
-    By default `{{link-to}}` is enabled. 
+    By default `{{link-to}}` is enabled.
     any passed value to `disabled` helper property will disable the `link-to` helper.
-     
+
     static use: the `disabled` option:
- 
+
     ```handlebars
     {{#link-to 'photoGallery' disabled=true}}
       Great Hamster Photos
     {{/link-to}}
     ```
-     
+
     dynamic use: the `disabledWhen` option:
-    
+
     ```handlebars
     {{#link-to 'photoGallery' disabledWhen=controller.someProperty}}
       Great Hamster Photos
     {{/link-to}}
     ```
-    
+
     any passed value to `disabled` will disable it except `undefined`.
     to ensure that only `true` disable the `link-to` helper you can
     override the global behaviour of `Ember.LinkView`.
-         
-    ```javascript  
+
+    ```javascript
     Ember.LinkView.reopen({
       disabled: Ember.computed(function(key, value) {
-        if (value !== undefined) { 
-          this.set('_isDisabled', value === true); 
+        if (value !== undefined) {
+          this.set('_isDisabled', value === true);
         }
         return value === true ? get(this, 'disabledClass') : false;
       })
     });
     ```
-     
+
     see "Overriding Application-wide Defaults" for more.
-    
+
     ### Handling `href`
     `{{link-to}}` will use your application's Router to
     fill the element's `href` property with a url that
@@ -757,7 +757,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     @param {Object} [context]*
     @return {String} HTML string
   */
-  Ember.Handlebars.registerHelper('linkTo', Ember.Handlebars.helpers['link-to']);
+  Ember.Handlebars.registerHelper('linkTo', function() {
+    Ember.warn("The 'linkTo' view helper is deprecated in favor of 'link-to'");
+    return Ember.Handlebars.helpers['link-to'].apply(this, arguments);
+  });
 });
 
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -652,7 +652,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
 
     Note that for routes with dynamic segments, this hook is only
     executed when entered via the URL. If the route is entered
-    through a transition (e.g. when using the `linkTo` Handlebars
+    through a transition (e.g. when using the `link-to` Handlebars
     helper), then a model context is already provided and this hook
     is not called. Routes without dynamic segments will always
     execute the model hook.

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -24,7 +24,7 @@ module("ember-testing Acceptance", {
       });
 
       App.PostsView = Ember.View.extend({
-        defaultTemplate: Ember.Handlebars.compile("<a class=\"dummy-link\"></a><div id=\"comments-link\">{{#linkTo 'comments'}}Comments{{/linkTo}}</div>"),
+        defaultTemplate: Ember.Handlebars.compile("<a class=\"dummy-link\"></a><div id=\"comments-link\">{{#link-to 'comments'}}Comments{{/link-to}}</div>"),
         classNames: ['posts-view']
       });
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -662,7 +662,7 @@ test("The {{link-to}} helper refreshes href element when one of params changes",
 });
 
 if (Ember.FEATURES.isEnabled("query-params")) {
-  test("The {{linkTo}} helper supports query params", function() {
+  test("The {{link-to}} helper supports query params", function() {
     expect(66);
 
     Router.map(function() {
@@ -670,8 +670,8 @@ if (Ember.FEATURES.isEnabled("query-params")) {
       this.resource("items", { queryParams: ['sort', 'direction'] });
     });
 
-    Ember.TEMPLATES.about = Ember.Handlebars.compile("<h1>About</h1> {{#linkTo 'about' id='about-link'}}About{{/linkTo}} {{#linkTo 'about' section='intro' id='about-link-with-qp'}}Intro{{/linkTo}}{{#linkTo 'about' section=false id='about-clear-qp'}}Intro{{/linkTo}}{{#if isIntro}} <p>Here is the intro</p>{{/if}}");
-    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#linkTo 'about' id='about-link'}}About{{/linkTo}} {{#linkTo 'items' id='items-link' direction=otherDirection}}Sort{{/linkTo}} {{#linkTo 'items' id='items-sort-link' sort='name'}}Sort Ascending{{/linkTo}} {{#linkTo 'items' id='items-clear-link' queryParams=false}}Clear Query Params{{/linkTo}}");
+    Ember.TEMPLATES.about = Ember.Handlebars.compile("<h1>About</h1> {{#link-to 'about' id='about-link'}}About{{/link-to}} {{#link-to 'about' section='intro' id='about-link-with-qp'}}Intro{{/link-to}}{{#link-to 'about' section=false id='about-clear-qp'}}Intro{{/link-to}}{{#if isIntro}} <p>Here is the intro</p>{{/if}}");
+    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#link-to 'about' id='about-link'}}About{{/link-to}} {{#link-to 'items' id='items-link' direction=otherDirection}}Sort{{/link-to}} {{#link-to 'items' id='items-sort-link' sort='name'}}Sort Ascending{{/link-to}} {{#link-to 'items' id='items-clear-link' queryParams=false}}Clear Query Params{{/link-to}}");
 
     App.AboutRoute = Ember.Route.extend({
       setupController: function(controller, context, queryParams) {
@@ -720,7 +720,7 @@ if (Ember.FEATURES.isEnabled("query-params")) {
       Ember.$('#about-link-with-qp', '#qunit-fixture').click();
     });
 
-    equal(router.get('url'), "/about?section=intro", "Clicking linkTo updates the url");
+    equal(router.get('url'), "/about?section=intro", "Clicking link-to updates the url");
     equal(Ember.$('p', '#qunit-fixture').text(), "Here is the intro", "Query param is applied to controller");
     equal(normalizeUrl(Ember.$('#about-link').attr('href')), '/about?section=intro', "The params have stuck");
     shouldBeActive('#about-link');
@@ -757,11 +757,11 @@ if (Ember.FEATURES.isEnabled("query-params")) {
       Ember.$('#items-link', '#qunit-fixture').click();
     });
 
-    equal(router.get('url'), "/items?direction=desc", "Clicking linkTo should direct to the correct url");
+    equal(router.get('url'), "/items?direction=desc", "Clicking link-to should direct to the correct url");
     equal(controller.get('currentDirection'), 'desc', "Current direction is desc");
     equal(controller.get('otherDirection'), 'asc', "Other direction is asc");
 
-    equal(normalizeUrl(Ember.$('#items-sort-link').attr('href')), '/items?direction=desc&sort=name', "linkTo href correctly merges query parmas");
+    equal(normalizeUrl(Ember.$('#items-sort-link').attr('href')), '/items?direction=desc&sort=name', "link-to href correctly merges query parmas");
     shouldNotBeActive('#items-sort-link');
 
     equal(normalizeUrl(Ember.$('#items-clear-link').attr('href')), '/items', "Can clear query params");
@@ -776,7 +776,7 @@ if (Ember.FEATURES.isEnabled("query-params")) {
     equal(controller.get('currentDirection'), 'desc', "Current direction is desc");
     equal(controller.get('otherDirection'), 'asc', "Other direction is asc");
 
-    equal(normalizeUrl(Ember.$('#items-sort-link').attr('href')), "/items?sort=name&direction=desc", "linkTo href correctly merges query parmas");
+    equal(normalizeUrl(Ember.$('#items-sort-link').attr('href')), "/items?sort=name&direction=desc", "link-to href correctly merges query parmas");
     shouldBeActive('#items-sort-link');
 
     equal(normalizeUrl(Ember.$('#items-link').attr('href')), "/items?sort=name&direction=asc", "Params can come from bindings");
@@ -794,7 +794,7 @@ if (Ember.FEATURES.isEnabled("query-params")) {
 
     equal(normalizeUrl(Ember.$('#items-link').attr('href')), "/items?sort=name&direction=desc", "Params are updated when bindings change");
     shouldBeActive('#items-link');
-    equal(normalizeUrl(Ember.$('#items-sort-link').attr('href')), '/items?sort=name&direction=desc', "linkTo href correctly merges query params when other params change");
+    equal(normalizeUrl(Ember.$('#items-sort-link').attr('href')), '/items?sort=name&direction=desc', "link-to href correctly merges query params when other params change");
     shouldBeActive('#items-sort-link');
 
     Ember.run(function() {
@@ -862,7 +862,7 @@ if (Ember.FEATURES.isEnabled("query-params")) {
 
 
 
-  test("The {{linkTo}} can work without a route name if query params are supplied", function() {
+  test("The {{link-to}} can work without a route name if query params are supplied", function() {
     expect(4);
 
     Router.map(function() {
@@ -870,7 +870,7 @@ if (Ember.FEATURES.isEnabled("query-params")) {
       this.route('about');
     });
 
-    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#linkTo page=2 id='next-page'}}Next Page{{/linkTo}}");
+    Ember.TEMPLATES.items = Ember.Handlebars.compile("<h1>Items</h1> {{#link-to page=2 id='next-page'}}Next Page{{/link-to}}");
 
     bootApplication();
 
@@ -920,7 +920,23 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
 });
 
 test("{{linkTo}} is aliased", function() {
-  equal(Ember.Handlebars.helpers.linkTo, Ember.Handlebars.helpers['link-to']);
+  var originalLinkTo = Ember.Handlebars.helpers['link-to'],
+    originalWarn = Ember.warn;
+
+  Ember.warn = function(msg) {
+    equal(msg, "The 'linkTo' view helper is deprecated in favor of 'link-to'", 'Warning called');
+  };
+
+  Ember.Handlebars.helpers['link-to'] = function() {
+    equal(arguments[0], 'foo', 'First arg match');
+    equal(arguments[1], 'bar', 'Second arg match');
+    return 'result';
+  };
+  var result = Ember.Handlebars.helpers.linkTo('foo', 'bar');
+  equal(result, 'result', 'Result match');
+
+  Ember.Handlebars.helpers['link-to'] = originalLinkTo;
+  Ember.warn = originalWarn;
 });
 
 test("The {{link-to}} helper is active when a resource is active", function() {


### PR DESCRIPTION
Although bindAttr and LinkTo are deprecated, I still see people using. So a warning could help.

In addition, thanks @rjackson for the Ember.warn suggestion.
