### PR TITLE
[BUGFIX beta] Use injected test helpers instead of local functions.

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -43,11 +43,11 @@ function visit(app, url) {
     run(app, app.handleURL, url);
   }
 
-  return wait(app);
+  return app.testHelpers.wait();
 }
 
 function click(app, selector, context) {
-  var $el = findWithAssert(app, selector, context);
+  var $el = app.testHelpers.findWithAssert(selector, context);
   run($el, 'mousedown');
 
   if ($el.is(':input')) {
@@ -69,7 +69,7 @@ function click(app, selector, context) {
   run($el, 'mouseup');
   run($el, 'click');
 
-  return wait(app);
+  return app.testHelpers.wait();
 }
 
 function triggerEvent(app, selector, context, type, options){
@@ -82,13 +82,13 @@ function triggerEvent(app, selector, context, type, options){
     options = {};
   }
 
-  var $el = findWithAssert(app, selector, context);
+  var $el = app.testHelpers.findWithAssert(selector, context);
 
   var event = jQuery.Event(type, options);
 
   run($el, 'trigger', event);
 
-  return wait(app);
+  return app.testHelpers.wait();
 }
 
 function keyEvent(app, selector, context, type, keyCode) {
@@ -98,7 +98,7 @@ function keyEvent(app, selector, context, type, keyCode) {
     context = null;
   }
 
-  return triggerEvent(app, selector, context, type, { keyCode: keyCode, which: keyCode });
+  return app.testHelpers.triggerEvent(selector, context, type, { keyCode: keyCode, which: keyCode });
 }
 
 function fillIn(app, selector, context, text) {
@@ -107,15 +107,15 @@ function fillIn(app, selector, context, text) {
     text = context;
     context = null;
   }
-  $el = findWithAssert(app, selector, context);
+  $el = app.testHelpers.findWithAssert(selector, context);
   run(function() {
     $el.val(text).change();
   });
-  return wait(app);
+  return app.testHelpers.wait();
 }
 
 function findWithAssert(app, selector, context) {
-  var $el = find(app, selector, context);
+  var $el = app.testHelpers.find(selector, context);
   if ($el.length === 0) {
     throw new EmberError("Element " + selector + " not found.");
   }
@@ -131,7 +131,7 @@ function find(app, selector, context) {
 }
 
 function andThen(app, callback) {
-  return wait(app, callback(app));
+  return app.testHelpers.wait(callback(app));
 }
 
 function wait(app, value) {
@@ -298,7 +298,7 @@ helper('findWithAssert', findWithAssert);
     .fillIn('#password', username)
     .click('.submit')
 
-    return wait();
+    return app.testHelpers.wait();
   });
 
   @method wait

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -26,6 +26,13 @@ var injectHelpersCallbacks = [];
   @namespace Ember
 */
 var Test = {
+  /**
+    Hash containing all known test helpers.
+
+    @property _helpers
+    @private
+  */
+  _helpers: helpers,
 
   /**
     `registerHelper` is used to register a test helper that will be injected

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -362,10 +362,10 @@ test("Ember.Application#removeTestHelpers resets the helperContainer's original 
 
   App.injectTestHelpers(helpers);
 
-  ok(helpers['visit'] !== 'snazzleflabber', "helper added to container");
+  ok(helpers.visit !== 'snazzleflabber', "helper added to container");
   App.removeTestHelpers();
 
-  ok(helpers['visit'] === 'snazzleflabber', "original value added back to container");
+  ok(helpers.visit === 'snazzleflabber', "original value added back to container");
 });
 
 test("`wait` respects registerWaiters", function() {
@@ -674,4 +674,59 @@ test("currentRouteName for '/user/profile'", function(){
     equal(currentURL(App), '/user/edit', "should equal '/user/edit'.");
     equal(App.__container__.lookup('route:user').get('controller.model.firstName'), 'Tom', "should equal 'Tom'.");
   });
+});
+
+var originalVisitHelper, originalFindHelper, originalWaitHelper;
+
+QUnit.module('can override built-in helpers', {
+  setup: function(){
+    originalVisitHelper = Test._helpers.visit;
+    originalFindHelper  = Test._helpers.find;
+    originalWaitHelper  = Test._helpers.wait;
+
+    jQuery('<style>#ember-testing-container { position: absolute; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; } #ember-testing { zoom: 50%; }</style>').appendTo('head');
+    jQuery('<div id="ember-testing-container"><div id="ember-testing"></div></div>').appendTo('body');
+    run(function() {
+      App = Ember.Application.create({
+        rootElement: '#ember-testing'
+      });
+
+      App.setupForTesting();
+    });
+  },
+
+  teardown: function(){
+    App.removeTestHelpers();
+    jQuery('#ember-testing-container, #ember-testing').remove();
+    run(App, App.destroy);
+    App = null;
+
+    Test._helpers.visit = originalVisitHelper;
+    Test._helpers.find  = originalFindHelper;
+    Test._helpers.wait  = originalWaitHelper;
+  }
+});
+
+test("can override visit helper", function(){
+  expect(1);
+
+  Test.registerHelper('visit', function(){
+    ok(true, 'custom visit helper was called');
+  });
+
+  App.injectTestHelpers();
+  App.testHelpers.visit();
+});
+
+test("can override find helper", function(){
+  expect(1);
+
+  Test.registerHelper('find', function(){
+    ok(true, 'custom find helper was called');
+
+    return ['not empty array'];
+  });
+
+  App.injectTestHelpers();
+  App.testHelpers.findWithAssert('.who-cares');
 });


### PR DESCRIPTION
Since we are injecting the application with our helpers (into the `App.testHelpers` hash), we should be using that helper and not simply calling the function in local scope.

As the tests show, this allows a user to override the internal helpers with a taylored version for their scenarios.
