### PR TITLE
[BUGFIX beta] Fix component registration tests under IE8.

### DIFF
--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -95,26 +95,26 @@ test("Late-registered components can be rendered with custom `template` property
 
 test("Late-registered components can be rendered with template registered on the container", function() {
 
-  Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{sally-rutherford}} {{#sally-rutherford}}!!!{{/sally-rutherford}}</div>");
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{sally-rutherford}}-{{#sally-rutherford}}!!!{{/sally-rutherford}}</div>");
 
   boot(function() {
     container.register('template:components/sally-rutherford', compile("funkytowny{{yield}}"));
     container.register('component:sally-rutherford', Ember.Component);
   });
 
-  equal(Ember.$('#wrapper').text(), "hello world funkytowny funkytowny!!!", "The component is composed correctly");
+  equal(Ember.$('#wrapper').text(), "hello world funkytowny-funkytowny!!!", "The component is composed correctly");
   ok(!Ember.Handlebars.helpers['sally-rutherford'], "Component wasn't saved to global Handlebars.helpers hash");
 });
 
 test("Late-registered components can be rendered with ONLY the template registered on the container", function() {
 
-  Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{borf-snorlax}} {{#borf-snorlax}}!!!{{/borf-snorlax}}</div>");
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>");
 
   boot(function() {
     container.register('template:components/borf-snorlax', compile("goodfreakingTIMES{{yield}}"));
   });
 
-  equal(Ember.$('#wrapper').text(), "hello world goodfreakingTIMES goodfreakingTIMES!!!", "The component is composed correctly");
+  equal(Ember.$('#wrapper').text(), "hello world goodfreakingTIMES-goodfreakingTIMES!!!", "The component is composed correctly");
   ok(!Ember.Handlebars.helpers['borf-snorlax'], "Component wasn't saved to global Handlebars.helpers hash");
 });
 


### PR DESCRIPTION
In IE8 whitespace between `<div>` elements is not respected, causing these
tests to fail.

Test run [here](https://saucelabs.com/tests/a35559bee688473bb29db7acaa76ea7b).

![screenshot](https://saucelabs.com/jobs/a35559bee688473bb29db7acaa76ea7b/0001screenshot.png)
