### PR TITLE
[FEATURE ember-views-bindable-attributes]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -158,3 +158,12 @@ for a detailed explanation.
   be fired.
 
   Added in [#3936](https://github.com/emberjs/ember.js/pull/3936)
+
+* `ember-views-bindable-attributes`
+  Allows setting up observers for binding to attributes only if the
+  property is present at the time of the first render. This enables us
+  to allow binding to most of the HTML5 attributes without the
+  performance penalty that you would get with `attributeBindings` alone.
+
+  Added in [#4170](https://github.com/emberjs/ember.js/pull/4170).
+

--- a/features.json
+++ b/features.json
@@ -17,7 +17,8 @@
     "ember-metal-is-blank": true,
     "ember-eager-url-update": true,
     "ember-routing-auto-location": null,
-    "ember-routing-bound-action-name": null
+    "ember-routing-bound-action-name": null,
+    "ember-views-bindable-attributes": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -31,6 +31,7 @@ Ember.TextArea = Ember.Component.extend(Ember.TextSupport, {
 
   tagName: "textarea",
   attributeBindings: ['rows', 'cols', 'name'],
+  bindableAttributes: ['selectionEnd', 'selectionStart', 'wrap'],
   rows: null,
   cols: null,
 

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -32,6 +32,12 @@ Ember.TextField = Ember.Component.extend(Ember.TextSupport, {
   classNames: ['ember-text-field'],
   tagName: "input",
   attributeBindings: ['type', 'value', 'size', 'pattern', 'name', 'min', 'max'],
+  bindableAttributes: ['accept', 'autocomplete', 'autosave', 'formaction',
+                       'formenctype', 'formmethod', 'formnovalidate', 'formtarget',
+                       'height', 'inputmode', 'list', 'multiple', 'pattern',
+                       'step', 'width'],
+
+
 
   /**
     The `value` attribute of the input element. As the user inputs text, this

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -14,13 +14,15 @@ var get = Ember.get, set = Ember.set;
   @class TextSupport
   @namespace Ember
   @uses Ember.TargetActionSupport
+  @uses Ember.BindableAttributesMixin
   @extends Ember.Mixin
   @private
 */
-Ember.TextSupport = Ember.Mixin.create(Ember.TargetActionSupport, {
+Ember.TextSupport = Ember.Mixin.create(Ember.TargetActionSupport, Ember.BindableAttributesMixin, {
   value: "",
 
   attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex', 'readonly'],
+  bindableAttributes: ['autofocus', 'form', 'selectionDirection', 'spellcheck', 'required'],
   placeholder: null,
   disabled: false,
   maxlength: null,

--- a/packages/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages/ember-handlebars/tests/controls/text_area_test.js
@@ -20,18 +20,27 @@ function destroy(object) {
   });
 }
 
+function setupTextArea(controller, template) {
+  if (template === undefined) {
+    template = controller;
+    controller = {};
+  }
+
+  textArea = Ember.View.extend({
+    controller: controller,
+    template: compile(template)
+  }).create();
+
+  append();
+}
+
 module("{{textarea}}", {
   setup: function() {
     controller = {
       val: 'Lorem ipsum dolor'
     };
 
-    textArea = Ember.View.extend({
-      controller: controller,
-      template: compile('{{textarea disabled=disabled value=val}}')
-    }).create();
-
-    append();
+    setupTextArea(controller, '{{textarea disabled=disabled value=val}}');
   },
 
   teardown: function() {
@@ -54,6 +63,20 @@ test("Should bind its contents to the specified value", function() {
   set(controller, 'val', "sit amet");
   equal(textArea.$('textarea').val(), "sit amet", "The new contents are included");
 });
+
+if (Ember.FEATURES.isEnabled('ember-views-bindable-attributes')) {
+  module("{{textarea}} - with bindableAttributes", {
+    teardown: function() {
+      destroy(textArea);
+    }
+  });
+
+  test("should add attributes for any bindableAttributes that are passed to the {{textarea}} helper", function() {
+    setupTextArea('{{textarea autofocus=true}}');
+
+    equal(textArea.$('textarea').attr('autofocus'), 'autofocus', 'has the bindableAttribute');
+  });
+}
 
 module("Ember.TextArea", {
   setup: function() {

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -17,6 +17,20 @@ function destroy(view) {
   });
 }
 
+function setupTextField(controller, template) {
+  if (template === undefined) {
+    template = controller;
+    controller = {};
+  }
+
+  textField = Ember.View.extend({
+    controller: controller,
+    template: compile(template)
+  }).create();
+
+  append();
+}
+
 var controller;
 
 module("{{input type='text'}}", {
@@ -30,12 +44,7 @@ module("{{input type='text'}}", {
       tab: 5
     };
 
-    textField = Ember.View.extend({
-      controller: controller,
-      template: compile('{{input type="text" disabled=disabled value=val placeholder=place name=name maxlength=max size=size tabindex=tab}}')
-    }).create();
-
-    append();
+    setupTextField(controller, '{{input type="text" disabled=disabled value=val placeholder=place name=name maxlength=max size=size tabindex=tab}}');
   },
 
   teardown: function() {
@@ -97,14 +106,7 @@ test("input tabindex is updated when setting tabindex property of view", functio
 
 module("{{input type='text'}} - static values", {
   setup: function() {
-    controller = {};
-
-    textField = Ember.View.extend({
-      controller: controller,
-      template: compile('{{input type="text" disabled=true value="hello" placeholder="Enter some text" name="some-name" maxlength=30 size=30 tabindex=5}}')
-    }).create();
-
-    append();
+    setupTextField('{{input type="text" disabled=true value="hello" placeholder="Enter some text" name="some-name" maxlength=30 size=30 tabindex=5}}');
   },
 
   teardown: function() {
@@ -146,14 +148,7 @@ test("input tabindex is updated when setting tabindex property of view", functio
 
 module("{{input}} - default type", {
   setup: function() {
-    controller = {};
-
-    textField = Ember.View.extend({
-      controller: controller,
-      template: compile('{{input}}')
-    }).create();
-
-    append();
+    setupTextField('{{input}}');
   },
 
   teardown: function() {
@@ -164,6 +159,20 @@ module("{{input}} - default type", {
 test("should have the default type", function() {
   equal(textField.$('input').attr('type'), 'text', "Has a default text type");
 });
+
+if (Ember.FEATURES.isEnabled('ember-views-bindable-attributes')) {
+  module("{{input}} - with bindableAttributes", {
+    teardown: function() {
+      destroy(textField);
+    }
+  });
+
+  test("should add attributes for any bindableAttributes that are passed to the {{input}} helper", function() {
+    setupTextField('{{input autofocus=true}}');
+
+    equal(textField.$('input').attr('autofocus'), 'autofocus', 'has the bindableAttribute');
+  });
+}
 
 module("Ember.TextField", {
   setup: function() {

--- a/packages/ember-views/lib/mixins.js
+++ b/packages/ember-views/lib/mixins.js
@@ -1,1 +1,2 @@
 require("ember-views/mixins/view_target_action_support");
+require("ember-views/mixins/bindable_attributes_mixin");

--- a/packages/ember-views/lib/mixins/bindable_attributes_mixin.js
+++ b/packages/ember-views/lib/mixins/bindable_attributes_mixin.js
@@ -1,0 +1,80 @@
+var get = Ember.get,
+    set = Ember.set;
+var a_forEach = Ember.EnumerableUtils.forEach;
+/**
+
+  `bindableAttributes` are used to allow certain attributes to be bound based
+  on whether they are present on the view at the time it is rendered. This means
+  that we do not setup property observers for any properties that do not exist
+  at the time the view is initially rendered.
+
+  Unlike the standard `attributeBindings` no observers are setup for properties
+  that do not initially exist.
+
+  @class BindableAttributesMixin
+  @namespace Ember
+  @extends Ember.Mixin
+  @private
+*/
+Ember.BindableAttributesMixin = Ember.Mixin.create({
+  concatenatedProperties: ['bindableAttributes'],
+
+  /**
+    A list of the properties that will be setup as bound attributes
+    if they are provided to the object at creation time.
+
+    @property bindableAttributes
+  */
+  bindableAttributes: [],
+
+  /**
+    Used to keep track of the `bindableAttributes` that existed at the
+    time of the first `render`.
+
+    @property _appliedBindableAttributes
+    @private
+  */
+  _appliedBindableAttributes: null,
+
+  /**
+    Used to determine the list of attributes to setup binding for based on
+    `bindableAttributes`. Any property in `bindableAttributes` that
+    exists on this instance will be added to `_appliedBindableAttributes`.
+
+    Please note that this is only called upon the first render. This is so that
+    we do not need to check every `bindableAttribute` on every render call.
+
+    @method _setupBindableAttributes
+    @private
+  */
+  _setupBindableAttributes: function(){
+    var bindableAttributes = get(this, 'bindableAttributes');
+
+    this._appliedBindableAttributes = [];
+
+    a_forEach(bindableAttributes, function(binding) {
+      var split = binding.split(':'),
+          property = split[0],
+          attributeName = split[1] || property;
+
+      if (get(this, attributeName) !== undefined) {
+        this._appliedBindableAttributes.push(binding);
+      }
+    }, this);
+  },
+
+  applyAttributesToBuffer: function(buffer) {
+    this._super.apply(this, arguments);
+
+    if (Ember.FEATURES.isEnabled('ember-views-bindable-attributes')) {
+      if (this._appliedBindableAttributes === null) {
+        this._setupBindableAttributes();
+      }
+
+      if (this._appliedBindableAttributes.length) {
+        // setup bindings only if the properties exist
+        this._applyAttributeBindings(buffer, this._appliedBindableAttributes, true);
+      }
+    }
+  }
+});

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -474,7 +474,14 @@ var EMPTY_ARRAY = [];
 
   The HTML attribute section of a view's tag can be set by providing an
   `attributeBindings` property set to an array of property names on the view.
-  The return value of these properties will be used as the value of the view's
+
+  `attributeBindings` always setup observers on the properties listed. This allows
+  missing properties to be specified at a later time and the new attributes will be
+  added to the views element. This has negative performance impact if you specify
+  many attributes that are not present, as setting up and maintaining the observers
+  in this case is not efficient.
+
+  The return value of the properties will be used as the value of the view's
   HTML associated attribute:
 
   ```javascript
@@ -528,8 +535,9 @@ var EMPTY_ARRAY = [];
   Updates to the the property of an attribute binding will result in automatic
   update of the  HTML attribute in the view's rendered HTML representation.
 
-  `attributeBindings` is a concatenated property. See [Ember.Object](/api/classes/Ember.Object.html)
-  documentation for more information about concatenated properties.
+  `attributeBindings` is concatenated property.
+  See [Ember.Object](/api/classes/Ember.Object.html) documentation for more
+  information about concatenated properties.
 
   ## Templates
 
@@ -1949,6 +1957,7 @@ Ember.View = Ember.CoreView.extend({
     @property attributeBindings
   */
   attributeBindings: EMPTY_ARRAY,
+
 
   // .......................................................
   // CORE DISPLAY METHODS

--- a/packages/ember-views/tests/mixins/bindable_attributes_mixin_test.js
+++ b/packages/ember-views/tests/mixins/bindable_attributes_mixin_test.js
@@ -1,0 +1,77 @@
+/*global Test:true*/
+var set = Ember.set, get = Ember.get;
+
+var originalLookup = Ember.lookup, lookup, view;
+
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+if (Ember.FEATURES.isEnabled('ember-views-bindable-attributes')) {
+  module("Ember.BindableAttributesMixin - Lazy Bound Attributes", {
+    setup: function(){
+      Ember.lookup = lookup = {};
+
+      view = Ember.View.extend(Ember.BindableAttributesMixin, {
+        bindableAttributes: ['fuzzy','wuzzy','wassa','bear']
+      }).create({
+        fuzzy: 'bingo',
+        wassa: 'dog'
+      });
+    },
+    teardown: function(){
+      if (view) {
+        Ember.run(function() {
+          view.destroy();
+        });
+        view = null;
+      }
+      Ember.lookup = originalLookup;
+    }
+  });
+
+  test("should render attribute bindings if the property exists at render time", function() {
+    Ember.run(function() {
+      view.createElement();
+    });
+
+    equal(view.$().attr('fuzzy'), 'bingo', "property that was present is bound");
+    equal(view.$().attr('wassa'), 'dog', "property that was present is bound");
+  });
+
+  test("should update when properties that were present are updated", function(){
+    Ember.run(function() {
+      view.createElement();
+    });
+
+    Ember.run(function(){
+      view.set('fuzzy', 'blanket');
+    });
+    equal(view.$().attr('fuzzy'), 'blanket', "property that was present is updated properly");
+  });
+
+  test("should not create observers for properties that did not exist", function(){
+    Ember.run(function() {
+      view.createElement();
+    });
+
+    equal(view.$().attr('wuzzy'), undefined, "attribute is not created when property is missing");
+
+    Ember.run(function(){
+      view.set('wuzzy', 'Lucy');
+    });
+
+    equal(view.$().attr('wuzzy'), undefined, "attribute is not updated because no observers were created");
+  });
+
+  test("should not pick up new properties during subsequent renderings", function(){
+    // mock the _appliedBindableAttributes for this test only
+    view._appliedBindableAttributes = [''];
+
+    Ember.run(function() {
+      view.createElement();
+    });
+
+    equal(view.$().attr('fuzzy'), undefined, "attribute is not created if it did not exist at first render");
+  });
+}

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -7,19 +7,23 @@ var appendView = function() {
   Ember.run(function() { view.appendTo('#qunit-fixture'); });
 };
 
-module("Ember.View - Attribute Bindings", {
-  setup: function() {
-    Ember.lookup = lookup = {};
-  },
-  teardown: function() {
-    if (view) {
-      Ember.run(function() {
-        view.destroy();
-      });
-      view = null;
-    }
-    Ember.lookup = originalLookup;
+function sharedSetup(){
+  Ember.lookup = lookup = {};
+}
+
+function sharedTeardown(){
+  if (view) {
+    Ember.run(function() {
+      view.destroy();
+    });
+    view = null;
   }
+  Ember.lookup = originalLookup;
+}
+
+module("Ember.View - Attribute Bindings", {
+  setup: sharedSetup,
+  teardown: sharedTeardown
 });
 
 test("should render attribute bindings", function() {
@@ -267,3 +271,4 @@ test("attributeBindings should not fail if view has been destroyed", function() 
   }
   ok(!error, error);
 });
+


### PR DESCRIPTION
Any properties listed in `bindableAttributes` that exist on the
at the time of the first render will be bound (and observed).
However, any properties that do not exist will not have observers
setup.

The main difference here from `attributeBindings` is the fact that the
observers are only setup when needed.

The `Ember.BindableAttributesMixin` is mixed into `Ember.TextSupport` by
default, and all HTML5 attributes for `<input type='text'>` and `<textarea>`.

---

Credit for the idea goes to @lukemelia. Any errors/mistakes in implementation are my own. :smiley: 
