### PR TITLE
'_id' variable name issue, increase MongoDB compatibility 

### DIFF
--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -946,7 +946,7 @@ var Route = EmberObject.extend(ActionHandler, {
     for (var prop in params) {
       if (prop === 'queryParams') { continue; }
 
-      if (match = prop.match(/^(.*)_id$/)) {
+      if (match = prop.match(/^(.+)_id$/)) {
         name = match[1];
         value = params[prop];
       }
@@ -1071,7 +1071,7 @@ var Route = EmberObject.extend(ActionHandler, {
 
     var name = params[0], object = {};
 
-    if (/_id$/.test(name) && params.length === 1) {
+    if (/.+_id$/.test(name) && params.length === 1) {
       object[name] = get(model, "id");
     } else {
       object = getProperties(model, params);

--- a/packages_es6/ember-routing/lib/vendor/router.amd.js
+++ b/packages_es6/ember-routing/lib/vendor/router.amd.js
@@ -282,7 +282,7 @@ define("router/handler-info/unresolved-handler-info-by-object",
 
         var name = names[0];
 
-        if (/_id$/.test(name)) {
+        if (/.+_id$/.test(name)) {
           object[name] = model.id;
         } else {
           object[name] = model;


### PR DESCRIPTION
'_id' variable name which is used in model can be placed in the route path
increase MongoDB compatibility
'post_id' regEx should be ".+_id$" neither ".*_id$"  nor "_id$"
