### PR TITLE
[DOC] Add action docs to input and textarea helpers

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -71,6 +71,35 @@ var helpers = EmberHandlebars.helpers;
   <input type="text" value="Stanley" disabled="disabled" size="50"/>
   ```
 
+  ## Actions
+
+  The helper can send multiple actions based on user events.
+
+  The action property defines the action which is send when
+  the user presses the return key.
+
+  ```handlebars
+  {{input action="submit"}}
+  ```
+
+  The helper allows some user events to send actions.
+
+* `enter`
+* `insert-newline`
+* `escape-press`
+* `focus-in`
+* `focus-out`
+* `key-press`
+
+  For example, if you desire an action to be sent when the input is blurred,
+  you only need to setup the action name to the event name property.
+
+  ```handlebars
+  {{input focus-in="alertMessage"}}
+  ```
+
+  See more about [Text Support Actions](api/classes/Ember.TextField.html)
+
   ## Extension
 
   Internally, `{{input type="text"}}` creates an instance of `Ember.TextField`, passing
@@ -307,6 +336,35 @@ export function inputHelper(options) {
     Lots of text that IS bound
   </textarea>
   ```
+
+  ## Actions
+
+  The helper can send multiple actions based on user events.
+
+  The action property defines the action which is send when
+  the user presses the return key.
+
+  ```handlebars
+  {{input action="submit"}}
+  ```
+
+  The helper allows some user events to send actions.
+
+* `enter`
+* `insert-newline`
+* `escape-press`
+* `focus-in`
+* `focus-out`
+* `key-press`
+
+  For example, if you desire an action to be sent when the input is blurred,
+  you only need to setup the action name to the event name property.
+
+  ```handlebars
+  {{textarea focus-in="alertMessage"}}
+  ```
+
+  See more about [Text Support Actions](api/classes/Ember.TextArea.html)
 
   ## Extension
 

--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -94,10 +94,10 @@ var TextSupport = Mixin.create(TargetActionSupport, {
   },
 
   /**
-    The action to be sent when the user inserts a new line.
+    Called when the user inserts a new line.
 
     Called by the `Ember.TextSupport` mixin on keyUp if keycode matches 13.
-    Uses sendAction to send the `enter` action to the controller.
+    Uses sendAction to send the `enter` action.
 
     @method insertNewline
     @param {Event} event
@@ -111,7 +111,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     Called when the user hits escape.
 
     Called by the `Ember.TextSupport` mixin on keyUp if keycode matches 27.
-    Uses sendAction to send the `escape-press` action to the controller.
+    Uses sendAction to send the `escape-press` action.
 
     @method cancel
     @param {Event} event
@@ -123,6 +123,8 @@ var TextSupport = Mixin.create(TargetActionSupport, {
   /**
     Called when the text area is focused.
 
+    Uses sendAction to send the `focus-in` action.
+
     @method focusIn
     @param {Event} event
   */
@@ -131,7 +133,9 @@ var TextSupport = Mixin.create(TargetActionSupport, {
   },
 
   /**
-    Called when the text area is blurred.
+    Called when the text area is blurred. 
+
+    Uses sendAction to send the `focus-out` action.
 
     @method focusOut
     @param {Event} event
@@ -141,10 +145,10 @@ var TextSupport = Mixin.create(TargetActionSupport, {
   },
 
   /**
-    The action to be sent when the user presses a key. Enabled by setting
+    Called when the user presses a key. Enabled by setting
     the `onEvent` property to `keyPress`.
 
-    Uses sendAction to send the `keyPress` action to the controller.
+    Uses sendAction to send the `key-press` action.
 
     @method keyPress
     @param {Event} event

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -9,6 +9,8 @@ import EmberHandlebars from "ember-handlebars";
 import EmberObject from "ember-runtime/system/object";
 import View from "ember-views/views/view";
 import TextField from "ember-handlebars/controls/text_field";
+import EventDispatcher from "ember-views/system/event_dispatcher";
+import jQuery from "ember-views/system/jquery";
 
 var textField;
 var K = Ember.K;
@@ -473,3 +475,137 @@ test("bubbling of handled actions can be enabled via bubbles property", function
   textField.trigger('keyUp', event);
   equal(stopPropagationCount, 1, "propagation was prevented if bubbles is false");
 });
+
+
+var dispatcher, StubController;
+QUnit.module("Ember.TextField - Action events", {
+  setup: function() {
+
+    dispatcher = EventDispatcher.create();
+    dispatcher.setup();
+
+    StubController = EmberObject.extend({
+      send: function(actionName, value, sender) {
+        equal(actionName, 'doSomething', "text field sent correct action name");
+      }
+    });
+ 
+  },
+ 
+  teardown: function() {
+    run(function() {
+      dispatcher.destroy();
+
+      if (textField) {
+        textField.destroy();
+      }
+    });
+  }
+});
+ 
+test("when the text field is blurred, the `focus-out` action is sent to the controller", function() {
+  expect(1);
+
+  textField = TextField.create({
+    'focus-out': 'doSomething',
+    targetObject: StubController.create({})
+  });
+
+  append();
+
+  run(function() { 
+    textField.$().blur();
+  });
+
+});
+
+test("when the text field is focused, the `focus-in` action is sent to the controller", function() {
+  expect(1);
+
+  textField = TextField.create({
+    'focus-in': 'doSomething',
+    targetObject: StubController.create({})
+  });
+
+  append();
+
+  run(function() { 
+    textField.$().focusin();
+  });
+
+
+});
+
+test("when the user presses a key, the `key-press` action is sent to the controller", function() {
+  expect(1);
+
+  textField = TextField.create({
+    'key-press': 'doSomething',
+    targetObject: StubController.create({})
+  });
+
+  append();
+  
+  run(function() { 
+    var event = jQuery.Event("keypress");
+    event.keyCode = event.which = 13;
+    textField.$().trigger(event);
+  });
+
+});
+
+test("when the user inserts a new line, the `insert-newline` action is sent to the controller", function() {
+  expect(1);
+
+  textField = TextField.create({
+    'insert-newline': 'doSomething',
+    targetObject: StubController.create({})
+  });
+
+  append();
+  
+  run(function() { 
+    var event = jQuery.Event("keyup");
+    event.keyCode = event.which = 13;
+    textField.$().trigger(event);
+  });
+
+});
+
+
+test("when the user presses the `enter` key, the `enter` action is sent to the controller", function() {
+  expect(1);
+
+  textField = TextField.create({
+    'enter': 'doSomething',
+    targetObject: StubController.create({})
+  });
+
+  append();
+  
+  run(function() { 
+    var event = jQuery.Event("keyup");
+    event.keyCode = event.which = 13;
+    textField.$().trigger(event);
+  });
+
+});
+
+test("when the user hits escape, the `escape-press` action is sent to the controller", function() {
+  expect(1);
+
+  textField = TextField.create({
+    'escape-press': 'doSomething',
+    targetObject: StubController.create({})
+  });
+
+  append();
+  
+  run(function() { 
+    var event = jQuery.Event("keyup");
+    event.keyCode = event.which = 27;
+    textField.$().trigger(event);
+  });
+
+});
+


### PR DESCRIPTION
I could not find any doc to explain how input helpers can send actions. I am not sure it has been forgotten or it was intentionally done.

I think, there are still some steps to be completed:
- [x] Add documentation to `TextSupport` properties of events (`focus-in`, `focus-out`...) like `action`.
- [x] Add missing tests of the different actionable events.
