### PR TITLE
[BUGFIX beta] Silently fail when disconnecting from an inactive view

### DIFF
--- a/packages/ember-routing/lib/ext/view.js
+++ b/packages/ember-routing/lib/ext/view.js
@@ -135,6 +135,7 @@ Ember.View.reopen({
     @method _finishDisconnections
    */
   _finishDisconnections: function() {
+    if (this.isDestroyed) return; // _outlets will be gone anyway
     var outlets = get(this, '_outlets');
     var pendingDisconnections = this._pendingDisconnections;
     this._pendingDisconnections = null;

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1247,7 +1247,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     options.outlet = options.outlet || 'main';
 
     var parentView = this.router._lookupActiveView(options.parentView);
-    parentView.disconnectOutlet(options.outlet);
+    if (parentView) { parentView.disconnectOutlet(options.outlet); }
   },
 
   willDestroy: function() {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2429,6 +2429,40 @@ test("Route supports clearing outlet explicitly", function() {
   equal(Ember.$('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 0, "The posts/extra template was removed");
 });
 
+test("Route silently fails when cleaning an outlet from an inactive view", function() {
+  expect(1); // handleURL
+
+  Ember.TEMPLATES.application = compile("{{outlet}}");
+  Ember.TEMPLATES.posts = compile("{{outlet modal}}");
+  Ember.TEMPLATES.modal = compile("A Yo.");
+
+  Router.map(function() {
+    this.route("posts");
+  });
+
+  App.PostsRoute = Ember.Route.extend({
+    actions: {
+      hideSelf: function() {
+        this.disconnectOutlet({outlet: 'main', parentView: 'application'});
+      },
+      showModal: function() {
+        this.render('modal', {into: 'posts', outlet: 'modal'});
+      },
+      hideModal: function() {
+        this.disconnectOutlet({outlet: 'modal', parentView: 'posts'});
+      }
+    }
+  });
+
+  bootApplication();
+
+  handleURL('/posts');
+
+  Ember.run(function() { router.send('showModal'); });
+  Ember.run(function() { router.send('hideSelf'); });
+  Ember.run(function() { router.send('hideModal'); });
+});
+
 test("Aborting/redirecting the transition in `willTransition` prevents LoadingRoute from being entered", function() {
   expect(8);
 


### PR DESCRIPTION
If the parent of an outlet has already been disconnected, we should allow `disconnectOutlet` to be called with the child and fail silently. Currently `null has no method disconnectOutlet` is raised.
