### PR TITLE
Move s3 publishing config from ember-publisher to ember.js

### DIFF
--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -15,5 +15,7 @@
 // ./bin/publish_to_s3.js
 // ```
 var S3Publisher = require('ember-publisher');
-publisher = new S3Publisher({project: 'ember'});
+var configPath = require('path').join(__dirname, '../config/s3ProjectConfig.js');
+
+publisher = new S3Publisher({projectConfigPath: configPath});
 publisher.publish();

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,0 +1,49 @@
+fileMap = function(revision,tag,date) {
+  return {
+    "ember.js":                   fileObject("ember",                   ".js",   "text/javascript",  revision, tag, date),
+    "ember-tests.js":             fileObject("ember-test",              ".js",   "text/javascript",  revision, tag, date),
+    "ember-template-compiler.js": fileObject("ember-template-compiler", ".js",   "text/javascript",  revision, tag, date),
+    "ember-runtime.js":           fileObject("ember-runtime",           ".js",   "text/javascript",  revision, tag, date),
+    "ember.min.js":               fileObject("ember.min",               ".js",   "text/javascript",  revision, tag, date),
+    "ember.prod.js":              fileObject("ember.prod",              ".js",   "text/javascript",  revision, tag, date),
+    "../docs/build/data.json":    fileObject("ember-docs",              ".json", "application/json", revision, tag, date)
+  };
+};
+
+function fileObject(baseName, extension, contentType, currentRevision, tag, date){
+  var fullName = "/" + baseName + extension;
+  var obj =  {
+    contentType: contentType,
+      destinations: {
+        canary: [
+          baseName + "-latest" + extension,
+          "latest" + fullName,
+          "canary" + fullName,
+          "canary/daily/" + date + fullName,
+          "canary/shas/" + currentRevision + fullName
+        ],
+        release: [
+          "stable" + fullName,
+          "release" + fullName,
+          "release/daily/" + date + fullName,
+          "release/shas/" + currentRevision + fullName
+        ],
+        beta: [
+          "beta" + fullName,
+          "beta/daily/" + date + fullName,
+          "beta/shas/" + currentRevision + fullName
+        ],
+        wildcard: []
+      }
+   };
+
+   if (tag) {
+     for (var key in obj.destinations) {
+       obj.destinations[key].push("tags/" + tag + fullName);
+     }
+   }
+
+   return obj;
+}
+
+module.exports = fileMap;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chalk": "~0.4.0",
     "defeatureify": "~0.2.0",
     "ember-cli": "0.0.40",
-    "ember-publisher": "0.0.3",
+    "ember-publisher": "0.0.6",
     "es6-module-transpiler": "~0.4.0",
     "express": "^4.5.0",
     "glob": "~3.2.8",


### PR DESCRIPTION
Several of us working on ember-publisher have decided that it would be better to keep the configuration within the including app.  This allows us to update the publishing for the including app without having to push a change to ember-publisher itself.  [[reference]](https://github.com/rondale-sc/ember-publisher/pull/6)

This PR should not change the functionality of `bin/publish_to_s3.js` at all.
