### PR TITLE
Add automated testing for prod/min builds.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,6 +31,7 @@
         "expectDeprecation",
         "expectNoDeprecation",
         "ignoreAssertion",
+        "ignoreDeprecation",
 
         // A safe subset of "browser:true":
         "window", "location", "document", "XMLSerializer",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emberjs/ember-dev.git
-  revision: 257349f0f123528f558757de1222828540353c24
+  revision: afead0cde6fad34b2313f4d4299c040eef5198ed
   branch: master
   specs:
     ember-dev (0.1)
@@ -33,7 +33,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.32.0)
+    aws-sdk (1.33.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)

--- a/ember-dev.yml
+++ b/ember-dev.yml
@@ -12,6 +12,8 @@ testing_suites:
     - "package=all&extendprototypes=true&nojshint=true&enableoptionalfeatures=true"
   built:
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
+    - "skipPackage=container,ember-testing&dist=min&prod=true"     # container isn't public, and ember-testing is stripped from prod/min
+    - "skipPackage=container,ember-testing&dist=prod&prod=true"    # container isn't public, and ember-testing is stripped from prod/min
   runtime:
     - "package=ember-metal,ember-runtime"
   views:
@@ -34,6 +36,8 @@ testing_suites:
     - "package=all&extendprototypes=true&jquery=git&nojshint=true"
     - "package=all&extendprototypes=true&jquery=git2&nojshint=true"
     - "package=all&skipPackage=container&dist=build&nojshint=true" # container isn't publicly available in the built version
+    - "skipPackage=container,ember-testing&dist=min&prod=true"     # container isn't public, and ember-testing is stripped from prod/min
+    - "skipPackage=container,ember-testing&dist=prod&prod=true"    # container isn't public, and ember-testing is stripped from prod/min
 testing_packages:
   - container
   - ember-metal

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -1,3 +1,5 @@
+/*globals EmberDev */
+
 var view;
 var app;
 var application;
@@ -89,7 +91,9 @@ test("acts like a namespace", function() {
 
 module("Ember.Application initialization", {
   teardown: function() {
-    Ember.run(app, 'destroy');
+    if (app) {
+      Ember.run(app, 'destroy');
+    }
     Ember.TEMPLATES = {};
   }
 });
@@ -192,6 +196,11 @@ test("Minimal Application initialized with just an application template", functi
 });
 
 test('enable log of libraries with an ENV var', function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
+
   var debug = Ember.debug;
   var messages = [];
 

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -1,3 +1,5 @@
+/*globals EmberDev */
+
 var App, logs, originalLogger;
 
 module("Ember.Application – logging of generated classes", {
@@ -66,6 +68,11 @@ function visit(path) {
 }
 
 test("log class generation if logging enabled", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
+
   Ember.run(App, 'advanceReadiness');
 
   visit('/posts').then(function() {
@@ -86,6 +93,11 @@ test("do NOT log class generation if logging disabled", function() {
 });
 
 test("actively generated classes get logged", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
+
   Ember.run(App, 'advanceReadiness');
 
   visit('/posts').then(function() {
@@ -155,6 +167,11 @@ module("Ember.Application – logging of view lookups", {
 });
 
 test("log when template and view are missing when flag is active", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
+
   App.register('template:application', function() { return ''; });
   Ember.run(App, 'advanceReadiness');
 
@@ -178,6 +195,11 @@ test("do not log when template and view are missing when flag is not true", func
 });
 
 test("log which view is used with a template", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
+
   App.register('template:application', function() { return 'Template with default view'; });
   App.register('template:foo', function() { return 'Template with custom view'; });
   App.register('view:posts', Ember.View.extend({templateName: 'foo'}));

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -1,3 +1,5 @@
+/*globals EmberDev */
+
 var view, originalLookup;
 
 var container = {
@@ -17,7 +19,10 @@ module("Handlebars {{#view}} helper", {
 
   teardown: function() {
     Ember.lookup = originalLookup;
-    Ember.run(view, 'destroy');
+
+    if (view) {
+      Ember.run(view, 'destroy');
+    }
   }
 });
 
@@ -100,6 +105,10 @@ test("id bindings downgrade to one-time property lookup", function() {
 });
 
 test("mixing old and new styles of property binding fires a warning, treats value as if it were quoted", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
 
   expect(2);
 

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -19,29 +19,32 @@ test("calls computed property setters", function() {
   equal(o.get('foo'), 'bar');
 });
 
-test("sets up mandatory setters for watched simple properties", function() {
-  var MyClass = Ember.Object.extend({
-    foo: null,
-    bar: null,
-    fooDidChange: Ember.observer('foo', function() {})
+if (Ember.ENV.MANDATORY_SETTER) {
+  test("sets up mandatory setters for watched simple properties", function() {
+
+    var MyClass = Ember.Object.extend({
+      foo: null,
+      bar: null,
+      fooDidChange: Ember.observer('foo', function() {})
+    });
+
+    var o = MyClass.create({foo: 'bar', bar: 'baz'});
+    equal(o.get('foo'), 'bar');
+
+    // Catch IE8 where Object.getOwnPropertyDescriptor exists but only works on DOM elements
+    try {
+      Object.getOwnPropertyDescriptor({}, 'foo');
+    } catch(e) {
+      return;
+    }
+
+    var descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
+    ok(descriptor.set, 'Mandatory setter was setup');
+
+    descriptor = Object.getOwnPropertyDescriptor(o, 'bar');
+    ok(!descriptor.set, 'Mandatory setter was not setup');
   });
-
-  var o = MyClass.create({foo: 'bar', bar: 'baz'});
-  equal(o.get('foo'), 'bar');
-
-  // Catch IE8 where Object.getOwnPropertyDescriptor exists but only works on DOM elements
-  try {
-    Object.getOwnPropertyDescriptor({}, 'foo');
-  } catch(e) {
-    return;
-  }
-
-  var descriptor = Object.getOwnPropertyDescriptor(o, 'foo');
-  ok(descriptor.set, 'Mandatory setter was setup');
-
-  descriptor = Object.getOwnPropertyDescriptor(o, 'bar');
-  ok(!descriptor.set, 'Mandatory setter was not setup');
-});
+}
 
 test("allows bindings to be defined", function() {
   var obj = Ember.Object.create({

--- a/packages/ember/tests/states_removal_test.js
+++ b/packages/ember/tests/states_removal_test.js
@@ -1,6 +1,13 @@
+/*globals EmberDev */
+
 module("ember-states removal");
 
 test("errors occur when attempting to use Ember.StateManager or Ember.State", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Ember.State & Ember.StateManager are not added to production builds');
+    return;
+  }
+
   raises(function() {
     Ember.StateManager.extend();
   }, /has been moved into a plugin/);

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -31,7 +31,8 @@
     spade:   'ember-spade.js',
     build:   'ember.js',
     prod:    'ember.prod.js',
-    runtime: 'ember-runtime.js'
+    runtime: 'ember-runtime.js',
+    min:     'ember.min.js'
   };
 
 


### PR DESCRIPTION
This adds automated testing in Travis for both `ember.prod.js` and `ember.min.js`.

You can run the build tests locally:
- From a console: `rake test[built]`
- From a browser (after running `rackup`): `http://localhost:9292/?skipPackage=container,ember-testing&dist=min&prod=true`

As requested by @stefanpenner.
