### PR TITLE
Using {{with controller="blah"}} and preserving context wraps keyword.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -9,6 +9,7 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.warn, uuid
 import EmberHandlebars from "ember-handlebars-compiler";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import { apply } from "ember-metal/utils";
 import { fmt } from "ember-runtime/system/string";
 import { create as o_create } from "ember-metal/platform";
 import isNone from 'ember-metal/is_none';
@@ -47,10 +48,55 @@ function exists(value) {
   return !isNone(value);
 }
 
-var _HandlebarsBoundWithControllerView = _HandlebarsBoundView.extend({
+var WithView = _HandlebarsBoundView.extend({
+  init: function() {
+    var controller;
+
+    apply(this, this._super, arguments);
+
+    var keywords        = this.get('templateData.keywords');
+    var keywordName     = this.get('templateHash.keywordName');
+    var keywordPath     = this.get('templateHash.keywordPath');
+    var controllerName  = this.get('templateHash.controller');
+    var preserveContext = this.get('preserveContext');
+
+    if (controllerName) {
+      var previousContext = this.get('previousContext');
+      controller = this.container.lookupFactory('controller:'+controllerName).create({
+        container: this.container,
+        parentController: previousContext,
+        target: previousContext
+      });
+
+      this.set('_generatedController', controller);
+
+      if (!preserveContext) {
+        this.set('controller', controller);
+
+        this.set('valueNormalizerFunc', function(result) {
+            controller.set('model', result);
+            return controller;
+        });
+      } else {
+        var controllerPath = jQuery.expando + guidFor(controller);
+        keywords[controllerPath] = controller;
+        emberBind(keywords, controllerPath + '.model', keywordPath);
+        keywordPath = controllerPath;
+      }
+    }
+
+    if (preserveContext) {
+      emberBind(keywords, keywordName, keywordPath);
+    }
+
+  },
   willDestroy: function() {
     this._super();
-    this.get('controller').destroy();
+
+    var generatedController = this.get('_generatedController');
+    if (generatedController) {
+      generatedController.destroy();
+    }
   }
 });
 
@@ -101,22 +147,12 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
         pathRoot: currentContext,
         previousContext: currentContext,
         isEscaped: !options.hash.unescaped,
-        templateData: options.data
+        templateData: options.data,
+        templateHash: options.hash
       };
 
-      if (options['withHelper'] && options.hash.controller) {
-        var controller = this.container.lookupFactory('controller:'+options.hash.controller).create({
-          container: currentContext.container,
-          parentController: currentContext,
-          target: currentContext
-        });
-
-        viewOptions.controller = controller;
-        viewOptions.valueNormalizerFunc = function(result) {
-          controller.set('model', result);
-          return controller;
-        };
-        viewClass = _HandlebarsBoundWithControllerView;
+      if (options['helperName'] === 'with') {
+        viewClass = WithView;
       }
 
       // Create the view that will wrap the output of this template/property
@@ -445,8 +481,6 @@ function unboundIfHelper(property, fn) {
   @return {String} HTML string
 */
 function withHelper(context, options) {
-  options['withHelper'] = true;
-
   var bindContext, preserveContext, controller;
 
   if (arguments.length === 4) {
@@ -478,7 +512,8 @@ function withHelper(context, options) {
       contextPath = path ? contextKey + '.' + path : contextKey;
     }
 
-    emberBind(localizedOptions.data.keywords, keywordName, contextPath);
+    localizedOptions.hash.keywordName = keywordName;
+    localizedOptions.hash.keywordPath = contextPath;
 
     bindContext = this;
     context = path;
@@ -491,6 +526,8 @@ function withHelper(context, options) {
     bindContext = options.contexts[0];
     preserveContext = false;
   }
+
+  options['helperName'] = 'with';
 
   return bind.call(bindContext, context, options, preserveContext, exists);
 }

--- a/packages/ember-handlebars/tests/helpers/if_unless_test.js
+++ b/packages/ember-handlebars/tests/helpers/if_unless_test.js
@@ -159,3 +159,21 @@ test("The `unbound if` helper does not update when the value changes", function(
   equal(view.$().text(), 'Nope');
 });
 
+test("The `if` helper ignores a controller option", function() {
+  var lookupCalled = false;
+
+  view = EmberView.create({
+    container: {
+      lookup: function() {
+        lookupCalled = true;
+      }
+    },
+    truthy: true,
+
+    template: compile('{{#if view.truthy controller="foo"}}Yep{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(lookupCalled, false, 'controller option should NOT be used');
+});


### PR DESCRIPTION
Previously, the keyword value available in the template was the raw unwrapped value  This is correct behavior when you are not using a `controller`, but with a `controller` the keyword value should be wrapped in the controller instance.

This refactors the custom `{{with}}` logic out of the general `bind` function, and adds it into the custom `WithView`.

The tests added in emberjs#4894 are all satisfied, so all the context resolution steps there are still correct.
