### PR TITLE
[FEATURE ember-routing-auto-location-uses-replace-state-for-history]

### DIFF
--- a/features.json
+++ b/features.json
@@ -9,6 +9,7 @@
     "ember-routing-will-change-hooks": null,
     "ember-routing-consistent-resources": true,
     "ember-routing-multi-current-when": null,
+    "ember-routing-auto-location-uses-replace-state-for-history": null,
     "event-dispatcher-can-disable-event-manager": null,
     "ember-metal-is-present": null,
     "property-brace-expansion-improvement": null,

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -351,8 +351,18 @@ export default {
       if (currentPath === historyPath) {
         implementationClass = this._HistoryLocation;
       } else {
-        cancelRouterSetup = true;
-        this._replacePath(historyPath);
+        if (Ember.FEATURES.isEnabled("ember-routing-auto-location-uses-replace-state-for-history")) {
+          if (currentPath.substr(0, 2) === '/#') {
+            this._history.replaceState({ path: historyPath }, null, historyPath);
+            implementationClass = this._HistoryLocation;
+          } else {
+            cancelRouterSetup = true;
+            this._replacePath(historyPath);
+          }
+        } else {
+          cancelRouterSetup = true;
+          this._replacePath(historyPath);
+        }
       }
 
     } else if (this._getSupportsHashChange()) {

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -208,32 +208,59 @@ test("AutoLocation.create() should transform the URL for hashchange-only browser
   equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
 });
 
-test("AutoLocation.create() should transform the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
-  expect(4);
+if (Ember.FEATURES.isEnabled('ember-routing-auto-location-uses-replace-state-for-history')) {
+  test("AutoLocation.create() should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
+    expect(2);
 
-  supportsHistory = true;
-  supportsHashChange = true;
+    supportsHistory = true;
+    supportsHashChange = true;
 
-  AutoTestLocation._location = {
-    hash: '#/test',
-    hostname: 'test.com',
-    href: 'http://test.com/#/test',
-    pathname: '/',
-    protocol: 'http:',
-    port: '',
-    search: '',
+    AutoTestLocation._location = {
+      hash: '#/test',
+      hostname: 'test.com',
+      href: 'http://test.com/#/test',
+      pathname: '/',
+      protocol: 'http:',
+      port: '',
+      search: ''
+    };
 
-    replace: function (path) {
-      equal(path, 'http://test.com/test', 'location.replace should be called with normalized HistoryLocation url');
-    }
-  };
+    AutoTestLocation._history.replaceState = function (state, title, path) {
+      equal(path, '/test', 'history.replaceState should be called with normalized HistoryLocation url');
+    };
 
-  createLocation();
+    createLocation();
 
-  equal(get(location, 'implementation'), 'none', 'NoneLocation should be returned while we attempt to location.replace()');
-  equal(location instanceof FakeNoneLocation, true, 'NoneLocation should be returned while we attempt to location.replace()');
-  equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
-});
+    equal(get(location, 'implementation'), 'history');
+  });  
+} else {
+  test("AutoLocation.create() should transform the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
+    expect(4);
+
+    supportsHistory = true;
+    supportsHashChange = true;
+
+    AutoTestLocation._location = {
+      hash: '#/test',
+      hostname: 'test.com',
+      href: 'http://test.com/#/test',
+      pathname: '/',
+      protocol: 'http:',
+      port: '',
+      search: '',
+
+      replace: function (path) {
+        equal(path, 'http://test.com/test', 'location.replace should be called with normalized HistoryLocation url');
+      }
+    };
+
+    createLocation();
+
+    equal(get(location, 'implementation'), 'none', 'NoneLocation should be returned while we attempt to location.replace()');
+    equal(location instanceof FakeNoneLocation, true, 'NoneLocation should be returned while we attempt to location.replace()');
+    equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
+  });
+}
 
 test("AutoLocation._getSupportsHistory() should handle false positive for Android 2.2/2.3, returning false", function() {
   expect(1);


### PR DESCRIPTION
This feature will simply allow AutoLocation to avoid an unnecessary page reload when a pushState-enabled browser receives a hash-based URL. `window.history.pushState` gets called with the normalized version of the hash-based URL and the router continues on it's merry way.
