### PR TITLE
expose asObject to precompile function

### DIFF
--- a/packages_es6/ember-handlebars-compiler/lib/main.js
+++ b/packages_es6/ember-handlebars-compiler/lib/main.js
@@ -264,8 +264,10 @@ EmberHandlebars.Compiler.prototype.mustache = function(mustache) {
   @for Ember.Handlebars
   @static
   @param {String} string The template to precompile
+  @param {Boolean} asObject optional parameter, defaulting to true, of whether or not the 
+                            compiled template should be returned as an Object or a String
 */
-EmberHandlebars.precompile = function(string) {
+EmberHandlebars.precompile = function(string, asObject) {
   var ast = Handlebars.parse(string);
 
   var options = {
@@ -281,8 +283,10 @@ EmberHandlebars.precompile = function(string) {
     stringParams: true
   };
 
+  asObject = asObject === undefined ? true : asObject;
+
   var environment = new EmberHandlebars.Compiler().compile(ast, options);
-  return new EmberHandlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
+  return new EmberHandlebars.JavaScriptCompiler().compile(environment, options, undefined, asObject);
 };
 
 // We don't support this for Handlebars runtime-only

--- a/packages_es6/ember-handlebars-compiler/tests/precompile_type_test.js
+++ b/packages_es6/ember-handlebars-compiler/tests/precompile_type_test.js
@@ -1,0 +1,21 @@
+import EmberHandlebars from "ember-handlebars-compiler";
+var precompile = EmberHandlebars.precompile,
+    template = 'Hello World',
+    result;
+
+module("Ember.Handlebars.precompileType");
+
+test("precompile creates a function when asObject isn't defined", function(){
+  result = precompile(template);
+  equal(typeof(result), "function");
+});
+
+test("precompile creates a function when asObject is true", function(){
+  result = precompile(template, true);
+  equal(typeof(result), "function");
+});
+
+test("precompile creates a string when asObject is false", function(){
+  result = precompile(template, false);
+  equal(typeof(result), "string");
+});


### PR DESCRIPTION
Allow precompilation to return a string instead of an object
