### PR TITLE
[FEATURE query-params-new] Don't eagerly init controllers

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -28,9 +28,9 @@ DSL.prototype = {
       route(dsl, 'loading');
       route(dsl, 'error', { path: "/_unused_dummy_error_path_route_" + name + "/:error" });
       callback.call(dsl);
-      this.push(options.path, name, dsl.generate(), options.queryParams);
+      this.push(options.path, name, dsl.generate());
     } else {
-      this.push(options.path, name, null, options.queryParams);
+      this.push(options.path, name, null);
     }
 
 
@@ -44,11 +44,11 @@ DSL.prototype = {
     }
   },
 
-  push: function(url, name, callback, queryParams) {
+  push: function(url, name, callback) {
     var parts = name.split('.');
     if (url === "" || url === "/" || parts[parts.length-1] === "index") { this.explicitIndex = true; }
 
-    this.matches.push([url, name, callback, queryParams]);
+    this.matches.push([url, name, callback]);
   },
 
   route: function(name, options) {
@@ -88,7 +88,7 @@ function route(dsl, name, options) {
     name = dsl.parent + "." + name;
   }
 
-  dsl.push(options.path, name, null, options.queryParams);
+  dsl.push(options.path, name, null);
 }
 
 DSL.map = function(callback) {


### PR DESCRIPTION
This uses the somewhat hacky approach of looking up a controller class's
proto() to read its queryParams configuration without instantiating it (unless
it's already been instantiated).

/cc @stefanpenner @ebryn
