### PR TITLE
Child views are only pushed into the buffer if they have no morph

### DIFF
--- a/packages/ember-views/lib/views/states/in_buffer.js
+++ b/packages/ember-views/lib/views/states/in_buffer.js
@@ -40,7 +40,9 @@ merge(inBuffer, {
 
     //childView.renderToBuffer(buffer); // done later on the render loop
 
-    buffer.pushChildView(childView);
+    if (!childView._morph) {
+      buffer.pushChildView(childView);
+    }
 
     view.propertyDidChange('childViews');
 


### PR DESCRIPTION
This is needed for views that already have access to their morph. The same 12 tests are failing in the browser tests.
