### PR TITLE
Revert "Remove unused distros from Assetfile."

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -1,7 +1,9 @@
 require 'ember-dev'
 
 distros = {
+  "runtime"           => %w(ember-metal rsvp container ember-runtime),
   "template-compiler" => %w(ember-handlebars-compiler),
+  "data-deps"         => %w(ember-metal rsvp container ember-runtime),
   "full"              => %w(ember-metal rsvp container ember-runtime ember-views metamorph handlebars ember-handlebars-compiler ember-handlebars ember-routing ember-application ember-extension-support)
 }
 


### PR DESCRIPTION
This reverts commit 247c9d0ecaa00b398eb0112c6ce1e326903ecaa3.

---

After discussing with @ebryn in IRC, these distros are actually used in some scenarios.

I will review splitting them up in a future PR so that all distros are not generated all the time.
