### PR TITLE
Cleanup test using Ember.$.trim

### DIFF
--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -63,7 +63,7 @@ test("can have options", function() {
 
   equal(select.$('option').length, 3, "Should have three options");
   // IE 8 adds whitespace
-  equal(select.$().text().replace(/\s+/g,''), "123", "Options should have content");
+  equal(trim(select.$().text()), "123", "Options should have content");
 });
 
 
@@ -102,7 +102,7 @@ test("can specify the property path for an option's label and value", function()
 
   equal(select.$('option').length, 2, "Should have two options");
   // IE 8 adds whitespace
-  equal(select.$().text().replace(/\s+/g,''), "YehudaTom", "Options should have content");
+  equal(trim(select.$().text()), "YehudaTom", "Options should have content");
   deepEqual(map(select.$('option').toArray(), function(el) { return Ember.$(el).attr('value'); }), ["1", "2"], "Options should have values");
 });
 
@@ -330,8 +330,8 @@ test("select with group can group options", function() {
   });
   equal(labels.join(''), ['TildeEnvato']);
 
-  equal(select.$('optgroup').first().text().replace(/\s+/g,''), 'YehudaTom');
-  equal(select.$('optgroup').last().text().replace(/\s+/g,''), 'Keith');
+  equal(trim(select.$('optgroup').first().text()), 'YehudaTom');
+  equal(trim(select.$('optgroup').last().text()), 'Keith');
 });
 
 test("select with group doesn't break options", function() {
@@ -351,7 +351,7 @@ test("select with group doesn't break options", function() {
   append();
 
   equal(select.$('option').length, 3);
-  equal(select.$().text().replace(/\s+/g,''), 'YehudaTomKeith');
+  equal(trim(select.$().text()), 'YehudaTomKeith');
 
   Ember.run(function() {
     content.set('firstObject.firstName', 'Peter');

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -212,5 +212,5 @@ test("#each with itemViewClass behaves like a normal bound #each", function() {
   equal(view.$('script').length, 2, "Correct number of Metamorph markers are output");
   equal(view.$('.ember-view').length, 3, "Correct number of views are output");
   // IE likes to add newlines
-  equal(view.$().text().replace(/\s+/g, ''), 'ErikPeterTom');
+  equal(trim(view.$().text()), 'ErikPeterTom');
 });

--- a/packages/ember-routing/tests/helpers/outlet_test.js
+++ b/packages/ember-routing/tests/helpers/outlet_test.js
@@ -2,9 +2,8 @@ var appendView = function(view) {
   Ember.run(function() { view.appendTo('#qunit-fixture'); });
 };
 
-var compile = function(template) {
-  return Ember.Handlebars.compile(template);
-};
+var compile = Ember.Handlebars.compile;
+var trim = Ember.$.trim;
 
 var view;
 
@@ -35,7 +34,7 @@ test("view should support connectOutlet for the main outlet", function() {
   });
 
   // Replace whitespace for older IE
-  equal(view.$().text().replace(/\s+/,''), 'HIBYE');
+  equal(trim(view.$().text()), 'HIBYE');
 });
 
 test("outlet should support connectOutlet in slots in prerender state", function() {
@@ -70,7 +69,7 @@ test("outlet should support an optional name", function() {
   });
 
   // Replace whitespace for older IE
-  equal(view.$().text().replace(/\s+/,''), 'HIBYE');
+  equal(trim(view.$().text()), 'HIBYE');
 });
 
 
@@ -96,7 +95,7 @@ test("outlet should support an optional view class", function() {
   ok(view.outletView.detectInstance(childView.get('_parentView')), "The custom view class should be used for the outlet");
 
   // Replace whitespace for older IE
-  equal(view.$().text().replace(/\s+/,''), 'HIBYE');
+  equal(trim(view.$().text()), 'HIBYE');
 });
 
 
@@ -148,14 +147,14 @@ test("view should support disconnectOutlet for the main outlet", function() {
   });
 
   // Replace whitespace for older IE
-  equal(view.$().text().replace(/\s+/,''), 'HIBYE');
+  equal(trim(view.$().text()), 'HIBYE');
 
   Ember.run(function() {
     view.disconnectOutlet('main');
   });
 
   // Replace whitespace for older IE
-  equal(view.$().text().replace(/\s+/,''), 'HI');
+  equal(trim(view.$().text()), 'HI');
 });
 
 test("Outlets bind to the current template's view, not inner contexts", function() {
@@ -199,5 +198,5 @@ test("should support layouts", function() {
     }));
   });
   // Replace whitespace for older IE
-  equal(view.$().text().replace(/\s+/,''), 'HIBYE');
+  equal(trim(view.$().text()), 'HIBYE');
 });

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -1,4 +1,4 @@
-var set = Ember.set, get = Ember.get;
+var set = Ember.set, get = Ember.get, trim = Ember.$.trim;
 
 // .......................................................
 //  render()
@@ -13,7 +13,7 @@ test("RenderBuffers combine strings", function() {
   buffer.push('b');
 
   // IE8 returns `element name as upper case with extra whitespace.
-  equal("<div>ab</div>", buffer.string().toLowerCase().replace(/\s+/g, ''), "Multiple pushes should concatenate");
+  equal("<div>ab</div>", trim(buffer.string().toLowerCase()), "Multiple pushes should concatenate");
 });
 
 test("value of 0 is included in output", function() {
@@ -108,7 +108,7 @@ test("handles browsers like Firefox < 11 that don't support outerHTML Issue #195
   var elementStub = '<div></div>';
   buffer.element = function() { return elementStub; };
   // IE8 returns `element name as upper case with extra whitespace.
-  equal(elementStub, buffer.string().toLowerCase().replace(/\s/g, ''));
+  equal(elementStub, trim(buffer.string().toLowerCase()));
 });
 
 module("Ember.RenderBuffer - without tagName");

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -1,5 +1,6 @@
 var set = Ember.set, get = Ember.get;
 var forEach = Ember.EnumerableUtils.forEach;
+var trim = Ember.$.trim;
 var view;
 
 module("Ember.CollectionView", {
@@ -393,7 +394,7 @@ test("should fire life cycle events when elements are added and removed", functi
   equal(willDestroy, 0);
   equal(destroy, 0);
   // Remove whitspace added by IE 8
-  equal(view.$().text().replace(/\s+/g,''), '01234');
+  equal(trim(view.$().text()), '01234');
 
   Ember.run(function () {
     content.popObject();
@@ -405,7 +406,7 @@ test("should fire life cycle events when elements are added and removed", functi
   equal(willDestroy, 2);
   equal(destroy, 2);
   // Remove whitspace added by IE 8
-  equal(view.$().text().replace(/\s+/g,''), '123');
+  equal(trim(view.$().text()), '123');
 
   Ember.run(function () {
     view.set('content', Ember.A([7,8,9]));
@@ -416,7 +417,7 @@ test("should fire life cycle events when elements are added and removed", functi
   equal(willDestroy, 5);
   equal(destroy, 5);
   // Remove whitspace added by IE 8
-  equal(view.$().text().replace(/\s+/g,''), '789');
+  equal(trim(view.$().text()), '789');
 
   Ember.run(function () {
     view.destroy();

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -1,4 +1,4 @@
-var get = Ember.get, set = Ember.set, container, view, otherContainer;
+var get = Ember.get, set = Ember.set, trim = Ember.$.trim, container, view, otherContainer;
 
 module("ember-views/views/container_view_test", {
   teardown: function() {
@@ -526,7 +526,7 @@ test("should be able to modify childViews many times during an run loop", functi
   });
 
   // Remove whitespace added by IE 8
-  equal(container.$().text().replace(/\s+/g,''), 'onetwothree');
+  equal(trim(container.$().text()), 'onetwothree');
 });
 
 test("should be able to modify childViews then remove the ContainerView in same run loop", function () {
@@ -615,7 +615,7 @@ test("should be able to modify childViews then rerender then modify again the Co
   equal(one.count, 1, 'rendered child only once');
   equal(two.count, 1, 'rendered child only once');
   // Remove whitespace added by IE 8
-  equal(container.$().text().replace(/\s+/g, ''), 'onetwo');
+  equal(trim(container.$().text()), 'onetwo');
 });
 
 test("should be able to modify childViews then rerender again the ContainerView in same run loop and then modify again", function () {
@@ -650,7 +650,7 @@ test("should be able to modify childViews then rerender again the ContainerView 
   equal(one.count, 1, 'rendered child only once');
   equal(two.count, 1, 'rendered child only once');
   // IE 8 adds a line break but this shouldn't affect validity
-  equal(container.$().text().replace(/\s/g, ''), 'onetwo');
+  equal(trim(container.$().text()), 'onetwo');
 });
 
 test("should invalidate `element` on itself and childViews when being rendered by ensureChildrenAreInDOM", function () {


### PR DESCRIPTION
`String#replace(/\s+/g, '')` is the same as `Ember.$.trim`.
To simplify test code, I rewrite with the latter.
