### PR TITLE
Allow enumerable/any to match undefined as value (issue #4139)

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -617,11 +617,23 @@ Ember.Enumerable = Ember.Mixin.create({
     @return {Boolean} `true` if the passed function returns `true` for any item
   */
   any: function(callback, target) {
-    var found = this.find(function(x, idx, i) {
-      return !!callback.call(target, x, idx, i);
-    });
+    var len     = get(this, 'length'),
+        context = popCtx(),
+        found   = false,
+        last    = null,
+        next, idx;
 
-    return typeof found !== 'undefined';
+    if (target === undefined) { target = null; }
+
+    for (idx = 0; idx < len && !found; idx++) {
+      next  = this.nextObject(idx, last, context);
+      found = callback.call(target, next, idx, this);
+      last  = next;
+    }
+
+    next = last = null;
+    context = pushCtx(context);
+    return found;
   },
 
   /**

--- a/packages/ember-runtime/tests/suites/enumerable/any.js
+++ b/packages/ember-runtime/tests/suites/enumerable/any.js
@@ -31,6 +31,31 @@ suite.test('any should stop invoking when you return true', function() {
   deepEqual(found, ary.slice(0,-2), 'items passed during any() should match');
 });
 
+
+suite.test('any should return true if any object matches the callback', function() {
+  var obj = Ember.A([0, 1, 2]), result;
+
+  result = obj.any(function(i) { return !!i; });
+  equal(result, true, 'return value of obj.any');
+});
+
+
+suite.test('any should return false if no object matches the callback', function() {
+  var obj = Ember.A([0, null, false]), result;
+
+  result = obj.any(function(i) { return !!i; });
+  equal(result, false, 'return value of obj.any');
+});
+
+
+suite.test('any should produce correct results even if the matching element is undefined', function() {
+  var obj = Ember.A([undefined]), result;
+
+  result = obj.any(function(i) { return true; });
+  equal(result, true, 'return value of obj.any');
+});
+
+
 suite.test('any should be aliased to some', function() {
   var obj = this.newObject(),
       ary = this.toArray(obj),


### PR DESCRIPTION
This change will make

```
Ember.A([undefined, 2, 3]).any(function (o) { return true; })
```

return "true" instead of "false" (see issue #4139).
