### PR TITLE
[BUGFIX beta] item/empty view should be lookuped from proper global path

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -6,6 +6,7 @@
 
 import Ember from "ember-metal/core"; // Ember.assert
 import { create } from "ember-metal/platform";
+import { isGlobalPath } from "ember-metal/binding";
 import merge from "ember-metal/merge";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
@@ -347,7 +348,7 @@ var CollectionView = ContainerView.extend({
     if (len) {
       itemViewClass = get(this, 'itemViewClass');
 
-      if ('string' === typeof itemViewClass) {
+      if ('string' === typeof itemViewClass && isGlobalPath(itemViewClass)) {
         itemViewClass = get(itemViewClass) || itemViewClass;
       }
 
@@ -370,7 +371,7 @@ var CollectionView = ContainerView.extend({
 
       if (!emptyView) { return; }
 
-      if ('string' === typeof emptyView) {
+      if ('string' === typeof emptyView && isGlobalPath(emptyView)) {
         emptyView = get(emptyView) || emptyView;
       }
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -630,11 +630,10 @@ test("should render the emptyView if content array is empty and emptyView is giv
 });
 
 test("should lookup against the container if itemViewClass is given as a string", function() {
-
   var ItemView = View.extend({
-      render: function(buf) {
-        buf.push(get(this, 'content'));
-      }
+    render: function(buf) {
+      buf.push(get(this, 'content'));
+    }
   });
 
   var container = {
@@ -660,23 +659,52 @@ test("should lookup against the container if itemViewClass is given as a string"
   }
 });
 
-test("should lookup against the container and render the emptyView if emptyView is given as string and content array is empty ", function() {
-  var EmptyView = View.extend({
-      tagName: 'kbd',
-      render: function(buf) {
-        buf.push("THIS IS AN EMPTY VIEW");
-      }
+test("should lookup only global path against the container if itemViewClass is given as a string", function() {
+  var ItemView = View.extend({
+    render: function(buf) {
+      buf.push(get(this, 'content'));
+    }
   });
 
   var container = {
     lookupFactory: lookupFactory
   };
 
-  view =  CollectionView.create({
+  view = CollectionView.create({
+    container: container,
+    content: Ember.A(['hi']),
+    itemViewClass: 'top'
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$().text(), 'hi');
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:top');
+
+    return ItemView;
+  }
+});
+
+test("should lookup against the container and render the emptyView if emptyView is given as string and content array is empty ", function() {
+  var EmptyView = View.extend({
+    tagName: 'kbd',
+    render: function(buf) {
+      buf.push("THIS IS AN EMPTY VIEW");
+    }
+  });
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = CollectionView.create({
     container: container,
     tagName: 'del',
     content: Ember.A(),
-
     emptyView: 'empty'
   });
 
@@ -688,6 +716,36 @@ test("should lookup against the container and render the emptyView if emptyView 
 
   function lookupFactory(fullName) {
     equal(fullName, 'view:empty');
+
+    return EmptyView;
+  }
+});
+
+test("should lookup from only global path against the container if emptyView is given as string and content array is empty ", function() {
+  var EmptyView = View.extend({
+    render: function(buf) {
+      buf.push("EMPTY");
+    }
+  });
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = CollectionView.create({
+    container: container,
+    content: Ember.A(),
+    emptyView: 'top'
+  });
+
+  run(function() {
+    view.append();
+  });
+
+  equal(view.$().text(), "EMPTY");
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:top');
 
     return EmptyView;
   }


### PR DESCRIPTION
When `itemViewClass` is given the same name as global property name,
`CollectionView` couldn't look up registered view from container.

For example:

``` handlebars
<!-- index.handlebars -->
{{view App.NamesView}}
```

``` javascript
App.NameView = Ember.View.extend({
  template: Ember.Handlebars.compile('hi, {{view.content}}')
});

App.NamesView = Ember.CollectionView.extend({
  itemViewClass: "name",
  content: ['tomster']
});
```

Then I expect:

``` html
hi, tomster
```

But actual, the assertion error (that is referenced global property `window.name`) is thrown.

---

jsbin here: http://emberjs.jsbin.com/madefoma/4/edit
