### PR TITLE
[DOC release] Remove private wording from makeBoundHelper.

### DIFF
--- a/packages_es6/ember-handlebars/lib/ext.js
+++ b/packages_es6/ember-handlebars/lib/ext.js
@@ -352,7 +352,7 @@ function registerBoundHelper(name, fn) {
 };
 
 /**
-  A (mostly) private helper function to `registerBoundHelper`. Takes the
+  A helper function used by `registerBoundHelper`. Takes the
   provided Handlebars helper function fn and returns it in wrapped
   bound helper form.
 
@@ -370,7 +370,6 @@ function registerBoundHelper(name, fn) {
   In the above example, if the helper function hadn't been wrapped in
   `makeBoundHelper`, the registered helper would be unbound.
 
-  @private
   @method makeBoundHelper
   @for Ember.Handlebars
   @param {Function} function


### PR DESCRIPTION
This function is required when storing helpers in the container.

Specifically, in ember-cli (or EAK/EAKR) you would need to use `Ember.Handelbars.makeBoundHelper` in your helpers default export.

Something like the following is needed (in `app/helpers/up-case.js`):

``` javascript
export default Ember.Handlebars.makeBoundHelper(function(value) {
 return value.toUpperCase();
});
```

The current "private" verbiage is misleading, and this should be a normally supported use case.
