### PR TITLE
[BUGFIX beta] Child containers shouldn't clobber resolver delegation

### DIFF
--- a/packages_es6/container/lib/container.js
+++ b/packages_es6/container/lib/container.js
@@ -1,5 +1,19 @@
 import InheritingDict from 'container/inheriting_dict';
 
+function identityResolver() {}
+
+identityResolver.describe = function(fullName) {
+  return fullName;
+};
+
+identityResolver.normalize = function (fullName) {
+  return fullName;
+};
+
+identityResolver.makeToString = function(factory, fullName) {
+  return factory.toString();
+};
+
 // A lightweight container that helps to assemble and decouple components.
 // Public api for the container is still in flux.
 // The public api, specified on the application namespace should be considered the stable api.
@@ -7,7 +21,7 @@ function Container(parent) {
   this.parent = parent;
   this.children = [];
 
-  this.resolver = parent && parent.resolver || function() {};
+  this.resolver = parent && parent.resolver || identityResolver;
 
   this.registry = new InheritingDict(parent && parent.registry);
   this.cache = new InheritingDict(parent && parent.cache);
@@ -237,11 +251,7 @@ Container.prototype = {
     @return {string} described fullName
   */
   describe: function(fullName) {
-    var resolver = this.resolver;
-    if (resolver && resolver.describe) {
-      return resolver.describe(fullName);
-    }
-    return fullName;
+    return this.resolver.describe(fullName);
   },
 
   /**
@@ -252,11 +262,7 @@ Container.prototype = {
     @return {string} normalized fullName
   */
   normalize: function(fullName) {
-    var resolver = this.resolver;
-    if (resolver && resolver.normalize) {
-      return resolver.normalize(fullName);
-    }
-    return fullName;
+    return this.resolver.normalize(fullName);
   },
 
   /**
@@ -267,11 +273,7 @@ Container.prototype = {
     @return {function} toString function
   */
   makeToString: function(factory, fullName) {
-    var resolver = this.resolver;
-    if (resolver && resolver.makeToString) {
-      return resolver.makeToString(factory, fullName);
-    }
-    return factory.toString();
+    return this.resolver.makeToString(factory, fullName);
   },
 
   /**

--- a/packages_es6/container/lib/container.js
+++ b/packages_es6/container/lib/container.js
@@ -237,6 +237,10 @@ Container.prototype = {
     @return {string} described fullName
   */
   describe: function(fullName) {
+    var resolver = this.resolver;
+    if (resolver && resolver.describe) {
+      return resolver.describe(fullName);
+    }
     return fullName;
   },
 
@@ -248,6 +252,10 @@ Container.prototype = {
     @return {string} normalized fullName
   */
   normalize: function(fullName) {
+    var resolver = this.resolver;
+    if (resolver && resolver.normalize) {
+      return resolver.normalize(fullName);
+    }
     return fullName;
   },
 
@@ -259,6 +267,10 @@ Container.prototype = {
     @return {function} toString function
   */
   makeToString: function(factory, fullName) {
+    var resolver = this.resolver;
+    if (resolver && resolver.makeToString) {
+      return resolver.makeToString(factory, fullName);
+    }
     return factory.toString();
   },
 

--- a/packages_es6/container/tests/container_helper.js
+++ b/packages_es6/container/tests/container_helper.js
@@ -77,4 +77,20 @@ var factory = function() {
   }
 };
 
-export {factory, o_create, setProperties};
+function makeResolver(resolverFn) {
+  resolverFn.describe = function(fullName) {
+    return fullName;
+  };
+
+  resolverFn.normalize = function (fullName) {
+    return fullName;
+  };
+
+  resolverFn.makeToString = function(factory, fullName) {
+    return factory.toString();
+  };
+
+  return resolverFn;
+}
+
+export {factory, o_create, setProperties, makeResolver };

--- a/packages_es6/container/tests/container_test.js
+++ b/packages_es6/container/tests/container_test.js
@@ -1,5 +1,6 @@
 import { factory,
          o_create,
+         makeResolver,
          setProperties} from 'container/tests/container_helper';
 
 import Container from 'container';
@@ -337,11 +338,11 @@ test("The container can take a hook to resolve factories lazily", function() {
   var container = new Container();
   var PostController = factory();
 
-  container.resolver = function(fullName) {
+  container.resolver = makeResolver(function(fullName) {
     if (fullName === 'controller:post') {
       return PostController;
     }
-  };
+  });
 
   var postController = container.lookup('controller:post');
 
@@ -352,11 +353,11 @@ test("The container respect the resolver hook for `has`", function() {
   var container = new Container();
   var PostController = factory();
 
-  container.resolver = function(fullName) {
+  container.resolver = makeResolver(function(fullName) {
     if (fullName === 'controller:post') {
       return PostController;
     }
-  };
+  });
 
   ok(container.has('controller:post'), "the `has` method uses the resolver hook");
 });
@@ -470,11 +471,11 @@ test("The container can get options that should be applied to all factories for 
   var container = new Container();
   var PostView = factory();
 
-  container.resolver = function(fullName) {
+  container.resolver = makeResolver(function(fullName) {
     if (fullName === 'view:post') {
       return PostView;
     }
-  };
+  });
 
   container.optionsForType('view', { singleton: false });
 
@@ -545,15 +546,15 @@ test('once resolved, always return the same result', function(){
 
   var container = new Container();
 
-  container.resolver = function() {
+  container.resolver = makeResolver(function() {
     return 'bar';
-  };
+  });
 
   var Bar = container.resolve('models:bar');
 
-  container.resolver = function() {
+  container.resolver = makeResolver(function() {
     return 'not bar';
-  };
+  });
 
   equal(container.resolve('models:bar'), Bar);
 });

--- a/packages_es6/container/tests/sub_container_test.js
+++ b/packages_es6/container/tests/sub_container_test.js
@@ -69,6 +69,21 @@ test("Resolver is inherited from parent container", function() {
   equal(container.resolve('controller:post'), otherController, 'should use resolver');
 });
 
+test("Resolver-delegating methods should be inherited", function() {
+  function resolver() { return {}; }
+  function K() { return "val"; }
+  resolver.normalize = K;
+  resolver.describe = K;
+  resolver.makeToString = K;
+
+  container.resolver = resolver;
+  var subContainer = container.child();
+
+  equal(subContainer.normalize(),    "val");
+  equal(subContainer.describe(),     "val");
+  equal(subContainer.makeToString(), "val");
+});
+
 test("Type injections should be inherited", function() {
   var container = new Container();
   var PostController = factory();
@@ -86,3 +101,5 @@ test("Type injections should be inherited", function() {
 
   equal(postController.store, store);
 });
+
+

--- a/packages_es6/container/tests/sub_container_test.js
+++ b/packages_es6/container/tests/sub_container_test.js
@@ -1,5 +1,6 @@
 import { factory,
          o_create,
+         makeResolver,
          setProperties} from 'container/tests/container_helper';
 
 import Container from 'container';
@@ -60,9 +61,9 @@ test("Destroying a parent container destroys the sub-containers", function() {
 
 test("Resolver is inherited from parent container", function() {
   var otherController = factory();
-  container.resolver = function(fullName) {
+  container.resolver = makeResolver(function(fullName) {
     return otherController;
-  };
+  });
   var subContainer = container.child();
 
   equal(subContainer.resolve('controller:post'), otherController, 'should use parent resolver');

--- a/packages_es6/ember-application/lib/system/application.js
+++ b/packages_es6/ember-application/lib/system/application.js
@@ -830,9 +830,6 @@ Application.reopenClass({
 
     container.set = set;
     container.resolver  = resolverFor(namespace);
-    container.normalize = container.resolver.normalize;
-    container.describe  = container.resolver.describe;
-    container.makeToString = container.resolver.makeToString;
 
     container.optionsForType('component', { singleton: false });
     container.optionsForType('view', { singleton: false });


### PR DESCRIPTION
Even though core Ember doesn't use the child container API, some libs like EPF
do, and there's currently a bug where child containers lose the following 
methods that are overridden in buildContainer to delegate to the resolver:

```
normalize
```

   describe
   makeToString

This PR moves the delegation into the Container  class rather than in
awkwardly overriding buildContainer fn.
