### PR TITLE
Add required to TextSupport attributeBindings

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -20,7 +20,7 @@ var get = Ember.get, set = Ember.set;
 Ember.TextSupport = Ember.Mixin.create(Ember.TargetActionSupport, {
   value: "",
 
-  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex', 'readonly'],
+  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex', 'readonly', 'required'],
   placeholder: null,
   disabled: false,
   maxlength: null,


### PR DESCRIPTION
I personally use the `required` attribute all the time since most modern browsers support it nowadays I suggest we add it to the default attribute bindings.
