### PR TITLE
Add a required option to Ember.Select for form validation

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -327,7 +327,7 @@ Ember.Select = Ember.View.extend({
   tagName: 'select',
   classNames: ['ember-select'],
   defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each view.groupedContent}}{{view view.groupView content=content label=label}}{{/each}}{{else}}{{#each view.content}}{{view view.optionView content=this}}{{/each}}{{/if}}'),
-  attributeBindings: ['multiple', 'disabled', 'tabindex', 'name'],
+  attributeBindings: ['multiple', 'disabled', 'tabindex', 'name', 'required'],
 
   /**
     The `multiple` attribute of the select element. Indicates whether multiple
@@ -348,6 +348,16 @@ Ember.Select = Ember.View.extend({
     @default false
   */
   disabled: false,
+
+  /**
+    The `required` attribute of the select element. Indicates whether
+    a selected option is required for form validation.
+
+    @property required
+    @type Boolean
+    @default false
+  */
+  required: false,
 
   /**
     The list of options.

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -45,6 +45,24 @@ test("should begin disabled if the disabled attribute is true", function() {
   ok(select.$().is(":disabled"));
 });
 
+test("should begin required if the required attribute is true", function() {
+  select.set('required', true);
+  append();
+
+  equal(select.$().attr('required'), 'required');
+});
+
+test("should become required if the required attribute is changed", function() {
+  append();
+  equal(select.$().attr('required'), undefined);
+
+  Ember.run(function() { select.set('required', true); });
+  equal(select.$().attr('required'), 'required');
+
+  Ember.run(function() { select.set('required', false); });
+  equal(select.$().attr('required'), undefined);
+});
+
 test("should become disabled if the disabled attribute is changed", function() {
   append();
   ok(select.$().is(":not(:disabled)"));


### PR DESCRIPTION
The use case is to be able to lean on HTML5 form validation.
This PR allows a required attribute to be added to the select view.
