### PR TITLE
Actions should be looked up via `Ember.get`.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -688,14 +688,15 @@ function triggerEvent(handlerInfos, ignoreFailure, args) {
   }
 
   var eventWasHandled = false;
-  var handlerInfo, handler;
+  var handlerInfo, handler, action;
 
   for (var i = handlerInfos.length - 1; i >= 0; i--) {
     handlerInfo = handlerInfos[i];
     handler = handlerInfo.handler;
+    action = get(handler, '_actions.' + name);
 
-    if (handler._actions && handler._actions[name]) {
-      if (handler._actions[name].apply(handler, args) === true) {
+    if (action) {
+      if (action.apply(handler, args) === true) {
         eventWasHandled = true;
       } else {
         return;

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -204,10 +204,13 @@ var ActionHandler = Mixin.create({
     @param {*} context a context to send with the action
   */
   send: function(actionName) {
-    var args = [].slice.call(arguments, 1), target;
+    var action = this.get('_actions.' + actionName);
+    var args, target;
 
-    if (this._actions && this._actions[actionName]) {
-      if (this._actions[actionName].apply(this, args) === true) {
+    if (action) {
+      args = [].slice.call(arguments, 1);
+
+      if (action.apply(this, args) === true) {
         // handler returned true, so this action will bubble
       } else {
         return;

--- a/packages/ember-runtime/tests/mixins/action_handler_test.js
+++ b/packages/ember-runtime/tests/mixins/action_handler_test.js
@@ -1,6 +1,8 @@
 import run from "ember-metal/run_loop";
 import Controller from "ember-runtime/controllers/controller";
 
+QUnit.module('ActionHandlerMixin');
+
 test("passing a function for the actions hash triggers an assertion", function() {
   expect(1);
 
@@ -13,4 +15,18 @@ test("passing a function for the actions hash triggers an assertion", function()
       controller.create();
     });
   });
+});
+
+test("the action function is looked up with Ember.get", function() {
+  expect(1);
+
+  var controller = Controller.extend({
+    actions: {
+      unknownProperty: function() {
+        ok(true, 'action triggered properly');
+      }
+    }
+  }).create();
+
+  controller.send('zomg-this-is-awesome');
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3256,4 +3256,30 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
   });
 }
 
+asyncTest("Actions are looked up with Ember.get", function() {
+  Router.map(function() {
+    this.resource("root", { path: "/" });
+  });
 
+  App.RootRoute = Ember.Route.extend({
+    actions: {
+      unknownProperty: function(name) {
+        if (name === 'some-randomly-weird-name') {
+          return function() {
+            ok(true, 'unknownProperty was used to lookup the action handler');
+
+            QUnit.start();
+          };
+        }
+      }
+    }
+  });
+
+  Ember.TEMPLATES['root'] = Ember.Handlebars.compile(
+    "<a id='root-action' {{action 'some-randomly-weird-name'}}>{{name}}</a>"
+  );
+
+  bootApplication();
+
+  Ember.$('#root-action').click();
+});


### PR DESCRIPTION
This allows much more flexibility in the way Actions are handled. For example the added test shows how you could add an `unknownProperty` to handle common actions, but there are a number of other possibilities that using `Ember.get` gives us.
