### PR TITLE
[BUGFIX beta] Remove false attribute from Ember.View for IE8

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2479,15 +2479,12 @@ Ember.View.applyAttributeBindings = function(elem, name, value) {
       elem.attr(name, value);
     }
   } else if (name === 'value' || type === 'boolean') {
-    // We can't set properties to undefined or null
-    if (Ember.isNone(value)) { value = ''; }
-
-    if (!value) {
+    if (Ember.isNone(value) || value === false) {
+      // `null`, `undefined` or `false` should remove attribute
       elem.removeAttr(name);
-    }
-
-    if (value !== elem.prop(name)) {
-      // value and booleans should always be properties
+      elem.prop(name, '');
+    } else if (value !== elem.prop(name)) {
+      // value should always be properties
       elem.prop(name, value);
     }
   } else if (!value) {

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -164,7 +164,7 @@ test("handles attribute bindings for properties", function() {
     view.set('checked', false);
   });
 
-  equal(view.$().prop('checked'), false, 'changes to unchecked');
+  equal(!!view.$().prop('checked'), false, 'changes to unchecked');
 });
 
 test("handles `undefined` value for properties", function() {


### PR DESCRIPTION
In IE8 (or older), `jQuery.fn.prop` always update DOM against our
expectation.(This is a jQuery bug but it couldn't fix)
- ref: http://bugs.jquery.com/ticket/13558

So the following test is failed due to `view.$().attr('foo')` returns `"false"`:
- https://github.com/emberjs/ember.js/blob/a449d445/packages/ember-views/tests/views/view/attribute_bindings_test.js#L126
  ![2014-01-04 23 24 13](https://f.cloud.github.com/assets/290782/1845350/21b379b0-7583-11e3-85d6-24ac03cf3889.png)

To avoid this issue, `removeAttr` should be called when `null`, `undefined` or `false` is given as value.

But this way contains incompatible changes:

Before:

``` javascript
view.set('checked', false);
view.$().prop('checked'); //=> false
```

After:

``` javascript
view.set('checked', false);
view.$().prop('checked'); //=> undefined
```

Would you mind this change?
Or, What do you know any cool idea...?
