### PR TITLE
[BUGFIX beta] Allow Component to lookup a templateName if specified.

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -108,7 +108,7 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, Ember.ComponentTe
   },
 
   /**
-  A components template property is set by passing a block to
+  A components template property is set by passing a block
   during its invocation. It is executed within the parent context.
 
   Example:
@@ -126,7 +126,16 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, Ember.ComponentTe
   @deprecated
   @property template
   */
-  template: null,
+  template: Ember.computed(function(key, value) {
+    if (value !== undefined) { return value; }
+
+    var templateName = get(this, 'templateName'),
+        template = this.templateForName(templateName, 'template');
+
+    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || template);
+
+    return template || get(this, 'defaultTemplate');
+  }).property('templateName'),
 
   /**
   Specifying a components `templateName` is deprecated without also

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -169,6 +169,28 @@ test("Assigning templateName to a component should setup the template as a layou
   equal(Ember.$('#wrapper').text(), "inner-outer", "The component is composed correctly");
 });
 
+test("Assigning templateName and layoutName should use the templates specified", function(){
+  expect(1);
+
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{my-component}}</div>");
+  Ember.TEMPLATES['foo'] = compile("{{text}}");
+  Ember.TEMPLATES['bar'] = compile("{{text}}-{{yield}}");
+
+  boot(function() {
+    container.register('controller:application', Ember.Controller.extend({
+      'text': 'outer'
+    }));
+
+    container.register('component:my-component', Ember.Component.extend({
+      text: 'inner',
+      layoutName: 'bar',
+      templateName: 'foo'
+    }));
+  });
+
+  equal(Ember.$('#wrapper').text(), "inner-outer", "The component is composed correctly");
+});
+
 module("Application Lifecycle - Component Context", {
   setup: prepare,
   teardown: cleanup


### PR DESCRIPTION
Prior to this change, specifying `templateName` to a component would not cause
that template to be used (since we were overriding the
`Ember.View.template` function with `null`).

This change uses the logic from `Ember.View.template`, which is not ideal, but
I think that these custom docs are pretty important to have.
(They help instruct users that the block passed to a component is interpreted
as its template.)

/cc @machty
