### PR TITLE
Remove deprecated action lookup as methods on controller.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Ember Changelog
 
 * Deprecate usage of Internet Explorer 6 & 7.
+* [BREAKING] Remove deprecated controller action lookup. Support for pre-1.0.0 applications with actions in the root
+  of the controller (instead of inside the `actions` hash) has been removed.
 
 ### Ember 1.7.0-beta.2 (July, 16, 2014)
 

--- a/features.json
+++ b/features.json
@@ -2,7 +2,6 @@
   "features": {
     "query-params-new": true,
     "ember-routing-named-substates": null,
-    "ember-routing-drop-deprecated-action-style": null,
     "ember-routing-add-model-option": true,
     "ember-routing-linkto-target-attribute": null,
     "ember-routing-will-change-hooks": null,

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -1103,42 +1103,6 @@ test("a quoteless parameter that also exists as an action name results in an ass
   Ember.assert = oldAssert;
 });
 
-test("a quoteless parameter that also exists as an action name in deprecated action in controller style results in an assertion", function(){
-  var dropDeprecatedActionStyleOrig = Ember.FEATURES['ember-routing-drop-deprecated-action-style'];
-  Ember.FEATURES['ember-routing-drop-deprecated-action-style'] = false;
-
-  var triggeredAction;
-
-  view = EmberView.create({
-    template: compile("<a id='oops-bound-param' {{action ohNoeNotValid}}>Hi</a>")
-  });
-
-  var controller = EmberController.extend({
-    ohNoeNotValid: function() {
-      triggeredAction = true;
-    }
-  }).create();
-
-  run(function() {
-    view.set('controller', controller);
-    view.appendTo('#qunit-fixture');
-  });
-
-  var oldAssert = Ember.assert;
-  Ember.assert = function(message, test){
-    ok(test, message + " -- was properly asserted");
-  };
-
-  run(function(){
-    view.$("#oops-bound-param").click();
-  });
-
-  ok(triggeredAction, 'the action was triggered');
-
-  Ember.assert = oldAssert;
-  Ember.FEATURES['ember-routing-drop-deprecated-action-style'] = dropDeprecatedActionStyleOrig;
-});
-
 QUnit.module("Ember.Handlebars - action helper - deprecated invoking directly on target", {
   setup: function() {
     originalActionHelper = EmberHandlebars.helpers['action'];
@@ -1158,32 +1122,6 @@ QUnit.module("Ember.Handlebars - action helper - deprecated invoking directly on
     });
   }
 });
-
-if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
-  test("should invoke a handler defined directly on the target (DEPRECATED)", function() {
-    var eventHandlerWasCalled,
-        model = EmberObject.create();
-
-    var controller = EmberController.extend({
-      edit: function() {
-        eventHandlerWasCalled = true;
-      }
-    }).create();
-
-    view = EmberView.create({
-      controller: controller,
-      template: EmberHandlebars.compile('<button {{action "edit"}}>edit</button>')
-    });
-
-    appendView();
-
-    expectDeprecation(/Action handlers implemented directly on controllers are deprecated/);
-
-    view.$('button').trigger('click');
-
-    ok(eventHandlerWasCalled, "the action was called");
-  });
-}
 
 test("should respect preventDefault=false option if provided", function(){
   view = EmberView.create({

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -212,13 +212,6 @@ var ActionHandler = Mixin.create({
       } else {
         return;
       }
-    } else if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style') && this.deprecatedSend && this.deprecatedSendHandles && this.deprecatedSendHandles(actionName)) {
-      Ember.warn("The current default is deprecated but will prefer to handle actions directly on the controller instead of a similarly named action in the actions hash. To turn off this deprecated feature set: Ember.FEATURES['ember-routing-drop-deprecated-action-style'] = true");
-      if (this.deprecatedSend.apply(this, [].slice.call(arguments)) === true) {
-        // handler return true, so this action will bubble
-      } else {
-        return;
-      }
     }
 
     if (target = get(this, 'target')) {

--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -46,19 +46,8 @@ export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecatio
   store: null,
 
   model: null,
-  content: computed.alias('model'),
+  content: computed.alias('model')
 
-  deprecatedSendHandles: function(actionName) {
-    return !!this[actionName];
-  },
-
-  deprecatedSend: function(actionName) {
-    var args = [].slice.call(arguments, 1);
-    Ember.assert('' + this + " has the action " + actionName + " but it is not a function", typeof this[actionName] === 'function');
-    Ember.deprecate('Action handlers implemented directly on controllers are deprecated in favor of action handlers on an `actions` object ( action: `' + actionName + '` on ' + this + ')', false);
-    this[actionName].apply(this, args);
-    return;
-  }
 });
 
 

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -125,19 +125,6 @@ test("Action can be handled by a superclass' actions object", function() {
 
 QUnit.module('Controller deprecations');
 
-if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
-  test("Action can be handled by method directly on controller (DEPRECATED)", function() {
-    expectDeprecation(/Action handlers implemented directly on controllers are deprecated/);
-    var TestController = Controller.extend({
-      poke: function() {
-        ok(true, 'poked');
-      }
-    });
-    var controller = TestController.create({});
-    controller.send("poke");
-  });
-}
-
 QUnit.module('Controller Content -> Model Alias');
 
 test("`model` is aliased as `content`", function() {

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -154,18 +154,6 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     }
   },
 
-  deprecatedSendHandles: function(actionName) {
-    return !!this[actionName];
-  },
-
-  deprecatedSend: function(actionName) {
-    var args = [].slice.call(arguments, 1);
-    Ember.assert('' + this + " has the action " + actionName + " but it is not a function", typeof this[actionName] === 'function');
-    Ember.deprecate('Action handlers implemented directly on views are deprecated in favor of action handlers on an `actions` object ( action: `' + actionName + '` on ' + this + ')', false);
-    this[actionName].apply(this, args);
-    return;
-  },
-
   has: function(name) {
     return typeOf(this[name]) === 'function' || this._super(name);
   },

--- a/packages/ember-views/tests/views/view/actions_test.js
+++ b/packages/ember-views/tests/views/view/actions_test.js
@@ -29,19 +29,6 @@ test("Action can be handled by a function on actions object", function() {
   view.send("poke");
 });
 
-if (!Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
-  test("Action can be handled by a function on the view (DEPRECATED)", function() {
-    expect(2);
-    expectDeprecation(/Action handlers implemented directly on views are deprecated/);
-    view = View.extend({
-      poke: function() {
-        ok(true, 'poked');
-      }
-    }).create();
-    view.send("poke");
-  });
-}
-
 test("A handled action can be bubbled to the target for continued processing", function() {
   expect(2);
   view = View.extend({

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1356,94 +1356,48 @@ test("Events can be handled by inherited event handlers", function() {
   router.send("baz");
 });
 
-if (Ember.FEATURES.isEnabled('ember-routing-drop-deprecated-action-style')) {
-  asyncTest("Actions are not triggered on the controller if a matching action name is implemented as a method", function() {
-    Router.map(function() {
-      this.route("home", { path: "/" });
-    });
-
-    var model = { name: "Tom Dale" };
-    var stateIsNotCalled = true;
-
-    App.HomeRoute = Ember.Route.extend({
-      model: function() {
-        return model;
-      },
-
-      actions: {
-        showStuff: function(context) {
-          ok (stateIsNotCalled, "an event on the state is not triggered");
-          deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
-          QUnit.start();
-        }
-      }
-    });
-
-    Ember.TEMPLATES.home = Ember.Handlebars.compile(
-      "<a {{action 'showStuff' model}}>{{name}}</a>"
-    );
-
-    var controller = Ember.Controller.extend({
-      showStuff: function(context) {
-        stateIsNotCalled = false;
-        ok (stateIsNotCalled, "an event on the state is not triggered");
-      }
-    });
-
-    container.register('controller:home', controller);
-
-    bootApplication();
-
-    var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-    var action = ActionManager.registeredActions[actionId];
-    var event = new Ember.$.Event("click");
-    action.handler(event);
+asyncTest("Actions are not triggered on the controller if a matching action name is implemented as a method", function() {
+  Router.map(function() {
+    this.route("home", { path: "/" });
   });
-} else {
-  asyncTest("Events are triggered on the controller if a matching action name is implemented as a method (DEPRECATED)", function() {
-    Router.map(function() {
-      this.route("home", { path: "/" });
-    });
 
-    var model = { name: "Tom Dale" };
-    var stateIsNotCalled = true;
+  var model = { name: "Tom Dale" };
+  var stateIsNotCalled = true;
 
-    App.HomeRoute = Ember.Route.extend({
-      model: function() {
-        return model;
-      },
+  App.HomeRoute = Ember.Route.extend({
+    model: function() {
+      return model;
+    },
 
-      events: {
-        showStuff: function(obj) {
-          stateIsNotCalled = false;
-          ok (stateIsNotCalled, "an event on the state is not triggered");
-        }
-      }
-    });
-
-    Ember.TEMPLATES.home = Ember.Handlebars.compile(
-      "<a {{action 'showStuff' model}}>{{name}}</a>"
-    );
-
-    var controller = Ember.Controller.extend({
+    actions: {
       showStuff: function(context) {
         ok (stateIsNotCalled, "an event on the state is not triggered");
         deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
         QUnit.start();
       }
-    });
-
-    container.register('controller:home', controller);
-
-    expectDeprecation(/Action handlers contained in an `events` object are deprecated/);
-    bootApplication();
-
-    var actionId = Ember.$("#qunit-fixture a").data("ember-action");
-    var action = ActionManager.registeredActions[actionId];
-    var event = new Ember.$.Event("click");
-    action.handler(event);
+    }
   });
-}
+
+  Ember.TEMPLATES.home = Ember.Handlebars.compile(
+    "<a {{action 'showStuff' model}}>{{name}}</a>"
+  );
+
+  var controller = Ember.Controller.extend({
+    showStuff: function(context) {
+      stateIsNotCalled = false;
+      ok (stateIsNotCalled, "an event on the state is not triggered");
+    }
+  });
+
+  container.register('controller:home', controller);
+
+  bootApplication();
+
+  var actionId = Ember.$("#qunit-fixture a").data("ember-action");
+  var action = ActionManager.registeredActions[actionId];
+  var event = new Ember.$.Event("click");
+  action.handler(event);
+});
 
 asyncTest("actions can be triggered with multiple arguments", function() {
   Router.map(function() {


### PR DESCRIPTION
The older lookup in the root of the controller has been deprecated since late-2013, and is a frequent cause of annoyance for newcomers. This PR removes the deprecated lookup completely.

This removal has been discussed and approved by the full core team.
