### PR TITLE
Revert #3218 and deprecate accessing global paths from Handlebars

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -25,13 +25,6 @@ for a detailed explanation.
 
   Added in [#3655](https://github.com/emberjs/ember.js/pull/3655).
 
-* `ember-handlebars-caps-lookup`
-  Forces Handlebars values starting with capital letters, like `{{CONSTANT}}`,
-  to always be looked up on `Ember.lookup`. Previously, these values would be
-  looked up on the controller in certain cases.
-
-  Added in [#3218](https://github.com/emberjs/ember.js/pull/3218)
-
 * `ember-testing-simple-setup`
   Removes the need for most of the ceremony of setting up an application for testing. The following
   examples are equivalent:

--- a/features.json
+++ b/features.json
@@ -4,7 +4,6 @@
     "query-params-new": null,
     "string-parameterize": null,
     "ember-routing-named-substates": null,
-    "ember-handlebars-caps-lookup": null,
     "ember-handlebars-log-primitives": true,
     "ember-testing-simple-setup": null,
     "ember-testing-routing-helpers": true,

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -61,29 +61,17 @@ var handlebarsGet = Ember.Handlebars.get = function(root, path, options) {
       normalizedPath = normalizePath(root, path, data),
       value;
 
-  if (Ember.FEATURES.isEnabled("ember-handlebars-caps-lookup")) {
+  // In cases where the path begins with a keyword, change the
+  // root to the value represented by that keyword, and ensure
+  // the path is relative to it.
+  root = normalizedPath.root;
+  path = normalizedPath.path;
 
-    // If the path starts with a capital letter, look it up on Ember.lookup,
-    // which defaults to the `window` object in browsers.
-    if (Ember.isGlobalPath(path)) {
-      value = Ember.get(Ember.lookup, path);
-    } else {
+  value = Ember.get(root, path);
 
-      // In cases where the path begins with a keyword, change the
-      // root to the value represented by that keyword, and ensure
-      // the path is relative to it.
-      value = Ember.get(normalizedPath.root, normalizedPath.path);
-    }
-
-  } else {
-    root = normalizedPath.root;
-    path = normalizedPath.path;
-
-    value = Ember.get(root, path);
-
-    if (value === undefined && root !== Ember.lookup && Ember.isGlobalPath(path)) {
-      value = Ember.get(Ember.lookup, path);
-    }
+  if (value === undefined && root !== Ember.lookup && Ember.isGlobalPath(path)) {
+    Ember.deprecate("Global lookup from a Handlebars template is deprecated.");
+    value = Ember.get(Ember.lookup, path);
   }
 
   return value;

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -401,8 +401,6 @@ Ember.Handlebars.registerHelper('each', function eachHelper(path, options) {
   }
 
   options.hash.dataSourceBinding = path;
-  // Set up emptyView as a metamorph with no tag
-  //options.hash.emptyViewClass = Ember._MetamorphView;
 
   if (options.data.insideGroup && !options.hash.groupedRows && !options.hash.itemViewClass) {
     new Ember.Handlebars.GroupedEach(this, path, options).render();

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -506,6 +506,38 @@ test("it works with the controller keyword", function() {
   equal(view.$().text(), "foobarbaz");
 });
 
+test("it looks up paths with capital letters on the controller", function() {
+  var controller = Ember.Object.create({
+    CONSTANT: Ember.A(["foo", "bar", "baz"])
+  });
+
+  Ember.run(function() { view.destroy(); });
+
+  view = Ember.View.create({
+    controller: controller,
+    template: templateFor("{{#view}}{{#each CONSTANT}}{{this}}{{/each}}{{/view}}")
+  });
+
+  append(view);
+
+  equal(view.$().text(), "foobarbaz");
+});
+
+test("it falls back to Ember.lookup for paths with capital letters", function() {
+  Ember.lookup.CONSTANT = Ember.A(["foo", "bar", "baz"]);
+
+  Ember.run(function() { view.destroy(); });
+
+  view = Ember.View.create({
+    controller: {},
+    template: templateFor("{{#view}}{{#each CONSTANT}}{{this}}{{/each}}{{/view}}")
+  });
+
+  append(view);
+
+  equal(view.$().text(), "foobarbaz");
+});
+
 module("{{#each foo in bar}}", {
   teardown: function() {
     Ember.run(function() {

--- a/packages/ember-handlebars/tests/lookup_test.js
+++ b/packages/ember-handlebars/tests/lookup_test.js
@@ -28,16 +28,23 @@ test("ID parameters should be looked up on the context", function() {
   deepEqual(params, ["Mr", "Tom", "Dale"]);
 });
 
-if (Ember.FEATURES.isEnabled("ember-handlebars-caps-lookup")) {
-  test("ID parameters that start with capital letters use Ember.lookup as their context", function() {
-    Ember.lookup.FOO = "BAR";
+test("ID parameters that start with capital letters fall back to Ember.lookup as their context", function() {
+  Ember.lookup.FOO = "BAR";
 
-    var context = { FOO: "BAZ" };
+  var context = {};
 
-    var params = Ember.Handlebars.resolveParams(context, ["FOO"], { types: ["ID"] });
-    deepEqual(params, ["BAR"]);
-  });
-}
+  var params = Ember.Handlebars.resolveParams(context, ["FOO"], { types: ["ID"] });
+  deepEqual(params, ["BAR"]);
+});
+
+test("ID parameters that start with capital letters look up on given context first", function() {
+  Ember.lookup.FOO = "BAR";
+
+  var context = { FOO: "BAZ" };
+
+  var params = Ember.Handlebars.resolveParams(context, ["FOO"], { types: ["ID"] });
+  deepEqual(params, ["BAZ"]);
+});
 
 test("ID parameters can look up keywords", function() {
   var controller = {

--- a/packages/ember-metal/tests/binding/connect_test.js
+++ b/packages/ember-metal/tests/binding/connect_test.js
@@ -48,6 +48,18 @@ testBoth('Connecting a binding between two objects', function(get, set) {
   performTest(binding, a, b, get, set);
 });
 
+testBoth('Connecting a binding to path with capital letters', function(get, set) {
+  var b = { bar: 'BAR' };
+  var a = { foo: 'FOO', B: b };
+
+  Ember.lookup.B = { bar: 'wrong' };
+
+  // b.bar -> a.foo
+  var binding = new Ember.Binding('foo', 'B.bar');
+
+  performTest(binding, a, b, get, set);
+});
+
 testBoth('Connecting a binding to path', function(get, set) {
   var a = { foo: 'FOO' };
   GlobalB = {


### PR DESCRIPTION
**In Progress**

As discussed in #3218, this PR reverts the addition of the `ember-handlebars-caps-lookup` feature flag and adds a deprecation warning when global paths are accessed from a Handlebars template.

I'm trying to fix the original inconsistency that was reported in #3098 (between `{{Foo}}` and `{{#each Foo}}`) by changing bindings to look up values on the given context before `Ember.lookup`. That part is incomplete and I'm not really sure what to change to get the rest of those tests to pass. Would love to be pointed in the right direction there.

I'm also not sure if it's possible to add a deprecation notice in the `{{#each Foo}}` case since the binding doesn't know whether it's being created from a template or not.

cc @ebryn
