### PR TITLE
Lazily bound attribute bindings

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -30,7 +30,7 @@ Ember.TextArea = Ember.Component.extend(Ember.TextSupport, {
   classNames: ['ember-text-area'],
 
   tagName: "textarea",
-  attributeBindings: ['rows', 'cols', 'name'],
+  attributeBindings: ['rows', 'cols', 'name', 'selectionEnd', 'selectionStart', 'wrap'],
   rows: null,
   cols: null,
 

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -31,7 +31,11 @@ Ember.TextField = Ember.Component.extend(Ember.TextSupport, {
 
   classNames: ['ember-text-field'],
   tagName: "input",
-  attributeBindings: ['type', 'value', 'size', 'pattern', 'name', 'min', 'max'],
+  attributeBindings: ['type', 'value', 'size', 'pattern', 'name', 'min', 'max',
+                      'accept', 'autocomplete', 'autosave', 'formaction',
+                      'formenctype', 'formmethod', 'formnovalidate', 'formtarget',
+                      'height', 'inputmode', 'list', 'multiple', 'pattern', 'step',
+                      'width'],
 
   /**
     The `value` attribute of the input element. As the user inputs text, this

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -20,7 +20,8 @@ var get = Ember.get, set = Ember.set;
 Ember.TextSupport = Ember.Mixin.create(Ember.TargetActionSupport, {
   value: "",
 
-  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex', 'readonly'],
+  attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex', 'readonly',
+                      'autofocus', 'form', 'selectionDirection', 'spellcheck', 'required'],
   placeholder: null,
   disabled: false,
   maxlength: null,


### PR DESCRIPTION
This change overhauls the internal implementation of `Ember.View.attributeBindings` to only setup bindings for properties that are present during the initial render, then adds a `setUnknownProperty` so that any `attributeBindings` that were not present during the first render get setup when they are first set.

This PR also adds `attributeBindings` for all of the HTML5 attributes for `TextField` and `TextArea`. Previously, binding to this many attributes unnecessarily added a significant performance penalty. Now these bindings are setup lazily for values that were not previously defined on the instance.

This change is completely backwards compatible and does not add new API exposure.  I would like to consider this a `BUGFIX` and pull it into the `beta` branch if there are no objections.

---

Thank you to @ebryn for working this up.
