### PR TITLE
[BUGFIX beta] gate reduceComputed item property changes.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -83,8 +83,12 @@ function DependentArraysObserver(callbacks, cp, instanceMeta, context, propertyN
   // because we only have the key; instead we make the observers no-ops
   this.suspended = false;
 
-  // This is used to coalesce item changes from property observers.
+  // This is used to coalesce item changes from property observers within a
+  // single item.
   this.changedItems = {};
+  // This is used to coalesce item changes for multiple items that depend on
+  // some shared state.
+  this.changedItemCount = 0;
 }
 
 function ItemPropertyObserverContext (dependentArray, index, trackedArray) {
@@ -322,12 +326,15 @@ DependentArraysObserver.prototype = {
         previousValues:   {}
       };
     }
+    ++this.changedItemCount;
 
     this.changedItems[guid].previousValues[keyName] = get(obj, keyName);
   },
 
   itemPropertyDidChange: function(obj, keyName, array, observerContext) {
-    this.flushChanges();
+    if (--this.changedItemCount === 0) {
+      this.flushChanges();
+    }
   },
 
   flushChanges: function() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -26,7 +26,7 @@ QUnit.module('arrayComputed', {
       otherNumbers: Ember.A([ 7, 8, 9 ]),
 
       // Users would obviously just use `Ember.computed.map`
-      // This implemantion is fine for these tests, but doesn't properly work as
+      // This implementation is fine for these tests, but doesn't properly work as
       // it's not index based.
       evenNumbers: arrayComputed('numbers', {
         addedItem: function (array, item) {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -15,7 +15,7 @@ import SubArray from "ember-runtime/system/subarray";
 
 var map = EnumerableUtils.map,
     metaFor = meta,
-    obj, addCalls, removeCalls, callbackItems;
+    obj, addCalls, removeCalls, callbackItems, shared;
 
 QUnit.module('arrayComputed', {
   setup: function () {
@@ -967,3 +967,54 @@ if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
     }, /must be an `Ember.Array`/, "Ember.reduceComputed complains about dependent non-extended native arrays");
   });
 }
+
+QUnit.module('arrayComputed - misc', {
+  setup: function () {
+    callbackItems = [];
+
+    shared = Ember.Object.create({
+      flag: false
+    });
+
+    var Item = Ember.Object.extend({
+      shared: shared,
+      flag: computed('shared.flag', function () {
+        return this.get('shared.flag');
+      })
+    });
+    
+    obj = Ember.Object.extend({
+      upstream: Ember.A([
+        Item.create(),
+        Item.create()
+      ]),
+      arrayCP: arrayComputed('upstream.@each.flag', {
+        addedItem: function (array, item) {
+          callbackItems.push('add:' + item.get('flag'));
+          return array;
+        },
+
+        removedItem: function (array, item) {
+          callbackItems.push('remove:' + item.get('flag'));
+          return array;
+        }
+      })
+    }).create();
+  },
+
+  teardown: function () {
+    run(function () {
+      obj.destroy();
+    });
+  },
+});
+
+test("item property change flushes are gated by a semaphore", function() {
+  obj.get('arrayCP');
+  deepEqual(callbackItems, ['add:false', 'add:false'], "precond - calls are initially correct");
+
+  callbackItems.splice(0, 2);
+
+  shared.set('flag', true);
+  deepEqual(callbackItems, ['remove:true', 'add:true', 'remove:true', 'add:true'], "item property flushes that depend on a shared prop are gated by a semaphore");
+});


### PR DESCRIPTION
When multiple items in an upstream CP have a property that a reduce cp's
`DependentArrayObserver` is watching, and that property depends on some
shared other property, it is possible for `flushChanges` to be called
before all the items have had their caches cleared.

This commit ensures that the item property changes are flushed on the
_last_ item's property change, rather than the _first_ item's property
change.  This used to be handled via the run loop, but now that reduce CPs
are synchronous (to keep them more in line with regular CPs) we need to
gate these changes with a semaphore.

Fix #4967.
