### PR TITLE
Add newline to fix document markup

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -71,6 +71,7 @@ require("ember-handlebars/controls/select");
   if you are deploying to browsers where the `required` attribute is used, you
   can add this to the `TextField`'s `attributeBindings` property:
 
+
   ```javascript
   Ember.TextField.reopen({
     attributeBindings: ['required']


### PR DESCRIPTION
Fix to highlight code example.
- before
  ![2013-12-19 4 27 20](https://f.cloud.github.com/assets/290782/1776724/9cf10ac8-681a-11e3-9b91-e3308ad170e3.png)
- after
  ![2013-12-19 4 36 25](https://f.cloud.github.com/assets/290782/1776803/b3cc5300-681b-11e3-9790-8411f1fc1af7.png)
