### PR TITLE
[FEATURE ember-routing-nested-resource-can-inherit-namespace]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -119,3 +119,22 @@ for a detailed explanation.
   Ember routes and leaf resources (without nested routes) will inherit the parent route's model.
   
   Added in [#4246](https://github.com/emberjs/ember.js/pull/4246)
+
+* `ember-routing-nested-resource-can-inherit-namespace`
+
+  Specifying `resetNamespace: false` in a nested resource declaration will automatically prefix the
+  new route with the parent's name (similar to `route`).
+
+  Example:
+
+  ```javascript
+  var router = Router.map(function(){
+    this.resource('bleep', function(){
+      this.resource('bloop', {resetNamespace: false});
+    });
+  });
+
+  // will create `bleep.bloop` route (without resetNamespace it would create `bloop` route)
+  ```
+
+  Added in [#4590](https://github.com/emberjs/ember.js/pull/4590).

--- a/features.json
+++ b/features.json
@@ -15,7 +15,8 @@
     "ember-routing-bound-action-name": true,
     "ember-runtime-test-friendly-promises": true,
     "ember-routing-inherits-parent-model": true,
-    "ember-routing-add-model-option": true
+    "ember-routing-add-model-option": true,
+    "ember-routing-nested-resource-can-inherit-namespace": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-routing/lib/system/dsl.js
+++ b/packages_es6/ember-routing/lib/system/dsl.js
@@ -27,6 +27,12 @@ DSL.prototype = {
       options.path = "/" + name;
     }
 
+    if (Ember.FEATURES.isEnabled('ember-routing-nested-resource-can-inherit-namespace')) {
+      if (canNest(this) && options.resetNamespace === false) {
+        name = this.parent + "." + name;
+      }
+    }
+
     if (callback) {
       var dsl = new DSL(name);
       route(dsl, 'loading');
@@ -90,11 +96,15 @@ function route(dsl, name, options) {
     options.path = "/" + name;
   }
 
-  if (dsl.parent && dsl.parent !== 'application') {
+  if (canNest(dsl)) {
     name = dsl.parent + "." + name;
   }
 
   dsl.push(options.path, name, null);
+}
+
+function canNest(dsl) {
+  return dsl.parent && dsl.parent !== 'application'
 }
 
 DSL.map = function(callback) {

--- a/packages_es6/ember-routing/tests/system/dsl_test.js
+++ b/packages_es6/ember-routing/tests/system/dsl_test.js
@@ -1,3 +1,4 @@
+import Ember from "ember-metal/core";
 import EmberRouter from "ember-routing/system/router";
 
 var Router;
@@ -26,3 +27,25 @@ test("should fail when using a reserved route name", function() {
     });
   }, "'basic' cannot be used as a resource name.");
 });
+
+test("will reset nested resource scope by default", function(){
+  var router = Router.map(function(){
+    this.resource('bleep', function(){
+      this.resource('bloop');
+    });
+  });
+
+  ok(!router.recognizer.names['bleep.bloop'], 'resource resets route namespacing by default');
+});
+
+if (Ember.FEATURES.isEnabled('ember-routing-nested-resource-can-inherit-namespace')) {
+  test("should retain resource namespace if `resetScope` is false", function(){
+    var router = Router.map(function(){
+      this.resource('bleep', function(){
+        this.resource('bloop', {resetNamespace: false});
+      });
+    });
+
+    ok(router.recognizer.names['bleep.bloop'], 'parent name was used as base of route with resetNamespace: false');
+  });
+}


### PR DESCRIPTION
Specifying `resetNamespace: false` in a nested resource declaration will automatically prefix the new route with the parent's name (similar to `route`). This is much closer in line with the way many people assume it works out of the box, and is likely a better default. The actual default can not be changed until Ember 2.0 is release due to SemVer compatibility issues.

Example:

``` javascript
var router = Router.map(function(){
 this.resource('bleep', function(){
   this.resource('bloop', {resetNamespace: false});
 });
});

// will create `bleep.bloop` route (without resetNamespace it would create `bloop` route)
```
