### PR TITLE
Migrate doc generation process to node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ node_js:
 - "0.10"
 install:
 - "npm install"
+- "./bin/generate_docs.js"
 after_success:
-  - bundle install --deployment --retry 3 --jobs 4
-  - bundle exec rake docs
   - "./bin/publish_to_s3.js"
   - "./bin/bower_ember_build"
 script:

--- a/Rakefile
+++ b/Rakefile
@@ -158,5 +158,3 @@ namespace :release do
   desc "Deploy a new Ember release"
   task :deploy => ['ember:release:deploy', 'starter_kit:deploy', 'website:deploy']
 end
-
-task :docs => "ember:docs"

--- a/bin/generate_docs.js
+++ b/bin/generate_docs.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+var DocGenerator = require('../lib/doc_generator.js');
+(new DocGenerator()).generate();

--- a/lib/doc_generator.js
+++ b/lib/doc_generator.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var calculateVersion = require('../lib/calculate-version');
+var exec             = require('child_process').exec;
+var fs               = require('fs');
+
+function DocGenerator(options) {
+  options = options || {};
+  this.exec = options.exec || require('child_process').exec;
+}
+
+DocGenerator.prototype.generate = function() {
+  var command = 'cd docs && ' + fs.realpathSync('./node_modules/.bin/yuidoc') +
+                ' -p -q --project-version ' + calculateVersion();
+
+  console.log('Executing command: ' + command);
+  this.exec(command, function(error, stdout, stderr){
+    if (error !== null) {
+      console.log('Error: ' + error);
+    }
+  });
+};
+
+module.exports = DocGenerator;

--- a/lib/s3_publisher.js
+++ b/lib/s3_publisher.js
@@ -63,6 +63,7 @@ S3Publisher.prototype.publish  = function() {
       if(!fs.existsSync(filePath)) {
         throw new Error("FilePath: '" + filePath + "' doesn't exist!");
       }
+      filePath = fs.realpathSync(filePath);
 
       var data = fs.readFileSync(filePath);
       this.uploadFile(data, files[file].contentType, destination, finished);
@@ -83,7 +84,8 @@ S3Publisher.prototype.fileMap = function() {
     "ember-template-compiler.js": fileObject("ember-template-compiler",    ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
     "ember-runtime.js":           fileObject("ember-runtime",              ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
     "ember.min.js":               fileObject("ember.min",                  ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
-    "ember.prod.js":              fileObject("ember.prod",                 ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date)
+    "ember.prod.js":              fileObject("ember.prod",                 ".js",   "text/javascript",  this.CURRENT_REVISION, this.TAG, date),
+    "../docs/build/data.json":    fileObject("ember-docs",                 ".json", "application/json", this.CURRENT_REVISION, this.TAG, date)
   };
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "ember build --environment production",
     "test": "bin/run-tests.js",
     "start": "ember serve",
-    "test-node": "mocha tests/*test.js"
+    "test-node": "mocha tests/**/*test.js"
   },
   "devDependencies": {
     "ember-cli": "0.0.37",

--- a/tests/unit/doc_generator_test.js
+++ b/tests/unit/doc_generator_test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var DocGenerator = require('../../lib/doc_generator.js');
+var calculateVersion = require('../../lib/calculate-version.js');
+var assert = require('assert');
+
+describe('generateDocs', function(){
+  it('calls the the appropriate command', function(){
+    var execFunc = function() {
+      var pattern = 'cd docs && .+/node_modules/yuidocjs/lib/cli.js -p -q --project-version ' + escapeRegExp(calculateVersion());
+      assert.ok((new RegExp(pattern)).test(arguments[0]));
+    };
+
+    var generator = new DocGenerator({exec: execFunc});
+    generator.generate();
+  });
+});
+
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}

--- a/tests/unit/s3_publisher_test.js
+++ b/tests/unit/s3_publisher_test.js
@@ -1,4 +1,4 @@
-var S3Publisher = require('../lib/s3_publisher.js');
+var S3Publisher = require('../../lib/s3_publisher.js');
 var assert = require("assert");
 
 describe('S3Publisher.publish', function(){
@@ -57,7 +57,13 @@ describe('S3Publisher.publish', function(){
       'canary/ember.prod.js',
       'canary/daily/' + date +  '/ember.prod.js',
       'canary/shas/foo-commit/ember.prod.js',
-      'tags/foo-tag/ember.prod.js' ]
+      'tags/foo-tag/ember.prod.js',
+      'ember-docs-latest.json',
+      'latest/ember-docs.json',
+      'canary/ember-docs.json',
+      'canary/daily/20140630/ember-docs.json',
+      'canary/shas/foo-commit/ember-docs.json',
+      'tags/foo-tag/ember-docs.json' ];
 
     publisher.publish();
     assert.deepEqual(expectedLocations, uploadFileLocations, "Destinations were not correct.");


### PR DESCRIPTION
This removes the call to bundler during build time, which should
increase the avg speed of builds in travis.
