### PR TITLE
 [Bugfix beta] fix click helper focus change issue

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -66,7 +66,7 @@ function click(app, selector, context) {
         if (!document.hasFocus || document.hasFocus()) {
           this.focus();
         } else {
-          this.trigger('focusin');
+          this.trigger('focus');
         }
       });
     }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -223,6 +223,44 @@ test("`click` triggers appropriate events in order", function() {
   });
 });
 
+test("`click` correctly handle focus changes", function() {
+  var click, wait, events;
+  expect(2);
+
+  Ember.run(function() {
+    App = Ember.Application.create();
+    App.setupForTesting();
+  });
+
+  App.IndexView = Ember.View.extend({
+
+    oneView: Ember.TextField.extend({
+      focusOut: function () {
+        this._super();
+        ok(true, "the first one has been focused out");
+      }
+    }),
+
+    twoView: Ember.TextField.extend({
+      focusIn: function () {
+        this._super();
+        ok(true, "the second one has been focused in");
+      }
+    })
+  });
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{view view.oneView id="one"}} {{view view.twoView id="two"}}');
+
+  App.injectTestHelpers();
+
+  Ember.run(App, App.advanceReadiness);
+
+  click = App.testHelpers.click;
+  wait  = App.testHelpers.wait;
+
+  wait().click('#one').click('#two');
+});
+
 test("Ember.Application#injectTestHelpers", function() {
   var documentEvents;
 


### PR DESCRIPTION
This hits me during my migration process from ember 1.0.0. A test in my application integration suite was failing intermitently, and after a tedious investigation and the help of @rjackson I finally find out what's happening.
After this https://github.com/emberjs/ember.js/pull/3563, it appears that when the window is not focused, then when switching from an input to an other one using the 'click' helper the first input is not focused out.

This fix works on chrome, but breaks again firefox :/ and the 'focusin' appears to be not enough to trig the focusout event on the previously focused element.
