### PR TITLE
[BUGFIX beta] Add alias descriptor

### DIFF
--- a/packages/ember-metal/lib/alias.js
+++ b/packages/ember-metal/lib/alias.js
@@ -1,0 +1,70 @@
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import EmberError from "ember-metal/error";
+import { Descriptor, defineProperty } from "ember-metal/properties";
+import { create } from "ember-metal/platform";
+import { meta, inspect } from "ember-metal/utils";
+import {
+  addDependentKeys,
+  removeDependentKeys
+} from "ember-metal/dependent_keys";
+
+export function alias(altKey) {
+  return new AliasedProperty(altKey);
+}
+
+export function AliasedProperty(altKey) {
+  this.altKey = altKey;
+  this._dependentKeys = [ altKey ];
+}
+
+AliasedProperty.prototype = create(Descriptor.prototype);
+
+AliasedProperty.prototype.get = function AliasedProperty_get(obj, keyName) {
+  return get(obj, this.altKey);
+};
+
+AliasedProperty.prototype.set = function AliasedProperty_set(obj, keyName, value) {
+  return set(obj, this.altKey, value);
+};
+
+AliasedProperty.prototype.willWatch = function(obj, keyName) {
+  addDependentKeys(this, obj, keyName, meta(obj));
+};
+
+AliasedProperty.prototype.didUnwatch = function(obj, keyName) {
+  removeDependentKeys(this, obj, keyName, meta(obj));
+};
+
+AliasedProperty.prototype.setup = function(obj, keyName) {
+  var m = meta(obj);
+  if (m.watching[keyName]) {
+    addDependentKeys(this, obj, keyName, m);
+  }
+};
+
+AliasedProperty.prototype.teardown = function(obj, keyName) {
+  var m = meta(obj);
+  if (m.watching[keyName]) {
+    removeDependentKeys(this, obj, keyName, m);
+  }
+};
+
+AliasedProperty.prototype.readOnly = function() {
+  this.set = AliasedProperty_readOnlySet;
+  return this;
+};
+
+function AliasedProperty_readOnlySet(obj, keyName, value) {
+  throw new EmberError('Cannot set read-only property "' + keyName + '" on object: ' + inspect(obj));
+}
+
+AliasedProperty.prototype.oneWay = function() {
+  this.set = AliasedProperty_oneWaySet;
+  return this;
+};
+
+function AliasedProperty_oneWaySet(obj, keyName, value) {
+  defineProperty(obj, keyName, null);
+  return set(obj, keyName, value);
+}

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -4,6 +4,7 @@ import { set } from "ember-metal/property_set";
 import { computed } from "ember-metal/computed";
 import isEmpty from 'ember-metal/is_empty';
 import { isNone } from 'ember-metal/is_none';
+import { alias } from 'ember-metal/alias';
 
 /**
 @module ember-metal
@@ -548,15 +549,7 @@ registerComputedWithProperties('collect', function(properties) {
   @return {Ember.ComputedProperty} computed property which creates an
   alias to the original value for property.
 */
-computed.alias = function(dependentKey) {
-  return computed(dependentKey, function(key, value) {
-    if (arguments.length > 1) {
-      set(this, dependentKey, value);
-    }
-
-    return get(this, dependentKey);
-  });
-};
+computed.alias = alias;
 
 /**
   Where `computed.alias` aliases `get` and `set`, and allows for bidirectional
@@ -591,9 +584,7 @@ computed.alias = function(dependentKey) {
   one way computed property to the original value for property.
 */
 computed.oneWay = function(dependentKey) {
-  return computed(dependentKey, function() {
-    return get(this, dependentKey);
-  });
+  return alias(dependentKey).oneWay();
 };
 
 if (Ember.FEATURES.isEnabled('query-params-new')) {
@@ -645,9 +636,7 @@ if (Ember.FEATURES.isEnabled('query-params-new')) {
   @since 1.5.0
 */
 computed.readOnly = function(dependentKey) {
-  return computed(dependentKey, function() {
-    return get(this, dependentKey);
-  }).readOnly();
+  return alias(dependentKey).readOnly();
 };
 /**
   A computed property that acts like a standard getter and setter,

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -120,6 +120,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
     } else {
       obj[keyName] = undefined; // make enumerable
     }
+    if (desc.setup) { desc.setup(obj, keyName); }
   } else {
     descs[keyName] = undefined; // shadow descriptor in proto
     if (desc == null) {

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -19,6 +19,9 @@ export function watchKey(obj, keyName, meta) {
   if (!watching[keyName]) {
     watching[keyName] = 1;
 
+    var desc = m.descs[keyName];
+    if (desc && desc.willWatch) { desc.willWatch(obj, keyName); }
+
     if ('function' === typeof obj.willWatchProperty) {
       obj.willWatchProperty(keyName);
     }
@@ -42,6 +45,9 @@ export function unwatchKey(obj, keyName, meta) {
 
   if (watching[keyName] === 1) {
     watching[keyName] = 0;
+
+    var desc = m.descs[keyName];
+    if (desc && desc.didUnwatch) { desc.didUnwatch(obj, keyName); }
 
     if ('function' === typeof obj.didUnwatchProperty) {
       obj.didUnwatchProperty(keyName);

--- a/packages/ember-metal/tests/alias_test.js
+++ b/packages/ember-metal/tests/alias_test.js
@@ -1,0 +1,60 @@
+import { alias } from "ember-metal/alias";
+import { Descriptor, defineProperty } from "ember-metal/properties";
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import { meta } from 'ember-metal/utils';
+import { isWatching } from "ember-metal/watching";
+import { addObserver, removeObserver } from "ember-metal/observer";
+import { mixin, observer } from 'ember-metal/mixin';
+
+var obj, count;
+
+QUnit.module('ember-metal/alias', {
+  setup: function() {
+    obj = { foo: { faz: 'FOO' } };
+    count = 0;
+  },
+  teardown: function() {
+    obj = null;
+  }
+});
+
+function incrementCount() {
+  count++;
+}
+
+test('should proxy get to alt key', function() {
+  defineProperty(obj, 'bar', alias('foo.faz'));
+  equal(get(obj, 'bar'), 'FOO');
+});
+
+test('should proxy set to alt key', function() {
+  defineProperty(obj, 'bar', alias('foo.faz'));
+  set(obj, 'bar', 'BAR');
+  equal(get(obj, 'foo.faz'), 'BAR');
+});
+
+test('basic lifecycle', function() {
+  defineProperty(obj, 'bar', alias('foo.faz'));
+  var m = meta(obj);
+  addObserver(obj, 'bar', incrementCount);
+  equal(m.deps['foo.faz'].bar, 1);
+  removeObserver(obj, 'bar', incrementCount);
+  equal(m.deps['foo.faz'].bar, 0);
+});
+
+test('begins watching alt key as soon as alias is watched', function() {
+  defineProperty(obj, 'bar', alias('foo.faz'));
+  addObserver(obj, 'bar', incrementCount);
+  ok(isWatching(obj, 'foo.faz'));
+  set(obj, 'foo.faz', 'BAR');
+  equal(count, 1);
+});
+
+test('immediately sets up dependencies if already being watched', function() {
+  addObserver(obj, 'bar', incrementCount);
+  defineProperty(obj, 'bar', alias('foo.faz'));
+  ok(isWatching(obj, 'foo.faz'));
+  set(obj, 'foo.faz', 'BAR');
+  equal(count, 1);
+});

--- a/packages/ember-runtime/tests/controllers/object_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/object_controller_test.js
@@ -1,7 +1,7 @@
 import ObjectController from "ember-runtime/controllers/object_controller";
+import { observer } from 'ember-metal/mixin';
 
 QUnit.module("Ember.ObjectController");
-
 
 test("should be able to set the target property of an ObjectController", function() {
   var controller = ObjectController.create();
@@ -9,4 +9,13 @@ test("should be able to set the target property of an ObjectController", functio
 
   controller.set('target', target);
   equal(controller.get('target'), target, "able to set the target property");
+});
+
+// See https://github.com/emberjs/ember.js/issues/5112
+test("can observe a path on an ObjectController", function() {
+  var controller = ObjectController.extend({
+    baz: observer('foo.bar', function() {})
+  }).create();
+  controller.set('model', {});
+  ok(true, "should not fail");
 });


### PR DESCRIPTION
Introduces a saner descriptor for aliasing properties via Ember.aliasProperty. Differences with Ember.computed.alias:
- It's not a computed property so there's no caching involved.
- get/sets are passed straight through.
- as soon as the alias is watched, it registers itself as a dependency of the alt key in meta.deps. This is in contrast to watching CPs, who do not register themselves until they have been consumed.

A couple hooks were reintroduced. When a key is watched for the first time a `willWatch` hook is fired on the descriptor, and when the last watcher is removed a `didUnwatch` hook is fired.

Example:

``` javascript
Ember.Object.extend({
  foo: "FOO",
  bar: Ember.aliasProperty('foo')
});
```
- [x] Review
- [x] Make sure it fixes #5112
- [x] Docs (not needed)

/cc @krisselden @stefanpenner
