### PR TITLE
[BUGFIX] inspect missing from QUnitAdapter scope

### DIFF
--- a/packages_es6/ember-testing/lib/adapters/qunit.js
+++ b/packages_es6/ember-testing/lib/adapters/qunit.js
@@ -1,4 +1,5 @@
 import Adapter from "ember-testing/adapters/adapter";
+import {inspect} from "ember-metal/utils";
 
 /**
   This class implements the methods defined by Ember.Test.Adapter for the

--- a/packages_es6/ember-testing/tests/adapters/adapter_test.js
+++ b/packages_es6/ember-testing/tests/adapters/adapter_test.js
@@ -1,0 +1,32 @@
+import Ember from "ember-metal/core"; // Ember.K
+import run from "ember-metal/run_loop";
+import Adapter from "ember-testing/adapters/adapter";
+
+var adapter;
+
+module("ember-testing Adapter", {
+  setup: function() {
+    adapter = new Adapter();
+  },
+  teardown: function() {
+    run(adapter, adapter.destroy);
+  }
+});
+
+test("asyncStart is a noop", function() {
+  equal(adapter.asyncStart, Ember.K);
+});
+
+test("asyncEnd is a noop", function() {
+  equal(adapter.asyncEnd, Ember.K);
+});
+
+test("exception throws", function() {
+  var error = "Hai", thrown;
+  try {
+    adapter.exception(error);
+  } catch (e) {
+    thrown = e;
+  }
+  equal(thrown, error);
+});

--- a/packages_es6/ember-testing/tests/adapters/qunit_test.js
+++ b/packages_es6/ember-testing/tests/adapters/qunit_test.js
@@ -1,0 +1,51 @@
+import Ember from "ember-metal/core"; // Ember.K
+import run from "ember-metal/run_loop";
+import QUnitAdapter from "ember-testing/adapters/qunit";
+
+var adapter;
+
+module("ember-testing QUnitAdapter", {
+  setup: function() {
+    adapter = new QUnitAdapter();
+  },
+  teardown: function() {
+    run(adapter, adapter.destroy);
+  }
+});
+
+test("asyncStart calls stop", function() {
+  var originalStop = window.stop;
+  try {
+    window.stop = function(){
+      ok(true, "stop called");
+    };
+    adapter.asyncStart();
+  } finally {
+    window.stop = originalStop;
+  }
+});
+
+test("asyncEnd calls start", function() {
+  var originalStart = window.start;
+  try {
+    window.start = function(){
+      ok(true, "start called");
+    };
+    adapter.asyncEnd();
+  } finally {
+    window.start = originalStart;
+  }
+});
+
+test("exception causes a failing assertion", function() {
+  var error = {err: 'hai'}, originalOk = window.ok;
+  try {
+    window.ok = function(val, msg){
+      originalOk(!val, "ok is called with false");
+      originalOk(msg, '{err: "hai"}');
+    };
+    adapter.exception(error);
+  } finally {
+    window.ok = originalOk;
+  }
+});


### PR DESCRIPTION
`QUnitAdapter` was un-tested, and failing due to a missing import.
