### PR TITLE
[FEATURE ember-eager-update-url] Eagerly update link-to urls

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -110,3 +110,9 @@ for a detailed explanation.
   a whitespace string.
 
   Added in [#4049](https://github.com/emberjs/ember.js/pull/4049).  
+
+* `ember-eager-url-update`
+  Invoking (clicking) `link-to` tags will immediately update the URL
+  instead of waiting for the transition to run to completion, unless
+  the transition was aborted/redirected within the same run loop.
+

--- a/features.json
+++ b/features.json
@@ -14,7 +14,8 @@
     "computed-read-only": null,
     "composable-computed-properties": true,
     "ember-routing-drop-deprecated-action-style": null,
-    "ember-metal-is-blank": null
+    "ember-metal-is-blank": null,
+    "ember-eager-url-update": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -336,7 +336,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     var transitionPromise = this.router[method].apply(this.router, args);
 
     transitionPromise.then(null, function(error) {
-      if (error.name === "UnrecognizedURLError") {
+      if (error && error.name === "UnrecognizedURLError") {
         Ember.assert("The URL '" + error.message + "' did not match any routes in your application");
       }
     }, 'Ember: Check for Router unrecognized URL error');
@@ -517,7 +517,7 @@ var defaultActionHandlers = {
       return;
     }
 
-    Ember.Logger.error('Error while loading route: ' + error.stack);
+    Ember.Logger.error('Error while loading route: ' + (error && error.stack));
   },
 
   loading: function(transition, originRoute) {


### PR DESCRIPTION
Previously, the url in the address bar would only update at the very end up
the transition. This change causes the url update to happen immediately unless
the transition was aborted/redirected within the same run loop, which provides
for a better UX 99% of the time.
