### PR TITLE
Update broccoli-jshint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "broccoli-file-mover": "~0.2.0",
     "broccoli-file-remover": "~0.2.0",
     "broccoli-export-tree": "~0.3.0",
-    "broccoli-jshint": "~0.4.0",
+    "broccoli-jshint": "~0.5.0",
     "rsvp": "~3.0.6",
     "chalk": "~0.4.0",
     "broccoli-cli": "0.0.1",

--- a/tests/index.html
+++ b/tests/index.html
@@ -58,7 +58,7 @@
         if (moduleName.match(skipPackageRegexp)) { continue; }
 
         if (moduleName.match(/[_-]test$/)) { Ember.__loader.require(moduleName); }
-        if (!QUnit.urlParams.nojshint && moduleName.match(/[-_]jshint$/)) { Ember.__loader.require(moduleName); }
+        if (!QUnit.urlParams.nojshint && moduleName.match(/[-_.]jshint$/)) { Ember.__loader.require(moduleName); }
       }
     </script>
   </head>


### PR DESCRIPTION
broccoli-jshint 0.5.0 moves to being an inheritor of `broccoli-filter`. This allows caching at the file level, and speeds up the rebuild times (since we aren't re-hinting the entire package).
