### PR TITLE
[BUGFIX] Don't call toString at extend time

### DIFF
--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -242,7 +242,7 @@ Ember.ActionHandler = Ember.Mixin.create({
     var hashName;
 
     if (!props._actions) {
-      Ember.assert(this + " 'actions' should not be a function", typeof(props.actions) !== 'function');
+      Ember.assert("'actions' should not be a function", typeof(props.actions) !== 'function');
 
       if (typeOf(props.actions) === 'object') {
         hashName = 'actions';


### PR DESCRIPTION
Doing so will memoize the function so that any Ember.View subclass will return the same value for toString.

This can be seen here: http://emberjs.jsbin.com/UsENAKiL/1/edit
It was introduced by c2a83893f5df634c0037b8a194c78734ba21ef5f

Probably a better way to fix this is to make sure that a view does not get the memoized toString from the prototype, I just wanted a quick fix before 1.3.0 is released.
