### PR TITLE
Fixed array_proxy’s clear method when sortable_array mixin is applied

### DIFF
--- a/packages_es6/ember-runtime/lib/system/array_proxy.js
+++ b/packages_es6/ember-runtime/lib/system/array_proxy.js
@@ -244,8 +244,8 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     return this;
   },
 
-  replace: function() {
-    if (get(this, 'arrangedContent') === get(this, 'content')) {
+  replace: function(idx, amt, objects) {
+    if (get(this, 'arrangedContent') === get(this, 'content') || objects.length === 0) {
       apply(this, this._replace, arguments);
     } else {
       throw new EmberError("Using replace on an arranged ArrayProxy is not allowed.");

--- a/packages_es6/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages_es6/ember-runtime/tests/mixins/sortable_test.js
@@ -372,3 +372,13 @@ test("Ember.Sortable with sortFunction on ArrayProxy should work like ArrayContr
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
+
+test("sortable array can be cleared with clear method", function() {
+  run(function() {
+    sortedArrayController.set('content', unsortedArray);
+  });
+
+  equal(sortedArrayController.get('length'), 3, 'array has 3 items');
+  sortedArrayController.clear();
+  equal(sortedArrayController.get('length'), 0, 'array has 0 items after clear');
+});


### PR DESCRIPTION
I've stumbled upon what I think is a bug.

Here you can see the [jsbin](http://emberjs.jsbin.com/jirec/2/edit) with the issue and the error being triggered.

I added a failing test that will pass with the submitted change.
## Description 

A instance of `ArrayProxy` that has applied the `SortableMixin` and has sorting properties an error will be triggered when `clear()` method is called with the message 'Using replace on an arranged ArrayProxy is not allowed.'
## Fix

The `clear` method calls `replace` method where it's checked if the current object is sortable (contains an `arrangeContent` attribute) and if sortable triggers the error.

I checked the way that `_replace` method works where `replaceContent` method is called which finally calls `EnumerableUtils.replace`. For the case when the `objects` array given as third parameter is empty the instance's content is cleared. So I mutated the if condition so that when an empty replacement objects array is given the `_replace` method will be called, the array will be cleared, and the error not thrown anymore.
