### PR TITLE
Register using the runtime only version of handlebars

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -255,7 +255,7 @@ var Application = Namespace.extend(DeferredMixin, {
 
     this.scheduleInitialize();
 
-    Ember.libraries.registerCoreLibrary('Handlebars', EmberHandlebars.VERSION);
+    Ember.libraries.registerCoreLibrary('Handlebars' + (EmberHandlebars.compile ? '' : '-runtime'), EmberHandlebars.VERSION);
     Ember.libraries.registerCoreLibrary('jQuery', jQuery().jquery);
 
     if ( Ember.LOG_VERSION ) {


### PR DESCRIPTION
For example:
`DEBUG: Handlebars-runtime     : 1.3.0`
