### PR TITLE
[BUGFIX beta] Ember.Select with multiple=true , doesn't set selection when the elements are deep equal objects #4331

### DIFF
--- a/packages_es6/ember-handlebars/lib/controls/select.js
+++ b/packages_es6/ember-handlebars/lib/controls/select.js
@@ -597,10 +597,32 @@ var Select = View.extend({
     if (el) { el.selectedIndex = selectionIndex; }
   },
 
-  _selectionDidChangeMultiple: function() {
+  _indexesOfSelection : function() {
     var content = get(this, 'content'),
         selection = get(this, 'selection'),
-        selectedIndexes = content ? indexesOf(content, selection) : [-1],
+        valuePath = get(this, 'optionValuePath').replace(/^content\.?/, ''),
+        selectedIndexes = [];
+
+    if(content){
+      if (!valuePath){
+        return indexesOf(content, selection);
+      }else{
+        for (var selectionIndex = 0, selectionLength = selection.length; selectionIndex < selectionLength; selectionIndex++) {
+          for (var contentIndex = 0, contentLength = content.length; contentIndex < contentLength; contentIndex++) {
+            if (get(selection[selectionIndex],valuePath) === get(content[contentIndex],valuePath)) { 
+              selectedIndexes.push(contentIndex);
+            }
+          }
+        }
+      }
+    }else{
+      selectedIndexes.push(-1); 
+    }
+    return selectedIndexes;
+  },
+
+  _selectionDidChangeMultiple: function() {
+    var selectedIndexes = this._indexesOfSelection(),
         prompt = get(this, 'prompt'),
         offset = prompt ? 1 : 0,
         options = this.$('option'),

--- a/packages_es6/ember-handlebars/tests/controls/select_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/select_test.js
@@ -175,6 +175,32 @@ test("can retrieve the current selected options when multiple=true", function() 
   deepEqual(select.get('selection'), [tom, david], "On change, the new options should be selected");
 });
 
+test("selection can be set with  deeply equal objects", function () {
+  var yehuda = { id: 1, firstName: 'Yehuda' },
+      tom = { id: 2, firstName: 'Tom' },
+      david = { id: 3, firstName: 'David' },
+      brennain = { id: 4, firstName: 'Brennain' },
+      aClonedTom = { id: 2, firstName: 'Tom' },
+      aClonedYehuda = { id: 1, firstName: 'Yehuda' };
+
+  run(function() {
+    select.set('content', Ember.A([yehuda, tom, david, brennain]));
+    select.set('multiple', true);
+    select.set('optionValuePath', 'content.id');
+    select.set('selection', aClonedTom);
+  });
+
+  append();
+
+  deepEqual(select.get('selection'), [tom], "Initial selection should be correct");
+
+  run(function() { select.set('selection', aClonedYehuda); });
+
+  deepEqual(select.get('selection'), [yehuda], "After changing it, selection should be correct");
+});
+
+
+
 test("selection can be set when multiple=false", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' },
       tom = { id: 2, firstName: 'Tom' };


### PR DESCRIPTION
fix for [BUG]Ember.Select with multiple=true , doesn't set selection when the elements are deep equal objects #4331
