### PR TITLE
[BUGFIX beta] Do not collide with user named objects.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -740,10 +740,10 @@ Ember.Application.reopenClass({
 
     container.register('application:main', namespace, { instantiate: false });
 
-    container.register('controller:basic', Ember.Controller, { instantiate: false });
-    container.register('controller:object', Ember.ObjectController, { instantiate: false });
-    container.register('controller:array', Ember.ArrayController, { instantiate: false });
-    container.register('route:basic', Ember.Route, { instantiate: false });
+    container.register('controller:-ember-basic', Ember.Controller, { instantiate: false });
+    container.register('controller:-ember-object', Ember.ObjectController, { instantiate: false });
+    container.register('controller:-ember-array', Ember.ArrayController, { instantiate: false });
+    container.register('route:-ember-basic', Ember.Route, { instantiate: false });
     container.register('event_dispatcher:main', Ember.EventDispatcher);
 
     container.register('router:main',  Ember.Router);

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -237,7 +237,7 @@ Ember.DefaultResolver = Ember.Object.extend({
   */
   useRouterNaming: function(parsedName) {
     parsedName.name = parsedName.name.replace(/\./g, '_');
-    if (parsedName.name === 'basic') {
+    if (parsedName.name === '-ember-basic') {
       parsedName.name = '';
     }
   },

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -41,7 +41,7 @@ test('the default resolver looks up templates in Ember.TEMPLATES', function() {
 });
 
 test('the default resolver looks up basic name as no prefix', function() {
-  ok(Ember.Controller.detect(locator.lookup('controller:basic')), 'locator looksup correct controller');
+  ok(Ember.Controller.detect(locator.lookup('controller:-ember-basic')), 'locator looksup correct controller');
 });
 
 function detectEqual(first, second, message) {

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -16,7 +16,7 @@ Ember.Handlebars.EachView = Ember.CollectionView.extend(Ember._Metamorph, {
     var binding;
 
     if (itemController) {
-      var controller = get(this, 'controller.container').lookupFactory('controller:array').create({
+      var controller = get(this, 'controller.container').lookupFactory('controller:-ember-array').create({
         _isVirtual: true,
         parentController: get(this, 'controller'),
         itemController: itemController,

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -207,7 +207,7 @@ test("it supports itemController", function() {
     container: container
   };
 
-  container.register('controller:array', Ember.ArrayController.extend());
+  container.register('controller:-ember-array', Ember.ArrayController.extend());
 
   view = Ember.View.create({
     container: container,
@@ -258,7 +258,7 @@ test("itemController specified in template gets a parentController property", fu
         company: 'Yapp'
       };
 
-  container.register('controller:array', Ember.ArrayController.extend());
+  container.register('controller:-ember-array', Ember.ArrayController.extend());
   Ember.run(function() { view.destroy(); }); // destroy existing view
 
   view = Ember.View.create({
@@ -346,7 +346,7 @@ test("it supports itemController when using a custom keyword", function() {
   });
 
   var container = new Ember.Container();
-  container.register('controller:array', Ember.ArrayController.extend());
+  container.register('controller:-ember-array', Ember.ArrayController.extend());
 
   Ember.run(function() { view.destroy(); }); // destroy existing view
   view = Ember.View.create({

--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -43,7 +43,7 @@ Ember.generateControllerFactory = function(container, controllerName, context) {
     controllerType = 'basic';
   }
 
-  factoryName = 'controller:' + controllerType;
+  factoryName = 'controller:-ember-' + controllerType;
 
   Factory = container.lookupFactory(factoryName).extend({
     isGenerated: true,

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -243,7 +243,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
 
   _getHandlerFunction: function() {
     var seen = {}, container = this.container,
-        DefaultRoute = container.lookupFactory('route:basic'),
+        DefaultRoute = container.lookupFactory('route:-ember-basic'),
         self = this;
 
     return function(name) {

--- a/packages/ember-routing/tests/helpers/outlet_test.js
+++ b/packages/ember-routing/tests/helpers/outlet_test.js
@@ -10,9 +10,9 @@ var buildContainer = function(namespace) {
 
   container.register('location:hash', Ember.HashLocation);
 
-  container.register('controller:basic', Ember.Controller, { instantiate: false });
-  container.register('controller:object', Ember.ObjectController, { instantiate: false });
-  container.register('controller:array', Ember.ArrayController, { instantiate: false });
+  container.register('controller:-ember-basic', Ember.Controller, { instantiate: false });
+  container.register('controller:-ember-object', Ember.ObjectController, { instantiate: false });
+  container.register('controller:-ember-array', Ember.ArrayController, { instantiate: false });
 
   container.typeInjection('route', 'router', 'router:main');
 

--- a/packages/ember-routing/tests/helpers/render_test.js
+++ b/packages/ember-routing/tests/helpers/render_test.js
@@ -22,9 +22,9 @@ var buildContainer = function(namespace) {
 
   container.register('location:hash', Ember.HashLocation);
 
-  container.register('controller:basic', Ember.Controller, { instantiate: false });
-  container.register('controller:object', Ember.ObjectController, { instantiate: false });
-  container.register('controller:array', Ember.ArrayController, { instantiate: false });
+  container.register('controller:-ember-basic', Ember.Controller, { instantiate: false });
+  container.register('controller:-ember-object', Ember.ObjectController, { instantiate: false });
+  container.register('controller:-ember-array', Ember.ArrayController, { instantiate: false });
 
   container.typeInjection('route', 'router', 'router:main');
 

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -7,9 +7,9 @@ var buildContainer = function(namespace) {
 
   container.register('application:main', namespace, { instantiate: false });
 
-  container.register('controller:basic', Ember.Controller, { instantiate: false });
-  container.register('controller:object', Ember.ObjectController, { instantiate: false });
-  container.register('controller:array', Ember.ArrayController, { instantiate: false });
+  container.register('controller:-ember-basic', Ember.Controller, { instantiate: false });
+  container.register('controller:-ember-object', Ember.ObjectController, { instantiate: false });
+  container.register('controller:-ember-array', Ember.ArrayController, { instantiate: false });
 
   return container;
 };
@@ -18,6 +18,10 @@ function resolverFor(namespace) {
   return function(fullName) {
     var nameParts = fullName.split(":"),
         type = nameParts[0], name = nameParts[1];
+
+    if (name.match(/-ember-/)) {
+      name = name.substr(7);
+    }
 
     if (name === 'basic') {
       name = '';


### PR DESCRIPTION
As evidenced in #4474, user objects currently cannot be named
`BasicRoute`, `BasicController`, `ObjectController`, `ArrayController`. Now it
does not seem like a very big issue, but it seems fairly simple to fix.

All internal routes and controllers are now registered with the
`-ember-` prefix.

Fixes #4474.
Fixes #4475.

---

If we still need to support `lookup('route:basic')` for legacy and/or SemVer reasons, I can incorporate the same deprecated container proxy that we use in Ember Data (see [here](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/container_proxy.js)). This will still allow the older syntax to work (for any third party libs) but will throw a deprecation warning.
