### PR TITLE
[NICETHING beta] helpful whitespace classNameBindings assert

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1277,6 +1277,8 @@ Ember.View = Ember.CoreView.extend({
     // ('content.isUrgent')
     a_forEach(classBindings, function(binding) {
 
+      Ember.assert("classNameBindings must not have spaces in them. Multiple class name bindings can be provided as elements of an array, e.g. ['foo', ':bar']", binding.indexOf(' ') === -1);
+
       // Variable in which the old class value is saved. The observer function
       // closes over this variable, so it knows which string to remove when
       // the property changes.

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -254,3 +254,14 @@ test("classNameBindings should not fail if view has been destroyed", function() 
   }
   ok(!error, error);
 });
+
+test("Providing a binding with a space in it asserts", function() {
+  view = Ember.View.create({
+    classNameBindings: 'i:think:i am:so:clever'
+  });
+
+  expectAssertion(function() {
+    view.createElement();
+  }, /classNameBindings must not have spaces in them/i);
+});
+


### PR DESCRIPTION
I've trolled myself many times thinking that  classNameBindings works with a
space separated string
(probably because of how bind-attr class="" works). This should help me never
troll myself again.

/cc @ebryn
