### PR TITLE
Revert "[BUGFIX release]  Fix usage of document.body.contains"

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -1,5 +1,3 @@
-/* global Node */
-
 import _default from "ember-views/views/states/default";
 import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
@@ -9,15 +7,6 @@ import merge from "ember-metal/merge";
 @submodule ember-views
 */
 var preRender = create(_default);
-
-var containsElement = Node.prototype.contains;
-if (!containsElement && Node.prototype.compareDocumentPosition) {
-  // polyfill for older Firefox.
-  // http://compatibility.shwups-cms.ch/en/polyfills/?&id=52
-  containsElement = function(node){
-    return !!(this.compareDocumentPosition(node) & 16);
-  };
-}
 
 merge(preRender, {
   // a view leaves the preRender state once its element has been
@@ -32,7 +21,7 @@ merge(preRender, {
 
     // We transition to `inDOM` if the element exists in the DOM
     var element = view.get('element');
-    if (containsElement.call(document.body, element)) {
+    if (document.body.contains(element)) {
       viewCollection.transitionTo('inDOM', false);
       viewCollection.trigger('didInsertElement');
     }


### PR DESCRIPTION
Reverts emberjs/ember.js#5240. We'll just not support older Firefox for now. This is addressed with HTMLBars.
