### PR TITLE
[BUGFIX beta] Prevent strict mode errors from superWrapper.

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -348,10 +348,10 @@ export function metaPath(obj, path, writable) {
 */
 export function wrap(func, superFunc) {
   function superWrapper() {
-    var ret, sup = this.__nextSuper;
-    this.__nextSuper = superFunc;
+    var ret, sup = this && this.__nextSuper;
+    if(this) { this.__nextSuper = superFunc; }
     ret = apply(this, func, arguments);
-    this.__nextSuper = sup;
+    if(this) { this.__nextSuper = sup; }
     return ret;
   }
 

--- a/packages/ember-runtime/tests/system/object/strict-mode-test.js
+++ b/packages/ember-runtime/tests/system/object/strict-mode-test.js
@@ -1,0 +1,30 @@
+import Ember from "ember-metal/core";
+import EmberObject from "ember-runtime/system/object";
+
+var originalLookup, lookup;
+
+QUnit.module('strict mode tests');
+
+test('__superWrapper does not throw errors in strict mode', function() {
+  var Foo = EmberObject.extend({
+    blah: function() {
+      return 'foo';
+    }
+  });
+
+  var Bar = Foo.extend({
+    blah: function() {
+      return 'bar';
+    },
+
+    callBlah: function() {
+      var blah = this.blah;
+
+      return blah();
+    }
+  });
+
+  var bar = Bar.create();
+
+  equal(bar.callBlah(), 'bar', 'can call local function without call/apply');
+});


### PR DESCRIPTION
In Strict Mode accessing the global `window` is considered insecure, and will cause errors. This changes just guards against setting properties on `window` which throws an error like the following:

```
Cannot read property '__nextSuper' of undefined TypeError: Cannot read property '__nextSuper' of undefined
    at superWrapper (http://builds.emberjs.com/tags/v1.6.1/ember.js:7568:28)
    at App.IndexRoute.App.FooRoute.extend.model (http://emberjs.jsbin.com/yelesahe/3:61:5)
    at apply (http://builds.emberjs.com/tags/v1.6.1/ember.js:7993:27)
    at superWrapper [as model] (http://builds.emberjs.com/tags/v1.6.1/ember.js:7570:15)
    at EmberObject.extend.deserialize (http://builds.emberjs.com/tags/v1.6.1/ember.js:38347:23)
    at Object.HandlerInfo.runSharedModelHook (http://builds.emberjs.com/tags/v1.6.1/ember.js:40437:61)
    at Object.subclass.getModel (http://builds.emberjs.com/tags/v1.6.1/ember.js:40661:21)
    at __exports__.bind (http://builds.emberjs.com/tags/v1.6.1/ember.js:42142:19)
    at invokeCallback (http://builds.emberjs.com/tags/v1.6.1/ember.js:10558:19)
    at publish (http://builds.emberjs.com/tags/v1.6.1/ember.js:10228:9) 
```

[Here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode#.22Securing.22_JavaScript) is what MDN has to say about "Securing" JavaScript.
