### PR TITLE
[DOC] Clarify the behaviour of `transitionTo` called from `redirect`

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -831,7 +831,11 @@ Ember.Route = Ember.Object.extend(Ember.ActionHandler, {
     A hook you can implement to optionally redirect to another route.
 
     If you call `this.transitionTo` from inside of this hook, this route
-    will not be entered in favor of the other hook.
+    will not be entered in favor of the other hook. In practical terms
+    this means that this route, and its parent routes, will *not*
+    complete their full lifecycle, and hooks such as `setupController`
+    will not be called. To transition at the end of the routes entire
+    lifecycle, call `transitionTo` in an `afterModel` hook.
 
     `redirect` and `afterModel` behave very similarly and are
     called almost at the same time, but they have an important


### PR DESCRIPTION
Calling `transitionTo` from within a `redirect` hook causes certain route hooks to be bypassed. This commit makes that more obvious in the documentation.

Happy to take suggestions on how to word this better.
