### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
I noticed Ember does not yet have an [EditorConfig](http://editorconfig.org/) file.

This file acts as a living style guide.  It's both human- and machine-readable.  With an EditorConfig plugin installed in your text editor, this file acts as a self-enforcing style guide.  Without a plugin installed, this is simply an easily-readable style guide.

This should reduce (or in the case of contributors using EditorConfig, entirely remove) problems such as the one in #5199.

Disclaimer: I'm one of the EditorConfig project team members.
