### PR TITLE
Assert if {{render}} is called with an unquoted name.

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -36,7 +36,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     ```handelbars
     <!-- application.hbs -->
     <h1>My great app</h1>
-    {{render navigation}}
+    {{render "navigation"}}
     ```
 
     ```html
@@ -99,6 +99,8 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     } else {
       throw Ember.Error("You must pass a templateName to render");
     }
+
+    Ember.deprecate("Using a quoteless parameter with {{render}} is deprecated. Please update to quoted usage '{{render \"" + name + "\"}}.", options.types[0] !== 'ID');
 
     // # legacy namespace
     name = name.replace(/\//g, '.');

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -70,11 +70,13 @@ module("Handlebars {{render}} helper", {
     });
 
     Ember.TEMPLATES = {};
+    Ember.ENV.TESTING_DEPRECATION = false;
+    Ember.ENV.RAISE_ON_DEPRECATION = false;
   }
 });
 
 test("{{render}} helper should render given template", function() {
-  var template = "<h1>HI</h1>{{render home}}";
+  var template = "<h1>HI</h1>{{render 'home'}}";
   var controller = Ember.Controller.extend({container: container});
   view = Ember.View.create({
     controller: controller.create(),
@@ -161,7 +163,7 @@ test("{{render}} helper with a supplied model should not fire observers on the c
 });
 
 test("{{render}} helper should raise an error when a given controller name does not resolve to a controller", function() {
-  var template = '<h1>HI</h1>{{render home controller="postss"}}';
+  var template = '<h1>HI</h1>{{render "home" controller="postss"}}';
   var controller = Ember.Controller.extend({container: container});
   container.register('controller:posts', Ember.ArrayController.extend());
   view = Ember.View.create({
@@ -177,7 +179,7 @@ test("{{render}} helper should raise an error when a given controller name does 
 });
 
 test("{{render}} helper should render with given controller", function() {
-  var template = '<h1>HI</h1>{{render home controller="posts"}}';
+  var template = '<h1>HI</h1>{{render "home" controller="posts"}}';
   var controller = Ember.Controller.extend({container: container});
   container.register('controller:posts', Ember.ArrayController.extend());
   view = Ember.View.create({
@@ -194,7 +196,7 @@ test("{{render}} helper should render with given controller", function() {
 });
 
 test("{{render}} helper should render a template without a model only once", function() {
-  var template = "<h1>HI</h1>{{render home}}<hr/>{{render home}}";
+  var template = "<h1>HI</h1>{{render 'home'}}<hr/>{{render home}}";
   var controller = Ember.Controller.extend({container: container});
   view = Ember.View.create({
     controller: controller.create(),
@@ -369,7 +371,7 @@ test("{{render}} helper should be able to render a template again when it was re
   Ember.run(function() {
     view.connectOutlet('main', Ember.View.create({
       controller: controller.create(),
-      template: compile("<p>1{{render home}}</p>")
+      template: compile("<p>1{{render 'home'}}</p>")
     }));
   });
 
@@ -378,7 +380,7 @@ test("{{render}} helper should be able to render a template again when it was re
   Ember.run(function() {
     view.connectOutlet('main', Ember.View.create({
       controller: controller.create(),
-      template: compile("<p>2{{render home}}</p>")
+      template: compile("<p>2{{render 'home'}}</p>")
     }));
   });
 
@@ -386,7 +388,7 @@ test("{{render}} helper should be able to render a template again when it was re
 });
 
 test("{{render}} works with dot notation", function() {
-  var template = '<h1>BLOG</h1>{{render blog.post}}';
+  var template = '<h1>BLOG</h1>{{render "blog.post"}}';
 
   var controller = Ember.Controller.extend({container: container});
   container.register('controller:blog.post', Ember.ObjectController.extend());
@@ -423,4 +425,44 @@ test("{{render}} works with slash notation", function() {
   var renderedView = container.lookup('router:main')._lookupActiveView('blog.post');
   equal(renderedView.get('viewName'), 'blogPost', 'camelizes the view name');
   equal(container.lookup('controller:blog.post'), renderedView.get('controller'), 'rendered with correct controller');
+});
+
+test("Using quoteless templateName is deprecated", function(){
+  Ember.ENV.RAISE_ON_DEPRECATION = true;
+
+  var template = '<h1>HI</h1>{{render home}}';
+  var controller = Ember.Controller.extend({container: container});
+  view = Ember.View.create({
+    controller: controller.create(),
+    template: Ember.Handlebars.compile(template)
+  });
+
+  Ember.TEMPLATES['home'] = compile("<p>BYE</p>");
+
+  try {
+    appendView(view);
+  } catch(e) {
+    equal(e.message, "Using a quoteless parameter with {{render}} is deprecated. Please update to quoted usage '{{render \"home\"}}.", "expected deprecation was raised");
+  }
+
+  Ember.ENV.RAISE_ON_DEPRECATION = false;
+});
+
+test("Using quoteless templateName works properly", function(){
+  Ember.ENV.TESTING_DEPRECATION = true;
+
+  var template = '<h1>HI</h1>{{render home}}';
+  var controller = Ember.Controller.extend({container: container});
+  view = Ember.View.create({
+    controller: controller.create(),
+    template: Ember.Handlebars.compile(template)
+  });
+
+  Ember.TEMPLATES['home'] = compile("<p>BYE</p>");
+
+  appendView(view);
+
+  equal(view.$('p:contains(BYE)').length, 1, "template was rendered");
+
+  Ember.TESTING_DEPRECATION = false;
 });


### PR DESCRIPTION
Eventually, `{{render}}` should be similar to `{{partial}}` where an unquoted
templateName is used to do bound parameter lookup.

This PR updates the tests to use quotes, and adds an assertion if an unquoted
param was provided.
