### PR TITLE
Silence Global template lookup deprecations.

### DIFF
--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -131,7 +131,9 @@ test("bound helpers should support global paths", function() {
     template: EmberHandlebars.compile("{{capitalize TemplateTests.text}}")
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, /Global lookup of TemplateTests.text from a Handlebars template is deprecated/);
 
   ok(view.$().text() === 'AB', "helper output is correct");
 });

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -122,16 +122,18 @@ test("nested {{with}} blocks shadow the outer scoped variable properly.", functi
 
   equal(view.$().text(), "Limbo-Wrath-Treachery-Wrath-Limbo", "should be properly scoped after updating");
 });
-QUnit.module("Handlebars {{#with}} globals helper", {
+QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
-    lookup.Foo = { bar: 'baz' };
-    view = EmberView.create({
-      template: EmberHandlebars.compile("{{#with Foo.bar as qux}}{{qux}}{{/with}}")
-    });
+    ignoreDeprecation(function() {
+      lookup.Foo = { bar: 'baz' };
+      view = EmberView.create({
+        template: EmberHandlebars.compile("{{#with Foo.bar as qux}}{{qux}}{{/with}}")
+      });
 
-    appendView(view);
+      appendView(view);
+    });
   },
 
   teardown: function() {
@@ -142,11 +144,13 @@ QUnit.module("Handlebars {{#with}} globals helper", {
   }
 });
 
-test("it should support #with Foo.bar as qux", function() {
+test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
   equal(view.$().text(), "baz", "should be properly scoped");
 
-  run(function() {
-    set(lookup.Foo, 'bar', 'updated');
+  ignoreDeprecation(function() {
+    run(function() {
+        set(lookup.Foo, 'bar', 'updated');
+    });
   });
 
   equal(view.$().text(), "updated", "should update");

--- a/packages/ember-handlebars/tests/lookup_test.js
+++ b/packages/ember-handlebars/tests/lookup_test.js
@@ -33,7 +33,7 @@ test("ID parameters that start with capital letters fall back to Ember.lookup as
 
   var context = {};
 
-  var params = Ember.Handlebars.resolveParams(context, ["Global"], { types: ["ID"] });
+  var params = Ember.Handlebars.resolveParams(context, ["Global"], { types: ["ID"], silenceGlobalDeprecation: true });
   deepEqual(params, [Ember.lookup.Global]);
 });
 


### PR DESCRIPTION
This removes the remaining global template lookup deprecation warnings while running tests.
