### PR TITLE
improve performance of Ember.guidFor and Ember.generateGuide on

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -18,9 +18,9 @@ var o_defineProperty = Ember.platform.defineProperty,
     o_create = Ember.create,
     // Used for guid generation...
     GUID_KEY = '__ember'+ (+ new Date()),
-    uuid         = 0,
     numberCache  = [],
-    stringCache  = {};
+    stringCache  = {},
+    uuid = 0;
 
 var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
@@ -68,8 +68,12 @@ Ember.generateGuid = function generateGuid(obj, prefix) {
   if (!prefix) prefix = Ember.GUID_PREFIX;
   var ret = (prefix + (uuid++));
   if (obj) {
-    GUID_DESC.value = ret;
-    o_defineProperty(obj, GUID_KEY, GUID_DESC);
+    if (obj[GUID_KEY] === null) {
+      obj[GUID_KEY] = ret;
+    } else {
+      GUID_DESC.value = ret;
+      o_defineProperty(obj, GUID_KEY, GUID_DESC);
+    }
   }
   return ret;
 };
@@ -116,9 +120,14 @@ Ember.guidFor = function guidFor(obj) {
       if (obj[GUID_KEY]) return obj[GUID_KEY];
       if (obj === Object) return '(Object)';
       if (obj === Array)  return '(Array)';
-      ret = 'ember'+(uuid++);
-      GUID_DESC.value = ret;
-      o_defineProperty(obj, GUID_KEY, GUID_DESC);
+      ret = 'ember' + (uuid++);
+
+      if (obj[GUID_KEY] === null) {
+        obj[GUID_KEY] = ret;
+      } else {
+        GUID_DESC.value = ret;
+        o_defineProperty(obj, GUID_KEY, GUID_DESC);
+      }
       return ret;
   }
 };

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -37,6 +37,13 @@ var undefinedDescriptor = {
   value: undefined
 };
 
+var nullDescriptor = {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+  value: null
+};
+
 function makeCtor() {
 
   // Note: avoid accessing any properties on the object since it makes the
@@ -49,7 +56,7 @@ function makeCtor() {
     if (!wasApplied) {
       Class.proto(); // prepare prototype...
     }
-    o_defineProperty(this, GUID_KEY, undefinedDescriptor);
+    o_defineProperty(this, GUID_KEY, nullDescriptor);
     o_defineProperty(this, '__nextSuper', undefinedDescriptor);
     var m = meta(this), proto = m.proto;
     m.proto = this;


### PR DESCRIPTION
Ember.Objects

Ember's guidKey uses defineProperty so that it is not enumerable,
this is a great idea, but can cost be a hard hit. Luckily though,
we pre-shape all ember objects to have a GUID_KEY slot. Unfortunately,
in guidFor and generateGuid we redefine the property. Not only is this
wasteful, but Object.defineProperty is incredibly costly.

Some micro-benchmarks:
- http://jsperf.com/generate-guid-key
- http://jsperf.com/faster-guid-for-test

more to come.

The cost of `guidFor` is about 5 - 10 times faster on `Ember.Object`s, and can still be improved.

``` js
// super scientific quick test.
var pool = []; for(var i =0; i < 10000; i++) { pool.push(Ember.Object.create()); }

console.time('guid');

for (var p = 0; p < pool.length; p++) {
  Ember.guidFor(pool[p]);
}

console.timeEnd('guid');
```

and the cost to Object.create seems essentially 0. Their is a slight memory usage increase for never guid'd Ember.Object's as they store their guid Number.

If we continue to need guid's I wonder if we should always store them merely as the integer value.

related, @ebryn is working on some directions which mitigate the need for defineProperty on some objects (like views). If we can drop [these](https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/core_object.js#L52-L53) safely across the board it would be a large win.
