### PR TITLE
[BUGFIX beta]  More descriptive error when setting read-only property

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -454,7 +454,7 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
       funcArgLength, cachedValue, ret;
 
   if (this._readOnly) {
-    throw new Ember.Error('Cannot Set: ' + keyName + ' on: ' + Ember.inspect(obj));
+    throw new Ember.Error('Cannot set read-only property "' + keyName + '" on object: ' + Ember.inspect(obj));
   }
 
   this._suspended = obj;

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -714,7 +714,7 @@ testBoth('protects against setting', function(get, set) {
 
   raises(function() {
     set(obj, 'bar', 'newBar');
-  }, /Cannot Set: bar on:/ );
+  }, /Cannot set read\-only property "bar" on object:/ );
 
   equal(get(obj, 'bar'), 'barValue');
 });


### PR DESCRIPTION
It currently doesn't say _why_ you can't set it.
