### PR TITLE
[BUGFIX beta] Ensure willMergeMixin is called on each Mixin.

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -212,7 +212,7 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
 
     if (props) {
       meta = Ember.meta(base);
-      if (base.willMergeMixin) { base.willMergeMixin(props); }
+      if (mixin.willMergeMixin) { mixin.willMergeMixin(props, base); }
       concats = concatenatedMixinProperties('concatenatedProperties', props, values, base);
       mergings = concatenatedMixinProperties('mergedProperties', props, values, base);
 

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -28,11 +28,11 @@ Ember.ActionHandler = Ember.Mixin.create({
 
     @method willMergeMixin
   */
-  willMergeMixin: function(props) {
+  willMergeMixin: function(props, baseObject) {
     var hashName;
 
     if (!props._actions) {
-      Ember.assert(this + " 'actions' should not be a function", typeof(props.actions) !== 'function');
+      Ember.assert(baseObject + " 'actions' should not be a function", typeof(props.actions) !== 'function');
 
       if (typeOf(props.actions) === 'object') {
         hashName = 'actions';


### PR DESCRIPTION
Call `willMergeMixin` for each Mixin in the list. This allows you to implement `willMergeMixin` for multiple mixins in the same object.

Unfortunately, `_super` cannot be used as it causes infinite recursion in some cases. (emberjs#3523 and emberjs#3683)
