### PR TITLE
Add one more setup step to readmes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ Building Ember is quite simple.
 ```sh
 cd ember.js
 npm install
+bower install
 bin/build.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ everything you need to get started.
 # Building Ember.js
 
 1. Ensure that [Node.js](http://nodejs.org/) is installed.
-2. Run `npm install` to ensure the required dependencies are installed.
-3. Run `bin/build.js` to build Ember.js. The builds will be placed in the `dist/` directory.
+2. Run `npm install` to ensure the required development dependencies are installed.
+3  Run `bower install` to install libraries dependencies.
+4. Run `bin/build.js` to build Ember.js. The builds will be placed in the `dist/` directory.
 
 # Contribution
 


### PR DESCRIPTION
It was identified while running tests for #4443.
`bower install` was not listed as a required setup step.
