### PR TITLE
[BUGFIX] The {{link-to}} helper should not transition for target=_blank

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -413,6 +413,13 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
       return false;
     }
 
+    if (Ember.FEATURES.isEnabled("ember-routing-linkto-target-attribute")) {
+      var targetAttribute2 = get(this, 'target');
+      if (targetAttribute2 && targetAttribute2 !== '_self') {
+        return false;
+      }
+    }
+
     var router = get(this, 'router');
     var loadedParams = get(this, 'loadedParams');
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -526,6 +526,26 @@ if(Ember.FEATURES.isEnabled('ember-routing-linkto-target-attribute')) {
 
     equal(event.isDefaultPrevented(), true, "should preventDefault when target attribute is `_self`");
   });
+
+  test("The {{link-to}} helper should not transition if target is not equal to _self or empty", function() {
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#linkTo 'about' id='about-link' replace=true target='_blank'}}About{{/linkTo}}");
+
+    Router.map(function() {
+      this.route("about");
+    });
+
+    bootApplication();
+
+    Ember.run(function() {
+      router.handleURL("/");
+    });
+
+    Ember.run(function() {
+      Ember.$('#about-link', '#qunit-fixture').click();
+    });
+
+    notEqual(container.lookup('controller:application').get('currentRouteName'), 'about', 'link-to should not transition if target is not equal to _self or empty');
+  });
 }
 
 test("The {{link-to}} helper accepts string/numeric arguments", function() {


### PR DESCRIPTION
I'm a bit uncertain about this change in behaviour, but I couldnt come up with a use case where one would want to open a link in a new window but also transition to that.

That's why I changed the link-to helper to only transition if the target is empty or _self.

Test included.
