### PR TITLE
[BUGFIX beta] Use document.body.contains if Node is undefined.

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -10,12 +10,20 @@ import merge from "ember-metal/merge";
 */
 var preRender = create(_default);
 
-var containsElement = Node.prototype.contains;
-if (!containsElement && Node.prototype.compareDocumentPosition) {
-  // polyfill for older Firefox.
-  // http://compatibility.shwups-cms.ch/en/polyfills/?&id=52
-  containsElement = function(node){
-    return !!(this.compareDocumentPosition(node) & 16);
+var containsElement;
+if (typeof Node === 'object') {
+  containsElement = Node.prototype.contains;
+
+  if (!containsElement && Node.prototype.compareDocumentPosition) {
+    // polyfill for older Firefox.
+    // http://compatibility.shwups-cms.ch/en/polyfills/?&id=52
+    containsElement = function(node){
+      return !!(this.compareDocumentPosition(node) & 16);
+    };
+  }
+} else {
+  containsElement = function(element) {
+    return this.contains(element);
   };
 }
 


### PR DESCRIPTION
Fixes the changes made in https://github.com/emberjs/ember.js/pull/5240 to work with IE8.

Closes https://github.com/emberjs/ember.js/issues/5250.
Closes https://github.com/emberjs/ember.js/pull/5256.
