### PR TITLE
[BUGFIX beta] Properly resolve helpers from {{unbound}}.

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/binding.js
+++ b/packages_es6/ember-handlebars/lib/helpers/binding.js
@@ -195,10 +195,6 @@ function shouldDisplayIfHelperContent(result) {
 function _triageMustacheHelper(property, options) {
   Ember.assert("You cannot pass more than one argument to the _triageMustache helper", arguments.length <= 2);
 
-  if (helpers[property]) {
-    return helpers[property].call(this, options);
-  }
-
   var helper = EmberHandlebars.resolveHelper(options.data.view.container, property);
   if (helper) {
     return helper.call(this, options);
@@ -207,7 +203,26 @@ function _triageMustacheHelper(property, options) {
   return helpers.bind.call(this, property, options);
 }
 
+/**
+  Used to lookup/resolve handlebars helpers. The lookup order is:
+
+  * Look for a registered helper
+  * If a dash exists in the name:
+    * Look for a helper registed in the container
+    * Use Ember.ComponentLookup to find an Ember.Component that resolves
+      to the given name
+
+  @private
+  @method resolveHelper
+  @param {Container} container
+  @param {String} name the name of the helper to lookup
+  @return {Handlebars Helper}
+*/
 function resolveHelper(container, name) {
+  if (helpers[name]) {
+    return helpers[name];
+  }
+
   if (!container || name.indexOf('-') === -1) {
     return;
   }

--- a/packages_es6/ember-handlebars/lib/helpers/unbound.js
+++ b/packages_es6/ember-handlebars/lib/helpers/unbound.js
@@ -8,6 +8,7 @@
 import EmberHandlebars from "ember-handlebars-compiler";
 var helpers = EmberHandlebars.helpers;
 
+import {resolveHelper} from "ember-handlebars/helpers/binding";
 import {handlebarsGet} from "ember-handlebars/ext";
 
 var slice = [].slice;
@@ -33,13 +34,15 @@ var slice = [].slice;
   @return {String} HTML string
 */
 function unboundHelper(property, fn) {
-  var options = arguments[arguments.length - 1], helper, context, out, ctx;
+  var options = arguments[arguments.length - 1],
+      container = options.data.view.container,
+      helper, context, out, ctx;
 
-  ctx = this || window;
+  ctx = this;
   if (arguments.length > 2) {
     // Unbound helper call.
     options.data.isUnbound = true;
-    helper = helpers[arguments[0]] || helpers.helperMissing;
+    helper = resolveHelper(container, property) || helpers.helperMissing;
     out = helper.apply(ctx, slice.call(arguments, 1));
     delete options.data.isUnbound;
     return out;


### PR DESCRIPTION
Prior to this referencing a helper that would normally need to be looked up
with the `{{unbound}}` helper would not work.

This meant that you could not use helpers that are stored in the container.

This commit fixes that issue.

---

Thanks to @jasonmit for reporting the issue.

Closes #4713.
