### PR TITLE
Fix run.bind to keep the arguments from the callback.

### DIFF
--- a/packages_es6/ember-metal/lib/run_loop.js
+++ b/packages_es6/ember-metal/lib/run_loop.js
@@ -158,9 +158,9 @@ run.join = function(target, method /* args */) {
   when called within an existing loop, no return value is possible.
 */
 run.bind = function(target, method /* args*/) {
-  var args = arguments;
+  var args = slice.call(arguments);
   return function() {
-    return apply(run, run.join, args);
+    return apply(run, run.join, args.concat(slice.call(arguments)));
   };
 };
 
@@ -560,7 +560,7 @@ run.cancel = function(timer) {
     then it will be looked up on the passed target.
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @param {Number} wait Number of milliseconds to wait.
-  @param {Boolean} immediate Trigger the function on the leading instead 
+  @param {Boolean} immediate Trigger the function on the leading instead
     of the trailing edge of the wait interval. Defaults to false.
   @return {Array} Timer information for use in cancelling, see `run.cancel`.
 */

--- a/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
@@ -26,7 +26,7 @@ test('Ember.run.bind keeps the async callback arguments', function() {
       ok(run.currentRunLoop, 'expected a run-loop');
       equal(increment, 1);
       equal(increment2, 2);
-      equal(increment2, 3);
+      equal(increment3, 3);
     }
   };
 

--- a/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
@@ -20,7 +20,7 @@ test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
 
 test('Ember.run.bind keeps the async callback arguments', function() {
 
-  function asyncCallback = function(increment, increment2, increment3) {
+  var asyncCallback = function(increment, increment2, increment3) {
     ok(run.currentRunLoop, 'expected a run-loop');
     equal(increment, 1);
     equal(increment2, 2);

--- a/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
@@ -17,3 +17,22 @@ test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
   equal(proxiedFunction(), 1);
   equal(obj.value, 1);
 });
+
+test('Ember.run.bind keeps the async callback arguments', function() {
+
+  var obj = {
+    value: 0,
+    increment: function(increment, increment2, increment3) {
+      ok(run.currentRunLoop, 'expected a run-loop');
+      equal(increment, 1);
+      equal(increment2, 2);
+      equal(increment2, 3);
+    }
+  };
+
+  var asyncFunction = function(fn) {
+    fn(2, 3);
+  };
+
+  asyncFunction(run.bind(obj, obj.increment, 1));
+});

--- a/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
@@ -31,5 +31,5 @@ test('Ember.run.bind keeps the async callback arguments', function() {
     fn(2, 3);
   };
 
-  asyncFunction(run.bind(asyncCallback, 1));
+  asyncFunction(run.bind(asyncCallback, asyncCallback, 1));
 });

--- a/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/run_bind_test.js
@@ -20,19 +20,16 @@ test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
 
 test('Ember.run.bind keeps the async callback arguments', function() {
 
-  var obj = {
-    value: 0,
-    increment: function(increment, increment2, increment3) {
-      ok(run.currentRunLoop, 'expected a run-loop');
-      equal(increment, 1);
-      equal(increment2, 2);
-      equal(increment3, 3);
-    }
+  function asyncCallback = function(increment, increment2, increment3) {
+    ok(run.currentRunLoop, 'expected a run-loop');
+    equal(increment, 1);
+    equal(increment2, 2);
+    equal(increment3, 3);
   };
 
   var asyncFunction = function(fn) {
     fn(2, 3);
   };
 
-  asyncFunction(run.bind(obj, obj.increment, 1));
+  asyncFunction(run.bind(asyncCallback, 1));
 });


### PR DESCRIPTION
There are some problems with the Ember.run.bind. An example is a jQuery click event where we want the handle the event argument. Currently the Ember.run.bind doesn't include this arguments in the callback.
