### PR TITLE
Fix {{#with view.foo as bar}}

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -529,7 +529,7 @@ function withHelper(context, options) {
     localizedOptions.hash.keywordPath = contextPath;
 
     bindContext = this;
-    context = path;
+    context = contextPath;
     options = localizedOptions;
     preserveContext = true;
   } else {

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -447,3 +447,30 @@ test("destroys the controller generated with {{with foo as bar controller='blah'
 
   ok(destroyed, 'controller was destroyed properly');
 });
+
+QUnit.module("{{#with}} helper binding to view keyword", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    view = EmberView.create({
+      template: EmberHandlebars.compile("We have: {{#with view.thing as fromView}}{{fromView.name}} and {{fromContext.name}}{{/with}}"),
+      thing: { name: 'this is from the view' },
+      context: {
+        fromContext: { name: "this is from the context" },
+      }
+    });
+
+    appendView(view);
+  },
+
+  teardown: function() {
+    run(function() {
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("{{with}} helper can bind to keywords with 'as'", function(){
+  equal(view.$().text(), "We have: this is from the view and this is from the context", "should render");
+});


### PR DESCRIPTION
The `with` helper can correctly bind through the `view` keyword when
it's used like this:

```
{{#with view.foo}}
```

But the binding is broken if you try it like this:

```
{{#with view.foo as bar}}
```

This change fixes it.
