### PR TITLE
Use documentElement instead of body for ember-extension detection

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -170,7 +170,7 @@ if (!Ember.testing) {
 
   if (typeof window !== 'undefined' && (isFirefox || isChrome) && window.addEventListener) {
     window.addEventListener("load", function() {
-      if (document.body && document.body.dataset && !document.body.dataset.emberExtension) {
+      if (document.documentElement && document.documentElement.dataset && !document.documentElement.dataset.emberExtension) {
         var downloadURL;
 
         if(isChrome) {


### PR DESCRIPTION
The new version of the Ember Inspector [uses documentElement](https://github.com/tildeio/ember-extension/blob/master/dist_chrome/content-script.js#L25).
