### PR TITLE
[FEATURE query-params-new] Fix failures in IE8.

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -178,7 +178,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
     _queryParamChanged: function(controller, key) {
       // Normalize array observer firings.
-      if (key.substr(-3) === '.[]') {
+      if (key.slice(key.length - 3) === '.[]') {
         key = key.substr(0, key.length-3);
       }
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -24,9 +24,8 @@ function shouldBeActive(selector) {
 }
 
 function checkActive(selector, active) {
-  var classList = Ember.$(selector, '#qunit-fixture')[0].classList;
-  equal(classList.contains('active'), active, selector + " active should be " + active.toString());
-
+  var classList = Ember.$(selector, '#qunit-fixture')[0].className;
+  equal(classList.indexOf('active') > -1, active, selector + " active should be " + active.toString());
 }
 
 var updateCount, replaceCount;
@@ -1229,7 +1228,6 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       sort: 'title',
       showDetails: true
     });
-
 
     bootApplication();
 


### PR DESCRIPTION
- IE8 does not allow `String.substr` to accept negative values. Replacing with
  `slice` works well.
- `DOMElem.classList` does not exist in IE8.

@raytiley / @rjackson

Resolves #4239.
