### PR TITLE
clean up duplication in computed.alias

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1146,10 +1146,9 @@ computed.alias = function(dependentKey) {
   return computed(dependentKey, function(key, value) {
     if (arguments.length > 1) {
       set(this, dependentKey, value);
-      return get(this, dependentKey);
-    } else {
-      return get(this, dependentKey);
     }
+
+    return get(this, dependentKey);
   });
 };
 


### PR DESCRIPTION
Cleanup as suggested in https://github.com/emberjs/ember.js/pull/4937

Simply removes duplication of the `get` call in `computed.alias` since it's required no matter what to let the aliased property possibly modify the set value.
