### PR TITLE
Add console statement to make debugger helper usage more clear

### DIFF
--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -94,6 +94,7 @@ function debuggerHelper(options) {
   // These are helpful values you can inspect while debugging.
   var templateContext = this;
   var typeOfTemplateContext = inspect(templateContext);
+  console.log('Use `this` to access the context of the calling template');
 
   debugger;
 }

--- a/packages/ember-handlebars/lib/helpers/debug.js
+++ b/packages/ember-handlebars/lib/helpers/debug.js
@@ -94,7 +94,7 @@ function debuggerHelper(options) {
   // These are helpful values you can inspect while debugging.
   var templateContext = this;
   var typeOfTemplateContext = inspect(templateContext);
-  console.log('Use `this` to access the context of the calling template');
+  Ember.Logger.info('Use `this` to access the context of the calling template.');
 
   debugger;
 }


### PR DESCRIPTION
This references issue #5071.
