### PR TITLE
Allow reuse of Application.buildContainer without full Application.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -725,18 +725,22 @@ Ember.Application.reopenClass({
 
     Ember.Container.defaultContainer = new DeprecatedContainer(container);
 
+    if(namespace) {
+      container.resolver  = resolverFor(namespace);
+      container.normalize = container.resolver.normalize;
+      container.describe  = container.resolver.describe;
+      container.makeToString = container.resolver.makeToString;
+
+      container.register('application:main', namespace, { instantiate: false });
+      container.injection('controller', 'namespace', 'application:main');
+    }
+
     container.set = Ember.set;
-    container.resolver  = resolverFor(namespace);
-    container.normalize = container.resolver.normalize;
-    container.describe  = container.resolver.describe;
-    container.makeToString = container.resolver.makeToString;
 
     container.optionsForType('component', { singleton: false });
     container.optionsForType('view', { singleton: false });
     container.optionsForType('template', { instantiate: false });
     container.optionsForType('helper', { instantiate: false });
-
-    container.register('application:main', namespace, { instantiate: false });
 
     container.register('controller:basic', Ember.Controller, { instantiate: false });
     container.register('controller:object', Ember.ObjectController, { instantiate: false });
@@ -752,7 +756,6 @@ Ember.Application.reopenClass({
     container.register('location:none', Ember.NoneLocation);
 
     container.injection('controller', 'target', 'router:main');
-    container.injection('controller', 'namespace', 'application:main');
 
     container.injection('route', 'router', 'router:main');
 


### PR DESCRIPTION
This will allow usage of `Ember.Application.buildContainer` without needing providing a namespace (or an Ember.Application instance).

The primary impetus of this is to prevent from having to create one-off container look-alikes for unit testing. This also allows us to consolidate the knowledge of what things are registered and setup by default to a single
place.

This will be directly usable from within EAK (see [isolatedContainer](https://github.com/stefanpenner/ember-app-kit/blob/master/tests/helpers/isolated_container.js#L4-L9)) for example.
