### PR TITLE
The "click" helper gives focus to elements with a tabindex attribute

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -50,7 +50,7 @@ function click(app, selector, context) {
   var $el = findWithAssert(app, selector, context);
   run($el, 'mousedown');
 
-  if ($el.is(':input')) {
+  if ($el.is(':input') || !Ember.isNone($el.attr('tabindex'))) {
     var type = $el.prop('type');
     if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
       run($el, function(){

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -271,6 +271,36 @@ test("`click` triggers appropriate events in order", function() {
   });
 });
 
+test("`click` gives focus to any focusable element", function() {
+  expect(3);
+  var click;
+
+  run(function() {
+    App = EmberApplication.create();
+    App.setupForTesting();
+  });
+
+  Ember.TEMPLATES.index = Ember.Handlebars.compile('{{input id="inputField" type="text"}} <ul><li tabindex="0" id="focusable">I can get focus</li><li id="not-focusable">I cannot</li></ul>');
+  App.injectTestHelpers();
+  run(App, App.advanceReadiness);
+  click = App.testHelpers.click;
+
+  click('#inputField').then(function () {
+    // is(':focus') can not be used in phantomjs, so activeElement provides the element that has
+    // the focus
+    equal(jQuery(document.activeElement).attr('id'), 'inputField',
+      'The input field has the focus after click');
+    return click('#focusable');
+  }).then(function () {
+    equal(jQuery(document.activeElement).attr('id'), 'focusable',
+      'The first <li> tag has a tabindex, so it can get the focus');
+    return click('#not-focusable');
+  }).then(function () {
+    equal(jQuery(document.activeElement).attr('id'), 'focusable',
+      'The second <li> has no tabindex, so it does not get the focus and the previous element keeps it');
+  });
+});
+
 test("Ember.Application#setupForTesting attaches ajax listeners", function() {
   var documentEvents;
 


### PR DESCRIPTION
I updated a bit the "click" test helper so an element that has a tabindex attribute gets the focus when clicked (which is the default behaviour of the browser).

I also added some tests showing that, but there is a slight issue with them. Normally they should run with PhantomJS (I used the same technique about focus checking for another project using PhantomJS but I was unable to check it as running the tests give me an error "spawn EACCES").
But when ran in the browser, they fail if the browser do not have the focus (and there is not much to be done or I haven't found a solution yet)
