### PR TITLE
Attribute bindings with a falsy value should always remove the attribute...

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2481,6 +2481,10 @@ Ember.View.applyAttributeBindings = function(elem, name, value) {
     // We can't set properties to undefined or null
     if (Ember.isNone(value)) { value = ''; }
 
+    if (!value) {
+      elem.removeAttr(name);
+    }
+
     if (value !== elem.prop(name)) {
       // value and booleans should always be properties
       elem.prop(name, value);

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -118,6 +118,12 @@ test("should allow binding to String objects", function() {
 
 
   equal(view.$().attr('foo'), 'bar', "should convert String object to bare string");
+
+  Ember.run(function() {
+    view.set('foo', false);
+  });
+
+  ok(!view.$().attr('foo'), "removes foo attribute when false");
 });
 
 test("should teardown observers on rerender", function() {


### PR DESCRIPTION
The documentation currently states that using a boolean will add or remove a given attribute. However, under the hood we're really dealing with attributes vs properties. This presents an issue if my bound value goes from being a string to a `false` bool, which will _not_ remove the attribute as expected. However, setting a string value to `null` or `undefined` will remove the attribute.

Ultimately, setting a bound attr to false should _always_ remove the attribute from the element, regardless of whether it's setting a property value.

Example:
controller:

``` javascript
...
myAttr: 'something'
...
```

template:

```
<button {{bindAttr data-my=myAttr}}>
```

output:

``` html
<button data-my="something">
```

then:

``` javascript
controller.set('myAttr', false); //I want to remove this attribute
```

currently output is still:

``` html
<button data-my="something">
```

but it should be:

``` html
<button>
```
