### PR TITLE
[BUGFIX release] Tests for triggerEvent's many argument signatures

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -74,13 +74,24 @@ function click(app, selector, context) {
 
 function triggerEvent(app, selector, context, type, options){
   if (arguments.length === 3) {
-    options = type;
+    // context and options are optional, so this is
+    // app, selector, type
     type = context;
     context = null;
+    options = {};
   }
 
-  if (typeof options === 'undefined') {
-    options = {};
+  if (arguments.length === 4) {
+    // context and options are optional, so this is
+    if (typeof type === "object") {  // either
+      // app, selector, type, options
+      options = type;
+      type = context;
+      context = null;
+    } else { // or
+      // app, selector, context, type
+      options = {};
+    }
   }
 
   var $el = app.testHelpers.findWithAssert(selector, context);
@@ -387,7 +398,7 @@ helper('currentURL', currentURL);
  @param {String} [context] jQuery selector that will limit the selector
                            argument to find only within the context's children
  @param {String} type The event type to be triggered.
- @param {Object} options The options to be passed to jQuery.Event.
+ @param {Object} [options] The options to be passed to jQuery.Event.
  @return {RSVP.Promise}
  @since 1.5.0
 */

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -555,6 +555,79 @@ test("pendingAjaxRequests is reset by setupForTesting", function() {
   equal(Test.pendingAjaxRequests, 0, 'pendingAjaxRequests is reset');
 });
 
+test("`triggerEvent accepts an optional options hash and context", function(){
+  expect(3);
+
+  var triggerEvent, wait, event;
+
+  run(function() {
+    App = EmberApplication.create();
+    App.setupForTesting();
+  });
+
+  App.IndexView = EmberView.extend({
+    template: Ember.Handlebars.compile('{{input type="text" id="outside-scope" class="input"}}<div id="limited">{{input type="text" id="inside-scope" class="input"}}</div>'),
+
+    didInsertElement: function() {
+      this.$('.input').on('blur change', function(e) {
+        event = e;
+      });
+    }
+  });
+
+  App.injectTestHelpers();
+
+  run(App, App.advanceReadiness);
+
+  triggerEvent = App.testHelpers.triggerEvent;
+  wait         = App.testHelpers.wait;
+
+  wait().then(function() {
+    return triggerEvent('.input', '#limited', 'blur', { keyCode: 13 });
+  }).then(function() {
+    equal(event.keyCode, 13, 'options were passed');
+    equal(event.type, 'blur', 'correct event was triggered');
+    equal(event.target.getAttribute('id'), 'inside-scope', 'triggered on the correct element');
+  });
+});
+
+
+test("`triggerEvent accepts an optional options hash without context", function(){
+  expect(3);
+
+  var triggerEvent, wait, event;
+
+  run(function() {
+    App = EmberApplication.create();
+    App.setupForTesting();
+  });
+
+  App.IndexView = EmberView.extend({
+    template: Ember.Handlebars.compile('{{input type="text" id="scope" class="input"}}'),
+
+    didInsertElement: function() {
+      this.$('.input').on('blur change', function(e) {
+        event = e;
+      });
+    }
+  });
+
+  App.injectTestHelpers();
+
+  run(App, App.advanceReadiness);
+
+  triggerEvent = App.testHelpers.triggerEvent;
+  wait         = App.testHelpers.wait;
+
+  wait().then(function() {
+    return triggerEvent('.input', 'blur', { keyCode: 13 });
+  }).then(function() {
+    equal(event.keyCode, 13, 'options were passed');
+    equal(event.type, 'blur', 'correct event was triggered');
+    equal(event.target.getAttribute('id'), 'scope', 'triggered on the correct element');
+  });
+});
+
 test("`triggerEvent can limit searching for a selector to a scope", function(){
   expect(2);
 


### PR DESCRIPTION
triggerEvent has many arities (some were untested):

```
selector, type
selector, type, options
selector, context, type
selector, context, type, options
```

see https://github.com/emberjs/ember.js/issues/5265 and https://github.com/emberjs/ember.js/pull/5165#discussion_r14915117
