### PR TITLE
Enable ember-debug to be loaded for non-prod builds.

### DIFF
--- a/Assetfile
+++ b/Assetfile
@@ -161,14 +161,20 @@ distros.each do |name, modules|
 
     # Add ember-testing to ember distro
     if name == "ember"
-      match "{ember-testing.js,ember-debug.js}" do
-        concat ["ember-testing.js", "ember-debug.js"], "#{name}.js"
+      match "{ember-testing.js}" do
+        concat ["ember-testing.js"], "#{name}.js"
       end
     end
 
     module_paths = modules.map{|m| "#{m}.js" }
     match "{#{module_paths.join(',')}}" do
       concat(module_paths){ ["#{name}.js", "#{name}.prod.js"] }
+    end
+
+    if name == "ember"
+      match "{ember-debug.js}" do
+        concat ["ember-debug.js"], "#{name}.js"
+      end
     end
 
     match "{#{name}.js,#{name}.prod.js}" do

--- a/packages_es6/ember-metal/lib/main.js
+++ b/packages_es6/ember-metal/lib/main.js
@@ -250,4 +250,10 @@ Ember.isBlank = isBlank;
 Ember.onerror = null;
 // END EXPORTS
 
+// do this for side-effects of updating Ember.assert, warn, etc when
+// ember-debug is present
+if (Ember.__loader.registry['ember-debug']) {
+  requireModule('ember-debug');
+}
+
 export default Ember;


### PR DESCRIPTION
The issue is that ember-debug has moved to an ES6 package and even though it exists in the build output, it is never required so the global `Ember` object is never extended.

This is a short-term fix, but the longer term solution is to remove the `ember-debug` package altogether (in favor of a better build process).
