### PR TITLE
Fix #4604 ComputedPropertyPrototype.didChange only calls removeDependent...

### DIFF
--- a/packages_es6/ember-metal/lib/computed.js
+++ b/packages_es6/ember-metal/lib/computed.js
@@ -348,7 +348,7 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
   // the cached value set by the setter
   if (this._cacheable && this._suspended !== obj) {
     var meta = metaFor(obj);
-    if (meta.cache !== undefined) {
+    if (meta.cache[keyName] !== undefined) {
       meta.cache[keyName] = undefined;
       removeDependentKeys(this, obj, keyName, meta);
     }


### PR DESCRIPTION
...Keys if the individual cache for the specific key is undefined, and not the cache itself
