### PR TITLE
Fix typo: sectionAction -> sendAction

### DIFF
--- a/packages_es6/ember-handlebars/lib/controls/text_support.js
+++ b/packages_es6/ember-handlebars/lib/controls/text_support.js
@@ -161,7 +161,7 @@ TextSupport.KEY_EVENTS = {
 };
 
 // In principle, this shouldn't be necessary, but the legacy
-// sectionAction semantics for TextField are different from
+// sendAction semantics for TextField are different from
 // the component semantics so this method normalizes them.
 function sendAction(eventName, view, event) {
   var action = get(view, eventName),


### PR DESCRIPTION
I think this should be called `sendAction` and not `sectionAction`. There is no other mention of `sectionAction` at all within Ember and within the context `sendAction` makes more sense.
