### PR TITLE
[BUGFIX beta] Ensure namespaces are cleaned up.

### DIFF
--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -46,7 +46,9 @@ var Namespace = Ember.Namespace = Ember.Object.extend({
 
   destroy: function() {
     var namespaces = Ember.Namespace.NAMESPACES;
+
     Ember.lookup[this.toString()] = undefined;
+    delete Ember.Namespace.NAMESPACES_BY_ID[this.toString()];
     namespaces.splice(indexOf.call(namespaces, this), 1);
     this._super();
   }

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -13,12 +13,8 @@ module('Ember.Namespace', {
   teardown: function() {
     Ember.BOOTED = false;
 
-    if (lookup.NamespaceA) { Ember.run(function() { lookup.NamespaceA.destroy(); }); }
-    if (lookup.NamespaceB) { Ember.run(function() { lookup.NamespaceB.destroy(); }); }
-    if (lookup.namespaceC) {
-      Ember.run(function() {
-        lookup.namespaceC.destroy();
-      });
+    for(var prop in lookup) {
+      if (lookup[prop]) { Ember.run(lookup[prop], 'destroy'); }
     }
 
     Ember.lookup = originalLookup;
@@ -120,4 +116,20 @@ test("A nested namespace can be looked up by its name", function() {
   UI.Nav = Ember.Namespace.create();
 
   equal(Ember.Namespace.byName('UI.Nav'), UI.Nav);
+});
+
+test("Destroying a namespace before caching lookup removes it from the list of namespaces", function(){
+  var CF = lookup.CF = Ember.Namespace.create();
+
+  Ember.run(CF,'destroy');
+  equal(Ember.Namespace.byName('CF'), undefined, "namespace can not be found after destroyed");
+});
+
+test("Destroying a namespace after looking up removes it from the list of namespaces", function(){
+  var CF = lookup.CF = Ember.Namespace.create();
+
+  equal(Ember.Namespace.byName('CF'), CF, "precondition - namespace can be looked up by name");
+
+  Ember.run(CF,'destroy');
+  equal(Ember.Namespace.byName('CF'), undefined, "namespace can not be found after destroyed");
 });


### PR DESCRIPTION
Prior to this change, calls to `Ember.Namespace.byName` would still return the cached class since it was being saved off to `Ember.Namespace.NAMESPACES_BY_ID` but not cleared.

Fixes #4363.
