### PR TITLE
Cleanup JSHint errors.

### DIFF
--- a/packages_es6/ember-handlebars/lib/main.js
+++ b/packages_es6/ember-handlebars/lib/main.js
@@ -71,7 +71,7 @@ import TextSupport from "ember-handlebars/controls/text_support";
 import {
   inputHelper,
   textareaHelper
-} from "ember-handlebars/controls"
+} from "ember-handlebars/controls";
 
 
 import ComponentLookup from "ember-handlebars/component_lookup";

--- a/packages_es6/ember-metal/lib/expand_properties.js
+++ b/packages_es6/ember-metal/lib/expand_properties.js
@@ -43,4 +43,4 @@ export default function expandProperties(pattern, callback) {
   } else {
     callback(pattern);
   }
-};
+}

--- a/packages_es6/ember-metal/lib/get_properties.js
+++ b/packages_es6/ember-metal/lib/get_properties.js
@@ -35,4 +35,4 @@ export default function getProperties(obj) {
     ret[propertyNames[i]] = get(obj, propertyNames[i]);
   }
   return ret;
-};
+}

--- a/packages_es6/ember-metal/lib/is_blank.js
+++ b/packages_es6/ember-metal/lib/is_blank.js
@@ -26,4 +26,4 @@ import isEmpty from 'ember-metal/is_empty';
   */
 export default function isBlank(obj) {
   return isEmpty(obj) || (typeof obj === 'string' && obj.match(/\S/) === null);
-};
+}

--- a/packages_es6/ember-metal/lib/merge.js
+++ b/packages_es6/ember-metal/lib/merge.js
@@ -19,4 +19,4 @@ export default function merge(original, updates) {
     original[prop] = updates[prop];
   }
   return original;
-};
+}

--- a/packages_es6/ember-metal/lib/set_properties.js
+++ b/packages_es6/ember-metal/lib/set_properties.js
@@ -26,4 +26,4 @@ export default function setProperties(self, hash) {
     }
   });
   return self;
-};
+}

--- a/packages_es6/ember-testing/lib/setup_for_testing.js
+++ b/packages_es6/ember-testing/lib/setup_for_testing.js
@@ -46,4 +46,4 @@ export default function setupForTesting() {
   jQuery(document).off('ajaxComplete', decrementAjaxPendingRequests);
   jQuery(document).on('ajaxSend', incrementAjaxPendingRequests);
   jQuery(document).on('ajaxComplete', decrementAjaxPendingRequests);
-};
+}


### PR DESCRIPTION
Current master builds do not get properly checked against JSHint, these few issues snuck through the cracks.
