### PR TITLE
Added documentation for controllerName property on Route

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -531,6 +531,15 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
   },
 
   /**
+    A hook to make the route use a specific controller
+
+    @property controllerName
+    @type String
+    @default null
+   */
+  controllerName: null,
+
+  /**
     This hook is the entry point for router.js
 
     @private


### PR DESCRIPTION
So I was trying to reuse a controller in multiple routes, and tucked away in the setup method on the routes I found the undocumented and very useful controllerName property I could use for just that.
