### PR TITLE
Disregard  currentWhen if there are too many contexts for handler

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -10,6 +10,21 @@ var slice = Array.prototype.slice;
 // require('ember-handlebars/helpers/view');
 requireModule('ember-handlebars');
 
+var numberOfContextsAcceptedByHandler = function(handler, handlerInfos) {
+  var req = 0;
+  for (var i = 0, l = handlerInfos.length; i < l; i++) {
+    req = req + handlerInfos[i].names.length;
+    if (handlerInfos[i].handler === handler)
+      break;
+  }
+
+  // query params adds an additional context
+  if (Ember.FEATURES.isEnabled("query-params-new")) {
+    req = req + 1;
+  }
+  return req;
+};
+
 Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
   var QueryParams = Ember.Object.extend({
@@ -351,16 +366,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
           routeArgs = get(this, 'routeArgs'),
           contexts = routeArgs.slice(1),
           resolvedParams = get(this, 'resolvedParams'),
-          currentWhen = this.currentWhen || routeArgs[0];
+          currentWhen = this.currentWhen || routeArgs[0],
+          maximumContexts = numberOfContextsAcceptedByHandler(currentWhen, router.router.recognizer.handlersFor(currentWhen));
 
-      // if overriding active w/ currentWhen then don't apply contexts since they won't match
-      if (this.currentWhen) {
-        contexts = [];
-        if (Ember.FEATURES.isEnabled("query-params-new")) {
-          contexts.push({ queryParams: get(this, 'queryParams') });
-        }
-      }
-
+      // if we don't have enough contexts revert back to full route name
+      // this is because the leaf route will use one of the contexts
+      if (contexts.length > maximumContexts)
+        currentWhen = routeArgs[0];
+      
       var isActive = router.isActive.apply(router, [currentWhen].concat(contexts));
 
       if (isActive) { return get(this, 'activeClass'); }

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1037,6 +1037,30 @@ test("the {{link-to}} helper does not throw an error if its route has exited", f
   });
 });
 
+test("{{link-to}} active property respects changing parent route context", function() {
+  Ember.TEMPLATES.application = Ember.Handlebars.compile(
+    "{{link-to 'OMG' 'things' 'omg' id='omg-link'}} " +
+    "{{link-to 'LOL' 'things' 'lol' id='lol-link'}} ");
+
+
+  Router.map(function() {
+    this.resource('things', { path: '/things/:name' }, function() {
+      this.route('other');
+    });
+  });
+
+  bootApplication();
+
+  Ember.run(router, 'handleURL', '/things/omg');
+  shouldBeActive('#omg-link');
+  shouldNotBeActive('#lol-link');
+
+  Ember.run(router, 'handleURL', '/things/omg/other');
+  shouldBeActive('#omg-link');
+  shouldNotBeActive('#lol-link');
+
+});
+
 if (Ember.FEATURES.isEnabled("query-params-new")) {
 
   test("{{link-to}} populates href with default query param values even without query-params object", function() {


### PR DESCRIPTION
This fixes the strange active behavior in issue #4277 and provides a better fix for #4201. 

The issue in #4201 was that using the shorthand for `parent.index` route would throw an error if `parent.index` took a dynamic segment and a context was passed to `link-to` for that segment. The original fix for #4201 was too disregard contexts all together when the requested handler isn't the same as the handler the `link-to` will actually transition to. This caused undesirable behavior as demonstrated in #4277.

This fix reverts what was done in #4201 and now passes all the contexts to `router.isActive`. The change is that if there are too many contexts passed in for the requested handler we disregard the `currentWhen` handlerName and actually use the full handler name to determine `active` status.

cc\ @machty
