### PR TITLE
A child view morph should not clobber existing DOM in the buffer

### DIFF
--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -60,7 +60,7 @@ EmberRenderer.prototype.createChildViewsMorph =
         view._childViewsMorph = this._dom.createMorph(element, start, end);
       }
     } else {
-      view._childViewsMorph = this._dom.createMorph(element, null, null);
+      view._childViewsMorph = this._dom.createMorph(element, element.lastChild, null);
     }
     return element;
   };


### PR DESCRIPTION
@krisselden This allows pushing into a buffer from `render` on a `ContainerView`.
