### PR TITLE
[BUGFIX beta] Force remove `required` attribute for IE8

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2617,7 +2617,12 @@ View.applyAttributeBindings = function(elem, name, value) {
     if (isNone(value) || value === false) {
       // `null`, `undefined` or `false` should remove attribute
       elem.removeAttr(name);
-      elem.prop(name, '');
+      // In IE8 `prop` couldn't remove attribute when name is `required`.
+      if (name === 'required') {
+        elem.removeProp(name);
+      } else {
+        elem.prop(name, '');
+      }
     } else if (value !== elem.prop(name)) {
       // value should always be properties
       elem.prop(name, value);


### PR DESCRIPTION
In IE8, `elem.prop('required', '')` couldn't remove attribute.
(This problem is occured at `required` only. Other attributes work as our expectation.)

``` javascript
view.set('required', false);
view.$().get(0).outerHTML; // this includes `required` attribute.
```

To remove attribute, `removeProp` is needed.

This commit fixes this failure:
![2014-05-27 0 00 09](https://cloud.githubusercontent.com/assets/290782/3083828/728121a0-e4e9-11e3-94ce-1c3de65adc4b.png)

I think this change may have far-reaching ramification.
So I tested the following browsers and confirmed working fine:
- FireFox 28.0
- Safari 7.0.4
- Google Chrome 36.0.1985.18 beta
- Internet Explorer 8
