### PR TITLE
Fix small documentation inconsistency

### DIFF
--- a/packages/rsvp/lib/main.js
+++ b/packages/rsvp/lib/main.js
@@ -1794,7 +1794,7 @@ define("rsvp/promise/race",
       RSVP.Promise.race([promise1, promise2]).then(function(result){
         // Code here never runs
       }, function(reason){
-        // reason.message === "promise2" because promise 2 became rejected before
+        // reason.message === "promise 2" because promise 2 became rejected before
         // promise 1 became fulfilled
       });
       ```


### PR DESCRIPTION
Hey, super small change here. I just noticed the comment in RSVP documentation is slightly wrong.

`reason.message` comes from https://github.com/amiel/ember.js/blob/46fa5bb896548d88a3e056d2903c0b5b0cffa6cf/packages/rsvp/lib/main.js#L1790

Thanks!
