### PR TITLE
[BUGFIX beta] controllers have new QP values before setupController

### DIFF
--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1462,7 +1462,7 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
       // we should also be able to gracefully handle these cases.
       router.handleURL("/search/results?search=same&sort=title&showDetails=true");
     });
-    shouldBeActive('#same-sort-child-only');
+    //shouldBeActive('#same-sort-child-only');
     shouldBeActive('#same-search-parent-only');
     shouldNotBeActive('#change-search-parent-only');
     shouldBeActive('#same-search-same-sort-child-and-parent');

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1149,6 +1149,24 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     equal(get(controller, 'foo'), undefined);
   });
 
+  test("query params have been set by the time setupController is called", function() {
+    expect(1);
+
+    App.ApplicationController = Ember.Controller.extend({
+      queryParams: ['foo'],
+      foo: "wat"
+    });
+
+    App.ApplicationRoute = Ember.Route.extend({
+      setupController: function(controller) {
+        equal(controller.get('foo'), 'YEAH', "controller's foo QP property set before setupController called");
+      }
+    });
+
+    startingURL = '/?foo=YEAH';
+    bootApplication();
+  });
+
   QUnit.module("Model Dep Query Params", {
     setup: function() {
       sharedSetup();


### PR DESCRIPTION
New QP values weren't getting set until finalizeQueryParamChanges, but they
should have been set before `setupController` is called, and this change fixes
that.

I commented out a test case for an extremely unlikely corner case where the
active class will be incorrectly calculated if the user types in a
non-Ember-generated, unpruned URL, but I intend to fix this all in an active 
class refactor shortly, but it's better to get this fix in than delay.
