### PR TITLE
[BUGFIX] Prevent publishing of tag s3 urls when TAG isn't present

### DIFF
--- a/lib/s3_publisher.js
+++ b/lib/s3_publisher.js
@@ -7,22 +7,30 @@ var date =  new Date().toISOString().replace(/-/g, '').replace(/T.+/, '');
 function S3Publisher(options){
   options = options || {};
 
-  this.S3_BUCKET_NAME       = options.S3_BUCKET_NAME || process.env.S3_BUCKET_NAME;
-  this.TRAVIS_BRANCH        = options.TRAVIS_BRANCH || process.env.TRAVIS_BRANCH;
-  this.TAG                  = options.TRAVIS_TAG || process.env.TRAVIS_TAG;
-  this.CURRENT_REVISION     = options.TRAVIS_COMMIT || process.env.TRAVIS_COMMIT;
+  this.setOption(options, 'S3_BUCKET_NAME');
+  this.setOption(options, 'TRAVIS_BRANCH', 'CURRENT_BRANCH');
+  this.setOption(options, 'TRAVIS_TAG', 'TAG');
+  this.setOption(options, 'TRAVIS_COMMIT', 'CURRENT_REVISION');
+  this.setOption(options, 'S3_ACCESS_KEY_ID');
+  this.setOption(options, 'S3_SECRET_ACCESS_KEY');
 
-  var S3_ACCESS_KEY_ID     = options.S3_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY_ID;
-  var S3_SECRET_ACCESS_KEY = options.S3_SECRET_ACCESS_KEY || process.env.S3_SECRET_ACCESS_KEY;
-
-  if (!this.S3_BUCKET_NAME || !S3_ACCESS_KEY_ID || !S3_SECRET_ACCESS_KEY) {
+  if (!this.S3_BUCKET_NAME || !this.S3_ACCESS_KEY_ID || !this.S3_SECRET_ACCESS_KEY) {
     throw new Error('No AWS credentials exist.');
-    return;
   }
 
-  AWS.config.update({accessKeyId: S3_ACCESS_KEY_ID, secretAccessKey: S3_SECRET_ACCESS_KEY});
+  AWS.config.update({accessKeyId: this.S3_ACCESS_KEY_ID, secretAccessKey: this.S3_SECRET_ACCESS_KEY});
   this.s3 = new AWS.S3();
 }
+
+S3Publisher.prototype.setOption = function(options, defaultPropName, setPropName){
+  if(!setPropName) { setPropName = defaultPropName};
+
+  if (options.hasOwnProperty(defaultPropName)) {
+    this[setPropName] = options[defaultPropName];
+  } else {
+    this[setPropName] = process.env[defaultPropName];
+  }
+};
 
 S3Publisher.prototype.uploadFile = function(data, type, destination, callback) {
   console.log("Type: " + type);
@@ -42,7 +50,7 @@ S3Publisher.prototype.currentBranch = function(){
     "beta": "beta",
     "stable": "release",
     "release": "release"
-  }[this.TRAVIS_BRANCH] || process.env.BUILD_TYPE;
+  }[this.CURRENT_BRANCH] || process.env.BUILD_TYPE;
 };
 
 S3Publisher.prototype.publish  = function() {
@@ -108,7 +116,7 @@ function fileObject(baseName, extension, contentType, currentRevision, tag, date
    };
 
    for( var key in obj.destinations) {
-     obj.destinations[key].push("tags/" + tag + fullName);
+     if(tag) { obj.destinations[key].push("tags/" + tag + fullName); }
    }
 
    return obj;

--- a/tests/s3_publisher_test.js
+++ b/tests/s3_publisher_test.js
@@ -63,6 +63,17 @@ describe('S3Publisher.publish', function(){
     assert.deepEqual(expectedLocations, uploadFileLocations, "Destinations were not correct.");
   });
 
+  it("doesn't create tag urls if TRAVIS_TAG is undefined", function(){
+    defaultOptions.TRAVIS_TAG = undefined;
+    var publisher             = new S3Publisher(defaultOptions);
+    publisher.uploadFile      = function(){ uploadFileLocations.push(arguments[2]); };
+    var uploadFileLocations   = [];
+
+    publisher.publish();
+    assert(uploadFileLocations.length > 0);
+    for(var location in uploadFileLocations) { assert(!/tags/.test(uploadFileLocations[location])) }
+  });
+
   it("errors when file doesn't exist in dist", function(){
     var publisher = new S3Publisher(defaultOptions);
     publisher.fileMap = function(){


### PR DESCRIPTION
This commit is a bit larger than I wanted it to be.  This is due to the fact that I need to explicitly set `defaultOptions.TRAVIS_TAG` to nil.  In order to accomplish that I had to mess with arguments.  The idea is that `S3Publisher.setOption` will take a property name, and either set it from options (allowing to be false) and still correctly fall back to the environment vars when it isn't.

Also, I've made it to where the `TRAVIS_` prefixed vars are set to more semantically meaningful vars for use within the program.  

Let me know what you think.  Any corrections shouldn't be a problem.  

Cheers
