### PR TITLE
Logic bug

### DIFF
--- a/packages/ember-runtime/lib/compare.js
+++ b/packages/ember-runtime/lib/compare.js
@@ -52,7 +52,7 @@ export default function compare(v, w) {
     }
 
     if (type2 === 'instance' && Comparable.detect(w.constructor)) {
-      return 1-w.constructor.compare(w, v);
+      return -w.constructor.compare(w, v);
     }
   }
 


### PR DESCRIPTION
If compare is a function which returns `-1`, `0` or `1`, then `1-compare()` has a result domain of `2`, `1`, `0`, which is wrong. I did not hit this bug, just encountered it while reading the source
