### PR TITLE
Allow view to know the original templateHash.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -162,6 +162,7 @@ export var ViewHelper = EmberObject.create({
 
   helper: function(thisContext, path, options) {
     var data = options.data,
+        hash = merge({}, options.hash),
         fn = options.fn,
         newView;
 
@@ -198,6 +199,7 @@ export var ViewHelper = EmberObject.create({
     var viewOptions = this.propertiesFromHTMLOptions(options, thisContext);
     var currentView = data.view;
     viewOptions.templateData = data;
+    viewOptions.templateHash = hash;
     var newViewProto = newView.proto ? newView.proto() : newView;
 
     if (fn) {

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -213,3 +213,19 @@ test("allows you to pass attributes that will be assigned to the class instance,
   ok(jQuery('#bar').hasClass('bar'));
   equal(jQuery('#bar').text(), 'Bar');
 });
+
+test("passes templateHash into the view", function() {
+  expect(1);
+
+  var container = new Container();
+  container.register('view:toplevel', EmberView.extend());
+
+  view = EmberView.extend({
+    template: Ember.Handlebars.compile('{{#view id="foo" bar="qux"}}{{view.templateHash.bar}}{{/view}}'),
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#foo').text(), 'qux');
+});


### PR DESCRIPTION
This is already provided to views created by `bind` and `simpleBind`, this PR just brings the `{{view}}` helper into parity.
