### PR TITLE
Close #5088 - Fix usage of document.body.contains

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -21,7 +21,7 @@ merge(preRender, {
 
     // We transition to `inDOM` if the element exists in the DOM
     var element = view.get('element');
-    if (document.body.contains(element)) {
+    if (document.body.contains && document.body.contains(element)) {
       viewCollection.transitionTo('inDOM', false);
       viewCollection.trigger('didInsertElement');
     }


### PR DESCRIPTION
`document.body.contains` is not supported by old Firefox browsers. This is a simple check whether browser support `contains` method before using it. 
