### PR TITLE
Allow jQuery version 1.11 and 2.1

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -8,7 +8,7 @@ if (!jQuery && typeof require === 'function') {
   jQuery = require('jquery');
 }
 
-Ember.assert("Ember Views require jQuery 1.7, 1.8, 1.9, 1.10, or 2.0", jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10))|2.0)(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
+Ember.assert("Ember Views require jQuery between 1.7 and 2.1", jQuery && (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) || Ember.ENV.FORCE_JQUERY));
 
 /**
   Alias for jQuery


### PR DESCRIPTION
Both RC1's of jQuery 1.11 and 2.1 have just been released.

(I screwed up last PR)
