### PR TITLE
[FEATURE ember-handlebars-log-primitives]

### DIFF
--- a/features.json
+++ b/features.json
@@ -8,6 +8,7 @@
     "string-parameterize": null,
     "ember-routing-named-substates": null,
     "ember-handlebars-caps-lookup": null,
+    "ember-handlebars-log-primitives": null,
     "ember-testing-simple-setup": null,
     "ember-testing-routing-helpers": true,
     "ember-testing-triggerEvent-helper": true,

--- a/packages/ember-handlebars/tests/helpers/debug_test.js
+++ b/packages/ember-handlebars/tests/helpers/debug_test.js
@@ -1,0 +1,71 @@
+var originalLookup = Ember.lookup, lookup;
+var originalLog, logCalls;
+var view;
+
+var appendView = function() {
+  Ember.run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+
+module("Handlebars {{log}} helper", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    originalLog = Ember.Logger.log;
+    logCalls = [];
+    Ember.Logger.log = function() { logCalls.push.apply(logCalls, arguments); };
+  },
+
+  teardown: function() {
+    if (view) {
+      Ember.run(function() {
+        view.destroy();
+      });
+      view = null;
+    }
+
+    Ember.Logger.log = originalLog;
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("should be able to log multiple properties", function() {
+  var context = {
+    value: 'one',
+    valueTwo: 'two'
+  };
+
+  view = Ember.View.create({
+    context: context,
+    template: Ember.Handlebars.compile('{{log value valueTwo}}')
+  });
+
+  appendView();
+
+  equal(view.$().text(), "", "shouldn't render any text");
+  equal(logCalls[0], 'one');
+  equal(logCalls[1], 'two');
+});
+
+if (Ember.FEATURES.isEnabled("ember-handlebars-log-primitives")) {
+  test("should be able to log primitives", function() {
+    var context = {
+      value: 'one',
+      valueTwo: 'two'
+    };
+
+    view = Ember.View.create({
+      context: context,
+      template: Ember.Handlebars.compile('{{log value "foo" 0 valueTwo true}}')
+    });
+
+    appendView();
+
+    equal(view.$().text(), "", "shouldn't render any text");
+    strictEqual(logCalls[0], 'one');
+    strictEqual(logCalls[1], 'foo');
+    strictEqual(logCalls[2], 0);
+    strictEqual(logCalls[3], 'two');
+    strictEqual(logCalls[4], true);
+  });
+}


### PR DESCRIPTION
This PR allows `{{log}}` to log multiple variables (not behind a flag) as well as to log primitives such as strings and numbers (behind a flag).
