### PR TITLE
[DOC] Refresh example for Ember.A()

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -142,12 +142,12 @@ if (ignore.length>0) {
   var Pagination = Ember.CollectionView.extend({
     tagName: 'ul',
     classNames: ['pagination'],
-    init: function() {
-      this._super();
+
+    defaultContent: function() {
       if (!this.get('content')) {
-        this.set('content', Ember.A([]));
+        this.set('content', Ember.A());
       }
-    }
+    }.on('init')
   });
   ```
 


### PR DESCRIPTION
`Ember.A([])` is redundant, so I've removed it from the example.

Also updated the function to not use `init` hook + `_super`, but to use a custom function with `on('init')`.
