### PR TITLE
[FEATURE composable-computed-properties] Fix another CCP bug.

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -596,10 +596,8 @@ if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
   var normalizeDependentKey = function (key) {
     if (key instanceof Ember.ComputedProperty) {
       return implicitKey(key);
-    } else if (typeof key === 'string' || key instanceof String || typeof key === 'object' || typeof key === 'number') {
-      return key;
     } else {
-      Ember.assert('Unexpected dependent key  ' + key + ' of type ' + typeof(key), false);
+      return key;
     }
   };
 


### PR DESCRIPTION
`normalizeDependentKey` had a typecheck, but it shouldn't really care about
the non-cp case.  More importantly, the typecheck didn't check for booleans so 
things like `Em.computed.equal('isThisTypeCheckWorking', false)` would error.

cc @stefanpenner
