### PR TITLE
[BUGFIX beta] Add 'autocapitalize' and 'autocorrect' attributeBindings.

### DIFF
--- a/packages_es6/ember-handlebars/lib/controls/text_support.js
+++ b/packages_es6/ember-handlebars/lib/controls/text_support.js
@@ -22,7 +22,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
   attributeBindings: ['placeholder', 'disabled', 'maxlength', 'tabindex', 'readonly',
                       'autofocus', 'form', 'selectionDirection', 'spellcheck', 'required',
-                      'title'],
+                      'title', 'autocapitalize', 'autocorrect'],
   placeholder: null,
   disabled: false,
   maxlength: null,


### PR DESCRIPTION
For Ios autocompletion disabling
