### PR TITLE
[BUGFIX beta] Do not use ENV if Ember.EmberENV exists.

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -1,4 +1,4 @@
-/*globals Em:true ENV */
+/*globals Em:true ENV EmberENV MetamorphENV:true */
 
 /**
 @module ember
@@ -50,32 +50,43 @@ Ember.toString = function() { return "Ember"; };
   @property VERSION
   @type String
   @default 'VERSION_STRING_PLACEHOLDER'
-  @final
+  @static
 */
 Ember.VERSION = 'VERSION_STRING_PLACEHOLDER';
 
 /**
-  Standard environmental variables. You can define these in a global `ENV`
-  variable before loading Ember to control various configuration
-  settings.
+  Standard environmental variables. You can define these in a global `EmberENV`
+  variable before loading Ember to control various configuration settings.
+
+  For backwards compatibility with earlier versions of Ember the global `ENV`
+  variable will be used if `EmberENV` is not defined.
 
   @property ENV
   @type Hash
 */
 
-if ('undefined' === typeof ENV) {
-  exports.ENV = {};
+if (Ember.ENV) {
+  // do nothing if Ember.ENV is already setup
+} else if ('undefined' !== typeof EmberENV) {
+  Ember.ENV = EmberENV;
+} else if('undefined' !== typeof ENV) {
+  Ember.ENV = ENV;
+} else {
+  Ember.ENV = {};
 }
-
-// We disable the RANGE API by default for performance reasons
-if ('undefined' === typeof ENV.DISABLE_RANGE_API) {
-  ENV.DISABLE_RANGE_API = true;
-}
-
-
-Ember.ENV = Ember.ENV || ENV;
 
 Ember.config = Ember.config || {};
+
+// We disable the RANGE API by default for performance reasons
+if ('undefined' === typeof Ember.ENV.DISABLE_RANGE_API) {
+  Ember.ENV.DISABLE_RANGE_API = true;
+}
+
+if ("undefined" === typeof MetamorphENV) {
+  exports.MetamorphENV = {};
+}
+
+MetamorphENV.DISABLE_RANGE_API = Ember.ENV.DISABLE_RANGE_API;
 
 /**
   Hash of enabled Canary features. Add to before creating your application.

--- a/packages/metamorph/lib/main.js
+++ b/packages/metamorph/lib/main.js
@@ -9,7 +9,15 @@ define("metamorph",
 
     var K = function() {},
         guid = 0,
-        disableRange = ('undefined' === typeof ENV ? {} : ENV).DISABLE_RANGE_API,
+        disableRange = (function(){
+          if ('undefined' !== typeof MetamorphENV) {
+            return MetamorphENV.DISABLE_RANGE_API;
+          } else if ('undefined' !== ENV) {
+            return ENV.DISABLE_RANGE_API;
+          } else {
+            return false;
+          }
+        })(),
 
         // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
         supportsRange = (!disableRange) && typeof document !== 'undefined' && ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,


### PR DESCRIPTION
This allows the use of `ENV` in your application without having Ember hijack it for its uses.

To avoid using `window.ENV`, but still provide customization to Ember's boot process you could use something like the following:

``` javascript
ENV = 'DO NOT USE ME!!!!';

EmberENV = {DISABLE_RANGE_API: true};
```

I did an audit of all usage of `window.ENV`, and this was the only instance (other than internal tests) where we were always using `window.ENV`.

---

The changes to `metamorph` are from tomhuda/metamorph.js#29 (which has been merged).
