### PR TITLE
Use `QUnit.module` instead of `module`.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,7 +20,6 @@
         "deepEqual",
         "ok",
         "strictEqual",
-        "module",
         "expect",
         "minispade",
         "expectAssertion",

--- a/packages_es6/container/tests/container_test.js
+++ b/packages_es6/container/tests/container_test.js
@@ -8,7 +8,7 @@ import Container from 'container';
 
 var originalModelInjections;
 
-module("Container", {
+QUnit.module("Container", {
   setup: function() {
     originalModelInjections = Ember.MODEL_FACTORY_INJECTIONS;
   },

--- a/packages_es6/container/tests/sub_container_test.js
+++ b/packages_es6/container/tests/sub_container_test.js
@@ -7,7 +7,7 @@ import {
 import Container from 'container';
 var container;
 
-module("Container (sub-containers)", {
+QUnit.module("Container (sub-containers)", {
   setup: function() {
     container = new Container();
     var PostController = factory();

--- a/packages_es6/ember-application/tests/system/application_test.js
+++ b/packages_es6/ember-application/tests/system/application_test.js
@@ -20,7 +20,7 @@ var trim = jQuery.trim;
 
 var view, app, application, originalLookup, originalDebug;
 
-module("Ember.Application", {
+QUnit.module("Ember.Application", {
   setup: function() {
     originalLookup = Ember.lookup;
     originalDebug = Ember.debug;
@@ -100,7 +100,7 @@ test("acts like a namespace", function() {
   equal(app.Foo.toString(), "TestApp.Foo", "Classes pick up their parent namespace");
 });
 
-module("Ember.Application initialization", {
+QUnit.module("Ember.Application initialization", {
   teardown: function() {
     if (app) {
       run(app, 'destroy');

--- a/packages_es6/ember-application/tests/system/controller_test.js
+++ b/packages_es6/ember-application/tests/system/controller_test.js
@@ -8,7 +8,7 @@ import { A } from "ember-runtime/system/native_array";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import { computed } from "ember-metal/computed";
 
-module("Controller dependencies");
+QUnit.module("Controller dependencies");
 
 test("If a controller specifies a dependency, but does not have a container it should error", function(){
   var AController = Controller.extend({

--- a/packages_es6/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -5,7 +5,7 @@ import { DefaultResolver } from "ember-application/system/resolver";
 
 var application;
 
-module("Ember.Application Depedency Injection – customResolver",{
+QUnit.module("Ember.Application Depedency Injection – customResolver",{
   setup: function() {
     function fallbackTemplate() { return "<h1>Fallback</h1>"; }
 

--- a/packages_es6/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -9,7 +9,7 @@ import Application from "ember-application/system/application";
 
 var locator, application, lookup, originalLookup, originalLoggerInfo;
 
-module("Ember.Application Depedency Injection", {
+QUnit.module("Ember.Application Depedency Injection", {
   setup: function() {
     originalLookup = Ember.lookup;
     application = run(Application, 'create');

--- a/packages_es6/ember-application/tests/system/dependency_injection/normalization_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/normalization_test.js
@@ -4,7 +4,7 @@ import Application from "ember-application/system/application";
 
 var application, locator;
 
-module("Ember.Application Depedency Injection – normalization", {
+QUnit.module("Ember.Application Depedency Injection – normalization", {
   setup: function() {
     application = run(Application, 'create');
     locator = application.__container__;

--- a/packages_es6/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -7,7 +7,7 @@ import { guidFor } from "ember-metal/utils";
 
 var originalLookup, App, originalModelInjections;
 
-module("Ember.Application Dependency Injection – toString",{
+QUnit.module("Ember.Application Dependency Injection – toString",{
   setup: function() {
     originalModelInjections = Ember.MODEL_FACTORY_INJECTIONS;
     Ember.MODEL_FACTORY_INJECTIONS = true;

--- a/packages_es6/ember-application/tests/system/dependency_injection_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection_test.js
@@ -11,7 +11,7 @@ var EmberApplication = Application;
 var locator, originalLookup = Ember.lookup, lookup,
     application, originalModelInjections;
 
-module("Ember.Application Dependency Injection", {
+QUnit.module("Ember.Application Dependency Injection", {
   setup: function() {
     originalModelInjections = Ember.MODEL_FACTORY_INJECTIONS;
     Ember.MODEL_FACTORY_INJECTIONS = true;

--- a/packages_es6/ember-application/tests/system/initializers_test.js
+++ b/packages_es6/ember-application/tests/system/initializers_test.js
@@ -5,7 +5,7 @@ import jQuery from "ember-views/system/jquery";
 
 var oldInitializers, app;
 
-module("Ember.Application initializers", {
+QUnit.module("Ember.Application initializers", {
   setup: function() {
   },
 

--- a/packages_es6/ember-application/tests/system/logging_test.js
+++ b/packages_es6/ember-application/tests/system/logging_test.js
@@ -12,7 +12,7 @@ import "ember-routing";
 
 var App, logs, originalLogger;
 
-module("Ember.Application – logging of generated classes", {
+QUnit.module("Ember.Application – logging of generated classes", {
   setup: function() {
     logs = {};
 
@@ -137,7 +137,7 @@ test("predefined classes do not get logged", function() {
   });
 });
 
-module("Ember.Application – logging of view lookups", {
+QUnit.module("Ember.Application – logging of view lookups", {
   setup: function() {
     logs = {};
 

--- a/packages_es6/ember-application/tests/system/readiness_test.js
+++ b/packages_es6/ember-application/tests/system/readiness_test.js
@@ -10,7 +10,7 @@ var readyWasCalled, domReady, readyCallbacks;
 // in a more minimal server environment that implements this behavior will be
 // sufficient for Ember's requirements.
 
-module("Application readiness", {
+QUnit.module("Application readiness", {
   setup: function() {
     readyWasCalled = 0;
     readyCallbacks = [];

--- a/packages_es6/ember-application/tests/system/reset_test.js
+++ b/packages_es6/ember-application/tests/system/reset_test.js
@@ -12,7 +12,7 @@ import Container from 'container/container';
 
 var application, EmberApplication = Application;
 
-module("Ember.Application - resetting", {
+QUnit.module("Ember.Application - resetting", {
   setup: function() {
     Application = EmberApplication.extend({
       name: "App",

--- a/packages_es6/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages_es6/ember-extension-support/tests/container_debug_adapter_test.js
@@ -12,7 +12,7 @@ function boot() {
   run(App, 'advanceReadiness');
 }
 
-module("Container Debug Adapter", {
+QUnit.module("Container Debug Adapter", {
   setup:function() {
     run(function() {
       App = Application.create();  // ES6TODO: this comes from the ember-application package NOT ember-runtime

--- a/packages_es6/ember-extension-support/tests/data_adapter_test.js
+++ b/packages_es6/ember-extension-support/tests/data_adapter_test.js
@@ -20,7 +20,7 @@ var DataAdapter = EmberDataAdapter.extend({
   }
 });
 
-module("Data Adapter", {
+QUnit.module("Data Adapter", {
   setup:function() {
     run(function() {
       App = EmberApplication.create();

--- a/packages_es6/ember-handlebars-compiler/tests/block_helper_missing_test.js
+++ b/packages_es6/ember-handlebars-compiler/tests/block_helper_missing_test.js
@@ -3,7 +3,7 @@ import EmberHandlebars from "ember-handlebars-compiler";
 var stringify = EmberHandlebars.JavaScriptCompiler.stringifyLastBlockHelperMissingInvocation,
     s;
 
-module("stringifyLastBlockHelperMissingInvocation", {
+QUnit.module("stringifyLastBlockHelperMissingInvocation", {
   setup: function() {
   },
 

--- a/packages_es6/ember-handlebars-compiler/tests/make_view_helper_test.js
+++ b/packages_es6/ember-handlebars-compiler/tests/make_view_helper_test.js
@@ -1,6 +1,6 @@
 import EmberHandlebars from "ember-handlebars-compiler";
 
-module("Ember.Handlebars.makeViewHelper");
+QUnit.module("Ember.Handlebars.makeViewHelper");
 
 test("makes helpful assertion when called with invalid arguments", function(){
   var viewClass = {toString: function(){ return 'Some Random Class';}};

--- a/packages_es6/ember-handlebars-compiler/tests/precompile_type_test.js
+++ b/packages_es6/ember-handlebars-compiler/tests/precompile_type_test.js
@@ -3,7 +3,7 @@ var precompile = EmberHandlebars.precompile,
     template = 'Hello World',
     result;
 
-module("Ember.Handlebars.precompileType");
+QUnit.module("Ember.Handlebars.precompileType");
 
 test("precompile creates a function when asObject isn't defined", function(){
   result = precompile(template);

--- a/packages_es6/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/checkbox_test.js
@@ -21,7 +21,7 @@ function destroy(view) {
   });
 }
 
-module("{{input type='checkbox'}}", {
+QUnit.module("{{input type='checkbox'}}", {
   setup: function() {
     controller = {
       tab: 6,
@@ -70,7 +70,7 @@ test("checkbox checked property is updated", function() {
   equal(checkboxView.$('input').prop('checked'), true, "the checkbox is checked now");
 });
 
-module("{{input type='checkbox'}} - prevent value= usage", {
+QUnit.module("{{input type='checkbox'}} - prevent value= usage", {
   setup: function() {
     checkboxView = EmberView.extend({
       controller: controller,
@@ -89,7 +89,7 @@ test("It works", function() {
   }, /you must use `checked=/);
 });
 
-module("{{input type='checkbox'}} - static values", {
+QUnit.module("{{input type='checkbox'}} - static values", {
   setup: function() {
     controller = {
       tab: 6,
@@ -126,7 +126,7 @@ test("checkbox checked property is updated", function() {
   equal(checkboxView.$('input').prop('checked'), false, "the checkbox isn't checked yet");
 });
 
-module("Ember.Checkbox", {
+QUnit.module("Ember.Checkbox", {
   setup: function() {
     dispatcher = EventDispatcher.create();
     dispatcher.setup();

--- a/packages_es6/ember-handlebars/tests/controls/select_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/select_test.js
@@ -14,7 +14,7 @@ var map = EnumerableUtils.map,
 
 var dispatcher, select, view;
 
-module("Ember.Select", {
+QUnit.module("Ember.Select", {
   setup: function() {
     dispatcher = EventDispatcher.create();
     dispatcher.setup();
@@ -658,7 +658,7 @@ test("should be able to set the current selection by value", function() {
   equal(select.get('selection'), ebryn);
 });
 
-module("Ember.Select - usage inside templates", {
+QUnit.module("Ember.Select - usage inside templates", {
   setup: function() {
     dispatcher = EventDispatcher.create();
     dispatcher.setup();

--- a/packages_es6/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/text_area_test.js
@@ -28,7 +28,7 @@ function destroy(object) {
   });
 }
 
-module("{{textarea}}", {
+QUnit.module("{{textarea}}", {
   setup: function() {
     controller = {
       val: 'Lorem ipsum dolor'
@@ -63,7 +63,7 @@ test("Should bind its contents to the specified value", function() {
   equal(textArea.$('textarea').val(), "sit amet", "The new contents are included");
 });
 
-module("TextArea", {
+QUnit.module("TextArea", {
   setup: function() {
    TestObject = window.TestObject = EmberObject.create({
       value: null

--- a/packages_es6/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/text_field_test.js
@@ -31,7 +31,7 @@ function destroy(view) {
   });
 }
 
-module("{{input type='text'}}", {
+QUnit.module("{{input type='text'}}", {
   setup: function() {
     controller = {
       val: "hello",
@@ -107,7 +107,7 @@ test("input tabindex is updated when setting tabindex property of view", functio
   equal(textField.$('input').attr('tabindex'), "3", "updates text field after tabindex changes");
 });
 
-module("{{input type='text'}} - static values", {
+QUnit.module("{{input type='text'}} - static values", {
   setup: function() {
     controller = {};
 
@@ -156,7 +156,7 @@ test("input tabindex is updated when setting tabindex property of view", functio
   equal(textField.$('input').attr('tabindex'), "5", "renders text field with the tabindex");
 });
 
-module("{{input}} - default type", {
+QUnit.module("{{input}} - default type", {
   setup: function() {
     controller = {};
 
@@ -177,7 +177,7 @@ test("should have the default type", function() {
   equal(textField.$('input').attr('type'), 'text', "Has a default text type");
 });
 
-module("Ember.TextField", {
+QUnit.module("Ember.TextField", {
   setup: function() {
     TestObject = window.TestObject = EmberObject.create({
       value: null

--- a/packages_es6/ember-handlebars/tests/handlebars_test.js
+++ b/packages_es6/ember-handlebars/tests/handlebars_test.js
@@ -101,7 +101,7 @@ var TemplateTests, container;
   If you add additional template support to View, you should create a new
   file in which to test.
 */
-module("View - handlebars integration", {
+QUnit.module("View - handlebars integration", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
     lookup.TemplateTests = window.TemplateTests = TemplateTests = Namespace.create();
@@ -2018,7 +2018,7 @@ test("should not escape HTML in primitive value contexts when using triple musta
   equal(view.$('i').length, 2, "creates an element when value is updated");
 });
 
-module("Ember.View - handlebars integration", {
+QUnit.module("Ember.View - handlebars integration", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -2087,7 +2087,7 @@ test("should be able to log `this`", function() {
 
 var MyApp;
 
-module("Templates redrawing and bindings", {
+QUnit.module("Templates redrawing and bindings", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
     MyApp = lookup.MyApp = EmberObject.create({});

--- a/packages_es6/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -31,7 +31,7 @@ function registerRepeatHelper() {
   });
 }
 
-module("Handlebars bound helpers", {
+QUnit.module("Handlebars bound helpers", {
   setup: function() {
     window.TemplateTests = Namespace.create();
   },

--- a/packages_es6/ember-handlebars/tests/helpers/custom_view_helper_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/custom_view_helper_test.js
@@ -14,7 +14,7 @@ function appendView() {
 
 var view;
 
-module("Handlebars custom view helpers", {
+QUnit.module("Handlebars custom view helpers", {
   setup: function() {
     window.TemplateTests = Namespace.create();
   },

--- a/packages_es6/ember-handlebars/tests/helpers/debug_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/debug_test.js
@@ -14,7 +14,7 @@ function appendView() {
   run(function() { view.appendTo('#qunit-fixture'); });
 }
 
-module("Handlebars {{log}} helper", {
+QUnit.module("Handlebars {{log}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 

--- a/packages_es6/ember-handlebars/tests/helpers/each_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/each_test.js
@@ -24,7 +24,7 @@ function templateFor(template) {
 
 var originalLookup = Ember.lookup, lookup;
 
-module("the #each helper", {
+QUnit.module("the #each helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -522,7 +522,7 @@ test("it works with the controller keyword", function() {
   equal(view.$().text(), "foobarbaz");
 });
 
-module("{{#each foo in bar}}", {
+QUnit.module("{{#each foo in bar}}", {
   setup: function() {
     container = new Container();
     container.register('view:default', EmberView.extend());

--- a/packages_es6/ember-handlebars/tests/helpers/group_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/group_test.js
@@ -17,7 +17,7 @@ function appendView() {
   run(function() { view.appendTo('#qunit-fixture'); });
 }
 
-module("EmberHandlebars - group flag", {
+QUnit.module("EmberHandlebars - group flag", {
   setup: function() {
     container = new Container();
     container.register('view:default', EmberView.extend());

--- a/packages_es6/ember-handlebars/tests/helpers/if_unless_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/if_unless_test.js
@@ -11,7 +11,7 @@ var compile = Ember.Handlebars.compile;
 
 var view;
 
-module("Handlebars {{#if}} and {{#unless}} helpers", {
+QUnit.module("Handlebars {{#if}} and {{#unless}} helpers", {
   teardown: function() {
     run(function() {
       if (view) {

--- a/packages_es6/ember-handlebars/tests/helpers/loc_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/loc_test.js
@@ -22,7 +22,7 @@ function destroyView(view) {
 
 var oldString;
 
-module('Handlebars {{loc valueToLocalize}} helper', {
+QUnit.module('Handlebars {{loc valueToLocalize}} helper', {
   setup: function() {
     oldString = Ember.STRINGS;
     Ember.STRINGS = {

--- a/packages_es6/ember-handlebars/tests/helpers/partial_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/partial_test.js
@@ -11,7 +11,7 @@ var compile = EmberHandlebars.compile;
 var MyApp;
 var originalLookup = Ember.lookup, lookup, TemplateTests, view, container;
 
-module("Support for {{partial}} helper", {
+QUnit.module("Support for {{partial}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
     MyApp = lookup.MyApp = EmberObject.create({});

--- a/packages_es6/ember-handlebars/tests/helpers/template_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/template_test.js
@@ -10,7 +10,7 @@ import EmberHandlebars from "ember-handlebars-compiler";
 var MyApp;
 var originalLookup = Ember.lookup, lookup, TemplateTests, view, container;
 
-module("Support for {{template}} helper", {
+QUnit.module("Support for {{template}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
     MyApp = lookup.MyApp = EmberObject.create({});

--- a/packages_es6/ember-handlebars/tests/helpers/unbound_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/unbound_test.js
@@ -21,7 +21,7 @@ var view;
 var originalLookup = Ember.lookup, lookup;
 var container;
 
-module("Handlebars {{#unbound}} helper -- classic single-property usage", {
+QUnit.module("Handlebars {{#unbound}} helper -- classic single-property usage", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -67,7 +67,7 @@ test("it should throw the helper missing error if multiple properties are provid
     }, EmberError);
 });
 
-module("Handlebars {{#unbound boundHelper arg1 arg2... argN}} form: render unbound helper invocations", {
+QUnit.module("Handlebars {{#unbound boundHelper arg1 arg2... argN}} form: render unbound helper invocations", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -257,7 +257,7 @@ test("should be able to render an unbound helper invocation with bound hash opti
   }
 });
 
-module("Handlebars {{#unbound}} helper -- Container Lookup", {
+QUnit.module("Handlebars {{#unbound}} helper -- Container Lookup", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
     container = new Container();

--- a/packages_es6/ember-handlebars/tests/helpers/view_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/view_test.js
@@ -14,7 +14,7 @@ function viewClass(options) {
   return EmberView.extend(options);
 }
 
-module("Handlebars {{#view}} helper", {
+QUnit.module("Handlebars {{#view}} helper", {
   setup: function() {
     originalLookup = Ember.lookup;
   },

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -17,7 +17,7 @@ function appendView(view) {
 var view;
 var originalLookup = Ember.lookup, lookup;
 
-module("Handlebars {{#with}} helper", {
+QUnit.module("Handlebars {{#with}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -70,7 +70,7 @@ test("updating a property on the view should update the HTML", function() {
   equal(view.$().text(), "Señorette Engineer: Tom Dale", "should be properly scoped after updating");
 });
 
-module("Multiple Handlebars {{with}} helpers with 'as'", {
+QUnit.module("Multiple Handlebars {{with}} helpers with 'as'", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -121,7 +121,7 @@ test("nested {{with}} blocks shadow the outer scoped variable properly.", functi
 
   equal(view.$().text(), "Limbo-Wrath-Treachery-Wrath-Limbo", "should be properly scoped after updating");
 });
-module("Handlebars {{#with}} globals helper", {
+QUnit.module("Handlebars {{#with}} globals helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -151,7 +151,7 @@ test("it should support #with Foo.bar as qux", function() {
   equal(view.$().text(), "updated", "should update");
 });
 
-module("Handlebars {{#with keyword as foo}}");
+QUnit.module("Handlebars {{#with keyword as foo}}");
 
 test("it should support #with view as foo", function() {
   var view = EmberView.create({
@@ -193,7 +193,7 @@ test("it should support #with name as food, then #with foo as bar", function() {
   });
 });
 
-module("Handlebars {{#with this as foo}}");
+QUnit.module("Handlebars {{#with this as foo}}");
 
 test("it should support #with this as qux", function() {
   var view = EmberView.create({
@@ -215,7 +215,7 @@ test("it should support #with this as qux", function() {
   });
 });
 
-module("Handlebars {{#with foo}} insideGroup");
+QUnit.module("Handlebars {{#with foo}} insideGroup");
 
 test("it should render without fail", function() {
   var View = EmberView.extend({
@@ -244,7 +244,7 @@ test("it should render without fail", function() {
   });
 });
 
-module("Handlebars {{#with foo}} with defined controller");
+QUnit.module("Handlebars {{#with foo}} with defined controller");
 
 test("it should wrap context with object controller", function() {
   var Controller = ObjectController.extend({

--- a/packages_es6/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/yield_test.js
@@ -13,7 +13,7 @@ import EmberError from "ember-metal/error";
 
 var originalLookup = Ember.lookup, lookup, TemplateTests, view, container;
 
-module("Support for {{yield}} helper", {
+QUnit.module("Support for {{yield}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -318,7 +318,7 @@ test("yield should work for views even if _parentView is null", function() {
 
 });
 
-module("Component {{yield}}", {
+QUnit.module("Component {{yield}}", {
   setup: function() {},
   teardown: function() {
     run(function() {

--- a/packages_es6/ember-handlebars/tests/loader_test.js
+++ b/packages_es6/ember-handlebars/tests/loader_test.js
@@ -5,7 +5,7 @@ var trim = jQuery.trim;
 
 var originalLookup = Ember.lookup, lookup, Tobias, App, view;
 
-module("test Ember.Handlebars.bootstrap", {
+QUnit.module("test Ember.Handlebars.bootstrap", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
   },

--- a/packages_es6/ember-handlebars/tests/lookup_test.js
+++ b/packages_es6/ember-handlebars/tests/lookup_test.js
@@ -1,4 +1,4 @@
-module("Ember.Handlebars.resolveParams");
+QUnit.module("Ember.Handlebars.resolveParams");
 
 test("Raw string parameters should be returned as Strings", function() {
   var params = Ember.Handlebars.resolveParams({}, ["foo", "bar", "baz"], { types: ["STRING", "STRING", "STRING"] });
@@ -66,7 +66,7 @@ test("ID parameters can look up keywords", function() {
   deepEqual(params, ["Mr", "Tom", "Dale", "State Charts"]);
 });
 
-module("Ember.Handlebars.resolveHash");
+QUnit.module("Ember.Handlebars.resolveHash");
 
 test("Raw string parameters should be returned as Strings", function() {
   var hash = Ember.Handlebars.resolveHash({}, { string: "foo" }, { hashTypes: { string: "STRING" } });

--- a/packages_es6/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages_es6/ember-handlebars/tests/views/collection_view_test.js
@@ -30,7 +30,7 @@ var firstChild = nthChild;
 
 var originalLookup = Ember.lookup, lookup, TemplateTests, view;
 
-module("ember-handlebars/tests/views/collection_view_test", {
+QUnit.module("ember-handlebars/tests/views/collection_view_test", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
     lookup.TemplateTests = TemplateTests = Namespace.create();

--- a/packages_es6/ember-handlebars/tests/views/metamorph_view_test.js
+++ b/packages_es6/ember-handlebars/tests/views/metamorph_view_test.js
@@ -10,7 +10,7 @@ import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
 
 var view, childView, metamorphView;
 
-module("Metamorph views", {
+QUnit.module("Metamorph views", {
   setup: function() {
     view = EmberView.create({
       render: function(buffer) {
@@ -60,7 +60,7 @@ test("a Metamorph view is not a view's parentView", function() {
   equal(children.objectAt(0), childView, "... and it is not the metamorph");
 });
 
-module("Metamorph views correctly handle DOM", {
+QUnit.module("Metamorph views correctly handle DOM", {
   setup: function() {
     view = EmberView.create({
       render: function(buffer) {
@@ -120,7 +120,7 @@ test("a metamorph view can be rerendered", function() {
 
 
 // Redefining without setup/teardown
-module("Metamorph views correctly handle DOM");
+QUnit.module("Metamorph views correctly handle DOM");
 
 test("a metamorph view calls its childrens' willInsertElement and didInsertElement", function() {
   var parentView;

--- a/packages_es6/ember-metal/tests/accessors/getPath_test.js
+++ b/packages_es6/ember-metal/tests/accessors/getPath_test.js
@@ -33,7 +33,7 @@ var obj, moduleOpts = {
   }
 };
 
-module('Ember.get with path', moduleOpts);
+QUnit.module('Ember.get with path', moduleOpts);
 
 // ..........................................................
 // LOCAL PATHS

--- a/packages_es6/ember-metal/tests/accessors/getProperties_test.js
+++ b/packages_es6/ember-metal/tests/accessors/getProperties_test.js
@@ -1,6 +1,6 @@
 import getProperties from "ember-metal/get_properties";
 
-module('Ember.getProperties');
+QUnit.module('Ember.getProperties');
 
 test('can retrieve a hash of properties from an object via an argument list or array of property names', function() {
   var obj = {

--- a/packages_es6/ember-metal/tests/accessors/get_test.js
+++ b/packages_es6/ember-metal/tests/accessors/get_test.js
@@ -10,7 +10,7 @@ import {
 import { addObserver } from "ember-metal/observer";
 import { create } from 'ember-metal/platform';
 
-module('Ember.get');
+QUnit.module('Ember.get');
 
 test('should get arbitrary properties on an object', function() {
   var obj = {
@@ -93,7 +93,7 @@ test('(regression) watched properties on unmodified inherited objects should sti
   equal(get(theRealObject, 'someProperty'), 'foo', 'should return the set value, not false');
 });
 
-module("Ember.getWithDefault");
+QUnit.module("Ember.getWithDefault");
 
 test('should get arbitrary properties on an object', function() {
   var obj = {

--- a/packages_es6/ember-metal/tests/accessors/isGlobalPath_test.js
+++ b/packages_es6/ember-metal/tests/accessors/isGlobalPath_test.js
@@ -1,6 +1,6 @@
 import { isGlobalPath } from "ember-metal/binding";
 
-module('Ember.isGlobalPath');
+QUnit.module('Ember.isGlobalPath');
 
 test("global path's are recognized", function() {
   ok( isGlobalPath('App.myProperty') );

--- a/packages_es6/ember-metal/tests/accessors/normalizeTuple_test.js
+++ b/packages_es6/ember-metal/tests/accessors/normalizeTuple_test.js
@@ -31,7 +31,7 @@ var obj, moduleOpts = {
   }
 };
 
-module('normalizeTuple', moduleOpts);
+QUnit.module('normalizeTuple', moduleOpts);
 
 // ..........................................................
 // LOCAL PATHS

--- a/packages_es6/ember-metal/tests/accessors/setPath_test.js
+++ b/packages_es6/ember-metal/tests/accessors/setPath_test.js
@@ -37,7 +37,7 @@ var obj, moduleOpts = {
   }
 };
 
-module('set with path', moduleOpts);
+QUnit.module('set with path', moduleOpts);
 
 test('[Foo, bar] -> Foo.bar', function() {
   Ember.lookup.Foo = {toString: function() { return 'Foo'; }}; // Behave like an Ember.Namespace
@@ -83,7 +83,7 @@ test('[null, Foo.bar] -> Foo.bar', function() {
 // DEPRECATED
 //
 
-module("set with path - deprecated", {
+QUnit.module("set with path - deprecated", {
   setup: function() {
     moduleOpts.setup();
   },

--- a/packages_es6/ember-metal/tests/accessors/set_test.js
+++ b/packages_es6/ember-metal/tests/accessors/set_test.js
@@ -1,7 +1,7 @@
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 
-module('set');
+QUnit.module('set');
 
 test('should set arbitrary properties on an object', function() {
   var obj = {

--- a/packages_es6/ember-metal/tests/binding/connect_test.js
+++ b/packages_es6/ember-metal/tests/binding/connect_test.js
@@ -37,7 +37,7 @@ function performTest(binding, a, b, get, set, connect) {
 
 var originalLookup, lookup, GlobalB;
 
-module("Ember.Binding", {
+QUnit.module("Ember.Binding", {
   setup: function(){
     originalLookup = Ember.lookup;
     Ember.lookup = lookup = {};

--- a/packages_es6/ember-metal/tests/binding/oneWay_test.js
+++ b/packages_es6/ember-metal/tests/binding/oneWay_test.js
@@ -5,7 +5,7 @@ import { oneWay } from "ember-metal/binding";
 
 var MyApp;
 
-module('system/mixin/binding/oneWay_test', {
+QUnit.module('system/mixin/binding/oneWay_test', {
   setup: function() {
     MyApp = {
       foo: { value: 'FOO' },

--- a/packages_es6/ember-metal/tests/binding/sync_test.js
+++ b/packages_es6/ember-metal/tests/binding/sync_test.js
@@ -11,7 +11,7 @@ import { rewatch } from "ember-metal/watching";
 import { computed } from "ember-metal/computed";
 import { defineProperty } from "ember-metal/properties";
 
-module("system/binding/sync_test.js");
+QUnit.module("system/binding/sync_test.js");
 
 testBoth("bindings should not sync twice in a single run loop", function(get, set) {
   var a, b, setValue, setCalled=0, getCalled=0;

--- a/packages_es6/ember-metal/tests/chains_test.js
+++ b/packages_es6/ember-metal/tests/chains_test.js
@@ -3,7 +3,7 @@ import { addObserver } from "ember-metal/observer";
 import { finishChains } from "ember-metal/chains";
 import { create } from 'ember-metal/platform';
 
-module("Chains");
+QUnit.module("Chains");
 
 test("finishChains should properly copy chains from prototypes to instances", function() {
   function didChange() {}

--- a/packages_es6/ember-metal/tests/computed_test.js
+++ b/packages_es6/ember-metal/tests/computed_test.js
@@ -23,7 +23,7 @@ import EnumerableUtils from 'ember-metal/enumerable_utils';
 var originalLookup = Ember.lookup, lookup;
 var obj, count, Global;
 
-module('computed');
+QUnit.module('computed');
 
 test('computed property should be an instance of descriptor', function() {
   ok(computed(function() {}) instanceof Descriptor);
@@ -60,7 +60,7 @@ test('defining computed property should invoke property on set', function() {
 });
 
 var objA, objB;
-module('computed should inherit through prototype', {
+QUnit.module('computed should inherit through prototype', {
   setup: function() {
     objA = { __foo: 'FOO' } ;
     defineProperty(objA, 'foo', computed(function(key, value) {
@@ -96,7 +96,7 @@ testBoth('using get() and set()', function(get, set) {
   equal(get(objB, 'foo'), 'computed bar', 'should NOT change B');
 });
 
-module('redefining computed property to normal', {
+QUnit.module('redefining computed property to normal', {
   setup: function() {
     objA = { __foo: 'FOO' } ;
     defineProperty(objA, 'foo', computed(function(key, value) {
@@ -132,7 +132,7 @@ testBoth('using get() and set()', function(get, set) {
   equal(get(objB, 'foo'), 'bar', 'should NOT change B');
 });
 
-module('redefining computed property to another property', {
+QUnit.module('redefining computed property to another property', {
   setup: function() {
     objA = { __foo: 'FOO' } ;
     defineProperty(objA, 'foo', computed(function(key, value) {
@@ -174,7 +174,7 @@ testBoth('using get() and set()', function(get, set) {
   equal(get(objB, 'foo'), 'B bar', 'should NOT change B');
 });
 
-module('computed - metadata');
+QUnit.module('computed - metadata');
 
 test("can set metadata on a computed property", function() {
   var computedProperty = computed(function() { });
@@ -192,7 +192,7 @@ test("meta should return an empty hash if no meta is set", function() {
 // CACHEABLE
 //
 
-module('computed - cacheable', {
+QUnit.module('computed - cacheable', {
   setup: function() {
     obj = {};
     count = 0;
@@ -304,7 +304,7 @@ testBoth("the old value is only passed in if the computed property specifies thr
 // DEPENDENT KEYS
 //
 
-module('computed - dependentkey', {
+QUnit.module('computed - dependentkey', {
   setup: function() {
     obj = { bar: 'baz' };
     count = 0;
@@ -489,7 +489,7 @@ var func, moduleOpts = {
   }
 };
 
-module('computed - dependentkey with chained properties', moduleOpts);
+QUnit.module('computed - dependentkey with chained properties', moduleOpts);
 
 testBoth('depending on simple chain', function(get, set) {
 
@@ -596,7 +596,7 @@ testBoth('chained dependent keys should evaluate computed properties lazily', fu
 // BUGS
 //
 
-module('computed edge cases');
+QUnit.module('computed edge cases');
 
 test('adding a computed property should show up in key iteration',function() {
 
@@ -610,7 +610,7 @@ test('adding a computed property should show up in key iteration',function() {
 });
 
 
-module('computed - setter');
+QUnit.module('computed - setter');
 
 testBoth('setting a watched computed property', function(get, set) {
   var obj = {
@@ -709,7 +709,7 @@ testBoth('setting a cached computed property that modifies the value you give it
   equal(plusOneDidChange, 2);
 });
 
-module('computed - default setter');
+QUnit.module('computed - default setter');
 
 testBoth("when setting a value on a computed property that doesn't handle sets", function(get, set) {
   var obj = {}, observerFired = false;
@@ -729,7 +729,7 @@ testBoth("when setting a value on a computed property that doesn't handle sets",
   ok(observerFired, 'The observer was still notified');
 });
 
-module('computed - readOnly');
+QUnit.module('computed - readOnly');
 
 test('is chainable', function() {
   var cp = computed(function() {}).readOnly();
@@ -754,7 +754,7 @@ testBoth('protects against setting', function(get, set) {
   equal(get(obj, 'bar'), 'barValue');
 });
 
-module('CP macros');
+QUnit.module('CP macros');
 
 testBoth('computed.not', function(get, set) {
   var obj = {foo: true};

--- a/packages_es6/ember-metal/tests/core/inspect_test.js
+++ b/packages_es6/ember-metal/tests/core/inspect_test.js
@@ -1,7 +1,7 @@
 import { inspect } from "ember-metal/utils";
 import Ember from 'ember-metal/core';
 
-module("Ember.inspect");
+QUnit.module("Ember.inspect");
 
 test("strings", function() {
   equal(inspect("foo"), "foo");

--- a/packages_es6/ember-metal/tests/enumerable_utils_test.js
+++ b/packages_es6/ember-metal/tests/enumerable_utils_test.js
@@ -1,6 +1,6 @@
 import EnumerableUtils from 'ember-metal/enumerable_utils';
 
-module('Ember.EnumerableUtils.intersection');
+QUnit.module('Ember.EnumerableUtils.intersection');
 
 test('returns an array of objects that appear in both enumerables', function() {
   var a = [1,2,3], b = [2,3,4], result;

--- a/packages_es6/ember-metal/tests/error_test.js
+++ b/packages_es6/ember-metal/tests/error_test.js
@@ -1,4 +1,4 @@
-module("Ember Error Throwing");
+QUnit.module("Ember Error Throwing");
 
 test("new Ember.Error displays provided message", function() {
   raises( function() {

--- a/packages_es6/ember-metal/tests/events_test.js
+++ b/packages_es6/ember-metal/tests/events_test.js
@@ -16,7 +16,7 @@ import {
   actionsUnion
 } from "ember-metal/events";
 
-module('system/props/events_test');
+QUnit.module('system/props/events_test');
 
 test('listener should receive event - removing should remove', function() {
   var obj = {}, count = 0;

--- a/packages_es6/ember-metal/tests/features_test.js
+++ b/packages_es6/ember-metal/tests/features_test.js
@@ -3,7 +3,7 @@ import Ember from 'ember-metal/core';
 var isEnabled = Ember.FEATURES.isEnabled,
     origFeatures, origEnableAll, origEnableOptional;
 
-module("Ember.FEATURES.isEnabled", {
+QUnit.module("Ember.FEATURES.isEnabled", {
   setup: function(){
     origFeatures       = Ember.FEATURES;
     origEnableAll      = Ember.ENV.ENABLE_ALL_FEATURES;

--- a/packages_es6/ember-metal/tests/instrumentation_test.js
+++ b/packages_es6/ember-metal/tests/instrumentation_test.js
@@ -5,7 +5,7 @@ import {
   reset
 } from "ember-metal/instrumentation";
 
-module("Ember Instrumentation", {
+QUnit.module("Ember Instrumentation", {
   setup: function() {
 
   },

--- a/packages_es6/ember-metal/tests/is_blank_test.js
+++ b/packages_es6/ember-metal/tests/is_blank_test.js
@@ -1,6 +1,6 @@
 import isBlank from 'ember-metal/is_blank';
 
-module("Ember.isBlank");
+QUnit.module("Ember.isBlank");
 
 test("Ember.isBlank", function() {
   var string = "string", fn = function() {},

--- a/packages_es6/ember-metal/tests/is_empty_test.js
+++ b/packages_es6/ember-metal/tests/is_empty_test.js
@@ -1,6 +1,6 @@
 import isEmpty from 'ember-metal/is_empty';
 
-module("Ember.isEmpty");
+QUnit.module("Ember.isEmpty");
 
 test("Ember.isEmpty", function() {
   var string = "string", fn = function() {},

--- a/packages_es6/ember-metal/tests/is_none_test.js
+++ b/packages_es6/ember-metal/tests/is_none_test.js
@@ -1,6 +1,6 @@
 import isNone from 'ember-metal/is_none';
 
-module("Ember.isNone");
+QUnit.module("Ember.isNone");
 
 test("Ember.isNone", function() {
   var string = "string", fn = function() {};

--- a/packages_es6/ember-metal/tests/map_test.js
+++ b/packages_es6/ember-metal/tests/map_test.js
@@ -11,7 +11,7 @@ var varieties = [['Map', Map], ['MapWithDefault', MapWithDefault]], variety;
 function testMap(nameAndFunc) {
   variety = nameAndFunc[0];
 
-  module("Ember." + variety + " (forEach and get are implicitly tested)", {
+  QUnit.module("Ember." + variety + " (forEach and get are implicitly tested)", {
     setup: function() {
       object = {};
       number = 42;
@@ -165,7 +165,7 @@ for (var i = 0;  i < varieties.length;  i++) {
   testMap(varieties[i]);
 }
 
-module("MapWithDefault - default values");
+QUnit.module("MapWithDefault - default values");
 
 test("Retrieving a value that has not been set returns and sets a default value", function() {
   var map = MapWithDefault.create({

--- a/packages_es6/ember-metal/tests/mixin/alias_method_test.js
+++ b/packages_es6/ember-metal/tests/mixin/alias_method_test.js
@@ -1,4 +1,4 @@
-module('Ember.aliasMethod');
+QUnit.module('Ember.aliasMethod');
 
 function validateAliasMethod(obj) {
   equal(obj.fooMethod(), 'FOO', 'obj.fooMethod()');

--- a/packages_es6/ember-metal/tests/mixin/apply_test.js
+++ b/packages_es6/ember-metal/tests/mixin/apply_test.js
@@ -1,6 +1,6 @@
 /*globals raises */
 
-module('Ember.Mixin.apply');
+QUnit.module('Ember.Mixin.apply');
 
 function K() {}
 

--- a/packages_es6/ember-metal/tests/mixin/computed_test.js
+++ b/packages_es6/ember-metal/tests/mixin/computed_test.js
@@ -5,7 +5,7 @@ import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";
 import { defineProperty } from "ember-metal/properties";
 
-module('Mixin Computed Properties');
+QUnit.module('Mixin Computed Properties');
 
 test('overriding computed properties', function() {
   var MixinA, MixinB, MixinC, MixinD;

--- a/packages_es6/ember-metal/tests/mixin/concatenatedProperties_test.js
+++ b/packages_es6/ember-metal/tests/mixin/concatenatedProperties_test.js
@@ -1,6 +1,6 @@
 /*globals setup */
 
-module('Ember.Mixin concatenatedProperties');
+QUnit.module('Ember.Mixin concatenatedProperties');
 
 test('defining concatenated properties should concat future version', function() {
 

--- a/packages_es6/ember-metal/tests/mixin/detect_test.js
+++ b/packages_es6/ember-metal/tests/mixin/detect_test.js
@@ -5,7 +5,7 @@ import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";
 import { defineProperty } from "ember-metal/properties";
 
-module('Mixin.detect');
+QUnit.module('Mixin.detect');
 
 test('detect() finds a directly applied mixin', function() {
 

--- a/packages_es6/ember-metal/tests/mixin/introspection_test.js
+++ b/packages_es6/ember-metal/tests/mixin/introspection_test.js
@@ -39,7 +39,7 @@ var Combined = Mixin.create(BarProperties, BarMethods);
 
 var obj ;
 
-module('Basic introspection', {
+QUnit.module('Basic introspection', {
   setup: function() {
     obj = {};
     mixin(obj, PrivateProperty, PublicProperty, PrivateMethod, PublicMethod, Combined);

--- a/packages_es6/ember-metal/tests/mixin/mergedProperties_test.js
+++ b/packages_es6/ember-metal/tests/mixin/mergedProperties_test.js
@@ -6,7 +6,7 @@ import {
   Mixin
 } from 'ember-metal/mixin';
 
-module('Mixin mergedProperties');
+QUnit.module('Mixin mergedProperties');
 
 test('defining mergedProperties should merge future version', function() {
 

--- a/packages_es6/ember-metal/tests/mixin/method_test.js
+++ b/packages_es6/ember-metal/tests/mixin/method_test.js
@@ -7,7 +7,7 @@ import {
   Mixin
 } from 'ember-metal/mixin';
 
-module('Mixin Methods');
+QUnit.module('Mixin Methods');
 
 test('defining simple methods', function() {
 
@@ -159,7 +159,7 @@ test('_super from a first-of-two mixins with no superclass function does not err
 // CONFLICTS
 //
 
-module('Method Conflicts');
+QUnit.module('Method Conflicts');
 
 
 test('overriding toString', function() {
@@ -180,7 +180,7 @@ test('overriding toString', function() {
 // BUGS
 //
 
-module('system/mixin/method_test BUGS');
+QUnit.module('system/mixin/method_test BUGS');
 
 test('applying several mixins at once with sup already defined causes infinite loop', function() {
 

--- a/packages_es6/ember-metal/tests/mixin/observer_test.js
+++ b/packages_es6/ember-metal/tests/mixin/observer_test.js
@@ -10,7 +10,7 @@ import {
 } from 'ember-metal/mixin';
 import { isWatching } from "ember-metal/watching";
 
-module('Mixin observer');
+QUnit.module('Mixin observer');
 
 testBoth('global observer helper', function(get, set) {
 

--- a/packages_es6/ember-metal/tests/mixin/reopen_test.js
+++ b/packages_es6/ember-metal/tests/mixin/reopen_test.js
@@ -1,6 +1,6 @@
 import Mixin from 'ember-metal/mixin';
 
-module('Ember.Mixin#reopen');
+QUnit.module('Ember.Mixin#reopen');
 
 test('using reopen() to add more properties to a simple', function() {
   var MixinA = Mixin.create({ foo: 'FOO', baz: 'BAZ' });

--- a/packages_es6/ember-metal/tests/mixin/required_test.js
+++ b/packages_es6/ember-metal/tests/mixin/required_test.js
@@ -8,7 +8,7 @@ import { get } from 'ember-metal/property_get';
 
 var PartialMixin, FinalMixin, obj;
 
-module('Module.required', {
+QUnit.module('Module.required', {
   setup: function() {
     PartialMixin = Mixin.create({
       foo: required(),

--- a/packages_es6/ember-metal/tests/observer_test.js
+++ b/packages_es6/ember-metal/tests/observer_test.js
@@ -40,7 +40,7 @@ import { set } from 'ember-metal/property_set';
 // ADD OBSERVER
 //
 
-module('addObserver');
+QUnit.module('addObserver');
 
 testBoth('observer should fire when property is modified', function(get,set) {
 
@@ -573,7 +573,7 @@ testBoth('addObserver should allow multiple objects to observe a property', func
 // REMOVE OBSERVER
 //
 
-module('removeObserver');
+QUnit.module('removeObserver');
 
 testBoth('removing observer should stop firing', function(get,set) {
 
@@ -657,7 +657,7 @@ testBoth('removeObserver should respect targets with methods', function(get,set)
 // BEFORE OBSERVER
 //
 
-module('addBeforeObserver');
+QUnit.module('addBeforeObserver');
 
 testBoth('observer should fire before a property is modified', function(get,set) {
 
@@ -848,7 +848,7 @@ testBoth('addBeforeObserver should respect targets with methods', function(get,s
 var obj, count;
 var originalLookup = Ember.lookup, lookup;
 
-module('addObserver - dependentkey with chained properties', {
+QUnit.module('addObserver - dependentkey with chained properties', {
   setup: function() {
     obj = {
       foo: {
@@ -975,13 +975,13 @@ testBoth('depending on a Global chain', function(get, set) {
   equal(count, 6, 'should be not have invoked observer');
 });
 
-module('removeBeforeObserver');
+QUnit.module('removeBeforeObserver');
 
 // ..........................................................
 // SETTING IDENTICAL VALUES
 //
 
-module('props/observer_test - setting identical values');
+QUnit.module('props/observer_test - setting identical values');
 
 testBoth('setting simple prop should not trigger', function(get, set) {
 
@@ -1029,7 +1029,7 @@ testBoth('setting a cached computed property whose value has changed should trig
   equal(get(obj, 'foo'), 'bar');
 });
 
-module("Ember.immediateObserver");
+QUnit.module("Ember.immediateObserver");
 
 testBoth("immediate observers should fire synchronously", function(get, set) {
   var obj = {},
@@ -1139,7 +1139,7 @@ testBoth("immediate observers are for internal properties only", function(get, s
   }, 'Immediate observers must observe internal properties only, not properties on other objects.');
 });
 
-module("changeProperties");
+QUnit.module("changeProperties");
 
 testBoth("observers added/removed during changeProperties should do the right thing.", function(get,set) {
   var obj = {

--- a/packages_es6/ember-metal/tests/performance_test.js
+++ b/packages_es6/ember-metal/tests/performance_test.js
@@ -16,7 +16,7 @@ import { addObserver } from "ember-metal/observer";
   bugs that cause them to get evaluated more than necessary should be put here.
 */
 
-module("Computed Properties - Number of times evaluated");
+QUnit.module("Computed Properties - Number of times evaluated");
 
 test("computed properties that depend on multiple properties should run only once per run loop", function() {
   var obj = {a: 'a', b: 'b', c: 'c'};

--- a/packages_es6/ember-metal/tests/platform/create_test.js
+++ b/packages_es6/ember-metal/tests/platform/create_test.js
@@ -1,6 +1,6 @@
 import { create } from "ember-metal/platform";
 
-module("Ember.create()");
+QUnit.module("Ember.create()");
 
 test("should inherit the properties from the parent object", function() {
   var obj = { foo: 'FOO' };

--- a/packages_es6/ember-metal/tests/platform/defineProperty_test.js
+++ b/packages_es6/ember-metal/tests/platform/defineProperty_test.js
@@ -9,7 +9,7 @@ function isEnumerable(obj, keyName) {
   return EnumerableUtils.indexOf(keys, keyName)>=0;
 }
 
-module("platform.defineProperty()");
+QUnit.module("platform.defineProperty()");
 
 test("defining a simple property", function() {
   var obj = {};

--- a/packages_es6/ember-metal/tests/properties_test.js
+++ b/packages_es6/ember-metal/tests/properties_test.js
@@ -4,7 +4,7 @@ import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
 import { defineProperty } from "ember-metal/properties";
 
-module('Ember.defineProperty');
+QUnit.module('Ember.defineProperty');
 
 test('toString', function() {
 

--- a/packages_es6/ember-metal/tests/run_loop/add_queue_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/add_queue_test.js
@@ -4,7 +4,7 @@ import { indexOf } from "ember-metal/array";
 var originalQueues = run.queues;
 var queues;
 
-module('system/run_loop/add_queue_test',{
+QUnit.module('system/run_loop/add_queue_test',{
   setup: function(){
     run.queues = queues = ['blork', 'bleep'];
   },

--- a/packages_es6/ember-metal/tests/run_loop/debounce_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/debounce_test.js
@@ -2,7 +2,7 @@ import run from 'ember-metal/run_loop';
 
 var originalDebounce = run.backburner.debounce;
 var wasCalled = false;
-module('Ember.run.debounce',{
+QUnit.module('Ember.run.debounce',{
   setup: function() {
     run.backburner.debounce = function() { wasCalled = true; };
   },

--- a/packages_es6/ember-metal/tests/run_loop/join_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/join_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/join_test');
+QUnit.module('system/run_loop/join_test');
 
 test('run.join brings its own run loop if none provided', function() {
   ok(!run.currentRunLoop, 'expects no existing run-loop');

--- a/packages_es6/ember-metal/tests/run_loop/later_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/later_test.js
@@ -18,7 +18,7 @@ function wait(callback, maxWaitCount) {
   }, 10);
 }
 
-module('run.later', {
+QUnit.module('run.later', {
   teardown: function() {
     window.setTimeout = originalSetTimeout;
     Date.prototype.valueOf = originalDateValueOf;

--- a/packages_es6/ember-metal/tests/run_loop/next_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/next_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('run.next');
+QUnit.module('run.next');
 
 asyncTest('should invoke immediately on next timeout', function() {
 

--- a/packages_es6/ember-metal/tests/run_loop/once_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/once_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/once_test');
+QUnit.module('system/run_loop/once_test');
 
 test('calling invokeOnce more than once invokes only once', function() {
 

--- a/packages_es6/ember-metal/tests/run_loop/onerror_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/onerror_test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember-metal';
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/onerror_test');
+QUnit.module('system/run_loop/onerror_test');
 
 test('With Ember.onerror undefined, errors in Ember.run are thrown', function () {
   var thrown = new Error('Boom!'),

--- a/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/run_bind_test');
+QUnit.module('system/run_loop/run_bind_test');
 
 test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
   expect(3);

--- a/packages_es6/ember-metal/tests/run_loop/run_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/run_test');
+QUnit.module('system/run_loop/run_test');
 
 test('Ember.run invokes passed function, returning value', function() {
   var obj = {

--- a/packages_es6/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/schedule_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/schedule_test');
+QUnit.module('system/run_loop/schedule_test');
 
 test('scheduling item in queue should defer until finished', function() {
   var cnt = 0;

--- a/packages_es6/ember-metal/tests/run_loop/sync_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/sync_test.js
@@ -1,6 +1,6 @@
 import run from 'ember-metal/run_loop';
 
-module('system/run_loop/sync_test');
+QUnit.module('system/run_loop/sync_test');
 
 test('sync() will immediately flush the sync queue only', function() {
   var cnt = 0;

--- a/packages_es6/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/unwind_test.js
@@ -1,7 +1,7 @@
 import run from 'ember-metal/run_loop';
 import EmberError from 'ember-metal/error';
 
-module('system/run_loop/unwind_test');
+QUnit.module('system/run_loop/unwind_test');
 
 test('RunLoop unwinds despite unhandled exception', function() {
   var initialRunLoop = run.currentRunLoop;

--- a/packages_es6/ember-metal/tests/utils/can_invoke_test.js
+++ b/packages_es6/ember-metal/tests/utils/can_invoke_test.js
@@ -2,7 +2,7 @@ import { canInvoke } from "ember-metal/utils";
 
 var obj;
 
-module("Ember.canInvoke", {
+QUnit.module("Ember.canInvoke", {
   setup: function() {
     obj = {
       foobar: "foobar",

--- a/packages_es6/ember-metal/tests/utils/generate_guid_test.js
+++ b/packages_es6/ember-metal/tests/utils/generate_guid_test.js
@@ -1,6 +1,6 @@
 import { generateGuid } from "ember-metal/utils";
 
-module("Ember.generateGuid");
+QUnit.module("Ember.generateGuid");
 
 test("Prefix", function() {
   var a = {};

--- a/packages_es6/ember-metal/tests/utils/guidFor_test.js
+++ b/packages_es6/ember-metal/tests/utils/guidFor_test.js
@@ -4,7 +4,7 @@ import {
 } from "ember-metal/utils";
 import { rewatch } from "ember-metal/watching";
 
-module("guidFor");
+QUnit.module("guidFor");
 
 var sameGuid = function(a, b, message) {
   equal( guidFor(a), guidFor(b), message );

--- a/packages_es6/ember-metal/tests/utils/is_array_test.js
+++ b/packages_es6/ember-metal/tests/utils/is_array_test.js
@@ -1,5 +1,5 @@
 import { isArray } from 'ember-metal/utils';
-module("Ember Type Checking");
+QUnit.module("Ember Type Checking");
 
 var global = this;
 

--- a/packages_es6/ember-metal/tests/utils/meta_test.js
+++ b/packages_es6/ember-metal/tests/utils/meta_test.js
@@ -11,7 +11,7 @@ import {
   metaPath
 } from 'ember-metal/utils';
 
-module("Ember.meta");
+QUnit.module("Ember.meta");
 
 test("should return the same hash for an object", function() {
   var obj = {};
@@ -21,7 +21,7 @@ test("should return the same hash for an object", function() {
   equal(meta(obj).foo, "bar", "returns same hash with multiple calls to Ember.meta()");
 });
 
-module("Ember.metaPath");
+QUnit.module("Ember.metaPath");
 
 test("should not create nested objects if writable is false", function() {
   var obj = {};
@@ -52,7 +52,7 @@ test("getMeta and setMeta", function() {
   equal(getMeta(obj, 'foo'), "bar", "foo property on meta now exists");
 });
 
-module("Ember.meta enumerable");
+QUnit.module("Ember.meta enumerable");
 // Tests fix for https://github.com/emberjs/ember.js/issues/344
 // This is primarily for older browsers such as IE8
 if (platform.defineProperty.isSimulated) {

--- a/packages_es6/ember-metal/tests/utils/try_catch_finally_test.js
+++ b/packages_es6/ember-metal/tests/utils/try_catch_finally_test.js
@@ -3,7 +3,7 @@ import { tryCatchFinally } from 'ember-metal/utils';
 var tryCount, catchCount, finalizeCount, tryable, catchable, finalizer, error,
 tryableResult, catchableResult, finalizerResult;
 
-module("Ember.tryFinally", {
+QUnit.module("Ember.tryFinally", {
   setup: function() {
     error = new Error('Test Error');
     tryCount = 0;

--- a/packages_es6/ember-metal/tests/utils/try_finally_test.js
+++ b/packages_es6/ember-metal/tests/utils/try_finally_test.js
@@ -2,7 +2,7 @@ import { tryFinally } from 'ember-metal/utils';
 
 var tryCount, finalizeCount, tryable, finalizer, error, tryableResult, finalizerResult;
 
-module("Ember.tryFinally", {
+QUnit.module("Ember.tryFinally", {
   setup: function() {
     error = new Error('Test Error');
     tryCount = 0;

--- a/packages_es6/ember-metal/tests/utils/try_invoke_test.js
+++ b/packages_es6/ember-metal/tests/utils/try_invoke_test.js
@@ -2,7 +2,7 @@ import { tryInvoke } from 'ember-metal/utils';
 
 var obj;
 
-module("Ember.tryInvoke", {
+QUnit.module("Ember.tryInvoke", {
   setup: function() {
     obj = {
       aMethodThatExists: function() { return true; },

--- a/packages_es6/ember-metal/tests/utils/type_of_test.js
+++ b/packages_es6/ember-metal/tests/utils/type_of_test.js
@@ -1,6 +1,6 @@
 import { typeOf } from 'ember-metal/utils';
 
-module("Ember Type Checking");
+QUnit.module("Ember Type Checking");
 
 test("Ember.typeOf", function() {
   var MockedDate = function() { };

--- a/packages_es6/ember-metal/tests/watching/isWatching_test.js
+++ b/packages_es6/ember-metal/tests/watching/isWatching_test.js
@@ -10,7 +10,7 @@ import {
 } from "ember-metal/observer";
 import { isWatching } from 'ember-metal/watching';
 
-module('isWatching');
+QUnit.module('isWatching');
 
 function testObserver(setup, teardown, key) {
   var obj = {}, fn = function() {};

--- a/packages_es6/ember-metal/tests/watching/unwatch_test.js
+++ b/packages_es6/ember-metal/tests/watching/unwatch_test.js
@@ -15,7 +15,7 @@ import { set } from 'ember-metal/property_set';
 
 var willCount, didCount;
 
-module('unwatch', {
+QUnit.module('unwatch', {
   setup: function() {
     willCount = didCount = 0;
   }

--- a/packages_es6/ember-metal/tests/watching/watch_test.js
+++ b/packages_es6/ember-metal/tests/watching/watch_test.js
@@ -13,7 +13,7 @@ var willCount, didCount,
     indexOf = EnumerableUtils.indexOf,
     originalLookup, lookup, Global;
 
-module('watch', {
+QUnit.module('watch', {
   setup: function() {
     willCount = didCount = 0;
     willKeys = [];

--- a/packages_es6/ember-routing/tests/helpers/action_test.js
+++ b/packages_es6/ember-routing/tests/helpers/action_test.js
@@ -26,7 +26,7 @@ var appendView = function() {
   run(function() { view.appendTo('#qunit-fixture'); });
 };
 
-module("Ember.Handlebars - action helper", {
+QUnit.module("Ember.Handlebars - action helper", {
   setup: function() {
     originalActionHelper = EmberHandlebars.helpers['action'];
     EmberHandlebars.registerHelper('action', actionHelper);
@@ -1001,7 +1001,7 @@ test("a quoteless parameter that also exists as an action name in deprecated act
   Ember.FEATURES['ember-routing-drop-deprecated-action-style'] = dropDeprecatedActionStyleOrig;
 });
 
-module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
+QUnit.module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
   setup: function() {
     originalActionHelper = EmberHandlebars.helpers['action'];
     EmberHandlebars.registerHelper('action', actionHelper);

--- a/packages_es6/ember-routing/tests/helpers/outlet_test.js
+++ b/packages_es6/ember-routing/tests/helpers/outlet_test.js
@@ -73,7 +73,7 @@ var trim = jQuery.trim;
 
 var view, container, originalOutletHelper;
 
-module("Handlebars {{outlet}} helpers", {
+QUnit.module("Handlebars {{outlet}} helpers", {
 
   setup: function() {
     originalOutletHelper = EmberHandlebars.helpers['outlet'];

--- a/packages_es6/ember-routing/tests/helpers/render_test.js
+++ b/packages_es6/ember-routing/tests/helpers/render_test.js
@@ -84,7 +84,7 @@ function resolverFor(namespace) {
 
 var view, container, originalRenderHelper, originalActionHelper, originalOutletHelper;
 
-module("Handlebars {{render}} helper", {
+QUnit.module("Handlebars {{render}} helper", {
   setup: function() {
     originalOutletHelper = EmberHandlebars.helpers['outlet'];
     EmberHandlebars.registerHelper('outlet', outletHelper);

--- a/packages_es6/ember-routing/tests/location/auto_location_test.js
+++ b/packages_es6/ember-routing/tests/location/auto_location_test.js
@@ -27,7 +27,7 @@ function createLocation(options) {
   location = AutoTestLocation.create(options);
 }
 
-module("Ember.AutoLocation", {
+QUnit.module("Ember.AutoLocation", {
   setup: function() {
     supportsHistory = supportsHashChange = null;
 

--- a/packages_es6/ember-routing/tests/location/history_location_test.js
+++ b/packages_es6/ember-routing/tests/location/history_location_test.js
@@ -11,7 +11,7 @@ function createLocation(options){
   location = HistoryTestLocation.create(options);
 }
 
-module("Ember.HistoryLocation", {
+QUnit.module("Ember.HistoryLocation", {
   setup: function() {
     FakeHistory = {
       state: null,

--- a/packages_es6/ember-routing/tests/system/controller_for_test.js
+++ b/packages_es6/ember-routing/tests/system/controller_for_test.js
@@ -49,7 +49,7 @@ function resolverFor(namespace) {
 
 var container, appController, namespace;
 
-module("Ember.controllerFor", {
+QUnit.module("Ember.controllerFor", {
   setup: function() {
     namespace = Namespace.create();
     container = buildContainer(namespace);
@@ -70,7 +70,7 @@ test("controllerFor should lookup for registered controllers", function() {
   equal(appController, controller, 'should find app controller');
 });
 
-module("Ember.generateController", {
+QUnit.module("Ember.generateController", {
   setup: function() {
     namespace = Namespace.create();
     container = buildContainer(namespace);

--- a/packages_es6/ember-routing/tests/system/dsl_test.js
+++ b/packages_es6/ember-routing/tests/system/dsl_test.js
@@ -2,7 +2,7 @@ import EmberRouter from "ember-routing/system/router";
 
 var Router;
 
-module("Ember Router DSL", {
+QUnit.module("Ember Router DSL", {
   setup: function() {
     Router = EmberRouter.extend();
   },

--- a/packages_es6/ember-routing/tests/system/route_test.js
+++ b/packages_es6/ember-routing/tests/system/route_test.js
@@ -14,7 +14,7 @@ function cleanupRoute(){
   run(route, 'destroy');
 }
 
-module("Ember.Route", {
+QUnit.module("Ember.Route", {
   setup: createRoute,
   teardown: cleanupRoute
 });
@@ -130,7 +130,7 @@ test("'store' does not need to be injected", function() {
   ok(true, 'no error was raised');
 });
 
-module("Ember.Route serialize", {
+QUnit.module("Ember.Route serialize", {
   setup: createRoute,
   teardown: cleanupRoute
 });
@@ -151,7 +151,7 @@ test("returns undefined if model is not set", function(){
   equal(route.serialize(undefined, ['post_id']), undefined, "serialized correctly");
 });
 
-module("Ember.Route interaction", {
+QUnit.module("Ember.Route interaction", {
   setup: function() {
     container = {
       lookup: function(fullName) {

--- a/packages_es6/ember-routing/tests/system/router_test.js
+++ b/packages_es6/ember-routing/tests/system/router_test.js
@@ -15,7 +15,7 @@ function createRouter(overrides) {
   router = Router.create(opts);
 }
 
-module("Ember Router", {
+QUnit.module("Ember Router", {
   setup: function() {
     container = new Container();
 

--- a/packages_es6/ember-runtime/tests/computed/compose_computed_test.js
+++ b/packages_es6/ember-runtime/tests/computed/compose_computed_test.js
@@ -12,7 +12,7 @@ import EmberObject from 'ember-runtime/system/object';
 if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
   var obj;
 
-  module('computed - composable', {
+  QUnit.module('computed - composable', {
     teardown: function () {
       if (obj && obj.destroy) {
         run(function() {

--- a/packages_es6/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages_es6/ember-runtime/tests/computed/computed_macros_test.js
@@ -2,7 +2,7 @@ import {computed} from "ember-metal/computed";
 import EmberObject from "ember-runtime/system/object";
 import {testBoth} from "ember-runtime/tests/props_helper";
 
-module('CP macros');
+QUnit.module('CP macros');
 
 if (Ember.FEATURES.isEnabled('ember-metal-computed-empty-array')) {
   testBoth('Ember.computed.empty', function (get, set) {

--- a/packages_es6/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages_es6/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -29,7 +29,7 @@ import NativeArray from "ember-runtime/system/native_array";
 
 var obj, sorted, sortProps, items, userFnCalls, todos, filtered;
 
-module('computedMap', {
+QUnit.module('computedMap', {
   setup: function() {
     run(function() {
       userFnCalls = 0;
@@ -162,7 +162,7 @@ test("it maps unshifted objects with property observers", function() {
   deepEqual(get(obj, 'mapped'), ['A', 'B', 'D'], "properties unshifted in sequence are mapped correctly");
 });
 
-module('computedMapBy', {
+QUnit.module('computedMapBy', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -214,7 +214,7 @@ test("it is observerable", function() {
 });
 
 
-module('computedFilter', {
+QUnit.module('computedFilter', {
   setup: function() {
     run(function() {
       userFnCalls = 0;
@@ -326,7 +326,7 @@ test("it updates as the array is replaced", function() {
   deepEqual(filtered, [20,22,24], "computed array is updated when array is changed");
 });
 
-module('computedFilterBy', {
+QUnit.module('computedFilterBy', {
   setup: function() {
     obj = EmberObject.createWithMixins({
       array: Ember.A([
@@ -429,7 +429,7 @@ forEach.call([['uniq', computedUniq], ['union', computedUnion]], function (tuple
   var alias  = tuple[0],
       testedFunc = tuple[1];
 
-  module('computed.' + alias, {
+  QUnit.module('computed.' + alias, {
     setup: function() {
       run(function() {
         obj = EmberObject.createWithMixins({
@@ -502,7 +502,7 @@ forEach.call([['uniq', computedUniq], ['union', computedUnion]], function (tuple
   });
 });
 
-module('computed.intersect', {
+QUnit.module('computed.intersect', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -555,7 +555,7 @@ test("it has set-intersection semantics", function() {
 });
 
 
-module('computedSetDiff', {
+QUnit.module('computedSetDiff', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -750,7 +750,7 @@ function commonSortTests() {
   });
 }
 
-module('computedSort - sortProperties', {
+QUnit.module('computedSort - sortProperties', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -994,7 +994,7 @@ function sortByFnameDesc(a, b) {
   return -sortByFnameAsc(a,b);
 }
 
-module('computedSort - sort function', {
+QUnit.module('computedSort - sort function', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -1062,7 +1062,7 @@ test("changing item properties not specified via @each does not trigger a resort
   deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "updating an unspecified property on an item does not resort it");
 });
 
-module('computedMax', {
+QUnit.module('computedMax', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -1115,7 +1115,7 @@ test("max recomputes when the current max is removed", function() {
   equal(get(obj, 'max'), 1, "max is recomputed when the current max is removed");
 });
 
-module('computedMin', {
+QUnit.module('computedMin', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -1168,7 +1168,7 @@ test("min recomputes when the current min is removed", function() {
   equal(get(obj, 'min'), 3, "min is recomputed when the current min is removed");
 });
 
-module('Ember.arrayComputed - mixed sugar', {
+QUnit.module('Ember.arrayComputed - mixed sugar', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
@@ -1254,7 +1254,7 @@ function evenPriorities(todo) {
   return p % 2 === 0;
 }
 
-module('Ember.arrayComputed - chains', {
+QUnit.module('Ember.arrayComputed - chains', {
   setup: function() {
     obj = EmberObject.createWithMixins({
       todos: Ember.A([todo('E', 4), todo('D', 3), todo('C', 2), todo('B', 1), todo('A', 0)]),
@@ -1297,7 +1297,7 @@ test("it can filter and sort when both depend on the same item property", functi
   deepEqual(filtered.mapProperty('name'), ['A', 'C', 'E', 'D'], "filtered updated correctly");
 });
 
-module('Chaining array and reduced CPs', {
+QUnit.module('Chaining array and reduced CPs', {
   setup: function() {
     run(function() {
       userFnCalls = 0;
@@ -1336,7 +1336,7 @@ test("it computes interdependent array computed properties", function() {
   equal(calls, 1, 'runtime created observers fire');
 });
 
-module('computedSum', {
+QUnit.module('computedSum', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({

--- a/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
@@ -17,7 +17,7 @@ var map = EnumerableUtils.map,
     metaFor = meta,
     obj, addCalls, removeCalls, callbackItems;
 
-module('arrayComputed', {
+QUnit.module('arrayComputed', {
   setup: function () {
     addCalls = removeCalls = 0;
 
@@ -508,7 +508,7 @@ test("removedItem is not erroneously called for dependent arrays during a recomp
   ok(true, "removedItem not invoked with invalid index");
 });
 
-module('arrayComputed - recomputation DKs', {
+QUnit.module('arrayComputed - recomputation DKs', {
   setup: function() {
     obj = EmberObject.extend({
       people: Ember.A([{
@@ -565,7 +565,7 @@ test("recomputations from `arrayComputed` observers add back dependent keys", fu
   equal(meta.watching.people, 2, "watching.people is unchanged");
 });
 
-module('Ember.arryComputed - self chains', {
+QUnit.module('Ember.arryComputed - self chains', {
   setup: function() {
     var a = EmberObject.create({ name: 'a' }),
     b = EmberObject.create({ name: 'b' });
@@ -610,7 +610,7 @@ test("@this can be used to treat the object as the array itself", function() {
   deepEqual(names, ['a', 'c', 'd'], "@this observes new items");
 });
 
-module('arrayComputed - changeMeta property observers', {
+QUnit.module('arrayComputed - changeMeta property observers', {
   setup: function() {
     callbackItems = [];
     run(function() {
@@ -823,7 +823,7 @@ test("when initialValue is undefined, everything works as advertised", function(
   equal(get(chars, 'firstUpper'), 'B', "result is the next match when the first matching object is removed");
 });
 
-module('arrayComputed - completely invalidating dependencies', {
+QUnit.module('arrayComputed - completely invalidating dependencies', {
   setup: function () {
     addCalls = removeCalls = 0;
   }

--- a/packages_es6/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages_es6/ember-runtime/tests/controllers/array_controller_test.js
@@ -2,7 +2,7 @@ import Ember from 'ember-metal/core';
 import MutableArrayTests from 'ember-runtime/tests/suites/mutable_array';
 import ArrayController from "ember-runtime/controllers/array_controller";
 
-module("ember-runtime/controllers/array_controller_test");
+QUnit.module("ember-runtime/controllers/array_controller_test");
 
 MutableArrayTests.extend({
   name: 'Ember.ArrayController',

--- a/packages_es6/ember-runtime/tests/controllers/controller_test.js
+++ b/packages_es6/ember-runtime/tests/controllers/controller_test.js
@@ -3,7 +3,7 @@ import {Controller, ControllerMixin} from "ember-runtime/controllers/controller"
 import ObjectController from "ember-runtime/controllers/object_controller";
 import {Mixin} from "ember-metal/mixin";
 
-module('Controller event handling');
+QUnit.module('Controller event handling');
 
 test("Action can be handled by a function on actions object", function() {
   expect(1);
@@ -123,7 +123,7 @@ test("Action can be handled by a superclass' actions object", function() {
   controller.send("baz");
 });
 
-module('Controller deprecations');
+QUnit.module('Controller deprecations');
 
 if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
   test("Action can be handled by method directly on controller (DEPRECATED)", function() {
@@ -138,7 +138,7 @@ if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
   });
 }
 
-module('Controller Content -> Model Alias');
+QUnit.module('Controller Content -> Model Alias');
 
 test("`model` is aliased as `content`", function() {
   expect(1);

--- a/packages_es6/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages_es6/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -13,7 +13,7 @@ import Container from "container";
 var lannisters, arrayController, controllerClass, otherControllerClass, container, itemControllerCount,
     tywin, jaime, cersei, tyrion;
 
-module("Ember.ArrayController - itemController", {
+QUnit.module("Ember.ArrayController - itemController", {
   setup: function() {
     container = new Container();
 
@@ -332,7 +332,7 @@ test("`itemController`'s life cycle should be entangled with its parent controll
   equal(jaimeController.get('isDestroyed'), true);
 });
 
-module('Ember.ArrayController - itemController with arrayComputed', {
+QUnit.module('Ember.ArrayController - itemController with arrayComputed', {
   setup: function() {
     container = new Container();
 

--- a/packages_es6/ember-runtime/tests/controllers/object_controller_tests.js
+++ b/packages_es6/ember-runtime/tests/controllers/object_controller_tests.js
@@ -1,6 +1,6 @@
 import ObjectController from "ember-runtime/controllers/object_controller";
 
-module("Ember.ObjectController");
+QUnit.module("Ember.ObjectController");
 
 
 test("should be able to set the target property of an ObjectController", function() {

--- a/packages_es6/ember-runtime/tests/core/compare_test.js
+++ b/packages_es6/ember-runtime/tests/core/compare_test.js
@@ -4,7 +4,7 @@ import compare from "ember-runtime/compare";
 
 // test parsing of query string
 var v = [];
-module("Ember.compare()", {
+QUnit.module("Ember.compare()", {
   setup: function() {
     // setup dummy data
     v[0]  = null;

--- a/packages_es6/ember-runtime/tests/core/copy_test.js
+++ b/packages_es6/ember-runtime/tests/core/copy_test.js
@@ -1,6 +1,6 @@
 import copy from "ember-runtime/copy";
 
-module("Ember Copy Method");
+QUnit.module("Ember Copy Method");
 
 test("Ember.copy null", function() {
   var obj = {field: null};

--- a/packages_es6/ember-runtime/tests/core/isEqual_test.js
+++ b/packages_es6/ember-runtime/tests/core/isEqual_test.js
@@ -1,6 +1,6 @@
 import {isEqual} from "ember-runtime/core";
 
-module("isEqual");
+QUnit.module("isEqual");
 
 test("undefined and null", function() {
   ok(  isEqual(undefined, undefined), "undefined is equal to undefined" );

--- a/packages_es6/ember-runtime/tests/core/is_array_test.js
+++ b/packages_es6/ember-runtime/tests/core/is_array_test.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core";
 import {isArray} from "ember-metal/utils";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 
-module("Ember Type Checking");
+QUnit.module("Ember Type Checking");
 
 test("Ember.isArray" ,function() {
   var arrayProxy = ArrayProxy.create({ content: Ember.A() });

--- a/packages_es6/ember-runtime/tests/core/is_empty_test.js
+++ b/packages_es6/ember-runtime/tests/core/is_empty_test.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core";
 import {isEmpty} from 'ember-metal/is_empty';
 import ArrayProxy from "ember-runtime/system/array_proxy";
 
-module("Ember.isEmpty");
+QUnit.module("Ember.isEmpty");
 
 test("Ember.isEmpty", function() {
   var arrayProxy = ArrayProxy.create({ content: Ember.A() });

--- a/packages_es6/ember-runtime/tests/core/keys_test.js
+++ b/packages_es6/ember-runtime/tests/core/keys_test.js
@@ -3,7 +3,7 @@ import keys from "ember-runtime/keys";
 import {addObserver, removeObserver} from "ember-metal/observer";
 import EmberObject from "ember-runtime/system/object";
 
-module("Fetch Keys ");
+QUnit.module("Fetch Keys ");
 
 test("should get a key array for a specified object", function() {
   var object1 = {};
@@ -58,7 +58,7 @@ test('should return properties that were set after object creation', function ()
   deepEqual(keys(beer), ['brand']);
 });
 
-module('Keys behavior with observers');
+QUnit.module('Keys behavior with observers');
 
 test('should not leak properties on the prototype', function () {
   var beer = EmberObject.extend({

--- a/packages_es6/ember-runtime/tests/core/type_test.js
+++ b/packages_es6/ember-runtime/tests/core/type_test.js
@@ -1,7 +1,7 @@
 import {typeOf} from "ember-metal/utils";
 import EmberObject from "ember-runtime/system/object";
 
-module("Ember Type Checking");
+QUnit.module("Ember Type Checking");
 
 test("Ember.typeOf", function() {
   var a = null,

--- a/packages_es6/ember-runtime/tests/ext/function_test.js
+++ b/packages_es6/ember-runtime/tests/ext/function_test.js
@@ -1,6 +1,6 @@
 import {testWithDefault, testBoth} from 'ember-runtime/tests/props_helper';
 
-module('Function.prototype.observes() helper');
+QUnit.module('Function.prototype.observes() helper');
 
 testBoth('global observer helper takes multiple params', function(get, set) {
 
@@ -27,7 +27,7 @@ testBoth('global observer helper takes multiple params', function(get, set) {
   equal(get(obj, 'count'), 2, 'should invoke observer after change');
 });
 
-module('Function.prototype.on() helper');
+QUnit.module('Function.prototype.on() helper');
 
 testBoth('sets up an event listener, and can trigger the function on multiple events', function(get, set) {
 
@@ -78,7 +78,7 @@ testBoth('can be chained with observes', function(get, set) {
   equal(get(obj, 'count'), 2, 'should invoke observer and listener');
 });
 
-module('Function.prototype.property() helper');
+QUnit.module('Function.prototype.property() helper');
 
 testBoth('sets up a ComputedProperty', function(get, set) {
 

--- a/packages_es6/ember-runtime/tests/ext/mixin_test.js
+++ b/packages_es6/ember-runtime/tests/ext/mixin_test.js
@@ -5,7 +5,7 @@ import {create, platform} from "ember-metal/platform";
 import {Binding, isGlobalPath, bind, oneWay} from "ember-metal/binding";
 import run from "ember-metal/run_loop";
 
-module('system/mixin/binding_test');
+QUnit.module('system/mixin/binding_test');
 
 test('Defining a property ending in Binding should setup binding when applied', function() {
 

--- a/packages_es6/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages_es6/ember-runtime/tests/ext/rsvp_test.js
@@ -1,7 +1,7 @@
 import run from "ember-metal/run_loop";
 import RSVP from "ember-runtime/ext/rsvp";
 
-module('Ember.RSVP');
+QUnit.module('Ember.RSVP');
 
 test('Ensure that errors thrown from within a promise are sent to the console', function(){
   var error = new Error('Error thrown in a promise for testing purposes.');

--- a/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -16,7 +16,7 @@ import {addObserver}  from "ember-metal/observer";
   * changed obj.addObserver() to addObserver()
 */
 
-module("Ember.Observable - Observing with @each");
+QUnit.module("Ember.Observable - Observing with @each");
 
 test("chained observers on enumerable properties are triggered when the observed property of any item changes", function() {
   var family = EmberObject.create({ momma: null });

--- a/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -46,7 +46,7 @@ var originalLookup = Ember.lookup, lookup;
 // GET()
 //
 
-module("object.get()", {
+QUnit.module("object.get()", {
 
   setup: function() {
     object = ObservableObject.createWithMixins(Observable, {
@@ -96,7 +96,7 @@ test("should call unknownProperty when value is undefined", function() {
 // ..........................................................
 // Ember.GET()
 //
-module("Ember.get()", {
+QUnit.module("Ember.get()", {
   setup: function() {
     objectA = ObservableObject.createWithMixins({
 
@@ -174,7 +174,7 @@ test("should work when object is Ember (used in Ember.get)", function() {
   equal(get(Ember, 'RunLoop'), Ember.RunLoop, 'Ember.get(Ember, RunLoop)');
 });
 
-module("Ember.get() with paths", {
+QUnit.module("Ember.get() with paths", {
   setup: function() {
     lookup = Ember.lookup = {};
   },
@@ -228,7 +228,7 @@ test("should return a property at a given path relative to the passed object - J
 // SET()
 //
 
-module("object.set()", {
+QUnit.module("object.set()", {
 
   setup: function() {
     object = ObservableObject.createWithMixins({
@@ -313,7 +313,7 @@ test("should call unknownProperty with value when property is undefined", functi
 // COMPUTED PROPERTIES
 //
 
-module("Computed properties", {
+QUnit.module("Computed properties", {
   setup: function() {
     lookup = Ember.lookup = {};
 
@@ -642,7 +642,7 @@ test("cacheable nested dependent keys should clear after their dependencies upda
 // OBSERVABLE OBJECTS
 //
 
-module("Observable objects & object properties ", {
+QUnit.module("Observable objects & object properties ", {
 
   setup: function() {
     object = ObservableObject.createWithMixins({
@@ -748,7 +748,7 @@ test('should notify array observer when array changes',function() {
   equal(object.abnormal, 'notifiedObserver', 'observer should be notified');
 });
 
-module("object.addObserver()", {
+QUnit.module("object.addObserver()", {
   setup: function() {
 
     ObjectC = ObservableObject.create({
@@ -793,7 +793,7 @@ test("should register an observer for a property - Special case of chained prope
   equal('chainedPropertyObserved',ObjectC.normal2);
 });
 
-module("object.removeObserver()", {
+QUnit.module("object.removeObserver()", {
   setup: function() {
     ObjectD = ObservableObject.create({
 
@@ -880,7 +880,7 @@ test("removing an observer inside of an observer shouldn’t cause any problems"
 
 
 
-module("Bind function ", {
+QUnit.module("Bind function ", {
 
   setup: function() {
     originalLookup = Ember.lookup;

--- a/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
@@ -24,7 +24,7 @@ var ObservableObject = EmberObject.extend(Observable);
 // GET()
 //
 
-module("object.observesForKey()");
+QUnit.module("object.observesForKey()");
 
 test("should get observers", function() {
   var o1 = ObservableObject.create({ foo: 100 }),

--- a/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -29,7 +29,7 @@ var ObservableObject = EmberObject.extend(Observable);
 
 var revMatches = false , ObjectA;
 
-module("object.propertyChanges", {
+QUnit.module("object.propertyChanges", {
   setup: function() {
     ObjectA = ObservableObject.createWithMixins({
       foo  : 'fooValue',

--- a/packages_es6/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -47,7 +47,7 @@ import EmberObject from 'ember-runtime/system/object';
 var TestNamespace, fromObject, toObject, binding, Bon1, bon2, root; // global variables
 var originalLookup, lookup;
 
-module("basic object binding", {
+QUnit.module("basic object binding", {
   setup: function() {
     fromObject = EmberObject.create({ value: 'start' }) ;
     toObject = EmberObject.create({ value: 'end' }) ;
@@ -125,7 +125,7 @@ test("binding disconnection actually works", function() {
 // one way binding
 //
 
-module("one way binding", {
+QUnit.module("one way binding", {
 
   setup: function() {
     run(function() {
@@ -162,7 +162,7 @@ var first, second, third, binding1, binding2; // global variables
 // chained binding
 //
 
-module("chained binding", {
+QUnit.module("chained binding", {
 
   setup: function() {
     run(function() {
@@ -206,7 +206,7 @@ test("changing first output should propograte to third after flush", function() 
 // Custom Binding
 //
 
-module("Custom Binding", {
+QUnit.module("Custom Binding", {
   setup: function() {
     originalLookup = Ember.lookup;
     Ember.lookup = lookup = {};
@@ -272,7 +272,7 @@ test("two bindings to the same value should sync in the order they are initializ
 // propertyNameBinding with longhand
 //
 
-module("propertyNameBinding with longhand", {
+QUnit.module("propertyNameBinding with longhand", {
   setup: function() {
     originalLookup = Ember.lookup;
     Ember.lookup = lookup = {};

--- a/packages_es6/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -29,7 +29,7 @@ import EmberObject from 'ember-runtime/system/object';
 var obj, obj1, don, don1 ; // global variables
 var TestNamespace, originalLookup, lookup;
 
-module("A new EmberObject instance", {
+QUnit.module("A new EmberObject instance", {
 
   setup: function() {
     obj = EmberObject.create({
@@ -65,7 +65,7 @@ test("Should allow changing of those properties by calling EmberObject#set", fun
 });
 
 
-module("EmberObject observers", {
+QUnit.module("EmberObject observers", {
   setup: function() {
     originalLookup = Ember.lookup;
     Ember.lookup = lookup = {};
@@ -122,7 +122,7 @@ test("Global+Local observer works", function() {
 
 
 
-module("EmberObject superclass and subclasses", {
+QUnit.module("EmberObject superclass and subclasses", {
   setup: function() {
     obj = EmberObject.extend ({
     method1: function() {

--- a/packages_es6/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
@@ -59,7 +59,7 @@ var bindModuleOpts = {
 
 };
 
-module("bind() method", bindModuleOpts);
+QUnit.module("bind() method", bindModuleOpts);
 
 test("bind(TestNamespace.fromObject.bar) should follow absolute path", function() {
   run(function() {
@@ -120,7 +120,7 @@ var fooBindingModuleOpts = {
 
 };
 
-module("fooBinding method", fooBindingModuleOpts);
+QUnit.module("fooBinding method", fooBindingModuleOpts);
 
 
 test("fooBinding: TestNamespace.fromObject.bar should follow absolute path", function() {

--- a/packages_es6/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -20,7 +20,7 @@ import EmberObject from 'ember-runtime/system/object';
 
   var klass;
 
-  module("EmberObject Concatenated Properties", {
+  QUnit.module("EmberObject Concatenated Properties", {
     setup: function() {
       klass = EmberObject.extend({
         concatenatedProperties: ['values', 'functions'],

--- a/packages_es6/ember-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -23,7 +23,7 @@ import EmberObject from 'ember-runtime/system/object';
 
 var MyApp, binding1, binding2, previousPreventRunloop;
 
-module("System:run_loop() - chained binding", {
+QUnit.module("System:run_loop() - chained binding", {
   setup: function() {
     MyApp = {};
     MyApp.first = EmberObject.createWithMixins(Observable, {

--- a/packages_es6/ember-runtime/tests/legacy_1x/system/set_test.js
+++ b/packages_es6/ember-runtime/tests/legacy_1x/system/set_test.js
@@ -16,7 +16,7 @@ import EmberArray from "ember-runtime/mixins/array";
 
 var a, b, c ; // global variables
 
-module("creating Set instances", {
+QUnit.module("creating Set instances", {
 
   setup: function() {
     // create objects...
@@ -64,7 +64,7 @@ var set ; // global variables
 
 // The tests below also end up testing the contains() method pretty
 // exhaustively.
-module("Set.add + Set.contains", {
+QUnit.module("Set.add + Set.contains", {
 
   setup: function() {
     set = new Set() ;
@@ -167,7 +167,7 @@ test("adding an item, removing it, adding another item", function() {
   equal(set.length, 2, "set.length") ;
 });
 
-module("Set.remove + Set.contains", {
+QUnit.module("Set.remove + Set.contains", {
 
   // generate a set with every type of object, but none of the specific
   // ones we add in the tests below...
@@ -277,7 +277,7 @@ test("should ignore removing an object not in the set", function() {
   equal(set.length, oldLength) ;
 });
 
-module("Set.pop + Set.copy", {
+QUnit.module("Set.pop + Set.copy", {
 // generate a set with every type of object, but none of the specific
 // ones we add in the tests below...
   setup: function() {

--- a/packages_es6/ember-runtime/tests/mixins/array_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/array_test.js
@@ -110,7 +110,7 @@ var obj, observer;
 // NOTIFY ARRAY OBSERVERS
 //
 
-module('mixins/array/arrayContent[Will|Did]Change');
+QUnit.module('mixins/array/arrayContent[Will|Did]Change');
 
 test('should notify observers of []', function() {
 
@@ -134,7 +134,7 @@ test('should notify observers of []', function() {
 // NOTIFY CHANGES TO LENGTH
 //
 
-module('notify observers of length', {
+QUnit.module('notify observers of length', {
   setup: function() {
     obj = DummyArray.createWithMixins({
       _after: 0,
@@ -182,7 +182,7 @@ test('should notify when passed lengths are different', function() {
 // NOTIFY ARRAY OBSERVER
 //
 
-module('notify array observers', {
+QUnit.module('notify array observers', {
   setup: function() {
     obj = DummyArray.create();
 
@@ -247,7 +247,7 @@ test('removing enumerable observer should disable', function() {
 // NOTIFY ENUMERABLE OBSERVER
 //
 
-module('notify enumerable observers as well', {
+QUnit.module('notify enumerable observers as well', {
   setup: function() {
     obj = DummyArray.create();
 
@@ -314,7 +314,7 @@ test('removing enumerable observer should disable', function() {
 
 var ary;
 
-module('EmberArray.@each support', {
+QUnit.module('EmberArray.@each support', {
   setup: function() {
     ary = new TestArray([
       { isDone: true,  desc: 'Todo 1' },

--- a/packages_es6/ember-runtime/tests/mixins/comparable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/comparable_test.js
@@ -19,7 +19,7 @@ var Rectangle = EmberObject.extend(Comparable, {
 
 var r1, r2;
 
-module("Comparable", {
+QUnit.module("Comparable", {
 
   setup: function() {
     r1 = Rectangle.create({length: 6, width: 12});

--- a/packages_es6/ember-runtime/tests/mixins/deferred_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/deferred_test.js
@@ -6,7 +6,7 @@ import EmberObject from 'ember-runtime/system/object';
 import Deferred from "ember-runtime/mixins/deferred";
 import RSVP from "ember-runtime/ext/rsvp";
 
-module("Deferred");
+QUnit.module("Deferred");
 
 test("can resolve deferred", function() {
   var deferred, count = 0;
@@ -328,7 +328,7 @@ if (Ember.FEATURES['ember-runtime-test-friendly-promises']) {
   var EmberTest;
   var EmberTesting;
 
-  module("Deferred RSVP's async + Testing", {
+  QUnit.module("Deferred RSVP's async + Testing", {
     setup: function() {
       EmberTest = Ember.Test;
       EmberTesting = Ember.testing;

--- a/packages_es6/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/enumerable_test.js
@@ -64,7 +64,7 @@ EnumerableTests.extend({
 
 }).run();
 
-module('Ember.Enumerable');
+QUnit.module('Ember.Enumerable');
 
 test("should apply Ember.Array to return value of map", function() {
   var x = EmberObject.createWithMixins(Enumerable);
@@ -175,7 +175,7 @@ var obj, observer;
 // NOTIFY ENUMERABLE PROPERTY
 //
 
-module('mixins/enumerable/enumerableContentDidChange');
+QUnit.module('mixins/enumerable/enumerableContentDidChange');
 
 test('should notify observers of []', function() {
 
@@ -199,7 +199,7 @@ test('should notify observers of []', function() {
 // NOTIFY CHANGES TO LENGTH
 //
 
-module('notify observers of length', {
+QUnit.module('notify observers of length', {
   setup: function() {
     obj = DummyEnum.createWithMixins({
       _after: 0,
@@ -266,7 +266,7 @@ test('should notify when passed old index API with delta', function() {
 // NOTIFY ENUMERABLE OBSERVER
 //
 
-module('notify enumerable observers', {
+QUnit.module('notify enumerable observers', {
   setup: function() {
     obj = DummyEnum.create();
 

--- a/packages_es6/ember-runtime/tests/mixins/observable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/observable_test.js
@@ -3,7 +3,7 @@ import {addObserver} from "ember-metal/observer";
 import EmberObject from 'ember-runtime/system/object';
 import {testBoth} from 'ember-runtime/tests/props_helper';
 
-module('mixins/observable');
+QUnit.module('mixins/observable');
 
 test('should be able to use getProperties to get a POJO of provided keys', function() {
   var obj = EmberObject.create({

--- a/packages_es6/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -13,7 +13,7 @@ test("present on ember namespace", function(){
   ok(PromiseProxyMixin, "expected PromiseProxyMixin to exist");
 });
 
-module("Ember.PromiseProxy - ObjectProxy", {
+QUnit.module("Ember.PromiseProxy - ObjectProxy", {
   setup: function() {
     ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
   }

--- a/packages_es6/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/sortable_test.js
@@ -11,9 +11,9 @@ import ArrayController from "ember-runtime/controllers/array_controller";
 
 var unsortedArray, sortedArrayController;
 
-module("Ember.Sortable");
+QUnit.module("Ember.Sortable");
 
-module("Ember.Sortable with content", {
+QUnit.module("Ember.Sortable with content", {
   setup: function() {
     run(function() {
       var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
@@ -146,7 +146,7 @@ test("changing sortProperties and sortAscending with setProperties, sortAscendin
 
 });
 
-module("Ember.Sortable with content and sortProperties", {
+QUnit.module("Ember.Sortable with content and sortProperties", {
   setup: function() {
     run(function() {
       var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
@@ -271,7 +271,7 @@ test("sortProperties observers removed on content removal", function() {
     "After removal, there should be no listeners for sortProperty change.");
 });
 
-module("Ember.Sortable with sortProperties", {
+QUnit.module("Ember.Sortable with sortProperties", {
   setup: function() {
     run(function() {
       sortedArrayController = ArrayController.create({
@@ -300,7 +300,7 @@ test("you can set content later and it will be sorted", function() {
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
 
-module("Ember.Sortable with sortFunction and sortProperties", {
+QUnit.module("Ember.Sortable with sortFunction and sortProperties", {
   setup: function() {
     run(function() {
       sortedArrayController = ArrayController.create({

--- a/packages_es6/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/target_action_support_test.js
@@ -4,7 +4,7 @@ import TargetActionSupport from "ember-runtime/mixins/target_action_support";
 
 var originalLookup;
 
-module("TargetActionSupport", {
+QUnit.module("TargetActionSupport", {
   setup: function() {
     originalLookup = Ember.lookup;
   },

--- a/packages_es6/ember-runtime/tests/suites/suite.js
+++ b/packages_es6/ember-runtime/tests/suites/suite.js
@@ -68,7 +68,7 @@ Suite.reopenClass({
       run: function() {
         this._super();
         var title = get(this, 'name')+': '+desc, ctx = this;
-        module(title, {
+        QUnit.module(title, {
           setup: function() {
             if (setup) setup.call(ctx);
           },

--- a/packages_es6/ember-runtime/tests/system/application/base_test.js
+++ b/packages_es6/ember-runtime/tests/system/application/base_test.js
@@ -1,7 +1,7 @@
 import Namespace from "ember-runtime/system/namespace";
 import Application from "ember-runtime/system/application";
 
-module('Ember.Application');
+QUnit.module('Ember.Application');
 
 test('Ember.Application should be a subclass of Ember.Namespace', function() {
 

--- a/packages_es6/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages_es6/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -5,7 +5,7 @@ import ArrayProxy from "ember-runtime/system/array_proxy";
 
 var array;
 
-module("ArrayProxy - arrangedContent", {
+QUnit.module("ArrayProxy - arrangedContent", {
   setup: function() {
     run(function() {
       array = ArrayProxy.createWithMixins({
@@ -172,7 +172,7 @@ test("firstObject - returns first arranged object", function() {
 });
 
 
-module("ArrayProxy - arrangedContent matching content", {
+QUnit.module("ArrayProxy - arrangedContent matching content", {
   setup: function() {
     run(function() {
       array = ArrayProxy.createWithMixins({
@@ -202,7 +202,7 @@ test("reverseObjects - reverses content", function() {
   deepEqual(array.get('content'), [5,4,2,1]);
 });
 
-module("ArrayProxy - arrangedContent with transforms", {
+QUnit.module("ArrayProxy - arrangedContent with transforms", {
   setup: function() {
     run(function() {
       array = ArrayProxy.createWithMixins({

--- a/packages_es6/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages_es6/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -4,7 +4,7 @@ import run from "ember-metal/run_loop";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import ArrayController from "ember-runtime/controllers/array_controller";
 
-module("ArrayProxy - content change");
+QUnit.module("ArrayProxy - content change");
 
 test("should update length for null content", function() {
   var proxy = ArrayProxy.create({

--- a/packages_es6/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages_es6/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core";
 import {computed} from "ember-metal/computed";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 
-module("Ember.ArrayProxy - content update");
+QUnit.module("Ember.ArrayProxy - content update");
 
 test("The `contentArrayDidChange` method is invoked after `content` is updated.", function() {
 

--- a/packages_es6/ember-runtime/tests/system/deferred_test.js
+++ b/packages_es6/ember-runtime/tests/system/deferred_test.js
@@ -2,7 +2,7 @@ import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import Deferred from "ember-runtime/system/deferred";
 
-module("Ember.Deferred all-in-one");
+QUnit.module("Ember.Deferred all-in-one");
 
 asyncTest("Can resolve a promise", function() {
   var value = { value: true };

--- a/packages_es6/ember-runtime/tests/system/lazy_load_test.js
+++ b/packages_es6/ember-runtime/tests/system/lazy_load_test.js
@@ -2,7 +2,7 @@ import Ember from 'ember-metal/core';
 import run from 'ember-metal/run_loop';
 import {onLoad, runLoadHooks} from "ember-runtime/system/lazy_load";
 
-module("Lazy Loading");
+QUnit.module("Lazy Loading");
 
 test("if a load hook is registered, it is executed when runLoadHooks are exected", function() {
   var count = 0;

--- a/packages_es6/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages_es6/ember-runtime/tests/system/namespace/base_test.js
@@ -7,7 +7,7 @@ import Namespace from "ember-runtime/system/namespace";
 
 var originalLookup, lookup;
 
-module('Namespace', {
+QUnit.module('Namespace', {
   setup: function() {
     originalLookup = Ember.lookup;
     Ember.BOOTED = false;

--- a/packages_es6/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages_es6/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -18,7 +18,7 @@ CopyableTests.extend({
   shouldBeFreezable: false
 }).run();
 
-module("NativeArray Copyable");
+QUnit.module("NativeArray Copyable");
 
 test("deep copy is respected", function() {
   var array = Ember.A([ { id: 1 }, { id: 2 }, { id: 3 } ]);

--- a/packages_es6/ember-runtime/tests/system/object/computed_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/computed_test.js
@@ -4,7 +4,7 @@ import {observer} from "ember-metal/mixin";
 import {testWithDefault, testBoth} from 'ember-runtime/tests/props_helper';
 import EmberObject from "ember-runtime/system/object";
 
-module('EmberObject computed property');
+QUnit.module('EmberObject computed property');
 
 testWithDefault('computed property on instance', function(get, set) {
 

--- a/packages_es6/ember-runtime/tests/system/object/create_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/create_test.js
@@ -21,7 +21,7 @@ moduleOptions = {
   }
 };
 
-module('EmberObject.create', moduleOptions);
+QUnit.module('EmberObject.create', moduleOptions);
 
 test("simple properties are set", function() {
   var o = EmberObject.create({ohai: 'there'});
@@ -153,7 +153,7 @@ test("EmberObject.create can take null as a parameter", function(){
   deepEqual(EmberObject.create(), o);
 });
 
-module('EmberObject.createWithMixins', moduleOptions);
+QUnit.module('EmberObject.createWithMixins', moduleOptions);
 
 test("Creates a new object that contains passed properties", function() {
 

--- a/packages_es6/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/destroy_test.js
@@ -10,7 +10,7 @@ import objectKeys from "ember-runtime/keys";
 import {testBoth} from 'ember-runtime/tests/props_helper';
 import EmberObject from 'ember-runtime/system/object';
 
-module('ember-runtime/system/object/destroy_test');
+QUnit.module('ember-runtime/system/object/destroy_test');
 
 testBoth("should schedule objects to be destroyed at the end of the run loop", function(get, set) {
   var obj = EmberObject.create(), meta;

--- a/packages_es6/ember-runtime/tests/system/object/detectInstance_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/detectInstance_test.js
@@ -1,6 +1,6 @@
 import EmberObject from "ember-runtime/system/object";
 
-module('system/object/detectInstance');
+QUnit.module('system/object/detectInstance');
 
 test('detectInstance detects instances correctly', function() {
 

--- a/packages_es6/ember-runtime/tests/system/object/detect_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/detect_test.js
@@ -1,6 +1,6 @@
 import EmberObject from "ember-runtime/system/object";
 
-module('system/object/detect');
+QUnit.module('system/object/detect');
 
 test('detect detects classes correctly', function() {
 

--- a/packages_es6/ember-runtime/tests/system/object/events_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/events_test.js
@@ -1,7 +1,7 @@
 import EmberObject from "ember-runtime/system/object";
 import Evented from "ember-runtime/mixins/evented";
 
-module("Object events");
+QUnit.module("Object events");
 
 test("a listener can be added to an object", function() {
   var count = 0;

--- a/packages_es6/ember-runtime/tests/system/object/extend_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/extend_test.js
@@ -1,7 +1,7 @@
 import {get} from "ember-metal/property_get";
 import EmberObject from "ember-runtime/system/object";
 
-module('EmberObject.extend');
+QUnit.module('EmberObject.extend');
 
 test('Basic extend', function() {
   var SomeClass = EmberObject.extend({ foo: 'BAR' });

--- a/packages_es6/ember-runtime/tests/system/object/observer_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/observer_test.js
@@ -4,7 +4,7 @@ import run from "ember-metal/run_loop";
 import {testWithDefault, testBoth} from 'ember-runtime/tests/props_helper';
 import EmberObject from "ember-runtime/system/object";
 
-module('EmberObject observer');
+QUnit.module('EmberObject observer');
 
 testBoth('observer on class', function(get, set) {
 

--- a/packages_es6/ember-runtime/tests/system/object/reopenClass_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/reopenClass_test.js
@@ -1,7 +1,7 @@
 import {get} from "ember-metal/property_get";
 import EmberObject from "ember-runtime/system/object";
 
-module('system/object/reopenClass');
+QUnit.module('system/object/reopenClass');
 
 test('adds new properties to subclass', function() {
 

--- a/packages_es6/ember-runtime/tests/system/object/reopen_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/reopen_test.js
@@ -1,7 +1,7 @@
 import {get} from "ember-metal/property_get";
 import EmberObject from "ember-runtime/system/object";
 
-module('system/core_object/reopen');
+QUnit.module('system/core_object/reopen');
 
 test('adds new properties to subclass instance', function() {
 

--- a/packages_es6/ember-runtime/tests/system/object/subclasses_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/subclasses_test.js
@@ -2,7 +2,7 @@ import run from "ember-metal/run_loop";
 import {computed} from "ember-metal/computed";
 import EmberObject from "ember-runtime/system/object";
 
-module('system/object/subclasses');
+QUnit.module('system/object/subclasses');
 
 test('chains should copy forward to subclasses when prototype created', function () {
   var ObjectWithChains, objWithChains, SubWithChains, SubSub, subSub;

--- a/packages_es6/ember-runtime/tests/system/object/toString_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/toString_test.js
@@ -5,7 +5,7 @@ import Namespace from "ember-runtime/system/namespace";
 
 var originalLookup, lookup;
 
-module('system/object/toString', {
+QUnit.module('system/object/toString', {
   setup: function() {
     originalLookup = Ember.lookup;
     lookup = Ember.lookup = {};

--- a/packages_es6/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages_es6/ember-runtime/tests/system/object_proxy_test.js
@@ -4,7 +4,7 @@ import {isWatching} from "ember-metal/watching";
 import {testBoth} from 'ember-runtime/tests/props_helper';
 import ObjectProxy from "ember-runtime/system/object_proxy";
 
-module("ObjectProxy");
+QUnit.module("ObjectProxy");
 
 testBoth("should not proxy properties passed to create", function (get, set) {
   var Proxy = ObjectProxy.extend({

--- a/packages_es6/ember-runtime/tests/system/set/extra_test.js
+++ b/packages_es6/ember-runtime/tests/system/set/extra_test.js
@@ -4,7 +4,7 @@ import {set} from "ember-metal/property_set";
 import {addObserver} from "ember-metal/observer";
 import Set from "ember-runtime/system/set";
 
-module('Set.init');
+QUnit.module('Set.init');
 
 test('passing an array to new Set() should instantiate w/ items', function() {
 
@@ -20,7 +20,7 @@ test('passing an array to new Set() should instantiate w/ items', function() {
   equal(count, 3, 'iterating should have returned three objects');
 });
 
-module('Set.clear');
+QUnit.module('Set.clear');
 
 test('should clear a set of its content', function() {
 
@@ -48,7 +48,7 @@ test('should clear a set of its content', function() {
 // Set.pop
 //
 
-module('Set.pop');
+QUnit.module('Set.pop');
 
 test('calling pop should return an object and remove it', function() {
 
@@ -69,7 +69,7 @@ test('calling pop should return an object and remove it', function() {
 // Set.aliases
 //
 
-module('Set aliases');
+QUnit.module('Set aliases');
 
 test('method aliases', function() {
   var aSet = new Set();

--- a/packages_es6/ember-runtime/tests/system/string/camelize_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/camelize_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {camelize} from "ember-runtime/system/string";
 
-module('EmberStringUtils.camelize');
+QUnit.module('EmberStringUtils.camelize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.camelize is not modified without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/capitalize_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/capitalize_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {capitalize} from "ember-runtime/system/string";
 
-module('EmberStringUtils.capitalize');
+QUnit.module('EmberStringUtils.capitalize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.capitalize is not modified without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/classify_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/classify_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {classify} from "ember-runtime/system/string";
 
-module('EmberStringUtils.classify');
+QUnit.module('EmberStringUtils.classify');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.classify is not modified without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/dasherize_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/dasherize_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {dasherize} from "ember-runtime/system/string";
 
-module('EmberStringUtils.dasherize');
+QUnit.module('EmberStringUtils.dasherize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.dasherize is not modified without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/decamelize_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/decamelize_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {decamelize} from "ember-runtime/system/string";
 
-module('EmberStringUtils.decamelize');
+QUnit.module('EmberStringUtils.decamelize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.decamelize is not modified without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/fmt_string_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/fmt_string_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {fmt} from "ember-runtime/system/string";
 
-module('EmberStringUtils.fmt');
+QUnit.module('EmberStringUtils.fmt');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.fmt is not modified without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/loc_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/loc_test.js
@@ -3,7 +3,7 @@ import {loc} from "ember-runtime/system/string";
 
 var oldString;
 
-module('EmberStringUtils.loc', {
+QUnit.module('EmberStringUtils.loc', {
   setup: function() {
     oldString = Ember.STRINGS;
     Ember.STRINGS = {

--- a/packages_es6/ember-runtime/tests/system/string/underscore_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/underscore_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {underscore} from "ember-runtime/system/string";
 
-module('EmberStringUtils.underscore');
+QUnit.module('EmberStringUtils.underscore');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.underscore is not available without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/string/w_test.js
+++ b/packages_es6/ember-runtime/tests/system/string/w_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import {w} from "ember-runtime/system/string";
 
-module('EmberStringUtils.w');
+QUnit.module('EmberStringUtils.w');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
   test("String.prototype.w is not available without EXTEND_PROTOTYPES", function() {

--- a/packages_es6/ember-runtime/tests/system/subarray_test.js
+++ b/packages_es6/ember-runtime/tests/system/subarray_test.js
@@ -3,7 +3,7 @@ import SubArray from "ember-runtime/system/subarray";
 
 var forEach = EnumerableUtils.forEach, subarray;
 
-module('SubArray', {
+QUnit.module('SubArray', {
   setup: function () {
     subarray = new SubArray();
   }

--- a/packages_es6/ember-runtime/tests/system/tracked_array_test.js
+++ b/packages_es6/ember-runtime/tests/system/tracked_array_test.js
@@ -6,7 +6,7 @@ var forEach = EnumerableUtils.forEach, trackedArray,
     INSERT = TrackedArray.INSERT,
     DELETE = TrackedArray.DELETE;
 
-module('Ember.TrackedArray');
+QUnit.module('Ember.TrackedArray');
 
 test("operations for a tracked array of length n are initially retain:n", function() {
   trackedArray = new TrackedArray([1,2,3,4]);

--- a/packages_es6/ember-testing/tests/acceptance_test.js
+++ b/packages_es6/ember-testing/tests/acceptance_test.js
@@ -13,7 +13,7 @@ import "ember-routing"; //ES6TODO: fixme?
 
 var App, find, click, fillIn, currentRoute, visit, originalAdapter, andThen, indexHitCount;
 
-module("ember-testing Acceptance", {
+QUnit.module("ember-testing Acceptance", {
   setup: function() {
     jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
     jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');

--- a/packages_es6/ember-testing/tests/adapters/adapter_test.js
+++ b/packages_es6/ember-testing/tests/adapters/adapter_test.js
@@ -4,7 +4,7 @@ import Adapter from "ember-testing/adapters/adapter";
 
 var adapter;
 
-module("ember-testing Adapter", {
+QUnit.module("ember-testing Adapter", {
   setup: function() {
     adapter = new Adapter();
   },

--- a/packages_es6/ember-testing/tests/adapters/qunit_test.js
+++ b/packages_es6/ember-testing/tests/adapters/qunit_test.js
@@ -4,7 +4,7 @@ import QUnitAdapter from "ember-testing/adapters/qunit";
 
 var adapter;
 
-module("ember-testing QUnitAdapter", {
+QUnit.module("ember-testing QUnitAdapter", {
   setup: function() {
     adapter = new QUnitAdapter();
   },

--- a/packages_es6/ember-testing/tests/adapters_test.js
+++ b/packages_es6/ember-testing/tests/adapters_test.js
@@ -6,7 +6,7 @@ import EmberApplication from "ember-application/system/application";
 
 var App, originalAdapter;
 
-module("ember-testing Adapters", {
+QUnit.module("ember-testing Adapters", {
   setup: function() {
     originalAdapter = Test.adapter;
   },

--- a/packages_es6/ember-testing/tests/helper_registration_test.js
+++ b/packages_es6/ember-testing/tests/helper_registration_test.js
@@ -36,7 +36,7 @@ function destroyApp(){
   }
 }
 
-module("Test - registerHelper/unregisterHelper", {
+QUnit.module("Test - registerHelper/unregisterHelper", {
   teardown: function(){
     Test.adapter = originalAdapter;
     destroyApp();

--- a/packages_es6/ember-testing/tests/helpers_test.js
+++ b/packages_es6/ember-testing/tests/helpers_test.js
@@ -92,7 +92,7 @@ function currentURL(app){
   }
 }
 
-module("ember-testing Helpers", {
+QUnit.module("ember-testing Helpers", {
   setup: function(){ cleanup(); },
   teardown: function() { cleanup(); }
 });
@@ -446,7 +446,7 @@ test("`wait` respects registerWaiters with optional context", function() {
 
 });
 
-module("ember-testing routing helpers", {
+QUnit.module("ember-testing routing helpers", {
   setup: function(){
     cleanup();
 
@@ -505,7 +505,7 @@ test("currentRouteName for '/posts/new'", function(){
   });
 });
 
-module("ember-testing pendingAjaxRequests", {
+QUnit.module("ember-testing pendingAjaxRequests", {
   setup: function(){
     cleanup();
 
@@ -590,7 +590,7 @@ test("`trigger` can be used to trigger arbitrary events", function() {
   });
 });
 
-module("ember-testing async router", {
+QUnit.module("ember-testing async router", {
   setup: function(){
     cleanup();
 

--- a/packages_es6/ember-testing/tests/integration_test.js
+++ b/packages_es6/ember-testing/tests/integration_test.js
@@ -13,7 +13,7 @@ import 'ember-application';
 
 var App, find, visit, originalAdapter = Test.adapter;
 
-module("ember-testing Integration", {
+QUnit.module("ember-testing Integration", {
   setup: function() {
     jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');
     run(function() {

--- a/packages_es6/ember-testing/tests/simple_setup.js
+++ b/packages_es6/ember-testing/tests/simple_setup.js
@@ -4,7 +4,7 @@ import jQuery from "ember-views/system/jquery";
 
 var App;
 
-module('Simple Testing Setup', {
+QUnit.module('Simple Testing Setup', {
   teardown: function() {
     if (App) {
       App.removeTestHelpers();

--- a/packages_es6/ember-views/tests/mixins/view_target_action_support_test.js
+++ b/packages_es6/ember-views/tests/mixins/view_target_action_support_test.js
@@ -3,7 +3,7 @@ import EmberObject from "ember-runtime/system/object";
 import { View } from "ember-views/views/view";
 import ViewTargetActionSupport from "ember-views/mixins/view_target_action_support";
 
-module("ViewTargetActionSupport");
+QUnit.module("ViewTargetActionSupport");
 
 test("it should return false if no action is specified", function() {
   expect(1);

--- a/packages_es6/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages_es6/ember-views/tests/system/event_dispatcher_test.js
@@ -12,7 +12,7 @@ import ContainerView from "ember-views/views/container_view";
 var view;
 var dispatcher;
 
-module("EventDispatcher", {
+QUnit.module("EventDispatcher", {
   setup: function() {
     run(function() {
       dispatcher = EventDispatcher.create();
@@ -286,7 +286,7 @@ test("event handlers should be wrapped in a run loop", function() {
   jQuery('#test-view').trigger('mousedown');
 });
 
-module("EventDispatcher#setup", {
+QUnit.module("EventDispatcher#setup", {
   setup: function() {
     run(function() {
       dispatcher = EventDispatcher.create({

--- a/packages_es6/ember-views/tests/system/ext_test.js
+++ b/packages_es6/ember-views/tests/system/ext_test.js
@@ -1,7 +1,7 @@
 import run from "ember-metal/run_loop";
 import { View } from "ember-views/views/view";
 
-module("Ember.View additions to run queue");
+QUnit.module("Ember.View additions to run queue");
 
 test("View hierarchy is done rendering to DOM when functions queued in afterRender execute", function() {
   var lookup1, lookup2;

--- a/packages_es6/ember-views/tests/system/jquery_ext_test.js
+++ b/packages_es6/ember-views/tests/system/jquery_ext_test.js
@@ -25,7 +25,7 @@ if (document.createEvent) {
   };
 }
 
-module("EventDispatcher", {
+QUnit.module("EventDispatcher", {
   setup: function() {
     run(function() {
       dispatcher = EventDispatcher.create();

--- a/packages_es6/ember-views/tests/system/render_buffer_test.js
+++ b/packages_es6/ember-views/tests/system/render_buffer_test.js
@@ -8,7 +8,7 @@ var trim = jQuery.trim;
 // .......................................................
 //  render()
 //
-module("RenderBuffer");
+QUnit.module("RenderBuffer");
 
 test("RenderBuffers combine strings", function() {
   var buffer = new RenderBuffer('div');
@@ -137,7 +137,7 @@ test("lets `setClasses` and `addClass` work together", function() {
   equal(buffer.string(), '<div class="foo bar baz"></div>');
 });
 
-module("RenderBuffer - without tagName");
+QUnit.module("RenderBuffer - without tagName");
 
 test("It is possible to create a RenderBuffer without a tagName", function() {
   var buffer = new RenderBuffer();
@@ -148,7 +148,7 @@ test("It is possible to create a RenderBuffer without a tagName", function() {
   equal(buffer.string(), "abc", "Buffers without tagNames do not wrap the content in a tag");
 });
 
-module("RenderBuffer#element");
+QUnit.module("RenderBuffer#element");
 
 test("properly handles old IE's zero-scope bug", function() {
   var buffer = new RenderBuffer('div');

--- a/packages_es6/ember-views/tests/views/collection_test.js
+++ b/packages_es6/ember-views/tests/views/collection_test.js
@@ -17,7 +17,7 @@ var view;
 
 var originalLookup;
 
-module("CollectionView", {
+QUnit.module("CollectionView", {
   setup: function() {
     CollectionView.CONTAINER_MAP.del = 'em';
     originalLookup = Ember.lookup;

--- a/packages_es6/ember-views/tests/views/component_test.js
+++ b/packages_es6/ember-views/tests/views/component_test.js
@@ -9,7 +9,7 @@ var a_slice = Array.prototype.slice;
 
 var component, controller, actionCounts, sendCount, actionArguments;
 
-module("Ember.Component", {
+QUnit.module("Ember.Component", {
   setup: function(){
     component = Component.create();
   },
@@ -81,7 +81,7 @@ test("Specifying a templateName on a component with a layoutName specified in a 
   }).create();
 });
 
-module("Ember.Component - Actions", {
+QUnit.module("Ember.Component - Actions", {
   setup: function() {
     actionCounts = {};
     sendCount = 0;

--- a/packages_es6/ember-views/tests/views/container_view_test.js
+++ b/packages_es6/ember-views/tests/views/container_view_test.js
@@ -9,7 +9,7 @@ import ContainerView from "ember-views/views/container_view";
 
 var trim = jQuery.trim, container, view, otherContainer;
 
-module("ember-views/views/container_view_test", {
+QUnit.module("ember-views/views/container_view_test", {
   teardown: function() {
     run(function() {
       container.destroy();

--- a/packages_es6/ember-views/tests/views/view/actions_test.js
+++ b/packages_es6/ember-views/tests/views/view/actions_test.js
@@ -9,7 +9,7 @@ import { View } from "ember-views/views/view";
 
 var view;
 
-module("View action handling", {
+QUnit.module("View action handling", {
   teardown: function() {
     run(function() {
       if (view) { view.destroy(); }

--- a/packages_es6/ember-views/tests/views/view/append_to_test.js
+++ b/packages_es6/ember-views/tests/views/view/append_to_test.js
@@ -9,7 +9,7 @@ import ContainerView from "ember-views/views/container_view";
 
 var View, view, willDestroyCalled, childView;
 
-module("EmberView - append() and appendTo()", {
+QUnit.module("EmberView - append() and appendTo()", {
   setup: function() {
     View = EmberView.extend({});
   },
@@ -150,7 +150,7 @@ test("destroy more forcibly removes the view", function() {
   equal(willDestroyCalled, 1, "the willDestroyElement hook was called once");
 });
 
-module("EmberView - append() and appendTo() in a view hierarchy", {
+QUnit.module("EmberView - append() and appendTo() in a view hierarchy", {
   setup: function() {
     View = ContainerView.extend({
       childViews: ['child'],
@@ -197,7 +197,7 @@ test("should be added to the document body when calling append()", function() {
   ok(viewElem.length > 0, "creates and appends the view's element");
 });
 
-module("EmberView - removing views in a view hierarchy", {
+QUnit.module("EmberView - removing views in a view hierarchy", {
   setup: function() {
     willDestroyCalled = 0;
 

--- a/packages_es6/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages_es6/ember-views/tests/views/view/attribute_bindings_test.js
@@ -12,7 +12,7 @@ var appendView = function() {
   run(function() { view.appendTo('#qunit-fixture'); });
 };
 
-module("EmberView - Attribute Bindings", {
+QUnit.module("EmberView - Attribute Bindings", {
   setup: function() {
     Ember.lookup = lookup = {};
   },

--- a/packages_es6/ember-views/tests/views/view/child_views_test.js
+++ b/packages_es6/ember-views/tests/views/view/child_views_test.js
@@ -6,7 +6,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var parentView, childView, childViews;
 
-module('tests/views/view/child_views_tests.js', {
+QUnit.module('tests/views/view/child_views_tests.js', {
   setup: function() {
     parentView = EmberView.create({
       render: function(buffer) {

--- a/packages_es6/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages_es6/ember-views/tests/views/view/class_name_bindings_test.js
@@ -9,7 +9,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var view;
 
-module("EmberView - Class Name Bindings", {
+QUnit.module("EmberView - Class Name Bindings", {
   teardown: function() {
     run(function() {
       view.destroy();

--- a/packages_es6/ember-views/tests/views/view/class_string_for_value_test.js
+++ b/packages_es6/ember-views/tests/views/view/class_string_for_value_test.js
@@ -1,6 +1,6 @@
 import { View } from "ember-views/views/view";
 
-module("View - _classStringForValue");
+QUnit.module("View - _classStringForValue");
 
 var cSFV = View._classStringForValue;
 

--- a/packages_es6/ember-views/tests/views/view/context_test.js
+++ b/packages_es6/ember-views/tests/views/view/context_test.js
@@ -4,7 +4,7 @@ import run from "ember-metal/run_loop";
 import {View as EmberView} from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
-module("EmberView - context property");
+QUnit.module("EmberView - context property");
 
 test("setting a controller on an inner view should change it context", function() {
   var App = {};

--- a/packages_es6/ember-views/tests/views/view/controller_test.js
+++ b/packages_es6/ember-views/tests/views/view/controller_test.js
@@ -3,7 +3,7 @@ import run from "ember-metal/run_loop";
 
 import ContainerView from "ember-views/views/container_view";
 
-module("Ember.View - controller property");
+QUnit.module("Ember.View - controller property");
 
 test("controller property should be inherited from nearest ancestor with controller", function() {
   var grandparent = ContainerView.create();

--- a/packages_es6/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages_es6/ember-views/tests/views/view/create_child_view_test.js
@@ -4,7 +4,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var view, myViewClass, newView, container;
 
-module("EmberView#createChildView", {
+QUnit.module("EmberView#createChildView", {
   setup: function() {
     container = { };
 

--- a/packages_es6/ember-views/tests/views/view/create_element_test.js
+++ b/packages_es6/ember-views/tests/views/view/create_element_test.js
@@ -5,7 +5,7 @@ import ContainerView from "ember-views/views/container_view";
 
 var view;
 
-module("Ember.View#createElement", {
+QUnit.module("Ember.View#createElement", {
   teardown: function() {
     run(function() {
       view.destroy();

--- a/packages_es6/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages_es6/ember-views/tests/views/view/destroy_element_test.js
@@ -5,7 +5,7 @@ import ContainerView from "ember-views/views/container_view";
 
 var view;
 
-module("EmberView#destroyElement", {
+QUnit.module("EmberView#destroyElement", {
   teardown: function() {
     run(function() {
       view.destroy();

--- a/packages_es6/ember-views/tests/views/view/destroy_test.js
+++ b/packages_es6/ember-views/tests/views/view/destroy_test.js
@@ -2,7 +2,7 @@ import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import { View as EmberView } from "ember-views/views/view";
 
-module("Ember.View#destroy");
+QUnit.module("Ember.View#destroy");
 
 test("should teardown viewName on parentView when childView is destroyed", function() {
   var viewName = "someChildView",

--- a/packages_es6/ember-views/tests/views/view/element_test.js
+++ b/packages_es6/ember-views/tests/views/view/element_test.js
@@ -8,7 +8,7 @@ import ContainerView from "ember-views/views/container_view";
 
 var parentView, child, parentDom, childDom, view;
 
-module("Ember.View#element", {
+QUnit.module("Ember.View#element", {
   teardown: function() {
     run(function() {
       if (parentView) { parentView.destroy(); }
@@ -45,7 +45,7 @@ test("returns element if you set the value", function() {
 });
 
 
-module("Ember.View#element - autodiscovery", {
+QUnit.module("Ember.View#element - autodiscovery", {
   setup: function() {
     parentView = ContainerView.create({
       childViews: [ EmberView.extend({

--- a/packages_es6/ember-views/tests/views/view/evented_test.js
+++ b/packages_es6/ember-views/tests/views/view/evented_test.js
@@ -5,7 +5,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var view;
 
-module("EmberView evented helpers", {
+QUnit.module("EmberView evented helpers", {
   teardown: function() {
     run(function() {
       view.destroy();

--- a/packages_es6/ember-views/tests/views/view/init_test.js
+++ b/packages_es6/ember-views/tests/views/view/init_test.js
@@ -7,7 +7,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var originalLookup = Ember.lookup, lookup, view;
 
-module("EmberView.create", {
+QUnit.module("EmberView.create", {
   setup: function() {
     Ember.lookup = lookup = {};
   },
@@ -28,7 +28,7 @@ test("registers view in the global views hash using layerId for event targeted",
   equal(EmberView.views[get(view, 'elementId')], view, 'registers view');
 });
 
-module("EmberView.createWithMixins");
+QUnit.module("EmberView.createWithMixins");
 
 test("should warn if a non-array is used for classNames", function() {
   expectAssertion(function() {

--- a/packages_es6/ember-views/tests/views/view/is_visible_test.js
+++ b/packages_es6/ember-views/tests/views/view/is_visible_test.js
@@ -8,7 +8,7 @@ import ContainerView from "ember-views/views/container_view";
 var View, view, parentBecameVisible, childBecameVisible, grandchildBecameVisible;
 var parentBecameHidden, childBecameHidden, grandchildBecameHidden;
 
-module("EmberView#isVisible", {
+QUnit.module("EmberView#isVisible", {
   setup: function() {
     parentBecameVisible=0;
     childBecameVisible=0;

--- a/packages_es6/ember-views/tests/views/view/jquery_test.js
+++ b/packages_es6/ember-views/tests/views/view/jquery_test.js
@@ -4,7 +4,7 @@ import EmberObject from "ember-runtime/system/object";
 import { View as EmberView } from "ember-views/views/view";
 
 var view ;
-module("EmberView#$", {
+QUnit.module("EmberView#$", {
   setup: function() {
     view = EmberView.extend({
       render: function(context, firstTime) {

--- a/packages_es6/ember-views/tests/views/view/layout_test.js
+++ b/packages_es6/ember-views/tests/views/view/layout_test.js
@@ -5,7 +5,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var container, view;
 
-module("EmberView - Layout Functionality", {
+QUnit.module("EmberView - Layout Functionality", {
   setup: function() {
     container = new Container();
     container.optionsForType('template', { instantiate: false });

--- a/packages_es6/ember-views/tests/views/view/nearest_of_type_test.js
+++ b/packages_es6/ember-views/tests/views/view/nearest_of_type_test.js
@@ -6,7 +6,7 @@ import { View } from "ember-views/views/view";
 
 var parentView, view;
 
-module("View#nearest*", {
+QUnit.module("View#nearest*", {
   teardown: function() {
     run(function() {
       if (parentView) { parentView.destroy(); }

--- a/packages_es6/ember-views/tests/views/view/parse_property_path_test.js
+++ b/packages_es6/ember-views/tests/views/view/parse_property_path_test.js
@@ -1,6 +1,6 @@
 import { View as EmberView } from "ember-views/views/view";
 
-module("EmberView - _parsePropertyPath");
+QUnit.module("EmberView - _parsePropertyPath");
 
 test("it works with a simple property path", function() {
   var parsed = EmberView._parsePropertyPath("simpleProperty");

--- a/packages_es6/ember-views/tests/views/view/remove_test.js
+++ b/packages_es6/ember-views/tests/views/view/remove_test.js
@@ -13,7 +13,7 @@ var indexOf = EnumerableUtils.indexOf;
 //
 
 var parentView, child;
-module("View#removeChild", {
+QUnit.module("View#removeChild", {
   setup: function() {
     parentView = ContainerView.create({ childViews: [View] });
     child = get(parentView, 'childViews').objectAt(0);
@@ -46,7 +46,7 @@ test("sets parentView property to null", function() {
 // removeAllChildren()
 //
 var view, childViews;
-module("View#removeAllChildren", {
+QUnit.module("View#removeAllChildren", {
   setup: function() {
     view = ContainerView.create({
       childViews: [View, View, View]
@@ -75,7 +75,7 @@ test("returns receiver", function() {
 // .......................................................
 // removeFromParent()
 //
-module("View#removeFromParent", {
+QUnit.module("View#removeFromParent", {
   teardown: function() {
     run(function() {
       if (parentView) { parentView.destroy(); }

--- a/packages_es6/ember-views/tests/views/view/render_test.js
+++ b/packages_es6/ember-views/tests/views/view/render_test.js
@@ -10,7 +10,7 @@ var view;
 // .......................................................
 //  render()
 //
-module("EmberView#render", {
+QUnit.module("EmberView#render", {
   teardown: function() {
     run(function() {
       view.destroy();

--- a/packages_es6/ember-views/tests/views/view/replace_in_test.js
+++ b/packages_es6/ember-views/tests/views/view/replace_in_test.js
@@ -6,7 +6,7 @@ import ContainerView from "ember-views/views/container_view";
 
 var View, view, willDestroyCalled, childView;
 
-module("EmberView - replaceIn()", {
+QUnit.module("EmberView - replaceIn()", {
   setup: function() {
     View = EmberView.extend({});
   },
@@ -71,7 +71,7 @@ test("should move the view to the inDOM state after replacing", function() {
   equal(view.currentState, view.states.inDOM, "the view is in the inDOM state");
 });
 
-module("EmberView - replaceIn() in a view hierarchy", {
+QUnit.module("EmberView - replaceIn() in a view hierarchy", {
   setup: function() {
     View = ContainerView.extend({
       childViews: ['child'],

--- a/packages_es6/ember-views/tests/views/view/template_test.js
+++ b/packages_es6/ember-views/tests/views/view/template_test.js
@@ -6,7 +6,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var container, view;
 
-module("EmberView - Template Functionality", {
+QUnit.module("EmberView - Template Functionality", {
   setup: function() {
     container = new Container();
     container.optionsForType('template', { instantiate: false });

--- a/packages_es6/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages_es6/ember-views/tests/views/view/view_lifecycle_test.js
@@ -7,7 +7,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var originalLookup = Ember.lookup, lookup, view;
 
-module("views/view/view_lifecycle_test - pre-render", {
+QUnit.module("views/view/view_lifecycle_test - pre-render", {
   setup: function() {
     Ember.lookup = lookup = {};
   },
@@ -90,7 +90,7 @@ test("should not affect rendering if destroyElement is called before initial ren
   equal(view.$().text(), "Don't destroy me!", "renders correctly if destroyElement is called first");
 });
 
-module("views/view/view_lifecycle_test - in render", {
+QUnit.module("views/view/view_lifecycle_test - in render", {
   setup: function() {
 
   },
@@ -156,7 +156,7 @@ test("rerender should throw inside a template", function() {
   }, /Something you did caused a view to re-render after it rendered but before it was inserted into the DOM./);
 });
 
-module("views/view/view_lifecycle_test - hasElement", {
+QUnit.module("views/view/view_lifecycle_test - hasElement", {
   teardown: function() {
     if (view) {
       run(function() {
@@ -192,7 +192,7 @@ test("trigger rerender on a view in the hasElement state doesn't change its stat
 });
 
 
-module("views/view/view_lifecycle_test - in DOM", {
+QUnit.module("views/view/view_lifecycle_test - in DOM", {
   teardown: function() {
     if (view) {
       run(function() {
@@ -300,7 +300,7 @@ test("should throw an exception if trying to append an element that is already i
   }, null, "raises an exception on second append");
 });
 
-module("views/view/view_lifecycle_test - destroyed");
+QUnit.module("views/view/view_lifecycle_test - destroyed");
 
 test("should throw an exception when calling appendChild after view is destroyed", function() {
   run(function() {

--- a/packages_es6/ember-views/tests/views/view/virtual_views_test.js
+++ b/packages_es6/ember-views/tests/views/view/virtual_views_test.js
@@ -7,7 +7,7 @@ import { View as EmberView } from "ember-views/views/view";
 
 var rootView, childView;
 
-module("virtual views", {
+QUnit.module("virtual views", {
   teardown: function() {
     run(function() {
       rootView.destroy();

--- a/packages_es6/ember/tests/application_lifecycle.js
+++ b/packages_es6/ember/tests/application_lifecycle.js
@@ -2,7 +2,7 @@ import "ember";
 
 var App, container, router;
 
-module("Application Lifecycle", {
+QUnit.module("Application Lifecycle", {
   setup: function() {
     Ember.run(function() {
       App = Ember.Application.create({

--- a/packages_es6/ember/tests/component_registration_test.js
+++ b/packages_es6/ember/tests/component_registration_test.js
@@ -31,7 +31,7 @@ function cleanupHandlebarsHelpers(){
   });
 }
 
-module("Application Lifecycle - Component Registration", {
+QUnit.module("Application Lifecycle - Component Registration", {
   setup: prepare,
   teardown: cleanup
 });
@@ -197,7 +197,7 @@ test("Assigning templateName and layoutName should use the templates specified",
   equal(Ember.$('#wrapper').text(), "inner-outer", "The component is composed correctly");
 });
 
-module("Application Lifecycle - Component Context", {
+QUnit.module("Application Lifecycle - Component Context", {
   setup: prepare,
   teardown: cleanup
 });

--- a/packages_es6/ember/tests/helpers/helper_registration_test.js
+++ b/packages_es6/ember/tests/helpers/helper_registration_test.js
@@ -8,7 +8,7 @@ function reverseHelper(value) {
 }
 
 
-module("Application Lifecycle - Helper Registration", {
+QUnit.module("Application Lifecycle - Helper Registration", {
   teardown: function() {
     Ember.run(function() {
       App.destroy();

--- a/packages_es6/ember/tests/helpers/link_to_test.js
+++ b/packages_es6/ember/tests/helpers/link_to_test.js
@@ -64,7 +64,7 @@ function sharedTeardown() {
   Ember.TEMPLATES = {};
 }
 
-module("The {{link-to}} helper", {
+QUnit.module("The {{link-to}} helper", {
   setup: function() {
     Ember.run(function() {
 
@@ -1208,7 +1208,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     equal(Ember.$('#the-link').attr('href'), "/?bar=NAW&foo=456", "link has right href");
   });
 
-  module("The {{link-to}} helper: invoking with query params", {
+  QUnit.module("The {{link-to}} helper: invoking with query params", {
     setup: function() {
       Ember.run(function() {
         sharedSetup();
@@ -1537,7 +1537,7 @@ function basicEagerURLUpdateTest(setTagName) {
 }
 
 var aboutDefer;
-module("The {{link-to}} helper: eager URL updating", {
+QUnit.module("The {{link-to}} helper: eager URL updating", {
   setup: function() {
     Ember.run(function() {
       sharedSetup();

--- a/packages_es6/ember/tests/homepage_example_test.js
+++ b/packages_es6/ember/tests/homepage_example_test.js
@@ -34,7 +34,7 @@ function setupExample() {
   });
 }
 
-module("Homepage Example", {
+QUnit.module("Homepage Example", {
   setup: function() {
     Ember.run(function() {
       App = Ember.Application.create({

--- a/packages_es6/ember/tests/location_test.js
+++ b/packages_es6/ember/tests/location_test.js
@@ -2,7 +2,7 @@ import "ember";
 
 var App;
 
-module('AutoLocation', {
+QUnit.module('AutoLocation', {
   setup: function() {
     Ember.AutoLocation._location = {
       href: 'http://test.com/',

--- a/packages_es6/ember/tests/routing/basic_test.js
+++ b/packages_es6/ember/tests/routing/basic_test.js
@@ -43,7 +43,7 @@ function handleURLRejectsWith(path, expectedReason) {
   });
 }
 
-module("Basic Routing", {
+QUnit.module("Basic Routing", {
   setup: function() {
     Ember.run(function() {
       App = Ember.Application.create({

--- a/packages_es6/ember/tests/routing/query_params_test.js
+++ b/packages_es6/ember/tests/routing/query_params_test.js
@@ -69,7 +69,7 @@ var TestLocation = Ember.NoneLocation.extend({
 
 if (Ember.FEATURES.isEnabled("query-params-new")) {
 
-  module("Routing w/ Query Params", {
+  QUnit.module("Routing w/ Query Params", {
     setup: function() {
       Ember.run(function() {
         App = Ember.Application.create({

--- a/packages_es6/ember/tests/routing/substates_test.js
+++ b/packages_es6/ember/tests/routing/substates_test.js
@@ -37,7 +37,7 @@ function handleURL(path) {
   });
 }
 
-module("Loading/Error Substates", {
+QUnit.module("Loading/Error Substates", {
   setup: function() {
     counter = 1;
 

--- a/packages_es6/ember/tests/states_removal_test.js
+++ b/packages_es6/ember/tests/states_removal_test.js
@@ -2,7 +2,7 @@ import "ember";
 
 /*globals EmberDev */
 
-module("ember-states removal");
+QUnit.module("ember-states removal");
 
 test("errors occur when attempting to use Ember.StateManager or Ember.State", function() {
   if (EmberDev && EmberDev.runningProdBuild){

--- a/tests/qunit_configuration.js
+++ b/tests/qunit_configuration.js
@@ -63,8 +63,8 @@
     return obj.toString();
   };
 
-  var originalModule = module;
-  module = function(name, origOpts) {
+  var originalModule = QUnit.module;
+  QUnit.module = function(name, origOpts) {
     var opts = {};
     if (origOpts && origOpts.setup) { opts.setup = origOpts.setup; }
     opts.teardown = function() {


### PR DESCRIPTION
`module` is a reserved word under Node.js, and without this change we cannot run the Ember test suite.

Related to #3827.
