### PR TITLE
Fix query params controllerOrProto (fixes #4420)

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -489,7 +489,7 @@ function getQueryParamsForRoute(route, result) {
 }
 
 function controllerOrProtoFor(controllerName, container) {
-  var fullName = 'controller:' + controllerName;
+  var fullName = container.normalize('controller:' + controllerName);
   if (container.cache.has(fullName)) {
     return container.lookup(fullName);
   } else {
@@ -794,5 +794,3 @@ Ember.Router.reopenClass({
     return result;
   }
 });
-
-


### PR DESCRIPTION
When doing `container.cache.has(fullName)`, `fullName` needs to be normalized, otherwise we will be asking from `controller:foo.index` when it gets stored as `controller:fooIndex`, returning always the prototype.
