### PR TITLE
[Bugfix BETA] App.destroy resets routes before destroying the container.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -666,6 +666,8 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
   willDestroy: function() {
     Ember.BOOTED = false;
+    // Ensure deactivation of routes before objects are destroyed
+    this.__container__.lookup('router:main').reset();
 
     this.__container__.destroy();
   },

--- a/packages/ember/tests/application_lifecycle.js
+++ b/packages/ember/tests/application_lifecycle.js
@@ -73,3 +73,40 @@ test("Resetting the application allows controller properties to be set when a ro
   equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), null);
   equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), null);
 });
+
+test("Destroying the application resets the router before the container is destroyed", function() {
+  App.Router.map(function() {
+    this.route('home', { path: '/' });
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+    setupController: function() {
+      this.controllerFor('home').set('selectedMenuItem', 'home');
+    },
+    deactivate: function() {
+      this.controllerFor('home').set('selectedMenuItem', null);
+    }
+  });
+  App.ApplicationRoute = Ember.Route.extend({
+    setupController: function() {
+      this.controllerFor('application').set('selectedMenuItem', 'home');
+    },
+    deactivate: function() {
+      this.controllerFor('application').set('selectedMenuItem', null);
+    }
+  });
+
+  var router = container.lookup('router:main');
+
+  Ember.run(App, 'advanceReadiness');
+
+  handleURL('/');
+
+  equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), 'home');
+  equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), 'home');
+
+  Ember.run(App, 'destroy');
+
+  equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), null);
+  equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), null);
+});


### PR DESCRIPTION
While testing it is common to create an App during setup and destroy it during
teardown.  To prevent ordering issues, routes should be destroyed before the
container is destroyed.  This behavior already exists in App.reset but should
also exist in App.destroy.
