### PR TITLE
[BUGFIX] Fix view keyword in component block (#3520)

### DIFF
--- a/packages_es6/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/yield_test.js
@@ -247,8 +247,6 @@ test("yield uses the layout context for non component", function() {
 
 test("yield view should be a virtual view", function() {
   var component = Component.extend({
-    isParentComponent: true,
-
     layout: EmberHandlebars.compile('{{yield}}')
   });
 
@@ -258,9 +256,7 @@ test("yield view should be a virtual view", function() {
       component: component,
       includedComponent: Component.extend({
         didInsertElement: function() {
-          var parentView = this.get('parentView');
-
-          ok(parentView.get('isParentComponent'), "parent view is the parent component");
+          strictEqual(this.get('parentView'), view, "parentView is the first non virtual parent view");
         }
       })
     }
@@ -379,4 +375,22 @@ test("yield works inside a conditional in a component that has Ember._Metamorph 
   });
 
   equal(view.$().text(), 'innerouter', "{{yield}} renders yielded content inside metamorph component");
+});
+
+test("view keyword works inside component yield", function () {
+  var component = Component.extend({
+    layout: EmberHandlebars.compile("<p>{{yield}}</p>")
+  });
+
+  view = EmberView.create({
+    dummyText: 'hello',
+    component: component,
+    template: EmberHandlebars.compile('{{#view view.component}}{{view.dummyText}}{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div > p').text(), "hello", "view keyword inside component yield block should refer to the correct view");
 });

--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -138,8 +138,9 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     @type Ember.View
     @default null
   */
-  parentView: computed('_parentView', function() {
-    var parent = this._parentView;
+  parentView: computed('_parentView', '_contextView', function() {
+    // _contextView take the priority over _parentView
+    var parent = get(this, '_contextView') || get(this, '_parentView');
 
     if (parent && parent.isVirtual) {
       return get(parent, 'parentView');
@@ -545,10 +546,10 @@ var EMPTY_ARRAY = [];
   ```html
   <a id="ember1" class="ember-view" href="http://google.com"></a>
   ```
-  
-  One property can be mapped on to another by placing a ":" between 
+
+  One property can be mapped on to another by placing a ":" between
   the source property and the destination property:
-  
+
   ```javascript
   AnchorView = Ember.View.extend({
     tagName: 'a',
@@ -556,13 +557,13 @@ var EMPTY_ARRAY = [];
     url: 'http://google.com'
   });
   ```
-  
+
   Will result in view instances with an HTML representation of:
 
   ```html
   <a id="ember1" class="ember-view" href="http://google.com"></a>
   ```
-  
+
   If the return value of an `attributeBindings` monitored property is a boolean
   the property will follow HTML's pattern of repeating the attribute's name as
   its value:
@@ -2525,9 +2526,9 @@ View.reopenClass({
   */
   _classStringForValue: function(path, val, className, falsyClassName) {
     if(isArray(val)) {
-      val = get(val, 'length') !== 0;  
+      val = get(val, 'length') !== 0;
     }
-    
+
     // When using the colon syntax, evaluate the truthiness or falsiness
     // of the value to determine which className to return
     if (className || falsyClassName) {


### PR DESCRIPTION
Fixes #3520 by setting the `concreteView` of the virtual view created to yield inside a component block
