### PR TITLE
[BUGFIX beta] Do not attempt to serialize undefined models.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -776,6 +776,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
   */
   serialize: function(model, params) {
     if (params.length < 1) { return; }
+    if (!model) { return; }
 
     var name = params[0], object = {};
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -1,13 +1,16 @@
 var route, routeOne, routeTwo, router, container, lookupHash;
 
-module("Ember.Route", {
-  setup: function() {
-    route = Ember.Route.create();
-  },
+function createRoute(){
+  route = Ember.Route.create();
+}
 
-  teardown: function() {
-    Ember.run(route, 'destroy');
-  }
+function cleanupRoute(){
+  Ember.run(route, 'destroy');
+}
+
+module("Ember.Route", {
+  setup: createRoute,
+  teardown: cleanupRoute
 });
 
 test("default store utilizes the container to acquire the model factory", function() {
@@ -70,6 +73,27 @@ test("'store' can be injected by data persistence frameworks", function() {
   equal(route.findModel('post', 1), post, '#findModel returns the correct post');
 });
 
+module("Ember.Route serialize", {
+  setup: createRoute,
+  teardown: cleanupRoute
+});
+
+test("returns the models properties if params does not include *_id", function(){
+  var model = {id: 2, firstName: 'Ned', lastName: 'Ryerson'};
+
+  deepEqual(route.serialize(model, ['firstName', 'lastName']), {firstName: 'Ned', lastName: 'Ryerson'}, "serialized correctly");
+});
+
+test("returns model.id if params include *_id", function(){
+  var model = {id: 2};
+
+  deepEqual(route.serialize(model, ['post_id']), {post_id: 2}, "serialized correctly");
+});
+
+test("returns undefined if model is not set", function(){
+  equal(route.serialize(undefined, ['post_id']), undefined, "serialized correctly");
+});
+
 module("Ember.Route interaction", {
   setup: function() {
     container = {
@@ -103,3 +127,4 @@ test("controllerFor uses route's controllerName if specified", function() {
 
   equal(routeTwo.controllerFor('one'), testController);
 });
+

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1185,3 +1185,34 @@ test("the {{link-to}} helper does not call preventDefault if `preventDefault=fal
 
   equal(event.isDefaultPrevented(), false, "should not preventDefault");
 });
+
+test("the {{link-to}} helper does not throw an error if its route has exited", function(){
+  expect(0);
+
+  Ember.TEMPLATES.application = Ember.Handlebars.compile("{{#link-to 'index' id='home-link'}}Home{{/link-to}}{{#link-to 'post' defaultPost id='default-post-link'}}Default Post{{/link-to}}{{#if currentPost}}{{#link-to 'post' id='post-link'}}Post{{/link-to}}{{/if}}");
+
+  App.ApplicationController = Ember.Controller.extend({
+    needs: ['post'],
+    currentPost: Ember.computed.alias('controllers.post.model')
+  });
+
+  App.PostController = Ember.Controller.extend({
+    model: {id: 1}
+  });
+
+  Router.map(function() {
+    this.route("post", {path: 'post/:post_id'});
+  });
+
+  bootApplication();
+
+  Ember.run(router, 'handleURL', '/');
+
+  Ember.run(function() {
+    Ember.$('#default-post-link', '#qunit-fixture').click();
+  });
+
+  Ember.run(function() {
+    Ember.$('#home-link', '#qunit-fixture').click();
+  });
+});


### PR DESCRIPTION
If a routes model is undefined do not attempt to serialize it.

Previously, this would cause an error like: `Cannot call get with 'id' on an undefined object.`.

Resolves #3859.
