### PR TITLE
Remove `Ember.handleErrors`

### DIFF
--- a/packages/ember-metal/lib/error.js
+++ b/packages/ember-metal/lib/error.js
@@ -55,26 +55,3 @@ Ember.Error.prototype = Ember.create(Error.prototype);
   @param {Exception} error the error object
 */
 Ember.onerror = null;
-
-/**
-  Wrap code block in a try/catch if `Ember.onerror` is set.
-
-  @private
-  @method handleErrors
-  @for Ember
-  @param {Function} func
-  @param [context]
-*/
-Ember.handleErrors = function(func, context) {
-  // Unfortunately in some browsers we lose the backtrace if we rethrow the existing error,
-  // so in the event that we don't have an `onerror` handler we don't wrap in a try/catch
-  if ('function' === typeof Ember.onerror) {
-    try {
-      return func.call(context || this);
-    } catch (error) {
-      Ember.onerror(error);
-    }
-  } else {
-    return func.call(context || this);
-  }
-};

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -139,36 +139,32 @@ Ember.EventDispatcher = Ember.Object.extend({
     var self = this;
 
     rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {
-      return Ember.handleErrors(function handleViewEvent() {
-        var view = Ember.View.views[this.id],
-            result = true, manager = null;
+      var view = Ember.View.views[this.id],
+          result = true, manager = null;
 
-        manager = self._findNearestEventManager(view,eventName);
+      manager = self._findNearestEventManager(view, eventName);
 
-        if (manager && manager !== triggeringManager) {
-          result = self._dispatchEvent(manager, evt, eventName, view);
-        } else if (view) {
-          result = self._bubbleEvent(view,evt,eventName);
-        } else {
-          evt.stopPropagation();
-        }
+      if (manager && manager !== triggeringManager) {
+        result = self._dispatchEvent(manager, evt, eventName, view);
+      } else if (view) {
+        result = self._bubbleEvent(view, evt, eventName);
+      } else {
+        evt.stopPropagation();
+      }
 
-        return result;
-      }, this);
+      return result;
     });
 
     rootElement.on(event + '.ember', '[data-ember-action]', function(evt) {
-      return Ember.handleErrors(function handleActionEvent() {
-        var actionId = Ember.$(evt.currentTarget).attr('data-ember-action'),
-            action   = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+      var actionId = Ember.$(evt.currentTarget).attr('data-ember-action'),
+          action   = Ember.Handlebars.ActionHelper.registeredActions[actionId];
 
-        // We have to check for action here since in some cases, jQuery will trigger
-        // an event on `removeChild` (i.e. focusout) after we've already torn down the
-        // action handlers for the view.
-        if (action && action.eventName === eventName) {
-          return action.handler(evt);
-        }
-      }, this);
+      // We have to check for action here since in some cases, jQuery will trigger
+      // an event on `removeChild` (i.e. focusout) after we've already torn down the
+      // action handlers for the view.
+      if (action && action.eventName === eventName) {
+        return action.handler(evt);
+      }
     });
   },
 
@@ -190,7 +186,7 @@ Ember.EventDispatcher = Ember.Object.extend({
 
     var handler = object[eventName];
     if (Ember.typeOf(handler) === 'function') {
-      result = Ember.run(function() {
+      result = Ember.run(function dispatchEvent() {
         return handler.call(object, evt, view);
       });
       // Do not preventDefault in eventManagers.


### PR DESCRIPTION
I see two benefits with this:
1. All error handling is kept in one place.
2. We avoid double-reporting of errors in case the error handler rethrows the error.

**Ember.handleErrors**
`Ember.handleErrors` catches errors and pass them to `Ember.onerrror`. It is used in two places, both in the `EventDispatcher`.
1. https://github.com/emberjs/ember.js/blob/3070328313b/packages/ember-views/lib/system/event_dispatcher.js#L145
2. https://github.com/emberjs/ember.js/blob/3070328313b/packages/ember-views/lib/system/event_dispatcher.js#L164

**Ember.run**
`Ember.run` catches errors and pass them to `Ember.onerrror`. I.e. it does the same thing in terms of error handling.

https://github.com/emberjs/ember.js/blob/0fcc6f8d23615/packages/ember-metal/lib/run_loop.js#L54

**This PR**
This pull request removes `Ember.handleErrors`. Errors occurring within event handlers will still be caught, but by `Ember.run`. All code-paths end up wrapped in `Ember.run`, but they are somewhat further down the call-chain (i.e. if there are errors in say `_findNearestEventManager` they will not be caught).

_See this issue for preceding discussion:_ https://github.com/emberjs/ember.js/issues/3848
