### PR TITLE
[BUGFIX beta] Ensure that the rootURL is available to location.

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -20,7 +20,6 @@ Ember.HistoryLocation = Ember.Object.extend({
 
   init: function() {
     set(this, 'location', get(this, 'location') || window.location);
-    this.initState();
   },
 
   /**

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -166,6 +166,10 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     if (typeof rootURL === 'string') {
       location.rootURL = rootURL;
     }
+
+    // ensure that initState is called AFTER the rootURL is set on
+    // the location instance
+    if (typeof location.initState === 'function') { location.initState(); }
   },
 
   _getHandlerFunction: function() {

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -1,0 +1,68 @@
+var FakeHistory, HistoryTestLocation, location,
+    get = Ember.get,
+    set = Ember.set,
+    rootURL = window.location.pathname;
+
+function createLocation(options){
+  if(!options) { options = {}; }
+  location = HistoryTestLocation.create(options);
+}
+
+module("History Location", {
+  setup: function() {
+    FakeHistory = {
+      state: null,
+      _states: [],
+      replaceState: function(state, title, url){
+        this.state = state;
+        this._states[0] = state;
+      },
+      pushState: function(state, title, url){
+        this.state = state;
+        this._states.unshift(state);
+      }
+    };
+
+    HistoryTestLocation = Ember.HistoryLocation.extend({
+      history: FakeHistory
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      if (location) { location.destroy(); }
+    });
+  }
+});
+
+test("HistoryLocation initState does not get fired on init", function() {
+  expect(1);
+
+  HistoryTestLocation.reopen({
+    init: function(){
+      ok(true, 'init was called');
+      this._super();
+    },
+    initState: function() {
+      ok(false, 'initState() should not be called automatically');
+    }
+  });
+
+  createLocation();
+});
+
+test("webkit doesn't fire popstate on page load", function() {
+  expect(1);
+
+  HistoryTestLocation.reopen({
+    initState: function() {
+      this._super();
+      // these two should be equal to be able
+      // to successfully detect webkit initial popstate
+      equal(this._previousURL, this.getURL());
+    }
+  });
+
+  createLocation();
+  location.initState();
+});

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1904,30 +1904,26 @@ test("Router accounts for rootURL on page load when using history location", fun
   ok(postsTemplateRendered, "Posts route successfully stripped from rootURL");
 });
 
-test("HistoryLocation has the correct rootURL on initState and webkit doesn't fire popstate on page load", function() {
-  expect(2);
-  var rootURL = window.location.pathname,
-      history,
+test("The rootURL is passed properly to the location implementation", function() {
+  expect(1);
+  var rootURL = "/blahzorz",
       HistoryTestLocation;
 
-  history = { replaceState: function() {} };
-
   HistoryTestLocation = Ember.HistoryLocation.extend({
-    history: history,
+    rootURL: 'this is not the URL you are looking for',
     initState: function() {
       equal(this.get('rootURL'), rootURL);
-      this._super();
-      // these two should be equal to be able
-      // to successfully detect webkit initial popstate
-      equal(this._previousURL, this.getURL());
     }
   });
 
-  container.register('location:historyTest', HistoryTestLocation);
+  container.register('location:history-test', HistoryTestLocation);
 
   Router.reopen({
-    location: 'historyTest',
-    rootURL: rootURL
+    location: 'history-test',
+    rootURL: rootURL,
+    // if we transition in this test we will receive failures
+    // if the tests are run from a static file
+    _doTransition: function(){}
   });
 
   bootApplication();


### PR DESCRIPTION
The refactoring in #3752 caused the rootURL to not be passed at initialization
time to the location implementation. This change reverses that by injecting
the `router:main` into the newly created location instance.

The tests were also refactored:
- Split HistoryLocation tests out from the router basic tests.
- Ensure that we are testing the right thing in router tests (ensuring
  that the rootURL is available to the location implementation).
- Fixed issue with existing rootURL check that made the test pass
  due to the fact that the default rootURL (`/`) just happens to be the
  rootURL while running the test via `rackup`.

Resolves: https://github.com/emberjs/ember-dev/issues/115
