### PR TITLE
[BUGFIX] Fix GroupedEach with `#each foo in bar` syntax

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/each.js
+++ b/packages_es6/ember-handlebars/lib/helpers/each.js
@@ -218,12 +218,15 @@ GroupedEach.prototype = {
 
     var content = this.content,
         contentLength = get(content, 'length'),
-        data = this.options.data,
+        options = this.options,
+        data = options.data,
         template = this.template;
 
     data.insideEach = true;
     for (var i = 0; i < contentLength; i++) {
-      template(content.objectAt(i), { data: data });
+      var context = content.objectAt(i);
+      options.data.keywords[options.hash.keyword] = context;
+      template(context, { data: data });
     }
   },
 

--- a/packages_es6/ember-handlebars/tests/helpers/group_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/group_test.js
@@ -184,6 +184,33 @@ test("#each can be used with an ArrayProxy", function() {
   equal(view.$().text(), '123', "The content was rendered");
 });
 
+test("should allow `#each item in array` format", function() {
+  var yehuda = {name: 'Yehuda'};
+  createGroupedView(
+    '{{#each person in people}}{{person.name}}{{/each}}',
+    {people: A([yehuda, {name: 'Tom'}])}
+  );
+  appendView();
+  equal(view.$('script').length, 0, "No Metamorph markers are output");
+  equal(view.$().text(), 'YehudaTom', "The content was rendered");
+
+  run(function() {
+    set(yehuda, 'name', 'Erik');
+  });
+  equal(view.$().text(), 'ErikTom', "The updated object value was rendered");
+
+  run(function() {
+    view.get('context.people').pushObject({name: 'Alex'});
+    view.get('context.people').removeObject(yehuda);
+  });
+  equal(view.$().text(), 'TomAlex', "The updated array content was rendered");
+
+  run(function() {
+    view.set('context.people', A([{name: 'Sarah'},{name: 'Gavin'}]));
+  });
+  equal(view.$().text(), 'SarahGavin', "The replaced array content was rendered");
+});
+
 test("an #each can be nested with a view inside", function() {
   var yehuda = {name: 'Yehuda'};
   createGroupedView(


### PR DESCRIPTION
When using the group-helper with `{{#each item in array}}` no content is rendered, but using `{{#each array}}` works fine.

This fixes that.
