### PR TITLE
[BUGFIX BETA] Breaking: Fixed how parentController property of an itemController when nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Ember Changelog
 
+* [BUGFIX] Fixed how parentController property of an itemController when nested. Breaking for apps that rely on previous broken behavior of an itemController's `parentController` property skipping its ArrayController when nested.
+
 ### Ember 1.4.0-beta.3 (January 20, 2014)
 
 * Document the send method on Ember.ActionHandler.
@@ -29,12 +31,12 @@
 * [SECURITY] Ensure {{group}} helper escapes properly.
 
 ### Ember 1.3.0 (January 6, 2014)
- 
+
 * Many documentation updates.
 * Update to RSVP 3.0.3.
 * Use defeatureify to strip debug statements allowing multi-line assert statements.
 * Added fail(), catch() and finally() methods to PromiseProxyMixin.
-* [BUGFIX Add 'view' option to {{outlet}} helper
+* [BUGFIX] Add 'view' option to {{outlet}} helper
 * Make `Ember.compare` return `date` when appropriate.
 * Prefer `EmberENV` over `ENV`, and do not create a global `ENV` if it was not supplied.
 * `{{unbound}}` helper supports bound helper static strings.

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -17,6 +17,7 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
 
     if (itemController) {
       var controller = get(this, 'controller.container').lookupFactory('controller:array').create({
+        _isVirtual: true,
         parentController: get(this, 'controller'),
         itemController: itemController,
         target: get(this, 'controller'),

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -244,12 +244,12 @@ test("it supports itemController", function() {
   strictEqual(view.get('_childViews')[0].get('_arrayController.target'), parentController, "the target property of the child controllers are set correctly");
 });
 
-test("itemController gets a parentController property", function() {
+test("itemController specified in template gets a parentController property", function() {
   // using an ObjectController for this test to verify that parentController does accidentally get set
   // on the proxied model.
   var Controller = Ember.ObjectController.extend({
         controllerName: Ember.computed(function() {
-          return "controller:"+this.get('content.name') + ' of ' + this.get('parentController.company');
+          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
         })
       }),
       container = new Ember.Container(),
@@ -269,6 +269,69 @@ test("itemController gets a parentController property", function() {
   });
 
   container.register('controller:person', Controller);
+
+  append(view);
+
+  equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
+});
+
+test("itemController specified in ArrayController gets a parentController property", function() {
+  var PersonController = Ember.ObjectController.extend({
+        controllerName: Ember.computed(function() {
+          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
+        })
+      }),
+      PeopleController = Ember.ArrayController.extend({
+        content: people,
+        itemController: 'person',
+        company: 'Yapp'
+      }),
+      container = new Ember.Container();
+
+  container.register('controller:people', PeopleController);
+  container.register('controller:person', PersonController);
+  Ember.run(function() { view.destroy(); }); // destroy existing view
+
+  view = Ember.View.create({
+    container: container,
+    template: templateFor('{{#each}}{{controllerName}}{{/each}}'),
+    controller: container.lookup('controller:people')
+  });
+
+
+  append(view);
+
+  equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
+});
+
+test("itemController's parentController property, when the ArrayController has a parentController", function() {
+  var PersonController = Ember.ObjectController.extend({
+        controllerName: Ember.computed(function() {
+          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
+        })
+      }),
+      PeopleController = Ember.ArrayController.extend({
+        content: people,
+        itemController: 'person',
+        parentController: Ember.computed(function(){
+          return this.container.lookup('controller:company');
+        }),
+        company: 'Yapp'
+      }),
+      CompanyController = Ember.Controller.extend(),
+      container = new Ember.Container();
+
+  container.register('controller:company', CompanyController);
+  container.register('controller:people', PeopleController);
+  container.register('controller:person', PersonController);
+
+  Ember.run(function() { view.destroy(); }); // destroy existing view
+  view = Ember.View.create({
+    container: container,
+    template: templateFor('{{#each}}{{controllerName}}{{/each}}'),
+    controller: container.lookup('controller:people')
+  });
+
 
   append(view);
 

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -88,8 +88,7 @@ var get = Ember.get, set = Ember.set, forEach = Ember.EnumerableUtils.forEach,
   ```
 
   The itemController instances will have a `parentController` property set to
-  either the the `parentController` property of the `ArrayController`
-  or to the `ArrayController` instance itself.
+  to the `ArrayController` instance.
 
   @class ArrayController
   @namespace Ember
@@ -190,6 +189,15 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
     return Ember.A();
   }),
 
+  /**
+   * Flag to mark as being "virtual". Used to keep this instance
+   * from participating in the parentController hierarchy.
+   *
+   * @private
+   * @type Boolean
+   */
+  _isVirtual: false,
+
   controllerAt: function(idx, object, controllerClass) {
     var container = get(this, 'container'),
         subControllers = get(this, '_subControllers'),
@@ -203,10 +211,14 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
     if (!container.has(fullName)) {
       throw new Ember.Error('Could not resolve itemController: "' + controllerClass + '"');
     }
-
+    var parentController;
+    if (this._isVirtual) {
+      parentController = get(this, 'parentController');
+    }
+    parentController = parentController || this;
     subController = container.lookupFactory(fullName).create({
       target: this,
-      parentController: get(this, 'parentController') || this,
+      parentController: parentController,
       content: object
     });
 


### PR DESCRIPTION
Fixed how parentController property of an itemController when nested.

When an `itemController` is specified for an ArrayController that itself has a `parentController`
set, the framework was previously setting the itemController's `parentController` property to the
ArrayController's `parentController` instead of the ArrayController itself. This commit fixes that
behavior, and improves the docs, naming, and logic around this case.

Fixes #4162
