### PR TITLE
[BUGFIX] Do not attach new listeners on each setupForTesting call

### DIFF
--- a/packages_es6/ember-testing/lib/setup_for_testing.js
+++ b/packages_es6/ember-testing/lib/setup_for_testing.js
@@ -4,10 +4,22 @@ import QUnitAdapter from "ember-testing/adapters/qunit";
 
 var Test;
 
+function incrementAjaxPendingRequests(){
+  Test.pendingAjaxRequests++;
+}
+
+function decrementAjaxPendingRequests(){
+  Ember.assert("An ajaxComplete event which would cause the number of pending AJAX " +
+               "requests to be negative has been triggered. This is most likely " +
+               "caused by AJAX events that were started before calling " +
+               "`injectTestHelpers()`.", Test.pendingAjaxRequests !== 0);
+  Test.pendingAjaxRequests--;
+}
+
 /**
   Sets Ember up for testing. This is useful to perform
   basic setup steps in order to unit test.
-  
+
   Use `App.setupForTesting` to perform integration tests (full
   application testing).
 
@@ -26,17 +38,10 @@ function setupForTesting() {
 
   Test.pendingAjaxRequests = 0;
 
-  Ember.$(document).ajaxSend(function() {
-    Test.pendingAjaxRequests++;
-  });
-
-  Ember.$(document).ajaxComplete(function() {
-    Ember.assert("An ajaxComplete event which would cause the number of pending AJAX " +
-                 "requests to be negative has been triggered. This is most likely " +
-                 "caused by AJAX events that were started before calling " +
-                 "`injectTestHelpers()`.", Test.pendingAjaxRequests !== 0);
-    Test.pendingAjaxRequests--;
-  });
+  Ember.$(document).off('ajaxSend', incrementAjaxPendingRequests);
+  Ember.$(document).off('ajaxComplete', decrementAjaxPendingRequests);
+  Ember.$(document).on('ajaxSend', incrementAjaxPendingRequests);
+  Ember.$(document).on('ajaxComplete', decrementAjaxPendingRequests);
 };
 
 export default setupForTesting;

--- a/packages_es6/ember-testing/tests/helpers_test.js
+++ b/packages_es6/ember-testing/tests/helpers_test.js
@@ -266,7 +266,7 @@ test("`click` triggers appropriate events in order", function() {
   });
 });
 
-test("Ember.Application#injectTestHelpers", function() {
+test("Ember.Application#setupForTesting attaches ajax listeners", function() {
   var documentEvents;
 
   documentEvents = jQuery._data(document, 'events');
@@ -278,6 +278,31 @@ test("Ember.Application#injectTestHelpers", function() {
   ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listers setup prior to calling injectTestHelpers');
   ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listers setup prior to calling injectTestHelpers');
 
+  run(function() {
+    setupForTesting();
+  });
+
+  documentEvents = jQuery._data(document, 'events');
+
+  equal(documentEvents['ajaxSend'].length, 1, 'calling injectTestHelpers registers an ajaxSend handler');
+  equal(documentEvents['ajaxComplete'].length, 1, 'calling injectTestHelpers registers an ajaxComplete handler');
+});
+
+test("Ember.Application#setupForTesting attaches ajax listeners only once", function() {
+  var documentEvents;
+
+  documentEvents = jQuery._data(document, 'events');
+
+  if (!documentEvents) {
+    documentEvents = {};
+  }
+
+  ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listers setup prior to calling injectTestHelpers');
+  ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listers setup prior to calling injectTestHelpers');
+
+  run(function() {
+    setupForTesting();
+  });
   run(function() {
     setupForTesting();
   });


### PR DESCRIPTION
The test explains the issue pretty clearly, but for a more practical example, using EAK and upgrading to master caused all these errors to pop up:

![](https://api.monosnap.com/image/download?id=BVr5FUGdUg2uhinvKVfK9Pyn807Thu)

The `ajaxComplete` hook is added each time you call `setupForTesting`, and in EAK you call this function for each `startApp` call. I'm not clear on why tracking pending requests this way is preferable to the old style, but regardless this brings back the beta API behavior.

/cc @rjackson
