### PR TITLE
Add Array.prototype.filter polyfill.

### DIFF
--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -70,6 +70,23 @@ var arrayIndexOf = isNativeFunc(Array.prototype.indexOf) ? Array.prototype.index
   return -1;
 };
 
+var arrayFilter = isNativeFunc(Array.prototype.filter) ? Array.prototype.filter : function (fn, context) {
+  var i,
+  value,
+  result = [],
+  length = this.length;
+
+  for (i = 0; i < length; i++) {
+    if (this.hasOwnProperty(i)) {
+      value = this[i];
+      if (fn.call(context, value, i, this)) {
+        result.push(value);
+      }
+    }
+  }
+  return result;
+};
+
 /**
   Array polyfills to support ES5 features in older browsers.
 
@@ -79,6 +96,7 @@ var arrayIndexOf = isNativeFunc(Array.prototype.indexOf) ? Array.prototype.index
 Ember.ArrayPolyfills = {
   map: arrayMap,
   forEach: arrayForEach,
+  filter: arrayFilter,
   indexOf: arrayIndexOf
 };
 
@@ -89,6 +107,10 @@ if (Ember.SHIM_ES5) {
 
   if (!Array.prototype.forEach) {
     Array.prototype.forEach = arrayForEach;
+  }
+
+  if (!Array.prototype.filter) {
+    Array.prototype.filter = arrayFilter;
   }
 
   if (!Array.prototype.indexOf) {


### PR DESCRIPTION
This is currently required (and only used by) the composable-computed-properties feature. If that feature is enabled it will not work in non-ES5 browsers (specifically it is not available in IE8 and lower).

This was the root cause of the issue reported in #4211 as the feature was accidentally enabled in the beta branch.

`Ember.EnumerableUtils.filter` is only used in [packages/ember-metal/lib/computed.js#L589](https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/computed.js#L589) (it is used by the `selectDependentCPs` function).

The original `composable-computed-properties` PR included this under a separate feature flag (`array-filter`) in f34661cb86, but that was not added to the `features.json` or `FEATURES.md` so it was removed in 71a21bd0 (as it was assumed to be dead code).

Since this is only used by an already feature-flagged feature and it seems to be the polyfill directly from MDN, I didn't think we would need to separately feature flag this. If y'all disagree I'll be happy to flag it.

/cc @hjdivad
