### PR TITLE
[FEATURE ember-routing-will-change-hooks] finer-grain transition hooks

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,3 +52,19 @@ for a detailed explanation.
     underlying test framework to start/stop between async steps.
 
   Added in [#4176](https://github.com/emberjs/ember.js/pull/4176)
+
+* `ember-routing-will-change-hooks`
+  Finer-grained `willTransition`-esque actions:
+
+  - `willLeave`: fires on routes that will no longer be active after
+    the transition
+  - `willChangeModel`: fires on routes that will still be active
+    but will re-resolve their models
+
+  Both of these hooks act like willTransition in the sense that they
+  give you an opportunity to abort the transition before it happens.
+  Common use cases include animating things away or prompting to user
+  to deal with unsaved changes.
+
+  Added in [#4760](https://github.com/emberjs/ember.js/pull/4760)
+

--- a/features.json
+++ b/features.json
@@ -7,7 +7,8 @@
     "ember-routing-drop-deprecated-action-style": null,
     "ember-runtime-test-friendly-promises": true,
     "ember-routing-add-model-option": true,
-    "ember-routing-linkto-target-attribute": null 
+    "ember-routing-linkto-target-attribute": null,
+    "ember-routing-will-change-hooks": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-routing/lib/system/router.js
+++ b/packages_es6/ember-routing/lib/system/router.js
@@ -668,6 +668,14 @@ EmberRouter.reopenClass({
     var router = this.router;
     if (!router) {
       router = new Router();
+
+      if (Ember.FEATURES.isEnabled("ember-routing-will-change-hooks")) {
+        router._willChangeContextEvent = 'willChangeModel';
+      } else {
+        router._triggerWillChangeContext = Ember.K;
+        router._triggerWillLeave = Ember.K;
+      }
+
       router.callbacks = [];
       router.triggerEvent = triggerEvent;
       this.reopenClass({ router: router });


### PR DESCRIPTION
Brought to you by @ef4, and demonstrated at his EmberConf talk:

http://confreaks.com/videos/3302-emberconf2014-animations-and-transitions-in-an-ember-app

See this router.js PR for details:

https://github.com/tildeio/router.js/pull/89

TL;DR adds `willLeave` and `willChangeModel` hooks (not that Ember renames the router.js `willChangeContext` hook to `willChangeModel`)
