### PR TITLE
[BUGFIX beta] - assert array gets returned from model hook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,5 @@ PLATFORMS
 DEPENDENCIES
   ember-dev!
   ember-source!
+  puma
   rake-pipeline!

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -469,6 +469,10 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
 
     var args = [controller, context];
 
+    Ember.assert(
+        fmt("ArrayControllers expect an array as their 'model', you set the model with %@", [context ? get(context, 'constructor') : context]),
+        !(context && typeof context === 'object' && controller && (controller instanceof Ember.ArrayController) && !Ember.isArray(context)));
+
     if (Ember.FEATURES.isEnabled("query-params")) {
       args.push(queryParams);
     }

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -181,6 +181,10 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
     var arrangedContent = get(this, 'arrangedContent');
 
     if (arrangedContent) {
+      if (Ember.isArray(arrangedContent) && typeof arrangedContent.addArrayObserver !== 'function'){
+        arrangedContent = Ember.A(arrangedContent);
+        set(this, 'arrangedContent', arrangedContent);
+      }
       arrangedContent.addArrayObserver(this, {
         willChange: 'arrangedContentArrayWillChange',
         didChange: 'arrangedContentArrayDidChange'

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -139,7 +139,7 @@ test("Slow promises waterfall on startup", function() {
   App.MomRoute = Ember.Route.extend({
     model: function() {
       step(2, "Mom#model");
-      return {};
+      return [];
     }
   });
 
@@ -157,7 +157,7 @@ test("Slow promises waterfall on startup", function() {
 
   equal(Ember.$('#app', '#qunit-fixture').text(), "LOADING", "The Loading template is nested in application template's outlet");
 
-  Ember.run(grandmaDeferred, 'resolve', {});
+  Ember.run(grandmaDeferred, 'resolve', []);
   equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA MOM MOMLOADING", "Mom's child loading route is displayed due to sally's slow promise");
 
   Ember.run(sallyDeferred, 'resolve', {});


### PR DESCRIPTION
Adds an assert at the route level to warn application authors if they
setup up an ArrayController with a non-array.

Also implemented wrapping of the content at ArrayProxy level due to
`intermediateTransitionTo` skipping the `setup` functino in routes
routes when transitioning from error/loading to another route.

fixes #3869
