### PR TITLE
[BUGFIX] Non reset pending ajax count

### DIFF
--- a/packages_es6/ember-testing/lib/setup_for_testing.js
+++ b/packages_es6/ember-testing/lib/setup_for_testing.js
@@ -36,7 +36,9 @@ function setupForTesting() {
     Test.adapter = QUnitAdapter.create();
   }
 
-  Test.pendingAjaxRequests = 0;
+  if (!Test.pendingAjaxRequests) {
+    Test.pendingAjaxRequests = 0;
+  }
 
   Ember.$(document).off('ajaxSend', incrementAjaxPendingRequests);
   Ember.$(document).off('ajaxComplete', decrementAjaxPendingRequests);

--- a/packages_es6/ember-testing/tests/helpers_test.js
+++ b/packages_es6/ember-testing/tests/helpers_test.js
@@ -14,18 +14,23 @@ import setupForTesting from "ember-testing/setup_for_testing";
 var App, originalAdapter = Test.adapter;
 
 function cleanup(){
+
+  // Teardown setupForTesting
+
   Test.adapter = originalAdapter;
+  run(function(){
+    jQuery(document).off('ajaxSend');
+    jQuery(document).off('ajaxComplete');
+  });
+  Test.pendingAjaxRequests = null;
+
+  // Other cleanup
 
   if (App) {
     run(App, App.destroy);
     App.removeTestHelpers();
     App = null;
   }
-
-  run(function(){
-    jQuery(document).off('ajaxSend');
-    jQuery(document).off('ajaxComplete');
-  });
 
   Ember.TEMPLATES = {};
 }
@@ -528,6 +533,14 @@ test("pendingAjaxRequests is decremented on each document ajaxComplete event", f
   Test.pendingAjaxRequests = 1;
   jQuery(document).trigger('ajaxComplete');
   equal(Test.pendingAjaxRequests, 0, 'Ember.Test.pendingAjaxRequests was decremented');
+});
+
+test("pendingAjaxRequests is not reset by setupForTesting", function() {
+  Test.pendingAjaxRequests = 1;
+  Ember.run(function(){
+    setupForTesting();
+  });
+  equal(Test.pendingAjaxRequests, 1, 'pendingAjaxRequests is not reset');
 });
 
 test("it should raise an assertion error if ajaxComplete is called without pendingAjaxRequests", function() {

--- a/packages_es6/ember-testing/tests/helpers_test.js
+++ b/packages_es6/ember-testing/tests/helpers_test.js
@@ -520,31 +520,20 @@ module("ember-testing pendingAjaxRequests", {
 
 test("pendingAjaxRequests is incremented on each document ajaxSend event", function() {
   Test.pendingAjaxRequests = 0;
-
-  run(function(){
-    jQuery(document).trigger('ajaxSend');
-  });
-
+  jQuery(document).trigger('ajaxSend');
   equal(Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests was incremented');
 });
 
 test("pendingAjaxRequests is decremented on each document ajaxComplete event", function() {
   Test.pendingAjaxRequests = 1;
-
-  run(function(){
-    jQuery(document).trigger('ajaxComplete');
-  });
-
+  jQuery(document).trigger('ajaxComplete');
   equal(Test.pendingAjaxRequests, 0, 'Ember.Test.pendingAjaxRequests was decremented');
 });
 
 test("it should raise an assertion error if ajaxComplete is called without pendingAjaxRequests", function() {
   Test.pendingAjaxRequests = 0;
-
   expectAssertion(function() {
-    run(function(){
-      jQuery(document).trigger('ajaxComplete');
-    });
+    jQuery(document).trigger('ajaxComplete');
   });
 });
 


### PR DESCRIPTION
An alternative to #4548 with a test and a small cleanup.

`pendingAjaxRequests` should not be reset upon `setupForTesting`. Doing so means that an in-flight request might be disregarded, and when the `ajaxComplete` event for it fires the count of in-flights goes negative.
