### PR TITLE
Replaces META_KEY with `__ember_meta__`

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -1,6 +1,6 @@
 import Ember from "ember-metal/core"; // warn, assert, etc;
 import {get, normalizeTuple} from "ember-metal/property_get";
-import {meta, META_KEY} from "ember-metal/utils";
+import {meta} from "ember-metal/utils";
 import {forEach} from "ember-metal/array";
 import {watchKey, unwatchKey} from "ember-metal/watch_key";
 
@@ -45,7 +45,7 @@ function addChainWatcher(obj, keyName, node) {
 function removeChainWatcher(obj, keyName, node) {
   if (!obj || 'object' !== typeof obj) { return; } // nothing to do
 
-  var m = obj[META_KEY];
+  var m = obj['__ember_meta__'];
   if (m && !m.hasOwnProperty('chainWatchers')) { return; } // nothing to do
 
   var nodes = m && m.chainWatchers;
@@ -99,7 +99,7 @@ var ChainNodePrototype = ChainNode.prototype;
 function lazyGet(obj, key) {
   if (!obj) return undefined;
 
-  var meta = obj[META_KEY];
+  var meta = obj['__ember_meta__'];
   // check if object meant only to be a prototype
   if (meta && meta.proto === obj) return undefined;
 
@@ -319,7 +319,7 @@ ChainNodePrototype.didChange = function(events) {
 
 export function finishChains(obj) {
   // We only create meta if we really have to
-  var m = obj[META_KEY], chains = m && m.chains;
+  var m = obj['__ember_meta__'], chains = m && m.chains;
   if (chains) {
     if (chains.value() !== obj) {
       metaFor(obj).chains = chains = chains.copy(obj);

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -3,7 +3,6 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import {
   meta,
-  META_KEY,
   inspect
 } from "ember-metal/utils";
 import expandProperties from "ember-metal/expand_properties";
@@ -503,7 +502,7 @@ function computed(func) {
   @return {Object} the cached value
 */
 function cacheFor(obj, key) {
-  var meta = obj[META_KEY];
+  var meta = obj['__ember_meta__'];
   var cache = meta && meta.cache;
   var ret = cache && cache[key];
 

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -4,7 +4,6 @@
 import Ember from "ember-metal/core";
 import {
   meta,
-  META_KEY,
   tryFinally,
   apply,
   applyStr
@@ -72,7 +71,7 @@ function actionsFor(obj, eventName) {
 }
 
 export function listenersUnion(obj, eventName, otherActions) {
-  var meta = obj[META_KEY],
+  var meta = obj['__ember_meta__'],
       actions = meta && meta.listeners && meta.listeners[eventName];
 
   if (!actions) { return; }
@@ -89,7 +88,7 @@ export function listenersUnion(obj, eventName, otherActions) {
 }
 
 export function listenersDiff(obj, eventName, otherActions) {
-  var meta = obj[META_KEY],
+  var meta = obj['__ember_meta__'],
       actions = meta && meta.listeners && meta.listeners[eventName],
       diffActions = [];
 
@@ -180,7 +179,7 @@ function removeListener(obj, eventName, target, method) {
   if (method) {
     _removeListener(target, method);
   } else {
-    var meta = obj[META_KEY],
+    var meta = obj['__ember_meta__'],
         actions = meta && meta.listeners && meta.listeners[eventName];
 
     if (!actions) { return; }
@@ -283,7 +282,7 @@ export function suspendListeners(obj, eventNames, target, method, callback) {
   @param obj
 */
 export function watchedEvents(obj) {
-  var listeners = obj[META_KEY].listeners, ret = [];
+  var listeners = obj['__ember_meta__'].listeners, ret = [];
 
   if (listeners) {
     for(var eventName in listeners) {
@@ -314,7 +313,7 @@ export function sendEvent(obj, eventName, params, actions) {
   }
 
   if (!actions) {
-    var meta = obj[META_KEY];
+    var meta = obj['__ember_meta__'];
     actions = meta && meta.listeners && meta.listeners[eventName];
   }
 
@@ -351,7 +350,7 @@ export function sendEvent(obj, eventName, params, actions) {
   @param {String} eventName
 */
 export function hasListeners(obj, eventName) {
-  var meta = obj[META_KEY],
+  var meta = obj['__ember_meta__'],
       actions = meta && meta.listeners && meta.listeners[eventName];
 
   return !!(actions && actions.length);
@@ -366,7 +365,7 @@ export function hasListeners(obj, eventName) {
 */
 export function listenersFor(obj, eventName) {
   var ret = [];
-  var meta = obj[META_KEY],
+  var meta = obj['__ember_meta__'],
       actions = meta && meta.listeners && meta.listeners[eventName];
 
   if (!actions) { return ret; }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -14,7 +14,6 @@ import { create } from "ember-metal/platform";
 import {
   guidFor,
   meta,
-  META_KEY,
   wrap,
   makeArray,
   apply
@@ -567,7 +566,7 @@ function _detect(curMixin, targetMixin, seen) {
 MixinPrototype.detect = function(obj) {
   if (!obj) { return false; }
   if (obj instanceof Mixin) { return _detect(obj, this, {}); }
-  var m = obj[META_KEY],
+  var m = obj['__ember_meta__'],
       mixins = m && m.mixins;
   if (mixins) {
     return !!mixins[guidFor(this)];
@@ -607,7 +606,7 @@ MixinPrototype.keys = function() {
 // returns the mixins currently applied to the specified object
 // TODO: Make Ember.mixin
 Mixin.mixins = function(obj) {
-  var m = obj[META_KEY],
+  var m = obj['__ember_meta__'],
       mixins = m && m.mixins, ret = [];
 
   if (!mixins) { return ret; }

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -3,10 +3,7 @@
 */
 
 import Ember from "ember-metal/core";
-import {
-  META_KEY,
-  meta
-} from "ember-metal/utils";
+import { meta } from "ember-metal/utils";
 import { platform } from "ember-metal/platform";
 import { overrideChains } from "ember-metal/property_events";
 import { get } from "ember-metal/property_get";
@@ -44,7 +41,7 @@ var MANDATORY_SETTER_FUNCTION = Ember.MANDATORY_SETTER_FUNCTION = function(value
 
 var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function DEFAULT_GETTER_FUNCTION(name) {
   return function() {
-    var meta = this[META_KEY];
+    var meta = this['__ember_meta__'];
     return meta && meta.values[name];
   };
 };

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -1,5 +1,4 @@
 import {
-  META_KEY,
   guidFor,
   tryFinally
 } from "ember-metal/utils";
@@ -34,7 +33,7 @@ var deferred = 0;
   @return {void}
 */
 function propertyWillChange(obj, keyName) {
-  var m = obj[META_KEY];
+  var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
   var desc = m && m.descs[keyName];
@@ -63,7 +62,7 @@ function propertyWillChange(obj, keyName) {
   @return {void}
 */
 function propertyDidChange(obj, keyName) {
-  var m = obj[META_KEY];
+  var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
   var desc = m && m.descs[keyName];

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -3,7 +3,6 @@
 */
 
 import Ember from "ember-metal/core";
-import { META_KEY } from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 import {
   isGlobalPath,
@@ -61,7 +60,7 @@ var get = function get(obj, keyName) {
 
   if (obj === null) { return _getPath(obj, keyName);  }
 
-  var meta = obj[META_KEY], desc = meta && meta.descs[keyName], ret;
+  var meta = obj['__ember_meta__'], desc = meta && meta.descs[keyName], ret;
 
   if (desc === undefined && isPath(keyName)) {
     return _getPath(obj, keyName);

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -1,6 +1,5 @@
 import Ember from "ember-metal/core";
 import { _getPath as getPath } from "ember-metal/property_get";
-import { META_KEY } from "ember-metal/utils";
 import {
   propertyWillChange,
   propertyDidChange
@@ -42,7 +41,7 @@ var set = function set(obj, keyName, value, tolerant) {
     return setPath(obj, keyName, value, tolerant);
   }
 
-  var meta = obj[META_KEY], desc = meta && meta.descs[keyName],
+  var meta = obj['__ember_meta__'], desc = meta && meta.descs[keyName],
       isUnknown, currentValue;
 
   if (desc === undefined && isPath(keyName)) {

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -161,17 +161,6 @@ var META_DESC = {
   value: null
 };
 
-/**
-  The key used to store meta information on object for property observing.
-
-  @property META_KEY
-  @for Ember
-  @private
-  @final
-  @type String
-*/
-var META_KEY = '__ember_meta__';
-
 var isDefinePropertySimulated = platform.defineProperty.isSimulated;
 
 function Meta(obj) {
@@ -235,23 +224,23 @@ if (MANDATORY_SETTER) { EMPTY_META.values = {}; }
 */
 function meta(obj, writable) {
 
-  var ret = obj[META_KEY];
+  var ret = obj['__ember_meta__'];
   if (writable===false) return ret || EMPTY_META;
 
   if (!ret) {
-    if (!isDefinePropertySimulated) o_defineProperty(obj, META_KEY, META_DESC);
+    if (!isDefinePropertySimulated) o_defineProperty(obj, '__ember_meta__', META_DESC);
 
     ret = new Meta(obj);
 
     if (MANDATORY_SETTER) { ret.values = {}; }
 
-    obj[META_KEY] = ret;
+    obj['__ember_meta__'] = ret;
 
     // make sure we don't accidentally try to create constructor like desc
     ret.descs.constructor = null;
 
   } else if (ret.source !== obj) {
-    if (!isDefinePropertySimulated) o_defineProperty(obj, META_KEY, META_DESC);
+    if (!isDefinePropertySimulated) o_defineProperty(obj, '__ember_meta__', META_DESC);
 
     ret = o_create(ret);
     ret.descs     = o_create(ret.descs);
@@ -262,7 +251,7 @@ function meta(obj, writable) {
 
     if (MANDATORY_SETTER) { ret.values = o_create(ret.values); }
 
-    obj[META_KEY] = ret;
+    obj['__ember_meta__'] = ret;
   }
   return ret;
 }
@@ -798,7 +787,6 @@ export {
   GUID_KEY,
   META_DESC,
   EMPTY_META,
-  META_KEY,
   meta,
   typeOf,
   tryCatchFinally,

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -4,7 +4,6 @@
 
 import {
   meta,
-  META_KEY,
   GUID_KEY,
   typeOf,
   generateGuid
@@ -56,7 +55,7 @@ function watch(obj, _keyPath, m) {
 export { watch };
 
 export function isWatching(obj, key) {
-  var meta = obj[META_KEY];
+  var meta = obj['__ember_meta__'];
   return (meta && meta.watching[key]) > 0;
 }
 
@@ -84,7 +83,7 @@ export function unwatch(obj, _keyPath, m) {
   @param obj
 */
 export function rewatch(obj) {
-  var m = obj[META_KEY], chains = m && m.chains;
+  var m = obj['__ember_meta__'], chains = m && m.chains;
 
   // make sure the object has its own guid.
   if (GUID_KEY in obj && !obj.hasOwnProperty(GUID_KEY)) {
@@ -109,9 +108,9 @@ var NODE_STACK = [];
   @return {void}
 */
 export function destroy(obj) {
-  var meta = obj[META_KEY], node, nodes, key, nodeObject;
+  var meta = obj['__ember_meta__'], node, nodes, key, nodeObject;
   if (meta) {
-    obj[META_KEY] = null;
+    obj['__ember_meta__'] = null;
     // remove chainWatchers to remove circular references that would prevent GC
     node = meta.chains;
     if (node) {

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -1,4 +1,3 @@
-import { META_KEY } from 'ember-metal/utils';
 import { addObserver } from "ember-metal/observer";
 import { finishChains } from "ember-metal/chains";
 import { create } from 'ember-metal/platform';
@@ -14,5 +13,5 @@ test("finishChains should properly copy chains from prototypes to instances", fu
   var childObj = create(obj);
   finishChains(childObj);
 
-  ok(obj[META_KEY].chains !== childObj[META_KEY].chains, "The chains object is copied");
+  ok(obj['__ember_meta__'].chains !== childObj['__ember_meta__'].chains, "The chains object is copied");
 });

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -19,7 +19,6 @@ import {
   generateGuid,
   GUID_KEY,
   meta,
-  META_KEY,
   makeArray
 } from "ember-metal/utils";
 import { rewatch } from "ember-metal/watching";
@@ -781,7 +780,7 @@ var ClassMixin = Mixin.create({
     @param key {String} property name
   */
   metaForProperty: function(key) {
-    var meta = this.proto()[META_KEY];
+    var meta = this.proto()['__ember_meta__'];
     var desc = meta && meta.descs[key];
 
     Ember.assert("metaForProperty() could not find a computed property with key '"+key+"'.", !!desc && desc instanceof ComputedProperty);

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -5,7 +5,6 @@ import {observer} from "ember-metal/mixin";
 import {set} from "ember-metal/property_set";
 import {bind} from "ember-metal/binding";
 import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_events";
-import {META_KEY} from "ember-metal/utils";
 import objectKeys from "ember-runtime/keys";
 import {testBoth} from 'ember-runtime/tests/props_helper';
 import EmberObject from 'ember-runtime/system/object';
@@ -17,13 +16,13 @@ testBoth("should schedule objects to be destroyed at the end of the run loop", f
 
   run(function() {
     obj.destroy();
-    meta = obj[META_KEY];
+    meta = obj['__ember_meta__'];
     ok(meta, "meta is not destroyed immediately");
     ok(get(obj, 'isDestroying'), "object is marked as destroying immediately");
     ok(!get(obj, 'isDestroyed'), "object is not destroyed immediately");
   });
 
-  meta = obj[META_KEY];
+  meta = obj['__ember_meta__'];
   ok(!meta, "meta is destroyed after run loop finishes");
   ok(get(obj, 'isDestroyed'), "object is destroyed after run loop finishes");
 });


### PR DESCRIPTION
V8 deoptimizes access to the object property:

``` javascript
function finishChains() {
  // Access to `obj[META_KEY]` will be deoptimized
  var m = obj[META_KEY], chains = m && m.chains;
  if (chains) {
    // ...
  }
}
```

[Relevant V8 trace](https://gist.github.com/twokul/00b0369dbe86f1ffa011#file-code-asm-L630-L640)
[Hygrogen trace](https://gist.github.com/twokul/dad7e4b671235bd64284#file-hydrogen-cfg-L23837)

Here's the sample that was profiled:

``` javascript
function createPeople() {
  var people = [];

  for (var i = 0; i < 500; i++) {
    people.push(
      Ember.Object.create()
    );
  }

  return people;
}
```

Result:

``` sh
[benchmark.js] META_KEY createPeople x 306 ops/sec ±0.60% (89 runs sampled)
[benchmark.js] '__ember_meta__' createPeople x 336 ops/sec ±0.60% (87 runs sampled)
```

Related [V8 bug](https://code.google.com/p/v8/issues/detail?id=3167).

Tested against:
- [V8 3.26](https://github.com/v8/v8/commits/3.26), Chrome 36.0.1985.125.
- [V8 master](https://github.com/v8/v8/commits/master), Chrome 38.0.2104.0.
