### PR TITLE
Throw error if improperly defined factory

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -582,8 +582,10 @@ Container.prototype = {
     validateFullName(fullName);
 
     if (this.factoryCache.has(normalizedName)) {
-      throw new Error("Attempted to register a factoryInjection for a type that has already been looked up. ('" + normalizedName + "', '" + property + "', '" + injectionName + "')");
+      throw new Error('Attempted to register a factoryInjection for a type that has already ' +
+        'been looked up. (\'' + normalizedName + '\', \'' + property + '\', \'' + injectionName + '\')');
     }
+
     addInjection(this.factoryInjections, normalizedName, property, normalizedInjectionName);
   },
 
@@ -594,7 +596,7 @@ Container.prototype = {
     @method destroy
   */
   destroy: function() {
-    for (var i=0, l=this.children.length; i<l; i++) {
+    for (var i = 0, length = this.children.length; i < length; i++) {
       this.children[i].destroy();
     }
 
@@ -612,9 +614,10 @@ Container.prototype = {
     @method reset
   */
   reset: function() {
-    for (var i=0, l=this.children.length; i<l; i++) {
+    for (var i = 0, length = this.children.length; i < length; i++) {
       resetCache(this.children[i]);
     }
+
     resetCache(this);
   }
 };
@@ -646,7 +649,7 @@ function lookup(container, fullName, options) {
 }
 
 function illegalChildOperation(operation) {
-  throw new Error(operation + " is not currently supported on child containers");
+  throw new Error(operation + ' is not currently supported on child containers');
 }
 
 function isSingleton(container, fullName) {
@@ -662,7 +665,7 @@ function buildInjections(container, injections) {
 
   var injection, injectable;
 
-  for (var i=0, l=injections.length; i<l; i++) {
+  for (var i = 0, length = injections.length; i < length; i++) {
     injection = injections[i];
     injectable = lookup(container, injection.fullName);
 
@@ -683,7 +686,7 @@ function option(container, fullName, optionName) {
     return options[optionName];
   }
 
-  var type = fullName.split(":")[0];
+  var type = fullName.split(':')[0];
   options = container._typeOptions.get(type);
 
   if (options) {
@@ -696,7 +699,7 @@ function factoryFor(container, fullName) {
   var factory = container.resolve(name);
   var injectedFactory;
   var cache = container.factoryCache;
-  var type = fullName.split(":")[0];
+  var type = fullName.split(':')[0];
 
   if (factory === undefined) { return; }
 
@@ -709,8 +712,7 @@ function factoryFor(container, fullName) {
     // for now just fallback to create time injection
     return factory;
   } else {
-
-    var injections        = injectionsFor(container, fullName);
+    var injections = injectionsFor(container, fullName);
     var factoryInjections = factoryInjectionsFor(container, fullName);
 
     factoryInjections._toString = container.makeToString(factory, fullName);
@@ -725,7 +727,7 @@ function factoryFor(container, fullName) {
 }
 
 function injectionsFor(container, fullName) {
-  var splitName = fullName.split(":"),
+  var splitName = fullName.split(':'),
     type = splitName[0],
     injections = [];
 
@@ -740,7 +742,7 @@ function injectionsFor(container, fullName) {
 }
 
 function factoryInjectionsFor(container, fullName) {
-  var splitName = fullName.split(":"),
+  var splitName = fullName.split(':'),
     type = splitName[0],
     factoryInjections = [];
 
@@ -761,6 +763,11 @@ function instantiate(container, fullName) {
   }
 
   if (factory) {
+    if (typeof factory.create !== 'function') {
+      throw new Error('Failed to create an instance of \'' + fullName + '\'. ' +
+        'Most likely an improperly defined class or an invalid module export.');
+    }
+
     if (typeof factory.extend === 'function') {
       // assume the factory was extendable and is already injected
       return factory.create();

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -51,7 +51,7 @@ test("A registered factory is returned from lookupFactory is the same factory ea
   deepEqual(container.lookupFactory('controller:post'), container.lookupFactory('controller:post'), 'The return of lookupFactory is always the same');
 });
 
-test("A factory returned from lookupFactory has a debugkey", function(){
+test("A factory returned from lookupFactory has a debugkey", function() {
   var container = new Container();
   var PostController = factory();
   var instance;
@@ -63,7 +63,7 @@ test("A factory returned from lookupFactory has a debugkey", function(){
   equal(PostFactory._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
 });
 
-test("fallback for to create time injections if factory has no extend", function(){
+test("fallback for to create time injections if factory has no extend", function() {
   var container = new Container();
   var AppleController = factory();
   var PostController = factory();
@@ -278,6 +278,16 @@ test("A failed lookup returns undefined", function() {
   var container = new Container();
 
   equal(container.lookup('doesnot:exist'), undefined);
+});
+
+test("An invalid factory throws an error", function() {
+  var container = new Container();
+
+  container.register('controller:foo', {});
+
+  throws(function() {
+    container.lookup('controller:foo');
+  }, /Failed to create an instance of \'controller:foo\'/);
 });
 
 test("Injecting a failed lookup raises an error", function() {
@@ -542,7 +552,7 @@ test('container.has should not accidentally cause injections on that factory to 
   ok(container.has('controller:apple'));
 });
 
-test('once resolved, always return the same result', function(){
+test('once resolved, always return the same result', function() {
   expect(1);
 
   var container = new Container();
@@ -560,7 +570,7 @@ test('once resolved, always return the same result', function(){
   equal(container.resolve('models:bar'), Bar);
 });
 
-test('once looked up, assert if an injection is registered for the entry', function(){
+test('once looked up, assert if an injection is registered for the entry', function() {
   expect(1);
 
   var container = new Container(),


### PR DESCRIPTION
Basically throws a better error then something like:

``` js
Error while processing route: managedExercise.edit undefined is not a function TypeError: undefined is not a function
    at instantiate (http://localhost:3000/scripts/application.js:15865:26)
    at lookup (http://localhost:3000/scripts/application.js:15731:19)
    at Object.Container.lookup (http://localhost:3000/scripts/application.js:15400:16)
    at EmberObject.extend.controllerFor (http://localhost:3000/scripts/application.js:36957:32)
    at EmberObject.extend.setup (http://localhost:3000/scripts/application.js:36472:31
```

Which is usually an incorrect export of a class from a module, at least when working with browserify. The factory comes back as `{}` and doesn't have a `create`, so it dies.. since it's truthy.
