### PR TITLE
[BUGFIX beta] link-to helper can be inserted in DOM when the router is not present

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -375,7 +375,10 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
     @property router
   **/
   router: computed(function() {
-    return get(this, 'controller').container.lookup('router:main');
+    var controller = get(this, 'controller');
+    if (controller && controller.container) {
+      return controller.container.lookup('router:main');
+    }
   }),
 
   /**
@@ -513,8 +516,10 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
     @return {Array} An array with the route name and any dynamic segments
   **/
   loadedParams: computed('resolvedParams', function computeLinkViewRouteArgs() {
+    var router = get(this, 'router');
+    if (!router) { return; }
+
     var resolvedParams = get(this, 'resolvedParams'),
-        router = get(this, 'router'),
         namedRoute = resolvedParams.targetRouteName;
 
     if (!namedRoute) { return; }

--- a/packages/ember-routing-handlebars/tests/helpers/link_to_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/link_to_test.js
@@ -1,0 +1,43 @@
+import Ember from 'ember-metal/core'; // TEMPLATES
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import run from "ember-metal/run_loop";
+
+import EmberHandlebars from "ember-handlebars";
+import EmberView from "ember-views/views/view";
+import jQuery from "ember-views/system/jquery";
+
+var view;
+
+var appendView = function(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+};
+
+var compile = EmberHandlebars.compile;
+
+
+QUnit.module("Handlebars {{link-to}} helper", {
+  setup: function() {
+
+  },
+
+  teardown: function() {
+    run(function() {
+      if (view) { view.destroy(); }
+    });
+  }
+});
+
+
+test("should be able to be inserted in DOM when the router is not present", function() {
+
+  var template = "{{#link-to 'index'}}Go to Index{{/link-to}}";
+  view = EmberView.create({
+    template: compile(template)
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'Go to Index');
+
+});


### PR DESCRIPTION
Closes rwjblue/ember-qunit#52.

I wonder if it is necessary to create a test for this case and in which package (ember/ember-routing-handlebars/ember-views) it should exactly be placed.
