### PR TITLE
Uses document.contains to figure if element exists in the DOM

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -20,13 +20,10 @@ Ember.merge(preRender, {
 
     // We transition to `inDOM` if the element exists in the DOM
     var element = view.get('element');
-    while (element = element.parentNode) {
-      if (element === document) {
-        viewCollection.transitionTo('inDOM', false);
-        viewCollection.trigger('didInsertElement');
-      }
+    if (document.body.contains(element)) {
+      viewCollection.transitionTo('inDOM', false);
+      viewCollection.trigger('didInsertElement');
     }
-
   },
 
   renderToBufferIfNeeded: function(view, buffer) {


### PR DESCRIPTION
As stated in the commit message, this PR tries to address the issue raised in [https://github.com/Polymer/ShadowDOM/issues/365](https://github.com/Polymer/ShadowDOM/issues/365).

According to a commenter, `document.contains` is in the happy path so performance shouldn't worsen. I'm sure there are other considerations I'm not aware of.
Looking for feedback on the feasibility of this change, thank you.

I've successfully run the tests locally in the following browsers:
- [x] phantom.js
- [x] Chrome stable (32.x)
- [x] Chrome Canary (34.x)
- [x] Firefox (26.0)
- [x] Safari (7.0.1)
