### PR TITLE
[Bugfix beta] [Fixes #4396] Controller#model is primary, content is now ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
   without Catch. Also no longer force deoptimization of the run loop
   queue flush.
 * [BREAKING BUGFIX] An empty array are treated as falsy value in `bind-attr` to be in consistent with `if` helper. Breaking for apps that relies on the previous behaviour which treats an empty array as truthy value in `bind-attr`.
+* [Bugfix beta] On Controllers, the content property is now derived from
+  model. This reduces many caveats with model/content, and also sets a
+  simple ground rule: Never set a controllers content, rather always set
+  it's model and ember will do the right thing.
 
 ### Ember 1.6.0-beta.1 (March 31, 2014)
 

--- a/packages_es6/ember-runtime/lib/controllers/array_controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/array_controller.js
@@ -23,16 +23,16 @@ var forEach = EnumerableUtils.forEach,
 
   The advantage of using an `ArrayController` is that you only have to set up
   your view bindings once; to change what's displayed, simply swap out the
-  `content` property on the controller.
+  `model` property on the controller.
 
   For example, imagine you wanted to display a list of items fetched via an XHR
-  request. Create an `Ember.ArrayController` and set its `content` property:
+  request. Create an `Ember.ArrayController` and set its `model` property:
 
   ```javascript
   MyApp.listController = Ember.ArrayController.create();
 
   $.get('people.json', function(data) {
-    MyApp.listController.set('content', data);
+    MyApp.listController.set('model', data);
   });
   ```
 
@@ -49,7 +49,7 @@ var forEach = EnumerableUtils.forEach,
   capability comes from `Ember.ArrayProxy`, which this class inherits from.
 
   Sometimes you want to display computed properties within the body of an
-  `#each` helper that depend on the underlying items in `content`, but are not
+  `#each` helper that depend on the underlying items in `model`, but are not
   present on those items.   To do this, set `itemController` to the name of a
   controller (probably an `ObjectController`) that will wrap each individual item.
 
@@ -190,7 +190,7 @@ var ArrayController = ArrayProxy.extend(ControllerMixin, SortableMixin, {
     this.set('_subControllers', Ember.A());
   },
 
-  content: computed(function () {
+  model: computed(function () {
     return Ember.A();
   }),
 
@@ -225,7 +225,7 @@ var ArrayController = ArrayProxy.extend(ControllerMixin, SortableMixin, {
     subController = container.lookupFactory(fullName).create({
       target: this,
       parentController: parentController,
-      content: object
+      model: object
     });
 
     subControllers[idx] = subController;

--- a/packages_es6/ember-runtime/lib/controllers/controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/controller.js
@@ -49,7 +49,8 @@ var ControllerMixin = Mixin.create(ActionHandler, {
 
   store: null,
 
-  model: computed.alias('content'),
+  model: null,
+  content: computed.alias('model'),
 
   deprecatedSendHandles: function(actionName) {
     return !!this[actionName];

--- a/packages_es6/ember-runtime/lib/controllers/object_controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/object_controller.js
@@ -9,7 +9,7 @@ import ObjectProxy from "ember-runtime/system/object_proxy";
 /**
   `Ember.ObjectController` is part of Ember's Controller layer. It is intended
   to wrap a single object, proxying unhandled attempts to `get` and `set` to the underlying
-  content object, and to forward unhandled action attempts to its `target`.
+  model object, and to forward unhandled action attempts to its `target`.
 
   `Ember.ObjectController` derives this functionality from its superclass
   `Ember.ObjectProxy` and the `Ember.ControllerMixin` mixin.

--- a/packages_es6/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages_es6/ember-runtime/lib/mixins/promise_proxy.js
@@ -99,7 +99,7 @@ var PromiseProxyMixin = Mixin.create({
     @property reason
     @default null
   */
-  reason:    null,
+  reason:  null,
 
   /**
     Once the proxied promise has settled this will become `false`.

--- a/packages_es6/ember-runtime/lib/mixins/sortable.js
+++ b/packages_es6/ember-runtime/lib/mixins/sortable.js
@@ -21,7 +21,7 @@ var forEach = EnumerableUtils.forEach;
   `Ember.SortableMixin` provides a standard interface for array proxies
   to specify a sort order and maintain this sorting when objects are added,
   removed, or updated without changing the implicit order of their underlying
-  content array:
+  modelarray:
 
   ```javascript
   songs = [
@@ -31,7 +31,7 @@ var forEach = EnumerableUtils.forEach;
   ];
 
   songsController = Ember.ArrayController.create({
-    content: songs,
+    model: songs,
     sortProperties: ['trackNumber'],
     sortAscending: true
   });
@@ -42,7 +42,7 @@ var forEach = EnumerableUtils.forEach;
   songsController.get('firstObject');  // {trackNumber: 1, title: 'Dear Prudence'}
   ```
 
-  If you add or remove the properties to sort by or change the sort direction the content
+  If you add or remove the properties to sort by or change the sort direction the model
   sort order will be automatically updated.
 
   ```javascript


### PR DESCRIPTION
content is now a reflection of model, and populated on consumption

External API should be to always set model directly
- [x] update docs
- [x] update commit message with more details
- [x] fix failing tests
- [x] fix the next set of failing tests
- [ ] ... ?
- [x] what about `arrayProxy` & `objectProxy`?

should this be bugfix beta or full release?
