### PR TITLE
[BUGFIX beta] Do not compare meta in deepEqual.

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -9,6 +9,14 @@ var get = Ember.get;
 var set = Ember.set;
 var compile = Ember.Handlebars.compile;
 
+function withoutMeta(object) {
+  var newObject = Ember.$.extend(true, {}, object);
+
+  delete newObject['__ember_meta__'];
+
+  return newObject;
+}
+
 function bootApplication() {
   router = container.lookup('router:main');
   Ember.run(App, 'advanceReadiness');
@@ -1037,7 +1045,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
     App.IndexRoute = Ember.Route.extend({
       setupController: function(controller, model) {
-        deepEqual(model, { woot: true }, "index route inherited model route from parent route");
+        deepEqual(withoutMeta(model), { woot: true }, "index route inherited model route from parent route");
       }
     });
 
@@ -1196,7 +1204,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
     equal(this.controller.get('q'), 'wat');
     equal(this.controller.get('z'), 0);
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-2' });
     equal(this.$link1.attr('href'), '/a/a-1?q=lol');
     equal(this.$link2.attr('href'), '/a/a-2');
     equal(this.$link3.attr('href'), '/a/a-3');
@@ -1209,7 +1217,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-1', q: 'lol', z: 0 };
     handleURL('/a/a-1?q=lol');
 
-    deepEqual(this.controller.get('model'), { id: 'a-1' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-1' });
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
     equal(this.$link1.attr('href'), '/a/a-1?q=lol');
@@ -1219,7 +1227,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
     handleURL('/a/a-2?q=lol');
 
-    deepEqual(this.controller.get('model'), { id: 'a-2' }, "controller's model changed to a-2");
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-2' }, "controller's model changed to a-2");
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
     equal(this.$link1.attr('href'), '/a/a-1?q=lol');
@@ -1245,7 +1253,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-1', q: 'wat', z: 0 };
     Ember.run(router, 'transitionTo', 'article', 'a-1');
 
-    deepEqual(this.controller.get('model'), { id: 'a-1' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-1' });
     equal(this.controller.get('q'), 'wat');
     equal(this.controller.get('z'), 0);
     equal(this.$link1.attr('href'), '/a/a-1');
@@ -1255,7 +1263,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
     Ember.run(router, 'transitionTo', 'article', 'a-2', { queryParams: { q: 'lol' } });
 
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-2' });
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
     equal(this.$link1.attr('href'), '/a/a-1');
@@ -1265,7 +1273,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
     Ember.run(router, 'transitionTo', 'article', 'a-3', { queryParams: { q: 'hay' } });
 
-    deepEqual(this.controller.get('model'), { id: 'a-3' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-3' });
     equal(this.controller.get('q'), 'hay');
     equal(this.controller.get('z'), 0);
     equal(this.$link1.attr('href'), '/a/a-1');
@@ -1275,7 +1283,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
     Ember.run(router, 'transitionTo', 'article', 'a-2', { queryParams: { z: 1 } });
 
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-2' });
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 1);
     equal(this.$link1.attr('href'), '/a/a-1');
@@ -1303,7 +1311,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
 
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-2' });
 
     equal(this.$link1.attr('href'), '/a/a-1?q=lol');
     equal(this.$link2.attr('href'), '/a/a-2?q=lol');
@@ -1312,7 +1320,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
     handleURL('/a/a-3?q=haha&z=123');
 
-    deepEqual(this.controller.get('model'), { id: 'a-3' });
+    deepEqual(withoutMeta(this.controller.get('model')), { id: 'a-3' });
     equal(this.controller.get('q'), 'haha');
     equal(this.controller.get('z'), 123);
 


### PR DESCRIPTION
In non-ES5 browsers the `QUnit.deepEqual` will also compare `__ember_meta__` property (which is highly unlikely to match).

This adds a helper method named `withoutMeta` for these tests specifically.

Before:

![screenshot](http://monosnap.com/image/8jH6q8qh5jSblPZCanQf1OP5fv0L6c.png)

After:

![screenshot](http://monosnap.com/image/5rLl6zgw5T58Z2RVWCA40j27JCGtzL.png)

(note: still working on the `computed.intersect` error)

Closes #5158.
