### PR TITLE
[FEATURE ember-runtime-sortable-sort-order] Sort order per proeprty in Sortable mixin

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -266,3 +266,13 @@ for a detailed explanation.
   ```
 
   Addd in [#10461](https://github.com/emberjs/ember.js/pull/10461)
+
+* `ember-runtime-sortable-sort-order`
+
+  Add the ability to define the sort order of `Sortable` on a
+  per-property base. The `Sortable` will look at `sortProperties`
+  as before, but there one can append `:desc` to sort that
+  property in DESC order. This is independent of `sortAscending`
+  which is still inverting the whole sort order.
+
+  Added in [#4785](https://github.com/emberjs/ember.js/pull/4785).

--- a/features.json
+++ b/features.json
@@ -18,7 +18,8 @@
     "ember-application-visit": null,
     "ember-views-component-block-info": null,
     "ember-routing-core-outlet": null,
-    "ember-libraries-isregistered": null
+    "ember-libraries-isregistered": null,
+    "ember-runtime-sortable-sort-order": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -6,7 +6,7 @@
 import Ember from "ember-metal/core"; // Ember.assert, Ember.A
 
 import { get } from "ember-metal/property_get";
-import { forEach } from "ember-metal/enumerable_utils";
+import EnumerableUtils from "ember-metal/enumerable_utils";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";
 import compare from "ember-runtime/compare";
 import {
@@ -20,6 +20,25 @@ import {
   beforeObserver,
   observer
 } from "ember-metal/mixin"; //ES6TODO: should we access these directly from their package or from how their exposed in ember-metal?
+
+var forEach = EnumerableUtils.forEach;
+
+// used to parse a property and extract its modifier
+// if the feature isn't enabled or no modifier defined
+// it'll just return a `null` modifier
+var parseSortProperty = function(name) {
+  var idx, meta;
+  meta = { modifier: null, name: name };
+  if (Ember.FEATURES.isEnabled("ember-runtime-sortable-sort-order")) {
+    // using indexOf for faster processing
+    if ((idx = name.indexOf(':')) !== -1) {
+      meta.name = name.substr(0, idx);
+      meta.modifier = name.substr(idx + 1);
+    }
+  }
+  return meta;
+};
+
 
 /**
   `Ember.SortableMixin` provides a standard interface for array proxies
@@ -81,6 +100,27 @@ export default Mixin.create(MutableEnumerable, {
     When specifying multiple properties the sorting will use properties
     from the `sortProperties` array prioritized from first to last.
 
+    Enabling the feature flag `ember-runtime-sortable-sort-order` you can
+    then append `:desc` to a property name. The sort order for that
+    specific property will be then inverted. That allows you to do some
+    ordering like this:
+
+    ```javascript
+    services = [
+      {name: 'Premium', price: 10},
+      {name: 'Premium Plus', price: 12},
+      {name: 'Standard Plus', price: 10},
+    ];
+
+    servicesController = Ember.ArrayController.create({
+      content: services,
+      sortProperties: ['price:desc', 'name'],
+      sortAscending: true
+    });
+    ```
+    to order by price from the highest to lowest with same price still
+    showing ordered names from A to Z for example.
+
     @property {Array} sortProperties
   */
   sortProperties: null,
@@ -120,15 +160,19 @@ export default Mixin.create(MutableEnumerable, {
 
   orderBy: function(item1, item2) {
     var result = 0;
-    var sortProperties = get(this, 'sortProperties');
+    var sortProperties = get(this, 'sortPropertiesParsed');
     var sortAscending = get(this, 'sortAscending');
     var sortFunction = get(this, 'sortFunction');
 
     Ember.assert("you need to define `sortProperties`", !!sortProperties);
 
-    forEach(sortProperties, function(propertyName) {
+    forEach(sortProperties, function(property) {
       if (result === 0) {
-        result = sortFunction.call(this, get(item1, propertyName), get(item2, propertyName));
+        if (property.modifier === 'desc') {
+          result = sortFunction.call(this, get(item2, property.name), get(item1, property.name));
+        } else {
+          result = sortFunction.call(this, get(item1, property.name), get(item2, property.name));
+        }
         if ((result !== 0) && !sortAscending) {
           result = (-1) * result;
         }
@@ -140,12 +184,12 @@ export default Mixin.create(MutableEnumerable, {
 
   destroy: function() {
     var content = get(this, 'content');
-    var sortProperties = get(this, 'sortProperties');
+    var sortProperties = get(this, 'sortPropertiesParsed');
 
     if (content && sortProperties) {
       forEach(content, function(item) {
         forEach(sortProperties, function(sortProperty) {
-          removeObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+          removeObserver(item, sortProperty.name, this, 'contentItemSortPropertyDidChange');
         }, this);
       }, this);
     }
@@ -164,7 +208,7 @@ export default Mixin.create(MutableEnumerable, {
   arrangedContent: computed('content', 'sortProperties.@each', function(key, value) {
     var content = get(this, 'content');
     var isSorted = get(this, 'isSorted');
-    var sortProperties = get(this, 'sortProperties');
+    var sortProperties = get(this, 'sortPropertiesParsed');
     var self = this;
 
     if (content && isSorted) {
@@ -174,7 +218,7 @@ export default Mixin.create(MutableEnumerable, {
       });
       forEach(content, function(item) {
         forEach(sortProperties, function(sortProperty) {
-          addObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+          addObserver(item, sortProperty.name, this, 'contentItemSortPropertyDidChange');
         }, this);
       }, this);
       return Ember.A(content);
@@ -183,14 +227,41 @@ export default Mixin.create(MutableEnumerable, {
     return content;
   }),
 
+  /**
+   * Used to have an array of parsed sort properties. If the feature
+   * `ember-runtime-sortable-sort-order` isn't activated all the
+   * modifiers will be null and the name will contain the modifier.
+   *
+   * The value is as follow:
+   * ```javascript
+   * myController.set('sortProperties', ['label', 'price:desc']);
+   * myController.get('sortPropertiesParsed');
+   * // will return [{name: 'label', modifier: null}, {name: 'price', modifier: 'desc'}]
+   * ```
+   *
+   * @property sortPropertiesParsed
+   * @type {Array}
+   */
+  sortPropertiesParsed: computed('sortProperties.@each', function(key, value) {
+    var parsed = [];
+    var sortProperties = get(this, 'sortProperties');
+    if (!sortProperties) {
+      return sortProperties;
+    }
+    forEach(sortProperties, function(sortProperty) {
+      parsed.push(parseSortProperty(sortProperty));
+    });
+    return parsed;
+  }),
+
   _contentWillChange: beforeObserver('content', function() {
     var content = get(this, 'content');
-    var sortProperties = get(this, 'sortProperties');
+    var sortProperties = get(this, 'sortPropertiesParsed');
 
     if (content && sortProperties) {
       forEach(content, function(item) {
         forEach(sortProperties, function(sortProperty) {
-          removeObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+          removeObserver(item, sortProperty.name, this, 'contentItemSortPropertyDidChange');
         }, this);
       }, this);
     }
@@ -223,13 +294,13 @@ export default Mixin.create(MutableEnumerable, {
     if (isSorted) {
       var arrangedContent = get(this, 'arrangedContent');
       var removedObjects = array.slice(idx, idx+removedCount);
-      var sortProperties = get(this, 'sortProperties');
+      var sortProperties = get(this, 'sortPropertiesParsed');
 
       forEach(removedObjects, function(item) {
         arrangedContent.removeObject(item);
 
         forEach(sortProperties, function(sortProperty) {
-          removeObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+          removeObserver(item, sortProperty.name, this, 'contentItemSortPropertyDidChange');
         }, this);
       }, this);
     }
@@ -239,7 +310,7 @@ export default Mixin.create(MutableEnumerable, {
 
   contentArrayDidChange: function(array, idx, removedCount, addedCount) {
     var isSorted = get(this, 'isSorted');
-    var sortProperties = get(this, 'sortProperties');
+    var sortProperties = get(this, 'sortPropertiesParsed');
 
     if (isSorted) {
       var addedObjects = array.slice(idx, idx+addedCount);
@@ -248,7 +319,7 @@ export default Mixin.create(MutableEnumerable, {
         this.insertItemSorted(item);
 
         forEach(sortProperties, function(sortProperty) {
-          addObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+          addObserver(item, sortProperty.name, this, 'contentItemSortPropertyDidChange');
         }, this);
       }, this);
     }


### PR DESCRIPTION
This is a non breaking change that would allow one to specify a different sort order per property in `sortProperties` array.

Let's say you have an array of users each of who has a weight. Weight can be the same for 2 users so then one would want the order to use the names, and logically the user with the most weight should be on the top of the list. With this feature it's possible now by adding a `:desc` at the end of the property which needs to be inverted before being included in the sort order:

``` javascript
sortProperties: ['weight:desc', 'name'],
```

Basically the `Sortable` mixin has the same behaviour as before (related to `sortProperties` and `sortAscending`) except that now you can append one or more property name(s) in `sortProperties` array with a `:desc` so that for that property(ies) the order function will work the other way around.
