### PR TITLE
Use normal resolution rules to lookup Components.

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -14,6 +14,7 @@ import {
 import EmberObject from 'ember-runtime/system/object';
 import Namespace from 'ember-runtime/system/namespace';
 import EmberHandlebars from 'ember-handlebars';
+import EmberComponent from 'ember-views/views/component';
 
 export var Resolver = EmberObject.extend({
   /**
@@ -320,6 +321,26 @@ export default EmberObject.extend({
   resolveRoute: function(parsedName) {
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
+  },
+
+  resolveComponent: function(parsedName) {
+    this.useRouterNaming(parsedName);
+
+    var Component = this.resolveOther(parsedName);
+    var layoutName = 'components/' + parsedName.name;
+    var layout = this.resolve('template:' + layoutName);
+
+    // Only treat as a component if either the component
+    // or a template has been registered.
+    if (layout || Component) {
+      if (!Component) {
+        Component = EmberComponent;
+      }
+
+      return Component.extend({
+        layout: layout
+      });
+    }
   },
 
   /**

--- a/packages/ember-handlebars/lib/component_lookup.js
+++ b/packages/ember-handlebars/lib/component_lookup.js
@@ -2,28 +2,10 @@ import EmberObject from "ember-runtime/system/object";
 
 var ComponentLookup = EmberObject.extend({
   lookupFactory: function(name, container) {
-
+    Ember.deprecate('Usage of component-lookup:main is no longer needed. Please use normal container lookup/lookupFactory methods instead.');
     container = container || this.container;
 
-    var fullName = 'component:' + name,
-        templateFullName = 'template:components/' + name,
-        templateRegistered = container && container.has(templateFullName);
-
-    if (templateRegistered) {
-      container.injection(fullName, 'layout', templateFullName);
-    }
-
-    var Component = container.lookupFactory(fullName);
-
-    // Only treat as a component if either the component
-    // or a template has been registered.
-    if (templateRegistered || Component) {
-      if (!Component) {
-        container.register(fullName, Ember.Component);
-        Component = container.lookupFactory(fullName);
-      }
-      return Component;
-    }
+    return container.lookupFactory('component:' + name);
   }
 });
 

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -305,10 +305,7 @@ function resolveHelper(container, name) {
 
   var helper = container.lookup('helper:' + name);
   if (!helper) {
-    var componentLookup = container.lookup('component-lookup:main');
-    Ember.assert("Could not find 'component-lookup:main' on the provided container, which is necessary for performing component lookups", componentLookup);
-
-    var Component = componentLookup.lookupFactory(name, container);
+    var Component = container.lookupFactory('component:' + name);
     if (Component) {
       helper = EmberHandlebars.makeViewHelper(Component);
       container.register('helper:' + name, helper);

--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -62,10 +62,6 @@ function _bootstrap() {
   bootstrap( jQuery(document) );
 }
 
-function registerComponentLookup(container) {
-  container.register('component-lookup:main', ComponentLookup);
-}
-
 /*
   We tie this to application.load to ensure that we've at least
   attempted to bootstrap at the point that the application is loaded.
@@ -81,12 +77,6 @@ onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: 'domTemplates',
     initialize: _bootstrap
-  });
-
-  Application.initializer({
-    name: 'registerComponentLookup',
-    after: 'domTemplates',
-    initialize: registerComponentLookup
   });
 });
 

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -68,9 +68,12 @@ test("The helper becomes the body of the component", function() {
 });
 
 test("If a component is registered, it is used", function() {
+  delete Ember.TEMPLATES['components/expand-it'];
+
   boot(function() {
     container.register('component:expand-it', Ember.Component.extend({
-      classNames: 'testing123'
+      classNames: 'testing123',
+      layout: compile('hello {{yield}}')
     }));
   });
 
@@ -102,6 +105,7 @@ test("Late-registered components can be rendered with template registered on the
   boot(function() {
     container.register('template:components/sally-rutherford', compile("funkytowny{{yield}}"));
     container.register('component:sally-rutherford', Ember.Component);
+    container.injection('component:sally-rutherford', 'layout', 'template:components/sally-rutherford');
   });
 
   equal(Ember.$('#wrapper').text(), "hello world funkytowny-funkytowny!!!", "The component is composed correctly");
@@ -111,10 +115,9 @@ test("Late-registered components can be rendered with template registered on the
 test("Late-registered components can be rendered with ONLY the template registered on the container", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>");
+  Ember.TEMPLATES['components/borf-snorlax'] = compile("goodfreakingTIMES{{yield}}");
 
-  boot(function() {
-    container.register('template:components/borf-snorlax', compile("goodfreakingTIMES{{yield}}"));
-  });
+  boot();
 
   equal(Ember.$('#wrapper').text(), "hello world goodfreakingTIMES-goodfreakingTIMES!!!", "The component is composed correctly");
   ok(!Ember.Handlebars.helpers['borf-snorlax'], "Component wasn't saved to global Handlebars.helpers hash");
@@ -207,12 +210,12 @@ test("Components with a block should have the proper content when a template is 
   Ember.TEMPLATES['components/my-component'] = compile("{{text}}-{{yield}}");
 
   boot(function() {
+    App.MyComponentComponent = Ember.Component.extend({
+      text: 'inner'
+    });
+
     container.register('controller:application', Ember.Controller.extend({
       'text': 'outer'
-    }));
-
-    container.register('component:my-component', Ember.Component.extend({
-      text: 'inner'
     }));
   });
 
@@ -240,12 +243,12 @@ test("Components without a block should have the proper content when a template 
   Ember.TEMPLATES['components/my-component'] = compile("{{text}}");
 
   boot(function() {
+    App.MyComponentComponent = Ember.Component.extend({
+      text: 'inner'
+    });
+
     container.register('controller:application', Ember.Controller.extend({
       'text': 'outer'
-    }));
-
-    container.register('component:my-component', Ember.Component.extend({
-      text: 'inner'
     }));
   });
 
@@ -323,13 +326,13 @@ test("Components trigger actions in the components context when called from with
       }
     }));
 
-    container.register('component:my-component', Ember.Component.extend({
+    App.MyComponentComponent = Ember.Component.extend({
       actions: {
         fizzbuzz: function(){
           ok(true, 'action triggered on component');
         }
       }
-    }));
+    });
   });
 
   Ember.$('#fizzbuzz', "#wrapper").click();


### PR DESCRIPTION
Deprecates `Ember.ComponentLookup` in favor of adding the logic to the resolver (in a custom `resolveComponent`).
