### PR TITLE
Add test for more than two nested async helpers

### DIFF
--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -187,6 +187,24 @@ test("Nested async helpers", function() {
   });
 });
 
+test("Multiple nested async helpers", function() {
+  expect(2);
+
+  visit('/posts');
+
+  andThen(function() {
+    click('a:first', '#comments-link');
+
+    fillIn('.ember-text-field', "hello");
+    fillIn('.ember-text-field', "goodbye");
+  });
+
+  andThen(function() {
+    equal(find('.ember-text-field').val(), 'goodbye', "Fillin successfully works");
+    equal(currentRoute, 'comments', "Successfully visited comments route");
+  });
+});
+
 test("Helpers nested in thens", function() {
   expect(3);
 


### PR DESCRIPTION
In ember prior to commit 633cf453, if an acceptance test has more
than 2 async test helpers in an `andThen`, those later test helpers will
not fire in the proper order.

This bug is reported in #5251.

This test serves as a regression protection for the bug.
