### PR TITLE
[BUGFIX beta] Do not presume extend is Ember's extend

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -694,6 +694,13 @@ function option(container, fullName, optionName) {
   }
 }
 
+function isExtendable(factory) {
+  // Check that this is an ember object and has an extend
+  // function. Other libraries (mootools) may add the own
+  // `extend` to functions or other factories in the container.
+  return factory && factory.__ember_meta__ && (typeof factory.extend === 'function');
+}
+
 function factoryFor(container, fullName) {
   var name = fullName;
   var factory = container.resolve(name);
@@ -707,7 +714,7 @@ function factoryFor(container, fullName) {
     return cache.get(fullName);
   }
 
-  if (!factory || typeof factory.extend !== 'function' || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
+  if (!isExtendable(factory) || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
     // TODO: think about a 'safe' merge style extension
     // for now just fallback to create time injection
     return factory;
@@ -768,7 +775,7 @@ function instantiate(container, fullName) {
         'Most likely an improperly defined class or an invalid module export.');
     }
 
-    if (typeof factory.extend === 'function') {
+    if (isExtendable(factory)) {
       // assume the factory was extendable and is already injected
       return factory.create();
     } else {

--- a/packages/container/tests/container_helper.js
+++ b/packages/container/tests/container_helper.js
@@ -43,6 +43,7 @@ var factory = function() {
   Klass.extend = extend;
   Klass.reopen = extend;
   Klass.reopenClass = reopenClass;
+  Klass.__ember_meta__ = {};
 
   return Klass;
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -84,6 +84,16 @@ test("fallback for to create time injections if factory has no extend", function
   ok(postController.apple instanceof AppleController, 'instance receives an apple of instance AppleController');
 });
 
+test("The container only extends Ember objects", function(){
+  var container = new Container();
+  var badApple = { extend: function(){} };
+
+  container.register('apples:bad', badApple, {instantiate: false});
+  var instance = container.lookup('apples:bad');
+
+  equal(instance, badApple, 'instance is not instantiated');
+});
+
 test("The descendants of a factory returned from lookupFactory have a container and debugkey", function(){
   var container = new Container();
   var PostController = factory();


### PR DESCRIPTION
The container cannot presume that extend is Ember's own extend function. Prototype and mootools extend native types (like functions used for templates) with the extend property.

@stefanpenner checking `__ember_meta__` is definitely not ideal, but if we are to rely upon detecting Ember-extendable objects I don't see a better way. An alternative would be to make extendability configurable, but, ugh.

Fixes #4554
