### PR TITLE
Remove `RSVP.Promise#fail` in favor of `catch`.

### DIFF
--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -216,7 +216,7 @@ test("Unhandled exceptions are logged via Ember.Test.adapter#exception", functio
   Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
     exception: function(error) {
       equal(error.message, "Element .does-not-exist not found.", "Exception successfully caught and passed to Ember.Test.adapter.exception");
-      asyncHandled.fail(function(){ }); // handle the rejection so it doesn't leak later.
+      asyncHandled['catch'](function(){ }); // handle the rejection so it doesn't leak later.
     }
   });
 

--- a/packages/rsvp/lib/main.js
+++ b/packages/rsvp/lib/main.js
@@ -900,7 +900,7 @@ define("rsvp/promise",
         return thenPromise;
       },
 
-      fail: function(onRejection, label) {
+      'catch': function(onRejection, label) {
         return this.then(null, onRejection, label);
       },
 
@@ -919,7 +919,6 @@ define("rsvp/promise",
       }
     };
 
-    Promise.prototype['catch'] = Promise.prototype.fail;
     Promise.cast = cast;
 
     function handleThenable(promise, value) {
@@ -1269,7 +1268,7 @@ define("rsvp/utils",
     __exports__.now = now;
   });
 define("rsvp", 
-  ["./rsvp/events","./rsvp/promise","./rsvp/node","./rsvp/all","./rsvp/race","./rsvp/hash","./rsvp/rethrow","./rsvp/defer","./rsvp/config","./rsvp/resolve","./rsvp/reject","exports"],
+  ["./rsvp/events","./rsvp/promise","./rsvp/node","./rsvp/all","./rsvp/race","./rsvp/hash","./rsvp/rethrow","./rsvp/defer","./rsvp/config","./rsvp/resolve","./rsvp/reject", "exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__, __dependency8__, __dependency9__, __dependency10__, __dependency11__, __exports__) {
     "use strict";
     var EventTarget = __dependency1__.EventTarget;


### PR DESCRIPTION
After discussion with @wycats and @domenic, it was decided we should remove
`fail` before it enters an official release
- es3 users should use the ['catch'] syntax
- plans are to add a transpiler for people to es5 -> es3 (for finally and catch) etc.
