### PR TITLE
[Query-Params-New] QP replace does not affect transitions between routes

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -480,6 +480,52 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     Ember.run(appController, 'set', 'alex', 'wallace');
   });
 
+  test("opting into replace does not affect transitions between routes", function() {
+    expect(5);
+    Ember.TEMPLATES.application = Ember.Handlebars.compile(
+      "{{link-to 'Foo' 'foo' id='foo-link'}}" +
+      "{{link-to 'Bar' 'bar' id='bar-no-qp-link'}}" +
+      "{{link-to 'Bar' 'bar' (query-params raytiley='isanerd') id='bar-link'}}" +
+      "{{outlet}}"
+    );
+    App.Router.map(function() {
+      this.route('foo');
+      this.route('bar');
+    });
+
+    App.BarController = Ember.Controller.extend({
+      queryParams: ['raytiley'],
+      raytiley: 'isadork'
+    });
+
+    App.BarRoute = Ember.Route.extend({
+      queryParams: {
+        raytiley: {
+          replace: true
+        }
+      }
+    });
+
+    bootApplication();
+    var controller = container.lookup('controller:bar');
+
+    expectedPushURL = '/foo';
+    Ember.run(Ember.$('#foo-link'), 'click');
+
+    expectedPushURL = '/bar';
+    Ember.run(Ember.$('#bar-no-qp-link'), 'click');
+
+    expectedReplaceURL = '/bar?raytiley=boo';
+    Ember.run(controller, 'set', 'raytiley', 'boo');
+
+    expectedPushURL = '/foo';
+    Ember.run(Ember.$('#foo-link'), 'click');
+
+    expectedPushURL = '/bar?raytiley=isanerd';
+    Ember.run(Ember.$('#bar-link'), 'click');
+
+  });
+
   test("can override incoming QP values in setupController", function() {
     expect(3);
 

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -399,7 +399,8 @@ var Route = EmberObject.extend(ActionHandler, {
             // Now check if this value actually changed.
             if (svalue !== qp.svalue) {
               var options = this.queryParams[qp.urlKey] || {};
-              if (options.replace) {
+              // Only use replace if transition wouldn't otherwise change the url
+              if (options.replace && !transition.targetName) {
                 transition.method('replace');
               }
 


### PR DESCRIPTION
This is a test and a fix for #4572. @machty has some ideas about how router.js api might be better for this so I'll redo this PR based on his feedback.
