### PR TITLE
[BUGFIX beta] Fix various issues related to ES6 import correctness.

### DIFF
--- a/packages_es6/ember-application/lib/ext/controller.js
+++ b/packages_es6/ember-application/lib/ext/controller.js
@@ -12,7 +12,6 @@ import {computed} from "ember-metal/computed";
 import {ControllerMixin} from "ember-runtime/controllers/controller";
 import {meta} from "ember-metal/utils";
 import {controllerFor} from "ember-routing/system/controller_for";
-import {meta} from "ember-metal/utils";
 
 function verifyNeedsDependencies(controller, container, needs) {
   var dependency, i, l, missing = [];

--- a/packages_es6/ember-handlebars/lib/main.js
+++ b/packages_es6/ember-handlebars/lib/main.js
@@ -33,7 +33,6 @@ import {Select, SelectOption, SelectOptgroup} from "ember-handlebars/controls/se
 import TextArea from "ember-handlebars/controls/text_area";
 import TextField from "ember-handlebars/controls/text_field";
 import TextSupport from "ember-handlebars/controls/text_support";
-import TextSupport from "ember-handlebars/controls/text_support";
 import {inputHelper, textareaHelper} from "ember-handlebars/controls"
 
 

--- a/packages_es6/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages_es6/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -131,7 +131,7 @@ SimpleHandlebarsView.prototype = {
   }
 };
 
-var states = cloneStates(viewStates);
+states = cloneStates(viewStates);
 
 merge(states._default, {
   rerenderIfNeeded: K

--- a/packages_es6/ember-metal/lib/enumerable_utils.js
+++ b/packages_es6/ember-metal/lib/enumerable_utils.js
@@ -1,12 +1,7 @@
-var map, forEach, indexOf, splice, filter;
+var splice;
 
 import {map, forEach, indexOf, filter} from "ember-metal/array";
 
-// ES6TODO: doesn't array polyfills already do this?
-map     = Array.prototype.map     || map;
-forEach = Array.prototype.forEach || forEach;
-indexOf = Array.prototype.indexOf || indexOf;
-filter  = Array.prototype.filter   || filter;
 splice  = Array.prototype.splice;
 
 /**

--- a/packages_es6/ember-metal/lib/mixin.js
+++ b/packages_es6/ember-metal/lib/mixin.js
@@ -21,7 +21,6 @@ var REQUIRED, Alias,
     a_forEach = forEach,
     a_slice = [].slice,
     o_create = create,
-    defineProperty = defineProperty,
     metaFor = meta;
 
 function superFunction(){

--- a/packages_es6/ember-routing/lib/helpers/action.js
+++ b/packages_es6/ember-routing/lib/helpers/action.js
@@ -4,7 +4,6 @@ import {forEach} from "ember-metal/array";
 import run from "ember-metal/run_loop";
 
 import {isSimpleClick} from "ember-views/system/utils";
-import EmberHandlebars from "ember-handlebars";
 import EmberRouter from "ember-routing/system/router";
 
 


### PR DESCRIPTION
- Remove duplicate imports.
- Ensure that modules do not declare variables with names matching local imports.

These things are currently allowed by the es6-module-transpiler but not by the ES6 spec.
