### PR TITLE
[FEATURE query-params-new] Don't overuse QP replace config

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -909,4 +909,51 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
     bootApplication();
   });
+
+  test("opting into replace does not affect transitions between routes", function() {
+    expect(5);
+    Ember.TEMPLATES.application = Ember.Handlebars.compile(
+      "{{link-to 'Foo' 'foo' id='foo-link'}}" +
+      "{{link-to 'Bar' 'bar' id='bar-no-qp-link'}}" +
+      "{{link-to 'Bar' 'bar' (query-params raytiley='isanerd') id='bar-link'}}" +
+      "{{outlet}}"
+    );
+    App.Router.map(function() {
+      this.route('foo');
+      this.route('bar');
+    });
+
+    App.BarController = Ember.Controller.extend({
+      queryParams: ['raytiley'],
+      raytiley: 'isadork'
+    });
+
+    App.BarRoute = Ember.Route.extend({
+      queryParams: {
+        raytiley: {
+          replace: true
+        }
+      }
+    });
+
+    bootApplication();
+    var controller = container.lookup('controller:bar');
+
+    expectedPushURL = '/foo';
+    Ember.run(Ember.$('#foo-link'), 'click');
+
+    expectedPushURL = '/bar';
+    Ember.run(Ember.$('#bar-no-qp-link'), 'click');
+
+    expectedReplaceURL = '/bar?raytiley=boo';
+    Ember.run(controller, 'set', 'raytiley', 'boo');
+
+    expectedPushURL = '/foo';
+    Ember.run(Ember.$('#foo-link'), 'click');
+
+    expectedPushURL = '/bar?raytiley=isanerd';
+    Ember.run(Ember.$('#bar-link'), 'click');
+
+  });
+
 }

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -427,7 +427,9 @@ var Route = EmberObject.extend(ActionHandler, {
             // Now check if this value actually changed.
             if (svalue !== qp.svalue) {
               var options = get(this.queryParams, qp.urlKey) || {};
-              if (get(options, 'replace')) {
+
+              // Only use replace if transition wouldn't otherwise change the url
+              if (!transition.targetName && get(options, 'replace')) {
                 transition.method('replace');
               }
 


### PR DESCRIPTION
We don't want to look at query param replaceState  config unless the only
thing that's changing in a  transition is query params.

This is entirely @raytiley's code/effort. Give him credit.

Closes #4572
