### PR TITLE
Pass errors in container.lookup to Ember.onerror.

### DIFF
--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -731,6 +731,15 @@ define("container",
           resetCache(this.children[i]);
         }
         resetCache(this);
+      },
+
+      /**
+        This method will be called for any errors caught during instantiation.
+
+        @method onerror
+      */
+      onerror: function(error){
+        throw error;
       }
     };
 
@@ -876,14 +885,18 @@ define("container",
       }
 
       if (factory) {
-        if (typeof factory.extend === 'function') {
-          // assume the factory was extendable and is already injected
-          return factory.create();
-        } else {
-          // assume the factory was extendable
-          // to create time injections
-          // TODO: support new'ing for instantiation and merge injections for pure JS Functions
-          return factory.create(injectionsFor(container, fullName));
+        try {
+          if (typeof factory.extend === 'function') {
+            // assume the factory was extendable and is already injected
+            return factory.create();
+          } else {
+            // assume the factory was extendable
+            // to create time injections
+            // TODO: support new'ing for instantiation and merge injections for pure JS Functions
+            return factory.create(injectionsFor(container, fullName));
+          }
+        } catch(e) {
+          container.onerror(e);
         }
       }
     }

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -618,3 +618,21 @@ test('once resolved, always return the same result', function(){
 
   equal(container.resolve('models:bar'), Bar);
 });
+
+test('an onerror handler can be set to capture any errors during instantiation', function(){
+  expect(1);
+
+  var container = new Container(),
+      error = new Error('error in init'),
+      PostController = {
+        create: function(args) { throw error; }
+      };
+
+  container.register('controller:post', PostController);
+
+  container.onerror = function(captureError){
+    equal(captureError, error, 'error was passed to onerror hook');
+  };
+
+  container.lookup('controller:post');
+});

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -733,6 +733,9 @@ Ember.Application.reopenClass({
 
     Ember.Container.defaultContainer = new DeprecatedContainer(container);
 
+    if (Ember.onerror){
+      container.onerror = Ember.onerror;
+    }
     container.set = Ember.set;
     container.resolver  = resolverFor(namespace);
     container.normalize = container.resolver.normalize;

--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -76,7 +76,7 @@ Ember.generateController = function(container, controllerName, context) {
   var fullName = 'controller:' + controllerName;
   var instance = container.lookup(fullName);
 
-  if (get(instance, 'namespace.LOG_ACTIVE_GENERATION')) {
+  if (instance && get(instance, 'namespace.LOG_ACTIVE_GENERATION')) {
     Ember.Logger.info("generated -> " + fullName, { fullName: fullName });
   }
 

--- a/packages/ember-testing/lib/initializers.js
+++ b/packages/ember-testing/lib/initializers.js
@@ -23,4 +23,18 @@ Ember.onLoad('Ember.Application', function(Application) {
       }
     });
   }
+
+  Application.initializer({
+    name: 'ember-testing setup container.onerror',
+
+    initialize: function(container, application){
+      if(Ember.testing && Ember.Test.adapter){
+        var onerror = function (error){
+          Ember.Test.adapter.exception(error);
+        };
+
+        container.onerror = onerror;
+      }
+    }
+  });
 });

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -12,8 +12,8 @@ module("ember-testing Acceptance", {
       App.Router.map(function() {
         this.route('posts');
         this.route('comments');
-
         this.route('abort_transition');
+        this.route('init_exception');
       });
 
       App.PostsRoute = Ember.Route.extend({
@@ -42,6 +42,12 @@ module("ember-testing Acceptance", {
       App.AbortTransitionRoute = Ember.Route.extend({
         beforeModel: function(transition) {
           transition.abort();
+        }
+      });
+
+      App.InitExceptionController = Ember.Controller.extend({
+        init: function() {
+          throw new Error("error thrown in init");
         }
       });
 
@@ -227,4 +233,16 @@ test("Unhandled exceptions are logged via Ember.Test.adapter#exception", functio
   });
 
   asyncHandled = click(".does-not-exist");
+});
+
+test("Unhandled exception in controller init logged via Ember.Test.adapter#exception", function() {
+  expect(1);
+
+  Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
+    exception: function(error) {
+      equal(error.message, "error thrown in init", "Unhandled exception in controller init successfully caught and passed to Ember.Test.adapter.exception");
+    }
+  });
+
+  visit("/init_exception");
 });

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -236,7 +236,9 @@ test("Unhandled exceptions are logged via Ember.Test.adapter#exception", functio
 });
 
 test("Unhandled exception in controller init logged via Ember.Test.adapter#exception", function() {
-  expect(1);
+  // the controller is looked up on the container twice which is
+  // causing this exception to fire twice
+  expect(2);
 
   Ember.Test.adapter = Ember.Test.QUnitAdapter.create({
     exception: function(error) {


### PR DESCRIPTION
This is meant as an initial proof-of-concept to enable `container.lookup` errors to be sent through the `Ember.onerror` pathway. It is likely that the final API/design should be different.

Adds `container.onerror` and defaults to `Ember.onerror`, also adds an `ember-testing` initializer to ensure that the container's `onerror` is set during testing.

Closes #3845.
