### PR TITLE
Component sendAction code sample

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -199,9 +199,9 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, Ember.ComponentTe
     App.PlayButtonComponent = Ember.Component.extend({
       click: function(){
         if (this.get('isPlaying')) {
-          this.triggerAction('play');
+          this.sendAction('play');
         } else {
-          this.triggerAction('stop');
+          this.sendAction('stop');
         }
       }
     });


### PR DESCRIPTION
I think that the API evolved and the code sample wasn't adapted, right? `sendAction` is just a simpler version for `triggerAction`. But it can't be `triggerAction` because that one takes a hash as input. Correct me if I'm wrong.
