### PR TITLE
[DOC beta] Fix warnings generated by yuidoc.

### DIFF
--- a/packages_es6/container/lib/main.js
+++ b/packages_es6/container/lib/main.js
@@ -1,4 +1,4 @@
-/**
+/*
 Public api for the container is still in flux.
 The public api, specified on the application namespace should be considered the stable api.
 // @module container

--- a/packages_es6/ember-extension-support/lib/data_adapter.js
+++ b/packages_es6/ember-extension-support/lib/data_adapter.js
@@ -225,6 +225,7 @@ var DataAdapter = EmberObject.extend({
   /**
     Clear all observers before destruction
     @private
+    @method willDestroy
   */
   willDestroy: function() {
     this._super();

--- a/packages_es6/ember-metal/lib/utils.js
+++ b/packages_es6/ember-metal/lib/utils.js
@@ -9,6 +9,10 @@ import {forEach} from "ember-metal/array";
 /**
   Prefix used for guids through out Ember.
   @private
+  @property GUID_PREFIX
+  @for Ember
+  @type String
+  @final
 */
 var GUID_PREFIX = 'ember';
 

--- a/packages_es6/ember-routing/lib/helpers/link_to.js
+++ b/packages_es6/ember-routing/lib/helpers/link_to.js
@@ -459,6 +459,9 @@ var LinkView = Ember.LinkView = EmberView.extend({
 
   /**
     @private
+    @method _eagerUpdateUrl
+    @param transition
+    @param href
    */
   _eagerUpdateUrl: function(transition, href) {
     if (!transition.isActive || !transition.urlMethod) {

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -967,6 +967,10 @@ var Route = EmberObject.extend(ActionHandler, {
 
   /**
     @private
+    @method deserialize
+    @param {Object} params the parameters extracted from the URL
+    @param {Transition} transition
+    @return {Object|Promise} the model for this route.
 
     Router.js hook.
    */

--- a/packages_es6/ember-routing/lib/system/router.js
+++ b/packages_es6/ember-routing/lib/system/router.js
@@ -80,7 +80,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     Represents the current URL.
 
     @method url
-    @returns {String} The current URL.
+    @return {String} The current URL.
   */
   url: computed(function() {
     return get(this, 'location').getURL();
@@ -186,7 +186,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     @method isActive
     @param routeName
-    @returns {Boolean}
+    @return {Boolean}
     @private
   */
   isActive: function(routeName) {
@@ -202,7 +202,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     Does this router instance have the given route.
 
     @method hasRoute
-    @returns {Boolean}
+    @return {Boolean}
     @private
   */
   hasRoute: function(route) {
@@ -460,7 +460,7 @@ function controllerOrProtoFor(controllerName, container, getProto) {
   }
 }
 
-/**
+/*
   Helper function for iterating root-ward, starting
   from (but not including) the provided `originRoute`.
 

--- a/packages_es6/ember-runtime/lib/controllers/array_controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/array_controller.js
@@ -199,6 +199,7 @@ var ArrayController = ArrayProxy.extend(ControllerMixin, SortableMixin, {
    * from participating in the parentController hierarchy.
    *
    * @private
+   * @property _isVirtual
    * @type Boolean
    */
   _isVirtual: false,

--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -1165,7 +1165,7 @@ var View = CoreView.extend({
   /**
     Return the nearest ancestor that has a given property.
 
-    @function nearestWithProperty
+    @method nearestWithProperty
     @param {String} property A property name
     @return Ember.View
   */


### PR DESCRIPTION
Currently yuidoc generates a handfull of warnings when run on the Ember code base. See https://github.com/emberjs/website/blob/master/data/api.yml#L27189-L27236. 

This pr fixes all but 2 of these warnings. The remaining warnings complain about the @version tag being non standard and one warning from RSVP which will need to be fixed upstream.
