### PR TITLE
[BUGFIX beta] Fixes duplicate message getting printed to console.error

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -607,9 +607,6 @@ var defaultActionHandlers = {
         router.intermediateTransitionTo('application_error', error);
         return;
       }
-    } else {
-      // Don't fire an assertion if we found an error substate.
-      return;
     }
 
     logError(error, 'Error while processing route: ' + transition.targetName);
@@ -836,12 +833,7 @@ function listenForTransitionErrors(transition) {
 
     if (error.name === "UnrecognizedURLError") {
       Ember.assert("The URL '" + error.message + "' did not match any routes in your application");
-    } else if (error.name === 'TransitionAborted') {
-      // just ignore TransitionAborted here
-    } else {
-      logError(error);
     }
-
     return error;
   }, 'Ember: Process errors from Router');
 }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3225,7 +3225,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-will-change-hooks")) {
 }
 
 test("Errors in transitionTo within redirect hook are logged", function() {
-  expect(2);
+  expect(3);
   var actual = [];
 
   Router.map(function() {
@@ -3239,14 +3239,16 @@ test("Errors in transitionTo within redirect hook are logged", function() {
     }
   });
 
-  Ember.Logger.error = function(message) {
-    actual.push(message);
+  Ember.Logger.error = function() {
+    // push the arguments onto an array so we can detect if the error gets logged twice
+    actual.push(arguments);
   };
 
   bootApplication();
 
-  equal(actual[0], 'Error while processing route: yondo', 'source route is printed');
-  ok(actual[1].match(/More context objects were passed than there are dynamic segments for the route: stink-bomb/), 'the error is printed');
+  equal(actual.length, 1, 'the error is only logged once');
+  equal(actual[0][0], 'Error while processing route: yondo', 'source route is printed');
+  ok(actual[0][1].match(/More context objects were passed than there are dynamic segments for the route: stink-bomb/), 'the error is printed');
 });
 
 test("Errors in transition show error template if available", function() {


### PR DESCRIPTION
Line 839's logError was logging generic errors and since the error is
not caught it was also logged by defaultActionHandler.error at line 609.

Previously for a model hook syntax error I would get: "Error while
processing route: index" "foo is not defined" logged and immediately
after it "foo is not defined".

This works with and without error substates and when a "too many dynamic
segments" transition error is thrown.
