### PR TITLE
[FEATURE ember-unloaded-model-warning] warn about unloaded models

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -116,3 +116,10 @@ for a detailed explanation.
   Enables `{{#with}}` to take a `controller=` option for wrapping the context.
 
   Added in [#3722](https://github.com/emberjs/ember.js/pull/3722)
+
+* `ember-unloaded-model-warning`
+
+  Fetching a falsy `model` property on a controller before the
+  associated route has loaded it issues an `Ember.warn`
+
+  Added in ____TODO____

--- a/features.json
+++ b/features.json
@@ -10,5 +10,6 @@
   "ember-testing-simple-setup": null,
   "ember-testing-routing-helpers": null,
   "ember-testing-triggerEvent-helper": null,
-  "with-controller": null
+  "with-controller": null,
+  "ember-unloaded-model-warning": null
 }

--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -20,3 +20,28 @@ require('ember-runtime/controllers/controller');
   @uses Ember.ControllerMixin
 **/
 Ember.ObjectController = Ember.ObjectProxy.extend(Ember.ControllerMixin);
+
+if (Ember.FEATURES.isEnabled("ember-unloaded-model-warning")) {
+  Ember.ObjectController.reopen({
+    model: Ember.computed('content', function(_, value) {
+      if (arguments.length > 1) {
+        Ember.set(this, 'content', value);
+        return value;
+      } else {
+
+        var model = Ember.get(this, 'content');
+        if (!model && this._debugContainerKey) {
+          var name = this._debugContainerKey.slice(11);
+          var routeContainerName = 'route:' + name;
+          var route = this.container.lookup(routeContainerName);
+          if (route && !('currentModel' in route)) {
+            Ember.warn("You retrieved the `model` property on the " + name + " controller before it was set by " + name + " route. Remember that you can use Route#modelFor to retrieve a model before a transition has completed");
+          }
+        }
+
+        return model;
+      }
+    })
+  });
+}
+

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2636,3 +2636,27 @@ test("Ember.Location.registerImplementation is deprecated", function(){
 
   Ember.ENV.RAISE_ON_DEPRECATION = false;
 });
+
+if (Ember.FEATURES.isEnabled("ember-unloaded-model-warning")) {
+  test("Accessing a controller's model when it hasn't yet been set by a route issues a warning", function() {
+    expect(1);
+
+    var oldWarn = Ember.warn;
+    Ember.warn = function(msg) {
+      ok(/retrieved the `model` property on the application controller/.exec(msg), "warning about unloaded `model` was issued");
+    };
+
+    App.ApplicationController = Ember.ObjectController.extend({});
+
+    App.IndexRoute = Ember.Route.extend({
+      beforeModel: function() {
+        this.controllerFor('application').get('model');
+      }
+    });
+
+    bootApplication();
+
+    Ember.warn = oldWarn;
+  });
+}
+


### PR DESCRIPTION
See twitter discussion:
https://twitter.com/markymark/status/406849353622368256

It can be difficult to convey that controllers aren't loaded with models
until the entire transition is finished, so to make this a bit more
obvious, this change adds an Ember.warn whenever you try to
retrieve a `model` from an `ObjectController` that yields a falsy value
and the route associated with that controller (determined via container
keys) hasn't yet had its model set by router.js
