### PR TITLE
[FEATURE classname-can-disable-handlers] Optional setup at the EventDispatcher

### DIFF
--- a/features.json
+++ b/features.json
@@ -8,7 +8,8 @@
     "ember-runtime-test-friendly-promises": true,
     "ember-routing-add-model-option": true,
     "ember-routing-linkto-target-attribute": null,
-    "ember-routing-will-change-hooks": null
+    "ember-routing-will-change-hooks": null,
+    "classname-can-disable-handlers": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages_es6/ember-routing/tests/helpers/action_test.js
+++ b/packages_es6/ember-routing/tests/helpers/action_test.js
@@ -759,6 +759,64 @@ test("it can trigger actions for keyboard events", function() {
   ok(showCalled, "should call action with keyup");
 });
 
+
+if (Ember.FEATURES.isEnabled("classname-can-disable-handlers")) {
+
+  test("it does not trigger actions when the disabledHandlerClassName property on the eventDispatcher has been setup and the action view has that className", function() {
+
+    expect(2);
+    var receivedEvent=0;
+
+    run(function() {
+      dispatcher.destroy();
+    });
+
+    dispatcher = EventDispatcher.create();
+    dispatcher.set('disabledHandlerClassName', 'disabled');
+    dispatcher.setup({});
+
+
+    view = EmberView.create({
+      template: compile("<div id='action-view' {{bind-attr class='disabled'}} {{action 'show' }}></div>")
+    });
+
+    var controller = EmberController.extend({
+      disabled: true,
+      actions: {
+        show: function() {
+          receivedEvent++;
+        }
+      }
+    }).create();
+
+    run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    run(function(){
+      view.$("#action-view").click();
+    });
+
+
+    equal(receivedEvent,0, 'should not call action because the disabled className is present');
+
+    run(function(){
+      controller.set('disabled', false);
+    });
+
+    run(function(){
+      view.$("#action-view").click();
+    });
+
+
+    equal(receivedEvent,1, 'should call action when the disabled className is not present');
+
+
+  });
+
+}
+
 test("a quoteless parameter should allow dynamic lookup of the actionName", function(){
   expect(4);
   var lastAction, actionOrder = [];

--- a/packages_es6/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages_es6/ember-views/tests/system/event_dispatcher_test.js
@@ -341,3 +341,38 @@ test("additional events and rootElement can be specified", function () {
 
   jQuery("#leView").trigger("myevent");
 });
+
+
+if (Ember.FEATURES.isEnabled("classname-can-disable-handlers")) {
+  test("disabledHandlerClassName stops the event delivery to views with that className", function () {
+    expect(2);
+
+    var receivedEvent=0;
+
+    run(function () {
+
+      dispatcher.set('disabledHandlerClassName', 'disabled');
+      dispatcher.setup({});
+
+      view = View.create({
+        elementId: "leView",
+        classNameBindings: ['disabled'],
+        disabled: true,
+        mouseDown: function() {
+          receivedEvent++;
+        }
+      }).appendTo( dispatcher.get("rootElement") );
+    });
+
+
+    jQuery("#leView").trigger("mousedown");
+    equal(receivedEvent,0, 'should not deliver the event because the disabled className is present');
+
+    run(function () {
+      view.set('disabled', false);
+    });
+
+    jQuery("#leView").trigger("mousedown");
+    equal(receivedEvent,1, 'should deliver the event when the disabled className is not present');
+  });
+}


### PR DESCRIPTION
EventDispatcher brings an optional `disabledHandlerClassName` property, which gives the ability to stop the event delivery and action trigger on the views with that specific className.

This specific question was posted at [SO](http://stackoverflow.com/questions/23632812/how-tell-ember-do-not-fire-click-event-on-disabled-link?noredirect=1#comment36293044_23632812).
