### PR TITLE
Add newline to highlight code example in document

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -135,6 +135,7 @@ require("ember-handlebars/controls/select");
   capablilties of checkbox inputs in your applications by reopening this class. For example,
   if you wanted to add a css class to all checkboxes in your application:
 
+
   ```javascript
   Ember.Checkbox.reopen({
     classNames: ['my-app-checkbox']


### PR DESCRIPTION
This is the same kind of fix as #3961.
- before
  ![2013-12-19 4 31 16](https://f.cloud.github.com/assets/290782/1776776/5c68619e-681b-11e3-82c4-8cc3f4c75018.png)
- after
  ![2013-12-19 4 33 03](https://f.cloud.github.com/assets/290782/1776775/5c680622-681b-11e3-9b9e-79878be5fd69.png)
