### PR TITLE
Clean up some ember-metal chains code

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -53,7 +53,10 @@ function removeChainWatcher(obj, keyName, node) {
   if (nodes && nodes[keyName]) {
     nodes = nodes[keyName];
     for (var i = 0, l = nodes.length; i < l; i++) {
-      if (nodes[i] === node) { nodes.splice(i, 1); }
+      if (nodes[i] === node) {
+        nodes.splice(i, 1);
+        break;
+      }
     }
   }
   unwatchKey(obj, keyName, m);
@@ -212,7 +215,7 @@ ChainNodePrototype.chain = function(key, path, src) {
   node.count++; // count chains...
 
   // chain rest of path if there is one
-  if (path && path.length>0) {
+  if (path) {
     key = firstKey(path);
     path = path.slice(key.length+1);
     node.chain(key, path); // NOTE: no src means it will observe changes...


### PR DESCRIPTION
1. The first change removes a weird instance of 
   improperly removing nodes from an array which
   would break in case there’s ever a time that
   a node appears in the array more than once
   (but I’m pretty certain this is never the case)
2. Removed unnecessary
   .length check of 
   (str && str.length > 0)

[edit: english]
