### PR TITLE
[BUGFIX beta] Ensure that ember-debug uses EmberENV.

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -19,7 +19,20 @@ if ('undefined' === typeof Ember) {
   }
 }
 
-Ember.ENV = 'undefined' === typeof ENV ? {} : ENV;
+// This needs to be kept in sync with the logic in
+// `packages/ember-metal/lib/core.js`.
+//
+// This is duplicated here to ensure that `Ember.ENV`
+// is setup even if `Ember` is not loaded yet.
+if (Ember.ENV) {
+  // do nothing if Ember.ENV is already setup
+} else if ('undefined' !== typeof EmberENV) {
+  Ember.ENV = EmberENV;
+} else if('undefined' !== typeof ENV) {
+  Ember.ENV = ENV;
+} else {
+  Ember.ENV = {};
+}
 
 if (!('MANDATORY_SETTER' in Ember.ENV)) {
   Ember.ENV.MANDATORY_SETTER = true; // default to true for debug dist

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -65,6 +65,8 @@ Ember.VERSION = 'VERSION_STRING_PLACEHOLDER';
   @type Hash
 */
 
+// This needs to be kept in sync with the logic in
+// `packages/ember-debug/lib/main.js`.
 if (Ember.ENV) {
   // do nothing if Ember.ENV is already setup
 } else if ('undefined' !== typeof EmberENV) {


### PR DESCRIPTION
This brings `ember-debug` in sync with the way
`packages/ember-metal/lib/core.js` pulls in `Ember.ENV`.

See https://github.com/emberjs/ember.js/pull/3947 for more info.
