### PR TITLE
Improved assertion message in `verifyNeedsDependencies`

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -6,7 +6,7 @@
 var get = Ember.get, set = Ember.set;
 
 function verifyNeedsDependencies(controller, container, needs) {
-  var dependency, i, l;
+  var dependency, i, l, missing = [];
 
   for (i=0, l=needs.length; i<l; i++) {
     dependency = needs[i];
@@ -19,9 +19,10 @@ function verifyNeedsDependencies(controller, container, needs) {
 
     // Structure assert to still do verification but not string concat in production
     if (!container.has(dependency)) {
-      Ember.assert(Ember.inspect(controller) + " needs " + dependency + " but it does not exist", false);
+      missing.push(dependency);
     }
   }
+  Ember.assert(Ember.inspect(controller) + " needs [ " + missing.join(', ') + " ] but " + (missing.length > 1 ? 'they' : 'it') + " could not be found", !missing.length);
 }
 
 var defaultControllersComputedProperty = Ember.computed(function() {

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -29,12 +29,20 @@ test("If a controller specifies an unavailable dependency, it raises", function(
   var container = new Ember.Container();
 
   container.register('controller:post', Ember.Controller.extend({
-    needs: 'posts'
+    needs: ['comments']
   }));
 
   expectAssertion(function() {
     container.lookup('controller:post');
-  }, /controller:posts/);
+  }, /controller:comments/);
+
+  container.register('controller:blog', Ember.Controller.extend({
+    needs: ['posts', 'comments']
+  }));
+
+  expectAssertion(function() {
+    container.lookup('controller:blog');
+  }, /controller:posts, controller:comments/);
 });
 
 test("Mixin sets up controllers if there is needs before calling super", function() {


### PR DESCRIPTION
In dev builds, the first failed assertion throws, with the result
that you only find out 1 of the missing dependencies in your
controller's needs list at a times. This commit collects all the
missing dependencies and then does one assertion listing them out
so you can address them all before kicking off your build, tests, etc
