### PR TITLE
[BUGFIX beta] Resolve context issues for with-controller.

### DIFF
--- a/packages_es6/ember-handlebars/lib/helpers/binding.js
+++ b/packages_es6/ember-handlebars/lib/helpers/binding.js
@@ -47,6 +47,13 @@ function exists(value) {
   return !isNone(value);
 }
 
+var _HandlebarsBoundWithControllerView = _HandlebarsBoundView.extend({
+  willDestroy: function() {
+    this._super();
+    this.get('controller').destroy();
+  }
+});
+
 // Binds a property into the DOM. This will create a hook in DOM that the
 // KVO system will look for and update if the property changes.
 function bind(property, options, preserveContext, shouldDisplay, valueNormalizer, childProperties) {
@@ -83,10 +90,8 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
 
       template(context, { data: options.data });
     } else {
-      // Create the view that will wrap the output of this template/property
-      // and add it to the nearest view's childViews array.
-      // See the documentation of Ember._HandlebarsBoundView for more.
-      var bindView = view.createChildView(Ember._HandlebarsBoundView, {
+      var viewClass = _HandlebarsBoundView;
+      var viewOptions = {
         preserveContext: preserveContext,
         shouldDisplayFunc: shouldDisplay,
         valueNormalizerFunc: valueNormalizer,
@@ -97,7 +102,7 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
         previousContext: currentContext,
         isEscaped: !options.hash.unescaped,
         templateData: options.data
-      });
+      };
 
       if (options['withHelper'] && options.hash.controller) {
         var controller = this.container.lookupFactory('controller:'+options.hash.controller).create({
@@ -106,15 +111,18 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
           target: currentContext
         });
 
-        bindView.setProperties({
-          controller: controller,
-          valueNormalizerFunc: function (result) {
-            controller.set('content', result);
-
-            return controller;
-          }
-        });
+        viewOptions.controller = controller;
+        viewOptions.valueNormalizerFunc = function(result) {
+          controller.set('content', result);
+          return controller;
+        };
+        viewClass = _HandlebarsBoundWithControllerView;
       }
+
+      // Create the view that will wrap the output of this template/property
+      // and add it to the nearest view's childViews array.
+      // See the documentation of Ember._HandlebarsBoundView for more.
+      var bindView = view.createChildView(viewClass, viewOptions);
 
       view.appendChild(bindView);
 

--- a/packages_es6/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages_es6/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -296,8 +296,6 @@ var _HandlebarsBoundView = _MetamorphView.extend({
         preserveContext = get(this, 'preserveContext'),
         context = get(this, 'previousContext');
 
-    var _contextController = get(this, '_contextController');
-
     var inverseTemplate = get(this, 'inverseTemplate'),
         displayTemplate = get(this, 'displayTemplate');
 
@@ -317,10 +315,6 @@ var _HandlebarsBoundView = _MetamorphView.extend({
       // Otherwise, determine if this is a block bind or not.
       // If so, pass the specified object to the template
         if (displayTemplate) {
-          if (_contextController) {
-            set(_contextController, 'content', result);
-            result = _contextController;
-          }
           set(this, '_context', result);
         } else {
         // This is not a bind block, just push the result of the

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -376,3 +376,36 @@ test("it should wrap keyword with object controller", function() {
 
   run(function() { view.destroy(); }); // destroy existing view
 });
+
+test("it should destroy the generated controller upon willDestroy", function() {
+  var destroyed = false;
+  var Controller = ObjectController.extend({
+    willDestroy: function() {
+      this._super();
+      destroyed = true;
+    }
+  });
+
+  var person = EmberObject.create({name: 'Steve Holt'});
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    person: person,
+    name: 'Bob Loblaw'
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: EmberHandlebars.compile('{{#with person controller="person"}}{{controllerName}}{{/with}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  appendView(view);
+
+  run(view, 'destroy'); // destroy existing view
+
+  ok(destroyed, 'controller was destroyed properly');
+});

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -294,7 +294,7 @@ test("it should wrap context with object controller", function() {
 
   equal(view.$().text(), "controller:Gob and Carl Weathers");
 
-  strictEqual(view.get('_childViews')[0].get('_contextController.target'), parentController, "the target property of the child controllers are set correctly");
+  strictEqual(view.get('_childViews')[0].get('controller.target'), parentController, "the target property of the child controllers are set correctly");
 
   run(function() { view.destroy(); }); // destroy existing view
 });
@@ -326,6 +326,53 @@ test("it should still have access to original parentController within an {{#each
   appendView(view);
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblawcontroller:Carl Weathers and Bob Loblaw");
+
+  run(function() { view.destroy(); }); // destroy existing view
+});
+
+test("it should wrap keyword with object controller", function() {
+  var PersonController = ObjectController.extend();
+
+  var person = EmberObject.create({name: 'Steve Holt'});
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    person: person,
+    name: 'Bob Loblaw'
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: EmberHandlebars.compile('{{#with person as steve controller="person"}}{{name}} - {{steve.name}}{{/with}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', PersonController);
+
+  appendView(view);
+
+  equal(view.$().text(), "Bob Loblaw - Steve Holt");
+
+  run(function() {
+    view.rerender();
+  });
+
+  equal(view.$().text(), "Bob Loblaw - Steve Holt");
+
+  run(function() {
+    parentController.set('name', 'Carl Weathers');
+    view.rerender();
+  });
+
+  equal(view.$().text(), "Carl Weathers - Steve Holt");
+
+  run(function() {
+    person.set('name', 'Gob');
+    view.rerender();
+  });
+
+  equal(view.$().text(), "Carl Weathers - Gob");
 
   run(function() { view.destroy(); }); // destroy existing view
 });

--- a/packages_es6/ember-routing/tests/helpers/action_test.js
+++ b/packages_es6/ember-routing/tests/helpers/action_test.js
@@ -180,6 +180,35 @@ test("should target the current controller inside an {{each}} loop", function() 
   ActionHelper.registerAction = originalRegisterAction;
 });
 
+test("should target the with-controller inside an {{#with controller='person'}}", function() {
+  var registeredTarget;
+
+  ActionHelper.registerAction = function(actionName, options) {
+    registeredTarget = options.target;
+  };
+
+  var PersonController = Ember.ObjectController.extend();
+  var container = new Ember.Container();
+  var parentController = Ember.Object.create({
+    container: container
+  });
+
+  view = Ember.View.create({
+    container: container,
+    template: Ember.Handlebars.compile('{{#with view.person controller="person"}}{{action "editTodo"}}{{/with}}'),
+    person: Ember.Object.create(),
+    controller: parentController
+  });
+
+  container.register('controller:person', PersonController);
+
+  appendView();
+
+  ok(registeredTarget.root instanceof PersonController, "the with-controller is the target of action");
+
+  ActionHelper.registerAction = originalRegisterAction;
+});
+
 test("should allow a target to be specified", function() {
   var registeredTarget;
 

--- a/packages_es6/ember-routing/tests/helpers/action_test.js
+++ b/packages_es6/ember-routing/tests/helpers/action_test.js
@@ -3,6 +3,7 @@ import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 
+import Container from "ember-runtime/system/container";
 import EmberObject from "ember-runtime/system/object";
 import { Controller as EmberController } from "ember-runtime/controllers/controller";
 import EmberObjectController from "ember-runtime/controllers/object_controller";
@@ -187,16 +188,16 @@ test("should target the with-controller inside an {{#with controller='person'}}"
     registeredTarget = options.target;
   };
 
-  var PersonController = Ember.ObjectController.extend();
-  var container = new Ember.Container();
-  var parentController = Ember.Object.create({
+  var PersonController = EmberObjectController.extend();
+  var container = new Container();
+  var parentController = EmberObject.create({
     container: container
   });
 
-  view = Ember.View.create({
+  view = EmberView.create({
     container: container,
-    template: Ember.Handlebars.compile('{{#with view.person controller="person"}}{{action "editTodo"}}{{/with}}'),
-    person: Ember.Object.create(),
+    template: EmberHandlebars.compile('{{#with view.person controller="person"}}{{action "editTodo"}}{{/with}}'),
+    person: EmberObject.create(),
     controller: parentController
   });
 
@@ -207,6 +208,40 @@ test("should target the with-controller inside an {{#with controller='person'}}"
   ok(registeredTarget.root instanceof PersonController, "the with-controller is the target of action");
 
   ActionHelper.registerAction = originalRegisterAction;
+});
+
+test("should target the with-controller inside an {{each}} in a {{#with controller='person'}}", function() {
+  var eventsCalled = [];
+
+  var PeopleController = EmberArrayController.extend({
+    actions: {
+      robert: function() { eventsCalled.push('robert'); },
+      brian: function() { eventsCalled.push('brian'); }
+    }
+  });
+
+  var container = new Container();
+  var parentController = EmberObject.create({
+    container: container,
+    people: Ember.A([
+      {name: 'robert'},
+      {name: 'brian'}
+    ]),
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: EmberHandlebars.compile('{{#with people controller="people"}}{{#each}}<a href="#" {{action name}}>{{name}}</a>{{/each}}{{/with}}'),
+    controller: parentController
+  });
+
+  container.register('controller:people', PeopleController);
+
+  appendView();
+
+  view.$('a').trigger('click');
+
+  deepEqual(eventsCalled, ['robert', 'brian'], 'the events are fired properly');
 });
 
 test("should allow a target to be specified", function() {


### PR DESCRIPTION
- Fixes action target when using `with-controller` (previously the action would never target the controller instantiated as the `with-controller`).
- Fixes action target within an `{{each}}` when using `with-controller` (pointed out in https://github.com/emberjs/ember.js/pull/4401#issuecomment-35959636).
- Ensures that using `with-controller` with keyword syntax works (previously mangled the scope).
- Removes `_contextController` reference completely (no longer needs modifications to `_HandlebarsBoundView`).
- Adds an additional guard around the setting of `controller` to ensure that the `bindView` only receives a `controller` when invoked from the `withHelper`. Previously, anything that uses `bind` would lookup and instantiate a controller if specified (e.g. `{{#if "foo" controller="zomg"}}{{/if}}` would have looked up `App.ZomgController` and instantiated it).
- Ensure that controllers created by `with-controller` are properly destroyed.

Closes #4401
Closes #4384
Closes #4398
Closes #4699

@rondale-sc / @rjackson
