### PR TITLE
[BUGFIX] Changing eager routing on link-to without href

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -348,7 +348,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       // Schedule eager URL update, but after we've given the transition
       // a chance to synchronously redirect.
       if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
-        Ember.run.scheduleOnce('routerTransitions', this, this._eagerUpdateUrl, transition, this.get('href'));
+        var href = this.get('href');
+        if(href !== undefined) {
+          Ember.run.scheduleOnce('routerTransitions', this, this._eagerUpdateUrl, transition, href);
+        }
       }
     },
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1335,6 +1335,7 @@ if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
 
         Router.map(function() {
           this.route('about');
+          this.route('contact');
         });
 
         App.AboutRoute = Ember.Route.extend({
@@ -1344,7 +1345,14 @@ if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
           }
         });
 
-        Ember.TEMPLATES.application = Ember.Handlebars.compile("{{outlet}}{{link-to 'Index' 'index' id='index-link'}}{{link-to 'About' 'about' id='about-link'}}");
+        App.ContactRoute = Ember.Route.extend({
+          model: function() {
+            aboutDefer = Ember.RSVP.defer();
+            return aboutDefer.promise;
+          }
+        });
+
+        Ember.TEMPLATES.application = Ember.Handlebars.compile("{{outlet}}{{link-to 'Index' 'index' id='index-link'}}{{link-to 'About' 'about' id='about-link'}}{{link-to 'Contact' 'contact' id='contact-link' tagName='li'}}");
       });
     },
 
@@ -1399,6 +1407,24 @@ if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
 
     bootApplication();
     Ember.run(Ember.$('#about-link'), 'click');
+
+    // Shouldn't have called update url.
+    equal(updateCount, 0);
+    equal(router.get('location.path'), '', 'url was not updated');
+  });
+
+  test("invoking a link-to whose tagName without an href attribute doesn't update the url", function() {
+    App.IndexRoute = Ember.Route.extend({
+      actions: {
+        willTransition: function(transition) {
+          ok(true, "aborting transition");
+          transition.abort();
+        }
+      }
+    });
+
+    bootApplication();
+    Ember.run(Ember.$('#contact-link'), 'click');
 
     // Shouldn't have called update url.
     equal(updateCount, 0);


### PR DESCRIPTION
When eager routing occurs on a {{link-to}} with a tagName
specified the router attemps to find an href attribute
and fails.
