### PR TITLE
split pluggable normalization hook and normalization api.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -141,7 +141,7 @@ Container.prototype = {
       throw new TypeError('Attempting to register an unknown factory: `' + fullName + '`');
     }
 
-    var normalizedName = this._normalize(fullName);
+    var normalizedName = this.normalize(fullName);
 
     if (normalizedName in this.cache) {
       throw new Error('Cannot re-register: `' + fullName +'`, as it has already been looked up.');
@@ -170,7 +170,7 @@ Container.prototype = {
   unregister: function(fullName) {
     Ember.assert('fullName must be a proper full name', validateFullName(fullName));
 
-    var normalizedName = this._normalize(fullName);
+    var normalizedName = this.normalize(fullName);
 
     delete this.registry[normalizedName];
     delete this.cache[normalizedName];
@@ -213,7 +213,7 @@ Container.prototype = {
   */
   resolve: function(fullName) {
     Ember.assert('fullName must be a proper full name', validateFullName(fullName));
-    return resolve(this, this._normalize(fullName));
+    return resolve(this, this.normalize(fullName));
   },
 
   /**
@@ -235,17 +235,24 @@ Container.prototype = {
   /**
     A hook to enable custom fullName normalization behaviour
 
+    @method normalizeFullName
+    @param {String} fullName
+    @return {string} normalized fullName
+  */
+  normalizeFullName: function(fullName) {
+    return fullName;
+  },
+
+  /**
+    normalize a fullName based on the applications conventions
+
     @method normalize
     @param {String} fullName
     @return {string} normalized fullName
   */
   normalize: function(fullName) {
-    return fullName;
-  },
-
-  _normalize: function(fullName) {
     return this.normalizeCache[fullName] || (
-      this.normalizeCache[fullName] = this.normalize(fullName)
+      this.normalizeCache[fullName] = this.normalizeFullName(fullName)
     );
   },
 
@@ -301,7 +308,7 @@ Container.prototype = {
   */
   lookup: function(fullName, options) {
     Ember.assert('fullName must be a proper full name', validateFullName(fullName));
-    return lookup(this, this._normalize(fullName), options);
+    return lookup(this, this.normalize(fullName), options);
   },
 
   /**
@@ -313,7 +320,7 @@ Container.prototype = {
   */
   lookupFactory: function(fullName) {
     Ember.assert('fullName must be a proper full name', validateFullName(fullName));
-    return factoryFor(this, this._normalize(fullName));
+    return factoryFor(this, this.normalize(fullName));
   },
 
   /**
@@ -326,7 +333,7 @@ Container.prototype = {
   */
   has: function(fullName) {
     Ember.assert('fullName must be a proper full name', validateFullName(fullName));
-    return has(this, this._normalize(fullName));
+    return has(this, this.normalize(fullName));
   },
 
   /**
@@ -467,14 +474,14 @@ Container.prototype = {
     if (this.parent) { illegalChildOperation('injection'); }
 
     validateFullName(injectionName);
-    var normalizedInjectionName = this._normalize(injectionName);
+    var normalizedInjectionName = this.normalize(injectionName);
 
     if (fullName.indexOf(':') === -1) {
       return this.typeInjection(fullName, property, normalizedInjectionName);
     }
 
     Ember.assert('fullName must be a proper full name', validateFullName(fullName));
-    var normalizedName = this._normalize(fullName);
+    var normalizedName = this.normalize(fullName);
 
     if (this.cache[normalizedName]) {
       throw new Error("Attempted to register an injection for a type that has already been looked up. ('" + normalizedName + "', '" + property + "', '" + injectionName + "')");
@@ -515,7 +522,7 @@ Container.prototype = {
   factoryTypeInjection: function(type, property, fullName) {
     if (this.parent) { illegalChildOperation('factoryTypeInjection'); }
 
-    addTypeInjection(this.factoryTypeInjections, type, property, this._normalize(fullName));
+    addTypeInjection(this.factoryTypeInjections, type, property, this.normalize(fullName));
   },
 
   /**
@@ -570,8 +577,8 @@ Container.prototype = {
   factoryInjection: function(fullName, property, injectionName) {
     if (this.parent) { illegalChildOperation('injection'); }
 
-    var normalizedName = this._normalize(fullName);
-    var normalizedInjectionName = this._normalize(injectionName);
+    var normalizedName = this.normalize(fullName);
+    var normalizedInjectionName = this.normalize(injectionName);
 
     validateFullName(injectionName);
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -943,9 +943,9 @@ Application.reopenClass({
     var container = new Container();
 
     container.set = set;
-    container.resolver  = resolverFor(namespace);
-    container.normalize = container.resolver.normalize;
-    container.describe  = container.resolver.describe;
+    container.resolver = resolverFor(namespace);
+    container.normalizeFullName = container.resolver.normalize;
+    container.describe = container.resolver.describe;
     container.makeToString = container.resolver.makeToString;
 
     container.optionsForType('component', { singleton: false });


### PR DESCRIPTION
The public API `Container#normalize` should benefit from caching even when a resolver provides its own normalize method, as ember-cli’s resolver does.

This commit ensures all `Container#normalize` calls are cached and share the same cache as internal container normalizations. This is a performance boost
for ember-data.
