### PR TITLE
Fix `Ember.isArray` on IE8

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -380,7 +380,7 @@ var EmberArray;
 */
 // ES6TODO: Move up to runtime? This is only use in ember-metal by concatenatedProperties
 function isArray(obj) {
-  var modulePath;
+  var modulePath, type;
 
   if (typeof EmberArray === "undefined") {
     modulePath = 'ember-runtime/mixins/array';
@@ -392,7 +392,10 @@ function isArray(obj) {
   if (!obj || obj.setInterval) { return false; }
   if (Array.isArray && Array.isArray(obj)) { return true; }
   if (EmberArray && EmberArray.detect(obj)) { return true; }
-  if ((obj.length !== undefined) && 'object'=== typeOf(obj)) { return true; }
+
+  type = typeOf(obj);
+  if ('array' === type) { return true; }
+  if ((obj.length !== undefined) && 'object' === type) { return true; }
   return false;
 }
 

--- a/packages/ember-metal/tests/utils/is_array_test.js
+++ b/packages/ember-metal/tests/utils/is_array_test.js
@@ -8,7 +8,7 @@ test("Ember.isArray" ,function() {
       number        = 23,
       strarray      = ["Hello", "Hi"],
       string        = "Hello",
-      object         = {},
+      object        = {},
       length        = {length: 12},
       fn            = function() {};
 


### PR DESCRIPTION
The previous code couldn't check correctly.

``` javascript
// On IE8
Ember.isArray([]);
//=> false
```

`Ember.isArray` is used in critical point such as `Ember.Object.extend`.
So many tests failed to run.

This patch fixes some tests.
But many tests are broken yet.

Before:
![2014-05-22 0 31 16](https://cloud.githubusercontent.com/assets/290782/3044156/dc8ed1e8-e10e-11e3-9832-8477b0599b4b.png)

After:
![2014-05-22 1 49 33](https://cloud.githubusercontent.com/assets/290782/3044157/dc935556-e10e-11e3-962f-f13ec9335e33.png)

I'll work through on this one by one.
