### PR TITLE
[FEATURE query-params-new] Fix null QP check in transitionTo

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -307,7 +307,9 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
       isQueryParamsOnly = false, queryParams;
 
     if (Ember.FEATURES.isEnabled("query-params-new")) {
-      if (args[args.length - 1].hasOwnProperty('queryParams')) {
+
+      var possibleQueryParamArg = args[args.length - 1];
+      if (possibleQueryParamArg && possibleQueryParamArg.hasOwnProperty('queryParams')) {
         if (args.length === 1) {
           isQueryParamsOnly = true;
           name = null;

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2819,4 +2819,29 @@ test("Specifying non-existent controller name in route#render throws", function(
   bootApplication();
 });
 
+test("Redirecting with null model doesn't error out", function() {
+  Router.map(function() {
+    this.route("home", { path: '/' });
+    this.route("about", { path: '/about/:hurhurhur' });
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+    beforeModel: function() {
+      this.transitionTo('about', null);
+    }
+  });
+
+  App.AboutRoute = Ember.Route.extend({
+    serialize: function(model) {
+      if (model === null) {
+        return { hurhurhur: 'TreeklesMcGeekles' };
+      }
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), "/about/TreeklesMcGeekles");
+});
+
 


### PR DESCRIPTION
redirecting with a null model was hitting some breaking code with QP flags
enabled.
