### PR TITLE
Remove unreachable return from blockHelperMissing helper

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -214,8 +214,6 @@ Ember.Handlebars.registerHelper('blockHelperMissing', function(path) {
   } else {
     return Handlebars.helpers.helperMissing.call(this, path);
   }
-
-  return Handlebars.helpers.blockHelperMissing.apply(this, arguments);
 });
 
 /**


### PR DESCRIPTION
Closure compiler found an [unreachable return](https://github.com/emberjs/ember.js/blob/0e7cf03cca93c4d39bb2c6d7efef9043ab0c892c/packages/ember-handlebars/lib/ext.js#L218) in the `'blockHelperMissing'` helper.

This PR removes it. That said, I don't understand the code well enough to check if this is just a stray line or a bug, so someone please review.
