### PR TITLE
Cleanup non-stripped Query Params feature flag.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -842,19 +842,21 @@ function resemblesURL(str) {
 }
 
 function forEachQueryParam(router, targetRouteName, queryParams, callback) {
-  if (!Ember.FEATURES.isEnabled("query-params-new")) { return {}; }
+  if (Ember.FEATURES.isEnabled("query-params-new")) {
+    var qpCache = router._queryParamsFor(targetRouteName),
+    qps = qpCache.qps;
 
-  var qpCache = router._queryParamsFor(targetRouteName),
-      qps = qpCache.qps;
+    for (var key in queryParams) {
+      if (!queryParams.hasOwnProperty(key)) { continue; }
+      var value = queryParams[key],
+      qp = qpCache.map[key];
 
-  for (var key in queryParams) {
-    if (!queryParams.hasOwnProperty(key)) { continue; }
-    var value = queryParams[key],
-        qp = qpCache.map[key];
-
-    if (qp) {
-      callback(key, value, qp);
+      if (qp) {
+        callback(key, value, qp);
+      }
     }
+  } else {
+    return {};
   }
 }
 


### PR DESCRIPTION
Unfortunately, we can't do actual logic in our feature flags (or they don't get stripped out). This is somewhat important when we enable a feature by default, as the `FEATURE.isEnabled` check does not get stripped, but the `ENV` var is also likely not present, massive trolling ensues.

/cc @machty (for review/confirmation)
