### PR TITLE
[BUGFIX beta] {{view}} helper no longer uses Ember.View global, instead uses container view:default

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/view.js
+++ b/packages_es6/ember-handlebars/lib/helpers/view.js
@@ -203,7 +203,7 @@ var ViewHelper = EmberObject.create({
 });
 
 /**
-  `{{view}}` inserts a new instance of `Ember.View` into a template passing its
+  `{{view}}` inserts a new instance of an `Ember.View` into a template passing its
   options to the `Ember.View`'s `create` method and using the supplied block as
   the view's own template.
 
@@ -370,11 +370,12 @@ var ViewHelper = EmberObject.create({
 function viewHelper(path, options) {
   Ember.assert("The view helper only takes a single argument", arguments.length <= 2);
 
-  // If no path is provided, treat path param as options.
-  // ES6TODO: find a way to do this without global lookup
+  // If no path is provided, treat path param as options
+  // and get an instance of the registered `view:default`
   if (path && path.data && path.data.isRenderData) {
     options = path;
-    path = "Ember.View";
+    Ember.assert('{{view}} helper requires parent view to have a container but none was found. This usually happens when you are manually-managing views.', !!options.data.view.container);
+    path = options.data.view.container.lookupFactory('view:default');
   }
 
   return ViewHelper.helper(this, path, options);

--- a/packages_es6/ember-handlebars/tests/handlebars_test.js
+++ b/packages_es6/ember-handlebars/tests/handlebars_test.js
@@ -103,15 +103,19 @@ module("View - handlebars integration", {
 
     container = new Container();
     container.optionsForType('template', { instantiate: false });
+    container.register('view:default', EmberView.extend());
   },
 
   teardown: function() {
-    if (view) {
-      run(function() {
-        view.destroy();
-      });
-      view = null;
-    }
+    run(function() {
+        if (container) {
+          container.destroy();
+        }
+        if (view) {
+          view.destroy();
+        }
+        container = view = null;
+    });
     Ember.lookup = originalLookup;
     window.TemplateTests = TemplateTests = undefined;
   }
@@ -1857,6 +1861,7 @@ test("should work with precompiled templates", function() {
 test("should expose a controller keyword when present on the view", function() {
   var templateString = "{{controller.foo}}{{#view}}{{controller.baz}}{{/view}}";
   view = EmberView.create({
+    container: container,
     controller: EmberObject.create({
       foo: "bar",
       baz: "bang"
@@ -1895,6 +1900,7 @@ test("should expose a controller keyword when present on the view", function() {
 test("should expose a controller keyword that can be used in conditionals", function() {
   var templateString = "{{#view}}{{#if controller}}{{controller.foo}}{{/if}}{{/view}}";
   view = EmberView.create({
+    container: container,
     controller: EmberObject.create({
       foo: "bar"
     }),
@@ -1916,6 +1922,7 @@ test("should expose a controller keyword that can be used in conditionals", func
 test("should expose a controller keyword that persists through Ember.ContainerView", function() {
   var templateString = "{{view Ember.ContainerView}}";
   view = EmberView.create({
+    container: container,
     controller: EmberObject.create({
       foo: "bar"
     }),
@@ -1940,6 +1947,7 @@ test("should expose a controller keyword that persists through Ember.ContainerVi
 test("should expose a view keyword", function() {
   var templateString = '{{#with view.differentContent}}{{view.foo}}{{#view baz="bang"}}{{view.baz}}{{/view}}{{/with}}';
   view = EmberView.create({
+    container: container,
     differentContent: {
       view: {
         foo: "WRONG",

--- a/packages_es6/ember-handlebars/tests/helpers/group_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/group_test.js
@@ -6,20 +6,30 @@ import {View as EmberView} from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import {A} from "ember-runtime/system/native_array";
+import Container from "ember-runtime/system/container";
 
 var trim = jQuery.trim;
 
 import {get} from "ember-metal/property_get";
 import {set} from "ember-metal/property_set";
 
-var view;
+var container, view;
 
 module("EmberHandlebars - group flag", {
-  setup: function() {},
+  setup: function() {
+    container = new Container();
+    container.register('view:default', EmberView.extend());
+  },
 
   teardown: function() {
     run(function() {
-      view.destroy();
+      if (view) {
+        view.destroy();
+      }
+      if (container) {
+        container.destroy();
+      }
+      container = view = null;
     });
     run.cancelTimers();
   }
@@ -27,6 +37,7 @@ module("EmberHandlebars - group flag", {
 
 function createGroupedView(template, context) {
   var options = {
+    container: container,
     context: context,
     template: EmberHandlebars.compile(template),
     templateData: {insideGroup: true, keywords: {}}

--- a/packages_es6/ember-handlebars/tests/helpers/view_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/view_test.js
@@ -17,7 +17,6 @@ function viewClass(options) {
 module("Handlebars {{#view}} helper", {
   setup: function() {
     originalLookup = Ember.lookup;
-
   },
 
   teardown: function() {
@@ -29,6 +28,31 @@ module("Handlebars {{#view}} helper", {
   }
 });
 
+test("By default view:default is used", function() {
+  var DefaultView = viewClass({
+    elementId: 'default-view',
+    template: Ember.Handlebars.compile('hello world')
+  });
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: Ember.Handlebars.compile('{{view}}'),
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#default-view').text(), 'hello world');
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:default');
+
+    return DefaultView;
+  }
+});
 
 test("View lookup - App.FuView", function() {
   Ember.lookup = {

--- a/packages_es6/ember-routing/tests/helpers/render_test.js
+++ b/packages_es6/ember-routing/tests/helpers/render_test.js
@@ -112,6 +112,7 @@ module("Handlebars {{render}} helper", {
       if (view) {
         view.destroy();
       }
+      container = view = null;
     });
 
     Ember.TEMPLATES = {};


### PR DESCRIPTION
During the ES6-ify process @rjackson left a comment mentioning that the `{{view}}` helper needs to not look up `Ember.View` globally. This PR fixes this by looking up `view:default` from the container (which `Ember.View` is registered at, by default).

Although I'd love to see this merged asap, it's possible some peoples are overriding `view:default` (we are) and this change from `Ember.View` _might_ produce unexpected results. On the other hand, if you're like us, this has been very desirable since we provide our own `default` base classes that inherit from their core objects. This is why I didn't `FEATURE` flag this, but I'm more than happy to.

Also of note is that there was not previously a unit test for using `{{view}}` without providing a path, which this now includes. Some minor adjustments were needed to some other tests, mostly just injecting a container with a `view:default`.
