### PR TITLE
WIP: more performance view instrumentation.

### DIFF
--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -15,7 +15,7 @@ import { computed } from "ember-metal/computed";
 
 import { typeOf } from "ember-metal/utils";
 
-import { instrument } from "ember-metal/instrumentation";
+import { instrumentFast } from "ember-metal/instrumentation";
 
 
 import renderBuffer from "ember-views/system/render_buffer";
@@ -87,6 +87,12 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     hash.view = this;
   },
 
+  _instrumentDetails: function() {
+    var details = {};
+    this.instrumentDetails(details);
+    return details;
+  },
+
   /**
     Invoked by the view system when this view needs to produce an HTML
     representation. This method will create a new render buffer, if needed,
@@ -105,8 +111,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     @private
   */
   renderToBuffer: function() {
-    // TODO bring back instrumentation
-    return this._renderToBuffer();
+    return instrumentFast('render.' + this.instrumentName, this, this._renderToBuffer);
   },
 
   _renderToBuffer: function() {


### PR DESCRIPTION
Specifically in the case for no-one is listening.

We can be more aggressive yet, once we settle on some idea I can propagate it through ember.

We we had a global `instrumentingMode === true` we could easily fast path, all the instrumenting code. [like here](https://github.com/emberjs/ember.js/pull/5146/files#diff-162a95b4162d14de7e38fd4debc5fbd4R114)

Additionally, we should publish instrumentation hooks out-of-band [like here](https://github.com/tildeio/rsvp.js/blob/master/lib/rsvp/instrument.js#L7) this will prevent the cost of informing ember-extension and other tooling from effecting typical app usage. 

cc @krisselden 
