### PR TITLE
Prevent non-js merge conflicts in Brocfile.js.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -167,6 +167,7 @@ function es6Package(packageName) {
 
   libTree = pickFiles('packages/' + packageName + '/lib', {
     srcDir: '/',
+    files: ['**/*.js'],
     destDir: packageName
   });
 
@@ -187,6 +188,7 @@ function es6Package(packageName) {
 
   var testTree = pickFiles('packages/' + packageName + '/tests', {
     srcDir: '/',
+    files: ['**/*.js'],
     destDir: '/' + packageName + '/tests'
   });
 


### PR DESCRIPTION
Prior to this, a file named `.DS_Store` in both the lib and test directories
of a single package would cause an error during the build.

This doesn't completely fix the issue, but does prevent the majority of cases
that are benign. If we end up having further merge conflicts where we have a
file with the same name in both `lib/` and `test/` dirs we can address those
individually.

This fixes the majority of trivial scenarios for now.
