### PR TITLE
[BUGFIX] Don't pass function UNDEFINED as oldValue to computed properties

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -385,7 +385,10 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
   try {
 
     if (cacheable && cache[keyName] !== undefined) {
-      cachedValue = cache[keyName];
+      if(cache[keyName] !== UNDEFINED) {
+        cachedValue = cache[keyName];
+      }
+
       hadCachedValue = true;
     }
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -609,6 +609,22 @@ test('adding a computed property should show up in key iteration',function() {
   ok('foo' in obj, 'foo in obj should pass');
 });
 
+testBoth("when setting a value after it had been retrieved empty don't pass function UNDEFINED as oldValue", function(get, set) {
+    var obj = {}, oldValueIsNoFunction = true;
+
+    defineProperty(obj, 'foo', computed(function(key, value, oldValue) {
+        if(typeof oldValue === 'function') {
+            oldValueIsNoFunction = false;
+        }
+
+        return undefined;
+    }));
+
+    get(obj, 'foo');
+    set(obj, 'foo', undefined);
+
+    ok(oldValueIsNoFunction);
+});
 
 QUnit.module('computed - setter');
 


### PR DESCRIPTION
was: "Failing test if computed property receives function UNDEFINED as oldValue"
Hey,

currently if you get a computed property that is undefined (unknown?) and then set it, the computed property gets function UNDEFINED passed as oldValue

Demo of the issue:
http://emberjs.jsbin.com/vijajora/2/edit

Best regards,
Domme

P.S.: @stefanpenner this is likely for you :+1: 
