### PR TITLE
[FEATURE propertyBraceExpansion] Ensure __ember_observes__ is set properly.

### DIFF
--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -114,6 +114,8 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
       for (var i=0; i<arguments.length; ++i) {
         expandProperties(arguments[i], addWatchedProperty);
       }
+
+      this.__ember_observes__ = watched;
     } else {
       this.__ember_observes__ = a_slice.call(arguments);
     }


### PR DESCRIPTION
The refactor in 5d95885 (specifically [this](https://github.com/emberjs/ember.js/commit/5d95885#diff-4482f877489694f981934999cbf3b194L163) section) to allow only the declarative form of expansion caused
the `__ember_observes__` property to be unset when the feature was enabled.

This was identified while fixing the Travis asset publishing and build 
failures in #3863.

@twokul / @rjackson

/cc @hjdivad
