### PR TITLE
[FEATURE ember-routing-inherits-parent-model] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -21,7 +21,7 @@
     "ember-routing-auto-location": true,
     "ember-routing-bound-action-name": true,
     "ember-runtime-test-friendly-promises": null,
-    "ember-routing-inherits-parent-model": null
+    "ember-routing-inherits-parent-model": true
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }


### PR DESCRIPTION
Confirmed as a 'Go' by @machty and @stefanpenner.
