### PR TITLE
fix Object.create sham for IE8

### DIFF
--- a/packages/ember-metal/lib/platform.js
+++ b/packages/ember-metal/lib/platform.js
@@ -183,6 +183,7 @@ if (!(Object.create && !Object.create(null).hasOwnProperty)) {
 
     return object;
   };
+  create.isSimulated = true;
 } else {
   create = Object.create;
 }


### PR DESCRIPTION
The `isSimulated` check was removed in
2fde5b7ee1005698be97c0738bba396b0dcf18ba.

The `isSimulated` check is used internally by
Ember for things like Ember.keys(Object.keys) polyfill.

Github link:
https://github.com/emberjs/ember.js/commit/2fde5b7ee1005698be97c0738bba396b0dcf18ba#diff-25956203ea0b0ebb26b37d88cf2a3338L54

I'm not sure how to test this except in IE8. The tests now pass in IE8 for me.
