### PR TITLE
[FEATURE ember-testing-triggerEvent-helper] Allow event options to be specified.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -77,6 +77,7 @@ for a detailed explanation.
   element.
 
   Added in [#3792](https://github.com/emberjs/ember.js/pull/3792).
+  Updated in [#4177](https://github.com/emberjs/ember.js/pull/4177).
 
 * `with-controller`
 

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -79,13 +79,19 @@ function click(app, selector, context) {
   return wait(app);
 }
 
-function triggerEvent(app, selector, context, event){
-  if (typeof method === 'undefined') {
-    event = context;
+function triggerEvent(app, selector, context, type, options){
+  if (arguments.length === 3) {
+    type = context;
     context = null;
   }
 
+  if (typeof options === 'undefined') {
+    options = {};
+  }
+
   var $el = findWithAssert(app, selector, context);
+
+  var event = Ember.$.Event(type, options);
 
   Ember.run($el, 'trigger', event);
 
@@ -93,16 +99,13 @@ function triggerEvent(app, selector, context, event){
 }
 
 function keyEvent(app, selector, context, type, keyCode) {
-  var $el;
   if (typeof keyCode === 'undefined') {
     keyCode = type;
     type = context;
     context = null;
   }
-  $el = findWithAssert(app, selector, context);
-  var event = Ember.$.Event(type, { keyCode: keyCode });
-  Ember.run($el, 'trigger', event);
-  return wait(app);
+
+  return triggerEvent(app, selector, context, type, { keyCode: keyCode });
 }
 
 function fillIn(app, selector, context, text) {
@@ -227,8 +230,8 @@ asyncHelper('click', click);
 *
 * @method keyEvent
 * @param {String} selector jQuery selector for finding element on the DOM
-* @param {String} the type of key event, e.g. `keypress`, `keydown`, `keyup`
-* @param {Number} the keyCode of the simulated key event
+* @param {String} type the type of key event, e.g. `keypress`, `keydown`, `keyup`
+* @param {Number} keyCode the keyCode of the simulated key event
 * @return {RSVP.Promise}
 */
 asyncHelper('keyEvent', keyEvent);
@@ -381,9 +384,16 @@ if (Ember.FEATURES.isEnabled('ember-testing-triggerEvent-helper')) {
     triggerEvent('#some-elem-id', 'blur');
     ```
 
+    This is actually used internally by the `keyEvent` helper like so:
+
+    ```javascript
+    triggerEvent('#some-elem-id', 'keypress', { keyCode: 13 });
+    ```
+
    @method triggerEvent
    @param {String} selector jQuery selector for finding element on the DOM
-   @param {String} event The event to be triggered.
+   @param {String} type The event type to be triggered.
+   @param {String} options The options to be passed to jQuery.Event.
    @return {RSVP.Promise}
   */
   asyncHelper('triggerEvent', triggerEvent);


### PR DESCRIPTION
Allow specifying options to the event created by the `triggerEvent` helper.
This allows us to utilize `triggerEvent` from `keyEvent`.

Addresses the request by @ebryn [here](https://github.com/emberjs/ember.js/pull/3792#issuecomment-32639977).
