### PR TITLE
[DOC release] Clarify reduceComputed's docs

### DIFF
--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -776,6 +776,10 @@ ReduceComputedProperty.prototype.property = function () {
   semantics.  Dependent keys which end in `.[]` do not use "one at a time"
   semantics.  When an item is added or removed from such a dependency, the
   computed property is completely recomputed.
+  
+  When the computed property is completely recomputed, the `accumulatedValue`
+  is discarded, it starts with `initialValue` again, and each item is passed
+  to `addedItem` in turn.
 
   Example
 


### PR DESCRIPTION
I felt it was unclear what "completely recomputed" meant in the context of non-array or `.[]` (square bracket) dependencies. Hopefully this should help others understand more quickly.
