### PR TITLE
[FEATURE query-params-new] Coerce numeric QPs to strings

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -295,7 +295,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
             // order of query params goes from root to leaf.
             finalParams.unshift({
               key: queryParams[k],
-              value: get(controller, k)
+              value: Ember.copy(get(controller, k))
             });
           }
         }

--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -1572,6 +1572,10 @@ define("router/utils",
     "use strict";
     var slice = Array.prototype.slice;
 
+    function isArray(test) {
+      return Object.prototype.toString.call(test) === "[object Array]";
+    }
+
     function merge(hash, other) {
       for (var prop in other) {
         if (other.hasOwnProperty(prop)) { hash[prop] = other[prop]; }
@@ -1601,6 +1605,22 @@ define("router/utils",
       }
     }
 
+    /**
+      @private
+
+      Coerces query param properties and array elements into strings.
+    **/
+    function coerceQueryParamsToString(queryParams) {
+      for (var key in queryParams) {
+        if (typeof queryParams[key] === 'number') {
+          queryParams[key] = '' + queryParams[key];
+        } else if (isArray(queryParams[key])) {
+          for (var i = 0, l = queryParams[key].length; i < l; i++) {
+            queryParams[key][i] = '' + queryParams[key][i];
+          }
+        }
+      }
+    }
     /**
       @private
      */
@@ -1702,7 +1722,6 @@ define("router/utils",
       }
     }
 
-
     function getChangelist(oldObject, newObject) {
       var key;
       var results = {
@@ -1714,6 +1733,8 @@ define("router/utils",
       merge(results.all, newObject);
 
       var didChange = false;
+      coerceQueryParamsToString(oldObject);
+      coerceQueryParamsToString(newObject);
 
       // Calculate removals
       for (key in oldObject) {
@@ -1728,9 +1749,24 @@ define("router/utils",
       // Calculate changes
       for (key in newObject) {
         if (newObject.hasOwnProperty(key)) {
-          if (oldObject[key] !== newObject[key]) {
-            results.changed[key] = newObject[key];
-            didChange = true;
+          if (isArray(oldObject[key]) && isArray(newObject[key])) {
+            if (oldObject[key].length !== newObject[key].length) {
+              results.changed[key] = newObject[key];
+              didChange = true;
+            } else {
+              for (var i = 0, l = oldObject[key].length; i < l; i++) {
+                if (oldObject[key][i] !== newObject[key][i]) {
+                  results.changed[key] = newObject[key];
+                  didChange = true;
+                }
+              }
+            }
+          }
+          else {
+            if (oldObject[key] !== newObject[key]) {
+              results.changed[key] = newObject[key];
+              didChange = true;
+            }
           }
         }
       }
@@ -1749,6 +1785,7 @@ define("router/utils",
     __exports__.slice = slice;
     __exports__.serialize = serialize;
     __exports__.getChangelist = getChangelist;
+    __exports__.coerceQueryParamsToString = coerceQueryParamsToString;
   });
 define("router", 
   ["./router/router","exports"],

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1274,6 +1274,56 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
 
   });
+
+  test("The {{link-to}} applies active class when query-param is number", function() {
+      Ember.TEMPLATES.index = Ember.Handlebars.compile(
+        "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} ");
+
+      App.IndexController = Ember.Controller.extend({
+        queryParams: ['page'],
+        page: 1,
+        pageNumber: 5
+      });
+
+      bootApplication();
+
+      shouldNotBeActive('#page-link');
+      Ember.run(router, 'handleURL', '/?index[page]=5');
+      shouldBeActive('#page-link');
+
+  });
+
+  test("The {{link-to}} applies active class when query-param is array", function() {
+      Ember.TEMPLATES.index = Ember.Handlebars.compile(
+        "{{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}} " +
+        "{{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}} " +
+        "{{#link-to (query-params pages=emptyArray) id='empty-link'}}Index{{/link-to}} "
+        );
+
+      App.IndexController = Ember.Controller.extend({
+        queryParams: ['pages'],
+        pages: [],
+        pagesArray: [1,2],
+        biggerArray: [1,2,3],
+        emptyArray: []
+      });
+
+      bootApplication();
+
+      shouldNotBeActive('#array-link');
+      Ember.run(router, 'handleURL', '/?index[pages][]=1&index[pages][]=2');
+      shouldBeActive('#array-link');
+      shouldNotBeActive('#bigger-link');
+      shouldNotBeActive('#empty-link');
+      Ember.run(router, 'handleURL', '/?index[pages][]=2&index[pages][]=1');
+      shouldNotBeActive('#array-link');
+      shouldNotBeActive('#bigger-link');
+      shouldNotBeActive('#empty-link');
+      Ember.run(router, 'handleURL', '/?index[pages][]=1&index[pages][]=2&index[pages][]=3');
+      shouldBeActive('#bigger-link');
+      shouldNotBeActive('#array-link');
+      shouldNotBeActive('#empty-link');
+  });
 }
 
 if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {


### PR DESCRIPTION
This should fix  #4118. QPs always get interpreted fromt the URL as
strings. This commit coerces numeric values into strings so when compared
against the url values they match.

This commit also depends on https://github.com/tildeio/router.js/pull/75

Because array QPs parsed from the query string will always be a
different instance from arrays passed into `query-params` helper we need
to compare arrays by there contents and not strict equality between the
arrays.
