### PR TITLE
Support colon in bound attribute name

### DIFF
--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -1407,9 +1407,9 @@ var View = CoreView.extend({
         unspecifiedAttributeBindings = this._unspecifiedAttributeBindings = this._unspecifiedAttributeBindings || {};
 
     a_forEach(attributeBindings, function(binding) {
-      var split = binding.split(':'),
-          property = split[0],
-          attributeName = split[1] || property;
+      var match = binding.match(/([^:]*):?(.*)/),
+          property = match[1],
+          attributeName = match[2] || property;
 
       if (property in this) {
         this._setupAttributeBindingObservation(property, attributeName);


### PR DESCRIPTION
It would be nice, if I could bind an attribute, that has colon in its name (ex. "xmlns:xlink"). At this moment the part after the second colon is ignored.

```
App.View = Em.View.extend({
  tagName: "svg",
  xmlns: "http://www.w3.org/2000/svg",
  xmlnsXlink: "http://www.w3.org/1999/xlink",
  attributeBindings: ["xmlns", "xmlnsXlink:xmlns:xlink"]
})
```

I get:

```
<svg id="ember426" xmlns="http://www.w3.org/1999/xlink"></svg>
```

I would like to get:

```
<svg id="ember426" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg>
```

I've modified the code to split using only the first colon, but I have no idea if what I'm doing is right and has any use. :smile: 
It's just a suggestion.
