### PR TITLE
Overwrite observers and listeners in Ember.CoreObject.create(). Fixes #4268

### DIFF
--- a/packages_es6/ember-metal/lib/mixin.js
+++ b/packages_es6/ember-metal/lib/mixin.js
@@ -801,4 +801,4 @@ function beforeObserver() {
   return func;
 };
 
-export {IS_BINDING, mixin, Mixin, required, aliasMethod, observer, immediateObserver, beforeObserver}
+export {IS_BINDING, mixin, Mixin, required, aliasMethod, observer, immediateObserver, beforeObserver, replaceObserversAndListeners}

--- a/packages_es6/ember-runtime/lib/system/core_object.js
+++ b/packages_es6/ember-runtime/lib/system/core_object.js
@@ -3,7 +3,7 @@
   @submodule ember-runtime
 */
 
-import Ember from "ember-metal/core"; 
+import Ember from "ember-metal/core";
 // Ember.ENV.MANDATORY_SETTER, Ember.assert, Ember.K, Ember.config
 
 // NOTE: this object should never be included directly. Instead use `Ember.Object`.
@@ -16,7 +16,7 @@ import {generateGuid, GUID_KEY, meta, META_KEY, makeArray} from "ember-metal/uti
 import {rewatch} from "ember-metal/watching";
 import {finishChains} from "ember-metal/chains";
 import {sendEvent} from "ember-metal/events";
-import {IS_BINDING, Mixin, required} from "ember-metal/mixin";
+import {IS_BINDING, Mixin, replaceObserversAndListeners, required} from "ember-metal/mixin";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import EmberError from "ember-metal/error";
 import {platform} from "ember-metal/platform";
@@ -98,6 +98,8 @@ function makeCtor() {
         for (var j = 0, ll = keyNames.length; j < ll; j++) {
           var keyName = keyNames[j];
           if (!properties.hasOwnProperty(keyName)) { continue; }
+
+          replaceObserversAndListeners(this, keyName, null);
 
           var value = properties[keyName];
 

--- a/packages_es6/ember-runtime/tests/system/object/create_test.js
+++ b/packages_es6/ember-runtime/tests/system/object/create_test.js
@@ -153,6 +153,19 @@ test("EmberObject.create can take null as a parameter", function(){
   deepEqual(EmberObject.create(), o);
 });
 
+test("overwrites observers and listeners", function() {
+  var MyClass = EmberObject.extend({
+    foo: on('init', function() { throw 'wrong'; }),
+    bar: observer('baz', function() { throw 'wrong'; })
+  });
+
+  var o = MyClass.create({ foo: 'foo', bar: 'bar' });
+  o.set('baz', 'baz');
+
+  equal(o.get('foo'), 'foo');
+  equal(o.get('bar'), 'bar');
+});
+
 module('EmberObject.createWithMixins', moduleOptions);
 
 test("Creates a new object that contains passed properties", function() {


### PR DESCRIPTION
This fixes the edge case with `Ember.Object.create()` described in #4268.

I basically just copied the observer/listener removal code from `ember-metal/lib/mixin.js`. If there's a better place to put those functions so that they can be shared by both files, let me know.
