### PR TITLE
[FEATURE query-params-new] query-params-reset

### DIFF
--- a/packages/ember-routing/lib/helpers/link_to.js
+++ b/packages/ember-routing/lib/helpers/link_to.js
@@ -12,7 +12,9 @@ require('ember-handlebars/helpers/view');
 Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
   var QueryParams = Ember.Object.extend({
-    values: null
+    values: null,
+    types: null,
+    reset: false
   });
 
   var resolveParams = Ember.Router.resolveParams,
@@ -22,6 +24,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
   function computeQueryParams(linkView, stripDefaultValues) {
     var helperParameters = linkView.parameters,
         queryParamsObject = get(linkView, 'queryParamsObject'),
+        resetParams = queryParamsObject && queryParamsObject.reset,
         suppliedParams = {};
 
     if (queryParamsObject) {
@@ -41,6 +44,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
       // Check if the link-to provides a value for this qp.
       var providedType = null, value;
+
       if (qp.prop in suppliedParams) {
         value = suppliedParams[qp.prop];
         providedType = queryParamsObject.types[qp.prop];
@@ -49,6 +53,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
         value = suppliedParams[qp.urlKey];
         providedType = queryParamsObject.types[qp.urlKey];
         delete suppliedParams[qp.urlKey];
+      } else if (resetParams) {
+        // query-params-reset was invoked, so reset param to default value
+        value = qp.def;
+        providedType = qp.type;
       }
 
       if (providedType) {
@@ -883,6 +891,16 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       Ember.assert(fmt("The `query-params` helper only accepts hash parameters, e.g. (query-params queryParamPropertyName='%@') as opposed to just (query-params '%@')", [options, options]), arguments.length === 1);
 
       return QueryParams.create({
+        values: options.hash,
+        types: options.hashTypes
+      });
+    });
+
+    Ember.Handlebars.registerHelper('query-params-reset', function queryParamsHelper(options) {
+      Ember.assert(fmt("The `query-params-reset` helper only accepts hash parameters, e.g. (query-params-reset queryParamPropertyName='%@') as opposed to just (query-params-reset '%@')", [options, options]), arguments.length === 1);
+
+      return QueryParams.create({
+        reset: true,
         values: options.hash,
         types: options.hashTypes
       });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1108,6 +1108,48 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     equal(Ember.$('#the-link').attr('href'), "/?bar=NAW&foo=456", "link has right href");
   });
 
+  test("query-params-reset restores unspecified QPs on target route to default values", function() {
+    expect(4);
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['foo', 'bar'],
+      foo: 'FOO',
+      bar: 'BAR'
+    });
+
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("{{link-to 'Home' 'index' id='the-link'}}{{link-to 'Home' 'index' (query-params-reset) id='the-reset-link'}}");
+    bootApplication();
+
+    equal(Ember.$('#the-link').attr('href'), "/", "link has right starting href");
+    equal(Ember.$('#the-reset-link').attr('href'), "/", "reset link has right starting href");
+
+    var indexController = container.lookup('controller:index');
+    Ember.run(indexController, 'set', 'foo', 'OOF');
+
+    equal(Ember.$('#the-link').attr('href'), "/?foo=OOF", "link has right href");
+    equal(Ember.$('#the-reset-link').attr('href'), "/", "reset link's href properly restored to default foo value");
+  });
+
+  test("query-params-reset accepts params", function() {
+    expect(4);
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['foo', 'bar'],
+      foo: 'FOO',
+      bar: 'BAR'
+    });
+
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("{{link-to 'Home' 'index' (query-params bar='RAB') id='the-link'}}{{link-to 'Home' 'index' (query-params-reset bar='RAB') id='the-reset-link'}}");
+    bootApplication();
+
+    equal(Ember.$('#the-link').attr('href'), "/?bar=RAB", "link has right starting href");
+    equal(Ember.$('#the-reset-link').attr('href'), "/?bar=RAB", "reset link has right starting href");
+
+    var indexController = container.lookup('controller:index');
+    Ember.run(indexController, 'set', 'foo', 'OOF');
+
+    equal(Ember.$('#the-link').attr('href'), "/?bar=RAB&foo=OOF", "link has right href");
+    equal(Ember.$('#the-reset-link').attr('href'), "/?bar=RAB", "reset link's href properly restored to default foo value");
+  });
+
   module("The {{link-to}} helper: invoking with query params", {
     setup: function() {
       Ember.run(function() {


### PR DESCRIPTION
This is the caller approach to resetting query params on a target route (vs.
the default behavior of stickiness). 

Will have a separate PR for the more intelligent default approach that
preserves stickiness based on model-dependent state.
