### PR TITLE
Enable features selected for next beta cycle.

### DIFF
--- a/features.json
+++ b/features.json
@@ -3,18 +3,18 @@
     "reduceComputed-non-array-dependencies": true,
     "ember-testing-lazy-routing": true,
     "ember-testing-wait-hooks": true,
+    "propertyBraceExpansion": true,
+    "ember-metal-run-bind": true,
+    "with-controller": true,
     "query-params-new": null,
     "string-humanize": null,
     "string-parameterize": null,
-    "propertyBraceExpansion": null,
     "ember-routing-named-substates": null,
     "ember-handlebars-caps-lookup": null,
     "ember-testing-simple-setup": null,
     "ember-testing-routing-helpers": null,
     "ember-testing-triggerEvent-helper": null,
-    "with-controller": null,
-    "computed-read-only": null,
-    "ember-metal-run-bind": null
+    "computed-read-only": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }


### PR DESCRIPTION
The following features have been selected by the core team as being ready to
go for the next beta cycle. As such, they should be enabled on all canary
builds to ensure they are stable.

See https://github.com/emberjs/ember.js/issues/4052 for details.
