### PR TITLE
[FEATURE string-parameterize]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -42,6 +42,11 @@ for a detailed explanation.
   Also strips `_id` suffixes. (E.g. `'first_name'.humanize() // 'First name'`)
 
   Added in [#3224](https://github.com/emberjs/ember.js/pull/3224)
+* `string-parameterize`
+
+  Transforms a string so that it may be used as part of a 'pretty' / SEO friendly URL.
+  (E.g. `'100 ways Ember.js is better than Angular.'.parameterize(); // '100-ways-emberjs-is-better-than-angular'`)
+
 * `ember-testing-wait-hooks`
 
   Allows registration of additional functions that the `wait` testing helper

--- a/features.json
+++ b/features.json
@@ -4,6 +4,7 @@
   "ember-testing-wait-hooks": true,
   "query-params": null,
   "string-humanize": null,
+  "string-parameterize": null,
   "propertyBraceExpansion": null,
   "ember-routing-named-substates": null,
   "ember-handlebars-caps-lookup": null,

--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -19,7 +19,11 @@ var fmt = Ember.String.fmt,
     classify = Ember.String.classify;
 
 if (Ember.FEATURES.isEnabled("string-humanize")) {
-    var humanize = Ember.String.humanize;
+  var humanize = Ember.String.humanize;
+}
+
+if (Ember.FEATURES.isEnabled("string-parameterize")) {
+  var parameterize = Ember.String.parameterize;
 }
 
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
@@ -123,6 +127,18 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
     */
     String.prototype.humanize = function() {
       return humanize(this);
+    };
+  }
+
+  if (Ember.FEATURES.isEnabled("string-parameterize")) {
+    /**
+      See [Ember.String.parameterize](/api/classes/Ember.String.html#method_parameterize).
+
+      @method parameterize
+      @for String
+    */
+    String.prototype.parameterize = function() {
+      return parameterize(this);
     };
   }
 

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -9,6 +9,10 @@ var STRING_DECAMELIZE_REGEXP = (/([a-z\d])([A-Z])/g);
 var STRING_CAMELIZE_REGEXP = (/(\-|_|\.|\s)+(.)?/g);
 var STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
 var STRING_UNDERSCORE_REGEXP_2 = (/\-|\s+/g);
+var STRING_PARAMETERIZE_REGEXP_1 = (/[_|\/|\s]+/g);
+var STRING_PARAMETERIZE_REGEXP_2 = (/[^a-z0-9\-]+/gi);
+var STRING_PARAMETERIZE_REGEXP_3 = (/[\-]+/g);
+var STRING_PARAMETERIZE_REGEXP_4 = (/^-+|-+$/g);
 
 /**
   Defines the hash of localized strings for the current language. Used by
@@ -270,6 +274,29 @@ if (Ember.FEATURES.isEnabled("string-humanize")) {
       replace(/^\w/g, function(s){
         return s.toUpperCase();
       });
+  };
+}
+
+if (Ember.FEATURES.isEnabled("string-parameterize")) {
+  /**
+    Transforms a string so that it may be used as part of a 'pretty' / SEO friendly URL.
+
+    ```javascript
+    'My favorite items.'.parameterize();                        // 'my-favorite-items'
+    'action_name'.parameterize();                               // 'action-name'
+    '100 ways Ember.js is better than Angular.'.parameterize(); // '100-ways-emberjs-is-better-than-angular'
+    ```
+
+    @method parameterize
+    @param {String} str The string to parameterize.
+    @return {String} the parameterized string.
+  */
+  Ember.String.parameterize = function(str) {
+    return str.replace(STRING_PARAMETERIZE_REGEXP_1, '-') // replace underscores, slashes and spaces with separator
+              .replace(STRING_PARAMETERIZE_REGEXP_2, '')  // remove non-alphanumeric characters except the separator
+              .replace(STRING_PARAMETERIZE_REGEXP_3, '-') // replace multiple occurring separators
+              .replace(STRING_PARAMETERIZE_REGEXP_4, '')  // trim leading and trailing separators 
+              .toLowerCase();
   };
 }
 

--- a/packages/ember-runtime/tests/system/string/parameterize.js
+++ b/packages/ember-runtime/tests/system/string/parameterize.js
@@ -1,0 +1,59 @@
+if (Ember.FEATURES.isEnabled("string-parameterize")) {
+  module('Ember.String.parameterize');
+
+  var runParameterizeTest = function(input, expected) {
+    deepEqual(Ember.String.parameterize(input), expected);
+    if (Ember.EXTEND_PROTOTYPES) {
+      deepEqual(input.parameterize(), expected);
+    }
+  };
+
+  if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
+    test('String.prototype.parameterize is not modified without EXTEND_PROTOTYPES', function() {
+      ok('undefined' === typeof String.prototype.parameterize, 'String.prototype helper disabled');
+    });
+  }
+
+  test('parameterize normal string', function() {
+    runParameterizeTest(
+      'My favorite items.',
+      'my-favorite-items'
+    );
+  });
+
+  test('parameterize underscored string', function() {
+    runParameterizeTest(
+      'action_name',
+      'action-name'
+    );
+  });
+
+  test('does nothing with parameterize string', function() {
+    runParameterizeTest(
+      'my-favorite-items',
+      'my-favorite-items'
+    );
+  });
+
+  test('parameterize real world strings with special characters', function() {
+    runParameterizeTest(
+      '100 ways Ember.js is better than Angular.',
+      '100-ways-emberjs-is-better-than-angular'
+    );
+    runParameterizeTest(
+      'You\'re (really) going to LOVE handling my "special" characters!?!',
+      'youre-really-going-to-love-handling-my-special-characters'
+    );
+    runParameterizeTest(
+      '#emberjs Core Team Meeting Minutes - 2013/12/06',
+      'emberjs-core-team-meeting-minutes-2013-12-06'
+    );
+  });
+
+  test('parameterize string with leading and trailing special characters', function() {
+    runParameterizeTest(
+      '   -- leading & --trailing  --_*-!-',
+      'leading-trailing'
+    );
+  });
+}


### PR DESCRIPTION
This feature transforms strings so they can be used for 'pretty' / SEO friendly urls.
With the router at the heart of ember, this becomes indispensable in most apps.

Similar to [ActiveSupport's String parameterize](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-parameterize)

Example:

``` javascript
'Core Team Meeting Minutes - 2013/12/06'.parameterize(); // => 'core-team-meeting-minutes-2013-12-06'
```
