### PR TITLE
[FEATURE ember-metal-injected-properties] Injected properties

### DIFF
--- a/features.json
+++ b/features.json
@@ -10,7 +10,8 @@
     "ember-metal-is-present": true,
     "property-brace-expansion-improvement": true,
     "ember-routing-handlebars-action-with-key-code": null,
-    "ember-runtime-item-controller-inline-class": null
+    "ember-runtime-item-controller-inline-class": null,
+    "ember-metal-injected-properties": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/container/tests/container_helper.js
+++ b/packages/container/tests/container_helper.js
@@ -50,6 +50,7 @@ var factory = function() {
     Child.prototype = new Parent();
     Child.prototype.constructor = Child;
 
+    setProperties(Child, Klass);
     setProperties(Child.prototype, options);
 
     Child.create = create;

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -647,4 +647,23 @@ test("factory for non extendables resolves are cached", function() {
   deepEqual(resolveWasCalled, ['foo:post']);
 });
 
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  test("A factory's lazy injections are validated when first instantiated", function() {
+    var container = new Container();
+    var Apple = factory();
+    var Orange = factory();
 
+    Apple.reopenClass({
+      lazyInjections: function() {
+        return [ 'orange:main', 'banana:main' ];
+      }
+    });
+
+    container.register('apple:main', Apple);
+    container.register('orange:main', Orange);
+
+    throws(function() {
+      container.lookup('apple:main');
+    }, /Attempting to inject an unknown injection: `banana:main`/);
+  });
+}

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -1,0 +1,47 @@
+import Ember from "ember-metal/core"; // Ember.assert
+import { ComputedProperty } from "ember-metal/computed";
+import { Descriptor } from "ember-metal/properties";
+import { create } from "ember-metal/platform";
+import { inspect } from "ember-metal/utils";
+import EmberError from "ember-metal/error";
+
+/**
+  Read-only property that returns the result of a container lookup.
+
+  @class InjectedProperty
+  @namespace Ember
+  @extends Ember.Descriptor
+  @constructor
+  @param {String} type The container type the property will lookup
+  @param {String} name (optional) The name the property will lookup, defaults
+         to the property's name
+*/
+function InjectedProperty(type, name) {
+  this.type = type;
+  this.name = name;
+
+  this._super$Constructor(function(keyName) {
+    Ember.assert("Attempting to lookup an injected property on an object " +
+                 "without a container, ensure that the object was " +
+                 "instantiated via a container.", this.container);
+
+    return this.container.lookup(type + ':' + (name || keyName));
+  }, { readOnly: true });
+}
+
+InjectedProperty.prototype = create(Descriptor.prototype);
+
+var InjectedPropertyPrototype = InjectedProperty.prototype;
+var ComputedPropertyPrototype = ComputedProperty.prototype;
+
+InjectedPropertyPrototype._super$Constructor = ComputedProperty;
+
+InjectedPropertyPrototype.get = ComputedPropertyPrototype.get;
+
+InjectedPropertyPrototype.set = function(obj, keyName) {
+  throw new EmberError("Cannot set injected property '" + keyName + "' on object: " + inspect(obj));
+};
+
+InjectedPropertyPrototype.teardown = ComputedPropertyPrototype.teardown;
+
+export default InjectedProperty;

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -1,0 +1,62 @@
+import {
+  Descriptor,
+  defineProperty
+} from "ember-metal/properties";
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
+import InjectedProperty from "ember-metal/injected_property";
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  QUnit.module('InjectedProperty');
+
+  test('injected properties should be descriptors', function() {
+    ok(new InjectedProperty() instanceof Descriptor);
+  });
+
+  test('setting the injected property should error', function() {
+    var obj = {};
+    defineProperty(obj, 'foo', new InjectedProperty());
+
+    throws(function() {
+      set(obj, 'foo', 'bar');
+    }, /Cannot set injected property 'foo' on object/);
+  });
+
+  test("getting on an object without a container should fail assertion", function() {
+    var obj = {};
+    defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
+
+    expectAssertion(function() {
+      get(obj, 'foo');
+    }, /Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container./);
+  });
+
+  test("getting should return a lookup on the container", function() {
+    expect(2);
+
+    var obj = {
+      container: {
+        lookup: function(key) {
+          ok(true, 'should call container.lookup');
+          return key;
+        }
+      }
+    };
+    defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
+
+    equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
+  });
+
+  test("omitting the lookup name should default to the property name", function() {
+    var obj = {
+      container: {
+        lookup: function(key) {
+          return key;
+        }
+      }
+    };
+    defineProperty(obj, 'foo', new InjectedProperty('type'));
+
+    equal(get(obj, 'foo'), 'type:foo', 'should lookup the type using the property name');
+  });
+}

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -1,7 +1,9 @@
 import run from "ember-metal/run_loop";
 import Container from 'container/container';
+import Service from "ember-runtime/system/service";
 import EmberObject from "ember-runtime/system/object";
 import EmberRoute from "ember-routing/system/route";
+import inject from "ember-runtime/inject";
 
 var route, routeOne, routeTwo, container, lookupHash;
 
@@ -199,3 +201,21 @@ test("controllerFor uses route's controllerName if specified", function() {
   equal(routeTwo.controllerFor('one'), testController);
 });
 
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  QUnit.module('Route injected properties');
+
+  test("services can be injected into routes", function() {
+    var container = new Container();
+
+    container.register('route:application', EmberRoute.extend({
+      authService: inject.service('auth')
+    }));
+
+    container.register('service:auth', Service.extend());
+
+    var appRoute = container.lookup('route:application'),
+      authService = container.lookup('service:auth');
+
+    equal(authService, appRoute.get('authService'), "service.auth is injected");
+  });
+}

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -1,5 +1,7 @@
+import Ember from "ember-metal/core"; // Ember.assert
 import EmberObject from 'ember-runtime/system/object';
 import Mixin from 'ember-runtime/mixins/controller';
+import { createInjectionHelper } from 'ember-runtime/inject';
 
 /**
 @module ember
@@ -12,4 +14,42 @@ import Mixin from 'ember-runtime/mixins/controller';
   @extends Ember.Object
   @uses Ember.ControllerMixin
 */
-export default EmberObject.extend(Mixin);
+var Controller = EmberObject.extend(Mixin);
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  /**
+    Creates a property that lazily looks up another controller in the container.
+    Can only be used when defining another controller.
+
+    Example:
+
+    ```javascript
+    App.PostController = Ember.Controller.extend({
+      posts: Ember.inject.controller()
+    });
+    ```
+
+    This example will create a `posts` property on the `post` controller that
+    looks up the `posts` controller in the container, making it easy to
+    reference other controllers. This is functionally equivalent to:
+
+    ```javascript
+    App.PostController = Ember.Controller.extend({
+      needs: 'posts',
+      posts: Ember.computed.alias('controllers.posts')
+    });
+    ```
+
+    @method inject.controller
+    @for Ember
+    @param {String} name (optional) name of the controller to inject, defaults
+           to the property's name
+    @return {Ember.InjectedProperty} injection descriptor instance
+    */
+  createInjectionHelper('controller', function(factory) {
+    Ember.assert("Defining an injected controller property on a " +
+                 "non-controller is not allowed.", Controller.detect(factory));
+  });
+}
+
+export default Controller;

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,0 +1,78 @@
+import Ember from "ember-metal/core"; // Ember.assert
+import { indexOf } from "ember-metal/enumerable_utils";
+import InjectedProperty from "ember-metal/injected_property";
+import keys from "ember-metal/keys";
+
+/**
+  Namespace for injection helper methods.
+
+  @class inject
+  @namespace Ember
+  */
+function inject() {
+  Ember.assert("Injected properties must be created through helpers, see `" +
+               keys(inject).join("`, `") + "`");
+}
+
+// Dictionary of injection validations by type, added to by `createInjectionHelper`
+var typeValidators = {};
+
+/**
+  This method allows other Ember modules to register injection helpers for a
+  given container type. Helpers are exported to the `inject` namespace as the
+  container type itself.
+
+  @private
+  @method createInjectionHelper
+  @namespace Ember
+  @param {String} type The container type the helper will inject
+  @param {Function} validator A validation callback that is executed at mixin-time
+*/
+export function createInjectionHelper(type, validator) {
+  typeValidators[type] = validator;
+
+  inject[type] = function(name) {
+    return new InjectedProperty(type, name);
+  };
+}
+
+/**
+  Validation function intended to be invoked at when extending a factory with
+  injected properties. Runs per-type validation functions once for each injected
+  type encountered.
+
+  Note that this currently modifies the mixin themselves, which is technically
+  dubious but is practically of little consequence. This may change in the
+  future.
+
+  @private
+  @method validatePropertyInjections
+  @namespace Ember
+  @param {Object} factory The factory object being extended
+  @param {Object} props A hash of properties to be added to the factory
+*/
+export function validatePropertyInjections(factory, props) {
+  var types = [];
+  var key, desc, validator, i, l;
+
+  for (key in props) {
+    desc = props[key];
+    if (desc instanceof InjectedProperty && indexOf(types, desc.type) === -1) {
+      types.push(desc.type);
+    }
+  }
+
+  if (types.length) {
+    for (i = 0, l = types.length; i < l; i++) {
+      validator = typeValidators[types[i]];
+
+      if (typeof validator === 'function') {
+        validator(factory);
+      }
+    }
+  }
+
+  return true;
+}
+
+export default inject;

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -11,6 +11,7 @@ import Ember from 'ember-metal';
 import { isEqual } from 'ember-runtime/core';
 import compare from 'ember-runtime/compare';
 import copy from 'ember-runtime/copy';
+import inject from 'ember-runtime/inject';
 
 import Namespace from 'ember-runtime/system/namespace';
 import EmberObject from 'ember-runtime/system/object';
@@ -94,6 +95,10 @@ import 'ember-runtime/ext/function'; // just for side effect of extending Functi
 Ember.compare = compare;
 Ember.copy = copy;
 Ember.isEqual = isEqual;
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  Ember.inject = inject;
+}
 
 Ember.Array = EmberArray;
 

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -86,6 +86,8 @@ import ObjectController from 'ember-runtime/controllers/object_controller';
 import Controller from 'ember-runtime/controllers/controller';
 import ControllerMixin from 'ember-runtime/mixins/controller';
 
+import Service from 'ember-runtime/system/service';
+
 import RSVP from 'ember-runtime/ext/rsvp';     // just for side effect of extending Ember.RSVP
 import 'ember-runtime/ext/string';   // just for side effect of extending String.prototype
 import 'ember-runtime/ext/function'; // just for side effect of extending Function.prototype
@@ -170,6 +172,10 @@ Ember.ArrayController = ArrayController;
 Ember.ObjectController = ObjectController;
 Ember.Controller = Controller;
 Ember.ControllerMixin = ControllerMixin;
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  Ember.Service = Service;
+}
 
 Ember._ProxyMixin = _ProxyMixin;
 

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -154,6 +154,12 @@ var ActionHandler = Mixin.create({
     @method willMergeMixin
   */
   willMergeMixin: function(props) {
+    if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+      // Calling super is only OK here since we KNOW that there is another
+      // Mixin loaded first (injection dependency verification)
+      this._super.apply(this, arguments);
+    }
+
     var hashName;
 
     if (!props._actions) {

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,8 +3,10 @@
 @submodule ember-runtime
 */
 
+import Ember from "ember-metal/core"; // Ember.assert
 import CoreObject from "ember-runtime/system/core_object";
 import Observable from "ember-runtime/mixins/observable";
+import { validatePropertyInjections } from "ember-runtime/inject";
 
 /**
   `Ember.Object` is the main base class for all Ember objects. It is a subclass
@@ -20,5 +22,21 @@ var EmberObject = CoreObject.extend(Observable);
 EmberObject.toString = function() {
   return "Ember.Object";
 };
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  EmberObject.reopen({
+    /**
+      Provides mixin-time validation for injected properties.
+
+      @private
+      @method willMergeMixin
+    */
+    willMergeMixin: function(props) {
+      // Injection validations are a debugging aid only, so ensure that they are
+      // not performed in production builds by invoking from an assertion
+      Ember.assert("Injected properties are invalid", validatePropertyInjections(this.constructor, props));
+    }
+  });
+}
 
 export default EmberObject;

--- a/packages/ember-runtime/lib/system/service.js
+++ b/packages/ember-runtime/lib/system/service.js
@@ -1,0 +1,43 @@
+import Object from "ember-runtime/system/object";
+import { createInjectionHelper } from 'ember-runtime/inject';
+
+var Service;
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  /**
+    @class Service
+    @namespace Ember
+    @extends Ember.Object
+  */
+  Service = Object.extend();
+
+  /**
+    Creates a property that lazily looks up a service in the container. There
+    are no restrictions as to what objects a service can be injected into.
+
+    Example:
+
+    ```javascript
+    App.ApplicationRoute = Ember.Route.extend({
+      authManager: Ember.inject.service('auth'),
+
+      model: function() {
+        return this.get('authManager').findCurrentUser();
+      }
+    });
+    ```
+
+    This example will create an `authManager` property on the application route
+    that looks up the `auth` service in the container, making it easily
+    accessible in the `model` hook.
+
+    @method inject.service
+    @for Ember
+    @param {String} name (optional) name of the service to inject, defaults to
+           the property's name
+    @return {Ember.InjectedProperty} injection descriptor instance
+  */
+  createInjectionHelper('service');
+}
+
+export default Service;

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -1,6 +1,9 @@
 import Controller from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import Mixin from "ember-metal/mixin";
+import Object from "ember-runtime/system/object";
+import Container from "ember-runtime/system/container";
+import inject from "ember-runtime/inject";
 
 QUnit.module('Controller event handling');
 
@@ -169,3 +172,33 @@ test("specifying `content` (with `model` specified) does not result in deprecati
     model: 'blammo'
   }).create();
 });
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  QUnit.module('Controller injected properties');
+
+  test("defining a controller on a non-controller should fail assertion", function(){
+    expectAssertion(function() {
+      var AnObject = Object.extend({
+        foo: inject.controller('bar')
+      });
+
+      // Prototype chains are lazy, make sure it's evaluated
+      AnObject.proto();
+    }, /Defining an injected controller property on a non-controller is not allowed./);
+  });
+
+  test("controllers can be injected into controllers", function() {
+    var container = new Container();
+
+    container.register('controller:post', Controller.extend({
+      postsController: inject.controller('posts')
+    }));
+
+    container.register('controller:posts', Controller.extend());
+
+    var postController = container.lookup('controller:post'),
+      postsController = container.lookup('controller:posts');
+
+    equal(postsController, postController.get('postsController'), "controller.posts is injected");
+  });
+}

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -1,4 +1,5 @@
 import Controller from "ember-runtime/controllers/controller";
+import Service from "ember-runtime/system/service";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import Mixin from "ember-metal/mixin";
 import Object from "ember-runtime/system/object";
@@ -200,5 +201,20 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
       postsController = container.lookup('controller:posts');
 
     equal(postsController, postController.get('postsController'), "controller.posts is injected");
+  });
+
+  test("services can be injected into controllers", function() {
+    var container = new Container();
+
+    container.register('controller:application', Controller.extend({
+      authService: inject.service('auth')
+    }));
+
+    container.register('service:auth', Service.extend());
+
+    var appController = container.lookup('controller:application'),
+      authService = container.lookup('service:auth');
+
+    equal(authService, appController.get('authService'), "service.auth is injected");
   });
 }

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -1,0 +1,56 @@
+import InjectedProperty from "ember-metal/injected_property";
+import {
+  createInjectionHelper,
+  default as inject
+} from "ember-runtime/inject";
+import Container from "ember-runtime/system/container";
+import Object from "ember-runtime/system/object";
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  QUnit.module('inject');
+
+  test("calling `inject` directly should error", function() {
+    throws(function() {
+      inject('foo');
+    }, /Injected properties must be created through helpers/);
+  });
+
+  test("injection type validation function is run once at mixin time", function() {
+    expect(1);
+
+    createInjectionHelper('foo', function() {
+      ok(true, 'should call validation function');
+    });
+
+    var AnObject = Object.extend({
+      bar: inject.foo(),
+      baz: inject.foo()
+    });
+
+    // Prototype chains are lazy, make sure it's evaluated
+    AnObject.proto();
+  });
+
+  test("attempting to inject a nonexistent container key should error", function() {
+    var container = new Container();
+    var AnObject = Object.extend({
+      container: container,
+      foo: new InjectedProperty('bar', 'baz')
+    });
+
+    container.register('foo:main', AnObject);
+
+    throws(function() {
+      container.lookup('foo:main');
+    }, /Attempting to inject an unknown injection: `bar:baz`/);
+  });
+
+  test("factories should return a list of lazy injection full names", function() {
+    var AnObject = Object.extend({
+      foo: new InjectedProperty('foo', 'bar'),
+      bar: new InjectedProperty('quux')
+    });
+
+    deepEqual(AnObject.lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, "should return injected container keys");
+  });
+}

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -1,6 +1,9 @@
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
+import Service from "ember-runtime/system/service";
+import Container from "ember-runtime/system/container";
+import inject from "ember-runtime/inject";
 
 import EmberView from "ember-views/views/view";
 import Component from "ember-views/views/component";
@@ -178,3 +181,22 @@ test("Calling sendAction on a component with multiple parameters", function() {
 
   deepEqual(actionArguments, [firstContext, secondContext], "arguments were sent to the action");
 });
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  QUnit.module('Ember.Component - injected properties');
+
+  test("services can be injected into components", function() {
+    var container = new Container();
+
+    container.register('component:application', Component.extend({
+      profilerService: inject.service('profiler')
+    }));
+
+    container.register('service:profiler', Service.extend());
+
+    var appComponent = container.lookup('component:application'),
+    profilerService = container.lookup('service:profiler');
+
+    equal(profilerService, appComponent.get('profilerService'), "service.profiler is injected");
+  });
+}

--- a/packages/ember-views/tests/views/view/inject_test.js
+++ b/packages/ember-views/tests/views/view/inject_test.js
@@ -1,0 +1,23 @@
+import Service from "ember-runtime/system/service";
+import Container from "ember-runtime/system/container";
+import inject from "ember-runtime/inject";
+import View from "ember-views/views/view";
+
+if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  QUnit.module('EmberView - injected properties');
+
+  test("services can be injected into views", function() {
+    var container = new Container();
+
+    container.register('view:application', View.extend({
+      profilerService: inject.service('profiler')
+    }));
+
+    container.register('service:profiler', Service.extend());
+
+    var appView = container.lookup('view:application'),
+      profilerService = container.lookup('service:profiler');
+
+    equal(profilerService, appView.get('profilerService'), "service.profiler is injected");
+  });
+}


### PR DESCRIPTION
# Injected Properties

This PR is intended to implement the necessary features for Ember 'services' (see #4861). It introduces 'injection helpers' which are computed properties that are container-aware, but whose use is type dependent (e.g., you cannot define an injected controller property on a view). As discussed on @tomdale's PR, there is ambiguity between an injection helper named `Ember.controller` and the actual `Ember.Controller` class, so to avoid this I've created a new top level namespace called `inject` (see below).

As an example, the following is enabled:

``` javascript
App.PostController = Ember.Controller.extend({
  posts: Ember.inject.controller()
});
```

Which is functionally equivalent to:

``` javascript
App.PostController = Ember.Controller.extend({
  needs: 'posts',
  posts: Ember.computed.alias('controllers.posts')
});
```

This PR also adds the `controller` and `service` injection helpers (as well as `Ember.Service`), but those commits can easily be extracted into another PR
## Validation

In order to enforce good practices, injection helpers can only be used with certain ember objects (or rather _can't_ be used with certain ember objects).
1. controllers can only be injected into other controllers
2. ~~services cannot be injected into views or components~~

This validation check can happen in one of two places:
1. at mixin time
2. at instantiation time

The first option seems better since it happens early and only once.

A second type of validation ensures that the object with injection properties has a reference to the container, and that the container has knowledge of the requested injections (through `app.register` or the resolver). This check can happen at one of two places:
1. at instantiation time
2. at access time

The first option seems better since it happens earlier (assuming that registration of container types happens during app bootstrap).
## Injection

When an injection helper property is declared on a class, all instances of that class need the property looked up and set. There are a few places this can happen:
1. at instantiation time via normal container injection
2. at instantiation time in `CoreObject`
3. lazy lookup on container in computed property getter

The first option would maintain consistency with current container injections and allow instances to access their properties without calling `.get()`, but require either accessing the injection at mixin time (where a container is not currently accessible), or by altering the container to be aware of the ember object model (which it is currently only vaguely aware of). The last approach has the advantage of not performing a lookup if never accessed, and being able to take advantage of CP cache, which seems to make it the best candidate.
## Design Decisions
### Feature name

This touches more than just `ember-metal`, but that package is the lowest common denominator. It would be trivial to split this up into multiple dependent features as an alternative.
### `inject` namespace

This is simply to avoid the potential ambiguity between `Ember.controller`/`Ember.Controller` `Ember.service`/`Ember.Service`. It also happens to read well, since what the developer wants to do is, for example, 'inject [a] controller'.
### `inject` namespace (not) as a function

Much like `Ember.run` and `Ember.computed`, the `Ember.inject` namespace could potentially be a convenience method for a container injection property, however that would enable the "injection of anything into anything" anti-pattern that should be avoided if possible. By only allowing injected properties through predefined methods, Ember is enforcing best practices.
### Referencing the container in ember-metal

The container is not mentioned anywhere in `ember-metal`, but since injected properties are type of descriptor, and all other descriptor properties are defined in `ember-metal`, it seemed like the best place. It could also easily go in the `ember-runtime` package.
### ~~Validation in `Ember.Object` `init` event~~ (no longer applies)

There are a few places instantiation-time validation can happen:
1. directly in `CoreObject`'s constructor
2. `Object`'s init` event/hook
3. `Object`'s `didDefineProperty` hook

Although nothing in Ember core (to my knowledge) currently uses the `init` event, it seemed like the best option since requiring _all_ existing subclasses that define `init` or `didDefineProperty` hooks call `_super` for validation to work, is IMHO dangerous and could be considered a breaking API change. Yes, controllers currently implement this check in the `init` hook, but extending it to all objects is much farther reaching.
### `willMergeMixin` on `Ember.Object`

This is obviously dubious for the potential performance hit. However, during my `ember-metal` spelunking, it seems like this private hook is specifically intended for doing any special mixin-time handling. So short of baking injected property validation into `ember-metal` itself, this is all I could come up with.
### Branding vs. `instanceof`

This is something that @stefanpenner mentioned in the original PR. I could not find much information on the performance implications of "branding" versus use of the `instanceof` operator, except by inference in this [jsperf](http://jsperf.com/instanceof-performance/2) (which only shows results in chrome). This did not seem to warrant breaking existing patterns, and can easily be changed later when other `instanceof` checks are converted.
### `Ember.assert` vs. `throw new EmberError(...)`

To be perfectly honest, I have no idea when something warrants a full production-time exception over a development assertion. Is there a guide for this anywhere? I ended up just making best-guesses.
### TODO

It should be possible to cache a list of injected properties on the constructor's meta object when mixin-time validation happens, thereby avoiding the repeated descriptor lookups at instantiation-time validation. I just don't know enough about how metadata is stored/accessed to be confident enough to do this, especially since there are additional considerations when classes get extended multiple times with new injected properties.
