### PR TITLE
[FEATURE ember-metal-test-friendly-promises]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -158,3 +158,12 @@ for a detailed explanation.
   be fired.
 
   Added in [#3936](https://github.com/emberjs/ember.js/pull/3936)
+
+* `ember-runtime-test-friendly-promises`
+  Ember.RSVP.Promise's are now ember testing aware
+
+  - they no longer cause autorun assertions
+  - if a test adapter is provided, they still automatically tell the
+    underlying test framework to start/stop between async steps.
+
+  Added in [#4176](https://github.com/emberjs/ember.js/pull/4176)

--- a/features.json
+++ b/features.json
@@ -18,7 +18,8 @@
     "ember-metal-is-blank": true,
     "ember-eager-url-update": true,
     "ember-routing-auto-location": null,
-    "ember-routing-bound-action-name": null
+    "ember-routing-bound-action-name": null,
+    "ember-runtime-test-friendly-promises": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }


### PR DESCRIPTION
This makes promises no longer subject to auto-run assertions.
This also automatically lets a test suite know about start/stop of async, so testing is smooth.

I've used this in some real app, and complex async scenarios, and it feels really nice.
- [x] thorough tests
- [x] more real-world
- [x] sanity checked by others
