### PR TITLE
Cleanup docs & tests to use `model` instead of `content` when dealing with Controllers.

### DIFF
--- a/packages_es6/ember-application/tests/system/controller_test.js
+++ b/packages_es6/ember-application/tests/system/controller_test.js
@@ -65,12 +65,12 @@ test("Mixin sets up controllers if there is needs before calling super", functio
 
   container.register('controller:another', ArrayController.extend({
     needs: 'posts',
-    contentBinding: 'controllers.posts'
+    modelBinding: 'controllers.posts'
   }));
 
   container.register('controller:posts', ArrayController.extend());
 
-  container.lookup('controller:posts').set('content', A(['a','b','c']));
+  container.lookup('controller:posts').set('model', A(['a','b','c']));
 
   deepEqual(['a','b','c'], container.lookup('controller:other').toArray());
   deepEqual(['a','b','c'], container.lookup('controller:another').toArray());

--- a/packages_es6/ember-handlebars/lib/helpers/binding.js
+++ b/packages_es6/ember-handlebars/lib/helpers/binding.js
@@ -113,7 +113,7 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
 
         viewOptions.controller = controller;
         viewOptions.valueNormalizerFunc = function(result) {
-          controller.set('content', result);
+          controller.set('model', result);
           return controller;
         };
         viewClass = _HandlebarsBoundWithControllerView;

--- a/packages_es6/ember-handlebars/lib/helpers/each.js
+++ b/packages_es6/ember-handlebars/lib/helpers/each.js
@@ -356,7 +356,7 @@ GroupedEach.prototype = {
   item needs to be presented by a custom controller you can provide a
   `itemController` option which references a controller by lookup name.
   Each item in the loop will be wrapped in an instance of this controller
-  and the item itself will be set to the `content` property of that controller.
+  and the item itself will be set to the `model` property of that controller.
 
   This is useful in cases where properties of model objects need transformation
   or synthesis for display:
@@ -364,7 +364,7 @@ GroupedEach.prototype = {
   ```javascript
   App.DeveloperController = Ember.ObjectController.extend({
     isAvailableForHire: function() {
-      return !this.get('content.isEmployed') && this.get('content.isSeekingWork');
+      return !this.get('model.isEmployed') && this.get('model.isSeekingWork');
     }.property('isEmployed', 'isSeekingWork')
   })
   ```

--- a/packages_es6/ember-handlebars/tests/handlebars_test.js
+++ b/packages_es6/ember-handlebars/tests/handlebars_test.js
@@ -593,7 +593,7 @@ test("Template updates correctly if a path is passed to the bind helper and the 
     price: "$4"
   });
 
-  set(controller, 'content', realObject);
+  set(controller, 'model', realObject);
 
   view = EmberView.create({
     container: container,

--- a/packages_es6/ember-handlebars/tests/helpers/each_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/each_test.js
@@ -220,7 +220,7 @@ test("it works inside a table element", function() {
 test("it supports itemController", function() {
   var Controller = EmberController.extend({
     controllerName: computed(function() {
-      return "controller:"+this.get('content.name');
+      return "controller:"+this.get('model.name');
     })
   });
 
@@ -272,7 +272,7 @@ test("itemController specified in template gets a parentController property", fu
   // on the proxied model.
   var Controller = ObjectController.extend({
         controllerName: computed(function() {
-          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
+          return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
         })
       }),
       parentController = {
@@ -300,7 +300,7 @@ test("itemController specified in template gets a parentController property", fu
 test("itemController specified in ArrayController gets a parentController property", function() {
   var PersonController = ObjectController.extend({
         controllerName: computed(function() {
-          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
+          return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
         })
       }),
       PeopleController = ArrayController.extend({
@@ -328,7 +328,7 @@ test("itemController specified in ArrayController gets a parentController proper
 test("itemController's parentController property, when the ArrayController has a parentController", function() {
   var PersonController = ObjectController.extend({
         controllerName: computed(function() {
-          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
+          return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
         })
       }),
       PeopleController = ArrayController.extend({
@@ -361,7 +361,7 @@ test("itemController's parentController property, when the ArrayController has a
 test("it supports itemController when using a custom keyword", function() {
   var Controller = EmberController.extend({
     controllerName: computed(function() {
-      return "controller:"+this.get('content.name');
+      return "controller:"+this.get('model.name');
     })
   });
 
@@ -674,7 +674,7 @@ test("it doesn't assert when the morph tags have the same parent", function() {
 test("itemController specified in template with name binding does not change context", function() {
   var Controller = EmberController.extend({
     controllerName: computed(function() {
-      return "controller:"+this.get('content.name');
+      return "controller:"+this.get('model.name');
     })
   });
 
@@ -723,7 +723,7 @@ test("itemController specified in ArrayController with name binding does not cha
 
   var PersonController = ObjectController.extend({
         controllerName: computed(function() {
-          return "controller:" + get(this, 'content.name') + ' of ' + get(this, 'parentController.company');
+          return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
         })
       }),
       PeopleController = ArrayController.extend({

--- a/packages_es6/ember-handlebars/tests/helpers/with_test.js
+++ b/packages_es6/ember-handlebars/tests/helpers/with_test.js
@@ -249,7 +249,7 @@ QUnit.module("Handlebars {{#with foo}} with defined controller");
 test("it should wrap context with object controller", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
-      return "controller:"+this.get('content.name') + ' and ' + this.get('parentController.name');
+      return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
     })
   });
 
@@ -302,7 +302,7 @@ test("it should wrap context with object controller", function() {
 test("it should still have access to original parentController within an {{#each}}", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
-      return "controller:"+this.get('content.name') + ' and ' + this.get('parentController.name');
+      return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
     })
   });
 

--- a/packages_es6/ember-routing/lib/system/route.js
+++ b/packages_es6/ember-routing/lib/system/route.js
@@ -1124,7 +1124,7 @@ var Route = EmberObject.extend(ActionHandler, {
     This method is called with the controller for the current route and the
     model supplied by the `model` hook.
 
-    By default, the `setupController` hook sets the `content` property of
+    By default, the `setupController` hook sets the `model` property of
     the controller to the `model`.
 
     If you implement the `setupController` hook in your Route, it will
@@ -1387,7 +1387,7 @@ var Route = EmberObject.extend(ActionHandler, {
     });
     ```
 
-    Remember that the controller's `content` will be the route's model. In
+    Remember that the controller's `model` will be the route's model. In
     this case, the default model will be `App.Post.find(params.post_id)`.
 
     @method render

--- a/packages_es6/ember-routing/tests/helpers/render_test.js
+++ b/packages_es6/ember-routing/tests/helpers/render_test.js
@@ -239,8 +239,8 @@ test("{{render}} helper with a supplied model should not fire observers on the c
   });
 
   var PostController = EmberObjectController.extend({
-    contentDidChange: observer('content', function(){
-      contentDidChange++;
+    modelDidChange: observer('model', function(){
+      modelDidChange++;
     })
   });
 
@@ -248,9 +248,9 @@ test("{{render}} helper with a supplied model should not fire observers on the c
 
   Ember.TEMPLATES['post'] = compile("<p>{{title}}</p>");
 
-  var contentDidChange = 0;
+  var modelDidChange = 0;
   appendView(view);
-  equal(contentDidChange, 0, "content observer did not fire");
+  equal(modelDidChange, 0, "model observer did not fire");
 
 });
 
@@ -394,7 +394,7 @@ test("{{render}} helper should not treat invocations with falsy contexts as cont
   var PostController = EmberObjectController.extend();
   container.register('controller:post', PostController, {singleton: false});
 
-  Ember.TEMPLATES['post'] = compile("<p>{{#unless content}}NOTHING{{/unless}}</p>");
+  Ember.TEMPLATES['post'] = compile("<p>{{#unless model}}NOTHING{{/unless}}</p>");
 
   appendView(view);
 

--- a/packages_es6/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages_es6/ember-runtime/tests/controllers/array_controller_test.js
@@ -10,7 +10,7 @@ MutableArrayTests.extend({
   newObject: function(ary) {
     var ret = ary ? ary.slice() : this.newFixture(3);
     return ArrayController.create({
-      content: Ember.A(ret)
+      model: Ember.A(ret)
     });
   },
 
@@ -23,15 +23,15 @@ MutableArrayTests.extend({
   }
 }).run();
 
-test("defaults it's `content` to an empty array", function () {
+test("defaults it's `model` to an empty array", function () {
   var Controller = ArrayController.extend();
-  deepEqual(Controller.create().get("content"), [], "`ArrayController` defaults it's content to an empty array");
+  deepEqual(Controller.create().get("model"), [], "`ArrayController` defaults it's model to an empty array");
   equal(Controller.create().get('firstObject'), undefined, 'can fetch firstObject');
   equal(Controller.create().get('lastObject'), undefined, 'can fetch lastObject');
 });
 
 
-test("Ember.ArrayController length property works even if content was not set initially", function() {
+test("Ember.ArrayController length property works even if model was not set initially", function() {
   var controller = ArrayController.create();
   controller.pushObject('item');
   equal(controller.get('length'), 1);

--- a/packages_es6/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages_es6/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -54,7 +54,7 @@ QUnit.module("Ember.ArrayController - itemController", {
 function createUnwrappedArrayController() {
   arrayController = ArrayController.create({
     container: container,
-    content: lannisters
+    model: lannisters
   });
 }
 
@@ -62,7 +62,7 @@ function createArrayController() {
   arrayController = ArrayController.create({
     container: container,
     itemController: 'Item',
-    content: lannisters
+    model: lannisters
   });
 }
 
@@ -76,7 +76,7 @@ function createDynamicArrayController() {
         return "OtherItem";
       }
     },
-    content: lannisters
+    model: lannisters
   });
 }
 
@@ -158,7 +158,7 @@ test("when the underlying array changes, old subcontainers are destroyed", funct
   equal(!!cerseiController.isDestroying, false, "precond - nobody is destroyed yet");
 
   run(function() {
-    arrayController.set('content', Ember.A());
+    arrayController.set('model', Ember.A());
   });
 
   equal(!!jaimeController.isDestroying, true, "old subcontainers are destroyed");
@@ -193,7 +193,7 @@ test("when items are removed from the arrayController, their respective subconta
   equal(!!jaimeController.isDestroying, false, "Retained objects' containers are not cleaned up");
 });
 
-test("one cannot remove wrapped content directly when specifying `itemController`", function() {
+test("one cannot remove wrapped model directly when specifying `itemController`", function() {
   createArrayController();
   var jaimeController = arrayController.objectAtContent(1),
       cerseiController = arrayController.objectAtContent(2);
@@ -242,7 +242,7 @@ test("when `idx` is out of range, `lookupItemController` is not called", functio
     lookupItemController: function(object) {
       ok(false, "`lookupItemController` should not be called when `idx` is out of range");
     },
-    content: lannisters
+    model: lannisters
   });
 
   strictEqual(arrayController.objectAtContent(50), undefined, "no controllers are created for indexes that are superior to the length");
@@ -255,7 +255,7 @@ test("if `lookupItemController` returns a string, it must be resolvable by the c
     lookupItemController: function(object) {
       return "NonExistant";
     },
-    content: lannisters
+    model: lannisters
   });
 
   throws(function() {
@@ -317,7 +317,7 @@ test("array observers can invoke `objectAt` without overwriting existing item co
   });
 
   equal(arrayObserverCalled, true, "Array observers are called normally");
-  equal(tywinController.get('name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' content");
+  equal(tywinController.get('name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' model");
 });
 
 test("`itemController`'s life cycle should be entangled with its parent controller", function() {

--- a/packages_es6/ember-testing/tests/helpers_test.js
+++ b/packages_es6/ember-testing/tests/helpers_test.js
@@ -661,7 +661,7 @@ test("currentRouteName for '/user'", function(){
     equal(currentRouteName(App), 'user.index', "should equal 'user.index'.");
     equal(currentPath(App), 'user.index', "should equal 'user.index'.");
     equal(currentURL(App), '/user', "should equal '/user'.");
-    equal(App.__container__.lookup('route:user').get('controller.content.firstName'), 'Tom', "should equal 'Tom'.");
+    equal(App.__container__.lookup('route:user').get('controller.model.firstName'), 'Tom', "should equal 'Tom'.");
   });
 });
 
@@ -672,6 +672,6 @@ test("currentRouteName for '/user/profile'", function(){
     equal(currentRouteName(App), 'user.edit', "should equal 'user.edit'.");
     equal(currentPath(App), 'user.edit', "should equal 'user.edit'.");
     equal(currentURL(App), '/user/edit', "should equal '/user/edit'.");
-    equal(App.__container__.lookup('route:user').get('controller.content.firstName'), 'Tom', "should equal 'Tom'.");
+    equal(App.__container__.lookup('route:user').get('controller.model.firstName'), 'Tom', "should equal 'Tom'.");
   });
 });

--- a/packages_es6/ember/tests/helpers/link_to_test.js
+++ b/packages_es6/ember/tests/helpers/link_to_test.js
@@ -779,7 +779,7 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
   var $link = Ember.$('#self-link', '#qunit-fixture');
   equal(normalizeUrl($link.attr('href')), '/posts/1', 'self link renders post 1');
 
-  Ember.run(postController, 'set', 'content', secondPost);
+  Ember.run(postController, 'set', 'model', secondPost);
   var linkView = Ember.View.views['self-link'];
 
   equal(normalizeUrl($link.attr('href')), '/posts/2', 'self link updated to post 2');

--- a/packages_es6/ember/tests/routing/basic_test.js
+++ b/packages_es6/ember/tests/routing/basic_test.js
@@ -259,7 +259,7 @@ test("The Homepage with explicit template name in renderTemplate and controller"
 });
 
 if(Ember.FEATURES.isEnabled("ember-routing-add-model-option")) {
-test("Model passed via renderTemplate model is set as controller's content", function(){
+test("Model passed via renderTemplate model is set as controller's model", function(){
   Ember.TEMPLATES['bio'] = compile("<p>{{name}}</p>");
 
   App.BioController = Ember.ObjectController.extend();
@@ -278,7 +278,7 @@ test("Model passed via renderTemplate model is set as controller's content", fun
 
   bootApplication();
 
-  equal(Ember.$('p:contains(emberjs)', '#qunit-fixture').length, 1, "Passed model was set as controllers content");
+  equal(Ember.$('p:contains(emberjs)', '#qunit-fixture').length, 1, "Passed model was set as controllers model");
 });
 }
 
@@ -645,12 +645,12 @@ test("The Specials Page getting its controller context by deserializing the para
     },
 
     setupController: function(controller, model) {
-      set(controller, 'content', model);
+      set(controller, 'model', model);
     }
   });
 
   Ember.TEMPLATES.special = Ember.Handlebars.compile(
-    "<p>{{content.menuItemId}}</p>"
+    "<p>{{model.menuItemId}}</p>"
   );
 
   bootApplication();
@@ -679,12 +679,12 @@ test("The Specials Page defaults to looking models up via `find`", function() {
 
   App.SpecialRoute = Ember.Route.extend({
     setupController: function(controller, model) {
-      set(controller, 'content', model);
+      set(controller, 'model', model);
     }
   });
 
   Ember.TEMPLATES.special = Ember.Handlebars.compile(
-    "<p>{{content.id}}</p>"
+    "<p>{{model.id}}</p>"
   );
 
   bootApplication();
@@ -721,12 +721,12 @@ test("The Special Page returning a promise puts the app into a loading state unt
 
   App.SpecialRoute = Ember.Route.extend({
     setupController: function(controller, model) {
-      set(controller, 'content', model);
+      set(controller, 'model', model);
     }
   });
 
   Ember.TEMPLATES.special = Ember.Handlebars.compile(
-    "<p>{{content.id}}</p>"
+    "<p>{{model.id}}</p>"
   );
 
   Ember.TEMPLATES.loading = Ember.Handlebars.compile(
@@ -769,12 +769,12 @@ test("The loading state doesn't get entered for promises that resolve on the sam
 
   App.SpecialRoute = Ember.Route.extend({
     setupController: function(controller, model) {
-      set(controller, 'content', model);
+      set(controller, 'model', model);
     }
   });
 
   Ember.TEMPLATES.special = Ember.Handlebars.compile(
-    "<p>{{content.id}}</p>"
+    "<p>{{model.id}}</p>"
   );
 
   Ember.TEMPLATES.loading = Ember.Handlebars.compile(
@@ -921,7 +921,7 @@ asyncTest("Moving from one page to another triggers the correct callbacks", func
 
   App.SpecialRoute = Ember.Route.extend({
     setupController: function(controller, model) {
-      set(controller, 'content', model);
+      set(controller, 'model', model);
     }
   });
 
@@ -930,7 +930,7 @@ asyncTest("Moving from one page to another triggers the correct callbacks", func
   );
 
   Ember.TEMPLATES.special = Ember.Handlebars.compile(
-    "<p>{{content.id}}</p>"
+    "<p>{{model.id}}</p>"
   );
 
   bootApplication();
@@ -1011,7 +1011,7 @@ asyncTest("Nested callbacks are not exited when moving to siblings", function() 
 
   App.SpecialRoute = Ember.Route.extend({
     setupController: function(controller, model) {
-      set(controller, 'content', model);
+      set(controller, 'model', model);
     }
   });
 
@@ -1020,7 +1020,7 @@ asyncTest("Nested callbacks are not exited when moving to siblings", function() 
   );
 
   Ember.TEMPLATES.special = Ember.Handlebars.compile(
-    "<p>{{content.id}}</p>"
+    "<p>{{model.id}}</p>"
   );
 
   Ember.TEMPLATES.loading = Ember.Handlebars.compile(
@@ -1087,7 +1087,7 @@ asyncTest("Events are triggered on the controller if a matching action name is i
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action 'showStuff' content}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{name}}</a>"
   );
 
   var controller = Ember.Controller.extend({
@@ -1133,7 +1133,7 @@ asyncTest("Events are triggered on the current state when defined in `actions` o
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action 'showStuff' content}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{name}}</a>"
   );
 
   bootApplication();
@@ -1171,7 +1171,7 @@ asyncTest("Events defined in `actions` object are triggered on the current state
   });
 
   Ember.TEMPLATES['root/index'] = Ember.Handlebars.compile(
-    "<a {{action 'showStuff' content}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{name}}</a>"
   );
 
   bootApplication();
@@ -1205,7 +1205,7 @@ asyncTest("Events are triggered on the current state when defined in `events` ob
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<a {{action 'showStuff' content}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{name}}</a>"
   );
 
   expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
@@ -1244,7 +1244,7 @@ asyncTest("Events defined in `events` object are triggered on the current state 
   });
 
   Ember.TEMPLATES['root/index'] = Ember.Handlebars.compile(
-    "<a {{action 'showStuff' content}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{name}}</a>"
   );
 
   expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
@@ -1319,7 +1319,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     });
 
     Ember.TEMPLATES.home = Ember.Handlebars.compile(
-      "<a {{action 'showStuff' content}}>{{name}}</a>"
+      "<a {{action 'showStuff' model}}>{{name}}</a>"
     );
 
     var controller = Ember.Controller.extend({
@@ -1361,7 +1361,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     });
 
     Ember.TEMPLATES.home = Ember.Handlebars.compile(
-      "<a {{action 'showStuff' content}}>{{name}}</a>"
+      "<a {{action 'showStuff' model}}>{{name}}</a>"
     );
 
     var controller = Ember.Controller.extend({


### PR DESCRIPTION
This is mostly additional cleanup to ensure that both the docs and tests reflect the change made in https://github.com/emberjs/ember.js/pull/4725 and https://github.com/emberjs/ember.js/pull/4857.
