### PR TITLE
added building message to build.js

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -14,6 +14,8 @@ var builder = new broccoli.Builder(tree);
 
 var buildPath = process.argv[2] || 'dist';
 
+console.log('Building ember.js "' + process.env.BROCCOLI_ENV + '" to "' + buildPath + '/"...');
+
 builder.build()
   .then(function(results) {
     return rimraf(buildPath)


### PR DESCRIPTION
There is currently a delay of 15 seconds or so when running `bin/build.js` before the user sees a messsge:

![image](https://cloud.githubusercontent.com/assets/2526/3025072/0f4fea7c-e001-11e3-853a-70caa0d1dec3.png)

This PR introduces a simple `Building ember.js ...` message which is displayed immediately:

![image](https://cloud.githubusercontent.com/assets/2526/3025093/2ead27c2-e001-11e3-8328-c45d68f749d7.png)
