### PR TITLE
[DOC beta] Assert if template for {{render}} not found.

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -143,7 +143,11 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     }
 
     options.hash.viewName = Ember.String.camelize(name);
-    options.hash.template = container.lookup('template:' + name);
+
+    var templateName = 'template:' + name;
+    Ember.assert("The template name you supplied '" + name + "' was not found.", container.has(templateName));
+    options.hash.template = container.lookup(templateName);
+
     options.hash.controller = controller;
 
     if (router && !context) {

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -89,6 +89,19 @@ test("{{render}} helper should render given template", function() {
   ok(container.lookup('router:main')._lookupActiveView('home'), 'should register home as active view');
 });
 
+test("{{render}} helper should have assertion if template is not found", function() {
+  var template = "<h1>HI</h1>{{render 'oops'}}";
+  var controller = Ember.Controller.extend({container: container});
+  view = Ember.View.create({
+    controller: controller.create(),
+    template: Ember.Handlebars.compile(template)
+  });
+
+  expectAssertion(function() {
+    appendView(view);
+  }, 'The template name you supplied \'oops\' was not found.');
+});
+
 test("{{render}} helper should render given template with a supplied model", function() {
   var template = "<h1>HI</h1>{{render 'post' post}}";
   var post = {
@@ -396,7 +409,7 @@ test("{{render}} works with dot notation", function() {
     template: Ember.Handlebars.compile(template)
   });
 
-  Ember.TEMPLATES['blog/post'] = compile("<p>POST</p>");
+  Ember.TEMPLATES['blog.post'] = compile("<p>POST</p>");
 
   appendView(view);
 
@@ -416,7 +429,7 @@ test("{{render}} works with slash notation", function() {
     template: Ember.Handlebars.compile(template)
   });
 
-  Ember.TEMPLATES['blog/post'] = compile("<p>POST</p>");
+  Ember.TEMPLATES['blog.post'] = compile("<p>POST</p>");
 
   appendView(view);
 


### PR DESCRIPTION
Added an assertion if the template name provided to `{{render}}` was not found.

Two tests were previously not working properly, and have been fixed. They registered templates as `"blog/post"`, which is never looked up with `{{render}}` (as any slashes in the name are translated to a period before this lookup happens).

Resolves #3926.
