### PR TITLE
[FEATURE query-params-new] alias computed.reads as computed.oneWay

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1218,6 +1218,20 @@ Ember.computed.oneWay = function(dependentKey) {
   });
 };
 
+if (Ember.FEATURES.isEnabled('query-params-new')) {
+  /**
+    This is a more semantically meaningful alias of `computed.oneWay`,
+    whose name is somewhat ambiguous as to which direction the data flows.
+
+    @method computed.reads
+    @for Ember
+    @param {String} dependentKey
+    @return {Ember.ComputedProperty} computed property which creates a
+      one way computed property to the original value for property.
+   */
+  Ember.computed.reads = Ember.computed.oneWay;
+}
+
 if (Ember.FEATURES.isEnabled('computed-read-only')) {
 /**
   Where `computed.oneWay` provides oneWay bindings, `computed.readOnly` provides

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -959,30 +959,37 @@ testBoth('Ember.computed.collect', function(get, set) {
   deepEqual(get(obj, 'all'), [0, 'bar', a, true], 'have all of them');
 });
 
-testBoth('Ember.computed.oneWay', function(get, set) {
-  var obj = {
-    firstName: 'Teddy',
-    lastName: 'Zeenny'
+function oneWayTest(methodName) {
+  return function(get, set) {
+    var obj = {
+      firstName: 'Teddy',
+      lastName: 'Zeenny'
+    };
+
+    Ember.defineProperty(obj, 'nickName', Ember.computed[methodName]('firstName'));
+
+    equal(get(obj, 'firstName'), 'Teddy');
+    equal(get(obj, 'lastName'), 'Zeenny');
+    equal(get(obj, 'nickName'), 'Teddy');
+
+    set(obj, 'nickName', 'TeddyBear');
+
+    equal(get(obj, 'firstName'), 'Teddy');
+    equal(get(obj, 'lastName'), 'Zeenny');
+
+    equal(get(obj, 'nickName'), 'TeddyBear');
+
+    set(obj, 'firstName', 'TEDDDDDDDDYYY');
+
+    equal(get(obj, 'nickName'), 'TeddyBear');
   };
+}
 
-  Ember.defineProperty(obj, 'nickName', Ember.computed.oneWay('firstName'));
+testBoth('Ember.computed.oneWay', oneWayTest('oneWay'));
 
-  equal(get(obj, 'firstName'), 'Teddy');
-  equal(get(obj, 'lastName'), 'Zeenny');
-  equal(get(obj, 'nickName'), 'Teddy');
-
-  set(obj, 'nickName', 'TeddyBear');
-
-  equal(get(obj, 'firstName'), 'Teddy');
-  equal(get(obj, 'lastName'), 'Zeenny');
-
-  equal(get(obj, 'nickName'), 'TeddyBear');
-
-  set(obj, 'firstName', 'TEDDDDDDDDYYY');
-
-  equal(get(obj, 'nickName'), 'TeddyBear');
-});
-
+if (Ember.FEATURES.isEnabled('query-params-new')) {
+  testBoth('Ember.computed.reads', oneWayTest('reads'));
+}
 
 if (Ember.FEATURES.isEnabled('computed-read-only')) {
 testBoth('Ember.computed.readOnly', function(get, set) {


### PR DESCRIPTION
oneWay is ambiguous. Which way?

Ember.computed.alias is a way more semantically meaningful alias of 
Ember.computed.oneWay.

Example: http://jsbin.com/ucanam/3000

Putting this in query params because I'd like to use this in some of the
examples for query params; seems like it'll be common lightweight pattern for
buffering small changes, and oneWay is just enough of a mental hurdle to
necessitate this.
