### PR TITLE
[BUGFIX release] fixes variable argument passing to triggerEvent helper

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -74,6 +74,7 @@ function click(app, selector, context) {
 
 function triggerEvent(app, selector, context, type, options){
   if (arguments.length === 3) {
+    options = type;
     type = context;
     context = null;
   }
@@ -367,7 +368,7 @@ click('#some-link-id').then(validateURL);
 helper('currentURL', currentURL);
 
 /**
-  Triggers the given event on the element identified by the provided selector.
+  Triggers the given DOM event on the element identified by the provided selector.
 
   Example:
 
@@ -383,8 +384,10 @@ helper('currentURL', currentURL);
 
  @method triggerEvent
  @param {String} selector jQuery selector for finding element on the DOM
+ @param {String} [context] jQuery selector that will limit the selector
+                           argument to find only within the context's children
  @param {String} type The event type to be triggered.
- @param {String} options The options to be passed to jQuery.Event.
+ @param {Object} options The options to be passed to jQuery.Event.
  @return {RSVP.Promise}
  @since 1.5.0
 */

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -555,7 +555,42 @@ test("pendingAjaxRequests is reset by setupForTesting", function() {
   equal(Test.pendingAjaxRequests, 0, 'pendingAjaxRequests is reset');
 });
 
-test("`trigger` can be used to trigger arbitrary events", function() {
+test("`triggerEvent can limit searching for a selector to a scope", function(){
+  expect(2);
+
+  var triggerEvent, wait, event;
+
+  run(function() {
+    App = EmberApplication.create();
+    App.setupForTesting();
+  });
+
+  App.IndexView = EmberView.extend({
+    template: Ember.Handlebars.compile('{{input type="text" id="outside-scope" class="input"}}<div id="limited">{{input type="text" id="inside-scope" class="input"}}</div>'),
+
+    didInsertElement: function() {
+      this.$('.input').on('blur change', function(e) {
+        event = e;
+      });
+    }
+  });
+
+  App.injectTestHelpers();
+
+  run(App, App.advanceReadiness);
+
+  triggerEvent = App.testHelpers.triggerEvent;
+  wait         = App.testHelpers.wait;
+
+  wait().then(function() {
+    return triggerEvent('.input', '#limited', 'blur');
+  }).then(function() {
+    equal(event.type, 'blur', 'correct event was triggered');
+    equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
+  });
+});
+
+test("`triggerEvent` can be used to trigger arbitrary events", function() {
   expect(2);
 
   var triggerEvent, wait, event;


### PR DESCRIPTION
triggerEvent takes an optional third argument, but were weren't properly 
resetting argument names if you didn't pass the third argument.

Passing a scope to triggerEvent was also untested.
