### PR TITLE
[BUGFIX beta] Fix auto location test for old browser

### DIFF
--- a/packages/ember/tests/location_test.js
+++ b/packages/ember/tests/location_test.js
@@ -1,10 +1,17 @@
 import "ember";
+import copy from "ember-runtime/copy";
 
-var App;
+var App, AutoTestLocation;
 
 QUnit.module('AutoLocation', {
   setup: function() {
-    Ember.AutoLocation._location = {
+    AutoTestLocation = copy(Ember.AutoLocation);
+
+    AutoTestLocation._getSupportsHistory = function () {
+      return true;
+    };
+
+    AutoTestLocation._location = {
       href: 'http://test.com/',
       pathname: '/rootdir/subdir',
       hash: '',
@@ -23,6 +30,7 @@ QUnit.module('AutoLocation', {
         location: 'none',
         rootURL: '/rootdir/'
       });
+      App.__container__.register('location:auto', AutoTestLocation );
       App.deferReadiness();
     });
   },


### PR DESCRIPTION
When the browser doesn't support history location (such as IE8), auto location is fallback to hash location.
The later uses `/#/` as its entry point.
So the current path(`/:rootURL`) is not equal as the hash path(`/:rootURL/#/`) and `location.replace` is called.

This commit fixes the following failing test in IE8.
![2014-05-26 18 16 10](https://cloud.githubusercontent.com/assets/290782/3080857/9e5e1aea-e4b6-11e3-8f72-7119a928c577.png)
