### PR TITLE
Don't access the webkitNotifications object while processing namespaces....

### DIFF
--- a/packages_es6/ember-runtime/lib/system/namespace.js
+++ b/packages_es6/ember-runtime/lib/system/namespace.js
@@ -42,7 +42,7 @@ var Namespace = EmberObject.extend({
     if (name) { return name; }
 
     findNamespaces();
-    return this[GUID_KEY+'_name'];
+    return this[NAME_KEY];
   },
 
   nameClasses: function() {
@@ -118,32 +118,30 @@ function processNamespace(paths, root, seen) {
   paths.length = idx; // cut out last item
 }
 
+var STARTS_WITH_UPPERCASE = /^[A-Z]/;
+
 function findNamespaces() {
   var lookup = Ember.lookup, obj, isNamespace;
 
   if (Namespace.PROCESSED) { return; }
 
   for (var prop in lookup) {
-    // These don't raise exceptions but can cause warnings
-    if (prop === "parent" || prop === "top" || prop === "frameElement" || prop === "webkitStorageInfo") { continue; }
+    // Only process entities that start with uppercase A-Z
+    if (!STARTS_WITH_UPPERCASE.test(prop)) { continue; }
 
-    //  get(window.globalStorage, 'isNamespace') would try to read the storage for domain isNamespace and cause exception in Firefox.
-    // globalStorage is a storage obsoleted by the WhatWG storage specification. See https://developer.mozilla.org/en/DOM/Storage#globalStorage
-    if (prop === "globalStorage" && lookup.StorageList && lookup.globalStorage instanceof lookup.StorageList) { continue; }
     // Unfortunately, some versions of IE don't support window.hasOwnProperty
     if (lookup.hasOwnProperty && !lookup.hasOwnProperty(prop)) { continue; }
 
     // At times we are not allowed to access certain properties for security reasons.
     // There are also times where even if we can access them, we are not allowed to access their properties.
     try {
-      obj = Ember.lookup[prop];
+      obj = lookup[prop];
       isNamespace = obj && obj.isNamespace;
     } catch (e) {
       continue;
     }
 
     if (isNamespace) {
-      Ember.deprecate("Namespaces should not begin with lowercase.", /^[A-Z]/.test(prop));
       obj[NAME_KEY] = prop;
     }
   }

--- a/packages_es6/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages_es6/ember-runtime/tests/system/namespace/base_test.js
@@ -59,18 +59,9 @@ test("Classes under Ember are properly named", function() {
   equal(Ember.TestObject.toString(), "Ember.TestObject", "class under Ember is given a string representation");
 });
 
-test("Lowercase namespaces should be deprecated", function() {
-  lookup.namespaceC = Namespace.create();
-
-  expectDeprecation(function(){
-    lookup.namespaceC.toString();
-  }, "Namespaces should not begin with lowercase.");
-
-  expectDeprecation(function(){
-    run(function() {
-      lookup.namespaceC.destroy();
-    });
-  }, "Namespaces should not begin with lowercase.");
+test("Lowercase namespaces are no longer supported", function() {
+  var nsC = lookup.namespaceC = Namespace.create();
+  equal(nsC.toString(), undefined);
 });
 
 test("A namespace can be assigned a custom name", function() {


### PR DESCRIPTION
... This causes crashes inside some Android WebViews, including the Verizon LG G2, which is a fairly popular device.

We started seeing a weird crash on several devices after rewriting our mobile web app (which is viewed through a WebView on Android) using Ember: https://gist.github.com/BenV/d40ce92b544ffbdfe53f

I got my hands on a Verizon LG G2 (the device that seems most likely to crash from our reports), and I was able to reproduce the issue easily. Any time I loaded up an ember app in a WebView and then tried to change the URL, the application would crash.

After much trial and error, I figured out that this was due to the findNamespaces function, which enumerates the window object at startup. For some reason touching the window.webkitNotifications object on this device inside a WebView in our application causes the crash when navigating away from the page.

I wish I had more information on how to reproduce in a less specific scenario, but this is a weird bug. We are running a forked version of Ember now in production and the crashes have stopped, where previously we were getting hundreds of them.

Please let me know if there is anything else I can do to help. I know this isn't exactly an ideal bug report, but hopefully the change is harmless enough that we can figure out how to get it (or something similar) into master.
