### PR TITLE
[BUGFIX beta] Use a bundler cache to speed builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ _yardoc
 assets
 assets/bpm_libs.js
 assets/bpm_styles.css
-bin/
 coverage
 dist
 docs/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 install:
 - "npm install"
 - "gem install bundler --pre"
-- "bundle install --deployment --retry 3 --jobs 4"
+- "bin/cached-bundle install --deployment --retry 3 --jobs 4"
 - sudo apt-get update && sudo apt-get install git
 after_success: bundle exec rake publish_build
 script: rake test\[$TEST_SUITE]
@@ -22,6 +22,7 @@ notifications:
     on_failure: always
 env:
   global:
+  - S3_BUILD_CACHE_BUCKET=emberjs-build-cache
   - S3_BUCKET_NAME=builds.emberjs.com
   - secure: ! 'KXJmcGLpnxnPmmei/qPNVcdQxLX1xyYIaVocinQ0YAjtBvCtAwg63EWMFnGp
 

--- a/bin/cached-bundle
+++ b/bin/cached-bundle
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Usage: cached-bundle install --deployment
+#
+# After running `bundle`, caches the `vendor/bundle` directory to S3.
+# On the next run, restores the cached directory before running `bundle`.
+# When `Gemfile.lock` changes, the cache gets rebuilt.
+#
+# Requirements:
+# - Gemfile.lock
+# - TRAVIS_REPO_SLUG
+# - TRAVIS_RUBY_VERSION
+# - S3_BUILD_CACHE_BUCKET
+# - script/s3-put
+# - bundle
+# - curl
+#
+# Author: Mislav Marohnić
+# Source: https://github.com/github/hub/blob/aadc8418d9e5dd27172d5d67c3da0bd2fdcf759a/script/cached-bundle
+
+set -e
+
+compute_md5() {
+  local output="$(openssl md5)"
+  echo "${output##* }"
+}
+
+download() {
+  curl --tcp-nodelay -qsfL "$1" -o "$2"
+}
+
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+bundle_path="vendor/bundle"
+cache_buster="${BUNDLE_GEMFILE:-Gemfile}.lock"
+if [ ! -f $cache_buster ]; then
+  cache_buster="$GEMSPEC"
+fi
+cache_busting_hash="$(compute_md5 <"$cache_buster")"
+
+cache_name="bundler-${TRAVIS_RUBY_VERSION}-${cache_busting_hash}.tgz"
+fetch_url="http://${S3_BUILD_CACHE_BUCKET}.s3.amazonaws.com/${TRAVIS_REPO_SLUG}/${cache_name}"
+
+if download "$fetch_url" "$cache_name"; then
+  echo "Reusing cached bundle ${cache_name}"
+  tar xzf "$cache_name"
+fi
+
+bundle "$@"
+
+if [ ! -f "$cache_name" ]; then
+  if [ -z "$S3_SECRET_ACCESS_KEY" ] || [ -z "$S3_ACCESS_KEY_ID" ]
+  then
+    echo "Enviroment variables not set. Exiting..."
+    exit 0
+  fi
+
+  echo "Caching \`${bundle_path}' to S3"
+  tar czf "$cache_name" "$bundle_path"
+  $script_dir/s3-put "$cache_name" "${S3_BUILD_CACHE_BUCKET}:${TRAVIS_REPO_SLUG}/${cache_name}"
+fi
+
+# vim: filetype=sh

--- a/bin/s3-put
+++ b/bin/s3-put
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Usage: s3-put <FILE> <S3_BUCKET>[:<PATH>] [<CONTENT_TYPE>]
+#
+# Uploads a file to the Amazon S3 service.
+# Outputs the URL for the newly uploaded file.
+#
+# Requirements:
+# - S3_ACCESS_KEY_ID
+# - S3_SECRET_ACCESS_KEY
+# - openssl
+# - curl
+#
+# Author: Mislav Marohnić
+# Source: https://github.com/github/hub/blob/aadc8418d9e5dd27172d5d67c3da0bd2fdcf759a/script/s3-put
+
+set -e
+
+authorization() {
+  local signature="$(string_to_sign | hmac_sha1 | base64)"
+  echo "AWS ${S3_ACCESS_KEY_ID?}:${signature}"
+}
+
+hmac_sha1() {
+  openssl dgst -binary -sha1 -hmac "${S3_SECRET_ACCESS_KEY?}"
+}
+
+base64() {
+  openssl enc -base64
+}
+
+bin_md5() {
+  openssl dgst -binary -md5
+}
+
+string_to_sign() {
+  echo "$http_method"
+  echo "$content_md5"
+  echo "$content_type"
+  echo "$date"
+  echo "x-amz-acl:$acl"
+  printf "/$bucket/$remote_path"
+}
+
+date_string() {
+  LC_TIME=C date "+%a, %d %h %Y %T %z"
+}
+
+file="$1"
+bucket="${2%%:*}"
+remote_path="${2#*:}"
+content_type="$3"
+
+if [ -z "$remote_path" ] || [ "$remote_path" = "$bucket" ]; then
+  remote_path="${file##*/}"
+fi
+
+http_method=PUT
+acl="public-read"
+content_md5="$(bin_md5 < "$file" | base64)"
+date="$(date_string)"
+
+url="https://$bucket.s3.amazonaws.com/$remote_path"
+
+curl -qsSf -T "$file" \
+  -H "Authorization: $(authorization)" \
+  -H "x-amz-acl: $acl" \
+  -H "Date: $date" \
+  -H "Content-MD5: $content_md5" \
+  -H "Content-Type: $content_type" \
+  "$url"
+
+echo "$url"
+
+# vim: filetype=sh


### PR DESCRIPTION
Stores a copy of the bundled cache in an S3 bucket to speed up builds. The cache is keyed on the repo + ruby version + MD5 of Gemfile.lock so that when any one of that combination is modified a new bundle cache will be created.
