### PR TITLE
[DOC beta] Remove JSDoc @scope directives.

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -323,9 +323,7 @@ Ember.SelectOptgroup = Ember.CollectionView.extend({
   @namespace Ember
   @extends Ember.View
 */
-Ember.Select = Ember.View.extend(
-  /** @scope Ember.Select.prototype */ {
-
+Ember.Select = Ember.View.extend({
   tagName: 'select',
   classNames: ['ember-select'],
   defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each view.groupedContent}}{{view view.groupView content=content label=label}}{{/each}}{{else}}{{#each view.content}}{{view view.optionView content=this}}{{/each}}{{/if}}'),

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -27,8 +27,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Component
   @uses Ember.TextSupport
 */
-Ember.TextField = Ember.Component.extend(Ember.TextSupport,
-  /* @scope Ember.TextField.prototype */ {
+Ember.TextField = Ember.Component.extend(Ember.TextSupport, {
 
   classNames: ['ember-text-field'],
   tagName: "input",

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -46,7 +46,7 @@ var get = Ember.get, set = Ember.set, isNone = Ember.isNone, map = Ember.Enumera
   @uses Ember.Enumerable
   @since Ember 0.9.0
 */
-Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.prototype */ {
+Ember.Array = Ember.Mixin.create(Ember.Enumerable, {
 
   /**
     Your array must support the `length` property. Your replace methods should

--- a/packages/ember-runtime/lib/mixins/comparable.js
+++ b/packages/ember-runtime/lib/mixins/comparable.js
@@ -16,7 +16,7 @@ require('ember-runtime/core');
   @namespace Ember
   @since Ember 0.9
 */
-Ember.Comparable = Ember.Mixin.create( /** @scope Ember.Comparable.prototype */{
+Ember.Comparable = Ember.Mixin.create({
 
   /**
     Override to return the result of the comparison of the two parameters. The

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -24,7 +24,7 @@ var get = Ember.get, set = Ember.set;
   @namespace Ember
   @since Ember 0.9
 */
-Ember.Copyable = Ember.Mixin.create(/** @scope Ember.Copyable.prototype */ {
+Ember.Copyable = Ember.Mixin.create({
 
   /**
     Override to return a copy of the receiver. Default implementation raises

--- a/packages/ember-runtime/lib/mixins/freezable.js
+++ b/packages/ember-runtime/lib/mixins/freezable.js
@@ -62,7 +62,7 @@ var get = Ember.get, set = Ember.set;
   @namespace Ember
   @since Ember 0.9
 */
-Ember.Freezable = Ember.Mixin.create(/** @scope Ember.Freezable.prototype */ {
+Ember.Freezable = Ember.Mixin.create({
 
   /**
     Set to `true` when the object is frozen. Use this property to detect

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -33,7 +33,7 @@ var get = Ember.get, set = Ember.set;
   @uses Ember.Array
   @uses Ember.MutableEnumerable
 */
-Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/** @scope Ember.MutableArray.prototype */ {
+Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable, {
 
   /**
     __Required.__ You must implement this method to apply this mixin.

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -49,7 +49,7 @@ var get = Ember.get, set = Ember.set;
   @extends Ember.Object
   @uses Ember.MutableArray
 */
-Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.ArrayProxy.prototype */ {
+Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray, {
 
   /**
     The content array. Must be an object that implements `Ember.Array` and/or

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -96,7 +96,7 @@ function contentPropertyDidChange(content, contentKey) {
   @namespace Ember
   @extends Ember.Object
 */
-Ember.ObjectProxy = Ember.Object.extend(/** @scope Ember.ObjectProxy.prototype */ {
+Ember.ObjectProxy = Ember.Object.extend({
   /**
     The object whose properties will be forwarded.
 

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -109,7 +109,7 @@ var get = Ember.get, set = Ember.set, guidFor = Ember.guidFor, isNone = Ember.is
   @since Ember 0.9
 */
 Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Ember.Freezable,
-  /** @scope Ember.Set.prototype */ {
+  {
 
   // ..........................................................
   // IMPLEMENT ENUMERABLE APIS

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -30,7 +30,7 @@
   @extends Ember.Object
   @private
 */
-Ember.Suite = Ember.Object.extend(/** @scope Ember.Suite.prototype */ {
+Ember.Suite = Ember.Object.extend({
 
   /**
     Define a name for these tests - all modules are prefixed w/ it.

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -16,7 +16,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   @private
   @extends Ember.Object
 */
-Ember.EventDispatcher = Ember.Object.extend(/** @scope Ember.EventDispatcher.prototype */{
+Ember.EventDispatcher = Ember.Object.extend({
 
   /**
     The set of events names (and associated handler function names) to be setup

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -98,8 +98,7 @@ Ember._RenderBuffer = function(tagName) {
   this.buffer = "";
 };
 
-Ember._RenderBuffer.prototype =
-/** @scope Ember.RenderBuffer.prototype */ {
+Ember._RenderBuffer.prototype = {
 
   // The root view's element
   _element: null,

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -156,7 +156,7 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   @extends Ember.ContainerView
   @since Ember 0.9
 */
-Ember.CollectionView = Ember.ContainerView.extend(/** @scope Ember.CollectionView.prototype */ {
+Ember.CollectionView = Ember.ContainerView.extend({
 
   /**
     A list of items to be displayed by the `Ember.CollectionView`.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -851,8 +851,7 @@ var EMPTY_ARRAY = [];
   @namespace Ember
   @extends Ember.CoreView
 */
-Ember.View = Ember.CoreView.extend(
-/* @scope Ember.View.prototype */ {
+Ember.View = Ember.CoreView.extend({
 
   concatenatedProperties: ['classNames', 'classNameBindings', 'attributeBindings'],
 


### PR DESCRIPTION
`@scope` is not valid `YUIDoc` syntax (see [syntax reference](http://yui.github.io/yuidoc/syntax/index.html)), and causes last properly documented method/property in a file to contain the text output of any undocumented items directly following the `@scope` directive.

Before:

![screenshot](https://www.monosnap.com/image/pZCrf3m2vdqlROOUCjIuJre4a.png)

After:

![screenshot](https://www.monosnap.com/image/rfCxDtISxjm19SM85RZKbbPgK.png)

Before:
![screenshot](https://www.monosnap.com/image/ZDxRuuf9vyxMBVqIZUlghxrID.png)

After:

![screenshot](https://www.monosnap.com/image/J9eCBqdHonuB8UXC0eWQ6gQuf.png)
