### PR TITLE
Container#resolve is now cached.

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -136,7 +136,8 @@ define("container",
 
       this.registry = new InheritingDict(parent && parent.registry);
       this.cache = new InheritingDict(parent && parent.cache);
-      this.factoryCache = new InheritingDict(parent && parent.cache);
+      this.factoryCache = new InheritingDict(parent && parent.factoryCache);
+      this.resolveCache = new InheritingDict(parent && parent.resolveCache);
       this.typeInjections = new InheritingDict(parent && parent.typeInjections);
       this.injections = {};
 
@@ -297,6 +298,7 @@ define("container",
         this.registry.remove(normalizedName);
         this.cache.remove(normalizedName);
         this.factoryCache.remove(normalizedName);
+        this.resolveCache.remove(normalizedName);
         this._options.remove(normalizedName);
       },
 
@@ -334,8 +336,17 @@ define("container",
       */
       resolve: function(fullName) {
         validateFullName(fullName);
+
         var normalizedName = this.normalize(fullName);
-        return this.resolver(normalizedName) || this.registry.get(normalizedName);
+        var cached = this.resolveCache.get(normalizedName);
+
+        if (cached) { return cached; }
+
+        var resolved = this.resolver(normalizedName) || this.registry.get(normalizedName);
+
+        this.resolveCache.set(normalizedName, resolved);
+
+        return resolved;
       },
 
       /**

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -600,3 +600,21 @@ test('container.has should not accidentally cause injections on that factory to 
 
   ok(container.has('controller:apple'));
 });
+
+test('once resolved, always return the same result', function(){
+  expect(1);
+
+  var container = new Container();
+
+  container.resolver = function() {
+    return 'bar';
+  };
+
+  var Bar = container.resolve('models:bar');
+
+  container.resolver = function() {
+    return 'not bar';
+  };
+
+  equal(container.resolve('models:bar'), Bar);
+});


### PR DESCRIPTION
- once resolved, a later resolve of the same fullName should not yield a new resolution
- once resolved, a later resolve should not needless query the Resolver, as this can be costly and  wasteful.
