### PR TITLE
[DOC beta] Fix `method` tag for `makeViewHelper` doc

### DIFF
--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -117,7 +117,7 @@ EmberHandlebars.helper = function(name, value) {
   involving helper/component registration.
 
   @private
-  @method helper
+  @method makeViewHelper
   @for Ember.Handlebars
   @param {Function} ViewClass view class constructor
 */


### PR DESCRIPTION
The API docs were incorrect (and private) for `helper` because it was being overridden here.
Now both `helper` and `makeViewHelper` will appear correctly.
