### PR TITLE
[BUGFIX] Deprecate manually assigned templates for Components.

### DIFF
--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -239,12 +239,11 @@ test("yield view should be a virtual view", function() {
   var component = Ember.Component.extend({
     isParentComponent: true,
 
-    template: Ember.Handlebars.compile('{{view includedComponent}}'),
     layout: Ember.Handlebars.compile('{{yield}}')
   });
 
   view = Ember.View.create({
-    template: Ember.Handlebars.compile('{{view component}}'),
+    template: Ember.Handlebars.compile('{{#view component}}{{view includedComponent}}{{/view}}'),
     controller: {
       component: component,
       includedComponent: Ember.Component.extend({

--- a/packages/ember-views/lib/mixins/component_template_deprecation.js
+++ b/packages/ember-views/lib/mixins/component_template_deprecation.js
@@ -1,0 +1,58 @@
+/**
+  The ComponentTemplateDeprecation mixin is used to provide a useful
+  deprecation warning when using either `template` or `templateName` with
+  a component. The `template` and `templateName` properties specified at
+  extend time are moved to `layout` and `layoutName` respectively.
+
+  `Ember.ComponentTemplateDeprecation` is used internally by Ember in
+  `Ember.Component`.
+
+  @class ComponentTemplateDeprecation
+  @namespace Ember
+*/
+Ember.ComponentTemplateDeprecation = Ember.Mixin.create({
+  /**
+    @private
+
+    Moves `templateName` to `layoutName` and `template` to `layout` at extend
+    time if a layout is not also specified.
+
+    Note that this currently modifies the mixin themselves, which is technically
+    dubious but is practically of little consequence. This may change in the
+    future.
+
+    @method willMergeMixin
+  */
+  willMergeMixin: function(props) {
+    // must call _super here to ensure that the ActionHandler
+    // mixin is setup properly (moves actions -> _actions)
+    //
+    // Calling super is only OK here since we KNOW that
+    // there is another Mixin loaded first.
+    this._super.apply(this, arguments);
+
+    var deprecatedProperty, replacementProperty,
+        layoutSpecified = (props.layoutName || props.layout);
+
+    if (props.templateName && !layoutSpecified) {
+      deprecatedProperty = 'templateName';
+      replacementProperty = 'layoutName';
+
+      props.layoutName = props.templateName;
+      delete props['templateName'];
+    }
+
+    if (props.template && !layoutSpecified) {
+      deprecatedProperty = 'template';
+      replacementProperty = 'layout';
+
+      props.layout = props.template;
+      delete props['template'];
+    }
+
+    if (deprecatedProperty) {
+      Ember.deprecate('Do not specify ' + deprecatedProperty + ' on a Component, use ' + replacementProperty + ' instead.', false);
+    }
+  }
+});
+

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -1,4 +1,5 @@
 require("ember-views/views/view");
+require("ember-views/mixins/component_template_deprecation");
 
 var get = Ember.get, set = Ember.set, isNone = Ember.isNone,
     a_slice = Array.prototype.slice;
@@ -94,7 +95,7 @@ var get = Ember.get, set = Ember.set, isNone = Ember.isNone,
   @namespace Ember
   @extends Ember.View
 */
-Ember.Component = Ember.View.extend(Ember.TargetActionSupport, {
+Ember.Component = Ember.View.extend(Ember.TargetActionSupport, Ember.ComponentTemplateDeprecation, {
   init: function() {
     this._super();
     set(this, 'context', this);
@@ -105,6 +106,36 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, {
     options.data = {view: options._context};
     Ember.Handlebars.helpers['yield'].apply(this, [options]);
   },
+
+  /**
+  A components template property is set by passing a block to
+  during its invocation. It is executed within the parent context.
+
+  Example:
+
+  ```handlebars
+  {{#my-component}}
+    // something that is run in the context
+    // of the parent context
+  {{/my-component}}
+  ```
+
+  Specifying a template directly to a component is deprecated without
+  also specifying the layout property.
+
+  @deprecated
+  @property template
+  */
+  template: null,
+
+  /**
+  Specifying a components `templateName` is deprecated without also
+  providing the `layout` or `layoutName` properties.
+
+  @deprecated
+  @property templateName
+  */
+  templateName: null,
 
   // during render, isolate keywords
   cloneKeywords: function() {

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -1,21 +1,89 @@
 var get = Ember.get, set = Ember.set,
     a_slice = Array.prototype.slice;
 
-module("Ember.Component");
+var component, controller, actionCounts, sendCount, actionArguments;
 
-var Component = Ember.Component.extend();
+module("Ember.Component", {
+  setup: function(){
+    component = Ember.Component.create();
+  },
+  teardown: function() {
+    Ember.run(function() {
+      if(component)  { component.destroy(); }
+      if(controller) { controller.destroy(); }
+    });
+
+    Ember.TESTING_DEPRECATION = false;
+    Ember.ENV.RAISE_ON_DEPRECATION = false;
+  }
+});
 
 test("The context of an Ember.Component is itself", function() {
-  var control = Component.create();
-  strictEqual(control, control.get('context'), "A control's context is itself");
+  strictEqual(component, component.get('context'), "A components's context is itself");
 });
 
 test("The controller (target of `action`) of an Ember.Component is itself", function() {
-  var control = Component.create();
-  strictEqual(control, control.get('controller'), "A control's controller is itself");
+  strictEqual(component, component.get('controller'), "A components's controller is itself");
 });
 
-var component, controller, actionCounts, sendCount, actionArguments;
+test("A templateName specified to a component is moved to the layoutName", function(){
+  Ember.TESTING_DEPRECATION = true;
+
+  component = Ember.Component.extend({
+    templateName: 'blah-blah'
+  }).create();
+
+  equal(component.get('layoutName'), 'blah-blah', "The layoutName now contains the templateName specified.");
+});
+
+test("A template specified to a component is moved to the layout", function(){
+  Ember.TESTING_DEPRECATION = true;
+
+  component = Ember.Component.extend({
+    template: 'blah-blah'
+  }).create();
+
+  equal(component.get('layout'), 'blah-blah', "The layoutName now contains the templateName specified.");
+});
+
+test("A template specified to a component is deprecated", function(){
+  Ember.ENV.RAISE_ON_DEPRECATION = true;
+
+  try {
+    component = Ember.Component.extend({
+      template: 'blah-blah'
+    }).create();
+  } catch (e) {
+    equal(e.message, 'Do not specify template on a Component, use layout instead.', "deprecation warning is present");
+  }
+});
+
+test("A templateName specified to a component is deprecated", function(){
+  Ember.ENV.RAISE_ON_DEPRECATION = true;
+
+  try {
+    component = Ember.Component.extend({
+      templateName: 'blah-blah'
+    }).create();
+  } catch (e) {
+    equal(e.message, 'Do not specify templateName on a Component, use layoutName instead.', "deprecation warning is present");
+  }
+});
+
+test("Specifying both templateName and layoutName to a component is NOT deprecated", function(){
+  expect(0);
+
+  Ember.ENV.RAISE_ON_DEPRECATION = true;
+
+  try {
+    component = Ember.Component.extend({
+      templateName: 'blah-blah',
+      layoutName: 'hum-drum'
+    }).create();
+  } catch (e) {
+    ok(false, "deprecation should not be thrown");
+  }
+});
 
 module("Ember.Component - Actions", {
   setup: function() {

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -1,9 +1,12 @@
 var App, container;
 var compile = Ember.Handlebars.compile;
+var originalHelpers;
 
 function prepare(){
   Ember.TEMPLATES["components/expand-it"] = compile("<p>hello {{yield}}</p>");
   Ember.TEMPLATES.application = compile("Hello world {{#expand-it}}world{{/expand-it}}");
+
+  originalHelpers = Ember.A(Ember.keys(Ember.Handlebars.helpers));
 }
 
 function cleanup(){
@@ -11,6 +14,18 @@ function cleanup(){
     App.destroy();
     App = null;
     Ember.TEMPLATES = {};
+
+    cleanupHandlebarsHelpers();
+  });
+}
+
+function cleanupHandlebarsHelpers(){
+  var currentHelpers = Ember.A(Ember.keys(Ember.Handlebars.helpers));
+
+  currentHelpers.forEach(function(name){
+    if (!originalHelpers.contains(name)) {
+      delete Ember.Handlebars.helpers[name];
+    }
   });
 }
 
@@ -134,6 +149,26 @@ test("Component lookups should take place on components' subcontainers", functio
   });
 });
 
+test("Assigning templateName to a component should setup the template as a layout", function(){
+  expect(1);
+
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>");
+  Ember.TEMPLATES['foo-bar-baz'] = compile("{{text}}-{{yield}}");
+
+  boot(function() {
+    container.register('controller:application', Ember.Controller.extend({
+      'text': 'outer'
+    }));
+
+    container.register('component:my-component', Ember.Component.extend({
+      text: 'inner',
+      templateName: 'foo-bar-baz'
+    }));
+  });
+
+  equal(Ember.$('#wrapper').text(), "inner-outer", "The component is composed correctly");
+});
+
 module("Application Lifecycle - Component Context", {
   setup: prepare,
   teardown: cleanup
@@ -232,7 +267,13 @@ test("Components trigger actions in the components context when called from with
   Ember.TEMPLATES['components/my-component'] = compile("<a href='#' id='fizzbuzz' {{action 'fizzbuzz'}}>Fizzbuzz</a>");
 
   boot(function() {
-    container.register('controller:application', Ember.Controller.extend());
+    container.register('controller:application', Ember.Controller.extend({
+      actions: {
+        fizzbuzz: function(){
+          ok(false, 'action triggered on the wrong context');
+        }
+      }
+    }));
 
     container.register('component:my-component', Ember.Component.extend({
       actions: {


### PR DESCRIPTION
In most circumstances a Component does not have a template or templateName property. In a component the block passed when calling it (in a handlebars template) is interpreted as its template, and a template that was registered as `components/my-component` becomes its layout. This was recently fixed in 1.2.0 (with the `container-renderables` feature), but many applications already existed that manually register their components (via `Ember.Handlebars.helper`).

This change allows usage of `template` and `templateName` properties on a component, but generates a deprecation warning if you do so.

Addresses the issue reported by @bradleypriest in [#3862](https://github.com/emberjs/ember.js/pull/3862#issuecomment-29963202).
