### PR TITLE
[Bugfix beta] Expose uuid

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -29,7 +29,8 @@ import {
   tryFinally,
   wrap,
   apply,
-  applyStr
+  applyStr,
+  uuid
 } from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 import EnumerableUtils from "ember-metal/enumerable_utils";
@@ -199,6 +200,7 @@ Ember.tryFinally      = tryFinally;
 Ember.wrap            = wrap;
 Ember.apply           = apply;
 Ember.applyStr        = applyStr;
+Ember.uuid            = uuid;
 
 Ember.Logger = Logger;
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -22,6 +22,15 @@ import keys from "ember-metal/keys";
 */
 var _uuid = 0;
 
+/**
+  Generates a universally unique identifier. This method
+  is used internally by Ember for assisting with
+  the generation of GUID's and other unique identifiers
+  such as `bind-attr` data attributes.
+
+  @public
+  @return {Number} [description]
+ */
 export function uuid() {
   return ++_uuid;
 }


### PR DESCRIPTION
I noticed that UUID is going to disappear from the publicly available API when 1.7 ships and I'm dependent on generating UUIDs for an i18n attribute helper.  Because I have accessibility and localization requirements that require me to fully support interpolated attributes I had to develop a helper.  The implementation is very similar to `bind-attr` which requires generating a data-bindattr with a uuid. I realize that this may go away when the metal-views branch gets merged but for the time being I don't see any problem in re-exposing it as it already is exposed in 1.6.1.
