### PR TITLE
[query-params-new] Fix issue with active class on parent route

### DIFF
--- a/packages/ember-routing/lib/vendor/router.js
+++ b/packages/ember-routing/lib/vendor/router.js
@@ -541,8 +541,18 @@ define("router/router",
 
         var newState = intent.applyToHandlers(state, recogHandlers, this.getHandler, targetHandler, true, true);
 
+        // Get a hash of QPs that will still be active on new route
+        var activeQPsOnNewHandler = {};
+        merge(activeQPsOnNewHandler, queryParams);
+        for (var key in activeQueryParams) {
+          if (activeQueryParams.hasOwnProperty(key) &&
+              activeQPsOnNewHandler.hasOwnProperty(key)) {
+            activeQPsOnNewHandler[key] = activeQueryParams[key];
+          }
+        }
+
         return handlerInfosEqual(newState.handlerInfos, state.handlerInfos) &&
-               !getChangelist(activeQueryParams, queryParams);
+               !getChangelist(activeQPsOnNewHandler, queryParams);
       },
 
       trigger: function(name) {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1372,6 +1372,31 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       shouldNotBeActive('#array-link');
       shouldNotBeActive('#empty-link');
   });
+
+  test("The {{link-to}} applies active class to parent route", function() {
+    App.Router.map(function() {
+      this.resource('parent', function() {
+        this.route('child');
+      });
+    });
+
+    Ember.TEMPLATES.application = Ember.Handlebars.compile(
+        "{{#link-to 'parent' id='parent-link'}}Parent{{/link-to}} " +
+        "{{#link-to 'parent.child' id='parent-child-link'}}Child{{/link-to}} " +
+        "{{outlet}}"
+        );
+
+    App.ParentChildController = Ember.ObjectController.extend({
+      queryParams: ['foo'],
+      foo: 'bar'
+    });
+
+    bootApplication();
+    shouldNotBeActive('#parent-link');
+    shouldNotBeActive('#parent-child-link');
+    Ember.run(router, 'handleURL', '/parent/child?foo=dog');
+    shouldBeActive('#parent-link');
+  });
 }
 
 function basicEagerURLUpdateTest(setTagName) {


### PR DESCRIPTION
This updates ember with the folliwing PR in router.js

https://github.com/tildeio/router.js/pull/78

The basic gist here is to only check for changes in query paramters that are passed in
to the `isActive` method. Additional query paramters that are active in the current state are
discared. This is because we want parent routes to be active but they were not because the
removal of query parsamters between the two routes caused the `isActive` method to return
`false` in router.js.
