### PR TITLE
[FEATURE ember-runtime-array-computed-reverse]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,3 +52,12 @@ for a detailed explanation.
     underlying test framework to start/stop between async steps.
 
   Added in [#4176](https://github.com/emberjs/ember.js/pull/4176)
+
+* `ember-runtime-array-computed-reverse`
+  A reduce computed macro for reversing an array.
+  Simply using toArray().reverse() will recreate a new array every time.
+  With a large array of items, or complex DOM representation of these items,
+  rerendering becomes expensive.  This leverages reduce computed arrays to
+  perform replace actions one at a time.
+
+  Added in [#4680](https://github.com/emberjs/ember.js/pull/4680)

--- a/features.json
+++ b/features.json
@@ -6,7 +6,8 @@
     "ember-handlebars-caps-lookup": null,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-runtime-test-friendly-promises": true,
-    "ember-routing-add-model-option": true
+    "ember-routing-add-model-option": true,
+    "ember-runtime-array-computed-reverse": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -761,5 +761,46 @@ function sort(itemsKey, sortDefinition) {
   });
 };
 
+var reverse;
+if (Ember.FEATURES.isEnabled('ember-runtime-array-computed-reverse')) {
+  /**
+    A computed property which returns a reversed array without 
+    recreating a new array on each replace action.
 
-export {sum, min, max, map, sort, setDiff, mapBy, mapProperty, filter, filterBy, filterProperty, uniq, union, intersect}
+    Example
+
+    ```javascript
+    App.Timeline = Ember.Object.extend({
+      reverseChronPosts: Ember.computed.reverse('posts')
+    });
+
+    var timeline = App.Timeline.create({posts: [
+      'good morning',
+      'grabbing lunch',
+      'making dinner'
+    ]});
+    timeline.get('reverseChronPosts'); // ['making dinner', 'grabbing lunch', 'good morning']
+    ```
+
+    @method computed.reverse
+    @for Ember
+    @param {String} dependentKey
+    @return {Ember.ComputedProperty} computes an array with the elements 
+    from the dependent array reversed
+  */
+  reverse = function(dependentKey) {
+    return arrayComputed(dependentKey, {
+      addedItem: function(array, item, changeMeta) {
+        array.insertAt(get(array, 'length') - changeMeta.index, item);
+        return array;
+      },
+
+      removedItem: function(array, item, changeMeta) {
+        array.removeAt(get(array, 'length') - changeMeta.index - 1);
+        return array;
+      }
+    });
+  };
+}
+
+export {sum, min, max, map, sort, setDiff, mapBy, mapProperty, filter, filterBy, filterProperty, uniq, union, intersect, reverse}

--- a/packages_es6/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages_es6/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -23,7 +23,8 @@ import {sum as computedSum,
         filterBy as computedFilterBy,
         uniq as computedUniq,
         union as computedUnion,
-        intersect as computedIntersect} from 'ember-runtime/computed/reduce_computed_macros';
+        intersect as computedIntersect,
+        reverse as computedReverse} from 'ember-runtime/computed/reduce_computed_macros';
 
 import NativeArray from "ember-runtime/system/native_array";
 
@@ -1374,3 +1375,95 @@ test('updates when array is modified', function(){
 
   equal(sum(), 6, 'recomputes when elements are removed');
 });
+
+if (Ember.FEATURES.isEnabled('ember-runtime-array-computed-reverse')) {
+  module('computedReverse', {
+    setup: function() {
+      run(function() {
+        obj = EmberObject.createWithMixins({
+          array: Ember.A([ 1, 2, 3, 4, 5 ]),
+          reverseArray: computedReverse('array')
+        });
+      });
+    },
+    teardown: function() {
+      run(function() {
+        obj.destroy();
+      });
+    }
+  });
+
+  test('reverses the values in the dependentKey', function(){
+    var reversed = get(obj, 'reverseArray');
+    deepEqual(reversed, [ 5, 4, 3, 2, 1 ], "reverses the original array");
+  });
+
+  test('reverses when pushing items', function(){
+    var array = get(obj, 'array');
+
+    array.pushObject(6);
+    deepEqual(get(obj, 'reverseArray'), [ 6, 5, 4, 3, 2, 1 ], "array is reversed after pushing object");
+
+    array.pushObjects([7, 8, 9]);
+    deepEqual(get(obj, 'reverseArray'), [ 9, 8, 7, 6, 5, 4, 3, 2, 1 ], "array is reversed after pushing multiple objects");
+  });
+
+  test('reverses when inserting items', function(){
+    var array = get(obj, 'array');
+
+    array.insertAt(3, 'A');
+    deepEqual(get(obj, 'reverseArray'), [ 5, 4, 'A', 3, 2, 1 ], "array is reversed after inserting object in the middle");
+
+    array.replace(4, 0, ['B', 'C', 'D']);
+    deepEqual(get(obj, 'reverseArray'), [ 5, 4, 'D', 'C', 'B', 'A', 3, 2, 1 ], "array is reversed after inserting multiple objects in the middle");
+
+    array.replace(0, 0, ['X', 'Y', 'Z']);
+    deepEqual(get(obj, 'reverseArray'), [ 5, 4, 'D', 'C', 'B', 'A', 3, 2, 1, 'Z', 'Y', 'X' ], "array is reversed after inserting multiple objects at the beginning");
+  });
+
+  test('reverses when replacing items', function(){
+    var array = get(obj, 'array');
+
+    array.replace(1, 3, ['X', 'Y']);
+    deepEqual(get(obj, 'reverseArray'), [ 5, 'Y', 'X', 1 ], "array is reversed after replacing objects");
+
+    array.replace(0, 1, ['A']);
+    deepEqual(get(obj, 'reverseArray'), [ 5, 'Y', 'X', 'A' ], "array is reversed after replacing objects");
+  });
+
+  test('reverses when removing items', function(){
+    var array = get(obj, 'array');
+
+    array.removeAt(2);
+    deepEqual(get(obj, 'reverseArray'), [ 5, 4, 2, 1 ], "array is reversed after removing object in middle");
+
+    array.removeAt(1, 2);
+    deepEqual(get(obj, 'reverseArray'), [ 5, 1 ], "array is reversed after removing multiple objects in middle");
+
+    array.popObject();
+    deepEqual(get(obj, 'reverseArray'), [ 1 ], "array is reversed after popping object");
+  });
+
+  test('reverse works starting with an empty array', function() {
+    var obj = EmberObject.createWithMixins({
+      array: Ember.A(),
+      reverseArray: computedReverse('array')
+    });
+
+    deepEqual(get(obj, 'reverseArray'), [], "reverses of empty array is empty");
+
+    var array = get(obj, 'array');
+    array.pushObjects([1, 2, 3]);
+    deepEqual(get(obj, 'reverseArray'), [ 3, 2, 1 ], "array is reversed after pushing objects onto empty array");
+  });
+
+  test('reverse works when setting an array', function() {
+    var obj = EmberObject.createWithMixins({
+      array: null,
+      reverseArray: computedReverse('array')
+    });
+
+    var array = set(obj, 'array', Ember.A([1, 2, 3]));
+    deepEqual(get(obj, 'reverseArray'), [ 3, 2, 1 ], "array is reversed after setting a new array");
+  });
+}


### PR DESCRIPTION
A reduce computed macro for reversing an array.

Simply using a computed property with toArray().reverse() will recreate a new array every time. With a large array of items, or complex DOM representation of these items, re-rendering becomes expensive.  This leverages reduce computed arrays to perform replace actions one at a time.

Example: http://jsbin.com/tefusare/2
