### PR TITLE
improve iterDep related bottlenecks 

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -367,13 +367,13 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
   @return {Object} The return value of the function backing the CP.
 */
 ComputedPropertyPrototype.set = function(obj, keyName, value) {
-  var cacheable = this._cacheable,
-      func = this.func,
-      meta = metaFor(obj, cacheable),
-      oldSuspended = this._suspended,
-      hadCachedValue = false,
-      cache = meta.cache,
-      funcArgLength, cachedValue, ret;
+  var cacheable = this._cacheable;
+  var func = this.func;
+  var meta = metaFor(obj, cacheable);
+  var oldSuspended = this._suspended;
+  var hadCachedValue = false;
+  var cache = meta.cache;
+  var funcArgLength, cachedValue, ret;
 
   if (this._readOnly) {
     throw new EmberError('Cannot set read-only property "' + keyName + '" on object: ' + inspect(obj));

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -97,7 +97,9 @@ export function defineProperty(obj, keyName, desc, data, meta) {
   if (!meta) meta = metaFor(obj);
   descs = meta.descs;
   existingDesc = meta.descs[keyName];
-  watching = meta.watching[keyName] > 0;
+  var watchEntry = meta.watching[keyName];
+
+  watching = watchEntry !== undefined && watchEntry > 0;
 
   if (existingDesc instanceof Descriptor) {
     existingDesc.teardown(obj, keyName);

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -100,27 +100,35 @@ function dependentKeysDidChange(obj, depKey, meta) {
   if (top) { DID_SEEN = null; }
 }
 
+function keysOf(obj) {
+  var keys = [];
+  for (var key in obj) {
+    keys.push(key);
+  }
+  return keys;
+}
+
 function iterDeps(method, obj, depKey, seen, meta) {
-  var guid, deps, keys, key, i, desc;
-  guid = guidFor(obj);
-  if (!seen[guid]) seen[guid] = {};
-  if (seen[guid][depKey]) return;
-  seen[guid][depKey] = true;
+  var deps, keys, key, i, desc, descs;
+  var guid = guidFor(obj);
+
+  var current = seen[guid];
+  if (!current) current = seen[guid] = {};
+  if (current[depKey]) return;
+  current[depKey] = true;
 
   deps = meta.deps;
   deps = deps && deps[depKey];
-  keys = [];
   if (deps) {
-    for(key in deps) {
-      keys.push(key);
-    }
-  }
+    keys = keysOf(deps);
+    descs = meta.descs;
 
-  for (i=0; i<keys.length; i++) {
-    key = keys[i];
-    desc = meta.descs[key];
-    if (desc && desc._suspended === obj) continue;
-    method(obj, key);
+    for (i=0; i<keys.length; i++) {
+      key = keys[i];
+      desc = descs[key];
+      if (desc && desc._suspended === obj) continue;
+      method(obj, key);
+    }
   }
 }
 

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -73,56 +73,58 @@ function propertyDidChange(obj, keyName) {
   if (desc && desc.didChange) { desc.didChange(obj, keyName); }
   if (!watching && keyName !== 'length') { return; }
 
-  dependentKeysDidChange(obj, keyName, m);
+  if (m && m.deps && m.deps[keyName]) {
+    dependentKeysDidChange(obj, keyName, m);
+  }
+
   chainsDidChange(obj, keyName, m, false);
   notifyObservers(obj, keyName);
 }
 
 var WILL_SEEN, DID_SEEN;
-
 // called whenever a property is about to change to clear the cache of any dependent keys (and notify those properties of changes, etc...)
 function dependentKeysWillChange(obj, depKey, meta) {
   if (obj.isDestroying) { return; }
 
-  var seen = WILL_SEEN, top = !seen;
-  if (top) { seen = WILL_SEEN = {}; }
-  iterDeps(propertyWillChange, obj, depKey, seen, meta);
-  if (top) { WILL_SEEN = null; }
+  var deps;
+  if (meta && meta.deps && (deps = meta.deps[depKey])) {
+    var seen = WILL_SEEN, top = !seen;
+    if (top) { seen = WILL_SEEN = {}; }
+    iterDeps(propertyWillChange, obj, deps, depKey, seen, meta);
+    if (top) { WILL_SEEN = null; }
+  }
 }
 
 // called whenever a property has just changed to update dependent keys
 function dependentKeysDidChange(obj, depKey, meta) {
   if (obj.isDestroying) { return; }
 
-  var seen = DID_SEEN, top = !seen;
-  if (top) { seen = DID_SEEN = {}; }
-  iterDeps(propertyDidChange, obj, depKey, seen, meta);
-  if (top) { DID_SEEN = null; }
+  var deps;
+  if (meta && meta.deps && (deps = meta.deps[depKey])) {
+    var seen = DID_SEEN, top = !seen;
+    if (top) { seen = DID_SEEN = {}; }
+    iterDeps(propertyDidChange, obj, deps, depKey, seen, meta);
+    if (top) { DID_SEEN = null; }
+  }
 }
 
 function keysOf(obj) {
   var keys = [];
-  for (var key in obj) {
-    keys.push(key);
-  }
+  for (var key in obj) keys.push(key);
   return keys;
 }
 
-function iterDeps(method, obj, depKey, seen, meta) {
-  var deps, keys, key, i, desc, descs;
+function iterDeps(method, obj, deps, depKey, seen, meta) {
+  var keys, key, i, desc;
   var guid = guidFor(obj);
-
   var current = seen[guid];
   if (!current) current = seen[guid] = {};
   if (current[depKey]) return;
   current[depKey] = true;
 
-  deps = meta.deps;
-  deps = deps && deps[depKey];
   if (deps) {
     keys = keysOf(deps);
-    descs = meta.descs;
-
+    var descs = meta.descs;
     for (i=0; i<keys.length; i++) {
       key = keys[i];
       desc = descs[key];

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -22,10 +22,13 @@ import {
 } from "ember-metal/watch_path";
 
 var metaFor = meta; // utils.js
+import {
+  isPathCache
+} from "ember-metal/path_cache";
 
 // returns true if the passed path is just a keyName
 function isKeyName(path) {
-  return path.indexOf('.') === -1;
+  return !isPathCache.get(path);
 }
 
 /**


### PR DESCRIPTION
...des in other evergreen browsers
1. don’t enumerate keys, if no deps exist to produce keys
2. in v8 for (x in y) where y is non enumerable deopts entire function [readmore](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#5-for-in)
3. if no deps exists, don't bother iterated the deps... (big win)

TL;DR this reduces the cost of iterDeps by 30%-40% but then also drastically reduces it's usage.
