### PR TITLE
Allow passing computed ES6 modules to {{view}}.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -166,16 +166,23 @@ export var ViewHelper = EmberObject.create({
     makeBindings(thisContext, options);
 
     if ('string' === typeof path) {
-
+      var lookup;
       // TODO: this is a lame conditional, this should likely change
       // but something along these lines will likely need to be added
       // as deprecation warnings
       //
       if (options.types[0] === 'STRING' && LOWERCASE_A_Z.test(path) && !VIEW_PREFIX.test(path)) {
-        Ember.assert("View requires a container", !!data.view.container);
-        newView = data.view.container.lookupFactory('view:' + path);
+        lookup = path;
       } else {
         newView = handlebarsGet(thisContext, path, options);
+        if (typeof newView === 'string') {
+          lookup = newView;
+        }
+      }
+
+      if (lookup) {
+        Ember.assert("View requires a container", !!data.view.container);
+        newView = data.view.container.lookupFactory('view:' + lookup);
       }
 
       Ember.assert("Unable to find view at path '" + path + "'", !!newView);

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -118,6 +118,33 @@ test("View lookup - 'fu'", function() {
   }
 });
 
+test("View lookup - view.computed", function() {
+  var FuView = viewClass({
+    elementId: "fu",
+    template: Ember.Handlebars.compile("bro")
+  });
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: Ember.Handlebars.compile("{{view view.computed}}"),
+    container: container,
+    computed: 'fu'
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#fu').text(), 'bro');
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
+});
+
 test("id bindings downgrade to one-time property lookup", function() {
   view = EmberView.extend({
     template: Ember.Handlebars.compile("{{#view Ember.View id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}"),


### PR DESCRIPTION
Right now, it's possible to pass a computed property to the {{view}}
helper, but that only works if the property returns an `Ember.View`.

This change allows the computed property to return a string, which
the helper will now try to interpret as an ES6 module and resolve.
