### PR TITLE
[Feature ember-metal-computed-not-empty-infinite-params] Update notEmpty computed function for accepts `n` params

### DIFF
--- a/features.json
+++ b/features.json
@@ -15,7 +15,8 @@
     "ember-routing-bound-action-name": true,
     "ember-runtime-test-friendly-promises": null,
     "ember-routing-inherits-parent-model": true,
-    "ember-routing-add-model-option": true
+    "ember-routing-add-model-option": true,
+    "ember-metal-computed-not-empty-infinite-params": null
   },
   "debugStatements": ["Ember.warn", "Ember.assert", "Ember.deprecate", "Ember.debug", "Ember.Logger.info", "Ember.runInDebug"]
 }

--- a/packages_es6/ember-metal/lib/computed.js
+++ b/packages_es6/ember-metal/lib/computed.js
@@ -707,8 +707,12 @@ if (Ember.FEATURES.isEnabled('ember-metal-computed-empty-array')) {
   @return {Ember.ComputedProperty} computed property which returns true if
   original value for property is not empty.
 */
-registerComputed('notEmpty', function(dependentKey) {
-  return !isEmpty(get(this, dependentKey));
+registerComputed('notEmpty', function() {
+  var properties = Array.prototype.slice.call(arguments, 0);
+
+  return properties.some(function(property) {
+    return !isEmpty(this.get(property));
+  }, this);
 });
 
 /**

--- a/packages_es6/ember-metal/lib/computed.js
+++ b/packages_es6/ember-metal/lib/computed.js
@@ -707,12 +707,16 @@ if (Ember.FEATURES.isEnabled('ember-metal-computed-empty-array')) {
   @return {Ember.ComputedProperty} computed property which returns true if
   original value for property is not empty.
 */
-registerComputed('notEmpty', function() {
-  var properties = Array.prototype.slice.call(arguments, 0);
+registerComputed('notEmpty', function(dependentKey) {
+  if (Ember.FEATURES.isEnabled('ember-metal-computed-not-empty-infinite-params')) {
+    var properties = Array.prototype.slice.call(arguments, 0);
 
-  return properties.some(function(property) {
-    return !isEmpty(this.get(property));
-  }, this);
+    return properties.some(function(property) {
+      return !isEmpty(this.get(property));
+    }, this);
+  } else {
+    return !isEmpty(get(this, dependentKey));
+  }
 });
 
 /**


### PR DESCRIPTION
With this now we can do:

``` javascript
var Hamster = Ember.Object.extend({
  food: true,
  sleepingBag: '',
  hasStuff: Ember.computed.notEmpty('food', 'sleepingBag')
});
```
