### PR TITLE
Fixes the wait() test helper which was broken since the introduction of the async router

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -158,7 +158,7 @@ function wait(app, value) {
     // Every 10ms, poll for the async thing to have finished
     var watcher = setInterval(function() {
       // 1. If the router is loading, keep polling
-      var routerIsLoading = app.__container__.lookup('router:main').router.isLoading;
+      var routerIsLoading = !!app.__container__.lookup('router:main').router.activeTransition;
       if (routerIsLoading) { return; }
 
       // 2. If there are pending Ajax requests, keep polling


### PR DESCRIPTION
For some reason it seems like the wait() helper was never updated after the router was made asynchronous. This fix alone made my integration tests way more stable.
