### PR TITLE
Do not transpile files ending in `.amd.js`.

### DIFF
--- a/bin/transpile-packages.js
+++ b/bin/transpile-packages.js
@@ -19,7 +19,8 @@ ES6Package.prototype = {
 
     glob(directory + '/**/*', function(err, files){
       files.forEach(function(filename){
-        var result;
+        var stats = fs.statSync(filename), result;
+        if (stats.isDirectory()) { return; }
 
         if (filename.match(/\.amd\.js$/)){
           result = fs.readFileSync(filename);

--- a/bin/transpile-packages.js
+++ b/bin/transpile-packages.js
@@ -19,12 +19,17 @@ ES6Package.prototype = {
 
     glob(directory + '/**/*', function(err, files){
       files.forEach(function(filename){
-        console.log('Processing '+filename);
+        var result;
 
-        var result = this.compileFile(directory, filename)
+        if (filename.match(/\.amd\.js$/)){
+          result = fs.readFileSync(filename);
+          compiledOutput.push(result);
+        } else {
+          result = this.compileFile(directory, filename);
+          compiledOutput.push(result['compiled']);
+          moduleNames.push(result['name']);
+        }
 
-        compiledOutput.push(result['compiled']);
-        moduleNames.push(result['name']);
       }.bind(this));
 
       callback({compiled: compiledOutput, moduleNames: moduleNames});


### PR DESCRIPTION
This allows `packages_es6/` to contain vendored files that are not to be transpiled.
