### PR TITLE
[Query Params New] - Use Ember.get to retrieve configuration

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -418,6 +418,55 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     equal(indexModelCount, 2);
   });
 
+  test("Use Ember.get to retrieve query params 'refreshModel' configuration", function() {
+    expect(6);
+    App.ApplicationController = Ember.Controller.extend({
+      queryParams: ['appomg'],
+      appomg: 'applol'
+    });
+
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['omg'],
+      omg: 'lol'
+    });
+
+    var appModelCount = 0;
+    App.ApplicationRoute = Ember.Route.extend({
+      model: function(params) {
+        appModelCount++;
+      }
+    });
+
+    var indexModelCount = 0;
+    App.IndexRoute = Ember.Route.extend({
+      queryParams: Ember.Object.create({
+        unknownProperty: function(keyName) {
+          return {refreshModel: true};
+        }
+      }),
+      model: function(params) {
+        indexModelCount++;
+
+        if (indexModelCount === 1) {
+          deepEqual(params, { omg: 'lol' });
+        } else if (indexModelCount === 2) {
+          deepEqual(params, { omg: 'lex' });
+        }
+      }
+    });
+
+    bootApplication();
+
+    equal(appModelCount, 1);
+    equal(indexModelCount, 1);
+
+    var indexController = container.lookup('controller:index');
+    Ember.run(indexController, 'set', 'omg', 'lex');
+
+    equal(appModelCount, 1);
+    equal(indexModelCount, 2);
+  });
+
   test("can use refreshModel even w URL changes that remove QPs from address bar", function() {
     expect(4);
 
@@ -469,6 +518,31 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
           replace: true
         }
       }
+    });
+
+    bootApplication();
+
+    equal(router.get('location.path'), "");
+
+    var appController = container.lookup('controller:application');
+    expectedReplaceURL = "/?alex=wallace";
+    Ember.run(appController, 'set', 'alex', 'wallace');
+  });
+
+  test("Use Ember.get to retrieve query params 'replace' configuration", function() {
+    expect(2);
+    App.ApplicationController = Ember.Controller.extend({
+      queryParams: ['alex'],
+      alex: 'matchneer'
+    });
+
+    App.ApplicationRoute = Ember.Route.extend({
+      queryParams: Ember.Object.create({
+        unknownProperty: function(keyName) {
+          // We are simulating all qps requiring refress
+          return { replace: true };
+        }
+      })
     });
 
     bootApplication();

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -341,8 +341,8 @@ var Route = EmberObject.extend(ActionHandler, {
         var totalChanged = keys(changed).concat(keys(removed));
         for (var i = 0, len = totalChanged.length; i < len; ++i) {
           var urlKey = totalChanged[i],
-              options = this.queryParams[urlKey] || {};
-          if (options.refreshModel) {
+              options = get(this.queryParams, urlKey) || {};
+          if (get(options, 'refreshModel')) {
             this.refresh();
           }
         }
@@ -398,8 +398,8 @@ var Route = EmberObject.extend(ActionHandler, {
 
             // Now check if this value actually changed.
             if (svalue !== qp.svalue) {
-              var options = this.queryParams[qp.urlKey] || {};
-              if (options.replace) {
+              var options = get(this.queryParams, qp.urlKey) || {};
+              if (get(options, 'replace')) {
                 transition.method('replace');
               }
 


### PR DESCRIPTION
This allows for the `queryParams` config to be an ember object
which can help dry out code where there a lots of computed properties.
See the tests for examples.
