### PR TITLE
[BUGFIX beta] Fix `Maximum call stack size exceeded` error when injecting un-lookup'd controller on controllers 

### DIFF
--- a/packages_es6/container/lib/container.js
+++ b/packages_es6/container/lib/container.js
@@ -412,6 +412,10 @@ Container.prototype = {
     validateFullName(fullName);
     if (this.parent) { illegalChildOperation('typeInjection'); }
 
+    var fullNameType = fullName.split(':')[0];        
+    if(fullNameType === type) {
+      throw new Error('Cannot inject a `' + fullName + '` on other ' + type + '(s). Register the `' + fullName + '` as a different type and perform the typeInjection.');
+    }
     addTypeInjection(this.typeInjections, type, property, fullName);
   },
 

--- a/packages_es6/container/tests/container_test.js
+++ b/packages_es6/container/tests/container_test.js
@@ -162,6 +162,17 @@ test("A container lookup has access to the container", function() {
   equal(postController.container, container);
 });
 
+test("Throw exception when trying to inject `type:thing` on all type(s)", function(){
+  var container = new Container(),
+    PostController = factory();
+
+  container.register('controller:post', PostController);
+  
+  throws(function(){
+    container.typeInjection('controller', 'injected', 'controller:post');      
+  }, 'Cannot inject a `controller:post` on other controller(s). Register the `controller:post` as a different type and perform the typeInjection.');
+});
+
 test("A factory type with a registered injection's instances receive that injection", function() {
   var container = new Container();
   var PostController = factory();


### PR DESCRIPTION
Prior to this commit, while trying to inject an un-lookup'd controller on other controllers causes redundant cycles during [buildInjections](https://github.com/emberjs/ember.js/blob/master/packages_es6/container/lib/container.js#L657) thereby resulting in `Maximum call stack size exceeded` error. 
[JS Fiddle Demonstrating the issue](http://jsfiddle.net/selvaG/bt6Gg/2/)

The case is valid for all similar type injections i.e., injecting [unresolved]controller on controlers || [unresolved]route on routes.

This PR fixes the issue.

/cc @stefanpenner 
