### PR TITLE
Improve `reduceComputed` array check assertion.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -93,8 +93,6 @@ DependentArraysObserver.prototype = {
   },
 
   setupObservers: function (dependentArray, dependentKey) {
-    Ember.assert("dependent array must be an `Ember.Array`", Ember.Array.detect(dependentArray));
-
     this.dependentKeysByGuid[guidFor(dependentArray)] = dependentKey;
 
     dependentArray.addArrayObserver(this, {
@@ -482,6 +480,11 @@ function ReduceComputedProperty(options) {
 
     meta.dependentArraysObserver.suspendArrayObservers(function () {
       forEach(cp._dependentKeys, function (dependentKey) {
+        Ember.assert(
+          "dependent array " + dependentKey + " must be an `Ember.Array`.  " +
+          "If you are not extending arrays, you will need to wrap native arrays with `Ember.A`",
+          !(Ember.isArray(get(this, dependentKey)) && !Ember.Array.detect(get(this, dependentKey))));
+
         if (!partiallyRecomputeFor(this, dependentKey)) { return; }
 
         var dependentArray = get(this, dependentKey),

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -834,3 +834,20 @@ test("array dependencies specified with `.[]` completely invalidate a reduceComp
   equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
   equal(removeCalls, 0, "remove not called");
 });
+
+if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
+  test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
+    var Type = Ember.Object.extend({
+      rc: Ember.reduceComputed('array', {
+        initialValue: 0,
+        addedItem: function(v){ return v; },
+        removedItem: function(v){ return v; }
+      })
+    });
+
+    expectAssertion(function() {
+      obj = Type.create({ array: [] });
+      get(obj, 'rc');
+    }, /must be an `Ember.Array`/, "Ember.reduceComputed complains about dependent non-extended native arrays");
+  });
+}


### PR DESCRIPTION
In #4078 the problem is that `reduceComputed` cannot be used against 
non-extended native arrays as we cannot `addArrayObserver`.  `reduceComputed` 
used to inform users of this, but no longer does so since support for
non-array dependent keys.  This commit corrects this grievous error.

Fix #4078

cc @alexspeller
