### PR TITLE
Add count to array computed meta

### DIFF
--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -262,7 +262,7 @@ DependentArraysObserver.prototype = {
 
       forEach(itemPropertyKeys, removeObservers, this);
 
-      changeMeta = createChangeMeta(dependentArray, item, itemIndex, this.instanceMeta.propertyName, this.cp);
+      changeMeta = new ChangeMeta(dependentArray, item, itemIndex, this.instanceMeta.propertyName, this.cp, normalizedRemoveCount);
       this.setValue( removedItem.call(
         this.instanceMeta.context, this.getValue(), item, changeMeta, this.instanceMeta.sugarMeta));
     }
@@ -292,7 +292,7 @@ DependentArraysObserver.prototype = {
         }, this);
       }
 
-      changeMeta = createChangeMeta(dependentArray, item, normalizedIndex + sliceIndex, this.instanceMeta.propertyName, this.cp);
+      changeMeta = new ChangeMeta(dependentArray, item, normalizedIndex + sliceIndex, this.instanceMeta.propertyName, this.cp, addedCount);
       this.setValue( addedItem.call(
         this.instanceMeta.context, this.getValue(), item, changeMeta, this.instanceMeta.sugarMeta));
     }, this);
@@ -328,7 +328,7 @@ DependentArraysObserver.prototype = {
 
       this.updateIndexes(c.observerContext.trackedArray, c.observerContext.dependentArray);
 
-      changeMeta = createChangeMeta(c.array, c.obj, c.observerContext.index, this.instanceMeta.propertyName, this.cp, c.previousValues);
+      changeMeta = new ChangeMeta(c.array, c.obj, c.observerContext.index, this.instanceMeta.propertyName, this.cp, changedItems.length, c.previousValues);
       this.setValue(
         this.callbacks.removedItem.call(this.instanceMeta.context, this.getValue(), c.obj, changeMeta, this.instanceMeta.sugarMeta));
       this.setValue(
@@ -352,27 +352,24 @@ function normalizeRemoveCount(index, length, removedCount) {
   return Math.min(removedCount, length - index);
 }
 
-function createChangeMeta(dependentArray, item, index, propertyName, property, previousValues) {
-  var meta = {
-    arrayChanged: dependentArray,
-    index: index,
-    item: item,
-    propertyName: propertyName,
-    property: property
-  };
+function ChangeMeta(dependentArray, item, index, propertyName, property, changedCount, previousValues){
+  this.arrayChanged = dependentArray;
+  this.index = index;
+  this.item = item;
+  this.propertyName = propertyName;
+  this.property = property;
+  this.changedCount = changedCount;
 
   if (previousValues) {
     // previous values only available for item property changes
-    meta.previousValues = previousValues;
+    this.previousValues = previousValues;
   }
-
-  return meta;
 }
 
 function addItems (dependentArray, callbacks, cp, propertyName, meta) {
   forEach(dependentArray, function (item, index) {
     meta.setValue( callbacks.addedItem.call(
-      this, meta.getValue(), item, createChangeMeta(dependentArray, item, index, propertyName, cp), meta.sugarMeta));
+      this, meta.getValue(), item, new ChangeMeta(dependentArray, item, index, propertyName, cp, dependentArray.length), meta.sugarMeta));
   }, this);
 }
 

--- a/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
@@ -713,6 +713,32 @@ test("changeMeta includes item and index", function() {
   deepEqual(callbackItems, expected, "items removed from the array had observers removed");
 });
 
+test("changeMeta includes changedCount and arrayChanged", function() {
+  var callbackLetters = [];
+  var obj = EmberObject.createWithMixins({
+    letters: Ember.A(['a', 'b']),
+    lettersArrayComputed: arrayComputed('letters', {
+      addedItem: function (array, item, changeMeta, instanceMeta) {
+        callbackItems.push('add:' + changeMeta.changedCount + ":" + changeMeta.arrayChanged.join(''));
+      },
+      removedItem: function (array, item, changeMeta, instanceMeta) {
+        callbackItems.push('remove:' + changeMeta.changedCount + ":" + changeMeta.arrayChanged.join(''));
+      }
+    })
+  });
+
+  var letters = get(obj, 'letters');
+
+  obj.get('lettersArrayComputed');
+  letters.pushObject('c');
+  letters.popObject();
+  letters.replace(0, 1, ['d']);
+  letters.removeAt(0, letters.length);
+
+  var expected = ["add:2:ab", "add:2:ab", "add:1:abc", "remove:1:abc", "remove:1:ab", "add:1:db", "remove:2:db", "remove:2:db"];
+  deepEqual(callbackItems, expected, "changeMeta has count and changed");
+});
+
 test("when initialValue is undefined, everything works as advertised", function() {
   var chars = EmberObject.createWithMixins({
     letters: Ember.A(),


### PR DESCRIPTION
As discussed with @hjdivad and @mmun this adds the change count to `changeMeta`. I've extracted this from work on `Ember.computed.slice` which is waiting for some feedback before I can PR it. This can probably help with performance on `Ember.computed.sort` out of the box.

```
Ember.computed.sort = function(itemsKey, begin, end) {

  var changsInBatch = 0;

  return Ember.arrayComputed(itemsKey, {
    /* ... */
    removedItem: function (array, item, changeMeta, instanceMeta) {
      if (changesInBatch > 1) {
        changesInBatch--;
      } else {
        changesInBatch = changeMeta.changeCount;
      }
      // changesInBatch is how many operations remain (including the current one)
    }
  });
};
```

Maybe this work should just go straight into  a patch for `sort`? I wanted to get it out there regardless.
