### PR TITLE
[Bugfix beta] container.has should not cause injections to be run.

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -454,7 +454,7 @@ define("container",
           return true;
         }
 
-        return !!factoryFor(this, fullName);
+        return !!this.resolve(fullName);
       },
 
       /**

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -492,3 +492,20 @@ test("cannot re-register a factory if has been looked up", function(){
 });
 
 
+test('container.has should not accidentally cause injections on that factory to be run. (Mitigate merely on observing)', function(){
+  expect(1);
+
+  var container = new Container(),
+    FirstApple = factory('first'),
+    SecondApple = factory('second');
+
+  SecondApple.extend = function(a,b,c) {
+    ok(false, 'should not extend or touch the injected model, merely to inspect existence of another');
+  };
+
+  container.register('controller:apple', FirstApple);
+  container.register('controller:second-apple', SecondApple);
+  container.injection('controller:apple', 'badApple', 'controller:second-apple');
+
+  ok(container.has('controller:apple'));
+});


### PR DESCRIPTION
This fixes an issue, were merely checking the existence of a potential
container managed object, could cause thrashing cycles.
