### PR TITLE
added Ember.ajax

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -4,7 +4,7 @@ distros = {
   "runtime"           => %w(ember-metal rsvp container ember-runtime),
   "template-compiler" => %w(ember-handlebars-compiler),
   "data-deps"         => %w(ember-metal rsvp container ember-runtime),
-  "full"              => %w(ember-metal rsvp container ember-runtime ember-views metamorph handlebars ember-handlebars-compiler ember-handlebars ember-routing ember-application ember-extension-support)
+  "full"              => %w(ember-metal rsvp container ember-runtime ember-views metamorph handlebars ember-handlebars-compiler ember-handlebars ember-routing ember-application ember-extension-support ic-ajax)
 }
 
 class AddMicroLoader < Rake::Pipeline::Filter

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -132,3 +132,10 @@ for a detailed explanation.
   the transition was aborted/redirected within the same run loop.
 
   Added in [#4122](https://github.com/emberjs/ember.js/pull/4122).
+
+* `ember-application-ajax`
+  Incorporates https://github.com/instructure/ic-ajax as an internal
+  vendored package, and makes it available as `Ember.ajax`.
+
+  Added in [#4148](https://github.com/emberjs/ember.js/pull/4148)
+

--- a/features.json
+++ b/features.json
@@ -15,7 +15,8 @@
     "composable-computed-properties": true,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-metal-is-blank": null,
-    "ember-eager-url-update": null
+    "ember-eager-url-update": null,
+    "ember-application-ajax": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-application/lib/ext.js
+++ b/packages/ember-application/lib/ext.js
@@ -1,1 +1,2 @@
 require('ember-application/ext/controller');
+require('ember-application/ext/ajax');

--- a/packages/ember-application/lib/ext/ajax.js
+++ b/packages/ember-application/lib/ext/ajax.js
@@ -1,0 +1,7 @@
+/*globals ic*/
+
+if (Ember.FEATURES.isEnabled("ember-application-ajax")) {
+  require('ic-ajax');
+
+  Ember.ajax = ic.ajax;
+}

--- a/packages/ic-ajax/lib/main.js
+++ b/packages/ic-ajax/lib/main.js
@@ -1,0 +1,126 @@
+/*!
+ * ic-ajax
+ *
+ * - (c) 2013 Instructure, Inc
+ * - please see license at https://github.com/instructure/ic-ajax/blob/master/LICENSE
+ * - inspired by discourse ajax: https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/mixins/ajax.js#L19
+ */
+
+;(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['ember'], function(Ember) { return factory(Ember); });
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require('ember'));
+  } else {
+    root.ic = root.ic || {};
+    root.ic.ajax = factory(Ember);
+  }
+}(this, function(Ember) {
+
+  /*
+   * jQuery.ajax wrapper, supports the same signature except providing
+   * `success` and `error` handlers will throw an error (use promises instead)
+   * and it resolves only the response (no access to jqXHR or textStatus).
+   */
+
+  var ajax = function() {
+    return ajax.raw.apply(null, arguments).then(function(result) {
+      return result.response;
+    });
+  };
+
+  /*
+   * Same as `ajax` except it resolves an object with `{response, textStatus,
+   * jqXHR}`, useful if you need access to the jqXHR object for headers, etc.
+   */
+
+  ajax.raw = function() {
+    return makePromise(parseArgs.apply(null, arguments));
+  };
+
+  /*
+   * Defines a fixture that will be used instead of an actual ajax
+   * request to a given url. This is useful for testing, allowing you to
+   * stub out responses your application will send without requiring
+   * libraries like sinon or mockjax, etc.
+   *
+   * For example:
+   *
+   *    ajax.defineFixture('/self', {
+   *      response: { firstName: 'Ryan', lastName: 'Florence' },
+   *      textStatus: 'success'
+   *      jqXHR: {}
+   *    });
+   *
+   * @param {String} url
+   * @param {Object} fixture
+   */
+  ajax.defineFixture = function(url, fixture) {
+    ajax.FIXTURES = ajax.FIXTURES || {};
+    ajax.FIXTURES[url] = fixture;
+  };
+
+  /*
+   * Looks up a fixture by url.
+   *
+   * @param {String} url
+   */
+
+  ajax.lookupFixture = function(url) {
+    return ajax.FIXTURES && ajax.FIXTURES[url];
+  };
+
+  function makePromise(settings) {
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      var fixture = ajax.lookupFixture(settings.url);
+      if (fixture) {
+        return Ember.run(null, resolve, fixture);
+      }
+      settings.success = makeSuccess(resolve, reject);
+      settings.error = makeError(resolve, reject);
+      Ember.$.ajax(settings);
+    });
+  };
+
+  function parseArgs() {
+    var settings = {};
+    if (arguments.length === 1) {
+      if (typeof arguments[0] === "string") {
+        settings.url = arguments[0];
+      } else {
+        settings = arguments[0];
+      }
+    } else if (arguments.length === 2) {
+      settings = arguments[1];
+      settings.url = arguments[0];
+    }
+    if (settings.success || settings.error) {
+      throw new Error("ajax should use promises, received 'success' or 'error' callback");
+    }
+    return settings;
+  }
+
+  function makeSuccess(resolve, reject) {
+    return function(response, textStatus, jqXHR) {
+      Ember.run(null, resolve, {
+        response: response,
+        textStatus: textStatus,
+        jqXHR: jqXHR
+      });
+    }
+  }
+
+  function makeError(resolve, reject) {
+    return function(jqXHR, textStatus, errorThrown) {
+      Ember.run(null, reject, {
+        jqXHR: jqXHR,
+        textStatus: textStatus,
+        errorThrown: errorThrown
+      });
+    };
+  }
+
+  return ajax;
+
+}));
+


### PR DESCRIPTION
I don't really get how this all works. Please tell me what I need to change.
1. Where should I assign Ember.ajax = ic.ajax?
2. How do I document this as Ember.ajax, and make sure it shows up in the docs for the website, etc?
3. do we care that the global `ic` is floating around?
4. what does the package.json need to look like in packages/ic-ajax/package.json?
5. when will the world agree on javascript module formats? :love_letter: 
6. should this be behind a feature flag?
