### PR TITLE
[FEATURE query-params-new]Support for Arrays

### DIFF
--- a/packages/ember-routing/lib/vendor/route-recognizer.js
+++ b/packages/ember-routing/lib/vendor/route-recognizer.js
@@ -403,10 +403,18 @@ define("route-recognizer",
               continue;
             }
             var pair = key;
-            if(value !== true) {
-              pair += "=" + encodeURIComponent(value);
+            if (Array.isArray(value)) {
+              for (var i = 0, l = value.length; i < l; i++) {
+                var arrayPair = key + '[]' + '=' + encodeURIComponent(value[i]);
+                pairs.push(arrayPair);
+              }
             }
-            pairs.push(pair);
+            else if (value !== true) {
+              pair += "=" + encodeURIComponent(value);
+              pairs.push(pair);
+            } else {
+              pairs.push(pair);
+            }
           }
         }
 
@@ -420,15 +428,28 @@ define("route-recognizer",
         for(var i=0; i < pairs.length; i++) {
           var pair      = pairs[i].split('='),
               key       = decodeURIComponent(pair[0]),
+              keyLength = key.length,
+              isArray = false,
               value;
-
           if (pair.length === 1) {
             value = true;
           } else {
+            //Handle arrays
+            if (keyLength > 2 && key.slice(keyLength -2) === '[]') {
+              isArray = true;
+              key = key.slice(0, keyLength - 2);
+              if(!queryParams[key]) {
+                queryParams[key] = [];
+              }
+            }
             value = pair[1] ? decodeURIComponent(pair[1]) : '';
           }
-
-          queryParams[key] = value;
+          if (isArray) {
+            queryParams[key].push(value);
+          } else {
+            queryParams[key] = value;
+          }
+          
         }
         return queryParams;
       },

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -485,4 +485,58 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     var controller = container.lookup('controller:index');
     equal(controller.get('foo'), "");
   });
+
+  test("Array query params can be set", function() {
+    Router.map(function() {
+      this.route("home", { path: '/' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: []
+    });
+
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+
+    Ember.run(controller, '_activateQueryParamObservers');
+    Ember.run(controller, 'set', 'foo', [1,2]);
+
+    equal(router.get('location.path'), "/?home[foo][]=1&home[foo][]=2");
+
+    Ember.run(controller, 'set', 'foo', [3,4]);
+    equal(router.get('location.path'), "/?home[foo][]=3&home[foo][]=4");
+  });
+
+  test("transitionTo supports array query params", function() {
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [1]
+    });
+
+    bootApplication();
+
+    equal(router.get('location.path'), "/?index[foo][]=1");
+
+    Ember.run(router, 'transitionTo', { queryParams: { foo: [2,3] } });
+    equal(router.get('location.path'), "/?index[foo][]=2&index[foo][]=3", "shorthand supported");
+    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4,5] } });
+    equal(router.get('location.path'), "/?index[foo][]=4&index[foo][]=5", "longform supported");
+    Ember.run(router, 'transitionTo', { queryParams: { foo: [] } });
+    equal(router.get('location.path'), "/", "longform supported");
+  });
+
+  test("Url with array query param sets controller property to array", function() {
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: ''
+    });
+
+    startingURL = "/?index[foo][]=1&index[foo][]=2&index[foo][]=3";
+    bootApplication();
+
+    var controller = container.lookup('controller:index');
+    deepEqual(controller.get('foo'), ["1","2","3"]);
+  });
 }


### PR DESCRIPTION
With the updated route-recognizer you can have a URL like
`\?authors[]=wycats&authors[]=tomdale` which will provide a queryParmas hash of

```
{
  authors: [
    'wycats',
    'tomdale',
  ]
}
```
