### PR TITLE
[FEATURE query-params-new] Model dep state and bugfixes

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -28,6 +28,7 @@ import HashLocation from "ember-routing/location/hash_location";
 import HistoryLocation from "ember-routing/location/history_location";
 import AutoLocation from "ember-routing/location/auto_location";
 import NoneLocation from "ember-routing/location/none_location";
+import BucketCache from "ember-routing/system/cache";
 
 import EmberHandlebars from "ember-handlebars-compiler";
 
@@ -980,6 +981,11 @@ Application.reopenClass({
 
     container.injection('controller', 'target', 'router:main');
     container.injection('controller', 'namespace', 'application:main');
+
+    container.register('-bucket-cache:main', BucketCache);
+    container.injection('router', '_bucketCache', '-bucket-cache:main');
+    container.injection('route',  '_bucketCache', '-bucket-cache:main');
+    container.injection('controller',  '_bucketCache', '-bucket-cache:main');
 
     container.injection('route', 'router', 'router:main');
     container.injection('location', 'rootURL', '-location-setting:root-url');

--- a/packages/ember-routing-handlebars/lib/helpers/shared.js
+++ b/packages/ember-routing-handlebars/lib/helpers/shared.js
@@ -1,9 +1,26 @@
 import {get} from "ember-metal/property_get";
 import {map} from "ember-metal/array";
-import {onLoad} from "ember-runtime/system/lazy_load";
 import {ControllerMixin} from "ember-runtime/controllers/controller";
-import EmberRouter from "ember-routing/system/router";
 import {resolveParams as handlebarsResolve, handlebarsGet} from "ember-handlebars/ext";
+import {typeOf} from 'ember-metal/utils';
+import { get } from "ember-metal/property_get";
+
+export function routeArgs(targetRouteName, models, queryParams) {
+  var args = [];
+  if (typeOf(targetRouteName) === 'string') {
+    args.push('' + targetRouteName);
+  }
+  args.push.apply(args, models);
+  args.push({ queryParams: queryParams });
+  return args;
+}
+
+export function getActiveTargetName(router) {
+  var handlerInfos = router.activeTransition ?
+                     router.activeTransition.state.handlerInfos :
+                     router.state.handlerInfos;
+  return handlerInfos[handlerInfos.length - 1].name;
+}
 
 export function resolveParams(context, params, options) {
   return map.call(resolvePaths(context, params, options), function(path, i) {
@@ -14,6 +31,34 @@ export function resolveParams(context, params, options) {
       return handlebarsGet(context, path, options);
     }
   });
+}
+
+export function stashParamNames(router, handlerInfos) {
+  if (handlerInfos._namesStashed) { return; }
+
+  // This helper exists because router.js/route-recognizer.js awkwardly
+  // keeps separate a handlerInfo's list of parameter names depending
+  // on whether a URL transition or named transition is happening.
+  // Hopefully we can remove this in the future.
+  var targetRouteName = handlerInfos[handlerInfos.length-1].name;
+  var recogHandlers = router.router.recognizer.handlersFor(targetRouteName);
+  var dynamicParent = null;
+
+  for (var i = 0, len = handlerInfos.length; i < len; ++i) {
+    var handlerInfo = handlerInfos[i];
+    var names = recogHandlers[i].names;
+
+    if (names.length) {
+      dynamicParent = handlerInfo;
+    }
+
+    handlerInfo._names = names;
+
+    var route = handlerInfo.handler;
+    route._stashNames(handlerInfo, dynamicParent);
+  }
+
+  handlerInfos._namesStashed = true;
 }
 
 export { resolvePaths };

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -1,6 +1,10 @@
 import Ember from "ember-metal/core"; // FEATURES, deprecate
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import { computed } from "ember-metal/computed";
+import { typeOf } from "ember-metal/utils";
+import { meta } from "ember-metal/utils";
+import merge from "ember-metal/merge";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 var map = EnumerableUtils.map;
 
@@ -10,7 +14,6 @@ import { ControllerMixin } from "ember-runtime/controllers/controller";
 @module ember
 @submodule ember-routing
 */
-
 
 ControllerMixin.reopen({
   /**
@@ -159,13 +162,144 @@ ControllerMixin.reopen({
   }
 });
 
+var ALL_PERIODS_REGEX = /\./g;
+
 if (Ember.FEATURES.isEnabled("query-params-new")) {
   ControllerMixin.reopen({
-    concatenatedProperties: ['queryParams'],
+    init: function() {
+      this._super.apply(this, arguments);
+      listenForQueryParamChanges(this);
+    },
+
+    concatenatedProperties: ['queryParams', '_pCacheMeta'],
     queryParams: null,
-    _finalizingQueryParams: false,
-    _queryParamChangesDuringSuspension: null
+
+    _qpDelegate: null,
+    _normalizedQueryParams: computed(function() {
+      var m = meta(this);
+      if (m.proto !== this) {
+        return get(m.proto, '_normalizedQueryParams');
+      }
+
+      var queryParams = this.queryParams;
+      if (queryParams._qpMap) {
+        return queryParams._qpMap;
+      }
+
+      var qpMap = queryParams._qpMap = {};
+
+      for (var i = 0, len = queryParams.length; i < len; ++i) {
+        accumulateQueryParamDescriptors(queryParams[i], qpMap);
+      }
+
+      return qpMap;
+    }),
+
+    _cacheMeta: computed(function() {
+      var m = meta(this);
+      if (m.proto !== this) {
+        return get(m.proto, '_cacheMeta');
+      }
+
+      var cacheMeta = {},
+          qpMap = get(this, '_normalizedQueryParams');
+      for (var prop in qpMap) {
+        if (!qpMap.hasOwnProperty(prop)) { continue; }
+
+        var qp = qpMap[prop],
+            scope = qp.scope,
+            parts;
+
+        if (scope === 'controller') {
+          parts = [];
+        }
+
+        cacheMeta[prop] = {
+          parts: parts, // provided by route if 'model' scope
+          values: null, // provided by route
+          scope: scope,
+          prefix: "",
+          def: get(this, prop)
+        };
+      }
+
+      return cacheMeta;
+    }),
+
+    _updateCacheParams: function(params) {
+      var cacheMeta = get(this, '_cacheMeta');
+      for (var prop in cacheMeta) {
+        if (!cacheMeta.hasOwnProperty(prop)) { continue; }
+        var propMeta = cacheMeta[prop];
+        propMeta.values = params;
+
+        var cacheKey = this._calculateCacheKey(propMeta.prefix, propMeta.parts, propMeta.values);
+        var cache = this._bucketCache;
+        var value = cache.lookup(cacheKey, prop, propMeta.def);
+
+        set(this, prop, value);
+      }
+    },
+
+    _qpChanged: function(controller, _prop) {
+      var prop = _prop.substr(0, _prop.length-3);
+      var cacheMeta = get(controller, '_cacheMeta');
+      var propCache = cacheMeta[prop];
+      var cacheKey = controller._calculateCacheKey(propCache.prefix || "", propCache.parts, propCache.values);
+      var value = get(controller, prop);
+
+      // 1. Update model-dep cache
+      controller._bucketCache.stash(cacheKey, prop, value);
+
+      // 2. Notify a delegate (e.g. to fire a qp transition)
+      var delegate = controller._qpDelegate;
+      if (delegate) {
+        delegate(controller, prop);
+      }
+    },
+
+    _calculateCacheKey: function(prefix, _parts, values) {
+      var parts = _parts || [], suffixes = "";
+      for (var i = 0, len = parts.length; i < len; ++i) {
+        var part = parts[i];
+        var value = get(values, part);
+        suffixes += "::" + part + ":" + value;
+      }
+      return prefix + suffixes.replace(ALL_PERIODS_REGEX, '-');
+    }
   });
 }
+
+function accumulateQueryParamDescriptors(_desc, accum) {
+  var desc = _desc, tmp;
+  if (typeOf(desc) === 'string') {
+    tmp = {};
+    tmp[desc] = { as: null };
+    desc = tmp;
+  }
+
+  for (var key in desc) {
+    if (!desc.hasOwnProperty(key)) { return; }
+
+    var singleDesc = desc[key];
+    if (typeOf(singleDesc) === 'string') {
+      singleDesc = { as: singleDesc };
+    }
+
+    tmp = accum[key] || { as: null, scope: 'model' };
+    merge(tmp, singleDesc);
+
+    accum[key] = tmp;
+  }
+}
+
+function listenForQueryParamChanges(controller) {
+  var qpMap = get(controller, '_normalizedQueryParams');
+  for (var prop in qpMap) {
+    if (!qpMap.hasOwnProperty(prop)) { continue; }
+    controller.addObserver(prop + '.[]', controller, controller._qpChanged);
+  }
+}
+
 
 export default ControllerMixin;

--- a/packages/ember-routing/lib/system/cache.js
+++ b/packages/ember-routing/lib/system/cache.js
@@ -1,0 +1,33 @@
+import EmberObject from "ember-runtime/system/object";
+
+var Cache = EmberObject.extend({
+  init: function() {
+    this.cache = {};
+  },
+  has: function(bucketKey) {
+    return bucketKey in this.cache;
+  },
+  stash: function(bucketKey, key, value) {
+    var bucket = this.cache[bucketKey];
+    if (!bucket) {
+      bucket = this.cache[bucketKey] = {};
+    }
+    bucket[key] = value;
+  },
+  lookup: function(bucketKey, prop, defaultValue) {
+    var cache = this.cache;
+    if (!(bucketKey in cache)) {
+      return defaultValue;
+    }
+    var bucket = cache[bucketKey];
+    if (prop in bucket) {
+      return bucket[prop];
+    } else {
+      return defaultValue;
+    }
+  },
+  cache: null
+});
+
+export default Cache;
+

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -288,7 +288,7 @@ test("The {{link-to}} helper supports custom, nested, currentWhen", function() {
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active since currentWhen is a parent route");
 });
 
-test("The {{link-to}} helper does not disregards currentWhen when it is given explicitly for a resource", function() {
+test("The {{link-to}} helper does not disregard currentWhen when it is given explicitly for a resource", function() {
   Router.map(function(match) {
     this.resource("index", { path: "/" }, function() {
       this.route("about");
@@ -522,9 +522,7 @@ test("Issue 4201 - Shorthand for route.index shouldn't throw errors about contex
   expect(2);
   Router.map(function() {
     this.resource('lobby', function() {
-      this.route('index', {
-        path: ':lobby_id'
-      });
+      this.route('index', { path: ':lobby_id' });
       this.route('list');
     });
   });
@@ -547,7 +545,11 @@ test("Issue 4201 - Shorthand for route.index shouldn't throw errors about contex
 });
 
 test("The {{link-to}} helper unwraps controllers", function() {
-  expect(3);
+  if (Ember.FEATURES.isEnabled("query-params-new")) {
+    expect(5);
+  } else {
+    expect(3);
+  }
 
   Router.map(function() {
     this.route('filter', { path: '/filters/:filter' });
@@ -1252,13 +1254,11 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, "controller QP properties not");
   });
 
-  test("doesn't update controller QP properties on current route when invoked (inferred route)", function() {
+  test("link-to with no params throws", function() {
     Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#link-to id='the-link'}}Index{{/link-to}}");
-    bootApplication();
-
-    Ember.run(Ember.$('#the-link'), 'click');
-    var indexController = container.lookup('controller:index');
-    deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, "controller QP properties not");
+    expectAssertion(function() {
+      bootApplication();
+    }, /one or more/);
   });
 
   test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
@@ -1358,7 +1358,6 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       "{{#link-to (query-params search='same' archive=true) id='both-same'}}Index{{/link-to}} " +
       "{{#link-to (query-params search='different' archive=true) id='change-one'}}Index{{/link-to}} " +
       "{{#link-to (query-params search='different' archive=false) id='remove-one'}}Index{{/link-to}} " +
-      "{{#link-to id='change-nothing'}}Index{{/link-to}} " +
       "{{outlet}}"
     );
 
@@ -1371,8 +1370,6 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       "{{#link-to (query-params search='change' sort='title') id='change-search-same-sort-child-and-parent'}}Index{{/link-to}} " +
       "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} "
     );
-
-
 
     Router.map(function() {
       this.resource("search", function() {
@@ -1414,17 +1411,19 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     shouldNotBeActive('#same-search-add-archive');
     shouldNotBeActive('#only-add-archive');
     shouldNotBeActive('#remove-one');
-    shouldBeActive('#change-nothing');
 
     Ember.run(function() {
-      router.handleURL("/search?search=same&archive");
+      router.handleURL("/search?search=same&archive=true");
     });
     shouldBeActive('#both-same');
     shouldNotBeActive('#change-one');
 
     //Nested Controllers
     Ember.run(function() {
-      router.handleURL("/search/results?search=same&sort=title&showDetails");
+      // Note: this is kind of a strange case; sort's default value is 'title',
+      // so this URL shouldn't have been generated in the first place, but
+      // we should also be able to gracefully handle these cases.
+      router.handleURL("/search/results?search=same&sort=title&showDetails=true");
     });
     shouldBeActive('#same-sort-child-only');
     shouldBeActive('#same-search-parent-only');
@@ -1432,26 +1431,23 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     shouldBeActive('#same-search-same-sort-child-and-parent');
     shouldNotBeActive('#same-search-different-sort-child-and-parent');
     shouldNotBeActive('#change-search-same-sort-child-and-parent');
-
-
   });
 
   test("The {{link-to}} applies active class when query-param is number", function() {
-      Ember.TEMPLATES.index = Ember.Handlebars.compile(
-        "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} ");
+    Ember.TEMPLATES.index = Ember.Handlebars.compile(
+      "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} ");
 
-      App.IndexController = Ember.Controller.extend({
-        queryParams: ['page'],
-        page: 1,
-        pageNumber: 5
-      });
+    App.IndexController = Ember.Controller.extend({
+      queryParams: ['page'],
+      page: 1,
+      pageNumber: 5
+    });
 
-      bootApplication();
+    bootApplication();
 
-      shouldNotBeActive('#page-link');
-      Ember.run(router, 'handleURL', '/?page=5');
-      shouldBeActive('#page-link');
-
+    shouldNotBeActive('#page-link');
+    Ember.run(router, 'handleURL', '/?page=5');
+    shouldBeActive('#page-link');
   });
 
   test("The {{link-to}} applies active class when query-param is array", function() {
@@ -1486,7 +1482,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       shouldNotBeActive('#empty-link');
   });
 
-  test("The {{link-to}} applies active class to parent route", function() {
+  test("The {{link-to}} helper applies active class to parent route", function() {
     App.Router.map(function() {
       this.resource('parent', function() {
         this.route('child');
@@ -1509,6 +1505,42 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     shouldNotBeActive('#parent-child-link');
     Ember.run(router, 'handleURL', '/parent/child?foo=dog');
     shouldBeActive('#parent-link');
+  });
+
+  test("The {{link-to}} helper disregards query-params in activeness computation when currentWhen specified", function() {
+    App.Router.map(function() {
+      this.route('parent');
+    });
+
+    Ember.TEMPLATES.application = Ember.Handlebars.compile(
+        "{{#link-to 'parent' (query-params page=1) currentWhen='parent' id='app-link'}}Parent{{/link-to}} {{outlet}}");
+    Ember.TEMPLATES.parent = Ember.Handlebars.compile(
+        "{{#link-to 'parent' (query-params page=1) currentWhen='parent' id='parent-link'}}Parent{{/link-to}} {{outlet}}");
+
+    App.ParentController = Ember.ObjectController.extend({
+      queryParams: ['page'],
+      page: 1
+    });
+
+    bootApplication();
+    equal(Ember.$('#app-link').attr('href'), '/parent');
+    shouldNotBeActive('#app-link');
+
+    Ember.run(router, 'handleURL', '/parent?page=2');
+    equal(Ember.$('#app-link').attr('href'), '/parent');
+    shouldBeActive('#app-link');
+    equal(Ember.$('#parent-link').attr('href'), '/parent');
+    shouldBeActive('#parent-link');
+
+    var parentController = container.lookup('controller:parent');
+    equal(parentController.get('page'), 2);
+    Ember.run(parentController, 'set', 'page', 3);
+    equal(router.get('location.path'), '/parent?page=3');
+    shouldBeActive('#app-link');
+    shouldBeActive('#parent-link');
+
+    Ember.$('#app-link').click();
+    equal(router.get('location.path'), '/parent');
   });
 }
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2138,7 +2138,7 @@ test("The rootURL is passed properly to the location implementation", function()
     rootURL: rootURL,
     // if we transition in this test we will receive failures
     // if the tests are run from a static file
-    _doTransition: function(){}
+    _doURLTransition: function(){}
   });
 
   bootApplication();
@@ -3209,3 +3209,51 @@ test("Errors in transitionTo within redirect hook are logged", function() {
   },
   /More context objects were passed than there are dynamic segments for the route: stink-bomb/);
 });
+
+
+if (Ember.FEATURES.isEnabled("query-params-new")) {
+  test("Route#resetController gets fired when changing models and exiting routes", function() {
+    expect(4);
+
+    Router.map(function() {
+      this.resource("a", function() {
+        this.resource("b", { path: '/b/:id' }, function() { });
+        this.resource("c", { path: '/c/:id' }, function() { });
+      });
+      this.route('out');
+    });
+
+    var calls = [];
+
+    var SpyRoute = Ember.Route.extend({
+      setupController: function(controller, model, transition) {
+        calls.push(['setup', this.routeName]);
+      },
+
+      resetController: function(controller) {
+        calls.push(['reset', this.routeName]);
+      }
+    });
+
+    App.ARoute = SpyRoute.extend();
+    App.BRoute = SpyRoute.extend();
+    App.CRoute = SpyRoute.extend();
+    App.OutRoute = SpyRoute.extend();
+
+    bootApplication();
+    deepEqual(calls, []);
+
+    Ember.run(router, 'transitionTo', 'b', 'b-1');
+    deepEqual(calls, [['setup', 'a'], ['setup', 'b']]);
+    calls.length = 0;
+
+    Ember.run(router, 'transitionTo', 'c', 'c-1');
+    deepEqual(calls, [['reset', 'b'], ['setup', 'c']]);
+    calls.length = 0;
+
+    Ember.run(router, 'transitionTo', 'out');
+    deepEqual(calls, [['reset', 'c'], ['reset', 'a'], ['setup', 'out']]);
+  });
+}
+
+

--- a/packages/router/lib/main.js
+++ b/packages/router/lib/main.js
@@ -380,6 +380,49 @@ define("router/router",
         return this.recognizer.hasRoute(route);
       },
 
+      queryParamsTransition: function(changelist, wasTransitioning, oldState, newState) {
+        var router = this;
+
+        // This is a little hacky but we need some way of storing
+        // changed query params given that no activeTransition
+        // is guaranteed to have occurred.
+        this._changedQueryParams = changelist.changed;
+        for (var k in changelist.removed) {
+          if (changelist.removed.hasOwnProperty(k)) {
+            this._changedQueryParams[k] = null;
+          }
+        }
+        fireQueryParamDidChange(this, newState, changelist);
+        this._changedQueryParams = null;
+
+        if (!wasTransitioning && this.activeTransition) {
+          // One of the handlers in queryParamsDidChange
+          // caused a transition. Just return that transition.
+          return this.activeTransition;
+        } else {
+          // Running queryParamsDidChange didn't change anything.
+          // Just update query params and be on our way.
+
+          // We have to return a noop transition that will
+          // perform a URL update at the end. This gives
+          // the user the ability to set the url update
+          // method (default is replaceState).
+          var newTransition = new Transition(this);
+          newTransition.queryParamsOnly = true;
+
+          oldState.queryParams = finalizeQueryParamChange(this, newState.handlerInfos, newState.queryParams, newTransition);
+
+          newTransition.promise = newTransition.promise.then(function(result) {
+            updateURL(newTransition, oldState, true);
+            if (router.didTransition) {
+              router.didTransition(router.currentHandlerInfos);
+            }
+            return result;
+          }, null, promiseLabel("Transition complete"));
+          return newTransition;
+        }
+      },
+
       // NOTE: this doesn't really belong here, but here
       // it shall remain until our ES6 transpiler can
       // handle cyclical deps.
@@ -392,48 +435,14 @@ define("router/router",
 
         try {
           var newState = intent.applyToState(oldState, this.recognizer, this.getHandler, isIntermediate);
+          var queryParamChangelist = getChangelist(oldState.queryParams, newState.queryParams);
 
           if (handlerInfosEqual(newState.handlerInfos, oldState.handlerInfos)) {
 
             // This is a no-op transition. See if query params changed.
-            var queryParamChangelist = getChangelist(oldState.queryParams, newState.queryParams);
             if (queryParamChangelist) {
-
-              // This is a little hacky but we need some way of storing
-              // changed query params given that no activeTransition
-              // is guaranteed to have occurred.
-              this._changedQueryParams = queryParamChangelist.changed;
-              for (var k in queryParamChangelist.removed) {
-                if (queryParamChangelist.removed.hasOwnProperty(k)) {
-                  this._changedQueryParams[k] = null;
-                }
-              }
-              trigger(this, newState.handlerInfos, true, ['queryParamsDidChange', queryParamChangelist.changed, queryParamChangelist.all, queryParamChangelist.removed]);
-              this._changedQueryParams = null;
-
-              if (!wasTransitioning && this.activeTransition) {
-                // One of the handlers in queryParamsDidChange
-                // caused a transition. Just return that transition.
-                return this.activeTransition;
-              } else {
-                // Running queryParamsDidChange didn't change anything.
-                // Just update query params and be on our way.
-
-                // We have to return a noop transition that will
-                // perform a URL update at the end. This gives
-                // the user the ability to set the url update
-                // method (default is replaceState).
-                newTransition = new Transition(this);
-
-                oldState.queryParams = finalizeQueryParamChange(this, newState.handlerInfos, newState.queryParams, newTransition);
-
-                newTransition.promise = newTransition.promise.then(function(result) {
-                  updateURL(newTransition, oldState, true);
-                  if (router.didTransition) {
-                    router.didTransition(router.currentHandlerInfos);
-                  }
-                  return result;
-                }, null, promiseLabel("Transition complete"));
+              newTransition = this.queryParamsTransition(queryParamChangelist, wasTransitioning, oldState, newState);
+              if (newTransition) {
                 return newTransition;
               }
             }
@@ -466,6 +475,8 @@ define("router/router",
           if (!wasTransitioning) {
             notifyExistingHandlers(this, newState, newTransition);
           }
+
+          fireQueryParamDidChange(this, newState, queryParamChangelist);
 
           return newTransition;
         } catch(e) {
@@ -617,13 +628,17 @@ define("router/router",
         return this.recognizer.generate(handlerName, params);
       },
 
-      isActive: function(handlerName) {
+      applyIntent: function(handlerName, contexts) {
+        var intent = new NamedTransitionIntent({
+          name: handlerName,
+          contexts: contexts
+        });
 
-        var partitionedArgs   = extractQueryParams(slice.call(arguments, 1)),
-            contexts          = partitionedArgs[0],
-            queryParams       = partitionedArgs[1],
-            activeQueryParams  = this.state.queryParams;
+        var state = this.activeTransition && this.activeTransition.state || this.state;
+        return intent.applyToState(state, this.recognizer, this.getHandler);
+      },
 
+      isActiveIntent: function(handlerName, contexts, queryParams) {
         var targetHandlerInfos = this.state.handlerInfos,
             found = false, names, object, handlerInfo, handlerObj, i, len;
 
@@ -654,9 +669,16 @@ define("router/router",
 
         var newState = intent.applyToHandlers(state, recogHandlers, this.getHandler, targetHandler, true, true);
 
+        var handlersEqual = handlerInfosEqual(newState.handlerInfos, state.handlerInfos);
+        if (!queryParams || !handlersEqual) {
+          return handlersEqual;
+        }
+
         // Get a hash of QPs that will still be active on new route
         var activeQPsOnNewHandler = {};
         merge(activeQPsOnNewHandler, queryParams);
+
+        var activeQueryParams  = this.state.queryParams;
         for (var key in activeQueryParams) {
           if (activeQueryParams.hasOwnProperty(key) &&
               activeQPsOnNewHandler.hasOwnProperty(key)) {
@@ -664,8 +686,12 @@ define("router/router",
           }
         }
 
-        return handlerInfosEqual(newState.handlerInfos, state.handlerInfos) &&
-               !getChangelist(activeQPsOnNewHandler, queryParams);
+        return handlersEqual && !getChangelist(activeQPsOnNewHandler, queryParams);
+      },
+
+      isActive: function(handlerName) {
+        var partitionedArgs = extractQueryParams(slice.call(arguments, 1));
+        return this.isActiveIntent(handlerName, partitionedArgs[0], partitionedArgs[1]);
       },
 
       trigger: function(name) {
@@ -689,6 +715,29 @@ define("router/router",
         trigger(this, handlerInfos, true, ['willLeave', newTransition, leavingChecker]);
       }
     };
+
+    /**
+      @private
+
+      Fires queryParamsDidChange event
+    */
+    function fireQueryParamDidChange(router, newState, queryParamChangelist) {
+      // If queryParams changed trigger event
+      if (queryParamChangelist) {
+
+        // This is a little hacky but we need some way of storing
+        // changed query params given that no activeTransition
+        // is guaranteed to have occurred.
+        router._changedQueryParams = queryParamChangelist.changed;
+        for (var i in queryParamChangelist.removed) {
+          if (queryParamChangelist.removed.hasOwnProperty(i)) {
+            router._changedQueryParams[i] = null;
+          }
+        }
+        trigger(router, newState.handlerInfos, true, ['queryParamsDidChange', queryParamChangelist.changed, queryParamChangelist.all, queryParamChangelist.removed]);
+        router._changedQueryParams = null;
+      }
+    }
 
     /**
       @private
@@ -737,7 +786,8 @@ define("router/router",
       forEach(partition.exited, function(handlerInfo) {
         var handler = handlerInfo.handler;
         delete handler.context;
-        if (handler.exit) { handler.exit(); }
+        if (handler.reset) { handler.reset(true, transition); }
+        if (handler.exit) { handler.exit(transition); }
       });
 
       var oldState = router.oldState = router.state;
@@ -745,6 +795,11 @@ define("router/router",
       var currentHandlerInfos = router.currentHandlerInfos = partition.unchanged.slice();
 
       try {
+        forEach(partition.reset, function(handlerInfo) {
+          var handler = handlerInfo.handler;
+          if (handler.reset) { handler.reset(false, transition); }
+        });
+
         forEach(partition.updatedContext, function(handlerInfo) {
           return handlerEnteredOrUpdated(currentHandlerInfos, handlerInfo, false, transition);
         });
@@ -844,7 +899,7 @@ define("router/router",
             unchanged: []
           };
 
-      var handlerChanged, contextChanged, queryParamsChanged, i, l;
+      var handlerChanged, contextChanged, i, l;
 
       for (i=0, l=newHandlers.length; i<l; i++) {
         var oldHandler = oldHandlers[i], newHandler = newHandlers[i];
@@ -856,7 +911,7 @@ define("router/router",
         if (handlerChanged) {
           handlers.entered.push(newHandler);
           if (oldHandler) { handlers.exited.unshift(oldHandler); }
-        } else if (contextChanged || oldHandler.context !== newHandler.context || queryParamsChanged) {
+        } else if (contextChanged || oldHandler.context !== newHandler.context) {
           contextChanged = true;
           handlers.updatedContext.push(newHandler);
         } else {
@@ -867,6 +922,9 @@ define("router/router",
       for (i=newHandlers.length, l=oldHandlers.length; i<l; i++) {
         handlers.exited.unshift(oldHandlers[i]);
       }
+
+      handlers.reset = handlers.updatedContext.slice();
+      handlers.reset.reverse();
 
       return handlers;
     }
@@ -1233,7 +1291,6 @@ define("router/transition-intent/named-transition-intent",
           this.invalidateChildren(newState.handlerInfos, invalidateIndex);
         }
 
-        merge(newState.queryParams, oldState.queryParams);
         merge(newState.queryParams, this.queryParams || {});
 
         return newState;
@@ -1544,6 +1601,7 @@ define("router/transition",
       if (state) {
         this.params = state.params;
         this.queryParams = state.queryParams;
+        this.handlerInfos = state.handlerInfos;
 
         var len = state.handlerInfos.length;
         if (len) {
@@ -1593,8 +1651,20 @@ define("router/transition",
       resolvedModels: null,
       isActive: true,
       state: null,
+      queryParamsOnly: false,
 
       isTransition: true,
+
+      isExiting: function(handler) {
+        var handlerInfos = this.handlerInfos;
+        for (var i = 0, len = handlerInfos.length; i < len; ++i) {
+          var handlerInfo = handlerInfos[i];
+          if (handlerInfo.name === handler || handlerInfo.handler === handler) {
+            return false;
+          }
+        }
+        return true;
+      },
 
       /**
         @public


### PR DESCRIPTION
Such model dependent state.

Query params values are stored in an application cache using cache keys
calculated from Route#serialize params. At some point this concept will be
generalized, but for now, only query params have model dependent state.

The caching behavior can be configured via a
`scope` property in the QP config hash.

```
Controller = Ember.Controller.extend({
  queryParams: ['page', 
    { foo: { scope: 'controller' } }
  ],
  page: 1,
  foo: 123
});
```

By default, a property's scope setting is 'model', as in
model-scoped state. The code above uses the only other option presently
available, which is to cache the property scoped only to the controller, and
not to the model currently loaded into the controller. Practically speaking,
this means that query param values will will be preserved even when switching
the model loaded into a route/controller.

Closes #4493
