### PR TITLE
Update to Ember.View's attributeBindings Documentation

### DIFF
--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -545,7 +545,24 @@ var EMPTY_ARRAY = [];
   ```html
   <a id="ember1" class="ember-view" href="http://google.com"></a>
   ```
+  
+  One property can be mapped on to another by placing a ":" between 
+  the source property and the destination property:
+  
+  ```javascript
+  AnchorView = Ember.View.extend({
+    tagName: 'a',
+    attributeBindings: ['url:href'],
+    url: 'http://google.com'
+  });
+  ```
+  
+  Will result in view instances with an HTML representation of:
 
+  ```html
+  <a id="ember1" class="ember-view" href="http://google.com"></a>
+  ```
+  
   If the return value of an `attributeBindings` monitored property is a boolean
   the property will follow HTML's pattern of repeating the attribute's name as
   its value:


### PR DESCRIPTION
You can map one property on to another within the `attributeBindings` array, but this wasn't represented in the documentation. I talked about this with @rjackson in #emberjs yesterday, and he recommended I update the docs. :smile:
