### PR TITLE
[BUGFIX] Check if value is still undefined when triggering Ember.Select's valueDidChange

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -507,7 +507,7 @@ Ember.Select = Ember.View.extend({
         selectedValue = (valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection')),
         selection;
 
-    if (value !== selectedValue) {
+    if (value !== selectedValue && typeof value !== "undefined") {
       selection = content ? content.find(function(obj) {
         return value === (valuePath ? get(obj, valuePath) : obj);
       }) : null;


### PR DESCRIPTION
This PR resolves [this issue](https://github.com/emberjs/ember.js/issues/4147), where Ember.Select's valueDidChange is being triggered even if the value is still undefined.
