### PR TITLE
[FEATURE pass-ast-to-precompile] Allow precompile to accept AST

### DIFF
--- a/features.json
+++ b/features.json
@@ -13,7 +13,8 @@
     "property-brace-expansion-improvement": null,
     "ember-runtime-proxy-mixin": null,
     "ember-routing-handlebars-action-with-key-code": null,
-    "ember-runtime-item-controller-inline-class": null
+    "ember-runtime-item-controller-inline-class": null,
+    "ember-handlebars-compiler-ast-to-precompile": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -266,12 +266,25 @@ EmberHandlebars.Compiler.prototype.mustache = function(mustache) {
   @method precompile
   @for Ember.Handlebars
   @static
-  @param {String} string The template to precompile
+  @param {String|Object} value The template to precompile or an Handlebars AST
   @param {Boolean} asObject optional parameter, defaulting to true, of whether or not the
                             compiled template should be returned as an Object or a String
 */
-EmberHandlebars.precompile = function(string, asObject) {
-  var ast = Handlebars.parse(string);
+EmberHandlebars.precompile = function(value, asObject) {
+  var ast;
+
+  if (Ember.FEATURES.isEnabled("ember-handlebars-compiler-ast-to-precompile")) {
+
+    if ( typeof value === 'string' ) {
+      ast = Handlebars.parse(value);
+    } else if ( typeof value === 'object' ) {
+      ast = value;
+    }
+
+    Ember.assert("You can only pass a template string or a Handlebars AST to precompiled. You passed an item that has the type of " + typeof value + " which is not a template or AST.", typeof value !== "string" || typeof value !== "object");
+  } else {
+    ast = Handlebars.parse(value);
+  }
 
   var options = {
     knownHelpers: {

--- a/packages/ember-handlebars-compiler/tests/precompile_type_test.js
+++ b/packages/ember-handlebars-compiler/tests/precompile_type_test.js
@@ -1,5 +1,6 @@
 import EmberHandlebars from "ember-handlebars-compiler";
 var precompile = EmberHandlebars.precompile,
+    parse = EmberHandlebars.parse,
     template = 'Hello World',
     result;
 
@@ -19,3 +20,13 @@ test("precompile creates a string when asObject is false", function(){
   result = precompile(template, false);
   equal(typeof(result), "string");
 });
+
+if (Ember.FEATURES.isEnabled("ember-handlebars-compiler-ast-to-precompile")) {
+  test("precompile creates a function when passed an AST", function(){
+    var ast = parse(template);
+    result = precompile(ast);
+    equal(typeof(result), "function");
+  });
+}
+
+


### PR DESCRIPTION
In certain cases when you are in a build pipeline you may want to perform some static analysis on templates and potentially modify the AST instead of writing some hacky RegEx to replace or remove items.  An example of this is if I need to extract i18n strings from a template. 

Developer writes this in project

```
{{i18n-t "i18n_some_uniq_key" text="Hello World"}}
```

What actually gets compiled

```
{{i18n-t "i18n_some_uniq_key"}}
```

From a developers point of view this is great because you can establish any strings in the template. As part of your build though you generally want to extract these strings and write them to some object literal manifest that can be looked up based upon locale.  This also means we want to remove the static strings from the template for the runtime use case. In other words, the templates that developers compose are the source of truth but at build time we do some magic to allow for locale specific translations.
