### PR TITLE
[FEATURE ember-metal-is-present] Add Ember.isPresent

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -75,3 +75,11 @@ for a detailed explanation.
   Prior to this feature `home.index` route would not be created for the above resource.
 
   Added in [#4251](https://github.com/emberjs/ember.js/pull/4251)
+
+* `ember-metal-is-present`
+
+  Adds `Ember.isPresent` as the inverse of `Ember.isBlank`. This convenience
+  method can lead to more semantic and clearer code.
+
+  Added in [#5136](https://github.com/emberjs/ember.js/pull/5136)
+

--- a/features.json
+++ b/features.json
@@ -8,7 +8,8 @@
     "ember-routing-linkto-target-attribute": null,
     "ember-routing-will-change-hooks": null,
     "ember-routing-consistent-resources": true,
-    "event-dispatcher-can-disable-event-manager": null
+    "event-dispatcher-can-disable-event-manager": null,
+    "ember-metal-is-present": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/is_present.js
+++ b/packages/ember-metal/lib/is_present.js
@@ -1,0 +1,33 @@
+import isBlank from 'ember-metal/is_blank';
+var isPresent;
+
+if (Ember.FEATURES.isEnabled('ember-metal-is-present')) {
+  /**
+    A value is present if it not `isBlank`.
+
+    ```javascript
+    Ember.isPresent();                // false
+    Ember.isPresent(null);            // false
+    Ember.isPresent(undefined);       // false
+    Ember.isPresent('');              // false
+    Ember.isPresent([]);              // false
+    Ember.isPresent('\n\t');          // false
+    Ember.isPresent('  ');            // false
+    Ember.isPresent({});              // true
+    Ember.isPresent('\n\t Hello');    // true
+    Ember.isPresent('Hello world');   // true
+    Ember.isPresent([1,2,3]);         // true
+    ```
+
+    @method isPresent
+    @for Ember
+    @param {Object} obj Value to test
+    @return {Boolean}
+    @since 1.7.0
+    */
+  isPresent = function isPresent(obj) {
+    return !isBlank(obj);
+  };
+}
+
+export default isPresent;

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -81,6 +81,7 @@ import libraries from "ember-metal/libraries";
 import {isNone, none} from 'ember-metal/is_none';
 import {isEmpty, empty} from 'ember-metal/is_empty';
 import isBlank from 'ember-metal/is_blank';
+import isPresent from 'ember-metal/is_present';
 // END IMPORTS
 
 // BEGIN EXPORTS
@@ -229,6 +230,10 @@ Ember.isEmpty = isEmpty;
 Ember.empty = empty;
 
 Ember.isBlank = isBlank;
+
+if (Ember.FEATURES.isEnabled('ember-metal-is-present')) {
+  Ember.isPresent = isPresent;
+}
 
 Ember.merge = merge;
 

--- a/packages/ember-metal/tests/is_present_test.js
+++ b/packages/ember-metal/tests/is_present_test.js
@@ -1,0 +1,27 @@
+import isPresent from 'ember-metal/is_present';
+
+if (Ember.FEATURES.isEnabled('ember-metal-is-present')) {
+  QUnit.module("Ember.isPresent");
+
+  test("Ember.isPresent", function() {
+    var string = "string", fn = function() {},
+    object = {length: 0};
+
+    equal(false, isPresent(),          "for no params");
+    equal(false, isPresent(null),      "for null");
+    equal(false, isPresent(undefined), "for undefined");
+    equal(false, isPresent(""),        "for an empty String");
+    equal(false, isPresent("  "),      "for a whitespace String");
+    equal(false, isPresent("\n\t"),    "for another whitespace String");
+    equal(true,  isPresent("\n\t Hi"), "for a String with whitespaces");
+    equal(true,  isPresent(true),      "for true");
+    equal(true,  isPresent(false),     "for false");
+    equal(true,  isPresent(string),    "for a String");
+    equal(true,  isPresent(fn),        "for a Function");
+    equal(true,  isPresent(0),         "for 0");
+    equal(false, isPresent([]),        "for an empty Array");
+    equal(true,  isPresent({}),        "for an empty Object");
+    equal(false, isPresent(object),    "for an Object that has zero 'length'");
+    equal(true,  isPresent([1,2,3]),   "for a non-empty array");
+  });
+}


### PR DESCRIPTION
Maybe it's because I come from rails, but I miss having `.present?` as the inverse of `.blank?`. I find that I end up using `! Ember.isBlank()` more than `Ember.isBlank()` by itself. I know this is a simple change, but I think the concept of presence is useful and more semantic. I first thought of this when working on jamesarosen/ember-cpm#36, and keep on finding times where it would make my code easier to understand.
