### PR TITLE
[DOC] Fixed issue with docs showing 'Ember.run' as 'run.run'

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -144,7 +144,7 @@ run.join = function(target, method /* args */) {
   ```
 
   @method bind
-  @namespace run
+  @namespace Ember
   @param {Object} [target] target of method to call
   @param {Function|String} method Method to invoke.
     May be a function or a string. If you pass a string


### PR DESCRIPTION
Fixes issue with docs reporting the namespace of `Ember.run` as `run`, resulting in the website showing it as `run.run`. This also changes the namespace of all `Ember.run` functions to `Ember` in the yuidoc output, however I don't think the website uses that data at all.
