### PR TITLE
Android property problem

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -144,7 +144,10 @@ export function guidFor(obj) {
         obj[GUID_KEY] = ret;
       } else {
         GUID_DESC.value = ret;
-        o_defineProperty(obj, GUID_KEY, GUID_DESC);
+        
+		if(!obj.hasOwnProperty(GUID_KEY)) {
+			o_defineProperty(obj, GUID_KEY, GUID_DESC);
+		}
       }
       return ret;
   }


### PR DESCRIPTION
Fixed "property already defined" crash Looks like on some android phones
the javascript implementation caches properties and the cache is not
refreshed frequently enough, so ember tries to access property, does not
find it, tries to define it as new property and crashes - because
property is actually already defined.
