### PR TITLE
exposed wrapMap on Ember._metamorphWrapMap

### DIFF
--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -80,10 +80,12 @@ import {
   SimpleHandlebarsView
 } from "ember-handlebars/views/handlebars_bound_view";
 import {
+  _wrapMap,
   _SimpleMetamorphView,
   _MetamorphView,
   _Metamorph
 } from "ember-handlebars/views/metamorph_view";
+
 
 /**
 Ember Handlebars
@@ -121,6 +123,7 @@ Ember._HandlebarsBoundView = _HandlebarsBoundView;
 Ember._SimpleMetamorphView = _SimpleMetamorphView;
 Ember._MetamorphView = _MetamorphView;
 Ember._Metamorph = _Metamorph;
+Ember._metamorphWrapMap = _wrapMap;
 Ember.TextSupport = TextSupport;
 Ember.Checkbox = Checkbox;
 Ember.Select = Select;

--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -119,6 +119,8 @@ export var _Metamorph = Mixin.create({
   domManager: DOMManager
 });
 
+export var _wrapMap = Metamorph._wrapMap;
+
 /**
   @class _MetamorphView
   @namespace Ember

--- a/packages/metamorph/lib/main.js
+++ b/packages/metamorph/lib/main.js
@@ -183,7 +183,7 @@ define("metamorph",
        * that as the key for the wrap map. In our case, we know the parent node, and
        * can use its type as the key for the wrap map.
        **/
-      var wrapMap = {
+      Metamorph._wrapMap = {
         select: [ 1, "<select multiple='multiple'>", "</select>" ],
         fieldset: [ 1, "<fieldset>", "</fieldset>" ],
         table: [ 1, "<table>", "</table>" ],
@@ -236,6 +236,7 @@ define("metamorph",
        * We need to do this because innerHTML in IE does not really parse the nodes.
        */
       var firstNodeFor = function(parentNode, html) {
+        var wrapMap = Metamorph._wrapMap;
         var arr = wrapMap[parentNode.tagName.toLowerCase()] || wrapMap._default;
         var depth = arr[0], start = arr[1], end = arr[2];
 


### PR DESCRIPTION
This was done to allow extensibility so Ember Handlebars can support SVG.

Issue #5021
