### PR TITLE
Route inherits parent's model by default.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -167,3 +167,9 @@ for a detailed explanation.
     underlying test framework to start/stop between async steps.
 
   Added in [#4176](https://github.com/emberjs/ember.js/pull/4176)
+  
+* `ember-routing-inherits-parent-model`
+
+  Ember routes and leaf resources (without nested routes) will inherit the parent route's model.
+  
+  Added in [#4246](https://github.com/emberjs/ember.js/pull/4246)

--- a/features.json
+++ b/features.json
@@ -20,7 +20,8 @@
     "ember-eager-url-update": true,
     "ember-routing-auto-location": true,
     "ember-routing-bound-action-name": true,
-    "ember-runtime-test-friendly-promises": null
+    "ember-runtime-test-friendly-promises": null,
+    "ember-routing-inherits-parent-model": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -882,7 +882,17 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     }
 
     if (!name && sawParams) { return Ember.copy(params); }
-    else if (!name) { return; }
+    else if (!name) {
+      if (Ember.FEATURES.isEnabled("ember-routing-inherits-parent-model")) {
+        if (transition.resolveIndex !== transition.state.handlerInfos.length-1) { return; }
+
+        var parentModel = transition.state.handlerInfos[transition.resolveIndex-1].context;
+
+        return parentModel;
+      } else {
+        return;
+      }
+    }
 
     return this.findModel(name, value);
   },
@@ -1333,7 +1343,7 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     Alternatively, you can pass the `outlet` name directly as a string.
 
     Example:
-    
+
     ```js
     hideModal: function(evt) {
       this.disconnectOutlet('modal');


### PR DESCRIPTION
Opening up discussion to address [Core f2f proposal: unspecified this.route() models default to parent resource](http://discuss.emberjs.com/t/core-f2f-proposal-unspecified-this-route-models-default-to-parent-resource/3612/10).

Went with the simplest approach I could think of to make it work. All tests passing locally, including the one introduced.
Looking for c+c, thanks in advance :)

Possible improvements:
- [x] Test nested `route`
- [x] Test more than one level of nesting
- [x] features.json
- [x] FEATURES.md
- [x] prefix commit
- [x] only leaf route/resources inherit model
