### PR TITLE
fix action bubbling for components with a component as parent

### DIFF
--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -215,7 +215,7 @@ Ember.ActionHandler = Ember.Mixin.create({
       }
     }
 
-    if (target = get(this, 'target')) {
+    if (target = get(this, 'target') || get(this, 'targetObject')) {
       Ember.assert("The `target` for " + this + " (" + target + ") does not have a `send` method", typeof target.send === 'function');
       target.send.apply(target, arguments);
     }

--- a/packages/ember-runtime/tests/mixins/action_handler_test.js
+++ b/packages/ember-runtime/tests/mixins/action_handler_test.js
@@ -11,3 +11,35 @@ test("passing a function for the actions hash triggers an assertion", function()
     });
   });
 });
+
+test("can use targetObject if target is not present in the case of components - GH-4430", function(){
+
+  expect(1);
+
+  var targetObject = Ember.Controller.create();
+
+  var Controller = Ember.Controller.extend({
+    targetObject: Ember.computed('target', '_targetObject', function(){
+      var target;
+      if (target = this.get('target')){
+        return target;
+      }
+      return this.get('_targetObject');
+    })
+  });
+
+  var controller = Controller.create();
+
+  Ember.run(function(){
+    controller.set('_targetObject', targetObject);
+  });
+
+  targetObject.send = function(){
+    ok(true, "Uses targetObject if target not present");
+  };
+
+  Ember.run(function(){
+    controller.send('openADialog');
+  });
+
+});


### PR DESCRIPTION
Fixes an issue where nesting a component inside another component would
cause actions to be swallowed and not delegated up to the route like
they should be. Ember.TargetActionSupport defines `targetObject` as
a computed property. This commit allows action bubbling to fall back
to that property instead of stopping the bubbling chain at the parent
component.

fixes GH-4430
