### PR TITLE
View without container

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -391,8 +391,11 @@ export function viewHelper(path, options) {
   // and get an instance of the registered `view:toplevel`
   if (path && path.data && path.data.isRenderData) {
     options = path;
-    Ember.assert('{{view}} helper requires parent view to have a container but none was found. This usually happens when you are manually-managing views.', !!options.data.view.container);
-    path = options.data.view.container.lookupFactory('view:toplevel');
+    if (options.data && options.data.view && options.data.view.container) {
+      path = options.data.view.container.lookupFactory('view:toplevel');
+    } else {
+      path = View;
+    }
   }
 
   options.helperName = options.helperName || 'view';

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -955,7 +955,7 @@ test("a view helper's bindings are to the parent context", function() {
 test("Child views created using the view helper should have their parent view set properly", function() {
   TemplateTests = {};
 
-  var template = '{{#view "Ember.View"}}{{#view "Ember.View"}}{{view "Ember.View"}}{{/view}}{{/view}}';
+  var template = '{{#view}}{{#view}}{{view}}{{/view}}{{/view}}';
 
   view = EmberView.create({
     template: EmberHandlebars.compile(template)
@@ -970,7 +970,7 @@ test("Child views created using the view helper should have their parent view se
 test("Child views created using the view helper should have their IDs registered for events", function() {
   TemplateTests = {};
 
-  var template = '{{view "Ember.View"}}{{view "Ember.View" id="templateViewTest"}}';
+  var template = '{{view}}{{view id="templateViewTest"}}';
 
   view = EmberView.create({
     template: EmberHandlebars.compile(template)
@@ -991,7 +991,7 @@ test("Child views created using the view helper should have their IDs registered
 test("Child views created using the view helper and that have a viewName should be registered as properties on their parentView", function() {
   TemplateTests = {};
 
-  var template = '{{#view Ember.View}}{{view Ember.View viewName="ohai"}}{{/view}}';
+  var template = '{{#view}}{{view viewName="ohai"}}{{/view}}';
 
   view = EmberView.create({
     template: EmberHandlebars.compile(template)
@@ -1216,7 +1216,7 @@ test("{{view}} class attribute should set class on layer", function() {
 test("{{view}} should not allow attributeBindings to be set", function() {
   expectAssertion(function() {
     view = EmberView.create({
-      template: EmberHandlebars.compile('{{view "Ember.View" attributeBindings="one two"}}')
+      template: EmberHandlebars.compile('{{view attributeBindings="one two"}}')
     });
     appendView();
   }, /Setting 'attributeBindings' via Handlebars is not allowed/);

--- a/packages/ember-handlebars/tests/helpers/if_unless_test.js
+++ b/packages/ember-handlebars/tests/helpers/if_unless_test.js
@@ -25,7 +25,7 @@ test("unless should keep the current context (#784)", function() {
   view = EmberView.create({
     o: EmberObject.create({foo: '42'}),
 
-    template: compile('{{#with view.o}}{{#view Ember.View}}{{#unless view.doesNotExist}}foo: {{foo}}{{/unless}}{{/view}}{{/with}}')
+    template: compile('{{#with view.o}}{{#view}}{{#unless view.doesNotExist}}foo: {{foo}}{{/unless}}{{/view}}{{/with}}')
   });
 
   appendView(view);

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -55,6 +55,16 @@ test("By default view:toplevel is used", function() {
   }
 });
 
+test("By default, without a container, EmberView is used", function() {
+  view = EmberView.extend({
+    template: Ember.Handlebars.compile('{{view tagName="span"}}'),
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#qunit-fixture').html().match(/<span/), 'contains view with span');
+});
+
 test("View lookup - App.FuView", function() {
   Ember.lookup = {
     App: {

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -158,7 +158,7 @@ test("View lookup - view.computed", function() {
 
 test("id bindings downgrade to one-time property lookup", function() {
   view = EmberView.extend({
-    template: Ember.Handlebars.compile("{{#view Ember.View id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}"),
+    template: Ember.Handlebars.compile("{{#view id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}"),
     meshuggah: 'stengah'
   }).create();
 
@@ -184,7 +184,7 @@ test("mixing old and new styles of property binding fires a warning, treats valu
   };
 
   view = EmberView.extend({
-    template: Ember.Handlebars.compile("{{#view Ember.View borfBinding=view.snork}}<p id='lol'>{{view.borf}}</p>{{/view}}"),
+    template: Ember.Handlebars.compile("{{#view borfBinding=view.snork}}<p id='lol'>{{view.borf}}</p>{{/view}}"),
     snork: "nerd"
   }).create();
 

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -98,7 +98,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
 
 test("templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
   TemplateTests.NestingView = EmberView.extend({
-    layout: EmberHandlebars.compile('{{#view Ember.View tagName="div" classNames="nesting"}}{{yield}}{{/view}}')
+    layout: EmberHandlebars.compile('{{#view tagName="div" classNames="nesting"}}{{yield}}{{/view}}')
   });
 
   view = EmberView.create({
@@ -114,7 +114,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
 
 test("block should not be required", function() {
   TemplateTests.YieldingView = EmberView.extend({
-    layout: EmberHandlebars.compile('{{#view Ember.View tagName="div" classNames="yielding"}}{{yield}}{{/view}}')
+    layout: EmberHandlebars.compile('{{#view tagName="div" classNames="yielding"}}{{yield}}{{/view}}')
   });
 
   view = EmberView.create({


### PR DESCRIPTION
Allow usage of `{{view}}` without a container, falling back to using `Ember.View`. This is is prep for #5294, where `{{view Ember.View}}` becomes deprecated.
