### PR TITLE
Fix to highlight code in document

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -293,7 +293,7 @@ Ember.Handlebars.registerHelper('input', function(options) {
   extend the capabilities of text areas in your application by reopening this
   class. For example, if you are deploying to browsers where the `required`
   attribute is used, you can globally add support for the `required` attribute
-  on all {{textarea}}'s' in your app by reopening `Ember.TextArea` or
+  on all `{{textarea}}`s' in your app by reopening `Ember.TextArea` or
   `Ember.TextSupport` and adding it to the `attributeBindings` concatenated
   property:
 


### PR DESCRIPTION
Fix to highlight `{{textarea}}`.
- before
  ![2013-12-19 4 11 35](https://f.cloud.github.com/assets/290782/1776569/98342134-6818-11e3-8c3c-1e945d2a5b44.png)
- after
  ![2013-12-19 4 12 17](https://f.cloud.github.com/assets/290782/1776570/98364c70-6818-11e3-80c6-98d5c423bccb.png)
