### PR TITLE
[BUGFIX beta] The `each` helper checks that the metamorph tags have the same parent.

### DIFF
--- a/features.json
+++ b/features.json
@@ -17,5 +17,5 @@
     "ember-routing-inherits-parent-model": true,
     "ember-routing-add-model-option": null
   },
-  "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
+  "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info", "Ember.runInDebug"]
 }

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -107,6 +107,24 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
   }
 });
 
+// Defeatureify doesn't seem to like nested functions that need to be removed
+function _addMetamorphCheck() {
+  Ember.Handlebars.EachView.reopen({
+    _checkMetamorph: Ember.on('didInsertElement', function() {
+      Ember.assert("The metamorph tags, " +
+                   this.morph.start + " and " + this.morph.end +
+                   ", have different parents.\nThe browser has fixed your template to output valid HTML (for example, check that you have properly closed all tags and have used a TBODY tag when creating a table with '{{#each}}')",
+        document.getElementById( this.morph.start ).parentNode ===
+        document.getElementById( this.morph.end ).parentNode
+      );
+    })
+  });
+}
+
+Ember.runInDebug( function() {
+  _addMetamorphCheck();
+});
+
 var GroupedEach = Ember.Handlebars.GroupedEach = function(context, path, options) {
   var self = this,
       normalized = Ember.Handlebars.normalizePath(context, path, options.data);

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -621,3 +621,24 @@ test("single-arg each will iterate over controller if present", function() {
   equal(view.$().text(), "AdamSteve");
 });
 
+test("it asserts when the morph tags disagree on their parentage", function() {
+  view = Ember.View.create({
+    controller: Ember.A(['Cyril', 'David']),
+    template: templateFor('<table>{{#each}}<tr><td>{{this}}</td></tr>{{/each}}</table>')
+  });
+
+  expectAssertion(function() {
+    append(view);
+  }, /The metamorph tags, metamorph-\d+-start and metamorph-\d+-end, have different parents.\nThe browser has fixed your template to output valid HTML \(for example, check that you have properly closed all tags and have used a TBODY tag when creating a table with '\{\{#each\}\}'\)/);
+});
+
+test("it doesn't assert when the morph tags have the same parent", function() {
+  view = Ember.View.create({
+    controller: Ember.A(['Cyril', 'David']),
+    template: templateFor('<table><tbody>{{#each}}<tr><td>{{this}}</td></tr>{{/each}}<tbody></table>')
+  });
+
+  append(view);
+
+  ok(true, "No assertion from valid template");
+});

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -362,7 +362,7 @@ test("The {{link-to}} helper moves into the named route with context", function(
     this.resource("item", { path: "/item/:id" });
   });
 
-  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each controller}}<li>{{#link-to 'item' this}}{{name}}{{/link-to}}<li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each controller}}<li>{{#link-to 'item' this}}{{name}}{{/link-to}}</li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
   App.AboutRoute = Ember.Route.extend({
     model: function() {

--- a/packages_es6/ember-debug/lib/main.js
+++ b/packages_es6/ember-debug/lib/main.js
@@ -140,6 +140,27 @@ Ember.deprecateFunc = function(message, func) {
 };
 
 
+/**
+  Run a function meant for debugging. Ember build tools will remove any calls to
+  `Ember.runInDebug()` when doing a production build.
+
+  ```javascript
+  Ember.runInDebug( function() {
+    Ember.Handlebars.EachView.reopen({
+      didInsertElement: function() {
+        console.log("I'm happy");
+      }
+    });
+  });
+  ```
+
+  @method runInDebug
+  @param {Function} func The function to be executed.
+*/
+Ember.runInDebug = function(func) {
+  func()
+};
+
 // Inform the developer about the Ember Inspector if not installed.
 if (!Ember.testing) {
   var isFirefox = typeof InstallTrigger !== 'undefined';

--- a/packages_es6/ember-metal/lib/core.js
+++ b/packages_es6/ember-metal/lib/core.js
@@ -196,6 +196,7 @@ Ember.K = function() { return this; };
 if ('undefined' === typeof Ember.assert) { Ember.assert = Ember.K; }
 if ('undefined' === typeof Ember.warn) { Ember.warn = Ember.K; }
 if ('undefined' === typeof Ember.debug) { Ember.debug = Ember.K; }
+if ('undefined' === typeof Ember.runInDebug) { Ember.runInDebug = Ember.K; }
 if ('undefined' === typeof Ember.deprecate) { Ember.deprecate = Ember.K; }
 if ('undefined' === typeof Ember.deprecateFunc) {
   Ember.deprecateFunc = function(_, func) { return func; };


### PR DESCRIPTION
In some cases, the browser may add or fix tags, which change the
parentage of metamorph tags. This problem happens frequently when the
developer doesn't not include the `TBODY` tag inside a table for example.
This prevents the framework to update or clean the underlying DOM
elements.

This helps to detect the issue described in #4273.
