### PR TITLE
[DOC beta] Add assertion for lowerCamelCase model name

### DIFF
--- a/packages_es6/ember-application/lib/system/resolver.js
+++ b/packages_es6/ember-application/lib/system/resolver.js
@@ -6,7 +6,7 @@
 import Ember from "ember-metal/core"; // Ember.TEMPLATES, Ember.assert
 import {get} from "ember-metal/property_get";
 import Logger from "ember-metal/logger";
-import {classify, capitalize, decamelize} from "ember-runtime/system/string";
+import {camelize, capitalize, classify, decamelize, fmt} from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import EmberHandlebars from "ember-handlebars";
@@ -325,7 +325,9 @@ var DefaultResolver = EmberObject.extend({
     var className = classify(parsedName.name),
         factory = get(parsedName.root, className);
 
-     if (factory) { return factory; }
+    Ember.assert(fmt("Model names should be lowerCamelCase: you passed `%@1`, but you should pass `%@2` instead.", [parsedName.name, camelize(parsedName.name)]), !/^[A-Z]/.test(parsedName.name));
+
+    if (factory) { return factory; }
   },
   /**
     Look up the specified object (from parsedName) on the appropriate

--- a/packages_es6/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -101,6 +101,12 @@ test("the default resolver throws an error if the fullName to resolve is invalid
   raises(function(){ locator.resolve(':type');  }, TypeError, /Invalid fullName/ );
 });
 
+test("the default resolver throws an error when the model name is not in lowerCamelCase", function() {
+  expectAssertion(function() {
+    locator.resolve("model:MyClass");
+  }, "Model names should be lowerCamelCase: you passed `MyClass`, but you should pass `myClass` instead.");
+});
+
 test("the default resolver logs hits if `LOG_RESOLVER` is set", function() {
   expect(3);
 


### PR DESCRIPTION
The naming convention as pointed out [here](http://emberjs.com/guides/models/defining-models/) is to use the `lowerCamelCase` version of the model name, though `store.find('MyModel', 1)` works, since the name is `classify`-ed in the [`Ember.Resolver#resolveModel`](http://git.io/1HDwJQ) method. This is problematic since the passed model name is set as `typeKey` on the factory in the [`Store#modelFor`](http://git.io/eb3iPQ) method, which in turn leads to bugs, like reported in https://github.com/emberjs/data/issues/1890.

This PR adds an assertion message to the `Ember.Resolver#resolveModel` hook, so the misuse of the naming convention is pointed out.
