### PR TITLE
Use the new async expectDeprecation helper

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -29,6 +29,7 @@
         "minispade",
         "expectAssertion",
         "expectDeprecation",
+        "expectNoDeprecation",
 
         // A safe subset of "browser:true":
         "window", "location", "document", "XMLSerializer",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 48ce37b50c2f59658ba70824a8b692bf9d690b9e
+  revision: 3d2336afe68ed638bfa94b4080c52342ffc59737
   branch: master
   specs:
     ember-dev (0.1)

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -44,10 +44,11 @@ test('container lookup is normalized', function() {
 });
 
 test('Ember.Container.defaultContainer is the same as the Apps container, but emits deprecation warnings', function() {
+  expectDeprecation(/Using the defaultContainer is no longer supported./);
   var routerFromContainer = locator.lookup('router:main'),
-    routerFromDefaultCOntainer = Ember.Container.defaultContainer.lookup('router:main');
+    routerFromDefaultContainer = Ember.Container.defaultContainer.lookup('router:main');
 
-  equal(routerFromContainer, routerFromDefaultCOntainer, 'routers from both containers are equal');
+  equal(routerFromContainer, routerFromDefaultContainer, 'routers from both containers are equal');
 });
 
 test('registered entities can be looked up later', function() {

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -369,12 +369,14 @@ test("it supports {{itemViewClass=}}", function() {
   assertText(view, "Steve HoltAnnabelle");
 });
 
-test("it supports {{itemViewClass=}} with tagName", function() {
+test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function() {
   Ember.run(function() { view.destroy(); }); // destroy existing view
   view = Ember.View.create({
       template: templateFor('{{each view.people itemViewClass="MyView" tagName="ul"}}'),
       people: people
   });
+
+  expectDeprecation(/Supplying a tagName to Metamorph views is unreliable and is deprecated./);
 
   append(view);
 

--- a/packages/ember-handlebars/tests/helpers/template_test.js
+++ b/packages/ember-handlebars/tests/helpers/template_test.js
@@ -18,13 +18,15 @@ module("Support for {{template}} helper", {
   }
 });
 
-test("should render other templates via the container", function() {
+test("should render other templates via the container (DEPRECATED)", function() {
   container.register('template:sub_template_from_container', Ember.Handlebars.compile('sub-template'));
 
   view = Ember.View.create({
     container: container,
     template: Ember.Handlebars.compile('This {{template "sub_template_from_container"}} is pretty great.')
   });
+
+  expectDeprecation(/The `template` helper has been deprecated in favor of the `partial` helper./);
 
   Ember.run(function() {
     view.appendTo('#qunit-fixture');
@@ -33,7 +35,7 @@ test("should render other templates via the container", function() {
   equal(Ember.$.trim(view.$().text()), "This sub-template is pretty great.");
 });
 
-test("should use the current view's context", function() {
+test("should use the current view's context (DEPRECATED)", function() {
   container.register('template:person_name', Ember.Handlebars.compile("{{firstName}} {{lastName}}"));
 
   view = Ember.View.create({
@@ -44,6 +46,8 @@ test("should use the current view's context", function() {
     firstName: 'Kris',
     lastName: 'Selden'
   }));
+
+  expectDeprecation(/The `template` helper has been deprecated in favor of the `partial` helper./);
 
   Ember.run(function() {
     view.appendTo('#qunit-fixture');

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -16,7 +16,9 @@ test("should not create nested objects if writable is false", function() {
   var obj = {};
 
   ok(!Ember.meta(obj).foo, "precond - foo property on meta does not yet exist");
-  equal(Ember.metaPath(obj, ['foo', 'bar', 'baz'], false), undefined, "should return undefined when writable is false and doesn't already exist") ;
+  expectDeprecation(function(){
+    equal(Ember.metaPath(obj, ['foo', 'bar', 'baz'], false), undefined, "should return undefined when writable is false and doesn't already exist");
+  });
   equal(Ember.meta(obj).foo, undefined, "foo property is not created");
 });
 
@@ -25,7 +27,9 @@ test("should create nested objects if writable is true", function() {
 
   ok(!Ember.meta(obj).foo, "precond - foo property on meta does not yet exist");
 
-  equal(typeof Ember.metaPath(obj, ['foo', 'bar', 'baz'], true), "object", "should return hash when writable is true and doesn't already exist") ;
+  expectDeprecation(function(){
+    equal(typeof Ember.metaPath(obj, ['foo', 'bar', 'baz'], true), "object", "should return hash when writable is true and doesn't already exist");
+  });
   ok(Ember.meta(obj).foo.bar.baz['bat'] = true, "can set a property on the newly created hash");
 });
 

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -763,6 +763,8 @@ if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
 
     appendView();
 
+    expectDeprecation(/Action handlers implemented directly on controllers are deprecated/);
+
     view.$('button').trigger('click');
 
     ok(eventHandlerWasCalled, "the action was called");

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -457,7 +457,7 @@ test("{{render}} works with slash notation", function() {
   equal(container.lookup('controller:blog.post'), renderedView.get('controller'), 'rendered with correct controller');
 });
 
-test("Using quoteless templateName is deprecated", function(){
+test("Using quoteless templateName works properly (DEPRECATED)", function(){
   var template = '<h1>HI</h1>{{render home}}';
   var controller = Ember.Controller.extend({container: container});
   view = Ember.View.create({
@@ -467,21 +467,7 @@ test("Using quoteless templateName is deprecated", function(){
 
   Ember.TEMPLATES['home'] = compile("<p>BYE</p>");
 
-  expectDeprecation(function(){
-    appendView(view);
-  }, "Using a quoteless parameter with {{render}} is deprecated. Please update to quoted usage '{{render \"home\"}}.");
-});
-
-test("Using quoteless templateName works properly", function(){
-  var template = '<h1>HI</h1>{{render home}}';
-  var controller = Ember.Controller.extend({container: container});
-  view = Ember.View.create({
-    controller: controller.create(),
-    template: Ember.Handlebars.compile(template)
-  });
-
-  Ember.TEMPLATES['home'] = compile("<p>BYE</p>");
-
+  expectDeprecation("Using a quoteless parameter with {{render}} is deprecated. Please update to quoted usage '{{render \"home\"}}.");
   appendView(view);
 
   equal(view.$('p:contains(BYE)').length, 1, "template was rendered");

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -122,7 +122,7 @@ module('Ember.Controller deprecations');
 
 if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
   test("Action can be handled by method directly on controller (DEPRECATED)", function() {
-    expect(1);
+    expectDeprecation(/Action handlers implemented directly on controllers are deprecated/);
     var TestController = Ember.Controller.extend({
       poke: function() {
         ok(true, 'poked');

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -67,6 +67,12 @@ test("Lowercase namespaces should be deprecated", function() {
   expectDeprecation(function(){
     lookup.namespaceC.toString();
   }, "Namespaces should not begin with lowercase.");
+
+  expectDeprecation(function(){
+    Ember.run(function() {
+      lookup.namespaceC.destroy();
+    });
+  }, "Namespaces should not begin with lowercase.");
 });
 
 test("A namespace can be assigned a custom name", function() {

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -24,6 +24,7 @@ test("The controller (target of `action`) of an Ember.Component is itself", func
 });
 
 test("A templateName specified to a component is moved to the layoutName", function(){
+  expectDeprecation(/Do not specify templateName on a Component, use layoutName instead/);
   component = Ember.Component.extend({
     templateName: 'blah-blah'
   }).create();
@@ -32,6 +33,7 @@ test("A templateName specified to a component is moved to the layoutName", funct
 });
 
 test("A template specified to a component is moved to the layout", function(){
+  expectDeprecation(/Do not specify template on a Component, use layout instead/);
   component = Ember.Component.extend({
     template: 'blah-blah'
   }).create();
@@ -56,20 +58,11 @@ test("A templateName specified to a component is deprecated", function(){
 });
 
 test("Specifying both templateName and layoutName to a component is NOT deprecated", function(){
-  expect(0);
-
-  Ember.ENV.RAISE_ON_DEPRECATION = true;
-
-  try {
-    component = Ember.Component.extend({
-      templateName: 'blah-blah',
-      layoutName: 'hum-drum'
-    }).create();
-  } catch (e) {
-    ok(false, "deprecation should not be thrown");
-  }
-
-  Ember.ENV.RAISE_ON_DEPRECATION = false;
+  expectNoDeprecation();
+  component = Ember.Component.extend({
+    templateName: 'blah-blah',
+    layoutName: 'hum-drum'
+  }).create();
 });
 
 module("Ember.Component - Actions", {

--- a/packages/ember-views/tests/views/view/actions_test.js
+++ b/packages/ember-views/tests/views/view/actions_test.js
@@ -22,7 +22,8 @@ test("Action can be handled by a function on actions object", function() {
 
 if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
   test("Action can be handled by a function on the view (DEPRECATED)", function() {
-    expect(1);
+    expect(2);
+    expectDeprecation(/Action handlers implemented directly on views are deprecated/);
     view = Ember.View.extend({
       poke: function() {
         ok(true, 'poked');

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -76,9 +76,11 @@ test("If a component is registered, it is used", function() {
 });
 
 
-test("Late-registered components can be rendered with custom `template` property", function() {
+test("Late-registered components can be rendered with custom `template` property (DEPRECATED)", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>there goes {{my-hero}}</div>");
+
+  expectDeprecation(/Do not specify template on a Component/);
 
   boot(function() {
     container.register('component:my-hero', Ember.Component.extend({
@@ -149,11 +151,13 @@ test("Component lookups should take place on components' subcontainers", functio
   });
 });
 
-test("Assigning templateName to a component should setup the template as a layout", function(){
-  expect(1);
+test("Assigning templateName to a component should setup the template as a layout (DEPRECATED)", function(){
+  expect(2);
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>");
   Ember.TEMPLATES['foo-bar-baz'] = compile("{{text}}-{{yield}}");
+
+  expectDeprecation(/Do not specify templateName on a Component/);
 
   boot(function() {
     container.register('controller:application', Ember.Controller.extend({

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1138,6 +1138,7 @@ asyncTest("Events are triggered on the current state when defined in `events` ob
     "<a {{action showStuff content}}>{{name}}</a>"
   );
 
+  expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
@@ -1176,6 +1177,7 @@ asyncTest("Events defined in `events` object are triggered on the current state 
     "<a {{action showStuff content}}>{{name}}</a>"
   );
 
+  expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
@@ -1302,6 +1304,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
 
     container.register('controller:home', controller);
 
+    expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
     bootApplication();
 
     var actionId = Ember.$("#qunit-fixture a").data("ember-action");
@@ -2715,10 +2718,12 @@ test("Route model hook finds the same model as a manual find", function() {
   equal(App.Post, Post);
 });
 
-test("Can register an implementation via Ember.Location.registerImplementation", function(){
+test("Can register an implementation via Ember.Location.registerImplementation (DEPRECATED)", function(){
   var TestLocation = Ember.NoneLocation.extend({
     implementation: 'test'
   });
+
+  expectDeprecation(/Using the Ember.Location.registerImplementation is no longer supported/);
 
   Ember.Location.registerImplementation('test', TestLocation);
 


### PR DESCRIPTION
This updates ember-dev to provide us the [new expectDeprecation helper](https://github.com/emberjs/ember-dev/pull/123), then updates many places in the test suite to use that helper. A test run with this change significantly lowers the number of deprecations during test:

![](https://api.monosnap.com/image/download?id=Vw9jHg8PeBmqhgRwXouIaYDcTsPRQw)
