### PR TITLE
Added `withKeyCode` option to action helper

### DIFF
--- a/features.json
+++ b/features.json
@@ -12,7 +12,9 @@
     "event-dispatcher-can-disable-event-manager": null,
     "ember-metal-is-present": null,
     "property-brace-expansion-improvement": null,
-    "ember-runtime-proxy-mixin": null
+    "ember-runtime-proxy-mixin": null,
+    "ember-routing-consistent-resources": null,
+    "ember-routing-handlebars-action-with-key-code": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -823,6 +823,79 @@ test("it can trigger actions for keyboard events", function() {
   ok(showCalled, "should call action with keyup");
 });
 
+if (Ember.FEATURES.isEnabled("ember-actions-with-key-code")) {
+  test("it can trigger actions for key events with specific key codes", function() {
+    var showCalled = false;
+
+    view = EmberView.create({
+      template: compile("<input type='text' class='keyup-with-key-codes' {{action 'show' on='keyUp' withKeyCode='13'}}>" +
+        "<input type='text' class='keydown-with-key-codes' {{action 'show' on='keyDown' withKeyCode='13'}}>" +
+        "<input type='text' class='keypress-with-key-codes' {{action 'show' on='keyPress' withKeyCode='13'}}>" +
+        "<input type='text' class='keyup-without-key-codes' {{action 'show' on='keyUp'}}>")
+    });
+
+    var controller = EmberController.extend({
+      actions: {
+        show: function() {
+          showCalled = true;
+        }
+      }
+    }).create();
+
+    run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    function enterEvent(eventType) {
+      var event = jQuery.Event(eventType);
+      event.char = '\n';
+      event.which = 13;
+      return event;
+    }
+
+    function nonEnterEvent(eventType) {
+      var event = jQuery.Event(eventType);
+      event.char = 'a';
+      event.which = 65;
+      return event;
+    }
+
+    view.$('input.keyup-with-key-codes').trigger(nonEnterEvent('keyup'));
+    ok(!showCalled, "should not call action with a's keyup");
+
+
+    view.$('input.keyup-with-key-codes').trigger(enterEvent('keyup'));
+    ok(showCalled, "should call action with enter's keyup");
+
+    showCalled = false;
+
+    view.$('input.keydown-with-key-codes').trigger(nonEnterEvent('keydown'));
+    ok(!showCalled, "should not call action with a's keydown");
+
+    view.$('input.keydown-with-key-codes').trigger(enterEvent('keydown'));
+    ok(showCalled, "should call action with enter's keydown");
+
+    showCalled = false;
+
+    view.$('input.keypress-with-key-codes').trigger(nonEnterEvent('keypress'));
+    ok(!showCalled, "should not call action with a's keypress");
+
+
+    view.$('input.keypress-with-key-codes').trigger(enterEvent('keypress'));
+    ok(showCalled, "should call action with enter's keypress");
+
+    showCalled = false;
+
+    view.$('input.keyup-without-key-codes').trigger(nonEnterEvent('keyup'));
+    ok(showCalled, "should call action with a's keyup");
+
+    showCalled = false;
+
+    view.$('input.keyup-without-key-codes').trigger(enterEvent('keyup'));
+    ok(showCalled, "should call action with enter's keyup");
+  });
+}
 test("a quoteless parameter should allow dynamic lookup of the actionName", function(){
   expect(4);
   var lastAction, actionOrder = [];


### PR DESCRIPTION
For actions that are fired on `keyUp`, `keyDown` or `keyPress` an option called `withKeyCode` is now available to use. It ensures that the action is called only when the given `withKeyCode` value matches the keyCode on the event.

For example:

```
<input type='text' {{action 'show' on='keyUp' withKeyCode='13'}}>
```

This action will only fire if the event is a `keyup` and the `keyCode` is 13.

This commit was done with help from: @tonycoco
