### PR TITLE
[FEATURE ember-routing-custom-link-view]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,3 +52,36 @@ for a detailed explanation.
     underlying test framework to start/stop between async steps.
 
   Added in [#4176](https://github.com/emberjs/ember.js/pull/4176)
+
+* `ember-routing-custom-link-view`
+
+  Allow usage of a custom view class from the `link-to` helper. This allows easier
+  customization of things like `classNameBindings`, `attributeBindings`, `active` state, etc
+  without having to reopen the core `Ember.LinkView` class.
+
+  Example:
+
+  ```handlebars
+  {{#link-to 'post' view="alternate-active"}}Post{{/link-to}}
+  ```
+
+  ```javascript
+  App.AlternateActiveView = Ember.LinkView.extend({
+    target: Ember.computed.alias('controller'),
+    active: Ember.computed('resolvedParams', 'routeArgs', function(){
+      var isActive = this._super();
+
+      this.send('active', isActive);
+
+      return isActive;
+    })
+  });
+  ```
+
+  This would send an `active` action when the views active/inactive state changes. If you
+  couple this with a component you very easily handle having a parent DOM element receive
+  an active class (think link-to nested inside an li for example).
+
+  Functional example: http://emberjs.jsbin.com/juzay/2/edit
+
+  Added in [#4647](https://github.com/emberjs/ember.js/pull/4647).

--- a/features.json
+++ b/features.json
@@ -6,7 +6,8 @@
     "ember-handlebars-caps-lookup": null,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-runtime-test-friendly-promises": true,
-    "ember-routing-add-model-option": true
+    "ember-routing-add-model-option": true,
+    "ember-routing-custom-link-view": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1575,3 +1575,32 @@ test("invoking a link-to whose transition gets aborted in will transition doesn'
   equal(router.get('location.path'), '', 'url was not updated');
 });
 
+if (Ember.FEATURES.isEnabled("ember-routing-custom-link-view")) {
+  test("The {{link-to}} helper allows specifying a custom linkView", function() {
+    var customLinkInstantiated = false;
+
+    Ember.TEMPLATES.application = Ember.Handlebars.compile("{{#link-to 'about' view='random'}}About{{/link-to}}");
+
+    Router.map(function() {
+      this.route("about");
+    });
+
+    container.register('view:random', Ember.LinkView.extend({
+      init: function(){
+        customLinkInstantiated = true;
+        this._super.apply(this, arguments);
+      },
+      classNameBindings: ['blammo'],
+      blammo: 'super-duper-awesome'
+    }));
+
+    bootApplication();
+
+    Ember.run(function() {
+      router.handleURL("/");
+    });
+
+    ok(customLinkInstantiated, 'The custom LinkView was instantiated.');
+    equal(Ember.$('.super-duper-awesome', '#qunit-fixture').length, 1, "The custom LinkView was used.");
+  });
+}


### PR DESCRIPTION
Allow usage of a custom view class from the `link-to` helper. This allows easier customization of things like `classNameBindings`, `attributeBindings`, `active` state, etc without having to reopen the core `Ember.LinkView` class.

Example:

``` handlebars
{{#link-to 'post' view="alternate-active"}}Post{{/link-to}}
```

``` javascript
App.AlternateActiveView = Ember.LinkView.extend({
  target: Ember.computed.alias('controller'),
  active: Ember.computed('resolvedParams', 'routeArgs', function(){
    var isActive = this._super();

    this.send('active', isActive);

    return isActive;
  })
});
```

This would send an `active` action when the views active/inactive state changes. If you
couple this with a component you very easily handle having a parent DOM element receive
an active class (think link-to nested inside an li for example).

Functional example: http://emberjs.jsbin.com/juzay/2/edit
