### PR TITLE
Close #5047 -- add warning to variable {{input type}}

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -166,6 +166,8 @@ export function inputHelper(options) {
       inputType = hash.type,
       onEvent = hash.on;
 
+  Ember.warn('You can only use a string as a `type` parameter, not a variable', types.type !== 'STRING');
+
   delete hash.type;
   delete hash.on;
 


### PR DESCRIPTION
Should be helpful for identifying situations in which similar things could occur.

Addresses https://github.com/emberjs/ember.js/issues/5047
