### PR TITLE
[FEATURE event-dispatcher-can-disable-event-manager] eventDispatcher can disable dispatching events to view `eventManager`

### DIFF
--- a/features.json
+++ b/features.json
@@ -7,7 +7,8 @@
     "ember-routing-add-model-option": true,
     "ember-routing-linkto-target-attribute": null,
     "ember-routing-will-change-hooks": null,
-    "ember-routing-consistent-resources": null
+    "ember-routing-consistent-resources": null,
+    "event-dispatcher-can-disable-event-manager": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -90,6 +90,34 @@ export default EmberObject.extend({
   rootElement: 'body',
 
   /**
+    It enables events to be dispatched to the view `eventManager` which object 
+    when present takes precedence over events of the same name handled through methods 
+    on the view.
+
+    Most of the ember applications does not implement view `eventManagers`, 
+    then disabling this property will provide some performance benefit 
+    because it skips the search for the `eventManager` on the view tree.
+
+    ```javascript
+    var EventDispatcher = Em.EventDispatcher.extend({
+      events: {
+          click       : 'click',
+          focusin     : 'focusIn',
+          focusout    : 'focusOut',
+          change      : 'change'
+      },
+      canDispatchToEventManager: false 
+    });
+    container.register('event_dispatcher:main', EventDispatcher);
+    ```
+
+    @property canDispatchToEventManager
+    @type boolean
+    @default 'true'
+  */
+  canDispatchToEventManager: true,
+
+  /**
     Sets up event listeners for standard browser events.
 
     This will be called after the browser sends a `DOMContentReady` event. By
@@ -154,9 +182,9 @@ export default EmberObject.extend({
 
     rootElement.on(event + '.ember', '.ember-view', function(evt, triggeringManager) {
       var view = View.views[this.id],
-          result = true, manager = null;
-
-      manager = self._findNearestEventManager(view, eventName);
+          result = true;
+      
+      var manager = self.canDispatchToEventManager ? self._findNearestEventManager(view, eventName) : null;
 
       if (manager && manager !== triggeringManager) {
         result = self._dispatchEvent(manager, evt, eventName, view);

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember-metal/core'; // A, FEATURES, assert, TESTING_DEPRECATION
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
@@ -285,6 +286,52 @@ test("event handlers should be wrapped in a run loop", function() {
 
   jQuery('#test-view').trigger('mousedown');
 });
+
+if (Ember.FEATURES.isEnabled("event-dispatcher-can-disable-event-manager")) {
+
+  test("should not dispatch events to view event Manager when canDispatchToEventManager is false", function () {
+
+    var eventManagerCounter=0,
+        viewCounter=0;
+
+    run(function() {
+      dispatcher.destroy();
+    });
+
+    run(function() {
+      dispatcher = EventDispatcher.create({
+        canDispatchToEventManager: false
+      });
+      dispatcher.setup();
+    });
+
+    view = ContainerView.create({
+      render: function(buffer) {
+        buffer.push('<input id="is-done" type="checkbox">');
+      },
+
+      eventManager: EmberObject.create({
+        mouseDown: function() {
+          eventManagerCounter++;
+        }
+      }),
+
+      mouseDown: function() {
+        viewCounter++;
+      }
+    });
+
+    run(function() {
+      view.append();
+    });
+
+    jQuery('#is-done').trigger('mousedown');
+    equal(viewCounter, 1, "event should go to view");
+    equal(eventManagerCounter, 0, "event should not go to manager");
+
+  });
+
+}
 
 QUnit.module("EventDispatcher#setup", {
   setup: function() {


### PR DESCRIPTION
`eventDispatcher` can be configured to disable/enable the event dispatch to the view `eventManager`. 

Disabling `eventDispatcher.canDispatchToEventManager` will provide some performance benefit because it skips the search for the `eventManager` on the view tree.

Closes #4355
