### PR TITLE
[BUGFIX beta] Fix initial render of {{input type=boundValue}} for checkboxes

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -6,11 +6,20 @@ import Ember from "ember-metal/core"; // Ember.assert
 // var emberAssert = Ember.assert;
 
 import EmberHandlebars from "ember-handlebars-compiler";
+import { handlebarsGet } from "ember-handlebars/ext";
 var helpers = EmberHandlebars.helpers;
 /**
 @module ember
 @submodule ember-handlebars-compiler
 */
+
+function _resolveOption(context, options, key) {
+  if (options.hashTypes[key] === "ID") {
+    return handlebarsGet(context, options.hash[key], options);
+  } else {
+    return options.hash[key];
+  }
+}
 
 /**
 
@@ -192,10 +201,8 @@ export function inputHelper(options) {
 
   var hash = options.hash,
       types = options.hashTypes,
-      inputType = hash.type,
+      inputType = _resolveOption(this, options, 'type'),
       onEvent = hash.on;
-
-  Ember.assert('You can only use a string as a `type` parameter, not a variable', types.type === 'STRING' || types.type === undefined);
 
   delete hash.type;
   delete hash.on;

--- a/packages/ember-handlebars/tests/controls/checkbox_test.js
+++ b/packages/ember-handlebars/tests/controls/checkbox_test.js
@@ -89,13 +89,19 @@ test("It works", function() {
   }, /you must use `checked=/);
 });
 
-QUnit.module("{{input type='checkbox'}} - prevent dynamic type", {
+QUnit.module("{{input type=boundType}}", {
   setup: function() {
+    controller = {
+      inputType: "checkbox",
+      isChecked: true,
+    };
+
     checkboxView = EmberView.extend({
       controller: controller,
-      inputType: "checkbox",
-      template: compile('{{input type=inputType}}')
+      template: compile('{{input type=inputType checked=isChecked}}')
     }).create();
+
+    append();
   },
 
   teardown: function() {
@@ -103,12 +109,15 @@ QUnit.module("{{input type='checkbox'}} - prevent dynamic type", {
   }
 });
 
-test("It works", function() {
-  expectAssertion(function() {
-    append();
-  }, /not a variable/);
+test("should append a checkbox", function() {
+  equal(checkboxView.$('input[type=checkbox]').length, 1, "A single checkbox is added");
 });
 
+// Checking for the checked property is a good way to verify that the correct
+// view was used.
+test("checkbox checked property is updated", function() {
+  equal(checkboxView.$('input').prop('checked'), true, "the checkbox is checked");
+});
 
 QUnit.module("{{input type='checkbox'}} - static values", {
   setup: function() {


### PR DESCRIPTION
Subsequent changes to `boundValue` will not work. This is intended.
