### PR TITLE
[FEATURE] Add `invalidate` hook to handle reduceComputed invalidations

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -152,7 +152,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
   // if key is being watched, override chains that
   // were initialized with the prototype
-  if (watching) { overrideChains(obj, keyName, meta); }
+  if (watching) { overrideChains(obj, keyName, meta, undefined, data); }
 
   // The `value` passed to the `didDefineProperty` hook is
   // either the descriptor or data, whichever was passed.

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -77,7 +77,7 @@ function propertyDidChange(obj, keyName, depKey, changeInfo) {
   if (desc && desc.didChange) { desc.didChange(obj, keyName, depKey, changeInfo); }
   if (!watching && keyName !== 'length') { return; }
 
-  if (!depKey || !desc.options || !desc.options.invalidate) {
+  if (!depKey || !desc || !desc.options || !desc.options.invalidate) {
     if (m && m.deps && m.deps[keyName]) {
       dependentKeysDidChange(obj, keyName, changeInfo, m);
     }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -77,12 +77,14 @@ function propertyDidChange(obj, keyName, depKey, changeInfo) {
   if (desc && desc.didChange) { desc.didChange(obj, keyName, depKey, changeInfo); }
   if (!watching && keyName !== 'length') { return; }
 
-  if (m && m.deps && m.deps[keyName]) {
-    dependentKeysDidChange(obj, keyName, changeInfo, m);
-  }
+  if (!depKey || !desc.options || !desc.options.invalidate) {
+    if (m && m.deps && m.deps[keyName]) {
+      dependentKeysDidChange(obj, keyName, changeInfo, m);
+    }
 
-  chainsDidChange(obj, keyName, m, false, depKey, changeInfo);
-  notifyObservers(obj, keyName);
+    chainsDidChange(obj, keyName, m, false, depKey, changeInfo);
+    notifyObservers(obj, keyName);
+  }
 }
 
 var WILL_SEEN, DID_SEEN;

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -30,9 +30,11 @@ var deferred = 0;
   @for Ember
   @param {Object} obj The object with the property that will change
   @param {String} keyName The property key (or path) that will change.
+  @param {String} depKey The named of the dependent key that fires the change (if any).
+  @param          newValue The new value of the property.
   @return {void}
 */
-function propertyWillChange(obj, keyName) {
+function propertyWillChange(obj, keyName, depKey, changeInfo) {
   var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
@@ -40,9 +42,9 @@ function propertyWillChange(obj, keyName) {
 
   if (!watching) { return; }
   if (proto === obj) { return; }
-  if (desc && desc.willChange) { desc.willChange(obj, keyName); }
-  dependentKeysWillChange(obj, keyName, m);
-  chainsWillChange(obj, keyName, m);
+  if (desc && desc.willChange) { desc.willChange(obj, keyName, depKey, changeInfo); }
+  dependentKeysWillChange(obj, keyName, changeInfo, m);
+  chainsWillChange(obj, keyName, m, depKey, changeInfo);
   notifyBeforeObservers(obj, keyName);
 }
 
@@ -57,11 +59,13 @@ function propertyWillChange(obj, keyName) {
 
   @method propertyDidChange
   @for Ember
-  @param {Object} obj The object with the property that will change
+  @param {Object} obj The object with the property that will change.
   @param {String} keyName The property key (or path) that will change.
+  @param {String} depKey The named of the dependent key that fires the change (if any).
+  @param          changeInfo Information about the change being made.
   @return {void}
 */
-function propertyDidChange(obj, keyName) {
+function propertyDidChange(obj, keyName, depKey, changeInfo) {
   var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
@@ -70,20 +74,20 @@ function propertyDidChange(obj, keyName) {
   if (proto === obj) { return; }
 
   // shouldn't this mean that we're watching this key?
-  if (desc && desc.didChange) { desc.didChange(obj, keyName); }
+  if (desc && desc.didChange) { desc.didChange(obj, keyName, depKey, changeInfo); }
   if (!watching && keyName !== 'length') { return; }
 
   if (m && m.deps && m.deps[keyName]) {
-    dependentKeysDidChange(obj, keyName, m);
+    dependentKeysDidChange(obj, keyName, changeInfo, m);
   }
 
-  chainsDidChange(obj, keyName, m, false);
+  chainsDidChange(obj, keyName, m, false, depKey, changeInfo);
   notifyObservers(obj, keyName);
 }
 
 var WILL_SEEN, DID_SEEN;
 // called whenever a property is about to change to clear the cache of any dependent keys (and notify those properties of changes, etc...)
-function dependentKeysWillChange(obj, depKey, meta) {
+function dependentKeysWillChange(obj, depKey, changeInfo, meta) {
   if (obj.isDestroying) { return; }
 
   var deps;
@@ -91,13 +95,13 @@ function dependentKeysWillChange(obj, depKey, meta) {
     var seen = WILL_SEEN;
     var top = !seen;
     if (top) { seen = WILL_SEEN = {}; }
-    iterDeps(propertyWillChange, obj, deps, depKey, seen, meta);
+    iterDeps(propertyWillChange, obj, deps, depKey, changeInfo, seen, meta);
     if (top) { WILL_SEEN = null; }
   }
 }
 
 // called whenever a property has just changed to update dependent keys
-function dependentKeysDidChange(obj, depKey, meta) {
+function dependentKeysDidChange(obj, depKey, changeInfo, meta) {
   if (obj.isDestroying) { return; }
 
   var deps;
@@ -105,7 +109,7 @@ function dependentKeysDidChange(obj, depKey, meta) {
     var seen = DID_SEEN;
     var top = !seen;
     if (top) { seen = DID_SEEN = {}; }
-    iterDeps(propertyDidChange, obj, deps, depKey, seen, meta);
+    iterDeps(propertyDidChange, obj, deps, depKey, changeInfo, seen, meta);
     if (top) { DID_SEEN = null; }
   }
 }
@@ -116,7 +120,7 @@ function keysOf(obj) {
   return keys;
 }
 
-function iterDeps(method, obj, deps, depKey, seen, meta) {
+function iterDeps(method, obj, deps, depKey, changeInfo, seen, meta) {
   var keys, key, i, desc;
   var guid = guidFor(obj);
   var current = seen[guid];
@@ -131,12 +135,12 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
       key = keys[i];
       desc = descs[key];
       if (desc && desc._suspended === obj) continue;
-      method(obj, key);
+      method(obj, key, depKey, changeInfo);
     }
   }
 }
 
-function chainsWillChange(obj, keyName, m) {
+function chainsWillChange(obj, keyName, m, depKey, changeInfo) {
   if (!(m.hasOwnProperty('chainWatchers') &&
         m.chainWatchers[keyName])) {
     return;
@@ -151,11 +155,11 @@ function chainsWillChange(obj, keyName, m) {
   }
 
   for (i = 0, l = events.length; i < l; i += 2) {
-    propertyWillChange(events[i], events[i+1]);
+    propertyWillChange(events[i], events[i+1], depKey, changeInfo);
   }
 }
 
-function chainsDidChange(obj, keyName, m, suppressEvents) {
+function chainsDidChange(obj, keyName, m, suppressEvents, depKey, changeInfo) {
   if (!(m && m.hasOwnProperty('chainWatchers') &&
         m.chainWatchers[keyName])) {
     return;
@@ -174,12 +178,12 @@ function chainsDidChange(obj, keyName, m, suppressEvents) {
   }
 
   for (i = 0, l = events.length; i < l; i += 2) {
-    propertyDidChange(events[i], events[i+1]);
+    propertyDidChange(events[i], events[i+1], depKey, changeInfo);
   }
 }
 
-function overrideChains(obj, keyName, m) {
-  chainsDidChange(obj, keyName, m, true);
+function overrideChains(obj, keyName, m, depKey, changeInfo) {
+  chainsDidChange(obj, keyName, m, true, depKey, changeInfo);
 }
 
 /**

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -73,7 +73,7 @@ var set = function set(obj, keyName, value, tolerant) {
       }
       // only trigger a change if the value has changed
       if (value !== currentValue) {
-        propertyWillChange(obj, keyName);
+        propertyWillChange(obj, keyName, undefined, value);
         if (Ember.FEATURES.isEnabled('mandatory-setter')) {
           if ((currentValue === undefined && !(keyName in obj)) || !obj.propertyIsEnumerable(keyName)) {
             defineProperty(obj, keyName, null, value); // setup mandatory setter
@@ -83,7 +83,7 @@ var set = function set(obj, keyName, value, tolerant) {
         } else {
           obj[keyName] = value;
         }
-        propertyDidChange(obj, keyName);
+        propertyDidChange(obj, keyName, undefined, currentValue);
       }
     } else {
       obj[keyName] = value;

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -672,7 +672,10 @@ ReduceComputedProperty.prototype.get = function (obj, key) {
     };
     delete instanceMeta._invalidatingChanges;
     var val = this.options.invalidate.call(obj, oldVal, changeMeta, instanceMeta.sugarMeta);
-    instanceMeta.setValue(val);
+    if (val !== oldVal) {
+      instanceMeta.setValue(val);
+      propertyDidChange(obj, key); // Notify observers.
+    }
     return val;
   } else {
     return ComputedProperty.prototype.get.call(this, obj, key);

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -969,7 +969,7 @@ export default Mixin.create({
     if (removing === -1) removing = null;
     if (adding   === -1) adding   = null;
 
-    propertyWillChange(this, '[]');
+    propertyWillChange(this, '[]', undefined, {removing: removing, adding: adding});
     if (hasDelta) propertyWillChange(this, 'length');
     sendEvent(this, '@enumerable:before', [this, removing, adding]);
 
@@ -1008,7 +1008,7 @@ export default Mixin.create({
 
     sendEvent(this, '@enumerable:change', [this, removing, adding]);
     if (hasDelta) propertyDidChange(this, 'length');
-    propertyDidChange(this, '[]');
+    propertyDidChange(this, '[]', undefined, {removing: removing, adding: adding});
 
     return this ;
   },

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -829,323 +829,323 @@ QUnit.module('reduceComputed - completely invalidating dependencies', {
   }
 });
 
-// test("non-array dependencies completely invalidate a arrayComputed CP", function() {
-//   var dependentArray = Ember.A([6,7]);
-
-//   obj = EmberObject.extend({
-//     nonArray: 'v0',
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'nonArray', {
-//       addedItem: function (array) {
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array) {
-//         --removeCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   get(obj, 'computed');
-
-//   equal(addCalls, 2, "precond - add has been called twice");
-//   equal(removeCalls, 0, "precond - remove has not initially been called");
-
-//   dependentArray.pushObjects([1, 2]);
-
-//   equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
-//   equal(removeCalls, 0, "remove not called");
-
-//   run(function() {
-//     set(obj, 'nonArray', 'v1');
-//   });
-
-//   equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
-//   equal(removeCalls, 0, "remove not called");
-// });
-
-// test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
-//   var dependentArray = Ember.A();
-//   var totallyInvalidatingDependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-//       addedItem: function (array, item) {
-//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array, item) {
-//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-//         --removeCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   get(obj, 'computed');
-
-//   equal(addCalls, 0, "precond - add has not initially been called");
-//   equal(removeCalls, 0, "precond - remove has not initially been called");
-
-//   dependentArray.pushObjects([1, 2]);
-
-//   equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
-//   equal(removeCalls, 0, "remove not called");
-
-//   run(function() {
-//     totallyInvalidatingDependentArray.pushObject(3);
-//   });
-
-//   equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
-//   equal(removeCalls, 0, "remove not called");
-// });
-
-// test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
-//   var dependentArray = Ember.A([3,2,1]);
-//   var counter = 0;
-
-//   obj = EmberObject.extend({
-//     dependentArray: dependentArray,
-
-//     computed: reduceComputed('dependentArray', {
-//       initialValue: Infinity,
-
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         return Math.min(accumulatedValue, item);
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         if (item > accumulatedValue) {
-//           return accumulatedValue;
-//         }
-//       }
-//     }),
-
-//     computedDidChange: observer('computed', function() {
-//       counter++;
-//     })
-//   }).create();
-
-//   get(obj, 'computed');
-//   equal(get(obj, 'computed'), 1);
-//   equal(counter, 0);
-
-//   dependentArray.pushObject(10);
-//   equal(get(obj, 'computed'), 1);
-//   equal(counter, 0);
-
-//   dependentArray.removeObject(10);
-//   equal(get(obj, 'computed'), 1);
-//   equal(counter, 0);
-
-//   dependentArray.removeObject(1);
-//   equal(get(obj, 'computed'), 2);
-//   equal(counter, 1);
-// });
-
-// test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
-//   var dependentArray = Ember.A([5,6]);
-
-//   obj = EmberObject.extend({
-//     myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
-//       initialValue: "123",
-//       initialize: function(initialValue, changeMeta, instanceMeta){
-//         instanceMeta.customField = "abc";
-//       },
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
-//         ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
-//         ok(changeMeta.changes.nonArray1 === 0 && changeMeta.changes.nonArray2 === 1,
-//           "changeMeta contains the dependencies that changed and its old values");
-//         equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
-//         equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
-//         var accum = "";
-//         for (var key in changeMeta.changes) {
-//           accum += changeMeta.changes[key];
-//         }
-//         return accumulatedValue + accum;
-//       }
-//     })
-//   }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
-
-//   deepEqual(get(obj, 'myComputed'), "123");
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   set(obj, 'nonArray1', 2);
-//   set(obj, 'nonArray2', 5);
-
-//   equal(addCalls, 2, "add has been called twice");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has not been called yet");
-
-//   equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
-//   equal(addCalls, 2, "add has not been called again");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "invalidate has been called just once");
-
-//   equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
-//   equal(invalidateCalls, 1, "invalidate has not been called again");
-// });
-
-// test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
-//   var dependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     myComputed: reduceComputed('dependentArray', 'nonArray', {
-//       initialValue: 123,
-//       initialize: function(initialValue, changeMeta, instanceMeta){
-//         instanceMeta.previousNonArray = this.get('nonArray');
-//       },
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
-//         ok(this.get('nonArray') === 1, "`this` is wrong");
-//         return accumulatedValue;
-//       }
-//     })
-//   }).create({nonArray: 0, dependentArray: dependentArray});
-
-//   deepEqual(get(obj, 'myComputed'), 123);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   dependentArray.pushObject(3);
-//   get(obj, 'myComputed');
-
-//   equal(addCalls, 1, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has not been called");
-// });
-
-// test("multiple changes in non-array dependencies only invoke the `invalidate` hook once", function() {
-//   var dependentArray = Ember.A([5,6]);
-//   var invalidatingDependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     nonArray1: 0,
-//     nonArray2: 0,
-//     invalidatingDependentArray: invalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'invalidatingDependentArray.[]', {
-//       initialValue: 123,
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-//         deepEqual(
-//           changeMeta.changes,
-//           { nonArray1: 0, nonArray2: 0 },
-//           '`changeMeta.changes` contains the old values of the dependencies that changed'
-//         );
-//         ++invalidateCalls;
-//         return accumulatedValue;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), 123);
-//   equal(addCalls, 2, "add has been called twice");
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   set(obj, 'nonArray1', 1);
-//   set(obj, 'nonArray2', 9);
-//   set(obj, 'nonArray2', 10);
-
-//   equal(addCalls, 2, "add has not been called again");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has not been called yet");
-
-//   get(obj, 'computed');
-//   equal(invalidateCalls, 1, "invalidate has been called once");
-// });
-
-// test("multiple additions/deletions in invalidating array dependencies invoke the `invalidate` hook just once", function() {
-//   var dependentArray = Ember.A([5,6]);
-//   var invalidatingDependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     invalidatingDependentArray: invalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: reduceComputed('dependentArray', 'invalidatingDependentArray.[]', {
-//       initialValue: 123,
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
-//         ++invalidateCalls;
-//         deepEqual(
-//           changeMeta.changes,
-//           { 'invalidatingDependentArray.[]': {adding: 3, removing: 1} },
-//           '`changeMeta.changes` contains the aggregated info of all the additions/deletions made'
-//         );
-//         return accumulatedValue;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), 123);
-//   equal(addCalls, 2, 'precond - add has been called during initialization');
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   invalidatingDependentArray.pushObject(3);
-//   invalidatingDependentArray.pushObjects([4, 5]);
-//   invalidatingDependentArray.removeAt(1);
-
-//   equal(addCalls, 2, "add has not been called again");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "`invalidate` has not been called yet");
-
-//   get(obj, 'computed');
-//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
-// });
-
-test("changes in dependencies of a RCP that don't modify its result don't invalidate other RCP watching the first one", function(){
-  var numbers = Ember.A();
-  var secondGradeCalls = 0;
+test("non-array dependencies completely invalidate a arrayComputed CP", function() {
+  var dependentArray = Ember.A([6,7]);
+
+  obj = EmberObject.extend({
+    nonArray: 'v0',
+    dependentArray: dependentArray,
+
+    computed: arrayComputed('dependentArray', 'nonArray', {
+      addedItem: function (array) {
+        ++addCalls;
+        return array;
+      },
+
+      removedItem: function (array) {
+        --removeCalls;
+        return array;
+      }
+    })
+  }).create();
+
+  get(obj, 'computed');
+
+  equal(addCalls, 2, "precond - add has been called twice");
+  equal(removeCalls, 0, "precond - remove has not initially been called");
+
+  dependentArray.pushObjects([1, 2]);
+
+  equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
+  equal(removeCalls, 0, "remove not called");
+
+  run(function() {
+    set(obj, 'nonArray', 'v1');
+  });
+
+  equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
+  equal(removeCalls, 0, "remove not called");
+});
+
+test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
+  var dependentArray = Ember.A();
+  var totallyInvalidatingDependentArray = Ember.A();
+
+  obj = EmberObject.extend({
+    totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+    dependentArray: dependentArray,
+
+    computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+      addedItem: function (array, item) {
+        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+        ++addCalls;
+        return array;
+      },
+
+      removedItem: function (array, item) {
+        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+        --removeCalls;
+        return array;
+      }
+    })
+  }).create();
+
+  get(obj, 'computed');
+
+  equal(addCalls, 0, "precond - add has not initially been called");
+  equal(removeCalls, 0, "precond - remove has not initially been called");
+
+  dependentArray.pushObjects([1, 2]);
+
+  equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
+  equal(removeCalls, 0, "remove not called");
+
+  run(function() {
+    totallyInvalidatingDependentArray.pushObject(3);
+  });
+
+  equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
+  equal(removeCalls, 0, "remove not called");
+});
+
+test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
+  var dependentArray = Ember.A([3,2,1]);
+  var counter = 0;
+
+  obj = EmberObject.extend({
+    dependentArray: dependentArray,
+
+    computed: reduceComputed('dependentArray', {
+      initialValue: Infinity,
+
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        return Math.min(accumulatedValue, item);
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        if (item > accumulatedValue) {
+          return accumulatedValue;
+        }
+      }
+    }),
+
+    computedDidChange: observer('computed', function() {
+      counter++;
+    })
+  }).create();
+
+  get(obj, 'computed');
+  equal(get(obj, 'computed'), 1);
+  equal(counter, 0);
+
+  dependentArray.pushObject(10);
+  equal(get(obj, 'computed'), 1);
+  equal(counter, 0);
+
+  dependentArray.removeObject(10);
+  equal(get(obj, 'computed'), 1);
+  equal(counter, 0);
+
+  dependentArray.removeObject(1);
+  equal(get(obj, 'computed'), 2);
+  equal(counter, 1);
+});
+
+test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
+  var dependentArray = Ember.A([5,6]);
+
+  obj = EmberObject.extend({
+    myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
+      initialValue: "123",
+      initialize: function(initialValue, changeMeta, instanceMeta){
+        instanceMeta.customField = "abc";
+      },
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
+
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+        ++invalidateCalls;
+        ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
+        ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
+        ok(changeMeta.changes.nonArray1 === 0 && changeMeta.changes.nonArray2 === 1,
+          "changeMeta contains the dependencies that changed and its old values");
+        equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
+        equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
+        var accum = "";
+        for (var key in changeMeta.changes) {
+          accum += changeMeta.changes[key];
+        }
+        return accumulatedValue + accum;
+      }
+    })
+  }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
+
+  deepEqual(get(obj, 'myComputed'), "123");
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+  set(obj, 'nonArray1', 2);
+  set(obj, 'nonArray2', 5);
+
+  equal(addCalls, 2, "add has been called twice");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+  equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
+  equal(addCalls, 2, "add has not been called again");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 1, "invalidate has been called just once");
+
+  equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
+  equal(invalidateCalls, 1, "invalidate has not been called again");
+});
+
+test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
+  var dependentArray = Ember.A();
+
+  obj = EmberObject.extend({
+    myComputed: reduceComputed('dependentArray', 'nonArray', {
+      initialValue: 123,
+      initialize: function(initialValue, changeMeta, instanceMeta){
+        instanceMeta.previousNonArray = this.get('nonArray');
+      },
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
+
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+        ++invalidateCalls;
+        ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
+        ok(this.get('nonArray') === 1, "`this` is wrong");
+        return accumulatedValue;
+      }
+    })
+  }).create({nonArray: 0, dependentArray: dependentArray});
+
+  deepEqual(get(obj, 'myComputed'), 123);
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+  dependentArray.pushObject(3);
+  get(obj, 'myComputed');
+
+  equal(addCalls, 1, "add has not been called");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "invalidate has not been called");
+});
+
+test("multiple changes in non-array dependencies only invoke the `invalidate` hook once", function() {
+  var dependentArray = Ember.A([5,6]);
+  var invalidatingDependentArray = Ember.A();
+
+  obj = EmberObject.extend({
+    nonArray1: 0,
+    nonArray2: 0,
+    invalidatingDependentArray: invalidatingDependentArray,
+    dependentArray: dependentArray,
+
+    computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'invalidatingDependentArray.[]', {
+      initialValue: 123,
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
+
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+        deepEqual(
+          changeMeta.changes,
+          { nonArray1: 0, nonArray2: 0 },
+          '`changeMeta.changes` contains the old values of the dependencies that changed'
+        );
+        ++invalidateCalls;
+        return accumulatedValue;
+      }
+    })
+  }).create();
+
+  deepEqual(get(obj, 'computed'), 123);
+  equal(addCalls, 2, "add has been called twice");
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+  set(obj, 'nonArray1', 1);
+  set(obj, 'nonArray2', 9);
+  set(obj, 'nonArray2', 10);
+
+  equal(addCalls, 2, "add has not been called again");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+  get(obj, 'computed');
+  equal(invalidateCalls, 1, "invalidate has been called once");
+});
+
+test("multiple additions/deletions in invalidating array dependencies invoke the `invalidate` hook just once", function() {
+  var dependentArray = Ember.A([5,6]);
+  var invalidatingDependentArray = Ember.A();
+
+  obj = EmberObject.extend({
+    invalidatingDependentArray: invalidatingDependentArray,
+    dependentArray: dependentArray,
+
+    computed: reduceComputed('dependentArray', 'invalidatingDependentArray.[]', {
+      initialValue: 123,
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
+
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
+        ++invalidateCalls;
+        deepEqual(
+          changeMeta.changes,
+          { 'invalidatingDependentArray.[]': {adding: 3, removing: 1} },
+          '`changeMeta.changes` contains the aggregated info of all the additions/deletions made'
+        );
+        return accumulatedValue;
+      }
+    })
+  }).create();
+
+  deepEqual(get(obj, 'computed'), 123);
+  equal(addCalls, 2, 'precond - add has been called during initialization');
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+  invalidatingDependentArray.pushObject(3);
+  invalidatingDependentArray.pushObjects([4, 5]);
+  invalidatingDependentArray.removeAt(1);
+
+  equal(addCalls, 2, "add has not been called again");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "`invalidate` has not been called yet");
+
+  get(obj, 'computed');
+  equal(invalidateCalls, 1, "`invalidate` has been called just once");
+});
+
+test("changes in non-array properties that do not modify the result of an reduceComputed CP do not invalidate other CP watching the first one", function(){
+  var numbers = Ember.A(),
+    secondGradeCalls = 0;
 
   obj = EmberObject.extend({
     min: 3,
@@ -1168,7 +1168,7 @@ test("changes in dependencies of a RCP that don't modify its result don't invali
       invalidate: function(accumulatedValue, changeMeta, instanceMeta){
         ++invalidateCalls;
         var count = 0;
-        this.get('numbers').forEach(function(num) {
+        this.get('numbers').forEach(function(num){
           if (num >= this.get('min')) ++count;
         }, this);
         return count;
@@ -1181,347 +1181,38 @@ test("changes in dependencies of a RCP that don't modify its result don't invali
     }).property('countBigNumbers')
   }).create();
 
-  equal(get(obj, 'countBigNumbers'), 0, 'precond - first CP has the proper initial value');
-  equal(get(obj, 'doubleCountBigNumbers'), 0, 'precond - second CP has the proper initial value');
+  deepEqual(get(obj, 'countBigNumbers'), 0);
+  deepEqual(get(obj, 'doubleCountBigNumbers'), 0);
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+  equal(secondGradeCalls, 1, "precond - `invalidate` of the other CP has not initially been called");
 
-  // Add elements to array dependency of first CP
   run(function() {
     numbers.pushObject(0);
     numbers.pushObject(1);
     numbers.pushObject(2);
+    numbers.pushObject(3);
+    numbers.pushObject(4);
+    numbers.pushObject(5);
     numbers.pushObject(6);
-    numbers.pushObject(7);
-    numbers.pushObject(8);
-    numbers.pushObject(9);
   });
 
-  // Get both CPs
-  equal(get(obj, 'countBigNumbers'), 4);
-  equal(get(obj, 'doubleCountBigNumbers'), 8);
+  deepEqual(get(obj, 'countBigNumbers'), 4);
+  deepEqual(get(obj, 'doubleCountBigNumbers'), 8);
+  equal(addCalls, 7);
+  equal(removeCalls, 0);
+  equal(invalidateCalls, 0);
+  equal(secondGradeCalls, 2);
 
-  // The hooks have been called properly.
-  equal(addCalls, 7, 'the first CP has received 7 elements');
-  equal(invalidateCalls, 0, 'the first CP has not been completely invalidated');
-  equal(secondGradeCalls, 2, 'the second CP has only been called once');
+  run(function() {
+    set(obj, 'min', 5);
+  });
 
-  // Change invalidating property of first CP twice
-  set(obj, 'min', 4);
-  set(obj, 'min', 5);
-
-  // Get both CPs
-  equal(get(obj, 'countBigNumbers'), 4, 'the value of the first CP has not changed');
-  equal(get(obj, 'doubleCountBigNumbers'), 8, 'the value of the second CP has not changed either');
-
-  // The hooks have been called properly.
-  equal(addCalls, 7, 'the first CP has not invoked `addedItem` again');
-  equal(invalidateCalls, 1, 'the first CP has been completely invalidated once');
-  equal(secondGradeCalls, 2, 'the second CP has not been called again');
-
-  // Change invalidating property of first CP that changes its value
-  set(obj, 'min', 8);
-
-  // Get both CPs
-  equal(get(obj, 'countBigNumbers'), 2, 'the value of the first CP has changed');
-  equal(get(obj, 'doubleCountBigNumbers'), 4, 'the value of the second CP has changed too');
-
-  // The hooks have been called properly.
-  equal(addCalls, 7, 'the first CP has not invoked `addedItem` again');
-  equal(invalidateCalls, 2, 'the first CP has been completely invalidated again');
-  equal(secondGradeCalls, 3, 'the second CP has been called this time');
-
-  // Change invalidating property of first CP that changes its value
-  set(obj, 'min', 9);
-
-  // Get both CPs in the inverse order.
-  equal(get(obj, 'doubleCountBigNumbers'), 2, 'the value of the second CP has changed');
-  equal(get(obj, 'countBigNumbers'), 1, 'the value of the first CP has changed');
-  // This fails and might be a problem because maybe nobody is watching the other property
-  // directly. We need a more complex mechanism.
+  deepEqual(get(obj, 'countBigNumbers'), 2);
+  deepEqual(get(obj, 'doubleCountBigNumbers'), 4);
+  equal(addCalls, 7);
+  equal(invalidateCalls, 1);
+  equal(secondGradeCalls, 3);
 });
-
-// test("changes in non-array properties that do not modify the result of an reduceComputed CP do not invalidate other CP watching the first one", function(){
-//   var numbers = Ember.A(),
-//     secondGradeCalls = 0;
-
-//   obj = EmberObject.extend({
-//     min: 3,
-//     numbers: numbers,
-
-//     countBigNumbers: reduceComputed('numbers', 'min', {
-//       initialValue: 0,
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         if (item >= this.get('min')) ++accumulatedValue;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         if (item >= this.get('min')) --accumulatedValue;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function(accumulatedValue, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         var count = 0;
-//         this.get('numbers').forEach(function(num){
-//           if (num >= this.get('min')) ++count;
-//         }, this);
-//         return count;
-//       }
-//     }),
-
-//     doubleCountBigNumbers: computed(function(){
-//       ++secondGradeCalls;
-//       return this.get('countBigNumbers') * 2;
-//     }).property('countBigNumbers')
-//   }).create();
-
-//   deepEqual(get(obj, 'countBigNumbers'), 0);
-//   deepEqual(get(obj, 'doubleCountBigNumbers'), 0);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-//   equal(secondGradeCalls, 1, "precond - `invalidate` of the other CP has not initially been called");
-
-//   run(function() {
-//     numbers.pushObject(0);
-//     numbers.pushObject(1);
-//     numbers.pushObject(2);
-//     numbers.pushObject(3);
-//     numbers.pushObject(4);
-//     numbers.pushObject(5);
-//     numbers.pushObject(6);
-//   });
-
-//   deepEqual(get(obj, 'countBigNumbers'), 4);
-//   deepEqual(get(obj, 'doubleCountBigNumbers'), 8);
-//   equal(addCalls, 7);
-//   equal(removeCalls, 0);
-//   equal(invalidateCalls, 0);
-//   equal(secondGradeCalls, 2);
-
-//   run(function() {
-//     set(obj, 'min', 5);
-//   });
-
-//   deepEqual(get(obj, 'countBigNumbers'), 2);
-//   deepEqual(get(obj, 'doubleCountBigNumbers'), 4);
-//   equal(addCalls, 7);
-//   equal(invalidateCalls, 1);
-//   equal(secondGradeCalls, 3);
-// });
-
-// QUnit.module('arrayComputed - completely invalidating dependencies', {
-//   setup: function () {
-//     addCalls = removeCalls = invalidateCalls = 0;
-//   }
-// });
-
-// test("changes in array dependencies specified with `.[]` invoke the `invalidate` hook of a arrayComputed CP", function() {
-//   var dependentArray = Ember.A([6,7]),
-//     totallyInvalidatingDependentArray = Ember.A([1,3]);
-
-//   obj = EmberObject.extend({
-//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         array.pushObject(item);
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         array.removeObject(item);
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta) {
-//         ++invalidateCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), [6,7]);
-//   equal(addCalls, 2, "precond - `addedItem` has called been called twice");
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   totallyInvalidatingDependentArray.pushObject(3);
-//   equal(addCalls, 2, "add has not been called any more time");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
-// });
-
-// test("changes in non-array dependencies invoke the `invalidate` hook of an arrayComputed CP", function() {
-//   var dependentArray = Ember.A([6,7]);
-
-//   obj = EmberObject.extend({
-//     nonArray: 0,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'nonArray', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), []);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   run(function(){
-//     set(obj, 'nonArray', 1);
-//   });
-//   equal(addCalls, 2, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "invalidate has been called just once");
-// });
-
-// test("changes in array dependencies do not invoke the `invalidate` hook of arrayComputed", function(){
-//   var dependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     nonArray: 0,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'nonArray', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), []);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   run(function(){
-//     dependentArray.pushObject(3);
-//   });
-//   equal(addCalls, 1, "add has been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has not been called");
-// });
-
-// test("changes in non-array properties that do not modify the result of an arrayComputed CP do not invalidate other CP watching the first one", function(){
-//   var numbers = Ember.A(),
-//     secondGradeAddCalls = 0,
-//     secondGradeRemoveCalls = 0,
-//     secondGradeInvalidationCalls = 0;
-
-//   obj = EmberObject.extend({
-//     min: 3,
-//     numbers: numbers,
-
-//     filteredNumbers: arrayComputed('numbers', 'min', {
-//       initialize: function(array, changeMeta, instanceMeta){
-//         instanceMeta.previousMin = this.get('min');
-//       },
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         if (item >= this.get('min')) array.pushObject(item);
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-
-//         --removeCalls;
-//         if (item >= this.get('min')) array.removeObject(item);
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         var newMin = this.get('min');
-//         if (newMin < instanceMeta.previousMin){
-//           for (var i = 0; i < array.length; i++){
-//             if (array[i] < newMin) array.removeAt(i);
-//           }
-//         } else {
-//           this.get('numbers').forEach(function(num){
-//             if (num >= newMin && num < instanceMeta.previousMin) array.push(num);
-//           });
-//         }
-//       }
-//     }),
-
-//     evenFilteredNumbers: arrayComputed('filteredNumbers', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++secondGradeAddCalls;
-//         if (item % 2 === 0) array.pushObject(item);
-//         return array;
-//       },
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++secondGradeRemoveCalls;
-//         if (item % 2 === 0) array.removeObject(item);
-//         return array;
-//       },
-//       invalidate: function (array, changeMeta, instanceMeta){
-//         ++secondGradeInvalidationCalls;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'filteredNumbers'), []);
-//   deepEqual(get(obj, 'evenFilteredNumbers'), []);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-//   equal(secondGradeInvalidationCalls, 0, "precond - `invalidate` of the other CP has not initially been called");
-
-//   run(function() {
-//     numbers.pushObject(0);
-//     numbers.pushObject(1);
-//     numbers.pushObject(2);
-//     numbers.pushObject(3);
-//     numbers.pushObject(4);
-//     numbers.pushObject(5);
-//     numbers.pushObject(6);
-//   });
-
-//   deepEqual(get(obj, 'filteredNumbers'), [3,4,5,6]);
-//   deepEqual(get(obj, 'evenFilteredNumbers'), [4,6]);
-//   equal(addCalls, 7);
-//   equal(removeCalls, 0);
-//   equal(invalidateCalls, 0);
-//   equal(secondGradeAddCalls, 4);
-//   equal(secondGradeRemoveCalls, 0);
-//   equal(secondGradeInvalidationCalls, 0);
-
-//   run(function() {
-//     set(obj, 'min', 5);
-//   });
-
-//   deepEqual(get(obj, 'filteredNumbers'), [5,6]);
-//   deepEqual(get(obj, 'evenFilteredNumbers'), [6]);
-//   equal(addCalls, 7);
-//   equal(removeCalls, 2);
-//   equal(invalidateCalls, 1);
-//   equal(secondGradeAddCalls, 4);
-//   equal(secondGradeRemoveCalls, 1);
-//   equal(secondGradeInvalidationCalls, 0);
-// });
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
   test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -823,239 +823,143 @@ test("when initialValue is undefined, everything works as advertised", function(
   equal(get(chars, 'firstUpper'), 'B', "result is the next match when the first matching object is removed");
 });
 
-QUnit.module('arrayComputed - completely invalidating dependencies', {
+QUnit.module('reduceComputed - completely invalidating dependencies', {
   setup: function () {
     addCalls = removeCalls = invalidateCalls = 0;
   }
 });
 
-// test("non-array dependencies completely invalidate a arrayComputed CP", function() {
-//   var dependentArray = Ember.A([6,7]);
-
-//   obj = EmberObject.extend({
-//     nonArray: 'v0',
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'nonArray', {
-//       addedItem: function (array) {
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array) {
-//         --removeCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   get(obj, 'computed');
-
-//   equal(addCalls, 2, "precond - add has been called twice");
-//   equal(removeCalls, 0, "precond - remove has not initially been called");
-
-//   dependentArray.pushObjects([1, 2]);
-
-//   equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
-//   equal(removeCalls, 0, "remove not called");
-
-//   run(function() {
-//     set(obj, 'nonArray', 'v1');
-//   });
-
-//   equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
-//   equal(removeCalls, 0, "remove not called");
-// });
-
-// test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
-//   var dependentArray = Ember.A();
-//   var totallyInvalidatingDependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-//       addedItem: function (array, item) {
-//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array, item) {
-//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-//         --removeCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   get(obj, 'computed');
-
-//   equal(addCalls, 0, "precond - add has not initially been called");
-//   equal(removeCalls, 0, "precond - remove has not initially been called");
-
-//   dependentArray.pushObjects([1, 2]);
-
-//   equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
-//   equal(removeCalls, 0, "remove not called");
-
-//   run(function() {
-//     totallyInvalidatingDependentArray.pushObject(3);
-//   });
-
-//   equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
-//   equal(removeCalls, 0, "remove not called");
-// });
-
-// test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
-//   var dependentArray = Ember.A([3,2,1]);
-//   var counter = 0;
-
-//   obj = EmberObject.extend({
-//     dependentArray: dependentArray,
-
-//     computed: reduceComputed('dependentArray', {
-//       initialValue: Infinity,
-
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         return Math.min(accumulatedValue, item);
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         if (item > accumulatedValue) {
-//           return accumulatedValue;
-//         }
-//       }
-//     }),
-
-//     computedDidChange: observer('computed', function() {
-//       counter++;
-//     })
-//   }).create();
-
-//   get(obj, 'computed');
-//   equal(get(obj, 'computed'), 1);
-//   equal(counter, 0);
-
-//   dependentArray.pushObject(10);
-//   equal(get(obj, 'computed'), 1);
-//   equal(counter, 0);
-
-//   dependentArray.removeObject(10);
-//   equal(get(obj, 'computed'), 1);
-//   equal(counter, 0);
-
-//   dependentArray.removeObject(1);
-//   equal(get(obj, 'computed'), 2);
-//   equal(counter, 1);
-// });
-
-// test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
-//   var dependentArray = Ember.A([5,6]);
-
-//   obj = EmberObject.extend({
-//     myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
-//       initialValue: "123",
-//       initialize: function(initialValue, changeMeta, instanceMeta){
-//         instanceMeta.customField = "abc";
-//       },
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
-//         ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
-//         ok(changeMeta.oldValues.nonArray1 === 0 && changeMeta.oldValues.nonArray2 === 1,
-//           "changeMeta contains the dependencies that changed and its old values");
-//         equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
-//         equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
-//         var accum = "";
-//         for (var key in changeMeta.oldValues) {
-//           accum += changeMeta.oldValues[key];
-//         }
-//         return accumulatedValue + accum;
-//       }
-//     })
-//   }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
-
-//   deepEqual(get(obj, 'myComputed'), "123");
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   set(obj, 'nonArray1', 2);
-//   set(obj, 'nonArray2', 5);
-
-//   equal(addCalls, 2, "add has been called twice");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has not been called yet");
-
-//   equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
-//   equal(addCalls, 2, "add has not been called again");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "invalidate has been called just once");
-
-//   equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
-// });
-
-// test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
-//   var dependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     myComputed: reduceComputed('dependentArray', 'nonArray', {
-//       initialValue: 123,
-//       initialize: function(initialValue, changeMeta, instanceMeta){
-//         instanceMeta.previousNonArray = this.get('nonArray');
-//       },
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
-//         ok(this.get('nonArray') === 1, "`this` is wrong");
-//         return accumulatedValue;
-//       }
-//     })
-//   }).create({nonArray: 0, dependentArray: dependentArray});
-
-//   deepEqual(get(obj, 'myComputed'), 123);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   Ember.run(function(){
-//     dependentArray.pushObject(3);
-//   });
-//   equal(addCalls, 1, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has been called just once");
-// });
-
-test("changes in several non-array dependencies simultaneously only invoke the `invalidate` hook once with both chages in the changeMeta", function() {
-  var dependentArray = Ember.A([5,6]),
-    totallyInvalidatingDependentArray = Ember.A();
+test("non-array dependencies completely invalidate a arrayComputed CP", function() {
+  var dependentArray = Ember.A([6,7]);
 
   obj = EmberObject.extend({
-    nonArray1: 0,
-    nonArray2: 0,
+    nonArray: 'v0',
+    dependentArray: dependentArray,
+
+    computed: arrayComputed('dependentArray', 'nonArray', {
+      addedItem: function (array) {
+        ++addCalls;
+        return array;
+      },
+
+      removedItem: function (array) {
+        --removeCalls;
+        return array;
+      }
+    })
+  }).create();
+
+  get(obj, 'computed');
+
+  equal(addCalls, 2, "precond - add has been called twice");
+  equal(removeCalls, 0, "precond - remove has not initially been called");
+
+  dependentArray.pushObjects([1, 2]);
+
+  equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
+  equal(removeCalls, 0, "remove not called");
+
+  run(function() {
+    set(obj, 'nonArray', 'v1');
+  });
+
+  equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
+  equal(removeCalls, 0, "remove not called");
+});
+
+test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
+  var dependentArray = Ember.A();
+  var totallyInvalidatingDependentArray = Ember.A();
+
+  obj = EmberObject.extend({
     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
     dependentArray: dependentArray,
 
-    computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'totallyInvalidatingDependentArray.[]', {
-      initialValue: 123,
+    computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+      addedItem: function (array, item) {
+        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+        ++addCalls;
+        return array;
+      },
+
+      removedItem: function (array, item) {
+        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+        --removeCalls;
+        return array;
+      }
+    })
+  }).create();
+
+  get(obj, 'computed');
+
+  equal(addCalls, 0, "precond - add has not initially been called");
+  equal(removeCalls, 0, "precond - remove has not initially been called");
+
+  dependentArray.pushObjects([1, 2]);
+
+  equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
+  equal(removeCalls, 0, "remove not called");
+
+  run(function() {
+    totallyInvalidatingDependentArray.pushObject(3);
+  });
+
+  equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
+  equal(removeCalls, 0, "remove not called");
+});
+
+test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
+  var dependentArray = Ember.A([3,2,1]);
+  var counter = 0;
+
+  obj = EmberObject.extend({
+    dependentArray: dependentArray,
+
+    computed: reduceComputed('dependentArray', {
+      initialValue: Infinity,
+
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        return Math.min(accumulatedValue, item);
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        if (item > accumulatedValue) {
+          return accumulatedValue;
+        }
+      }
+    }),
+
+    computedDidChange: observer('computed', function() {
+      counter++;
+    })
+  }).create();
+
+  get(obj, 'computed');
+  equal(get(obj, 'computed'), 1);
+  equal(counter, 0);
+
+  dependentArray.pushObject(10);
+  equal(get(obj, 'computed'), 1);
+  equal(counter, 0);
+
+  dependentArray.removeObject(10);
+  equal(get(obj, 'computed'), 1);
+  equal(counter, 0);
+
+  dependentArray.removeObject(1);
+  equal(get(obj, 'computed'), 2);
+  equal(counter, 1);
+});
+
+test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
+  var dependentArray = Ember.A([5,6]);
+
+  obj = EmberObject.extend({
+    myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
+      initialValue: "123",
+      initialize: function(initialValue, changeMeta, instanceMeta){
+        instanceMeta.customField = "abc";
+      },
       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
         ++addCalls;
         return accumulatedValue;
@@ -1068,6 +972,108 @@ test("changes in several non-array dependencies simultaneously only invoke the `
 
       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
         ++invalidateCalls;
+        ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
+        ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
+        ok(changeMeta.changes.nonArray1 === 0 && changeMeta.changes.nonArray2 === 1,
+          "changeMeta contains the dependencies that changed and its old values");
+        equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
+        equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
+        var accum = "";
+        for (var key in changeMeta.changes) {
+          accum += changeMeta.changes[key];
+        }
+        return accumulatedValue + accum;
+      }
+    })
+  }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
+
+  deepEqual(get(obj, 'myComputed'), "123");
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+  set(obj, 'nonArray1', 2);
+  set(obj, 'nonArray2', 5);
+
+  equal(addCalls, 2, "add has been called twice");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+  equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
+  equal(addCalls, 2, "add has not been called again");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 1, "invalidate has been called just once");
+
+  equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
+  equal(invalidateCalls, 1, "invalidate has not been called again");
+});
+
+test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
+  var dependentArray = Ember.A();
+
+  obj = EmberObject.extend({
+    myComputed: reduceComputed('dependentArray', 'nonArray', {
+      initialValue: 123,
+      initialize: function(initialValue, changeMeta, instanceMeta){
+        instanceMeta.previousNonArray = this.get('nonArray');
+      },
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
+
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+        ++invalidateCalls;
+        ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
+        ok(this.get('nonArray') === 1, "`this` is wrong");
+        return accumulatedValue;
+      }
+    })
+  }).create({nonArray: 0, dependentArray: dependentArray});
+
+  deepEqual(get(obj, 'myComputed'), 123);
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+  dependentArray.pushObject(3);
+  get(obj, 'myComputed');
+
+  equal(addCalls, 1, "add has not been called");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "invalidate has not been called");
+});
+
+test("multiple changes in non-array dependencies only invoke the `invalidate` hook once", function() {
+  var dependentArray = Ember.A([5,6]);
+  var invalidatingDependentArray = Ember.A();
+
+  obj = EmberObject.extend({
+    nonArray1: 0,
+    nonArray2: 0,
+    invalidatingDependentArray: invalidatingDependentArray,
+    dependentArray: dependentArray,
+
+    computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'invalidatingDependentArray.[]', {
+      initialValue: 123,
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
+
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
+
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+        deepEqual(
+          changeMeta.changes,
+          { nonArray1: 0, nonArray2: 0 },
+          '`changeMeta.changes` contains the old values of the dependencies that changed'
+        );
+        ++invalidateCalls;
         return accumulatedValue;
       }
     })
@@ -1077,213 +1083,65 @@ test("changes in several non-array dependencies simultaneously only invoke the `
   equal(addCalls, 2, "add has been called twice");
   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
 
-  Ember.run(function(){
-    // set(obj, 'nonArray1', 1);
-    // set(obj, 'nonArray2', 9);
-    debugger;
-    totallyInvalidatingDependentArray.pushObject(3);
-  });
+  set(obj, 'nonArray1', 1);
+  set(obj, 'nonArray2', 9);
+  set(obj, 'nonArray2', 10);
+
   equal(addCalls, 2, "add has not been called again");
   equal(removeCalls, 0, "remove has not been called");
-  equal(invalidateCalls, 1, "invalidate has been called just once");
+  equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+  get(obj, 'computed');
+  equal(invalidateCalls, 1, "invalidate has been called once");
 });
 
-// test("changes in array dependencies specified with `.[]` invoke the `invalidate` hook of a reduceComputed CP", function() {
-//   var dependentArray = Ember.A(),
-//     totallyInvalidatingDependentArray = Ember.A();
+test("multiple additions/deletions in invalidating array dependencies invoke the `invalidate` hook just once", function() {
+  var dependentArray = Ember.A([5,6]);
+  var invalidatingDependentArray = Ember.A();
 
-//   obj = EmberObject.extend({
-//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-//     dependentArray: dependentArray,
+  obj = EmberObject.extend({
+    invalidatingDependentArray: invalidatingDependentArray,
+    dependentArray: dependentArray,
 
-//     computed: reduceComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-//       initialValue: 123,
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
+    computed: reduceComputed('dependentArray', 'invalidatingDependentArray.[]', {
+      initialValue: 123,
+      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        ++addCalls;
+        return accumulatedValue;
+      },
 
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
+      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+        --removeCalls;
+        return accumulatedValue;
+      },
 
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
-//         ++invalidateCalls;
-//         return accumulatedValue;
-//       }
-//     })
-//   }).create();
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
+        ++invalidateCalls;
+        deepEqual(
+          changeMeta.changes,
+          { 'invalidatingDependentArray.[]': {adding: 3, removing: 1} },
+          '`changeMeta.changes` contains the aggregated info of all the additions/deletions made'
+        );
+        return accumulatedValue;
+      }
+    })
+  }).create();
 
-//   deepEqual(get(obj, 'computed'), 123);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+  deepEqual(get(obj, 'computed'), 123);
+  equal(addCalls, 2, 'precond - add has been called during initialization');
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
 
-//   run(function() {
-//     totallyInvalidatingDependentArray.pushObject(3);
-//   });
-//   equal(addCalls, 0, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
-// });
+  invalidatingDependentArray.pushObject(3);
+  invalidatingDependentArray.pushObjects([4, 5]);
+  invalidatingDependentArray.removeAt(1);
 
-// test("changes in array dependencies specified with `.[]` invoke the `invalidate` hook of a arrayComputed CP", function() {
-//   var dependentArray = Ember.A([6,7]),
-//     totallyInvalidatingDependentArray = Ember.A([1,3]);
+  equal(addCalls, 2, "add has not been called again");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 0, "`invalidate` has not been called yet");
 
-//   obj = EmberObject.extend({
-//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         array.pushObject(item);
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         array.removeObject(item);
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta) {
-//         ++invalidateCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), [6,7]);
-//   equal(addCalls, 2, "precond - `addedItem` has called been called twice");
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   run(function() {
-//     totallyInvalidatingDependentArray.pushObject(3);
-//   })
-//   equal(addCalls, 2, "add has not been called any more time");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
-// });
-
-// test("changes in non-array dependencies invoke the `invalidate` hook of an arrayComputed CP", function() {
-//   var dependentArray = Ember.A([6,7]);
-
-//   obj = EmberObject.extend({
-//     nonArray: 0,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'nonArray', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), []);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   run(function(){
-//     set(obj, 'nonArray', 1);
-//   });
-//   equal(addCalls, 2, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "invalidate has been called just once");
-// });
-
-// test("changes in array dependencies do not invoke the `invalidate` hook", function(){
-//   var dependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     nonArray: 0,
-//     dependentArray: dependentArray,
-
-//     computed: arrayComputed('dependentArray', 'nonArray', {
-//       addedItem: function (array, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return array;
-//       },
-
-//       removedItem: function (array, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return array;
-//       },
-
-//       invalidate: function (array, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         return array;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), []);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   run(function(){
-//     dependentArray.pushObject(3);
-//   });
-//   equal(addCalls, 1, "add has been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 0, "invalidate has not been called");
-// });
-
-// test("the `invalidate` hook is called when ANY of the non-array dependent properties change", function() {
-//   var dependentArray = Ember.A(),
-//     totallyInvalidatingDependentArray = Ember.A();
-
-//   obj = EmberObject.extend({
-//     nonArray: 0,
-//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-//     dependentArray: dependentArray,
-
-//     computed: reduceComputed('dependentArray', 'nonArray', 'totallyInvalidatingDependentArray.[]', {
-//       initialValue: 123,
-//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         ++addCalls;
-//         return accumulatedValue;
-//       },
-
-//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-//         --removeCalls;
-//         return accumulatedValue;
-//       },
-
-//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-//         ++invalidateCalls;
-//         return accumulatedValue;
-//       }
-//     })
-//   }).create();
-
-//   deepEqual(get(obj, 'computed'), 123);
-//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-//   run(function() {
-//     set(obj, 'nonArray', 1);
-//   });
-//   equal(addCalls, 0, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 1, "invalidate has been called just once");
-
-//   run(function() {
-//     totallyInvalidatingDependentArray.pushObject(3);
-//   });
-
-//   equal(addCalls, 0, "add has not been called");
-//   equal(removeCalls, 0, "remove has not been called");
-//   equal(invalidateCalls, 2, "invalidate has been called again");
-// });
+  get(obj, 'computed');
+  equal(invalidateCalls, 1, "`invalidate` has been called just once");
+});
 
 // test("changes in non-array properties that do not modify the result of an reduceComputed CP do not invalidate other CP watching the first one", function(){
 //   var numbers = Ember.A(),
@@ -1354,6 +1212,122 @@ test("changes in several non-array dependencies simultaneously only invoke the `
 //   equal(addCalls, 7);
 //   equal(invalidateCalls, 1);
 //   equal(secondGradeCalls, 3);
+// });
+
+// QUnit.module('arrayComputed - completely invalidating dependencies', {
+//   setup: function () {
+//     addCalls = removeCalls = invalidateCalls = 0;
+//   }
+// });
+
+// test("changes in array dependencies specified with `.[]` invoke the `invalidate` hook of a arrayComputed CP", function() {
+//   var dependentArray = Ember.A([6,7]),
+//     totallyInvalidatingDependentArray = Ember.A([1,3]);
+
+//   obj = EmberObject.extend({
+//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         array.pushObject(item);
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         array.removeObject(item);
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta) {
+//         ++invalidateCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), [6,7]);
+//   equal(addCalls, 2, "precond - `addedItem` has called been called twice");
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   totallyInvalidatingDependentArray.pushObject(3);
+//   equal(addCalls, 2, "add has not been called any more time");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
+// });
+
+// test("changes in non-array dependencies invoke the `invalidate` hook of an arrayComputed CP", function() {
+//   var dependentArray = Ember.A([6,7]);
+
+//   obj = EmberObject.extend({
+//     nonArray: 0,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'nonArray', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), []);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function(){
+//     set(obj, 'nonArray', 1);
+//   });
+//   equal(addCalls, 2, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "invalidate has been called just once");
+// });
+
+// test("changes in array dependencies do not invoke the `invalidate` hook of arrayComputed", function(){
+//   var dependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     nonArray: 0,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'nonArray', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), []);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function(){
+//     dependentArray.pushObject(3);
+//   });
+//   equal(addCalls, 1, "add has been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has not been called");
 // });
 
 // test("changes in non-array properties that do not modify the result of an arrayComputed CP do not invalidate other CP watching the first one", function(){
@@ -1453,70 +1427,70 @@ test("changes in several non-array dependencies simultaneously only invoke the `
 //   equal(secondGradeInvalidationCalls, 0);
 // });
 
-// if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
-//   test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
-//     var Type = EmberObject.extend({
-//       rc: reduceComputed('array', {
-//         initialValue: 0,
-//         addedItem: function(v){ return v; },
-//         removedItem: function(v){ return v; }
-//       })
-//     });
+if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
+  test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
+    var Type = EmberObject.extend({
+      rc: reduceComputed('array', {
+        initialValue: 0,
+        addedItem: function(v){ return v; },
+        removedItem: function(v){ return v; }
+      })
+    });
 
-//     expectAssertion(function() {
-//       obj = Type.create({ array: [] });
-//       get(obj, 'rc');
-//     }, /must be an `Ember.Array`/, "Ember.reduceComputed complains about dependent non-extended native arrays");
-//   });
-// }
+    expectAssertion(function() {
+      obj = Type.create({ array: [] });
+      get(obj, 'rc');
+    }, /must be an `Ember.Array`/, "Ember.reduceComputed complains about dependent non-extended native arrays");
+  });
+}
 
-// QUnit.module('arrayComputed - misc', {
-//   setup: function () {
-//     callbackItems = [];
+QUnit.module('arrayComputed - misc', {
+  setup: function () {
+    callbackItems = [];
 
-//     shared = Ember.Object.create({
-//       flag: false
-//     });
+    shared = Ember.Object.create({
+      flag: false
+    });
 
-//     var Item = Ember.Object.extend({
-//       shared: shared,
-//       flag: computed('shared.flag', function () {
-//         return this.get('shared.flag');
-//       })
-//     });
+    var Item = Ember.Object.extend({
+      shared: shared,
+      flag: computed('shared.flag', function () {
+        return this.get('shared.flag');
+      })
+    });
 
-//     obj = Ember.Object.extend({
-//       upstream: Ember.A([
-//         Item.create(),
-//         Item.create()
-//       ]),
-//       arrayCP: arrayComputed('upstream.@each.flag', {
-//         addedItem: function (array, item) {
-//           callbackItems.push('add:' + item.get('flag'));
-//           return array;
-//         },
+    obj = Ember.Object.extend({
+      upstream: Ember.A([
+        Item.create(),
+        Item.create()
+      ]),
+      arrayCP: arrayComputed('upstream.@each.flag', {
+        addedItem: function (array, item) {
+          callbackItems.push('add:' + item.get('flag'));
+          return array;
+        },
 
-//         removedItem: function (array, item) {
-//           callbackItems.push('remove:' + item.get('flag'));
-//           return array;
-//         }
-//       })
-//     }).create();
-//   },
+        removedItem: function (array, item) {
+          callbackItems.push('remove:' + item.get('flag'));
+          return array;
+        }
+      })
+    }).create();
+  },
 
-//   teardown: function () {
-//     run(function () {
-//       obj.destroy();
-//     });
-//   }
-// });
+  teardown: function () {
+    run(function () {
+      obj.destroy();
+    });
+  }
+});
 
-// test("item property change flushes are gated by a semaphore", function() {
-//   obj.get('arrayCP');
-//   deepEqual(callbackItems, ['add:false', 'add:false'], "precond - calls are initially correct");
+test("item property change flushes are gated by a semaphore", function() {
+  obj.get('arrayCP');
+  deepEqual(callbackItems, ['add:false', 'add:false'], "precond - calls are initially correct");
 
-//   callbackItems.splice(0, 2);
+  callbackItems.splice(0, 2);
 
-//   shared.set('flag', true);
-//   deepEqual(callbackItems, ['remove:true', 'add:true', 'remove:true', 'add:true'], "item property flushes that depend on a shared prop are gated by a semaphore");
-// });
+  shared.set('flag', true);
+  deepEqual(callbackItems, ['remove:true', 'add:true', 'remove:true', 'add:true'], "item property flushes that depend on a shared prop are gated by a semaphore");
+});

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -19,7 +19,7 @@ import { reduceComputed } from "ember-runtime/computed/reduce_computed";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import SubArray from "ember-runtime/system/subarray";
 
-var obj, addCalls, removeCalls, callbackItems, shared;
+var obj, addCalls, removeCalls, invalidateCalls, callbackItems, shared;
 
 QUnit.module('arrayComputed', {
   setup: function () {
@@ -825,196 +825,698 @@ test("when initialValue is undefined, everything works as advertised", function(
 
 QUnit.module('arrayComputed - completely invalidating dependencies', {
   setup: function () {
-    addCalls = removeCalls = 0;
+    addCalls = removeCalls = invalidateCalls = 0;
   }
 });
 
-test("non-array dependencies completely invalidate a reduceComputed CP", function() {
-  var dependentArray = Ember.A();
+// test("non-array dependencies completely invalidate a arrayComputed CP", function() {
+//   var dependentArray = Ember.A([6,7]);
+
+//   obj = EmberObject.extend({
+//     nonArray: 'v0',
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'nonArray', {
+//       addedItem: function (array) {
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array) {
+//         --removeCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   get(obj, 'computed');
+
+//   equal(addCalls, 2, "precond - add has been called twice");
+//   equal(removeCalls, 0, "precond - remove has not initially been called");
+
+//   dependentArray.pushObjects([1, 2]);
+
+//   equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
+//   equal(removeCalls, 0, "remove not called");
+
+//   run(function() {
+//     set(obj, 'nonArray', 'v1');
+//   });
+
+//   equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
+//   equal(removeCalls, 0, "remove not called");
+// });
+
+// test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
+//   var dependentArray = Ember.A();
+//   var totallyInvalidatingDependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+//       addedItem: function (array, item) {
+//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array, item) {
+//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+//         --removeCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   get(obj, 'computed');
+
+//   equal(addCalls, 0, "precond - add has not initially been called");
+//   equal(removeCalls, 0, "precond - remove has not initially been called");
+
+//   dependentArray.pushObjects([1, 2]);
+
+//   equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
+//   equal(removeCalls, 0, "remove not called");
+
+//   run(function() {
+//     totallyInvalidatingDependentArray.pushObject(3);
+//   });
+
+//   equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
+//   equal(removeCalls, 0, "remove not called");
+// });
+
+// test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
+//   var dependentArray = Ember.A([3,2,1]);
+//   var counter = 0;
+
+//   obj = EmberObject.extend({
+//     dependentArray: dependentArray,
+
+//     computed: reduceComputed('dependentArray', {
+//       initialValue: Infinity,
+
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         return Math.min(accumulatedValue, item);
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         if (item > accumulatedValue) {
+//           return accumulatedValue;
+//         }
+//       }
+//     }),
+
+//     computedDidChange: observer('computed', function() {
+//       counter++;
+//     })
+//   }).create();
+
+//   get(obj, 'computed');
+//   equal(get(obj, 'computed'), 1);
+//   equal(counter, 0);
+
+//   dependentArray.pushObject(10);
+//   equal(get(obj, 'computed'), 1);
+//   equal(counter, 0);
+
+//   dependentArray.removeObject(10);
+//   equal(get(obj, 'computed'), 1);
+//   equal(counter, 0);
+
+//   dependentArray.removeObject(1);
+//   equal(get(obj, 'computed'), 2);
+//   equal(counter, 1);
+// });
+
+// test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
+//   var dependentArray = Ember.A([5,6]);
+
+//   obj = EmberObject.extend({
+//     myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
+//       initialValue: "123",
+//       initialize: function(initialValue, changeMeta, instanceMeta){
+//         instanceMeta.customField = "abc";
+//       },
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
+//         ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
+//         ok(changeMeta.oldValues.nonArray1 === 0 && changeMeta.oldValues.nonArray2 === 1,
+//           "changeMeta contains the dependencies that changed and its old values");
+//         equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
+//         equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
+//         var accum = "";
+//         for (var key in changeMeta.oldValues) {
+//           accum += changeMeta.oldValues[key];
+//         }
+//         return accumulatedValue + accum;
+//       }
+//     })
+//   }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
+
+//   deepEqual(get(obj, 'myComputed'), "123");
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   set(obj, 'nonArray1', 2);
+//   set(obj, 'nonArray2', 5);
+
+//   equal(addCalls, 2, "add has been called twice");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+//   equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
+//   equal(addCalls, 2, "add has not been called again");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "invalidate has been called just once");
+
+//   equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
+// });
+
+// test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
+//   var dependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     myComputed: reduceComputed('dependentArray', 'nonArray', {
+//       initialValue: 123,
+//       initialize: function(initialValue, changeMeta, instanceMeta){
+//         instanceMeta.previousNonArray = this.get('nonArray');
+//       },
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
+//         ok(this.get('nonArray') === 1, "`this` is wrong");
+//         return accumulatedValue;
+//       }
+//     })
+//   }).create({nonArray: 0, dependentArray: dependentArray});
+
+//   deepEqual(get(obj, 'myComputed'), 123);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   Ember.run(function(){
+//     dependentArray.pushObject(3);
+//   });
+//   equal(addCalls, 1, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has been called just once");
+// });
+
+test("changes in several non-array dependencies simultaneously only invoke the `invalidate` hook once with both chages in the changeMeta", function() {
+  var dependentArray = Ember.A([5,6]),
+    totallyInvalidatingDependentArray = Ember.A();
 
   obj = EmberObject.extend({
-    nonArray: 'v0',
-    dependentArray: dependentArray,
-
-    computed: arrayComputed('dependentArray', 'nonArray', {
-      addedItem: function (array) {
-        ++addCalls;
-        return array;
-      },
-
-      removedItem: function (array) {
-        --removeCalls;
-        return array;
-      }
-    })
-  }).create();
-
-  get(obj, 'computed');
-
-  equal(addCalls, 0, "precond - add has not initially been called");
-  equal(removeCalls, 0, "precond - remove has not initially been called");
-
-  dependentArray.pushObjects([1, 2]);
-
-  equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
-  equal(removeCalls, 0, "remove not called");
-
-  run(function() {
-    set(obj, 'nonArray', 'v1');
-  });
-
-  equal(addCalls, 4, "array completely recomputed when non-array dependency changed");
-  equal(removeCalls, 0, "remove not called");
-});
-
-test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
-  var dependentArray = Ember.A();
-  var totallyInvalidatingDependentArray = Ember.A();
-
-  obj = EmberObject.extend({
+    nonArray1: 0,
+    nonArray2: 0,
     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
     dependentArray: dependentArray,
 
-    computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-      addedItem: function (array, item) {
-        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-        ++addCalls;
-        return array;
-      },
-
-      removedItem: function (array, item) {
-        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-        --removeCalls;
-        return array;
-      }
-    })
-  }).create();
-
-  get(obj, 'computed');
-
-  equal(addCalls, 0, "precond - add has not initially been called");
-  equal(removeCalls, 0, "precond - remove has not initially been called");
-
-  dependentArray.pushObjects([1, 2]);
-
-  equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
-  equal(removeCalls, 0, "remove not called");
-
-  run(function() {
-    totallyInvalidatingDependentArray.pushObject(3);
-  });
-
-  equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
-  equal(removeCalls, 0, "remove not called");
-});
-
-test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
-  var dependentArray = Ember.A([3,2,1]);
-  var counter = 0;
-
-  obj = EmberObject.extend({
-    dependentArray: dependentArray,
-
-    computed: reduceComputed('dependentArray', {
-      initialValue: Infinity,
-
+    computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'totallyInvalidatingDependentArray.[]', {
+      initialValue: 123,
       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        return Math.min(accumulatedValue, item);
+        ++addCalls;
+        return accumulatedValue;
       },
 
       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        if (item > accumulatedValue) {
-          return accumulatedValue;
-        }
-      }
-    }),
+        --removeCalls;
+        return accumulatedValue;
+      },
 
-    computedDidChange: observer('computed', function() {
-      counter++;
+      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+        ++invalidateCalls;
+        return accumulatedValue;
+      }
     })
   }).create();
 
-  get(obj, 'computed');
-  equal(get(obj, 'computed'), 1);
-  equal(counter, 0);
+  deepEqual(get(obj, 'computed'), 123);
+  equal(addCalls, 2, "add has been called twice");
+  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
 
-  dependentArray.pushObject(10);
-  equal(get(obj, 'computed'), 1);
-  equal(counter, 0);
-
-  dependentArray.removeObject(10);
-  equal(get(obj, 'computed'), 1);
-  equal(counter, 0);
-
-  dependentArray.removeObject(1);
-  equal(get(obj, 'computed'), 2);
-  equal(counter, 1);
-});
-
-if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
-  test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
-    var Type = EmberObject.extend({
-      rc: reduceComputed('array', {
-        initialValue: 0,
-        addedItem: function(v){ return v; },
-        removedItem: function(v){ return v; }
-      })
-    });
-
-    expectAssertion(function() {
-      obj = Type.create({ array: [] });
-      get(obj, 'rc');
-    }, /must be an `Ember.Array`/, "Ember.reduceComputed complains about dependent non-extended native arrays");
+  Ember.run(function(){
+    // set(obj, 'nonArray1', 1);
+    // set(obj, 'nonArray2', 9);
+    debugger;
+    totallyInvalidatingDependentArray.pushObject(3);
   });
-}
-
-QUnit.module('arrayComputed - misc', {
-  setup: function () {
-    callbackItems = [];
-
-    shared = Ember.Object.create({
-      flag: false
-    });
-
-    var Item = Ember.Object.extend({
-      shared: shared,
-      flag: computed('shared.flag', function () {
-        return this.get('shared.flag');
-      })
-    });
-
-    obj = Ember.Object.extend({
-      upstream: Ember.A([
-        Item.create(),
-        Item.create()
-      ]),
-      arrayCP: arrayComputed('upstream.@each.flag', {
-        addedItem: function (array, item) {
-          callbackItems.push('add:' + item.get('flag'));
-          return array;
-        },
-
-        removedItem: function (array, item) {
-          callbackItems.push('remove:' + item.get('flag'));
-          return array;
-        }
-      })
-    }).create();
-  },
-
-  teardown: function () {
-    run(function () {
-      obj.destroy();
-    });
-  }
+  equal(addCalls, 2, "add has not been called again");
+  equal(removeCalls, 0, "remove has not been called");
+  equal(invalidateCalls, 1, "invalidate has been called just once");
 });
 
-test("item property change flushes are gated by a semaphore", function() {
-  obj.get('arrayCP');
-  deepEqual(callbackItems, ['add:false', 'add:false'], "precond - calls are initially correct");
+// test("changes in array dependencies specified with `.[]` invoke the `invalidate` hook of a reduceComputed CP", function() {
+//   var dependentArray = Ember.A(),
+//     totallyInvalidatingDependentArray = Ember.A();
 
-  callbackItems.splice(0, 2);
+//   obj = EmberObject.extend({
+//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+//     dependentArray: dependentArray,
 
-  shared.set('flag', true);
-  deepEqual(callbackItems, ['remove:true', 'add:true', 'remove:true', 'add:true'], "item property flushes that depend on a shared prop are gated by a semaphore");
-});
+//     computed: reduceComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+//       initialValue: 123,
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
+//         ++invalidateCalls;
+//         return accumulatedValue;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), 123);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function() {
+//     totallyInvalidatingDependentArray.pushObject(3);
+//   });
+//   equal(addCalls, 0, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
+// });
+
+// test("changes in array dependencies specified with `.[]` invoke the `invalidate` hook of a arrayComputed CP", function() {
+//   var dependentArray = Ember.A([6,7]),
+//     totallyInvalidatingDependentArray = Ember.A([1,3]);
+
+//   obj = EmberObject.extend({
+//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         array.pushObject(item);
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         array.removeObject(item);
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta) {
+//         ++invalidateCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), [6,7]);
+//   equal(addCalls, 2, "precond - `addedItem` has called been called twice");
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function() {
+//     totallyInvalidatingDependentArray.pushObject(3);
+//   })
+//   equal(addCalls, 2, "add has not been called any more time");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
+// });
+
+// test("changes in non-array dependencies invoke the `invalidate` hook of an arrayComputed CP", function() {
+//   var dependentArray = Ember.A([6,7]);
+
+//   obj = EmberObject.extend({
+//     nonArray: 0,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'nonArray', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), []);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function(){
+//     set(obj, 'nonArray', 1);
+//   });
+//   equal(addCalls, 2, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "invalidate has been called just once");
+// });
+
+// test("changes in array dependencies do not invoke the `invalidate` hook", function(){
+//   var dependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     nonArray: 0,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'nonArray', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), []);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function(){
+//     dependentArray.pushObject(3);
+//   });
+//   equal(addCalls, 1, "add has been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has not been called");
+// });
+
+// test("the `invalidate` hook is called when ANY of the non-array dependent properties change", function() {
+//   var dependentArray = Ember.A(),
+//     totallyInvalidatingDependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     nonArray: 0,
+//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: reduceComputed('dependentArray', 'nonArray', 'totallyInvalidatingDependentArray.[]', {
+//       initialValue: 123,
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         return accumulatedValue;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), 123);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   run(function() {
+//     set(obj, 'nonArray', 1);
+//   });
+//   equal(addCalls, 0, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "invalidate has been called just once");
+
+//   run(function() {
+//     totallyInvalidatingDependentArray.pushObject(3);
+//   });
+
+//   equal(addCalls, 0, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 2, "invalidate has been called again");
+// });
+
+// test("changes in non-array properties that do not modify the result of an reduceComputed CP do not invalidate other CP watching the first one", function(){
+//   var numbers = Ember.A(),
+//     secondGradeCalls = 0;
+
+//   obj = EmberObject.extend({
+//     min: 3,
+//     numbers: numbers,
+
+//     countBigNumbers: reduceComputed('numbers', 'min', {
+//       initialValue: 0,
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         if (item >= this.get('min')) ++accumulatedValue;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         if (item >= this.get('min')) --accumulatedValue;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function(accumulatedValue, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         var count = 0;
+//         this.get('numbers').forEach(function(num){
+//           if (num >= this.get('min')) ++count;
+//         }, this);
+//         return count;
+//       }
+//     }),
+
+//     doubleCountBigNumbers: computed(function(){
+//       ++secondGradeCalls;
+//       return this.get('countBigNumbers') * 2;
+//     }).property('countBigNumbers')
+//   }).create();
+
+//   deepEqual(get(obj, 'countBigNumbers'), 0);
+//   deepEqual(get(obj, 'doubleCountBigNumbers'), 0);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+//   equal(secondGradeCalls, 1, "precond - `invalidate` of the other CP has not initially been called");
+
+//   run(function() {
+//     numbers.pushObject(0);
+//     numbers.pushObject(1);
+//     numbers.pushObject(2);
+//     numbers.pushObject(3);
+//     numbers.pushObject(4);
+//     numbers.pushObject(5);
+//     numbers.pushObject(6);
+//   });
+
+//   deepEqual(get(obj, 'countBigNumbers'), 4);
+//   deepEqual(get(obj, 'doubleCountBigNumbers'), 8);
+//   equal(addCalls, 7);
+//   equal(removeCalls, 0);
+//   equal(invalidateCalls, 0);
+//   equal(secondGradeCalls, 2);
+
+//   run(function() {
+//     set(obj, 'min', 5);
+//   });
+
+//   deepEqual(get(obj, 'countBigNumbers'), 2);
+//   deepEqual(get(obj, 'doubleCountBigNumbers'), 4);
+//   equal(addCalls, 7);
+//   equal(invalidateCalls, 1);
+//   equal(secondGradeCalls, 3);
+// });
+
+// test("changes in non-array properties that do not modify the result of an arrayComputed CP do not invalidate other CP watching the first one", function(){
+//   var numbers = Ember.A(),
+//     secondGradeAddCalls = 0,
+//     secondGradeRemoveCalls = 0,
+//     secondGradeInvalidationCalls = 0;
+
+//   obj = EmberObject.extend({
+//     min: 3,
+//     numbers: numbers,
+
+//     filteredNumbers: arrayComputed('numbers', 'min', {
+//       initialize: function(array, changeMeta, instanceMeta){
+//         instanceMeta.previousMin = this.get('min');
+//       },
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         if (item >= this.get('min')) array.pushObject(item);
+//         return array;
+//       },
+
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+
+//         --removeCalls;
+//         if (item >= this.get('min')) array.removeObject(item);
+//         return array;
+//       },
+
+//       invalidate: function (array, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         var newMin = this.get('min');
+//         if (newMin < instanceMeta.previousMin){
+//           for (var i = 0; i < array.length; i++){
+//             if (array[i] < newMin) array.removeAt(i);
+//           }
+//         } else {
+//           this.get('numbers').forEach(function(num){
+//             if (num >= newMin && num < instanceMeta.previousMin) array.push(num);
+//           });
+//         }
+//       }
+//     }),
+
+//     evenFilteredNumbers: arrayComputed('filteredNumbers', {
+//       addedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++secondGradeAddCalls;
+//         if (item % 2 === 0) array.pushObject(item);
+//         return array;
+//       },
+//       removedItem: function (array, item, changeMeta, instanceMeta) {
+//         ++secondGradeRemoveCalls;
+//         if (item % 2 === 0) array.removeObject(item);
+//         return array;
+//       },
+//       invalidate: function (array, changeMeta, instanceMeta){
+//         ++secondGradeInvalidationCalls;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'filteredNumbers'), []);
+//   deepEqual(get(obj, 'evenFilteredNumbers'), []);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+//   equal(secondGradeInvalidationCalls, 0, "precond - `invalidate` of the other CP has not initially been called");
+
+//   run(function() {
+//     numbers.pushObject(0);
+//     numbers.pushObject(1);
+//     numbers.pushObject(2);
+//     numbers.pushObject(3);
+//     numbers.pushObject(4);
+//     numbers.pushObject(5);
+//     numbers.pushObject(6);
+//   });
+
+//   deepEqual(get(obj, 'filteredNumbers'), [3,4,5,6]);
+//   deepEqual(get(obj, 'evenFilteredNumbers'), [4,6]);
+//   equal(addCalls, 7);
+//   equal(removeCalls, 0);
+//   equal(invalidateCalls, 0);
+//   equal(secondGradeAddCalls, 4);
+//   equal(secondGradeRemoveCalls, 0);
+//   equal(secondGradeInvalidationCalls, 0);
+
+//   run(function() {
+//     set(obj, 'min', 5);
+//   });
+
+//   deepEqual(get(obj, 'filteredNumbers'), [5,6]);
+//   deepEqual(get(obj, 'evenFilteredNumbers'), [6]);
+//   equal(addCalls, 7);
+//   equal(removeCalls, 2);
+//   equal(invalidateCalls, 1);
+//   equal(secondGradeAddCalls, 4);
+//   equal(secondGradeRemoveCalls, 1);
+//   equal(secondGradeInvalidationCalls, 0);
+// });
+
+// if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
+//   test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
+//     var Type = EmberObject.extend({
+//       rc: reduceComputed('array', {
+//         initialValue: 0,
+//         addedItem: function(v){ return v; },
+//         removedItem: function(v){ return v; }
+//       })
+//     });
+
+//     expectAssertion(function() {
+//       obj = Type.create({ array: [] });
+//       get(obj, 'rc');
+//     }, /must be an `Ember.Array`/, "Ember.reduceComputed complains about dependent non-extended native arrays");
+//   });
+// }
+
+// QUnit.module('arrayComputed - misc', {
+//   setup: function () {
+//     callbackItems = [];
+
+//     shared = Ember.Object.create({
+//       flag: false
+//     });
+
+//     var Item = Ember.Object.extend({
+//       shared: shared,
+//       flag: computed('shared.flag', function () {
+//         return this.get('shared.flag');
+//       })
+//     });
+
+//     obj = Ember.Object.extend({
+//       upstream: Ember.A([
+//         Item.create(),
+//         Item.create()
+//       ]),
+//       arrayCP: arrayComputed('upstream.@each.flag', {
+//         addedItem: function (array, item) {
+//           callbackItems.push('add:' + item.get('flag'));
+//           return array;
+//         },
+
+//         removedItem: function (array, item) {
+//           callbackItems.push('remove:' + item.get('flag'));
+//           return array;
+//         }
+//       })
+//     }).create();
+//   },
+
+//   teardown: function () {
+//     run(function () {
+//       obj.destroy();
+//     });
+//   }
+// });
+
+// test("item property change flushes are gated by a semaphore", function() {
+//   obj.get('arrayCP');
+//   deepEqual(callbackItems, ['add:false', 'add:false'], "precond - calls are initially correct");
+
+//   callbackItems.splice(0, 2);
+
+//   shared.set('flag', true);
+//   deepEqual(callbackItems, ['remove:true', 'add:true', 'remove:true', 'add:true'], "item property flushes that depend on a shared prop are gated by a semaphore");
+// });

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -829,318 +829,414 @@ QUnit.module('reduceComputed - completely invalidating dependencies', {
   }
 });
 
-test("non-array dependencies completely invalidate a arrayComputed CP", function() {
-  var dependentArray = Ember.A([6,7]);
+// test("non-array dependencies completely invalidate a arrayComputed CP", function() {
+//   var dependentArray = Ember.A([6,7]);
+
+//   obj = EmberObject.extend({
+//     nonArray: 'v0',
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'nonArray', {
+//       addedItem: function (array) {
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array) {
+//         --removeCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   get(obj, 'computed');
+
+//   equal(addCalls, 2, "precond - add has been called twice");
+//   equal(removeCalls, 0, "precond - remove has not initially been called");
+
+//   dependentArray.pushObjects([1, 2]);
+
+//   equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
+//   equal(removeCalls, 0, "remove not called");
+
+//   run(function() {
+//     set(obj, 'nonArray', 'v1');
+//   });
+
+//   equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
+//   equal(removeCalls, 0, "remove not called");
+// });
+
+// test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
+//   var dependentArray = Ember.A();
+//   var totallyInvalidatingDependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
+//       addedItem: function (array, item) {
+//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+//         ++addCalls;
+//         return array;
+//       },
+
+//       removedItem: function (array, item) {
+//         ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
+//         --removeCalls;
+//         return array;
+//       }
+//     })
+//   }).create();
+
+//   get(obj, 'computed');
+
+//   equal(addCalls, 0, "precond - add has not initially been called");
+//   equal(removeCalls, 0, "precond - remove has not initially been called");
+
+//   dependentArray.pushObjects([1, 2]);
+
+//   equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
+//   equal(removeCalls, 0, "remove not called");
+
+//   run(function() {
+//     totallyInvalidatingDependentArray.pushObject(3);
+//   });
+
+//   equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
+//   equal(removeCalls, 0, "remove not called");
+// });
+
+// test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
+//   var dependentArray = Ember.A([3,2,1]);
+//   var counter = 0;
+
+//   obj = EmberObject.extend({
+//     dependentArray: dependentArray,
+
+//     computed: reduceComputed('dependentArray', {
+//       initialValue: Infinity,
+
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         return Math.min(accumulatedValue, item);
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         if (item > accumulatedValue) {
+//           return accumulatedValue;
+//         }
+//       }
+//     }),
+
+//     computedDidChange: observer('computed', function() {
+//       counter++;
+//     })
+//   }).create();
+
+//   get(obj, 'computed');
+//   equal(get(obj, 'computed'), 1);
+//   equal(counter, 0);
+
+//   dependentArray.pushObject(10);
+//   equal(get(obj, 'computed'), 1);
+//   equal(counter, 0);
+
+//   dependentArray.removeObject(10);
+//   equal(get(obj, 'computed'), 1);
+//   equal(counter, 0);
+
+//   dependentArray.removeObject(1);
+//   equal(get(obj, 'computed'), 2);
+//   equal(counter, 1);
+// });
+
+// test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
+//   var dependentArray = Ember.A([5,6]);
+
+//   obj = EmberObject.extend({
+//     myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
+//       initialValue: "123",
+//       initialize: function(initialValue, changeMeta, instanceMeta){
+//         instanceMeta.customField = "abc";
+//       },
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
+//         ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
+//         ok(changeMeta.changes.nonArray1 === 0 && changeMeta.changes.nonArray2 === 1,
+//           "changeMeta contains the dependencies that changed and its old values");
+//         equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
+//         equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
+//         var accum = "";
+//         for (var key in changeMeta.changes) {
+//           accum += changeMeta.changes[key];
+//         }
+//         return accumulatedValue + accum;
+//       }
+//     })
+//   }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
+
+//   deepEqual(get(obj, 'myComputed'), "123");
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   set(obj, 'nonArray1', 2);
+//   set(obj, 'nonArray2', 5);
+
+//   equal(addCalls, 2, "add has been called twice");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+//   equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
+//   equal(addCalls, 2, "add has not been called again");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 1, "invalidate has been called just once");
+
+//   equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
+//   equal(invalidateCalls, 1, "invalidate has not been called again");
+// });
+
+// test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
+//   var dependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     myComputed: reduceComputed('dependentArray', 'nonArray', {
+//       initialValue: 123,
+//       initialize: function(initialValue, changeMeta, instanceMeta){
+//         instanceMeta.previousNonArray = this.get('nonArray');
+//       },
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+//         ++invalidateCalls;
+//         ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
+//         ok(this.get('nonArray') === 1, "`this` is wrong");
+//         return accumulatedValue;
+//       }
+//     })
+//   }).create({nonArray: 0, dependentArray: dependentArray});
+
+//   deepEqual(get(obj, 'myComputed'), 123);
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   dependentArray.pushObject(3);
+//   get(obj, 'myComputed');
+
+//   equal(addCalls, 1, "add has not been called");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has not been called");
+// });
+
+// test("multiple changes in non-array dependencies only invoke the `invalidate` hook once", function() {
+//   var dependentArray = Ember.A([5,6]);
+//   var invalidatingDependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     nonArray1: 0,
+//     nonArray2: 0,
+//     invalidatingDependentArray: invalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'invalidatingDependentArray.[]', {
+//       initialValue: 123,
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta){
+//         deepEqual(
+//           changeMeta.changes,
+//           { nonArray1: 0, nonArray2: 0 },
+//           '`changeMeta.changes` contains the old values of the dependencies that changed'
+//         );
+//         ++invalidateCalls;
+//         return accumulatedValue;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), 123);
+//   equal(addCalls, 2, "add has been called twice");
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   set(obj, 'nonArray1', 1);
+//   set(obj, 'nonArray2', 9);
+//   set(obj, 'nonArray2', 10);
+
+//   equal(addCalls, 2, "add has not been called again");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "invalidate has not been called yet");
+
+//   get(obj, 'computed');
+//   equal(invalidateCalls, 1, "invalidate has been called once");
+// });
+
+// test("multiple additions/deletions in invalidating array dependencies invoke the `invalidate` hook just once", function() {
+//   var dependentArray = Ember.A([5,6]);
+//   var invalidatingDependentArray = Ember.A();
+
+//   obj = EmberObject.extend({
+//     invalidatingDependentArray: invalidatingDependentArray,
+//     dependentArray: dependentArray,
+
+//     computed: reduceComputed('dependentArray', 'invalidatingDependentArray.[]', {
+//       initialValue: 123,
+//       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         ++addCalls;
+//         return accumulatedValue;
+//       },
+
+//       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+//         --removeCalls;
+//         return accumulatedValue;
+//       },
+
+//       invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
+//         ++invalidateCalls;
+//         deepEqual(
+//           changeMeta.changes,
+//           { 'invalidatingDependentArray.[]': {adding: 3, removing: 1} },
+//           '`changeMeta.changes` contains the aggregated info of all the additions/deletions made'
+//         );
+//         return accumulatedValue;
+//       }
+//     })
+//   }).create();
+
+//   deepEqual(get(obj, 'computed'), 123);
+//   equal(addCalls, 2, 'precond - add has been called during initialization');
+//   equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+
+//   invalidatingDependentArray.pushObject(3);
+//   invalidatingDependentArray.pushObjects([4, 5]);
+//   invalidatingDependentArray.removeAt(1);
+
+//   equal(addCalls, 2, "add has not been called again");
+//   equal(removeCalls, 0, "remove has not been called");
+//   equal(invalidateCalls, 0, "`invalidate` has not been called yet");
+
+//   get(obj, 'computed');
+//   equal(invalidateCalls, 1, "`invalidate` has been called just once");
+// });
+
+test("changes in dependencies of a RCP that don't modify its result don't invalidate other RCP watching the first one", function(){
+  var numbers = Ember.A();
+  var secondGradeCalls = 0;
 
   obj = EmberObject.extend({
-    nonArray: 'v0',
-    dependentArray: dependentArray,
+    min: 3,
+    numbers: numbers,
 
-    computed: arrayComputed('dependentArray', 'nonArray', {
-      addedItem: function (array) {
-        ++addCalls;
-        return array;
-      },
-
-      removedItem: function (array) {
-        --removeCalls;
-        return array;
-      }
-    })
-  }).create();
-
-  get(obj, 'computed');
-
-  equal(addCalls, 2, "precond - add has been called twice");
-  equal(removeCalls, 0, "precond - remove has not initially been called");
-
-  dependentArray.pushObjects([1, 2]);
-
-  equal(addCalls, 4, "add called one-at-a-time for dependent array changes");
-  equal(removeCalls, 0, "remove not called");
-
-  run(function() {
-    set(obj, 'nonArray', 'v1');
-  });
-
-  equal(addCalls, 8, "array completely recomputed when non-array dependency changed");
-  equal(removeCalls, 0, "remove not called");
-});
-
-test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
-  var dependentArray = Ember.A();
-  var totallyInvalidatingDependentArray = Ember.A();
-
-  obj = EmberObject.extend({
-    totallyInvalidatingDependentArray: totallyInvalidatingDependentArray,
-    dependentArray: dependentArray,
-
-    computed: arrayComputed('dependentArray', 'totallyInvalidatingDependentArray.[]', {
-      addedItem: function (array, item) {
-        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-        ++addCalls;
-        return array;
-      },
-
-      removedItem: function (array, item) {
-        ok(item !== 3, "totally invalidating items are never passed to the one-at-a-time callbacks");
-        --removeCalls;
-        return array;
-      }
-    })
-  }).create();
-
-  get(obj, 'computed');
-
-  equal(addCalls, 0, "precond - add has not initially been called");
-  equal(removeCalls, 0, "precond - remove has not initially been called");
-
-  dependentArray.pushObjects([1, 2]);
-
-  equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
-  equal(removeCalls, 0, "remove not called");
-
-  run(function() {
-    totallyInvalidatingDependentArray.pushObject(3);
-  });
-
-  equal(addCalls, 4, "array completely recomputed when totally invalidating dependent array modified");
-  equal(removeCalls, 0, "remove not called");
-});
-
-test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
-  var dependentArray = Ember.A([3,2,1]);
-  var counter = 0;
-
-  obj = EmberObject.extend({
-    dependentArray: dependentArray,
-
-    computed: reduceComputed('dependentArray', {
-      initialValue: Infinity,
-
+    countBigNumbers: reduceComputed('numbers', 'min', {
+      initialValue: 0,
       addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        return Math.min(accumulatedValue, item);
+        ++addCalls;
+        if (item >= this.get('min')) ++accumulatedValue;
+        return accumulatedValue;
       },
 
       removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        if (item > accumulatedValue) {
-          return accumulatedValue;
-        }
+        --removeCalls;
+        if (item >= this.get('min')) --accumulatedValue;
+        return accumulatedValue;
+      },
+
+      invalidate: function(accumulatedValue, changeMeta, instanceMeta){
+        ++invalidateCalls;
+        var count = 0;
+        this.get('numbers').forEach(function(num) {
+          if (num >= this.get('min')) ++count;
+        }, this);
+        return count;
       }
     }),
 
-    computedDidChange: observer('computed', function() {
-      counter++;
-    })
+    doubleCountBigNumbers: computed(function(){
+      ++secondGradeCalls;
+      return this.get('countBigNumbers') * 2;
+    }).property('countBigNumbers')
   }).create();
 
-  get(obj, 'computed');
-  equal(get(obj, 'computed'), 1);
-  equal(counter, 0);
+  equal(get(obj, 'countBigNumbers'), 0, 'precond - first CP has the proper initial value');
+  equal(get(obj, 'doubleCountBigNumbers'), 0, 'precond - second CP has the proper initial value');
 
-  dependentArray.pushObject(10);
-  equal(get(obj, 'computed'), 1);
-  equal(counter, 0);
+  // Add elements to array dependency of first CP
+  run(function() {
+    numbers.pushObject(0);
+    numbers.pushObject(1);
+    numbers.pushObject(2);
+    numbers.pushObject(6);
+    numbers.pushObject(7);
+    numbers.pushObject(8);
+    numbers.pushObject(9);
+  });
 
-  dependentArray.removeObject(10);
-  equal(get(obj, 'computed'), 1);
-  equal(counter, 0);
+  // Get both CPs
+  equal(get(obj, 'countBigNumbers'), 4);
+  equal(get(obj, 'doubleCountBigNumbers'), 8);
 
-  dependentArray.removeObject(1);
-  equal(get(obj, 'computed'), 2);
-  equal(counter, 1);
-});
+  // The hooks have been called properly.
+  equal(addCalls, 7, 'the first CP has received 7 elements');
+  equal(invalidateCalls, 0, 'the first CP has not been completely invalidated');
+  equal(secondGradeCalls, 2, 'the second CP has only been called once');
 
-test("changes in non-array dependencies invoke the `invalidate` hook of a reduceComputed CP", function() {
-  var dependentArray = Ember.A([5,6]);
+  // Change invalidating property of first CP twice
+  set(obj, 'min', 4);
+  set(obj, 'min', 5);
 
-  obj = EmberObject.extend({
-    myComputed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', {
-      initialValue: "123",
-      initialize: function(initialValue, changeMeta, instanceMeta){
-        instanceMeta.customField = "abc";
-      },
-      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        ++addCalls;
-        return accumulatedValue;
-      },
+  // Get both CPs
+  equal(get(obj, 'countBigNumbers'), 4, 'the value of the first CP has not changed');
+  equal(get(obj, 'doubleCountBigNumbers'), 8, 'the value of the second CP has not changed either');
 
-      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        --removeCalls;
-        return accumulatedValue;
-      },
+  // The hooks have been called properly.
+  equal(addCalls, 7, 'the first CP has not invoked `addedItem` again');
+  equal(invalidateCalls, 1, 'the first CP has been completely invalidated once');
+  equal(secondGradeCalls, 2, 'the second CP has not been called again');
 
-      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-        ++invalidateCalls;
-        ok(instanceMeta.customField === "abc", "`instanceMeta` has the proper content");
-        ok(this.get('nonArray1') === 2 && this.get('nonArray2') === 5, "`this` has been updated");
-        ok(changeMeta.changes.nonArray1 === 0 && changeMeta.changes.nonArray2 === 1,
-          "changeMeta contains the dependencies that changed and its old values");
-        equal(changeMeta.property.options.initialValue, '123', 'changeMeta contains the property');
-        equal(changeMeta.propertyName, 'myComputed', 'changeMeta contains the name of the property');
-        var accum = "";
-        for (var key in changeMeta.changes) {
-          accum += changeMeta.changes[key];
-        }
-        return accumulatedValue + accum;
-      }
-    })
-  }).create({nonArray1: 0, nonArray2: 1, dependentArray: dependentArray});
+  // Change invalidating property of first CP that changes its value
+  set(obj, 'min', 8);
 
-  deepEqual(get(obj, 'myComputed'), "123");
-  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
+  // Get both CPs
+  equal(get(obj, 'countBigNumbers'), 2, 'the value of the first CP has changed');
+  equal(get(obj, 'doubleCountBigNumbers'), 4, 'the value of the second CP has changed too');
 
-  set(obj, 'nonArray1', 2);
-  set(obj, 'nonArray2', 5);
+  // The hooks have been called properly.
+  equal(addCalls, 7, 'the first CP has not invoked `addedItem` again');
+  equal(invalidateCalls, 2, 'the first CP has been completely invalidated again');
+  equal(secondGradeCalls, 3, 'the second CP has been called this time');
 
-  equal(addCalls, 2, "add has been called twice");
-  equal(removeCalls, 0, "remove has not been called");
-  equal(invalidateCalls, 0, "invalidate has not been called yet");
+  // Change invalidating property of first CP that changes its value
+  set(obj, 'min', 9);
 
-  equal(get(obj, 'myComputed'), "12301", 'the computed property is updated properly');
-  equal(addCalls, 2, "add has not been called again");
-  equal(removeCalls, 0, "remove has not been called");
-  equal(invalidateCalls, 1, "invalidate has been called just once");
-
-  equal(get(obj, 'myComputed'), "12301", 'getting the propery does not trigger invalidation again');
-  equal(invalidateCalls, 1, "invalidate has not been called again");
-});
-
-test("changes in array dependencies do not invoke the `invalidate` hook of a reduceComputed CP", function() {
-  var dependentArray = Ember.A();
-
-  obj = EmberObject.extend({
-    myComputed: reduceComputed('dependentArray', 'nonArray', {
-      initialValue: 123,
-      initialize: function(initialValue, changeMeta, instanceMeta){
-        instanceMeta.previousNonArray = this.get('nonArray');
-      },
-      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        ++addCalls;
-        return accumulatedValue;
-      },
-
-      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        --removeCalls;
-        return accumulatedValue;
-      },
-
-      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-        ++invalidateCalls;
-        ok(instanceMeta.previousNonArray === 0, "`instanceMeta` is wrong");
-        ok(this.get('nonArray') === 1, "`this` is wrong");
-        return accumulatedValue;
-      }
-    })
-  }).create({nonArray: 0, dependentArray: dependentArray});
-
-  deepEqual(get(obj, 'myComputed'), 123);
-  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-  dependentArray.pushObject(3);
-  get(obj, 'myComputed');
-
-  equal(addCalls, 1, "add has not been called");
-  equal(removeCalls, 0, "remove has not been called");
-  equal(invalidateCalls, 0, "invalidate has not been called");
-});
-
-test("multiple changes in non-array dependencies only invoke the `invalidate` hook once", function() {
-  var dependentArray = Ember.A([5,6]);
-  var invalidatingDependentArray = Ember.A();
-
-  obj = EmberObject.extend({
-    nonArray1: 0,
-    nonArray2: 0,
-    invalidatingDependentArray: invalidatingDependentArray,
-    dependentArray: dependentArray,
-
-    computed: reduceComputed('dependentArray', 'nonArray1', 'nonArray2', 'invalidatingDependentArray.[]', {
-      initialValue: 123,
-      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        ++addCalls;
-        return accumulatedValue;
-      },
-
-      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        --removeCalls;
-        return accumulatedValue;
-      },
-
-      invalidate: function (accumulatedValue, changeMeta, instanceMeta){
-        deepEqual(
-          changeMeta.changes,
-          { nonArray1: 0, nonArray2: 0 },
-          '`changeMeta.changes` contains the old values of the dependencies that changed'
-        );
-        ++invalidateCalls;
-        return accumulatedValue;
-      }
-    })
-  }).create();
-
-  deepEqual(get(obj, 'computed'), 123);
-  equal(addCalls, 2, "add has been called twice");
-  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-  set(obj, 'nonArray1', 1);
-  set(obj, 'nonArray2', 9);
-  set(obj, 'nonArray2', 10);
-
-  equal(addCalls, 2, "add has not been called again");
-  equal(removeCalls, 0, "remove has not been called");
-  equal(invalidateCalls, 0, "invalidate has not been called yet");
-
-  get(obj, 'computed');
-  equal(invalidateCalls, 1, "invalidate has been called once");
-});
-
-test("multiple additions/deletions in invalidating array dependencies invoke the `invalidate` hook just once", function() {
-  var dependentArray = Ember.A([5,6]);
-  var invalidatingDependentArray = Ember.A();
-
-  obj = EmberObject.extend({
-    invalidatingDependentArray: invalidatingDependentArray,
-    dependentArray: dependentArray,
-
-    computed: reduceComputed('dependentArray', 'invalidatingDependentArray.[]', {
-      initialValue: 123,
-      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        ++addCalls;
-        return accumulatedValue;
-      },
-
-      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
-        --removeCalls;
-        return accumulatedValue;
-      },
-
-      invalidate: function (accumulatedValue, changeMeta, instanceMeta) {
-        ++invalidateCalls;
-        deepEqual(
-          changeMeta.changes,
-          { 'invalidatingDependentArray.[]': {adding: 3, removing: 1} },
-          '`changeMeta.changes` contains the aggregated info of all the additions/deletions made'
-        );
-        return accumulatedValue;
-      }
-    })
-  }).create();
-
-  deepEqual(get(obj, 'computed'), 123);
-  equal(addCalls, 2, 'precond - add has been called during initialization');
-  equal(invalidateCalls, 0, "precond - `invalidate` has not initially been called");
-
-  invalidatingDependentArray.pushObject(3);
-  invalidatingDependentArray.pushObjects([4, 5]);
-  invalidatingDependentArray.removeAt(1);
-
-  equal(addCalls, 2, "add has not been called again");
-  equal(removeCalls, 0, "remove has not been called");
-  equal(invalidateCalls, 0, "`invalidate` has not been called yet");
-
-  get(obj, 'computed');
-  equal(invalidateCalls, 1, "`invalidate` has been called just once");
+  // Get both CPs in the inverse order.
+  equal(get(obj, 'doubleCountBigNumbers'), 2, 'the value of the second CP has changed');
+  equal(get(obj, 'countBigNumbers'), 1, 'the value of the first CP has changed');
+  // This fails and might be a problem because maybe nobody is watching the other property
+  // directly. We need a more complex mechanism.
 });
 
 // test("changes in non-array properties that do not modify the result of an reduceComputed CP do not invalidate other CP watching the first one", function(){


### PR DESCRIPTION
Still a WIP.

See #4724 for motivation.

Right now, when any non-array dependent property of `reduceComputed` CPs (and therefore `arrayComputed` CPs too) changes, the whole CP is reset, and `addedItem` is called once per each element in dependent arrays. 
Depending on the goal, this behavior is pretty inefficient, specially if there is other CPs depending on this one, because they will also receive tons of changes in waterfall.

This PR add a new `invalidate` hook the the options hash of `reduceComputed`/`arrayComputed` properties where you can specify a more custom behavior.

Very simple example: 

``` js
var people = [
  {name: 'Cris', age: 24},
  {name: 'Jane', age: 17},
  {name: 'Paul', age: 18},
  {name: 'Robb', age: 23},
  {name: 'Mark', age: 19},
  {name: 'Anne', age: 21},
  {name: 'Mike', age: 15},
  {name: 'John', age: 16},
  {name: 'Kate', age: 20},
  {name: 'Bert', age: 22},
];

Ember.Object.extend({
  minDrinkingAge: 21,
  numberOfBarClients: Ember.reduceComputed('people', 'minDrinkingAge', {
    initialValue: 0,
    initialize: function(initialValue, changeMeta, instanceMeta){
      instanceMeta.drinkingPeople = [];
      instanceMeta.notDinkingPeople = [];
      instanceMeta.minDrinkingAge = this.get('minDrinkingAge')
    },

    // Keep updated the array of people who can/cannot drink and the accum.
    addedItem: function(accum, person, changeMeta, instanceMeta){
      if (person.get('age') >= instanceMeta.minDrinkingAge) {
        ++accum;
        instanceMeta.drinkingPeople.push(person);
      } else {
        instanceMeta.notDrinkingPeople.push(person);
      }
      return accum;
    },

    // Keep updated the array of people who can/cannot drink and the accum.
    removedItem: function(accum, person, changeMeta, instanceMeta){
      if (person.get('age') < instanceMeta.minDrinkingAge) {
        --accum;
        instanceMeta.notDrinkingPeople.removeObject(person);
      } else {
        instanceMeta.drinkingPeople.removeObject(person);
      }
      return accum;
    },

    // When the minimum drinking age changes, it can become higher or lower. 
    // In both cases, only one half of the elements in the `people` array need
    // to be checked.
    invalidate: function(accum, changeMeta, instanceMeta){
      var newMinDrinkingAge = this.get('minDrinkingAge');

      if (newMinDrinkingAge > instanceMeta.minDrinkingAge) { 
        // The min age to drink is higher now. Some people used to drink but now they can't.
        // I only need to check among the people that was allowed to drink to check who can't now.
        instanceMeta.drinkingPeople = instanceMeta.drinkingPeople.filter(function(person){ 
          if (person.get('age') >= newMinDrinkingAge){
            return true;
          } else {
            instanceMeta.notDrinkingPeople.push(person);
            return false;
          }
        });
      } else {
        // The min age to drink is lower now. Some people was not allowed to drink but now they are.
        // I only need to check among the people that was not allowed to drink to check who now can.
        instanceMeta.notDrinkingPeople = instanceMeta.notDrinkingPeople.filter(function(person){ 
          if (person.get('age') < newMinDrinkingAge){
            return true;
          } else {
            instanceMeta.drinkingPeople.push(person);
            return false;
          }
        });
      }
      accum = instanceMeta.drinkingPeople.length;
      instanceMeta.minDrinkingAge = newMinDrinkingAge;
    }
  });
}).create({people: people});
```

If not `invalidate` hook is provided, all works as it used to: The full CP is reset and recomputed again.

TODOs:
- [x] Initial implementation and tests.
- [x] `invalidate` runs asynchronously within the roundLoop only once.
- [ ] Update documentation
- [ ] Hide behind a feature flag?
