### PR TITLE
Revert #3218, replace #4358. Deprecate global access from templates

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -18,13 +18,6 @@ for a detailed explanation.
 
   Added in [#3655](https://github.com/emberjs/ember.js/pull/3655).
 
-* `ember-handlebars-caps-lookup`
-  Forces Handlebars values starting with capital letters, like `{{CONSTANT}}`,
-  to always be looked up on `Ember.lookup`. Previously, these values would be
-  looked up on the controller in certain cases.
-
-  Added in [#3218](https://github.com/emberjs/ember.js/pull/3218)
-
 * `composable-computed-properties`
 
   This feature allows you to combine (compose) different computed

--- a/features.json
+++ b/features.json
@@ -2,7 +2,6 @@
   "features": {
     "query-params-new": true,
     "ember-routing-named-substates": null,
-    "ember-handlebars-caps-lookup": null,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-routing-add-model-option": true,
     "ember-routing-linkto-target-attribute": null,

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -77,28 +77,21 @@ function handlebarsGet(root, path, options) {
       normalizedPath = normalizePath(root, path, data),
       value;
 
-  if (Ember.FEATURES.isEnabled("ember-handlebars-caps-lookup")) {
+  // In cases where the path begins with a keyword, change the
+  // root to the value represented by that keyword, and ensure
+  // the path is relative to it.
+  root = normalizedPath.root;
+  path = normalizedPath.path;
 
-    // If the path starts with a capital letter, look it up on Ember.lookup,
-    // which defaults to the `window` object in browsers.
-    if (isGlobalPath(path)) {
-      value = get(Ember.lookup, path);
-    } else {
+  value = get(root, path);
 
-      // In cases where the path begins with a keyword, change the
-      // root to the value represented by that keyword, and ensure
-      // the path is relative to it.
-      value = get(normalizedPath.root, normalizedPath.path);
+  if (isGlobalPath(path)) {
+    if (value === undefined && root !== Ember.lookup) {
+      root = Ember.lookup;
+      value = get(root, path);
     }
-
-  } else {
-    root = normalizedPath.root;
-    path = normalizedPath.path;
-
-    value = get(root, path);
-
-    if (value === undefined && root !== Ember.lookup && isGlobalPath(path)) {
-      value = get(Ember.lookup, path);
+    if (root === Ember.lookup || root === null) {
+      Ember.deprecate("Global lookup of "+path+" from a Handlebars template is deprecated.", options.silenceGlobalDeprecation);
     }
   }
 

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -167,6 +167,7 @@ function collectionHelper(path, options) {
   if (path) {
     controller = data.keywords.controller;
     container = controller && controller.container;
+    options.silenceGlobalDeprecation = true;
     collectionClass = handlebarsGet(this, path, options) || container.lookupFactory('view:' + path);
     Ember.assert(fmt("%@ #collection: Could not find collection class %@", [data.view, path]), !!collectionClass);
   }
@@ -193,6 +194,7 @@ function collectionHelper(path, options) {
                  "not found at " + container.describe("view:" + hash.itemView) +
                  " (and it was not registered in the container)", !!itemViewClass);
   } else if (hash.itemViewClass) {
+    options.silenceGlobalDeprecation = true;
     itemViewClass = handlebarsGet(collectionPrototype, hash.itemViewClass, options);
   } else {
     itemViewClass = collectionPrototype.itemViewClass;
@@ -232,6 +234,7 @@ function collectionHelper(path, options) {
           tagName: itemHash.tagName
     });
   } else if (hash.emptyViewClass) {
+    options.silenceGlobalDeprecation = true;
     emptyViewClass = handlebarsGet(this, hash.emptyViewClass, options);
   }
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -47,6 +47,7 @@ function makeBindings(thisContext, options) {
 
   if (hash.hasOwnProperty('idBinding')) {
     // id can't be bound, so just perform one-time lookup.
+    options.silenceGlobalDeprecation = true;
     hash.id = handlebarsGet(thisContext, hash.idBinding, options);
     hashType.id = 'STRING';
     delete hash.idBinding;
@@ -174,6 +175,7 @@ export var ViewHelper = EmberObject.create({
       if (options.types[0] === 'STRING' && LOWERCASE_A_Z.test(path) && !VIEW_PREFIX.test(path)) {
         lookup = path;
       } else {
+        options.silenceGlobalDeprecation = true;
         newView = handlebarsGet(thisContext, path, options);
         if (typeof newView === 'string') {
           lookup = newView;

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -177,6 +177,68 @@ test("should allow values from normal JavaScript hash objects to be used", funct
   equal(view.$().text(), "Señor CFC (and Fido)", "prints out values from a hash");
 });
 
+test("should read from globals [DEPRECATED]", function() {
+  Ember.lookup.Global = 'Klarg';
+  view = EmberView.create({
+    template: EmberHandlebars.compile('{{Global}}')
+  });
+
+  expectDeprecation(function(){
+    appendView();
+  }, "Global lookup of Global from a Handlebars template is deprecated.");
+  equal(view.$().text(), Ember.lookup.Global);
+});
+
+test("should read from globals with a path [DEPRECATED]", function() {
+  Ember.lookup.Global = { Space: 'Klarg' };
+  view = EmberView.create({
+    template: EmberHandlebars.compile('{{Global.Space}}')
+  });
+
+  expectDeprecation(function(){
+    appendView();
+  }, "Global lookup of Global.Space from a Handlebars template is deprecated.");
+  equal(view.$().text(), Ember.lookup.Global.Space);
+});
+
+test("with context, should read from globals [DEPRECATED]", function() {
+  Ember.lookup.Global = 'Klarg';
+  view = EmberView.create({
+    context: {},
+    template: EmberHandlebars.compile('{{Global}}')
+  });
+
+  expectDeprecation(function(){
+    appendView();
+  }, "Global lookup of Global from a Handlebars template is deprecated.");
+  equal(view.$().text(), Ember.lookup.Global);
+});
+
+test("with context, should read from globals with a path [DEPRECATED]", function() {
+  Ember.lookup.Global = { Space: 'Klarg' };
+  view = EmberView.create({
+    context: {},
+    template: EmberHandlebars.compile('{{Global.Space}}')
+  });
+
+  expectDeprecation(function(){
+    appendView();
+  }, "Global lookup of Global.Space from a Handlebars template is deprecated.");
+  equal(view.$().text(), Ember.lookup.Global.Space);
+});
+
+test("should read from a global-ish simple local path without deprecation", function() {
+  view = EmberView.create({
+    context: { NotGlobal: 'Gwar' },
+    template: EmberHandlebars.compile('{{NotGlobal}}')
+  });
+
+  expectNoDeprecation();
+  appendView();
+
+  equal(view.$().text(), 'Gwar');
+});
+
 test("htmlSafe should return an instance of Handlebars.SafeString", function() {
   var safeString = htmlSafe("you need to be more <b>bold</b>");
 

--- a/packages/ember-handlebars/tests/lookup_test.js
+++ b/packages/ember-handlebars/tests/lookup_test.js
@@ -28,16 +28,23 @@ test("ID parameters should be looked up on the context", function() {
   deepEqual(params, ["Mr", "Tom", "Dale"]);
 });
 
-if (Ember.FEATURES.isEnabled("ember-handlebars-caps-lookup")) {
-  test("ID parameters that start with capital letters use Ember.lookup as their context", function() {
-    Ember.lookup.FOO = "BAR";
+test("ID parameters that start with capital letters fall back to Ember.lookup as their context", function() {
+  Ember.lookup.Global = "I'm going global, what you ain't a local?";
 
-    var context = { FOO: "BAZ" };
+  var context = {};
 
-    var params = Ember.Handlebars.resolveParams(context, ["FOO"], { types: ["ID"] });
-    deepEqual(params, ["BAR"]);
-  });
-}
+  var params = Ember.Handlebars.resolveParams(context, ["Global"], { types: ["ID"] });
+  deepEqual(params, [Ember.lookup.Global]);
+});
+
+test("ID parameters that start with capital letters look up on given context first", function() {
+  Ember.lookup.Global = "I'm going global, what you ain't a local?";
+
+  var context = { Global: "Steal away from lookup" };
+
+  var params = Ember.Handlebars.resolveParams(context, ["Global"], { types: ["ID"] });
+  deepEqual(params, [context.Global]);
+});
 
 test("ID parameters can look up keywords", function() {
   var controller = {


### PR DESCRIPTION
Replaces #4358. These deprecations are narrow in scope, and only impact `{{Global}}`. They do not deprecate any other global access in templates. Deprecating all global access from templates would a) need to be done helper-by-helper or b) would impact the `get` and binding code at a lower level.

@xtian I'm rewritten your first commit but preserved it here.

@ebryn yo.
