### PR TITLE
[DOC] Clarify where a controllers `target` property gets defined

### DIFF
--- a/packages_es6/ember-runtime/lib/controllers/controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/controller.js
@@ -29,8 +29,14 @@ var ControllerMixin = Mixin.create(ActionHandler, {
     For example, when a Handlebars template uses the `{{action}}` helper,
     it will attempt to send the action to the view's controller's `target`.
 
-    By default, a controller's `target` is set to the router after it is
-    instantiated by `Ember.Application#initialize`.
+    By default, the value of the target property is set to the router, and
+    is injected when a controller is instantiated. This injection is defined
+    in Ember.Application#buildContainer, and is applied as part of the
+    applications initialization process. It can also be set after a controller
+    has been instantiated, for instance when using the render helper in a
+    template, or when a controller is used as an `itemController`. In most
+    cases the `target` property will automatically be set to the logical
+    consumer of actions for the controller.
 
     @property target
     @default null


### PR DESCRIPTION
The previous documentation was correct but still required a little
digging to find the actual place where the injection is defined.
