### PR TITLE
[BUGFIX beta] Provide helpful error even if modelClass isn't found.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,6 +30,7 @@
         "expectAssertion",
         "expectDeprecation",
         "expectNoDeprecation",
+        "ignoreAssertion",
 
         // A safe subset of "browser:true":
         "window", "location", "document", "XMLSerializer",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 3d2336afe68ed638bfa94b4080c52342ffc59737
+  revision: d99ab73e754317fde34b82139edd8c433a845aad
   branch: master
   specs:
     ember-dev (0.1)

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -916,6 +916,8 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
                      " did not exist and you did not override your route's `model` " +
                      "hook.", modelClass);
 
+        if (!modelClass) { return; }
+
         return modelClass.find(value);
       }
     };

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -28,6 +28,7 @@ test("default store utilizes the container to acquire the model factory", functi
   });
 
   container = {
+    has: function() { return true; },
     lookupFactory: lookupFactory
   };
 
@@ -71,6 +72,38 @@ test("'store' can be injected by data persistence frameworks", function() {
 
   equal(route.model({ post_id: 1}), post, '#model returns the correct post');
   equal(route.findModel('post', 1), post, '#findModel returns the correct post');
+});
+
+test("asserts if model class is not found", function() {
+  expect(1);
+  Ember.run(route, 'destroy');
+
+  var container = new Ember.Container();
+  container.register('route:index',  Ember.Route);
+
+  route = container.lookup('route:index');
+
+  expectAssertion(function() {
+    route.model({ post_id: 1});
+  }, "You used the dynamic segment post_id in your route undefined, but undefined.Post did not exist and you did not override your route's `model` hook.");
+});
+
+test("'store' does not need to be injected", function() {
+  expect(1);
+
+  Ember.run(route, 'destroy');
+  var originalAssert = Ember.assert;
+
+  var container = new Ember.Container();
+  container.register('route:index',  Ember.Route);
+
+  route = container.lookup('route:index');
+
+  ignoreAssertion(function(){
+    route.model({ post_id: 1});
+  });
+
+  ok(true, 'no error was raised');
 });
 
 module("Ember.Route serialize", {


### PR DESCRIPTION
Previously, you would receive an error if no model was found corresponding to
the route name that you are in. We were already providing a nice assertion
(which lets the user know that the model hook wasn't defined and can't be
inferred), but immediately after that we would throw an error because we were
still calling `find` on a non-existent model factory.

This simply short curcuits the `find` call if `modelClass` isn't found.

Resolves #4109.
