### PR TITLE
WIP: Entries by type

### DIFF
--- a/packages/ember-application/lib/main.js
+++ b/packages/ember-application/lib/main.js
@@ -1,5 +1,6 @@
 require('ember-views');
 require('ember-routing');
+require('ember-extension-support/container_debug_adapter');
 require('ember-application/system');
 require('ember-application/ext');
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -762,9 +762,10 @@ Ember.Application.reopenClass({
 
     container.injection('route', 'router', 'router:main');
 
+    // DEBUGGING
     container.register('resolver-for-debugging:main', container.resolver.__resolver__, { instantiate: false });
     container.injection('container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
-
+    container.injection('data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
     // Custom resolver authors may want to register their own ContainerDebugAdapter with this key
     container.register('container-debug-adapter:main', Ember.ContainerDebugAdapter);
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -762,6 +762,12 @@ Ember.Application.reopenClass({
 
     container.injection('route', 'router', 'router:main');
 
+    container.register('resolver-for-debugging:main', container.resolver.__resolver__, { instantiate: false });
+    container.injection('container-debug-adapter:main', 'resolver', 'resolver-for-debugging:main');
+
+    // Custom resolver authors may want to register their own ContainerDebugAdapter with this key
+    container.register('container-debug-adapter:main', Ember.ContainerDebugAdapter);
+
     return container;
   }
 });
@@ -812,6 +818,8 @@ function resolverFor(namespace) {
       return fullName;
     }
   };
+
+  resolve.__resolver__ = resolver;
 
   return resolve;
 }

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -8,7 +8,7 @@ var get = Ember.get,
     capitalize = Ember.String.capitalize,
     decamelize = Ember.String.decamelize;
 
-Ember.AbstractResolver = Ember.Object.extend({
+Ember.Resolver = Ember.Object.extend({
   /**
     This will be set to the Application instance when it is
     created.
@@ -17,40 +17,22 @@ Ember.AbstractResolver = Ember.Object.extend({
   */
   namespace: null,
   normalize: function(fullName) {
-    throw new Error("Invalid call to `resolver.normalize(fullName)`. Please override the 'normalize' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");    
+    throw new Error("Invalid call to `resolver.normalize(fullName)`. Please override the 'normalize' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");
   },
   resolve: function(fullName) {
-   throw new Error("Invalid call to `resolver.resolve(parsedName)`. Please override the 'resolve' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
+   throw new Error("Invalid call to `resolver.resolve(parsedName)`. Please override the 'resolve' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");
   },
   parseName: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveByType(parsedName)`. Please override the 'resolveByType' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
+   throw new Error("Invalid call to `resolver.resolveByType(parsedName)`. Please override the 'resolveByType' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");
   },
   lookupDescription: function(fullName) {
-    throw new Error("Invalid call to `resolver.lookupDescription(fullName)`. Please override the 'lookupDescription' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");    
+    throw new Error("Invalid call to `resolver.lookupDescription(fullName)`. Please override the 'lookupDescription' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");
   },
   makeToString: function(factory, fullName) {
-    throw new Error("Invalid call to `resolver.makeToString(factory, fullName)`. Please override the 'makeToString' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");    
+    throw new Error("Invalid call to `resolver.makeToString(factory, fullName)`. Please override the 'makeToString' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");
   },
-  resolveTemplate: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveTemplate(parsedName)`. Please override the 'resolveTemplate' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
-  },
-  resolveView: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveView(parsedName)`. Please override the 'resolveView' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
-  },
-  resolveController: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveController(parsedName)`. Please override the 'resolveController' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
-  },
-  resolveRoute: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveRoute(parsedName)`. Please override the 'resolveRoute' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
-  },
-  resolveModel: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveModel(parsedName)`. Please override the 'resolveModel' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
-  },
-  // resolveHelper: function(parsedName) {
-  //  throw new Error("Invalid call to `resolver.resolveHelper(parsedName)`. Please override the 'resolveHelper' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
-  // },
   resolveOther: function(parsedName) {
-   throw new Error("Invalid call to `resolver.resolveDefault(parsedName)`. Please override the 'resolveDefault' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");        
+   throw new Error("Invalid call to `resolver.resolveDefault(parsedName)`. Please override the 'resolveDefault' method in subclass of `Ember.AbstractResolver` to prevent falling through to this error.");
   }
 });
 
@@ -339,9 +321,9 @@ Ember.DefaultResolver = Ember.Object.extend({
       fullName lookup string
     @method resolveHelper
   */
-  // resolveHelper: function(parsedName) {
-  //   return this.resolveOther(parsedName);
-  // },
+  resolveHelper: function(parsedName) {
+    return this.resolveOther(parsedName) || Ember.Handlebars.helpers[parsedName.fullNameWithoutType];
+  },
   /**
     Look up the specified object (from parsedName) on the appropriate
     namespace (usually on the Application)

--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -5,8 +5,8 @@ module("Ember.Application Depedency Injection – customResolver",{
     function fallbackTemplate() { return "<h1>Fallback</h1>"; }
 
     var Resolver = Ember.DefaultResolver.extend({
-      resolveTemplate: function(parsedName) {
-        var resolvedTemplate = this._super(parsedName);
+      resolveTemplate: function(resolvable) {
+        var resolvedTemplate = this._super(resolvable);
         if (resolvedTemplate) { return resolvedTemplate; }
         return fallbackTemplate;
       }

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -12,6 +12,8 @@ module("Ember.Application Depedency Injection", {
     Ember.TEMPLATES = {};
     Ember.lookup = originalLookup;
     Ember.run(application, 'destroy');
+    var UserInterfaceNamespace = Ember.Namespace.NAMESPACES_BY_ID['UserInterface'];
+    if (UserInterfaceNamespace) { Ember.run(UserInterfaceNamespace, 'destroy'); }
   }
 });
 
@@ -27,7 +29,7 @@ test('the default resolver can look things up in other namespaces', function() {
 test('the default resolver looks up templates in Ember.TEMPLATES', function() {
   function fooTemplate() {}
   function fooBarTemplate() {}
-  function fooBarBazTemplate() {}
+  function fooBarBazTemplate() {} 
 
   Ember.TEMPLATES['foo'] = fooTemplate;
   Ember.TEMPLATES['fooBar'] = fooBarTemplate;

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -39,10 +39,6 @@ require('ember-application');
   @extends Ember.Object
 */
 Ember.ContainerDebugAdapter = Ember.Object.extend({
-  init: function() {
-    this._super();
-  },
-
   /**
     The container of the application being debugged.
     This property will be injected
@@ -86,6 +82,7 @@ Ember.ContainerDebugAdapter = Ember.Object.extend({
   catalogEntriesByType: function(type) {
     var namespaces = Ember.A(Ember.Namespace.NAMESPACES), types = Ember.A(), self = this;
     var typeSuffixRegex = new RegExp(Ember.String.classify(type) + "$");
+     
     namespaces.forEach(function(namespace) {
       if (namespace !== Ember) {
         for (var key in namespace) {
@@ -98,6 +95,7 @@ Ember.ContainerDebugAdapter = Ember.Object.extend({
           }
         }
       }
+      
     });
     return types;
   }

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -1,0 +1,105 @@
+/**
+@module ember
+@submodule ember-extension-support
+*/
+
+require('ember-application');
+
+/**
+  The `ContainerDebugAdapter` helps the container and resolver interface
+  with tools that debug Ember such as the
+  [Ember Extension](https://github.com/tildeio/ember-extension)
+  for Chrome and Firefox.
+
+  This class can be extended by a custom resolver implementer
+  to override some of the methods with library-specific code.
+
+  The methods likely to be overridden are:
+
+  * `canCatalogEntriesByType`
+  * `catalogEntriesByType`
+
+  The adapter will need to be registered
+  in the application's container as `container-debug-adapter:main`
+
+  Example:
+
+  ```javascript
+  Application.initializer({
+    name: "containerDebugAdapter",
+
+    initialize: function(container, application) {
+      application.register('container-debug-adapter:main', require('app/container-debug-adapter'));
+    }
+  });
+  ```
+
+  @class ContainerDebugAdapter
+  @namespace Ember
+  @extends Ember.Object
+*/
+Ember.ContainerDebugAdapter = Ember.Object.extend({
+  init: function() {
+    this._super();
+  },
+
+  /**
+    The container of the application being debugged.
+    This property will be injected
+    on creation.
+
+    @property container
+    @default null
+  */
+  container: null,
+
+  /**
+    The resolver instance of the application
+    being debugged. This property will be injected
+    on creation.
+
+    @property resolver
+    @default null
+  */
+  resolver: null,
+
+  /**
+    Returns true if it is possible to catalog a list of available
+    classes in the resolver for a given type.
+
+    @method canCatalogEntriesByType
+    @param {string} type The type. e.g. "model", "controller", "route"
+    @return {boolean} whether a list is available for this type.
+  */
+  canCatalogEntriesByType: function(type) {
+    if (type === 'model' || type === 'template') return false;
+    return true;
+  },
+
+  /**
+    Returns the available classes a given type.
+
+    @method catalogEntriesByType
+    @param {string} type The type. e.g. "model", "controller", "route"
+    @return {Array} An array of classes.
+  */
+  catalogEntriesByType: function(type) {
+    var namespaces = Ember.A(Ember.Namespace.NAMESPACES), types = Ember.A(), self = this;
+    var typeSuffixRegex = new RegExp(Ember.String.classify(type) + "$");
+    namespaces.forEach(function(namespace) {
+      if (namespace !== Ember) {
+        for (var key in namespace) {
+          if (!namespace.hasOwnProperty(key)) { continue; }
+          if (typeSuffixRegex.test(key)) {
+            var klass = namespace[key];
+            if (Ember.typeOf(klass) === 'class') {
+              types.push(klass);
+            }
+          }
+        }
+      }
+    });
+    return types;
+  }
+});
+

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -77,12 +77,12 @@ Ember.ContainerDebugAdapter = Ember.Object.extend({
 
     @method catalogEntriesByType
     @param {string} type The type. e.g. "model", "controller", "route"
-    @return {Array} An array of classes.
+    @return {Array} An array of strings.
   */
   catalogEntriesByType: function(type) {
     var namespaces = Ember.A(Ember.Namespace.NAMESPACES), types = Ember.A(), self = this;
     var typeSuffixRegex = new RegExp(Ember.String.classify(type) + "$");
-     
+
     namespaces.forEach(function(namespace) {
       if (namespace !== Ember) {
         for (var key in namespace) {
@@ -90,12 +90,11 @@ Ember.ContainerDebugAdapter = Ember.Object.extend({
           if (typeSuffixRegex.test(key)) {
             var klass = namespace[key];
             if (Ember.typeOf(klass) === 'class') {
-              types.push(klass);
+              types.push(Ember.String.dasherize(key.replace(typeSuffixRegex, '')));
             }
           }
         }
       }
-      
     });
     return types;
   }

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -306,9 +306,18 @@ Ember.DataAdapter = Ember.Object.extend({
     @method getModelTypes
     @return {Array} Array of model types
   */
-
- // TODO: Use the resolver instead of looping over namespaces.
   getModelTypes: function() {
+    var containerDebugAdapter = this.container.lookup('container-debug-adapter:main');
+    if (containerDebugAdapter.canCatalogEntriesByType('model')) {
+      return containerDebugAdapter.catalogEntriesByType('model');
+    }
+    else
+    {
+      return this.getModelTypesViaNamespaces();
+    }
+  },
+
+  getModelTypesViaNamespaces: function() {
     var namespaces = Ember.A(Ember.Namespace.NAMESPACES), types = Ember.A(), self = this;
 
     namespaces.forEach(function(namespace) {

--- a/packages/ember-extension-support/lib/main.js
+++ b/packages/ember-extension-support/lib/main.js
@@ -6,4 +6,5 @@ Ember Extension Support
 @requires ember-application
 */
 
+require('ember-extension-support/container_debug_adapter');
 require('ember-extension-support/data_adapter');

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -34,6 +34,7 @@ test("the default ContainerDebugAdapter can catalog typical entries by type", fu
 test("the default ContainerDebugAdapter catalogs controller entries", function(){
   App.PostController = Ember.Controller.extend();
   var controllerClasses = adapter.catalogEntriesByType('controller');
+ 
   equal(controllerClasses.length, 1, "found 1 class");
   equal(controllerClasses[0], App.PostController, "found the right class");
 });

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -1,0 +1,49 @@
+var adapter, App, get = Ember.get,
+    set = Ember.set, Model = Ember.Object.extend();
+
+module("Container Debug Adapter", {
+  setup:function() {
+    Ember.run(function() {
+      App = Ember.Application.create();
+      App.toString = function() { return 'App'; };
+      App.deferReadiness();
+      App.__container__.register('container-debug-adapter:main', Ember.ContainerDebugAdapter);
+      adapter = App.__container__.lookup('container-debug-adapter:main');
+    });
+  },
+  teardown: function() {
+    Ember.run(function() {
+      adapter.destroy();
+      App.destroy();
+      App = null;
+    });
+  }
+});
+
+test("the default ContainerDebugAdapter cannot catalog certain entries by type", function(){
+  equal(adapter.canCatalogEntriesByType('model'), false, "canCatalogEntriesByType should return false for model");
+  equal(adapter.canCatalogEntriesByType('template'), false, "canCatalogEntriesByType should return false for template");
+});
+
+test("the default ContainerDebugAdapter can catalog typical entries by type", function(){
+  equal(adapter.canCatalogEntriesByType('controller'), true, "canCatalogEntriesByType should return true for controller");
+  equal(adapter.canCatalogEntriesByType('route'), true, "canCatalogEntriesByType should return true for route");
+  equal(adapter.canCatalogEntriesByType('view'), true, "canCatalogEntriesByType should return true for view");
+});
+
+test("the default ContainerDebugAdapter catalogs controller entries", function(){
+  App.PostController = Ember.Controller.extend();
+  var controllerClasses = adapter.catalogEntriesByType('controller');
+  equal(controllerClasses.length, 1, "found 1 class");
+  equal(controllerClasses[0], App.PostController, "found the right class");
+});
+
+/*
+ [ ] Update getModelTypes to return an array of strings (model names) instead of classes
+ [ ] Update ContainerDebugAdapter#catalogEntriesByType to return an array of strings (model names) instead of classes
+ [ ] Update Ember Inspector to work with models as names (strings) instead of class references
+ [ ] Get tests passing in Ember with new approach
+ [ ] Implement the container-debug-adapter in EAK
+ [ ] What's up with timing for registering the container-debug-adapter?
+ [ ] Verify that no changes are necessary for ember-data models to start showing up in Ember Extension
+*/

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -1,13 +1,21 @@
 var adapter, App, get = Ember.get,
     set = Ember.set, Model = Ember.Object.extend();
 
+
+function boot() {
+  Ember.run(App, 'advanceReadiness');
+}
+
 module("Container Debug Adapter", {
   setup:function() {
     Ember.run(function() {
       App = Ember.Application.create();
       App.toString = function() { return 'App'; };
       App.deferReadiness();
-      App.__container__.register('container-debug-adapter:main', Ember.ContainerDebugAdapter);
+
+    });
+    boot();
+    Ember.run(function() {
       adapter = App.__container__.lookup('container-debug-adapter:main');
     });
   },
@@ -34,17 +42,7 @@ test("the default ContainerDebugAdapter can catalog typical entries by type", fu
 test("the default ContainerDebugAdapter catalogs controller entries", function(){
   App.PostController = Ember.Controller.extend();
   var controllerClasses = adapter.catalogEntriesByType('controller');
- 
-  equal(controllerClasses.length, 1, "found 1 class");
-  equal(controllerClasses[0], App.PostController, "found the right class");
-});
 
-/*
- [ ] Update getModelTypes to return an array of strings (model names) instead of classes
- [ ] Update ContainerDebugAdapter#catalogEntriesByType to return an array of strings (model names) instead of classes
- [ ] Update Ember Inspector to work with models as names (strings) instead of class references
- [ ] Get tests passing in Ember with new approach
- [ ] Implement the container-debug-adapter in EAK
- [ ] What's up with timing for registering the container-debug-adapter?
- [ ] Verify that no changes are necessary for ember-data models to start showing up in Ember Extension
-*/
+  equal(controllerClasses.length, 1, "found 1 class");
+  equal(controllerClasses[0], 'post', "found the right class");
+});

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -54,7 +54,7 @@ test("Model types added with DefaultResolver", function() {
 });
 
 test("Model types added with custom container-debug-adapter", function() {
-  var PostClass = Model.extend(),
+  var PostClass = Model.extend() ,
       StubContainerDebugAdapter = Ember.DefaultResolver.extend({
         canCatalogEntriesByType: function(type){
           return true;
@@ -76,12 +76,13 @@ test("Model types added with custom container-debug-adapter", function() {
   });
 
   Ember.run(App, 'advanceReadiness');
-
+ 
   var modelTypesAdded = function(types) {
 
     equal(types.length, 1);
     var postType = types[0];
-    equal(postType.name, 'Post', 'Correctly sets the name');
+
+    equal(postType.name, PostClass.toString(), 'Correctly sets the name');
     equal(postType.count, 3, 'Correctly sets the record count');
     strictEqual(postType.object, PostClass, 'Correctly sets the object');
     deepEqual(postType.columns, [ {name: 'title', desc: 'Title'} ], 'Correctly sets the columns');

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -13,7 +13,7 @@ module("Data Adapter", {
       App = Ember.Application.create();
       App.toString = function() { return 'App'; };
       App.deferReadiness();
-      App.__container__.register('dataAdapter:main', DataAdapter);
+      App.__container__.register('data-adapter:main', DataAdapter);
     });
   },
   teardown: function() {
@@ -27,7 +27,7 @@ module("Data Adapter", {
 test("Model types added with DefaultResolver", function() {
   App.Post = Model.extend();
 
-  adapter = App.__container__.lookup('dataAdapter:main');
+  adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords: function() {
       return Ember.A([1,2,3]);
@@ -43,7 +43,7 @@ test("Model types added with DefaultResolver", function() {
 
     equal(types.length, 1);
     var postType = types[0];
-    equal(postType.name, 'App.Post', 'Correctly sets the name');
+    equal(postType.name, 'post', 'Correctly sets the name');
     equal(postType.count, 3, 'Correctly sets the record count');
     strictEqual(postType.object, App.Post, 'Correctly sets the object');
     deepEqual(postType.columns, [ {name: 'title', desc: 'Title'} ], 'Correctly sets the columns');
@@ -65,7 +65,7 @@ test("Model types added with custom container-debug-adapter", function() {
       });
   App.__container__.register('container-debug-adapter:main', StubContainerDebugAdapter);
 
-  adapter = App.__container__.lookup('dataAdapter:main');
+  adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords: function() {
       return Ember.A([1,2,3]);
@@ -76,7 +76,7 @@ test("Model types added with custom container-debug-adapter", function() {
   });
 
   Ember.run(App, 'advanceReadiness');
- 
+
   var modelTypesAdded = function(types) {
 
     equal(types.length, 1);
@@ -94,7 +94,7 @@ test("Model types added with custom container-debug-adapter", function() {
 test("Model Types Updated", function() {
   App.Post = Model.extend();
 
-  adapter = App.__container__.lookup('dataAdapter:main');
+  adapter = App.__container__.lookup('data-adapter:main');
   var records = Ember.A([1,2,3]);
   adapter.reopen({
     getRecords: function() {
@@ -129,7 +129,7 @@ test("Records Added", function() {
   var post = App.Post.create();
   var recordList = Ember.A([post]);
 
-  adapter = App.__container__.lookup('dataAdapter:main');
+  adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords: function() {
       return recordList;
@@ -166,7 +166,7 @@ test("Observes and releases a record correctly", function() {
   var post = App.Post.create({ title: 'Post' });
   var recordList = Ember.A([post]);
 
-  adapter = App.__container__.lookup('dataAdapter:main');
+  adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords: function() {
       return recordList;


### PR DESCRIPTION
Add the ability for the container to list all entries of a specific type.  This is part of an effort to fix the Ember Inspector's Data tab compatibility with module based resolvers (such as EAK).

99% of the work was done by @yapplabs @lukemelia @stefanpenner @brendanoh over the course of 2 months.

I'm just going to complete the remaining todos and make sure it's ready to be merged and works well with Ember Inspector.  I hope to finish it this weekend.
- [x] Make sure tests passing in Ember and minor fixes.
- [x] Fix issues with `container-debug-adapter` registration / injection.
- [x] Update ContainerDebugAdapter#catalogEntriesByType to return an array of strings (model names) instead of classes.
- [x] Make sure the Inspector supports both string and classes.
- [x] Rely on the model's key instead of `toString` .
- [x] Implement the `container-debug-adapter` in EAK's resolver (https://github.com/stefanpenner/ember-jj-abrams-resolver/pull/31)
- [x] Clean commits
