### PR TITLE
Convert thrown strings into Ember.Errors

### DIFF
--- a/packages_es6/ember-views/lib/views/states/default.js
+++ b/packages_es6/ember-views/lib/views/states/default.js
@@ -2,6 +2,7 @@ import Ember from "ember-metal/core"; // Ember.K
 import {get} from "ember-metal/property_get";
 import {set} from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
+import EmberError from "ember-metal/error";
 
 /**
 @module ember
@@ -10,7 +11,7 @@ import run from "ember-metal/run_loop";
 var _default = {
   // appendChild is only legal while rendering the buffer.
   appendChild: function() {
-    throw "You can't use appendChild outside of the rendering process";
+    throw new EmberError("You can't use appendChild outside of the rendering process");
   },
 
   $: function() {

--- a/packages_es6/ember-views/lib/views/states/destroying.js
+++ b/packages_es6/ember-views/lib/views/states/destroying.js
@@ -2,6 +2,7 @@ import merge from "ember-metal/merge";
 import {create} from "ember-metal/platform";
 import {fmt} from "ember-runtime/system/string";
 import _default from "ember-views/views/states/default";
+import EmberError from "ember-metal/error";
 /**
 @module ember
 @submodule ember-views
@@ -13,20 +14,20 @@ var destroying = create(_default);
 
 merge(destroying, {
   appendChild: function() {
-    throw fmt(destroyingError, ['appendChild']);
+    throw new EmberError(fmt(destroyingError, ['appendChild']));
   },
   rerender: function() {
-    throw fmt(destroyingError, ['rerender']);
+    throw new EmberError(fmt(destroyingError, ['rerender']));
   },
   destroyElement: function() {
-    throw fmt(destroyingError, ['destroyElement']);
+    throw new EmberError(fmt(destroyingError, ['destroyElement']));
   },
   empty: function() {
-    throw fmt(destroyingError, ['empty']);
+    throw new EmberError(fmt(destroyingError, ['empty']));
   },
 
   setElement: function() {
-    throw fmt(destroyingError, ["set('element', ...)"]);
+    throw new EmberError(fmt(destroyingError, ["set('element', ...)"]));
   },
 
   renderToBufferIfNeeded: function() {

--- a/packages_es6/ember-views/lib/views/states/has_element.js
+++ b/packages_es6/ember-views/lib/views/states/has_element.js
@@ -3,6 +3,7 @@ import run from "ember-metal/run_loop";
 import merge from "ember-metal/merge";
 import {create} from "ember-metal/platform";
 import jQuery from "ember-views/system/jquery";
+import EmberError from "ember-metal/error";
 
 /**
 @module ember
@@ -31,7 +32,7 @@ merge(hasElement, {
     if (value === null) {
       view.transitionTo('preRender');
     } else {
-      throw "You cannot set an element to a non-null value when the element is already in the DOM.";
+      throw new EmberError("You cannot set an element to a non-null value when the element is already in the DOM.");
     }
 
     return value;

--- a/packages_es6/ember-views/lib/views/states/in_buffer.js
+++ b/packages_es6/ember-views/lib/views/states/in_buffer.js
@@ -70,7 +70,7 @@ merge(inBuffer, {
   // It should be impossible for a rendered view to be scheduled for
   // insertion.
   insertElement: function() {
-    throw "You can't insert an element that has already been rendered";
+    throw new EmberError("You can't insert an element that has already been rendered");
   },
 
   setElement: function(view, value) {

--- a/packages_es6/ember-views/lib/views/states/in_dom.js
+++ b/packages_es6/ember-views/lib/views/states/in_dom.js
@@ -36,7 +36,7 @@ merge(inDOM, {
   },
 
   insertElement: function(view, fn) {
-    throw "You can't insert an element into the DOM that has already been inserted";
+    throw new EmberError("You can't insert an element into the DOM that has already been inserted");
   }
 });
 


### PR DESCRIPTION
Just converting all the errors that were being thrown as strings as Ember.Errors instead.
