### PR TITLE
Add `item-controller` type.

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -62,6 +62,8 @@ var get = Ember.get,
   'controller:posts.index' //=> App.PostsIndexController
   'controller:blog/post' //=> Blog.PostController
   'controller:basic' //=> Ember.Controller
+  'item-controller:post' //=> App.PostItemController
+  'item-controller:post' //=> App.PostController
   'route:post' //=> App.PostRoute
   'route:posts.index' //=> App.PostsIndexRoute
   'route:blog/post' //=> Blog.PostRoute
@@ -218,6 +220,30 @@ Ember.DefaultResolver = Ember.Object.extend({
   resolveController: function(parsedName) {
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
+  },
+  /**
+    Lookup the itemController using `resolveOther`, if no factory is found
+    change the type to 'controller' and call `resolveOther` again.
+
+    This means we look for `App.FooItemController` and fallback to
+    `App.FooController` if the first lookup fails.
+
+    @protected
+    @param {Object} parsedName a parseName object with the parsed
+      fullName lookup string
+    @method resolveController
+  */
+  resolveItemController: function(parsedName){
+    this.useRouterNaming(parsedName);
+
+    // resolve as App.PostItemController first
+    var factory = this.resolveOther(parsedName);
+
+    if (factory) { return factory; }
+
+    // fall back to App.PostController
+    parsedName.type = 'controller';
+    factory = this.resolveOther(parsedName);
   },
   /**
     Lookup the route using `resolveOther`

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -86,3 +86,22 @@ test("the default resolver throws an error if the fullName to resolve is invalid
   raises(function(){ locator.resolve('model:'); }, TypeError, /Invalid fullName/ );
   raises(function(){ locator.resolve(':type');  }, TypeError, /Invalid fullName/ );
 });
+
+test('the default resolver looks up item-controller as FooItemController on namespace', function() {
+  application.FooItemController = Ember.Object.extend({});
+
+  detectEqual(application.FooItemController, locator.resolver('item-controller:foo'),"looks up FooItemController on application");
+});
+
+test('the default resolver looks up item-controller as FooController on namespace', function() {
+  application.FooController = Ember.Object.extend({});
+
+  detectEqual(application.FooController, locator.resolver('item-controller:foo'),"looks up FooController on application");
+});
+
+test('the default resolver looks up item-controller as FooItemController if both FooItemController and FooController exist on namespace', function() {
+  application.FooItemController = Ember.Object.extend({});
+  application.FooController = Ember.Object.extend({});
+
+  detectEqual(application.FooItemController, locator.resolver('item-controller:foo'),"looks up FooItemController on application");
+});

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -216,7 +216,7 @@ test("it supports itemController", function() {
     controller: parentController
   });
 
-  container.register('controller:person', Controller);
+  container.register('item-controller:person', Controller);
 
   append(view);
 
@@ -268,7 +268,7 @@ test("itemController specified in template gets a parentController property", fu
     controller: parentController
   });
 
-  container.register('controller:person', Controller);
+  container.register('item-controller:person', Controller);
 
   append(view);
 
@@ -358,7 +358,7 @@ test("it supports itemController when using a custom keyword", function() {
     }
   });
 
-  container.register('controller:person', Controller);
+  container.register('item-controller:person', Controller);
 
   append(view);
 

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -206,7 +206,7 @@ Ember.ArrayController = Ember.ArrayProxy.extend(Ember.ControllerMixin,
 
     if (subController) { return subController; }
 
-    fullName = "controller:" + controllerClass;
+    fullName = "item-controller:" + controllerClass;
 
     if (!container.has(fullName)) {
       throw new Ember.Error('Could not resolve itemController: "' + controllerClass + '"');

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -30,8 +30,8 @@ module("Ember.ArrayController - itemController", {
       }
     });
 
-    container.register("controller:Item", controllerClass);
-    container.register("controller:OtherItem", otherControllerClass);
+    container.register("item-controller:Item", controllerClass);
+    container.register("item-controller:OtherItem", otherControllerClass);
   },
   teardown: function() {
     Ember.run(function() {
@@ -301,7 +301,7 @@ module('Ember.ArrayController - itemController with arrayComputed', {
       }
     });
 
-    container.register("controller:Item", controllerClass);
+    container.register("item-controller:Item", controllerClass);
   },
   teardown: function() {
     Ember.run(function() {


### PR DESCRIPTION
This should be a completely backwards compatible change. The new format allows for the item-controller to fall within the new pod structure alongside the template/route/controller that it is used within.

For example:

``` javascript
App.PostsRoute = Ember.Route.extend();
App.PostsController = Ember.Route.extend();
App.PostsItemController = Ember.Route.extend();
```

Could allow the following structure:

```
app/posts/route.js
app/posts/controller.js
app/posts/item-controller.js
app/posts/template.hbs
```

---

Questions:

1) Should we change the `with-controller` feature to use `item-controller` (or possibly add another type for `with-controller`)?
2) Does this need feature flagging? (interal change with backwards compatibility)
