### PR TITLE
[BUGFIX beta] Add warning to variable {{input type}}, with working tests

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -195,6 +195,8 @@ export function inputHelper(options) {
       inputType = hash.type,
       onEvent = hash.on;
 
+  Ember.assert('You can only use a string as a `type` parameter, not a variable', types.type === 'STRING' || types.type === undefined);
+
   delete hash.type;
   delete hash.on;
 

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -89,6 +89,27 @@ test("It works", function() {
   }, /you must use `checked=/);
 });
 
+QUnit.module("{{input type='checkbox'}} - prevent dynamic type", {
+  setup: function() {
+    checkboxView = EmberView.extend({
+      controller: controller,
+      inputType: "checkbox",
+      template: compile('{{input type=inputType}}')
+    }).create();
+  },
+
+  teardown: function() {
+    destroy(checkboxView);
+  }
+});
+
+test("It works", function() {
+  expectAssertion(function() {
+    append();
+  }, /not a variable/);
+});
+
+
 QUnit.module("{{input type='checkbox'}} - static values", {
   setup: function() {
     controller = {

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -57,7 +57,7 @@ QUnit.module("ember-testing Acceptance", {
       });
 
       App.CommentsView = EmberView.extend({
-        defaultTemplate: EmberHandlebars.compile("{{input type=text}}")
+        defaultTemplate: EmberHandlebars.compile('{{input type="text"}}')
       });
 
       App.AbortTransitionRoute = EmberRoute.extend({


### PR DESCRIPTION
This is an update to #5056, which should fix the tests.
