### PR TITLE
Made mandatory setter function return a function that calls "Ember.set" for you

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -38,11 +38,13 @@ export function Descriptor() {}
 // DEFINING PROPERTIES API
 //
 
-var MANDATORY_SETTER_FUNCTION = Ember.MANDATORY_SETTER_FUNCTION = function(value) {
-  Ember.assert("You must use Ember.set() to access this property (of " + this + ")", false);
+var MANDATORY_SETTER_FUNCTION = Ember.MANDATORY_SETTER_FUNCTION = function(name) {
+  return function(value) {
+    Ember.set(this, name, value);
+  };
 };
 
-var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function DEFAULT_GETTER_FUNCTION(name) {
+var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function(name) {
   return function() {
     var meta = this[META_KEY];
     return meta && meta.values[name];

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -232,7 +232,7 @@ function meta(obj, writable) {
 
     ret = new Meta(obj);
 
-    if (MANDATORY_SETTER) { ret.values = {}; }
+    ret.values = {};
 
     obj[META_KEY] = ret;
 

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -6,7 +6,6 @@ import {
 import { platform } from "ember-metal/platform";
 
 var metaFor = meta; // utils.js
-var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 var o_defineProperty = platform.defineProperty;
 
 export function watchKey(obj, keyName, meta) {
@@ -23,12 +22,12 @@ export function watchKey(obj, keyName, meta) {
       obj.willWatchProperty(keyName);
     }
 
-    if (MANDATORY_SETTER && keyName in obj) {
+    if (Ember.ENV.MANDATORY_SETTER && keyName in obj) {
       m.values[keyName] = obj[keyName];
       o_defineProperty(obj, keyName, {
         configurable: true,
         enumerable: obj.propertyIsEnumerable(keyName),
-        set: Ember.MANDATORY_SETTER_FUNCTION,
+        set: Ember.MANDATORY_SETTER_FUNCTION(keyName),
         get: Ember.DEFAULT_GETTER_FUNCTION(keyName)
       });
     }
@@ -47,7 +46,7 @@ export function unwatchKey(obj, keyName, meta) {
       obj.didUnwatchProperty(keyName);
     }
 
-    if (MANDATORY_SETTER && keyName in obj) {
+    if (Ember.ENV.MANDATORY_SETTER && keyName in obj) {
       o_defineProperty(obj, keyName, {
         configurable: true,
         enumerable: obj.propertyIsEnumerable(keyName),

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -21,6 +21,14 @@ test("should return the same hash for an object", function() {
   equal(meta(obj).foo, "bar", "returns same hash with multiple calls to Ember.meta()");
 });
 
+test("should provide an empty 'values' object as a default", function() {
+  var obj = {};
+
+  var subject = meta(obj).values;
+
+  equal(Ember.inspect(subject), '{}', 'should be an empty object');
+});
+
 QUnit.module("Ember.metaPath");
 
 test("should not create nested objects if writable is false", function() {

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -11,7 +11,8 @@ import {
 var willCount, didCount,
     willKeys, didKeys,
     indexOf = EnumerableUtils.indexOf,
-    originalLookup, lookup, Global;
+    originalLookup, lookup, Global,
+    originalSet;
 
 QUnit.module('watch', {
   setup: function() {
@@ -21,10 +22,13 @@ QUnit.module('watch', {
 
     originalLookup = Ember.lookup;
     Ember.lookup = lookup = {};
+    originalSet = Ember.set;
   },
 
   teardown: function(){
     Ember.lookup = originalLookup;
+    Ember.set = originalSet;
+    Ember.ENV.MANDATORY_SETTER = false;
   }
 });
 
@@ -276,4 +280,21 @@ testBoth('watching "length" property on an array', function(get, set) {
 
   equal(get(arr, 'length'), 10, 'should get new value');
   equal(arr.length, 10, 'property should be accessible on arr');
+});
+
+test('setters defined by watch', function(){
+  expect(1);
+
+  var obj = {foo: 'bar'},
+      setterArguments = [];
+  Ember.ENV.MANDATORY_SETTER = true;
+
+  Ember.set = function() {
+    setterArguments = [].slice.call(arguments);
+  };
+
+  watch(obj, 'foo');
+  obj.foo = 'baz';
+
+  deepEqual(setterArguments, [obj, 'foo', 'baz'], 'should call "set" with the appropriate arguments');
 });


### PR DESCRIPTION
I've changed `Ember.MANDATORY_SETTER_FUNCTION` to return a function that calls `Ember.set` for you instead of throwing an error that tells you to call `Ember.set`. I think this is an improvement for a few reasons.

This way Ember does what you mean, which it should because it has all of the information necessary on hand to do so. Also, while the error that was thrown had a descriptive message, it could occur in confusing ways.

For instance, if you mutate a plain object before it's rendered to the page and mutate again after it's rendered, you'll only get the error on the second mutation. [jsbin example here](http://jsbin.com/dedom/1/edit?js,console,output). The error only being thrown the second time is extremely confusing if you don't know Ember is defining setters (or if you don't even know that you _can_ do that in JavaScript), because why would `foo.bar = 'baz'` work the first time but then throw an error the second time?

Alternatively, Ember could throw an error whenever you try to render a non-Ember object to the page if the setter calling set is too much magic.
