### PR TITLE
Ensure that Ember.DataAdapter exists after Ember is loaded.

### DIFF
--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -1,4 +1,8 @@
 require('ember-application');
+require('ember-extension-support');
+
+// ES6TODO: resolve this via import once ember-application package is ES6'ed
+requireModule('ember-extension-support');
 
 /**
 Ember


### PR DESCRIPTION
This fixes the underlying issue that #4505 was attempting to resolve
(but failed). #4505 ensured that the globals were setup properly upon creation
of an Ember.Application, but it unfortunately doesn't fix Ember Data's initial
boot.

After this PR the globals are all exported as part of the Ember boot process.
