### PR TITLE
[FEATURE ember-routing-linkto-target-attribute]

### DIFF
--- a/features.json
+++ b/features.json
@@ -6,7 +6,8 @@
     "ember-handlebars-caps-lookup": null,
     "ember-routing-drop-deprecated-action-style": null,
     "ember-runtime-test-friendly-promises": true,
-    "ember-routing-add-model-option": true
+    "ember-routing-add-model-option": true,
+    "ember-routing-linkto-target-attribute": null 
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -447,6 +447,48 @@ test("The {{link-to}} helper binds some anchor html tag common attributes", func
   equal(link.attr('rel'), 'rel-attr', "The self-link contains rel attribute");
 });
 
+if(Ember.FEATURES.isEnabled('ember-routing-linkto-target-attribute')) {
+  test("The {{link-to}} helper supports `target` attribute", function() {
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'index' id='self-link' target='_blank'}}Self{{/link-to}}");
+    bootApplication();
+    
+    Ember.run(function() {
+      router.handleURL("/");
+    });
+    
+    var link = Ember.$('#self-link', '#qunit-fixture');
+    equal(link.attr('target'), '_blank', "The self-link contains `target` attribute");
+  });
+  
+  test("The {{link-to}} helper does not call preventDefault if `target` attribute is provided", function() {
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'index' id='self-link' target='_blank'}}Self{{/link-to}}");
+    bootApplication();
+    
+    Ember.run(function() {
+      router.handleURL("/");
+    });
+    
+    var event = Ember.$.Event("click");
+    Ember.$('#self-link', '#qunit-fixture').trigger(event);
+    
+    equal(event.isDefaultPrevented(), false, "should not preventDefault when target attribute is specified");
+  });
+
+  test("The {{link-to}} helper should preventDefault when `target = _self`", function() {
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'index' id='self-link' target='_self'}}Self{{/link-to}}");
+    bootApplication();
+    
+    Ember.run(function() {
+      router.handleURL("/");
+    });
+    
+    var event = Ember.$.Event("click");
+    Ember.$('#self-link', '#qunit-fixture').trigger(event);
+    
+    equal(event.isDefaultPrevented(), true, "should preventDefault when target attribute is `_self`");
+  });
+}
+
 test("The {{link-to}} helper accepts string/numeric arguments", function() {
   Router.map(function() {
     this.route('filter', { path: '/filters/:filter' });

--- a/packages_es6/ember-routing/lib/helpers/link_to.js
+++ b/packages_es6/ember-routing/lib/helpers/link_to.js
@@ -427,7 +427,17 @@ var LinkView = Ember.LinkView = EmberView.extend({
   _invoke: function(event) {
     if (!isSimpleClick(event)) { return true; }
 
-    if (this.preventDefault !== false) { event.preventDefault(); }
+    if (this.preventDefault !== false) { 
+      if (Ember.FEATURES.isEnabled("ember-routing-linkto-target-attribute")) {
+        var targetAttribute = get(this, 'target');
+        if (!targetAttribute || targetAttribute === '_self') {
+          event.preventDefault();
+        }
+      } else {
+        event.preventDefault();
+      }
+    }
+    
     if (this.bubbles === false) { event.stopPropagation(); }
 
     if (get(this, '_isDisabled')) { return false; }
@@ -609,6 +619,20 @@ var LinkView = Ember.LinkView = EmberView.extend({
 });
 
 LinkView.toString = function() { return "LinkView"; };
+
+if (Ember.FEATURES.isEnabled("ember-routing-linkto-target-attribute")) {
+  LinkView.reopen({
+    attributeBindings: ['target'],
+    
+    /**
+      Sets the `target` attribute of the `LinkView`'s anchor element.
+
+      @property target
+      @default null
+    **/
+    target: null    
+  });
+}
 
 /**
   The `{{link-to}}` helper renders a link to the supplied


### PR DESCRIPTION
Taking up the row of #3924 . Supports `target` attribute for the `link-to anchor` element
