### PR TITLE
[FEATURE property action]: Actions can fire property functions

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -116,3 +116,11 @@ for a detailed explanation.
   Enables `{{#with}}` to take a `controller=` option for wrapping the context.
 
   Added in [#3722](https://github.com/emberjs/ember.js/pull/3722)
+
+* `property-action`
+
+  Allows in-line property functions to be called on a given property.
+{{action toggle=show}} calls `this.toggleProperty('show')`, {{action
+increment=age}} calls `this.incrementProperty('age'). As long as there
+is a corresponding function that ends in `Property` it will be called on
+the property.

--- a/features.json
+++ b/features.json
@@ -10,5 +10,6 @@
   "ember-testing-simple-setup": null,
   "ember-testing-routing-helpers": null,
   "ember-testing-triggerEvent-helper": null,
-  "with-controller": null
+  "with-controller": null,
+  "property-action": null
 }

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -731,6 +731,47 @@ test("it can trigger actions for keyboard events", function() {
   ok(showCalled, "should call action with keyup");
 });
 
+if (Ember.FEATURES.isEnabled('property-action')) {
+  test("it can call an inline Ember property function", function() {
+    view = Ember.View.create({
+      template: compile("<button {{action toggle=show}}>Show</button>")
+    });
+
+    var controller = Ember.Controller.create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    var e = Ember.$.Event("click");
+    view.$('button').trigger(e);
+    ok(controller.get('show'), "should set 'show' to true");
+  });
+
+  test("it can call a custom property function", function() {
+    view = Ember.View.create({
+      template: compile("<button {{action double=age}}>Double</button>")
+    });
+
+    var controller = Ember.Controller.extend({
+      doubleProperty: function(property) {
+        this.set(property, this.get(property) * 2);
+      },
+      age: 20
+    }).create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    var e = Ember.$.Event("click");
+    view.$('button').trigger(e);
+    equal(controller.get('age'), 40);
+  });
+}
+
 module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
   setup: function() {
     dispatcher = Ember.EventDispatcher.create();


### PR DESCRIPTION
A common pattern I find myself doing is a toggle action to call
toggleProperty to switch a boolean value. It would be nice to not have
to recreate this pattern over and over. Now you can do:

``` handlebars
<button {{action toggle=show}}>Show</button>
```

This works on any `xProperty` function on the controller. For example,
`incrementProperty`

``` handlebars
<button {{action increment=count}}Add 1</button>
```

It can even work on custom functions defined on the controller that
conform to `xProperty` naming:

``` javascript
controller = Ember.Controller.extend({
  doubleProperty: function(property) {
    this.set(property, (this.get(property) || 0) * 2);
  }
});
```

``` handlebars
<button {{action double=wins}}>Cheat</button>
```
