### PR TITLE
ES6 spring cleaning.

### DIFF
--- a/packages_es6/container/tests/container_helper.js
+++ b/packages_es6/container/tests/container_helper.js
@@ -77,4 +77,8 @@ var factory = function() {
   }
 };
 
-export {factory, o_create, setProperties};
+export {
+  factory,
+  o_create,
+  setProperties
+};

--- a/packages_es6/container/tests/container_test.js
+++ b/packages_es6/container/tests/container_test.js
@@ -1,6 +1,8 @@
-import { factory,
-         o_create,
-         setProperties} from 'container/tests/container_helper';
+import {
+  factory,
+  o_create,
+  setProperties
+} from 'container/tests/container_helper';
 
 import Container from 'container';
 

--- a/packages_es6/container/tests/sub_container_test.js
+++ b/packages_es6/container/tests/sub_container_test.js
@@ -1,6 +1,8 @@
-import { factory,
-         o_create,
-         setProperties} from 'container/tests/container_helper';
+import {
+  factory,
+  o_create,
+  setProperties
+} from 'container/tests/container_helper';
 
 import Container from 'container';
 var container;

--- a/packages_es6/ember-application/lib/ext/controller.js
+++ b/packages_es6/ember-application/lib/ext/controller.js
@@ -4,14 +4,14 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.assert
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import EmberError from "ember-metal/error";
-import {inspect} from "ember-metal/utils";
-import {computed} from "ember-metal/computed";
-import {ControllerMixin} from "ember-runtime/controllers/controller";
-import {meta} from "ember-metal/utils";
-import {controllerFor} from "ember-routing/system/controller_for";
+import { inspect } from "ember-metal/utils";
+import { computed } from "ember-metal/computed";
+import { ControllerMixin } from "ember-runtime/controllers/controller";
+import { meta } from "ember-metal/utils";
+import { controllerFor } from "ember-routing/system/controller_for";
 
 function verifyNeedsDependencies(controller, container, needs) {
   var dependency, i, l, missing = [];

--- a/packages_es6/ember-application/lib/main.js
+++ b/packages_es6/ember-application/lib/main.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core";
-import {runLoadHooks} from "ember-runtime/system/lazy_load";
+import { runLoadHooks } from "ember-runtime/system/lazy_load";
 
 /**
 Ember Application
@@ -10,7 +10,10 @@ Ember Application
 */
 
 import DAG from "ember-application/system/dag";
-import {Resolver, DefaultResolver} from "ember-application/system/resolver";
+import {
+  Resolver,
+  DefaultResolver
+} from "ember-application/system/resolver";
 import Application from "ember-application/system/application";
 import "ember-application/ext/controller"; // side effect of extending ControllerMixin
 

--- a/packages_es6/ember-application/lib/system/application.js
+++ b/packages_es6/ember-application/lib/system/application.js
@@ -4,18 +4,18 @@
 */
 
 import Ember from "ember-metal"; // Ember.FEATURES, Ember.deprecate, Ember.assert, Ember.libraries, LOG_VERSION, Namespace, BOOTED
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {runLoadHooks} from "ember-runtime/system/lazy_load";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { runLoadHooks } from "ember-runtime/system/lazy_load";
 import DAG from "ember-application/system/dag";
 import Namespace from "ember-runtime/system/namespace";
 import DeferredMixin from "ember-runtime/mixins/deferred";
-import {DefaultResolver} from "ember-application/system/resolver";
-import {create} from "ember-metal/platform";
+import { DefaultResolver } from "ember-application/system/resolver";
+import { create } from "ember-metal/platform";
 import run from "ember-metal/run_loop";
-import {canInvoke} from "ember-metal/utils";
+import { canInvoke } from "ember-metal/utils";
 import Container from 'container/container';
-import {Controller} from "ember-runtime/controllers/controller";
+import { Controller } from "ember-runtime/controllers/controller";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";

--- a/packages_es6/ember-application/lib/system/resolver.js
+++ b/packages_es6/ember-application/lib/system/resolver.js
@@ -4,14 +4,18 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.TEMPLATES, Ember.assert
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import Logger from "ember-metal/logger";
-import {classify, capitalize, decamelize} from "ember-runtime/system/string";
+import {
+  classify,
+  capitalize,
+  decamelize
+} from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import EmberHandlebars from "ember-handlebars";
 
-var Resolver = EmberObject.extend({
+export var Resolver = EmberObject.extend({
   /**
     This will be set to the Application instance when it is
     created.
@@ -114,7 +118,7 @@ var Resolver = EmberObject.extend({
   @namespace Ember
   @extends Ember.Object
 */
-var DefaultResolver = EmberObject.extend({
+export var DefaultResolver = EmberObject.extend({
   /**
     This will be set to the Application instance when it is
     created.
@@ -375,5 +379,3 @@ var DefaultResolver = EmberObject.extend({
     Logger.info(symbol, parsedName.fullName, padding, this.lookupDescription(parsedName.fullName));
   }
 });
-
-export {Resolver, DefaultResolver};

--- a/packages_es6/ember-application/tests/system/controller_test.js
+++ b/packages_es6/ember-application/tests/system/controller_test.js
@@ -1,12 +1,12 @@
 /*jshint newcap:false */
 
-import {Controller} from "ember-runtime/controllers/controller";
+import { Controller } from "ember-runtime/controllers/controller";
 import "ember-application/ext/controller";
 
 import Container from "ember-runtime/system/container";
-import {A} from "ember-runtime/system/native_array";
+import { A } from "ember-runtime/system/native_array";
 import ArrayController from "ember-runtime/controllers/array_controller";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 
 module("Controller dependencies");
 

--- a/packages_es6/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -1,7 +1,7 @@
 import jQuery from "ember-views/system/jquery";
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
-import {DefaultResolver} from "ember-application/system/resolver";
+import { DefaultResolver } from "ember-application/system/resolver";
 
 var application;
 

--- a/packages_es6/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core"; // Ember.TEMPLATES
 import run from "ember-metal/run_loop";
 import Logger from "ember-metal/logger";
-import {Controller} from "ember-runtime/controllers/controller";
+import { Controller } from "ember-runtime/controllers/controller";
 import EmberObject from "ember-runtime/system/object";
 import EmberHandlebars from "ember-handlebars";
 import Namespace from "ember-runtime/system/namespace";

--- a/packages_es6/ember-application/tests/system/dependency_injection/normalization_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/normalization_test.js
@@ -1,5 +1,5 @@
 import run from "ember-metal/run_loop";
-import {forEach} from "ember-metal/array";
+import { forEach } from "ember-metal/array";
 import Application from "ember-application/system/application";
 
 var application, locator;

--- a/packages_es6/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -2,8 +2,8 @@ import Ember from "ember-metal/core"; // lookup, etc
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import EmberObject from "ember-runtime/system/object";
-import {DefaultResolver} from "ember-application/system/resolver";
-import {guidFor} from "ember-metal/utils";
+import { DefaultResolver } from "ember-application/system/resolver";
+import { guidFor } from "ember-metal/utils";
 
 var originalLookup, App, originalModelInjections;
 

--- a/packages_es6/ember-application/tests/system/dependency_injection_test.js
+++ b/packages_es6/ember-application/tests/system/dependency_injection_test.js
@@ -1,7 +1,7 @@
 import run from "ember-metal/run_loop";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {forEach} from "ember-metal/array";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { forEach } from "ember-metal/array";
 import EmberObject from "ember-runtime/system/object";
 import Application from "ember-application/system/application";
 import Container from "ember-runtime/system/container";

--- a/packages_es6/ember-application/tests/system/initializers_test.js
+++ b/packages_es6/ember-application/tests/system/initializers_test.js
@@ -1,6 +1,6 @@
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
-import {indexOf} from "ember-metal/array";
+import { indexOf } from "ember-metal/array";
 import jQuery from "ember-views/system/jquery";
 
 var oldInitializers, app;

--- a/packages_es6/ember-application/tests/system/logging_test.js
+++ b/packages_es6/ember-application/tests/system/logging_test.js
@@ -2,8 +2,8 @@
 
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
-import {View} from "ember-views/views/view";
-import {Controller} from "ember-runtime/controllers/controller";
+import { View } from "ember-views/views/view";
+import { Controller } from "ember-runtime/controllers/controller";
 import Route from "ember-routing/system/route";
 import RSVP from "ember-runtime/ext/rsvp";
 import keys from "ember-runtime/keys";

--- a/packages_es6/ember-application/tests/system/reset_test.js
+++ b/packages_es6/ember-application/tests/system/reset_test.js
@@ -1,10 +1,10 @@
 import run from "ember-metal/run_loop";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import Application from "ember-application/system/application";
 import EmberObject from "ember-runtime/system/object";
 import Router from "ember-routing/system/router";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 import {Controller} from "ember-runtime/controllers/controller";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import jQuery from "ember-views/system/jquery";

--- a/packages_es6/ember-debug/lib/main.js
+++ b/packages_es6/ember-debug/lib/main.js
@@ -159,7 +159,7 @@ Ember.deprecateFunc = function(message, func) {
   @since 1.5.0
 */
 Ember.runInDebug = function(func) {
-  func()
+  func();
 };
 
 // Inform the developer about the Ember Inspector if not installed.

--- a/packages_es6/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages_es6/ember-extension-support/lib/container_debug_adapter.js
@@ -1,6 +1,9 @@
 import Ember from "ember-metal/core";
-import {typeOf} from "ember-metal/utils";
-import {dasherize, classify} from "ember-runtime/system/string";
+import { typeOf } from "ember-metal/utils";
+import {
+  dasherize,
+  classify
+} from "ember-runtime/system/string";
 import Namespace from "ember-runtime/system/namespace";
 import EmberObject from "ember-runtime/system/object";
 

--- a/packages_es6/ember-extension-support/lib/data_adapter.js
+++ b/packages_es6/ember-extension-support/lib/data_adapter.js
@@ -1,10 +1,10 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {dasherize} from "ember-runtime/system/string";
+import { dasherize } from "ember-runtime/system/string";
 import Namespace from "ember-runtime/system/namespace";
 import EmberObject from "ember-runtime/system/object";
-import {A as emberA} from "ember-runtime/system/native_array";
+import { A as emberA } from "ember-runtime/system/native_array";
 import Application from "ember-application/system/application";
 
 /**
@@ -53,7 +53,7 @@ import Application from "ember-application/system/application";
   @namespace Ember
   @extends EmberObject
 */
-var DataAdapter = EmberObject.extend({
+export default EmberObject.extend({
   init: function() {
     this._super();
     this.releaseMethods = emberA();
@@ -475,7 +475,4 @@ var DataAdapter = EmberObject.extend({
   observeRecord: function(record, recordUpdated) {
     return function(){};
   }
-
 });
-
-export default DataAdapter;

--- a/packages_es6/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages_es6/ember-extension-support/tests/container_debug_adapter_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import {Controller as EmberController} from "ember-runtime/controllers/controller";
+import { Controller as EmberController } from "ember-runtime/controllers/controller";
 import "ember-extension-support"; // Must be required to export Ember.ContainerDebugAdapter
 import Application from "ember-application/system/application";
 

--- a/packages_es6/ember-extension-support/tests/data_adapter_test.js
+++ b/packages_es6/ember-extension-support/tests/data_adapter_test.js
@@ -1,13 +1,16 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {addObserver, removeObserver} from "ember-metal/observer";
+import {
+  addObserver,
+  removeObserver
+} from "ember-metal/observer";
 import EmberObject from "ember-runtime/system/object";
-import {Controller as EmberController} from "ember-runtime/controllers/controller";
+import { Controller as EmberController } from "ember-runtime/controllers/controller";
 import EmberDataAdapter from "ember-extension-support/data_adapter";
 import EmberApplication from "ember-application/system/application";
-import {DefaultResolver} from "ember-application/system/resolver";
+import { DefaultResolver } from "ember-application/system/resolver";
 
 var adapter, App, Model = EmberObject.extend();
 

--- a/packages_es6/ember-handlebars/lib/controls.js
+++ b/packages_es6/ember-handlebars/lib/controls.js
@@ -158,7 +158,7 @@ var helpers = EmberHandlebars.helpers;
   @for Ember.Handlebars.helpers
   @param {Hash} options
 */
-function inputHelper(options) {
+export function inputHelper(options) {
   Ember.assert('You can only pass attributes to the `input` helper, not arguments', arguments.length < 2);
 
   var hash = options.hash,
@@ -335,7 +335,7 @@ function inputHelper(options) {
   @for Ember.Handlebars.helpers
   @param {Hash} options
 */
-function textareaHelper(options) {
+export function textareaHelper(options) {
   Ember.assert('You can only pass attributes to the `textarea` helper, not arguments', arguments.length < 2);
 
   var hash = options.hash,
@@ -343,5 +343,3 @@ function textareaHelper(options) {
 
   return helpers.view.call(this, TextArea, options);
 }
-
-export {inputHelper, textareaHelper};

--- a/packages_es6/ember-handlebars/lib/controls/checkbox.js
+++ b/packages_es6/ember-handlebars/lib/controls/checkbox.js
@@ -1,6 +1,6 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {View} from "ember-views/views/view";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { View } from "ember-views/views/view";
 
 /**
 @module ember

--- a/packages_es6/ember-handlebars/lib/controls/select.js
+++ b/packages_es6/ember-handlebars/lib/controls/select.js
@@ -5,16 +5,16 @@
 
 import EmberHandlebars from "ember-handlebars-compiler";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {View} from "ember-views/views/view";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { View } from "ember-views/views/view";
 import CollectionView from "ember-views/views/collection_view";
-import {isArray} from "ember-metal/utils";
+import { isArray } from "ember-metal/utils";
 import isNone from 'ember-metal/is_none';
-import {computed} from "ember-metal/computed";
-import {A as emberA} from "ember-runtime/system/native_array";
-import {observer} from "ember-metal/mixin";
-import {defineProperty} from "ember-metal/properties";
+import { computed } from "ember-metal/computed";
+import { A as emberA } from "ember-runtime/system/native_array";
+import { observer } from "ember-metal/mixin";
+import { defineProperty } from "ember-metal/properties";
 
 var indexOf = EnumerableUtils.indexOf,
     indexesOf = EnumerableUtils.indexesOf,
@@ -620,4 +620,8 @@ var Select = View.extend({
 });
 
 export default Select;
-export {Select, SelectOption, SelectOptgroup};
+export {
+  Select,
+  SelectOption,
+  SelectOptgroup
+};

--- a/packages_es6/ember-handlebars/lib/controls/text_area.js
+++ b/packages_es6/ember-handlebars/lib/controls/text_area.js
@@ -3,10 +3,10 @@
 @module ember
 @submodule ember-handlebars
 */
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import Component from "ember-views/views/component";
 import TextSupport from "ember-handlebars/controls/text_support";
-import {observer} from "ember-metal/mixin";
+import { observer } from "ember-metal/mixin";
 
 /**
   The internal class used to create textarea element when the `{{textarea}}`
@@ -25,7 +25,7 @@ import {observer} from "ember-metal/mixin";
   @extends Ember.Component
   @uses Ember.TextSupport
 */
-var TextArea = Component.extend(TextSupport, {
+export default Component.extend(TextSupport, {
   classNames: ['ember-text-area'],
 
   tagName: "textarea",
@@ -46,7 +46,4 @@ var TextArea = Component.extend(TextSupport, {
     this._super();
     this.on("didInsertElement", this, this._updateElementValue);
   }
-
 });
-
-export default TextArea;

--- a/packages_es6/ember-handlebars/lib/controls/text_field.js
+++ b/packages_es6/ember-handlebars/lib/controls/text_field.js
@@ -3,8 +3,8 @@
 @submodule ember-handlebars
 */
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import Component from "ember-views/views/component";
 import TextSupport from "ember-handlebars/controls/text_support";
 
@@ -26,7 +26,7 @@ import TextSupport from "ember-handlebars/controls/text_support";
   @extends Ember.Component
   @uses Ember.TextSupport
 */
-var TextField = Component.extend(TextSupport, {
+export default Component.extend(TextSupport, {
 
   classNames: ['ember-text-field'],
   tagName: "input",
@@ -93,5 +93,3 @@ var TextField = Component.extend(TextSupport, {
   */
   max: null
 });
-
-export default TextField;

--- a/packages_es6/ember-handlebars/lib/controls/text_support.js
+++ b/packages_es6/ember-handlebars/lib/controls/text_support.js
@@ -3,9 +3,9 @@
 @submodule ember-handlebars
 */
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {Mixin} from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { Mixin } from "ember-metal/mixin";
 import TargetActionSupport from "ember-runtime/mixins/target_action_support";
 
 /**

--- a/packages_es6/ember-handlebars/lib/ext.js
+++ b/packages_es6/ember-handlebars/lib/ext.js
@@ -1,15 +1,15 @@
 import Ember from "ember-metal/core"; // Ember.FEATURES, Ember.assert, Ember.Handlebars, Ember.lookup
 // var emberAssert = Ember.assert;
 
-import {fmt} from "ember-runtime/system/string";
+import { fmt } from "ember-runtime/system/string";
 
 import EmberHandlebars from "ember-handlebars-compiler";
 var helpers = EmberHandlebars.helpers;
 
-import {get} from "ember-metal/property_get";
-import {isGlobalPath} from "ember-metal/binding";
+import { get } from "ember-metal/property_get";
+import { isGlobalPath } from "ember-metal/binding";
 import EmberError from "ember-metal/error";
-import {IS_BINDING} from "ember-metal/mixin";
+import { IS_BINDING } from "ember-metal/mixin";
 
 // late bound via requireModule because of circular dependencies.
 var resolveHelper,
@@ -118,7 +118,7 @@ function handlebarsGet(root, path, options) {
   @param {Object} options The template's option hash
   @since 1.4.0
 */
-function getEscaped(root, path, options) {
+export function getEscaped(root, path, options) {
   var result = handlebarsGet(root, path, options);
 
   if (result === null || result === undefined) {
@@ -133,7 +133,7 @@ function getEscaped(root, path, options) {
   return result;
 }
 
-function resolveParams(context, params, options) {
+export function resolveParams(context, params, options) {
   var resolvedParams = [], types = options.types, param, type;
 
   for (var i=0, l=params.length; i<l; i++) {
@@ -150,7 +150,7 @@ function resolveParams(context, params, options) {
   return resolvedParams;
 }
 
-function resolveHash(context, hash, options) {
+export function resolveHash(context, hash, options) {
   var resolvedHash = {}, types = options.hashTypes, type;
 
   for (var key in hash) {
@@ -182,7 +182,7 @@ function resolveHash(context, hash, options) {
   @param {String} path
   @param {Hash} options
 */
-function helperMissingHelper(path) {
+export function helperMissingHelper(path) {
   if (!resolveHelper) { resolveHelper = requireModule('ember-handlebars/helpers/binding')['resolveHelper']; } // ES6TODO: stupid circular dep
 
   var error, view = "";
@@ -216,7 +216,7 @@ function helperMissingHelper(path) {
   @param {String} path
   @param {Hash} options
 */
-function blockHelperMissingHelper(path) {
+export function blockHelperMissingHelper(path) {
   if (!resolveHelper) { resolveHelper = requireModule('ember-handlebars/helpers/binding')['resolveHelper']; } // ES6TODO: stupid circular dep
 
   var options = arguments[arguments.length - 1];
@@ -345,7 +345,7 @@ function blockHelperMissingHelper(path) {
   @param {Function} function
   @param {String} dependentKeys*
 */
-function registerBoundHelper(name, fn) {
+export function registerBoundHelper(name, fn) {
   var boundHelperArgs = slice.call(arguments, 1),
       boundFn = makeBoundHelper.apply(this, boundHelperArgs);
   EmberHandlebars.registerHelper(name, boundFn);
@@ -547,10 +547,15 @@ function evaluateUnboundHelper(context, fn, normalizedProperties, options) {
   @for Ember.Handlebars
   @param {String} spec
 */
-function template(spec) {
+export function template(spec) {
   var t = originalTemplate(spec);
   t.isTop = true;
   return t;
 }
 
-export {normalizePath, template, makeBoundHelper, registerBoundHelper, resolveHash, resolveParams, handlebarsGet, getEscaped, evaluateUnboundHelper, helperMissingHelper, blockHelperMissingHelper};
+export {
+  normalizePath,
+  makeBoundHelper,
+  handlebarsGet,
+  evaluateUnboundHelper
+};

--- a/packages_es6/ember-handlebars/lib/helpers/binding.js
+++ b/packages_es6/ember-handlebars/lib/helpers/binding.js
@@ -7,28 +7,41 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.warn, uuid
 // var emberAssert = Ember.assert, Ember.warn = Ember.warn;
 
 import EmberHandlebars from "ember-handlebars-compiler";
-var helpers = EmberHandlebars.helpers;
-var SafeString = EmberHandlebars.SafeString;
-
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {fmt} from "ember-runtime/system/string";
-import {create as o_create} from "ember-metal/platform";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { fmt } from "ember-runtime/system/string";
+import { create as o_create } from "ember-metal/platform";
 import isNone from 'ember-metal/is_none';
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {forEach} from "ember-metal/array";
-import {View} from "ember-views/views/view";
+import { forEach } from "ember-metal/array";
+import { View } from "ember-views/views/view";
 import run from "ember-metal/run_loop";
-import {_HandlebarsBoundView, SimpleHandlebarsView} from "ember-handlebars/views/handlebars_bound_view";
-import {removeObserver} from "ember-metal/observer";
-import {isGlobalPath} from "ember-metal/binding";
-import {bind as emberBind} from "ember-metal/binding";
-import {guidFor, typeOf} from "ember-metal/utils";
+import { removeObserver } from "ember-metal/observer";
+import { isGlobalPath } from "ember-metal/binding";
+import { bind as emberBind } from "ember-metal/binding";
 import jQuery from "ember-views/system/jquery";
-import {isArray} from "ember-metal/utils";
-import {normalizePath, handlebarsGet, getEscaped} from "ember-handlebars/ext";
-import {getEscaped as handlebarsGetEscaped} from "ember-handlebars/ext";
+import { isArray } from "ember-metal/utils";
+import { getEscaped as handlebarsGetEscaped } from "ember-handlebars/ext";
 import keys from "ember-runtime/keys";
+
+import {
+  _HandlebarsBoundView,
+  SimpleHandlebarsView
+} from "ember-handlebars/views/handlebars_bound_view";
+
+import {
+  normalizePath,
+  handlebarsGet,
+  getEscaped
+} from "ember-handlebars/ext";
+
+import {
+  guidFor,
+  typeOf
+} from "ember-metal/utils";
+
+var helpers = EmberHandlebars.helpers;
+var SafeString = EmberHandlebars.SafeString;
 
 function exists(value) {
   return !isNone(value);
@@ -842,4 +855,17 @@ function bindClasses(context, classBindings, view, bindAttrId, options) {
   return ret;
 }
 
-export {bind, _triageMustacheHelper, resolveHelper, bindHelper, boundIfHelper, unboundIfHelper, withHelper, ifHelper, unlessHelper, bindAttrHelper, bindAttrHelperDeprecated, bindClasses};
+export {
+  bind,
+  _triageMustacheHelper,
+  resolveHelper,
+  bindHelper,
+  boundIfHelper,
+  unboundIfHelper,
+  withHelper,
+  ifHelper,
+  unlessHelper,
+  bindAttrHelper,
+  bindAttrHelperDeprecated,
+  bindClasses
+};

--- a/packages_es6/ember-handlebars/lib/helpers/collection.js
+++ b/packages_es6/ember-handlebars/lib/helpers/collection.js
@@ -4,7 +4,7 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.assert, Ember.deprecate
-import {inspect} from "ember-metal/utils";
+import { inspect } from "ember-metal/utils";
 
 // var emberAssert = Ember.assert;
     // emberDeprecate = Ember.deprecate;
@@ -12,11 +12,11 @@ import {inspect} from "ember-metal/utils";
 import EmberHandlebars from "ember-handlebars-compiler";
 var helpers = EmberHandlebars.helpers;
 
-import {fmt} from "ember-runtime/system/string";
-import {get} from "ember-metal/property_get";
-import {handlebarsGet} from "ember-handlebars/ext";
-import {ViewHelper} from "ember-handlebars/helpers/view";
-import {computed} from "ember-metal/computed";
+import { fmt } from "ember-runtime/system/string";
+import { get } from "ember-metal/property_get";
+import { handlebarsGet } from "ember-handlebars/ext";
+import { ViewHelper } from "ember-handlebars/helpers/view";
+import { computed } from "ember-metal/computed";
 import CollectionView from "ember-views/views/collection_view";
 
 var alias = computed.alias;

--- a/packages_es6/ember-handlebars/lib/helpers/debug.js
+++ b/packages_es6/ember-handlebars/lib/helpers/debug.js
@@ -5,11 +5,14 @@
 @submodule ember-handlebars
 */
 import Ember from "ember-metal/core"; // Ember.FEATURES,
-import {inspect} from "ember-metal/utils";
+import { inspect } from "ember-metal/utils";
 import Logger from "ember-metal/logger";
 
-import {get} from "ember-metal/property_get";
-import {normalizePath, handlebarsGet} from "ember-handlebars/ext";
+import { get } from "ember-metal/property_get";
+import {
+  normalizePath,
+  handlebarsGet
+} from "ember-handlebars/ext";
 
 var a_slice = [].slice;
 

--- a/packages_es6/ember-handlebars/lib/helpers/each.js
+++ b/packages_es6/ember-handlebars/lib/helpers/each.js
@@ -10,21 +10,30 @@ var K = Ember.K;
 import EmberHandlebars from "ember-handlebars-compiler";
 var helpers = EmberHandlebars.helpers;
 
-import {fmt} from "ember-runtime/system/string";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {_Metamorph, _MetamorphView} from "ember-handlebars/views/metamorph_view";
+import { fmt } from "ember-runtime/system/string";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import CollectionView from "ember-views/views/collection_view";
-import {Binding} from "ember-metal/binding";
-import {ControllerMixin} from "ember-runtime/controllers/controller";
+import { Binding } from "ember-metal/binding";
+import { ControllerMixin } from "ember-runtime/controllers/controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import EmberArray from "ember-runtime/mixins/array";
 import copy from "ember-runtime/copy";
 import run from "ember-metal/run_loop";
-import {addObserver, removeObserver, addBeforeObserver, removeBeforeObserver} from "ember-metal/observer";
-import {on} from "ember-metal/events";
+import { on } from "ember-metal/events";
+import { handlebarsGet } from "ember-handlebars/ext";
 
-import {handlebarsGet} from "ember-handlebars/ext";
+import {
+  addObserver,
+  removeObserver,
+  addBeforeObserver,
+  removeBeforeObserver
+} from "ember-metal/observer";
+
+import {
+  _Metamorph,
+  _MetamorphView
+} from "ember-handlebars/views/metamorph_view";
 
 var EachView = CollectionView.extend(_Metamorph, {
   init: function() {
@@ -452,5 +461,9 @@ function eachHelper(path, options) {
   }
 }
 
-export {EachView, GroupedEach, eachHelper};
+export {
+  EachView,
+  GroupedEach,
+  eachHelper
+};
 

--- a/packages_es6/ember-handlebars/lib/helpers/loc.js
+++ b/packages_es6/ember-handlebars/lib/helpers/loc.js
@@ -1,4 +1,4 @@
-import {loc} from "ember-runtime/system/string";
+import { loc } from "ember-runtime/system/string";
 
 /**
 @module ember
@@ -32,8 +32,6 @@ import {loc} from "ember-runtime/system/string";
   @param {String} str The string to format
   @see {Ember.String#loc}
 */
-function locHelper(str) {
+export default function locHelper(str) {
   return loc(str);
 }
-
-export default locHelper;

--- a/packages_es6/ember-handlebars/lib/helpers/partial.js
+++ b/packages_es6/ember-handlebars/lib/helpers/partial.js
@@ -1,9 +1,9 @@
 import Ember from "ember-metal/core"; // Ember.assert
 // var emberAssert = Ember.assert;
 
-import {isNone} from 'ember-metal/is_none';
-import {handlebarsGet} from "ember-handlebars/ext";
-import {bind} from "ember-handlebars/helpers/binding";
+import { isNone } from 'ember-metal/is_none';
+import { handlebarsGet } from "ember-handlebars/ext";
+import { bind } from "ember-handlebars/helpers/binding";
 
 /**
 @module ember
@@ -60,7 +60,7 @@ import {bind} from "ember-handlebars/helpers/binding";
   @param {String} partialName the name of the template to render minus the leading underscore
 */
 
-function partialHelper(name, options) {
+export default function partialHelper(name, options) {
 
   var context = (options.contexts && options.contexts.length) ? options.contexts[0] : this;
 
@@ -101,5 +101,3 @@ function renderPartial(context, name, options) {
 
   template(context, { data: options.data });
 }
-
-export default partialHelper;

--- a/packages_es6/ember-handlebars/lib/helpers/shared.js
+++ b/packages_es6/ember-handlebars/lib/helpers/shared.js
@@ -1,16 +1,14 @@
-import {handlebarsGet} from "ember-handlebars/ext";
+import { handlebarsGet } from "ember-handlebars/ext";
 
-function resolvePaths(options) {
+export default function resolvePaths(options) {
   var ret = [],
       contexts = options.contexts,
       roots = options.roots,
       data = options.data;
 
   for (var i=0, l=contexts.length; i<l; i++) {
-    ret.push( handlebarsGet(roots[i], contexts[i], { data: data }) );
+    ret.push(handlebarsGet(roots[i], contexts[i], { data: data }));
   }
 
   return ret;
 }
-
-export default resolvePaths;

--- a/packages_es6/ember-handlebars/lib/helpers/template.js
+++ b/packages_es6/ember-handlebars/lib/helpers/template.js
@@ -51,9 +51,7 @@ var helpers = EmberHandlebars.helpers;
   @for Ember.Handlebars.helpers
   @param {String} templateName the template to render
 */
-function templateHelper(name, options) {
+export default function templateHelper(name, options) {
   Ember.deprecate("The `template` helper has been deprecated in favor of the `partial` helper. Please use `partial` instead, which will work the same way.");
   return helpers.partial.apply(this, arguments);
 }
-
-export default templateHelper;

--- a/packages_es6/ember-handlebars/lib/helpers/unbound.js
+++ b/packages_es6/ember-handlebars/lib/helpers/unbound.js
@@ -8,8 +8,8 @@
 import EmberHandlebars from "ember-handlebars-compiler";
 var helpers = EmberHandlebars.helpers;
 
-import {resolveHelper} from "ember-handlebars/helpers/binding";
-import {handlebarsGet} from "ember-handlebars/ext";
+import { resolveHelper } from "ember-handlebars/helpers/binding";
+import { handlebarsGet } from "ember-handlebars/ext";
 
 var slice = [].slice;
 
@@ -33,7 +33,7 @@ var slice = [].slice;
   @param {String} property
   @return {String} HTML string
 */
-function unboundHelper(property, fn) {
+export default function unboundHelper(property, fn) {
   var options = arguments[arguments.length - 1],
       container = options.data.view.container,
       helper, context, out, ctx;
@@ -51,5 +51,3 @@ function unboundHelper(property, fn) {
   context = (fn.contexts && fn.contexts.length) ? fn.contexts[0] : ctx;
   return handlebarsGet(context, property, fn);
 }
-
-export default unboundHelper;

--- a/packages_es6/ember-handlebars/lib/helpers/view.js
+++ b/packages_es6/ember-handlebars/lib/helpers/view.js
@@ -9,13 +9,16 @@ import Ember from "ember-metal/core"; // Ember.warn, Ember.assert
 // var emberWarn = Ember.warn, emberAssert = Ember.assert;
 
 import EmberObject from "ember-runtime/system/object";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {IS_BINDING} from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { IS_BINDING } from "ember-metal/mixin";
 import jQuery from "ember-views/system/jquery";
-import {View} from "ember-views/views/view";
-import {isGlobalPath} from "ember-metal/binding";
-import {normalizePath, handlebarsGet} from "ember-handlebars/ext";
+import { View } from "ember-views/views/view";
+import { isGlobalPath } from "ember-metal/binding";
+import {
+  normalizePath,
+  handlebarsGet
+} from "ember-handlebars/ext";
 import EmberString from "ember-runtime/system/string";
 
 
@@ -51,7 +54,7 @@ function makeBindings(thisContext, options) {
   }
 }
 
-var ViewHelper = EmberObject.create({
+export var ViewHelper = EmberObject.create({
 
   propertiesFromHTMLOptions: function(options) {
     var hash = options.hash, data = options.data;
@@ -367,7 +370,7 @@ var ViewHelper = EmberObject.create({
   @param {Hash} options
   @return {String} HTML string
 */
-function viewHelper(path, options) {
+export function viewHelper(path, options) {
   Ember.assert("The view helper only takes a single argument", arguments.length <= 2);
 
   // If no path is provided, treat path param as options
@@ -380,5 +383,3 @@ function viewHelper(path, options) {
 
   return ViewHelper.helper(this, path, options);
 }
-
-export {ViewHelper, viewHelper};

--- a/packages_es6/ember-handlebars/lib/helpers/yield.js
+++ b/packages_es6/ember-handlebars/lib/helpers/yield.js
@@ -6,7 +6,7 @@
 import Ember from "ember-metal/core";
 // var emberAssert = Ember.assert;
 
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 
 /**
   `{{yield}}` denotes an area of a template that will be rendered inside
@@ -90,7 +90,7 @@ import {get} from "ember-metal/property_get";
   @param {Hash} options
   @return {String} HTML string
 */
-function yieldHelper(options) {
+export default function yieldHelper(options) {
   var view = options.data.view;
 
   while (view && !get(view, 'layout')) {
@@ -105,5 +105,3 @@ function yieldHelper(options) {
 
   view._yield(this, options);
 }
-
-export default yieldHelper;

--- a/packages_es6/ember-handlebars/lib/main.js
+++ b/packages_es6/ember-handlebars/lib/main.js
@@ -1,12 +1,21 @@
 import EmberHandlebars from "ember-handlebars-compiler";
 import Ember from "ember-metal/core"; // to add to globals
 
-import {runLoadHooks} from "ember-runtime/system/lazy_load";
+import { runLoadHooks } from "ember-runtime/system/lazy_load";
 import bootstrap from "ember-handlebars/loader";
 
-import {normalizePath, template, makeBoundHelper, registerBoundHelper,
-    resolveHash, resolveParams, getEscaped, handlebarsGet, evaluateUnboundHelper,
-    helperMissingHelper, blockHelperMissingHelper
+import {
+  normalizePath,
+  template,
+  makeBoundHelper,
+  registerBoundHelper,
+  resolveHash,
+  resolveParams,
+  getEscaped,
+  handlebarsGet,
+  evaluateUnboundHelper,
+  helperMissingHelper,
+  blockHelperMissingHelper
 } from "ember-handlebars/ext";
 
 
@@ -14,14 +23,36 @@ import {normalizePath, template, makeBoundHelper, registerBoundHelper,
 import "ember-handlebars/string";
 
 import resolvePaths from "ember-handlebars/helpers/shared";
-import {bind, _triageMustacheHelper, resolveHelper, bindHelper, boundIfHelper, unboundIfHelper, withHelper, ifHelper, unlessHelper, bindAttrHelper, bindAttrHelperDeprecated, bindClasses} from "ember-handlebars/helpers/binding";
+import {
+  bind,
+  _triageMustacheHelper,
+  resolveHelper,
+  bindHelper,
+  boundIfHelper,
+  unboundIfHelper,
+  withHelper,
+  ifHelper,
+  unlessHelper,
+  bindAttrHelper,
+  bindAttrHelperDeprecated,
+  bindClasses
+} from "ember-handlebars/helpers/binding";
 
 import collectionHelper from "ember-handlebars/helpers/collection";
-import {ViewHelper, viewHelper} from "ember-handlebars/helpers/view";
+import {
+  ViewHelper,
+  viewHelper
+} from "ember-handlebars/helpers/view";
 import unboundHelper from "ember-handlebars/helpers/unbound";
-import {logHelper, debuggerHelper} from "ember-handlebars/helpers/debug";
-import {EachView, GroupedEach, eachHelper} from "ember-handlebars/helpers/each";
-
+import {
+  logHelper,
+  debuggerHelper
+} from "ember-handlebars/helpers/debug";
+import {
+  EachView,
+  GroupedEach,
+  eachHelper
+} from "ember-handlebars/helpers/each";
 import templateHelper from "ember-handlebars/helpers/template";
 import partialHelper from "ember-handlebars/helpers/partial";
 import yieldHelper from "ember-handlebars/helpers/yield";
@@ -29,16 +60,30 @@ import locHelper from "ember-handlebars/helpers/loc";
 
 
 import Checkbox from "ember-handlebars/controls/checkbox";
-import {Select, SelectOption, SelectOptgroup} from "ember-handlebars/controls/select";
+import {
+  Select,
+  SelectOption,
+  SelectOptgroup
+} from "ember-handlebars/controls/select";
 import TextArea from "ember-handlebars/controls/text_area";
 import TextField from "ember-handlebars/controls/text_field";
 import TextSupport from "ember-handlebars/controls/text_support";
-import {inputHelper, textareaHelper} from "ember-handlebars/controls"
+import {
+  inputHelper,
+  textareaHelper
+} from "ember-handlebars/controls"
 
 
 import ComponentLookup from "ember-handlebars/component_lookup";
-import {_HandlebarsBoundView, SimpleHandlebarsView} from "ember-handlebars/views/handlebars_bound_view";
-import {_SimpleMetamorphView, _MetamorphView, _Metamorph} from "ember-handlebars/views/metamorph_view";
+import {
+  _HandlebarsBoundView,
+  SimpleHandlebarsView
+} from "ember-handlebars/views/handlebars_bound_view";
+import {
+  _SimpleMetamorphView,
+  _MetamorphView,
+  _Metamorph
+} from "ember-handlebars/views/metamorph_view";
 
 /**
 Ember Handlebars

--- a/packages_es6/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages_es6/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -16,16 +16,19 @@ var K = Ember.K;
 var Metamorph = requireModule('metamorph');
 
 import EmberError from "ember-metal/error";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
-import {View} from "ember-views/views/view";
-import {cloneStates, states} from "ember-views/views/states";
+import { View } from "ember-views/views/view";
+import {
+  cloneStates,
+  states
+} from "ember-views/views/states";
 var viewStates = states;
 
-import {_MetamorphView} from "ember-handlebars/views/metamorph_view";
-import {handlebarsGet} from "ember-handlebars/ext";
+import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
+import { handlebarsGet } from "ember-handlebars/ext";
 
 function SimpleHandlebarsView(path, pathRoot, isEscaped, templateData) {
   this.path = path;
@@ -349,4 +352,7 @@ var _HandlebarsBoundView = _MetamorphView.extend({
   }
 });
 
-export {_HandlebarsBoundView, SimpleHandlebarsView};
+export {
+  _HandlebarsBoundView,
+  SimpleHandlebarsView
+};

--- a/packages_es6/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages_es6/ember-handlebars/lib/views/metamorph_view.js
@@ -4,11 +4,14 @@
 import Ember from "ember-metal/core"; // Ember.deprecate
 // var emberDeprecate = Ember.deprecate;
 
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import set from "ember-metal/property_set";
 
-import {CoreView, View} from "ember-views/views/view";
-import {Mixin} from "ember-metal/mixin";
+import {
+  CoreView,
+  View
+} from "ember-views/views/view";
+import { Mixin } from "ember-metal/mixin";
 import run from "ember-metal/run_loop";
 
 /**
@@ -87,7 +90,7 @@ var DOMManager = {
   @namespace Ember
   @private
 */
-var _Metamorph = Mixin.create({
+export var _Metamorph = Mixin.create({
   isVirtual: true,
   tagName: '',
 
@@ -125,7 +128,7 @@ var _Metamorph = Mixin.create({
   @uses Ember._Metamorph
   @private
 */
-var _MetamorphView = View.extend(_Metamorph);
+export var _MetamorphView = View.extend(_Metamorph);
 
 /**
   @class _SimpleMetamorphView
@@ -134,6 +137,4 @@ var _MetamorphView = View.extend(_Metamorph);
   @uses Ember._Metamorph
   @private
 */
-var _SimpleMetamorphView = CoreView.extend(_Metamorph);
-
-export {_SimpleMetamorphView, _MetamorphView, _Metamorph};
+export var _SimpleMetamorphView = CoreView.extend(_Metamorph);

--- a/packages_es6/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/checkbox_test.js
@@ -1,18 +1,18 @@
-import {get} from "ember-metal/property_get";
-import {set as o_set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set as o_set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EventDispatcher from "ember-views/system/event_dispatcher";
+import EmberHandlebars from "ember-handlebars-compiler";
 
 // import {expectAssertion} from "ember-metal/tests/debug_helpers";
 
-var set = function(obj, key, value) {
+function set(obj, key, value) {
   run(function() { o_set(obj, key, value); });
-};
+}
 
 var checkboxView, dispatcher, controller;
 
-import EmberHandlebars from "ember-handlebars-compiler";
 var compile = EmberHandlebars.compile;
 
 function destroy(view) {

--- a/packages_es6/ember-handlebars/tests/controls/select_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/select_test.js
@@ -1,10 +1,10 @@
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import jQuery from "ember-views/system/jquery";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import EventDispatcher from "ember-views/system/event_dispatcher";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 import Namespace from "ember-runtime/system/namespace";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import ArrayProxy from "ember-runtime/system/array_proxy";

--- a/packages_es6/ember-handlebars/tests/controls/text_area_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/text_area_test.js
@@ -1,17 +1,18 @@
 /*globals TestObject:true */
 import EmberObject from "ember-runtime/system/object";
-import {forEach} from "ember-metal/array";
+import { forEach } from "ember-metal/array";
 import run from "ember-metal/run_loop";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 import TextArea from "ember-handlebars/controls/text_area";
 import EmberHandlebars from "ember-handlebars";
-import {get} from "ember-metal/property_get";
-import {set as o_set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set as o_set } from "ember-metal/property_set";
 
 var textArea, controller, TestObject;
-var set = function(object, key, value) {
+
+function set(object, key, value) {
   run(function() { o_set(object, key, value); });
-};
+}
 
 var compile = EmberHandlebars.compile;
 

--- a/packages_es6/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages_es6/ember-handlebars/tests/controls/text_field_test.js
@@ -1,20 +1,23 @@
 /*globals TestObject:true */
 
-var textField;
 import Ember from "ember-metal/core"; // Ember.K
-var K = Ember.K;
 
 import run from "ember-metal/run_loop";
-import {get} from "ember-metal/property_get";
-import {set as o_set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set as o_set } from "ember-metal/property_set";
 import EmberHandlebars from "ember-handlebars";
 import EmberObject from "ember-runtime/system/object";
-import {View} from "ember-views/views/view";
-
+import { View } from "ember-views/views/view";
 import TextField from "ember-handlebars/controls/text_field";
-var set = function(object, key, value) {
+
+var textField;
+var K = Ember.K;
+var controller;
+var TestObject;
+
+function set(object, key, value) {
   run(function() { o_set(object, key, value); });
-};
+}
 
 function append() {
   run(function() {
@@ -27,8 +30,6 @@ function destroy(view) {
     view.destroy();
   });
 }
-
-var controller, TestObject;
 
 module("{{input type='text'}}", {
   setup: function() {

--- a/packages_es6/ember-handlebars/tests/handlebars_test.js
+++ b/packages_es6/ember-handlebars/tests/handlebars_test.js
@@ -7,19 +7,19 @@ import jQuery from "ember-views/system/jquery";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import run from "ember-metal/run_loop";
 import Namespace from "ember-runtime/system/namespace";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars";
 import EmberObject from "ember-runtime/system/object";
 import ObjectController from "ember-runtime/controllers/object_controller";
-import {A} from "ember-runtime/system/native_array";
-import {computed} from "ember-metal/computed";
-import {fmt} from "ember-runtime/system/string";
-import {typeOf} from "ember-metal/utils";
+import { A } from "ember-runtime/system/native_array";
+import { computed } from "ember-metal/computed";
+import { fmt } from "ember-runtime/system/string";
+import { typeOf } from "ember-metal/utils";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import CollectionView from "ember-views/views/collection_view";
 import ContainerView from "ember-views/views/container_view";
-import {Binding} from "ember-metal/binding";
-import {observersFor} from "ember-metal/observer";
+import { Binding } from "ember-metal/binding";
+import { observersFor } from "ember-metal/observer";
 import TextField from "ember-handlebars/controls/text_field";
 import Container from "ember-runtime/system/container";
 import Logger from "ember-metal/logger";
@@ -34,15 +34,17 @@ Ember.Logger = Logger;
 var trim = jQuery.trim;
 var forEach = EnumerableUtils.forEach;
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
-var firstGrandchild = function(view) {
+function firstGrandchild(view) {
   return get(get(view, 'childViews').objectAt(0), 'childViews').objectAt(0);
-};
-var nthChild = function(view, nth) {
+}
+
+function nthChild(view, nth) {
   return get(view, 'childViews').objectAt(nth || 0);
-};
+}
+
 var firstChild = nthChild;
 
 var originalLog, logCalls;

--- a/packages_es6/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -1,26 +1,26 @@
 /*globals TemplateTests*/
 /*jshint newcap:false*/
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
-import {A} from "ember-runtime/system/native_array";
+import { A } from "ember-runtime/system/native_array";
 
 // import {expectAssertion} from "ember-metal/tests/debug_helpers";
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 import EmberHandlebars from "ember-handlebars-compiler";
 var compile = EmberHandlebars.compile;
 
 var view;
 
-var appendView = function() {
+function appendView() {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
+}
 
-var registerRepeatHelper = function() {
+function registerRepeatHelper() {
   EmberHandlebars.helper('repeat', function(value, options) {
     var count = options.hash.count;
     var a = [];
@@ -29,7 +29,7 @@ var registerRepeatHelper = function() {
     }
     return a.join('');
   });
-};
+}
 
 module("Handlebars bound helpers", {
   setup: function() {

--- a/packages_es6/ember-handlebars/tests/helpers/custom_view_helper_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/custom_view_helper_test.js
@@ -1,19 +1,18 @@
 /*globals TemplateTests*/
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import EmberHandlebars from "ember-handlebars-compiler";
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
-var appendView = function() {
+function appendView() {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
+}
 
 var view;
-
 
 module("Handlebars custom view helpers", {
   setup: function() {

--- a/packages_es6/ember-handlebars/tests/helpers/debug_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/debug_test.js
@@ -1,19 +1,18 @@
 import Ember from "ember-metal/core"; // Ember.lookup
 import EmberLogger from "ember-metal/logger";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
-import {logHelper} from "ember-handlebars/helpers/debug";
+import { logHelper } from "ember-handlebars/helpers/debug";
 
 var originalLookup = Ember.lookup, lookup;
 var originalLog, logCalls;
 var originalLogHelper;
 var view;
 
-var appendView = function() {
+function appendView() {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
-
+}
 
 module("Handlebars {{log}} helper", {
   setup: function() {

--- a/packages_es6/ember-handlebars/tests/helpers/each_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/each_test.js
@@ -2,24 +2,25 @@
 import Ember from "ember-metal/core"; // Ember.lookup;
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
-import {computed} from "ember-metal/computed";
+import { View as EmberView } from "ember-views/views/view";
+import { computed } from "ember-metal/computed";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import EmberHandlebars from "ember-handlebars-compiler";
 // import {expectAssertion} from "ember-metal/tests/debug_helpers";
-import {A} from "ember-runtime/system/native_array";
-import {Controller as EmberController} from "ember-runtime/controllers/controller";
+import { A } from "ember-runtime/system/native_array";
+import { Controller as EmberController } from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import Container from "ember-runtime/system/container";
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 var people, view, container;
 var template, templateMyView;
-var templateFor = function(template) {
+
+function templateFor(template) {
   return EmberHandlebars.compile(template);
-};
+}
 
 var originalLookup = Ember.lookup, lookup;
 

--- a/packages_es6/ember-handlebars/tests/helpers/group_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/group_test.js
@@ -2,18 +2,20 @@
 
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
 import ArrayProxy from "ember-runtime/system/array_proxy";
-import {A} from "ember-runtime/system/native_array";
+import { A } from "ember-runtime/system/native_array";
 import Container from "ember-runtime/system/container";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 var trim = jQuery.trim;
-
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-
 var container, view;
+
+function appendView() {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
 
 module("EmberHandlebars - group flag", {
   setup: function() {
@@ -45,10 +47,6 @@ function createGroupedView(template, context) {
   run(function() {
     view = EmberView.create(options);
   });
-}
-
-function appendView() {
-  run(function() { view.appendTo('#qunit-fixture'); });
 }
 
 test("should properly modify behavior inside the block", function() {

--- a/packages_es6/ember-handlebars/tests/helpers/if_unless_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/if_unless_test.js
@@ -3,9 +3,9 @@ import run from "ember-metal/run_loop";
 import {View as EmberView} from "ember-views/views/view";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 
-var appendView = function(view) {
+function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
+}
 
 var compile = Ember.Handlebars.compile;
 

--- a/packages_es6/ember-handlebars/tests/helpers/loc_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/loc_test.js
@@ -1,23 +1,24 @@
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
-var buildView = function(template, context) {
+import { View as EmberView } from "ember-views/views/view";
+
+function buildView(template, context) {
   return EmberView.create({
     template: Ember.Handlebars.compile(template),
     context: (context || {})
   });
-};
+}
 
-var appendView = function(view) {
+function appendView(view) {
   run(function() {
     view.appendTo('#qunit-fixture');
   });
-};
+}
 
-var destroyView = function(view) {
+function destroyView(view) {
   run(function() {
     view.destroy();
   });
-};
+}
 
 var oldString;
 

--- a/packages_es6/ember-handlebars/tests/helpers/partial_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/partial_test.js
@@ -1,10 +1,11 @@
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import jQuery from "ember-views/system/jquery";
 var trim = jQuery.trim;
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
+
 var compile = EmberHandlebars.compile;
 
 var MyApp;

--- a/packages_es6/ember-handlebars/tests/helpers/template_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/template_test.js
@@ -1,5 +1,5 @@
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
 var trim = jQuery.trim;

--- a/packages_es6/ember-handlebars/tests/helpers/unbound_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/unbound_test.js
@@ -1,21 +1,21 @@
 /*globals Foo */
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberObject from "ember-runtime/system/object";
 
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EmberHandlebars from "ember-handlebars-compiler";
 import EmberError from "ember-metal/error";
 
 import Container from "ember-runtime/system/container";
 
-import {makeBoundHelper} from "ember-handlebars/ext";
+import { makeBoundHelper } from "ember-handlebars/ext";
 
-var appendView = function(view) {
+function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
+}
 
 var view;
 var originalLookup = Ember.lookup, lookup;

--- a/packages_es6/ember-handlebars/tests/helpers/view_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/view_test.js
@@ -1,5 +1,5 @@
 /*globals EmberDev */
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -1,18 +1,18 @@
 /*globals Foo */
 /*jshint newcap:false*/
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 import EmberHandlebars from "ember-handlebars-compiler";
-import {set} from "ember-metal/property_set";
+import { set } from "ember-metal/property_set";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import Container from "ember-runtime/system/container";
-import {A} from "ember-runtime/system/native_array";
+import { A } from "ember-runtime/system/native_array";
 
-var appendView = function(view) {
+function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
+}
 
 var view;
 var originalLookup = Ember.lookup, lookup;

--- a/packages_es6/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/yield_test.js
@@ -1,13 +1,13 @@
 /*jshint newcap:false*/
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import {computed} from "ember-metal/computed";
 import Namespace from "ember-runtime/system/namespace";
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {A} from "ember-runtime/system/native_array";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { A } from "ember-runtime/system/native_array";
 import Component from "ember-views/views/component";
 import EmberError from "ember-metal/error";
 

--- a/packages_es6/ember-handlebars/tests/loader_test.js
+++ b/packages_es6/ember-handlebars/tests/loader_test.js
@@ -1,6 +1,6 @@
 import jQuery from "ember-views/system/jquery";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 var trim = jQuery.trim;
 
 var originalLookup = Ember.lookup, lookup, Tobias, App, view;

--- a/packages_es6/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages_es6/ember-handlebars/tests/views/collection_view_test.js
@@ -1,29 +1,31 @@
 /*globals TemplateTests:true,App:true */
 /*jshint newcap:false*/
 
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 import EmberObject from "ember-runtime/system/object";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 import Namespace from "ember-runtime/system/namespace";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import CollectionView from "ember-views/views/collection_view";
-import {A} from "ember-runtime/system/native_array";
+import { A } from "ember-runtime/system/native_array";
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
 
 var trim = jQuery.trim;
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
-var firstGrandchild = function(view) {
+function firstGrandchild(view) {
   return get(get(view, 'childViews').objectAt(0), 'childViews').objectAt(0);
-};
-var nthChild = function(view, nth) {
+}
+
+function nthChild(view, nth) {
   return get(view, 'childViews').objectAt(nth || 0);
-};
+}
+
 var firstChild = nthChild;
 
 var originalLookup = Ember.lookup, lookup, TemplateTests, view;

--- a/packages_es6/ember-handlebars/tests/views/metamorph_view_test.js
+++ b/packages_es6/ember-handlebars/tests/views/metamorph_view_test.js
@@ -1,12 +1,12 @@
 import jQuery from "ember-views/system/jquery";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {observer} from "ember-metal/mixin";
+import { View as EmberView } from "ember-views/views/view";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { observer } from "ember-metal/mixin";
 import EmberHandlebars from "ember-handlebars-compiler";
 
-import {_MetamorphView} from "ember-handlebars/views/metamorph_view";
+import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
 
 var view, childView, metamorphView;
 

--- a/packages_es6/ember-metal/lib/array.js
+++ b/packages_es6/ember-metal/lib/array.js
@@ -114,5 +114,10 @@ if (Ember.SHIM_ES5) {
   @namespace Ember
   @property ArrayPolyfills
 */
-export {map, forEach, filter, indexOf};
+export {
+  map,
+  forEach,
+  filter,
+  indexOf
+};
 

--- a/packages_es6/ember-metal/lib/binding.js
+++ b/packages_es6/ember-metal/lib/binding.js
@@ -1,9 +1,13 @@
 import Ember from "ember-metal/core"; // Ember.Logger, Ember.LOG_BINDINGS, assert
-import {get} from "ember-metal/property_get";
-import {set, trySet} from "ember-metal/property_set";
-import {guidFor} from "ember-metal/utils";
-import {Map} from "ember-metal/map";
-import {addObserver, removeObserver, _suspendObserver} from "ember-metal/observer";
+import { get } from "ember-metal/property_get";
+import { set, trySet } from "ember-metal/property_set";
+import { guidFor } from "ember-metal/utils";
+import { Map } from "ember-metal/map";
+import {
+  addObserver,
+  removeObserver,
+  _suspendObserver
+} from "ember-metal/observer";
 import run from "ember-metal/run_loop";
 
 // ES6TODO: where is Ember.lookup defined?
@@ -453,7 +457,7 @@ mixinProperties(Binding, {
     Must be relative to obj or a global path.
   @return {Ember.Binding} binding instance
 */
-function bind(obj, to, from) {
+export function bind(obj, to, from) {
   return new Binding(to, from).connect(obj);
 }
 
@@ -467,8 +471,11 @@ function bind(obj, to, from) {
     Must be relative to obj or a global path.
   @return {Ember.Binding} binding instance
 */
-function oneWay(obj, to, from) {
+export function oneWay(obj, to, from) {
   return new Binding(to, from).oneWay().connect(obj);
 }
 
-export {Binding, bind, oneWay, isGlobalPath};
+export {
+  Binding,
+  isGlobalPath
+};

--- a/packages_es6/ember-metal/lib/chains.js
+++ b/packages_es6/ember-metal/lib/chains.js
@@ -17,7 +17,7 @@ var pendingQueue = [];
 // attempts to add the pendingQueue chains again. If some of them end up
 // back in the queue and reschedule is true, schedules a timeout to try
 // again.
-function flushPendingChains() {
+export function flushPendingChains() {
   if (pendingQueue.length === 0) { return; } // nothing to do
 
   var queue = pendingQueue;
@@ -27,7 +27,6 @@ function flushPendingChains() {
 
   warn('Watching an undefined global, Ember expects watched globals to be setup by the time the run loop is flushed, check for typos', pendingQueue.length === 0);
 }
-
 
 function addChainWatcher(obj, keyName, node) {
   if (!obj || ('object' !== typeof obj)) { return; } // nothing to do
@@ -315,7 +314,7 @@ ChainNodePrototype.didChange = function(events) {
   if (this._parent) { this._parent.chainDidChange(this, this._key, 1, events); }
 };
 
-function finishChains(obj) {
+export function finishChains(obj) {
   // We only create meta if we really have to
   var m = obj[META_KEY], chains = m && m.chains;
   if (chains) {
@@ -327,4 +326,7 @@ function finishChains(obj) {
   }
 }
 
-export {flushPendingChains, removeChainWatcher, ChainNode, finishChains};
+export {
+  removeChainWatcher,
+  ChainNode
+};

--- a/packages_es6/ember-metal/lib/computed.js
+++ b/packages_es6/ember-metal/lib/computed.js
@@ -1,16 +1,31 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {meta, META_KEY, guidFor, typeOf, inspect} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  meta,
+  META_KEY,
+  guidFor,
+  typeOf,
+  inspect
+} from "ember-metal/utils";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {create} from "ember-metal/platform";
-import {watch, unwatch} from "ember-metal/watching";
+import { create } from "ember-metal/platform";
+import {
+  watch,
+  unwatch
+} from "ember-metal/watching";
 import expandProperties from "ember-metal/expand_properties";
 import EmberError from "ember-metal/error";
-import {Descriptor, defineProperty} from "ember-metal/properties";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
+import {
+  Descriptor,
+  defineProperty
+} from "ember-metal/properties";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
 import isEmpty from 'ember-metal/is_empty';
-import {isNone} from 'ember-metal/is_none';
+import { isNone } from 'ember-metal/is_none';
 
 /**
 @module ember-metal
@@ -1300,4 +1315,8 @@ computed.defaultTo = function(defaultPath) {
   });
 };
 
-export {ComputedProperty, computed, cacheFor};
+export {
+  ComputedProperty,
+  computed,
+  cacheFor
+};

--- a/packages_es6/ember-metal/lib/enumerable_utils.js
+++ b/packages_es6/ember-metal/lib/enumerable_utils.js
@@ -1,6 +1,11 @@
 var splice;
 
-import {map, forEach, indexOf, filter} from "ember-metal/array";
+import {
+  map,
+  forEach,
+  indexOf,
+  filter
+} from "ember-metal/array";
 
 splice  = Array.prototype.splice;
 

--- a/packages_es6/ember-metal/lib/error.js
+++ b/packages_es6/ember-metal/lib/error.js
@@ -1,6 +1,14 @@
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 
-var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
+var errorProps = [
+  'description',
+  'fileName',
+  'lineNumber',
+  'message',
+  'name',
+  'number',
+  'stack'
+];
 
 /**
   A subclass of the JavaScript Error object for use in Ember.
@@ -10,7 +18,7 @@ var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'n
   @extends Error
   @constructor
 */
-var EmberError = function() {
+function EmberError() {
   var tmp = Error.apply(this, arguments);
 
   // Adds a `stack` property to the given error object that will yield the
@@ -27,7 +35,7 @@ var EmberError = function() {
   for (var idx = 0; idx < errorProps.length; idx++) {
     this[errorProps[idx]] = tmp[errorProps[idx]];
   }
-};
+}
 
 EmberError.prototype = create(Error.prototype);
 

--- a/packages_es6/ember-metal/lib/events.js
+++ b/packages_es6/ember-metal/lib/events.js
@@ -2,8 +2,14 @@
 @module ember-metal
 */
 import Ember from "ember-metal/core";
-import {meta, META_KEY, tryFinally, apply, applyStr} from "ember-metal/utils";
-import {create} from "ember-metal/platform";
+import {
+  meta,
+  META_KEY,
+  tryFinally,
+  apply,
+  applyStr
+} from "ember-metal/utils";
+import { create } from "ember-metal/platform";
 
 var a_slice = [].slice,
     metaFor = meta,
@@ -65,7 +71,7 @@ function actionsFor(obj, eventName) {
   return actions;
 }
 
-function listenersUnion(obj, eventName, otherActions) {
+export function listenersUnion(obj, eventName, otherActions) {
   var meta = obj[META_KEY],
       actions = meta && meta.listeners && meta.listeners[eventName];
 
@@ -82,7 +88,7 @@ function listenersUnion(obj, eventName, otherActions) {
   }
 }
 
-function listenersDiff(obj, eventName, otherActions) {
+export function listenersDiff(obj, eventName, otherActions) {
   var meta = obj[META_KEY],
       actions = meta && meta.listeners && meta.listeners[eventName],
       diffActions = [];
@@ -114,7 +120,7 @@ function listenersDiff(obj, eventName, otherActions) {
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Boolean} once A flag whether a function should only be called once
 */
-function addListener(obj, eventName, target, method, once) {
+export function addListener(obj, eventName, target, method, once) {
   Ember.assert("You must pass at least an object and event name to Ember.addListener", !!obj && !!eventName);
 
   if (!method && 'function' === typeof target) {
@@ -202,7 +208,7 @@ function removeListener(obj, eventName, target, method) {
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Function} callback
 */
-function suspendListener(obj, eventName, target, method, callback) {
+export function suspendListener(obj, eventName, target, method, callback) {
   if (!method && 'function' === typeof target) {
     method = target;
     target = null;
@@ -234,7 +240,7 @@ function suspendListener(obj, eventName, target, method, callback) {
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Function} callback
 */
-function suspendListeners(obj, eventNames, target, method, callback) {
+export function suspendListeners(obj, eventNames, target, method, callback) {
   if (!method && 'function' === typeof target) {
     method = target;
     target = null;
@@ -276,7 +282,7 @@ function suspendListeners(obj, eventNames, target, method, callback) {
   @for Ember
   @param obj
 */
-function watchedEvents(obj) {
+export function watchedEvents(obj) {
   var listeners = obj[META_KEY].listeners, ret = [];
 
   if (listeners) {
@@ -301,7 +307,7 @@ function watchedEvents(obj) {
   @param {Array} actions Optional array of actions (listeners).
   @return true
 */
-function sendEvent(obj, eventName, params, actions) {
+export function sendEvent(obj, eventName, params, actions) {
   // first give object a chance to handle it
   if (obj !== Ember && 'function' === typeof obj.sendEvent) {
     obj.sendEvent(eventName, params);
@@ -344,7 +350,7 @@ function sendEvent(obj, eventName, params, actions) {
   @param obj
   @param {String} eventName
 */
-function hasListeners(obj, eventName) {
+export function hasListeners(obj, eventName) {
   var meta = obj[META_KEY],
       actions = meta && meta.listeners && meta.listeners[eventName];
 
@@ -358,7 +364,7 @@ function hasListeners(obj, eventName) {
   @param obj
   @param {String} eventName
 */
-function listenersFor(obj, eventName) {
+export function listenersFor(obj, eventName) {
   var ret = [];
   var meta = obj[META_KEY],
       actions = meta && meta.listeners && meta.listeners[eventName];
@@ -395,11 +401,13 @@ function listenersFor(obj, eventName) {
   @param {Function} func
   @return func
 */
-function on(){
+export function on(){
   var func = a_slice.call(arguments, -1)[0],
       events = a_slice.call(arguments, 0, -1);
   func.__ember_listens__ = events;
   return func;
 }
 
-export {on, addListener, removeListener, suspendListener, suspendListeners, sendEvent, hasListeners, watchedEvents, listenersFor, listenersDiff, listenersUnion};
+export {
+  removeListener
+};

--- a/packages_es6/ember-metal/lib/expand_properties.js
+++ b/packages_es6/ember-metal/lib/expand_properties.js
@@ -30,7 +30,7 @@ BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
   @param {function} callback The callback to invoke.  It is invoked once per
   expansion, and is passed the expansion.
   */
-function expandProperties(pattern, callback) {
+export default function expandProperties(pattern, callback) {
   var match, prefix, list;
 
   if (match = BRACE_EXPANSION.exec(pattern)) {
@@ -43,6 +43,4 @@ function expandProperties(pattern, callback) {
   } else {
     callback(pattern);
   }
-}
-
-export default expandProperties;
+};

--- a/packages_es6/ember-metal/lib/get_properties.js
+++ b/packages_es6/ember-metal/lib/get_properties.js
@@ -1,5 +1,5 @@
-import {get} from "ember-metal/property_get";
-import {typeOf} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { typeOf } from "ember-metal/utils";
 
 /**
   To get multiple properties at once, call `Ember.getProperties`
@@ -22,7 +22,7 @@ import {typeOf} from "ember-metal/utils";
   @param {String...|Array} list of keys to get
   @return {Hash}
 */
-function getProperties(obj) {
+export default function getProperties(obj) {
   var ret = {},
       propertyNames = arguments,
       i = 1;
@@ -35,6 +35,4 @@ function getProperties(obj) {
     ret[propertyNames[i]] = get(obj, propertyNames[i]);
   }
   return ret;
-}
-
-export default getProperties;
+};

--- a/packages_es6/ember-metal/lib/instrumentation.js
+++ b/packages_es6/ember-metal/lib/instrumentation.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core";
-import {tryCatchFinally} from "ember-metal/utils";
+import { tryCatchFinally } from "ember-metal/utils";
 
 /**
   The purpose of the Ember Instrumentation module is
@@ -81,7 +81,7 @@ var time = (function() {
   @param {Function} callback Function that you're instrumenting.
   @param {Object} binding Context that instrument function is called with.
 */
-function instrument(name, payload, callback, binding) {
+export function instrument(name, payload, callback, binding) {
   var listeners = cache[name], timeName, ret;
 
   // ES6TODO: Docs. What is this?
@@ -141,7 +141,7 @@ function instrument(name, payload, callback, binding) {
 
   @return {Subscriber}
 */
-function subscribe(pattern, object) {
+export function subscribe(pattern, object) {
   var paths = pattern.split("."), path, regex = [];
 
   for (var i=0, l=paths.length; i<l; i++) {
@@ -176,7 +176,7 @@ function subscribe(pattern, object) {
 
   @param {Object} [subscriber]
 */
-function unsubscribe(subscriber) {
+export function unsubscribe(subscriber) {
   var index;
 
   for (var i=0, l=subscribers.length; i<l; i++) {
@@ -195,9 +195,7 @@ function unsubscribe(subscriber) {
   @method reset
   @namespace Ember.Instrumentation
 */
-function reset() {
+export function reset() {
   subscribers = [];
   cache = {};
 }
-
-export {instrument, subscribe, unsubscribe, reset};

--- a/packages_es6/ember-metal/lib/is_blank.js
+++ b/packages_es6/ember-metal/lib/is_blank.js
@@ -24,8 +24,6 @@ import isEmpty from 'ember-metal/is_empty';
   @return {Boolean}
   @since 1.5.0
   */
-function isBlank(obj) {
+export default function isBlank(obj) {
   return isEmpty(obj) || (typeof obj === 'string' && obj.match(/\S/) === null);
-}
-
-export default isBlank;
+};

--- a/packages_es6/ember-metal/lib/is_empty.js
+++ b/packages_es6/ember-metal/lib/is_empty.js
@@ -1,5 +1,5 @@
 import Ember from 'ember-metal/core'; // deprecateFunc
-import {get} from 'ember-metal/property_get';
+import { get } from 'ember-metal/property_get';
 import isNone from 'ember-metal/is_none';
 
 /**
@@ -24,10 +24,14 @@ import isNone from 'ember-metal/is_none';
   @param {Object} obj Value to test
   @return {Boolean}
 */
-var isEmpty = function(obj) {
+function isEmpty(obj) {
   return isNone(obj) || (obj.length === 0 && typeof obj !== 'function') || (typeof obj === 'object' && get(obj, 'length') === 0);
-};
-var empty = Ember.deprecateFunc("Ember.empty is deprecated. Please use Ember.isEmpty instead.", isEmpty);
+}
+
+export var empty = Ember.deprecateFunc("Ember.empty is deprecated. Please use Ember.isEmpty instead.", isEmpty);
 
 export default isEmpty;
-export {isEmpty, empty};
+export {
+  isEmpty,
+  empty
+};

--- a/packages_es6/ember-metal/lib/is_none.js
+++ b/packages_es6/ember-metal/lib/is_none.js
@@ -19,10 +19,11 @@ import Ember from 'ember-metal/core'; // deprecateFunc
   @param {Object} obj Value to test
   @return {Boolean}
 */
-var isNone = function(obj) {
+function isNone(obj) {
   return obj === null || obj === undefined;
-};
-var none = Ember.deprecateFunc("Ember.none is deprecated. Please use Ember.isNone instead.", isNone);
+}
+
+export var none = Ember.deprecateFunc("Ember.none is deprecated. Please use Ember.isNone instead.", isNone);
 
 export default isNone;
-export {isNone, none};
+export { isNone };

--- a/packages_es6/ember-metal/lib/logger.js
+++ b/packages_es6/ember-metal/lib/logger.js
@@ -48,7 +48,7 @@ function assertPolyfill(test, message) {
   @class Logger
   @namespace Ember
 */
-var Logger = {
+export default {
   /**
    Logs the arguments to the console.
    You can pass as many arguments as you want and they will be joined together with a space.
@@ -141,5 +141,3 @@ var Logger = {
   */
   assert: consoleMethod('assert') || assertPolyfill
 };
-
-export default Logger;

--- a/packages_es6/ember-metal/lib/map.js
+++ b/packages_es6/ember-metal/lib/map.js
@@ -22,10 +22,10 @@
   `Ember.Map.create()` for symmetry with other Ember classes.
 */
 
-import {set} from "ember-metal/property_set";
-import {guidFor} from "ember-metal/utils";
-import {indexOf} from "ember-metal/array";
-import {create} from "ember-metal/platform";
+import { set } from "ember-metal/property_set";
+import { guidFor } from "ember-metal/utils";
+import { indexOf } from "ember-metal/array";
+import { create } from "ember-metal/platform";
 
 function copy(obj) {
   var output = {};
@@ -375,4 +375,8 @@ MapWithDefault.prototype.copy = function() {
   }));
 };
 
-export {OrderedSet, Map, MapWithDefault};
+export {
+  OrderedSet,
+  Map,
+  MapWithDefault
+};

--- a/packages_es6/ember-metal/lib/merge.js
+++ b/packages_es6/ember-metal/lib/merge.js
@@ -13,12 +13,10 @@
   @param {Object} updates The object to copy properties from
   @return {Object}
 */
-function merge(original, updates) {
+export default function merge(original, updates) {
   for (var prop in updates) {
     if (!updates.hasOwnProperty(prop)) { continue; }
     original[prop] = updates[prop];
   }
   return original;
-}
-
-export default merge;
+};

--- a/packages_es6/ember-metal/lib/mixin.js
+++ b/packages_es6/ember-metal/lib/mixin.js
@@ -5,15 +5,37 @@
 
 import Ember from "ember-metal/core"; // warn, assert, wrap, et;
 import merge from "ember-metal/merge";
-import {map, indexOf, forEach} from "ember-metal/array";
-import {create} from "ember-metal/platform";
-import {guidFor, meta, META_KEY, wrap, makeArray, apply} from "ember-metal/utils";
+import {
+  map,
+  indexOf,
+  forEach
+} from "ember-metal/array";
+import { create } from "ember-metal/platform";
+import {
+  guidFor,
+  meta,
+  META_KEY,
+  wrap,
+  makeArray,
+  apply
+} from "ember-metal/utils";
 import expandProperties from "ember-metal/expand_properties";
-import {Descriptor, defineProperty} from "ember-metal/properties";
-import {ComputedProperty} from "ember-metal/computed";
-import {Binding} from "ember-metal/binding";
-import {addObserver, removeObserver, addBeforeObserver, removeBeforeObserver} from "ember-metal/observer";
-import {addListener, removeListener} from "ember-metal/events";
+import {
+  Descriptor,
+  defineProperty
+} from "ember-metal/properties";
+import { ComputedProperty } from "ember-metal/computed";
+import { Binding } from "ember-metal/binding";
+import {
+  addObserver,
+  removeObserver,
+  addBeforeObserver,
+  removeBeforeObserver
+} from "ember-metal/observer";
+import {
+  addListener,
+  removeListener
+} from "ember-metal/events";
 
 var REQUIRED, Alias,
     a_map = map,
@@ -381,7 +403,7 @@ function applyMixin(obj, mixins, partial) {
   @param mixins*
   @return obj
 */
-function mixin(obj) {
+export function mixin(obj) {
   var args = a_slice.call(arguments, 1);
   applyMixin(obj, args, false);
   return obj;
@@ -441,8 +463,8 @@ function mixin(obj) {
   @class Mixin
   @namespace Ember
 */
+export default Mixin;
 function Mixin() { return initMixin(this, arguments); }
-
 Mixin.prototype = {
   properties: null,
   mixins: null,
@@ -609,13 +631,14 @@ REQUIRED.toString = function() { return '(Required Property)'; };
   @method required
   @for Ember
 */
-function required() {
+export function required() {
   return REQUIRED;
 }
 
-Alias = function(methodName) {
+function Alias(methodName) {
   this.methodName = methodName;
-};
+}
+
 Alias.prototype = new Descriptor();
 
 /**
@@ -637,7 +660,7 @@ Alias.prototype = new Descriptor();
   @param {String} methodName name of the method to alias
   @return {Ember.Descriptor}
 */
-function aliasMethod(methodName) {
+export function aliasMethod(methodName) {
   return new Alias(methodName);
 }
 
@@ -668,7 +691,7 @@ function aliasMethod(methodName) {
   @param {Function} func
   @return func
 */
-function observer() {
+export function observer() {
   var func  = a_slice.call(arguments, -1)[0];
   var paths;
 
@@ -719,7 +742,7 @@ function observer() {
   @param {Function} func
   @return func
 */
-function immediateObserver() {
+export function immediateObserver() {
   for (var i=0, l=arguments.length; i<l; i++) {
     var arg = arguments[i];
     Ember.assert("Immediate observers must observe internal properties only, not properties on other objects.", typeof arg !== "string" || arg.indexOf('.') === -1);
@@ -771,7 +794,7 @@ function immediateObserver() {
   @param {Function} func
   @return func
 */
-function beforeObserver() {
+export function beforeObserver() {
   var func  = a_slice.call(arguments, -1)[0];
   var paths;
 
@@ -800,4 +823,7 @@ function beforeObserver() {
   return func;
 }
 
-export {IS_BINDING, mixin, Mixin, required, aliasMethod, observer, immediateObserver, beforeObserver};
+export {
+  IS_BINDING,
+  Mixin
+};

--- a/packages_es6/ember-metal/lib/observer.js
+++ b/packages_es6/ember-metal/lib/observer.js
@@ -1,19 +1,28 @@
-import {watch, unwatch} from "ember-metal/watching";
-import {map} from "ember-metal/array";
-import {listenersFor, addListener, removeListener, suspendListeners, suspendListener} from "ember-metal/events";
+import {
+  watch,
+  unwatch
+} from "ember-metal/watching";
+import { map } from "ember-metal/array";
+import {
+  listenersFor,
+  addListener,
+  removeListener,
+  suspendListeners,
+  suspendListener
+} from "ember-metal/events";
 /**
 @module ember-metal
 */
 
-var AFTER_OBSERVERS = ':change',
-    BEFORE_OBSERVERS = ':before';
+var AFTER_OBSERVERS = ':change';
+var BEFORE_OBSERVERS = ':before';
 
 function changeEvent(keyName) {
-  return keyName+AFTER_OBSERVERS;
+  return keyName + AFTER_OBSERVERS;
 }
 
 function beforeEvent(keyName) {
-  return keyName+BEFORE_OBSERVERS;
+  return keyName + BEFORE_OBSERVERS;
 }
 
 /**
@@ -24,14 +33,14 @@ function beforeEvent(keyName) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-function addObserver(obj, _path, target, method) {
+export function addObserver(obj, _path, target, method) {
   addListener(obj, changeEvent(_path), target, method);
   watch(obj, _path);
 
   return this;
 }
 
-function observersFor(obj, path) {
+export function observersFor(obj, path) {
   return listenersFor(obj, changeEvent(path));
 }
 
@@ -43,7 +52,7 @@ function observersFor(obj, path) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-function removeObserver(obj, _path, target, method) {
+export function removeObserver(obj, _path, target, method) {
   unwatch(obj, _path);
   removeListener(obj, changeEvent(_path), target, method);
 
@@ -58,7 +67,7 @@ function removeObserver(obj, _path, target, method) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-function addBeforeObserver(obj, _path, target, method) {
+export function addBeforeObserver(obj, _path, target, method) {
   addListener(obj, beforeEvent(_path), target, method);
   watch(obj, _path);
 
@@ -69,25 +78,25 @@ function addBeforeObserver(obj, _path, target, method) {
 //
 // This should only be used by the target of the observer
 // while it is setting the observed path.
-function _suspendBeforeObserver(obj, path, target, method, callback) {
+export function _suspendBeforeObserver(obj, path, target, method, callback) {
   return suspendListener(obj, beforeEvent(path), target, method, callback);
 }
 
-function _suspendObserver(obj, path, target, method, callback) {
+export function _suspendObserver(obj, path, target, method, callback) {
   return suspendListener(obj, changeEvent(path), target, method, callback);
 }
 
-function _suspendBeforeObservers(obj, paths, target, method, callback) {
+export function _suspendBeforeObservers(obj, paths, target, method, callback) {
   var events = map.call(paths, beforeEvent);
   return suspendListeners(obj, events, target, method, callback);
 }
 
-function _suspendObservers(obj, paths, target, method, callback) {
+export function _suspendObservers(obj, paths, target, method, callback) {
   var events = map.call(paths, changeEvent);
   return suspendListeners(obj, events, target, method, callback);
 }
 
-function beforeObserversFor(obj, path) {
+export function beforeObserversFor(obj, path) {
   return listenersFor(obj, beforeEvent(path));
 }
 
@@ -99,11 +108,9 @@ function beforeObserversFor(obj, path) {
   @param {Object|Function} targetOrMethod
   @param {Function|String} [method]
 */
-function removeBeforeObserver(obj, _path, target, method) {
+export function removeBeforeObserver(obj, _path, target, method) {
   unwatch(obj, _path);
   removeListener(obj, beforeEvent(_path), target, method);
 
   return this;
 }
-
-export {addObserver, observersFor, removeObserver, addBeforeObserver, _suspendBeforeObserver, _suspendObserver,_suspendBeforeObservers, _suspendObservers, beforeObserversFor, removeBeforeObserver};

--- a/packages_es6/ember-metal/lib/observer_set.js
+++ b/packages_es6/ember-metal/lib/observer_set.js
@@ -1,5 +1,5 @@
-import {guidFor} from "ember-metal/utils";
-import {sendEvent} from "ember-metal/events";
+import { guidFor } from "ember-metal/utils";
+import { sendEvent } from "ember-metal/events";
 
 /*
   this.observerSet = {
@@ -19,9 +19,11 @@ import {sendEvent} from "ember-metal/events";
     ...
   ]
 */
+export default ObserverSet;
 function ObserverSet() {
   this.clear();
 }
+
 
 ObserverSet.prototype.add = function(sender, keyName, eventName) {
   var observerSet = this.observerSet,
@@ -62,4 +64,3 @@ ObserverSet.prototype.clear = function() {
   this.observers = [];
 };
 
-export default ObserverSet;

--- a/packages_es6/ember-metal/lib/platform.js
+++ b/packages_es6/ember-metal/lib/platform.js
@@ -161,4 +161,7 @@ if (Ember.ENV.MANDATORY_SETTER && !platform.hasPropertyAccessors) {
   Ember.ENV.MANDATORY_SETTER = false;
 }
 
-export {create, platform};
+export {
+  create,
+  platform
+};

--- a/packages_es6/ember-metal/lib/properties.js
+++ b/packages_es6/ember-metal/lib/properties.js
@@ -3,9 +3,12 @@
 */
 
 import Ember from "ember-metal/core";
-import {META_KEY, meta} from "ember-metal/utils";
-import {platform} from "ember-metal/platform";
-import {overrideChains} from "ember-metal/property_events";
+import {
+  META_KEY,
+  meta
+} from "ember-metal/utils";
+import { platform } from "ember-metal/platform";
+import { overrideChains } from "ember-metal/property_events";
 var metaFor = meta,
     objectDefineProperty = platform.defineProperty;
 
@@ -27,6 +30,7 @@ var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
   @constructor
 */
 function Descriptor() {}
+export var Descriptor = Descriptor;
 
 // ..........................................................
 // DEFINING PROPERTIES API
@@ -36,7 +40,7 @@ var MANDATORY_SETTER_FUNCTION = Ember.MANDATORY_SETTER_FUNCTION = function(value
   Ember.assert("You must use Ember.set() to access this property (of " + this + ")", false);
 };
 
-var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function(name) {
+var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function DEFAULT_GETTER_FUNCTION(name) {
   return function() {
     var meta = this[META_KEY];
     return meta && meta.values[name];
@@ -88,7 +92,7 @@ var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function(name) {
   @param {*} [data] something other than a descriptor, that will
     become the explicit value of this property.
 */
-function defineProperty(obj, keyName, desc, data, meta) {
+export function defineProperty(obj, keyName, desc, data, meta) {
   var descs, existingDesc, watching, value;
 
   if (!meta) meta = metaFor(obj);
@@ -148,5 +152,3 @@ function defineProperty(obj, keyName, desc, data, meta) {
 
   return this;
 }
-
-export {Descriptor, defineProperty};

--- a/packages_es6/ember-metal/lib/property_events.js
+++ b/packages_es6/ember-metal/lib/property_events.js
@@ -1,10 +1,18 @@
-import { META_KEY, guidFor, tryFinally} from "ember-metal/utils";
-import {sendEvent, listenersUnion, listenersDiff} from "ember-metal/events";
+import {
+  META_KEY,
+  guidFor,
+  tryFinally
+} from "ember-metal/utils";
+import {
+  sendEvent,
+  listenersUnion,
+  listenersDiff
+} from "ember-metal/events";
 import ObserverSet from "ember-metal/observer_set";
 
-var beforeObserverSet = new ObserverSet(),
-    observerSet = new ObserverSet(),
-    deferred = 0;
+var beforeObserverSet = new ObserverSet();
+var observerSet = new ObserverSet();
+var deferred = 0;
 
 // ..........................................................
 // PROPERTY CHANGES
@@ -222,4 +230,11 @@ function notifyObservers(obj, keyName) {
   }
 }
 
-export {propertyWillChange, propertyDidChange, overrideChains, beginPropertyChanges, endPropertyChanges, changeProperties};
+export {
+  propertyWillChange,
+  propertyDidChange,
+  overrideChains,
+  beginPropertyChanges,
+  endPropertyChanges,
+  changeProperties
+};

--- a/packages_es6/ember-metal/lib/property_get.js
+++ b/packages_es6/ember-metal/lib/property_get.js
@@ -3,7 +3,7 @@
 */
 
 import Ember from "ember-metal/core";
-import {META_KEY} from "ember-metal/utils";
+import { META_KEY } from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 
 var get;
@@ -45,7 +45,7 @@ var FIRST_KEY = /^([^\.]+)/;
   @param {String} keyName The property key to retrieve
   @return {Object} the property value or `null`.
 */
-get = function get(obj, keyName) {
+var get = function get(obj, keyName) {
   // Helpers that operate with 'this' within an #each
   if (keyName === '') {
     return obj;
@@ -152,7 +152,7 @@ function _getPath(root, path) {
   return root;
 }
 
-function getWithDefault(root, key, defaultValue) {
+export function getWithDefault(root, key, defaultValue) {
   var value = get(root, key);
 
   if (value === undefined) { return defaultValue; }
@@ -160,4 +160,8 @@ function getWithDefault(root, key, defaultValue) {
 }
 
 export default get;
-export {get, getWithDefault, normalizeTuple, _getPath};
+export {
+  get,
+  normalizeTuple,
+  _getPath
+};

--- a/packages_es6/ember-metal/lib/property_set.js
+++ b/packages_es6/ember-metal/lib/property_set.js
@@ -1,12 +1,15 @@
 import Ember from "ember-metal/core";
-import {_getPath as getPath} from "ember-metal/property_get";
-import {META_KEY} from "ember-metal/utils";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
-import {defineProperty} from "ember-metal/properties";
+import { _getPath as getPath } from "ember-metal/property_get";
+import { META_KEY } from "ember-metal/utils";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import { defineProperty } from "ember-metal/properties";
 import EmberError from "ember-metal/error";
 
-var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER,
-    IS_GLOBAL = /^([A-Z$]|([0-9][A-Z$]))/;
+var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
+var IS_GLOBAL = /^([A-Z$]|([0-9][A-Z$]))/;
 
 /**
   Sets the value of a property on an object, respecting computed properties
@@ -135,8 +138,10 @@ function setPath(root, path, value, tolerant) {
   @param {String} path The property path to set
   @param {Object} value The value to set
 */
-function trySet(root, path, value) {
+export function trySet(root, path, value) {
   return set(root, path, value, true);
 }
 
-export {set, trySet};
+export {
+  set
+};

--- a/packages_es6/ember-metal/lib/run_loop.js
+++ b/packages_es6/ember-metal/lib/run_loop.js
@@ -1,31 +1,34 @@
 import Ember from 'ember-metal/core';
-import {apply} from 'ember-metal/utils';
-import {indexOf} from "ember-metal/array";
-import {beginPropertyChanges, endPropertyChanges} from 'ember-metal/property_events';
+import { apply } from 'ember-metal/utils';
+import { indexOf } from "ember-metal/array";
+import {
+  beginPropertyChanges,
+  endPropertyChanges
+} from 'ember-metal/property_events';
 
-var onBegin = function(current) {
+function onBegin(current) {
   run.currentRunLoop = current;
-};
+}
 
-var onEnd = function(current, next) {
+function onEnd(current, next) {
   run.currentRunLoop = next;
-};
+}
 
 // ES6TODO: should Backburner become es6?
-var Backburner = requireModule('backburner').Backburner,
-    backburner = new Backburner(['sync', 'actions', 'destroy'], {
-      sync: {
-        before: beginPropertyChanges,
-        after: endPropertyChanges
-      },
-      defaultQueue: 'actions',
-      onBegin: onBegin,
-      onEnd: onEnd,
-      onErrorTarget: Ember,
-      onErrorMethod: 'onerror'
-    }),
-    slice = [].slice,
-    concat = [].concat;
+var Backburner = requireModule('backburner').Backburner;
+var backburner = new Backburner(['sync', 'actions', 'destroy'], {
+  sync: {
+    before: beginPropertyChanges,
+    after: endPropertyChanges
+  },
+  defaultQueue: 'actions',
+  onBegin: onBegin,
+  onEnd: onEnd,
+  onErrorTarget: Ember,
+  onErrorMethod: 'onerror'
+});
+var slice = [].slice;
+var concat = [].concat;
 
 // ..........................................................
 // run - this is ideally the only public API the dev sees
@@ -58,9 +61,10 @@ var Backburner = requireModule('backburner').Backburner,
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
   @return {Object} return value from invoking the passed function.
 */
-var run = function() {
+export default run;
+function run() {
   return apply(backburner, backburner.run, arguments);
-};
+}
 
 /**
   If no run-loop is present, it creates a new one. If a run loop is
@@ -617,5 +621,3 @@ run._addQueue = function(name, after) {
     run.queues.splice(indexOf.call(run.queues, after)+1, 0, name);
   }
 };
-
-export default run;

--- a/packages_es6/ember-metal/lib/set_properties.js
+++ b/packages_es6/ember-metal/lib/set_properties.js
@@ -1,5 +1,5 @@
-import {changeProperties} from "ember-metal/property_events";
-import {set} from "ember-metal/property_set";
+import { changeProperties } from "ember-metal/property_events";
+import { set } from "ember-metal/property_set";
 
 /**
   Set a list of properties on an object. These properties are set inside
@@ -19,13 +19,11 @@ import {set} from "ember-metal/property_set";
   @param {Object} hash
   @return self
 */
-function setProperties(self, hash) {
+export default function setProperties(self, hash) {
   changeProperties(function() {
     for(var prop in hash) {
       if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
     }
   });
   return self;
-}
-
-export default setProperties;
+};

--- a/packages_es6/ember-metal/lib/utils.js
+++ b/packages_es6/ember-metal/lib/utils.js
@@ -1,6 +1,12 @@
 import Ember from "ember-metal/core";
-import {platform, create} from "ember-metal/platform";
-import {forEach} from "ember-metal/array";
+import {
+  platform,
+  create
+} from "ember-metal/platform";
+
+import {
+  forEach
+} from "ember-metal/array";
 
 /**
 @module ember-metal
@@ -16,13 +22,12 @@ import {forEach} from "ember-metal/array";
 */
 var GUID_PREFIX = 'ember';
 
-
-var o_defineProperty = platform.defineProperty,
-    o_create = create,
-    // Used for guid generation...
-    numberCache  = [],
-    stringCache  = {},
-    uuid = 0;
+var o_defineProperty = platform.defineProperty;
+var o_create = create;
+// Used for guid generation...
+var numberCache  = [];
+var stringCache  = {};
+var uuid = 0;
 
 var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
@@ -66,7 +71,7 @@ var GUID_DESC = {
     separate the guid into separate namespaces.
   @return {String} the guid
 */
-function generateGuid(obj, prefix) {
+export function generateGuid(obj, prefix) {
   if (!prefix) prefix = GUID_PREFIX;
   var ret = (prefix + (uuid++));
   if (obj) {
@@ -94,7 +99,7 @@ function generateGuid(obj, prefix) {
   @param {Object} obj any object, string, number, Element, or primitive
   @return {String} the unique guid for this instance.
 */
-function guidFor(obj) {
+export function guidFor(obj) {
 
   // special cases where we don't want to add a key to object
   if (obj === undefined) return "(undefined)";
@@ -139,12 +144,11 @@ function guidFor(obj) {
 //
 
 var META_DESC = {
-  writable:    true,
+  writable: true,
   configurable: false,
-  enumerable:  false,
+  enumerable: false,
   value: null
 };
-
 
 /**
   The key used to store meta information on object for property observing.
@@ -252,12 +256,12 @@ function meta(obj, writable) {
   return ret;
 }
 
-function getMeta(obj, property) {
+export function getMeta(obj, property) {
   var _meta = meta(obj, false);
   return _meta[property];
 }
 
-function setMeta(obj, property, value) {
+export function setMeta(obj, property, value) {
   var _meta = meta(obj, true);
   _meta[property] = value;
   return value;
@@ -296,7 +300,7 @@ function setMeta(obj, property, value) {
     (or meta property) if one does not already exist or if it's
     shared with its constructor
 */
-function metaPath(obj, path, writable) {
+export function metaPath(obj, path, writable) {
   Ember.deprecate("Ember.metaPath is deprecated and will be removed from future releases.");
   var _meta = meta(obj, writable), keyName, value;
 
@@ -331,7 +335,7 @@ function metaPath(obj, path, writable) {
   @param {Function} superFunc The super function.
   @return {Function} wrapped function.
 */
-function wrap(func, superFunc) {
+export function wrap(func, superFunc) {
   function superWrapper() {
     var ret, sup = this.__nextSuper;
     this.__nextSuper = superFunc;
@@ -413,7 +417,7 @@ function isArray(obj) {
   @param {Object} obj the object
   @return {Array}
 */
-function makeArray(obj) {
+export function makeArray(obj) {
   if (obj === null || obj === undefined) { return []; }
   return isArray(obj) ? obj : [obj];
 }
@@ -456,7 +460,7 @@ function canInvoke(obj, methodName) {
   @param {Array} [args] The arguments to pass to the method
   @return {*} the return value of the invoked method or undefined if it cannot be invoked
 */
-function tryInvoke(obj, methodName, args) {
+export function tryInvoke(obj, methodName, args) {
   if (canInvoke(obj, methodName)) {
     return args ? applyStr(obj, methodName, args) : applyStr(obj, methodName);
   }
@@ -720,7 +724,7 @@ function typeOf(item) {
   @return {String} A description of the object
   @since 1.4.0
 */
-function inspect(obj) {
+export function inspect(obj) {
   var type = typeOf(obj);
   if (type === 'array') {
     return '[' + obj + ']';
@@ -744,7 +748,7 @@ function inspect(obj) {
 // The following functions are intentionally minified to keep the functions
 // below Chrome's function body size inlining limit of 600 chars.
 
-function apply(t /* target */, m /* method */, a /* args */) {
+export function apply(t /* target */, m /* method */, a /* args */) {
   var l = a && a.length;
   if (!a || !l) { return m.call(t); }
   switch (l) {
@@ -757,7 +761,7 @@ function apply(t /* target */, m /* method */, a /* args */) {
   }
 }
 
-function applyStr(t /* target */, m /* method */, a /* args */) {
+export function applyStr(t /* target */, m /* method */, a /* args */) {
   var l = a && a.length;
   if (!a || !l) { return t[m](); }
   switch (l) {
@@ -770,4 +774,16 @@ function applyStr(t /* target */, m /* method */, a /* args */) {
   }
 }
 
-export {generateGuid, GUID_KEY, GUID_PREFIX, guidFor, META_DESC, EMPTY_META, META_KEY, meta, getMeta, setMeta, metaPath, inspect, typeOf, tryCatchFinally, isArray, makeArray, canInvoke, tryInvoke, tryFinally, wrap, applyStr, apply};
+export {
+  GUID_KEY,
+  GUID_PREFIX,
+  META_DESC,
+  EMPTY_META,
+  META_KEY,
+  meta,
+  typeOf,
+  tryCatchFinally,
+  isArray,
+  canInvoke,
+  tryFinally
+};

--- a/packages_es6/ember-metal/lib/watch_key.js
+++ b/packages_es6/ember-metal/lib/watch_key.js
@@ -1,12 +1,15 @@
 import Ember from "ember-metal/core";
-import {meta, typeOf} from "ember-metal/utils";
-import {platform} from "ember-metal/platform";
+import {
+  meta,
+  typeOf
+} from "ember-metal/utils";
+import { platform } from "ember-metal/platform";
 
-var metaFor = meta, // utils.js
-    MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER,
-    o_defineProperty = platform.defineProperty;
+var metaFor = meta; // utils.js
+var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
+var o_defineProperty = platform.defineProperty;
 
-function watchKey(obj, keyName, meta) {
+export function watchKey(obj, keyName, meta) {
   // can't watch length on Array - it is special...
   if (keyName === 'length' && typeOf(obj) === 'array') { return; }
 
@@ -34,7 +37,7 @@ function watchKey(obj, keyName, meta) {
   }
 }
 
-function unwatchKey(obj, keyName, meta) {
+export function unwatchKey(obj, keyName, meta) {
   var m = meta || metaFor(obj), watching = m.watching;
 
   if (watching[keyName] === 1) {
@@ -65,5 +68,3 @@ function unwatchKey(obj, keyName, meta) {
     watching[keyName]--;
   }
 }
-
-export {watchKey, unwatchKey};

--- a/packages_es6/ember-metal/lib/watch_path.js
+++ b/packages_es6/ember-metal/lib/watch_path.js
@@ -1,5 +1,8 @@
-import {meta, typeOf} from "ember-metal/utils";
-import {ChainNode} from "ember-metal/chains";
+import {
+  meta,
+  typeOf
+} from "ember-metal/utils";
+import { ChainNode } from "ember-metal/chains";
 
 var metaFor = meta;
 
@@ -16,7 +19,7 @@ function chainsFor(obj, meta) {
   return ret;
 }
 
-function watchPath(obj, keyPath, meta) {
+export function watchPath(obj, keyPath, meta) {
   // can't watch length on Array - it is special...
   if (keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
@@ -30,7 +33,7 @@ function watchPath(obj, keyPath, meta) {
   }
 }
 
-function unwatchPath(obj, keyPath, meta) {
+export function unwatchPath(obj, keyPath, meta) {
   var m = meta || metaFor(obj), watching = m.watching;
 
   if (watching[keyPath] === 1) {
@@ -40,5 +43,3 @@ function unwatchPath(obj, keyPath, meta) {
     watching[keyPath]--;
   }
 }
-
-export {watchPath, unwatchPath};

--- a/packages_es6/ember-metal/lib/watching.js
+++ b/packages_es6/ember-metal/lib/watching.js
@@ -2,10 +2,25 @@
 @module ember-metal
 */
 
-import {meta, META_KEY, GUID_KEY, typeOf, generateGuid} from "ember-metal/utils";
-import {removeChainWatcher, flushPendingChains} from "ember-metal/chains";
-import {watchKey, unwatchKey} from "ember-metal/watch_key";
-import {watchPath, unwatchPath} from "ember-metal/watch_path";
+import {
+  meta,
+  META_KEY,
+  GUID_KEY,
+  typeOf,
+  generateGuid
+} from "ember-metal/utils";
+import {
+  removeChainWatcher,
+  flushPendingChains
+} from "ember-metal/chains";
+import {
+  watchKey,
+  unwatchKey
+} from "ember-metal/watch_key";
+import {
+  watchPath,
+  unwatchPath
+} from "ember-metal/watch_path";
 
 var metaFor = meta; // utils.js
 
@@ -38,14 +53,16 @@ function watch(obj, _keyPath, m) {
   }
 }
 
-function isWatching(obj, key) {
+export { watch };
+
+export function isWatching(obj, key) {
   var meta = obj[META_KEY];
   return (meta && meta.watching[key]) > 0;
 }
 
 watch.flushPending = flushPendingChains;
 
-function unwatch(obj, _keyPath, m) {
+export function unwatch(obj, _keyPath, m) {
   // can't watch length on Array - it is special...
   if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
@@ -66,7 +83,7 @@ function unwatch(obj, _keyPath, m) {
   @for Ember
   @param obj
 */
-function rewatch(obj) {
+export function rewatch(obj) {
   var m = obj[META_KEY], chains = m && m.chains;
 
   // make sure the object has its own guid.
@@ -91,7 +108,7 @@ var NODE_STACK = [];
   @param {Object} obj  the object to destroy
   @return {void}
 */
-function destroy(obj) {
+export function destroy(obj) {
   var meta = obj[META_KEY], node, nodes, key, nodeObject;
   if (meta) {
     obj[META_KEY] = null;
@@ -122,5 +139,3 @@ function destroy(obj) {
     }
   }
 }
-
-export {watch, isWatching, unwatch, rewatch, destroy};

--- a/packages_es6/ember-metal/tests/accessors/getPath_test.js
+++ b/packages_es6/ember-metal/tests/accessors/getPath_test.js
@@ -1,6 +1,6 @@
 /*globals Foo:true $foo:true */
 
-import {get} from 'ember-metal/property_get';
+import { get } from 'ember-metal/property_get';
 
 var obj, moduleOpts = {
   setup: function() {

--- a/packages_es6/ember-metal/tests/accessors/get_test.js
+++ b/packages_es6/ember-metal/tests/accessors/get_test.js
@@ -1,8 +1,14 @@
 import testBoth from 'ember-metal/tests/props_helper';
-import {get, getWithDefault} from 'ember-metal/property_get';
-import {Mixin, observer} from 'ember-metal/mixin';
-import {addObserver} from "ember-metal/observer";
-import {create} from 'ember-metal/platform';
+import {
+  get,
+  getWithDefault
+} from 'ember-metal/property_get';
+import {
+  Mixin,
+  observer
+} from 'ember-metal/mixin';
+import { addObserver } from "ember-metal/observer";
+import { create } from 'ember-metal/platform';
 
 module('Ember.get');
 

--- a/packages_es6/ember-metal/tests/accessors/isGlobalPath_test.js
+++ b/packages_es6/ember-metal/tests/accessors/isGlobalPath_test.js
@@ -1,4 +1,4 @@
-import {isGlobalPath} from "ember-metal/binding";
+import { isGlobalPath } from "ember-metal/binding";
 
 module('Ember.isGlobalPath');
 

--- a/packages_es6/ember-metal/tests/accessors/normalizeTuple_test.js
+++ b/packages_es6/ember-metal/tests/accessors/normalizeTuple_test.js
@@ -1,5 +1,5 @@
 /*globals Foo:true, $foo:true */
-import {normalizeTuple} from "ember-metal/property_get";
+import { normalizeTuple } from "ember-metal/property_get";
 
 var obj, moduleOpts = {
   setup: function() {

--- a/packages_es6/ember-metal/tests/accessors/setPath_test.js
+++ b/packages_es6/ember-metal/tests/accessors/setPath_test.js
@@ -1,5 +1,8 @@
-import {set, trySet} from 'ember-metal/property_set';
-import {get} from 'ember-metal/property_get';
+import {
+  set,
+  trySet
+} from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
 
 var originalLookup = Ember.lookup;
 

--- a/packages_es6/ember-metal/tests/accessors/set_test.js
+++ b/packages_es6/ember-metal/tests/accessors/set_test.js
@@ -1,5 +1,5 @@
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 
 module('set');
 

--- a/packages_es6/ember-metal/tests/binding/connect_test.js
+++ b/packages_es6/ember-metal/tests/binding/connect_test.js
@@ -1,11 +1,14 @@
 import Ember from 'ember-metal/core';
 import testBoth from 'ember-metal/tests/props_helper';
-import {Binding, bind} from "ember-metal/binding";
+import {
+  Binding,
+  bind
+} from "ember-metal/binding";
 import run from 'ember-metal/run_loop';
-import {create} from 'ember-metal/platform';
-import {set} from 'ember-metal/property_set';
-import {get} from 'ember-metal/property_get';
-import {rewatch} from "ember-metal/watching";
+import { create } from 'ember-metal/platform';
+import { set } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { rewatch } from "ember-metal/watching";
 
 function performTest(binding, a, b, get, set, connect) {
   if (connect === undefined) connect = function() {binding.connect(a);};

--- a/packages_es6/ember-metal/tests/binding/oneWay_test.js
+++ b/packages_es6/ember-metal/tests/binding/oneWay_test.js
@@ -1,8 +1,7 @@
-import {set} from 'ember-metal/property_set';
-import {get} from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
 import run from 'ember-metal/run_loop';
-import {oneWay} from "ember-metal/binding";
-
+import { oneWay } from "ember-metal/binding";
 
 var MyApp;
 

--- a/packages_es6/ember-metal/tests/binding/sync_test.js
+++ b/packages_es6/ember-metal/tests/binding/sync_test.js
@@ -1,11 +1,15 @@
 import testBoth from 'ember-metal/tests/props_helper';
 import run from 'ember-metal/run_loop';
-import {addObserver, removeObserver, _suspendObserver} from "ember-metal/observer";
-import {create}  from 'ember-metal/platform';
-import {bind} from "ember-metal/binding";
-import {rewatch} from "ember-metal/watching";
-import {computed} from "ember-metal/computed";
-import {defineProperty} from "ember-metal/properties";
+import {
+  addObserver,
+  removeObserver,
+  _suspendObserver
+} from "ember-metal/observer";
+import { create }  from 'ember-metal/platform';
+import { bind } from "ember-metal/binding";
+import { rewatch } from "ember-metal/watching";
+import { computed } from "ember-metal/computed";
+import { defineProperty } from "ember-metal/properties";
 
 module("system/binding/sync_test.js");
 

--- a/packages_es6/ember-metal/tests/chains_test.js
+++ b/packages_es6/ember-metal/tests/chains_test.js
@@ -1,7 +1,7 @@
-import {META_KEY} from 'ember-metal/utils';
-import {addObserver} from "ember-metal/observer";
-import {finishChains} from "ember-metal/chains";
-import {create} from 'ember-metal/platform';
+import { META_KEY } from 'ember-metal/utils';
+import { addObserver } from "ember-metal/observer";
+import { finishChains } from "ember-metal/chains";
+import { create } from 'ember-metal/platform';
 
 module("Chains");
 

--- a/packages_es6/ember-metal/tests/computed_test.js
+++ b/packages_es6/ember-metal/tests/computed_test.js
@@ -1,13 +1,23 @@
 import Ember from 'ember-metal/core';
 import testBoth from 'ember-metal/tests/props_helper';
-import {create} from 'ember-metal/platform';
-import {ComputedProperty, computed, cacheFor} from "ember-metal/computed";
-import {Descriptor, defineProperty} from "ember-metal/properties";
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
-import {meta} from 'ember-metal/utils';
-import {isWatching} from "ember-metal/watching";
-import {addObserver, addBeforeObserver} from "ember-metal/observer";
+import { create } from 'ember-metal/platform';
+import {
+  ComputedProperty,
+  computed,
+  cacheFor
+} from "ember-metal/computed";
+import {
+  Descriptor,
+  defineProperty
+} from "ember-metal/properties";
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { meta } from 'ember-metal/utils';
+import { isWatching } from "ember-metal/watching";
+import {
+  addObserver,
+  addBeforeObserver
+} from "ember-metal/observer";
 import EnumerableUtils from 'ember-metal/enumerable_utils';
 
 var originalLookup = Ember.lookup, lookup;

--- a/packages_es6/ember-metal/tests/core/inspect_test.js
+++ b/packages_es6/ember-metal/tests/core/inspect_test.js
@@ -1,4 +1,4 @@
-import {inspect} from "ember-metal/utils";
+import { inspect } from "ember-metal/utils";
 import Ember from 'ember-metal/core';
 
 module("Ember.inspect");

--- a/packages_es6/ember-metal/tests/events_test.js
+++ b/packages_es6/ember-metal/tests/events_test.js
@@ -1,6 +1,6 @@
-import {Mixin} from 'ember-metal/mixin';
-import {create} from 'ember-metal/platform';
-import {meta} from 'ember-metal/utils';
+import { Mixin } from 'ember-metal/mixin';
+import { create } from 'ember-metal/platform';
+import { meta } from 'ember-metal/utils';
 
 import {
   on,

--- a/packages_es6/ember-metal/tests/instrumentation_test.js
+++ b/packages_es6/ember-metal/tests/instrumentation_test.js
@@ -1,4 +1,9 @@
-import {instrument, subscribe, unsubscribe, reset} from "ember-metal/instrumentation";
+import {
+  instrument,
+  subscribe,
+  unsubscribe,
+  reset
+} from "ember-metal/instrumentation";
 
 module("Ember Instrumentation", {
   setup: function() {

--- a/packages_es6/ember-metal/tests/map_test.js
+++ b/packages_es6/ember-metal/tests/map_test.js
@@ -1,4 +1,8 @@
-import {OrderedSet, Map, MapWithDefault} from "ember-metal/map";
+import {
+  OrderedSet,
+  Map,
+  MapWithDefault
+} from "ember-metal/map";
 
 var object, number, string, map;
 

--- a/packages_es6/ember-metal/tests/mixin/computed_test.js
+++ b/packages_es6/ember-metal/tests/mixin/computed_test.js
@@ -1,9 +1,9 @@
 import Ember from "ember-metal/core"; // Ember.K
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {Mixin} from "ember-metal/mixin";
-import {computed} from "ember-metal/computed";
-import {defineProperty} from "ember-metal/properties";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { Mixin } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
+import { defineProperty } from "ember-metal/properties";
 
 module('Mixin Computed Properties');
 

--- a/packages_es6/ember-metal/tests/mixin/detect_test.js
+++ b/packages_es6/ember-metal/tests/mixin/detect_test.js
@@ -1,9 +1,9 @@
 import Ember from "ember-metal/core"; // Ember.K
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {Mixin} from "ember-metal/mixin";
-import {computed} from "ember-metal/computed";
-import {defineProperty} from "ember-metal/properties";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { Mixin } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
+import { defineProperty } from "ember-metal/properties";
 
 module('Mixin.detect');
 

--- a/packages_es6/ember-metal/tests/mixin/introspection_test.js
+++ b/packages_es6/ember-metal/tests/mixin/introspection_test.js
@@ -2,8 +2,11 @@
 // as well as methods vs props.  We are just keeping these for testing; the
 // current impl doesn't care about the differences as much...
 
-import {guidFor} from 'ember-metal/utils';
-import {mixin, Mixin} from 'ember-metal/mixin';
+import { guidFor } from 'ember-metal/utils';
+import {
+  mixin,
+  Mixin
+} from 'ember-metal/mixin';
 import EnumerableUtils from 'ember-metal/enumerable_utils';
 
 var PrivateProperty = Mixin.create({

--- a/packages_es6/ember-metal/tests/mixin/mergedProperties_test.js
+++ b/packages_es6/ember-metal/tests/mixin/mergedProperties_test.js
@@ -1,7 +1,10 @@
 /*globals setup */
 
-import {get} from 'ember-metal/property_get';
-import {mixin, Mixin} from 'ember-metal/mixin';
+import { get } from 'ember-metal/property_get';
+import {
+  mixin,
+  Mixin
+} from 'ember-metal/mixin';
 
 module('Mixin mergedProperties');
 

--- a/packages_es6/ember-metal/tests/mixin/method_test.js
+++ b/packages_es6/ember-metal/tests/mixin/method_test.js
@@ -1,8 +1,11 @@
 /*globals raises */
 
-import {get} from 'ember-metal/property_get';
-import {create} from 'ember-metal/platform';
-import {mixin, Mixin} from 'ember-metal/mixin';
+import { get } from 'ember-metal/property_get';
+import { create } from 'ember-metal/platform';
+import {
+  mixin,
+  Mixin
+} from 'ember-metal/mixin';
 
 module('Mixin Methods');
 

--- a/packages_es6/ember-metal/tests/mixin/observer_test.js
+++ b/packages_es6/ember-metal/tests/mixin/observer_test.js
@@ -1,10 +1,14 @@
 /*globals testBoth */
 
 import testBoth from 'ember-metal/tests/props_helper';
-import {get} from 'ember-metal/property_get';
-import {create} from 'ember-metal/platform';
-import {observer, mixin, Mixin} from 'ember-metal/mixin';
-import {isWatching} from "ember-metal/watching";
+import { get } from 'ember-metal/property_get';
+import { create } from 'ember-metal/platform';
+import {
+  observer,
+  mixin,
+  Mixin
+} from 'ember-metal/mixin';
+import { isWatching } from "ember-metal/watching";
 
 module('Mixin observer');
 

--- a/packages_es6/ember-metal/tests/mixin/reopen_test.js
+++ b/packages_es6/ember-metal/tests/mixin/reopen_test.js
@@ -1,4 +1,4 @@
-import {Mixin} from 'ember-metal/mixin';
+import Mixin from 'ember-metal/mixin';
 
 module('Ember.Mixin#reopen');
 

--- a/packages_es6/ember-metal/tests/mixin/required_test.js
+++ b/packages_es6/ember-metal/tests/mixin/required_test.js
@@ -1,6 +1,10 @@
 /*globals setup raises */
-import {mixin, Mixin, required} from 'ember-metal/mixin';
-import {get} from 'ember-metal/property_get';
+import {
+  mixin,
+  Mixin,
+  required
+} from 'ember-metal/mixin';
+import { get } from 'ember-metal/property_get';
 
 var PartialMixin, FinalMixin, obj;
 

--- a/packages_es6/ember-metal/tests/mixin/without_test.js
+++ b/packages_es6/ember-metal/tests/mixin/without_test.js
@@ -1,4 +1,4 @@
-import {Mixin} from 'ember-metal/mixin';
+import { Mixin } from 'ember-metal/mixin';
 
 test('without should create a new mixin excluding named properties', function() {
 

--- a/packages_es6/ember-metal/tests/observer_test.js
+++ b/packages_es6/ember-metal/tests/observer_test.js
@@ -2,16 +2,39 @@
 
 import Ember from 'ember-metal/core';
 import testBoth from 'ember-metal/tests/props_helper';
-import {addObserver, removeObserver, addBeforeObserver, _suspendObserver, _suspendObservers, removeBeforeObserver} from "ember-metal/observer";
-import {propertyWillChange, propertyDidChange} from 'ember-metal/property_events';
-import {create} from 'ember-metal/platform';
-import {defineProperty} from 'ember-metal/properties';
-import {computed, cacheFor} from 'ember-metal/computed';
-import {Mixin, mixin, observer, beforeObserver, immediateObserver} from 'ember-metal/mixin';
+import {
+  addObserver,
+  removeObserver,
+  addBeforeObserver,
+  _suspendObserver,
+  _suspendObservers,
+  removeBeforeObserver
+} from "ember-metal/observer";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from 'ember-metal/property_events';
+import { create } from 'ember-metal/platform';
+import { defineProperty } from 'ember-metal/properties';
+import {
+  computed,
+  cacheFor
+} from 'ember-metal/computed';
+import {
+  Mixin,
+  mixin,
+  observer,
+  beforeObserver,
+  immediateObserver
+} from 'ember-metal/mixin';
 import run from 'ember-metal/run_loop';
-import { beginPropertyChanges, endPropertyChanges, changeProperties} from "ember-metal/property_events";
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
+import {
+  beginPropertyChanges,
+  endPropertyChanges,
+  changeProperties
+} from "ember-metal/property_events";
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 
 // ..........................................................
 // ADD OBSERVER

--- a/packages_es6/ember-metal/tests/performance_test.js
+++ b/packages_es6/ember-metal/tests/performance_test.js
@@ -1,9 +1,13 @@
-import {set} from 'ember-metal/property_set';
-import {get} from 'ember-metal/property_get';
-import {computed} from 'ember-metal/computed';
-import {defineProperty} from "ember-metal/properties";
-import {propertyDidChange, beginPropertyChanges, endPropertyChanges} from "ember-metal/property_events";
-import {addObserver} from "ember-metal/observer";
+import { set } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { computed } from 'ember-metal/computed';
+import { defineProperty } from "ember-metal/properties";
+import {
+  propertyDidChange,
+  beginPropertyChanges,
+  endPropertyChanges
+} from "ember-metal/property_events";
+import { addObserver } from "ember-metal/observer";
 
 /*
   This test file is designed to capture performance regressions related to

--- a/packages_es6/ember-metal/tests/platform/create_test.js
+++ b/packages_es6/ember-metal/tests/platform/create_test.js
@@ -1,4 +1,4 @@
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 
 module("Ember.create()");
 

--- a/packages_es6/ember-metal/tests/platform/defineProperty_test.js
+++ b/packages_es6/ember-metal/tests/platform/defineProperty_test.js
@@ -1,4 +1,4 @@
-import {platform} from 'ember-metal/platform';
+import { platform } from 'ember-metal/platform';
 import EnumerableUtils from 'ember-metal/enumerable_utils';
 
 function isEnumerable(obj, keyName) {

--- a/packages_es6/ember-metal/tests/properties_test.js
+++ b/packages_es6/ember-metal/tests/properties_test.js
@@ -1,8 +1,8 @@
 import Ember from 'ember-metal/core';
-import {set} from 'ember-metal/property_set';
-import {get} from 'ember-metal/property_get';
-import {computed} from 'ember-metal/computed';
-import {defineProperty} from "ember-metal/properties";
+import { set } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { computed } from 'ember-metal/computed';
+import { defineProperty } from "ember-metal/properties";
 
 module('Ember.defineProperty');
 

--- a/packages_es6/ember-metal/tests/props_helper.js
+++ b/packages_es6/ember-metal/tests/props_helper.js
@@ -1,7 +1,7 @@
 /*global testBoth:true */
 
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 
 // used by unit tests to test both accessor mode and non-accessor mode
 export default function(testname, callback) {

--- a/packages_es6/ember-metal/tests/run_loop/add_queue_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/add_queue_test.js
@@ -1,7 +1,8 @@
 import run from 'ember-metal/run_loop';
-import {indexOf} from "ember-metal/array";
+import { indexOf } from "ember-metal/array";
 
-var originalQueues = run.queues, queues;
+var originalQueues = run.queues;
+var queues;
 
 module('system/run_loop/add_queue_test',{
   setup: function(){

--- a/packages_es6/ember-metal/tests/run_loop/later_test.js
+++ b/packages_es6/ember-metal/tests/run_loop/later_test.js
@@ -1,10 +1,10 @@
 import isNone from 'ember-metal/is_none';
 import run from 'ember-metal/run_loop';
 
-var originalSetTimeout = window.setTimeout,
-    originalDateValueOf = Date.prototype.valueOf;
+var originalSetTimeout = window.setTimeout;
+var originalDateValueOf = Date.prototype.valueOf;
 
-var wait = function(callback, maxWaitCount) {
+function wait(callback, maxWaitCount) {
   maxWaitCount = isNone(maxWaitCount) ? 100 : maxWaitCount;
 
   originalSetTimeout(function() {
@@ -16,7 +16,7 @@ var wait = function(callback, maxWaitCount) {
 
     callback();
   }, 10);
-};
+}
 
 module('run.later', {
   teardown: function() {

--- a/packages_es6/ember-metal/tests/utils/can_invoke_test.js
+++ b/packages_es6/ember-metal/tests/utils/can_invoke_test.js
@@ -1,4 +1,4 @@
-import {canInvoke} from "ember-metal/utils";
+import { canInvoke } from "ember-metal/utils";
 
 var obj;
 

--- a/packages_es6/ember-metal/tests/utils/generate_guid_test.js
+++ b/packages_es6/ember-metal/tests/utils/generate_guid_test.js
@@ -1,4 +1,4 @@
-import {generateGuid} from "ember-metal/utils";
+import { generateGuid } from "ember-metal/utils";
 
 module("Ember.generateGuid");
 

--- a/packages_es6/ember-metal/tests/utils/guidFor_test.js
+++ b/packages_es6/ember-metal/tests/utils/guidFor_test.js
@@ -1,5 +1,8 @@
-import {guidFor, generateGuid} from "ember-metal/utils";
-import {rewatch} from "ember-metal/watching";
+import {
+  guidFor,
+  generateGuid
+} from "ember-metal/utils";
+import { rewatch } from "ember-metal/watching";
 
 module("guidFor");
 

--- a/packages_es6/ember-metal/tests/utils/is_array_test.js
+++ b/packages_es6/ember-metal/tests/utils/is_array_test.js
@@ -1,4 +1,4 @@
-import {isArray} from 'ember-metal/utils';
+import { isArray } from 'ember-metal/utils';
 module("Ember Type Checking");
 
 var global = this;

--- a/packages_es6/ember-metal/tests/utils/meta_test.js
+++ b/packages_es6/ember-metal/tests/utils/meta_test.js
@@ -1,7 +1,15 @@
 /*global jQuery*/
 import Ember from 'ember-metal/core';
-import {create, platform} from 'ember-metal/platform';
-import {getMeta, setMeta, meta, metaPath} from 'ember-metal/utils';
+import {
+  create,
+  platform
+} from 'ember-metal/platform';
+import {
+  getMeta,
+  setMeta,
+  meta,
+  metaPath
+} from 'ember-metal/utils';
 
 module("Ember.meta");
 

--- a/packages_es6/ember-metal/tests/utils/try_catch_finally_test.js
+++ b/packages_es6/ember-metal/tests/utils/try_catch_finally_test.js
@@ -1,4 +1,4 @@
-import {tryCatchFinally} from 'ember-metal/utils';
+import { tryCatchFinally } from 'ember-metal/utils';
 
 var tryCount, catchCount, finalizeCount, tryable, catchable, finalizer, error,
 tryableResult, catchableResult, finalizerResult;

--- a/packages_es6/ember-metal/tests/utils/try_finally_test.js
+++ b/packages_es6/ember-metal/tests/utils/try_finally_test.js
@@ -1,4 +1,4 @@
-import {tryFinally} from 'ember-metal/utils';
+import { tryFinally } from 'ember-metal/utils';
 
 var tryCount, finalizeCount, tryable, finalizer, error, tryableResult, finalizerResult;
 

--- a/packages_es6/ember-metal/tests/utils/try_invoke_test.js
+++ b/packages_es6/ember-metal/tests/utils/try_invoke_test.js
@@ -1,4 +1,4 @@
-import {tryInvoke} from 'ember-metal/utils';
+import { tryInvoke } from 'ember-metal/utils';
 
 var obj;
 

--- a/packages_es6/ember-metal/tests/utils/type_of_test.js
+++ b/packages_es6/ember-metal/tests/utils/type_of_test.js
@@ -1,4 +1,4 @@
-import {typeOf} from 'ember-metal/utils';
+import { typeOf } from 'ember-metal/utils';
 
 module("Ember Type Checking");
 

--- a/packages_es6/ember-metal/tests/watching/isWatching_test.js
+++ b/packages_es6/ember-metal/tests/watching/isWatching_test.js
@@ -1,12 +1,18 @@
-import {get} from 'ember-metal/property_get';
-import {defineProperty} from "ember-metal/properties";
-import {Mixin, observer} from 'ember-metal/mixin';
-import {addObserver, removeObserver} from "ember-metal/observer";
-import {isWatching} from 'ember-metal/watching';
+import { get } from 'ember-metal/property_get';
+import { defineProperty } from "ember-metal/properties";
+import {
+  Mixin,
+  observer
+} from 'ember-metal/mixin';
+import {
+  addObserver,
+  removeObserver
+} from "ember-metal/observer";
+import { isWatching } from 'ember-metal/watching';
 
 module('isWatching');
 
-var testObserver = function(setup, teardown, key) {
+function testObserver(setup, teardown, key) {
   var obj = {}, fn = function() {};
   key = key || 'foo';
 
@@ -15,7 +21,7 @@ var testObserver = function(setup, teardown, key) {
   equal(isWatching(obj, key), true, "isWatching is true when observers are added");
   teardown(obj, key, fn);
   equal(isWatching(obj, key), false, "isWatching is false after observers are removed");
-};
+}
 
 test("isWatching is true for regular local observers", function() {
   testObserver(function(obj, key, fn) {

--- a/packages_es6/ember-metal/tests/watching/unwatch_test.js
+++ b/packages_es6/ember-metal/tests/watching/unwatch_test.js
@@ -1,11 +1,17 @@
 import testBoth from 'ember-metal/tests/props_helper';
-import {watch, unwatch} from "ember-metal/watching";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
-import {defineProperty} from 'ember-metal/properties';
+import {
+  watch,
+  unwatch
+} from "ember-metal/watching";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import { defineProperty } from 'ember-metal/properties';
 import { addListener } from "ember-metal/events";
-import {computed} from 'ember-metal/computed';
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
+import { computed } from 'ember-metal/computed';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 
 var willCount, didCount;
 

--- a/packages_es6/ember-metal/tests/watching/watch_test.js
+++ b/packages_es6/ember-metal/tests/watching/watch_test.js
@@ -2,8 +2,11 @@ import Ember from 'ember-metal/core';
 import testBoth from 'ember-metal/tests/props_helper';
 import EnumerableUtils from 'ember-metal/enumerable_utils';
 import { addListener } from "ember-metal/events";
-import {watch, unwatch, destroy} from "ember-metal/watching";
-
+import {
+  watch,
+  unwatch,
+  destroy
+} from "ember-metal/watching";
 
 var willCount, didCount,
     willKeys, didKeys,

--- a/packages_es6/ember-routing/lib/ext/controller.js
+++ b/packages_es6/ember-routing/lib/ext/controller.js
@@ -1,10 +1,10 @@
 import Ember from "ember-metal/core"; // FEATURES, deprecate
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 var map = EnumerableUtils.map;
 
-import {ControllerMixin} from "ember-runtime/controllers/controller";
+import { ControllerMixin } from "ember-runtime/controllers/controller";
 
 /**
 @module ember

--- a/packages_es6/ember-routing/lib/ext/view.js
+++ b/packages_es6/ember-routing/lib/ext/view.js
@@ -1,7 +1,7 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 /**
 @module ember

--- a/packages_es6/ember-routing/lib/helpers/action.js
+++ b/packages_es6/ember-routing/lib/helpers/action.js
@@ -1,16 +1,18 @@
 import Ember from "ember-metal/core"; // Handlebars, uuid, FEATURES, assert, deprecate
-import {get} from "ember-metal/property_get";
-import {forEach} from "ember-metal/array";
+import { get } from "ember-metal/property_get";
+import { forEach } from "ember-metal/array";
 import run from "ember-metal/run_loop";
 
-import {isSimpleClick} from "ember-views/system/utils";
+import { isSimpleClick } from "ember-views/system/utils";
 import EmberRouter from "ember-routing/system/router";
 
-
 import EmberHandlebars from "ember-handlebars";
-import {handlebarsGet} from "ember-handlebars/ext";
-import {viewHelper} from "ember-handlebars/helpers/view";
-import {resolveParams, resolvePath} from "ember-routing/helpers/shared";
+import { handlebarsGet } from "ember-handlebars/ext";
+import { viewHelper } from "ember-handlebars/helpers/view";
+import {
+  resolveParams,
+  resolvePath
+} from "ember-routing/helpers/shared";
 
 // requireModule('ember-handlebars');
 
@@ -19,8 +21,8 @@ import {resolveParams, resolvePath} from "ember-routing/helpers/shared";
 @submodule ember-routing
 */
 
-var SafeString = EmberHandlebars.SafeString,
-    a_slice = Array.prototype.slice;
+var SafeString = EmberHandlebars.SafeString;
+var a_slice = Array.prototype.slice;
 
 function args(options, actionName) {
   var ret = [];
@@ -35,6 +37,8 @@ function args(options, actionName) {
 var ActionHelper = {
   registeredActions: {}
 };
+
+export { ActionHelper };
 
 var keys = ["alt", "shift", "meta", "ctrl"];
 
@@ -290,7 +294,7 @@ ActionHelper.registerAction = function(actionNameOrPath, options, allowedKeys) {
   @param {Object} [context]*
   @param {Hash} options
 */
-function actionHelper(actionName) {
+export function actionHelper(actionName) {
   var options = arguments[arguments.length - 1],
       contexts = a_slice.call(arguments, 1, -1);
 
@@ -322,5 +326,3 @@ function actionHelper(actionName) {
   var actionId = ActionHelper.registerAction(actionName, action, hash.allowedKeys);
   return new SafeString('data-ember-action="' + actionId + '"');
 }
-
-export {ActionHelper, actionHelper};

--- a/packages_es6/ember-routing/lib/helpers/link_to.js
+++ b/packages_es6/ember-routing/lib/helpers/link_to.js
@@ -1,20 +1,23 @@
 import Ember from "ember-metal/core"; // FEATURES, Logger, Handlebars, warn, assert
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 
-import {onLoad} from "ember-runtime/system/lazy_load";
-import {fmt} from "ember-runtime/system/string";
+import { onLoad } from "ember-runtime/system/lazy_load";
+import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import keys from "ember-runtime/keys";
-import {isSimpleClick} from "ember-views/system/utils";
+import { isSimpleClick } from "ember-views/system/utils";
 import EmberComponent from "ember-views/views/component";
 import EmberHandlebars from "ember-handlebars";
-import {viewHelper} from "ember-handlebars/helpers/view";
+import { viewHelper } from "ember-handlebars/helpers/view";
 import EmberRouter from "ember-routing/system/router";
-import {resolveParams, resolvePaths} from "ember-routing/helpers/shared";
+import {
+  resolveParams,
+  resolvePaths
+} from "ember-routing/helpers/shared";
 
 // requireModule('ember-handlebars');
 
@@ -948,4 +951,8 @@ function deprecatedLinkToHelper() {
   return linkToHelper.apply(this, arguments);
 }
 
-export {LinkView, deprecatedLinkToHelper, linkToHelper};
+export {
+  LinkView,
+  deprecatedLinkToHelper,
+  linkToHelper
+};

--- a/packages_es6/ember-routing/lib/helpers/outlet.js
+++ b/packages_es6/ember-routing/lib/helpers/outlet.js
@@ -1,10 +1,10 @@
 import Ember from "ember-metal/core"; // assert
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {onLoad} from "ember-runtime/system/lazy_load";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { onLoad } from "ember-runtime/system/lazy_load";
 import ContainerView from "ember-views/views/container_view";
-import {_Metamorph} from "ember-handlebars/views/metamorph_view";
-import {viewHelper} from "ember-handlebars/helpers/view";
+import { _Metamorph } from "ember-handlebars/views/metamorph_view";
+import { viewHelper } from "ember-handlebars/helpers/view";
 
 // requireModule('ember-handlebars');
 
@@ -19,7 +19,7 @@ import {viewHelper} from "ember-handlebars/helpers/view";
   */
 
 var OutletView = ContainerView.extend(_Metamorph);
-
+export { OutletView };
 /**
   The `outlet` helper is a placeholder that the router will fill in with
   the appropriate template based on the current state of the application.
@@ -83,13 +83,12 @@ var OutletView = ContainerView.extend(_Metamorph);
     that holds the view for this outlet
   @return {String} HTML string
 */
-function outletHelper(property, options) {
-
-  var outletSource,
-      container,
-      viewName,
-      viewClass,
-      viewFullName;
+export function outletHelper(property, options) {
+  var outletSource;
+  var container;
+  var viewName;
+  var viewClass;
+  var viewFullName;
 
   if (property && property.data && property.data.isRenderData) {
     options = property;
@@ -119,5 +118,3 @@ function outletHelper(property, options) {
 
   return viewHelper.call(this, viewClass, options);
 }
-
-export {outletHelper, OutletView};

--- a/packages_es6/ember-routing/lib/helpers/render.js
+++ b/packages_es6/ember-routing/lib/helpers/render.js
@@ -1,11 +1,14 @@
 import Ember from "ember-metal/core"; // assert, deprecate
 import EmberError from "ember-metal/error";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {camelize} from "ember-runtime/system/string";
-import {generateControllerFactory, generateController} from "ember-routing/system/controller_for";
-import {handlebarsGet} from "ember-handlebars/ext";
-import {viewHelper} from "ember-handlebars/helpers/view";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { camelize } from "ember-runtime/system/string";
+import {
+  generateControllerFactory,
+  generateController
+} from "ember-routing/system/controller_for";
+import { handlebarsGet } from "ember-handlebars/ext";
+import { viewHelper } from "ember-handlebars/helpers/view";
 
 import "ember-handlebars/helpers/view";
 
@@ -86,7 +89,7 @@ You could render it inside the `post` template using the `render` helper.
   @param {Hash} options
   @return {String} HTML string
 */
-function renderHelper(name, contextString, options) {
+export default function renderHelper(name, contextString, options) {
   var length = arguments.length;
 
   var contextProvided = length === 3,
@@ -172,5 +175,3 @@ function renderHelper(name, contextString, options) {
 
   viewHelper.call(this, view, options);
 }
-
-export default renderHelper;

--- a/packages_es6/ember-routing/lib/helpers/shared.js
+++ b/packages_es6/ember-routing/lib/helpers/shared.js
@@ -5,7 +5,7 @@ import {ControllerMixin} from "ember-runtime/controllers/controller";
 import EmberRouter from "ember-routing/system/router";
 import {resolveParams as handlebarsResolve, handlebarsGet} from "ember-handlebars/ext";
 
-function resolveParams(context, params, options) {
+export function resolveParams(context, params, options) {
   return map.call(resolvePaths(context, params, options), function(path, i) {
     if (null === path) {
       // Param was string/number, not a path, so just return raw string/number.
@@ -16,6 +16,7 @@ function resolveParams(context, params, options) {
   });
 }
 
+export { resolvePaths };
 function resolvePaths(context, params, options) {
   var resolved = handlebarsResolve(context, params, options),
       types = options.types;
@@ -38,5 +39,3 @@ function resolvePaths(context, params, options) {
     }
   }
 }
-
-export {resolveParams, resolvePaths};

--- a/packages_es6/ember-routing/lib/location/api.js
+++ b/packages_es6/ember-routing/lib/location/api.js
@@ -1,6 +1,6 @@
 import Ember from "ember-metal/core"; // deprecate, assert
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 /**
 @module ember
@@ -119,7 +119,7 @@ import {set} from "ember-metal/property_set";
   @namespace Ember
   @static
 */
-var EmberLocation = {
+export default {
   /**
    This is deprecated in favor of using the container to lookup the location
    implementation as desired.
@@ -204,5 +204,3 @@ var EmberLocation = {
     }
   }
 };
-
-export default EmberLocation;

--- a/packages_es6/ember-routing/lib/location/auto_location.js
+++ b/packages_es6/ember-routing/lib/location/auto_location.js
@@ -1,6 +1,6 @@
 import Ember from "ember-metal/core"; // FEATURES
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 import EmberLocation from "ember-routing/location/api";
 import HistoryLocation from "ember-routing/location/history_location";
@@ -26,7 +26,7 @@ import NoneLocation from "ember-routing/location/none_location";
   @namespace Ember
   @static
 */
-var AutoLocation = {
+export default {
 
   /**
     @private
@@ -370,5 +370,3 @@ var AutoLocation = {
     return implementation;
   }
 };
-
-export default AutoLocation;

--- a/packages_es6/ember-routing/lib/location/hash_location.js
+++ b/packages_es6/ember-routing/lib/location/hash_location.js
@@ -21,7 +21,7 @@ import jQuery from "ember-views/system/jquery";
   @namespace Ember
   @extends Ember.Object
 */
-var HashLocation = EmberObject.extend({
+export default EmberObject.extend({
   implementation: 'hash',
 
   init: function() {
@@ -126,5 +126,3 @@ var HashLocation = EmberObject.extend({
     jQuery(window).off('hashchange.ember-location-'+guid);
   }
 });
-
-export default HashLocation;

--- a/packages_es6/ember-routing/lib/location/history_location.js
+++ b/packages_es6/ember-routing/lib/location/history_location.js
@@ -22,7 +22,7 @@ var supportsHistoryState = window.history && 'state' in window.history;
   @namespace Ember
   @extends Ember.Object
 */
-var HistoryLocation = EmberObject.extend({
+export default EmberObject.extend({
   implementation: 'history',
 
   init: function() {
@@ -219,5 +219,3 @@ var HistoryLocation = EmberObject.extend({
     jQuery(window).off('popstate.ember-location-'+guid);
   }
 });
-
-export default HistoryLocation;

--- a/packages_es6/ember-routing/lib/location/none_location.js
+++ b/packages_es6/ember-routing/lib/location/none_location.js
@@ -17,7 +17,7 @@ import EmberObject from "ember-runtime/system/object";
   @namespace Ember
   @extends Ember.Object
 */
-var NoneLocation = EmberObject.extend({
+export default EmberObject.extend({
   implementation: 'none',
   path: '',
 
@@ -88,5 +88,3 @@ var NoneLocation = EmberObject.extend({
     return url;
   }
 });
-
-export default NoneLocation;

--- a/packages_es6/ember-routing/lib/main.js
+++ b/packages_es6/ember-routing/lib/main.js
@@ -18,10 +18,15 @@ import "ember-routing/ext/run_loop";
 import "ember-routing/ext/controller";
 import "ember-routing/ext/view";
 
-import {resolvePaths, resolveParams} from "ember-routing/helpers/shared";
-import {deprecatedLinkToHelper, linkToHelper, LinkView} from "ember-routing/helpers/link_to";
-
-
+import {
+  resolvePaths,
+  resolveParams
+} from "ember-routing/helpers/shared";
+import {
+  deprecatedLinkToHelper,
+  linkToHelper,
+  LinkView
+} from "ember-routing/helpers/link_to";
 // require('ember-views');
 import EmberLocation from "ember-routing/location/api";
 import NoneLocation from "ember-routing/location/none_location";
@@ -29,14 +34,23 @@ import HashLocation from "ember-routing/location/hash_location";
 import HistoryLocation from "ember-routing/location/history_location";
 import AutoLocation from "ember-routing/location/auto_location";
 
-import {controllerFor, generateControllerFactory, generateController} from "ember-routing/system/controller_for";
+import {
+  controllerFor,
+  generateControllerFactory,
+  generateController
+} from "ember-routing/system/controller_for";
 import RouterDSL from "ember-routing/system/dsl";
 import Router from "ember-routing/system/router";
 import Route from "ember-routing/system/route";
-import {outletHelper, OutletView} from "ember-routing/helpers/outlet";
+import {
+  outletHelper,
+  OutletView
+} from "ember-routing/helpers/outlet";
 import renderHelper from "ember-routing/helpers/render";
-import {ActionHelper, actionHelper} from "ember-routing/helpers/action";
-
+import {
+  ActionHelper,
+  actionHelper
+} from "ember-routing/helpers/action";
 
 Ember.Location = EmberLocation;
 Ember.AutoLocation = AutoLocation;

--- a/packages_es6/ember-routing/lib/system/controller_for.js
+++ b/packages_es6/ember-routing/lib/system/controller_for.js
@@ -1,6 +1,6 @@
 import Ember from "ember-metal/core"; // Logger
-import {get} from "ember-metal/property_get";
-import {isArray} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { isArray } from "ember-metal/utils";
 
 /**
 @module ember
@@ -15,9 +15,9 @@ import {isArray} from "ember-metal/utils";
   @method controllerFor
   @private
 */
-var controllerFor = function(container, controllerName, lookupOptions) {
+export function controllerFor(container, controllerName, lookupOptions) {
   return container.lookup('controller:' + controllerName, lookupOptions);
-};
+}
 
 /**
   Generates a controller factory
@@ -34,7 +34,9 @@ var controllerFor = function(container, controllerName, lookupOptions) {
   @method generateControllerFactory
   @private
 */
-var generateControllerFactory = function(container, controllerName, context) {
+
+export { generateControllerFactory };
+function generateControllerFactory(container, controllerName, context) {
   var Factory, fullName, instance, name, factoryName, controllerType;
 
   if (context && isArray(context)) {
@@ -59,7 +61,7 @@ var generateControllerFactory = function(container, controllerName, context) {
   container.register(fullName,  Factory);
 
   return Factory;
-};
+}
 
 /**
   Generates and instantiates a controller.
@@ -74,7 +76,7 @@ var generateControllerFactory = function(container, controllerName, context) {
   @private
   @since 1.3.0
 */
-var generateController = function(container, controllerName, context) {
+export function generateController(container, controllerName, context) {
   generateControllerFactory(container, controllerName, context);
   var fullName = 'controller:' + controllerName;
   var instance = container.lookup(fullName);
@@ -84,6 +86,4 @@ var generateController = function(container, controllerName, context) {
   }
 
   return instance;
-};
-
-export {controllerFor, generateControllerFactory, generateController};
+}

--- a/packages_es6/ember-routing/lib/system/dsl.js
+++ b/packages_es6/ember-routing/lib/system/dsl.js
@@ -9,6 +9,7 @@ function DSL(name) {
   this.parent = name;
   this.matches = [];
 }
+export default DSL;
 
 DSL.prototype = {
   resource: function(name, options, callback) {
@@ -103,4 +104,3 @@ DSL.map = function(callback) {
   return dsl;
 };
 
-export default DSL;

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -1,28 +1,30 @@
 import Ember from "ember-metal/core"; // FEATURES, K, A, deprecate, assert, Logger
 import EmberError from "ember-metal/error";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import getProperties from "ember-metal/get_properties";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {isNone} from "ember-metal/is_none";
-import {computed} from "ember-metal/computed";
-import {typeOf} from "ember-metal/utils";
+import { isNone } from "ember-metal/is_none";
+import { computed } from "ember-metal/computed";
+import { typeOf } from "ember-metal/utils";
 import run from "ember-metal/run_loop";
-
 import keys from "ember-runtime/keys";
 import copy from "ember-runtime/copy";
-import {classify, fmt} from "ember-runtime/system/string";
+import {
+  classify,
+  fmt
+} from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import ActionHandler from "ember-runtime/mixins/action_handler";
-import {generateController} from "ember-routing/system/controller_for";
+import { generateController } from "ember-routing/system/controller_for";
 
 /**
 @module ember
 @submodule ember-routing
 */
 
-var a_forEach = EnumerableUtils.forEach,
-    a_replace = EnumerableUtils.replace;
+var a_forEach = EnumerableUtils.forEach;
+var a_replace = EnumerableUtils.replace;
 
 /**
   The `Ember.Route` class is used to define individual routes. Refer to

--- a/packages_es6/ember-routing/lib/system/router.js
+++ b/packages_es6/ember-routing/lib/system/router.js
@@ -1,21 +1,21 @@
 import Ember from "ember-metal/core"; // FEATURES, Logger, K, assert
 import EmberError from "ember-metal/error";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {forEach} from "ember-metal/array";
-import {defineProperty} from "ember-metal/properties";
-import {computed} from "ember-metal/computed";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { forEach } from "ember-metal/array";
+import { defineProperty } from "ember-metal/properties";
+import { computed } from "ember-metal/computed";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 
-import {fmt} from "ember-runtime/system/string";
+import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import Evented from "ember-runtime/mixins/evented";
 import EmberRouterDSL from "ember-routing/system/dsl";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberLocation from "ember-routing/location/api";
-import {_MetamorphView} from "ember-handlebars/views/metamorph_view";
+import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
 
 // requireModule("ember-handlebars");
 // requireModule("ember-runtime");

--- a/packages_es6/ember-routing/tests/helpers/action_test.js
+++ b/packages_es6/ember-routing/tests/helpers/action_test.js
@@ -1,20 +1,23 @@
 import Ember from 'ember-metal/core'; // A, FEATURES, assert, TESTING_DEPRECATION
-import {set} from "ember-metal/property_set";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 
 import EmberObject from "ember-runtime/system/object";
-import {Controller as EmberController} from "ember-runtime/controllers/controller";
+import { Controller as EmberController } from "ember-runtime/controllers/controller";
 import EmberObjectController from "ember-runtime/controllers/object_controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 
 import EmberHandlebars from "ember-handlebars";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import EmberComponent from "ember-views/views/component";
 import jQuery from "ember-views/system/jquery";
 
 import "ember-routing/helpers/shared";
-import {ActionHelper, actionHelper} from "ember-routing/helpers/action";
+import {
+  ActionHelper,
+  actionHelper
+} from "ember-routing/helpers/action";
 
 var dispatcher, view, originalActionHelper,
     originalRegisterAction = ActionHelper.registerAction;

--- a/packages_es6/ember-routing/tests/helpers/outlet_test.js
+++ b/packages_es6/ember-routing/tests/helpers/outlet_test.js
@@ -1,12 +1,15 @@
 import Ember from 'ember-metal/core'; // TEMPLATES
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 
 import Container from 'container/container';
 import Namespace from "ember-runtime/system/namespace";
-import {decamelize, classify} from "ember-runtime/system/string";
-import {Controller} from "ember-runtime/controllers/controller";
+import {
+  decamelize,
+  classify
+} from "ember-runtime/system/string";
+import { Controller } from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 
@@ -19,7 +22,7 @@ import EmberView from "ember-routing/ext/view";
 import EmberContainerView from "ember-views/views/container_view";
 import jQuery from "ember-views/system/jquery";
 
-import {outletHelper} from "ember-routing/helpers/outlet";
+import { outletHelper } from "ember-routing/helpers/outlet";
 
 var buildContainer = function(namespace) {
   var container = new Container();

--- a/packages_es6/ember-routing/tests/helpers/render_test.js
+++ b/packages_es6/ember-routing/tests/helpers/render_test.js
@@ -1,15 +1,18 @@
 import Ember from 'ember-metal/core'; // TEMPLATES
-import {get} from "ember-metal/property_get";
-import {set as emberSet} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set as emberSet } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {create} from 'ember-metal/platform';
-import {observer} from 'ember-metal/mixin';
+import { create } from 'ember-metal/platform';
+import { observer } from 'ember-metal/mixin';
 
 import Container from 'container/container';
 import Namespace from "ember-runtime/system/namespace";
-import {classify, decamelize} from "ember-runtime/system/string";
+import {
+  classify,
+  decamelize
+} from "ember-runtime/system/string";
 
-import {Controller as EmberController} from "ember-runtime/controllers/controller";
+import { Controller as EmberController } from "ember-runtime/controllers/controller";
 import EmberObjectController from "ember-runtime/controllers/object_controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 
@@ -21,22 +24,25 @@ import EmberView from "ember-routing/ext/view";
 import jQuery from "ember-views/system/jquery";
 
 import renderHelper from "ember-routing/helpers/render";
-import {ActionHelper, actionHelper} from "ember-routing/helpers/action";
-import {outletHelper} from "ember-routing/helpers/outlet";
+import {
+  ActionHelper,
+  actionHelper
+} from "ember-routing/helpers/action";
+import { outletHelper } from "ember-routing/helpers/outlet";
 
-var appendView = function(view) {
+function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });
-};
+}
 
-var set = function(object, key, value) {
+function set(object, key, value) {
   run(function() { emberSet(object, key, value); });
-};
+}
 
-var compile = function(template) {
+function compile(template) {
   return EmberHandlebars.compile(template);
-};
+}
 
-var buildContainer = function(namespace) {
+function buildContainer(namespace) {
   var container = new Container();
 
   container.set = emberSet;
@@ -55,7 +61,7 @@ var buildContainer = function(namespace) {
   container.typeInjection('route', 'router', 'router:main');
 
   return container;
-};
+}
 
 function resolverFor(namespace) {
   return function(fullName) {

--- a/packages_es6/ember-routing/tests/location/auto_location_test.js
+++ b/packages_es6/ember-routing/tests/location/auto_location_test.js
@@ -1,5 +1,5 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import copy from "ember-runtime/copy";
 import EmberObject from "ember-runtime/system/object";

--- a/packages_es6/ember-routing/tests/location/history_location_test.js
+++ b/packages_es6/ember-routing/tests/location/history_location_test.js
@@ -1,5 +1,5 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import HistoryLocation from "ember-routing/location/history_location";
 
@@ -7,7 +7,7 @@ var FakeHistory, HistoryTestLocation, location,
     rootURL = window.location.pathname;
 
 function createLocation(options){
-  if(!options) { options = {}; }
+  if (!options) { options = {}; }
   location = HistoryTestLocation.create(options);
 }
 

--- a/packages_es6/ember-routing/tests/system/controller_for_test.js
+++ b/packages_es6/ember-routing/tests/system/controller_for_test.js
@@ -1,15 +1,18 @@
 import Ember from 'ember-metal/core'; // A
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 
 import Container from 'container/container';
 import Namespace from "ember-runtime/system/namespace";
-import {classify} from "ember-runtime/system/string";
-import {Controller} from "ember-runtime/controllers/controller";
+import { classify } from "ember-runtime/system/string";
+import { Controller } from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
-import {controllerFor, generateController} from "ember-routing/system/controller_for";
+import {
+  controllerFor,
+  generateController
+} from "ember-routing/system/controller_for";
 
 var buildContainer = function(namespace) {
   var container = new Container();

--- a/packages_es6/ember-runtime/lib/compare.js
+++ b/packages_es6/ember-runtime/lib/compare.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core";  // for Ember.ORDER_DEFINITION
-import {typeOf} from "ember-metal/utils";
+import { typeOf } from "ember-metal/utils";
 import Comparable from "ember-runtime/mixins/comparable";
 
 // Used by Ember.compare
@@ -40,7 +40,7 @@ Ember.ORDER_DEFINITION = Ember.ENV.ORDER_DEFINITION || [
  @param {Object} w Second value to compare
  @return {Number} -1 if v < w, 0 if v = w and 1 if v > w.
 */
-function compare(v, w) {
+export default function compare(v, w) {
   if (v === w) { return 0; }
 
   var type1 = typeOf(v);
@@ -127,5 +127,3 @@ function compare(v, w) {
       return 0;
   }
 }
-
-export default compare;

--- a/packages_es6/ember-runtime/lib/computed/array_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/array_computed.js
@@ -1,13 +1,16 @@
 import Ember from "ember-metal/core";
-import {reduceComputed, ReduceComputedProperty } from "ember-runtime/computed/reduce_computed";
+import {
+  reduceComputed,
+  ReduceComputedProperty
+} from "ember-runtime/computed/reduce_computed";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {create} from "ember-metal/platform";
-import {addObserver} from "ember-metal/observer";
+import { create } from "ember-metal/platform";
+import { addObserver } from "ember-metal/observer";
 import EmberError from "ember-metal/error";
 
-var a_slice = [].slice,
-    o_create = create,
-    forEach = EnumerableUtils.forEach;
+var a_slice = [].slice;
+var o_create = create;
+var forEach = EnumerableUtils.forEach;
 
 function ArrayComputedProperty() {
   var cp = this;
@@ -183,4 +186,7 @@ function arrayComputed (options) {
   return cp;
 }
 
-export {arrayComputed, ArrayComputedProperty};
+export {
+  arrayComputed,
+  ArrayComputedProperty
+};

--- a/packages_es6/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed.js
@@ -1,31 +1,46 @@
 import Ember from "ember-metal/core"; // Ember.assert
-import {get as e_get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {guidFor, meta as metaFor} from "ember-metal/utils";
+import { get as e_get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  guidFor,
+  meta as metaFor
+} from "ember-metal/utils";
 import EmberError from "ember-metal/error";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
 import expandProperties from "ember-metal/expand_properties";
-import {addObserver, observersFor, removeObserver, addBeforeObserver, removeBeforeObserver} from "ember-metal/observer";
-import {ComputedProperty, cacheFor} from "ember-metal/computed";
-import {create} from "ember-metal/platform";
+import {
+  addObserver,
+  observersFor,
+  removeObserver,
+  addBeforeObserver,
+  removeBeforeObserver
+} from "ember-metal/observer";
+import {
+  ComputedProperty,
+  cacheFor
+} from "ember-metal/computed";
+import { create } from "ember-metal/platform";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import TrackedArray from "ember-runtime/system/tracked_array";
 import EmberArray from "ember-runtime/mixins/array";
 import run from "ember-metal/run_loop";
 import Set from "ember-runtime/system/set";
-import {isArray} from "ember-metal/utils";
+import { isArray } from "ember-metal/utils";
 
-var cacheSet = cacheFor.set,
-    cacheGet = cacheFor.get,
-    cacheRemove = cacheFor.remove,
-    a_slice = [].slice,
-    o_create = create,
-    forEach = EnumerableUtils.forEach,
-    // Here we explicitly don't allow `@each.foo`; it would require some special
-    // testing, but there's no particular reason why it should be disallowed.
-    eachPropertyPattern = /^(.*)\.@each\.(.*)/,
-    doubleEachPropertyPattern = /(.*\.@each){2,}/,
-    arrayBracketPattern = /\.\[\]$/;
+var cacheSet = cacheFor.set;
+var cacheGet = cacheFor.get;
+var cacheRemove = cacheFor.remove;
+var a_slice = [].slice;
+var o_create = create;
+var forEach = EnumerableUtils.forEach;
+// Here we explicitly don't allow `@each.foo`; it would require some special
+// testing, but there's no particular reason why it should be disallowed.
+var eachPropertyPattern = /^(.*)\.@each\.(.*)/;
+var doubleEachPropertyPattern = /(.*\.@each){2,}/;
+var arrayBracketPattern = /\.\[\]$/;
 
 function get(obj, key) {
   if (key === '@this') {
@@ -451,6 +466,8 @@ ReduceComputedPropertyInstanceMeta.prototype = {
   @extends Ember.ComputedProperty
   @constructor
 */
+
+export { ReduceComputedProperty }; // TODO: default export
 function ReduceComputedProperty(options) {
   var cp = this;
 
@@ -806,7 +823,7 @@ ReduceComputedProperty.prototype.property = function () {
   @param {Object} options
   @return {Ember.ComputedProperty}
 */
-function reduceComputed(options) {
+export function reduceComputed(options) {
   var args;
 
   if (arguments.length > 1) {
@@ -830,5 +847,3 @@ function reduceComputed(options) {
 
   return cp;
 }
-
-export {reduceComputed, ReduceComputedProperty};

--- a/packages_es6/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages_es6/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -5,23 +5,26 @@
 
 import Ember from "ember-metal/core"; // Ember.assert
 import merge from "ember-metal/merge";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {isArray, guidFor} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  isArray,
+  guidFor
+} from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import run from 'ember-metal/run_loop';
-import {addObserver} from "ember-metal/observer";
-import {arrayComputed} from "ember-runtime/computed/array_computed";
-import {reduceComputed} from "ember-runtime/computed/reduce_computed";
+import { addObserver } from "ember-metal/observer";
+import { arrayComputed } from "ember-runtime/computed/array_computed";
+import { reduceComputed } from "ember-runtime/computed/reduce_computed";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 import SubArray from "ember-runtime/system/subarray";
 import keys from "ember-runtime/keys";
 import compare from "ember-runtime/compare";
 
-var a_slice = [].slice,
-    forEach = EnumerableUtils.forEach,
-    SearchProxy;
+var a_slice = [].slice;
+var forEach = EnumerableUtils.forEach;
+var SearchProxy;
 
 /**
  A computed property that returns the sum of the value
@@ -34,7 +37,7 @@ var a_slice = [].slice,
  @since 1.4.0
 */
 
-function sum(dependentKey){
+export function sum(dependentKey){
   return reduceComputed(dependentKey, {
     initialValue: 0,
 
@@ -80,7 +83,7 @@ function sum(dependentKey){
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computes the largest value in the dependentKey's array
 */
-function max (dependentKey) {
+export function max (dependentKey) {
   return reduceComputed(dependentKey, {
     initialValue: -Infinity,
 
@@ -128,7 +131,7 @@ function max (dependentKey) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computes the smallest value in the dependentKey's array
 */
-function min(dependentKey) {
+export function min(dependentKey) {
   return reduceComputed(dependentKey, {
     initialValue: Infinity,
 
@@ -175,7 +178,7 @@ function min(dependentKey) {
   @param {Function} callback
   @return {Ember.ComputedProperty} an array mapped via the callback
 */
-function map(dependentKey, callback) {
+export function map(dependentKey, callback) {
   var options = {
     addedItem: function(array, item, changeMeta, instanceMeta) {
       var mapped = callback.call(this, item);
@@ -231,7 +234,8 @@ function mapBy (dependentKey, propertyKey) {
   @param dependentKey
   @param propertyKey
 */
-var mapProperty = mapBy;
+export var mapProperty = mapBy;
+export var mapBy = mapProperty;
 
 /**
   Filters the array by the callback.
@@ -264,6 +268,7 @@ var mapProperty = mapBy;
   @param {Function} callback
   @return {Ember.ComputedProperty} the filtered array
 */
+export var filter = filter;
 function filter(dependentKey, callback) {
   var options = {
     initialize: function (array, changeMeta, instanceMeta) {
@@ -318,6 +323,7 @@ function filter(dependentKey, callback) {
   @param {*} value
   @return {Ember.ComputedProperty} the filtered array
 */
+export var filterBy = filterBy;
 function filterBy (dependentKey, propertyKey, value) {
   var callback;
 
@@ -342,7 +348,7 @@ function filterBy (dependentKey, propertyKey, value) {
   @param value
   @deprecated Use `Ember.computed.filterBy` instead
 */
-var filterProperty = filterBy;
+export var filterProperty = filterBy;
 
 /**
   A computed property which returns a new array with all the unique
@@ -370,6 +376,7 @@ var filterProperty = filterBy;
   @return {Ember.ComputedProperty} computes a new array with all the
   unique elements from the dependent array
 */
+export var uniq = uniq;
 function uniq() {
   var args = a_slice.call(arguments);
   args.push({
@@ -410,7 +417,7 @@ function uniq() {
   @return {Ember.ComputedProperty} computes a new array with all the
   unique elements from the dependent array
 */
-var union = uniq;
+export var union = uniq;
 
 /**
   A computed property which returns a new array with all the duplicated
@@ -434,7 +441,7 @@ var union = uniq;
   @return {Ember.ComputedProperty} computes a new array with all the
   duplicated elements from the dependent arrays
 */
-function intersect() {
+export function intersect() {
   var getDependentKeyGuids = function (changeMeta) {
     return EnumerableUtils.map(changeMeta.property._dependentKeys, function (dependentKey) {
       return guidFor(dependentKey);
@@ -516,7 +523,7 @@ function intersect() {
   items from the first dependent array that are not in the second
   dependent array
 */
-function setDiff(setAProperty, setBProperty) {
+export function setDiff(setAProperty, setBProperty) {
   if (arguments.length !== 2) {
     throw new EmberError("setDiff requires exactly two dependent arrays.");
   }
@@ -658,7 +665,7 @@ var SearchProxy = ObjectProxy.extend();
   @return {Ember.ComputedProperty} computes a new sorted array based
   on the sort property array or callback function
 */
-function sort(itemsKey, sortDefinition) {
+export function sort(itemsKey, sortDefinition) {
   Ember.assert("Ember.computed.sort requires two arguments: an array key to sort and either a sort properties key or sort function", arguments.length === 2);
 
   var initFn, sortPropertiesKey;
@@ -761,6 +768,3 @@ function sort(itemsKey, sortDefinition) {
     }
   });
 }
-
-
-export {sum, min, max, map, sort, setDiff, mapBy, mapProperty, filter, filterBy, filterProperty, uniq, union, intersect};

--- a/packages_es6/ember-runtime/lib/controllers/array_controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/array_controller.js
@@ -4,17 +4,17 @@
 */
 
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import SortableMixin from "ember-runtime/mixins/sortable";
-import {ControllerMixin} from "ember-runtime/controllers/controller";
+import { ControllerMixin } from "ember-runtime/controllers/controller";
 import {computed} from "ember-metal/computed";
 import EmberError from "ember-metal/error";
 
-var forEach = EnumerableUtils.forEach,
-    replace = EnumerableUtils.replace;
+var forEach = EnumerableUtils.forEach;
+var replace = EnumerableUtils.replace;
 
 /**
   `Ember.ArrayController` provides a way for you to publish a collection of

--- a/packages_es6/ember-runtime/lib/controllers/controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/controller.js
@@ -1,8 +1,8 @@
 import Ember from "ember-metal/core"; // Ember.assert, Ember.deprecate
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import EmberObject from "ember-runtime/system/object";
-import {Mixin} from "ember-metal/mixin";
-import {computed} from "ember-metal/computed";
+import { Mixin } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 
 /**
@@ -71,7 +71,9 @@ var ControllerMixin = Mixin.create(ActionHandler, {
   @extends Ember.Object
   @uses Ember.ControllerMixin
 */
-var Controller = EmberObject.extend(ControllerMixin);
-
-export {Controller, ControllerMixin};
+export var Controller = EmberObject.extend(ControllerMixin);
+// TODO: export default
+export {
+  ControllerMixin
+};
 

--- a/packages_es6/ember-runtime/lib/controllers/object_controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/object_controller.js
@@ -1,4 +1,4 @@
-import {ControllerMixin} from "ember-runtime/controllers/controller";
+import { ControllerMixin } from "ember-runtime/controllers/controller";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 
 /**
@@ -19,5 +19,4 @@ import ObjectProxy from "ember-runtime/system/object_proxy";
   @extends Ember.ObjectProxy
   @uses Ember.ControllerMixin
 **/
-var ObjectController = ObjectProxy.extend(ControllerMixin);
-export default ObjectController;
+export default ObjectProxy.extend(ControllerMixin);

--- a/packages_es6/ember-runtime/lib/copy.js
+++ b/packages_es6/ember-runtime/lib/copy.js
@@ -1,8 +1,8 @@
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {typeOf} from "ember-metal/utils";
+import { typeOf } from "ember-metal/utils";
 import EmberObject from "ember-runtime/system/object";
 import Copyable from "ember-runtime/mixins/copyable";
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 
 var indexOf = EnumerableUtils.indexOf;
 
@@ -64,11 +64,9 @@ function _copy(obj, deep, seen, copies) {
   @param {Boolean} deep If true, a deep copy of the object is made
   @return {Object} The cloned object
 */
-function copy(obj, deep) {
+export default function copy(obj, deep) {
   // fast paths
   if ('object' !== typeof obj || obj===null) return obj; // can't copy primitives
   if (Copyable && Copyable.detect(obj)) return obj.copy(deep);
   return _copy(obj, deep, deep ? [] : null, deep ? [] : null);
 }
-
-export default copy;

--- a/packages_es6/ember-runtime/lib/core.js
+++ b/packages_es6/ember-runtime/lib/core.js
@@ -21,12 +21,10 @@
   @param {Object} b second object to compare
   @return {Boolean}
 */
-function isEqual(a, b) {
+export var isEqual = function isEqual(a, b) {
   if (a && 'function'===typeof a.isEqual) return a.isEqual(b);
   if (a instanceof Date && b instanceof Date) {
     return a.getTime() === b.getTime();
-  } 
+  }
   return a === b;
-}
-
-export {isEqual};
+};

--- a/packages_es6/ember-runtime/lib/ext/function.js
+++ b/packages_es6/ember-runtime/lib/ext/function.js
@@ -5,7 +5,7 @@
 
 import Ember from "ember-metal/core"; // Ember.EXTEND_PROTOTYPES, Ember.assert
 import expandProperties from "ember-metal/expand_properties";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 
 var a_slice = Array.prototype.slice;
 var FunctionPrototype = Function.prototype;
@@ -214,4 +214,3 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
     return this;
   };
 }
-

--- a/packages_es6/ember-runtime/lib/ext/string.js
+++ b/packages_es6/ember-runtime/lib/ext/string.js
@@ -4,7 +4,18 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.EXTEND_PROTOTYPES, Ember.assert, Ember.FEATURES
-import {fmt, w, loc, camelize, decamelize, dasherize, underscore, capitalize, classify} from "ember-runtime/system/string";
+import {
+  fmt,
+  w,
+  loc,
+  camelize,
+  decamelize,
+  dasherize,
+  underscore,
+  capitalize,
+  classify
+} from "ember-runtime/system/string";
+
 var StringPrototype = String.prototype;
 
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {

--- a/packages_es6/ember-runtime/lib/main.js
+++ b/packages_es6/ember-runtime/lib/main.js
@@ -8,7 +8,7 @@ Ember Runtime
 
 // BEGIN IMPORTS
 import Ember from "ember-metal";
-import {isEqual} from "ember-runtime/core";
+import { isEqual } from "ember-runtime/core";
 import keys from "ember-runtime/keys";
 import compare from "ember-runtime/compare";
 import copy from "ember-runtime/copy";
@@ -33,7 +33,7 @@ import EmberArray from "ember-runtime/mixins/array";
 import Comparable from "ember-runtime/mixins/comparable";
 import Copyable from "ember-runtime/mixins/copyable";
 import Enumerable from "ember-runtime/mixins/enumerable";
-import {Freezable, FROZEN_ERROR} from "ember-runtime/mixins/freezable";
+import { Freezable, FROZEN_ERROR } from "ember-runtime/mixins/freezable";
 import Observable from "ember-runtime/mixins/observable";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import DeferredMixin from "ember-runtime/mixins/deferred";
@@ -44,19 +44,42 @@ import Evented from "ember-runtime/mixins/evented";
 import PromiseProxyMixin from "ember-runtime/mixins/promise_proxy";
 import SortableMixin from "ember-runtime/mixins/sortable";
 
-import {arrayComputed, ArrayComputedProperty} from "ember-runtime/computed/array_computed";
-import {reduceComputed, ReduceComputedProperty} from "ember-runtime/computed/reduce_computed";
-import {sum, min, max, map, sort, setDiff, mapBy, mapProperty, filter, filterBy, filterProperty, uniq, union, intersect} from 'ember-runtime/computed/reduce_computed_macros';
+import {
+  arrayComputed,
+  ArrayComputedProperty
+} from "ember-runtime/computed/array_computed";
+import {
+  reduceComputed,
+  ReduceComputedProperty
+} from "ember-runtime/computed/reduce_computed";
+import {
+  sum,
+  min,
+  max,
+  map,
+  sort,
+  setDiff,
+  mapBy,
+  mapProperty,
+  filter,
+  filterBy,
+  filterProperty,
+  uniq,
+  union,
+  intersect
+} from 'ember-runtime/computed/reduce_computed_macros';
 
 import ArrayController from "ember-runtime/controllers/array_controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
-import {Controller, ControllerMixin} from "ember-runtime/controllers/controller";
+import {
+  Controller,
+  ControllerMixin
+} from "ember-runtime/controllers/controller";
 
 import RSVP from "ember-runtime/ext/rsvp";     // just for side effect of extending Ember.RSVP
 import "ember-runtime/ext/string";   // just for side effect of extending String.prototype
 import "ember-runtime/ext/function"; // just for side effect of extending Function.prototype
 // END IMPORTS
-
 
 // BEGIN EXPORTS
 Ember.compare = compare;

--- a/packages_es6/ember-runtime/lib/mixins/action_handler.js
+++ b/packages_es6/ember-runtime/lib/mixins/action_handler.js
@@ -3,9 +3,9 @@
 @submodule ember-runtime
 */
 import merge from "ember-metal/merge";
-import {Mixin} from 'ember-metal/mixin';
-import {get} from "ember-metal/property_get";
-import {typeOf} from "ember-metal/utils";
+import { Mixin } from 'ember-metal/mixin';
+import { get } from "ember-metal/property_get";
+import { typeOf } from "ember-metal/utils";
 
 /**
   The `Ember.ActionHandler` mixin implements support for moving an `actions`

--- a/packages_es6/ember-runtime/lib/mixins/array.js
+++ b/packages_es6/ember-runtime/lib/mixins/array.js
@@ -8,16 +8,33 @@
 //
 import Ember from "ember-metal/core"; // ES6TODO: Ember.A
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {computed, cacheFor} from "ember-metal/computed";
-import {isNone, none} from 'ember-metal/is_none';
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  computed,
+  cacheFor
+} from "ember-metal/computed";
+import {
+  isNone,
+  none
+} from 'ember-metal/is_none';
 import Enumerable from "ember-runtime/mixins/enumerable";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {Mixin, required} from "ember-metal/mixin";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
-import {addListener, removeListener, sendEvent, hasListeners } from "ember-metal/events";
-import {isWatching} from "ember-metal/watching";
+import {
+  Mixin,
+  required
+} from "ember-metal/mixin";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import {
+  addListener,
+  removeListener,
+  sendEvent,
+  hasListeners
+} from "ember-metal/events";
+import { isWatching } from "ember-metal/watching";
 
 var map = EnumerableUtils.map;
 
@@ -60,7 +77,7 @@ var map = EnumerableUtils.map;
   @uses Ember.Enumerable
   @since Ember 0.9.0
 */
-var EmberArray = Mixin.create(Enumerable, {
+export default Mixin.create(Enumerable, {
 
   /**
     Your array must support the `length` property. Your replace methods should
@@ -441,7 +458,4 @@ var EmberArray = Mixin.create(Enumerable, {
 
     return this.__each;
   })
-
 });
-
-export default EmberArray;

--- a/packages_es6/ember-runtime/lib/mixins/comparable.js
+++ b/packages_es6/ember-runtime/lib/mixins/comparable.js
@@ -1,10 +1,12 @@
-import {Mixin, required} from "ember-metal/mixin";
+import {
+  Mixin,
+  required
+} from "ember-metal/mixin";
 
 /**
 @module ember
 @submodule ember-runtime
 */
-
 
 /**
   Implements some standard methods for comparing objects. Add this mixin to
@@ -16,7 +18,7 @@ import {Mixin, required} from "ember-metal/mixin";
   @namespace Ember
   @since Ember 0.9
 */
-var Comparable = Mixin.create({
+export default Mixin.create({
 
   /**
     Override to return the result of the comparison of the two parameters. The
@@ -34,7 +36,4 @@ var Comparable = Mixin.create({
     @return {Integer} the result of the comparison
   */
   compare: required(Function)
-
 });
-
-export default Comparable;

--- a/packages_es6/ember-runtime/lib/mixins/copyable.js
+++ b/packages_es6/ember-runtime/lib/mixins/copyable.js
@@ -4,12 +4,12 @@
 */
 
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {required} from "ember-metal/mixin";
-import {Freezable} from "ember-runtime/mixins/freezable";
-import {Mixin} from 'ember-metal/mixin';
-import {fmt} from "ember-runtime/system/string";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { required } from "ember-metal/mixin";
+import { Freezable } from "ember-runtime/mixins/freezable";
+import { Mixin } from 'ember-metal/mixin';
+import { fmt } from "ember-runtime/system/string";
 import EmberError from 'ember-metal/error';
 
 
@@ -28,8 +28,7 @@ import EmberError from 'ember-metal/error';
   @namespace Ember
   @since Ember 0.9
 */
-var Copyable = Mixin.create({
-
+export default Mixin.create({
   /**
     Override to return a copy of the receiver. Default implementation raises
     an exception.
@@ -62,5 +61,3 @@ var Copyable = Mixin.create({
     }
   }
 });
-
-export default Copyable;

--- a/packages_es6/ember-runtime/lib/mixins/deferred.js
+++ b/packages_es6/ember-runtime/lib/mixins/deferred.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core"; // Ember.FEATURES, Ember.Test
-import {get} from "ember-metal/property_get";
-import {Mixin} from "ember-metal/mixin";
-import {computed} from "ember-metal/computed";
+import { get } from "ember-metal/property_get";
+import { Mixin } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
 import run from "ember-metal/run_loop";
 import RSVP from "ember-runtime/ext/rsvp";
 
@@ -52,7 +52,7 @@ RSVP.Promise.prototype.fail = function(callback, label){
   @class Deferred
   @namespace Ember
  */
-var DeferredMixin = Mixin.create({
+export default Mixin.create({
   /**
     Add handlers to be called when the Deferred object is resolved or rejected.
 
@@ -109,5 +109,3 @@ var DeferredMixin = Mixin.create({
     return RSVP.defer('Ember: DeferredMixin - ' + this);
   })
 });
-
-export default DeferredMixin;

--- a/packages_es6/ember-runtime/lib/mixins/enumerable.js
+++ b/packages_es6/ember-runtime/lib/mixins/enumerable.js
@@ -8,14 +8,26 @@
 //
 
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {apply} from "ember-metal/utils";
-import {Mixin, required, aliasMethod} from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { apply } from "ember-metal/utils";
+import {
+  Mixin,
+  required,
+  aliasMethod
+} from "ember-metal/mixin";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {computed} from "ember-metal/computed";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
-import {addListener, removeListener, sendEvent, hasListeners} from "ember-metal/events";
+import { computed } from "ember-metal/computed";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import {
+  addListener,
+  removeListener,
+  sendEvent,
+  hasListeners
+} from "ember-metal/events";
 import compare from "ember-runtime/compare";
 
 var a_slice = Array.prototype.slice;
@@ -79,7 +91,7 @@ function iter(key, value) {
   @namespace Ember
   @since Ember 0.9
 */
-var Enumerable = Mixin.create({
+export default Mixin.create({
 
   /**
     Implement this method to make your class enumerable.
@@ -1027,5 +1039,3 @@ var Enumerable = Mixin.create({
     });
   }
 });
-
-export default Enumerable;

--- a/packages_es6/ember-runtime/lib/mixins/evented.js
+++ b/packages_es6/ember-runtime/lib/mixins/evented.js
@@ -1,5 +1,10 @@
-import {Mixin} from "ember-metal/mixin";
-import {addListener, removeListener, hasListeners, sendEvent} from "ember-metal/events";
+import { Mixin } from "ember-metal/mixin";
+import {
+  addListener,
+  removeListener,
+  hasListeners,
+  sendEvent
+} from "ember-metal/events";
 
 /**
 @module ember
@@ -41,7 +46,7 @@ import {addListener, removeListener, hasListeners, sendEvent} from "ember-metal/
   @class Evented
   @namespace Ember
  */
-var Evented = Mixin.create({
+export default Mixin.create({
 
   /**
    Subscribes to a named event with given function.
@@ -147,5 +152,3 @@ var Evented = Mixin.create({
     return hasListeners(this, name);
   }
 });
-
-export default Evented;

--- a/packages_es6/ember-runtime/lib/mixins/freezable.js
+++ b/packages_es6/ember-runtime/lib/mixins/freezable.js
@@ -3,9 +3,9 @@
 @submodule ember-runtime
 */
 
-import {Mixin} from "ember-metal/mixin";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { Mixin } from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 /**
   The `Ember.Freezable` mixin implements some basic methods for marking an
@@ -63,7 +63,7 @@ import {set} from "ember-metal/property_set";
   @namespace Ember
   @since Ember 0.9
 */
-var Freezable = Mixin.create({
+export var Freezable = Mixin.create({
 
   /**
     Set to `true` when the object is frozen. Use this property to detect
@@ -89,6 +89,4 @@ var Freezable = Mixin.create({
 
 });
 
-var FROZEN_ERROR = "Frozen object cannot be modified.";
-
-export {Freezable, FROZEN_ERROR};
+export var FROZEN_ERROR = "Frozen object cannot be modified.";

--- a/packages_es6/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages_es6/ember-runtime/lib/mixins/mutable_array.js
@@ -18,11 +18,14 @@ var EMPTY = [];
 // HELPERS
 //
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {isArray} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { isArray } from "ember-metal/utils";
 import EmberError from "ember-metal/error";
-import {Mixin, required} from "ember-metal/mixin";
+import {
+  Mixin,
+  required
+} from "ember-metal/mixin";
 import EmberArray from "ember-runtime/mixins/array";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";
 import Enumerable from "ember-runtime/mixins/enumerable";
@@ -46,7 +49,7 @@ import Enumerable from "ember-runtime/mixins/enumerable";
   @uses Ember.Array
   @uses Ember.MutableEnumerable
 */
-var MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
+export default Mixin.create(EmberArray, MutableEnumerable, {
 
   /**
     __Required.__ You must implement this method to apply this mixin.
@@ -346,5 +349,3 @@ var MutableArray = Mixin.create(EmberArray, MutableEnumerable, {
   }
 
 });
-
-export default MutableArray;

--- a/packages_es6/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages_es6/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -49,7 +49,7 @@ var forEach = EnumerableUtils.forEach;
   @namespace Ember
   @uses Ember.Enumerable
 */
-var MutableEnumerable = Mixin.create(Enumerable, {
+export default Mixin.create(Enumerable, {
 
   /**
     __Required.__ You must implement this method to apply this mixin.
@@ -112,5 +112,3 @@ var MutableEnumerable = Mixin.create(Enumerable, {
     return this;
   }
 });
-
-export default MutableEnumerable;

--- a/packages_es6/ember-runtime/lib/mixins/observable.js
+++ b/packages_es6/ember-runtime/lib/mixins/observable.js
@@ -4,17 +4,30 @@
 */
 import Ember from "ember-metal/core"; // Ember.assert
 
-import {get, getWithDefault} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {apply} from "ember-metal/utils";
+import {
+  get,
+  getWithDefault
+} from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { apply } from "ember-metal/utils";
 import getProperties from "ember-metal/get_properties";
 import setProperties from "ember-metal/set_properties";
-import {Mixin} from "ember-metal/mixin";
-import {hasListeners} from "ember-metal/events";
-import {beginPropertyChanges, propertyWillChange, propertyDidChange, endPropertyChanges} from "ember-metal/property_events";
-import {addObserver, addBeforeObserver, removeObserver, observersFor} from "ember-metal/observer";
-import {cacheFor} from "ember-metal/computed";
-import {isNone} from "ember-metal/is_none";
+import { Mixin } from "ember-metal/mixin";
+import { hasListeners } from "ember-metal/events";
+import {
+  beginPropertyChanges,
+  propertyWillChange,
+  propertyDidChange,
+  endPropertyChanges
+} from "ember-metal/property_events";
+import {
+  addObserver,
+  addBeforeObserver,
+  removeObserver,
+  observersFor
+} from "ember-metal/observer";
+import { cacheFor } from "ember-metal/computed";
+import { isNone } from "ember-metal/is_none";
 
 
 var slice = Array.prototype.slice;
@@ -83,7 +96,7 @@ var slice = Array.prototype.slice;
   @class Observable
   @namespace Ember
 */
-var Observable = Mixin.create({
+export default Mixin.create({
 
   /**
     Retrieves the value of a property from the object.
@@ -493,5 +506,3 @@ var Observable = Mixin.create({
     return observersFor(this, keyName);
   }
 });
-
-export default Observable;

--- a/packages_es6/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages_es6/ember-runtime/lib/mixins/promise_proxy.js
@@ -1,10 +1,11 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {computed} from "ember-metal/computed";
-import {Mixin} from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { computed } from "ember-metal/computed";
+import { Mixin } from "ember-metal/mixin";
 import EmberError from "ember-metal/error";
 
-var not = computed.not, or = computed.or;
+var not = computed.not;
+var or = computed.or;
 
 /**
   @module ember
@@ -91,7 +92,7 @@ function tap(proxy, promise) {
   ```
   @class Ember.PromiseProxyMixin
 */
-var PromiseProxyMixin = Mixin.create({
+export default Mixin.create({
   /**
     If the proxied promise is rejected this will contain the reason
     provided.
@@ -200,5 +201,3 @@ function promiseAlias(name) {
     return promise[name].apply(promise, arguments);
   };
 }
-
-export default PromiseProxyMixin;

--- a/packages_es6/ember-runtime/lib/mixins/sortable.js
+++ b/packages_es6/ember-runtime/lib/mixins/sortable.js
@@ -5,15 +5,21 @@
 
 import Ember from "ember-metal/core"; // Ember.assert, Ember.A
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {Mixin} from "ember-metal/mixin";
+import { Mixin } from "ember-metal/mixin";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";
 import compare from "ember-runtime/compare";
-import {addObserver, removeObserver} from "ember-metal/observer";
-import {computed} from "ember-metal/computed";
-import {beforeObserver, observer} from "ember-metal/mixin"; //ES6TODO: should we access these directly from their package or from how thier exposed in ember-metal?
+import {
+  addObserver,
+  removeObserver
+} from "ember-metal/observer";
+import { computed } from "ember-metal/computed";
+import {
+  beforeObserver,
+  observer
+} from "ember-metal/mixin"; //ES6TODO: should we access these directly from their package or from how thier exposed in ember-metal?
 
 var forEach = EnumerableUtils.forEach;
 
@@ -69,7 +75,7 @@ var forEach = EnumerableUtils.forEach;
   @namespace Ember
   @uses Ember.MutableEnumerable
 */
-var SortableMixin = Mixin.create(MutableEnumerable, {
+export default Mixin.create(MutableEnumerable, {
 
   /**
     Specifies which properties dictate the arrangedContent's sort order.
@@ -297,5 +303,3 @@ var SortableMixin = Mixin.create(MutableEnumerable, {
     return mid;
   }
 });
-
-export default SortableMixin;

--- a/packages_es6/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages_es6/ember-runtime/lib/mixins/target_action_support.js
@@ -4,11 +4,11 @@
 */
 import Ember from "ember-metal/core"; // Ember.lookup, Ember.assert
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {typeOf} from "ember-metal/utils";
-import {Mixin} from "ember-metal/mixin";
-import {computed} from "ember-metal/computed";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { typeOf } from "ember-metal/utils";
+import { Mixin } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
 
 /**
 `Ember.TargetActionSupport` is a mixin that can be included in a class

--- a/packages_es6/ember-runtime/lib/system/application.js
+++ b/packages_es6/ember-runtime/lib/system/application.js
@@ -1,4 +1,3 @@
 import Namespace from "ember-runtime/system/namespace";
 
-var Application = Namespace.extend();
-export default Application;
+export default Namespace.extend();

--- a/packages_es6/ember-runtime/lib/system/array_proxy.js
+++ b/packages_es6/ember-runtime/lib/system/array_proxy.js
@@ -1,15 +1,24 @@
 import Ember from "ember-metal/core"; // Ember.K, Ember.assert
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {isArray, apply} from "ember-metal/utils";
-import {computed} from "ember-metal/computed";
-import {beforeObserver, observer} from "ember-metal/mixin";
-import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_events";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  isArray,
+  apply
+} from "ember-metal/utils";
+import { computed } from "ember-metal/computed";
+import {
+  beforeObserver,
+  observer
+} from "ember-metal/mixin";
+import {
+  beginPropertyChanges,
+  endPropertyChanges
+} from "ember-metal/property_events";
 import EmberError from "ember-metal/error";
 import EmberObject from "ember-runtime/system/object";
 import MutableArray from "ember-runtime/mixins/mutable_array";
 import Enumerable from "ember-runtime/mixins/enumerable";
-import {fmt} from "ember-runtime/system/string";
+import { fmt } from "ember-runtime/system/string";
 
 /**
 @module ember

--- a/packages_es6/ember-runtime/lib/system/core_object.js
+++ b/packages_es6/ember-runtime/lib/system/core_object.js
@@ -8,36 +8,48 @@ import Ember from "ember-metal/core";
 
 // NOTE: this object should never be included directly. Instead use `Ember.Object`.
 // We only define this separately so that `Ember.Set` can depend on it.
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {guidFor, apply} from "ember-metal/utils";
-import {create} from "ember-metal/platform";
-import {generateGuid, GUID_KEY, meta, META_KEY, makeArray} from "ember-metal/utils";
-import {rewatch} from "ember-metal/watching";
-import {finishChains} from "ember-metal/chains";
-import {sendEvent} from "ember-metal/events";
-import {IS_BINDING, Mixin, required} from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  guidFor,
+  apply
+} from "ember-metal/utils";
+import { create } from "ember-metal/platform";
+import {
+  generateGuid,
+  GUID_KEY,
+  meta,
+  META_KEY,
+  makeArray
+} from "ember-metal/utils";
+import { rewatch } from "ember-metal/watching";
+import { finishChains } from "ember-metal/chains";
+import { sendEvent } from "ember-metal/events";
+import {
+  IS_BINDING,
+  Mixin,
+  required
+} from "ember-metal/mixin";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import EmberError from "ember-metal/error";
-import {platform} from "ember-metal/platform";
+import { platform } from "ember-metal/platform";
 import keys from "ember-runtime/keys";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import {defineProperty} from "ember-metal/properties";
-import {Binding} from "ember-metal/binding";
-import {ComputedProperty} from "ember-metal/computed";
+import { Binding } from "ember-metal/binding";
+import { ComputedProperty } from "ember-metal/computed";
 import run from 'ember-metal/run_loop';
-import {destroy} from "ember-metal/watching";
+import { destroy } from "ember-metal/watching";
 
-
-var o_create = create,
-    o_defineProperty = platform.defineProperty,
-    schedule = run.schedule,
-    applyMixin = Mixin._apply,
-    finishPartial = Mixin.finishPartial,
-    reopen = Mixin.prototype.reopen,
-    MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER,
-    indexOf = EnumerableUtils.indexOf,
-    K = Ember.K;
+var o_create = create;
+var o_defineProperty = platform.defineProperty;
+var schedule = run.schedule;
+var applyMixin = Mixin._apply;
+var finishPartial = Mixin.finishPartial;
+var reopen = Mixin.prototype.reopen;
+var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
+var indexOf = EnumerableUtils.indexOf;
+var K = Ember.K;
 
 var undefinedDescriptor = {
   configurable: true,

--- a/packages_es6/ember-runtime/lib/system/each_proxy.js
+++ b/packages_es6/ember-runtime/lib/system/each_proxy.js
@@ -5,19 +5,30 @@
 
 import Ember from "ember-metal/core"; // Ember.assert
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {guidFor} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { guidFor } from "ember-metal/utils";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {indexOf} from "ember-metal/array";
+import { indexOf } from "ember-metal/array";
 import EmberArray from "ember-runtime/mixins/array"; // ES6TODO: WAT? Circular dep?
 import EmberObject from "ember-runtime/system/object";
-import {computed} from "ember-metal/computed";
-import {addObserver, addBeforeObserver, removeBeforeObserver, removeObserver} from "ember-metal/observer";
-import {typeOf} from "ember-metal/utils";
-import {watchedEvents} from "ember-metal/events";
-import {defineProperty} from "ember-metal/properties";
-import {beginPropertyChanges, propertyDidChange, propertyWillChange, endPropertyChanges, changeProperties} from "ember-metal/property_events";
+import { computed } from "ember-metal/computed";
+import {
+  addObserver,
+  addBeforeObserver,
+  removeBeforeObserver,
+  removeObserver
+} from "ember-metal/observer";
+import { typeOf } from "ember-metal/utils";
+import { watchedEvents } from "ember-metal/events";
+import { defineProperty } from "ember-metal/properties";
+import {
+  beginPropertyChanges,
+  propertyDidChange,
+  propertyWillChange,
+  endPropertyChanges,
+  changeProperties
+} from "ember-metal/property_events";
 
 var forEach = EnumerableUtils.forEach;
 
@@ -213,4 +224,7 @@ var EachProxy = EmberObject.extend({
 
 });
 
-export {EachArray, EachProxy};
+export {
+  EachArray,
+  EachProxy
+};

--- a/packages_es6/ember-runtime/lib/system/lazy_load.js
+++ b/packages_es6/ember-runtime/lib/system/lazy_load.js
@@ -1,7 +1,7 @@
 /*globals CustomEvent */
 
 import Ember from "ember-metal/core"; // Ember.ENV.EMBER_LOAD_HOOKS
-import {forEach} from "ember-metal/array";
+import { forEach } from "ember-metal/array";
 import "ember-runtime/system/native_array"; // make sure Ember.A is setup.
 
 /**
@@ -30,7 +30,7 @@ var loaded = {};
   @param name {String} name of hook
   @param callback {Function} callback to be called
 */
-function onLoad(name, callback) {
+export function onLoad(name, callback) {
   var object;
 
   loadHooks[name] = loadHooks[name] || Ember.A();
@@ -50,7 +50,7 @@ function onLoad(name, callback) {
   @param name {String} name of hook
   @param object {Object} object to pass to callbacks
 */
-function runLoadHooks(name, object) {
+export function runLoadHooks(name, object) {
   loaded[name] = object;
 
   if (typeof window === 'object' && typeof window.dispatchEvent === 'function' && typeof CustomEvent === "function") {
@@ -64,5 +64,3 @@ function runLoadHooks(name, object) {
     });
   }
 }
-
-export {onLoad, runLoadHooks};

--- a/packages_es6/ember-runtime/lib/system/namespace.js
+++ b/packages_es6/ember-runtime/lib/system/namespace.js
@@ -5,10 +5,13 @@
 
 // Ember.lookup, Ember.BOOTED, Ember.deprecate, Ember.NAME_KEY, Ember.anyUnprocessedMixins
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {indexOf} from "ember-metal/array";
-import {GUID_KEY, guidFor} from "ember-metal/utils";
-import {Mixin} from "ember-metal/mixin";
+import { get } from "ember-metal/property_get";
+import { indexOf } from "ember-metal/array";
+import {
+  GUID_KEY,
+  guidFor
+} from "ember-metal/utils";
+import { Mixin } from "ember-metal/mixin";
 
 import EmberObject from "ember-runtime/system/object";
 

--- a/packages_es6/ember-runtime/lib/system/native_array.js
+++ b/packages_es6/ember-runtime/lib/system/native_array.js
@@ -5,19 +5,19 @@
 
 import Ember from "ember-metal/core"; // Ember.EXTEND_PROTOTYPES
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {Mixin} from "ember-metal/mixin";
+import { Mixin } from "ember-metal/mixin";
 import EmberArray from "ember-runtime/mixins/array";
 import MutableArray from "ember-runtime/mixins/mutable_array";
 import Observable from "ember-runtime/mixins/observable";
 import Copyable from "ember-runtime/mixins/copyable";
-import {FROZEN_ERROR} from "ember-runtime/mixins/freezable";
+import { FROZEN_ERROR } from "ember-runtime/mixins/freezable";
 import copy from "ember-runtime/copy";
 
-var replace = EnumerableUtils._replace,
-    forEach = EnumerableUtils.forEach;
+var replace = EnumerableUtils._replace;
+var forEach = EnumerableUtils.forEach;
 
 // Add Ember.Array to Array.prototype. Remove methods with native
 // implementations and supply some more optimized versions of generic methods
@@ -190,5 +190,8 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Array) {
 }
 
 Ember.A = A; // ES6TODO: Setting A onto the object returned by ember-metal/core to avoid circles
-export {A, NativeArray};
+export {
+  A,
+  NativeArray // TODO: only use default export
+};
 export default NativeArray;

--- a/packages_es6/ember-runtime/lib/system/object.js
+++ b/packages_es6/ember-runtime/lib/system/object.js
@@ -17,6 +17,8 @@ import Observable from "ember-runtime/mixins/observable";
   @uses Ember.Observable
 */
 var EmberObject = CoreObject.extend(Observable);
-EmberObject.toString = function() { return "Ember.Object"; };
+EmberObject.toString = function() {
+  return "Ember.Object";
+};
 
 export default EmberObject;

--- a/packages_es6/ember-runtime/lib/system/object_proxy.js
+++ b/packages_es6/ember-runtime/lib/system/object_proxy.js
@@ -3,15 +3,23 @@
 @submodule ember-runtime
 */
 import Ember from "ember-metal/core"; // Ember.assert
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {meta} from "ember-metal/utils";
-import {addObserver, removeObserver, addBeforeObserver, removeBeforeObserver} from "ember-metal/observer";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
-import {computed} from "ember-metal/computed";
-import {defineProperty} from "ember-metal/properties";
-import {observer} from "ember-metal/mixin";
-import {fmt} from "ember-runtime/system/string";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { meta } from "ember-metal/utils";
+import {
+  addObserver,
+  removeObserver,
+  addBeforeObserver,
+  removeBeforeObserver
+} from "ember-metal/observer";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import { computed } from "ember-metal/computed";
+import { defineProperty } from "ember-metal/properties";
+import { observer } from "ember-metal/mixin";
+import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 
 function contentPropertyWillChange(content, contentKey) {

--- a/packages_es6/ember-runtime/lib/system/set.js
+++ b/packages_es6/ember-runtime/lib/system/set.js
@@ -4,20 +4,26 @@
 */
 import Ember from "ember-metal/core"; // Ember.isNone
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {guidFor} from "ember-metal/utils";
-import {isNone} from 'ember-metal/is_none';
-import {fmt} from "ember-runtime/system/string";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { guidFor } from "ember-metal/utils";
+import { isNone } from 'ember-metal/is_none';
+import { fmt } from "ember-runtime/system/string";
 import CoreObject from "ember-runtime/system/core_object";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";
 import Enumerable from "ember-runtime/mixins/enumerable";
 import Copyable from "ember-runtime/mixins/copyable";
-import {Freezable, FROZEN_ERROR} from "ember-runtime/mixins/freezable";
+import {
+  Freezable,
+  FROZEN_ERROR
+} from "ember-runtime/mixins/freezable";
 import EmberError from "ember-metal/error";
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
-import {aliasMethod} from "ember-metal/mixin";
-import {computed} from "ember-metal/computed";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import { aliasMethod } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
 
 /**
   An unordered collection of objects.
@@ -116,8 +122,7 @@ import {computed} from "ember-metal/computed";
   @uses Ember.Freezable
   @since Ember 0.9
 */
-export default CoreObject.extend(MutableEnumerable, Copyable, Freezable,
-  {
+export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
   // ..........................................................
   // IMPLEMENT ENUMERABLE APIS
@@ -461,5 +466,4 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable,
     }
     return fmt("Ember.Set<%@>", [array.join(',')]);
   }
-
 });

--- a/packages_es6/ember-runtime/lib/system/string.js
+++ b/packages_es6/ember-runtime/lib/system/string.js
@@ -3,8 +3,10 @@
 @submodule ember-runtime
 */
 import Ember from "ember-metal/core"; // Ember.STRINGS, Ember.FEATURES
-import {isArray, inspect as emberInspect} from "ember-metal/utils";
-
+import {
+  isArray,
+  inspect as emberInspect
+} from "ember-metal/utils";
 
 var STRING_DASHERIZE_REGEXP = (/[ _]/g);
 var STRING_DASHERIZE_CACHE = {};
@@ -108,8 +110,7 @@ Ember.STRINGS = {};
   @namespace Ember
   @static
 */
-var EmberStringUtils = {
-
+export default {
   /**
     Apply formatting options to the string. This will look for occurrences
     of "%@" in your string and substitute them with the arguments you pass into
@@ -278,5 +279,14 @@ var EmberStringUtils = {
   capitalize: capitalize
 };
 
-export default EmberStringUtils;
-export {fmt, loc, w, decamelize, dasherize, camelize, classify, underscore, capitalize};
+export {
+  fmt,
+  loc,
+  w,
+  decamelize,
+  dasherize,
+  camelize,
+  classify,
+  underscore,
+  capitalize
+};

--- a/packages_es6/ember-runtime/lib/system/subarray.js
+++ b/packages_es6/ember-runtime/lib/system/subarray.js
@@ -2,13 +2,15 @@ import {get} from "ember-metal/property_get";
 import EmberError from "ember-metal/error";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 
-var RETAIN = 'r',
-    FILTER = 'f';
+var RETAIN = 'r';
+var FILTER = 'f';
 
-function Operation (type, count) {
+function Operation(type, count) {
   this.type = type;
   this.count = count;
 }
+
+export default SubArray;
 
 /**
   An `Ember.SubArray` tracks an array in a way similar to, but more specialized
@@ -27,6 +29,7 @@ function SubArray (length) {
     this._operations = [];
   }
 }
+
 
 SubArray.prototype = {
   /**
@@ -176,5 +179,3 @@ SubArray.prototype = {
     return str.substring(1);
   }
 };
-
-export default SubArray;

--- a/packages_es6/ember-runtime/lib/system/tracked_array.js
+++ b/packages_es6/ember-runtime/lib/system/tracked_array.js
@@ -1,11 +1,12 @@
 import {get} from "ember-metal/property_get";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 
-var forEach = EnumerableUtils.forEach,
-    RETAIN = 'r',
-    INSERT = 'i',
-    DELETE = 'd';
+var forEach = EnumerableUtils.forEach;
+var RETAIN = 'r';
+var INSERT = 'i';
+var DELETE = 'd';
 
+export default TrackedArray;
 
 /**
   An `Ember.TrackedArray` tracks array operations.  It's useful when you want to
@@ -332,5 +333,3 @@ function ArrayOperationMatch(operation, index, split, rangeStart) {
   this.split = split;
   this.rangeStart = rangeStart;
 }
-
-export default TrackedArray;

--- a/packages_es6/ember-testing/lib/adapters/adapter.js
+++ b/packages_es6/ember-testing/lib/adapters/adapter.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core"; // Ember.K
-import {inspect} from "ember-metal/utils";
+import { inspect } from "ember-metal/utils";
 import EmberObject from "ember-runtime/system/object";
 
 /**

--- a/packages_es6/ember-testing/lib/adapters/qunit.js
+++ b/packages_es6/ember-testing/lib/adapters/qunit.js
@@ -1,5 +1,5 @@
 import Adapter from "ember-testing/adapters/adapter";
-import {inspect} from "ember-metal/utils";
+import { inspect } from "ember-metal/utils";
 
 /**
   This class implements the methods defined by Ember.Test.Adapter for the
@@ -9,7 +9,7 @@ import {inspect} from "ember-metal/utils";
   @namespace Ember.Test
   @extends Ember.Test.Adapter
 */
-var QUnitAdapter = Adapter.extend({
+export default Adapter.extend({
   asyncStart: function() {
     QUnit.stop();
   },
@@ -20,5 +20,3 @@ var QUnitAdapter = Adapter.extend({
     ok(false, inspect(error));
   }
 });
-
-export default QUnitAdapter;

--- a/packages_es6/ember-testing/lib/helpers.js
+++ b/packages_es6/ember-testing/lib/helpers.js
@@ -1,4 +1,4 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import EmberError from "ember-metal/error";
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
@@ -9,9 +9,9 @@ import Test from "ember-testing/test";
 * @submodule ember-testing
 */
 
-var helper = Test.registerHelper,
-    asyncHelper = Test.registerAsyncHelper,
-    countAsync = 0;
+var helper = Test.registerHelper;
+var asyncHelper = Test.registerAsyncHelper;
+var countAsync = 0;
 
 function currentRouteName(app){
   var appController = app.__container__.lookup('controller:application');

--- a/packages_es6/ember-testing/lib/initializers.js
+++ b/packages_es6/ember-testing/lib/initializers.js
@@ -1,4 +1,4 @@
-import {onLoad} from "ember-runtime/system/lazy_load";
+import { onLoad } from "ember-runtime/system/lazy_load";
 
 var name = 'deferReadiness in `testing` mode';
 

--- a/packages_es6/ember-testing/lib/setup_for_testing.js
+++ b/packages_es6/ember-testing/lib/setup_for_testing.js
@@ -28,7 +28,7 @@ function decrementAjaxPendingRequests(){
   @namespace Ember
   @since 1.5.0
 */
-function setupForTesting() {
+export default function setupForTesting() {
   if (!Test) { Test = requireModule('ember-testing/test')['default']; }
 
   Ember.testing = true;
@@ -46,6 +46,4 @@ function setupForTesting() {
   jQuery(document).off('ajaxComplete', decrementAjaxPendingRequests);
   jQuery(document).on('ajaxSend', incrementAjaxPendingRequests);
   jQuery(document).on('ajaxComplete', decrementAjaxPendingRequests);
-}
-
-export default setupForTesting;
+};

--- a/packages_es6/ember-testing/lib/test.js
+++ b/packages_es6/ember-testing/lib/test.js
@@ -1,6 +1,6 @@
 import Ember from "ember-metal/core";
 import emberRun from "ember-metal/run_loop";
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import compare from "ember-runtime/compare";
 import RSVP from "ember-runtime/ext/rsvp";
 import setupForTesting from "ember-testing/setup_for_testing";
@@ -10,9 +10,9 @@ import EmberApplication from "ember-application/system/application";
   @module ember
   @submodule ember-testing
  */
-var slice = [].slice,
-    helpers = {},
-    injectHelpersCallbacks = [];
+var slice = [].slice;
+var helpers = {};
+var injectHelpersCallbacks = [];
 
 /**
   This is a container for an assortment of testing related functionality:

--- a/packages_es6/ember-testing/tests/helpers_test.js
+++ b/packages_es6/ember-testing/tests/helpers_test.js
@@ -1,10 +1,10 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import RSVP from "ember-runtime/ext/rsvp";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import jQuery from "ember-views/system/jquery";
 
 import Test from "ember-testing/test";
@@ -18,7 +18,6 @@ import EmberApplication from "ember-application/system/application";
 var App, originalAdapter = Test.adapter;
 
 function cleanup(){
-
   // Teardown setupForTesting
 
   Test.adapter = originalAdapter;

--- a/packages_es6/ember-views/lib/main.js
+++ b/packages_es6/ember-views/lib/main.js
@@ -10,12 +10,22 @@ Ember Views
 // BEGIN IMPORTS
 import Ember from "ember-runtime";
 import jQuery from "ember-views/system/jquery";
-import {setInnerHTML, isSimpleClick} from "ember-views/system/utils";
+import {
+  setInnerHTML,
+  isSimpleClick
+} from "ember-views/system/utils";
 import RenderBuffer from "ember-views/system/render_buffer";
 import "ember-views/system/ext";  // for the side effect of extending Ember.run.queues
-import {cloneStates, states} from "ember-views/views/states";
+import {
+  cloneStates,
+  states
+} from "ember-views/views/states";
 
-import {CoreView, View, ViewCollection} from "ember-views/views/view";
+import {
+  CoreView,
+  View,
+  ViewCollection
+} from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 import CollectionView from "ember-views/views/collection_view";
 import Component from "ember-views/views/component";

--- a/packages_es6/ember-views/lib/mixins/component_template_deprecation.js
+++ b/packages_es6/ember-views/lib/mixins/component_template_deprecation.js
@@ -1,6 +1,6 @@
 import Ember from 'ember-metal/core'; // Ember.deprecate
-import {get} from "ember-metal/property_get";
-import {Mixin} from 'ember-metal/mixin';
+import { get } from "ember-metal/property_get";
+import { Mixin } from 'ember-metal/mixin';
 
 /**
   The ComponentTemplateDeprecation mixin is used to provide a useful
@@ -14,7 +14,7 @@ import {Mixin} from 'ember-metal/mixin';
   @class ComponentTemplateDeprecation
   @namespace Ember
 */
-var ComponentTemplateDeprecation = Mixin.create({
+export default Mixin.create({
   /**
     @private
 
@@ -60,6 +60,3 @@ var ComponentTemplateDeprecation = Mixin.create({
     }
   }
 });
-
-export default ComponentTemplateDeprecation;
-

--- a/packages_es6/ember-views/lib/mixins/view_target_action_support.js
+++ b/packages_es6/ember-views/lib/mixins/view_target_action_support.js
@@ -1,8 +1,8 @@
-import {Mixin} from 'ember-metal/mixin';
+import { Mixin } from 'ember-metal/mixin';
 import TargetActionSupport from "ember-runtime/mixins/target_action_support";
 
 // ES6TODO: computed should have its own export path so you can do import {defaultTo} from computed
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 var alias = computed.alias;
 
 /**
@@ -46,7 +46,7 @@ App.SaveButtonView = Ember.View.extend(Ember.ViewTargetActionSupport, {
 @namespace Ember
 @extends Ember.TargetActionSupport
 */
-var ViewTargetActionSupport = Mixin.create(TargetActionSupport, {
+export default Mixin.create(TargetActionSupport, {
   /**
   @property target
   */
@@ -56,5 +56,3 @@ var ViewTargetActionSupport = Mixin.create(TargetActionSupport, {
   */
   actionContext: alias('context')
 });
-
-export default ViewTargetActionSupport;

--- a/packages_es6/ember-views/lib/system/event_dispatcher.js
+++ b/packages_es6/ember-views/lib/system/event_dispatcher.js
@@ -4,15 +4,15 @@
 */
 import Ember from "ember-metal/core"; // Ember.assert
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {isNone} from 'ember-metal/is_none';
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { isNone } from 'ember-metal/is_none';
 import run from "ember-metal/run_loop";
-import {typeOf} from "ember-metal/utils";
-import {fmt} from "ember-runtime/system/string";
+import { typeOf } from "ember-metal/utils";
+import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
 var ActionHelper;
 
@@ -30,7 +30,7 @@ var ActionHelper;
   @private
   @extends Ember.Object
 */
-var EventDispatcher = EmberObject.extend({
+export default EmberObject.extend({
 
   /**
     The set of events names (and associated handler function names) to be setup
@@ -224,5 +224,3 @@ var EventDispatcher = EmberObject.extend({
     return this._super();
   }
 });
-
-export default EventDispatcher;

--- a/packages_es6/ember-views/lib/system/render_buffer.js
+++ b/packages_es6/ember-views/lib/system/render_buffer.js
@@ -5,16 +5,15 @@
 
 import Ember from 'ember-metal/core'; // jQuery
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {setInnerHTML} from "ember-views/system/utils";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { setInnerHTML } from "ember-views/system/utils";
 import jQuery from "ember-views/system/jquery";
 
 function ClassSet() {
   this.seen = {};
   this.list = [];
 }
-
 
 ClassSet.prototype = {
   add: function(string) {
@@ -95,14 +94,14 @@ var canSetNameOnInputs = (function() {
   @constructor
   @param {String} tagName tag name (such as 'div' or 'p') used for the buffer
 */
-var RenderBuffer = function(tagName) {
+export default function RenderBuffer(tagName) {
   return new _RenderBuffer(tagName); // jshint ignore:line
-};
+}
 
-var _RenderBuffer = function(tagName) {
+function _RenderBuffer(tagName) {
   this.tagNames = [tagName || null];
   this.buffer = "";
-};
+}
 
 _RenderBuffer.prototype = {
 
@@ -543,5 +542,3 @@ _RenderBuffer.prototype = {
     return this.buffer;
   }
 };
-
-export default RenderBuffer;

--- a/packages_es6/ember-views/lib/system/utils.js
+++ b/packages_es6/ember-views/lib/system/utils.js
@@ -103,7 +103,7 @@ var canSetInnerHTML = function(tagName) {
   return canSet;
 };
 
-var setInnerHTML = function(element, html) {
+export function setInnerHTML(element, html) {
   var tagName = element.tagName;
 
   if (canSetInnerHTML(tagName)) {
@@ -125,14 +125,11 @@ var setInnerHTML = function(element, html) {
   }
 
   return element;
-};
+}
 
-function isSimpleClick(event) {
+export function isSimpleClick(event) {
   var modifier = event.shiftKey || event.metaKey || event.altKey || event.ctrlKey,
       secondaryClick = event.which > 1; // IE9 may return undefined
 
   return !modifier && !secondaryClick;
 }
-
-export {setInnerHTML, isSimpleClick};
-

--- a/packages_es6/ember-views/lib/views/collection_view.js
+++ b/packages_es6/ember-views/lib/views/collection_view.js
@@ -5,14 +5,20 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.assert
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {fmt} from "ember-runtime/system/string";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { fmt } from "ember-runtime/system/string";
 import ContainerView from "ember-views/views/container_view";
-import {CoreView, View} from "ember-views/views/view";
-import {observer, beforeObserver} from "ember-metal/mixin";
+import {
+  CoreView,
+  View
+} from "ember-views/views/view";
+import {
+  observer,
+  beforeObserver
+} from "ember-metal/mixin";
 import EmberArray from "ember-runtime/mixins/array";
 
 /**

--- a/packages_es6/ember-views/lib/views/component.js
+++ b/packages_es6/ember-views/lib/views/component.js
@@ -2,13 +2,13 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.Handlebars
 
 import ComponentTemplateDeprecation from "ember-views/mixins/component_template_deprecation";
 import TargetActionSupport from "ember-runtime/mixins/target_action_support";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {isNone} from 'ember-metal/is_none';
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { isNone } from 'ember-metal/is_none';
 
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 
 var a_slice = Array.prototype.slice;
 

--- a/packages_es6/ember-views/lib/views/container_view.js
+++ b/packages_es6/ember-views/lib/views/container_view.js
@@ -2,11 +2,18 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.K
 
 import merge from "ember-metal/merge";
 import MutableArray from "ember-runtime/mixins/mutable_array";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
-import {View, ViewCollection} from "ember-views/views/view";
-import {cloneStates, states as EmberViewStates} from "ember-views/views/states";
+import {
+  View,
+  ViewCollection
+} from "ember-views/views/view";
+
+import {
+  cloneStates,
+  states as EmberViewStates
+} from "ember-views/views/states";
 
 import EmberError from "ember-metal/error";
 
@@ -14,12 +21,15 @@ import EmberError from "ember-metal/error";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 var forEach = EnumerableUtils.forEach;
 
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 import run from "ember-metal/run_loop";
-import {defineProperty} from "ember-metal/properties";
+import { defineProperty } from "ember-metal/properties";
 import renderBuffer from "ember-views/system/render_buffer";
-import {observer, beforeObserver} from "ember-metal/mixin";
-import {A as emberA} from "ember-runtime/system/native_array";
+import {
+  observer,
+  beforeObserver
+} from "ember-metal/mixin";
+import { A as emberA } from "ember-runtime/system/native_array";
 
 /**
 @module ember

--- a/packages_es6/ember-views/lib/views/states.js
+++ b/packages_es6/ember-views/lib/views/states.js
@@ -1,4 +1,4 @@
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
 import _default from "ember-views/views/states/default";
 import preRender from "ember-views/views/states/pre_render";
@@ -7,7 +7,7 @@ import hasElement from "ember-views/views/states/has_element";
 import inDOM from "ember-views/views/states/in_dom";
 import destroying from "ember-views/views/states/destroying";
 
-function cloneStates(from) {
+export function cloneStates(from) {
   var into = {};
 
   into._default = {};
@@ -25,7 +25,7 @@ function cloneStates(from) {
   return into;
 }
 
-var states = {
+export var states = {
   _default: _default,
   preRender: preRender,
   inDOM: inDOM,
@@ -33,5 +33,3 @@ var states = {
   hasElement: hasElement,
   destroying: destroying
 };
-
-export {cloneStates, states};

--- a/packages_es6/ember-views/lib/views/states/default.js
+++ b/packages_es6/ember-views/lib/views/states/default.js
@@ -8,7 +8,7 @@ import EmberError from "ember-metal/error";
 @module ember
 @submodule ember-views
 */
-var _default = {
+export default {
   // appendChild is only legal while rendering the buffer.
   appendChild: function() {
     throw new EmberError("You can't use appendChild outside of the rendering process");
@@ -43,5 +43,3 @@ var _default = {
   rerender: Ember.K,
   invokeObserver: Ember.K
 };
-
-export default _default;

--- a/packages_es6/ember-views/lib/views/states/has_element.js
+++ b/packages_es6/ember-views/lib/views/states/has_element.js
@@ -1,7 +1,7 @@
 import _default from "ember-views/views/states/default";
 import run from "ember-metal/run_loop";
 import merge from "ember-metal/merge";
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import jQuery from "ember-views/system/jquery";
 import EmberError from "ember-metal/error";
 
@@ -10,8 +10,8 @@ import EmberError from "ember-metal/error";
 @submodule ember-views
 */
 
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 var hasElement = create(_default);
 

--- a/packages_es6/ember-views/lib/views/states/in_buffer.js
+++ b/packages_es6/ember-views/lib/views/states/in_buffer.js
@@ -2,7 +2,7 @@ import _default from "ember-views/views/states/default";
 import EmberError from "ember-metal/error";
 
 import Ember from "ember-metal/core"; // Ember.assert
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
 
 /**

--- a/packages_es6/ember-views/lib/views/states/in_dom.js
+++ b/packages_es6/ember-views/lib/views/states/in_dom.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core"; // Ember.assert
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
 import EmberError from "ember-metal/error";
 

--- a/packages_es6/ember-views/lib/views/states/pre_render.js
+++ b/packages_es6/ember-views/lib/views/states/pre_render.js
@@ -1,5 +1,5 @@
 import _default from "ember-views/views/states/default";
-import {create} from "ember-metal/platform";
+import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
 
 /**

--- a/packages_es6/ember-views/lib/views/view.js
+++ b/packages_es6/ember-views/lib/views/view.js
@@ -9,27 +9,30 @@ import EmberObject from "ember-runtime/system/object";
 import Evented from "ember-runtime/mixins/evented";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import renderBuffer from "ember-views/system/render_buffer";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import setProperties from "ember-metal/set_properties";
 import run from "ember-metal/run_loop";
-import {addObserver, removeObserver} from "ember-metal/observer";
+import { addObserver, removeObserver } from "ember-metal/observer";
 
-import {defineProperty} from "ember-metal/properties";
-import {guidFor} from "ember-metal/utils";
-import {meta} from "ember-metal/utils";
-import {computed} from "ember-metal/computed";
-import {observer} from "ember-metal/mixin";
+import { defineProperty } from "ember-metal/properties";
+import { guidFor } from "ember-metal/utils";
+import { meta } from "ember-metal/utils";
+import { computed } from "ember-metal/computed";
+import { observer } from "ember-metal/mixin";
 
-import {typeOf, isArray} from "ember-metal/utils";
-import {isNone} from 'ember-metal/is_none';
-import {Mixin} from 'ember-metal/mixin';
+import {
+  typeOf,
+  isArray
+} from "ember-metal/utils";
+import { isNone } from 'ember-metal/is_none';
+import { Mixin } from 'ember-metal/mixin';
 import Container from 'container/container';
-import {A as emberA} from "ember-runtime/system/native_array";
+import { A as emberA } from "ember-runtime/system/native_array";
 
-import {instrument} from "ember-metal/instrumentation";
+import { instrument } from "ember-metal/instrumentation";
 
-import {dasherize} from "ember-runtime/system/string";
+import { dasherize } from "ember-runtime/system/string";
 
 // ES6TODO: functions on EnumerableUtils should get their own export
 import EnumerableUtils from "ember-metal/enumerable_utils";
@@ -37,13 +40,19 @@ var a_forEach = EnumerableUtils.forEach,
     a_addObject = EnumerableUtils.addObject,
     a_removeObject = EnumerableUtils.removeObject;
 
-import {beforeObserver} from "ember-metal/mixin";
+import { beforeObserver } from "ember-metal/mixin";
 import copy from "ember-runtime/copy";
-import {isGlobalPath} from "ember-metal/binding";
+import { isGlobalPath } from "ember-metal/binding";
 
-import {propertyWillChange, propertyDidChange} from "ember-metal/property_events";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
 
-import {cloneStates, states} from "ember-views/views/states";
+import {
+  cloneStates,
+  states
+} from "ember-views/views/states";
 import jQuery from "ember-views/system/jquery";
 import "ember-views/system/ext";  // for the side effect of extending Ember.run.queues
 
@@ -2615,4 +2624,8 @@ View.applyAttributeBindings = function(elem, name, value) {
   }
 };
 
-export {CoreView, View, ViewCollection};
+export {
+  CoreView,
+  View,
+  ViewCollection
+};

--- a/packages_es6/ember-views/tests/mixins/view_target_action_support_test.js
+++ b/packages_es6/ember-views/tests/mixins/view_target_action_support_test.js
@@ -1,6 +1,6 @@
 import Ember from "ember-metal/core";
 import EmberObject from "ember-runtime/system/object";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 import ViewTargetActionSupport from "ember-views/mixins/view_target_action_support";
 
 module("ViewTargetActionSupport");

--- a/packages_es6/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages_es6/ember-views/tests/system/event_dispatcher_test.js
@@ -1,11 +1,11 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 
 import EmberObject from "ember-runtime/system/object";
 
 import jQuery from "ember-views/system/jquery";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import ContainerView from "ember-views/views/container_view";
 

--- a/packages_es6/ember-views/tests/system/ext_test.js
+++ b/packages_es6/ember-views/tests/system/ext_test.js
@@ -1,5 +1,5 @@
 import run from "ember-metal/run_loop";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
 module("Ember.View additions to run queue");
 

--- a/packages_es6/ember-views/tests/system/jquery_ext_test.js
+++ b/packages_es6/ember-views/tests/system/jquery_ext_test.js
@@ -1,7 +1,7 @@
 import run from "ember-metal/run_loop";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import jQuery from "ember-views/system/jquery";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
 var view, dispatcher;
 

--- a/packages_es6/ember-views/tests/system/render_buffer_test.js
+++ b/packages_es6/ember-views/tests/system/render_buffer_test.js
@@ -1,5 +1,5 @@
-import {set} from "ember-metal/property_set";
-import {get} from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
 import jQuery from "ember-views/system/jquery";
 import RenderBuffer from "ember-views/system/render_buffer";
 

--- a/packages_es6/ember-views/tests/views/collection_test.js
+++ b/packages_es6/ember-views/tests/views/collection_test.js
@@ -1,15 +1,15 @@
 import Ember from "ember-metal/core"; // Ember.A
-import {set} from "ember-metal/property_set";
-import {get} from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EnumerableUtils from "ember-metal/enumerable_utils";
-import {Mixin} from "ember-metal/mixin";
-import {fmt} from "ember-runtime/system/string";
+import { Mixin } from "ember-metal/mixin";
+import { fmt } from "ember-runtime/system/string";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import jQuery from "ember-views/system/jquery";
 import CollectionView from "ember-views/views/collection_view";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
 var forEach = EnumerableUtils.forEach;
 var trim = jQuery.trim;

--- a/packages_es6/ember-views/tests/views/component_test.js
+++ b/packages_es6/ember-views/tests/views/component_test.js
@@ -1,8 +1,8 @@
-import {set} from "ember-metal/property_set";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import Component from "ember-views/views/component";
 
 var a_slice = Array.prototype.slice;

--- a/packages_es6/ember-views/tests/views/container_view_test.js
+++ b/packages_es6/ember-views/tests/views/container_view_test.js
@@ -1,10 +1,10 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {computed} from "ember-metal/computed";
-import {Controller} from "ember-runtime/controllers/controller";
+import { computed } from "ember-metal/computed";
+import { Controller } from "ember-runtime/controllers/controller";
 import jQuery from "ember-views/system/jquery";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var trim = jQuery.trim, container, view, otherContainer;

--- a/packages_es6/ember-views/tests/views/view/actions_test.js
+++ b/packages_es6/ember-views/tests/views/view/actions_test.js
@@ -1,11 +1,11 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {Mixin} from "ember-metal/mixin";
-import {Controller} from "ember-runtime/controllers/controller";
+import { Mixin } from "ember-metal/mixin";
+import { Controller } from "ember-runtime/controllers/controller";
 import EmberObject from "ember-runtime/system/object";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
 var view;
 

--- a/packages_es6/ember-views/tests/views/view/append_to_test.js
+++ b/packages_es6/ember-views/tests/views/view/append_to_test.js
@@ -1,10 +1,10 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var View, view, willDestroyCalled, childView;

--- a/packages_es6/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages_es6/ember-views/tests/views/view/attribute_bindings_test.js
@@ -1,10 +1,10 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {observersFor} from "ember-metal/observer";
-import {changeProperties} from "ember-metal/property_events";
+import { observersFor } from "ember-metal/observer";
+import { changeProperties } from "ember-metal/property_events";
 
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var originalLookup = Ember.lookup, lookup, view;
 

--- a/packages_es6/ember-views/tests/views/view/child_views_test.js
+++ b/packages_es6/ember-views/tests/views/view/child_views_test.js
@@ -1,8 +1,8 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var parentView, childView, childViews;
 

--- a/packages_es6/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages_es6/ember-views/tests/views/view/class_name_bindings_test.js
@@ -1,11 +1,11 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {changeProperties} from "ember-metal/property_events";
-import {isWatching} from "ember-metal/watching";
+import { changeProperties } from "ember-metal/property_events";
+import { isWatching } from "ember-metal/watching";
 import EmberObject from "ember-runtime/system/object";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var view;
 

--- a/packages_es6/ember-views/tests/views/view/class_string_for_value_test.js
+++ b/packages_es6/ember-views/tests/views/view/class_string_for_value_test.js
@@ -1,4 +1,4 @@
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 
 module("View - _classStringForValue");
 

--- a/packages_es6/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages_es6/ember-views/tests/views/view/create_child_view_test.js
@@ -1,6 +1,6 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var view, myViewClass, newView, container;
 

--- a/packages_es6/ember-views/tests/views/view/create_element_test.js
+++ b/packages_es6/ember-views/tests/views/view/create_element_test.js
@@ -1,6 +1,6 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var view;

--- a/packages_es6/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages_es6/ember-views/tests/views/view/destroy_element_test.js
@@ -1,6 +1,6 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var view;

--- a/packages_es6/ember-views/tests/views/view/destroy_test.js
+++ b/packages_es6/ember-views/tests/views/view/destroy_test.js
@@ -1,6 +1,6 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 module("Ember.View#destroy");
 

--- a/packages_es6/ember-views/tests/views/view/element_test.js
+++ b/packages_es6/ember-views/tests/views/view/element_test.js
@@ -1,9 +1,9 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var parentView, child, parentDom, childDom, view;

--- a/packages_es6/ember-views/tests/views/view/evented_test.js
+++ b/packages_es6/ember-views/tests/views/view/evented_test.js
@@ -1,7 +1,7 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var view;
 

--- a/packages_es6/ember-views/tests/views/view/init_test.js
+++ b/packages_es6/ember-views/tests/views/view/init_test.js
@@ -1,9 +1,9 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {computed} from "ember-metal/computed";
+import { computed } from "ember-metal/computed";
 import EmberObject from "ember-runtime/system/object";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var originalLookup = Ember.lookup, lookup, view;
 

--- a/packages_es6/ember-views/tests/views/view/is_visible_test.js
+++ b/packages_es6/ember-views/tests/views/view/is_visible_test.js
@@ -1,8 +1,8 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var View, view, parentBecameVisible, childBecameVisible, grandchildBecameVisible;

--- a/packages_es6/ember-views/tests/views/view/jquery_test.js
+++ b/packages_es6/ember-views/tests/views/view/jquery_test.js
@@ -1,7 +1,7 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var view ;
 module("EmberView#$", {

--- a/packages_es6/ember-views/tests/views/view/layout_test.js
+++ b/packages_es6/ember-views/tests/views/view/layout_test.js
@@ -1,7 +1,7 @@
 import Container from "container";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var container, view;
 

--- a/packages_es6/ember-views/tests/views/view/nearest_of_type_test.js
+++ b/packages_es6/ember-views/tests/views/view/nearest_of_type_test.js
@@ -1,8 +1,8 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import {Mixin as EmberMixin} from "ember-metal/mixin";
-import {View} from "ember-views/views/view";
+import { Mixin as EmberMixin } from "ember-metal/mixin";
+import { View } from "ember-views/views/view";
 
 var parentView, view;
 

--- a/packages_es6/ember-views/tests/views/view/parse_property_path_test.js
+++ b/packages_es6/ember-views/tests/views/view/parse_property_path_test.js
@@ -1,4 +1,4 @@
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 module("EmberView - _parsePropertyPath");
 

--- a/packages_es6/ember-views/tests/views/view/remove_test.js
+++ b/packages_es6/ember-views/tests/views/view/remove_test.js
@@ -1,9 +1,9 @@
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import jQuery from "ember-views/system/jquery";
-import {View} from "ember-views/views/view";
+import { View } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var indexOf = EnumerableUtils.indexOf;

--- a/packages_es6/ember-views/tests/views/view/render_test.js
+++ b/packages_es6/ember-views/tests/views/view/render_test.js
@@ -1,8 +1,8 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var view;

--- a/packages_es6/ember-views/tests/views/view/replace_in_test.js
+++ b/packages_es6/ember-views/tests/views/view/replace_in_test.js
@@ -1,7 +1,7 @@
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 
 var View, view, willDestroyCalled, childView;

--- a/packages_es6/ember-views/tests/views/view/template_test.js
+++ b/packages_es6/ember-views/tests/views/view/template_test.js
@@ -1,8 +1,8 @@
 import Container from "container";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var container, view;
 

--- a/packages_es6/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages_es6/ember-views/tests/views/view/view_lifecycle_test.js
@@ -1,9 +1,9 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var originalLookup = Ember.lookup, lookup, view;
 

--- a/packages_es6/ember-views/tests/views/view/virtual_views_test.js
+++ b/packages_es6/ember-views/tests/views/view/virtual_views_test.js
@@ -1,9 +1,9 @@
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
+import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
-import {View as EmberView} from "ember-views/views/view";
+import { View as EmberView } from "ember-views/views/view";
 
 var rootView, childView;
 


### PR DESCRIPTION
First pass to improve usage, the ultimately our goal will be to expose the modules as a public api.

Mostly this PR splits long single line import/export statements, into legible multiple statements. Also it aims it improve locality of export statements, the goal is to make it clear when looking at a function that it is part of the external interface.
