### PR TITLE
Send events from `Ember.runLoadHooks`

### DIFF
--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -1,3 +1,5 @@
+/*globals CustomEvent */
+
 var forEach = Ember.ArrayPolyfills.forEach;
 
 /**
@@ -48,6 +50,11 @@ Ember.onLoad = function(name, callback) {
 */
 Ember.runLoadHooks = function(name, object) {
   loaded[name] = object;
+
+  if (typeof window === 'object' && typeof window.dispatchEvent === 'function' && typeof CustomEvent === "function") {
+    var event = new CustomEvent(name, {detail: object, name: name});
+    window.dispatchEvent(event);
+  }
 
   if (loadHooks[name]) {
     forEach.call(loadHooks[name], function(callback) {

--- a/packages/ember-runtime/tests/system/lazy_load_test.js
+++ b/packages/ember-runtime/tests/system/lazy_load_test.js
@@ -1,3 +1,5 @@
+/* globals CustomEvent */
+
 module("Lazy Loading");
 
 test("if a load hook is registered, it is executed when runLoadHooks are exected", function() {
@@ -49,3 +51,18 @@ test("hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed", function() {
 
   equal(window.ENV.__test_hook_count__, 1, "the object was passed into the load hook");
 });
+
+if (typeof window === 'object' && typeof window.dispatchEvent === 'function' && typeof CustomEvent === "function") {
+  test("load hooks trigger a custom event", function() {
+    var eventObject = "super duper awesome events";
+
+    window.addEventListener('__test_hook_for_events__', function(e) {
+      ok(true, 'custom event was fired');
+      equal(e.detail, eventObject, 'event details are provided properly');
+    });
+
+    Ember.run(function() {
+      Ember.runLoadHooks("__test_hook_for_events__", eventObject);
+    });
+  });
+}


### PR DESCRIPTION
This will allow debugging tools such as the Ember Inspector to support applications that load Ember asynchronously.
