### PR TITLE
[BUGFIX beta] Deprecate quoteless action names.

### DIFF
--- a/packages/ember-routing/lib/helpers/action.js
+++ b/packages/ember-routing/lib/helpers/action.js
@@ -94,6 +94,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
               actionName = actionNameOrPath;
             }
           }
+        } else {
+          if (options.boundProperty) {
+            Ember.deprecate("Using a quoteless parameter with {{action}} is deprecated. Please update to quoted usage '{{action \"" + actionNameOrPath + "\"}}.", false);
+          }
         }
 
         if (!actionName) {

--- a/packages/ember-routing/tests/helpers/action_test.js
+++ b/packages/ember-routing/tests/helpers/action_test.js
@@ -843,6 +843,37 @@ if (Ember.FEATURES.isEnabled("ember-routing-bound-action-name")) {
 
     Ember.assert = oldAssert;
   });
+} else {
+  test("a quoteless parameter as an action name", function(){
+    expect(2);
+
+    expectDeprecation("Using a quoteless parameter with {{action}} is deprecated. Please update to quoted usage '{{action \"ohNoeNotValid\"}}.");
+
+    var triggeredAction;
+
+    view = Ember.View.create({
+      template: compile("<a id='oops-bound-param'' {{action ohNoeNotValid}}>Hi</a>")
+    });
+
+    var controller = Ember.Controller.extend({
+      actions: {
+        ohNoeNotValid: function() {
+          triggeredAction = true;
+        }
+      }
+    }).create();
+
+    Ember.run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    Ember.run(function(){
+      view.$("#oops-bound-param").click();
+    });
+
+    ok(triggeredAction, 'the action was triggered');
+  });
 }
 
 module("Ember.Handlebars - action helper - deprecated invoking directly on target", {


### PR DESCRIPTION
This is preparation for enabling the `ember-routing-bound-action-name` feature.

As requested by @tomdale in https://github.com/emberjs/ember.js/pull/3936#issuecomment-33835794.

This should be pulled into the current 1.4.0 beta series, so that we can enable `ember-routing-bound-action-name` in the 1.5.0 beta series.
