### PR TITLE
contextualizeBindingPath should be aware of empty paths

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -139,7 +139,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
       return 'templateData.keywords.' + path;
     } else if (Ember.isGlobalPath(path)) {
       return null;
-    } else if (path === 'this') {
+    } else if (path === 'this' || path === '') {
       return '_parentView.context';
     } else {
       return '_parentView.context.' + path;

--- a/packages/ember-handlebars/tests/helpers/custom_view_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/custom_view_helper_test.js
@@ -1,6 +1,6 @@
 /*globals TemplateTests*/
 
-var view;
+var view, get = Ember.get, set = Ember.set;
 
 var appendView = function() {
   Ember.run(function() { view.appendTo('#qunit-fixture'); });
@@ -35,6 +35,35 @@ test("should render an instance of the specified view", function() {
   appendView();
 
   var oceanViews = view.$().find("strong:contains('zomg, nice view')");
+
+  equal(oceanViews.length, 1, "helper rendered an instance of the view");
+});
+
+test("Should bind to this keyword", function() {
+  TemplateTests.OceanView = Ember.View.extend({
+    model: null,
+    template: Ember.Handlebars.compile('{{view.model}}')
+  });
+
+  Ember.Handlebars.helper('oceanView', TemplateTests.OceanView);
+
+  view = Ember.View.create({
+    context: 'foo',
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{oceanView tagName="strong" viewName="ocean" model=this}}')
+  });
+
+  appendView();
+
+  var oceanViews = view.$().find("strong:contains('foo')");
+
+  equal(oceanViews.length, 1, "helper rendered an instance of the view");
+
+  Ember.run(function() {
+    set(view, 'ocean.model', 'bar');
+  });
+
+  oceanViews = view.$().find("strong:contains('bar')");
 
   equal(oceanViews.length, 1, "helper rendered an instance of the view");
 });


### PR DESCRIPTION
Binding a property to `this` keyword when calling a helper created with `Ember.Handlebars.helper`, make 
[contextualizeBindingPath](https://github.com/emberjs/ember.js/blob/a316fa4bbd335b08b6ff3b9145e340bc64003fa0/packages/ember-handlebars/lib/helpers/view.js#L145), fallback in `'_parentView.context.' + path` but the path variable is empty and this result in a wrong path `_parentView.context.` (trailing dot). So, we need to check the empty value. Because handlebars generate `{ hash: { model: '' }, hasContext: { model: <instance> } }` when `model=this` is specified in the template.

close #3860

//cc @machty
