### PR TITLE
[query-params-new] Fix failure when using QP array values

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -585,6 +585,37 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     equal(router.get('location.path'), "/?omg=OVERRIDE");
   });
 
+  test("can override incoming QP array values in setupController", function() {
+    expect(3);
+
+    App.Router.map(function() {
+      this.route('about');
+    });
+
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['omg'],
+      omg: ['lol']
+    });
+
+    App.IndexRoute = Ember.Route.extend({
+      setupController: function(controller) {
+        ok(true, "setupController called");
+        controller.set('omg', ['OVERRIDE']);
+      },
+      actions: {
+        queryParamsDidChange: function() {
+          ok(false, "queryParamsDidChange shouldn't fire");
+        }
+      }
+    });
+
+    startingURL = "/about";
+    bootApplication();
+    equal(router.get('location.path'), "/about");
+    Ember.run(router, 'transitionTo', 'index');
+    equal(router.get('location.path'), "/?omg=" + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
+  });
+
   test("URL transitions that remove QPs still register as QP changes", function() {
     expect(2);
 

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -377,8 +377,8 @@ var Route = EmberObject.extend(ActionHandler, {
             var value, svalue;
             if (changes && qp.urlKey in changes) {
               // Controller overrode this value in setupController
-              svalue = get(controller, qp.prop);
-              value = this.deserializeQueryParam(svalue, qp.urlKey, qp.type);
+              value = get(controller, qp.prop);
+              svalue = this.serializeQueryParam(value, qp.urlKey, qp.type);
             } else {
               if (qpProvided) {
                 svalue = params[qp.urlKey];


### PR DESCRIPTION
Using QP array values and changing them in setup controller is currently causing the app to fail. The QP values from controller are being deserialized instead of serialized. 
