### PR TITLE
 Router should log all errors produced by transitions, not just unrecognized URLs

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -360,7 +360,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
       if (error && error.name === "UnrecognizedURLError") {
         Ember.assert("The URL '" + error.message + "' did not match any routes in your application");
       } else {
-        Ember.Logger.error("Problem transitioning: ", error.stack);
+        Ember.Logger.error("Problem transitioning: ", error == undefined ? "unknown reason" : error.stack);
       }
     }, 'Ember: Check for Router unrecognized URL error');
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -360,7 +360,7 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
       if (error && error.name === "UnrecognizedURLError") {
         Ember.assert("The URL '" + error.message + "' did not match any routes in your application");
       } else {
-        Ember.Logger.error("Problem transitioning: ", error == undefined ? "unknown reason" : error.stack);
+        Ember.Logger.error("Problem transitioning: ", error === undefined ? "unknown reason" : error.stack);
       }
     }, 'Ember: Check for Router unrecognized URL error');
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -359,6 +359,8 @@ Ember.Router = Ember.Object.extend(Ember.Evented, {
     transitionPromise.then(null, function(error) {
       if (error && error.name === "UnrecognizedURLError") {
         Ember.assert("The URL '" + error.message + "' did not match any routes in your application");
+      } else {
+        Ember.Logger.error("Problem transitioning: ", error.stack);
       }
     }, 'Ember: Check for Router unrecognized URL error');
 


### PR DESCRIPTION
Hey, I ran into a nasty error-swallowing scenario (very painful for a new Ember developer; white screen of death with no logs at all) with a new app built with EAK (and thus, their fancy ES6 module transpiler integration via the JJ Abrams resolver).

It seems that an error (even a simple one, like an attempt to call a method on undefined) produced by autoloading an ES6 module (containing either a route or controller) will arrive in in the transition processing stack in Ember's router and be ultimately ignored.  I assume this is because the resolver is injected into the Router's attempts to inspect the routes.

I've tried all the other documented things, like setting a global RSVP handler for "error" events, setting Ember.onerror, and so on, all to no effect.

I stepped through the ember router stack as best as I could, and determined that errors being emitted by doTransition (that is, by the promise emitted by that Transition) are ultimately dropped on the floor unless it was an unrecognized URL error.

As such, might be a bad approach, but log all errors occurring on router transition rather than dropping them on the floor.  I must stress that I am a complete newb with Ember, and as such, my reasoning here may (likely) be faulty.  This patch is more to document my thinking in navigating this problem. 

I'm not entirely sure what the bug here is; it could be that the Resolver is breaking a contract, or even likelier, I misunderstand something.  I think I read somewhere that Ember doesn't greedily log all errors because some might be asynchronously handled.  However, in this case, the error has already happened synchronously, and the promise rejects instantly.

As cherry on the cake, this patch is untested, because rake test and rackup seem to fail on my system with an urelated odd error (and I need to go sleep), and I expect it's unlikely this patch will be accepted in its current for anyway.

Cheers.
