### PR TITLE
[FEATURE fastMerge-merge-mergeIf] updated and new mergeIf method

### DIFF
--- a/features.json
+++ b/features.json
@@ -6,6 +6,7 @@
     "query-params-new": null,
     "string-humanize": null,
     "string-parameterize": null,
+    "core-merge-mergeIf-fastMerge": null,
     "ember-routing-named-substates": null,
     "ember-handlebars-caps-lookup": null,
     "ember-testing-simple-setup": null,

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -287,7 +287,6 @@ var genMergeArgs = function (args, replace) {
   @param {Object/Array} [source]* Source objects to copy properties from
   @return {Object}
 */
-
 Ember.merge = function() {
   //replace is by default true
   var args = genMergeArgs.call(this, arguments);
@@ -315,11 +314,27 @@ Ember.merge = function() {
   @param {Object/Array} [source]* Source objects to copy properties from
   @return {Object}
 */
-
 Ember.mergeIf = function() {
   //same as merge except that it sets replace to false
   var args = genMergeArgs.call(this, arguments, false);
   return merge.apply(this, args);
+};
+
+/**
+  A faster version of `Ember.merge` that accepts only two objects and does not allow deep merge.
+
+  @method fastMerge
+  @for Ember
+  @param {Object} original The object to merge into
+  @param {Object} updates The object to copy properties from
+  @return {Object}
+*/
+Ember.fastMerge = function(original, updates) {
+  for (var prop in updates) {
+    if (!updates.hasOwnProperty(prop)) { continue; }
+    original[prop] = updates[prop];
+  }
+  return original;
 };
 
 /**

--- a/packages/ember-metal/tests/core/merge_mergeif_test.js
+++ b/packages/ember-metal/tests/core/merge_mergeif_test.js
@@ -1,19 +1,60 @@
-module('Ember.merge/Ember.mergeIf');
-var expected, a, b, c, d, e,
-  reset = function () {
-    a = {name: 'Gasmi'};
-    b = {firstName: 'Aboubakr'};
-    c = {name: ''};
-    d = {
-      firstLevel: {
-        prop1: false,
-        languages: [1, 2],
-        secondLevel: {
-            prop2: 'a string'
+
+if (Ember.FEATURES.isEnabled('core-merge-mergeIf-fastMerge')) {
+  module('Ember.merge/Ember.mergeIf');
+  var expected, a, b, c, d, e,
+    reset = function () {
+      a = {name: 'Gasmi'};
+      b = {firstName: 'Aboubakr'};
+      c = {name: ''};
+      d = {
+        firstLevel: {
+          prop1: false,
+          languages: [1, 2],
+          secondLevel: {
+              prop2: 'a string'
+          }
         }
-      }
+      };
+      e = {
+        firstLevel: {
+          prop1: true,
+          languages: [3, 4],
+          secondLevel: {
+              prop1: true,
+              prop2: ''
+          }
+        }
+      };
     };
-    e = {
+  test('Ember.merge', function() {
+    reset();
+    expected = {name: 'Gasmi', firstName: 'Aboubakr'};
+    deepEqual(expected, Ember.merge(a, b), 'merges two objects');
+
+    reset();
+    expected = {
+        name: '',
+        firstName: 'Aboubakr',
+        firstLevel: {
+          prop1: false,
+          languages: [1, 2],
+          secondLevel: {
+              prop2: 'a string'
+          }
+        }
+    };
+    deepEqual(expected, Ember.merge(a, b, c, d), 'merges a list of objects submited as arguments');
+    deepEqual(expected, Ember.merge(a, [b, c, d]), 'merges a list of objects submited in array');
+    deepEqual(expected, Ember.merge(a, [b, c], d), 'merges a list of objects submited as a mix of arguments and array');
+
+    reset();
+    deepEqual(e, Ember.merge(d, e), 'by default overrides nested objects if the first parameter is not boolean');
+
+    reset();
+    deepEqual(e, Ember.merge(false, d, e), 'overrides nested objects if the first parameter is false');
+
+    reset();
+    expected = {
       firstLevel: {
         prop1: true,
         languages: [3, 4],
@@ -23,15 +64,19 @@ var expected, a, b, c, d, e,
         }
       }
     };
-  };
-test('Ember.merge', function() {
-  reset();
-  expected = {name: 'Gasmi', firstName: 'Aboubakr'};
-  deepEqual(expected, Ember.merge(a, b), 'merges two objects');
+    deepEqual(expected, Ember.merge(true, d, e), 'merges nested objects if the first parameter is true');
 
-  reset();
-  expected = {
-      name: '',
+  });
+
+  //almost the same behavior, except that in some cases keys tested as falsy with Ember.isEmpty() will not be applied
+  test('Conditional keys merge with Ember.mergeIf', function() {
+    reset();
+    expected = {name: 'Gasmi', firstName: 'Aboubakr'};
+    deepEqual(expected, Ember.merge(a, b), 'merges two objects');
+
+    reset();
+    expected = {
+      name: 'Gasmi',
       firstName: 'Aboubakr',
       firstLevel: {
         prop1: false,
@@ -40,70 +85,28 @@ test('Ember.merge', function() {
             prop2: 'a string'
         }
       }
-  };
-  deepEqual(expected, Ember.merge(a, b, c, d), 'merges a list of objects submited as arguments');
-  deepEqual(expected, Ember.merge(a, [b, c, d]), 'merges a list of objects submited in array');
-  deepEqual(expected, Ember.merge(a, [b, c], d), 'merges a list of objects submited as a mix of arguments and array');
+    };
+    deepEqual(expected, Ember.mergeIf(a, b, c, d), 'merges a list of objects submited as arguments');
+    deepEqual(expected, Ember.mergeIf(a, [b, c, d]), 'merges a list of objects submited in array');
+    deepEqual(expected, Ember.mergeIf(a, [b, c], d), 'merges a list of objects submited as a mix of arguments and array');
+    reset();
+    deepEqual(e, Ember.mergeIf(d, e), 'by default overrides nested objects if the first parameter is not boolean');
 
-  reset();
-  deepEqual(e, Ember.merge(d, e), 'by default overrides nested objects if the first parameter is not boolean');
+    reset();
+    deepEqual(e, Ember.mergeIf(false, d, e), 'overrides nested objects if the first parameter is false');
 
-  reset();
-  deepEqual(e, Ember.merge(false, d, e), 'overrides nested objects if the first parameter is false');
-
-  reset();
-  expected = {
-    firstLevel: {
-      prop1: true,
-      languages: [3, 4],
-      secondLevel: {
-          prop1: true,
-          prop2: ''
+    reset();
+    expected = {
+      firstLevel: {
+        prop1: true,
+        languages: [3, 4],
+        secondLevel: {
+            prop1: true,
+            prop2: 'a string'
+        }
       }
-    }
-  };
-  deepEqual(expected, Ember.merge(true, d, e), 'merges nested objects if the first parameter is true');
+    };
+    deepEqual(expected, Ember.mergeIf(true, d, e), 'merges nested objects if the first parameter is true');
 
-});
-
-//almost the same behavior, except that in some cases keys tested as falsy with Ember.isEmpty() will not be applied
-test('Conditional keys merge with Ember.mergeIf', function() {
-  reset();
-  expected = {name: 'Gasmi', firstName: 'Aboubakr'};
-  deepEqual(expected, Ember.merge(a, b), 'merges two objects');
-
-  reset();
-  expected = {
-    name: 'Gasmi',
-    firstName: 'Aboubakr',
-    firstLevel: {
-      prop1: false,
-      languages: [1, 2],
-      secondLevel: {
-          prop2: 'a string'
-      }
-    }
-  };
-  deepEqual(expected, Ember.mergeIf(a, b, c, d), 'merges a list of objects submited as arguments');
-  deepEqual(expected, Ember.mergeIf(a, [b, c, d]), 'merges a list of objects submited in array');
-  deepEqual(expected, Ember.mergeIf(a, [b, c], d), 'merges a list of objects submited as a mix of arguments and array');
-  reset();
-  deepEqual(e, Ember.mergeIf(d, e), 'by default overrides nested objects if the first parameter is not boolean');
-
-  reset();
-  deepEqual(e, Ember.mergeIf(false, d, e), 'overrides nested objects if the first parameter is false');
-
-  reset();
-  expected = {
-    firstLevel: {
-      prop1: true,
-      languages: [3, 4],
-      secondLevel: {
-          prop1: true,
-          prop2: 'a string'
-      }
-    }
-  };
-  deepEqual(expected, Ember.mergeIf(true, d, e), 'merges nested objects if the first parameter is true');
-
-});
+  });
+}

--- a/packages/ember-metal/tests/core/merge_mergeif_test.js
+++ b/packages/ember-metal/tests/core/merge_mergeif_test.js
@@ -1,0 +1,109 @@
+module('Ember.merge/Ember.mergeIf');
+var expected, a, b, c, d, e,
+  reset = function () {
+    a = {name: 'Gasmi'};
+    b = {firstName: 'Aboubakr'};
+    c = {name: ''};
+    d = {
+      firstLevel: {
+        prop1: false,
+        languages: [1, 2],
+        secondLevel: {
+            prop2: 'a string'
+        }
+      }
+    };
+    e = {
+      firstLevel: {
+        prop1: true,
+        languages: [3, 4],
+        secondLevel: {
+            prop1: true,
+            prop2: ''
+        }
+      }
+    };
+  };
+test('Ember.merge', function() {
+  reset();
+  expected = {name: 'Gasmi', firstName: 'Aboubakr'};
+  deepEqual(expected, Ember.merge(a, b), 'merges two objects');
+
+  reset();
+  expected = {
+      name: '',
+      firstName: 'Aboubakr',
+      firstLevel: {
+        prop1: false,
+        languages: [1, 2],
+        secondLevel: {
+            prop2: 'a string'
+        }
+      }
+  };
+  deepEqual(expected, Ember.merge(a, b, c, d), 'merges a list of objects submited as arguments');
+  deepEqual(expected, Ember.merge(a, [b, c, d]), 'merges a list of objects submited in array');
+  deepEqual(expected, Ember.merge(a, [b, c], d), 'merges a list of objects submited as a mix of arguments and array');
+
+  reset();
+  deepEqual(e, Ember.merge(d, e), 'by default overrides nested objects if the first parameter is not boolean');
+
+  reset();
+  deepEqual(e, Ember.merge(false, d, e), 'overrides nested objects if the first parameter is false');
+
+  reset();
+  expected = {
+    firstLevel: {
+      prop1: true,
+      languages: [3, 4],
+      secondLevel: {
+          prop1: true,
+          prop2: ''
+      }
+    }
+  };
+  deepEqual(expected, Ember.merge(true, d, e), 'merges nested objects if the first parameter is true');
+
+});
+
+//almost the same behavior, except that in some cases keys tested as falsy with Ember.isEmpty() will not be applied
+test('Conditional keys merge with Ember.mergeIf', function() {
+  reset();
+  expected = {name: 'Gasmi', firstName: 'Aboubakr'};
+  deepEqual(expected, Ember.merge(a, b), 'merges two objects');
+
+  reset();
+  expected = {
+    name: 'Gasmi',
+    firstName: 'Aboubakr',
+    firstLevel: {
+      prop1: false,
+      languages: [1, 2],
+      secondLevel: {
+          prop2: 'a string'
+      }
+    }
+  };
+  deepEqual(expected, Ember.mergeIf(a, b, c, d), 'merges a list of objects submited as arguments');
+  deepEqual(expected, Ember.mergeIf(a, [b, c, d]), 'merges a list of objects submited in array');
+  deepEqual(expected, Ember.mergeIf(a, [b, c], d), 'merges a list of objects submited as a mix of arguments and array');
+  reset();
+  deepEqual(e, Ember.mergeIf(d, e), 'by default overrides nested objects if the first parameter is not boolean');
+
+  reset();
+  deepEqual(e, Ember.mergeIf(false, d, e), 'overrides nested objects if the first parameter is false');
+
+  reset();
+  expected = {
+    firstLevel: {
+      prop1: true,
+      languages: [3, 4],
+      secondLevel: {
+          prop1: true,
+          prop2: 'a string'
+      }
+    }
+  };
+  deepEqual(expected, Ember.mergeIf(true, d, e), 'merges nested objects if the first parameter is true');
+
+});


### PR DESCRIPTION
Allow Ember.merge to accept multiple objects or arrays of object with a deep merge option. Ember.mergeIf has the same behavior except that it does not merge empty keys from sources.
