### PR TITLE
[BUGFIX] When selecting controller for view prioritize controllerName over controller matching template or route name

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1707,10 +1707,12 @@ function normalizeOptions(route, name, template, options) {
 
   if (options.controller) {
     controller = options.controller;
+  } else if (route.controllerName) {
+    controller = route.controllerName;
   } else if (namedController = route.container.lookup('controller:' + name)) {
     controller = namedController;
   } else {
-    controller = route.controllerName || route.routeName;
+    controller = route.routeName;
   }
 
   if (typeof controller === 'string') {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1340,6 +1340,7 @@ var Route = EmberObject.extend(ActionHandler, {
     }
 
     options = options || {};
+    options.namePassed = namePassed;
 
     var templateName;
 
@@ -1707,12 +1708,10 @@ function normalizeOptions(route, name, template, options) {
 
   if (options.controller) {
     controller = options.controller;
-  } else if (route.controllerName) {
-    controller = route.controllerName;
-  } else if (namedController = route.container.lookup('controller:' + name)) {
-    controller = namedController;
+  } else if (options.namePassed) {
+    controller = route.container.lookup('controller:' + name) || route.controllerName || route.routeName;
   } else {
-    controller = route.routeName;
+    controller = route.controllerName || route.container.lookup('controller:' + name);
   }
 
   if (typeof controller === 'string') {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -553,6 +553,33 @@ test("The route controller specified via controllerName is used in render", func
   equal(Ember.$('p', '#qunit-fixture').text(), "alternative home: foo", "The homepage template was rendered with data from the custom controller");
 });
 
+test("The route controller specified via controllerName is used in render even when a controller with the routeName is available", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  Ember.TEMPLATES.home = Ember.Handlebars.compile(
+    "<p>home: {{myValue}}</p>"
+  );
+
+  App.HomeRoute = Ember.Route.extend({
+    controllerName: 'myController'
+  });
+
+  container.register('controller:home', Ember.Controller.extend({
+    myValue: "home"
+  }));
+
+  container.register('controller:myController', Ember.Controller.extend({
+    myValue: "myController"
+  }));
+
+  bootApplication();
+
+  deepEqual(container.lookup('route:home').controller, container.lookup('controller:myController'), "route controller is set by controllerName");
+  equal(Ember.$('p', '#qunit-fixture').text(), "home: myController", "The homepage template was rendered with data from the custom controller");
+});
+
 test("The Homepage with a `setupController` hook modifying other controllers", function() {
   Router.map(function() {
     this.route("home", { path: "/" });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -218,6 +218,31 @@ test("An alternate template will pull in an alternate controller", function() {
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from homepage)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
+test("An alternate template will pull in an alternate controller instead of controllerName", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
+  });
+
+  App.HomeRoute = Ember.Route.extend({
+    controllerName: 'foo',
+    renderTemplate: function() {
+      this.render('homepage');
+    }
+  });
+
+  App.FooController = Ember.Controller.extend({
+    home: "Comes from Foo"
+  });
+
+  App.HomepageController = Ember.Controller.extend({
+    home: "Comes from homepage"
+  });
+
+  bootApplication();
+
+  equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from homepage)', '#qunit-fixture').length, 1, "The homepage template was rendered");
+});
+
 test("The template will pull in an alternate controller via key/value", function() {
   Router.map(function() {
     this.route("homepage", { path: "/" });


### PR DESCRIPTION
When specifying `controllerName` in a route, if a controller exists with a name matching the template name, it will be ignored.

This seems to go against the documentation for `controllerName` which states that the specified `controllerName` will be "used as the controller for the view being rendered by the route."

We have added a test for this particular case. All existing tests pass unchanged.

The new priority for looking up the controller passed to the view is as follows:
- use controller explicitly passed in `render`
- use controller based on `controllerName`
- use controller based on `templateName`
- use controller based on `routeName`
