### PR TITLE
[BUGFIX beta] {{yield}} works inside a Metamorph'ed component

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/yield.js
+++ b/packages_es6/ember-handlebars/lib/helpers/yield.js
@@ -97,7 +97,7 @@ function yieldHelper(options) {
     if (view._contextView) {
       view = view._contextView;
     } else {
-      view = get(view, 'parentView');
+      view = get(view, '_parentView');
     }
   }
 

--- a/packages_es6/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/yield_test.js
@@ -362,3 +362,21 @@ test("yield with nested components (#3220)", function(){
 
   equal(view.$('div > span').text(), "Hello world");
 });
+
+test("yield works inside a conditional in a component that has Ember._Metamorph mixed in", function() {
+  var component = Component.extend(Ember._Metamorph, {
+    item: "inner",
+    layout: Ember.Handlebars.compile("<p>{{item}}</p>{{#if item}}<p>{{yield}}</p>{{/if}}")
+  });
+
+  view = Ember.View.create({
+    controller: { item: "outer", component: component },
+    template: Ember.Handlebars.compile('{{#view component}}{{item}}{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$().text(), 'innerouter', "{{yield}} renders yielded content inside metamorph component");
+});


### PR DESCRIPTION
This was working in the simple case, but was previously not working if
the `{{yield}}` was inside a conditional or other metamorph-generating
helper.
