### PR TITLE
[FEATURE ember-routing-consistent-resources]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -68,3 +68,19 @@ for a detailed explanation.
 
   Added in [#4760](https://github.com/emberjs/ember.js/pull/4760)
 
+* `ember-routing-consistent-resources`
+
+  Adds `.index`, `.loading`, and `.error` sub-routes for resources created
+  even if no callback was provided.
+
+  For example:
+
+  ```javascript
+    App.Router.map(function() {
+      this.resource("home");
+    });
+  ```
+
+  Prior to this feature `home.index` route would not be created for the above resource.
+
+  Added in [#4251](https://github.com/emberjs/ember.js/pull/4251)

--- a/features.json
+++ b/features.json
@@ -8,7 +8,8 @@
     "ember-runtime-test-friendly-promises": true,
     "ember-routing-add-model-option": true,
     "ember-routing-linkto-target-attribute": null,
-    "ember-routing-will-change-hooks": null
+    "ember-routing-will-change-hooks": null,
+    "ember-routing-consistent-resources": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-application/tests/system/logging_test.js
+++ b/packages_es6/ember-application/tests/system/logging_test.js
@@ -86,7 +86,11 @@ test("log class generation if logging enabled", function() {
   run(App, 'advanceReadiness');
 
   visit('/posts').then(function() {
-    equal(keys(logs).length, 6, 'expected logs');
+    if (Ember.FEATURES.isEnabled('ember-routing-consistent-resources')) {
+      equal(Ember.keys(logs).length, 8, 'expected logs');
+    } else {
+      equal(Ember.keys(logs).length, 6, 'expected logs');
+    }
   });
 });
 

--- a/packages_es6/ember-routing/lib/system/dsl.js
+++ b/packages_es6/ember-routing/lib/system/dsl.js
@@ -28,11 +28,20 @@ DSL.prototype = {
       options.path = "/" + name;
     }
 
-    if (callback) {
+    var createSubRoutes = false;
+    if (Ember.FEATURES.isEnabled('ember-routing-consistent-resources')) {
+      createSubRoutes = true;
+    } else {
+      if (callback) { createSubRoutes = true; }
+    }
+
+    if (createSubRoutes) {
       var dsl = new DSL(name);
       route(dsl, 'loading');
       route(dsl, 'error', { path: "/_unused_dummy_error_path_route_" + name + "/:error" });
-      callback.call(dsl);
+
+      if (callback) { callback.call(dsl); }
+
       this.push(options.path, name, dsl.generate());
     } else {
       this.push(options.path, name, null);

--- a/packages_es6/ember/tests/routing/basic_test.js
+++ b/packages_es6/ember/tests/routing/basic_test.js
@@ -1054,7 +1054,12 @@ asyncTest("Nested callbacks are not exited when moving to siblings", function() 
       equal(rootModel, 1, "The root model was called again");
 
       deepEqual(router.location.path, '/specials/1');
-      equal(currentPath, 'root.special');
+
+      if (Ember.FEATURES.isEnabled('ember-routing-consistent-resources')) {
+        equal(currentPath, 'root.special.index');
+      } else {
+        equal(currentPath, 'root.special');
+      }
 
       QUnit.start();
     });
@@ -3166,3 +3171,25 @@ if (Ember.FEATURES.isEnabled("ember-routing-will-change-hooks")) {
   });
 }
 
+if (Ember.FEATURES.isEnabled('ember-routing-consistent-resources')) {
+  test("specifying no callback to `this.resources` still generates ", function() {
+    expect(1);
+
+    Router.map(function() {
+      this.resource("home");
+    });
+
+    var currentPath;
+
+    App.ApplicationController = Ember.Controller.extend({
+      currentPathDidChange: Ember.observer('currentPath', function() {
+        currentPath = get(this, 'currentPath');
+      })
+    });
+
+    bootApplication();
+
+    Ember.run(router, 'transitionTo', 'home');
+    equal(currentPath, 'home.index');
+  });
+}


### PR DESCRIPTION
Adds `.index`, `.loading`, and `.error` sub-routes for resources created even
if no callback was provided.

For example:

``` javascript
 App.Router.map(function() {
   this.resource("home");
 });
```

Prior to this feature `home.index` route would not be created for the above
resource.
