### PR TITLE
[BUGFIX beta] Move reduceComputed instanceMetas into object's meta

### DIFF
--- a/packages_es6/ember-metal/lib/utils.js
+++ b/packages_es6/ember-metal/lib/utils.js
@@ -159,6 +159,7 @@ function Meta(obj) {
   this.descs = {};
   this.watching = {};
   this.cache = {};
+  this.cacheMeta = {};
   this.source = obj;
 }
 
@@ -168,6 +169,7 @@ Meta.prototype = {
   watching: null,
   listeners: null,
   cache: null,
+  cacheMeta: null,
   source: null,
   mixins: null,
   bindings: null,
@@ -233,10 +235,11 @@ function meta(obj, writable) {
     if (!isDefinePropertySimulated) o_defineProperty(obj, META_KEY, META_DESC);
 
     ret = o_create(ret);
-    ret.descs    = o_create(ret.descs);
-    ret.watching = o_create(ret.watching);
-    ret.cache    = {};
-    ret.source   = obj;
+    ret.descs     = o_create(ret.descs);
+    ret.watching  = o_create(ret.watching);
+    ret.cache     = {};
+    ret.cacheMeta = {};
+    ret.source    = obj;
 
     if (MANDATORY_SETTER) { ret.values = o_create(ret.values); }
 

--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import {get as e_get} from "ember-metal/property_get";
 import {set} from "ember-metal/property_set";
-import {guidFor, meta} from "ember-metal/utils";
+import {guidFor, meta as metaFor} from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
 import expandProperties from "ember-metal/expand_properties";
@@ -21,7 +21,6 @@ var cacheSet = cacheFor.set,
     a_slice = [].slice,
     o_create = create,
     forEach = EnumerableUtils.forEach,
-    metaFor = meta,
     // Here we explicitly don't allow `@each.foo`; it would require some special
     // testing, but there's no particular reason why it should be disallowed.
     eachPropertyPattern = /^(.*)\.@each\.(.*)/,
@@ -459,7 +458,6 @@ function ReduceComputedProperty(options) {
   var cp = this;
 
   this.options = options;
-  this._instanceMetas = {};
 
   this._dependentKeys = null;
   // A map of dependentKey -> [itemProperty, ...] that tracks what properties of
@@ -556,19 +554,15 @@ ReduceComputedProperty.prototype._callbacks = function () {
 };
 
 ReduceComputedProperty.prototype._hasInstanceMeta = function (context, propertyName) {
-  var guid = guidFor(context),
-      key = guid + ':' + propertyName;
-
-  return !!this._instanceMetas[key];
+  return !!metaFor(context).cacheMeta[propertyName];
 };
 
 ReduceComputedProperty.prototype._instanceMeta = function (context, propertyName) {
-  var guid = guidFor(context),
-      key = guid + ':' + propertyName,
-      meta = this._instanceMetas[key];
+  var cacheMeta = metaFor(context).cacheMeta,
+      meta = cacheMeta[propertyName];
 
   if (!meta) {
-    meta = this._instanceMetas[key] = new ReduceComputedPropertyInstanceMeta(context, propertyName, this.initialValue());
+    meta = cacheMeta[propertyName] = new ReduceComputedPropertyInstanceMeta(context, propertyName, this.initialValue());
     meta.dependentArraysObserver = new DependentArraysObserver(this._callbacks(), this, meta, context, propertyName, meta.sugarMeta);
   }
 


### PR DESCRIPTION
Closes #4552. Also opens the door to new types of computed properties that require storing extra data related to caching, eg. throttled and debounced computed properties.
