### PR TITLE
Do not allow overwriting of controllers proxy properties

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -140,6 +140,9 @@ Ember.ControllerMixin.reopen({
 
         var errorMessage = Ember.inspect(controller) + '#needs does not include `' + controllerName + '`. To access the ' + controllerName + ' controller from ' + Ember.inspect(controller) + ', ' + Ember.inspect(controller) + ' should have a `needs` property that is an array of the controllers it has access to.';
         throw new ReferenceError(errorMessage);
+      },
+      setUnknownProperty: function (key, value) {
+        throw new Error("You cannot overwrite the value of `controllers." + key + "` of " + Ember.inspect(controller));
       }
     };
   }).readOnly()

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -93,3 +93,25 @@ test("setting the controllers property directly, should not be possible", functi
 
   equal(controller.get('controllers'), controllers, 'original controllers CP should have been unchanged');
 });
+
+test ("setting the value of a controller dependency should not be possible", function(){
+  var container = new Ember.Container();
+
+  container.register('controller:post', Ember.Controller.extend({
+    needs: 'posts'
+  }));
+
+  container.register('controller:posts', Ember.Controller.extend());
+
+  var postController = container.lookup('controller:post'),
+      postsController = container.lookup('controller:posts');
+
+  throws(function(){
+    postController.set('controllers.posts', 'epic-self-troll');
+  },
+  /You cannot overwrite the value of `controllers.posts` of .+/,
+  'should raise when attempting to set the value of a controller dependency property');
+
+  postController.set('controllers.posts.title', "A Troll's Life");
+  equal(postController.get('controllers.posts.title'), "A Troll's Life", "can set the value of controllers.posts.title");
+});


### PR DESCRIPTION
It was possible to accidentally set the value of `controllers.foo`, where
foo is a container-retrieved controller value as specified using `needs`.

There is no case where a developer would want to do this on purpose, and
it can cause confusion. This commit throws an error when this occurs.
