### PR TITLE
sync RSVP 3.0.7

### DIFF
--- a/packages/ember-runtime/tests/mixins/deferred_test.js
+++ b/packages/ember-runtime/tests/mixins/deferred_test.js
@@ -368,7 +368,7 @@ test("given `Ember.testing = true`, correctly informs the test suite about async
     name: 'tomster'
   });
 
-  equal(asyncStarted, 1);
+  equal(asyncStarted, 0);
   equal(asyncEnded, 0);
 
   user.then(function(user){


### PR DESCRIPTION
The test failure on 371 of defered_test.js:

RSVP’s latest performance tuning reduced many unneeded nextTick’s. In this specific scenario, with no subscribers the promise did not need to publish its state change and now it correctly does not.
