### PR TITLE
[FEATURE toggle action]: Actions can toggle a property

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -116,3 +116,9 @@ for a detailed explanation.
   Enables `{{#with}}` to take a `controller=` option for wrapping the context.
 
   Added in [#3722](https://github.com/emberjs/ember.js/pull/3722)
+
+* `toggle-action`
+
+  Enables `{{action toggle=property}}` that calls `toggleProperty(property)` to toggle between boolean values.
+
+  Added in [#3834](https://github.com/emberjs/ember.js/pull/3834)

--- a/features.json
+++ b/features.json
@@ -10,5 +10,6 @@
   "ember-testing-simple-setup": null,
   "ember-testing-routing-helpers": null,
   "ember-testing-triggerEvent-helper": null,
-  "with-controller": null
+  "with-controller": null,
+  "toggle-action": null
 }

--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -255,6 +255,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     Clicking "click me" will trigger the `edit` method on the current controller
     with the value of `person` as a parameter.
 
+    You can use `{{action}}` as a toggle for a boolean value.
+
+    ```handlebars
+    <button {{action toggle=show}}>Show</button>
+    ```
+
+    The `show` property will be toggled between `true` and `false`.
+
     @method action
     @for Ember.Handlebars.helpers
     @param {String} actionName
@@ -264,6 +272,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   EmberHandlebars.registerHelper('action', function(actionName) {
     var options = arguments[arguments.length - 1],
         contexts = a_slice.call(arguments, 1, -1);
+    var fooName = actionName;
 
     var hash = options.hash,
         controller;
@@ -288,6 +297,22 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       target = hash.target;
     } else if (controller = options.data.keywords.controller) {
       root = controller;
+    }
+
+    if (Ember.FEATURES.isEnabled('toggle-action')) {
+      if (hash.toggle) {
+        if (!root._actions) {
+          root._actions = {};
+        }
+
+        if (!root._actions['toggle:' + hash.toggle]) {
+          root._actions['toggle:' + hash.toggle] = function() {
+            this.toggleProperty(hash.toggle);
+          };
+        }
+
+        actionName = 'toggle:' + hash.toggle;
+      }
     }
 
     action.target = { root: root, target: target, options: options };

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -731,6 +731,25 @@ test("it can trigger actions for keyboard events", function() {
   ok(showCalled, "should call action with keyup");
 });
 
+if (Ember.FEATURES.isEnabled('toggle-action')) {
+  test("it can toggle a property", function() {
+    view = Ember.View.create({
+      template: compile("<button {{action toggle=show}}>Show</button>")
+    });
+
+    var controller = Ember.Controller.create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    var e = Ember.$.Event("click");
+    view.$('button').trigger(e);
+    ok(controller.get('show'), "should set 'show' to true");
+  });
+}
+
 module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
   setup: function() {
     dispatcher = Ember.EventDispatcher.create();
@@ -768,4 +787,3 @@ test("should invoke a handler defined directly on the target (DEPRECATED)", func
 
   ok(eventHandlerWasCalled, "the action was called");
 });
-


### PR DESCRIPTION
A common pattern I find myself doing is a toggle action to call
toggleProperty to switch a boolean value. It would be nice to not have
to recreate this pattern over and over. This PR adds the following param
to the `action` helper:

``` handlebars
<button {{action toggle=show}}>Show</button>
```

Which would called `toggleProperty('show')`
