### PR TITLE
[BUGFIX beta] Do not use a `window` local variable.

### DIFF
--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -174,10 +174,10 @@ export default {
     @method _getSupportsHashChange
   */
   _getSupportsHashChange: function () {
-    var window = this._window,
-        documentMode = window.document.documentMode;
+    var _window = this._window,
+        documentMode = _window.document.documentMode;
 
-    return ('onhashchange' in window && (documentMode === undefined || documentMode > 7 ));
+    return ('onhashchange' in _window && (documentMode === undefined || documentMode > 7 ));
   },
 
   /**


### PR DESCRIPTION
Certain tools have a really hard time when you create a local window variable.
