### PR TITLE
Close #5047 -- add warning to variable {{input type}}

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -166,6 +166,8 @@ export function inputHelper(options) {
       inputType = hash.type,
       onEvent = hash.on;
 
+  Ember.assert('You can only use a string as a `type` parameter, not a variable', types.type === 'STRING' || types.type === undefined);
+
   delete hash.type;
   delete hash.on;
 


### PR DESCRIPTION
Realized how Ember.warn was supposed to properly be used, so I closed my last PR.
