### PR TITLE
[BUGFIX] Add `which` attribute to event triggered by test helper

### DIFF
--- a/packages_es6/ember-testing/lib/helpers.js
+++ b/packages_es6/ember-testing/lib/helpers.js
@@ -98,7 +98,7 @@ function keyEvent(app, selector, context, type, keyCode) {
     context = null;
   }
 
-  return triggerEvent(app, selector, context, type, { keyCode: keyCode });
+  return triggerEvent(app, selector, context, type, { keyCode: keyCode, which: keyCode });
 }
 
 function fillIn(app, selector, context, text) {

--- a/packages_es6/ember-testing/tests/acceptance_test.js
+++ b/packages_es6/ember-testing/tests/acceptance_test.js
@@ -111,7 +111,7 @@ test("helpers can be chained with then", function() {
 // Keep this for backwards compatibility
 
 test("helpers can be chained to each other", function() {
-  expect(4);
+  expect(5);
 
   currentRoute = 'index';
 
@@ -123,6 +123,7 @@ test("helpers can be chained to each other", function() {
     equal(jQuery('.ember-text-field').val(), 'hello', "Fillin successfully works");
     find('.ember-text-field').one('keypress', function(e) {
       equal(e.keyCode, 13, "keyevent chained with correct keyCode.");
+      equal(e.which, 13, "keyevent chained with correct which.");
     });
   })
   .keyEvent('.ember-text-field', 'keypress', 13)


### PR DESCRIPTION
[According to jQuery](http://api.jquery.com/event.which/), "It is recommended to watch event.which for keyboard key input." Many libraries (such as [bootstrap](https://github.com/twbs/bootstrap/blob/v3.1.1/js/modal.js#L128)) use `event.which` and not `event.keyCode` in keyboard event handling code. jQuery normally does a good job of normalizing both of these attributes for native keyboard events.

However, when constructing artificial keyboard events with `jQuery.Event`, those properties are not 'normalized' like natively generated events, e.g. specifying only `keyCode` when creating an event means that `which` will be undefined in the event handler (see [this jsbin](http://jsbin.com/siyicuwo/1/)). [It doesn't look like this is going to be fixed in jQuery anytime soon](http://bugs.jquery.com/ticket/9101).

This patch adds the `which` attribute to events created by the `keyEvent` test helper to simulate the event normalization done by jQuery.
