### PR TITLE
[BUGFIX beta] Mixin.without() is now considered for prop deprecation warnings

### DIFF
--- a/packages_es6/ember-metal/lib/mixin.js
+++ b/packages_es6/ember-metal/lib/mixin.js
@@ -210,8 +210,10 @@ function addNormalizedProperty(base, key, value, meta, descs, values, concats, m
   }
 }
 
-function mergeMixins(mixins, m, descs, values, base, keys) {
+function mergeMixins(mixins, m, descs, values, base, keys, without) {
   var mixin, props, key, concats, mergings, meta;
+  
+  without = without || [];
 
   function removeKeys(keyName) {
     delete descs[keyName];
@@ -228,7 +230,7 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
 
     if (props) {
       meta = metaFor(base);
-      if (base.willMergeMixin) { base.willMergeMixin(props); }
+      if (base.willMergeMixin) { base.willMergeMixin(props, without); }
       concats = concatenatedMixinProperties('concatenatedProperties', props, values, base);
       mergings = concatenatedMixinProperties('mergedProperties', props, values, base);
 
@@ -241,7 +243,10 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
       // manually copy toString() because some JS engines do not enumerate it
       if (props.hasOwnProperty('toString')) { base.toString = props.toString; }
     } else if (mixin.mixins) {
-      mergeMixins(mixin.mixins, m, descs, values, base, keys);
+      // This is so nested mixins can know about `without` exclusions
+      without.push.apply(without, mixin._without);
+
+      mergeMixins(mixin.mixins, m, descs, values, base, keys, without);
       if (mixin._without) { a_forEach.call(mixin._without, removeKeys); }
     }
   }

--- a/packages_es6/ember-metal/tests/mixin/without_test.js
+++ b/packages_es6/ember-metal/tests/mixin/without_test.js
@@ -1,5 +1,7 @@
 import {Mixin} from 'ember-metal/mixin';
 
+var toString = Object.prototype.toString;
+
 test('without should create a new mixin excluding named properties', function() {
 
   var MixinA = Mixin.create({
@@ -15,4 +17,24 @@ test('without should create a new mixin excluding named properties', function() 
   equal(obj.foo, 'FOO', 'should defined foo');
   equal(obj.bar, undefined, 'should not define bar');
 
+});
+
+test('willMergeMixin should receive an array of without properties', function() {
+  expect(2);
+
+  var MixinA = Mixin.create({
+    foo: 'FOO',
+    bar: 'BAR'
+  });
+
+  var MixinB = MixinA.without('bar');
+
+  var obj = {
+    willMergeMixin: function (props, without) {
+      equal(toString.call(without), '[object Array]');
+      deepEqual(['bar'], without);
+    }
+  };
+
+  MixinB.apply(obj);
 });

--- a/packages_es6/ember-views/lib/mixins/component_template_deprecation.js
+++ b/packages_es6/ember-views/lib/mixins/component_template_deprecation.js
@@ -1,6 +1,7 @@
 import Ember from 'ember-metal/core'; // Ember.deprecate
-import {get} from "ember-metal/property_get";
+import {get} from 'ember-metal/property_get';
 import {Mixin} from 'ember-metal/mixin';
+import {indexOf} from 'ember-metal/array';
 
 /**
   The ComponentTemplateDeprecation mixin is used to provide a useful
@@ -27,7 +28,7 @@ var ComponentTemplateDeprecation = Mixin.create({
 
     @method willMergeMixin
   */
-  willMergeMixin: function(props) {
+  willMergeMixin: function(props, without) {
     // must call _super here to ensure that the ActionHandler
     // mixin is setup properly (moves actions -> _actions)
     //
@@ -41,21 +42,21 @@ var ComponentTemplateDeprecation = Mixin.create({
     if (props.templateName && !layoutSpecified) {
       deprecatedProperty = 'templateName';
       replacementProperty = 'layoutName';
-
-      props.layoutName = props.templateName;
-      delete props['templateName'];
     }
 
     if (props.template && !layoutSpecified) {
       deprecatedProperty = 'template';
       replacementProperty = 'layout';
-
-      props.layout = props.template;
-      delete props['template'];
     }
 
     if (deprecatedProperty) {
-      Ember.deprecate('Do not specify ' + deprecatedProperty + ' on a Component, use ' + replacementProperty + ' instead.', false);
+      // If the mixin actually has a record not to include this property,
+      // we don't need to complain because it won't be included.
+      if (!without || indexOf.call(without, deprecatedProperty) === -1) {
+        props[replacementProperty] = props[deprecatedProperty];
+        delete props[deprecatedProperty];
+        Ember.deprecate('Do not specify ' + deprecatedProperty + ' on a Component, use ' + replacementProperty + ' instead.', false);
+      }
     }
   }
 });


### PR DESCRIPTION
`Ember.ComponentTemplateDeprecation` has some warnings about deprecated property usage but `willMergeMixin` isn't told what properties are actually going to be excluded in the final merge so if you use `Mixin.without('deprecatedKey')`, `ComponentTemplateDeprecation` will incorrectly complain and actually switch it to the `layout` property so it ends up _not_ being excluded, just moved.

Example:

``` javascript
var ViewMixin = Ember.Mixin.create({
    template: function () {
        return 'foobar';
    }
});

var Component = Ember.Component.extend(ViewMixin.without('template'), {

});
```

For me, this is annoying as we create our own "base classes" instead of reopening Ember's.

This PR keeps track of the `without` exclusions and gives them to `willMergeMixin` for consideration.
