### PR TITLE
[BUGFIX beta] Ember.imports.jQuery || this.jQuery

### DIFF
--- a/packages/ember-views/lib/core.js
+++ b/packages/ember-views/lib/core.js
@@ -3,7 +3,7 @@
 @submodule ember-views
 */
 
-var jQuery = (this && this.jQuery) || (Ember.imports && Ember.imports.jQuery);
+var jQuery = (Ember.imports && Ember.imports.jQuery) || (this && this.jQuery);
 if (!jQuery && typeof require === 'function') {
   jQuery = require('jquery');
 }


### PR DESCRIPTION
Ember.imports.jQuery should be used before this.jQuery

Close #4449
