### PR TITLE
[DOC Beta] New behaviour with itemController

### DIFF
--- a/packages_es6/ember-runtime/lib/controllers/array_controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/array_controller.js
@@ -57,7 +57,7 @@ var forEach = EnumerableUtils.forEach,
 
   ```handlebars
     {{#each post in controller}}
-      <li>{{title}} ({{titleLength}} characters)</li>
+      <li>{{post.title}} ({{post.titleLength}} characters)</li>
     {{/each}}
   ```
 


### PR DESCRIPTION
This [BUGFIX beta - Ensure context is unchanged when using keywords with itemController](https://github.com/emberjs/ember.js/pull/4636) changed the way `itemController` behaves inside `#each` helper. I had problems making it work out because documentation doesn't clear this out and I had to debug it.

These two JsBins describe what changed from the developer using `#each` helper with `itemController`.
- [JsBin with Ember (1.5.1)](http://jsbin.com/ucanam/4838/edit) -> we can call itemController's property without prepending `person`
- [JsBin with Ember (1.6.0-beta.3)](http://jsbin.com/ucanam/4837/edit) -> if we don't prepend `person` for itemController's property we won't get result
