### PR TITLE
[BUGFIX beta] Update CollectionView's contentIndex correctly

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -287,9 +287,13 @@ ChainNode.prototype = {
 
   willChange(events) {
     var chains = this._chains;
+    var node;
     if (chains) {
       for (var key in chains) {
-        chains[key].willChange(events);
+        node = chains[key];
+        if (node !== undefined) {
+          node.willChange(events);
+        }
       }
     }
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -464,6 +464,58 @@ QUnit.test('should allow items to access to the CollectionView\'s current index 
   deepEqual(view.$(':nth-child(3)').text(), '2');
 });
 
+QUnit.test('should update the CollectionView items\' content index correctly', function () {
+  var content = Ember.A(['2', '4']);
+  view = CollectionView.create({
+    content: content,
+
+    itemViewClass: View.extend({
+      render: function (buf) {
+        buf.push(this.get('content'));
+      }
+    })
+  });
+
+  run(function () {
+    view.append();
+  });
+
+  var toArray = function(view) {
+    return view.$().children().map(function () { return jQuery(this).text(); }).toArray();
+  };
+
+  deepEqual(toArray(view), ['2', '4'], 'precond - generates pre-existing content correctly');
+  deepEqual(view.get('childViews').mapBy('contentIndex'), [0, 1], 'precond - generates pre-existing content indexes correctly');
+
+  run(function () {
+    content.unshiftObject('1');
+  });
+
+  deepEqual(toArray(view), ['1', '2', '4'], 'update content after unshiftObject');
+  deepEqual(view.get('childViews').mapBy('contentIndex'), [0, 1, 2], 'update content index after unshiftObject');
+
+  run(function () {
+    content.insertAt(2, '3');
+  });
+
+  deepEqual(toArray(view), ['1', '2', '3', '4'], 'update content after insertAt');
+  deepEqual(view.get('childViews').mapBy('contentIndex'), [0, 1, 2, 3], 'update content index after insertAt');
+
+  run(function () {
+    content.removeAt(1);
+  });
+
+  deepEqual(toArray(view), ['1', '3', '4'], 'update content after removeAt');
+  deepEqual(view.get('childViews').mapBy('contentIndex'), [0, 1, 2], 'update content index after removeAt');
+
+  run(function () {
+    content.pushObject('5');
+  });
+
+  deepEqual(toArray(view), ['1', '3', '4', '5'], 'update content after pushObject');
+  deepEqual(view.get('childViews').mapBy('contentIndex'), [0, 1, 2, 3], 'update content index after pushObject');
+});
+
 QUnit.test('should allow declaration of itemViewClass as a string', function() {
   registry.register('view:simple-view', View.extend());
 


### PR DESCRIPTION
Fix for issue #3548.

This commit allows `Ember.CollectionView` to properly update the `contentIndex` on each of its `childViews` whenever an item is added or removed from its `content`.
