### PR TITLE
Route#controllerName takes precedence over Route#routeName during render

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1458,10 +1458,12 @@ function normalizeOptions(route, name, template, options) {
 
   if (options.controller) {
     controller = options.controller;
+  } else if (route.controllerName) {
+    controller = route.controllerName;
   } else if (namedController = route.container.lookup('controller:' + name)) {
     controller = namedController;
   } else {
-    controller = route.controllerName || route.routeName;
+    controller = route.routeName;
   }
 
   if (typeof controller === 'string') {


### PR DESCRIPTION
This pull assumes that in defining the `controllerName` property on an `Ember.Route`, the expected default behavior for the `render` method would be to use the controller defined by that property when rendering the view.

The changed precedence would be:
1. The controller option specifically passed to `Route#render`. If it is passed specifically during
   invocation, that's a no-brainer.
2. The controller specified by the Route's `controllerName` property. If the user took the time to define
   the property, then it makes sense that the expected behavior is to use that controller as the context
   for the view.
3. If found, use the controller that matches the name of the template.
4. Finally, use the controller that matches the name of the route.

There are no tests associated with this pull because the [`normalizeOptions`](https://github.com/bschaeffer/ember.js/blob/route-controller-presedence/packages/ember-routing/lib/system/route.js#L1447) function is isolated and also I wouldn't know where to start.
