### PR TITLE
[DOC] Deprecate `Ember.computed.defaultTo`.

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -674,10 +674,13 @@ computed.readOnly = function(dependentKey) {
   @param {String} defaultPath
   @return {Ember.ComputedProperty} computed property which acts like
   a standard getter and setter, but defaults to the value from `defaultPath`.
+  @deprecated Use `Ember.computed.oneWay` or custom CP with default instead.
 */
 // ES6TODO: computed should have its own export path so you can do import {defaultTo} from computed
 computed.defaultTo = function(defaultPath) {
   return computed(function(key, newValue, cachedValue) {
+    Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
+
     if (arguments.length === 1) {
       return get(this, defaultPath);
     }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -843,20 +843,31 @@ testBoth('computed.alias set', function(get, set) {
 });
 
 testBoth('computed.defaultTo', function(get, set) {
+  expect(6);
+
   var obj = { source: 'original source value' };
   defineProperty(obj, 'copy', computed.defaultTo('source'));
 
-  equal(get(obj, 'copy'), 'original source value');
+  ignoreDeprecation(function() {
+    equal(get(obj, 'copy'), 'original source value');
 
-  set(obj, 'copy', 'new copy value');
-  equal(get(obj, 'source'), 'original source value');
-  equal(get(obj, 'copy'), 'new copy value');
+    set(obj, 'copy', 'new copy value');
+    equal(get(obj, 'source'), 'original source value');
+    equal(get(obj, 'copy'), 'new copy value');
 
-  set(obj, 'source', 'new source value');
-  equal(get(obj, 'copy'), 'new copy value');
+    set(obj, 'source', 'new source value');
+    equal(get(obj, 'copy'), 'new copy value');
 
-  set(obj, 'copy', null);
-  equal(get(obj, 'copy'), 'new source value');
+    set(obj, 'copy', null);
+    equal(get(obj, 'copy'), 'new source value');
+  });
+
+  expectDeprecation(function() {
+    var obj = { source: 'original source value' };
+    defineProperty(obj, 'copy', computed.defaultTo('source'));
+
+    get(obj, 'copy');
+  }, 'Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
 });
 
 testBoth('computed.match', function(get, set) {


### PR DESCRIPTION
Having three similar but subtly different functions (`oneWay`, `defaultTo`, and `readOnly`) is confusing.

I think `oneWay` serves this use case much better, and has other uses outside of an initial default value.
