### PR TITLE
[BUGFIX beta] Don't assume that the router has a container.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -290,7 +290,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     var location = get(this, 'location');
     var rootURL = get(this, 'rootURL');
 
-    if (rootURL && !this.container.has('-location-setting:root-url')) {
+    if (rootURL && this.container && !this.container.has('-location-setting:root-url')) {
       this.container.register('-location-setting:root-url', rootURL, { instantiate: false });
     }
 

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -31,6 +31,12 @@ QUnit.module("Ember Router", {
   }
 });
 
+test("can create a router without a container", function() {
+  var router = Router.create();
+
+  ok(router.router);
+});
+
 test("should create a router if one does not exist on the constructor", function() {
   createRouter();
 


### PR DESCRIPTION
As part of ember-flows-generator I `eval()` an entire second route file separate from the context of the currently running application. That router does not have an attached container object. As part of the 1.5.1 fixes we have one unprotected property access for `this.container.has()` which this PR fixes.

Tagged release so that it gets into that branch, but it doesn't need to trigger 1.5.2. Let me know if you'd prefer it retagged beta.
