### PR TITLE
Add Ember.setupForTesting.

### DIFF
--- a/packages/ember-testing/lib/ext.js
+++ b/packages/ember-testing/lib/ext.js
@@ -1,0 +1,18 @@
+/**
+  Sets Ember up for testing. This is useful to perform
+  basic setup steps in order to unit test.
+  
+  Use `App.setupForTesting` to perform integration tests (full
+  application testing).
+
+  @method setupForTesting
+  @namespace Ember
+*/
+Ember.setupForTesting = function() {
+  Ember.testing = true;
+
+  // if adapter is not manually set default to QUnit
+  if (!Ember.Test.adapter) {
+    Ember.Test.adapter = Ember.Test.QUnitAdapter.create();
+  }
+};

--- a/packages/ember-testing/lib/main.js
+++ b/packages/ember-testing/lib/main.js
@@ -1,5 +1,6 @@
 require('ember-application');
 require('ember-routing');
+require('ember-testing/ext');
 require('ember-testing/test');
 require('ember-testing/initializers');
 require('ember-testing/support');

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -351,18 +351,13 @@ Ember.Application.reopen({
     @method setupForTesting
   */
   setupForTesting: function() {
-    Ember.testing = true;
+    Ember.setupForTesting();
 
     this.testing = true;
 
     this.Router.reopen({
       location: 'none'
     });
-
-    // if adapter is not manually set default to QUnit
-    if (!Ember.Test.adapter) {
-       Ember.Test.adapter = Ember.Test.QUnitAdapter.create();
-    }
 
     if (Ember.FEATURES.isEnabled('ember-testing-simple-setup')){
       this.testingSetup = true;


### PR DESCRIPTION
This makes it somewhat easier to unit-test Ember. It also gives us a good
place to add additional customization (as opposed to advocating simply setting
`Ember.testing = true`).
