### PR TITLE
Remove references to `window`.

### DIFF
--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -1,7 +1,7 @@
 var define, requireModule, require, requirejs, Ember;
 
 (function() {
-  Ember = window.Ember = window.Ember || {};
+  Ember = this.Ember = this.Ember || {};
   if (typeof Ember === 'undefined') { Ember = {} };
 
   if (typeof Ember.__loader === 'undefined') {

--- a/packages_es6/ember-metal/lib/core.js
+++ b/packages_es6/ember-metal/lib/core.js
@@ -25,9 +25,6 @@
   @version VERSION_STRING_PLACEHOLDER
 */
 
-// We need to make sure to operate on the same object if window.Ember already
-// existed.
-Ember = window.Ember;
 if ('undefined' === typeof Ember) {
   // Create core object. Make it act like an instance of Ember.Namespace so that
   // objects assigned to it are given a sane string representation.
@@ -211,7 +208,5 @@ if ('undefined' === typeof Ember.deprecateFunc) {
   @private
 */
 Ember.uuid = 0;
-
-window.Em = window.Ember = Ember;
 
 export default Ember;


### PR DESCRIPTION
These references are already setup properly using `this` which will work even in non-browser environments or when we do not want to be working in globals mode (for example when supplying `Ember.lookup` or `Ember.exports` as mentioned in https://github.com/emberjs/ember.js/commit/305202f).

This allows us to set the stage for CJS builds of ember-metal and ember-runtime (still needs more work in transpiler and tests).
