### PR TITLE
[BUGFIX beta] Preserve base URL when using history location for routing

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -20,6 +20,7 @@ Ember.HistoryLocation = Ember.Object.extend({
 
   init: function() {
     set(this, 'location', get(this, 'location') || window.location);
+    set(this, 'baseURL', Ember.$('base').attr('href') || '');
   },
 
   /**
@@ -53,10 +54,12 @@ Ember.HistoryLocation = Ember.Object.extend({
   getURL: function() {
     var rootURL = get(this, 'rootURL'),
         location = get(this, 'location'),
-        path = location.pathname;
+        path = location.pathname,
+        baseURL = get(this, 'baseURL');
 
     rootURL = rootURL.replace(/\/$/, '');
-    var url = path.replace(rootURL, '');
+    baseURL = baseURL.replace(/\/$/, '');
+    var url = path.replace(baseURL, '').replace(rootURL, '');
 
     if (Ember.FEATURES.isEnabled("query-params")) {
       var search = location.search || '';
@@ -192,13 +195,17 @@ Ember.HistoryLocation = Ember.Object.extend({
     @return formatted url {String}
   */
   formatURL: function(url) {
-    var rootURL = get(this, 'rootURL');
+    var rootURL = get(this, 'rootURL'),
+        baseURL = get(this, 'baseURL');
 
     if (url !== '') {
       rootURL = rootURL.replace(/\/$/, '');
+      baseURL = baseURL.replace(/\/$/, '');
+    } else if(baseURL.match(/^\//) && rootURL.match(/^\//)) {
+      baseURL = baseURL.replace(/\/$/, '');
     }
 
-    return rootURL + url;
+    return baseURL + rootURL + url;
   },
 
   /**

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -66,3 +66,44 @@ test("webkit doesn't fire popstate on page load", function() {
   createLocation();
   location.initState();
 });
+
+test("base URL is removed when retrieving the current pathname", function() {
+    expect(1);
+
+    HistoryTestLocation.reopen({
+        init: function() {
+            this._super();
+
+            set(this, 'location', { pathname: '/base/foo/bar' });
+            set(this, 'baseURL', '/base/');
+        },
+
+        initState: function() {
+            this._super();
+
+            equal(this.getURL(), '/foo/bar');
+        }
+    });
+
+    createLocation();
+    location.initState();
+});
+
+test("base URL is preserved when moving around", function() {
+    expect(1);
+
+    HistoryTestLocation.reopen({
+        init: function() {
+            this._super();
+
+            set(this, 'location', { pathname: '/base/foo/bar' });
+            set(this, 'baseURL', '/base/');
+        }
+    });
+
+    createLocation();
+    location.initState();
+    location.setURL('/one/two');
+
+    equal(FakeHistory.state.path, '/base/one/two');
+});


### PR DESCRIPTION
When setting a base URL `<base href="/base/">` `/base/` should be preserved when changing the URL through push state. This is the expected behavior when setting a base URL.
