### PR TITLE
[BUGFIX] ReduceComputed.property() appends to depKeys

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -611,7 +611,7 @@ ReduceComputedProperty.prototype.clearItemPropertyKeys = function (dependentArra
 ReduceComputedProperty.prototype.property = function () {
   var cp = this,
       args = a_slice.call(arguments),
-      propertyArgs = new Set(),
+      propertyArgs = new Set(this._dependentKeys),
       match,
       dependentArrayKey,
       itemPropertyKey;
@@ -828,7 +828,7 @@ export function reduceComputed(options) {
 
   if (arguments.length > 1) {
     args = a_slice.call(arguments, 0, -1);
-    options = a_slice.call(arguments, -1)[0];
+    options = arguments[arguments.length-1];
   }
 
   if (typeof options !== "object") {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -84,6 +84,21 @@ test("array computed properties are instances of ComputedProperty", function() {
   ok(arrayComputed({}) instanceof ComputedProperty);
 });
 
+test(".property() appends to rather than replaces dependent keys", function() {
+  var ac = arrayComputed({});
+  ok(!ac._dependentKeys);
+  ac.property('dk');
+  deepEqual(ac._dependentKeys, ['dk']);
+  ac.property('lol');
+  deepEqual(ac._dependentKeys, ['dk', 'lol']);
+  ac.property('dk', 'lol');
+  deepEqual(ac._dependentKeys, ['dk', 'lol']);
+  ac.property('omg');
+  deepEqual(ac._dependentKeys, ['dk', 'lol', 'omg']);
+  ac.property('omg', 'dk');
+  deepEqual(ac._dependentKeys, ['dk', 'lol', 'omg']);
+});
+
 test("when the dependent array is null or undefined, `addedItem` is not called and only the initial value is returned", function() {
   obj = EmberObject.createWithMixins({
     numbers: null,
@@ -565,7 +580,7 @@ test("recomputations from `arrayComputed` observers add back dependent keys", fu
   equal(meta.watching.people, 2, "watching.people is unchanged");
 });
 
-QUnit.module('Ember.arryComputed - self chains', {
+QUnit.module('Ember.arrayComputed - self chains', {
   setup: function() {
     var a = EmberObject.create({ name: 'a' }),
     b = EmberObject.create({ name: 'b' });


### PR DESCRIPTION
Maybe this is enough of an enhancement to be considered a feature, but if
you’re using a reduce / array computed, and you’d like to add additional
dependencies that should invalidate that property, you have to call
.property() on the CP and then repeat all of the previously established
dependent keys already supplied by the internal API for reduce/array computed.

This changes makes it so that calling .property() on a reduce/array CP will
append to the list of dependent keys, so that you can just write something 
like:

```
filteredItems: Ember.computed.filter(‘model’, function(i) {
 return i.get(‘val’) === this.get(‘filterValue’);
}).property(‘filterValue’);
```

rather than having to annoyingly retype ‘model’

```
filteredItems: Ember.computed.filter(‘model’, function(i) {
 return i.get(‘val’) === this.get(‘filterValue’);
}).property(‘model’, ‘filterValue’);
```

I can’t think of a use case for array/reduce CP where you actually want to
rewrite the dep keys vs append to it but lemme know if i’m craycray.
