### PR TITLE
[BUGFIX beta] incrementProperty should parseFloat value before incrementing

### DIFF
--- a/packages_es6/ember-runtime/lib/mixins/observable.js
+++ b/packages_es6/ember-runtime/lib/mixins/observable.js
@@ -435,7 +435,7 @@ var Observable = Mixin.create({
   incrementProperty: function(keyName, increment) {
     if (isNone(increment)) { increment = 1; }
     Ember.assert("Must pass a numeric value to incrementProperty", (!isNaN(parseFloat(increment)) && isFinite(increment)));
-    set(this, keyName, (get(this, keyName) || 0) + increment);
+    set(this, keyName, (parseFloat(get(this, keyName)) || 0) + increment);
     return get(this, keyName);
   },
 

--- a/packages_es6/ember-runtime/tests/mixins/observable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/observable_test.js
@@ -90,3 +90,11 @@ testBoth("should be able to retrieve cached values of computed properties withou
 
   equal(obj.cacheFor('bar'), undefined, "returns undefined if the value is not a computed property");
 });
+
+test('incrementProperty should work even if value is number in string', function() {
+  var obj = EmberObject.create({
+    age: "24"
+  });
+  obj.incrementProperty('age');
+  equal(25, obj.get('age'));
+});


### PR DESCRIPTION
This is a rebase of #4189 into ES6 land.
