### PR TITLE
[BUGFIX release] Do not throw uncaught errors mid-transition.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -612,16 +612,7 @@ var defaultActionHandlers = {
       return;
     }
 
-    var errorArgs = ['Error while processing route: ' + transition.targetName];
-
-    if (error) {
-      if (error.message) { errorArgs.push(error.message); }
-      if (error.stack)   { errorArgs.push(error.stack); }
-
-      if (typeof error === "string") { errorArgs.push(error); }
-    }
-
-    Ember.Logger.error.apply(this, errorArgs);
+    logError(error, 'Error while processing route: ' + transition.targetName);
   },
 
   loading: function(transition, originRoute) {
@@ -651,6 +642,21 @@ var defaultActionHandlers = {
     }
   }
 };
+
+function logError(error, initialMessage) {
+  var errorArgs = [];
+
+  if (initialMessage) { errorArgs.push(initialMessage); }
+
+  if (error) {
+    if (error.message) { errorArgs.push(error.message); }
+    if (error.stack)   { errorArgs.push(error.stack); }
+
+    if (typeof error === "string") { errorArgs.push(error); }
+  }
+
+  Ember.Logger.error.apply(this, errorArgs);
+}
 
 function findChildRouteName(parentRoute, originatingChildRoute, name) {
   var router = parentRoute.router;
@@ -833,7 +839,7 @@ function listenForTransitionErrors(transition) {
     } else if (error.name === 'TransitionAborted') {
       // just ignore TransitionAborted here
     } else {
-      throw error;
+      logError(error);
     }
 
     return error;


### PR DESCRIPTION
The primary intent of this was to rethrow the error when it wasn't a known (ignorable) type, and the default RSVP error handler would ensure that it was printed to the console.

This worked wonderfully, except that it caused an error to occur (an `Ember.assert` throws an error) during the rendering of the `error` route (or template).

This changes from `throw`ing the error to just logging it, but the userland result is the same: useful console error messages showing when bad things happen in route hook promises.

Closes #5148.

1.6.1 will need to be released after this has been merged.
