### PR TITLE
[BUGFIX beta] Use controller keywords to get the current context control...

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/binding.js
+++ b/packages_es6/ember-handlebars/lib/helpers/binding.js
@@ -100,10 +100,11 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
       });
 
       if (options.hash.controller) {
-        bindView.set('_contextController', this.container.lookupFactory('controller:'+options.hash.controller).create({
-          container: currentContext.container,
-          parentController: currentContext,
-          target: currentContext
+        var parentController = data.keywords.controller;
+        bindView.set('_contextController', parentController.container.lookupFactory('controller:'+options.hash.controller).create({
+          container: parentController.container,
+          parentController: parentController,
+          target: parentController
         }));
       }
 

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -299,7 +299,7 @@ test("it should wrap context with object controller", function() {
   run(function() { view.destroy(); }); // destroy existing view
 });
 
-test("it should still have access to original parentController within an {{#each}}", function() {
+test("it should still have access to original parentController within an {{#each var in context}}", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('content.name') + ' and ' + this.get('parentController.name');
@@ -318,6 +318,37 @@ test("it should still have access to original parentController within an {{#each
   view = EmberView.create({
     container: container,
     template: EmberHandlebars.compile('{{#each person in people}}{{#with person controller="person"}}{{controllerName}}{{/with}}{{/each}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  appendView(view);
+
+  equal(view.$().text(), "controller:Steve Holt and Bob Loblawcontroller:Carl Weathers and Bob Loblaw");
+
+  run(function() { view.destroy(); }); // destroy existing view
+});
+
+test("it should still have access to original parentController within an {{#each}}", function() {
+  var Controller = ObjectController.extend({
+    controllerName: computed(function() {
+      return "controller:"+this.get('content.name') + ' and ' + this.get('parentController.name');
+    })
+  });
+
+  var people = A([{ name: "Steve Holt" }, { name: "Carl Weathers" }]);
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    name: 'Bob Loblaw',
+    people: people
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: EmberHandlebars.compile('{{#each people}}{{#with this controller="person"}}{{controllerName}}{{/with}}{{/each}}'),
     controller: parentController
   });
 


### PR DESCRIPTION
...ler

When using the `with` helper with the `controller` option, the controller instance is created via [this.container](https://github.com/emberjs/ember.js/blob/c25a546997edcc24522394bcb3526d915003075b/packages_es6/ember-handlebars/lib/helpers/binding.js#L90), where `this` is expected to be a controller instance.

But the `this` context can be changed, for instance with the `each` helper:

```
{{#each}}
  {{#with this controller="foo"}}
    ...
  {{/with}}
{{/each}}
```

Causing an `Uncaught TypeError: Cannot read property 'lookupFactory' of undefined`.
This is a [jsbin](http://emberjs.jsbin.com/jupoyabo/2/edit) showing the problem

//cc @bcardarella
