### PR TITLE
[DOC] Example fixes for Ember namespace (plus some)

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -23,8 +23,9 @@ Ember Debug
   ```javascript
   // Test for truthiness
   Ember.assert('Must pass a valid object', obj);
+
   // Fail unconditionally
-  Ember.assert('This code path should never be run')
+  Ember.assert('This code path should never be run');
   ```
 
   @method assert
@@ -61,7 +62,7 @@ Ember.warn = function(message, test) {
   `Ember.debug()` when doing a production build.
 
   ```javascript
-  Ember.debug("I'm a debug notice!");
+  Ember.debug('I\'m a debug notice!');
   ```
 
   @method debug
@@ -148,7 +149,7 @@ Ember.deprecateFunc = function(message, func) {
   Ember.runInDebug(function() {
     Ember.Handlebars.EachView.reopen({
       didInsertElement: function() {
-        console.log("I'm happy");
+        console.log('I\'m happy');
       }
     });
   });

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -48,9 +48,9 @@ var lengthPattern = /\.(length|\[\])$/;
 
 // data structure:
 //  meta.deps = {
-//   'depKey': {
-//     'keyName': count,
-//   }
+//    'depKey': {
+//      'keyName': count,
+//    }
 //  }
 
 /*
@@ -134,7 +134,7 @@ function removeDependentKeys(desc, obj, keyName, meta) {
   values.
 
   ```javascript
-  Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     // these will be supplied by `create`
     firstName: null,
     lastName: null,
@@ -161,8 +161,7 @@ function removeDependentKeys(desc, obj, keyName, meta) {
   third parameter.
 
   ```javascript
-
- Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     // these will be supplied by `create`
     firstName: null,
     lastName: null,
@@ -177,7 +176,7 @@ function removeDependentKeys(desc, obj, keyName, meta) {
 
       // setter
       } else {
-        var name = value.split(" ");
+        var name = value.split(' ');
 
         this.set('firstName', name[0]);
         this.set('lastName', name[1]);
@@ -188,9 +187,10 @@ function removeDependentKeys(desc, obj, keyName, meta) {
   });
 
   var person = Person.create();
+
   person.set('fullName', 'Peter Wagenet');
-  person.get('firstName') // 'Peter'
-  person.get('lastName') // 'Wagenet'
+  person.get('firstName'); // 'Peter'
+  person.get('lastName');  // 'Wagenet'
   ```
 
   @class ComputedProperty
@@ -239,7 +239,7 @@ ComputedPropertyPrototype.cacheable = function(aFlag) {
   mode the computed property will not automatically cache the return value.
 
   ```javascript
-  MyApp.outsideService = Ember.Object.extend({
+  var outsideService = Ember.Object.extend({
     value: function() {
       return OutsideService.getValue();
     }.property().volatile()
@@ -259,15 +259,15 @@ ComputedPropertyPrototype.volatile = function() {
   mode the computed property will throw an error when set.
 
   ```javascript
-  MyApp.Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     guid: function() {
       return 'guid-guid-guid';
     }.property().readOnly()
   });
 
-  MyApp.person = MyApp.Person.create();
+  var person = Person.create();
 
-  MyApp.person.set('guid', 'new-guid'); // will throw an exception
+  person.set('guid', 'new-guid'); // will throw an exception
   ```
 
   @method readOnly
@@ -284,7 +284,7 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
   arguments containing key paths that this computed property depends on.
 
   ```javascript
-  MyApp.President = Ember.Object.extend({
+  var President = Ember.Object.extend({
     fullName: computed(function() {
       return this.get('firstName') + ' ' + this.get('lastName');
 
@@ -293,12 +293,12 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
     }).property('firstName', 'lastName')
   });
 
-  MyApp.president = MyApp.President.create({
+  var president = President.create({
     firstName: 'Barack',
     lastName: 'Obama'
   });
 
-  MyApp.president.get('fullName'); // 'Barack Obama'
+  president.get('fullName'); // 'Barack Obama'
   ```
 
   @method property
@@ -382,10 +382,9 @@ function finishChains(chainNodes)
   Otherwise, call the function passing the property name as an argument.
 
   ```javascript
-  Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     fullName: function(keyName) {
       // the keyName parameter is 'fullName' in this case.
-
       return this.get('firstName') + ' ' + this.get('lastName');
     }.property('firstName', 'lastName')
   });
@@ -647,7 +646,9 @@ function registerComputedWithProperties(name, macro) {
     done: Ember.computed.empty('todos')
   });
 
-  var todoList = ToDoList.create({todos: ['Unit Test', 'Documentation', 'Release']});
+  var todoList = ToDoList.create({
+    todos: ['Unit Test', 'Documentation', 'Release']
+  });
 
   todoList.get('done'); // false
   todoList.get('todos').clear();
@@ -682,11 +683,11 @@ computed.empty = function (dependentKey) {
     hasStuff: Ember.computed.notEmpty('backpack.[]')
   });
 
-  var hamster = Hamster.create({backpack: ['Food', 'Sleeping Bag', 'Tent']});
+  var hamster = Hamster.create({ backpack: ['Food', 'Sleeping Bag', 'Tent'] });
 
-  hamster.get('hasStuff'); // true
+  hamster.get('hasStuff');         // true
   hamster.get('backpack').clear(); // []
-  hamster.get('hasStuff'); // false
+  hamster.get('hasStuff');         // false
   ```
 
   @method computed.notEmpty
@@ -1122,12 +1123,12 @@ registerComputedWithProperties('collect', function(properties) {
   though they were called on the original property.
 
   ```javascript
-  Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     name: 'Alex Matchneer',
     nomen: Ember.computed.alias('name')
   });
 
-  alex = Person.create();
+  var alex = Person.create();
 
   alex.get('nomen'); // 'Alex Matchneer'
   alex.get('name');  // 'Alex Matchneer'
@@ -1173,9 +1174,9 @@ computed.alias = function(dependentKey) {
     lastName:  'Zeenny'
   });
 
-  teddy.get('nickName'); // 'Teddy'
+  teddy.get('nickName');              // 'Teddy'
   teddy.set('nickName', 'TeddyBear'); // 'TeddyBear'
-  teddy.get('firstName'); // 'Teddy'
+  teddy.get('firstName');             // 'Teddy'
   ```
 
   @method computed.oneWay
@@ -1225,10 +1226,10 @@ if (Ember.FEATURES.isEnabled('query-params-new')) {
     lastName:  'Zeenny'
   });
 
-  teddy.get('nickName'); // 'Teddy'
+  teddy.get('nickName');              // 'Teddy'
   teddy.set('nickName', 'TeddyBear'); // throws Exception
   // throw new Ember.Error('Cannot Set: nickName on: <User:ember27288>' );`
-  teddy.get('firstName'); // 'Teddy'
+  teddy.get('firstName');             // 'Teddy'
   ```
 
   @method computed.readOnly
@@ -1255,12 +1256,12 @@ computed.readOnly = function(dependentKey) {
     wishList: Ember.computed.defaultTo('favoriteFood')
   });
 
-  var hamster = Hamster.create({favoriteFood: 'Banana'});
+  var hamster = Hamster.create({ favoriteFood: 'Banana' });
 
-  hamster.get('wishList'); // 'Banana'
+  hamster.get('wishList');                     // 'Banana'
   hamster.set('wishList', 'More Unit Tests');
-  hamster.get('wishList'); // 'More Unit Tests'
-  hamster.get('favoriteFood'); // 'Banana'
+  hamster.get('wishList');                     // 'More Unit Tests'
+  hamster.get('favoriteFood');                 // 'Banana'
   ```
 
   @method computed.defaultTo

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -387,12 +387,14 @@ export function listenersFor(obj, eventName) {
 
   ``` javascript
   var Job = Ember.Object.extend({
-    logCompleted: Ember.on('completed', function(){
+    logCompleted: Ember.on('completed', function() {
       console.log('Job completed!');
     })
   });
+
   var job = Job.create();
-  Ember.sendEvent(job, 'completed'); // Logs "Job completed!"
+
+  Ember.sendEvent(job, 'completed'); // Logs 'Job completed!'
  ```
 
   @method on

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -763,7 +763,6 @@ export function immediateObserver() {
 
   ```javascript
   App.PersonView = Ember.View.extend({
-
     friends: [{ name: 'Tom' }, { name: 'Stefan' }, { name: 'Kris' }],
 
     valueWillChange: Ember.beforeObserver('content.value', function(obj, keyName) {

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -7,11 +7,13 @@ import { set } from "ember-metal/property_set";
   observers will be buffered.
 
   ```javascript
+  var anObject = Ember.Object.create();
+
   anObject.setProperties({
-    firstName: "Stanley",
-    lastName: "Stuart",
-    age: "21"
-  })
+    firstName: 'Stanley',
+    lastName: 'Stuart',
+    age: 21
+  });
   ```
 
   @method setProperties

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -379,9 +379,9 @@ var EmberArray;
   not formally array but appears to be array-like (i.e. implements `Ember.Array`)
 
   ```javascript
-  Ember.isArray();                                            // false
-  Ember.isArray([]);                                          // true
-  Ember.isArray( Ember.ArrayProxy.create({ content: [] }) );  // true
+  Ember.isArray();                                          // false
+  Ember.isArray([]);                                        // true
+  Ember.isArray(Ember.ArrayProxy.create({ content: [] }));  // true
   ```
 
   @method isArray
@@ -416,13 +416,14 @@ function isArray(obj) {
   an array. If obj is `null` or `undefined`, returns an empty array.
 
   ```javascript
-  Ember.makeArray();                           // []
-  Ember.makeArray(null);                       // []
-  Ember.makeArray(undefined);                  // []
-  Ember.makeArray('lindsay');                  // ['lindsay']
-  Ember.makeArray([1,2,42]);                   // [1,2,42]
+  Ember.makeArray();            // []
+  Ember.makeArray(null);        // []
+  Ember.makeArray(undefined);   // []
+  Ember.makeArray('lindsay');   // ['lindsay']
+  Ember.makeArray([1, 2, 42]);  // [1, 2, 42]
 
   var controller = Ember.ArrayProxy.create({ content: [] });
+
   Ember.makeArray(controller) === controller;  // true
   ```
 
@@ -440,7 +441,8 @@ export function makeArray(obj) {
   Checks to see if the `methodName` exists on the `obj`.
 
   ```javascript
-  var foo = {bar: Ember.K, baz: null};
+  var foo = { bar: Ember.K, baz: null };
+
   Ember.canInvoke(foo, 'bar'); // true
   Ember.canInvoke(foo, 'baz'); // false
   Ember.canInvoke(foo, 'bat'); // false
@@ -462,8 +464,9 @@ function canInvoke(obj, methodName) {
 
   ```javascript
   var d = new Date('03/15/2013');
-  Ember.tryInvoke(d, 'getTime'); // 1363320000000
-  Ember.tryInvoke(d, 'setFullYear', [2014]); // 1394856000000
+
+  Ember.tryInvoke(d, 'getTime');              // 1363320000000
+  Ember.tryInvoke(d, 'setFullYear', [2014]);  // 1394856000000
   Ember.tryInvoke(d, 'noSuchMethod', [2014]); // undefined
   ```
 
@@ -495,7 +498,7 @@ var needsFinallyFix = (function() {
 })();
 
 /**
-  Provides try { } finally { } functionality, while working
+  Provides try/finally functionality, while working
   around Safari's double finally bug.
 
   ```javascript
@@ -503,9 +506,11 @@ var needsFinallyFix = (function() {
     someResource.lock();
     runCallback(); // May throw error.
   };
+
   var finalizer = function() {
     someResource.unlock();
   };
+
   Ember.tryFinally(tryable, finalizer);
   ```
 
@@ -557,12 +562,12 @@ if (needsFinallyFix) {
 }
 
 /**
-  Provides try { } catch finally { } functionality, while working
+  Provides try/catch/finally functionality, while working
   around Safari's double finally bug.
 
   ```javascript
   var tryable = function() {
-    for (i=0, l=listeners.length; i<l; i++) {
+    for (i = 0, l = listeners.length; i < l; i++) {
       listener = listeners[i];
       beforeValues[i] = listener.before(name, time(), payload);
     }
@@ -576,11 +581,12 @@ if (needsFinallyFix) {
   };
 
   var finalizer = function() {
-    for (i=0, l=listeners.length; i<l; i++) {
+    for (i = 0, l = listeners.length; i < l; i++) {
       listener = listeners[i];
       listener.after(name, time(), payload, beforeValues[i]);
     }
   };
+
   Ember.tryCatchFinally(tryable, catchable, finalizer);
   ```
 
@@ -685,15 +691,15 @@ var EmberObject;
   Ember.typeOf(true);                   // 'boolean'
   Ember.typeOf(new Boolean(true));      // 'boolean'
   Ember.typeOf(Ember.makeArray);        // 'function'
-  Ember.typeOf([1,2,90]);               // 'array'
+  Ember.typeOf([1, 2, 90]);             // 'array'
   Ember.typeOf(/abc/);                  // 'regexp'
   Ember.typeOf(new Date());             // 'date'
   Ember.typeOf(Ember.Object.extend());  // 'class'
   Ember.typeOf(Ember.Object.create());  // 'instance'
   Ember.typeOf(new Error('teamocil'));  // 'error'
 
-  // "normal" JavaScript object
-  Ember.typeOf({a: 'b'});              // 'object'
+  // 'normal' JavaScript object
+  Ember.typeOf({ a: 'b' });             // 'object'
   ```
 
   @method typeOf

--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -76,7 +76,7 @@ ArrayComputedProperty.prototype.didChange = function (obj, keyName) {
   The `initialize` function has the following signature:
 
   ```javascript
-   function (array, changeMeta, instanceMeta)
+  function(array, changeMeta, instanceMeta)
   ```
 
   `array` - The initial value of the arrayComputed, an empty array.
@@ -96,7 +96,7 @@ ArrayComputedProperty.prototype.didChange = function (obj, keyName) {
   The `removedItem` and `addedItem` functions both have the following signature:
 
   ```javascript
-  function (accumulatedValue, item, changeMeta, instanceMeta)
+  function(accumulatedValue, item, changeMeta, instanceMeta)
   ```
 
   `accumulatedValue` - The value returned from the last time

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -667,7 +667,7 @@ ReduceComputedProperty.prototype.property = function () {
   The `initialize` function has the following signature:
 
   ```javascript
-   function (initialValue, changeMeta, instanceMeta)
+  function(initialValue, changeMeta, instanceMeta)
   ```
 
   `initialValue` - The value of the `initialValue` property from the
@@ -688,7 +688,7 @@ ReduceComputedProperty.prototype.property = function () {
   The `removedItem` and `addedItem` functions both have the following signature:
 
   ```javascript
-  function (accumulatedValue, item, changeMeta, instanceMeta)
+  function(accumulatedValue, item, changeMeta, instanceMeta)
   ```
 
   `accumulatedValue` - The value returned from the last time
@@ -738,15 +738,15 @@ ReduceComputedProperty.prototype.property = function () {
   Example
 
   ```javascript
-  Ember.computed.max = function (dependentKey) {
+  Ember.computed.max = function(dependentKey) {
     return Ember.reduceComputed(dependentKey, {
       initialValue: -Infinity,
 
-      addedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+      addedItem: function(accumulatedValue, item, changeMeta, instanceMeta) {
         return Math.max(accumulatedValue, item);
       },
 
-      removedItem: function (accumulatedValue, item, changeMeta, instanceMeta) {
+      removedItem: function(accumulatedValue, item, changeMeta, instanceMeta) {
         if (item < accumulatedValue) {
           return accumulatedValue;
         }
@@ -780,10 +780,10 @@ ReduceComputedProperty.prototype.property = function () {
   });
 
   App.PersonController = Ember.ObjectController.extend({
-    reversedName: function () {
+    reversedName: function() {
       return reverse(get(this, 'name'));
     }.property('name')
-  })
+  });
   ```
 
   Dependent keys whose values are not arrays are treated as regular

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -57,12 +57,13 @@ export function sum(dependentKey){
   array is empty.
 
   ```javascript
-  App.Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     childAges: Ember.computed.mapBy('children', 'age'),
     maxChildAge: Ember.computed.max('childAges')
   });
 
-  var lordByron = App.Person.create({children: []});
+  var lordByron = Person.create({ children: [] });
+
   lordByron.get('maxChildAge'); // -Infinity
   lordByron.get('children').pushObject({
     name: 'Augusta Ada Byron', age: 7
@@ -105,12 +106,13 @@ export function max (dependentKey) {
   array is empty.
 
   ```javascript
-  App.Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     childAges: Ember.computed.mapBy('children', 'age'),
     minChildAge: Ember.computed.min('childAges')
   });
 
-  var lordByron = App.Person.create({children: []});
+  var lordByron = Person.create({ children: [] });
+
   lordByron.get('minChildAge'); // Infinity
   lordByron.get('children').pushObject({
     name: 'Augusta Ada Byron', age: 7
@@ -160,15 +162,16 @@ export function min(dependentKey) {
   Example
 
   ```javascript
-  App.Hamster = Ember.Object.extend({
+  var Hamster = Ember.Object.extend({
     excitingChores: Ember.computed.map('chores', function(chore) {
       return chore.toUpperCase() + '!';
     })
   });
 
-  var hamster = App.Hamster.create({
+  var hamster = Hamster.create({
     chores: ['clean', 'write more unit tests']
   });
+
   hamster.get('excitingChores'); // ['CLEAN!', 'WRITE MORE UNIT TESTS!']
   ```
 
@@ -198,13 +201,14 @@ export function map(dependentKey, callback) {
   Returns an array mapped to the specified key.
 
   ```javascript
-  App.Person = Ember.Object.extend({
+  var Person = Ember.Object.extend({
     childAges: Ember.computed.mapBy('children', 'age')
   });
 
-  var lordByron = App.Person.create({children: []});
+  var lordByron = Person.create({ children: [] });
+
   lordByron.get('childAges'); // []
-  lordByron.get('children').pushObject({name: 'Augusta Ada Byron', age: 7});
+  lordByron.get('children').pushObject({ name: 'Augusta Ada Byron', age: 7 });
   lordByron.get('childAges'); // [7]
   lordByron.get('children').pushObjects([{
     name: 'Allegra Byron',
@@ -247,17 +251,20 @@ export var mapProperty = mapBy;
   ```
 
   ```javascript
-  App.Hamster = Ember.Object.extend({
+  var Hamster = Ember.Object.extend({
     remainingChores: Ember.computed.filter('chores', function(chore) {
       return !chore.done;
     })
   });
 
-  var hamster = App.Hamster.create({chores: [
-    {name: 'cook', done: true},
-    {name: 'clean', done: true},
-    {name: 'write more unit tests', done: false}
-  ]});
+  var hamster = Hamster.create({ 
+    chores: [
+      { name: 'cook', done: true },
+      { name: 'clean', done: true },
+      { name: 'write more unit tests', done: false }
+    ] 
+  });
+
   hamster.get('remainingChores'); // [{name: 'write more unit tests', done: false}]
   ```
 
@@ -302,16 +309,19 @@ export function filter(dependentKey, callback) {
   Filters the array by the property and value
 
   ```javascript
-  App.Hamster = Ember.Object.extend({
+  var Hamster = Ember.Object.extend({
     remainingChores: Ember.computed.filterBy('chores', 'done', false)
   });
 
-  var hamster = App.Hamster.create({chores: [
-    {name: 'cook', done: true},
-    {name: 'clean', done: true},
-    {name: 'write more unit tests', done: false}
-  ]});
-  hamster.get('remainingChores'); // [{name: 'write more unit tests', done: false}]
+  var hamster = Hamster.create({
+    chores: [
+      { name: 'cook', done: true },
+      { name: 'clean', done: true },
+      { name: 'write more unit tests', done: false }
+    ]
+  });
+
+  hamster.get('remainingChores'); // [{ name: 'write more unit tests', done: false }]
   ```
 
   @method computed.filterBy
@@ -354,16 +364,19 @@ export var filterProperty = filterBy;
   Example
 
   ```javascript
-  App.Hamster = Ember.Object.extend({
+  var Hamster = Ember.Object.extend({
     uniqueFruits: Ember.computed.uniq('fruits')
   });
 
-  var hamster = App.Hamster.create({fruits: [
-    'banana',
-    'grape',
-    'kale',
-    'banana'
-  ]});
+  var hamster = Hamster.create({
+    fruits: [
+      'banana',
+      'grape',
+      'kale',
+      'banana'
+    ]
+  });
+
   hamster.get('uniqueFruits'); // ['banana', 'grape', 'kale']
   ```
 
@@ -499,15 +512,18 @@ export function intersect() {
   Example
 
   ```javascript
-  App.Hamster = Ember.Object.extend({
+  var Hamster = Ember.Object.extend({
     likes: ['banana', 'grape', 'kale'],
     wants: Ember.computed.setDiff('likes', 'fruits')
   });
 
-  var hamster = App.Hamster.create({fruits: [
-    'grape',
-    'kale',
-  ]});
+  var hamster = Hamster.create({
+    fruits: [
+      'grape',
+      'kale',
+    ]
+  });
+
   hamster.get('wants'); // ['banana']
   ```
 
@@ -639,18 +655,20 @@ var SearchProxy = ObjectProxy.extend();
       } else if (a.priority < b.priority) {
         return -1;
       }
+
       return 0;
     })
   });
+
   var todoList = ToDoList.create({todos: [
-    {name: 'Unit Test', priority: 2},
-    {name: 'Documentation', priority: 3},
-    {name: 'Release', priority: 1}
+    { name: 'Unit Test', priority: 2 },
+    { name: 'Documentation', priority: 3 },
+    { name: 'Release', priority: 1 }
   ]});
 
-  todoList.get('sortedTodos'); // [{name:'Documentation', priority:3}, {name:'Release', priority:1}, {name:'Unit Test', priority:2}]
-  todoList.get('sortedTodosDesc'); // [{name:'Unit Test', priority:2}, {name:'Release', priority:1}, {name:'Documentation', priority:3}]
-  todoList.get('priorityTodos'); // [{name:'Release', priority:1}, {name:'Unit Test', priority:2}, {name:'Documentation', priority:3}]
+  todoList.get('sortedTodos');      // [{ name:'Documentation', priority:3 }, { name:'Release', priority:1 }, { name:'Unit Test', priority:2 }]
+  todoList.get('sortedTodosDesc');  // [{ name:'Unit Test', priority:2 }, { name:'Release', priority:1 }, { name:'Documentation', priority:3 }]
+  todoList.get('priorityTodos');    // [{ name:'Release', priority:1 }, { name:'Unit Test', priority:2 }, { name:'Documentation', priority:3 }]
   ```
 
   @method computed.sort

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -12,7 +12,7 @@
   ```javascript
   Ember.isEqual('hello', 'hello');  // true
   Ember.isEqual(1, 2);              // false
-  Ember.isEqual([4,2], [4,2]);      // false
+  Ember.isEqual([4, 2], [4, 2]);    // false
   ```
 
   @method isEqual

--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -20,7 +20,7 @@ var loaded = {};
   resolved from a string into the object:
 
   ``` javascript
-  Ember.onLoad('Ember.Handlebars' function(hbars){
+  Ember.onLoad('Ember.Handlebars' function(hbars) {
     hbars.registerHelper(...);
   });
   ```

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -142,10 +142,11 @@ if (ignore.length>0) {
   var Pagination = Ember.CollectionView.extend({
     tagName: 'ul',
     classNames: ['pagination'],
+
     init: function() {
       this._super();
       if (!this.get('content')) {
-        this.set('content', Ember.A([]));
+        this.set('content', Ember.A());
       }
     }
   });


### PR DESCRIPTION
Lots of fixes in several files.

Removed unnecessary uses of `App` or `MyApp`, when it didn't help for understanding of the example.
