### PR TITLE
Experiment: branding over instanceof

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -55,12 +55,13 @@ function getWithGlobals(obj, path) {
 // BINDING
 //
 
-var Binding = function(toPath, fromPath) {
+function Binding(toPath, fromPath) {
   this._direction = 'fwd';
   this._from = fromPath;
   this._to   = toPath;
   this._directionMap = Map.create();
-};
+  this.__isBinding__ = true;
+}
 
 /**
 @class Binding

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -200,6 +200,7 @@ function removeDependentKeys(desc, obj, keyName, meta) {
 */
 function ComputedProperty(func, opts) {
   func.__ember_arity__ = func.length;
+  this.__isComputedProperty__ = true;
   this.func = func;
 
   this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : true;

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -32,7 +32,9 @@ var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
   @private
   @constructor
 */
-export function Descriptor() {}
+export function Descriptor() {
+  this.__isDescriptor__ = true;
+}
 
 // ..........................................................
 // DEFINING PROPERTIES API
@@ -102,11 +104,11 @@ export function defineProperty(obj, keyName, desc, data, meta) {
   existingDesc = meta.descs[keyName];
   watching = meta.watching[keyName] > 0;
 
-  if (existingDesc instanceof Descriptor) {
+  if (existingDesc && existingDesc.__isDescriptor__) {
     existingDesc.teardown(obj, keyName);
   }
 
-  if (desc instanceof Descriptor) {
+  if (desc && desc.__isDescriptor__) {
     value = desc;
 
     descs[keyName] = desc;


### PR DESCRIPTION
My motivation was to reduce the cost of the Alias check. I'm just playing with this, but posting it as a PR so others can see.

My initial take has been the rest of the costs are much higher, so this doesn't really have a large impact yet.

cost of instanceof vs brand check: http://jsperf.com/brand-verse-isntance-of

Perfs:
- prefer brand check of internal Constructors then an very costly instance of
  - Mixin
  - ComputedProperty
  - Alias
  - Descriptor

Mixin:
- initialization now interactions with arguments in an efficient manner
- initialization now uses a fast for loop instead of a map
- ensure the object shape stays the same (always has a mixins property)

Micro benchmarks:
http://jsperf.com/brand-verse-isntance-of
