### PR TITLE
[BUGFIX beta] Allow setting of `undefined` value to a `content` property

### DIFF
--- a/packages_es6/ember-metal/lib/property_set.js
+++ b/packages_es6/ember-metal/lib/property_set.js
@@ -49,7 +49,7 @@ var set = function set(obj, keyName, value, tolerant) {
     desc.set(obj, keyName, value);
   } else {
 
-    if (typeof obj === 'object' && obj !== null && obj[keyName] === value) {
+    if (typeof obj === 'object' && obj !== null && value !== undefined && obj[keyName] === value) {
       return value;
     }
 

--- a/packages_es6/ember-metal/tests/accessors/set_test.js
+++ b/packages_es6/ember-metal/tests/accessors/set_test.js
@@ -9,17 +9,19 @@ test('should set arbitrary properties on an object', function() {
     number: 23,
     boolTrue: true,
     boolFalse: false,
-    nullValue: null
+    nullValue: null,
+    undefinedValue: undefined
   };
 
-  var newObj = {};
+  var newObj = {
+    undefinedValue: 'emberjs'
+  };
 
   for(var key in obj) {
     if (!obj.hasOwnProperty(key)) continue;
     equal(set(newObj, key, obj[key]), obj[key], 'should return value');
     equal(get(newObj, key), obj[key], 'should set value');
   }
-
 });
 
 test('should call setUnknownProperty if defined and value is undefined', function() {

--- a/packages_es6/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages_es6/ember-runtime/tests/system/object_proxy_test.js
@@ -182,3 +182,13 @@ testBoth("should transition between watched and unwatched strategies", function(
   equal(get(content, 'foo'), 'foo');
   equal(get(proxy, 'foo'), 'foo');
 });
+
+testBoth('setting `undefined` to a proxied content property should override its existing value', function(get, set) {
+  var proxyObject = ObjectProxy.create({
+    content: {
+      prop: 'emberjs'
+    }
+  });
+  set(proxyObject, 'prop', undefined);
+  equal(get(proxyObject, 'prop'), undefined, 'sets the `undefined` value to the proxied content');
+});


### PR DESCRIPTION
Fixes setting of `undefined` value to a content property. 

Still, checking `obj[keyName] === value` in these [lines](https://github.com/selvagsz/ember.js/blob/master/packages_es6/ember-metal/lib/property_set.js#L52-54) is bypassed in two cases
1. If the setter value is `undefined`
2. If the setter property lies inside the proxied content

Using `get(obj, keyName)` might resolve. But was quite nervous to do that as it may involve some additional function calls

Fixes #4644
