### PR TITLE
[DOC] dragOver was missing

### DIFF
--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -894,8 +894,9 @@ var EMPTY_ARRAY = [];
   * `drag`
   * `dragEnter`
   * `dragLeave`
-  * `drop`
+  * `dragOver`
   * `dragEnd`
+  * `drop`
 
   ## Handlebars `{{view}}` Helper
 


### PR DESCRIPTION
I think it's good if it's mentioned as other events are already listed as well
