### PR TITLE
[FEATURE beta] Allow CollectionView createChildView override to prevent item from rendering

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -115,6 +115,9 @@ var get = Ember.get, set = Ember.set, fmt = Ember.String.fmt;
   });
   ```
 
+  Explicitly returning `false` from `createChildView` prevents that item from
+  rendering in the collection.
+
   ## Empty View
 
   You can provide an `Ember.View` subclass to the `Ember.CollectionView`
@@ -350,7 +353,13 @@ Ember.CollectionView = Ember.ContainerView.extend({
           contentIndex: idx
         });
 
-        addedViews.push(view);
+        Ember.assert(fmt("Ember.CollectionView items must be an instance of Ember.View, not %@",
+                     [view]),
+                     Ember.View.detectInstance(view) || view === false);
+
+        if (Ember.View.detectInstance(view)) {
+            addedViews.push(view);
+        }
       }
     } else {
       emptyView = get(this, 'emptyView');
@@ -363,6 +372,7 @@ Ember.CollectionView = Ember.ContainerView.extend({
 
       emptyView = this.createChildView(emptyView);
       addedViews.push(emptyView);
+
       set(this, 'emptyView', emptyView);
 
       if (Ember.CoreView.detect(emptyView)) {

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -110,6 +110,40 @@ test("should allow custom item views by setting itemViewClass", function() {
   });
 });
 
+test("should allow override of createChildView to omit items by returning 'false'", function() {
+  var content = Ember.A([
+    { include: true, content: 'foo' },
+    { include: false, content: 'bar' },
+    { include: true, content: 'baz' }
+  ]);
+
+  var CollectionView = Ember.CollectionView.extend({
+    content: content,
+
+    itemViewClass: Ember.View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content.content'));
+      }
+    }),
+
+    createChildView: function (viewClass, attrs) {
+      if (attrs && !get(attrs.content, 'include')) {
+        return false;
+      }
+      return this._super(viewClass, attrs);
+    }
+  });
+
+  view = CollectionView.create();
+
+  Ember.run(function() {
+    view.append();
+  });
+
+  equal(view.$().children().length, 2, "correct number of items");
+  equal(view.$(':contains(bar)').length, 0, "the falsy item did not render");
+});
+
 test("should insert a new item in DOM when an item is added to the content array", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
 


### PR DESCRIPTION
The docs specifically point out the ability to override `createChildView` for more advanced management of each item view. However, given the use cases of the override, I would also assume I should be able to fully omit a child view if it doesn't match my criteria.

My pull request allows this to be possible:

``` javascript
CustomCollectionView = Ember.CollectionView.extend({
  createChildView: function(viewClass, attrs) {
    if (attrs.content.kind == 'album') {
      viewClass = App.AlbumView;
    } else {
      return; //I don't want to see songs in this iteration of the view
    }
    return this._super(viewClass, attrs);
  }
});
```
