### PR TITLE
Make `sendAction` available from TargetActionSupport.

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -94,6 +94,8 @@ var get = Ember.get, set = Ember.set, isNone = Ember.isNone,
   @class Component
   @namespace Ember
   @extends Ember.View
+  @uses Ember.TargetActionSupport
+  @uses Ember.ComponentTemplateDeprecation
 */
 Ember.Component = Ember.View.extend(Ember.TargetActionSupport, Ember.ComponentTemplateDeprecation, {
   init: function() {
@@ -184,112 +186,5 @@ Ember.Component = Ember.View.extend(Ember.TargetActionSupport, Ember.ComponentTe
   targetObject: Ember.computed(function(key) {
     var parentView = get(this, '_parentView');
     return parentView ? get(parentView, 'controller') : null;
-  }).property('_parentView'),
-
-  /**
-    Triggers a named action on the controller context where the component is used if
-    this controller has registered for notifications of the action.
-
-    For example a component for playing or pausing music may translate click events
-    into action notifications of "play" or "stop" depending on some internal state
-    of the component:
-
-
-    ```javascript
-    App.PlayButtonComponent = Ember.Component.extend({
-      click: function(){
-        if (this.get('isPlaying')) {
-          this.sendAction('play');
-        } else {
-          this.sendAction('stop');
-        }
-      }
-    });
-    ```
-
-    When used inside a template these component actions are configured to
-    trigger actions in the outer application context:
-
-    ```handlebars
-    {{! application.hbs }}
-    {{play-button play="musicStarted" stop="musicStopped"}}
-    ```
-
-    When the component receives a browser `click` event it translate this
-    interaction into application-specific semantics ("play" or "stop") and
-    triggers the specified action name on the controller for the template
-    where the component is used: 
-
-
-    ```javascript
-    App.ApplicationController = Ember.Controller.extend({
-      actions: {
-        musicStarted: function(){
-          // called when the play button is clicked
-          // and the music started playing
-        },
-        musicStopped: function(){
-          // called when the play button is clicked
-          // and the music stopped playing
-        }
-      }
-    });
-    ```
-
-    If no action name is passed to `sendAction` a default name of "action"
-    is assumed.
-
-    ```javascript
-    App.NextButtonComponent = Ember.Component.extend({
-      click: function(){
-        this.sendAction();
-      }
-    });
-    ```
-
-    ```handlebars
-    {{! application.hbs }}
-    {{next-button action="playNextSongInAlbum"}}
-    ```
-
-    ```javascript
-    App.ApplicationController = Ember.Controller.extend({
-      actions: {
-        playNextSongInAlbum: function(){
-          ...
-        }
-      }
-    });
-    ```
-
-    @method sendAction
-    @param [action] {String} the action to trigger
-    @param [context] {*} a context to send with the action
-  */
-  sendAction: function(action) {
-    var actionName,
-        contexts = a_slice.call(arguments, 1);
-
-    // Send the default action
-    if (action === undefined) {
-      actionName = get(this, 'action');
-      Ember.assert("The default action was triggered on the component " + this.toString() +
-                   ", but the action name (" + actionName + ") was not a string.",
-                   isNone(actionName) || typeof actionName === 'string');
-    } else {
-      actionName = get(this, action);
-      Ember.assert("The " + action + " action was triggered on the component " +
-                   this.toString() + ", but the action name (" + actionName +
-                   ") was not a string.",
-                   isNone(actionName) || typeof actionName === 'string');
-    }
-
-    // If no action name for that action could be found, just abort.
-    if (actionName === undefined) { return; }
-
-    this.triggerAction({
-      action: actionName,
-      actionContext: contexts
-    });
-  }
+  }).property('_parentView')
 });


### PR DESCRIPTION
`sendAction` is essentially just a nicer API around
`TargetActionSupport`'s `triggerAction`. Currently, it is not possible to use
`sendAction` from anything that is not an `Ember.Component`.

`Ember.TargetActionSupport` is currently only used by `Ember.Component` and
`Ember.ViewTargetActionSupport` (which itself is unused internally). This
change just moves `sendAction` up into the mixin where it can be reused by
devs needing these same semantics.
