### PR TITLE
[wip] - commonjs support

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -168,3 +168,7 @@ if (!Ember.testing) {
     }, false);
   }
 }
+
+if ('undefined' !== typeof module && module.exports) {
+  module.exports = Ember;
+}


### PR DESCRIPTION
There has been some discussion in #emberjs-dev, and I don't think there's any reason we can't create an npm compatible version of Ember. We should be able to publish to npm automatically as part of the release process. I'm not familiar enough with the ruby tools to know where to make the right changes and could use some guidance.

The [current repo](https://github.com/charlesjolley/node-ember) exports Ember as a global, which I don't think is quite necessary. The version of ember in this repository is also quite out of date.

TODO:
- Handlebars? How do we load this for Ember?
- jQuery? How do we load this for Ember?
- Do we allow peerDependencies for the above?
- is ember-debug the right place to put the detection code?
