### PR TITLE
[BUGFIX beta] Use better ajax events for counters

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -14,12 +14,12 @@ var get = Ember.get,
 Test.pendingAjaxRequests = 0;
 
 Test.onInjectHelpers(function() {
-  Ember.$(document).ajaxStart(function() {
+  Ember.$(document).ajaxSend(function() {
     Test.pendingAjaxRequests++;
   });
 
-  Ember.$(document).ajaxStop(function() {
-    Ember.assert("An ajaxStop event which would cause the number of pending AJAX " +
+  Ember.$(document).ajaxComplete(function() {
+    Ember.assert("An ajaxComplete event which would cause the number of pending AJAX " +
                  "requests to be negative has been triggered. This is most likely " +
                  "caused by AJAX events that were started before calling " +
                  "`injectTestHelpers()`.", Test.pendingAjaxRequests !== 0);

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -130,11 +130,11 @@ Ember.Test = {
 
     ```javascript
     Ember.Test.onInjectHelpers(function() {
-      Ember.$(document).ajaxStart(function() {
+      Ember.$(document).ajaxSend(function() {
         Test.pendingAjaxRequests++;
       });
 
-      Ember.$(document).ajaxStop(function() {
+      Ember.$(document).ajaxComplete(function() {
         Test.pendingAjaxRequests--;
       });
     });

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -10,8 +10,8 @@ function cleanup(){
   }
 
   Ember.run(function(){
-    Ember.$(document).off('ajaxStart');
-    Ember.$(document).off('ajaxStop');
+    Ember.$(document).off('ajaxSend');
+    Ember.$(document).off('ajaxComplete');
   });
 
   Ember.TEMPLATES = {};
@@ -267,14 +267,14 @@ test("Ember.Application#injectTestHelpers", function() {
     documentEvents = {};
   }
 
-  ok(documentEvents['ajaxStart'] === undefined, 'there are no ajaxStart listers setup prior to calling injectTestHelpers');
-  ok(documentEvents['ajaxStop'] === undefined, 'there are no ajaxStop listers setup prior to calling injectTestHelpers');
+  ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listers setup prior to calling injectTestHelpers');
+  ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listers setup prior to calling injectTestHelpers');
 
   App.injectTestHelpers();
   documentEvents = Ember.$._data(document, 'events');
 
-  equal(documentEvents['ajaxStart'].length, 1, 'calling injectTestHelpers registers an ajaxStart handler');
-  equal(documentEvents['ajaxStop'].length, 1, 'calling injectTestHelpers registers an ajaxStop handler');
+  equal(documentEvents['ajaxSend'].length, 1, 'calling injectTestHelpers registers an ajaxSend handler');
+  equal(documentEvents['ajaxComplete'].length, 1, 'calling injectTestHelpers registers an ajaxComplete handler');
 });
 
 test("Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers", function(){
@@ -482,32 +482,32 @@ module("ember-testing pendingAjaxRequests", {
   teardown: function() { cleanup(); }
 });
 
-test("pendingAjaxRequests is incremented on each document ajaxStart event", function() {
+test("pendingAjaxRequests is incremented on each document ajaxSend event", function() {
   Ember.Test.pendingAjaxRequests = 0;
 
   Ember.run(function(){
-    Ember.$(document).trigger('ajaxStart');
+    Ember.$(document).trigger('ajaxSend');
   });
 
   equal(Ember.Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests was incremented');
 });
 
-test("pendingAjaxRequests is decremented on each document ajaxStop event", function() {
+test("pendingAjaxRequests is decremented on each document ajaxComplete event", function() {
   Ember.Test.pendingAjaxRequests = 1;
 
   Ember.run(function(){
-    Ember.$(document).trigger('ajaxStop');
+    Ember.$(document).trigger('ajaxComplete');
   });
 
   equal(Ember.Test.pendingAjaxRequests, 0, 'Ember.Test.pendingAjaxRequests was decremented');
 });
 
-test("it should raise an assertion error if ajaxStop is called without pendingAjaxRequests", function() {
+test("it should raise an assertion error if ajaxComplete is called without pendingAjaxRequests", function() {
   Ember.Test.pendingAjaxRequests = 0;
 
   expectAssertion(function() {
     Ember.run(function(){
-      Ember.$(document).trigger('ajaxStop');
+      Ember.$(document).trigger('ajaxComplete');
     });
   });
 });


### PR DESCRIPTION
Using `ajaxSend` and `ajaxComplete` instead of `ajaxStart` and
`ajaxStop`. See http://api.jquery.com/ajaxSend/ and
http://api.jquery.com/ajaxComplete/ for more information on each one.

It turns out that `ajaxStart` and `ajaxStop` are only called when the
request in question is the only one running. This is problematic for the
`wait()` helper. Changing to events that are called on _every_ request
fixes this problem.
