### PR TITLE
[query-params-new] don't serialize null or undefined to url

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -782,4 +782,61 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
     Ember.run(router, 'transitionTo', 'other');
   });
+
+  test("Setting bound query pram property to null or undefined do not seralize to url", function() {
+    Router.map(function() {
+      this.route("home", { path: '/home' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [1, 2]
+    });
+
+    startingURL = '/home';
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+
+    deepEqual(controller.get('foo'), [1,2]);
+    equal(router.get('location.path'), "/home");
+
+    Ember.run(controller, 'set', 'foo', [1,3]);
+    equal(router.get('location.path'), "/home?foo=%5B1%2C3%5D");
+
+    Ember.run(router, 'transitionTo', '/home');
+    deepEqual(controller.get('foo'), [1,2]);
+    
+    Ember.run(controller, 'set', 'foo', null);
+    equal(router.get('location.path'), "/home", "Setting property to null");
+
+    Ember.run(controller, 'set', 'foo', [1,3]);
+    equal(router.get('location.path'), "/home?foo=%5B1%2C3%5D");
+
+    Ember.run(controller, 'set', 'foo', undefined);
+    equal(router.get('location.path'), "/home", "Setting property to undefined");
+  });
+
+  test("{{link-to}} with null or undefined qps do not get serialized into url", function() {
+    Ember.TEMPLATES.home = Ember.Handlebars.compile(
+      "{{link-to 'Home' 'home' (query-params foo=nullValue) id='null-link'}}" +
+      "{{link-to 'Home' 'home' (query-params foo=undefinedValue) id='undefined-link'}}");
+    Router.map(function() {
+      this.route("home", { path: '/home' });
+    });
+
+    App.HomeController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: [],
+      nullValue: null,
+      undefinedValue: undefined
+    });
+
+    startingURL = '/home';
+    bootApplication();
+
+    var controller = container.lookup('controller:home');
+    equal(Ember.$('#null-link').attr('href'), "/home");
+    equal(Ember.$('#undefined-link').attr('href'), "/home");
+  });
 }

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -1636,7 +1636,9 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       // urlKey isn't used here, but anyone overriding
       // can use it to provide serialization specific
       // to a certain query param.
-      if (defaultValueType === 'array') {
+      if (value === null || value === undefined) {
+        return null;
+      } else if (defaultValueType === 'array') {
         return JSON.stringify(value);
       }
       return '' + value;


### PR DESCRIPTION
`null` and `undefined` are no longer serialized into the url. This behavior might not be right though as its now ambiguous as to weather you want the default value for a query param, or you want the value to be `null` There is more of a discussion in #4570.
