### PR TITLE
[bugfix] computed.alias not always equal to aliased property

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1182,7 +1182,7 @@ computed.alias = function(dependentKey) {
   return computed(dependentKey, function(key, value) {
     if (arguments.length > 1) {
       set(this, dependentKey, value);
-      return value;
+      return get(this, dependentKey);
     } else {
       return get(this, dependentKey);
     }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -824,6 +824,24 @@ testBoth('computed.alias', function(get, set) {
   equal(get(obj, 'quz'), null);
 });
 
+testBoth('computed.alias set', function(get, set) {
+  var obj = {};
+  var constantValue = 'always `a`';
+
+  defineProperty(obj, 'original', computed(function(key, value) {
+    return constantValue;
+  }));
+  defineProperty(obj, 'aliased', computed.alias('original'));
+
+  equal(get(obj, 'original'), constantValue);
+  equal(get(obj, 'aliased'), constantValue);
+
+  set(obj, 'aliased', 'should not set to this value');
+
+  equal(get(obj, 'original'), constantValue);
+  equal(get(obj, 'aliased'), constantValue);
+});
+
 testBoth('computed.defaultTo', function(get, set) {
   var obj = { source: 'original source value' };
   defineProperty(obj, 'copy', computed.defaultTo('source'));


### PR DESCRIPTION
There's currently inconsistent behaviour with `computed.alias` where if you set the alias and the aliased computed ignores the set value, the alias and the underlying computed can get out of sync. See http://emberjs.jsbin.com/mekowusi/1/edit for examples.
