### PR TITLE
[BUGFIX #4248] Route#viewName overriding explicit name parameter when calling render method

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -420,6 +420,45 @@ test('defining templateName allows other templates to be rendered', function() {
 
 });
 
+test('Specifying a name to render should have precedence over everything else', function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  App.HomeController = Ember.Controller.extend();
+  App.HomeRoute = Ember.Route.extend({
+    templateName: 'home',
+    controllerName: 'home',
+    viewName: 'home',
+
+    renderTemplate: function() {
+      this.render('homepage');
+    }
+  });
+
+  App.HomeView = Ember.View.extend({
+    template: Ember.Handlebars.compile("<h3>This should not be rendered</h3><p>{{home}}</p>")
+  });
+
+  App.HomepageController = Ember.ObjectController.extend({
+    content: {
+      home: 'Tinytroll'
+    }
+  });
+  App.HomepageView = Ember.View.extend({
+    layout: Ember.Handlebars.compile(
+      "<span>Outer</span>{{yield}}<span>troll</span>"
+    ),
+    templateName: 'homepage'
+  });
+
+  bootApplication();
+
+  equal(Ember.$('h3', '#qunit-fixture').text(), "Megatroll", "The homepage template was rendered");
+  equal(Ember.$('p', '#qunit-fixture').text(), "Tinytroll", "The homepage controller was used");
+  equal(Ember.$('span', '#qunit-fixture').text(), "Outertroll", "The homepage view was used");
+});
+
 test("The Homepage with a `setupController` hook", function() {
   Router.map(function() {
     this.route("home", { path: "/" });

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -1354,7 +1354,7 @@ var Route = EmberObject.extend(ActionHandler, {
   render: function(name, options) {
     Ember.assert("The name in the given arguments is undefined", arguments.length > 0 ? !isNone(arguments[0]) : true);
 
-    var namePassed = !!name;
+    var namePassed = typeof name === 'string' && !!name;
 
     if (typeof name === 'object' && !options) {
       options = name;
@@ -1373,7 +1373,7 @@ var Route = EmberObject.extend(ActionHandler, {
       templateName = this.templateName || name;
     }
 
-    var viewName = options.view || this.viewName || name;
+    var viewName = options.view || namePassed && name || this.viewName || name;
 
     var container = this.container,
         view = container.lookup('view:' + viewName),
@@ -1384,7 +1384,7 @@ var Route = EmberObject.extend(ActionHandler, {
     }
 
     if (!view && !template) {
-      Ember.assert("Could not find \"" + name + "\" template or view.", !namePassed);
+      Ember.assert("Could not find \"" + name + "\" template or view.", Ember.isEmpty(arguments[0]));
       if (get(this.router, 'namespace.LOG_VIEW_LOOKUPS')) {
         Ember.Logger.info("Could not find \"" + name + "\" template or view. Nothing will be rendered", { fullName: 'template:' + name });
       }


### PR DESCRIPTION
Fixes #4248 

_Edit: copied my description from bug report since it was closed in favor of this PR_

Demonstrated in http://jsbin.com/ucanam/3502#/first
Both routes should be rendered with the same view, since they are both extending a route which is explicitly rendering using the name parameter.

The sources from which controller, view and template is derived in the render method should, from what I've been able to gleam from tests and code, be the following:
1. From the options hash ({view: 'foo', controller: 'bar'})
2. From the name parameter (either a template- or a view name)
3. Explicitly defined route properties (`this.controllerName`, `this.viewName` etc)
4. Route defaults (resolved using `this.routeName`)

`this.viewName`, as demonstrated in the fiddle, does not respect this order and will have higher precedence than the name parameter.
