### PR TITLE
[BUGFIX] Fixed broken import of `generateController`

### DIFF
--- a/packages/ember-routing/lib/main.js
+++ b/packages/ember-routing/lib/main.js
@@ -21,10 +21,10 @@ import HistoryLocation from "ember-routing/location/history_location";
 import AutoLocation from "ember-routing/location/auto_location";
 
 import {
-  controllerFor,
   generateControllerFactory,
-  generateController
-} from "ember-routing/system/controller_for";
+  default as generateController
+} from "ember-routing/system/generate_controller";
+import controllerFor from "ember-routing/system/controller_for";
 import RouterDSL from "ember-routing/system/dsl";
 import Router from "ember-routing/system/router";
 import Route from "ember-routing/system/route";

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -10,7 +10,10 @@ import Controller from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import controllerFor from "ember-routing/system/controller_for";
-import generateController from "ember-routing/system/generate_controller";
+import {
+  generateControllerFactory,
+  default as generateController
+} from "ember-routing/system/generate_controller";
 
 var buildContainer = function(namespace) {
   var container = new Container();
@@ -79,6 +82,11 @@ QUnit.module("Ember.generateController", {
       namespace.destroy();
     });
   }
+});
+
+test("generateController and generateControllerFactory are properties on the root namespace", function() {
+  equal(Ember.generateController, generateController, 'should export generateController');
+  equal(Ember.generateControllerFactory, generateControllerFactory, 'should export generateControllerFactory');
 });
 
 test("generateController should create Ember.Controller", function() {


### PR DESCRIPTION
The `generateController` and `generateControllerFactory` methods in the root namespace are undefined in the `1.7.0-beta.1` build. Is it worth writing tests ensuring that public APIs like this simply exist? If so, where would they go?
