### PR TITLE
[BUGFIX beta] Drop dead code for * in paths

### DIFF
--- a/packages_es6/ember-metal/lib/chains.js
+++ b/packages_es6/ember-metal/lib/chains.js
@@ -6,7 +6,7 @@ import {watchKey, unwatchKey} from "ember-metal/watch_key";
 
 var metaFor = meta,
     warn = Ember.warn,
-    FIRST_KEY = /^([^\.\*]+)/;
+    FIRST_KEY = /^([^\.]+)/;
 
 function firstKey(path) {
   return path.match(FIRST_KEY)[0];

--- a/packages_es6/ember-metal/lib/property_get.js
+++ b/packages_es6/ember-metal/lib/property_get.js
@@ -10,9 +10,9 @@ var get;
 
 var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
-var IS_GLOBAL_PATH = /^([A-Z$]|([0-9][A-Z$])).*[\.\*]/;
-var HAS_THIS  = /^this[\.\*]/;
-var FIRST_KEY = /^([^\.\*]+)/;
+var IS_GLOBAL_PATH = /^([A-Z$]|([0-9][A-Z$])).*[\.]/;
+var HAS_THIS  = 'this.';
+var FIRST_KEY = /^([^\.]+)/;
 
 // ..........................................................
 // GET AND SET
@@ -96,7 +96,7 @@ if (Ember.config.overrideAccessors) {
   Normalizes a target/path pair to reflect that actual target/path that should
   be observed, etc. This takes into account passing in global property
   paths (i.e. a path beginning with a captial letter not defined on the
-  target) and * separators.
+  target).
 
   @private
   @method normalizeTuple
@@ -106,7 +106,7 @@ if (Ember.config.overrideAccessors) {
   @return {Array} a temporary array with the normalized target/path pair.
 */
 function normalizeTuple(target, path) {
-  var hasThis  = HAS_THIS.test(path),
+  var hasThis  = path.indexOf(HAS_THIS) === 0,
       isGlobal = !hasThis && IS_GLOBAL_PATH.test(path),
       key;
 
@@ -134,7 +134,7 @@ function _getPath(root, path) {
   if (root === null && path.indexOf('.') === -1) { return get(Ember.lookup, path); }
 
   // detect complicated paths and normalize them
-  hasThis  = HAS_THIS.test(path);
+  hasThis = path.indexOf(HAS_THIS) === 0;
 
   if (!root || hasThis) {
     tuple = normalizeTuple(root, path);

--- a/packages_es6/ember-metal/lib/watching.js
+++ b/packages_es6/ember-metal/lib/watching.js
@@ -7,12 +7,11 @@ import {removeChainWatcher, flushPendingChains} from "ember-metal/chains";
 import {watchKey, unwatchKey} from "ember-metal/watch_key";
 import {watchPath, unwatchPath} from "ember-metal/watch_path";
 
-var metaFor = meta, // utils.js
-    IS_PATH = /[\.\*]/;
+var metaFor = meta; // utils.js
 
 // returns true if the passed path is just a keyName
 function isKeyName(path) {
-  return path==='*' || !IS_PATH.test(path);
+  return path.indexOf('.') === -1;
 }
 
 /**


### PR DESCRIPTION
The only guidance I can find on using `*` in paths has [just been removed](https://github.com/emberjs/ember.js/pull/4624/files#diff-a2a8793237eb99624784efe1d784df4eL50). And that example did not work on the console anyway. The `*` was used in Sproutcore for "Chained Property Paths":

http://guides.sproutcore.com/core_concepts_kvo.html

> Observers are able to use a special type of property path called a +chained property path+. When using an observer (or a binding as we will see), usually the actual observer is only added to the second to last object in the property path. Therefore, if you add an observer for the path "MyApp.usersController.mainUser.name", SproutCore finds the object at "MyApp.usersController.mainUser" and adds the observer to its name property. In this case, nothing is observing MyApp.usersController to see if its mainUser property changes.
> 
> What we want to do is watch for changes to usersController.mainUser and for changes to mainUser.name. This is where chained property paths come in. To let SproutCore know that we want observers on both, we use a chained property path like MyApp.usersController*mainUser.name.
> 
> The asterisk (*) in the property path indicates that we want SproutCore to observe changes to all properties following the asterisk. In this case, that is both mainUser and name.
> 
> So why don't we always use chained observers? Observers are "expensive", they take time to set up and they have to run each time their properties change and often times we don't have changes in all levels. In the previous example, we don't care about changes to MyApp.usersController, because we are never going to replace it. If the same were true for mainUser, we wouldn't want to observe it either. Therefore, it is advisable in practice to use chained observers as little as possible, in order to protect performance.

Which is a type of observed path that Ember itself does not distinguish. I propose removing this cruft, especially in light of discussions like #4619 where alternative uses for `*` are being discussed.
