### PR TITLE
[NICETHING beta] assert `needs` incompatibility with periods

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -10,6 +10,9 @@ function verifyNeedsDependencies(controller, container, needs) {
 
   for (i=0, l=needs.length; i<l; i++) {
     dependency = needs[i];
+
+    Ember.assert(Ember.inspect(controller) + "#needs must not specify dependencies with periods in their names (" + dependency + ")", dependency.indexOf('.') === -1);
+
     if (dependency.indexOf(':') === -1) {
       dependency = "controller:" + dependency;
     }

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -115,3 +115,18 @@ test ("setting the value of a controller dependency should not be possible", fun
   postController.set('controllers.posts.title', "A Troll's Life");
   equal(postController.get('controllers.posts.title'), "A Troll's Life", "can set the value of controllers.posts.title");
 });
+
+test("raises if a dependency with a period is requested", function() {
+  var container = new Ember.Container();
+
+  container.register('controller:big.bird', Ember.Controller.extend());
+  container.register('controller:foo', Ember.Controller.extend({
+    needs: 'big.bird'
+  }));
+
+  expectAssertion(function() {
+    container.lookup('controller:foo');
+  }, /needs must not specify dependencies with periods in their names \(big\.bird\)/,
+  'throws if periods used');
+});
+


### PR DESCRIPTION
needs isn't compatible with periods, because ultimately
you're going to need to call get('controllers.foo.bar')
(assuming needs: 'foo.bar'), which doesn't and can't
do what you want.

EAK solution is to slashify
global ember solution is to camelcase

Not sure if we can make a better error than just saying "don't use periods"
