### PR TITLE
[BUGFIX beta] Update `verifyNeedsDependencies` to throw instead of assert

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -22,7 +22,9 @@ function verifyNeedsDependencies(controller, container, needs) {
       missing.push(dependency);
     }
   }
-  Ember.assert(Ember.inspect(controller) + " needs [ " + missing.join(', ') + " ] but " + (missing.length > 1 ? 'they' : 'it') + " could not be found", !missing.length);
+  if (missing.length) {
+    throw new Ember.Error(Ember.inspect(controller) + " needs [ " + missing.join(', ') + " ] but " + (missing.length > 1 ? 'they' : 'it') + " could not be found");
+  }
 }
 
 var defaultControllersComputedProperty = Ember.computed(function() {

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -32,7 +32,7 @@ test("If a controller specifies an unavailable dependency, it raises", function(
     needs: ['comments']
   }));
 
-  expectAssertion(function() {
+  throws(function() {
     container.lookup('controller:post');
   }, /controller:comments/);
 
@@ -40,7 +40,7 @@ test("If a controller specifies an unavailable dependency, it raises", function(
     needs: ['posts', 'comments']
   }));
 
-  expectAssertion(function() {
+  throws(function() {
     container.lookup('controller:blog');
   }, /controller:posts, controller:comments/);
 });


### PR DESCRIPTION
A missing `needs` dependency should raise an error in production builds, not just
in dev builds.
