### PR TITLE
Use ActionManager to register in-template actions

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/action.js
+++ b/packages/ember-routing-handlebars/lib/helpers/action.js
@@ -5,6 +5,7 @@ import { uuid } from "ember-metal/utils";
 import run from "ember-metal/run_loop";
 
 import { isSimpleClick } from "ember-views/system/utils";
+import ActionManager from "ember-views/system/action_manager";
 import EmberRouter from "ember-routing/system/router";
 
 import EmberHandlebars from "ember-handlebars";
@@ -33,9 +34,7 @@ function args(options, actionName) {
   return ret.concat(resolveParams(options.context, options.params, { types: types, data: data }));
 }
 
-var ActionHelper = {
-  registeredActions: {}
-};
+var ActionHelper = {};
 
 export { ActionHelper };
 
@@ -80,7 +79,7 @@ function ignoreKeyEvent(eventName, event, keyCode) {
 ActionHelper.registerAction = function(actionNameOrPath, options, allowedKeys) {
   var actionId = uuid();
 
-  ActionHelper.registeredActions[actionId] = {
+  ActionManager.registeredActions[actionId] = {
     eventName: options.eventName,
     handler: function handleRegisteredAction(event) {
       if (!isAllowedEvent(event, allowedKeys)) { return true; }
@@ -135,7 +134,7 @@ ActionHelper.registerAction = function(actionNameOrPath, options, allowedKeys) {
   };
 
   options.view.on('willClearRender', function() {
-    delete ActionHelper.registeredActions[actionId];
+    delete ActionManager.registeredActions[actionId];
   });
 
   return actionId;

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -2,6 +2,7 @@ import Ember from 'ember-metal/core'; // A, FEATURES, assert, TESTING_DEPRECATIO
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EventDispatcher from "ember-views/system/event_dispatcher";
+import ActionManager from "ember-views/system/action_manager";
 
 import Container from "ember-runtime/system/container";
 import EmberObject from "ember-runtime/system/object";
@@ -328,7 +329,7 @@ test("should register an event handler", function() {
 
   var actionId = view.$('a[data-ember-action]').attr('data-ember-action');
 
-  ok(ActionHelper.registeredActions[actionId], "The action was registered");
+  ok(ActionManager.registeredActions[actionId], "The action was registered");
 
   view.$('a').trigger('click');
 
@@ -354,7 +355,7 @@ test("handles whitelisted modifier keys", function() {
 
   var actionId = view.$('a[data-ember-action]').attr('data-ember-action');
 
-  ok(ActionHelper.registeredActions[actionId], "The action was registered");
+  ok(ActionManager.registeredActions[actionId], "The action was registered");
 
   var e = jQuery.Event('click');
   e.altKey = true;
@@ -512,11 +513,11 @@ test("should unregister event handlers on rerender", function() {
     view.rerender();
   });
 
-  ok(!ActionHelper.registeredActions[previousActionId], "On rerender, the event handler was removed");
+  ok(!ActionManager.registeredActions[previousActionId], "On rerender, the event handler was removed");
 
   var newActionId = view.$('a[data-ember-action]').attr('data-ember-action');
 
-  ok(ActionHelper.registeredActions[newActionId], "After rerender completes, a new event handler was added");
+  ok(ActionManager.registeredActions[newActionId], "After rerender completes, a new event handler was added");
 });
 
 test("should unregister event handlers on inside virtual views", function() {
@@ -538,7 +539,7 @@ test("should unregister event handlers on inside virtual views", function() {
     things.removeAt(0);
   });
 
-  ok(!ActionHelper.registeredActions[actionId], "After the virtual view was destroyed, the action was unregistered");
+  ok(!ActionManager.registeredActions[actionId], "After the virtual view was destroyed, the action was unregistered");
 });
 
 test("should properly capture events on child elements of a container with an action", function() {

--- a/packages/ember-routing-handlebars/tests/helpers/render_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/render_test.js
@@ -23,12 +23,10 @@ import EmberHandlebars from "ember-handlebars";
 import EmberView from "ember-routing/ext/view";
 import _MetamorphView from "ember-handlebars/views/metamorph_view";
 import jQuery from "ember-views/system/jquery";
+import ActionManager from "ember-views/system/action_manager";
 
 import renderHelper from "ember-routing-handlebars/helpers/render";
-import {
-  ActionHelper,
-  actionHelper
-} from "ember-routing-handlebars/helpers/action";
+import { actionHelper } from "ember-routing-handlebars/helpers/action";
 import { outletHelper } from "ember-routing-handlebars/helpers/outlet";
 
 function appendView(view) {
@@ -476,7 +474,7 @@ test("{{render}} helper should link child controllers to the parent controller",
 
   var button = jQuery("#parent-action"),
       actionId = button.data('ember-action'),
-      action = ActionHelper.registeredActions[actionId],
+      action = ActionManager.registeredActions[actionId],
       handler = action.handler;
 
   equal(button.text(), "Go to Mom", "The parentController property is set on the child controller");

--- a/packages/ember-views/lib/system/action_manager.js
+++ b/packages/ember-views/lib/system/action_manager.js
@@ -1,0 +1,17 @@
+/**
+@module ember
+@submodule ember-views
+*/
+
+function ActionManager() {}
+
+/**
+  Global action id hash.
+
+  @private
+  @property registeredActions
+  @type Object
+*/
+ActionManager.registeredActions = {};
+
+export default ActionManager;

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -12,10 +12,9 @@ import { typeOf } from "ember-metal/utils";
 import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
+import ActionManager from "ember-views/system/action_manager";
 import View from "ember-views/views/view";
 import merge from "ember-metal/merge";
-
-var ActionHelper;
 
 //ES6TODO:
 // find a better way to do Ember.View.views without global state
@@ -189,11 +188,8 @@ export default EmberObject.extend({
     });
 
     rootElement.on(event + '.ember', '[data-ember-action]', function(evt) {
-      //ES6TODO: Needed for ActionHelper (generally not available in ember-views test suite)
-      if (!ActionHelper) { ActionHelper = requireModule("ember-routing-handlebars/helpers/action")["ActionHelper"]; }
-
       var actionId = jQuery(evt.currentTarget).attr('data-ember-action'),
-          action   = ActionHelper.registeredActions[actionId];
+          action   = ActionManager.registeredActions[actionId];
 
       // We have to check for action here since in some cases, jQuery will trigger
       // an event on `removeChild` (i.e. focusout) after we've already torn down the
@@ -244,6 +240,6 @@ export default EmberObject.extend({
   },
 
   toString: function() {
-    return '(EventDisptacher)';
+    return '(EventDispatcher)';
   }
 });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2,6 +2,7 @@ import "ember";
 import { forEach } from "ember-metal/enumerable_utils";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import ActionManager from "ember-views/system/action_manager";
 
 var Router, App, AppView, templates, router, container, originalLoggerError;
 var compile = Ember.Handlebars.compile;
@@ -1165,7 +1166,7 @@ asyncTest("Events are triggered on the controller if a matching action name is i
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var action = ActionManager.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
@@ -1199,7 +1200,7 @@ asyncTest("Events are triggered on the current state when defined in `actions` o
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var action = ActionManager.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
@@ -1237,7 +1238,7 @@ asyncTest("Events defined in `actions` object are triggered on the current state
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var action = ActionManager.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
@@ -1272,7 +1273,7 @@ asyncTest("Events are triggered on the current state when defined in `events` ob
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var action = ActionManager.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
@@ -1311,7 +1312,7 @@ asyncTest("Events defined in `events` object are triggered on the current state 
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var action = ActionManager.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });
@@ -1394,7 +1395,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     bootApplication();
 
     var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-    var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+    var action = ActionManager.registeredActions[actionId];
     var event = new Ember.$.Event("click");
     action.handler(event);
   });
@@ -1438,7 +1439,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
     bootApplication();
 
     var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-    var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+    var action = ActionManager.registeredActions[actionId];
     var event = new Ember.$.Event("click");
     action.handler(event);
   });
@@ -1478,7 +1479,7 @@ asyncTest("actions can be triggered with multiple arguments", function() {
   bootApplication();
 
   var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-  var action = Ember.Handlebars.ActionHelper.registeredActions[actionId];
+  var action = ActionManager.registeredActions[actionId];
   var event = new Ember.$.Event("click");
   action.handler(event);
 });


### PR DESCRIPTION
Adds a simple `ActionManager` class to keep track of actions registered in a template via `{{action 'edit'}}`.

The intent is to decouple `EventDispatcher` from Handlebars in lieu of HTMLBars. The non-Handlebars specific parts of `ActionHelper.registerAction` should also be extracted into `ActionManager`.
