### PR TITLE
Container throws if injection registered for already instantiated type

### DIFF
--- a/packages_es6/container/lib/container.js
+++ b/packages_es6/container/lib/container.js
@@ -476,6 +476,9 @@ Container.prototype = {
     validateFullName(fullName);
     var normalizedName = this.normalize(fullName);
 
+    if (this.cache.has(normalizedName)) {
+      throw new Error("Attempted to register an injection for a type that has already been looked up. ('" + normalizedName + "', '" + property + "', '" + injectionName + "')");
+    }
     addInjection(this.injections, normalizedName, property, normalizedInjectionName);
   },
 
@@ -578,6 +581,9 @@ Container.prototype = {
 
     validateFullName(fullName);
 
+    if (this.factoryCache.has(normalizedName)) {
+      throw new Error("Attempted to register a factoryInjection for a type that has already been looked up. ('" + normalizedName + "', '" + property + "', '" + injectionName + "')");
+    }
     addInjection(this.factoryInjections, normalizedName, property, normalizedInjectionName);
   },
 

--- a/packages_es6/container/tests/container_test.js
+++ b/packages_es6/container/tests/container_test.js
@@ -557,3 +557,36 @@ test('once resolved, always return the same result', function(){
 
   equal(container.resolve('models:bar'), Bar);
 });
+
+test('once looked up, assert if an injection is registered for the entry', function(){
+  expect(1);
+
+  var container = new Container(),
+      Apple = factory(),
+      Worm = factory();
+
+  container.register('apple:main', Apple);
+  container.register('worm:main', Worm);
+  var apple = container.lookup('apple:main');
+  throws(function() {
+    container.injection('apple:main', 'worm', 'worm:main');
+  }, "Attempted to register an injection for a type that has already been looked up. ('apple:main', 'worm', 'worm:main')");
+});
+
+test("Once looked up, assert if a factoryInjection is registered for the factory", function() {
+  expect(1);
+
+  var container = new Container(),
+      Apple = factory(),
+      Worm = factory();
+
+  container.register('apple:main', Apple);
+  container.register('worm:main', Worm);
+
+  var AppleFactory = container.lookupFactory('apple:main');
+  throws(function() {
+    container.factoryInjection('apple:main', 'worm', 'worm:main');
+  }, "Attempted to register a factoryInjection for a type that has already been looked up. ('apple:main', 'worm', 'worm:main')");
+});
+
+


### PR DESCRIPTION
Prior to this commit, the container would happily allow you to register an injection for a type that had already been instantiated. This led to confusing-to-debug situations where an injection is registered but a container-created instance doesn't have the injection applied.
