### PR TITLE
[DOC] Fix invalid syntax for classNames property in link-to helper

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -730,7 +730,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     key/value pairs, like so:
 
     ```handlebars
-    {{#link-to  aPhoto tagName='li' title='Following this link will change your life' classNames=['pic', 'sweet']}}
+    {{#link-to  aPhoto tagName='li' title='Following this link will change your life' classNames='pic sweet'}}
       Uh-mazing!
     {{/link-to}}
     ```


### PR DESCRIPTION
Trying to use array syntax throws `TypeError: this.classNames is undefined`
when rendering.
