### PR TITLE
Reorder Ember.View#_toggleVisibility

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2047,15 +2047,17 @@ var View = CoreView.extend({
 
   _toggleVisibility: function() {
     var $el = this.$();
-    if (!$el) { return; }
-
     var isVisible = get(this, 'isVisible');
 
     if (this._isVisible === isVisible) { return ; }
 
-    $el.toggle(isVisible);
-
+    // It's important to keep these in sync, even if we don't yet have
+    // an element in the DOM to manipulate:
     this._isVisible = isVisible;
+
+    if (!$el) { return; }
+
+    $el.toggle(isVisible);
 
     if (this._isAncestorHidden()) { return; }
 


### PR DESCRIPTION
Previously, this function was a no-op if the view's element was not in the DOM. That meant that if such a view's `isVisible` property changed, `_toggleVisibility` wouldn't make it far enough to sync up its internal `_isVisible` property with the new `isVisible` value.

With those two values out of sync, if the view's `isVisible` changed _again_, `_isVisibleDidChange` wouldn't properly schedule (or properly _not_ schedule) a subsequent call to `_toggleVisibility`. Thus, the view's actual DOM visibility would no longer match its `isVisible` property.

Closes #5329
