### PR TITLE
deprecate RSVP.Promise.prototype.fail

### DIFF
--- a/packages/ember-runtime/lib/mixins/deferred.js
+++ b/packages/ember-runtime/lib/mixins/deferred.js
@@ -4,6 +4,11 @@ RSVP.configure('async', function(callback, promise) {
   Ember.run.schedule('actions', promise, callback, promise);
 });
 
+RSVP.Promise.prototype.fail = function(callback, label){
+  Ember.deprecate('RSVP.Promise.fail has been renamed as RSVP.Promise.catch');
+  return this['catch'](callback, label);
+};
+
 /**
 @module ember
 @submodule ember-runtime


### PR DESCRIPTION
RSVP.Promise.Prototype.fail has been removed in upstream RSVP.js. It made it into Ember.js 1.2, we should deprecate instead of remove absolutely.
