### PR TITLE
[BUGFIX beta] Move AJAX listeners into Ember.setupForTesting.

### DIFF
--- a/packages/ember-testing/lib/ext.js
+++ b/packages/ember-testing/lib/ext.js
@@ -1,3 +1,7 @@
+require('ember-testing/test');
+
+var Test = Ember.Test;
+
 /**
   Sets Ember up for testing. This is useful to perform
   basic setup steps in order to unit test.
@@ -15,4 +19,18 @@ Ember.setupForTesting = function() {
   if (!Ember.Test.adapter) {
     Ember.Test.adapter = Ember.Test.QUnitAdapter.create();
   }
+
+  Test.pendingAjaxRequests = 0;
+
+  Ember.$(document).ajaxSend(function() {
+    Test.pendingAjaxRequests++;
+  });
+
+  Ember.$(document).ajaxComplete(function() {
+    Ember.assert("An ajaxComplete event which would cause the number of pending AJAX " +
+                 "requests to be negative has been triggered. This is most likely " +
+                 "caused by AJAX events that were started before calling " +
+                 "`injectTestHelpers()`.", Test.pendingAjaxRequests !== 0);
+    Test.pendingAjaxRequests--;
+  });
 };

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -11,22 +11,6 @@ var get = Ember.get,
     asyncHelper = Test.registerAsyncHelper,
     countAsync = 0;
 
-Test.pendingAjaxRequests = 0;
-
-Test.onInjectHelpers(function() {
-  Ember.$(document).ajaxSend(function() {
-    Test.pendingAjaxRequests++;
-  });
-
-  Ember.$(document).ajaxComplete(function() {
-    Ember.assert("An ajaxComplete event which would cause the number of pending AJAX " +
-                 "requests to be negative has been triggered. This is most likely " +
-                 "caused by AJAX events that were started before calling " +
-                 "`injectTestHelpers()`.", Test.pendingAjaxRequests !== 0);
-    Test.pendingAjaxRequests--;
-  });
-});
-
 function currentRouteName(app){
   var appController = app.__container__.lookup('controller:application');
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -256,11 +256,6 @@ test("`click` triggers appropriate events in order", function() {
 test("Ember.Application#injectTestHelpers", function() {
   var documentEvents;
 
-  Ember.run(function() {
-    App = Ember.Application.create();
-    App.setupForTesting();
-  });
-
   documentEvents = Ember.$._data(document, 'events');
 
   if (!documentEvents) {
@@ -270,7 +265,10 @@ test("Ember.Application#injectTestHelpers", function() {
   ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listers setup prior to calling injectTestHelpers');
   ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listers setup prior to calling injectTestHelpers');
 
-  App.injectTestHelpers();
+  Ember.run(function() {
+    Ember.setupForTesting();
+  });
+
   documentEvents = Ember.$._data(document, 'events');
 
   equal(documentEvents['ajaxSend'].length, 1, 'calling injectTestHelpers registers an ajaxSend handler');


### PR DESCRIPTION
Currently, if AJAX is being performed in an initializer the standard `wait` helper will not be aware of it since the `Test.pendingAjaxRequests` is initialized to 0 upon `App.injectTestHelpers`. This is AFTER the application initializers have run.

This changes to allow calling `Ember.setupForTesting` before creating your application instance (for environments like EAK that create a new application for each test), and is completely backwards compatible.
