### PR TITLE
[FEATURE ember-routing-add-model-option] Enable by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -15,7 +15,7 @@
     "ember-routing-bound-action-name": true,
     "ember-runtime-test-friendly-promises": null,
     "ember-routing-inherits-parent-model": true,
-    "ember-routing-add-model-option": null
+    "ember-routing-add-model-option": true
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info"]
 }


### PR DESCRIPTION
As discussed in the core team meeting on 2014/02/28.

http://emberjs.com/blog/2014/03/04/core-team-meeting-minutes-2014-02-28.html
