### PR TITLE
[BUGFIX beta] Prevent error in LOG_RESOLVER during unit testing.

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -178,7 +178,7 @@ export var DefaultResolver = EmberObject.extend({
       resolved = this.resolveOther(parsedName);
     }
 
-    if (parsedName.root.LOG_RESOLVER) {
+    if (parsedName.root && parsedName.root.LOG_RESOLVER) {
       this._logLookup(resolved, parsedName);
     }
 


### PR DESCRIPTION
When using `ember-qunit` to unit test a component, an error is thrown since there is no `root` object (i.e. no application is booted).

Thanks to @chancancode for tracking this down.

Fixes #4949.
