### PR TITLE
Enable ember-routing-auto-location in canary.

### DIFF
--- a/features.json
+++ b/features.json
@@ -18,7 +18,7 @@
     "ember-routing-drop-deprecated-action-style": null,
     "ember-metal-is-blank": true,
     "ember-eager-url-update": true,
-    "ember-routing-auto-location": null,
+    "ember-routing-auto-location": true,
     "ember-routing-bound-action-name": null,
     "ember-runtime-test-friendly-promises": null
   },


### PR DESCRIPTION
This feature was given a 'Go' in the core team meeting today (2014-01-31). As such it should be enabled by default for all future canary builds. This will help ensure that it has more review prior to shipping the 1.5.0 beta series.
