### PR TITLE
Ember.computed.readOnly

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -116,3 +116,11 @@ for a detailed explanation.
   Enables `{{#with}}` to take a `controller=` option for wrapping the context.
 
   Added in [#3722](https://github.com/emberjs/ember.js/pull/3722)
+
+
+* `computed-read-only`
+
+  Enables `Ember.computed.readOnly` which is the shortHand for
+Ember.computed.oneWay('foo').readOnly().
+
+  Added in [#3879](https://github.com/emberjs/ember.js/pull/3879)

--- a/features.json
+++ b/features.json
@@ -10,5 +10,6 @@
   "ember-testing-simple-setup": null,
   "ember-testing-routing-helpers": null,
   "ember-testing-triggerEvent-helper": null,
-  "with-controller": null
+  "with-controller": null,
+  "computed-read-only": null
 }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -982,3 +982,32 @@ testBoth('Ember.computed.oneWay', function(get, set) {
 
   equal(get(obj, 'nickName'), 'TeddyBear');
 });
+
+
+if (Ember.FEATURES.isEnabled('computed-read-only')) {
+testBoth('Ember.computed.readOnly', function(get, set) {
+  var obj = {
+    firstName: 'Teddy',
+    lastName: 'Zeenny'
+  };
+
+  Ember.defineProperty(obj, 'nickName', Ember.computed.readOnly('firstName'));
+
+  equal(get(obj, 'firstName'), 'Teddy');
+  equal(get(obj, 'lastName'), 'Zeenny');
+  equal(get(obj, 'nickName'), 'Teddy');
+
+  throws(function(){
+    set(obj, 'nickName', 'TeddyBear');
+  }, / /);
+
+  equal(get(obj, 'firstName'), 'Teddy');
+  equal(get(obj, 'lastName'), 'Zeenny');
+
+  equal(get(obj, 'nickName'), 'Teddy');
+
+  set(obj, 'firstName', 'TEDDDDDDDDYYY');
+
+  equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
+});
+}


### PR DESCRIPTION
Basically nearly every time one uses oneWay, one actually
want's to also ensure no data propagates back up. Rather then
constantly using `oneWay` and `readOnly` in conjunction, this
merely combines them.
