### PR TITLE
[BUGFIX beta] Fix `DataAdapter#getModelTypes()` to return Ember.Array

### DIFF
--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -345,15 +345,19 @@ export default EmberObject.extend({
     } else {
       types = this._getObjectsOnNamespaces();
     }
+
     // New adapters return strings instead of classes
-    return types.map(function(name) {
+    types = emberA(types).map(function(name) {
       return {
         klass: self._nameToClass(name),
         name: name
       };
-    }).filter(function(type) {
+    });
+    types = emberA(types).filter(function(type) {
       return self.detect(type.klass);
     });
+
+    return emberA(types);
   },
 
   /**


### PR DESCRIPTION
IE8 doesn't have `Array#map` and `Array#filter`.
This PR fixes:
![__________2014-05-26_23 55 21](https://cloud.githubusercontent.com/assets/290782/3096380/55dec21a-e5d3-11e3-933e-917b818bbf82.png)

---

And #4931, #4936 and this errors are resolved, all tests are passed on IE8.
![2014-05-28 4 11 20](https://cloud.githubusercontent.com/assets/290782/3096393/7ce9f690-e5d3-11e3-86f4-16d23c0e52ab.png)
