### PR TITLE
Migrate s3 publishing to node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ install:
 - "npm install"
 after_success:
   - bundle install --deployment --retry 3 --jobs 4
-  - bundle exec rake publish_build
+  - bundle exec rake docs
+  - "./bin/publish_to_s3.js"
   - "./bin/bower_ember_build"
 script:
   - npm test
+  - npm run-script test-node
 env:
   global:
   - BROCCOLI_ENV=production

--- a/Rakefile
+++ b/Rakefile
@@ -159,26 +159,4 @@ namespace :release do
   task :deploy => ['ember:release:deploy', 'starter_kit:deploy', 'website:deploy']
 end
 
-def files_to_publish
-  %w{ember.js ember-docs.json ember-tests.js ember-template-compiler.js ember-runtime.js}
-end
-
-task :publish_build => [:docs] do
-  root_dir = Pathname.new(__FILE__).dirname
-  dist_dir = root_dir.join('dist')
-
-  FileUtils.cp root_dir.join('docs', 'build', 'data.json'),
-               dist_dir.join('ember-docs.json')
-
-  files = files_to_publish
-
-  EmberDev::Publish.to_s3({
-    :access_key_id => ENV['S3_ACCESS_KEY_ID'],
-    :secret_access_key => ENV['S3_SECRET_ACCESS_KEY'],
-    :bucket_name => ENV['S3_BUCKET_NAME'],
-
-    :files => files.map { |f| dist_dir.join(f) }
-  })
-end
-
 task :docs => "ember:docs"

--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+// To invoke this from the commandline you need the following to env vars to exist:
+//
+// S3_BUCKET_NAME
+// TRAVIS_BRANCH
+// TRAVIS_TAG
+// TRAVIS_COMMIT
+// S3_SECRET_ACCESS_KEY
+// S3_ACCESS_KEY_ID
+//
+// Once you have those you execute with the following:
+//
+// ```sh
+// ./bin/publish_to_s3.js
+// ```
+var S3Publisher = require('../lib/s3_publisher.js');
+publisher = new S3Publisher();
+publisher.publish();

--- a/lib/s3_publisher.js
+++ b/lib/s3_publisher.js
@@ -1,0 +1,115 @@
+/* global process, module */
+var fs   = require('fs');
+var path = require('path');
+var AWS  = require('aws-sdk');
+var date =  new Date().toISOString().replace(/-/g, '').replace(/T.+/, '');
+
+function S3Publisher(options){
+  options = options || {};
+
+  this.S3_BUCKET_NAME       = options.S3_BUCKET_NAME || process.env.S3_BUCKET_NAME;
+  this.TRAVIS_BRANCH        = options.TRAVIS_BRANCH || process.env.TRAVIS_BRANCH;
+  this.TAG                  = options.TRAVIS_TAG || process.env.TRAVIS_TAG;
+  this.CURRENT_REVISION     = options.TRAVIS_COMMIT || process.env.TRAVIS_COMMIT;
+
+  var S3_ACCESS_KEY_ID     = options.S3_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY_ID;
+  var S3_SECRET_ACCESS_KEY = options.S3_SECRET_ACCESS_KEY || process.env.S3_SECRET_ACCESS_KEY;
+
+  if (!this.S3_BUCKET_NAME || !S3_ACCESS_KEY_ID || !S3_SECRET_ACCESS_KEY) {
+    throw new Error('No AWS credentials exist.');
+    return;
+  }
+
+  AWS.config.update({accessKeyId: S3_ACCESS_KEY_ID, secretAccessKey: S3_SECRET_ACCESS_KEY});
+  this.s3 = new AWS.S3();
+}
+
+S3Publisher.prototype.uploadFile = function(data, type, destination, callback) {
+  console.log("Type: " + type);
+  console.log("Destination: " + destination);
+
+  this.s3.putObject({
+    Body: data,
+    Bucket: this.S3_BUCKET_NAME,
+    ContentType: type,
+    Key: destination
+  }, callback);
+};
+
+S3Publisher.prototype.currentBranch = function(){
+  return {
+    "master": "canary",
+    "beta": "beta",
+    "stable": "release",
+    "release": "release"
+  }[this.TRAVIS_BRANCH] || process.env.BUILD_TYPE;
+};
+
+S3Publisher.prototype.publish  = function() {
+  var files = this.fileMap();
+  function finished(err,result) { if(err) { throw Error("Upload failed with error: " + err); } }
+
+  var uploader = function(destination) {
+    var filePath = path.join(process.cwd(), "dist", file);
+
+      if(!fs.existsSync(filePath)) {
+        throw new Error("FilePath: '" + filePath + "' doesn't exist!");
+      }
+
+      var data = fs.readFileSync(filePath);
+      this.uploadFile(data, files[file].contentType, destination, finished);
+    }.bind(this);
+
+  for(var file in files) {
+    var localDests = files[file].destinations[this.currentBranch()]
+    if(localDests.length <= 0) { throw Error("There are no locations for this branch") };
+
+    localDests.forEach(uploader);
+  }
+};
+
+S3Publisher.prototype.fileMap = function() {
+  return {
+    "ember.js":                   fileObject("ember",                      ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
+    "ember-tests.js":             fileObject("ember-test",                 ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
+    "ember-template-compiler.js": fileObject("ember-template-compiler",    ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
+    "ember-runtime.js":           fileObject("ember-runtime",              ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date)
+  };
+
+
+};
+
+function fileObject(baseName, extension, contentType, currentRevision, tag, date){
+  var fullName = "/" + baseName + extension;
+  var obj =  {
+    contentType: contentType,
+      destinations: {
+        canary: [
+          baseName + "-latest" + extension,
+          "latest" + fullName,
+          "canary" + fullName,
+          "canary/daily/" + date + fullName,
+          "canary/shas/" + currentRevision + fullName
+        ],
+        release: [
+          "stable" + fullName,
+          "release" + fullName,
+          "release/daily/" + date + fullName,
+          "release/shas/" + currentRevision + fullName
+        ],
+        beta: [
+          "beta" + fullName,
+          "beta/daily/" + date + fullName,
+          "beta/shas/" + currentRevision + fullName
+        ]
+      }
+   };
+
+   for( var key in obj.destinations) {
+     obj.destinations[key].push("tags/" + tag + fullName);
+   }
+
+   return obj;
+}
+
+module.exports = S3Publisher;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "postinstall": "bower install",
     "pretest": "ember build --environment production",
     "test": "bin/run-tests.js",
-    "start": "ember serve"
+    "start": "ember serve",
+    "test-node": "mocha tests/*test.js"
   },
   "devDependencies": {
     "ember-cli": "0.0.34",
@@ -36,6 +37,8 @@
     "handlebars": "^1.3",
     "broccoli-filter": "~0.1.6",
     "ncp": "~0.5.1",
-    "rimraf": "~2.2.8"
+    "rimraf": "~2.2.8",
+    "aws-sdk": "~2.0.0-rc8",
+    "mocha": "1.20.1"
   }
 }

--- a/tests/s3_publisher_test.js
+++ b/tests/s3_publisher_test.js
@@ -1,0 +1,61 @@
+var S3Publisher = require('../lib/s3_publisher.js');
+var assert = require("assert");
+
+describe('S3Publisher.publish', function(){
+  var defaultOptions = {
+    S3_BUCKET_NAME:"myBucket",
+    TRAVIS_BRANCH: "master",
+    TRAVIS_TAG: "foo-tag",
+    TRAVIS_COMMIT: "foo-commit",
+    S3_SECRET_ACCESS_KEY: "s3-secret-access-key",
+    S3_ACCESS_KEY_ID: "s3-access-key"
+  }
+
+  it('publishes to the appropriate locations for master', function(){
+    var publisher = new S3Publisher(defaultOptions);
+    publisher.uploadFile = function(){
+      uploadFileLocations.push(arguments[2]);
+    };
+
+    var uploadFileLocations = [];
+    var date =  new Date().toISOString().replace(/-/g, '').replace(/T.+/, '');
+
+
+    expectedLocations = [
+      'ember-latest.js',
+      'latest/ember.js',
+      'canary/ember.js',
+      'canary/daily/' + date + '/ember.js',
+      'canary/shas/foo-commit/ember.js',
+      'tags/foo-tag/ember.js',
+      'ember-test-latest.js',
+      'latest/ember-test.js',
+      'canary/ember-test.js',
+      'canary/daily/' + date + '/ember-test.js',
+      'canary/shas/foo-commit/ember-test.js',
+      'tags/foo-tag/ember-test.js',
+      'ember-template-compiler-latest.js',
+      'latest/ember-template-compiler.js',
+      'canary/ember-template-compiler.js',
+      'canary/daily/' + date + '/ember-template-compiler.js',
+      'canary/shas/foo-commit/ember-template-compiler.js',
+      'tags/foo-tag/ember-template-compiler.js',
+      'ember-runtime-latest.js',
+      'latest/ember-runtime.js',
+      'canary/ember-runtime.js',
+      'canary/daily/' + date + '/ember-runtime.js',
+      'canary/shas/foo-commit/ember-runtime.js',
+      'tags/foo-tag/ember-runtime.js' ]
+
+    publisher.publish();
+    assert.deepEqual(expectedLocations, uploadFileLocations, "Destinations were not correct.");
+  });
+
+  it("errors when file doesn't exist in dist", function(){
+    var publisher = new S3Publisher(defaultOptions);
+    publisher.fileMap = function(){
+      return { "non-existent-file.js": {destinations: {canary: ["foo/bar"]}} }
+    };
+    assert.throws(publisher.publish.bind(publisher), /doesn't exist!/, "unexpected error");
+  });
+})


### PR DESCRIPTION
This effectively transitions the dependency on [ EmberDev::Publish.to_s3](https://github.com/emberjs/ember-dev/blob/master/lib/ember-dev/publish.rb) to the `lib/s3_publisher.js`.  The eventual goal is to remove the need to run `bundle install` from the `.travis.yml` which will quicken build times.
## Configuration

The following environment variables need to exist for the build to be published to s3

export S3_ACCESS_KEY_ID
export S3_SECRET_ACCESS_KEY
export S3_BUCKET_NAME (this is fine as is)

These are likely already specified in the secure keys of the `.travis.yml`, but I am unsure if it is exact (and as such should probably be updated.

Any feedback would be great! :))

Would love to pair on merging this if you decide to merge.  Thanks!
