### PR TITLE
Clarify test-run instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,10 @@ We love pull requests. Here's a quick guide:
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && rake test[all]`. (To see tests
-in the browser, run `rackup` and open `http://localhost:9292/`.)
+to know that you have a clean slate: `bundle && npm install && rake test[all]`.
+(To see tests in the browser, run `rackup` and open `http://localhost:9292/`.)
+If you're using ZSH, you'll have to escape the test command (i.e.
+`rake test\[all\]`).
 
 3. Add a test for your change. Only refactoring and documentation changes
 require no new tests. If you are adding functionality or fixing a bug, we need


### PR DESCRIPTION
`es6-module-transpiler` is needed to run the tests, so an `npm install` is needed. Furthermore, users using zsh will have issues with the brackets inside the test command and will need to escape the test command lest they receive the `zsh: no matches found: test[all]` error.
