### PR TITLE
Add support for required property in checkbox

### DIFF
--- a/packages_es6/ember-handlebars/lib/controls/checkbox.js
+++ b/packages_es6/ember-handlebars/lib/controls/checkbox.js
@@ -37,7 +37,7 @@ var Checkbox = View.extend({
   tagName: 'input',
 
   attributeBindings: ['type', 'checked', 'indeterminate', 'disabled', 'tabindex', 'name',
-                      'autofocus', 'form'],
+                      'autofocus', 'required', 'form'],
 
   type: "checkbox",
   checked: false,


### PR DESCRIPTION
Required attribute binding is here by default for TextField, but not for checkbox, but it is a perfectly valid attribute for checkbox too.
