### PR TITLE
Cleanup some un-used imports

### DIFF
--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -2,10 +2,6 @@
 
 /*jshint newcap:false*/
 import Ember from "ember-metal/core"; // Ember.deprecate
-// var emberDeprecate = Ember.deprecate;
-
-import { get } from "ember-metal/property_get";
-import set from "ember-metal/property_set";
 
 import CoreView from "ember-views/views/core_view";
 import View from "ember-views/views/view";

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -82,20 +82,19 @@ var canSetNameOnInputs = (function() {
 })();
 
 /**
-  `Ember.RenderBuffer` gathers information regarding the view and generates the
-  final representation. `Ember.RenderBuffer` will generate HTML which can be pushed
+  `Ember.renderBuffer` gathers information regarding the view and generates the
+  final representation. `Ember.renderBuffer` will generate HTML which can be pushed
   to the DOM.
 
    ```javascript
-   var buffer = Ember.RenderBuffer('div');
+   var buffer = Ember.renderBuffer('div');
   ```
 
-  @class RenderBuffer
+  @method renderBuffer
   @namespace Ember
-  @constructor
   @param {String} tagName tag name (such as 'div' or 'p') used for the buffer
 */
-export default function RenderBuffer(tagName) {
+export default function renderBuffer(tagName) {
   return new _RenderBuffer(tagName); // jshint ignore:line
 }
 
@@ -374,7 +373,7 @@ _RenderBuffer.prototype = {
   },
 
   generateElement: function() {
-    var tagName = this.tagName, // pop since we don't need to close
+    var tagName = this.tagName,
         id = this.elementId,
         classes = this.classes,
         attrs = this.elementAttributes,

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -17,9 +17,6 @@ import { typeOf } from "ember-metal/utils";
 
 import { instrument } from "ember-metal/instrumentation";
 
-
-import renderBuffer from "ember-views/system/render_buffer";
-
 /**
   `Ember.CoreView` is an abstract class that exists to give view-like behavior
   to both Ember's main view class `Ember.View` and other classes like


### PR DESCRIPTION
@krisselden drop some imports and swap a `var foo = NonStandard.Thing()` to a `var blah = Standard.thing()`
