### PR TITLE
[DOC] Add docs for ArrayProxy content observer methods

### DIFF
--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -143,7 +143,28 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     }
   },
 
+  /**
+    Override to implement content array `willChange` observer.
+
+    @method contentArrayWillChange
+
+    @param {Ember.Array} contentArray the content array
+    @param {Number} start starting index of the change
+    @param {Number} removeCount count of items removed
+    @param {Number} addCount count of items added
+
+  */
   contentArrayWillChange: K,
+  /**
+    Override to implement content array `didChange` observer.
+
+    @method contentArrayDidChange
+
+    @param {Ember.Array} contentArray the content array
+    @param {Number} start starting index of the change
+    @param {Number} removeCount count of items removed
+    @param {Number} addCount count of items added
+  */
   contentArrayDidChange: K,
 
   /**


### PR DESCRIPTION
Came across these hooks while reading [this article on live collections](http://joefiorini.com/posts/user-friendly-live-collections-in-emberjs).

Seems like they're only there to be overridden, so lets document this magic!

Let me know if I'm mistaken, or if these are not recommended hooks to use.
