### PR TITLE
Make Ember.computed.uniq only add unique objects when they are first detected

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -399,11 +399,10 @@ export function uniq() {
 
       if (!instanceMeta.itemCounts[guid]) {
         instanceMeta.itemCounts[guid] = 1;
+        array.pushObject(item);
       } else {
         ++instanceMeta.itemCounts[guid];
       }
-
-      array.addObject(item);
       return array;
     },
 


### PR DESCRIPTION
The current implementation relies on `MutableEnumerable#addObject` to
decide whether to actually add the candidate object to the computed
array. This causes a walk of the accumulated array on each call to
`addedItem()`.

Since the item counts are being tracked anyhow, there is no need to call
`addObject()` except the first time it is known that the item should be
in the array.
