### PR TITLE
Update header comment format to keep it on minify

### DIFF
--- a/generators/license.js
+++ b/generators/license.js
@@ -1,8 +1,8 @@
-// ==========================================================================
-// Project:   Ember - JavaScript Application Framework
-// Copyright: Copyright 2011-2013 Tilde Inc. and contributors
-//            Portions Copyright 2006-2011 Strobe Inc.
-//            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
-// License:   Licensed under MIT license
-//            See https://raw.github.com/emberjs/ember.js/master/LICENSE
-// ==========================================================================
+/*!
+ * @overview  Ember - JavaScript Application Framework
+ * @copyright Copyright 2011-2013 Tilde Inc. and contributors
+ *            Portions Copyright 2006-2011 Strobe Inc.
+ *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
+ * @license   Licensed under MIT license
+ *            See https://raw.github.com/emberjs/ember.js/master/LICENSE
+ */


### PR DESCRIPTION
Some minifier keep header comment over its format.
1. YUI Compressor
   It keeps the header comments beggining with `/*!`
   - http://yui.github.io/yuicompressor/css.html#special-comments
2. Closure compiler
   It keeps the header comments containing `@license` or `@preserve`
   - https://developers.google.com/closure/compiler/docs/js-for-compiler#tag-license

I think header comment is very important because it includes its own license.
