### PR TITLE
[FEATURE ember-routing-bound-action-name]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -151,3 +151,10 @@ for a detailed explanation.
   to the hash-equivalent and vice versa so future transitions look consistent.
 
   Added in [#3725](https://github.com/emberjs/ember.js/pull/3725).
+
+* `ember-routing-bound-action-name`
+
+  Enables using a bound property lookup to determine the action name to
+  be fired.
+
+  Added in [#3936](https://github.com/emberjs/ember.js/pull/3936)

--- a/features.json
+++ b/features.json
@@ -16,7 +16,8 @@
     "ember-routing-drop-deprecated-action-style": null,
     "ember-metal-is-blank": true,
     "ember-eager-url-update": true,
-    "ember-routing-auto-location": null
+    "ember-routing-auto-location": null,
+    "ember-routing-bound-action-name": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -17,6 +17,8 @@ module("Ember.Handlebars - action helper", {
       dispatcher.destroy();
       if (view) { view.destroy(); }
     });
+
+    Ember.TESTING_DEPRECATION = false;
   }
 });
 
@@ -549,7 +551,7 @@ test("should send the view, event and current Handlebars context to the action",
 
   view = Ember.View.create({
     aContext: aContext,
-    template: Ember.Handlebars.compile('{{#with view.aContext}}<a id="edit" href="#" {{action edit this target="aTarget"}}>edit</a>{{/with}}')
+    template: Ember.Handlebars.compile('{{#with view.aContext}}<a id="edit" href="#" {{action "edit" this target="aTarget"}}>edit</a>{{/with}}')
   });
 
   appendView();
@@ -615,7 +617,7 @@ test("should allow multiple contexts to be specified", function() {
     controller: controller,
     modelA: models[0],
     modelB: models[1],
-    template: Ember.Handlebars.compile('<button {{action edit view.modelA view.modelB}}>edit</button>')
+    template: Ember.Handlebars.compile('<button {{action "edit" view.modelA view.modelB}}>edit</button>')
   });
 
   appendView();
@@ -640,7 +642,7 @@ test("should allow multiple contexts to be specified mixed with string args", fu
   view = Ember.View.create({
     controller: controller,
     modelA: model,
-    template: Ember.Handlebars.compile('<button {{action edit "herp" view.modelA}}>edit</button>')
+    template: Ember.Handlebars.compile('<button {{action "edit" "herp" view.modelA}}>edit</button>')
   });
 
   appendView();
@@ -665,7 +667,7 @@ test("it does not trigger action with special clicks", function() {
   var showCalled = false;
 
   view = Ember.View.create({
-    template: compile("<a {{action show href=true}}>Hi</a>")
+    template: compile("<a {{action 'show' href=true}}>Hi</a>")
   });
 
   var controller = Ember.Controller.extend({
@@ -708,7 +710,7 @@ test("it can trigger actions for keyboard events", function() {
   var showCalled = false;
 
   view = Ember.View.create({
-    template: compile("<input type='text' {{action show on='keyUp'}}>")
+    template: compile("<input type='text' {{action 'show' on='keyUp'}}>")
   });
 
   var controller = Ember.Controller.extend({
@@ -730,6 +732,118 @@ test("it can trigger actions for keyboard events", function() {
   view.$('input').trigger(event);
   ok(showCalled, "should call action with keyup");
 });
+
+if (Ember.FEATURES.isEnabled("ember-routing-bound-action-name")) {
+  test("a quoteless parameter should allow dynamic lookup of the actionName", function(){
+    expect(4);
+    var lastAction, actionOrder = [];
+
+    view = Ember.View.create({
+      template: compile("<a id='woot-bound-param'' {{action hookMeUp}}>Hi</a>")
+    });
+
+    var controller = Ember.Controller.extend({
+      hookMeUp: 'biggityBoom',
+      actions: {
+        biggityBoom: function() {
+          lastAction = 'biggityBoom';
+          actionOrder.push(lastAction);
+        },
+        whompWhomp: function() {
+          lastAction = 'whompWhomp';
+          actionOrder.push(lastAction);
+        },
+        sloopyDookie: function(){
+          lastAction = 'sloopyDookie';
+          actionOrder.push(lastAction);
+        }
+      }
+    }).create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    var testBoundAction = function(propertyValue){
+      controller.set('hookMeUp', propertyValue);
+
+      Ember.run(function(){
+        view.$("#woot-bound-param").click();
+      });
+
+      equal(lastAction, propertyValue, 'lastAction set to ' + propertyValue);
+    };
+
+    testBoundAction('whompWhomp');
+    testBoundAction('sloopyDookie');
+    testBoundAction('biggityBoom');
+
+    deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
+  });
+
+  test("a quoteless parameter that also exists as an action name functions properly", function(){
+    Ember.TESTING_DEPRECATION = true;
+    var triggeredAction;
+
+    view = Ember.View.create({
+      template: compile("<a id='oops-bound-param'' {{action ohNoeNotValid}}>Hi</a>")
+    });
+
+    var controller = Ember.Controller.extend({
+      actions: {
+        ohNoeNotValid: function() {
+          triggeredAction = true;
+        }
+      }
+    }).create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    Ember.run(function(){
+      view.$("#oops-bound-param").click();
+    });
+
+    ok(triggeredAction, 'the action was triggered');
+  });
+
+  test("a quoteless parameter that also exists as an action name results in an assertion", function(){
+    var triggeredAction;
+
+    view = Ember.View.create({
+      template: compile("<a id='oops-bound-param'' {{action ohNoeNotValid}}>Hi</a>")
+    });
+
+    var controller = Ember.Controller.extend({
+      actions: {
+        ohNoeNotValid: function() {
+          triggeredAction = true;
+        }
+      }
+    }).create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    var oldAssert = Ember.assert;
+    Ember.assert = function(message, test){
+      ok(test, message + " -- was properly asserted");
+    };
+
+    Ember.run(function(){
+      view.$("#oops-bound-param").click();
+    });
+
+    ok(triggeredAction, 'the action was triggered');
+
+    Ember.assert = oldAssert;
+  });
+}
 
 module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
   setup: function() {
@@ -758,7 +872,7 @@ if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
 
     view = Ember.View.create({
       controller: controller,
-      template: Ember.Handlebars.compile('<button {{action edit}}>edit</button>')
+      template: Ember.Handlebars.compile('<button {{action "edit"}}>edit</button>')
     });
 
     appendView();
@@ -773,7 +887,7 @@ if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
 
 test("should respect preventDefault=false option if provided", function(){
   view = Ember.View.create({
-    template: compile("<a {{action show preventDefault=false}}>Hi</a>")
+    template: compile("<a {{action 'show' preventDefault=false}}>Hi</a>")
   });
 
   var controller = Ember.Controller.extend({

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1017,7 +1017,7 @@ asyncTest("Events are triggered on the controller if a matching action name is i
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action showStuff content}}>{{name}}</a>"
+    "<a {{action 'showStuff' content}}>{{name}}</a>"
   );
 
   var controller = Ember.Controller.extend({
@@ -1063,7 +1063,7 @@ asyncTest("Events are triggered on the current state when defined in `actions` o
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action showStuff content}}>{{name}}</a>"
+    "<a {{action 'showStuff' content}}>{{name}}</a>"
   );
 
   bootApplication();
@@ -1101,7 +1101,7 @@ asyncTest("Events defined in `actions` object are triggered on the current state
   });
 
   Ember.TEMPLATES['root/index'] = Ember.Handlebars.compile(
-    "<a {{action showStuff content}}>{{name}}</a>"
+    "<a {{action 'showStuff' content}}>{{name}}</a>"
   );
 
   bootApplication();
@@ -1135,7 +1135,7 @@ asyncTest("Events are triggered on the current state when defined in `events` ob
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action showStuff content}}>{{name}}</a>"
+    "<a {{action 'showStuff' content}}>{{name}}</a>"
   );
 
   expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
@@ -1174,7 +1174,7 @@ asyncTest("Events defined in `events` object are triggered on the current state 
   });
 
   Ember.TEMPLATES['root/index'] = Ember.Handlebars.compile(
-    "<a {{action showStuff content}}>{{name}}</a>"
+    "<a {{action 'showStuff' content}}>{{name}}</a>"
   );
 
   expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
@@ -1249,7 +1249,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     });
 
     Ember.TEMPLATES.home = Ember.Handlebars.compile(
-      "<a {{action showStuff content}}>{{name}}</a>"
+      "<a {{action 'showStuff' content}}>{{name}}</a>"
     );
 
     var controller = Ember.Controller.extend({
@@ -1342,7 +1342,7 @@ asyncTest("actions can be triggered with multiple arguments", function() {
   });
 
   Ember.TEMPLATES['root/index'] = Ember.Handlebars.compile(
-    "<a {{action showStuff model1 model2}}>{{model1.name}}</a>"
+    "<a {{action 'showStuff' model1 model2}}>{{model1.name}}</a>"
   );
 
   bootApplication();


### PR DESCRIPTION
The `{{action}}` helper will now use a non-quoted parameter and perform a bound property lookup against the action's target at the time the event is triggered.

If a non-quoted param is used, but the property lookup returns `undefined` a helpful assertion is made, and the specified parameter is used as a plain string action name (thus preventing this from breaking anyones applications).

Also, cleans up a few unrelated non-quoted uses of `{{action}}` in the test suite.

Cleaned up the website of any unquoted `{{action}}` helper usage here: https://github.com/emberjs/website/pull/1149.

Closes #3368.
