### PR TITLE
[BUGFIX beta] Update to the latest `ember-dev` and fix build publishing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
 - "0.10"
 install:
 - "npm install"
-- "bundle install --deployment"
+- "gem install bundler --pre"
+- "bundle install --deployment --retry 3 --jobs 4"
+- sudo apt-get update && sudo apt-get install git
 after_success: bundle exec rake publish_build
 script: rake test\[$TEST_SUITE]
 notifications:
@@ -32,7 +34,9 @@ env:
 
       I/BFT0MbnR6JVCZiPV7TCWPgY1gvgZ6TEEIKGqauDMUBdL8ZK6I='
   matrix:
-    - TEST_SUITE=packages
-    - TEST_SUITE=old_jquery
-    - TEST_SUITE=extend_prototypes
-    - TEST_SUITE=built
+    - MULTI_BRANCH_TESTS=false TEST_SUITE=packages
+    - MULTI_BRANCH_TESTS=false TEST_SUITE=old_jquery
+    - MULTI_BRANCH_TESTS=false TEST_SUITE=extend_prototypes
+    - MULTI_BRANCH_TESTS=false TEST_SUITE=built
+    - MULTI_BRANCH_TESTS=false TEST_SUITE=standard FORCE_BRANCH=beta
+    - MULTI_BRANCH_TESTS=false TEST_SUITE=standard FORCE_BRANCH=stable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 81d5486f625051710682711de177056885e64fce
+  revision: 3c984d570e346c2a4979e18c52ab4a9a9f1e4fe7
   branch: master
   specs:
     ember-dev (0.1)
@@ -33,14 +33,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.24.0)
+    aws-sdk (1.29.1)
       json (~> 1.4)
-      nokogiri (>= 1.4.4, < 1.6.0)
+      nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
     colored (1.2)
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     execjs (2.0.2)
     ffi (1.9.3)
     grit (2.5.0)
@@ -49,16 +47,20 @@ GEM
       posix-spawn (~> 0.3.6)
     handlebars-source (1.1.2)
     json (1.8.1)
-    kicker (2.6.1)
-      listen
-    listen (2.2.0)
-      celluloid (>= 0.15.2)
+    kicker (3.0.0)
+      listen (~> 1.3.0)
+      notify (~> 0.5.2)
+    listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    mime-types (1.25)
-    nokogiri (1.5.10)
-    posix-spawn (0.3.6)
-    puma (2.6.0)
+      rb-kqueue (>= 0.2)
+    mime-types (1.25.1)
+    mini_portile (0.5.2)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    notify (0.5.2)
+    posix-spawn (0.3.8)
+    puma (2.7.1)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rake (10.1.0)
@@ -68,9 +70,10 @@ GEM
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)
       ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
     thor (0.18.1)
-    timers (1.1.0)
-    uglifier (2.3.0)
+    uglifier (2.3.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uuidtools (2.1.4)

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -6,10 +6,10 @@ testing_suites:
     - "EACH_PACKAGE"
   old_jquery:
     - "package=all&jquery=1.7.2&nojshint=true"
-    - "package=all&jquery=1.7.2&nojshint=true&enableallfeatures=true"
+    - "package=all&jquery=1.7.2&nojshint=true&enableoptionalfeatures=true"
   extend_prototypes:
     - "package=all&extendprototypes=true&nojshint=true"
-    - "package=all&extendprototypes=true&nojshint=true&enableallfeatures=true"
+    - "package=all&extendprototypes=true&nojshint=true&enableoptionalfeatures=true"
   built:
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
   runtime:


### PR DESCRIPTION
- Updates to the latest `ember-dev` which ensures that the `git config
  user.name` and `git config user.email` values are present before calling
  `git cherry-pick`. This is due to a recent change in git `1.8.5` which
  requires the user information be present prior to a cherry-pick.
- Updates to bundler `1.5.0.rc1` to use the following features:
  - Automatically retry 3 times (should help with gem installation failures
    in Travis).
  - Install gems in parallel (use 4 workers by default).
- Forces each branch to be tested independently (prevents a resource
  contention issue when checking out another branch in the same test
  run).
- Travis accidentally reverted to using an older git version that does not
  support the `--points-at` flag that we are using in `ember-dev`.  This
  forces the system to upgrade to the latest version.

Travis ticket for reference:
  travis-ci/travis-ci#1710.

---

 #3635 caused the Travis builds to use the `enableallfeatures` flag to
 enable features, but this was changed in `ember-dev` (and updated in
 Ember in #3633) to `enableoptionalfeatures`.
