### PR TITLE
Add acceptance test for uncaught exception in controller init

### DIFF
--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -12,8 +12,8 @@ module("ember-testing Acceptance", {
       App.Router.map(function() {
         this.route('posts');
         this.route('comments');
-
         this.route('abort_transition');
+        this.route('init_exception');
       });
 
       App.PostsRoute = Ember.Route.extend({
@@ -42,6 +42,12 @@ module("ember-testing Acceptance", {
       App.AbortTransitionRoute = Ember.Route.extend({
         beforeModel: function(transition) {
           transition.abort();
+        }
+      });
+
+      App.InitExceptionController = Ember.Controller.extend({
+        init: function() {
+          throw new Error("error thrown in init");
         }
       });
 
@@ -225,4 +231,16 @@ test("Unhandled exceptions are logged via Ember.Test.adapter#exception", functio
   });
 
   click(".does-not-exist");
+});
+
+test("Unhandled exception in controller init logged via Ember.Test.adapter#exception", function() {
+  expect(1);
+
+  Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
+    exception: function(error) {
+      equal(error.message, "error thrown in init", "Unhandled exception in controller init successfully caught and passed to Ember.Test.adapter.exception");
+    }
+  });
+
+  visit("/init_exception");
 });


### PR DESCRIPTION
Added a failing test to reproduce an uncaught exception thrown from a controller's `init` function...  See emberjs/ember.js#3829

I wasn't sure if I can use the `Ember.Test.adapter = Ember.Test.QUnitAdapter.create({})` twice in the same test function to change the exception handler, so I created a separate test function, after `Unhandled exceptions are logged via Ember.Test.adapter#exception`... So, please let me know if this can be implemented within the same test.  This is my very first pull request for ANY open source project!! :)

I'd be willing to come up with a fix for this as well, but it may take some time as I still need to familiarize myself with the whole project.

Thanks,
Ian
