### PR TITLE
[BUGFIX beta] reduceComputed detect retain:n better.

### DIFF
--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -214,11 +214,11 @@ DependentArraysObserver.prototype = {
     var length = get(array, 'length');
     // OPTIMIZE: we could stop updating once we hit the object whose observer
     // fired; ie partially apply the transformations
-    trackedArray.apply(function (observerContexts, offset, operation) {
+    trackedArray.apply(function (observerContexts, offset, operation, operationIndex) {
       // we don't even have observer contexts for removed items, even if we did,
       // they no longer have any index in the array
       if (operation === TrackedArray.DELETE) { return; }
-      if (operation === TrackedArray.RETAIN && observerContexts.length === length && offset === 0) {
+      if (operationIndex === 0 && operation === TrackedArray.RETAIN && observerContexts.length === length && offset === 0) {
         // If we update many items we don't want to walk the array each time: we
         // only need to update the indexes at most once per run loop.
         return;
@@ -829,6 +829,6 @@ function reduceComputed(options) {
   }
 
   return cp;
-};
+}
 
-export {reduceComputed, ReduceComputedProperty}
+export {reduceComputed, ReduceComputedProperty};

--- a/packages_es6/ember-runtime/lib/system/tracked_array.js
+++ b/packages_es6/ember-runtime/lib/system/tracked_array.js
@@ -27,7 +27,7 @@ function TrackedArray(items) {
   } else {
     this._operations = [];
   }
-};
+}
 
 TrackedArray.RETAIN = RETAIN;
 TrackedArray.INSERT = INSERT;
@@ -125,8 +125,8 @@ TrackedArray.prototype = {
     var items = [],
         offset = 0;
 
-    forEach(this._operations, function (arrayOperation) {
-      callback(arrayOperation.items, offset, arrayOperation.type);
+    forEach(this._operations, function (arrayOperation, operationIndex) {
+      callback(arrayOperation.items, offset, arrayOperation.type, operationIndex);
 
       if (arrayOperation.type !== DELETE) {
         offset += arrayOperation.count;


### PR DESCRIPTION
Fix #4620.

reduceComputed tries to skip walking all observer contexts when an item
property changes if the current tracked array state is [retain:n].  However,
this check occurs while applying the operations.  If [delete:m retain:(n-m)]
is applied, when the retain operation is visisted it will have been updated to
retain:n.

This commit updates the check so that retain:n is only checked for the _first_ 
operation.
