### PR TITLE
[BUGFIX beta] Fixes issue - class given as unconditional binding to view not applied.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -134,8 +134,10 @@ export var ViewHelper = EmberObject.create({
           //
           //     classNameBinding="_parentView.context.isGreen:green"
           var parsedPath = View._parsePropertyPath(full);
-          path = this.contextualizeBindingPath(parsedPath.path, data);
-          if (path) { extensions.classNameBindings[b] = path + parsedPath.classNames; }
+          if(parsedPath.path !== '') {
+            path = this.contextualizeBindingPath(parsedPath.path, data); 
+            if (path) { extensions.classNameBindings[b] = path + parsedPath.classNames; }
+          }
         }
       }
     }

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -213,3 +213,15 @@ test("allows you to pass attributes that will be assigned to the class instance,
   ok(jQuery('#bar').hasClass('bar'));
   equal(jQuery('#bar').text(), 'Bar');
 });
+test("Should apply class without condition always", function() {
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
+
+});


### PR DESCRIPTION
Passing `classBinding` to `view` helper is broken.  
When the context for the view is an arrayController and it's content is empty then  the class which is given unconditional, is not applied..  
Failing bin: http://emberjs.jsbin.com/yokej/2/edit  

Working bin in 1.5.0: http://emberjs.jsbin.com/vikuza/1/edit  

This PR addresses it.

cc: @rwjblue
