### PR TITLE
Fix components inside group helper

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -118,6 +118,9 @@ function bind(property, options, preserveContext, shouldDisplay, valueNormalizer
   if ('object' === typeof this) {
     if (data.insideGroup) {
       observer = function() {
+        while (view._contextView) {
+          view = view._contextView;
+        }
         run.once(view, 'rerender');
       };
 
@@ -197,6 +200,9 @@ function simpleBind(currentContext, property, options) {
   if (pathRoot && ('object' === typeof pathRoot)) {
     if (data.insideGroup) {
       observer = function() {
+        while (view._contextView) {
+          view = view._contextView;
+        }
         run.once(view, 'rerender');
       };
 

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -9,6 +9,7 @@ import { A } from "ember-runtime/system/native_array";
 import Container from "ember-runtime/system/container";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import Component from "ember-views/views/component";
 
 var trim = jQuery.trim;
 var container, view;
@@ -215,6 +216,25 @@ test("an #each can be nested with a view inside", function() {
     '{{#each people}}{{#view}}{{name}}{{/view}}{{/each}}',
     {people: A([yehuda, {name: 'Tom'}])}
   );
+  appendView();
+  equal(view.$('script').length, 0, "No Metamorph markers are output");
+  equal(view.$().text(), 'YehudaTom', "The content was rendered");
+
+  run(function() {
+    set(yehuda, 'name', 'Erik');
+  });
+
+  equal(view.$().text(), 'ErikTom', "The updated object's view was rerendered");
+});
+
+test("an #each can be nested with a component inside", function() {
+  var yehuda = {name: 'Yehuda'};
+  container.register('view:test', Component.extend());
+  createGroupedView(
+    '{{#each people}}{{#view "test"}}{{name}}{{/view}}{{/each}}',
+    {people: A([yehuda, {name: 'Tom'}])}
+  );
+
   appendView();
   equal(view.$('script').length, 0, "No Metamorph markers are output");
   equal(view.$().text(), 'YehudaTom', "The content was rendered");

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -112,6 +112,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
 
   init: function() {
     this._super();
+    set(this, 'origContext', get(this, 'context'));
     set(this, 'context', this);
     set(this, 'controller', this);
   },
@@ -180,9 +181,9 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
         tagName: '',
         _contextView: parentView,
         template: template,
-        context: get(parentView, 'context'),
+        context: options.data.insideGroup ? get(this, 'origContext') : get(parentView, 'context'),
         controller: get(parentView, 'controller'),
-        templateData: { keywords: parentView.cloneKeywords() }
+        templateData: { keywords: parentView.cloneKeywords(), insideGroup: options.data.insideGroup }
       });
     }
   },


### PR DESCRIPTION
This fixes a regression in canary. Components (including `link-to`) end up with the wrong context when used inside a `#group` helper. And their templates don't get grouped.

(I understand that #group is experimental, but as long as the support for it remains in master, it makes sense to not leave it broken.)

This resolves #4883.
