### PR TITLE
Silence Ember.Set deprecations in test suite.

### DIFF
--- a/packages/ember-runtime/tests/legacy_1x/system/set_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/set_test.js
@@ -34,16 +34,20 @@ QUnit.module("creating Set instances", {
 });
 
 test("new Set() should create empty set", function() {
-  var set = new Set() ;
-  equal(set.length, 0) ;
+  ignoreDeprecation(function() {
+    var set = new Set() ;
+    equal(set.length, 0) ;
+  });
 });
 
 test("new Set([1,2,3]) should create set with three items in them", function() {
-  var set = new Set(Ember.A([a,b,c])) ;
-  equal(set.length, 3) ;
-  equal(set.contains(a), true) ;
-  equal(set.contains(b), true) ;
-  equal(set.contains(c), true) ;
+  ignoreDeprecation(function() {
+    var set = new Set(Ember.A([a,b,c])) ;
+    equal(set.length, 3) ;
+    equal(set.contains(a), true) ;
+    equal(set.contains(b), true) ;
+    equal(set.contains(c), true) ;
+  });
 });
 
 test("new Set() should accept anything that implements EmberArray", function() {
@@ -53,11 +57,13 @@ test("new Set() should accept anything that implements EmberArray", function() {
     objectAt: function(idx) { return this._content[idx]; }
   }) ;
 
-  var set = new Set(arrayLikeObject) ;
-  equal(set.length, 3) ;
-  equal(set.contains(a), true) ;
-  equal(set.contains(b), true) ;
-  equal(set.contains(c), true) ;
+  ignoreDeprecation(function() {
+    var set = new Set(arrayLikeObject) ;
+    equal(set.length, 3) ;
+    equal(set.contains(a), true) ;
+    equal(set.contains(b), true) ;
+    equal(set.contains(c), true) ;
+  });
 });
 
 var set ; // global variables
@@ -67,7 +73,9 @@ var set ; // global variables
 QUnit.module("Set.add + Set.contains", {
 
   setup: function() {
-    set = new Set() ;
+    ignoreDeprecation(function() {
+      set = new Set() ;
+    });
   },
 
   teardown: function() {
@@ -172,11 +180,13 @@ QUnit.module("Set.remove + Set.contains", {
   // generate a set with every type of object, but none of the specific
   // ones we add in the tests below...
   setup: function() {
-    set = new Set(Ember.A([
-      EmberObject.create({ dummy: true }),
-      { isHash: true },
-      "Not the String",
-      16, true, false, 0])) ;
+    ignoreDeprecation(function() {
+      set = new Set(Ember.A([
+        EmberObject.create({ dummy: true }),
+        { isHash: true },
+        "Not the String",
+        16, true, false, 0])) ;
+    });
   },
 
   teardown: function() {
@@ -281,16 +291,18 @@ QUnit.module("Set.pop + Set.copy", {
 // generate a set with every type of object, but none of the specific
 // ones we add in the tests below...
   setup: function() {
-    set = new Set(Ember.A([
-      EmberObject.create({ dummy: true }),
-      { isHash: true },
-      "Not the String",
-      16, false])) ;
-    },
+    ignoreDeprecation(function() {
+      set = new Set(Ember.A([
+        EmberObject.create({ dummy: true }),
+        { isHash: true },
+        "Not the String",
+        16, false])) ;
+    });
+  },
 
-    teardown: function() {
-      set = undefined ;
-    }
+  teardown: function() {
+    set = undefined ;
+  }
 });
 
 test("the pop() should remove an arbitrary object from the set", function() {
@@ -301,16 +313,22 @@ test("the pop() should remove an arbitrary object from the set", function() {
 });
 
 test("should pop false and 0", function() {
-  set = new Set(Ember.A([false]));
-  ok(set.pop() === false, "should pop false");
+  ignoreDeprecation(function() {
+    set = new Set(Ember.A([false]));
+    ok(set.pop() === false, "should pop false");
 
-  set = new Set(Ember.A([0]));
-  ok(set.pop() === 0, "should pop 0");
+    set = new Set(Ember.A([0]));
+    ok(set.pop() === 0, "should pop 0");
+  });
 });
 
 test("the copy() should return an indentical set", function() {
-  var oldLength = set.length ;
-  var obj = set.copy();
+  var oldLength = set.length, obj;
+
+  ignoreDeprecation(function() {
+    obj = set.copy();
+  });
+
   equal(oldLength,obj.length,'length of the clone should be same');
   equal(obj.contains(set[0]), true);
   equal(obj.contains(set[1]), true);

--- a/packages/ember-runtime/tests/system/set/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/set/copyable_suite_test.js
@@ -3,12 +3,29 @@ import Set from "ember-runtime/system/set";
 import {generateGuid} from 'ember-metal/utils';
 import {get} from 'ember-metal/property_get';
 
+ignoreDeprecation(function() {
 CopyableTests.extend({
   name: 'Ember.Set Copyable',
 
   newObject: function() {
-    var set = new Set();
+    var set, originalCopy;
+    ignoreDeprecation(function() {
+      set = new Set();
+    });
+
     set.addObject(generateGuid());
+
+    originalCopy = set.copy;
+    set.copy = function() {
+      var ret;
+
+      ignoreDeprecation(function() {
+        ret = originalCopy.apply(set, arguments);
+      });
+
+      return ret;
+    };
+
     return set;
   },
 
@@ -21,4 +38,4 @@ CopyableTests.extend({
   shouldBeFreezable: true
 }).run();
 
-
+});

--- a/packages/ember-runtime/tests/system/set/enumerable_suite_test.js
+++ b/packages/ember-runtime/tests/system/set/enumerable_suite_test.js
@@ -7,18 +7,31 @@ MutableEnumerableTests.extend({
   name: 'Ember.Set',
 
   newObject: function(ary) {
+    var ret;
     ary = ary ? ary.slice() : this.newFixture(3);
-    var ret = new Set();
-    ret.addObjects(ary);
+
+    ignoreDeprecation(function() {
+      ret =  new Set();
+      ret.addObjects(ary);
+    });
+
     return ret;
   },
 
   mutate: function(obj) {
-    obj.addObject(get(obj, 'length')+1);
+    ignoreDeprecation(function() {
+      obj.addObject(get(obj, 'length')+1);
+    });
   },
 
   toArray: function(obj) {
-    return obj.toArray ? obj.toArray() : obj.slice(); // make a copy.
+    var ret;
+
+    ignoreDeprecation(function() {
+      ret = obj.toArray ? obj.toArray() : obj.slice(); // make a copy.
+    });
+
+    return ret;
   }
 
 }).run();

--- a/packages/ember-runtime/tests/system/set/extra_test.js
+++ b/packages/ember-runtime/tests/system/set/extra_test.js
@@ -7,10 +7,14 @@ import Set from "ember-runtime/system/set";
 QUnit.module('Set.init');
 
 test('passing an array to new Set() should instantiate w/ items', function() {
+  var aSet;
 
   var ary  = [1,2,3];
-  var aSet = new Set(ary);
   var count = 0;
+
+  ignoreDeprecation(function() {
+    aSet = new Set(ary);
+  });
 
   equal(get(aSet, 'length'), 3, 'should have three items');
   aSet.forEach(function(x) {
@@ -23,9 +27,12 @@ test('passing an array to new Set() should instantiate w/ items', function() {
 QUnit.module('Set.clear');
 
 test('should clear a set of its content', function() {
-
-  var aSet = new Set([1,2,3]);
+  var aSet;
   var count = 0;
+
+  ignoreDeprecation(function() {
+    aSet = new Set([1,2,3]);
+  });
 
   equal(get(aSet, 'length'), 3, 'should have three items');
   ok(get(aSet, 'firstObject'), 'firstObject should return an object');
@@ -51,9 +58,13 @@ test('should clear a set of its content', function() {
 QUnit.module('Set.pop');
 
 test('calling pop should return an object and remove it', function() {
-
-  var aSet = new Set([1,2,3]);
+  var aSet;
   var count = 0, obj;
+
+  ignoreDeprecation(function() {
+    aSet = new Set([1,2,3]);
+  });
+
   while(count<10 && (obj = aSet.pop())) {
     equal(aSet.contains(obj), false, 'set should no longer contain object');
     count++;
@@ -72,7 +83,12 @@ test('calling pop should return an object and remove it', function() {
 QUnit.module('Set aliases');
 
 test('method aliases', function() {
-  var aSet = new Set();
+  var aSet;
+
+  ignoreDeprecation(function() {
+    aSet = new Set();
+  });
+
   equal(aSet.add, aSet.addObject, 'add -> addObject');
   equal(aSet.remove, aSet.removeObject, 'remove -> removeObject');
   equal(aSet.addEach, aSet.addObjects, 'addEach -> addObjects');


### PR DESCRIPTION
This gets rid all the extraneous `Ember.Set` deprecation warnings while running the test suite.
