### PR TITLE
Don't raise error when a destroyed array is assigned to ArrayProxy

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -148,7 +148,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray, {
     if (content) {
       Ember.assert(Ember.String.fmt('ArrayProxy expects an Array or ' + 
         'Ember.ArrayProxy, but you passed %@', [typeof content]), 
-        Ember.isArray(content));
+        Ember.isArray(content) || content.isDestroyed);
 
       content.addArrayObserver(this, {
         willChange: 'contentArrayWillChange',
@@ -185,7 +185,7 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray, {
     if (arrangedContent) {
       Ember.assert(Ember.String.fmt('ArrayProxy expects an Array or ' + 
         'Ember.ArrayProxy, but you passed %@', [typeof arrangedContent]), 
-        Ember.isArray(arrangedContent));
+        Ember.isArray(arrangedContent) || arrangedContent.isDestroyed);
 
       arrangedContent.addArrayObserver(this, {
         willChange: 'arrangedContentArrayWillChange',

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -61,3 +61,17 @@ test("The `arrangedContentDidChange` method is invoked after `content` is change
   proxy.set('content', Ember.A(['a', 'b']));
   equal(callCount, 1, "replacing the content array triggers the hook");
 });
+
+
+test("The ArrayProxy doesn't explode when assigned a destroyed object", function() {
+  var arrayController = Ember.ArrayController.create();
+  var proxy = Ember.ArrayProxy.create();
+
+  Ember.run(function() {
+    arrayController.destroy();
+  });
+
+  Ember.set(proxy, 'content', arrayController);
+
+  ok(true, "No exception was raised");
+});


### PR DESCRIPTION
Sometimes due to timing in test suites, an array that has become
destroyed (most likely due to a call to `DS.Store#unloadAll` in Ember Data)
is assigned to an array proxy. This leads to an intermittent problem
where an assertion is raised due to a destroyed array-like object
no longer being considered an array by Ember.

The root cause is that `Ember.isArray` relies on `Ember.Array.detect` to
determine "Array-ness", and when `Ember.Array.detect` is used on a
destroyed object false is returned because the meta information has
been removed.
