### PR TITLE
Revert "[BUGFIX beta] Total invalidation of arrayComputed by non-array d...

### DIFF
--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -466,10 +466,11 @@ function ReduceComputedProperty(options) {
   this.cacheable();
 
   this.recomputeOnce = function(propertyName) {
-    // TODO: Coalesce recomputation by <this, propertyName, cp>.
-    recompute.call(this, propertyName);
+    // What we really want to do is coalesce by <cp, propertyName>.
+    // We need a form of `scheduleOnce` that accepts an arbitrary token to
+    // coalesce by, in addition to the target and method.
+    run.once(this, recompute, propertyName);
   };
-
   var recompute = function(propertyName) {
     var dependentKeys = cp._dependentKeys,
         meta = cp._instanceMeta(this, propertyName),

--- a/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
@@ -796,39 +796,35 @@ test("non-array dependencies completely invalidate a reduceComputed CP", functio
   var dependentArray = Ember.A();
 
   obj = EmberObject.extend({
-    nonArray: 0,
+    nonArray: 'v0',
     dependentArray: dependentArray,
 
     computed: arrayComputed('dependentArray', 'nonArray', {
-      addedItem: function (array, item) {
+      addedItem: function (array) {
         ++addCalls;
-        if (item % 2 === this.get('nonArray')) {
-          array.pushObject(item);
-        }
         return array;
       },
 
-      removedItem: function (array, item) {
+      removedItem: function (array) {
         --removeCalls;
-        array.removeObject(item);
         return array;
       }
     })
   }).create();
 
-  deepEqual(get(obj, 'computed'), []);
+  get(obj, 'computed');
 
   equal(addCalls, 0, "precond - add has not initially been called");
   equal(removeCalls, 0, "precond - remove has not initially been called");
 
   dependentArray.pushObjects([1, 2]);
-  deepEqual(get(obj, 'computed'), [2]);
 
   equal(addCalls, 2, "add called one-at-a-time for dependent array changes");
   equal(removeCalls, 0, "remove not called");
 
-  set(obj, 'nonArray', 1);
-  deepEqual(get(obj, 'computed'), [1], "array is recomputed synchronously");
+  run(function() {
+    set(obj, 'nonArray', 'v1');
+  });
 
   equal(addCalls, 4, "array completely recomputed when non-array dependency changed");
   equal(removeCalls, 0, "remove not called");


### PR DESCRIPTION
...ependencies should be synchronous"

This reverts commit 7af8beb0bb9e484ab7427b447f6b6dbb76b4aad8 which attempted to
bring the semantics of ReduceComputedProperty closer to those of ComputedProperty
but inadvertently introduced a performance regression in some cases.

ComputedProperty guarantees that any `set` calls that occur before a `get` call
will be run before the `get` call is triggered. For example

``` javascript
var obj = Ember.Object.extend({
  foo: Ember.computed.alias('bar')
}).create();

obj.set('foo', 1);
obj.get('foo'); // returns 1
```

For technical reasons ReduceComputedProperty does not offer the same
guarantees.

``` javascript
var obj = Ember.Object.extend({
  filtered: Ember.computed.filter('things', function(n) {
    return n % 2 === this.get('parity');
  }).property('things', 'parity')
}).create({
  things: [0, 1, 2, 3, 4, 5]
});

o.set('parity', 0);
o.get('filtered'); // returns [0, 2, 4]

o.set('parity', 1);
o.get('filtered'); // returns [0, 2, 4], but we expected [1, 3, 5]

Ember.run.next(function() {
  o.get('filtered'); // returns [1, 3, 5]
});
```

The commit fixed this issue but introduced a performance regression. Every call
to `set` would eagerly force a recomputation of the reduced computed value,
instead of deferring the work until a subsequent `get` call. This was seen
most prominently in Ember.computed.sort with sortProperties that changed
quickly. You can find more details about the regression at:

https://github.com/emberjs/ember.js/issues/4712
https://github.com/emberjs/ember.js/issues/4740

Conflicts:
    packages_es6/ember-runtime/tests/computed/reduce_computed_test.js
