### PR TITLE
[DOC release] Move example comments to new line

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -145,13 +145,15 @@ export default Mixin.create({
     with a list of strings or an array:
 
     ```javascript
-    record.getProperties('firstName', 'lastName', 'zipCode');  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    record.getProperties('firstName', 'lastName', 'zipCode');
+    // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
     ```
 
     is equivalent to:
 
     ```javascript
-    record.getProperties(['firstName', 'lastName', 'zipCode']);  // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
+    record.getProperties(['firstName', 'lastName', 'zipCode']);
+    // { firstName: 'John', lastName: 'Doe', zipCode: '10011' }
     ```
 
     @method getProperties


### PR DESCRIPTION
Prevents the user from having to scroll horizontally to
read the examples.
