### PR TITLE
[BUGFIX beta] Watching non-configurable properties

### DIFF
--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -7,6 +7,9 @@ var metaFor = Ember.meta, // utils.js
     o_defineProperty = Ember.platform.defineProperty;
 
 Ember.watchKey = function(obj, keyName) {
+  var propertyDescriptor = Object.getOwnPropertyDescriptor(obj, keyName),
+      configurable = (!propertyDescriptor) ? true : (propertyDescriptor.configurable) ? true : false;
+
   // can't watch length on Array - it is special...
   if (keyName === 'length' && typeOf(obj) === 'array') { return; }
 
@@ -22,6 +25,7 @@ Ember.watchKey = function(obj, keyName) {
 
     if (MANDATORY_SETTER && keyName in obj) {
       m.values[keyName] = obj[keyName];
+      Ember.assert('You cannot watch non-configurable property: ' + keyName, configurable);
       o_defineProperty(obj, keyName, {
         configurable: true,
         enumerable: true,

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -263,3 +263,15 @@ testBoth('watching "length" property on an array', function(get, set) {
   equal(get(arr, 'length'), 10, 'should get new value');
   equal(arr.length, 10, 'property should be accessible on arr');
 });
+
+test('watching non-configurable property should assert', function() {
+  var obj = {
+    state: 'happy'
+  };
+
+  Ember.platform.defineProperty(obj, 'sleepy', {});
+
+  expectAssertion(function() {
+    Ember.watchKey(obj, 'sleepy');
+  }, 'You cannot watch non-configurable property: sleepy');
+});


### PR DESCRIPTION
If you try to re-define property that is non-configurable, the error is going to be thrown `You can't re-define property X`.

To illustrate the issue:

``` javascript
var obj = {};

Object.defineProperty(obj, 'name', {});

// the following code throws exception
Object.defineProperty(obj, 'name', {
  configurable: true
});
```

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FObject%2FdefineProperty) when you define property without specifying the descriptor, `configurable` defaults to `false`.

This PR adds an assertion if you're trying to watch `non-configurable` properties.

Thanks to @danmcclain for pointing it out.

/cc @kselden
