### PR TITLE
[BUGFIX] Normalize the `if` and `bind-attr` truthiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Ember Changelog
 
+* [BREAKING BUGFIX] An empty array are treated as falsy value in `bind-attr` to be in consistent with `if` helper. Breaking for apps that relies on the previous behaviour which treats an empty array as truthy value in `bind-attr`.
+
 ### Ember 1.6.0-beta.1 (March 31, 2014)
 
 * [BUGFIX] Add `which` attribute to event triggered by keyEvent test helper.

--- a/packages_es6/ember-metal/lib/utils.js
+++ b/packages_es6/ember-metal/lib/utils.js
@@ -384,7 +384,7 @@ function isArray(obj) {
   if (!obj || obj.setInterval) { return false; }
   if (Array.isArray && Array.isArray(obj)) { return true; }
   if (EmberArray && EmberArray.detect(obj)) { return true; }
-  if ((obj.length !== undefined) && 'object'===typeof obj) { return true; }
+  if ((obj.length !== undefined) && 'object'=== typeOf(obj)) { return true; }
   return false;
 };
 

--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -21,7 +21,7 @@ import {meta} from "ember-metal/utils";
 import {computed} from "ember-metal/computed";
 import {observer} from "ember-metal/mixin";
 
-import {typeOf} from "ember-metal/utils";
+import {typeOf, isArray} from "ember-metal/utils";
 import {isNone} from 'ember-metal/is_none';
 import {Mixin} from 'ember-metal/mixin';
 import Container from 'container/container';
@@ -2505,6 +2505,10 @@ View.reopenClass({
     @private
   */
   _classStringForValue: function(path, val, className, falsyClassName) {
+    if(isArray(val)) {
+      val = get(val, 'length') !== 0;  
+    }
+    
     // When using the colon syntax, evaluate the truthiness or falsiness
     // of the value to determine which className to return
     if (className || falsyClassName) {

--- a/packages_es6/ember-views/tests/views/view/class_string_for_value_test.js
+++ b/packages_es6/ember-views/tests/views/view/class_string_for_value_test.js
@@ -41,3 +41,13 @@ test("returns the value if the value is truthy", function() {
   equal(cSFV("propertyName", "123"), 123, "returns value if the value is truthy");
   equal(cSFV("content.propertyName", 123), 123, "returns value if the value is truthy");
 });
+
+test("treat empty array as falsy value and return null", function() {
+  equal(cSFV("propertyName", [], "truthyClass"), null, "returns null if value is false");
+  equal(cSFV("content.propertyName", [], "truthyClass"), null, "returns null if value is false");
+});
+
+test("treat non-empty array as truthy value and return the className if specified", function() {
+  equal(cSFV("propertyName", ['emberjs'], "truthyClass"), "truthyClass", "returns className if given");
+  equal(cSFV("content.propertyName", ['emberjs'], "truthyClass"), "truthyClass", "returns className if given");
+});


### PR DESCRIPTION
There exists some inconsistent in evaluating the truthiness of an empty array between the `{{#if}}` and `{{bind-attr}}` helpers. The former treats an empty array as `falsy` value (still i'm not sure [why handlebars {{#if}} treats an empty array as falsy](https://github.com/wycats/handlebars.js/pull/66)) while the latter treats it as `truthy` one.

[JSbin demonstrating the inconsistent behaviour](http://emberjs.jsbin.com/pagawife/2/edit)
[JSbin fixing the inconsistent](http://emberjs.jsbin.com/tofisetu/1/edit)

This PR addresses the inconsistent behaviour.
Fixes #4330

/cc @wagenet 
