### PR TITLE
[BUGFIX beta] Make Ember.RenderBuffer#addClass work as expected.

### DIFF
--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -62,7 +62,7 @@ function escapeAttribute(value) {
   return string.replace(BAD_CHARS_REGEXP, escapeChar);
 }
 
-// IE 6/7 have bugs arond setting names on inputs during creation.
+// IE 6/7 have bugs around setting names on inputs during creation.
 // From http://msdn.microsoft.com/en-us/library/ie/ms536389(v=vs.85).aspx:
 // "To include the NAME attribute at run time on objects created with the createElement method, use the eTag."
 var canSetNameOnInputs = (function() {
@@ -240,7 +240,11 @@ Ember._RenderBuffer.prototype = {
   },
 
   setClasses: function(classNames) {
-    this.classes = classNames;
+    this.elementClasses = null;
+    var len = classNames.length, i;
+    for (i = 0; i < len; i++) {
+      this.addClass(classNames[i]);
+    }
   },
 
   /**
@@ -294,7 +298,7 @@ Ember._RenderBuffer.prototype = {
   },
 
   /**
-    Adds an property which will be rendered to the element.
+    Adds a property which will be rendered to the element.
 
     @method prop
     @param {String} name The name of the property
@@ -374,6 +378,7 @@ Ember._RenderBuffer.prototype = {
     if (classes) {
       buffer += ' class="' + escapeAttribute(classes.join(' ')) + '"';
       this.classes = null;
+      this.elementClasses = null;
     }
 
     if (style) {
@@ -456,6 +461,7 @@ Ember._RenderBuffer.prototype = {
     if (classes) {
       $element.attr('class', classes.join(' '));
       this.classes = null;
+      this.elementClasses = null;
     }
 
     if (style) {

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -111,6 +111,27 @@ test("handles browsers like Firefox < 11 that don't support outerHTML Issue #195
   equal(elementStub, trim(buffer.string().toLowerCase()));
 });
 
+test("resets classes after pushing the opening tag", function() {
+  var buffer = new Ember.RenderBuffer('div');
+  buffer.addClass('foo');
+  buffer.pushOpeningTag();
+  buffer.begin('div');
+  buffer.addClass('bar');
+  buffer.pushOpeningTag();
+  buffer.pushClosingTag();
+  buffer.pushClosingTag();
+  equal(buffer.string(), '<div class="foo"><div class="bar"></div></div>');
+});
+
+test("lets `setClasses` and `addClass` work together", function() {
+  var buffer = new Ember.RenderBuffer('div');
+  buffer.setClasses(['foo', 'bar']);
+  buffer.addClass('baz');
+  buffer.pushOpeningTag();
+  buffer.pushClosingTag();
+  equal(buffer.string(), '<div class="foo bar baz"></div>');
+});
+
 module("Ember.RenderBuffer - without tagName");
 
 test("It is possible to create a RenderBuffer without a tagName", function() {


### PR DESCRIPTION
RenderBuffer#addClass currently works in surprising ways, take the following example:

``` javascript
var buffer = new Ember.RenderBuffer('div')
buffer.setClasses(['foo', 'bar']);
buffer.addClass('baz'); // I'd say I'm adding 'baz' to the two classes I've set before
buffer.pushOpeningTag();
buffer.pushClosingTag();
```

will produce:

``` html
<div class="baz"></div>
```

after this commit:

``` html
<div class="foo bar baz"></div>
```

Another example:

``` javascript
var buffer = new Ember.RenderBuffer('div')
buffer.addClass('foo')
buffer.pushOpeningTag();
buffer.pushClosingTag();
buffer.begin('div').addClass('bar');
buffer.pushOpeningTag();
buffer.pushClosingTag();
```

will produce:

``` html
<div class="foo"></div><div class="foo bar"></div>
```

after this commit:

``` html
<div class="foo"></div><div class="bar"></div>
```
