### PR TITLE
[BUGFIX beta] Support Handlebars ~> 1.0.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
   remote: .
   specs:
     ember-source (1.5.0.beta.1.canary)
-      handlebars-source (~> 1.3.0)
+      handlebars-source (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/ember-source.gemspec
+++ b/ember-source.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.version       = Ember.rubygems_version_string
 
-  gem.add_dependency "handlebars-source", ["~> 1.3.0"]
+  gem.add_dependency "handlebars-source", ["~> 1.0"]
 
   gem.files = %w(VERSION) + Dir['dist/*.js', 'lib/ember/*.rb']
 end


### PR DESCRIPTION
Ember is compatible with Handlebars versions from 1.0.0 forward.
