### PR TITLE
[BUGFIX beta] Handle beta branch builds properly.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: ef16d023644e44630aa96648820b266b658b594a
+  revision: e287354a5e67c0b8793e7b93d3d9a1d27ed00524
   branch: master
   specs:
     ember-dev (0.1)


### PR DESCRIPTION
The initial implementation of the `FORCE_BRANCH` flag did not properly account
for all scenarios.  This attempts to fix an issue with builds of commits
pushed directly to the beta/stable branches.

As discussed with @wagenet in IRC.

The main changes were implemented in `ember-dev` in these PRs:
- https://github.com/emberjs/ember-dev/pull/112
- https://github.com/emberjs/ember-dev/pull/113
