### PR TITLE
Deprecate edge-case get and normalizeTuple behavior before fixes

### DIFF
--- a/packages/ember-metal/tests/accessors/getPath_test.js
+++ b/packages/ember-metal/tests/accessors/getPath_test.js
@@ -24,12 +24,15 @@ var obj, moduleOpts = {
         baz: { biff: '$FOOBIFF' }
       }
     };
+
+    window.localPathGlobal = 5;
   },
 
   teardown: function() {
     obj = undefined;
     window.Foo = undefined;
     window.$foo = undefined;
+    window.localPathGlobal = undefined;
   }
 };
 
@@ -61,6 +64,22 @@ test('[obj, this.Foo.bar] -> (null)', function() {
 
 test('[obj, falseValue.notDefined] -> (null)', function() {
   deepEqual(get(obj, 'falseValue.notDefined'), undefined);
+});
+
+// ..........................................................
+// LOCAL PATHS WITH NO TARGET DEPRECATION
+//
+
+test('[null, length] returning data is deprecated', function() {
+  expectDeprecation(function(){
+    equal(5, Ember.get(null, 'localPathGlobal'));
+  }, "Ember.get fetched 'localPathGlobal' from the global context. This behavior will change in the future (issue #3852)");
+});
+
+test('[length] returning data is deprecated', function() {
+  expectDeprecation(function(){
+    equal(5, Ember.get('localPathGlobal'));
+  }, "Ember.get fetched 'localPathGlobal' from the global context. This behavior will change in the future (issue #3852)");
 });
 
 // ..........................................................

--- a/packages/ember-metal/tests/accessors/normalizeTuple_test.js
+++ b/packages/ember-metal/tests/accessors/normalizeTuple_test.js
@@ -74,7 +74,9 @@ test('[obj, this.Foo.bar] -> [obj, Foo.bar]', function() {
 //
 
 test('[obj, Foo] -> [obj, Foo]', function() {
-  deepEqual(normalizeTuple(obj, 'Foo'), [obj, 'Foo']);
+  expectDeprecation(function(){
+    deepEqual(normalizeTuple(obj, 'Foo'), [obj, 'Foo']);
+  }, "normalizeTuple will return 'Foo' as a non-global. This behavior will change in the future (issue #3852)");
 });
 
 test('[obj, Foo.bar] -> [Foo, bar]', function() {


### PR DESCRIPTION
Requires #4123.

PR #3852 changes some edge case behavior for get and normalizeTuple. Ahead of those changes, this commit introduces deprecation notices.
- Deprecate get for local paths on global contexts, only if they
  return data.
- Deprecate normalizeTuple calls that return a non-global contenxt
  and a simple global path.

/cc @ebryn @wagenet
