### PR TITLE
[FEATURE ember-handlebars-radio-buttons] Implement radio buttons

### DIFF
--- a/features.json
+++ b/features.json
@@ -6,7 +6,8 @@
     "ember-handlebars-caps-lookup": null,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-runtime-test-friendly-promises": true,
-    "ember-routing-add-model-option": true
+    "ember-routing-add-model-option": true,
+    "ember-handlebars-radio-buttons": true
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-handlebars/lib/controls.js
+++ b/packages_es6/ember-handlebars/lib/controls.js
@@ -1,6 +1,8 @@
 import Checkbox from "ember-handlebars/controls/checkbox";
 import TextField from "ember-handlebars/controls/text_field";
 import TextArea from "ember-handlebars/controls/text_area";
+import {RadioButton, RadioButtonGroup} from "ember-handlebars/controls/radio_button";
+import RadioButtonGroup from "ember-handlebars/controls/radio_button";
 
 import Ember from "ember-metal/core"; // Ember.assert
 // var emberAssert = Ember.assert;
@@ -344,4 +346,23 @@ function textareaHelper(options) {
   return helpers.view.call(this, TextArea, options);
 }
 
-export {inputHelper, textareaHelper}
+
+function radiobuttonHelper(options) {
+  Ember.assert('You can only pass attributes to the `radio` helper, not arguments', arguments.length < 2);
+
+  var hash = options.hash,
+      types = options.hashTypes;
+
+  return helpers.view.call(this, 'view.RadioButton', options);
+}
+
+function radiogroupHelper(options) {
+  Ember.assert('You can only pass attributes to the `radiogroup` helper, not arguments', arguments.length < 2);
+
+  var hash = options.hash,
+      types = options.hashTypes;
+
+  return helpers.view.call(this, RadioButtonGroup, options);
+}
+
+export {inputHelper, textareaHelper, radiobuttonHelper, radiogroupHelper}

--- a/packages_es6/ember-handlebars/lib/controls/radio_button.js
+++ b/packages_es6/ember-handlebars/lib/controls/radio_button.js
@@ -1,0 +1,184 @@
+import Ember from "ember-metal/core"; //FEATURES
+import {get} from "ember-metal/property_get";
+import {set} from "ember-metal/property_set";
+import Component from "ember-views/views/component";
+import {observer} from "ember-metal/mixin";
+import {computed} from "ember-metal/computed";
+import run from "ember-metal/run_loop";
+import isEmpty from "ember-metal/is_empty";
+
+if(Ember.FEATURES.isEnabled('ember-handlebars-radio-buttons')) {
+
+  /**
+    @class
+
+    The `Ember.RadioButton` view class renders an html radio input, allowing the
+    user to select a single value from a list of values.
+
+    Dealing with multiple radio buttons can be simplified by using an
+    `Ember.RadioButtonGroup`. See the {@link Ember.RadioButtonGroup} documentation
+    for more information.
+
+    @extends Ember.Component
+  */
+
+  var RadioButton = Component.extend({  
+    /** @scope Ember.RadioButton.prototype */
+
+    attributeBindings: ["disabled", "type", "name", "value", "checked"],
+    classNames: ["ember-radio-button"],
+
+    /**
+      The value of this radio button.
+
+      @type Object
+    */
+    value: null,
+
+    /**
+      The selected value in this group of radio buttons.
+
+      @type Object
+    */
+    selectedValue: null,
+
+    /**
+      Sets the disabled property on the element.
+
+      @default false
+      @type Boolean
+    */
+    isDisabled: false,
+
+    /**
+      Sets the checked property on the element.
+
+      @default false
+      @type Boolean
+    */
+    checked: false,
+
+    tagName: "input",
+    type: "radio",
+
+    selectedValueChanged: observer(function() {
+      var selectedValue = get(this, 'selectedValue');
+      if(!isEmpty(selectedValue) && get(this, 'value') === selectedValue) {
+        set(this, "checked", true);
+      } else {
+        set(this, "checked", false);
+      }
+    }, 'selectedValue'),
+
+    checkedChanged: observer(function() {
+      this._updateElementValue();
+    }, 'checked'),
+
+    init: function() {
+      this._super();
+      this.selectedValueChanged();
+      this.on('change', this, this._change);
+    },
+
+    _change: function() {
+      set(this, 'checked', this.$().prop('checked'));
+      run.once(this, this._updateElementValue);
+    },
+
+    _updateElementValue: function() {
+      if(!get(this, 'checked')) return;
+      set(this, 'selectedValue', get(this, 'value'));
+    }
+
+  });
+
+  /*
+    @class
+
+    The `Ember.RadioButtonGroup` view class provides a simplfied method for dealing
+    with multiple `Ember.RadioButton` instances.
+
+    ## Simple Example
+
+    ```handlebars
+    {{#view Ember.RadioButtonGroup name="role" value=role}}
+      {{view view.RadioButton value="admin"}}
+      {{view view.RadioButton value="owner"}}
+      {{view view.RadioButton value="user"}}
+    {{/view}}
+    ```
+
+    Note that the radio buttons are declared as `{{view view.RadioButton ...}}` as opposed
+    to `{{view Ember.RadioButton ...}}`. When inside the body of a RadioButtonGroup,
+    a `RadioButton` view is provided which automatically picks up the same name and value
+    binding as the containing group.
+
+    ## More Complex Example
+
+    ```javascript
+    App.person = Ember.Object.create({name: 'Gordon', role: 'admin'})
+    App.PersonController = Ember.Controller.extend({
+      content: 'App.person',
+      roleOptions: ['admin', 'owner', 'user', 'banned']
+    });
+    ```
+
+    ```handlebars
+    {{#view Ember.RadioButtonGroup name="role" value=role}}
+      {{#each role in controller.roleOptions}}
+        <label>
+          {{view view.RadioButton value="role"}}
+          {{role}}
+        </label>
+      {{/each}}
+    {{/view}}
+    ```
+
+    Again, you can also use the helpers to simplify this template:
+
+    ```handlebars
+    {{#radiogroup name="role" value=roleOptions}}
+      {{#each role in controller.roleOptions}}
+        <label>
+          {{radio value=role}
+          {{role}}
+        </label>
+      {{/each}}
+    {{/radiogroup}}
+    ```
+
+    The above controller/template combination will render html containing a
+    radio input for each item in the `roleOptions` property of the controller.
+    Initially, the `admin` option will be checked. If the user selects a different
+    radio, the `role` property of the controller's `content` will be updated
+    accordingly.
+
+    @extends Ember.Component
+  */
+  var RadioButtonGroup = Component.extend({
+  /** @scope Ember.RadioButtonGroup.prototype */
+
+    classNames: ['ember-radio-button-group'],
+    attributeBindings: ['name:data-name'],
+
+    //name: Ember.required(),
+    /**
+      The value of the selected radio button in this group
+
+      @type Object
+    */
+    value: null,
+
+    RadioButton: computed(function() {
+      return RadioButton.extend({
+        group: this,
+        selectedValueBinding: 'group.value',
+        nameBinding: 'group.name'
+      });
+    })
+
+  });
+}
+
+export default RadioButtonGroup
+export {RadioButton, RadioButtonGroup}

--- a/packages_es6/ember-handlebars/lib/main.js
+++ b/packages_es6/ember-handlebars/lib/main.js
@@ -29,12 +29,15 @@ import locHelper from "ember-handlebars/helpers/loc";
 
 
 import Checkbox from "ember-handlebars/controls/checkbox";
+import {RadioButton, RadioButtonGroup} from "ember-handlebars/controls/radio_button";
+
 import {Select, SelectOption, SelectOptgroup} from "ember-handlebars/controls/select";
 import TextArea from "ember-handlebars/controls/text_area";
 import TextField from "ember-handlebars/controls/text_field";
 import TextSupport from "ember-handlebars/controls/text_support";
 import TextSupport from "ember-handlebars/controls/text_support";
 import {inputHelper, textareaHelper} from "ember-handlebars/controls"
+import {radiobuttonHelper, radiogroupHelper} from "ember-handlebars/controls"
 
 
 import ComponentLookup from "ember-handlebars/component_lookup";
@@ -79,6 +82,9 @@ Ember._MetamorphView = _MetamorphView;
 Ember._Metamorph = _Metamorph;
 Ember.TextSupport = TextSupport;
 Ember.Checkbox = Checkbox;
+Ember.RadioButton = RadioButton;
+Ember.RadioButtonGroup = RadioButtonGroup;
+
 Ember.Select = Select;
 Ember.SelectOption = SelectOption;
 Ember.SelectOptgroup = SelectOptgroup;
@@ -110,6 +116,8 @@ EmberHandlebars.registerHelper("view", viewHelper);
 EmberHandlebars.registerHelper("unbound", unboundHelper);
 EmberHandlebars.registerHelper("input", inputHelper);
 EmberHandlebars.registerHelper("textarea", textareaHelper);
+EmberHandlebars.registerHelper("radio", radiobuttonHelper);
+EmberHandlebars.registerHelper("radiogroup", radiogroupHelper);
 
 // run load hooks
 runLoadHooks('Ember.Handlebars', EmberHandlebars);

--- a/packages_es6/ember-handlebars/tests/controls/radio_button_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/radio_button_test.js
@@ -1,0 +1,167 @@
+import Ember from "ember-metal/core"; //FEATURES
+import run from "ember-metal/run_loop";
+import jQuery from "ember-views/system/jquery";
+import EventDispatcher from "ember-views/system/event_dispatcher";
+import {get} from "ember-metal/property_get";
+import {set as o_set} from "ember-metal/property_set";
+
+
+var dispatcher, view, radio, component;
+
+var set = function(object, key, value) {
+  run(function() { o_set(object, key, value); });
+};
+
+function append() {
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+}
+
+if (Ember.FEATURES.isEnabled("ember-handlebars-radio-buttons")) {
+
+  module("Ember.RadioButton", {
+    setup: function() {
+
+      run(function() {
+        dispatcher = EventDispatcher.create();
+        dispatcher.setup();
+      });
+      
+      radio = Ember.RadioButton.create({
+        name: 'radio_button',
+        value: 'tahoe'
+      });
+
+      view = radio;
+
+      append();
+    },
+    teardown: function() {
+      run(function() {
+        radio.destroy();
+        dispatcher.destroy();
+      });
+    }
+  });
+
+  test("setting selectedValue should update the checked property", function() {
+
+    strictEqual(radio.$().prop('checked'), false, "precond - the element is not checked");
+    strictEqual(get(radio, "checked"), false, "precond - checked returns false");
+
+    set(radio, 'selectedValue', 'tahoe');
+
+    ok(radio.$().prop('checked'), "after clicking a radio button, the checked property changed in the DOM.");
+    equal(get(radio, "checked"), true, "after clicking a radio button, the checked property changed in the view.");
+  });
+
+
+  test("setting checked should update the selected value", function() {
+    set(radio, 'checked', true);
+
+    ok(radio.$().prop('checked'), "checked attribute should be set");
+    equal(get(radio, 'selectedValue'), 'tahoe', 'selectedValue should be set');
+  });
+
+  test("trigger change event should update checked property", function() {
+    jQuery('[value="tahoe"]').click();
+
+    ok(jQuery('[value="tahoe"]').prop('checked'), "checked attribute should be set");
+  });
+
+  module("Ember.RadioButtonGroup", {
+    setup: function() {
+      run(function() {
+        dispatcher = EventDispatcher.create();
+        dispatcher.setup();
+        view = Ember.ContainerView.create();
+        var group = Ember.RadioButtonGroup.create({
+          name: "options",
+          template: Ember.Handlebars.compile(
+            '{{view view.RadioButton value="option1"}}' +
+            '{{view view.RadioButton value="option2"}}'
+          )
+        });
+        append();
+        view.pushObject(group);
+        component = view.objectAt(0);
+      });
+    },
+    teardown: function() {
+      if (view) {
+        run(function() {
+          view.removeAt(0);
+          view.destroy();
+          dispatcher.destroy();
+          view = null;
+        });
+
+      }
+    }
+  });
+
+  test("value should update correctly", function() {
+
+    set(component, 'value', 'option1');
+
+    equal(get(component, 'value'), 'option1', 'value should be set');
+    equal(component.$().find("[value='option1']").prop('checked'), true, 'checkbox should be checked');
+    equal(component.$().find("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
+
+    set(component, 'value', 'option2');
+
+    equal(get(component, 'value'), 'option2', 'value should be set');
+    equal(component.$("[value='option2']").prop('checked'), true, 'checkbox should be checked');
+    equal(component.$("[value='option1']").prop('checked'), false, 'checkbox should not be checked');
+  });
+
+  test("value should work even if the view is not in the DOM", function() {
+
+    set(component, 'value', 'option1');
+
+    equal(get(component, 'value'), 'option1', 'value should be set');
+    equal(component.$("[value='option1']").prop('checked'), true, 'checkbox should be checked');
+    equal(component.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
+  });
+
+  test("should uncheck previous selection when new value is null", function() {
+
+    set(component, 'value', null);
+
+    equal(get(component, 'value'), null, 'value should be set');
+    equal(component.$("[value='option1']").prop('checked'), false, 'checkbox should not be checked');
+    equal(component.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
+  });
+
+  test("value should update correctly after change event", function() {
+    
+    // Can't find a way to programatically trigger a checkbox in IE and have it generate the
+    // same events as if a user actually clicks
+    run(function() {
+      var radio = component.$('[value="option1"]');
+      if (jQuery.support.changeBubbles) {
+        radio.click();
+      } else {
+        radio.trigger('click');
+        radio.prop('checked', true).trigger('change');
+      }
+    });
+
+    equal(get(component, 'value'), 'option1', 'value should be set');
+    equal(component.$("[value='option1']").prop('checked'), true, 'checkbox should be checked');
+    equal(component.$("[value='option2']").prop('checked'), false, 'checkbox should not be checked');
+    
+  });
+
+  test("checked property is removed when value changes to an unknown value", function() {
+
+    var button1 = component.$("[value='option1']");
+
+    set(component, 'value', 'option1');
+    equal(button1.prop('checked'), true, "option1 should be checked");
+
+    set(component, 'value', 'foobar');
+    equal(button1.prop('checked'), false, "option1 should not be checked");
+  });
+}


### PR DESCRIPTION
This updates #1235 to extend component, adds handlebar helpers, updates tests and documentation. I think a lot of people would be pleased to see radio buttons in the core and I see a lot of developers at my company have a hard time with radio buttons when they first get started with Ember, so I think this would be a great addition to the core.
