### PR TITLE
[BUGFIX] isEqual now supports dates

### DIFF
--- a/packages_es6/ember-runtime/lib/core.js
+++ b/packages_es6/ember-runtime/lib/core.js
@@ -23,6 +23,9 @@
 */
 function isEqual(a, b) {
   if (a && 'function'===typeof a.isEqual) return a.isEqual(b);
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  } 
   return a === b;
 };
 

--- a/packages_es6/ember-runtime/tests/core/isEqual_test.js
+++ b/packages_es6/ember-runtime/tests/core/isEqual_test.js
@@ -19,6 +19,11 @@ test("numericals should be equal",function() {
   ok( !isEqual(24, 21), "different numbers are inequal" );
 });
 
+test("dates should be equal",function() {
+  ok (  isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), "same dates are equal" );
+  ok ( !isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), "different dates are not equal" );
+});
+
 test("array should be equal",function() {
   // NOTE: We don't test for array contents -- that would be too expensive.
   ok( !isEqual( [1,2], [1,2] ), 'two array instances with the same values should not be equal' );
@@ -31,5 +36,3 @@ test("first object implements isEqual should use it", function() {
   var obj = { isEqual: function() { return false; } };
   equal(isEqual(obj, obj), false, 'should return false because isEqual returns false');
 });
-
-


### PR DESCRIPTION
This is in the same vein as #4545. Ember.isEqual should support all native objects.
