### PR TITLE
[DOC beta] Update the FEATURES.isEnabled docs so it doesn't look like a ...

### DIFF
--- a/packages_es6/ember-metal/lib/core.js
+++ b/packages_es6/ember-metal/lib/core.js
@@ -93,8 +93,9 @@ MetamorphENV.DISABLE_RANGE_API = Ember.ENV.DISABLE_RANGE_API;
 
   You can also define `ENV.FEATURES` if you need to enable features flagged at runtime.
 
-  @property FEATURES
-  @type Hash
+  @class FEATURES
+  @namespace Ember
+  @static
   @since 1.1.0
 */
 
@@ -111,7 +112,9 @@ Ember.FEATURES = Ember.ENV.FEATURES || {};
     enabled/disabled.
 
   @method isEnabled
-  @param {string} feature
+  @param {String} feature
+  @return {Boolean}
+  @for Ember.FEATURES
   @since 1.1.0
 */
 
@@ -146,6 +149,7 @@ Ember.FEATURES.isEnabled = function(feature) {
   @property EXTEND_PROTOTYPES
   @type Boolean
   @default true
+  @for Ember
 */
 Ember.EXTEND_PROTOTYPES = Ember.ENV.EXTEND_PROTOTYPES;
 


### PR DESCRIPTION
...method on the Ember object.

Currently the docs make it look like the `isEnabled` method is attached to the Ember object.
![screen shot 2014-04-11 at 10 22 25 am](https://cloud.githubusercontent.com/assets/54056/2681074/3ade6218-c189-11e3-8f74-87d6971fec72.png)

This pr updates the docs to make it clear that the `isEnabled` method is attached to the `Ember.FEATURES` object.
![screen shot 2014-04-11 at 10 21 52 am](https://cloud.githubusercontent.com/assets/54056/2681080/49d77778-c189-11e3-922e-03e80624d18b.png)
