### PR TITLE
Use _states and _state throughout ember-views.

### DIFF
--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -164,7 +164,7 @@ merge(states.inDOM, {
 */
 var _HandlebarsBoundView = _MetamorphView.extend({
   instrumentName: 'boundHandlebars',
-  states: states,
+  _states: states,
 
   /**
     The function used to determine if the `displayTemplate` or

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1316,6 +1316,31 @@ computed.defaultTo = function(defaultPath) {
   });
 };
 
+/**
+  Creates a new property that is an alias for another property
+  on an object. Calls to `get` or `set` this property behave as
+  though they were called on the original property, but also
+  print a deprecation warning.
+
+  @method computed.deprecatingAlias
+  @for Ember
+  @param {String} dependentKey
+  @return {Ember.ComputedProperty} computed property which creates an
+  alias with a deprecation to the original value for property.
+*/
+computed.deprecatingAlias = function(dependentKey) {
+  return computed(dependentKey, function(key, value) {
+    Ember.deprecate('Usage of `' + key + '` is deprecated, use `' + dependentKey + '` instead.');
+
+    if (arguments.length > 1) {
+      set(this, dependentKey, value);
+      return value;
+    } else {
+      return get(this, dependentKey);
+    }
+  });
+};
+
 export {
   ComputedProperty,
   computed,

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -1049,3 +1049,52 @@ testBoth('computed.readOnly', function(get, set) {
 
   equal(get(obj, 'nickName'), 'TEDDDDDDDDYYY');
 });
+
+testBoth('computed.deprecatingAlias', function(get, set) {
+  var obj = { bar: 'asdf', baz: null, quz: false};
+  defineProperty(obj, 'bay', computed(function(key) {
+    return 'apple';
+  }));
+
+  defineProperty(obj, 'barAlias', computed.deprecatingAlias('bar'));
+  defineProperty(obj, 'bazAlias', computed.deprecatingAlias('baz'));
+  defineProperty(obj, 'quzAlias', computed.deprecatingAlias('quz'));
+  defineProperty(obj, 'bayAlias', computed.deprecatingAlias('bay'));
+
+  expectDeprecation(function() {
+    equal(get(obj, 'barAlias'), 'asdf');
+  }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
+
+  expectDeprecation(function() {
+    equal(get(obj, 'bazAlias'), null);
+  }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
+
+  expectDeprecation(function() {
+    equal(get(obj, 'quzAlias'), false);
+  }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
+
+  expectDeprecation(function() {
+    equal(get(obj, 'bayAlias'), 'apple');
+  }, 'Usage of `bayAlias` is deprecated, use `bay` instead.');
+
+  expectDeprecation(function() {
+    set(obj, 'barAlias', 'newBar');
+  }, 'Usage of `barAlias` is deprecated, use `bar` instead.');
+
+  expectDeprecation(function() {
+    set(obj, 'bazAlias', 'newBaz');
+  }, 'Usage of `bazAlias` is deprecated, use `baz` instead.');
+
+  expectDeprecation(function() {
+    set(obj, 'quzAlias', null);
+  }, 'Usage of `quzAlias` is deprecated, use `quz` instead.');
+
+
+  equal(get(obj, 'barAlias'), 'newBar');
+  equal(get(obj, 'bazAlias'), 'newBaz');
+  equal(get(obj, 'quzAlias'), null);
+
+  equal(get(obj, 'bar'), 'newBar');
+  equal(get(obj, 'baz'), 'newBaz');
+  equal(get(obj, 'quz'), null);
+});

--- a/packages/ember-metal/tests/properties_test.js
+++ b/packages/ember-metal/tests/properties_test.js
@@ -1,8 +1,11 @@
 import Ember from 'ember-metal/core';
+import { platform } from "ember-metal/platform";
 import { set } from 'ember-metal/property_set';
 import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
-import { defineProperty } from "ember-metal/properties";
+import { defineProperty,
+         deprecateProperty
+} from "ember-metal/properties";
 
 QUnit.module('Ember.defineProperty');
 
@@ -41,3 +44,45 @@ test("for descriptor properties, didDefineProperty hook should be called if impl
   defineProperty(obj, 'foo', computedProperty);
 });
 
+if (platform.hasPropertyAccessors) {
+
+  QUnit.module('Ember.deprecateProperty');
+
+  test("enables access to deprecated property and returns the value of the new property", function() {
+    expect(3);
+    var obj = {foo: 'bar'};
+
+    deprecateProperty(obj, 'baz', 'foo');
+
+    expectDeprecation();
+    equal(obj.baz, obj.foo, 'baz and foo are equal');
+
+    obj.foo = 'blammo';
+    equal(obj.baz, obj.foo, 'baz and foo are equal');
+  });
+
+  test("deprecatedKey is not enumerable", function() {
+    expect(2);
+    var obj = {foo: 'bar', blammo: 'whammy'};
+
+    deprecateProperty(obj, 'baz', 'foo');
+
+    for (var prop in obj) {
+      if (obj.hasOwnProperty(prop)) {
+        notEqual(prop, 'baz');
+      }
+    }
+  });
+
+  test("enables setter to deprecated property and updates the value of the new property", function() {
+    expect(3);
+    var obj = {foo: 'bar'};
+
+    deprecateProperty(obj, 'baz', 'foo');
+
+    expectDeprecation();
+    obj.baz = 'bloop';
+    equal(obj.foo, 'bloop', 'updating baz updates foo');
+    equal(obj.baz, obj.foo, 'baz and foo are equal');
+  });
+}

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -189,7 +189,7 @@ var states = cloneStates(EmberViewStates);
   @extends Ember.View
 */
 var ContainerView = View.extend(MutableArray, {
-  states: states,
+  _states: states,
 
   init: function() {
     this._super();

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -15,7 +15,7 @@ import setProperties from "ember-metal/set_properties";
 import run from "ember-metal/run_loop";
 import { addObserver, removeObserver } from "ember-metal/observer";
 
-import { defineProperty } from "ember-metal/properties";
+import { defineProperty, deprecateProperty } from "ember-metal/properties";
 import { guidFor } from "ember-metal/utils";
 import { meta } from "ember-metal/utils";
 import { computed } from "ember-metal/computed";
@@ -131,12 +131,15 @@ Ember.TEMPLATES = {};
 var CoreView = EmberObject.extend(Evented, ActionHandler, {
   isView: true,
 
-  states: cloneStates(states),
+  _states: cloneStates(states),
 
   init: function() {
     this._super();
     this.transitionTo('preRender');
     this._isVisible = get(this, 'isVisible');
+
+    deprecateProperty(this, 'states', '_states');
+    deprecateProperty(this, 'state', '_state');
   },
 
   /**
@@ -157,7 +160,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     }
   }),
 
-  state: null,
+  _state: null,
 
   _parentView: null,
 
@@ -2333,8 +2336,8 @@ var View = CoreView.extend({
 
   transitionTo: function(state, children) {
     var priorState = this.currentState,
-        currentState = this.currentState = this.states[state];
-    this.state = state;
+        currentState = this.currentState = this._states[state];
+    this._state = state;
 
     if (priorState && priorState.exit) { priorState.exit(this); }
     if (currentState.enter) { currentState.enter(this); }

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -68,7 +68,7 @@ test("should move the view to the inDOM state after replacing", function() {
     view.replaceIn('#menu');
   });
 
-  equal(view.currentState, view.states.inDOM, "the view is in the inDOM state");
+  equal(view.currentState, view._states.inDOM, "the view is in the inDOM state");
 });
 
 QUnit.module("EmberView - replaceIn() in a view hierarchy", {

--- a/packages/ember-views/tests/views/view/state_deprecation_test.js
+++ b/packages/ember-views/tests/views/view/state_deprecation_test.js
@@ -1,0 +1,41 @@
+import { platform } from "ember-metal/platform";
+import run from "ember-metal/run_loop";
+import { View as EmberView } from "ember-views/views/view";
+
+var view;
+
+
+QUnit.module("views/view/state_deprecation", {
+  teardown: function() {
+    if (view) {
+      run(view, 'destroy');
+    }
+  }
+});
+
+if (platform.hasPropertyAccessors) {
+  test("view.state should be an alias of view._state with a deprecation", function() {
+    expect(2);
+    view = EmberView.create();
+
+    expectDeprecation(function() {
+      equal(view._state, view.state, '_state and state are aliased');
+    }, 'Usage of `state` is deprecated, use `_state` instead.');
+  });
+
+  test("view.states should be an alias of view._states with a deprecation", function() {
+    expect(2);
+    view = EmberView.create();
+
+    expectDeprecation(function() {
+      equal(view._states, view.states, '_states and states are aliased');
+    }, 'Usage of `states` is deprecated, use `_states` instead.');
+  });
+}
+
+test("no deprecation is printed if view.state or view._state is not looked up", function() {
+  expect(1);
+  expectNoDeprecation();
+
+  EmberView.create();
+});

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -175,7 +175,7 @@ test("createElement puts the view into the hasElement state", function() {
     view.createElement();
   });
 
-  equal(view.currentState, view.states.hasElement, "the view is in the hasElement state");
+  equal(view.currentState, view._states.hasElement, "the view is in the hasElement state");
 });
 
 test("trigger rerender on a view in the hasElement state doesn't change its state to inDOM", function() {
@@ -188,7 +188,7 @@ test("trigger rerender on a view in the hasElement state doesn't change its stat
     view.rerender();
   });
 
-  equal(view.currentState, view.states.hasElement, "the view is still in the hasElement state");
+  equal(view.currentState, view._states.hasElement, "the view is still in the hasElement state");
 });
 
 
@@ -371,7 +371,7 @@ test("trigger rerender on a view in the inDOM state keeps its state as inDOM", f
     view.rerender();
   });
 
-  equal(view.currentState, view.states.inDOM, "the view is still in the inDOM state");
+  equal(view.currentState, view._states.inDOM, "the view is still in the inDOM state");
 
   run(function() {
     view.destroy();


### PR DESCRIPTION
Resolves #4764

Added `deprecateProperty` helper that uses `defineProperty` to allow the old property names (`state` and `states`) to still function properly, but print a deprecation warning when accessed (or set).
