### PR TITLE
Fix iter deps

### DIFF
--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -30,13 +30,14 @@ var viewStates = states;
 
 import _MetamorphView from "ember-handlebars/views/metamorph_view";
 import { handlebarsGet } from "ember-handlebars/ext";
+import { uuid } from "ember-metal/utils";
 
 function SimpleHandlebarsView(path, pathRoot, isEscaped, templateData) {
   this.path = path;
   this.pathRoot = pathRoot;
   this.isEscaped = isEscaped;
   this.templateData = templateData;
-
+  this[Ember.GUID_KEY] = uuid();
   this._lastNormalizedValue = undefined;
   this.morph = Metamorph();
   this.state = 'preRender';

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -367,13 +367,13 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
   @return {Object} The return value of the function backing the CP.
 */
 ComputedPropertyPrototype.set = function(obj, keyName, value) {
-  var cacheable = this._cacheable,
-      func = this.func,
-      meta = metaFor(obj, cacheable),
-      oldSuspended = this._suspended,
-      hadCachedValue = false,
-      cache = meta.cache,
-      funcArgLength, cachedValue, ret;
+  var cacheable = this._cacheable;
+  var func = this.func;
+  var meta = metaFor(obj, cacheable);
+  var oldSuspended = this._suspended;
+  var hadCachedValue = false;
+  var cache = meta.cache;
+  var funcArgLength, cachedValue, ret;
 
   if (this._readOnly) {
     throw new EmberError('Cannot set read-only property "' + keyName + '" on object: ' + inspect(obj));

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -97,7 +97,9 @@ export function defineProperty(obj, keyName, desc, data, meta) {
   if (!meta) meta = metaFor(obj);
   descs = meta.descs;
   existingDesc = meta.descs[keyName];
-  watching = meta.watching[keyName] > 0;
+  var watchEntry = meta.watching[keyName];
+
+  watching = watchEntry !== undefined && watchEntry > 0;
 
   if (existingDesc instanceof Descriptor) {
     existingDesc.teardown(obj, keyName);

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -100,27 +100,35 @@ function dependentKeysDidChange(obj, depKey, meta) {
   if (top) { DID_SEEN = null; }
 }
 
+function keysOf(obj) {
+  var keys = [];
+  for (var key in obj) {
+    keys.push(key);
+  }
+  return keys;
+}
+
 function iterDeps(method, obj, depKey, seen, meta) {
-  var guid, deps, keys, key, i, desc;
-  guid = guidFor(obj);
-  if (!seen[guid]) seen[guid] = {};
-  if (seen[guid][depKey]) return;
-  seen[guid][depKey] = true;
+  var deps, keys, key, i, desc, descs;
+  var guid = guidFor(obj);
+
+  var current = seen[guid];
+  if (!current) current = seen[guid] = {};
+  if (current[depKey]) return;
+  current[depKey] = true;
 
   deps = meta.deps;
   deps = deps && deps[depKey];
-  keys = [];
   if (deps) {
-    for(key in deps) {
-      keys.push(key);
-    }
-  }
+    keys = keysOf(deps);
+    descs = meta.descs;
 
-  for (i=0; i<keys.length; i++) {
-    key = keys[i];
-    desc = meta.descs[key];
-    if (desc && desc._suspended === obj) continue;
-    method(obj, key);
+    for (i=0; i<keys.length; i++) {
+      key = keys[i];
+      desc = descs[key];
+      if (desc && desc._suspended === obj) continue;
+      method(obj, key);
+    }
   }
 }
 

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -73,56 +73,58 @@ function propertyDidChange(obj, keyName) {
   if (desc && desc.didChange) { desc.didChange(obj, keyName); }
   if (!watching && keyName !== 'length') { return; }
 
-  dependentKeysDidChange(obj, keyName, m);
+  if (m && m.deps && m.deps[keyName]) {
+    dependentKeysDidChange(obj, keyName, m);
+  }
+
   chainsDidChange(obj, keyName, m, false);
   notifyObservers(obj, keyName);
 }
 
 var WILL_SEEN, DID_SEEN;
-
 // called whenever a property is about to change to clear the cache of any dependent keys (and notify those properties of changes, etc...)
 function dependentKeysWillChange(obj, depKey, meta) {
   if (obj.isDestroying) { return; }
 
-  var seen = WILL_SEEN, top = !seen;
-  if (top) { seen = WILL_SEEN = {}; }
-  iterDeps(propertyWillChange, obj, depKey, seen, meta);
-  if (top) { WILL_SEEN = null; }
+  var deps;
+  if (meta && meta.deps && (deps = meta.deps[depKey])) {
+    var seen = WILL_SEEN, top = !seen;
+    if (top) { seen = WILL_SEEN = {}; }
+    iterDeps(propertyWillChange, obj, deps, depKey, seen, meta);
+    if (top) { WILL_SEEN = null; }
+  }
 }
 
 // called whenever a property has just changed to update dependent keys
 function dependentKeysDidChange(obj, depKey, meta) {
   if (obj.isDestroying) { return; }
 
-  var seen = DID_SEEN, top = !seen;
-  if (top) { seen = DID_SEEN = {}; }
-  iterDeps(propertyDidChange, obj, depKey, seen, meta);
-  if (top) { DID_SEEN = null; }
+  var deps;
+  if (meta && meta.deps && (deps = meta.deps[depKey])) {
+    var seen = DID_SEEN, top = !seen;
+    if (top) { seen = DID_SEEN = {}; }
+    iterDeps(propertyDidChange, obj, deps, depKey, seen, meta);
+    if (top) { DID_SEEN = null; }
+  }
 }
 
 function keysOf(obj) {
   var keys = [];
-  for (var key in obj) {
-    keys.push(key);
-  }
+  for (var key in obj) keys.push(key);
   return keys;
 }
 
-function iterDeps(method, obj, depKey, seen, meta) {
-  var deps, keys, key, i, desc, descs;
+function iterDeps(method, obj, deps, depKey, seen, meta) {
+  var keys, key, i, desc;
   var guid = guidFor(obj);
-
   var current = seen[guid];
   if (!current) current = seen[guid] = {};
   if (current[depKey]) return;
   current[depKey] = true;
 
-  deps = meta.deps;
-  deps = deps && deps[depKey];
   if (deps) {
     keys = keysOf(deps);
-    descs = meta.descs;
-
+    var descs = meta.descs;
     for (i=0; i<keys.length; i++) {
       key = keys[i];
       desc = descs[key];

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -43,6 +43,50 @@ var stringCache  = {};
 var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
 
 /**
+  Strongly hint runtimes to intern the provided string.
+
+  When do I need to use this function?
+
+  For the most part, never. Pre-mature optimization is bad, and often the
+  runtime does exactly what you need it to, and more often the trade-off isn't
+  worth it.
+
+  Why?
+
+  Runtimes store strings in atleast 2 different representations:
+  Ropes and Symbols (interned strings). The Rope provides a memory efficient
+  data-structure for strings created from concatenation or some other string
+  manipulation like splitting.
+
+  Unfortunately checking equality of different ropes can be quite costly as
+  runtimes must resort to clever string comparison algorithims. These
+  algorithims typically cost in proportion to the length of the string.
+  Luckily, this is where the Symbols (interned strings) shine. As Symbols are
+  unique by their string content, equality checks can be done by pointer
+  comparision.
+
+  How do I know if my string is a rope or symbol?
+
+  Typically (warning general sweeping statement, but truthy in runtimes at
+  present) static strings created as part of the JS source are interned.
+  Strings often used for comparisions can be interned at runtime if some
+  criteria are met.  One of these criteria can be the size of the entire rope.
+  For example, in chrome 38 a rope longer then 12 characters will not
+  intern, nor will segments of that rope.
+
+  Some numbers: http://jsperf.com/eval-vs-keys/8
+
+  Known Trick™
+
+  @private
+  @return {String} interned version of the provided string
+*/
+function intern(string) {
+  "use strict";
+  return new Function('return "' + string + '"')();
+}
+
+/**
   A unique key used to assign guids and other private metadata to objects.
   If you inspect an object in your browser debugger you will often see these.
   They can be safely ignored.
@@ -56,7 +100,7 @@ var MANDATORY_SETTER = Ember.ENV.MANDATORY_SETTER;
   @type String
   @final
 */
-var GUID_KEY = '__ember' + (+ new Date());
+var GUID_KEY = intern('__ember' + (+ new Date()));
 
 var GUID_DESC = {
   writable:    false,

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -22,11 +22,9 @@ import {
 } from "ember-metal/watch_path";
 
 var metaFor = meta; // utils.js
-
-// returns true if the passed path is just a keyName
-function isKeyName(path) {
-  return path.indexOf('.') === -1;
-}
+import {
+  isPath
+} from "ember-metal/path_cache";
 
 /**
   Starts watching a property on an object. Whenever the property changes,
@@ -45,7 +43,7 @@ function watch(obj, _keyPath, m) {
   // can't watch length on Array - it is special...
   if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  if (isKeyName(_keyPath)) {
+  if (!isPath(_keyPath)) {
     watchKey(obj, _keyPath, m);
   } else {
     watchPath(obj, _keyPath, m);
@@ -65,7 +63,7 @@ export function unwatch(obj, _keyPath, m) {
   // can't watch length on Array - it is special...
   if (_keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  if (isKeyName(_keyPath)) {
+  if (!isPath(_keyPath)) {
     unwatchKey(obj, _keyPath, m);
   } else {
     unwatchPath(obj, _keyPath, m);


### PR DESCRIPTION
much performance
- don’t enumerate keys, if no deps exist to produce keys
- in v8 for (x in y) where y is non enumerable deopts entire function readmore
- if no deps exists, don't bother iterated the deps... (big win)

TL;DR this reduces the cost of iterDeps by 30%-40% but then also drastically reduces it's usage. In many scenarios it is no longer called at all.
