### PR TITLE
[BUGFIX beta] Lookup actionName in context instead of target

### DIFF
--- a/packages_es6/ember-routing/lib/helpers/action.js
+++ b/packages_es6/ember-routing/lib/helpers/action.js
@@ -82,7 +82,7 @@ ActionHelper.registerAction = function(actionNameOrPath, options, allowedKeys) {
       }
 
       var target = options.target,
-          actionName;
+          actionName, context;
 
       if (target.target) {
         target = handlebarsGet(target.root, target.target, target.options);
@@ -91,7 +91,8 @@ ActionHelper.registerAction = function(actionNameOrPath, options, allowedKeys) {
       }
 
       if (options.boundProperty) {
-        actionName = handlebarsGet(target, actionNameOrPath, options.options);
+        context = options.parameters.context;
+        actionName = handlebarsGet(context, actionNameOrPath, options.options);
 
         if(typeof actionName === 'undefined' || typeof actionName === 'function') {
           Ember.assert("You specified a quoteless path to the {{action}} helper '" + actionNameOrPath + "' which did not resolve to an actionName. Perhaps you meant to use a quoted actionName? (e.g. {{action '" + actionNameOrPath + "'}}).", true);

--- a/packages_es6/ember-routing/tests/helpers/action_test.js
+++ b/packages_es6/ember-routing/tests/helpers/action_test.js
@@ -804,6 +804,54 @@ test("a quoteless parameter should allow dynamic lookup of the actionName", func
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
+test("a quoteless parameter should lookup actionName in context", function(){
+  expect(4);
+  var lastAction, actionOrder = [];
+
+  view = EmberView.create({
+    template: compile("{{#each allactions}}<a {{bind-attr id='name'}} {{action name}}>{{title}}</a>{{/each}}")
+  });
+
+  var controller = EmberController.extend({
+    allactions: Ember.A([{title: 'Biggity Boom',name: 'biggityBoom'},
+                         {title: 'Whomp Whomp',name: 'whompWhomp'},
+                         {title: 'Sloopy Dookie',name: 'sloopyDookie'}]),
+    actions: {
+      biggityBoom: function() {
+        lastAction = 'biggityBoom';
+        actionOrder.push(lastAction);
+      },
+      whompWhomp: function() {
+        lastAction = 'whompWhomp';
+        actionOrder.push(lastAction);
+      },
+      sloopyDookie: function(){
+        lastAction = 'sloopyDookie';
+        actionOrder.push(lastAction);
+      }
+    }
+  }).create();
+
+  run(function() {
+    view.set('controller', controller);
+    view.appendTo('#qunit-fixture');
+  });
+
+  var testBoundAction = function(propertyValue){
+    run(function(){
+      view.$("#"+propertyValue).click();
+    });
+
+    equal(lastAction, propertyValue, 'lastAction set to ' + propertyValue);
+  };
+
+  testBoundAction('whompWhomp');
+  testBoundAction('sloopyDookie');
+  testBoundAction('biggityBoom');
+
+  deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
+});
+
 test("a quoteless parameter that also exists as an action name functions properly", function(){
   Ember.TESTING_DEPRECATION = true;
   var triggeredAction;


### PR DESCRIPTION
The `actionName` lookup introduced in #3936 now looks up `actionName` in the target.

But while iterating over an array using the each helper, and if the actionName is given as a bound property, the actionName should be looked up on the context, not the controller.

``` javascript
App.IndexController = Ember.ArrayController.extend({
  allactions: [{title: 'Alert 1',name: 'alert1'},
              {title: 'Alert 2',name: 'alert2'},
              {title: 'Alert 3',name: 'alert3'}],
  actions: {
    alert1: function(){
      alert('clicked 1');
    },
    alert2: function(){
      alert('clicked 2');
    },
    alert3: function(){
      alert('clicked 3');
    }
  }
});
```

with template 

``` html
{{#each allactions}}
    <button {{action name}}>{{title}}</button>
{{/each}}
```

Clicking the Alert1 button should look up `name` property in the context and resolve to `alert1` and should not look up on the target (controller).

Failing jsbin [here](http://emberjs.jsbin.com/gegob/4/edit)
