### PR TITLE
[BUGFIX beta] Still update HTML5 history if the previous state was null

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -78,7 +78,7 @@ Ember.HistoryLocation = Ember.Object.extend({
     var state = this.getState();
     path = this.formatURL(path);
 
-    if (state && state.path !== path) {
+    if (!state || state.path !== path) {
       this.pushState(path);
     }
   },
@@ -95,15 +95,16 @@ Ember.HistoryLocation = Ember.Object.extend({
     var state = this.getState();
     path = this.formatURL(path);
 
-    if (state && state.path !== path) {
+    if (!state || state.path !== path) {
       this.replaceState(path);
     }
   },
 
   /**
-   Get the current `history.state`
-   Polyfill checks for native browser support and falls back to retrieving
-   from a private _historyState variable
+   Get the current `history.state`. Checks for if a polyfill is
+   required and if so fetches this._historyState. The state returned
+   from getState may be null if an iframe has changed a window's
+   history.
 
    @private
    @method getState

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -107,3 +107,27 @@ test("base URL is preserved when moving around", function() {
 
     equal(FakeHistory.state.path, '/base/one/two');
 });
+
+test("setURL continues to set even with a null state (iframes may set this)", function() {
+    expect(1);
+
+    createLocation();
+    location.initState();
+
+    FakeHistory.pushState(null);
+    location.setURL('/three/four');
+
+    equal(FakeHistory.state && FakeHistory.state.path, '/three/four');
+});
+
+test("replaceURL continues to set even with a null state (iframes may set this)", function() {
+    expect(1);
+
+    createLocation();
+    location.initState();
+
+    FakeHistory.pushState(null);
+    location.replaceURL('/three/four');
+
+    equal(FakeHistory.state && FakeHistory.state.path, '/three/four');
+});


### PR DESCRIPTION
Iframes may set null values onto the HTML5 history state. The router will sometimes pick up the null value as current instead of the window's nominal state (which was set by Ember). The old logic required that a prior state be present, this logic allows a null state to be replaced or pushed over.

Note that the back button is still wonky in this case (there are null values or iframes moving back and the the main window will not change as you move backwards), but the URL will now continue to change for new routing which seems as correct as we can hope for.

Fixes #3195, Closes #3580
