### PR TITLE
[FEATURE ember-eager-url-update] link-to should generate the url if it eagerly updates it, not use the href because it includes rootURL. Fixes #1244

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -357,11 +357,12 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       // Schedule eager URL update, but after we've given the transition
       // a chance to synchronously redirect.
       if (Ember.FEATURES.isEnabled("ember-eager-url-update")) {
-        var href = get(this, 'href');
-        if (typeof href === 'undefined') {
-          href = router.generate.apply(router, get(this, 'routeArgs'));
-        }
-        Ember.run.scheduleOnce('routerTransitions', this, this._eagerUpdateUrl, transition, href);
+        // We need to always generate the URL instead of using the href because
+        // the href will include any rootURL set, but the router expects a URL
+        // without it! Note that we don't use the first level router because it
+        // calls location.formatURL(), which also would add the rootURL!
+        var url = router.router.generate.apply(router.router, get(this, 'routeArgs'));
+        Ember.run.scheduleOnce('routerTransitions', this, this._eagerUpdateUrl, transition, url);
       }
     },
 


### PR DESCRIPTION
`link-to` used to let the transition [update the URL](https://github.com/emberjs/ember.js/blob/ba40ac334fba5bee67b6fc0e1fefbe492b00627c/packages/ember-routing/lib/vendor/router.js#L760), but https://github.com/emberjs/ember.js/pull/4122 made `link-to` request a URL update with the router, providing its own URL based off the `href` cp.

Unfortunately, the `href` includes the `rootURL`, if one is used, which the router, nor the `Location` classes are expecting it to already have, so they prepend it again.

This PR makes `link-to` **always** generate the URL, just like [the transition does](https://github.com/emberjs/ember.js/blob/ba40ac334fba5bee67b6fc0e1fefbe492b00627c/packages/ember-routing/lib/vendor/router.js#L760).

Fixes #1244
