### PR TITLE
[BUGFIX beta] Make `{{render...}}` set a `parentController` property

### DIFF
--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -117,7 +117,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       Ember.assert("The controller name you supplied '" + controllerName + "' did not resolve to a controller.", container.has(controllerFullName));
     }
 
-    var target = options.data.keywords.controller;
+    var parentController = options.data.keywords.controller;
 
     // choose name
     if (length > 2) {
@@ -126,14 +126,18 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
       controller = factory.create({
         model: context,
-        target: target
+        parentController: parentController,
+        target: parentController
       });
 
     } else {
       controller = container.lookup(controllerFullName) ||
                    Ember.generateController(container, controllerName);
 
-      controller.set('target', target);
+      controller.setProperties({
+        target: parentController,
+        parentController: parentController
+      });
     }
 
     var root = options.contexts[1];

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -362,7 +362,8 @@ test("{{render}} helper should link child controllers to the parent controller",
       parentPlease: function() {
         parentTriggered++;
       }
-    }
+    },
+    role: "Mom"
   });
 
   container.register('controller:posts', Ember.ArrayController.extend());
@@ -372,13 +373,16 @@ test("{{render}} helper should link child controllers to the parent controller",
     template: Ember.Handlebars.compile(template)
   });
 
-  Ember.TEMPLATES['posts'] = compile('<button id="parent-action" {{action "parentPlease"}}>Go to Parent</button>');
+  Ember.TEMPLATES['posts'] = compile('<button id="parent-action" {{action "parentPlease"}}>Go to {{parentController.role}}</button>');
 
   appendView(view);
 
-  var actionId = Ember.$("#parent-action").data('ember-action'),
+  var button = Ember.$("#parent-action"),
+      actionId = button.data('ember-action'),
       action = Ember.Handlebars.ActionHelper.registeredActions[actionId],
       handler = action.handler;
+
+  equal(button.text(), "Go to Mom", "The parentController property is set on the child controller");
 
   Ember.run(null, handler, new Ember.$.Event("click"));
 


### PR DESCRIPTION
The `render` helper now sets a `parentController` property on the child controller.

This makes it behave consistently with the `each` helper.

/cc @kselden
