### PR TITLE
brace expansion with spaces throws error

### DIFF
--- a/packages_es6/ember-metal/lib/expand_properties.js
+++ b/packages_es6/ember-metal/lib/expand_properties.js
@@ -1,18 +1,19 @@
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import EmberError from 'ember-metal/error';
+import EnumerableUtils from 'ember-metal/enumerable_utils';
 
 /**
   @module ember-metal
   */
 
 var forEach = EnumerableUtils.forEach,
-BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
+  BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
 
 /**
   Expands `pattern`, invoking `callback` for each expansion.
 
   The only pattern supported is brace-expansion, anything else will be passed
   once to `callback` directly. Brace expansion can only appear at the end of a
-  pattern, for example as the last item in a chain.
+  pattern, for an example see the last call below.
 
   Example
   ```js
@@ -33,12 +34,17 @@ BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
 function expandProperties(pattern, callback) {
   var match, prefix, list;
 
+  if (pattern.indexOf(' ') > -1) {
+    throw new EmberError('Brace expanded properties cannot contain spaces, ' + 
+      'e.g. `user.{firstName, lastName}` should be `user.{firstName,lastName}`');
+  }
+
   if (match = BRACE_EXPANSION.exec(pattern)) {
     prefix = match[1];
     list = match[2];
 
     forEach(list.split(','), function (suffix) {
-      callback(prefix + suffix);
+        callback(prefix + suffix);
     });
   } else {
     callback(pattern);

--- a/packages_es6/ember-metal/tests/computed_test.js
+++ b/packages_es6/ember-metal/tests/computed_test.js
@@ -425,6 +425,15 @@ testBoth('can watch multiple dependent keys specified declaratively via brace ex
   equal(get(obj, 'foo'), 'foo 3', "foo not invalidated by quux");
 });
 
+testBoth('throws assertion if brace expansion notation has spaces', function (get, set) {
+  throws(function () {
+    defineProperty(obj, 'roo', computed(function (key, value) {
+      count++;
+      return 'roo ' + count;
+    }).property('fee.{bar, baz,bop , }'));
+  }, /cannot contain spaces/);
+});
+
 // ..........................................................
 // CHAINED DEPENDENT KEYS
 //


### PR DESCRIPTION
Forbids you to do `foo.{bar, baz}`. Throws an error.
