### PR TITLE
[FEATURE ember-routing-bound-action-name] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -19,7 +19,7 @@
     "ember-metal-is-blank": true,
     "ember-eager-url-update": true,
     "ember-routing-auto-location": true,
-    "ember-routing-bound-action-name": null,
+    "ember-routing-bound-action-name": true,
     "ember-runtime-test-friendly-promises": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1291,7 +1291,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     });
 
     Ember.TEMPLATES.home = Ember.Handlebars.compile(
-      "<a {{action showStuff content}}>{{name}}</a>"
+      "<a {{action 'showStuff' content}}>{{name}}</a>"
     );
 
     var controller = Ember.Controller.extend({


### PR DESCRIPTION
As discussed in https://github.com/emberjs/ember.js/pull/3936#issuecomment-33835794 a deprecation has been made for 1.4 (in 2ef00a2).

This will enable the feature for future canary builds, as it will be enabled by default in 1.5.
