### PR TITLE
[Performance] MISC micro performance improvments

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -193,7 +193,7 @@ function ComputedProperty(func, opts) {
 
   this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : true;
   this._dependentKeys = opts && opts.dependentKeys;
-  this._readOnly = opts && (opts.readOnly !== undefined || !!opts.readOnly);
+  this._readOnly = opts && (opts.readOnly !== undefined || !!opts.readOnly) || false;
 }
 
 Ember.ComputedProperty = ComputedProperty;

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -552,9 +552,7 @@ Ember.cacheFor = function cacheFor(obj, key) {
   var meta = obj[META_KEY],
       cache = meta && meta.cache;
 
-  if (cache && key in cache) {
-    return cache[key];
-  }
+  return cache && cache[key];
 };
 
 function getProperties(self, propertyNames) {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -570,13 +570,31 @@ Ember.computed = function(func) {
     to return
   @return {Object} the cached value
 */
-Ember.cacheFor = function cacheFor(obj, key) {
+var cacheFor = Ember.cacheFor = function cacheFor(obj, key) {
   var meta = obj[META_KEY],
       cache = meta && meta.cache,
       ret = cache && cache[key];
 
   if (ret === UNDEFINED) { return undefined; }
   return ret;
+};
+
+cacheFor.set = function(cache, key, value) {
+  if (value === undefined) {
+    cache[key] = UNDEFINED;
+  } else {
+    cache[key] = value;
+  }
+};
+
+cacheFor.get = function(cache, key) {
+  var ret = cache[key];
+  if (ret === UNDEFINED) { return undefined; }
+  return ret;
+};
+
+cacheFor.remove = function(cache, key) {
+  cache[key] = undefined;
 };
 
 function getProperties(self, propertyNames) {

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -59,11 +59,14 @@ get = function get(obj, keyName) {
   Ember.assert("Cannot call get with "+ keyName +" key.", !!keyName);
   Ember.assert("Cannot call get with '"+ keyName +"' on an undefined object.", obj !== undefined);
 
-  if (obj === null || keyName.indexOf('.') !== -1) {
+  if (obj === null) { return getPath(obj, keyName);  }
+
+  var meta = obj[META_KEY], desc = meta && meta.descs[keyName], ret;
+
+  if (desc === undefined && keyName.indexOf('.') !== -1) {
     return getPath(obj, keyName);
   }
 
-  var meta = obj[META_KEY], desc = meta && meta.descs[keyName], ret;
   if (desc) {
     return desc.get(obj, keyName);
   } else {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -30,18 +30,28 @@ var set = function set(obj, keyName, value, tolerant) {
 
   Ember.assert("Cannot call set with "+ keyName +" key.", !!keyName);
 
-  if (!obj || keyName.indexOf('.') !== -1) {
+  if (!obj) {
+    return setPath(obj, keyName, value, tolerant);
+  }
+
+  var meta = obj[META_KEY], desc = meta && meta.descs[keyName],
+      isUnknown, currentValue;
+
+  if (desc === undefined && keyName.indexOf('.') !== -1) {
     return setPath(obj, keyName, value, tolerant);
   }
 
   Ember.assert("You need to provide an object and key to `set`.", !!obj && keyName !== undefined);
   Ember.assert('calling set on destroyed object', !obj.isDestroyed);
 
-  var meta = obj[META_KEY], desc = meta && meta.descs[keyName],
-      isUnknown, currentValue;
-  if (desc) {
+  if (desc !== undefined) {
     desc.set(obj, keyName, value);
   } else {
+
+    if (typeof obj === 'object' && obj !== null && obj[keyName] === value) {
+      return value;
+    }
+
     isUnknown = 'object' === typeof obj && !(keyName in obj);
 
     // setUnknownProperty is called if `obj` is an object,

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -143,7 +143,7 @@ var META_DESC = Ember.META_DESC = {
   value: null
 };
 
-var META_KEY = Ember.GUID_KEY+'_meta';
+var META_KEY = '__ember_meta__';
 
 /**
   The key used to store meta information on object for property observing.

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -339,6 +339,7 @@ Ember.wrap = function(func, superFunc) {
   }
 
   superWrapper.wrappedFunction = func;
+  superWrapper.wrappedFunction.__ember_arity__ = func.length;
   superWrapper.__ember_observes__ = func.__ember_observes__;
   superWrapper.__ember_observesBefore__ = func.__ember_observesBefore__;
   superWrapper.__ember_listens__ = func.__ember_listens__;

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -6,6 +6,10 @@ var e_get = Ember.get,
     set = Ember.set,
     guidFor = Ember.guidFor,
     metaFor = Ember.meta,
+    cacheFor = Ember.cacheFor,
+    cacheSet = cacheFor.set,
+    cacheGet = cacheFor.get,
+    cacheRemove = cacheFor.remove,
     propertyWillChange = Ember.propertyWillChange,
     propertyDidChange = Ember.propertyDidChange,
     addBeforeObserver = Ember.addBeforeObserver,
@@ -411,8 +415,9 @@ function ReduceComputedPropertyInstanceMeta(context, propertyName, initialValue)
 
 ReduceComputedPropertyInstanceMeta.prototype = {
   getValue: function () {
-    if (this.propertyName in this.cache) {
-      return this.cache[this.propertyName];
+    var value = cacheGet(this.cache, this.propertyName);
+    if (value !== undefined) {
+      return value;
     } else {
       return this.initialValue;
     }
@@ -421,7 +426,7 @@ ReduceComputedPropertyInstanceMeta.prototype = {
   setValue: function(newValue, triggerObservers) {
     // This lets sugars force a recomputation, handy for very simple
     // implementations of eg max.
-    if (newValue === this.cache[this.propertyName]) {
+    if (newValue === cacheGet(this.cache, this.propertyName)) {
       return;
     }
 
@@ -430,9 +435,9 @@ ReduceComputedPropertyInstanceMeta.prototype = {
     }
 
     if (newValue === undefined) {
-      delete this.cache[this.propertyName];
+      cacheRemove(this.cache, this.propertyName);
     } else {
-      this.cache[this.propertyName] = newValue;
+      cacheSet(this.cache, this.propertyName, newValue);
     }
 
     if (triggerObservers) {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -16,6 +16,11 @@ var get = Ember.get, set = Ember.set,
 
 function nullViewsBuffer(view) {
   view.buffer = null;
+
+}
+
+function clearCachedElement(view) {
+  meta(view).cache.element = undefined;
 }
 
 var childViewsProperty = Ember.computed(function() {
@@ -1809,9 +1814,7 @@ Ember.View = Ember.CoreView.extend({
     @private
   */
   _elementDidChange: Ember.observer('element', function() {
-    this.forEachChildView(function(view) {
-      delete meta(view).cache.element;
-    });
+    this.forEachChildView(clearCachedElement);
   }),
 
   /**
@@ -2264,7 +2267,7 @@ Ember.View = Ember.CoreView.extend({
 
     if (priorState && priorState.exit) { priorState.exit(this); }
     if (currentState.enter) { currentState.enter(this); }
-    if (state === 'inDOM') { delete Ember.meta(this).cache.element; }
+    if (state === 'inDOM') { Ember.meta(this).cache.element = undefined; }
 
     if (children !== false) {
       this.forEachChildView(function(view) {


### PR DESCRIPTION
Motivation:

things that are cached should be as close to free to retrieve as possible, this PR targets cached CP values.
- [x] improve Ember.cacheFor throughput see: http://jsperf.com/fffffffffffffffff1111a/2
- [x] improve throughput of get of a cached CP see: http://jsperf.com/slow-get-fast-get
- [x] [Performance] improve META lookup 10x throughput on chrome 32/34 [homework](https://gist.github.com/stefanpenner/ede92fbd00bf49bc5f09) + [benchmarks](http://jsperf.com/lookup-key-length/2)
- [x] [Performance] minimize extra indexOf hits in Ember.get
- [x] before/after high level benchmark
- [x] open a [ticket on v8/chrome](https://code.google.com/p/v8/issues/detail?id=3144&thanks=3144&ts=1391994334) RE: concat string perf hit. 
- [x] improve CP set's 2 - 5X by repeating similar patterns on the set side of things.
- [x] explore killing all code that deletes from the meta cache. (this object may always be stuck in dict mode..)
- [ ] open ticket on V8 (maybe the rest of the vendors) regarding the cost of getting `function.length`
- [x] although tests pass, reduce computed will likely break in some places until I patch it
## outcomes:

getting a cached CP, appears to be now between 2x and 5x faster
setting a cached CP, appears to be now between 2x and 5x faster
some other aspects of CP's may also be improved.

complete un-scientific MICRO benchmark (I ran out of time):

given:

``` js
a = Ember.Object.createWithMixins({
  foo: Ember.computed(function() {
    return 'hi';
  })
});

a.get("foo"); // prime
b = {
  foo: 'hi'
};

function test(){
  console.time('cp');
  for ( var i = 0; i < 100000; i++ ){
    Ember.get(a, 'foo');
  }
  console.timeEnd('cp');
}
```

before this PR:

``` sh
test() => cp: 54.936ms
test() => cp: 42.300ms
test() => cp: 33.344ms
test() => cp: 32.220ms
test() => cp: 55.750ms
test() => cp: 38.422ms
```

with this PR

``` sh
test() => cp: 5.886ms
test() => cp: 4.363ms
test() => cp: 4.474ms 
test() => cp: 4.658ms
test() => cp: 6.384ms
test() => cp: 4.420ms
```

Nothing ground breaking, we can likely improve this more yet, we really need a better perf harness.. (cc @twokul)

Also, I was careful to ensure these changes didn't drastically degrade other paths. Other code-paths, especially ones utilizing meta should now be quicker, and generate much less garbage.
