### PR TITLE
[FEATURE ember-eager-url-update] non a-tags work

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -348,7 +348,11 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       // Schedule eager URL update, but after we've given the transition
       // a chance to synchronously redirect.
       if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
-        Ember.run.scheduleOnce('routerTransitions', this, this._eagerUpdateUrl, transition, this.get('href'));
+        var href = get(this, 'href');
+        if (typeof href === 'undefined') {
+          href = router.generate.apply(router, get(this, 'routeArgs'));
+        }
+        Ember.run.scheduleOnce('routerTransitions', this, this._eagerUpdateUrl, transition, href);
       }
     },
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1324,6 +1324,30 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
   });
 }
 
+function basicEagerURLUpdateTest(setTagName) {
+  expect(6);
+
+  if (setTagName) {
+    Ember.TEMPLATES.application = Ember.Handlebars.compile("{{outlet}}{{link-to 'Index' 'index' id='index-link'}}{{link-to 'About' 'about' id='about-link' tagName='span'}}");
+  }
+
+  bootApplication();
+  equal(updateCount, 0);
+  Ember.run(Ember.$('#about-link'), 'click');
+
+  // URL should be eagerly updated now
+  equal(updateCount, 1);
+  equal(router.get('location.path'), '/about');
+
+  // Resolve the promise.
+  Ember.run(aboutDefer, 'resolve');
+  equal(router.get('location.path'), '/about');
+
+  // Shouldn't have called update url again.
+  equal(updateCount, 1);
+  equal(router.get('location.path'), '/about');
+}
+
 if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
   var aboutDefer;
   module("The {{link-to}} helper: eager URL updating", {
@@ -1355,21 +1379,11 @@ if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
   });
 
   test("invoking a link-to with a slow promise eager updates url", function() {
-    bootApplication();
-    equal(updateCount, 0);
-    Ember.run(Ember.$('#about-link'), 'click');
+    basicEagerURLUpdateTest(false);
+  });
 
-    // URL should be eagerly updated now
-    equal(updateCount, 1);
-    equal(router.get('location.path'), '/about');
-
-    // Resolve the promise.
-    Ember.run(aboutDefer, 'resolve');
-    equal(router.get('location.path'), '/about');
-
-    // Shouldn't have called update url again.
-    equal(updateCount, 1);
-    equal(router.get('location.path'), '/about');
+  test("non `a` tags also eagerly update URL", function() {
+    basicEagerURLUpdateTest(true);
   });
 
   test("invoking a link-to with a promise that rejects on the run loop doesn't update url", function() {


### PR DESCRIPTION
Eager url updating was breaking for non a tags 
since their hrefs weren't being generated.

Thanks @jonnii for pointing this out
