### PR TITLE
Es6 cleanup

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -9,9 +9,9 @@ import { set } from "ember-metal/property_set";
 import EmberError from "ember-metal/error";
 import { inspect } from "ember-metal/utils";
 import { computed } from "ember-metal/computed";
-import { ControllerMixin } from "ember-runtime/controllers/controller";
+import ControllerMixin from "ember-runtime/mixins/controller";
 import { meta } from "ember-metal/utils";
-import { controllerFor } from "ember-routing/system/controller_for";
+import controllerFor from "ember-routing/system/controller_for";
 
 function verifyNeedsDependencies(controller, container, needs) {
   var dependency, i, l, missing = [];

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -10,12 +10,12 @@ import { runLoadHooks } from "ember-runtime/system/lazy_load";
 import DAG from "ember-application/system/dag";
 import Namespace from "ember-runtime/system/namespace";
 import DeferredMixin from "ember-runtime/mixins/deferred";
-import { DefaultResolver } from "ember-application/system/resolver";
+import DefaultResolver from "ember-application/system/resolver";
 import { create } from "ember-metal/platform";
 import run from "ember-metal/run_loop";
 import { canInvoke } from "ember-metal/utils";
 import Container from 'container/container';
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
@@ -30,30 +30,13 @@ import AutoLocation from "ember-routing/location/auto_location";
 import NoneLocation from "ember-routing/location/none_location";
 import BucketCache from "ember-routing/system/cache";
 
+import {
+  K
+} from 'ember-metal/core';
 import EmberHandlebars from "ember-handlebars-compiler";
+import DeprecatedContainer from "ember-application/system/deprecated-container";
 
-var K = Ember.K;
 var ContainerDebugAdapter;
-
-function DeprecatedContainer(container) {
-  this._container = container;
-}
-
-DeprecatedContainer.deprecate = function(method) {
-  return function() {
-    var container = this._container;
-
-    Ember.deprecate('Using the defaultContainer is no longer supported. [defaultContainer#' + method + '] see: http://git.io/EKPpnA', false);
-    return container[method].apply(container, arguments);
-  };
-};
-
-DeprecatedContainer.prototype = {
-  _container: null,
-  lookup: DeprecatedContainer.deprecate('lookup'),
-  resolve: DeprecatedContainer.deprecate('resolve'),
-  register: DeprecatedContainer.deprecate('register')
-};
 
 /**
   An instance of `Ember.Application` is the starting point for every Ember

--- a/packages/ember-application/lib/system/deprecated-container.js
+++ b/packages/ember-application/lib/system/deprecated-container.js
@@ -1,0 +1,21 @@
+function DeprecatedContainer(container) {
+  this._container = container;
+}
+
+DeprecatedContainer.deprecate = function(method) {
+  return function() {
+    var container = this._container;
+
+    Ember.deprecate('Using the defaultContainer is no longer supported. [defaultContainer#' + method + '] see: http://git.io/EKPpnA', false);
+    return container[method].apply(container, arguments);
+  };
+};
+
+DeprecatedContainer.prototype = {
+  _container: null,
+  lookup: DeprecatedContainer.deprecate('lookup'),
+  resolve: DeprecatedContainer.deprecate('resolve'),
+  register: DeprecatedContainer.deprecate('register')
+};
+
+export default DeprecatedContainer;

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -118,7 +118,8 @@ export var Resolver = EmberObject.extend({
   @namespace Ember
   @extends Ember.Object
 */
-export var DefaultResolver = EmberObject.extend({
+
+export default EmberObject.extend({
   /**
     This will be set to the Application instance when it is
     created.

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -1,21 +1,21 @@
 /*globals EmberDev */
 
 import Ember from "ember-metal/core";
-import {get} from "ember-metal/property_get";
-import {set} from "ember-metal/property_set";
-import {forEach} from "ember-metal/array";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { forEach } from "ember-metal/array";
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
-import {DefaultResolver} from "ember-application/system/resolver";
+import DefaultResolver from "ember-application/system/resolver";
 import Router from "ember-routing/system/router";
 import View from "ember-views/views/view";
-import {Controller} from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import NoneLocation from "ember-routing/location/none_location";
 import EmberHandlebars from "ember-handlebars";
 import EmberObject from "ember-runtime/system/object";
-import {outletHelper} from "ember-routing-handlebars/helpers/outlet";
-
+import { outletHelper } from "ember-routing-handlebars/helpers/outlet";
 import jQuery from "ember-views/system/jquery";
+
 var trim = jQuery.trim;
 
 var view, app, application, originalLookup, originalDebug;

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -1,6 +1,6 @@
 /*jshint newcap:false */
 
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import "ember-application/ext/controller";
 
 import Container from "ember-runtime/system/container";

--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -1,7 +1,7 @@
 import jQuery from "ember-views/system/jquery";
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
-import { DefaultResolver } from "ember-application/system/resolver";
+import DefaultResolver from "ember-application/system/resolver";
 
 var application;
 

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core"; // Ember.TEMPLATES
 import run from "ember-metal/run_loop";
 import Logger from "ember-metal/logger";
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import EmberObject from "ember-runtime/system/object";
 import EmberHandlebars from "ember-handlebars";
 import Namespace from "ember-runtime/system/namespace";

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core"; // lookup, etc
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import EmberObject from "ember-runtime/system/object";
-import { DefaultResolver } from "ember-application/system/resolver";
+import DefaultResolver from "ember-application/system/resolver";
 import { guidFor } from "ember-metal/utils";
 
 var originalLookup, App, originalModelInjections;

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -3,7 +3,7 @@
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import View from "ember-views/views/view";
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import Route from "ember-routing/system/route";
 import RSVP from "ember-runtime/ext/rsvp";
 import keys from "ember-runtime/keys";

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -5,7 +5,7 @@ import Application from "ember-application/system/application";
 import EmberObject from "ember-runtime/system/object";
 import Router from "ember-routing/system/router";
 import View from "ember-views/views/view";
-import {Controller} from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import jQuery from "ember-views/system/jquery";
 import Container from 'container/container';

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import { A as emberA } from "ember-runtime/system/native_array";
 import { typeOf } from "ember-metal/utils";
 import {
   dasherize,
@@ -46,7 +47,7 @@ import EmberObject from "ember-runtime/system/object";
   @extends EmberObject
   @since 1.5.0
 */
-var ContainerDebugAdapter = EmberObject.extend({
+export default EmberObject.extend({
   /**
     The container of the application being debugged.
     This property will be injected
@@ -88,7 +89,7 @@ var ContainerDebugAdapter = EmberObject.extend({
     @return {Array} An array of strings.
   */
   catalogEntriesByType: function(type) {
-    var namespaces = Ember.A(Namespace.NAMESPACES), types = Ember.A(), self = this;
+    var namespaces = emberA(Namespace.NAMESPACES), types = emberA(), self = this;
     var typeSuffixRegex = new RegExp(classify(type) + "$");
 
     namespaces.forEach(function(namespace) {
@@ -107,5 +108,3 @@ var ContainerDebugAdapter = EmberObject.extend({
     return types;
   }
 });
-
-export default ContainerDebugAdapter;

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
-import { Controller as EmberController } from "ember-runtime/controllers/controller";
+import { default as EmberController } from "ember-runtime/controllers/controller";
 import "ember-extension-support"; // Must be required to export Ember.ContainerDebugAdapter
 import Application from "ember-application/system/application";
 

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -7,10 +7,10 @@ import {
   removeObserver
 } from "ember-metal/observer";
 import EmberObject from "ember-runtime/system/object";
-import { Controller as EmberController } from "ember-runtime/controllers/controller";
+import { default as EmberController } from "ember-runtime/controllers/controller";
 import EmberDataAdapter from "ember-extension-support/data_adapter";
 import EmberApplication from "ember-application/system/application";
-import { DefaultResolver } from "ember-application/system/resolver";
+import DefaultResolver from "ember-application/system/resolver";
 
 var adapter, App, Model = EmberObject.extend();
 

--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -31,24 +31,33 @@ import View from "ember-views/views/view";
   @namespace Ember
   @extends Ember.View
 */
-var Checkbox = View.extend({
+export default View.extend({
   instrumentDisplay: '{{input type="checkbox"}}',
 
   classNames: ['ember-checkbox'],
 
   tagName: 'input',
 
-  attributeBindings: ['type', 'checked', 'indeterminate', 'disabled', 'tabindex', 'name',
-                      'autofocus', 'required', 'form'],
+  attributeBindings: [
+    'type',
+    'checked',
+    'indeterminate',
+    'disabled',
+    'tabindex',
+    'name',
+    'autofocus',
+    'required',
+    'form'
+  ],
 
-  type: "checkbox",
+  type: 'checkbox',
   checked: false,
   disabled: false,
   indeterminate: false,
 
   init: function() {
     this._super();
-    this.on("change", this, this._updateElementValue);
+    this.on('change', this, this._updateElementValue);
   },
 
   didInsertElement: function() {
@@ -60,5 +69,3 @@ var Checkbox = View.extend({
     set(this, 'checked', this.$().prop('checked'));
   }
 });
-
-export default Checkbox;

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -4,7 +4,14 @@
 */
 
 import EmberHandlebars from "ember-handlebars-compiler";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+
+import {
+  forEach,
+  indexOf,
+  indexesOf,
+  replace
+} from "ember-metal/enumerable_utils";
+
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import View from "ember-views/views/view";
@@ -16,11 +23,7 @@ import { A as emberA } from "ember-runtime/system/native_array";
 import { observer } from "ember-metal/mixin";
 import { defineProperty } from "ember-metal/properties";
 
-var indexOf = EnumerableUtils.indexOf,
-    indexesOf = EnumerableUtils.indexesOf,
-    forEach = EnumerableUtils.forEach,
-    replace = EnumerableUtils.replace,
-    precompileTemplate = EmberHandlebars.compile;
+var precompileTemplate = EmberHandlebars.compile;
 
 var SelectOption = View.extend({
   instrumentDisplay: 'Ember.SelectOption',

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -15,7 +15,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import CollectionView from "ember-views/views/collection_view";
 import { Binding } from "ember-metal/binding";
-import { ControllerMixin } from "ember-runtime/controllers/controller";
+import ControllerMixin from "ember-runtime/mixins/controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import EmberArray from "ember-runtime/mixins/array";
 import copy from "ember-runtime/copy";

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -28,7 +28,7 @@ import {
 } from "ember-views/views/states";
 var viewStates = states;
 
-import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
 import { handlebarsGet } from "ember-handlebars/ext";
 
 function SimpleHandlebarsView(path, pathRoot, isEscaped, templateData) {

--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -136,3 +136,4 @@ export var _MetamorphView = View.extend(_Metamorph);
   @private
 */
 export var _SimpleMetamorphView = CoreView.extend(_Metamorph);
+export default View.extend(_Metamorph);

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -2,15 +2,14 @@ import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import jQuery from "ember-views/system/jquery";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { map } from "ember-metal/enumerable_utils";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import { computed } from "ember-metal/computed";
 import Namespace from "ember-runtime/system/namespace";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 
-var map = EnumerableUtils.map,
-    trim = jQuery.trim;
+var trim = jQuery.trim;
 
 var dispatcher, select, view;
 

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -4,7 +4,7 @@
 import Ember from "ember-metal/core"; // Ember.lookup
 import jQuery from "ember-views/system/jquery";
 // import {expectAssertion} from "ember-metal/tests/debug_helpers";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 import run from "ember-metal/run_loop";
 import Namespace from "ember-runtime/system/namespace";
 import EmberView from "ember-views/views/view";
@@ -32,7 +32,6 @@ Ember.ContainerView = ContainerView;
 Ember.Logger = Logger;
 
 var trim = jQuery.trim;
-var forEach = EnumerableUtils.forEach;
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -8,7 +8,7 @@ import ArrayController from "ember-runtime/controllers/array_controller";
 import EmberHandlebars from "ember-handlebars-compiler";
 // import {expectAssertion} from "ember-metal/tests/debug_helpers";
 import { A } from "ember-runtime/system/native_array";
-import { Controller as EmberController } from "ember-runtime/controllers/controller";
+import { default as EmberController } from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import Container from "ember-runtime/system/container";
 

--- a/packages/ember-handlebars/tests/views/metamorph_view_test.js
+++ b/packages/ember-handlebars/tests/views/metamorph_view_test.js
@@ -6,7 +6,7 @@ import { set } from "ember-metal/property_set";
 import { observer } from "ember-metal/mixin";
 import EmberHandlebars from "ember-handlebars-compiler";
 
-import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
 
 var view, childView, metamorphView;
 

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -191,8 +191,10 @@ Ember.LOG_VERSION = (Ember.ENV.LOG_VERSION === false) ? false : true;
   @private
   @return {Object}
 */
-Ember.K = function() { return this; };
-
+var K = function() { return this; };
+export var K = K;
+Ember.K = K;
+//TODO: ES6 GLOBL TODO
 
 // Stub out the methods defined by the ember-debug package in case it's not loaded
 

--- a/packages/ember-metal/lib/enumerable_utils.js
+++ b/packages/ember-metal/lib/enumerable_utils.js
@@ -1,9 +1,9 @@
 import {
-  map,
-  forEach,
-  indexOf,
-  filter
-} from "ember-metal/array";
+  filter as _filter,
+  forEach as a_forEach,
+  indexOf as _indexOf,
+  map as _map
+} from 'ember-metal/array';
 
 var splice = Array.prototype.splice;
 
@@ -15,208 +15,219 @@ var splice = Array.prototype.splice;
  * @namespace Ember
  * @static
  * */
-var utils = {
-  /**
-   * Calls the map function on the passed object with a specified callback. This
-   * uses `Ember.ArrayPolyfill`'s-map method when necessary.
-   *
-   * @method map
-   * @param {Object} obj The object that should be mapped
-   * @param {Function} callback The callback to execute
-   * @param {Object} thisArg Value to use as this when executing *callback*
-   *
-   * @return {Array} An array of mapped values.
-   */
-  map: function(obj, callback, thisArg) {
-    return obj.map ? obj.map.call(obj, callback, thisArg) : map.call(obj, callback, thisArg);
-  },
 
-  /**
-   * Calls the forEach function on the passed object with a specified callback. This
-   * uses `Ember.ArrayPolyfill`'s-forEach method when necessary.
-   *
-   * @method forEach
-   * @param {Object} obj The object to call forEach on
-   * @param {Function} callback The callback to execute
-   * @param {Object} thisArg Value to use as this when executing *callback*
-   *
-   */
-  forEach: function(obj, callback, thisArg) {
-    return obj.forEach ? obj.forEach.call(obj, callback, thisArg) : forEach.call(obj, callback, thisArg);
-  },
+/**
+ * Calls the map function on the passed object with a specified callback. This
+ * uses `Ember.ArrayPolyfill`'s-map method when necessary.
+ *
+ * @method map
+ * @param {Object} obj The object that should be mapped
+ * @param {Function} callback The callback to execute
+ * @param {Object} thisArg Value to use as this when executing *callback*
+ *
+ * @return {Array} An array of mapped values.
+ */
+export function map(obj, callback, thisArg) {
+  return obj.map ? obj.map.call(obj, callback, thisArg) : _map.call(obj, callback, thisArg);
+}
 
-  /**
-   * Calls the filter function on the passed object with a specified callback. This
-   * uses `Ember.ArrayPolyfill`'s-filter method when necessary.
-   *
-   * @method filter
-   * @param {Object} obj The object to call filter on
-   * @param {Function} callback The callback to execute
-   * @param {Object} thisArg Value to use as this when executing *callback*
-   *
-   * @return {Array} An array containing the filtered values
-   * @since 1.4.0
-   */
-  filter: function(obj, callback, thisArg) {
-    return obj.filter ? obj.filter.call(obj, callback, thisArg) : filter.call(obj, callback, thisArg);
-  },
+/**
+ * Calls the forEach function on the passed object with a specified callback. This
+ * uses `Ember.ArrayPolyfill`'s-forEach method when necessary.
+ *
+ * @method forEach
+ * @param {Object} obj The object to call forEach on
+ * @param {Function} callback The callback to execute
+ * @param {Object} thisArg Value to use as this when executing *callback*
+ *
+ */
+export function forEach(obj, callback, thisArg) {
+  return obj.forEach ? obj.forEach.call(obj, callback, thisArg) : a_forEach.call(obj, callback, thisArg);
+}
 
-  /**
-   * Calls the indexOf function on the passed object with a specified callback. This
-   * uses `Ember.ArrayPolyfill`'s-indexOf method when necessary.
-   *
-   * @method indexOf
-   * @param {Object} obj The object to call indexOn on
-   * @param {Function} callback The callback to execute
-   * @param {Object} index The index to start searching from
-   *
-   */
-  indexOf: function(obj, element, index) {
-    return obj.indexOf ? obj.indexOf.call(obj, element, index) : indexOf.call(obj, element, index);
-  },
+/**
+ * Calls the filter function on the passed object with a specified callback. This
+ * uses `Ember.ArrayPolyfill`'s-filter method when necessary.
+ *
+ * @method filter
+ * @param {Object} obj The object to call filter on
+ * @param {Function} callback The callback to execute
+ * @param {Object} thisArg Value to use as this when executing *callback*
+ *
+ * @return {Array} An array containing the filtered values
+ * @since 1.4.0
+ */
+export function filter(obj, callback, thisArg) {
+  return obj.filter ? obj.filter.call(obj, callback, thisArg) : _filter.call(obj, callback, thisArg);
+}
 
-  /**
-   * Returns an array of indexes of the first occurrences of the passed elements
-   * on the passed object.
-   *
-   * ```javascript
-   *  var array = [1, 2, 3, 4, 5];
-   *  Ember.EnumerableUtils.indexesOf(array, [2, 5]); // [1, 4]
-   *
-   *  var fubar = "Fubarr";
-   *  Ember.EnumerableUtils.indexesOf(fubar, ['b', 'r']); // [2, 4]
-   * ```
-   *
-   * @method indexesOf
-   * @param {Object} obj The object to check for element indexes
-   * @param {Array} elements The elements to search for on *obj*
-   *
-   * @return {Array} An array of indexes.
-   *
-   */
-  indexesOf: function(obj, elements) {
-    return elements === undefined ? [] : utils.map(elements, function(item) {
-      return utils.indexOf(obj, item);
-    });
-  },
+/**
+ * Calls the indexOf function on the passed object with a specified callback. This
+ * uses `Ember.ArrayPolyfill`'s-indexOf method when necessary.
+ *
+ * @method indexOf
+ * @param {Object} obj The object to call indexOn on
+ * @param {Function} callback The callback to execute
+ * @param {Object} index The index to start searching from
+ *
+ */
+export function indexOf(obj, element, index) {
+  return obj.indexOf ? obj.indexOf.call(obj, element, index) : _indexOf.call(obj, element, index);
+}
 
-  /**
-   * Adds an object to an array. If the array already includes the object this
-   * method has no effect.
-   *
-   * @method addObject
-   * @param {Array} array The array the passed item should be added to
-   * @param {Object} item The item to add to the passed array
-   *
-   * @return 'undefined'
-   */
-  addObject: function(array, item) {
-    var index = utils.indexOf(array, item);
-    if (index === -1) { array.push(item); }
-  },
+/**
+ * Returns an array of indexes of the first occurrences of the passed elements
+ * on the passed object.
+ *
+ * ```javascript
+ *  var array = [1, 2, 3, 4, 5];
+ *  Ember.EnumerableUtils.indexesOf(array, [2, 5]); // [1, 4]
+ *
+ *  var fubar = "Fubarr";
+ *  Ember.EnumerableUtils.indexesOf(fubar, ['b', 'r']); // [2, 4]
+ * ```
+ *
+ * @method indexesOf
+ * @param {Object} obj The object to check for element indexes
+ * @param {Array} elements The elements to search for on *obj*
+ *
+ * @return {Array} An array of indexes.
+ *
+ */
+export function indexesOf(obj, elements) {
+  return elements === undefined ? [] : map(elements, function(item) {
+    return indexOf(obj, item);
+  });
+}
 
-  /**
-   * Removes an object from an array. If the array does not contain the passed
-   * object this method has no effect.
-   *
-   * @method removeObject
-   * @param {Array} array The array to remove the item from.
-   * @param {Object} item The item to remove from the passed array.
-   *
-   * @return 'undefined'
-   */
-  removeObject: function(array, item) {
-    var index = utils.indexOf(array, item);
-    if (index !== -1) { array.splice(index, 1); }
-  },
+/**
+ * Adds an object to an array. If the array already includes the object this
+ * method has no effect.
+ *
+ * @method addObject
+ * @param {Array} array The array the passed item should be added to
+ * @param {Object} item The item to add to the passed array
+ *
+ * @return 'undefined'
+ */
+export function addObject(array, item) {
+  var index = indexOf(array, item);
+  if (index === -1) { array.push(item); }
+}
 
-  _replace: function(array, idx, amt, objects) {
-    var args = [].concat(objects), chunk, ret = [],
-        // https://code.google.com/p/chromium/issues/detail?id=56588
-        size = 60000, start = idx, ends = amt, count;
+/**
+ * Removes an object from an array. If the array does not contain the passed
+ * object this method has no effect.
+ *
+ * @method removeObject
+ * @param {Array} array The array to remove the item from.
+ * @param {Object} item The item to remove from the passed array.
+ *
+ * @return 'undefined'
+ */
+export function removeObject(array, item) {
+  var index = indexOf(array, item);
+  if (index !== -1) { array.splice(index, 1); }
+}
 
-    while (args.length) {
-      count = ends > size ? size : ends;
-      if (count <= 0) { count = 0; }
+export function _replace(array, idx, amt, objects) {
+  var args = [].concat(objects), chunk, ret = [],
+      // https://code.google.com/p/chromium/issues/detail?id=56588
+      size = 60000, start = idx, ends = amt, count;
 
-      chunk = args.splice(0, size);
-      chunk = [start, count].concat(chunk);
+  while (args.length) {
+    count = ends > size ? size : ends;
+    if (count <= 0) { count = 0; }
 
-      start += size;
-      ends -= count;
+    chunk = args.splice(0, size);
+    chunk = [start, count].concat(chunk);
 
-      ret = ret.concat(splice.apply(array, chunk));
-    }
-    return ret;
-  },
+    start += size;
+    ends -= count;
 
-  /**
-   * Replaces objects in an array with the passed objects.
-   *
-   * ```javascript
-   *   var array = [1,2,3];
-   *   Ember.EnumerableUtils.replace(array, 1, 2, [4, 5]); // [1, 4, 5]
-   *
-   *   var array = [1,2,3];
-   *   Ember.EnumerableUtils.replace(array, 1, 1, [4, 5]); // [1, 4, 5, 3]
-   *
-   *   var array = [1,2,3];
-   *   Ember.EnumerableUtils.replace(array, 10, 1, [4, 5]); // [1, 2, 3, 4, 5]
-   * ```
-   *
-   * @method replace
-   * @param {Array} array The array the objects should be inserted into.
-   * @param {Number} idx Starting index in the array to replace. If *idx* >=
-   * length, then append to the end of the array.
-   * @param {Number} amt Number of elements that should be removed from the array,
-   * starting at *idx*
-   * @param {Array} objects An array of zero or more objects that should be
-   * inserted into the array at *idx*
-   *
-   * @return {Array} The modified array.
-   */
-  replace: function(array, idx, amt, objects) {
-    if (array.replace) {
-      return array.replace(idx, amt, objects);
-    } else {
-      return utils._replace(array, idx, amt, objects);
-    }
-  },
-
-  /**
-   * Calculates the intersection of two arrays. This method returns a new array
-   * filled with the records that the two passed arrays share with each other.
-   * If there is no intersection, an empty array will be returned.
-   *
-   * ```javascript
-   * var array1 = [1, 2, 3, 4, 5];
-   * var array2 = [1, 3, 5, 6, 7];
-   *
-   * Ember.EnumerableUtils.intersection(array1, array2); // [1, 3, 5]
-   *
-   * var array1 = [1, 2, 3];
-   * var array2 = [4, 5, 6];
-   *
-   * Ember.EnumerableUtils.intersection(array1, array2); // []
-   * ```
-   *
-   * @method intersection
-   * @param {Array} array1 The first array
-   * @param {Array} array2 The second array
-   *
-   * @return {Array} The intersection of the two passed arrays.
-   */
-  intersection: function(array1, array2) {
-    var intersection = [];
-
-    utils.forEach(array1, function(element) {
-      if (utils.indexOf(array2, element) >= 0) {
-        intersection.push(element);
-      }
-    });
-
-    return intersection;
+    ret = ret.concat(splice.apply(array, chunk));
   }
-};
+  return ret;
+}
 
-export default utils;
+/**
+ * Replaces objects in an array with the passed objects.
+ *
+ * ```javascript
+ *   var array = [1,2,3];
+ *   Ember.EnumerableUtils.replace(array, 1, 2, [4, 5]); // [1, 4, 5]
+ *
+ *   var array = [1,2,3];
+ *   Ember.EnumerableUtils.replace(array, 1, 1, [4, 5]); // [1, 4, 5, 3]
+ *
+ *   var array = [1,2,3];
+ *   Ember.EnumerableUtils.replace(array, 10, 1, [4, 5]); // [1, 2, 3, 4, 5]
+ * ```
+ *
+ * @method replace
+ * @param {Array} array The array the objects should be inserted into.
+ * @param {Number} idx Starting index in the array to replace. If *idx* >=
+ * length, then append to the end of the array.
+ * @param {Number} amt Number of elements that should be removed from the array,
+ * starting at *idx*
+ * @param {Array} objects An array of zero or more objects that should be
+ * inserted into the array at *idx*
+ *
+ * @return {Array} The modified array.
+ */
+export function replace(array, idx, amt, objects) {
+  if (array.replace) {
+    return array.replace(idx, amt, objects);
+  } else {
+    return _replace(array, idx, amt, objects);
+  }
+}
+
+/**
+ * Calculates the intersection of two arrays. This method returns a new array
+ * filled with the records that the two passed arrays share with each other.
+ * If there is no intersection, an empty array will be returned.
+ *
+ * ```javascript
+ * var array1 = [1, 2, 3, 4, 5];
+ * var array2 = [1, 3, 5, 6, 7];
+ *
+ * Ember.EnumerableUtils.intersection(array1, array2); // [1, 3, 5]
+ *
+ * var array1 = [1, 2, 3];
+ * var array2 = [4, 5, 6];
+ *
+ * Ember.EnumerableUtils.intersection(array1, array2); // []
+ * ```
+ *
+ * @method intersection
+ * @param {Array} array1 The first array
+ * @param {Array} array2 The second array
+ *
+ * @return {Array} The intersection of the two passed arrays.
+ */
+export function intersection(array1, array2) {
+  var result = [];
+  forEach(array1, function(element) {
+    if (indexOf(array2, element) >= 0) {
+      result.push(element);
+    }
+  });
+
+  return result;
+}
+
+// TODO: this only exists to maintain the existing api, as we move forward it
+// should only be part of the "global build" via some shim
+export default {
+  _replace: _replace,
+  addObject: addObject,
+  filter: filter,
+  forEach: forEach,
+  indexOf: indexOf,
+  indexesOf: indexesOf,
+  intersection: intersection,
+  map: map,
+  removeObject: removeObject,
+  replace: replace
+};

--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -1,12 +1,11 @@
 import EmberError from 'ember-metal/error';
-import EnumerableUtils from 'ember-metal/enumerable_utils';
+import { forEach } from 'ember-metal/enumerable_utils';
 
 /**
   @module ember-metal
   */
 
-var forEach = EnumerableUtils.forEach,
-  BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
+var BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
 
 /**
   Expands `pattern`, invoking `callback` for each expansion.

--- a/packages/ember-metal/lib/libraries.js
+++ b/packages/ember-metal/lib/libraries.js
@@ -1,8 +1,8 @@
 // Provides a way to register library versions with ember.
-import EnumerableUtils from "ember-metal/enumerable_utils";
-
-var forEach = EnumerableUtils.forEach,
-    indexOf = EnumerableUtils.indexOf;
+import {
+  forEach,
+  indexOf
+} from "ember-metal/enumerable_utils";
 
 var libraries = function() {
   var _libraries   = [];

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -18,7 +18,7 @@ import {
   addObserver,
   addBeforeObserver
 } from "ember-metal/observer";
-import EnumerableUtils from 'ember-metal/enumerable_utils';
+import { indexOf } from 'ember-metal/enumerable_utils';
 
 var originalLookup = Ember.lookup, lookup;
 var obj, count, Global;
@@ -605,7 +605,7 @@ test('adding a computed property should show up in key iteration',function() {
 
   var found = [];
   for(var key in obj) found.push(key);
-  ok(EnumerableUtils.indexOf(found, 'foo')>=0, 'should find computed property in iteration found='+found);
+  ok(indexOf(found, 'foo')>=0, 'should find computed property in iteration found=' + found);
   ok('foo' in obj, 'foo in obj should pass');
 });
 

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember-metal/core';
 import testBoth from 'ember-metal/tests/props_helper';
-import EnumerableUtils from 'ember-metal/enumerable_utils';
+import { indexOf } from 'ember-metal/enumerable_utils';
 import { addListener } from "ember-metal/events";
 import {
   watch,
@@ -10,7 +10,6 @@ import {
 
 var willCount, didCount,
     willKeys, didKeys,
-    indexOf = EnumerableUtils.indexOf,
     originalLookup, lookup, Global;
 
 QUnit.module('watch', {

--- a/packages/ember-routing-handlebars/lib/helpers/render.js
+++ b/packages/ember-routing-handlebars/lib/helpers/render.js
@@ -5,8 +5,8 @@ import { set } from "ember-metal/property_set";
 import { camelize } from "ember-runtime/system/string";
 import {
   generateControllerFactory,
-  generateController
-} from "ember-routing/system/controller_for";
+  default as generateController
+} from "ember-routing/system/generate_controller";
 import { handlebarsGet } from "ember-handlebars/ext";
 import { viewHelper } from "ember-handlebars/helpers/view";
 

--- a/packages/ember-routing-handlebars/lib/helpers/shared.js
+++ b/packages/ember-routing-handlebars/lib/helpers/shared.js
@@ -1,8 +1,11 @@
-import {get} from "ember-metal/property_get";
-import {map} from "ember-metal/array";
-import {ControllerMixin} from "ember-runtime/controllers/controller";
-import {resolveParams as handlebarsResolve, handlebarsGet} from "ember-handlebars/ext";
-import {typeOf} from 'ember-metal/utils';
+import { get } from "ember-metal/property_get";
+import { map } from "ember-metal/array";
+import ControllerMixin from "ember-runtime/mixins/controller";
+import {
+  resolveParams as handlebarsResolve,
+  handlebarsGet
+} from "ember-handlebars/ext";
+import { typeOf } from 'ember-metal/utils';
 import { get } from "ember-metal/property_get";
 
 export function routeArgs(targetRouteName, models, queryParams) {
@@ -61,8 +64,7 @@ export function stashParamNames(router, handlerInfos) {
   handlerInfos._namesStashed = true;
 }
 
-export { resolvePaths };
-function resolvePaths(context, params, options) {
+export function resolvePaths(context, params, options) {
   var resolved = handlebarsResolve(context, params, options),
       types = options.types;
 

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -5,7 +5,7 @@ import EventDispatcher from "ember-views/system/event_dispatcher";
 
 import Container from "ember-runtime/system/container";
 import EmberObject from "ember-runtime/system/object";
-import { Controller as EmberController } from "ember-runtime/controllers/controller";
+import { default as EmberController } from "ember-runtime/controllers/controller";
 import EmberObjectController from "ember-runtime/controllers/object_controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 

--- a/packages/ember-routing-handlebars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/outlet_test.js
@@ -9,7 +9,7 @@ import {
   decamelize,
   classify
 } from "ember-runtime/system/string";
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 

--- a/packages/ember-routing-handlebars/tests/helpers/render_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/render_test.js
@@ -12,7 +12,7 @@ import {
   decamelize
 } from "ember-runtime/system/string";
 
-import { Controller as EmberController } from "ember-runtime/controllers/controller";
+import { default as EmberController } from "ember-runtime/controllers/controller";
 import EmberObjectController from "ember-runtime/controllers/object_controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -5,10 +5,9 @@ import { computed } from "ember-metal/computed";
 import { typeOf } from "ember-metal/utils";
 import { meta } from "ember-metal/utils";
 import merge from "ember-metal/merge";
-import EnumerableUtils from "ember-metal/enumerable_utils";
-var map = EnumerableUtils.map;
+import { map } from "ember-metal/enumerable_utils";
 
-import { ControllerMixin } from "ember-runtime/controllers/controller";
+import ControllerMixin from "ember-runtime/mixins/controller";
 
 /**
 @module ember

--- a/packages/ember-routing/lib/system/cache.js
+++ b/packages/ember-routing/lib/system/cache.js
@@ -1,6 +1,6 @@
 import EmberObject from "ember-runtime/system/object";
 
-var Cache = EmberObject.extend({
+export default EmberObject.extend({
   init: function() {
     this.cache = {};
   },
@@ -28,6 +28,3 @@ var Cache = EmberObject.extend({
   },
   cache: null
 });
-
-export default Cache;
-

--- a/packages/ember-routing/lib/system/controller_for.js
+++ b/packages/ember-routing/lib/system/controller_for.js
@@ -1,7 +1,3 @@
-import Ember from "ember-metal/core"; // Logger
-import { get } from "ember-metal/property_get";
-import { isArray } from "ember-metal/utils";
-
 /**
 @module ember
 @submodule ember-routing
@@ -15,75 +11,6 @@ import { isArray } from "ember-metal/utils";
   @method controllerFor
   @private
 */
-export function controllerFor(container, controllerName, lookupOptions) {
+export default function controllerFor(container, controllerName, lookupOptions) {
   return container.lookup('controller:' + controllerName, lookupOptions);
-}
-
-/**
-  Generates a controller factory
-
-  The type of the generated controller factory is derived
-  from the context. If the context is an array an array controller
-  is generated, if an object, an object controller otherwise, a basic
-  controller is generated.
-
-  You can customize your generated controllers by defining
-  `App.ObjectController` or `App.ArrayController`.
-
-  @for Ember
-  @method generateControllerFactory
-  @private
-*/
-
-export { generateControllerFactory };
-function generateControllerFactory(container, controllerName, context) {
-  var Factory, fullName, instance, name, factoryName, controllerType;
-
-  if (context && isArray(context)) {
-    controllerType = 'array';
-  } else if (context) {
-    controllerType = 'object';
-  } else {
-    controllerType = 'basic';
-  }
-
-  factoryName = 'controller:' + controllerType;
-
-  Factory = container.lookupFactory(factoryName).extend({
-    isGenerated: true,
-    toString: function() {
-      return "(generated " + controllerName + " controller)";
-    }
-  });
-
-  fullName = 'controller:' + controllerName;
-
-  container.register(fullName,  Factory);
-
-  return Factory;
-}
-
-/**
-  Generates and instantiates a controller.
-
-  The type of the generated controller factory is derived
-  from the context. If the context is an array an array controller
-  is generated, if an object, an object controller otherwise, a basic
-  controller is generated.
-
-  @for Ember
-  @method generateController
-  @private
-  @since 1.3.0
-*/
-export function generateController(container, controllerName, context) {
-  generateControllerFactory(container, controllerName, context);
-  var fullName = 'controller:' + controllerName;
-  var instance = container.lookup(fullName);
-
-  if (get(instance, 'namespace.LOG_ACTIVE_GENERATION')) {
-    Ember.Logger.info("generated -> " + fullName, { fullName: fullName });
-  }
-
-  return instance;
 }

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -1,0 +1,76 @@
+import Ember from "ember-metal/core"; // Logger
+import { get } from "ember-metal/property_get";
+import { isArray } from "ember-metal/utils";
+
+/**
+@module ember
+@submodule ember-routing
+*/
+
+/**
+  Generates a controller factory
+
+  The type of the generated controller factory is derived
+  from the context. If the context is an array an array controller
+  is generated, if an object, an object controller otherwise, a basic
+  controller is generated.
+
+  You can customize your generated controllers by defining
+  `App.ObjectController` or `App.ArrayController`.
+
+  @for Ember
+  @method generateControllerFactory
+  @private
+*/
+
+export function generateControllerFactory(container, controllerName, context) {
+  var Factory, fullName, instance, name, factoryName, controllerType;
+
+  if (context && isArray(context)) {
+    controllerType = 'array';
+  } else if (context) {
+    controllerType = 'object';
+  } else {
+    controllerType = 'basic';
+  }
+
+  factoryName = 'controller:' + controllerType;
+
+  Factory = container.lookupFactory(factoryName).extend({
+    isGenerated: true,
+    toString: function() {
+      return "(generated " + controllerName + " controller)";
+    }
+  });
+
+  fullName = 'controller:' + controllerName;
+
+  container.register(fullName,  Factory);
+
+  return Factory;
+}
+
+/**
+  Generates and instantiates a controller.
+
+  The type of the generated controller factory is derived
+  from the context. If the context is an array an array controller
+  is generated, if an object, an object controller otherwise, a basic
+  controller is generated.
+
+  @for Ember
+  @method generateController
+  @private
+  @since 1.3.0
+*/
+export default function generateController(container, controllerName, context) {
+  generateControllerFactory(container, controllerName, context);
+  var fullName = 'controller:' + controllerName;
+  var instance = container.lookup(fullName);
+
+  if (get(instance, 'namespace.LOG_ACTIVE_GENERATION')) {
+    Ember.Logger.info("generated -> " + fullName, { fullName: fullName });
+  }
+
+  return instance;
+}

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -3,11 +3,17 @@ import EmberError from "ember-metal/error";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import getProperties from "ember-metal/get_properties";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import {
+  forEach,
+  replace
+}from "ember-metal/enumerable_utils";
 import { isNone } from "ember-metal/is_none";
 import { computed } from "ember-metal/computed";
 import merge from "ember-metal/merge";
-import { isArray, typeOf } from "ember-metal/utils";
+import {
+  isArray,
+  typeOf
+} from "ember-metal/utils";
 import run from "ember-metal/run_loop";
 import keys from "ember-runtime/keys";
 import copy from "ember-runtime/copy";
@@ -17,18 +23,13 @@ import {
 } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import ActionHandler from "ember-runtime/mixins/action_handler";
-import { generateController } from "ember-routing/system/controller_for";
+import generateController from "ember-routing/system/generate_controller";
 import { stashParamNames } from "ember-routing-handlebars/helpers/shared";
 
 /**
 @module ember
 @submodule ember-routing
 */
-
-var a_forEach = EnumerableUtils.forEach;
-var a_replace = EnumerableUtils.replace;
-var a_find    = EnumerableUtils.find;
-
 
 /**
   The `Ember.Route` class is used to define individual routes. Refer to
@@ -408,7 +409,7 @@ var Route = EmberObject.extend(ActionHandler, {
           transition.method('replace');
         }
 
-        a_forEach(qpMeta.qps, function(qp) {
+        forEach(qpMeta.qps, function(qp) {
           var routeQpMeta = get(qp.route, '_qp');
           var finalizedController = qp.route.controller;
           finalizedController._qpDelegate = get(routeQpMeta, 'states.active');
@@ -1467,7 +1468,7 @@ var Route = EmberObject.extend(ActionHandler, {
 
     // Tear down any outlets rendered with 'into'
     var teardownOutletViews = this.teardownOutletViews || [];
-    a_forEach(teardownOutletViews, function(teardownOutletView) {
+    forEach(teardownOutletViews, function(teardownOutletView) {
       teardownOutletView();
     });
 
@@ -1841,7 +1842,7 @@ function appendView(route, view, options) {
     var parentView = route.router._lookupActiveView(options.into);
     var teardownOutletView = generateOutletTeardown(parentView, options.outlet);
     if (!route.teardownOutletViews) { route.teardownOutletViews = []; }
-    a_replace(route.teardownOutletViews, 0, 0, [teardownOutletView]);
+    replace(route.teardownOutletViews, 0, 0, [teardownOutletView]);
     parentView.connectOutlet(options.outlet, view);
   } else {
     var rootElement = get(route, 'router.namespace.rootElement');

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -2,12 +2,11 @@ import Ember from "ember-metal/core"; // FEATURES, Logger, K, assert
 import EmberError from "ember-metal/error";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import { forEach } from "ember-metal/array";
 import { defineProperty } from "ember-metal/properties";
 import { computed } from "ember-metal/computed";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 
 import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
@@ -15,8 +14,12 @@ import Evented from "ember-runtime/mixins/evented";
 import EmberRouterDSL from "ember-routing/system/dsl";
 import EmberView from "ember-views/views/view";
 import EmberLocation from "ember-routing/location/api";
-import { _MetamorphView } from "ember-handlebars/views/metamorph_view";
-import { routeArgs, getActiveTargetName, stashParamNames } from "ember-routing-handlebars/helpers/shared";
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
+import {
+  routeArgs,
+  getActiveTargetName,
+  stashParamNames
+} from "ember-routing-handlebars/helpers/shared";
 
 // requireModule("ember-handlebars");
 // requireModule("ember-runtime");
@@ -35,11 +38,7 @@ import { routeArgs, getActiveTargetName, stashParamNames } from "ember-routing-h
 var Router = requireModule("router")['default'];
 var Transition = requireModule("router/transition").Transition;
 
-var slice = Array.prototype.slice;
-var forEach = EnumerableUtils.forEach;
-var map = EnumerableUtils.map;
-
-var DefaultView = _MetamorphView;
+var slice = [].slice;
 
 /**
   The `Ember.Router` class manages the application state and URLs. Refer to
@@ -124,7 +123,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     this._setupRouter(router, location);
 
-    container.register('view:default', DefaultView);
+    container.register('view:default', _MetamorphView);
     container.register('view:toplevel', EmberView.extend());
 
     location.onUpdateURL(function(url) {

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -6,13 +6,11 @@ import run from "ember-metal/run_loop";
 import Container from 'container/container';
 import Namespace from "ember-runtime/system/namespace";
 import { classify } from "ember-runtime/system/string";
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
-import {
-  controllerFor,
-  generateController
-} from "ember-routing/system/controller_for";
+import controllerFor from "ember-routing/system/controller_for";
+import generateController from "ember-routing/system/generate_controller";
 
 var buildContainer = function(namespace) {
   var container = new Container();

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -1,14 +1,13 @@
 import run from "ember-metal/run_loop";
 import copy from "ember-runtime/copy";
 import merge from "ember-metal/merge";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { map } from "ember-metal/enumerable_utils";
 import Container from 'container/container';
 import HashLocation from "ember-routing/location/hash_location";
 import AutoLocation from "ember-routing/location/auto_location";
 import EmberRouter from "ember-routing/system/router";
 
-var map = EnumerableUtils.map,
-    container, Router, router;
+var container, Router, router;
 
 function createRouter(overrides) {
   var opts = merge({ container: container }, overrides);

--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -3,14 +3,12 @@ import {
   reduceComputed,
   ReduceComputedProperty
 } from "ember-runtime/computed/reduce_computed";
-import EnumerableUtils from "ember-metal/enumerable_utils";
-import { create } from "ember-metal/platform";
+import { forEach } from "ember-metal/enumerable_utils";
+import { create as o_create } from "ember-metal/platform";
 import { addObserver } from "ember-metal/observer";
 import EmberError from "ember-metal/error";
 
 var a_slice = [].slice;
-var o_create = create;
-var forEach = EnumerableUtils.forEach;
 
 function ArrayComputedProperty() {
   var cp = this;

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -22,8 +22,8 @@ import {
   ComputedProperty,
   cacheFor
 } from "ember-metal/computed";
-import { create } from "ember-metal/platform";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { create as o_create } from "ember-metal/platform";
+import { forEach } from "ember-metal/enumerable_utils";
 import TrackedArray from "ember-runtime/system/tracked_array";
 import EmberArray from "ember-runtime/mixins/array";
 import run from "ember-metal/run_loop";
@@ -34,8 +34,6 @@ var cacheSet = cacheFor.set;
 var cacheGet = cacheFor.get;
 var cacheRemove = cacheFor.remove;
 var a_slice = [].slice;
-var o_create = create;
-var forEach = EnumerableUtils.forEach;
 // Here we explicitly don't allow `@each.foo`; it would require some special
 // testing, but there's no particular reason why it should be disallowed.
 var eachPropertyPattern = /^(.*)\.@each\.(.*)/;

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -12,7 +12,9 @@ import {
   guidFor
 } from "ember-metal/utils";
 import EmberError from "ember-metal/error";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import {
+  forEach
+} from "ember-metal/enumerable_utils";
 import run from 'ember-metal/run_loop';
 import { addObserver } from "ember-metal/observer";
 import { arrayComputed } from "ember-runtime/computed/array_computed";
@@ -23,8 +25,6 @@ import keys from "ember-runtime/keys";
 import compare from "ember-runtime/compare";
 
 var a_slice = [].slice;
-var forEach = EnumerableUtils.forEach;
-var SearchProxy;
 
 /**
  A computed property that returns the sum of the value
@@ -439,7 +439,7 @@ export var union = uniq;
 */
 export function intersect() {
   var getDependentKeyGuids = function (changeMeta) {
-    return EnumerableUtils.map(changeMeta.property._dependentKeys, function (dependentKey) {
+    return map(changeMeta.property._dependentKeys, function (dependentKey) {
       return guidFor(dependentKey);
     });
   };

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -6,15 +6,16 @@
 import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import {
+  forEach,
+  replace
+} from "ember-metal/enumerable_utils";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import SortableMixin from "ember-runtime/mixins/sortable";
-import { ControllerMixin } from "ember-runtime/controllers/controller";
-import {computed} from "ember-metal/computed";
+import ControllerMixin from "ember-runtime/mixins/controller";
+import { computed } from "ember-metal/computed";
 import EmberError from "ember-metal/error";
 
-var forEach = EnumerableUtils.forEach;
-var replace = EnumerableUtils.replace;
 
 /**
   `Ember.ArrayController` provides a way for you to publish a collection of

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -1,10 +1,5 @@
-import Ember from "ember-metal/core"; // Ember.assert, Ember.deprecate
-import { get } from "ember-metal/property_get";
-import EmberObject from "ember-runtime/system/object";
-import { Mixin } from "ember-metal/mixin";
-import { computed } from "ember-metal/computed";
-import ActionHandler from "ember-runtime/mixins/action_handler";
-import ControllerContentModelAliasDeprecation from "ember-runtime/mixins/controller_content_model_alias_deprecation";
+import EmberObject from 'ember-runtime/system/object';
+import Mixin from 'ember-runtime/mixins/controller';
 
 /**
 @module ember
@@ -12,69 +7,9 @@ import ControllerContentModelAliasDeprecation from "ember-runtime/mixins/control
 */
 
 /**
-  `Ember.ControllerMixin` provides a standard interface for all classes that
-  compose Ember's controller layer: `Ember.Controller`,
-  `Ember.ArrayController`, and `Ember.ObjectController`.
-
-  @class ControllerMixin
-  @namespace Ember
-  @uses Ember.ActionHandler
-*/
-var ControllerMixin = Mixin.create(ActionHandler, ControllerContentModelAliasDeprecation, {
-  /* ducktype as a controller */
-  isController: true,
-
-  /**
-    The object to which actions from the view should be sent.
-
-    For example, when a Handlebars template uses the `{{action}}` helper,
-    it will attempt to send the action to the view's controller's `target`.
-
-    By default, the value of the target property is set to the router, and
-    is injected when a controller is instantiated. This injection is defined
-    in Ember.Application#buildContainer, and is applied as part of the
-    applications initialization process. It can also be set after a controller
-    has been instantiated, for instance when using the render helper in a
-    template, or when a controller is used as an `itemController`. In most
-    cases the `target` property will automatically be set to the logical
-    consumer of actions for the controller.
-
-    @property target
-    @default null
-  */
-  target: null,
-
-  container: null,
-
-  parentController: null,
-
-  store: null,
-
-  model: null,
-  content: computed.alias('model'),
-
-  deprecatedSendHandles: function(actionName) {
-    return !!this[actionName];
-  },
-
-  deprecatedSend: function(actionName) {
-    var args = [].slice.call(arguments, 1);
-    Ember.assert('' + this + " has the action " + actionName + " but it is not a function", typeof this[actionName] === 'function');
-    Ember.deprecate('Action handlers implemented directly on controllers are deprecated in favor of action handlers on an `actions` object ( action: `' + actionName + '` on ' + this + ')', false);
-    this[actionName].apply(this, args);
-    return;
-  }
-});
-
-/**
   @class Controller
   @namespace Ember
   @extends Ember.Object
   @uses Ember.ControllerMixin
 */
-export var Controller = EmberObject.extend(ControllerMixin);
-// TODO: export default
-export {
-  ControllerMixin
-};
-
+export default EmberObject.extend(Mixin);

--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -1,4 +1,4 @@
-import { ControllerMixin } from "ember-runtime/controllers/controller";
+import ControllerMixin from "ember-runtime/mixins/controller";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 
 /**

--- a/packages/ember-runtime/lib/copy.js
+++ b/packages/ember-runtime/lib/copy.js
@@ -1,10 +1,8 @@
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { indexOf } from "ember-metal/enumerable_utils";
 import { typeOf } from "ember-metal/utils";
 import EmberObject from "ember-runtime/system/object";
 import Copyable from "ember-runtime/mixins/copyable";
 import { create } from "ember-metal/platform";
-
-var indexOf = EnumerableUtils.indexOf;
 
 function _copy(obj, deep, seen, copies) {
   var ret, loc, key;
@@ -66,7 +64,7 @@ function _copy(obj, deep, seen, copies) {
 */
 export default function copy(obj, deep) {
   // fast paths
-  if ('object' !== typeof obj || obj===null) return obj; // can't copy primitives
+  if ('object' !== typeof obj || obj === null) return obj; // can't copy primitives
   if (Copyable && Copyable.detect(obj)) return obj.copy(deep);
   return _copy(obj, deep, deep ? [] : null, deep ? [] : null);
 }

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -22,18 +22,29 @@ import Application from "ember-runtime/system/application";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 import CoreObject from "ember-runtime/system/core_object";
-import {EachArray, EachProxy} from "ember-runtime/system/each_proxy";
+import {
+  EachArray,
+  EachProxy
+} from "ember-runtime/system/each_proxy";
+
 import NativeArray from "ember-runtime/system/native_array";
 import Set from "ember-runtime/system/set";
 import EmberStringUtils from "ember-runtime/system/string";
 import Deferred from "ember-runtime/system/deferred";
-import {onLoad, runLoadHooks} from "ember-runtime/system/lazy_load";
+import {
+  onLoad,
+  runLoadHooks
+} from "ember-runtime/system/lazy_load";
 
 import EmberArray from "ember-runtime/mixins/array";
 import Comparable from "ember-runtime/mixins/comparable";
 import Copyable from "ember-runtime/mixins/copyable";
 import Enumerable from "ember-runtime/mixins/enumerable";
-import { Freezable, FROZEN_ERROR } from "ember-runtime/mixins/freezable";
+import {
+  Freezable,
+  FROZEN_ERROR
+} from "ember-runtime/mixins/freezable";
+
 import Observable from "ember-runtime/mixins/observable";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import DeferredMixin from "ember-runtime/mixins/deferred";
@@ -43,15 +54,16 @@ import TargetActionSupport from "ember-runtime/mixins/target_action_support";
 import Evented from "ember-runtime/mixins/evented";
 import PromiseProxyMixin from "ember-runtime/mixins/promise_proxy";
 import SortableMixin from "ember-runtime/mixins/sortable";
-
 import {
   arrayComputed,
   ArrayComputedProperty
 } from "ember-runtime/computed/array_computed";
+
 import {
   reduceComputed,
   ReduceComputedProperty
 } from "ember-runtime/computed/reduce_computed";
+
 import {
   sum,
   min,
@@ -71,10 +83,8 @@ import {
 
 import ArrayController from "ember-runtime/controllers/array_controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
-import {
-  Controller,
-  ControllerMixin
-} from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
+import ControllerMixin from "ember-runtime/mixins/controller";
 
 import RSVP from "ember-runtime/ext/rsvp";     // just for side effect of extending Ember.RSVP
 import "ember-runtime/ext/string";   // just for side effect of extending String.prototype

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -19,7 +19,7 @@ import {
   none
 } from 'ember-metal/is_none';
 import Enumerable from "ember-runtime/mixins/enumerable";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { map } from "ember-metal/enumerable_utils";
 import {
   Mixin,
   required
@@ -35,8 +35,6 @@ import {
   hasListeners
 } from "ember-metal/events";
 import { isWatching } from "ember-metal/watching";
-
-var map = EnumerableUtils.map;
 
 // ..........................................................
 // ARRAY

--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -1,0 +1,64 @@
+import Ember from "ember-metal/core"; // Ember.assert, Ember.deprecate
+import { get } from "ember-metal/property_get";
+import EmberObject from "ember-runtime/system/object";
+import { Mixin } from "ember-metal/mixin";
+import { computed } from "ember-metal/computed";
+import ActionHandler from "ember-runtime/mixins/action_handler";
+import ControllerContentModelAliasDeprecation from "ember-runtime/mixins/controller_content_model_alias_deprecation";
+
+/**
+  `Ember.ControllerMixin` provides a standard interface for all classes that
+  compose Ember's controller layer: `Ember.Controller`,
+  `Ember.ArrayController`, and `Ember.ObjectController`.
+
+  @class ControllerMixin
+  @namespace Ember
+  @uses Ember.ActionHandler
+*/
+export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecation, {
+  /* ducktype as a controller */
+  isController: true,
+
+  /**
+    The object to which actions from the view should be sent.
+
+    For example, when a Handlebars template uses the `{{action}}` helper,
+    it will attempt to send the action to the view's controller's `target`.
+
+    By default, the value of the target property is set to the router, and
+    is injected when a controller is instantiated. This injection is defined
+    in Ember.Application#buildContainer, and is applied as part of the
+    applications initialization process. It can also be set after a controller
+    has been instantiated, for instance when using the render helper in a
+    template, or when a controller is used as an `itemController`. In most
+    cases the `target` property will automatically be set to the logical
+    consumer of actions for the controller.
+
+    @property target
+    @default null
+  */
+  target: null,
+
+  container: null,
+
+  parentController: null,
+
+  store: null,
+
+  model: null,
+  content: computed.alias('model'),
+
+  deprecatedSendHandles: function(actionName) {
+    return !!this[actionName];
+  },
+
+  deprecatedSend: function(actionName) {
+    var args = [].slice.call(arguments, 1);
+    Ember.assert('' + this + " has the action " + actionName + " but it is not a function", typeof this[actionName] === 'function');
+    Ember.deprecate('Action handlers implemented directly on controllers are deprecated in favor of action handlers on an `actions` object ( action: `' + actionName + '` on ' + this + ')', false);
+    this[actionName].apply(this, args);
+    return;
+  }
+});
+
+

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -16,7 +16,7 @@ import {
   required,
   aliasMethod
 } from "ember-metal/mixin";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { indexOf } from "ember-metal/enumerable_utils";
 import { computed } from "ember-metal/computed";
 import {
   propertyWillChange,
@@ -31,7 +31,6 @@ import {
 import compare from "ember-runtime/compare";
 
 var a_slice = Array.prototype.slice;
-var a_indexOf = EnumerableUtils.indexOf;
 
 var contexts = [];
 
@@ -51,7 +50,8 @@ function iter(key, value) {
     var cur = get(item, key);
     return valueProvided ? value===cur : !!cur;
   }
-  return i ;
+
+  return i;
 }
 
 /**
@@ -149,15 +149,15 @@ export default Mixin.create({
     @property firstObject
     @return {Object} the object or undefined
   */
-  firstObject: computed(function() {
+  firstObject: computed('[]', function() {
     if (get(this, 'length')===0) return undefined ;
 
     // handle generic enumerables
     var context = popCtx(), ret;
     ret = this.nextObject(0, null, context);
     pushCtx(context);
-    return ret ;
-  }).property('[]'),
+    return ret;
+  }),
 
   /**
     Helper method returns the last object from a collection. If your enumerable
@@ -175,7 +175,7 @@ export default Mixin.create({
     @property lastObject
     @return {Object} the last object or undefined
   */
-  lastObject: computed(function() {
+  lastObject: computed('[]', function() {
     var len = get(this, 'length');
     if (len===0) return undefined ;
     var context = popCtx(), idx=0, cur, last = null;
@@ -185,7 +185,7 @@ export default Mixin.create({
     } while (cur !== undefined);
     pushCtx(context);
     return last;
-  }).property('[]'),
+  }),
 
   /**
     Returns `true` if the passed object can be found in the receiver. The
@@ -232,7 +232,7 @@ export default Mixin.create({
     @return {Object} receiver
   */
   forEach: function(callback, target) {
-    if (typeof callback !== "function") throw new TypeError() ;
+    if (typeof callback !== 'function') throw new TypeError() ;
     var len = get(this, 'length'), last = null, context = popCtx();
 
     if (target === undefined) target = null;
@@ -862,7 +862,7 @@ export default Mixin.create({
   uniq: function() {
     var ret = Ember.A();
     this.forEach(function(k) {
-      if (a_indexOf(ret, k)<0) ret.push(k);
+      if (indexOf(ret, k)<0) ret.push(k);
     });
     return ret;
   },

--- a/packages/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -1,4 +1,4 @@
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 import Enumerable from "ember-runtime/mixins/enumerable";
 import {Mixin, required} from "ember-metal/mixin";
 import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_events";
@@ -7,8 +7,6 @@ import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_eve
 @module ember
 @submodule ember-runtime
 */
-
-var forEach = EnumerableUtils.forEach;
 
 /**
   This mixin defines the API for modifying generic enumerables. These methods

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -7,7 +7,7 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.A
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 import { Mixin } from "ember-metal/mixin";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";
 import compare from "ember-runtime/compare";
@@ -20,8 +20,6 @@ import {
   beforeObserver,
   observer
 } from "ember-metal/mixin"; //ES6TODO: should we access these directly from their package or from how thier exposed in ember-metal?
-
-var forEach = EnumerableUtils.forEach;
 
 /**
   `Ember.SortableMixin` provides a standard interface for array proxies

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -14,7 +14,7 @@ import {
   guidFor,
   apply
 } from "ember-metal/utils";
-import { create } from "ember-metal/platform";
+import { create as o_create } from "ember-metal/platform";
 import {
   generateGuid,
   GUID_KEY,
@@ -30,7 +30,7 @@ import {
   Mixin,
   required
 } from "ember-metal/mixin";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { indexOf } from "ember-metal/enumerable_utils";
 import EmberError from "ember-metal/error";
 import { platform } from "ember-metal/platform";
 import keys from "ember-runtime/keys";
@@ -41,15 +41,15 @@ import { ComputedProperty } from "ember-metal/computed";
 import run from 'ember-metal/run_loop';
 import { destroy } from "ember-metal/watching";
 
-var o_create = create;
+import {
+  K
+} from 'ember-metal/core';
 var o_defineProperty = platform.defineProperty;
 var schedule = run.schedule;
 var applyMixin = Mixin._apply;
 var finishPartial = Mixin.finishPartial;
 var reopen = Mixin.prototype.reopen;
 var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
-var indexOf = EnumerableUtils.indexOf;
-var K = Ember.K;
 
 var undefinedDescriptor = {
   configurable: true,
@@ -767,7 +767,6 @@ var ClassMixin = Mixin.create({
       }
     }
   }
-
 });
 
 ClassMixin.ownerConstructor = CoreObject;

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -8,7 +8,7 @@ import Ember from "ember-metal/core"; // Ember.assert
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { guidFor } from "ember-metal/utils";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 import { indexOf } from "ember-metal/array";
 import EmberArray from "ember-runtime/mixins/array"; // ES6TODO: WAT? Circular dep?
 import EmberObject from "ember-runtime/system/object";
@@ -29,8 +29,6 @@ import {
   endPropertyChanges,
   changeProperties
 } from "ember-metal/property_events";
-
-var forEach = EnumerableUtils.forEach;
 
 var EachArray = EmberObject.extend(EmberArray, {
 
@@ -221,7 +219,6 @@ var EachProxy = EmberObject.extend({
   contentKeyDidChange: function(obj, keyName) {
     propertyDidChange(this, keyName);
   }
-
 });
 
 export {

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -7,7 +7,10 @@ import Ember from "ember-metal/core"; // Ember.EXTEND_PROTOTYPES
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import {
+  _replace as replace,
+  forEach
+} from "ember-metal/enumerable_utils";
 import { Mixin } from "ember-metal/mixin";
 import EmberArray from "ember-runtime/mixins/array";
 import MutableArray from "ember-runtime/mixins/mutable_array";
@@ -15,9 +18,6 @@ import Observable from "ember-runtime/mixins/observable";
 import Copyable from "ember-runtime/mixins/copyable";
 import { FROZEN_ERROR } from "ember-runtime/mixins/freezable";
 import copy from "ember-runtime/copy";
-
-var replace = EnumerableUtils._replace;
-var forEach = EnumerableUtils.forEach;
 
 // Add Ember.Array to Array.prototype. Remove methods with native
 // implementations and supply some more optimized versions of generic methods

--- a/packages/ember-runtime/lib/system/tracked_array.js
+++ b/packages/ember-runtime/lib/system/tracked_array.js
@@ -1,7 +1,6 @@
-import {get} from "ember-metal/property_get";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { get } from "ember-metal/property_get";
+import { forEach } from "ember-metal/enumerable_utils";
 
-var forEach = EnumerableUtils.forEach;
 var RETAIN = 'r';
 var INSERT = 'i';
 var DELETE = 'd';

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -3,27 +3,32 @@ import EnumerableUtils from 'ember-metal/enumerable_utils';
 import EmberObject from 'ember-runtime/system/object';
 import setProperties from "ember-metal/set_properties";
 import ObjectProxy from 'ember-runtime/system/object_proxy';
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
-import {computed} from 'ember-metal/computed';
-import {addObserver} from "ember-metal/observer";
-import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_events";
-import {forEach} from "ember-metal/array";
-import {observer} from 'ember-metal/mixin';
-import {sum as computedSum,
-        min as computedMin,
-        max as computedMax,
-        map as computedMap,
-        sort as computedSort,
-        setDiff as computedSetDiff,
-        mapBy as computedMapBy,
-        mapProperty,
-        filter as computedFilter,
-        filterBy as computedFilterBy,
-        uniq as computedUniq,
-        union as computedUnion,
-        intersect as computedIntersect} from 'ember-runtime/computed/reduce_computed_macros';
+import { computed } from 'ember-metal/computed';
+import { addObserver } from "ember-metal/observer";
+import {
+  beginPropertyChanges,
+  endPropertyChanges
+} from "ember-metal/property_events";
+import { forEach } from "ember-metal/array";
+import { observer } from 'ember-metal/mixin';
+import {
+  sum as computedSum,
+  min as computedMin,
+  max as computedMax,
+  map as computedMap,
+  sort as computedSort,
+  setDiff as computedSetDiff,
+  mapBy as computedMapBy,
+  mapProperty,
+  filter as computedFilter,
+  filterBy as computedFilterBy,
+  uniq as computedUniq,
+  union as computedUnion,
+  intersect as computedIntersect
+} from 'ember-runtime/computed/reduce_computed_macros';
 
 import NativeArray from "ember-runtime/system/native_array";
 

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -1,21 +1,25 @@
 import Ember from 'ember-metal/core';
-import EnumerableUtils from 'ember-metal/enumerable_utils';
-import {get, getWithDefault} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
-import {meta} from 'ember-metal/utils';
+import { map } from 'ember-metal/enumerable_utils';
+import {
+  get,
+  getWithDefault
+} from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { meta as metaFor } from 'ember-metal/utils';
 import run from 'ember-metal/run_loop';
-import {observer} from 'ember-metal/mixin';
+import { observer } from 'ember-metal/mixin';
 import keys from "ember-runtime/keys";
 import EmberObject from "ember-runtime/system/object";
-import {ComputedProperty, computed} from "ember-metal/computed";
-import {arrayComputed} from "ember-runtime/computed/array_computed";
-import {reduceComputed} from "ember-runtime/computed/reduce_computed";
+import {
+  ComputedProperty,
+  computed
+} from "ember-metal/computed";
+import { arrayComputed } from "ember-runtime/computed/array_computed";
+import { reduceComputed } from "ember-runtime/computed/reduce_computed";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import SubArray from "ember-runtime/system/subarray";
 
-var map = EnumerableUtils.map,
-    metaFor = meta,
-    obj, addCalls, removeCalls, callbackItems, shared;
+var obj, addCalls, removeCalls, callbackItems, shared;
 
 QUnit.module('arrayComputed', {
   setup: function () {

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
-import {Controller, ControllerMixin} from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
-import {Mixin} from "ember-metal/mixin";
+import Mixin from "ember-metal/mixin";
 
 QUnit.module('Controller event handling');
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -1,15 +1,16 @@
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
-import EnumerableUtils from 'ember-metal/enumerable_utils';
-import {computed} from 'ember-metal/computed';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { forEach } from 'ember-metal/enumerable_utils';
+import { computed } from 'ember-metal/computed';
 import run from 'ember-metal/run_loop';
-import {typeOf} from 'ember-metal/utils';
-import {observer} from 'ember-metal/mixin';
-import {fmt, w} from "ember-runtime/system/string";
+import { typeOf } from 'ember-metal/utils';
+import { observer } from 'ember-metal/mixin';
+import {
+  fmt,
+  w
+} from "ember-runtime/system/string";
 import EmberObject from 'ember-runtime/system/object';
 import Observable from 'ember-runtime/mixins/observable';
-
-var forEach = EnumerableUtils.forEach;
 
 /*
   NOTE: This test is adapted from the 1.x series of unit tests.  The tests

--- a/packages/ember-runtime/tests/mixins/action_handler_test.js
+++ b/packages/ember-runtime/tests/mixins/action_handler_test.js
@@ -1,5 +1,5 @@
 import run from "ember-metal/run_loop";
-import {Controller, ControllerMixin} from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 
 test("passing a function for the actions hash triggers an assertion", function() {
   expect(1);

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -1,15 +1,13 @@
 import Ember from 'ember-metal/core'; // for Ember.K and Ember.A
 import EnumerableTests from 'ember-runtime/tests/suites/enumerable';
-import EnumerableUtils from 'ember-metal/enumerable_utils';
+import { indexOf } from 'ember-metal/enumerable_utils';
 import EmberObject from 'ember-runtime/system/object';
 import Enumerable from 'ember-runtime/mixins/enumerable';
 import EmberArray from 'ember-runtime/mixins/array';
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
-import {computed} from 'ember-metal/computed';
-import {observer as emberObserver} from 'ember-metal/mixin';
-
-var indexOf = EnumerableUtils.indexOf;
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { computed } from 'ember-metal/computed';
+import { observer as emberObserver } from 'ember-metal/mixin';
 
 /*
   Implement a basic fake enumerable.  This validates that any non-native

--- a/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
@@ -1,12 +1,10 @@
 import MutableEnumerableTests from 'ember-runtime/tests/suites/mutable_enumerable';
 import MutableEnumerable from 'ember-runtime/mixins/mutable_enumerable';
-import EnumerableUtils from 'ember-metal/enumerable_utils';
+import { indexOf } from 'ember-metal/enumerable_utils';
 import EmberObject from 'ember-runtime/system/object';
-import {computed} from 'ember-metal/computed';
-import {get} from 'ember-metal/property_get';
-import {set} from 'ember-metal/property_set';
-
-var indexOf = EnumerableUtils.indexOf;
+import { computed } from 'ember-metal/computed';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 
 /*
   Implement a basic fake mutable array.  This validates that any non-native

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -1,7 +1,7 @@
-import {computed} from "ember-metal/computed";
-import {addObserver} from "ember-metal/observer";
+import { computed } from "ember-metal/computed";
+import { addObserver } from "ember-metal/observer";
 import EmberObject from 'ember-runtime/system/object';
-import {testBoth} from 'ember-runtime/tests/props_helper';
+import { testBoth } from 'ember-runtime/tests/props_helper';
 
 QUnit.module('mixins/observable');
 

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -1,10 +1,11 @@
 import EmberObject from "ember-runtime/system/object";
-import {required} from "ember-metal/mixin";
-import {guidFor, generateGuid} from "ember-metal/utils";
-import {get} from "ember-metal/property_get";
-import EnumerableUtils from "ember-metal/enumerable_utils";
-
-var forEach = EnumerableUtils.forEach;
+import { required } from "ember-metal/mixin";
+import {
+  guidFor,
+  generateGuid
+} from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
+import { forEach } from "ember-metal/enumerable_utils";
 
 /**
   @class

--- a/packages/ember-runtime/tests/system/subarray_test.js
+++ b/packages/ember-runtime/tests/system/subarray_test.js
@@ -1,7 +1,7 @@
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 import SubArray from "ember-runtime/system/subarray";
 
-var forEach = EnumerableUtils.forEach, subarray;
+var subarray;
 
 QUnit.module('SubArray', {
   setup: function () {

--- a/packages/ember-runtime/tests/system/tracked_array_test.js
+++ b/packages/ember-runtime/tests/system/tracked_array_test.js
@@ -1,10 +1,10 @@
-import EnumerableUtils from 'ember-metal/enumerable_utils';
+import { forEach } from 'ember-metal/enumerable_utils';
 import TrackedArray from "ember-runtime/system/tracked_array";
 
-var forEach = EnumerableUtils.forEach, trackedArray,
-    RETAIN = TrackedArray.RETAIN,
-    INSERT = TrackedArray.INSERT,
-    DELETE = TrackedArray.DELETE;
+var trackedArray;
+var RETAIN = TrackedArray.RETAIN;
+var INSERT = TrackedArray.INSERT;
+var DELETE = TrackedArray.DELETE;
 
 QUnit.module('Ember.TrackedArray');
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -222,5 +222,8 @@ export default EmberObject.extend({
     var rootElement = get(this, 'rootElement');
     jQuery(rootElement).off('.ember', '**').removeClass('ember-application');
     return this._super();
+  },
+  toString: function() {
+    return '(EventDisptacher)';
   }
 });

--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -1,9 +1,8 @@
 import Ember from 'ember-metal/core'; // Ember.assert
-import {w} from "ember-runtime/system/string";
+import { w } from "ember-runtime/system/string";
 
 // ES6TODO: the functions on EnumerableUtils need their own exports
-import EnumerableUtils from "ember-metal/enumerable_utils";
-var forEach = EnumerableUtils.forEach;
+import { forEach } from "ember-metal/enumerable_utils";
 
 /**
 Ember Views

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -15,9 +15,7 @@ import {
 
 import EmberError from "ember-metal/error";
 
-// ES6TODO: functions on EnumerableUtils should get their own export
-import EnumerableUtils from "ember-metal/enumerable_utils";
-var forEach = EnumerableUtils.forEach;
+import { forEach } from "ember-metal/enumerable_utils";
 
 import { computed } from "ember-metal/computed";
 import run from "ember-metal/run_loop";

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -31,10 +31,11 @@ import { A as emberA } from "ember-runtime/system/native_array";
 import { dasherize } from "ember-runtime/system/string";
 
 // ES6TODO: functions on EnumerableUtils should get their own export
-import EnumerableUtils from "ember-metal/enumerable_utils";
-var a_forEach = EnumerableUtils.forEach,
-    a_addObject = EnumerableUtils.addObject,
-    a_removeObject = EnumerableUtils.removeObject;
+import {
+  forEach,
+  addObject,
+  removeObject
+} from "ember-metal/enumerable_utils";
 
 import { beforeObserver } from "ember-metal/mixin";
 import copy from "ember-runtime/copy";
@@ -70,7 +71,7 @@ function clearCachedElement(view) {
 var childViewsProperty = computed(function() {
   var childViews = this._childViews, ret = emberA(), view = this;
 
-  a_forEach(childViews, function(view) {
+  forEach(childViews, function(view) {
     var currentChildViews;
     if (view.isVirtual) {
       if (currentChildViews = get(view, 'childViews')) {
@@ -1130,7 +1131,7 @@ var View = CoreView.extend({
     // Loop through all of the configured bindings. These will be either
     // property names ('isUrgent') or property paths relative to the view
     // ('content.isUrgent')
-    a_forEach(classBindings, function(binding) {
+    forEach(classBindings, function(binding) {
 
       Ember.assert("classNameBindings must not have spaces in them. Multiple class name bindings can be provided as elements of an array, e.g. ['foo', ':bar']", binding.indexOf(' ') === -1);
 
@@ -1172,7 +1173,7 @@ var View = CoreView.extend({
       if (dasherizedClass) {
         // Ensure that it gets into the classNames array
         // so it is displayed when we render.
-        a_addObject(classNames, dasherizedClass);
+        addObject(classNames, dasherizedClass);
 
         // Save a reference to the class name so we can remove it
         // if the observer fires. Remember that this variable has
@@ -1207,7 +1208,7 @@ var View = CoreView.extend({
     var attributeValue,
         unspecifiedAttributeBindings = this._unspecifiedAttributeBindings = this._unspecifiedAttributeBindings || {};
 
-    a_forEach(attributeBindings, function(binding) {
+    forEach(attributeBindings, function(binding) {
       var split = binding.split(':'),
           property = split[0],
           attributeName = split[1] || property;
@@ -1894,7 +1895,7 @@ var View = CoreView.extend({
     // remove view from childViews array.
     var childViews = this._childViews;
 
-    a_removeObject(childViews, view);
+    removeObject(childViews, view);
 
     this.propertyDidChange('childViews'); // HUH?! what happened to will change?
 

--- a/packages/ember-views/lib/views/view_collection.js
+++ b/packages/ember-views/lib/views/view_collection.js
@@ -1,10 +1,9 @@
-import EnumerableUtils from "ember-metal/enumerable_utils";
-var a_forEach = EnumerableUtils.forEach;
+import { forEach } from "ember-metal/enumerable_utils";
 
-var ViewCollection = function(initialViews) {
+function ViewCollection(initialViews) {
   var views = this.views = initialViews || [];
   this.length = views.length;
-};
+}
 
 ViewCollection.prototype = {
   length: 0,
@@ -52,7 +51,7 @@ ViewCollection.prototype = {
 
   forEach: function(callback) {
     var views = this.views;
-    return a_forEach(views, callback);
+    return forEach(views, callback);
   },
 
   clear: function() {

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core"; // Ember.A
 import { set } from "ember-metal/property_set";
 import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { forEach } from "ember-metal/enumerable_utils";
 import { Mixin } from "ember-metal/mixin";
 import { fmt } from "ember-runtime/system/string";
 import ArrayProxy from "ember-runtime/system/array_proxy";
@@ -11,7 +11,6 @@ import jQuery from "ember-views/system/jquery";
 import CollectionView from "ember-views/views/collection_view";
 import View from "ember-views/views/view";
 
-var forEach = EnumerableUtils.forEach;
 var trim = jQuery.trim;
 var view;
 

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -2,7 +2,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import { computed } from "ember-metal/computed";
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import jQuery from "ember-views/system/jquery";
 import View from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";

--- a/packages/ember-views/tests/views/view/actions_test.js
+++ b/packages/ember-views/tests/views/view/actions_test.js
@@ -3,7 +3,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import { Mixin } from "ember-metal/mixin";
-import { Controller } from "ember-runtime/controllers/controller";
+import Controller from "ember-runtime/controllers/controller";
 import EmberObject from "ember-runtime/system/object";
 import View from "ember-views/views/view";
 

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -1,12 +1,10 @@
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
-import EnumerableUtils from "ember-metal/enumerable_utils";
+import { indexOf } from "ember-metal/enumerable_utils";
 import jQuery from "ember-views/system/jquery";
 import View from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
-
-var indexOf = EnumerableUtils.indexOf;
 
 // .......................................................
 // removeChild()

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1,10 +1,10 @@
 import "ember";
+import { forEach } from "ember-metal/enumerable_utils";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
 
 var Router, App, AppView, templates, router, container;
-var get = Ember.get,
-    set = Ember.set,
-    compile = Ember.Handlebars.compile,
-    forEach = Ember.EnumerableUtils.forEach;
+var compile = Ember.Handlebars.compile;
 
 function bootApplication() {
   router = container.lookup('router:main');

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,11 +1,13 @@
 import "ember";
+import {
+  forEach,
+  map
+}  from "ember-metal/enumerable_utils";
 
 var Router, App, AppView, templates, router, container;
-var get = Ember.get,
-    set = Ember.set,
-    compile = Ember.Handlebars.compile,
-    forEach = Ember.EnumerableUtils.forEach,
-    map = Ember.EnumerableUtils.map;
+var get = Ember.get;
+var set = Ember.set;
+var compile = Ember.Handlebars.compile;
 
 function bootApplication() {
   router = container.lookup('router:main');


### PR DESCRIPTION
I need some mindless work, doing some further ES6 cleanup.

This also, begins to fix some issues @eventualbuddha uncovered during his recent v2 transpile process.

goals: 
- to stop doing things that break when using a proper es6 build
- slowly unwind quickfix hacks
- prefer granular import/exports , as the new transpiler + uglifer can better optimize.
- migrate global specific work-arounds to global shim files

some examples:
## example: diverging bindings

this is an issue when dealing with cycles.

bad: (diverges bindings)

``` js
import { foo } from 'bar';

var otherFoo = foo;
```

foo: (if the rename is actually needed)

``` js
import { foo as otherFoo } from 'bar';
```
## example: closure compiler dead code remove friendly:

bad: closure compile wont drop, bar if foo is used, or foo if bar is used

``` js
export default {
  foo: function() { },
  bar: function() { }
}
```

good: closure compile will drop whats not used correctly.

``` js
export function foo() { }
export function bar() { }
```
