### PR TITLE
[beta] sync router.js

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -1228,6 +1228,7 @@ define("router/transition-state",
     var forEach = __dependency2__.forEach;
     var promiseLabel = __dependency2__.promiseLabel;
     var resolve = __dependency3__.resolve;
+    var reject = __dependency3__.reject;
 
     function TransitionState(other) {
       this.handlerInfos = [];
@@ -1276,7 +1277,7 @@ define("router/transition-state",
             // during resolution (e.g. beforeModel/model/afterModel),
             // and aborts due to a rejecting promise from shouldContinue().
             wasAborted = true;
-            throw reason;
+            return reject(reason);
           }, promiseLabel("Handle abort"));
         }
 
@@ -1286,12 +1287,12 @@ define("router/transition-state",
           var handlerInfos = currentState.handlerInfos;
           var errorHandlerIndex = payload.resolveIndex >= handlerInfos.length ?
                                   handlerInfos.length - 1 : payload.resolveIndex;
-          throw {
+          return reject({
             error: error,
             handlerWithError: currentState.handlerInfos[errorHandlerIndex].handler,
             wasAborted: wasAborted,
             state: currentState
-          };
+          });
         }
 
         function proceed(resolvedHandlerInfo) {
@@ -1388,11 +1389,11 @@ define("router/transition",
         this.sequence = Transition.currentSequence++;
         this.promise = state.resolve(router.async, checkForAbort, this)['catch'](function(result) {
           if (result.wasAborted) {
-            throw logAbort(transition);
+            return reject(logAbort(transition));
           } else {
             transition.trigger('error', result.error, transition, result.handlerWithError);
             transition.abort();
-            throw result.error;
+            return reject(result.error);
           }
         }, promiseLabel('Handle Abort'));
       } else {
@@ -1522,7 +1523,7 @@ define("router/transition",
 
         Note: This method is also aliased as `send`
 
-        @param {Boolean} ignoreFailure the name of the event to fire
+        @param {Boolean} [ignoreFailure=false] a boolean specifying whether unhandled events throw an error
         @param {String} name the name of the event to fire
        */
       trigger: function (ignoreFailure) {
@@ -1554,7 +1555,7 @@ define("router/transition",
           if (router.activeTransition) {
             return router.activeTransition.followRedirects();
           }
-          throw reason;
+          return reject(reason);
         });
       },
 


### PR DESCRIPTION
Brings in a change which prefers internal rejecting promises to
`throw`, which was causing Pause on All Exceptions to pause on internal stuff
in response to simple things like redirecting. Note that in the case of actual
errors, Pause on All Exceptions will continue to pause on the original error
that caused any unintentional redirects, so, hooray.
