### PR TITLE
[FEATURE ember-routing-add-model-option]

### DIFF
--- a/features.json
+++ b/features.json
@@ -17,7 +17,8 @@
     "ember-routing-auto-location": true,
     "ember-routing-bound-action-name": true,
     "ember-runtime-test-friendly-promises": null,
-    "ember-routing-inherits-parent-model": true
+    "ember-routing-inherits-parent-model": true,
+    "ember-routing-add-model-option": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1508,7 +1508,9 @@ function normalizeOptions(route, name, template, options) {
 
   Ember.assert("An outlet ("+options.outlet+") was specified but was not found.", options.outlet === 'main' || options.into);
 
-  var controller = options.controller, namedController;
+  var controller = options.controller,
+      model = options.model,
+      namedController;
 
   if (options.controller) {
     controller = options.controller;
@@ -1524,6 +1526,12 @@ function normalizeOptions(route, name, template, options) {
     if (!controller) {
       throw new Ember.Error("You passed `controller: '" + controllerName + "'` into the `render` method, but no such controller could be found.");
     }
+  }
+
+  if(Ember.FEATURES.isEnabled("ember-routing-add-model-option")) {
+    if(model) {
+      controller.set('content', model);
+    }    
   }
 
   options.controller = controller;

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -256,6 +256,30 @@ test("The Homepage with explicit template name in renderTemplate and controller"
   equal(Ember.$('h3:contains(Megatroll) + p:contains(YES I AM HOME)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
+if(Ember.FEATURES.isEnabled("ember-routing-add-model-option")) {
+test("Model passed via renderTemplate model is set as controller's content", function(){
+  Ember.TEMPLATES['bio'] = compile("<p>{{name}}</p>");
+  
+  App.BioController = Ember.ObjectController.extend();
+  
+  Router.map(function(){
+    this.route('home', { path: '/'});
+  });
+  
+  App.HomeRoute = Ember.Route.extend({
+    renderTemplate: function(){
+      this.render('bio', {
+        model: {name: 'emberjs'} 
+      });
+    }
+  });
+  
+  bootApplication();
+  
+  equal(Ember.$('p:contains(emberjs)', '#qunit-fixture').length, 1, "Passed model was set as controllers content");
+});
+}
+
 test("Renders correct view with slash notation", function() {
   Ember.TEMPLATES['home/page'] = compile("<p>{{view.name}}</p>");
 


### PR DESCRIPTION
Prior to this commit, one needs to set the `model` explicitly on the other controller using `controllerFor` (while trying to render a different template with `renderTemplate#render`)

```
App.BioController = Em.ObjectController.extend();

App.HomeRoute = Em.Route.extend({
  renderTemplate: function(){
    this.controllerFor('bio').set('content', model);
    this.render('bio');
  }
});
```

This commit provides an option to set the `model` that will set to the  `controller's` content after the controller has been looked-up

```
App.HomeRoute = Em.Route.extend({
  renderTemplate: function(){          
    this.render('bio', {
      model: model
    });
  }
});
```

Also this addresses the functionality difference between `{{render}}` and `route#render`
Fixes #3796
