### PR TITLE
Fix operator typo

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/render.js
+++ b/packages/ember-routing-handlebars/lib/helpers/render.js
@@ -93,7 +93,7 @@ export default function renderHelper(name, contextString, options) {
   var contextProvided = length === 3,
       container, router, controller, view, context, lookupOptions;
 
-  container = (options || contextString).data.keywords.controller.container;
+  container = (options && contextString).data.keywords.controller.container;
   router = container.lookup('router:main');
 
   if (length === 2) {


### PR DESCRIPTION
Certainly this should take the 3rd argument and fallback to the 2nd argument, right?

However, if both `contextString` and `options` are provided, it will pull `.data` off of `contextString`. That seems incorrect.

Am I crazy?
