### PR TITLE
[BUGFIX beta] pass context to sortFunction to avoid calling __nextSuper ...

### DIFF
--- a/packages_es6/ember-runtime/lib/mixins/sortable.js
+++ b/packages_es6/ember-runtime/lib/mixins/sortable.js
@@ -123,12 +123,12 @@ var SortableMixin = Mixin.create(MutableEnumerable, {
 
     forEach(sortProperties, function(propertyName) {
       if (result === 0) {
-        result = sortFunction(get(item1, propertyName), get(item2, propertyName));
+        result = sortFunction.call(this, get(item1, propertyName), get(item2, propertyName));
         if ((result !== 0) && !sortAscending) {
           result = (-1) * result;
         }
       }
-    });
+    }, this);
 
     return result;
   },

--- a/packages_es6/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/sortable_test.js
@@ -284,3 +284,33 @@ test("you can sort with custom sorting function", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag bryn', 'array is sorted by custom sort');
 });
+
+test("Ember.Sortable with sortFunction on ArrayProxy should work like ArrayController", function() {
+  run(function() {
+    sortedArrayController = ArrayProxy.createWithMixins(SortableMixin, {
+      sortProperties: ['name'],
+      sortFunction: function(v, w) {
+            var lowerV = v.toLowerCase(),
+                lowerW = w.toLowerCase();
+
+            if (lowerV < lowerW) {
+              return -1;
+            }
+            if (lowerV > lowerW) {
+              return 1;
+            }
+            return 0;
+        }
+    });
+    var array = [{ id: 1, name: "Scumbag Dale" }, { id: 2, name: "Scumbag Katz" }, { id: 3, name: "Scumbag Bryn" }];
+    unsortedArray = Ember.A(Ember.A(array).copy());
+  });
+  equal(sortedArrayController.get('length'), 0, 'array has 0 items');
+
+  run(function() {
+    sortedArrayController.set('content', unsortedArray);
+  });
+
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+  equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
+});


### PR DESCRIPTION
...on undefined

May fix #4661, but I think there is a deeper cause around the __nextSuper thing.
The bug seems to appear only by calling ArrayProxy.createWithMixins(SortableMixin), and overriding the sortFunction.
