### PR TITLE
[BUGFIX beta] Ensure context is unchanged when using keywords with itemController.

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/collection.js
+++ b/packages_es6/ember-handlebars/lib/helpers/collection.js
@@ -236,7 +236,9 @@ function collectionHelper(path, options) {
   }
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }
 
-  if (!hash.keyword) {
+  if (hash.keyword) {
+    itemHash._context = this;
+  } else {
     itemHash._context = alias('content');
   }
 

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -311,13 +311,13 @@ test("it should still have access to original parentController within an {{#each
 
   var parentController = EmberObject.create({
     container: container,
-    name: 'Bob Loblaw'
+    name: 'Bob Loblaw',
+    people: people
   });
 
   view = EmberView.create({
     container: container,
     template: EmberHandlebars.compile('{{#each person in people}}{{#with person controller="person"}}{{controllerName}}{{/with}}{{/each}}'),
-    context: { people: people },
     controller: parentController
   });
 


### PR DESCRIPTION
Prior to this change the following code would bind `this` in the template block to the itemController's content (even though the keyword form of `{{each}}` is used).

This change sets the child view's `_context` property to the current context when using the keyword form of `{{each}}`, and a couple of confirming tests to demonstrate using `itemController` specified in either the `ArrayController` or the template directly.

Failing JSBin: http://emberjs.jsbin.com/zokali/1/edit.

Passing JSBin: http://emberjs.jsbin.com/kecen/1/edit.

Fixes #4634.
