### PR TITLE
Added fail() method to PromiseProxyMixin

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -104,6 +104,10 @@ Ember.PromiseProxyMixin = Ember.Mixin.create({
 
   then: function(fulfill, reject) {
     return get(this, 'promise').then(fulfill, reject);
+  },
+
+  fail: function(reject) {
+    return get(this, 'promise').fail(reject);
   }
 });
 

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -102,13 +102,14 @@ Ember.PromiseProxyMixin = Ember.Mixin.create({
     }
   }),
 
-  then: function(fulfill, reject) {
-    return get(this, 'promise').then(fulfill, reject);
-  },
+  then: promiseAlias('then'),
 
-  fail: function(reject) {
-    return get(this, 'promise').fail(reject);
-  }
+  fail: promiseAlias('fail')
+
 });
 
-
+function promiseAlias(name) {
+  return function () {
+    get(this, 'promise')[name].apply(promise, arguments)
+  }
+}

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -158,6 +158,29 @@ test("rejection", function(){
   equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
 });
 
+test("fail method", function(){
+  var reason = new Error("failure");
+
+  var proxy = ObjectPromiseProxy.create({
+    promise: deferred.promise
+  });
+
+  var didFulfillCount = 0;
+  var didRejectCount  = 0;
+
+  proxy.then(function(){
+    didFulfillCount++;
+  });
+  proxy.fail(function(){
+    didRejectCount++;
+  });
+
+  Ember.run(deferred, 'reject', reason);
+
+  equal(didFulfillCount, 0, 'should not yet have been fulfilled');
+  equal(didRejectCount, 1, 'should have been rejected');
+});
+
 test("unhandled rejects still propogate to RSVP.on('error', ...) ", function(){
   expect(1);
 


### PR DESCRIPTION
[See here](https://github.com/emberjs/data/issues/1523#issuecomment-29442981) for an example why we should have this.
