### PR TITLE
Version the resolver.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -813,6 +813,9 @@ function resolverFor(namespace) {
     }
   };
 
+  resolve.version = resolver.version;
+  resolve.lookupType = resolver.lookupType;
+
   return resolve;
 }
 

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -86,6 +86,21 @@ Ember.DefaultResolver = Ember.Object.extend({
     @property namespace
   */
   namespace: null,
+  /**
+    This indicates the resolver style. This will be used internally
+    to determine the type of resolution that will be performed.
+
+    @property lookupType
+  */
+  lookupType: 'global',
+
+  /**
+    This indicates the resolver version. This will be used internally
+    to determine the type of resolution that will be performed.
+
+    @property version
+  */
+  version: 1,
 
   normalize: function(fullName) {
     var split = fullName.split(':', 2),

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -86,3 +86,11 @@ test("the default resolver throws an error if the fullName to resolve is invalid
   raises(function(){ locator.resolve('model:'); }, TypeError, /Invalid fullName/ );
   raises(function(){ locator.resolve(':type');  }, TypeError, /Invalid fullName/ );
 });
+
+test("the default resolver identifies its own version", function() {
+  equal(1, locator.resolver.version, 'the resolver indicates its own version');
+});
+
+test("the default resolver identifies its own lookupType", function() {
+  equal(locator.resolver.lookupType, 'global', 'the resolver indicates its own lookupType');
+});


### PR DESCRIPTION
This will allow us to determine internally if we are using global lookup (`lookupType === 'global'`) or module lookup (`lookupType === 'modules'`) and what version of that particular `lookupType`.

This was discussed in relation to the `ember-routing-named-substates` feature, and should allow the feature to be enabled when the lookupType is not `global`.

Reference:

https://github.com/emberjs/ember.js/pull/3655#issuecomment-33832960
