### PR TITLE
Remove `.vagrant` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ tmp.bpm
 tmp.spade
 tests/source
 node_modules
-.vagrant
 bundle/
 *~


### PR DESCRIPTION
Vagrant itself was removed in bd4ee53f1aee1888a9468dc04af7fbe3039264fa
