### PR TITLE
[event-dispatcher-toggle-handlers] Dispatcher disable/enable events on execution

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,14 @@ for a detailed explanation.
 
 ## Feature Flags
 
+* `event-dispatcher-toggle-handlers`
+
+  Add `addHandler` and `removeHandler` methods to  `eventDispatcher` 
+  providing a public API to enable or disable specific events during
+  execution.
+
+  Added in [#4783](https://github.com/emberjs/ember.js/pull/4783).
+
 * `ember-routing-named-substates`
 
   Add named substates; e.g. when resolving a `loading` or `error`

--- a/features.json
+++ b/features.json
@@ -8,7 +8,8 @@
     "ember-runtime-test-friendly-promises": true,
     "ember-routing-add-model-option": true,
     "ember-routing-linkto-target-attribute": null,
-    "ember-routing-will-change-hooks": null
+    "ember-routing-will-change-hooks": null,
+    "event-dispatcher-toggle-handlers": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-views/lib/system/event_dispatcher.js
+++ b/packages_es6/ember-views/lib/system/event_dispatcher.js
@@ -123,7 +123,7 @@ var EventDispatcher = EmberObject.extend({
 
     for (event in events) {
       if (events.hasOwnProperty(event)) {
-        this.setupHandler(rootElement, event, events[event]);
+        this._setupHandler(rootElement, event, events[event]);
       }
     }
   },
@@ -140,9 +140,41 @@ var EventDispatcher = EmberObject.extend({
     a `mousedown` event is received from the browser, do the following:
 
     ```javascript
-    setupHandler('mousedown', 'mouseDown');
+    this.addHandler('mousedown', 'mouseDown');
     ```
 
+    @method addHandler
+    @param {String} event the browser-originated event to listen to
+    @param {String} eventName the name of the method to call on the view
+  */
+  addHandler: function(event, eventName) {
+    var rootElement = jQuery(get(this, 'rootElement'));
+    this._setupHandler(rootElement, event, eventName);
+  },
+
+  /**
+    Remove an event listener on the document. The eventDispatcher will 
+    not dispatch those events to their corresponding `Ember.Views`.
+
+    If this event needs to be re-enabled, the `addHandler` method must be called.
+
+    ```javascript
+    this.removeHandler('mousedown');
+    ```
+
+    @method removeHandler
+    @param {String} event the browser-originated event to listen to
+  */
+  removeHandler: function(event) {
+    var rootElement = jQuery(get(this, 'rootElement'));
+    rootElement.off(event + '.ember', '.ember-view');
+    rootElement.off(event + '.ember', '[data-ember-action]');
+  },
+
+  /**
+    Registers an event listener on the document. 
+
+    @deprecated
     @private
     @method setupHandler
     @param {Element} rootElement
@@ -150,6 +182,20 @@ var EventDispatcher = EmberObject.extend({
     @param {String} eventName the name of the method to call on the view
   */
   setupHandler: function(rootElement, event, eventName) {
+    Ember.deprecate('EventDispatcher.setupHandler is deprecated in favor of addHandler', false);
+    this._setupHandler(rootElement, event, eventName);
+  },
+
+  /**
+    Registers an event listener on the document. 
+
+    @private
+    @method _setupHandler
+    @param {Element} rootElement
+    @param {String} event the browser-originated event to listen to
+    @param {String} eventName the name of the method to call on the view
+  */
+  _setupHandler: function(rootElement, event, eventName) {
     var self = this;
 
     rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {

--- a/packages_es6/ember-views/lib/system/event_dispatcher.js
+++ b/packages_es6/ember-views/lib/system/event_dispatcher.js
@@ -133,61 +133,68 @@ var EventDispatcher = EmberObject.extend({
     }
   },
 
-  if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {
 
-    /**
-      Registers an event listener on the document. If the given event is
-      triggered, the provided event handler will be triggered on the target view.
+  /**
+    Registers an event listener on the document. If the given event is
+    triggered, the provided event handler will be triggered on the target view.
 
-      If the target view does not implement the event handler, or if the handler
-      returns `false`, the parent view will be called. The event will continue to
-      bubble to each successive parent view until it reaches the top.
+    If the target view does not implement the event handler, or if the handler
+    returns `false`, the parent view will be called. The event will continue to
+    bubble to each successive parent view until it reaches the top.
 
-      For example, to have the `mouseDown` method called on the target view when
-      a `mousedown` event is received from the browser, do the following:
+    For example, to have the `mouseDown` method called on the target view when
+    a `mousedown` event is received from the browser, do the following:
 
-      ```javascript
-      this.addHandler('mousedown', 'mouseDown');
-      ```
-
-      @method addHandler
-      @param {String} event the browser-originated event (`mousedown`) to listen to
-      @param {String} eventName the name of the method (`mouseDown`) to call on the view
-    */
-    addHandler: function(event, eventName) {
+    ```javascript
+    this.addHandler('mousedown', 'mouseDown');
+    ```
+    @private
+    @method addHandler
+    @param {String} event the browser-originated event (`mousedown`) to listen to
+    @param {String} eventName the name of the method (`mouseDown`) to call on the view
+  */
+  addHandler: function(event, eventName) {
+    if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {
       var rootElement = jQuery(get(this, 'rootElement'));
       this._setupHandler(rootElement, event, eventName);
-    },
+    }
+  },
 
-    /**
-      Remove an event listener on the document. The eventDispatcher will 
-      not dispatch those events to their corresponding `Ember.Views`.
+  /**
+    Remove an event listener on the document. The eventDispatcher will 
+    not dispatch those events to their corresponding `Ember.Views`.
 
-      If this event needs to be re-enabled, the `addHandler` method must be called.
+    If this event needs to be re-enabled, the `addHandler` method must be called.
 
-      ```javascript
-      this.removeHandler('mousedown');
-      ```
+    ```javascript
+    this.removeHandler('mousedown');
+    ```
 
-      @method removeHandler
-      @param {String} event the browser-originated event (`mousedown`) to listen to
-    */
-    removeHandler: function(event) {
+    @private
+    @method removeHandler
+    @param {String} event the browser-originated event (`mousedown`) to listen to
+  */
+  removeHandler: function(event) {
+
+    if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {
       var rootElement = jQuery(get(this, 'rootElement'));
       rootElement.off(event + '.ember', '.ember-view');
       rootElement.off(event + '.ember', '[data-ember-action]');
-    },
+    }
+  },
 
-    /**
-      Registers an event listener on the document.
+  /**
+    Registers an event listener on the document.
 
-      @private
-      @method _setupHandler
-      @param {Element} rootElement
-      @param {String} event the browser-originated event (`mousedown`) to listen to
-      @param {String} eventName the name of the method (`mouseDown`) to call on the view
-    */
-    _setupHandler: function(rootElement, event, eventName) {
+    @private
+    @method _setupHandler
+    @param {Element} rootElement
+    @param {String} event the browser-originated event (`mousedown`) to listen to
+    @param {String} eventName the name of the method (`mouseDown`) to call on the view
+  */
+  _setupHandler: function(rootElement, event, eventName) {
+
+    if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {
       var self = this;
 
       rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {
@@ -221,45 +228,30 @@ var EventDispatcher = EmberObject.extend({
           return action.handler(evt);
         }
       });
-    },
+    }
+  },
 
-  }
+  /**
+    Registers an event listener on the document. If the given event is
+    triggered, the provided event handler will be triggered on the target view.
 
+    If the target view does not implement the event handler, or if the handler
+    returns `false`, the parent view will be called. The event will continue to
+    bubble to each successive parent view until it reaches the top.
 
-  if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {
-    /**
-      Registers an event listener on the document. 
+    For example, to have the `mouseDown` method called on the target view when
+    a `mousedown` event is received from the browser, do the following:
 
-      @deprecated
-      @private
-      @method setupHandler
-      @param {Element} rootElement
-      @param {String} event the browser-originated event to listen to
-      @param {String} eventName the name of the method to call on the view
-    */
-  } else {
-    /**
-      Registers an event listener on the document. If the given event is
-      triggered, the provided event handler will be triggered on the target view.
+    ```javascript
+    setupHandler('mousedown', 'mouseDown');
+    ```
 
-      If the target view does not implement the event handler, or if the handler
-      returns `false`, the parent view will be called. The event will continue to
-      bubble to each successive parent view until it reaches the top.
-
-      For example, to have the `mouseDown` method called on the target view when
-      a `mousedown` event is received from the browser, do the following:
-
-      ```javascript
-      setupHandler('mousedown', 'mouseDown');
-      ```
-
-      @private
-      @method setupHandler
-      @param {Element} rootElement
-      @param {String} event the browser-originated event to listen to
-      @param {String} eventName the name of the method to call on the view
-    */
-  }
+    @private
+    @method setupHandler
+    @param {Element} rootElement
+    @param {String} event the browser-originated event to listen to
+    @param {String} eventName the name of the method to call on the view
+  */
   setupHandler: function(rootElement, event, eventName) {
 
     if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {

--- a/packages_es6/ember-views/lib/system/event_dispatcher.js
+++ b/packages_es6/ember-views/lib/system/event_dispatcher.js
@@ -144,8 +144,8 @@ var EventDispatcher = EmberObject.extend({
     ```
 
     @method addHandler
-    @param {String} event the browser-originated event to listen to
-    @param {String} eventName the name of the method to call on the view
+    @param {String} event the browser-originated event (`mousedown`) to listen to
+    @param {String} eventName the name of the method (`mouseDown`) to call on the view
   */
   addHandler: function(event, eventName) {
     var rootElement = jQuery(get(this, 'rootElement'));
@@ -163,7 +163,7 @@ var EventDispatcher = EmberObject.extend({
     ```
 
     @method removeHandler
-    @param {String} event the browser-originated event to listen to
+    @param {String} event the browser-originated event (`mousedown`) to listen to
   */
   removeHandler: function(event) {
     var rootElement = jQuery(get(this, 'rootElement'));
@@ -178,8 +178,8 @@ var EventDispatcher = EmberObject.extend({
     @private
     @method setupHandler
     @param {Element} rootElement
-    @param {String} event the browser-originated event to listen to
-    @param {String} eventName the name of the method to call on the view
+    @param {String} event the browser-originated event (`mousedown`) to listen to
+    @param {String} eventName the name of the method (`mouseDown`) to call on the view
   */
   setupHandler: function(rootElement, event, eventName) {
     Ember.deprecate('EventDispatcher.setupHandler is deprecated in favor of addHandler', false);
@@ -192,8 +192,8 @@ var EventDispatcher = EmberObject.extend({
     @private
     @method _setupHandler
     @param {Element} rootElement
-    @param {String} event the browser-originated event to listen to
-    @param {String} eventName the name of the method to call on the view
+    @param {String} event the browser-originated event (`mousedown`) to listen to
+    @param {String} eventName the name of the method (`mouseDown`) to call on the view
   */
   _setupHandler: function(rootElement, event, eventName) {
     var self = this;

--- a/packages_es6/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages_es6/ember-views/tests/system/event_dispatcher_test.js
@@ -286,6 +286,43 @@ test("event handlers should be wrapped in a run loop", function() {
   jQuery('#test-view').trigger('mousedown');
 });
 
+test("should be able to enable and disable an event type on execution", function () {
+  expect(6);
+  
+  var counter = 0;
+  view = ContainerView.create({
+    elementId: 'test-view',
+    mouseDown: function() {
+      counter++;
+    }
+  });
+
+  run(function() {
+    view.append();
+  });
+
+  var el$ = jQuery('#test-view');
+  el$.trigger('mousedown');
+  equal(counter, 1, "first event was received");
+  el$.trigger('mousedown');
+  equal(counter, 2, "second event was received");
+
+  dispatcher.removeHandler('mousedown');
+
+  el$.trigger('mousedown');
+  equal(counter, 2, "third event was NOT received because removeHandler was called");
+  el$.trigger('mousedown');
+  equal(counter, 2, "fourth event was NOT received because removeHandler was called");
+
+  dispatcher.addHandler('mousedown', 'mouseDown');
+  el$.trigger('mousedown');
+  equal(counter, 3, "fifth event was received because addHandler was called");
+  el$.trigger('mousedown');
+  equal(counter, 4, "sixth event was received because addHandler was called");
+
+
+});
+
 module("EventDispatcher#setup", {
   setup: function() {
     run(function() {

--- a/packages_es6/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages_es6/ember-views/tests/system/event_dispatcher_test.js
@@ -286,42 +286,46 @@ test("event handlers should be wrapped in a run loop", function() {
   jQuery('#test-view').trigger('mousedown');
 });
 
-test("should be able to enable and disable an event type on execution", function () {
-  expect(6);
-  
-  var counter = 0;
-  view = ContainerView.create({
-    elementId: 'test-view',
-    mouseDown: function() {
-      counter++;
-    }
+if (Ember.FEATURES.isEnabled("event-dispatcher-toggle-handlers")) {
+
+  test("should be able to enable and disable an event type on execution", function () {
+    expect(6);
+    
+    var counter = 0;
+    view = ContainerView.create({
+      elementId: 'test-view',
+      mouseDown: function() {
+        counter++;
+      }
+    });
+
+    run(function() {
+      view.append();
+    });
+
+    var el$ = jQuery('#test-view');
+    el$.trigger('mousedown');
+    equal(counter, 1, "first event was received");
+    el$.trigger('mousedown');
+    equal(counter, 2, "second event was received");
+
+    dispatcher.removeHandler('mousedown');
+
+    el$.trigger('mousedown');
+    equal(counter, 2, "third event was NOT received because removeHandler was called");
+    el$.trigger('mousedown');
+    equal(counter, 2, "fourth event was NOT received because removeHandler was called");
+
+    dispatcher.addHandler('mousedown', 'mouseDown');
+    el$.trigger('mousedown');
+    equal(counter, 3, "fifth event was received because addHandler was called");
+    el$.trigger('mousedown');
+    equal(counter, 4, "sixth event was received because addHandler was called");
+
+
   });
 
-  run(function() {
-    view.append();
-  });
-
-  var el$ = jQuery('#test-view');
-  el$.trigger('mousedown');
-  equal(counter, 1, "first event was received");
-  el$.trigger('mousedown');
-  equal(counter, 2, "second event was received");
-
-  dispatcher.removeHandler('mousedown');
-
-  el$.trigger('mousedown');
-  equal(counter, 2, "third event was NOT received because removeHandler was called");
-  el$.trigger('mousedown');
-  equal(counter, 2, "fourth event was NOT received because removeHandler was called");
-
-  dispatcher.addHandler('mousedown', 'mouseDown');
-  el$.trigger('mousedown');
-  equal(counter, 3, "fifth event was received because addHandler was called");
-  el$.trigger('mousedown');
-  equal(counter, 4, "sixth event was received because addHandler was called");
-
-
-});
+}
 
 module("EventDispatcher#setup", {
   setup: function() {


### PR DESCRIPTION
Sometimes, I would like to enable/disable specific events for a moment.

This PR adds two public methods to the EventDispatcher `addHandler` and `removeHandler` to be used during execution.

One of the case is to disable user events during a promise resolution, I also [open the discussion](http://discuss.emberjs.com/t/blocking-actions-and-user-events-until-promise-resolution/4936) which would like to be considered.
