### PR TITLE
[BUGFIX beta] Ensure {{link-to}} path observers are reregistered after render.

### DIFF
--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1027,7 +1027,7 @@ test("The non-block form {{link-to}} helper moves into the named route", functio
 });
 
 test("The non-block form {{link-to}} helper updates the link text when it is a binding", function() {
-  expect(7);
+  expect(8);
   Router.map(function(match) {
     this.route("contact");
   });
@@ -1044,14 +1044,19 @@ test("The non-block form {{link-to}} helper updates the link text when it is a b
   Ember.run(function() {
     router.handleURL("/");
   });
+  var controller = container.lookup('controller:index');
 
   equal(Ember.$('#contact-link:contains(Jane)', '#qunit-fixture').length, 1, "The link title is correctly resolved");
 
-  var controller = container.lookup('controller:index');
   Ember.run(function() {
     controller.set('contactName', 'Joe');
   });
   equal(Ember.$('#contact-link:contains(Joe)', '#qunit-fixture').length, 1, "The link title is correctly updated when the bound property changes");
+
+  Ember.run(function() {
+    controller.set('contactName', 'Robert');
+  });
+  equal(Ember.$('#contact-link:contains(Robert)', '#qunit-fixture').length, 1, "The link title is correctly updated when the bound property changes a second time");
 
   Ember.run(function() {
     Ember.$('#contact-link', '#qunit-fixture').click();
@@ -1066,7 +1071,7 @@ test("The non-block form {{link-to}} helper updates the link text when it is a b
   });
 
   equal(Ember.$('h3:contains(Home)', '#qunit-fixture').length, 1, "The index template was rendered");
-  equal(Ember.$('#contact-link:contains(Joe)', '#qunit-fixture').length, 1, "The link title is correctly updated when the route changes");
+  equal(Ember.$('#contact-link:contains(Robert)', '#qunit-fixture').length, 1, "The link title is correctly updated when the route changes");
 });
 
 test("The non-block form {{link-to}} helper moves into the named route with context", function() {


### PR DESCRIPTION
Prior to this change we called `registerObserver` on `init` so that `this.rerender` was triggered when the link text changes (see [here](https://github.com/emberjs/ember.js/blob/3a7f4ae7c0be07f064f31e1df3f06d38ff866f4c/packages/ember-routing/lib/helpers/link_to.js#L192-L196)).

This worked properly to trigger the first `rerender`, but since `registerObserver` tears down the observer on `willClearRender` (see [here](https://github.com/emberjs/ember.js/blob/3a7f4ae7c0be07f064f31e1df3f06d38ff866f4c/packages/ember-views/lib/views/view.js#L2273-2275)) and the observers were not set back up, we would only handle a single change.

This change ensures that the observers are setup after each time the view is rerendered.

**Please Note:** This issue exists in 1.2.0, but I was unsure if this is a large enough issue to cause a point release update.  Let me know if I should change the commit tag to `[BUGFIX stable]`.

Resolves https://github.com/emberjs/ember.js/issues/3925.
