### PR TITLE
[beta] Do not manually install git && bundler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 ---
 rvm:
-- 1.9.3
+- 2.1.0
 node_js:
 - "0.10"
 install:
 - "npm install"
-- "gem install bundler --pre"
 - "bin/cached-bundle install --deployment --retry 3 --jobs 4"
-- sudo apt-get update && sudo apt-get install git
 after_success: bundle exec rake publish_build
 script: rake test\[$TEST_SUITE]
 notifications:


### PR DESCRIPTION
- Remove manual git installation. https://github.com/travis-ci/travis-ci/issues/1710 has been closed, and Travis VM's should now have git 1.8.5.3.
- Bundler 1.5+ is installed by default on Travis now, no need to install manually.
