### PR TITLE
Allow both before and after for initializers

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -899,7 +899,6 @@ Application.reopenClass({
     }
 
     Ember.assert("The initializer '" + initializer.name + "' has already been registered", !this.initializers[initializer.name]);
-    Ember.assert("An initializer cannot be registered with both a before and an after", !(initializer.before && initializer.after));
     Ember.assert("An initializer cannot be registered without an initialize function", canInvoke(initializer, 'initialize'));
 
     this.initializers[initializer.name] = initializer;

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -29,6 +29,7 @@ test("initializers can be registered in a specified order", function() {
 
   MyApplication.initializer({
     name: 'second',
+    after: 'first',
     before: 'third',
     initialize: function(container) {
       order.push('second');
@@ -38,6 +39,7 @@ test("initializers can be registered in a specified order", function() {
   MyApplication.initializer({
     name: 'fifth',
     after: 'fourth',
+    before: 'sixth',
     initialize: function(container) {
       order.push('fifth');
     }
@@ -58,6 +60,13 @@ test("initializers can be registered in a specified order", function() {
     }
   });
 
+  MyApplication.initializer({
+    name: 'sixth',
+    initialize: function(container) {
+      order.push('sixth');
+    }
+  });
+
   run(function() {
     app = MyApplication.create({
       router: false,
@@ -65,7 +74,7 @@ test("initializers can be registered in a specified order", function() {
     });
   });
 
-  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth']);
+  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
 });
 
 test("initializers can have multiple dependencies", function () {


### PR DESCRIPTION
This removes the assertion checking that initializers don't have both the `before` and the `after` options set and update the initializers ordering test to cover that; see issue #5061.

The PR with the related doc changes is here: emberjs/ember.js#5062
