### PR TITLE
[BUGFIX beta] HashLocation no longer looks the hash up with location.hash because of a Firefox decode bug. Fixes #4262

### DIFF
--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -176,5 +176,25 @@ Ember.Location = {
     this.implementations[name] = implementation;
   },
 
-  implementations: {}
+  implementations: {},
+
+  /**
+    Returns the current `location.hash` by parsing location.href since browsers
+    inconsistently URL-decode `location.hash`.
+  
+    https://bugzilla.mozilla.org/show_bug.cgi?id=483304
+
+    @private
+    @method getHash
+  */
+  getHash: function () {
+    var href = window.location.href,
+        hashIndex = href.indexOf('#');
+
+    if (hashIndex === -1) {
+      return '';
+    } else {
+      return href.substr(hashIndex);
+    }
+  }
 };

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -7,7 +7,8 @@ if (Ember.FEATURES.isEnabled("ember-routing-auto-location")) {
   var get = Ember.get, set = Ember.set;
   var documentMode = document.documentMode,
       history = window.history,
-      location = window.location;
+      location = window.location,
+      getHash = Ember.Location.getHash;
 
   /**
     Ember.AutoLocation will select the best location option based off browser
@@ -142,7 +143,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-auto-location")) {
       @method getFullPath
     */
     getFullPath: function () {
-      return this.getPath() + location.hash;
+      return this.getPath() + getHash().substr(1);
     },
 
     /**
@@ -156,7 +157,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-auto-location")) {
     */
     getHistoryPath: function () {
       var path = this.getPath(),  
-          hashPath = location.hash.substr(1),
+          hashPath = getHash().substr(1),
           url = path + hashPath;
 
       // Removes any stacked double stashes

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -3,7 +3,8 @@
 @submodule ember-routing
 */
 
-var get = Ember.get, set = Ember.set;
+var get = Ember.get, set = Ember.set,
+    getHash = Ember.Location.getHash;
 
 /**
   `Ember.HashLocation` implements the location API using the browser's
@@ -28,20 +29,7 @@ Ember.HashLocation = Ember.Object.extend({
     @method getURL
   */
   getURL: function() {
-    if (Ember.FEATURES.isEnabled("query-params-new")) {
-      // location.hash is not used because it is inconsistently
-      // URL-decoded between browsers.
-      var href = get(this, 'location').href,
-        hashIndex = href.indexOf('#');
-
-      if ( hashIndex === -1 ) {
-        return "";
-      } else {
-        return href.substr(hashIndex + 1);
-      }
-    }
-    // Default implementation without feature flag enabled
-    return get(this, 'location').hash.substr(1);
+    return getHash().substr(1);
   },
 
   /**
@@ -86,7 +74,7 @@ Ember.HashLocation = Ember.Object.extend({
 
     Ember.$(window).on('hashchange.ember-location-'+guid, function() {
       Ember.run(function() {
-        var path = location.hash.substr(1);
+        var path = self.getURL();
         if (get(self, 'lastSetURL') === path) { return; }
 
         set(self, 'lastSetURL', null);


### PR DESCRIPTION
HashLocation no longer looks the hash up with location.hash because of a Firefox decode bug. Fixes #4262

https://github.com/emberjs/ember.js/pull/4008 fixed this [here](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/location/hash_location.js#L31), but since the `query-params-new` feature may or may not land in a stable release for some time, I think this should be fixed separately without being behind that feature flag.

Technically, this PR fixes this issue with the yet-to-be-released `AutoLocation` as well. I can break that out into a separate PR if you'd like, no problem. The common helper between the two was made at `Ember.Location.getHash()` since it seemed logical IMO.

If anyone can think of a way to test this...I'm all ears. Coverage on all the `Location` classes is lacking, as is already known. (on my bucket list as well)
