### PR TITLE
[BUGFIX beta] Calling a overrided method in builtin array, not change the enumerable properties

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -24,6 +24,13 @@ var o_defineProperty = Ember.platform.defineProperty,
 
 var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
+var undefinedDescriptor = {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+  value: undefined
+};
+
 /**
   A unique key used to assign guids and other private metadata to objects.
   If you inspect an object in your browser debugger you will often see these.
@@ -332,6 +339,9 @@ Ember.metaPath = function metaPath(obj, path, writable) {
 Ember.wrap = function(func, superFunc) {
   function superWrapper() {
     var ret, sup = this.__nextSuper;
+    if (!this.hasOwnProperty('__nextSuper')) {
+      o_defineProperty(this, '__nextSuper', undefinedDescriptor);
+    }
     this.__nextSuper = superFunc;
     ret = func.apply(this, arguments);
     this.__nextSuper = sup;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -30,13 +30,6 @@ var set = Ember.set, get = Ember.get,
     MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER,
     indexOf = Ember.EnumerableUtils.indexOf;
 
-var undefinedDescriptor = {
-  configurable: true,
-  writable: true,
-  enumerable: false,
-  value: undefined
-};
-
 var nullDescriptor = {
   configurable: true,
   writable: true,
@@ -57,7 +50,6 @@ function makeCtor() {
       Class.proto(); // prepare prototype...
     }
     o_defineProperty(this, GUID_KEY, nullDescriptor);
-    o_defineProperty(this, '__nextSuper', undefinedDescriptor);
     var m = meta(this), proto = m.proto;
     m.proto = this;
     if (initMixins) {

--- a/packages/ember-runtime/tests/system/native_array/suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/suite_test.js
@@ -16,5 +16,18 @@ Ember.MutableArrayTests.extend({
 
 }).run();
 
+if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Array) {
+  test("Calling a overrided method not change the enumerable properties", function() {
+    var array = [],
+      hasOwnProperties = [];
 
+    array.objectAt(0);
 
+    for(var key in array) {
+      if (!array.hasOwnProperty(key)) { continue; }
+      hasOwnProperties.push(key);
+    }
+
+    deepEqual(hasOwnProperties, [], 'Array hasOwnProperties must be empty');
+  });
+}


### PR DESCRIPTION
Given the following example:

``` js
var array = [1];
array.objectAt(0);
Em.keys(array); // ["0", "__nextSuper"]
```

The `array` will end with the `__nextSuper` property, because when a overrided method is called, in that case `objectAt`, the `Ember.wrap` change the [`__nextSuper`](https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/utils.js#L335). 
That property is prevented to be enumerable in [`makeCtor`](https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/system/core_object.js#L60), but not in a builtin array.
