### PR TITLE
Ensure es3recast processes files one at a time.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -65,6 +65,10 @@ function concatES6(sourceTrees, options) {
     moduleName: true
   });
 
+  if (options.es3Safe) {
+    sourceTrees = es3recast(sourceTrees);
+  }
+
   if (!disableDefeatureify) {
     sourceTrees = defeatureify(sourceTrees, defeatureifyConfig(options.defeatureifyOptions));
   }
@@ -303,6 +307,7 @@ function backburner() {
 }
 
 var compiledSource = concatES6(sourceTrees, {
+  es3Safe: env !== 'development',
   includeLoader: true,
   bootstrapModule: 'ember',
   vendorTrees: vendorTrees,
@@ -338,6 +343,7 @@ var prodCompiledSource = removeFile(sourceTrees, {
 });
 
 prodCompiledSource = concatES6(prodCompiledSource, {
+  es3Safe: env !== 'development',
   includeLoader: true,
   bootstrapModule: 'ember',
   vendorTrees: vendorTrees,
@@ -353,6 +359,7 @@ var minCompiledSource = moveFile(prodCompiledSource, {
 minCompiledSource = uglifyJavaScript(minCompiledSource);
 
 var compiledTests = concatES6(testTrees, {
+  es3Safe: env !== 'development',
   includeLoader: true,
   inputFiles: ['**/*.js'],
   destFile: '/ember-tests.js'
@@ -364,10 +371,6 @@ if (env !== 'development') {
   distTrees.push(prodCompiledSource);
   distTrees.push(minCompiledSource);
   distTrees.push(buildRuntimeTree());
-  distTrees = distTrees.map(function(tree){
-    return es3recast(tree);
-  });
-  //distTrees.push(compiledPackageTrees);
 }
 
 distTrees = mergeTrees(distTrees);


### PR DESCRIPTION
Production builds before this change took approximately 70 seconds on my machine.
After this change they take ~52 seconds, and rebuilds take ~7 seconds.

**BEFORE**

```
Build successful - 70423ms.

Slowest Trees                  | Total
-------------------------------+----------------
ES3SafeFilter                  | 16020ms
ES3SafeFilter                  | 7443ms
ES3SafeFilter                  | 7278ms
ES3SafeFilter                  | 6979ms
DefeatureifyFilter             | 5292ms
ES3SafeFilter                  | 3916ms
ES3SafeFilter                  | 3615ms

file changed mixins/deferred_test.js

Build successful - 47688ms.
... Reload LiveReload files ...

Slowest Trees                  | Total
-------------------------------+----------------
ES3SafeFilter                  | 17385ms
ES3SafeFilter                  | 8278ms
ES3SafeFilter                  | 7518ms
ES3SafeFilter                  | 7363ms
ES3SafeFilter                  | 3658ms
```

**AFTER**

```
Build successful - 57506ms.

Slowest Trees                  | Total
-------------------------------+----------------
ES3SafeFilter                  | 16911ms
ES3SafeFilter                  | 9628ms
ES3SafeFilter                  | 9211ms
DefeatureifyFilter             | 6179ms

file changed main.js

Build successful - 6344ms.

Slowest Trees                  | Total
-------------------------------+----------------
UglifyJSFilter                 | 1252ms
```
