### PR TITLE
[BUGFIX][QueryParams] - Support for empty string QPs

### DIFF
--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -420,7 +420,14 @@ define("route-recognizer",
         for(var i=0; i < pairs.length; i++) {
           var pair      = pairs[i].split('='),
               key       = decodeURIComponent(pair[0]),
-              value     = pair[1] ? decodeURIComponent(pair[1]) : true;
+              value;
+
+          if (pair.length === 1) {
+            value = true;
+          } else {
+            value = pair[1] ? decodeURIComponent(pair[1]) : '';
+          }
+
           queryParams[key] = value;
         }
         return queryParams;

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -459,4 +459,30 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     expectedReplaceURL = "/?index[foo]=";
     Ember.run(router, 'transitionTo', { queryParams: { foo: '' } });
   });
+
+  test("Query param without =value are boolean", function() {
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: false
+    });
+
+    startingURL = "/?index[foo]";
+    bootApplication();
+
+    var controller = container.lookup('controller:index');
+    equal(controller.get('foo'), true);
+  });
+
+  test("Query param without value are empty string", function() {
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: ''
+    });
+
+    startingURL = "/?index[foo]=";
+    bootApplication();
+
+    var controller = container.lookup('controller:index');
+    equal(controller.get('foo'), "");
+  });
 }


### PR DESCRIPTION
This PR actually only adds tests to verify a fix
made in the route-recognizer. It should fix this bug:
https://github.com/emberjs/ember.js/issues/4054

This PR depends on: https://github.com/tildeio/route-recognizer/pull/19

That above PR changes the how QPs are parsed so that

`route/?foo` => `{ foo: true }`
and
`route/?foo=` => `{foo: ''}`
