### PR TITLE
[BUGFIX beta] Total invalidation of arrayComputed should be synchronous

### DIFF
--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -471,11 +471,10 @@ function ReduceComputedProperty(options) {
   this.cacheable();
 
   this.recomputeOnce = function(propertyName) {
-    // What we really want to do is coalesce by <cp, propertyName>.
-    // We need a form of `scheduleOnce` that accepts an arbitrary token to
-    // coalesce by, in addition to the target and method.
-    run.once(this, recompute, propertyName);
+    // TODO: Coalesce recomputation by <this, propertyName, cp>.
+    recompute.call(this, propertyName);
   };
+
   var recompute = function(propertyName) {
     var dependentKeys = cp._dependentKeys,
         meta = cp._instanceMeta(this, propertyName),

--- a/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
@@ -770,35 +770,39 @@ test("non-array dependencies completely invalidate a reduceComputed CP", functio
   var dependentArray = Ember.A();
 
   obj = EmberObject.extend({
-    nonArray: 'v0',
+    nonArray: 0,
     dependentArray: dependentArray,
 
     computed: arrayComputed('dependentArray', 'nonArray', {
-      addedItem: function (array) {
+      addedItem: function (array, item) {
         ++addCalls;
+        if (item % 2 === this.get('nonArray')) {
+          array.pushObject(item);
+        }
         return array;
       },
 
-      removedItem: function (array) {
+      removedItem: function (array, item) {
         --removeCalls;
+        array.removeObject(item);
         return array;
       }
     })
   }).create();
 
-  get(obj, 'computed');
+  deepEqual(get(obj, 'computed'), []);
 
   equal(addCalls, 0, "precond - add has not initially been called");
   equal(removeCalls, 0, "precond - remove has not initially been called");
 
   dependentArray.pushObjects([1, 2]);
+  deepEqual(get(obj, 'computed'), [2]);
 
   equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
   equal(removeCalls, 0, "remove not called");
 
-  run(function() {
-    set(obj, 'nonArray', 'v1');
-  });
+  set(obj, 'nonArray', 1);
+  deepEqual(get(obj, 'computed'), [1], "array is recomputed synchronously");
 
   equal(addCalls, 4, "array completely recomputed when non-array dependency changed");
   equal(removeCalls, 0, "remove not called");


### PR DESCRIPTION
Currently, a total invalidation of an arrayComputed by a non-array dependency does not immediately invalidate. See http://emberjs.jsbin.com/uLeFezIP/1/edit.

This PR makes the invalidation immediate at the cost of losing some coalescing granted by `Ember.run.once`. Ultimately, I don't think this form of coalescing should be tied to the run loop, but rather deferred and coalesced until a subsequent `get`-type operation.

/cc @hjdivad @mixonic
