### PR TITLE
Prioritize imported Handlebars over global Handlebars

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -10,7 +10,7 @@ var objectCreate = Object.create || function(parent) {
   return new F();
 };
 
-var Handlebars = (this && this.Handlebars) || (Ember.imports && Ember.imports.Handlebars);
+var Handlebars = (Ember.imports && Ember.imports.Handlebars) || (this && this.Handlebars);
 if (!Handlebars && typeof require === 'function') {
   Handlebars = require('handlebars');
 }


### PR DESCRIPTION
Prioritizing the global Handlebars causes problems in environments with multiple versions of Handlebars (yes, in real life, sad trombone). 

Hat tip to @meirish and @rpflorence for bringing this to my attention.
