### PR TITLE
All views should use helperName as default instrumentation display

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -37,11 +37,6 @@ import {
 } from "ember-handlebars/views/metamorph_view";
 
 var EachView = CollectionView.extend(_Metamorph, {
-  instrumentDisplay: computed(function() {
-    if (this.helperName) {
-      return '{{' + this.helperName + '}}';
-    }
-  }),
 
   init: function() {
     var itemController = get(this, 'itemController');

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -165,11 +165,6 @@ merge(states.inDOM, {
 */
 var _HandlebarsBoundView = _MetamorphView.extend({
   instrumentName: 'boundHandlebars',
-  instrumentDisplay: computed(function() {
-    if (this.helperName) {
-      return '{{' + this.helperName + '}}';
-    }
-  }),
 
   _states: states,
 

--- a/packages/ember-routing/lib/helpers/render.js
+++ b/packages/ember-routing/lib/helpers/render.js
@@ -173,7 +173,7 @@ export default function renderHelper(name, contextString, options) {
     router._connectActiveView(name, view);
   }
 
-  options.helperName = options.helperName || 'render';
+  options.helperName = options.helperName || ('render "' + name + '"');
 
   viewHelper.call(this, view, options);
 }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -980,6 +980,18 @@ var View = CoreView.extend({
   layoutName: null,
 
   /**
+    Used to identify this view during debugging
+
+    @property instrumentDisplay
+    @type String
+  */
+  instrumentDisplay: computed(function() {
+    if (this.helperName) {
+      return '{{' + this.helperName + '}}';
+    }
+  }),
+
+  /**
     The template used to render the view. This should be a function that
     accepts an optional context parameter and returns a string of HTML that
     will be inserted into the DOM relative to its parent view.


### PR DESCRIPTION
Views generated from `outlet` and `render` helpers need the helper name in
instrumentation display.

Also added name to the render helper. Example:
`{{render "person"}}`

//cc @rjackson
