### PR TITLE
Allow Ember.computed.sort to use property paths in sortDefinitions.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -697,10 +697,12 @@ Ember.computed.sort = function (itemsKey, sortDefinition) {
 
 
       instanceMeta.order = function (itemA, itemB) {
-        var sortProperty, result, asc;
+        var isProxy = itemB instanceof SearchProxy,
+            sortProperty, result, asc;
+
         for (var i = 0; i < this.sortProperties.length; ++i) {
           sortProperty = this.sortProperties[i];
-          result = Ember.compare(get(itemA, sortProperty), get(itemB, sortProperty));
+          result = Ember.compare(get(itemA, sortProperty), isProxy ? itemB[sortProperty] : get(itemB, sortProperty));
 
           if (result !== 0) {
             asc = this.sortPropertyAscending[sortProperty];

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -755,7 +755,7 @@ test("updating sort properties in place updates the sorted array", function() {
   });
 
   deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "precond - array is initially sorted");
-  
+
   Ember.run(function() {
     sortProps.clear();
     sortProps.pushObject('fname');
@@ -877,6 +877,53 @@ test("updating an item's sort properties does not error when binary search does 
   deepEqual(get(obj, 'sortedPeople'), [jaime, cersei], "array is sorted correctly");
 });
 
+test("property paths in sort properties update the sorted array", function () {
+  var jaime, cersei, sansa;
+
+  Ember.run(function () {
+    jaime = Ember.Object.create({
+      relatedObj: Ember.Object.create({ status: 1, firstName: 'Jaime', lastName: 'Lannister' })
+    });
+    cersei = Ember.Object.create({
+      relatedObj: Ember.Object.create({ status: 2, firstName: 'Cersei', lastName: 'Lannister' })
+    });
+    sansa = Ember.Object.create({
+      relatedObj: Ember.Object.create({ status: 3, firstName: 'Sansa', lastName: 'Stark' })
+    });
+
+    obj = Ember.Object.createWithMixins({
+      people: Ember.A([jaime, cersei, sansa]),
+      sortProps: Ember.A(['relatedObj.status']),
+      sortedPeople: Ember.computed.sort('people', 'sortProps')
+    });
+  });
+
+  deepEqual(get(obj, 'sortedPeople'), [jaime, cersei, sansa], "precond - array is initially sorted");
+
+  Ember.run(function () {
+    cersei.set('status', 3);
+  });
+
+  deepEqual(get(obj, 'sortedPeople'), [jaime, cersei, sansa], "array is sorted correctly");
+
+  Ember.run(function () {
+    cersei.set('status', 1);
+  });
+
+  deepEqual(get(obj, 'sortedPeople'), [jaime, cersei, sansa], "array is sorted correctly");
+
+  Ember.run(function () {
+    sansa.set('status', 1);
+  });
+
+  deepEqual(get(obj, 'sortedPeople'), [jaime, cersei, sansa], "array is sorted correctly");
+
+  Ember.run(function () {
+    obj.set('sortProps', Ember.A(['relatedObj.firstName']));
+  });
+
+  deepEqual(get(obj, 'sortedPeople'), [cersei, jaime, sansa], "array is sorted correctly");
+});
 
 function sortByLnameFname(a, b) {
   var lna = get(a, 'lname'),


### PR DESCRIPTION
`Ember.computed.sort` only works if sortDefinitions contain simple properties. It will fail if a `sortDefinition` contains a property path (i.e. somehting like `person.name`).

A `SearchProxy` is used to shadow the new value of an underlying property with the old value to ensure proper comparisons take place while searching for an item in the sorted array. When using a property path rather than a simple property to sort on, `SearchProxy` will use the actual property path in its attempt to shadow underlying properties - something like: `{ person.name: 'John Doe' }`. This causes things to blow up because every comparison between an existing item `get(itemA, sortProperty)` and a search proxy `get(itemB, sortProperty)` will return a bogus result. In this case, `get(itemB, 'person.name')` will not return the shadowed value (stored as `{ person.name: 'John Doe' }`) but rather the current value of that path on the search proxy's underlying `content`.

This commit allows a proper comparison to take place when a `sortDefinition` contains a property path.
