### PR TITLE
[BUGFIX beta] Sortable nonempty

### DIFF
--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -152,7 +152,7 @@ export default Mixin.create(MutableEnumerable, {
     return this._super();
   },
 
-  isSorted: computed.bool('sortProperties'),
+  isSorted: computed.notEmpty('sortProperties'),
 
   /**
     Overrides the default arrangedContent from arrayProxy in order to sort by sortFunction.

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -42,6 +42,12 @@ test("if you do not specify `sortProperties` sortable have no effect", function(
 
   equal(sortedArrayController.get('length'), 4, 'array has 4 items');
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Chavard', 'a new object was inserted in the natural order');
+
+  sortedArrayController.set('sortProperties', []);
+  unsortedArray.pushObject({id: 5, name: 'Scumbag Jackson'});
+
+  equal(sortedArrayController.get('length'), 5, 'array has 5 items');
+  equal(sortedArrayController.objectAt(4).name, 'Scumbag Jackson', 'a new object was inserted in the natural order with empty array as sortProperties');
 });
 
 test("you can change sorted properties", function() {
@@ -227,7 +233,7 @@ test("addObject does not insert duplicates", function() {
   equal(sortedArrayProxy.get('length'), 1, 'array still has 1 item');
 });
 
-test("you can change a sort property and the content will rearrenge", function() {
+test("you can change a sort property and the content will rearrange", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'bryn is first');
 


### PR DESCRIPTION
SortableMixin should probably use computed.nonEmpty rather than computed.bool for the isSorted property. When sortProperties is set to an empty array, isSorted would evaluate to true, and arrangedContent would attempt to sort. orderBy returns 0, which in some browsers (Chrome with an array length > 22) leads to an unstable sort. 

See this fiddle:

http://jsfiddle.net/46fT8/7/

In Chrome (I'm on 35.0.1916.153), there are swaps (Chrome uses quicksort for arrays > 22). Firefox (I'm at 30.0) leaves the names in their natural order.

I would expect that when sortProperties is empty, no sorting should be taking place.
