### PR TITLE
Fix a bug with composable computed properties.

### DIFF
--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -70,49 +70,17 @@ var arrayIndexOf = isNativeFunc(Array.prototype.indexOf) ? Array.prototype.index
   return -1;
 };
 
-if (Ember.FEATURES.isEnabled('array-filter')) {
-  var arrayFilter = isNativeFunc(Array.prototype.filter) ? Array.prototype.filter : function (fn, context) {
-    var i,
-    value,
-    result = [],
-    length = this.length;
+/**
+  Array polyfills to support ES5 features in older browsers.
 
-    for (i = 0; i < length; i++) {
-      if (this.hasOwnProperty(i)) {
-        value = this[i];
-        if (fn.call(context, value, i, this)) {
-          result.push(value);
-        }
-      }
-    }
-    return result;
-  };
-
-  /**
-    Array polyfills to support ES5 features in older browsers.
-
-    @namespace Ember
-    @property ArrayPolyfills
-  */
-  Ember.ArrayPolyfills = {
-    map: arrayMap,
-    forEach: arrayForEach,
-    filter: arrayFilter,
-    indexOf: arrayIndexOf
-  };
-} else {
-  /**
-    Array polyfills to support ES5 features in older browsers.
-
-    @namespace Ember
-    @property ArrayPolyfills
-  */
-  Ember.ArrayPolyfills = {
-    map: arrayMap,
-    forEach: arrayForEach,
-    indexOf: arrayIndexOf
-  };
-}
+  @namespace Ember
+  @property ArrayPolyfills
+*/
+Ember.ArrayPolyfills = {
+  map: arrayMap,
+  forEach: arrayForEach,
+  indexOf: arrayIndexOf
+};
 
 if (Ember.SHIM_ES5) {
   if (!Array.prototype.map) {

--- a/packages/ember-metal/lib/composable_computed.js
+++ b/packages/ember-metal/lib/composable_computed.js
@@ -1,6 +1,0 @@
-require('ember-metal/core');
-require('ember-metal/platform');
-require('ember-metal/utils');
-
-if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
-}

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -24,10 +24,6 @@ var get = Ember.get,
     watch = Ember.watch,
     unwatch = Ember.unwatch;
 
-
-if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
-}
-
 if (Ember.FEATURES.isEnabled('propertyBraceExpansion')) {
   var expandProperties = Ember.expandProperties;
 }
@@ -594,7 +590,7 @@ if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
       typeOf = Ember.typeOf;
 
   var implicitKey = function (cp) {
-    return [guidFor(cp)].concat(cp._dependentKeys).join('_');
+    return [guidFor(cp)].concat(cp._dependentKeys).join('_').replace(/\./g, '_DOT_');
   };
 
   var normalizeDependentKey = function (key) {
@@ -623,11 +619,10 @@ if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
     if (dependentKeys) {
       cp._dependentKeys = normalizeDependentKeys(dependentKeys);
       cp._dependentCPs = selectDependentCPs(dependentKeys);
-      cp.implicitCPKey = implicitKey(cp);
     } else {
       cp._dependentKeys = cp._dependentCPs = [];
-      delete cp.implicitCPKey;
     }
+    cp.implicitCPKey = implicitKey(cp);
   };
   // expose `normalizeDependentKey[s]` so user CP macros can easily support
   // composition


### PR DESCRIPTION
Also add a couple other tests.

The failure case was dependent paths which would get an implicit cp key that
contained `.` and therefore interpreted as a path by `Em.get`.
