### PR TITLE
[FEATURE ember-runtime-proxy-mixin]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -89,3 +89,10 @@ for a detailed explanation.
   as well as not restricting their location in the string.
 
   Added in [#4617](https://github.com/emberjs/ember.js/pull/4617)
+
+* `ember-runtime-proxy-mixin`
+
+  Makes the logic behind `Ember.ObjectProxy` into a `Mixin` that can be used when you cannot
+  inherit from `Ember.ObjectProxy` directly.
+
+  Added in [#5156](https://github.com/emberjs/ember.js/pull/5156)

--- a/features.json
+++ b/features.json
@@ -10,7 +10,8 @@
     "ember-routing-consistent-resources": true,
     "event-dispatcher-can-disable-event-manager": null,
     "ember-metal-is-present": null,
-    "property-brace-expansion-improvement": null
+    "property-brace-expansion-improvement": null,
+    "ember-runtime-proxy-mixin": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -44,6 +44,7 @@ import {
   Freezable,
   FROZEN_ERROR
 } from "ember-runtime/mixins/freezable";
+import ProxyMixin from "ember-runtime/mixins/proxy";
 
 import Observable from "ember-runtime/mixins/observable";
 import ActionHandler from "ember-runtime/mixins/action_handler";
@@ -167,6 +168,10 @@ Ember.ArrayController = ArrayController;
 Ember.ObjectController = ObjectController;
 Ember.Controller = Controller;
 Ember.ControllerMixin = ControllerMixin;
+
+if (Ember.FEATURES.isEnabled('ember-runtime-proxy-mixin')) {
+  Ember.ProxyMixin = ProxyMixin;
+}
 
 Ember.RSVP = RSVP;
 // END EXPORTS

--- a/packages/ember-runtime/lib/mixins/proxy.js
+++ b/packages/ember-runtime/lib/mixins/proxy.js
@@ -1,0 +1,95 @@
+/**
+@module ember
+@submodule ember-runtime
+*/
+
+import Ember from "ember-metal/core"; // Ember.assert
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import { meta } from "ember-metal/utils";
+import {
+  addObserver,
+  removeObserver,
+  addBeforeObserver,
+  removeBeforeObserver
+} from "ember-metal/observer";
+import {
+  propertyWillChange,
+  propertyDidChange
+} from "ember-metal/property_events";
+import { computed } from "ember-metal/computed";
+import { defineProperty } from "ember-metal/properties";
+import { Mixin, observer } from "ember-metal/mixin";
+import { fmt } from "ember-runtime/system/string";
+import EmberObject from "ember-runtime/system/object";
+
+function contentPropertyWillChange(content, contentKey) {
+  var key = contentKey.slice(8); // remove "content."
+  if (key in this) { return; }  // if shadowed in proxy
+  propertyWillChange(this, key);
+}
+
+function contentPropertyDidChange(content, contentKey) {
+  var key = contentKey.slice(8); // remove "content."
+  if (key in this) { return; } // if shadowed in proxy
+  propertyDidChange(this, key);
+}
+
+/**
+  `Ember.ProxyMixin` forwards all properties not defined by the proxy itself
+  to a proxied `content` object.  See Ember.ObjectProxy for more details.
+
+  @class ProxyMixin
+  @namespace Ember
+*/
+export default Mixin.create({
+  /**
+    The object whose properties will be forwarded.
+
+    @property content
+    @type Ember.Object
+    @default null
+  */
+  content: null,
+  _contentDidChange: observer('content', function() {
+    Ember.assert("Can't set Proxy's content to itself", get(this, 'content') !== this);
+  }),
+
+  isTruthy: computed.bool('content'),
+
+  _debugContainerKey: null,
+
+  willWatchProperty: function (key) {
+    var contentKey = 'content.' + key;
+    addBeforeObserver(this, contentKey, null, contentPropertyWillChange);
+    addObserver(this, contentKey, null, contentPropertyDidChange);
+  },
+
+  didUnwatchProperty: function (key) {
+    var contentKey = 'content.' + key;
+    removeBeforeObserver(this, contentKey, null, contentPropertyWillChange);
+    removeObserver(this, contentKey, null, contentPropertyDidChange);
+  },
+
+  unknownProperty: function (key) {
+    var content = get(this, 'content');
+    if (content) {
+      return get(content, key);
+    }
+  },
+
+  setUnknownProperty: function (key, value) {
+    var m = meta(this);
+    if (m.proto === this) {
+      // if marked as prototype then just defineProperty
+      // rather than delegate
+      defineProperty(this, key, null, value);
+      return value;
+    }
+
+    var content = get(this, 'content');
+    Ember.assert(fmt("Cannot delegate set('%@', %@) to the 'content' property of object proxy %@: its 'content' is undefined.", [key, value, this]), content);
+    return set(content, key, value);
+  }
+
+});

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -1,38 +1,5 @@
-/**
-@module ember
-@submodule ember-runtime
-*/
-import Ember from "ember-metal/core"; // Ember.assert
-import { get } from "ember-metal/property_get";
-import { set } from "ember-metal/property_set";
-import { meta } from "ember-metal/utils";
-import {
-  addObserver,
-  removeObserver,
-  addBeforeObserver,
-  removeBeforeObserver
-} from "ember-metal/observer";
-import {
-  propertyWillChange,
-  propertyDidChange
-} from "ember-metal/property_events";
-import { computed } from "ember-metal/computed";
-import { defineProperty } from "ember-metal/properties";
-import { observer } from "ember-metal/mixin";
-import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
-
-function contentPropertyWillChange(content, contentKey) {
-  var key = contentKey.slice(8); // remove "content."
-  if (key in this) { return; }  // if shadowed in proxy
-  propertyWillChange(this, key);
-}
-
-function contentPropertyDidChange(content, contentKey) {
-  var key = contentKey.slice(8); // remove "content."
-  if (key in this) { return; } // if shadowed in proxy
-  propertyDidChange(this, key);
-}
+import ProxyMixin from "ember-runtime/mixins/proxy";
 
 /**
   `Ember.ObjectProxy` forwards all properties not defined by the proxy itself
@@ -100,57 +67,7 @@ function contentPropertyDidChange(content, contentKey) {
   @class ObjectProxy
   @namespace Ember
   @extends Ember.Object
+  @extends Ember.ProxyMixin
 */
-var ObjectProxy = EmberObject.extend({
-  /**
-    The object whose properties will be forwarded.
 
-    @property content
-    @type Ember.Object
-    @default null
-  */
-  content: null,
-  _contentDidChange: observer('content', function() {
-    Ember.assert("Can't set ObjectProxy's content to itself", get(this, 'content') !== this);
-  }),
-
-  isTruthy: computed.bool('content'),
-
-  _debugContainerKey: null,
-
-  willWatchProperty: function (key) {
-    var contentKey = 'content.' + key;
-    addBeforeObserver(this, contentKey, null, contentPropertyWillChange);
-    addObserver(this, contentKey, null, contentPropertyDidChange);
-  },
-
-  didUnwatchProperty: function (key) {
-    var contentKey = 'content.' + key;
-    removeBeforeObserver(this, contentKey, null, contentPropertyWillChange);
-    removeObserver(this, contentKey, null, contentPropertyDidChange);
-  },
-
-  unknownProperty: function (key) {
-    var content = get(this, 'content');
-    if (content) {
-      return get(content, key);
-    }
-  },
-
-  setUnknownProperty: function (key, value) {
-    var m = meta(this);
-    if (m.proto === this) {
-      // if marked as prototype then just defineProperty
-      // rather than delegate
-      defineProperty(this, key, null, value);
-      return value;
-    }
-
-    var content = get(this, 'content');
-    Ember.assert(fmt("Cannot delegate set('%@', %@) to the 'content' property of object proxy %@: its 'content' is undefined.", [key, value, this]), content);
-    return set(content, key, value);
-  }
-
-});
-
-export default ObjectProxy;
+export default EmberObject.extend(ProxyMixin);


### PR DESCRIPTION
Moves most functionality of Ember.ObjectProxy into a mixin that use used for `Ember.ObjectProxy`, but can also be used on its own (for mixin into custom objects).
