### PR TITLE
Deprecate global access to view classes from templates

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -19,6 +19,7 @@ import Controller from "ember-runtime/controllers/controller";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
+import SelectView from "ember-handlebars/controls/select";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 //import ContainerDebugAdapter from "ember-extension-support/container_debug_adapter";
 import jQuery from "ember-views/system/jquery";
@@ -958,6 +959,9 @@ Application.reopenClass({
     container.register('controller:basic', Controller, { instantiate: false });
     container.register('controller:object', ObjectController, { instantiate: false });
     container.register('controller:array', ArrayController, { instantiate: false });
+
+    container.register('view:select', SelectView);
+
     container.register('route:basic', Route, { instantiate: false });
     container.register('event_dispatcher:main', EventDispatcher);
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -297,3 +297,13 @@ test("throws helpful error if `app.then` is used", function() {
     run(app, 'then', Ember.K);
   }, /Do not use `.then` on an instance of Ember.Application.  Please use the `.ready` hook instead./);
 });
+
+test("registers controls onto to container", function() {
+  run(function() {
+    app = Application.create({
+      rootElement: '#qunit-fixture'
+    });
+  });
+
+  ok(app.__container__.lookup('view:select'), "Select control is registered into views");
+});

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -93,7 +93,7 @@ var EmberHandlebars = Ember.Handlebars = objectCreate(Handlebars);
   Which is functionally equivalent to:
 
   ```handlebars
-  {{view App.CalendarView}}
+  {{view 'calendar'}}
   ```
 
   Options in the helper will be passed to the view in exactly the same

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -115,7 +115,7 @@ var SelectOptgroup = CollectionView.extend({
   ```
 
   ```handlebars
-  {{view Ember.Select content=names}}
+  {{view "select" content=names}}
   ```
 
   Would result in the following HTML:
@@ -138,10 +138,7 @@ var SelectOptgroup = CollectionView.extend({
   ```
 
   ```handlebars
-  {{view Ember.Select
-         content=names
-         value=selectedName
-  }}
+  {{view "select" content=names value=selectedName}}
   ```
 
   Would result in the following HTML with the `<option>` for 'Tom' selected:
@@ -180,7 +177,7 @@ var SelectOptgroup = CollectionView.extend({
   ```
 
   ```handlebars
-  {{view Ember.Select
+  {{view "select"
          content=programmers
          optionValuePath="content.id"
          optionLabelPath="content.firstName"}}
@@ -211,7 +208,7 @@ var SelectOptgroup = CollectionView.extend({
   ```
 
   ```handlebars
-  {{view Ember.Select
+  {{view "select"
          content=programmers
          optionValuePath="content.id"
          optionLabelPath="content.firstName"
@@ -244,15 +241,12 @@ var SelectOptgroup = CollectionView.extend({
 
   App.ApplicationController = Ember.ObjectController.extend({
     selectedPerson: tom,
-    programmers: [
-      yehuda,
-      tom
-    ]
+    programmers: [ yehuda, tom ]
   });
   ```
 
   ```handlebars
-  {{view Ember.Select
+  {{view "select"
          content=programmers
          optionValuePath="content.id"
          optionLabelPath="content.firstName"
@@ -281,15 +275,12 @@ var SelectOptgroup = CollectionView.extend({
   ```javascript
   App.ApplicationController = Ember.ObjectController.extend({
     selectedProgrammer: null,
-    programmers: [
-      "Yehuda",
-      "Tom"
-    ]
+    programmers: ["Yehuda", "Tom"]
   });
   ```
 
   ``` handlebars
-  {{view Ember.Select
+  {{view "select"
          content=programmers
          value=selectedProgrammer
   }}
@@ -313,15 +304,12 @@ var SelectOptgroup = CollectionView.extend({
   ```javascript
   App.ApplicationController = Ember.ObjectController.extend({
     selectedProgrammer: null,
-    programmers: [
-      "Yehuda",
-      "Tom"
-    ]
+    programmers: [ "Yehuda", "Tom" ]
   });
   ```
 
   ```handlebars
-  {{view Ember.Select
+  {{view "select"
          content=programmers
          value=selectedProgrammer
          prompt="Please select a name"
@@ -391,7 +379,8 @@ var Select = View.extend({
     Otherwise, this should be a list of objects. For instance:
 
     ```javascript
-    Ember.Select.create({
+    var App = Ember.Application.create();
+    var App.MySelect = Ember.Select.extend({
       content: Ember.A([
           { id: 1, firstName: 'Yehuda' },
           { id: 2, firstName: 'Tom' }

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -36,7 +36,8 @@ var alias = computed.alias;
   Given an empty `<body>` the following template:
 
   ```handlebars
-  {{#collection contentBinding="App.items"}}
+  {{! application.hbs }}
+  {{#collection content=model}}
     Hi {{view.content.name}}
   {{/collection}}
   ```
@@ -44,44 +45,45 @@ var alias = computed.alias;
   And the following application code
 
   ```javascript
-  App = Ember.Application.create()
-  App.items = [
-    Ember.Object.create({name: 'Dave'}),
-    Ember.Object.create({name: 'Mary'}),
-    Ember.Object.create({name: 'Sara'})
-  ]
+  App = Ember.Application.create();
+  App.ApplicationRoute = Ember.Route.extend({
+    model: function(){
+      return [{name: 'Yehuda'},{name: 'Tom'},{name: 'Peter'}];
+    }
+  });
   ```
 
-  Will result in the HTML structure below
+  The following HTML will result:
 
   ```html
   <div class="ember-view">
-    <div class="ember-view">Hi Dave</div>
-    <div class="ember-view">Hi Mary</div>
-    <div class="ember-view">Hi Sara</div>
+    <div class="ember-view">Hi Yehuda</div>
+    <div class="ember-view">Hi Tom</div>
+    <div class="ember-view">Hi Peter</div>
   </div>
   ```
 
-  ### Blockless use in a collection
+  ### Non-block version of collection
 
-  If you provide an `itemViewClass` option that has its own `template` you can
+  If you provide an `itemViewClass` option that has its own `template` you may
   omit the block.
 
   The following template:
 
   ```handlebars
-  {{collection contentBinding="App.items" itemViewClass="App.AnItemView"}}
+  {{! application.hbs }}
+  {{collection content=model itemViewClass="an-item"}}
   ```
 
   And application code
 
   ```javascript
   App = Ember.Application.create();
-  App.items = [
-    Ember.Object.create({name: 'Dave'}),
-    Ember.Object.create({name: 'Mary'}),
-    Ember.Object.create({name: 'Sara'})
-  ];
+  App.ApplicationRoute = Ember.Route.extend({
+    model: function(){
+      return [{name: 'Yehuda'},{name: 'Tom'},{name: 'Peter'}];
+    }
+  });
 
   App.AnItemView = Ember.View.extend({
     template: Ember.Handlebars.compile("Greetings {{view.content.name}}")
@@ -92,9 +94,9 @@ var alias = computed.alias;
 
   ```html
   <div class="ember-view">
-    <div class="ember-view">Greetings Dave</div>
-    <div class="ember-view">Greetings Mary</div>
-    <div class="ember-view">Greetings Sara</div>
+    <div class="ember-view">Greetings Yehuda</div>
+    <div class="ember-view">Greetings Tom</div>
+    <div class="ember-view">Greetings Peter</div>
   </div>
   ```
 
@@ -105,10 +107,12 @@ var alias = computed.alias;
   the helper by passing it as the first argument:
 
   ```handlebars
-  {{#collection App.MyCustomCollectionClass contentBinding="App.items"}}
+  {{#collection "my-custom-collection" content=model}}
     Hi {{view.content.name}}
   {{/collection}}
   ```
+
+  This example would look for the class `App.MyCustomCollection`.
 
   ### Forwarded `item.*`-named Options
 
@@ -118,7 +122,7 @@ var alias = computed.alias;
   item (note the camelcasing):
 
   ```handlebars
-  {{#collection contentBinding="App.items"
+  {{#collection content=model
                 itemTagName="p"
                 itemClassNames="greeting"}}
     Howdy {{view.content.name}}
@@ -129,9 +133,9 @@ var alias = computed.alias;
 
   ```html
   <div class="ember-view">
-    <p class="ember-view greeting">Howdy Dave</p>
-    <p class="ember-view greeting">Howdy Mary</p>
-    <p class="ember-view greeting">Howdy Sara</p>
+    <p class="ember-view greeting">Howdy Yehuda</p>
+    <p class="ember-view greeting">Howdy Tom</p>
+    <p class="ember-view greeting">Howdy Peter</p>
   </div>
   ```
 

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -469,8 +469,7 @@ function eachHelper(path, options) {
   if (options.data.insideGroup && !options.hash.groupedRows && !options.hash.itemViewClass) {
     new GroupedEach(ctx, path, options).render();
   } else {
-    // ES6TODO: figure out how to do this without global lookup.
-    return helpers.collection.call(ctx, 'Ember.Handlebars.EachView', options);
+    return helpers.collection.call(ctx, EmberHandlebars.EachView, options);
   }
 }
 

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -335,7 +335,7 @@ export var ViewHelper = EmberObject.create({
   specify a path to a custom view class.
 
   ```handlebars
-  {{#view "MyApp.CustomView"}}
+  {{#view "custom"}}{{! will look up App.CustomView }}
     hello.
   {{/view}}
   ```
@@ -349,7 +349,7 @@ export var ViewHelper = EmberObject.create({
     innerViewClass: Ember.View.extend({
       classNames: ['a-custom-view-class-as-property']
     }),
-    template: Ember.Handlebars.compile('{{#view "view.innerViewClass"}} hi {{/view}}')
+    template: Ember.Handlebars.compile('{{#view view.innerViewClass}} hi {{/view}}')
   });
 
   MyApp.OuterView.create().appendTo('body');
@@ -372,8 +372,21 @@ export var ViewHelper = EmberObject.create({
   supplying a block. Attempts to use both a `templateName` option and supply a
   block will throw an error.
 
+  ```javascript
+  var App = Ember.Application.create();
+  App.WithTemplateDefinedView = Ember.View.extend({
+    templateName: 'defined-template'
+  });
+  ```
+
   ```handlebars
-  {{view "MyApp.ViewWithATemplateDefined"}}
+  {{! application.hbs }}
+  {{view 'with-template-defined'}}
+  ```
+
+  ```handlebars
+  {{! defined-template.hbs }}
+  Some content for the defined template view.
   ```
 
   ### `viewName` property

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -9,6 +9,8 @@ import Namespace from "ember-runtime/system/namespace";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 
+import SelectView from "ember-handlebars/controls/select";
+
 var trim = jQuery.trim;
 
 var dispatcher, select, view;
@@ -703,13 +705,14 @@ test("works from a template with bindings", function() {
 
   view = EmberView.create({
     app: application,
+    selectView: SelectView,
     template: Ember.Handlebars.compile(
-      '{{view Ember.Select viewName="select"' +
-      '                    contentBinding="view.app.peopleController"' +
-      '                    optionLabelPath="content.fullName"' +
-      '                    optionValuePath="content.id"' +
-      '                    prompt="Pick a person:"' +
-      '                    selectionBinding="view.app.selectedPersonController.person"}}'
+      '{{view view.selectView viewName="select"' +
+      '    contentBinding="view.app.peopleController"' +
+      '    optionLabelPath="content.fullName"' +
+      '    optionValuePath="content.id"' +
+      '    prompt="Pick a person:"' +
+      '    selectionBinding="view.app.selectedPersonController.person"}}'
     )
   });
 
@@ -742,8 +745,9 @@ test("upon content change, the DOM should reflect the selection (#481)", functio
 
   view = EmberView.create({
     user: userOne,
+    selectView: SelectView,
     template: Ember.Handlebars.compile(
-      '{{view Ember.Select viewName="select"' +
+      '{{view view.selectView viewName="select"' +
       '    contentBinding="view.user.options"' +
       '    selectionBinding="view.user.selectedOption"}}'
     )
@@ -778,8 +782,9 @@ test("upon content change with Array-like content, the DOM should reflect the se
 
   view = EmberView.create({
     proxy: proxy,
+    selectView: SelectView,
     template: Ember.Handlebars.compile(
-      '{{view Ember.Select viewName="select"' +
+      '{{view view.selectView viewName="select"' +
       '    contentBinding="view.proxy"' +
       '    selectionBinding="view.proxy.selectedOption"}}'
     )
@@ -806,6 +811,7 @@ function testValueBinding(templateString) {
   view = EmberView.create({
     collection: Ember.A([{name: 'Wes', value: 'w'}, {name: 'Gordon', value: 'g'}]),
     val: 'g',
+    selectView: SelectView,
     template: Ember.Handlebars.compile(templateString)
   });
 
@@ -831,7 +837,7 @@ function testValueBinding(templateString) {
 
 test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (old xBinding='' syntax)", function() {
   testValueBinding(
-    '{{view Ember.Select viewName="select"' +
+    '{{view view.selectView viewName="select"' +
     '    contentBinding="view.collection"' +
     '    optionLabelPath="content.name"' +
     '    optionValuePath="content.value"' +
@@ -842,7 +848,7 @@ test("select element should correctly initialize and update selectedIndex and bo
 
 test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (new quoteless binding shorthand)", function() {
   testValueBinding(
-    '{{view Ember.Select viewName="select"' +
+    '{{view view.selectView viewName="select"' +
     '    content=view.collection' +
     '    optionLabelPath="content.name"' +
     '    optionValuePath="content.value"' +

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1493,20 +1493,24 @@ test("should be able to bind to view attributes with {{bind-attr}}", function() 
   equal(view.$('img').attr('alt'), "Updated", "updates value");
 });
 
-test("should be able to bind to globals with {{bind-attr}}", function() {
+test("should be able to bind to globals with {{bind-attr}} (DEPRECATED)", function() {
   TemplateTests.set('value', 'Test');
 
   view = EmberView.create({
     template: EmberHandlebars.compile('<img src="test.jpg" {{bind-attr alt="TemplateTests.value"}}>')
   });
 
-  appendView();
+  expectDeprecation(function(){
+    appendView();
+  }, /Global lookup of TemplateTests.value from a Handlebars template is deprecated/);
 
   equal(view.$('img').attr('alt'), "Test", "renders initial value");
 
-  run(function() {
-    TemplateTests.set('value', 'Updated');
-  });
+  expectDeprecation(function(){
+    run(function() {
+      TemplateTests.set('value', 'Updated');
+    });
+  }, /Global lookup of TemplateTests.value from a Handlebars template is deprecated/);
 
   equal(view.$('img').attr('alt'), "Updated", "updates value");
 });
@@ -1776,20 +1780,24 @@ test("should be able to add multiple classes using {{bind-attr class}}", functio
   ok(view.$('div').hasClass('disabled'), "falsy class in ternary classname definition is rendered");
 });
 
-test("should be able to bind classes to globals with {{bind-attr class}}", function() {
+test("should be able to bind classes to globals with {{bind-attr class}} (DEPRECATED)", function() {
   TemplateTests.set('isOpen', true);
 
   view = EmberView.create({
     template: EmberHandlebars.compile('<img src="test.jpg" {{bind-attr class="TemplateTests.isOpen"}}>')
   });
 
-  appendView();
+  expectDeprecation(function(){
+    appendView();
+  }, /Global lookup of TemplateTests.isOpen from a Handlebars template is deprecated/);
 
   ok(view.$('img').hasClass('is-open'), "sets classname to the dasherized value of the global property");
 
-  run(function() {
-    TemplateTests.set('isOpen', false);
-  });
+  expectDeprecation(function(){
+    run(function() {
+      TemplateTests.set('isOpen', false);
+    });
+  }, /Global lookup of TemplateTests.isOpen from a Handlebars template is deprecated/);
 
   ok(!view.$('img').hasClass('is-open'), "removes the classname when the global property has changed");
 });

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1,5 +1,3 @@
-/*globals TemplateTests:true,MyApp:true,App:true,Ember:true */
-
 /*jshint newcap:false*/
 import Ember from "ember-metal/core"; // Ember.lookup
 import jQuery from "ember-views/system/jquery";
@@ -26,11 +24,6 @@ import Container from "ember-runtime/system/container";
 import Logger from "ember-metal/logger";
 
 import htmlSafe from "ember-handlebars/string";
-
-// for global lookups in template. :(
-Ember.View = EmberView;
-Ember.ContainerView = ContainerView;
-Ember.Logger = Logger;
 
 var trim = jQuery.trim;
 
@@ -103,9 +96,8 @@ var TemplateTests, container, lookup;
 */
 QUnit.module("View - handlebars integration", {
   setup: function() {
-    Ember.lookup = lookup = { Ember: Ember };
-    lookup.TemplateTests = window.TemplateTests = TemplateTests = Namespace.create();
-
+    Ember.lookup = lookup = {};
+    lookup.TemplateTests = TemplateTests = Namespace.create();
     container = new Container();
     container.optionsForType('template', { instantiate: false });
     container.register('view:default', _MetamorphView);
@@ -122,8 +114,8 @@ QUnit.module("View - handlebars integration", {
         }
         container = view = null;
     });
-    Ember.lookup = originalLookup;
-    window.TemplateTests = TemplateTests = undefined;
+    Ember.lookup = lookup = originalLookup;
+    TemplateTests = null;
   }
 });
 
@@ -179,7 +171,7 @@ test("should allow values from normal JavaScript hash objects to be used", funct
   equal(view.$().text(), "Señor CFC (and Fido)", "prints out values from a hash");
 });
 
-test("should read from globals [DEPRECATED]", function() {
+test("should read from globals (DEPRECATED)", function() {
   Ember.lookup.Global = 'Klarg';
   view = EmberView.create({
     template: EmberHandlebars.compile('{{Global}}')
@@ -191,7 +183,7 @@ test("should read from globals [DEPRECATED]", function() {
   equal(view.$().text(), Ember.lookup.Global);
 });
 
-test("should read from globals with a path [DEPRECATED]", function() {
+test("should read from globals with a path (DEPRECATED)", function() {
   Ember.lookup.Global = { Space: 'Klarg' };
   view = EmberView.create({
     template: EmberHandlebars.compile('{{Global.Space}}')
@@ -203,7 +195,7 @@ test("should read from globals with a path [DEPRECATED]", function() {
   equal(view.$().text(), Ember.lookup.Global.Space);
 });
 
-test("with context, should read from globals [DEPRECATED]", function() {
+test("with context, should read from globals (DEPRECATED)", function() {
   Ember.lookup.Global = 'Klarg';
   view = EmberView.create({
     context: {},
@@ -216,7 +208,7 @@ test("with context, should read from globals [DEPRECATED]", function() {
   equal(view.$().text(), Ember.lookup.Global);
 });
 
-test("with context, should read from globals with a path [DEPRECATED]", function() {
+test("with context, should read from globals with a path (DEPRECATED)", function() {
   Ember.lookup.Global = { Space: 'Klarg' };
   view = EmberView.create({
     context: {},
@@ -297,20 +289,21 @@ test("should not escape HTML if string is a Handlebars.SafeString", function() {
 });
 
 test("child views can be inserted using the {{view}} Handlebars helper", function() {
-  container.register('template:nester', EmberHandlebars.compile("<h1 id='hello-world'>Hello {{world}}</h1>{{view \"TemplateTests.LabelView\"}}"));
+  container.register('template:nester', EmberHandlebars.compile("<h1 id='hello-world'>Hello {{world}}</h1>{{view view.labelView}}"));
   container.register('template:nested', EmberHandlebars.compile("<div id='child-view'>Goodbye {{cruel}} {{world}}</div>"));
 
   var context = {
     world: "world!"
   };
 
-  TemplateTests.LabelView = EmberView.extend({
+  var LabelView = EmberView.extend({
     container: container,
     tagName: "aside",
     templateName: 'nested'
   });
 
   view = EmberView.create({
+    labelView: LabelView,
     container: container,
     templateName: 'nester',
     context: context
@@ -342,27 +335,29 @@ test("should accept relative paths to views", function() {
 });
 
 test("child views can be inserted inside a bind block", function() {
-  container.register('template:nester', EmberHandlebars.compile("<h1 id='hello-world'>Hello {{world}}</h1>{{view \"TemplateTests.BQView\"}}"));
-  container.register('template:nested', EmberHandlebars.compile("<div id='child-view'>Goodbye {{#with content}}{{blah}} {{view \"TemplateTests.OtherView\"}}{{/with}} {{world}}</div>"));
+  container.register('template:nester', EmberHandlebars.compile("<h1 id='hello-world'>Hello {{world}}</h1>{{view view.bqView}}"));
+  container.register('template:nested', EmberHandlebars.compile("<div id='child-view'>Goodbye {{#with content}}{{blah}} {{view view.otherView}}{{/with}} {{world}}</div>"));
   container.register('template:other', EmberHandlebars.compile("cruel"));
 
   var context = {
     world: "world!"
   };
 
-  TemplateTests.BQView = EmberView.extend({
-    container: container,
-    tagName: "blockquote",
-    templateName: 'nested'
-  });
-
-  TemplateTests.OtherView = EmberView.extend({
+  var OtherView = EmberView.extend({
     container: container,
     templateName: 'other'
   });
 
+  var BQView = EmberView.extend({
+    container: container,
+    otherView: OtherView,
+    tagName: "blockquote",
+    templateName: 'nested'
+  });
+
   view = EmberView.create({
     container: container,
+    bqView: BQView,
     context: context,
     templateName: 'nester'
   });
@@ -828,16 +823,17 @@ test("Layout views return throw if their layout cannot be found", function() {
 });
 
 test("Template views add an elementId to child views created using the view helper", function() {
-  container.register('template:parent', EmberHandlebars.compile('<div>{{view "TemplateTests.ChildView"}}</div>'));
+  container.register('template:parent', EmberHandlebars.compile('<div>{{view view.childView}}</div>'));
   container.register('template:child', EmberHandlebars.compile("I can't believe it's not butter."));
 
-  TemplateTests.ChildView = EmberView.extend({
+  var ChildView = EmberView.extend({
     container: container,
     templateName: 'child'
   });
 
   view = EmberView.create({
     container: container,
+    childView: ChildView,
     templateName: 'parent'
   });
 
@@ -847,9 +843,7 @@ test("Template views add an elementId to child views created using the view help
 });
 
 test("views set the template of their children to a passed block", function() {
-  container.register('template:parent', EmberHandlebars.compile('<h1>{{#view "TemplateTests.NoTemplateView"}}<span>It worked!</span>{{/view}}</h1>'));
-
-  TemplateTests.NoTemplateView = EmberView.extend();
+  container.register('template:parent', EmberHandlebars.compile('<h1>{{#view}}<span>It worked!</span>{{/view}}</h1>'));
 
   view = EmberView.create({
     container: container,
@@ -951,8 +945,6 @@ test("a view helper's bindings are to the parent context", function() {
 // });
 
 test("Child views created using the view helper should have their parent view set properly", function() {
-  TemplateTests = {};
-
   var template = '{{#view}}{{#view}}{{view}}{{/view}}{{/view}}';
 
   view = EmberView.create({
@@ -966,8 +958,6 @@ test("Child views created using the view helper should have their parent view se
 });
 
 test("Child views created using the view helper should have their IDs registered for events", function() {
-  TemplateTests = {};
-
   var template = '{{view}}{{view id="templateViewTest"}}';
 
   view = EmberView.create({
@@ -987,8 +977,6 @@ test("Child views created using the view helper should have their IDs registered
 });
 
 test("Child views created using the view helper and that have a viewName should be registered as properties on their parentView", function() {
-  TemplateTests = {};
-
   var template = '{{#view}}{{view viewName="ohai"}}{{/view}}';
 
   view = EmberView.create({
@@ -1004,7 +992,7 @@ test("Child views created using the view helper and that have a viewName should 
 });
 
 test("Collection views that specify an example view class have their children be of that class", function() {
-  TemplateTests.ExampleViewCollection = CollectionView.extend({
+  var ExampleViewCollection = CollectionView.extend({
     itemViewClass: EmberView.extend({
       isCustom: true
     }),
@@ -1012,19 +1000,16 @@ test("Collection views that specify an example view class have their children be
     content: A(['foo'])
   });
 
-  var parentView = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.ExampleViewCollection"}}OHAI{{/collection}}')
+  view = EmberView.create({
+    exampleViewCollection: ExampleViewCollection,
+    template: EmberHandlebars.compile('{{#collection view.exampleViewCollection}}OHAI{{/collection}}')
   });
 
   run(function() {
-    parentView.append();
+    view.append();
   });
 
-  ok(firstGrandchild(parentView).isCustom, "uses the example view class");
-
-  run(function() {
-    parentView.destroy();
-  });
+  ok(firstGrandchild(view).isCustom, "uses the example view class");
 });
 
 test("itemViewClass works in the #collection helper with a global (DEPRECATED)", function() {
@@ -1032,7 +1017,7 @@ test("itemViewClass works in the #collection helper with a global (DEPRECATED)",
     isAlsoCustom: true
   });
 
-  var parentView = EmberView.create({
+  view = EmberView.create({
     exampleController: ArrayProxy.create({
       content: A(['alpha'])
     }),
@@ -1040,42 +1025,34 @@ test("itemViewClass works in the #collection helper with a global (DEPRECATED)",
   });
 
   expectDeprecation(function(){
-    run(parentView, 'append');
+    run(view, 'append');
   }, /Resolved the view "TemplateTests.ExampleItemView" on the global context/);
 
-  ok(firstGrandchild(parentView).isAlsoCustom, "uses the example view class specified in the #collection helper");
-
-  run(function() {
-    parentView.destroy();
-  });
+  ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
 
 test("itemViewClass works in the #collection helper relatively", function() {
-  TemplateTests.ExampleItemView = EmberView.extend({
+  var ExampleItemView = EmberView.extend({
     isAlsoCustom: true
   });
 
-  TemplateTests.CollectionView = CollectionView.extend({
-    possibleItemView: TemplateTests.ExampleItemView
+  var ExampleCollectionView = CollectionView.extend({
+    possibleItemView: ExampleItemView
   });
 
-  var parentView = EmberView.create({
-    collectionView: TemplateTests.CollectionView,
+  view = EmberView.create({
+    exampleCollectionView: ExampleCollectionView,
     exampleController: ArrayProxy.create({
       content: A(['alpha'])
     }),
-    template: EmberHandlebars.compile('{{#collection view.collectionView content=view.exampleController itemViewClass="possibleItemView"}}beta{{/collection}}')
+    template: EmberHandlebars.compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass="possibleItemView"}}beta{{/collection}}')
   });
 
   run(function() {
-    parentView.append();
+    view.append();
   });
 
-  ok(firstGrandchild(parentView).isAlsoCustom, "uses the example view class specified in the #collection helper");
-
-  run(function() {
-    parentView.destroy();
-  });
+  ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
 
 test("itemViewClass works in the #collection via container", function() {
@@ -1083,28 +1060,20 @@ test("itemViewClass works in the #collection via container", function() {
     isAlsoCustom: true
   }));
 
-  TemplateTests.CollectionView = CollectionView.extend({
-    possibleItemView: TemplateTests.ExampleItemView
-  });
-
-  var parentView = EmberView.create({
+  view = EmberView.create({
     container: container,
-    collectionView: TemplateTests.CollectionView,
+    exampleCollectionView: CollectionView.extend(),
     exampleController: ArrayProxy.create({
       content: A(['alpha'])
     }),
-    template: EmberHandlebars.compile('{{#collection view.collectionView content=view.exampleController itemViewClass="example-item"}}beta{{/collection}}')
+    template: EmberHandlebars.compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass="example-item"}}beta{{/collection}}')
   });
 
   run(function() {
-    parentView.append();
+    view.append();
   });
 
-  ok(firstGrandchild(parentView).isAlsoCustom, "uses the example view class specified in the #collection helper");
-
-  run(function() {
-    parentView.destroy();
-  });
+  ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
 
 test("should update boundIf blocks if the conditional changes", function() {
@@ -1193,11 +1162,12 @@ test("boundIf should support parent access", function() {
 });
 
 test("{{view}} id attribute should set id on layer", function() {
-  container.register('template:foo', EmberHandlebars.compile('{{#view "TemplateTests.IdView" id="bar"}}baz{{/view}}'));
+  container.register('template:foo', EmberHandlebars.compile('{{#view view.idView id="bar"}}baz{{/view}}'));
 
-  TemplateTests.IdView = EmberView;
+  var IdView = EmberView;
 
   view = EmberView.create({
+    idView: IdView,
     container: container,
     templateName: 'foo'
   });
@@ -1209,11 +1179,12 @@ test("{{view}} id attribute should set id on layer", function() {
 });
 
 test("{{view}} tag attribute should set tagName of the view", function() {
-  container.register('template:foo', EmberHandlebars.compile('{{#view "TemplateTests.TagView" tag="span"}}baz{{/view}}'));
+  container.register('template:foo', EmberHandlebars.compile('{{#view view.tagView tag="span"}}baz{{/view}}'));
 
-  TemplateTests.TagView = EmberView;
+  var TagView = EmberView;
 
   view = EmberView.create({
+    tagView: TagView,
     container: container,
     templateName: 'foo'
   });
@@ -1225,11 +1196,12 @@ test("{{view}} tag attribute should set tagName of the view", function() {
 });
 
 test("{{view}} class attribute should set class on layer", function() {
-  container.register('template:foo', EmberHandlebars.compile('{{#view "TemplateTests.IdView" class="bar"}}baz{{/view}}'));
+  container.register('template:foo', EmberHandlebars.compile('{{#view view.idView class="bar"}}baz{{/view}}'));
 
-  TemplateTests.IdView = EmberView;
+  var IdView = EmberView;
 
   view = EmberView.create({
+    idView: IdView,
     container: container,
     templateName: 'foo'
   });
@@ -1276,7 +1248,8 @@ test("{{view}} should evaluate class bindings set to global paths", function() {
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{view Ember.TextField class="unbound" classBinding="App.isGreat:great App.directClass App.isApp App.isEnabled:enabled:disabled"}}')
+    textField: TextField,
+    template: EmberHandlebars.compile('{{view view.textField class="unbound" classBinding="App.isGreat:great App.directClass App.isApp App.isEnabled:enabled:disabled"}}')
   });
 
   appendView();
@@ -1308,7 +1281,8 @@ test("{{view}} should evaluate class bindings set in the current context", funct
     isEditable:  true,
     directClass: "view-direct",
     isEnabled: true,
-    template: EmberHandlebars.compile('{{view Ember.TextField class="unbound" classBinding="view.isEditable:editable view.directClass view.isView view.isEnabled:enabled:disabled"}}')
+    textField: TextField,
+    template: EmberHandlebars.compile('{{view view.textField class="unbound" classBinding="view.isEditable:editable view.directClass view.isView view.isEnabled:enabled:disabled"}}')
   });
 
   appendView();
@@ -1341,7 +1315,8 @@ test("{{view}} should evaluate class bindings set with either classBinding or cl
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{view Ember.TextField class="unbound" classBinding="App.isGreat:great App.isEnabled:enabled:disabled" classNameBindings="App.isGreat:really-great App.isEnabled:really-enabled:really-disabled"}}')
+    textField: TextField,
+    template: EmberHandlebars.compile('{{view view.textField class="unbound" classBinding="App.isGreat:great App.isEnabled:enabled:disabled" classNameBindings="App.isGreat:really-great App.isEnabled:really-enabled:really-disabled"}}')
   });
 
   appendView();
@@ -1376,7 +1351,8 @@ test("{{view}} should evaluate other attribute bindings set to global paths", fu
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{view Ember.TextField valueBinding="App.name"}}')
+    textField: TextField,
+    template: EmberHandlebars.compile('{{view view.textField valueBinding="App.name"}}')
   });
 
   appendView();
@@ -1391,7 +1367,8 @@ test("{{view}} should evaluate other attribute bindings set to global paths", fu
 test("{{view}} should evaluate other attributes bindings set in the current context", function() {
   view = EmberView.create({
     name: "myView",
-    template: EmberHandlebars.compile('{{view Ember.TextField valueBinding="view.name"}}')
+    textField: TextField,
+    template: EmberHandlebars.compile('{{view view.textField valueBinding="view.name"}}')
   });
 
   appendView();
@@ -1400,11 +1377,12 @@ test("{{view}} should evaluate other attributes bindings set in the current cont
 });
 
 test("{{view}} should be able to bind class names to truthy properties", function() {
-  container.register('template:template', EmberHandlebars.compile('{{#view "TemplateTests.classBindingView" classBinding="view.number:is-truthy"}}foo{{/view}}'));
+  container.register('template:template', EmberHandlebars.compile('{{#view view.classBindingView classBinding="view.number:is-truthy"}}foo{{/view}}'));
 
-  TemplateTests.classBindingView = EmberView.extend();
+  var ClassBindingView = EmberView.extend();
 
   view = EmberView.create({
+    classBindingView: ClassBindingView,
     container: container,
     number: 5,
     templateName: 'template'
@@ -1422,11 +1400,12 @@ test("{{view}} should be able to bind class names to truthy properties", functio
 });
 
 test("{{view}} should be able to bind class names to truthy or falsy properties", function() {
-  container.register('template:template', EmberHandlebars.compile('{{#view "TemplateTests.classBindingView" classBinding="view.number:is-truthy:is-falsy"}}foo{{/view}}'));
+  container.register('template:template', EmberHandlebars.compile('{{#view view.classBindingView classBinding="view.number:is-truthy:is-falsy"}}foo{{/view}}'));
 
-  TemplateTests.classBindingView = EmberView.extend();
+  var ClassBindingView = EmberView.extend();
 
   view = EmberView.create({
+    classBindingView: ClassBindingView,
     container: container,
     number: 5,
     templateName: 'template'
@@ -2017,8 +1996,9 @@ test("should expose a controller keyword that can be used in conditionals", func
 });
 
 test("should expose a controller keyword that persists through Ember.ContainerView", function() {
-  var templateString = "{{view Ember.ContainerView}}";
+  var templateString = "{{view view.containerView}}";
   view = EmberView.create({
+    containerView: ContainerView,
     container: container,
     controller: EmberObject.create({
       foo: "bar"
@@ -2067,13 +2047,14 @@ test("should be able to explicitly set a view's context", function() {
     test: 'test'
   });
 
-  TemplateTests.CustomContextView = EmberView.extend({
+  var CustomContextView = EmberView.extend({
     context: context,
     template: EmberHandlebars.compile("{{test}}")
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile("{{view TemplateTests.CustomContextView}}")
+    customContextView: CustomContextView,
+    template: EmberHandlebars.compile("{{view view.customContextView}}")
   });
 
   appendView();
@@ -2374,7 +2355,7 @@ test("should not enter an infinite loop when binding an attribute in Handlebars"
   });
 
   App.test = EmberObject.create({ href: 'test' });
-  App.Link = EmberView.extend({
+  var LinkView = EmberView.extend({
     classNames: ['app-link'],
     tagName: 'a',
     attributeBindings: ['href'],
@@ -2386,7 +2367,8 @@ test("should not enter an infinite loop when binding an attribute in Handlebars"
   });
 
   var parentView = EmberView.create({
-    template: EmberHandlebars.compile('{{#view App.Link hrefBinding="App.test.href"}} Test {{/view}}')
+    linkView: LinkView,
+    template: EmberHandlebars.compile('{{#view view.linkView hrefBinding="App.test.href"}} Test {{/view}}')
   });
 
 

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -1,4 +1,3 @@
-/*globals TemplateTests*/
 /*jshint newcap:false*/
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
@@ -15,6 +14,8 @@ import EmberHandlebars from "ember-handlebars-compiler";
 var compile = EmberHandlebars.compile;
 
 var view;
+
+var originalLookup = Ember.lookup;
 
 function appendView() {
   run(function() { view.appendTo('#qunit-fixture'); });
@@ -33,7 +34,6 @@ function registerRepeatHelper() {
 
 QUnit.module("Handlebars bound helpers", {
   setup: function() {
-    window.TemplateTests = Namespace.create();
   },
   teardown: function() {
     run(function() {
@@ -41,7 +41,7 @@ QUnit.module("Handlebars bound helpers", {
         view.destroy();
       }
     });
-    window.TemplateTests = undefined;
+    Ember.lookup = originalLookup;
   }
 });
 
@@ -120,20 +120,20 @@ test("bound helpers should support keywords", function() {
   ok(view.$().text() === 'AB', "helper output is correct");
 });
 
-test("bound helpers should support global paths", function() {
+test("bound helpers should support global paths [DEPRECATED]", function() {
   EmberHandlebars.helper('capitalize', function(value) {
     return value.toUpperCase();
   });
 
-  TemplateTests.text = 'ab';
+  Ember.lookup = {Text: 'ab'};
 
   view = EmberView.create({
-    template: EmberHandlebars.compile("{{capitalize TemplateTests.text}}")
+    template: EmberHandlebars.compile("{{capitalize Text}}")
   });
 
   expectDeprecation(function() {
     appendView();
-  }, /Global lookup of TemplateTests.text from a Handlebars template is deprecated/);
+  }, /Global lookup of Text from a Handlebars template is deprecated/);
 
   ok(view.$().text() === 'AB', "helper output is correct");
 });

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -266,8 +266,9 @@ test("#each with groupedRows=true behaves like a normal bound #each", function()
 });
 
 test("#each with itemViewClass behaves like a normal bound #each", function() {
+  container.register('view:nothing-special-view', Ember.View);
   createGroupedView(
-    '{{#each people itemViewClass="Ember.View"}}{{name}}{{/each}}',
+    '{{#each people itemViewClass="nothing-special-view"}}{{name}}{{/each}}',
     {people: A([{name: 'Erik'}, {name: 'Peter'}])}
   );
   appendView();

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -35,6 +35,12 @@ test("By default view:toplevel is used", function() {
     template: Ember.Handlebars.compile('hello world')
   });
 
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:toplevel');
+
+    return DefaultView;
+  }
+
   var container = {
     lookupFactory: lookupFactory
   };
@@ -47,12 +53,6 @@ test("By default view:toplevel is used", function() {
   run(view, 'appendTo', '#qunit-fixture');
 
   equal(jQuery('#toplevel-view').text(), 'hello world');
-
-  function lookupFactory(fullName) {
-    equal(fullName, 'view:toplevel');
-
-    return DefaultView;
-  }
 });
 
 test("By default, without a container, EmberView is used", function() {
@@ -65,7 +65,7 @@ test("By default, without a container, EmberView is used", function() {
   ok(jQuery('#qunit-fixture').html().match(/<span/), 'contains view with span');
 });
 
-test("View lookup - App.FuView", function() {
+test("View lookup - App.FuView (DEPRECATED)", function() {
   Ember.lookup = {
     App: {
       FuView: viewClass({
@@ -79,12 +79,14 @@ test("View lookup - App.FuView", function() {
     template: Ember.Handlebars.compile("{{view App.FuView}}")
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  expectDeprecation(function(){
+    run(view, 'appendTo', '#qunit-fixture');
+  }, /Resolved the view "App.FuView" on the global context/);
 
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test("View lookup - 'App.FuView'", function() {
+test("View lookup - 'App.FuView' (DEPRECATED)", function() {
   Ember.lookup = {
     App: {
       FuView: viewClass({
@@ -98,7 +100,9 @@ test("View lookup - 'App.FuView'", function() {
     template: Ember.Handlebars.compile("{{view 'App.FuView'}}")
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  expectDeprecation(function(){
+    run(view, 'appendTo', '#qunit-fixture');
+  }, /Resolved the view "App.FuView" on the global context/);
 
   equal(jQuery('#fu').text(), 'bro');
 });
@@ -108,6 +112,12 @@ test("View lookup - 'fu'", function() {
     elementId: "fu",
     template: Ember.Handlebars.compile("bro")
   });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
 
   var container = {
     lookupFactory: lookupFactory
@@ -121,12 +131,6 @@ test("View lookup - 'fu'", function() {
   run(view, 'appendTo', '#qunit-fixture');
 
   equal(jQuery('#fu').text(), 'bro');
-
-  function lookupFactory(fullName) {
-    equal(fullName, 'view:fu');
-
-    return FuView;
-  }
 });
 
 test("View lookup - view.computed", function() {
@@ -134,6 +138,12 @@ test("View lookup - view.computed", function() {
     elementId: "fu",
     template: Ember.Handlebars.compile("bro")
   });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
 
   var container = {
     lookupFactory: lookupFactory
@@ -148,12 +158,6 @@ test("View lookup - view.computed", function() {
   run(view, 'appendTo', '#qunit-fixture');
 
   equal(jQuery('#fu').text(), 'bro');
-
-  function lookupFactory(fullName) {
-    equal(fullName, 'view:fu');
-
-    return FuView;
-  }
 });
 
 test("id bindings downgrade to one-time property lookup", function() {

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -147,9 +147,11 @@ QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
 test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
   equal(view.$().text(), "baz", "should be properly scoped");
 
-  run(function() {
-    set(lookup.Foo, 'bar', 'updated');
-  });
+  expectDeprecation(function() {
+    run(function() {
+      set(lookup.Foo, 'bar', 'updated');
+    });
+  }, /Global lookup of Foo.bar from a Handlebars template is deprecated/);
 
   equal(view.$().text(), "updated", "should update");
 });

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -126,12 +126,12 @@ QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
-    ignoreDeprecation(function() {
-      lookup.Foo = { bar: 'baz' };
-      view = EmberView.create({
-        template: EmberHandlebars.compile("{{#with Foo.bar as qux}}{{qux}}{{/with}}")
-      });
+    lookup.Foo = { bar: 'baz' };
+    view = EmberView.create({
+      template: EmberHandlebars.compile("{{#with Foo.bar as qux}}{{qux}}{{/with}}")
+    });
 
+    ignoreDeprecation(function() {
       appendView(view);
     });
   },
@@ -147,10 +147,8 @@ QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
 test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
   equal(view.$().text(), "baz", "should be properly scoped");
 
-  ignoreDeprecation(function() {
-    run(function() {
-        set(lookup.Foo, 'bar', 'updated');
-    });
+  run(function() {
+    set(lookup.Foo, 'bar', 'updated');
   });
 
   equal(view.$().text(), "updated", "should update");

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -11,15 +11,10 @@ import { A } from "ember-runtime/system/native_array";
 import Component from "ember-views/views/component";
 import EmberError from "ember-metal/error";
 
-var originalLookup = Ember.lookup;
-var lookup, TemplateTests, view, container;
+var view, container;
 
 QUnit.module("Support for {{yield}} helper", {
   setup: function() {
-    Ember.lookup = lookup = { Ember: Ember };
-
-    lookup.TemplateTests = TemplateTests = Namespace.create();
-
     container = new Container();
     container.optionsForType('template', { instantiate: false });
   },
@@ -30,18 +25,17 @@ QUnit.module("Support for {{yield}} helper", {
         view.destroy();
       }
     });
-
-    Ember.lookup = originalLookup;
   }
 });
 
 test("a view with a layout set renders its template where the {{yield}} helper appears", function() {
-  TemplateTests.ViewWithLayout = EmberView.extend({
+  var ViewWithLayout = EmberView.extend({
     layout: EmberHandlebars.compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>')
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#view TemplateTests.ViewWithLayout title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
+    withLayout: ViewWithLayout,
+    template: EmberHandlebars.compile('{{#view view.withLayout title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
   });
 
   run(function() {
@@ -53,12 +47,12 @@ test("a view with a layout set renders its template where the {{yield}} helper a
 
 test("block should work properly even when templates are not hard-coded", function() {
   container.register('template:nester', EmberHandlebars.compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>'));
-  container.register('template:nested', EmberHandlebars.compile('{{#view TemplateTests.ViewWithLayout title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}'));
+  container.register('template:nested', EmberHandlebars.compile('{{#view "with-layout" title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}'));
 
-  TemplateTests.ViewWithLayout = EmberView.extend({
+  container.register('view:with-layout', EmberView.extend({
     container: container,
     layoutName: 'nester'
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -74,7 +68,7 @@ test("block should work properly even when templates are not hard-coded", functi
 });
 
 test("templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
-  TemplateTests.TimesView = EmberView.extend({
+  var TimesView = EmberView.extend({
     layout: EmberHandlebars.compile('<div class="times">{{#each view.index}}{{yield}}{{/each}}</div>'),
     n: null,
     index: computed(function() {
@@ -88,7 +82,8 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('<div id="container"><div class="title">Counting to 5</div>{{#view TemplateTests.TimesView n=5}}<div class="times-item">Hello</div>{{/view}}</div>')
+    timesView: TimesView,
+    template: EmberHandlebars.compile('<div id="container"><div class="title">Counting to 5</div>{{#view view.timesView n=5}}<div class="times-item">Hello</div>{{/view}}</div>')
   });
 
   run(function() {
@@ -99,12 +94,13 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
 });
 
 test("templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
-  TemplateTests.NestingView = EmberView.extend({
+  var NestingView = EmberView.extend({
     layout: EmberHandlebars.compile('{{#view tagName="div" classNames="nesting"}}{{yield}}{{/view}}')
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('<div id="container">{{#view TemplateTests.NestingView}}<div id="block">Hello</div>{{/view}}</div>')
+    nestingView: NestingView,
+    template: EmberHandlebars.compile('<div id="container">{{#view view.nestingView}}<div id="block">Hello</div>{{/view}}</div>')
   });
 
   run(function() {
@@ -115,12 +111,13 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
 });
 
 test("block should not be required", function() {
-  TemplateTests.YieldingView = EmberView.extend({
+  var YieldingView = EmberView.extend({
     layout: EmberHandlebars.compile('{{#view tagName="div" classNames="yielding"}}{{yield}}{{/view}}')
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('<div id="container">{{view TemplateTests.YieldingView}}</div>')
+    yieldingView: YieldingView,
+    template: EmberHandlebars.compile('<div id="container">{{view view.yieldingView}}</div>')
   });
 
   run(function() {

--- a/packages/ember-handlebars/tests/lookup_test.js
+++ b/packages/ember-handlebars/tests/lookup_test.js
@@ -28,12 +28,14 @@ test("ID parameters should be looked up on the context", function() {
   deepEqual(params, ["Mr", "Tom", "Dale"]);
 });
 
-test("ID parameters that start with capital letters fall back to Ember.lookup as their context", function() {
+test("ID parameters that start with capital letters fall back to Ember.lookup as their context (DEPRECATED)", function() {
   Ember.lookup.Global = "I'm going global, what you ain't a local?";
 
-  var context = {};
+  var context = {}, params;
 
-  var params = Ember.Handlebars.resolveParams(context, ["Global"], { types: ["ID"], silenceGlobalDeprecation: true });
+  expectDeprecation(function(){
+    params = Ember.Handlebars.resolveParams(context, ["Global"], { types: ["ID"] });
+  }, /Global lookup of Global from a Handlebars template is deprecated./);
   deepEqual(params, [Ember.lookup.Global]);
 });
 

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -1,4 +1,3 @@
-/*globals TemplateTests:true,App:true */
 /*jshint newcap:false*/
 
 import EmberView from "ember-views/views/view";
@@ -48,13 +47,14 @@ QUnit.module("ember-handlebars/tests/views/collection_view_test", {
 });
 
 test("passing a block to the collection helper sets it as the template for example views", function() {
-  TemplateTests.CollectionTestView = CollectionView.extend({
+  var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection TemplateTests.CollectionTestView}} <label></label> {{/collection}}')
+    collectionTestView: CollectionTestView,
+    template: EmberHandlebars.compile('{{#collection view.collectionTestView}} <label></label> {{/collection}}')
   });
 
   run(function() {
@@ -110,12 +110,12 @@ test("empty views should be removed when content is added to the collection (reg
     lookup.App = App = Namespace.create();
   });
 
-  App.EmptyView = EmberView.extend({
+  var EmptyView = EmberView.extend({
     template : EmberHandlebars.compile("<td>No Rows Yet</td>")
   });
 
-  App.ListView = CollectionView.extend({
-    emptyView: App.EmptyView
+  var ListView = CollectionView.extend({
+    emptyView: EmptyView
   });
 
   App.listController = ArrayProxy.create({
@@ -123,7 +123,8 @@ test("empty views should be removed when content is added to the collection (reg
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection App.ListView contentBinding="App.listController" tagName="table"}} <td>{{view.content.title}}</td> {{/collection}}')
+    listView: ListView,
+    template: EmberHandlebars.compile('{{#collection view.listView contentBinding="App.listController" tagName="table"}} <td>{{view.content.title}}</td> {{/collection}}')
   });
 
   run(function() {
@@ -149,12 +150,17 @@ test("should be able to specify which class should be used for the empty view", 
     lookup.App = App = Namespace.create();
   });
 
-  App.EmptyView = EmberView.extend({
+  var EmptyView = EmberView.extend({
     template: EmberHandlebars.compile('This is an empty view')
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{collection emptyViewClass="App.EmptyView"}}')
+    container: {
+      lookupFactory: function(){
+        return EmptyView;
+      }
+    },
+    template: EmberHandlebars.compile('{{collection emptyViewClass="empty-view"}}')
   });
 
   run(function() {
@@ -169,13 +175,14 @@ test("should be able to specify which class should be used for the empty view", 
 });
 
 test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {
-  TemplateTests.CollectionTestView = CollectionView.extend({
+  var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A()
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.CollectionTestView"}} <aside></aside> {{/collection}}')
+    collectionTestView: CollectionTestView,
+    template: EmberHandlebars.compile('{{#collection view.collectionTestView}} <aside></aside> {{/collection}}')
   });
 
   run(function() {
@@ -186,13 +193,14 @@ test("if no content is passed, and no 'else' is specified, nothing is rendered",
 });
 
 test("if no content is passed, and 'else' is specified, the else block is rendered", function() {
-  TemplateTests.CollectionTestView = CollectionView.extend({
+  var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A()
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.CollectionTestView"}} <aside></aside> {{ else }} <del></del> {{/collection}}')
+    collectionTestView: CollectionTestView,
+    template: EmberHandlebars.compile('{{#collection view.collectionTestView}} <aside></aside> {{ else }} <del></del> {{/collection}}')
   });
 
   run(function() {
@@ -203,13 +211,14 @@ test("if no content is passed, and 'else' is specified, the else block is render
 });
 
 test("a block passed to a collection helper defaults to the content property of the context", function() {
-  TemplateTests.CollectionTestView = CollectionView.extend({
+  var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.CollectionTestView"}} <label>{{view.content}}</label> {{/collection}}')
+    collectionTestView: CollectionTestView,
+    template: EmberHandlebars.compile('{{#collection view.collectionTestView}} <label>{{view.content}}</label> {{/collection}}')
   });
 
   run(function() {
@@ -225,13 +234,14 @@ test("a block passed to a collection helper defaults to the content property of 
 });
 
 test("a block passed to a collection helper defaults to the view", function() {
-  TemplateTests.CollectionTestView = CollectionView.extend({
+  var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.CollectionTestView"}} <label>{{view.content}}</label> {{/collection}}')
+    collectionTestView: CollectionTestView,
+    template: EmberHandlebars.compile('{{#collection view.collectionTestView}} <label>{{view.content}}</label> {{/collection}}')
   });
 
   run(function() {
@@ -253,13 +263,14 @@ test("a block passed to a collection helper defaults to the view", function() {
 });
 
 test("should include an id attribute if id is set in the options hash", function() {
-  TemplateTests.CollectionTestView = CollectionView.extend({
+  var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.CollectionTestView" id="baz"}}foo{{/collection}}')
+    collectionTestView: CollectionTestView,
+    template: EmberHandlebars.compile('{{#collection view.collectionTestView id="baz"}}foo{{/collection}}')
   });
 
   run(function() {
@@ -270,12 +281,13 @@ test("should include an id attribute if id is set in the options hash", function
 });
 
 test("should give its item views the class specified by itemClass", function() {
-  TemplateTests.itemClassTestCollectionView = CollectionView.extend({
+  var ItemClassTestCollectionView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
   });
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.itemClassTestCollectionView" itemClass="baz"}}foo{{/collection}}')
+    itemClassTestCollectionView: ItemClassTestCollectionView,
+    template: EmberHandlebars.compile('{{#collection view.itemClassTestCollectionView itemClass="baz"}}foo{{/collection}}')
   });
 
   run(function() {
@@ -286,14 +298,15 @@ test("should give its item views the class specified by itemClass", function() {
 });
 
 test("should give its item views the classBinding specified by itemClassBinding", function() {
-  TemplateTests.itemClassBindingTestCollectionView = CollectionView.extend({
+  var ItemClassBindingTestCollectionView = CollectionView.extend({
     tagName: 'ul',
     content: A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })])
   });
 
   view = EmberView.create({
+    itemClassBindingTestCollectionView: ItemClassBindingTestCollectionView,
     isBar: true,
-    template: EmberHandlebars.compile('{{#collection "TemplateTests.itemClassBindingTestCollectionView" itemClassBinding="view.isBar"}}foo{{/collection}}')
+    template: EmberHandlebars.compile('{{#collection view.itemClassBindingTestCollectionView itemClassBinding="view.isBar"}}foo{{/collection}}')
   });
 
   run(function() {
@@ -307,7 +320,7 @@ test("should give its item views the classBinding specified by itemClassBinding"
 });
 
 test("should give its item views the property specified by itemPropertyBinding", function() {
-  TemplateTests.itemPropertyBindingTestItemView = EmberView.extend({
+  var ItemPropertyBindingTestItemView = EmberView.extend({
     tagName: 'li'
   });
 
@@ -316,7 +329,12 @@ test("should give its item views the property specified by itemPropertyBinding",
   view = EmberView.create({
     baz: "baz",
     content: A([EmberObject.create(), EmberObject.create(), EmberObject.create()]),
-    template: EmberHandlebars.compile('{{#collection contentBinding="view.content" tagName="ul" itemViewClass="TemplateTests.itemPropertyBindingTestItemView" itemPropertyBinding="view.baz" preserveContext=false}}{{view.property}}{{/collection}}')
+    container: {
+      lookupFactory: function(){
+        return ItemPropertyBindingTestItemView;
+      }
+    },
+    template: EmberHandlebars.compile('{{#collection contentBinding="view.content" tagName="ul" itemViewClass="item-property-binding-test-item-view" itemPropertyBinding="view.baz" preserveContext=false}}{{view.property}}{{/collection}}')
   });
 
   run(function() {
@@ -338,13 +356,14 @@ test("should give its item views the property specified by itemPropertyBinding",
 
 test("should work inside a bound {{#if}}", function() {
   var testData = A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })]);
-  TemplateTests.ifTestCollectionView = CollectionView.extend({
+  var IfTestCollectionView = CollectionView.extend({
     tagName: 'ul',
     content: testData
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#if view.shouldDisplay}}{{#collection "TemplateTests.ifTestCollectionView"}}{{content.isBaz}}{{/collection}}{{/if}}'),
+    ifTestCollectionView: IfTestCollectionView,
+    template: EmberHandlebars.compile('{{#if view.shouldDisplay}}{{#collection view.ifTestCollectionView}}{{content.isBaz}}{{/collection}}{{/if}}'),
     shouldDisplay: true
   });
 
@@ -381,13 +400,14 @@ test("should pass content as context when using {{#each}} helper", function() {
 });
 
 test("should re-render when the content object changes", function() {
-  TemplateTests.RerenderTest = CollectionView.extend({
+  var RerenderTest = CollectionView.extend({
     tagName: 'ul',
     content: A()
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection TemplateTests.RerenderTest}}{{view.content}}{{/collection}}')
+    rerenderTestView: RerenderTest,
+    template: EmberHandlebars.compile('{{#collection view.rerenderTestView}}{{view.content}}{{/collection}}')
   });
 
   run(function() {
@@ -408,12 +428,13 @@ test("should re-render when the content object changes", function() {
 });
 
 test("select tagName on collection helper automatically sets child tagName to option", function() {
-  TemplateTests.RerenderTest = CollectionView.extend({
+  var RerenderTest = CollectionView.extend({
     content: A(['foo'])
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection TemplateTests.RerenderTest tagName="select"}}{{view.content}}{{/collection}}')
+    rerenderTestView: RerenderTest,
+    template: EmberHandlebars.compile('{{#collection view.rerenderTestView tagName="select"}}{{view.content}}{{/collection}}')
   });
 
   run(function() {
@@ -425,12 +446,13 @@ test("select tagName on collection helper automatically sets child tagName to op
 });
 
 test("tagName works in the #collection helper", function() {
-  TemplateTests.RerenderTest = CollectionView.extend({
+  var RerenderTest = CollectionView.extend({
     content: A(['foo', 'bar'])
   });
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection TemplateTests.RerenderTest tagName="ol"}}{{view.content}}{{/collection}}')
+    rerenderTestView: RerenderTest,
+    template: EmberHandlebars.compile('{{#collection view.rerenderTestView tagName="ol"}}{{view.content}}{{/collection}}')
   });
 
   run(function() {
@@ -450,18 +472,20 @@ test("tagName works in the #collection helper", function() {
 
 test("should render nested collections", function() {
 
-  TemplateTests.InnerList = CollectionView.extend({
+  var container = new Container();
+  container.register('view:inner-list', CollectionView.extend({
     tagName: 'ul',
     content: A(['one','two','three'])
-  });
+  }));
 
-  TemplateTests.OuterList = CollectionView.extend({
+  container.register('view:outer-list', CollectionView.extend({
     tagName: 'ul',
     content: A(['foo'])
-  });
+  }));
 
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#collection TemplateTests.OuterList class="outer"}}{{content}}{{#collection TemplateTests.InnerList class="inner"}}{{content}}{{/collection}}{{/collection}}')
+    container: container,
+    template: EmberHandlebars.compile('{{#collection "outer-list" class="outer"}}{{content}}{{#collection "inner-list" class="inner"}}{{content}}{{/collection}}{{/collection}}')
   });
 
   run(function() {
@@ -482,26 +506,28 @@ test("should render multiple, bound nested collections (#68)", function() {
       content: A(['foo','bar'])
     });
 
-    TemplateTests.InnerList = CollectionView.extend({
+    var InnerList = CollectionView.extend({
       tagName: 'ul',
       contentBinding: 'parentView.innerListContent'
     });
 
-    TemplateTests.OuterListItem = EmberView.extend({
-      template: EmberHandlebars.compile('{{#collection TemplateTests.InnerList class="inner"}}{{content}}{{/collection}}{{content}}'),
+    var OuterListItem = EmberView.extend({
+      innerListView: InnerList,
+      template: EmberHandlebars.compile('{{#collection view.innerListView class="inner"}}{{content}}{{/collection}}{{content}}'),
       innerListContent: computed(function() {
         return A([1,2,3]);
       })
     });
 
-    TemplateTests.OuterList = CollectionView.extend({
+    var OuterList = CollectionView.extend({
       tagName: 'ul',
       contentBinding: 'TemplateTests.contentController',
-      itemViewClass: TemplateTests.OuterListItem
+      itemViewClass: OuterListItem
     });
 
     view = EmberView.create({
-      template: EmberHandlebars.compile('{{collection TemplateTests.OuterList class="outer"}}')
+      outerListView: OuterList,
+      template: EmberHandlebars.compile('{{collection view.outerListView class="outer"}}')
     });
   });
 
@@ -525,20 +551,21 @@ test("should allow view objects to be swapped out without throwing an error (#78
   run(function() {
     TemplateTests.datasetController = EmberObject.create();
 
-    TemplateTests.ReportingView = EmberView.extend({
-      datasetBinding: 'TemplateTests.datasetController.dataset',
-      readyBinding: 'dataset.ready',
-      itemsBinding: 'dataset.items',
-      template: EmberHandlebars.compile("{{#if view.ready}}{{collection TemplateTests.CollectionView}}{{else}}Loading{{/if}}")
-    });
-
-    TemplateTests.CollectionView = CollectionView.extend({
+    var ExampleCollectionView = CollectionView.extend({
       contentBinding: 'parentView.items',
       tagName: 'ul',
       template: EmberHandlebars.compile("{{view.content}}")
     });
 
-    view = TemplateTests.ReportingView.create();
+    var ReportingView = EmberView.extend({
+      exampleCollectionView: ExampleCollectionView,
+      datasetBinding: 'TemplateTests.datasetController.dataset',
+      readyBinding: 'dataset.ready',
+      itemsBinding: 'dataset.items',
+      template: EmberHandlebars.compile("{{#if view.ready}}{{collection view.exampleCollectionView}}{{else}}Loading{{/if}}")
+    });
+
+    view = ReportingView.create();
   });
 
   run(function() {
@@ -576,22 +603,26 @@ test("context should be content", function() {
     lookup.App = App = Namespace.create();
   });
 
+  var container = new Container();
+
   App.items = A([
     EmberObject.create({name: 'Dave'}),
     EmberObject.create({name: 'Mary'}),
     EmberObject.create({name: 'Sara'})
   ]);
 
-  App.AnItemView = EmberView.extend({
+  container.register('view:an-item', EmberView.extend({
     template: EmberHandlebars.compile("Greetings {{name}}")
-  });
+  }));
 
   App.AView = EmberView.extend({
-    template: EmberHandlebars.compile('{{collection contentBinding="App.items" itemViewClass="App.AnItemView"}}')
+    template: EmberHandlebars.compile('{{collection contentBinding="App.items" itemViewClass="an-item"}}')
   });
 
   run(function() {
-    view = App.AView.create();
+    view = App.AView.create({
+      container: container
+    });
   });
 
   run(function() {

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -62,7 +62,7 @@ var get = function get(obj, keyName) {
     var value = _getPath(obj, keyName);
     Ember.deprecate(
       "Ember.get fetched '"+keyName+"' from the global context. This behavior will change in the future (issue #3852)",
-      !value || (obj && obj !== Ember.lookup) || keyName.indexOf('.') !== -1 || isGlobalPath(keyName+".") // Add a . to ensure simple paths are matched.
+      !value || (obj && obj !== Ember.lookup) || isPath(keyName) || isGlobalPath(keyName+".") // Add a . to ensure simple paths are matched.
     );
     return value;
   }

--- a/packages/ember-routing-handlebars/lib/helpers/render.js
+++ b/packages/ember-routing-handlebars/lib/helpers/render.js
@@ -8,7 +8,7 @@ import {
   default as generateController
 } from "ember-routing/system/generate_controller";
 import { handlebarsGet } from "ember-handlebars/ext";
-import { viewHelper } from "ember-handlebars/helpers/view";
+import { ViewHelper } from "ember-handlebars/helpers/view";
 
 import "ember-handlebars/helpers/view";
 
@@ -172,5 +172,5 @@ export default function renderHelper(name, contextString, options) {
 
   options.helperName = options.helperName || ('render "' + name + '"');
 
-  viewHelper.call(this, view, options);
+  ViewHelper.instanceHelper(this, view, options);
 }

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -44,27 +44,32 @@ import EmberArray from "ember-runtime/mixins/array";
   The view for each item in the collection will have its `content` property set
   to the item.
 
-  ## Specifying itemViewClass
+  ## Specifying `itemViewClass`
 
   By default the view class for each item in the managed collection will be an
   instance of `Ember.View`. You can supply a different class by setting the
   `CollectionView`'s `itemViewClass` property.
 
-  Given an empty `<body>` and the following code:
+  Given the following application code:
 
   ```javascript
-  someItemsView = Ember.CollectionView.create({
+  var App = Ember.Application.create();
+  App.ItemListView = Ember.CollectionView.extend({
     classNames: ['a-collection'],
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
       template: Ember.Handlebars.compile("the letter: {{view.content}}")
     })
   });
-
-  someItemsView.appendTo('body');
   ```
 
-  Will result in the following HTML structure
+  And a simple application template:
+
+  ```handlebars
+  {{view 'item-list'}}
+  ```
+
+  The following HTML will result:
 
   ```html
   <div class="ember-view a-collection">
@@ -80,21 +85,26 @@ import EmberArray from "ember-runtime/mixins/array";
   "ul", "ol", "table", "thead", "tbody", "tfoot", "tr", or "select" will result
   in the item views receiving an appropriately matched `tagName` property.
 
-  Given an empty `<body>` and the following code:
+  Given the following application code:
 
   ```javascript
-  anUnorderedListView = Ember.CollectionView.create({
+  var App = Ember.Application.create();
+  App.UnorderedListView = Ember.CollectionView.create({
     tagName: 'ul',
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
       template: Ember.Handlebars.compile("the letter: {{view.content}}")
     })
   });
-
-  anUnorderedListView.appendTo('body');
   ```
 
-  Will result in the following HTML structure
+  And a simple application template:
+
+  ```handlebars
+  {{view 'unordered-list-view'}}
+  ```
+
+  The following HTML will result:
 
   ```html
   <ul class="ember-view a-collection">
@@ -105,7 +115,7 @@ import EmberArray from "ember-runtime/mixins/array";
   ```
 
   Additional `tagName` pairs can be provided by adding to
-  `Ember.CollectionView.CONTAINER_MAP `
+  `Ember.CollectionView.CONTAINER_MAP`. For example:
 
   ```javascript
   Ember.CollectionView.CONTAINER_MAP['article'] = 'section'
@@ -118,7 +128,7 @@ import EmberArray from "ember-runtime/mixins/array";
   `createChildView` method can be overidden:
 
   ```javascript
-  CustomCollectionView = Ember.CollectionView.extend({
+  App.CustomCollectionView = Ember.CollectionView.extend({
     createChildView: function(viewClass, attrs) {
       if (attrs.content.kind == 'album') {
         viewClass = App.AlbumView;
@@ -138,18 +148,23 @@ import EmberArray from "ember-runtime/mixins/array";
   will be the `CollectionView`s only child.
 
   ```javascript
-  aListWithNothing = Ember.CollectionView.create({
+  var App = Ember.Application.create();
+  App.ListWithNothing = Ember.CollectionView.create({
     classNames: ['nothing']
     content: null,
     emptyView: Ember.View.extend({
       template: Ember.Handlebars.compile("The collection is empty")
     })
   });
-
-  aListWithNothing.appendTo('body');
   ```
 
-  Will result in the following HTML structure
+  And a simple application template:
+
+  ```handlebars
+  {{view 'list-with-nothing'}}
+  ```
+
+  The following HTML will result:
 
   ```html
   <div class="ember-view nothing">

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -18,6 +18,9 @@ import {
   observer,
   beforeObserver
 } from "ember-metal/mixin";
+import {
+  handlebarsGetView
+} from "ember-handlebars/ext";
 import EmberArray from "ember-runtime/mixins/array";
 
 /**
@@ -345,14 +348,7 @@ var CollectionView = ContainerView.extend({
 
     if (len) {
       itemViewClass = get(this, 'itemViewClass');
-
-      if ('string' === typeof itemViewClass && isGlobalPath(itemViewClass)) {
-        itemViewClass = get(itemViewClass) || itemViewClass;
-      }
-
-      Ember.assert(fmt("itemViewClass must be a subclass of Ember.View, not %@",
-                       [itemViewClass]),
-                       'string' === typeof itemViewClass || View.detect(itemViewClass));
+      itemViewClass = handlebarsGetView(content, itemViewClass, this.container);
 
       for (idx = start; idx < start+added; idx++) {
         item = content.objectAt(idx);

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -600,8 +600,9 @@ var EMPTY_ARRAY = [];
   on the descendent.
 
   ```javascript
-  OuterView = Ember.View.extend({
-    template: Ember.Handlebars.compile("outer {{#view InnerView}}inner{{/view}} outer"),
+  var App = Ember.Application.create();
+  App.OuterView = Ember.View.extend({
+    template: Ember.Handlebars.compile("outer {{#view 'inner'}}inner{{/view}} outer"),
     eventManager: Ember.Object.create({
       mouseEnter: function(event, view) {
         // view might be instance of either
@@ -611,7 +612,7 @@ var EMPTY_ARRAY = [];
     })
   });
 
-  InnerView = Ember.View.extend({
+  App.InnerView = Ember.View.extend({
     click: function(event) {
       // will be called if rendered inside
       // an OuterView because OuterView's

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -487,15 +487,16 @@ test("should allow items to access to the CollectionView's current index in the 
 });
 
 test("should allow declaration of itemViewClass as a string", function() {
-  Ember.lookup = {
-    "Ember": {
-      "View": View
+  var container = {
+    lookupFactory: function(){
+      return Ember.View.extend();
     }
   };
 
   view = CollectionView.create({
+    container: container,
     content: Ember.A([1, 2, 3]),
-    itemViewClass: 'Ember.View'
+    itemViewClass: 'simple-view'
   });
 
   run(function() {


### PR DESCRIPTION
This deprecates accessing views as globals. These are all deprecated cases with this patch:

``` hbs
{{view "App.SomeThing"}}
{{view Oh.ThisToo}}
{{#collection itemViewClass="Some.Wow"}}
{{#collection itemViewClass=Not.Yet}}
{{#each itemView="Ugh.Why"}}
{{#each itemView=Something.Something}}
```

This patch also introduces a syntax for accessing parts of Ember that still rely on these APIs. For example select uses the old API:

``` hbs
{{view Ember.Select value=whut}}
```

Here we have added the select control to the views namespace on the container. This is the new syntax:

``` hbs
{{view "select" value=whut}}
```

Some tests have been updated to avoid the deprecated syntax, but many more will need to change to avoid deprecations getting spat out all over. We will need to pick names for the controls to be registered as.

We are explicitly _not_ making these components, b/c when the do become components we may change the behavior or API (for example, the infamous select box). Using the container for these legacy views allows us to avoid globals, deprecate them, and be better prepared to drop them entirely in 2.x.
- [x] Confirm `{{view 'select'` syntax
- [x] Confirm not implementing `{{view 'checkbox'`, `{{view 'text-field'`, `{{view 'text-area'` as they are already available as components
- [x] Any other views that need an interim story besides select?
- [x] Ensure the test suite does not kick out deprecations (unless they are being asserted)
- [x] Ensure docs are updated to use new syntax
- [x] Ensure [guides](http://emberjs.com/guides/views/built-in-views/) are updated to use new syntax (separate emberjs/website#1657) 
- [x] Add deprecations page to the guide, link to it from the message and explain how to fix the deprecation.
