### PR TITLE
render helper with context, now creates the controller

### DIFF
--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -6,7 +6,7 @@ var get = Ember.get;
 */
 
 /**
-  
+
   Finds a controller instance.
 
   @for Ember
@@ -18,17 +18,22 @@ Ember.controllerFor = function(container, controllerName, lookupOptions) {
 };
 
 /**
-  Generates a controller automatically if none was provided.
-  The type of generated controller depends on the context.
+  Generates a controller factory
+
+  The type of the generated controller factory is derived
+  from the context. If the context is an array an array controller
+  is generated, if an object, an object controller otherwise, a basic
+  controller is generated.
+
   You can customize your generated controllers by defining
-  `App.ObjectController` and `App.ArrayController`
-  
+  `App.ObjectController` or `App.ArrayController`.
+
   @for Ember
-  @method generateController
+  @method generateControllerFactory
   @private
 */
-Ember.generateController = function(container, controllerName, context) {
-  var ControllerFactory, fullName, instance, name, factoryName, controllerType;
+Ember.generateControllerFactory = function(container, controllerName, context) {
+  var Factory, fullName, instance, name, factoryName, controllerType;
 
   if (context && Ember.isArray(context)) {
     controllerType = 'array';
@@ -40,7 +45,7 @@ Ember.generateController = function(container, controllerName, context) {
 
   factoryName = 'controller:' + controllerType;
 
-  ControllerFactory = container.lookupFactory(factoryName).extend({
+  Factory = container.lookupFactory(factoryName).extend({
     isGenerated: true,
     toString: function() {
       return "(generated " + controllerName + " controller)";
@@ -49,9 +54,27 @@ Ember.generateController = function(container, controllerName, context) {
 
   fullName = 'controller:' + controllerName;
 
-  container.register(fullName, ControllerFactory);
+  container.register(fullName,  Factory);
 
-  instance = container.lookup(fullName);
+  return Factory;
+};
+
+/**
+  Generates and instantiates a controller.
+
+  The type of the generated controller factory is derived
+  from the context. If the context is an array an array controller
+  is generated, if an object, an object controller otherwise, a basic
+  controller is generated.
+
+  @for Ember
+  @method generateController
+  @private
+*/
+Ember.generateController = function(container, controllerName, context) {
+  Ember.generateControllerFactory(container, controllerName, context);
+  var fullName = 'controller:' + controllerName;
+  var instance = container.lookup(fullName);
 
   if (get(instance, 'namespace.LOG_ACTIVE_GENERATION')) {
     Ember.Logger.info("generated -> " + fullName, { fullName: fullName });

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -100,7 +100,8 @@ test("{{render}} helper should render given template with a supplied model", fun
     post: post
   });
 
-  var controller = Controller.create();
+  var controller = Controller.create({
+  });
 
   view = Ember.View.create({
     controller: controller,
@@ -127,6 +128,36 @@ test("{{render}} helper should render given template with a supplied model", fun
   } else {
     deepEqual(postController.get('model'), { title: "Rails is unagi" });
   }
+});
+
+test("{{render}} helper with a supplied model should not fire observers on the controller", function () {
+  var template = "<h1>HI</h1>{{render 'post' post}}";
+  var post = {
+    title: "Rails is omakase"
+  };
+
+  view = Ember.View.create({
+    controller: Ember.Controller.create({
+      container: container,
+      post: post
+    }),
+    template: Ember.Handlebars.compile(template)
+  });
+
+  var PostController = Ember.ObjectController.extend({
+    contentDidChange: Ember.observer('content', function(){
+      contentDidChange++;
+    })
+  });
+
+  container.register('controller:post', PostController);
+
+  Ember.TEMPLATES['post'] = compile("<p>{{title}}</p>");
+
+  var contentDidChange = 0;
+  appendView(view);
+  equal(contentDidChange, 0, "content observer did not fire");
+
 });
 
 test("{{render}} helper should raise an error when a given controller name does not resolve to a controller", function() {


### PR DESCRIPTION
with its model, rather than setting the model post creation.

Setting the context post creating causes unneeded and wasteful change events.

@hjdivad & @stefanpenner
