### PR TITLE
[BUGFIX] Fix issue where bad params are passed to arrayWillChange on Col...

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -290,7 +290,7 @@ var CollectionView = ContainerView.extend({
 
     @method arrayWillChange
     @param {Array} content the managed collection of objects
-    @param {Number} start the index at which the changes will occurr
+    @param {Number} start the index at which the changes will occur
     @param {Number} removed number of object to be removed from content
   */
   arrayWillChange: function(content, start, removedCount) {
@@ -307,6 +307,10 @@ var CollectionView = ContainerView.extend({
     var childViews = this._childViews, childView, idx, len;
 
     len = this._childViews.length;
+
+    if (removedCount > len) {
+      removedCount = len;
+    }
 
     var removingAll = removedCount === len;
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -750,3 +750,24 @@ test("should lookup from only global path against the container if emptyView is 
     return EmptyView;
   }
 });
+
+test("arrayWillChange can be given a removedCount greater than the length of the child views and not explode", function() {
+  var content = Ember.A(['foo', 'bar', 'baz']);
+
+  view = CollectionView.create({
+    content: content,
+    tagName: 'div',
+
+    itemViewClass: View.extend({
+      render: function(buf) {
+        buf.push(get(this, 'content'));
+      }
+    })
+  });
+
+  view.currentState.empty = function(self) { equal(view, self); };
+
+  run(function() {
+    view.arrayWillChange(content, 0, 42);
+  });
+});


### PR DESCRIPTION
[BUGFIX] Fix issue where bad params are passed to arrayWillChange on CollectionView.

There is an sporadic issue that comes up where when you modifying the underlying array for a collection view, you can generate an error like so:

![screen shot 2014-06-12 at 2 17 30 pm](https://cloud.githubusercontent.com/assets/325737/3265502/3edbb538-f293-11e3-87a1-ad5080e5134b.png)

The issue is arrayWillChange takes a param, _removedCount_, but never checks if that value is greater than the current number of child views the parent view contains. 

To test this, I added a console log to the arrayWillChange method, where I output the value of removedCount(the first number) and the length of the childViews array (the second number).

![screen shot 2014-06-12 at 5 38 58 pm](https://cloud.githubusercontent.com/assets/325737/3265511/73b810ee-f293-11e3-8d72-5eba487a1bce.png)

Notice the bottom line of this screen shot. The _removedCount_ is 7, but the length of the child views is 0. 
