### PR TITLE
[BUGFIX] Ember.copy now supports Date

### DIFF
--- a/packages_es6/ember-runtime/lib/copy.js
+++ b/packages_es6/ember-runtime/lib/copy.js
@@ -27,6 +27,8 @@ function _copy(obj, deep, seen, copies) {
     }
   } else if (Copyable && Copyable.detect(obj)) {
     ret = obj.copy(deep, seen, copies);
+  } else if (obj instanceof Date) {
+    ret = new Date(obj.getTime());
   } else {
     ret = {};
     for(key in obj) {

--- a/packages_es6/ember-runtime/tests/core/copy_test.js
+++ b/packages_es6/ember-runtime/tests/core/copy_test.js
@@ -7,3 +7,8 @@ test("Ember.copy null", function() {
   equal(copy(obj, true).field, null, "null should still be null");
 });
 
+test("Ember.copy date", function() {
+  var date = new Date(2014, 7, 22),
+      dateCopy = copy(date);
+  equal(date.getTime(), dateCopy.getTime(), "dates should be equivalent");
+});


### PR DESCRIPTION
IMO the correct behavior of Ember.copy should be to copy all native objects. Currently, `Ember.copy(new Date)` returns an empty POJO `{}`.
