### PR TITLE
Add documentation for tagName: '' option on view.

### DIFF
--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -728,6 +728,9 @@ var EMPTY_ARRAY = [];
   A context can also be explicitly supplied through the view's `context`
   property. If the view has neither `context` nor `controller` properties, the
   `parentView`'s context will be used.
+  
+  If you do not want your view to automatically insert a 'div' into the dom, you can specify 
+  specify  `tagName: ''` on your view. Doing so will prevent the view from automatically wrapping its generated  html in the default `div`. 
 
   ## Layouts
 


### PR DESCRIPTION
I found that specifying tagName: '' on a view will not wrap the generated html in a 'div'. Since I've had to do this a couple of times and there was no documentation about this, thought I'd add it.
