### PR TITLE
[beta] better docs for modelFor

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -911,10 +911,13 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
   },
 
   /**
-    Returns the current model for a given route.
-
-    This is the object returned by the `model` hook of the route
-    in question.
+    Returns the model of a parent (or any ancestor) route
+    in a route hierarchy.  During a transition, all routes
+    must resolve a model object, and if a route
+    needs access to a parent route's model in order to
+    resolve a model (or just reuse the model from a parent),
+    it can call `this.modelFor(theNameOfParentRoute)` to
+    retrieve it.
 
     Example
 


### PR DESCRIPTION
I wanted to stress that its main utility was for accessing models on parent
routes rather than giving the impression that it's useful/meaningful for
grabbing models from any ol route, even if it's not in the current route
hierarchy, which doesn't really make sense, right?
