### PR TITLE
Ensure that `content` -> `model` alias does not break SemVer.

### DIFF
--- a/packages_es6/ember-runtime/lib/controllers/controller.js
+++ b/packages_es6/ember-runtime/lib/controllers/controller.js
@@ -4,6 +4,7 @@ import EmberObject from "ember-runtime/system/object";
 import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";
 import ActionHandler from "ember-runtime/mixins/action_handler";
+import ControllerContentModelAliasDeprecation from "ember-runtime/mixins/controller_content_model_alias_deprecation";
 
 /**
 @module ember
@@ -19,7 +20,7 @@ import ActionHandler from "ember-runtime/mixins/action_handler";
   @namespace Ember
   @uses Ember.ActionHandler
 */
-var ControllerMixin = Mixin.create(ActionHandler, {
+var ControllerMixin = Mixin.create(ActionHandler, ControllerContentModelAliasDeprecation, {
   /* ducktype as a controller */
   isController: true,
 

--- a/packages_es6/ember-runtime/lib/mixins/controller_content_model_alias_deprecation.js
+++ b/packages_es6/ember-runtime/lib/mixins/controller_content_model_alias_deprecation.js
@@ -1,0 +1,51 @@
+import Ember from 'ember-metal/core'; // Ember.deprecate
+import { get } from "ember-metal/property_get";
+import { Mixin } from 'ember-metal/mixin';
+
+/**
+  The ControllerContentModelAliasDeprecation mixin is used to provide a useful
+  deprecation warning when specifying `content` directly on a `Ember.Controller`
+  (without also specifying `model`).
+
+  Ember versions prior to 1.7 used `model` as an alias of `content`, but due to
+  much confusion this alias was reversed (so `content` is now an alias of `model).
+
+  This change reduces many caveats with model/content, and also sets a
+  simple ground rule: Never set a controllers content, rather always set
+  it's model and ember will do the right thing.
+
+
+  `Ember.ControllerContentModelAliasDeprecation` is used internally by Ember in
+  `Ember.Controller`.
+
+  @class ControllerContentModelAliasDeprecation
+  @namespace Ember
+*/
+export default Mixin.create({
+  /**
+    @private
+
+    Moves `content` to `model`  at extend time if a `model` is not also specified.
+
+    Note that this currently modifies the mixin themselves, which is technically
+    dubious but is practically of little consequence. This may change in the
+    future.
+
+    @method willMergeMixin
+    @since 1.4.0
+  */
+  willMergeMixin: function(props) {
+    // Calling super is only OK here since we KNOW that
+    // there is another Mixin loaded first.
+    this._super.apply(this, arguments);
+
+    var modelSpecified = !!props.model;
+
+    if (props.content && !modelSpecified) {
+      props.model = props.content;
+      delete props['content'];
+
+      Ember.deprecate('Do not specify `content` on a Controller, use `model` instead.', false);
+    }
+  }
+});

--- a/packages_es6/ember-runtime/tests/controllers/controller_test.js
+++ b/packages_es6/ember-runtime/tests/controllers/controller_test.js
@@ -137,3 +137,49 @@ if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     controller.send("poke");
   });
 }
+
+module('Controller Content -> Model Alias');
+
+test("`model` is aliased as `content`", function() {
+  expect(1);
+  var controller = Controller.extend({
+    model: 'foo-bar'
+  }).create();
+
+  equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
+});
+
+test("`content` is moved to `model` when `model` is unset", function() {
+  expect(2);
+  var controller;
+
+  ignoreDeprecation(function() {
+    controller = Controller.extend({
+      content: 'foo-bar'
+    }).create();
+  });
+
+  equal(controller.get('model'), 'foo-bar', 'model is set properly');
+  equal(controller.get('content'), 'foo-bar', 'content is set properly');
+});
+
+test("specifying `content` (without `model` specified) results in deprecation", function() {
+  expect(1);
+  var controller;
+
+  expectDeprecation(function() {
+    controller = Controller.extend({
+      content: 'foo-bar'
+    }).create();
+  }, 'Do not specify `content` on a Controller, use `model` instead.');
+});
+
+test("specifying `content` (with `model` specified) does not result in deprecation", function() {
+  expect(1);
+  expectNoDeprecation();
+
+  Controller.extend({
+    content: 'foo-bar',
+    model: 'blammo'
+  }).create();
+});


### PR DESCRIPTION
The ControllerContentModelAliasDeprecation mixin is used to provide a useful
deprecation warning when specifying `content` directly on a `Ember.Controller`
(without also specifying `model`).

Ember versions prior to 1.7 used `model` as an alias of `content`, but due to
much confusion this alias was reversed (so `content` is now an alias of `model).

This change reduces many caveats with model/content, and also sets a
simple ground rule: Never set a controllers content, rather always set
it's model and ember will do the right thing.
