### PR TITLE
[BUGFIX beta] Only set pendingAjaxRequests once.

### DIFF
--- a/packages_es6/ember-testing/lib/setup_for_testing.js
+++ b/packages_es6/ember-testing/lib/setup_for_testing.js
@@ -36,7 +36,7 @@ function setupForTesting() {
     Test.adapter = QUnitAdapter.create();
   }
 
-  Test.pendingAjaxRequests = 0;
+  if (typeof Test.pendingAjaxRequests === "undefined") { Test.pendingAjaxRequests =  0};
 
   Ember.$(document).off('ajaxSend', incrementAjaxPendingRequests);
   Ember.$(document).off('ajaxComplete', decrementAjaxPendingRequests);


### PR DESCRIPTION
This was introduced in https://github.com/emberjs/ember.js/pull/4435, where we are setting `pendingAjaxRequests` everytime Ember.setupForTesting is called.  This causes assertions in an EAK style test suite where a new application is created for each test, since their might be a pending ajax request that was left over from a prior test.

/cc @mixonic
