### PR TITLE
Get benchmarks running again, using external URLs

### DIFF
--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <script src="../lib/jquery-1.9.0.js"></script>
+    <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
     <script src="benchmark.js"></script>
     <script src="runner.js"></script>
   </head>

--- a/benchmarks/runner.js
+++ b/benchmarks/runner.js
@@ -13,9 +13,9 @@ function makeiframe(emberPath, suitePath, suiteCode, profile, callback) {
   iframe.name = name;
 
   write("<title>" + name + "</title>");
-  write("<script src='../lib/jquery-1.9.0.js'></script>");
+  write("<script src='http://code.jquery.com/jquery-1.10.1.min.js'></script>");
   write("<script>ENV = {VIEW_PRESERVES_CONTEXT: true};</script>");
-  write("<script src='../lib/handlebars-1.0.rc.1.js'></script>");
+  write("<script src='//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.1.2/handlebars.min.js'></script>");
   write("<script src='" + emberPath + "'></script>");
   write("<script src='benchmark.js'></script>");
   write("<script src='iframe_runner.js'></script>");

--- a/benchmarks/simple.html
+++ b/benchmarks/simple.html
@@ -2,8 +2,9 @@
 
 <html>
   <head>
-    <script src="../lib/jquery-1.9.0.js"></script>
-    <script src="../lib/ember.js"></script>
+    <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+    <script src='//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.1.2/handlebars.min.js'></script>
+    <script src="../dist/ember.prod.js"></script>
   </head>
   <body>
     <script type="text/x-handlebars">


### PR DESCRIPTION
Had to benchmark some changes, and figured I would take a look at the existing benchmark suite. These were some changes to make the instructions in `benchmarks/README.md` work.

I'm loathe to use external URLs, but this is better than the benchmarks just not running. Fwiw.
