### PR TITLE
Use one variable assignment per declaration.

### DIFF
--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -89,10 +89,9 @@ var lastIndexOf = defineNativeShim(ArrayPrototype.lastIndexOf, function(obj, fro
 });
 
 var filter = defineNativeShim(ArrayPrototype.filter, function (fn, context) {
-  var i,
-      value,
-      result = [],
-      length = this.length;
+  var i, value;
+  var result = [];
+  var length = this.length;
 
   for (i = 0; i < length; i++) {
     if (this.hasOwnProperty(i)) {

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -160,7 +160,8 @@ Binding.prototype = {
   connect: function(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.connect()', !!obj);
 
-    var fromPath = this._from, toPath = this._to;
+    var fromPath = this._from;
+    var toPath = this._to;
     trySet(obj, toPath, getWithGlobals(obj, fromPath));
 
     // add an observer on the object to be notified when the binding should be updated
@@ -240,7 +241,8 @@ Binding.prototype = {
     var directionMap = this._directionMap;
     var direction = directionMap.get(obj);
 
-    var fromPath = this._from, toPath = this._to;
+    var fromPath = this._from;
+    var toPath = this._to;
 
     directionMap.remove(obj);
 
@@ -288,7 +290,8 @@ mixinProperties(Binding, {
     @static
   */
   from: function() {
-    var C = this, binding = new C();
+    var C = this;
+    var binding = new C();
     return binding.from.apply(binding, arguments);
   },
 
@@ -299,7 +302,8 @@ mixinProperties(Binding, {
     @static
   */
   to: function() {
-    var C = this, binding = new C();
+    var C = this;
+    var binding = new C();
     return binding.to.apply(binding, arguments);
   },
 
@@ -320,7 +324,8 @@ mixinProperties(Binding, {
     @return {Ember.Binding} `this`
   */
   oneWay: function(from, flag) {
-    var C = this, binding = new C(null, from);
+    var C = this;
+    var binding = new C(null, from);
     return binding.oneWay(flag);
   }
 

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -4,9 +4,9 @@ import {meta} from "ember-metal/utils";
 import {forEach} from "ember-metal/array";
 import {watchKey, unwatchKey} from "ember-metal/watch_key";
 
-var metaFor = meta,
-    warn = Ember.warn,
-    FIRST_KEY = /^([^\.]+)/;
+var metaFor = meta;
+var warn = Ember.warn;
+var FIRST_KEY = /^([^\.]+)/;
 
 function firstKey(path) {
   return path.match(FIRST_KEY)[0];
@@ -31,7 +31,8 @@ export function flushPendingChains() {
 function addChainWatcher(obj, keyName, node) {
   if (!obj || ('object' !== typeof obj)) { return; } // nothing to do
 
-  var m = metaFor(obj), nodes = m.chainWatchers;
+  var m = metaFor(obj);
+  var nodes = m.chainWatchers;
 
   if (!m.hasOwnProperty('chainWatchers')) {
     nodes = m.chainWatchers = {};
@@ -136,8 +137,10 @@ ChainNodePrototype.destroy = function() {
 
 // copies a top level object only
 ChainNodePrototype.copy = function(obj) {
-  var ret = new ChainNode(null, null, obj),
-      paths = this._paths, path;
+  var ret = new ChainNode(null, null, obj);
+  var paths = this._paths;
+  var path;
+
   for (path in paths) {
     if (paths[path] <= 0) { continue; } // this check will also catch non-number vals.
     ret.add(path);
@@ -223,7 +226,8 @@ ChainNodePrototype.chain = function(key, path, src) {
 };
 
 ChainNodePrototype.unchain = function(key, path) {
-  var chains = this._chains, node = chains[key];
+  var chains = this._chains;
+  var node = chains[key];
 
   // unchain rest of path first...
   if (path && path.length>1) {

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -27,8 +27,8 @@ import {
 Ember.warn("The CP_DEFAULT_CACHEABLE flag has been removed and computed properties are always cached by default. Use `volatile` if you don't want caching.", Ember.ENV.CP_DEFAULT_CACHEABLE !== false);
 
 
-var metaFor = meta,
-    a_slice = [].slice;
+var metaFor = meta;
+var a_slice = [].slice;
 
 function UNDEFINED() { }
 

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -10,10 +10,12 @@ import {
 } from "ember-metal/utils";
 import { create } from "ember-metal/platform";
 
-var a_slice = [].slice,
-    metaFor = meta,
-    /* listener flags */
-    ONCE = 1, SUSPENDED = 2;
+var a_slice = [].slice;
+var metaFor = meta;
+
+/* listener flags */
+var ONCE = 1;
+var SUSPENDED = 2;
 
 
 /*
@@ -71,15 +73,15 @@ function actionsFor(obj, eventName) {
 }
 
 export function listenersUnion(obj, eventName, otherActions) {
-  var meta = obj['__ember_meta__'],
-      actions = meta && meta.listeners && meta.listeners[eventName];
+  var meta = obj['__ember_meta__'];
+  var actions = meta && meta.listeners && meta.listeners[eventName];
 
   if (!actions) { return; }
   for (var i = actions.length - 3; i >= 0; i -= 3) {
-    var target = actions[i],
-        method = actions[i+1],
-        flags = actions[i+2],
-        actionIndex = indexOf(otherActions, target, method);
+    var target = actions[i];
+    var method = actions[i+1];
+    var flags = actions[i+2];
+    var actionIndex = indexOf(otherActions, target, method);
 
     if (actionIndex === -1) {
       otherActions.push(target, method, flags);
@@ -94,10 +96,10 @@ export function listenersDiff(obj, eventName, otherActions) {
 
   if (!actions) { return; }
   for (var i = actions.length - 3; i >= 0; i -= 3) {
-    var target = actions[i],
-        method = actions[i+1],
-        flags = actions[i+2],
-        actionIndex = indexOf(otherActions, target, method);
+    var target = actions[i];
+    var method = actions[i+1];
+    var flags = actions[i+2];
+    var actionIndex = indexOf(otherActions, target, method);
 
     if (actionIndex !== -1) { continue; }
 
@@ -127,9 +129,9 @@ export function addListener(obj, eventName, target, method, once) {
     target = null;
   }
 
-  var actions = actionsFor(obj, eventName),
-      actionIndex = indexOf(actions, target, method),
-      flags = 0;
+  var actions = actionsFor(obj, eventName);
+  var actionIndex = indexOf(actions, target, method);
+  var flags = 0;
 
   if (once) flags |= ONCE;
 
@@ -163,8 +165,8 @@ function removeListener(obj, eventName, target, method) {
   }
 
   function _removeListener(target, method) {
-    var actions = actionsFor(obj, eventName),
-        actionIndex = indexOf(actions, target, method);
+    var actions = actionsFor(obj, eventName);
+    var actionIndex = indexOf(actions, target, method);
 
     // action doesn't exist, give up silently
     if (actionIndex === -1) { return; }
@@ -179,8 +181,8 @@ function removeListener(obj, eventName, target, method) {
   if (method) {
     _removeListener(target, method);
   } else {
-    var meta = obj['__ember_meta__'],
-        actions = meta && meta.listeners && meta.listeners[eventName];
+    var meta = obj['__ember_meta__'];
+    var actions = meta && meta.listeners && meta.listeners[eventName];
 
     if (!actions) { return; }
     for (var i = actions.length - 3; i >= 0; i -= 3) {
@@ -213,8 +215,8 @@ export function suspendListener(obj, eventName, target, method, callback) {
     target = null;
   }
 
-  var actions = actionsFor(obj, eventName),
-      actionIndex = indexOf(actions, target, method);
+  var actions = actionsFor(obj, eventName);
+  var actionIndex = indexOf(actions, target, method);
 
   if (actionIndex !== -1) {
     actions[actionIndex+2] |= SUSPENDED; // mark the action as suspended

--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -6,8 +6,8 @@ import { forEach } from 'ember-metal/enumerable_utils';
   @module ember-metal
   */
 
-var BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/,
-    SPLIT_REGEX = /\{|\}/;
+var BRACE_EXPANSION = /^((?:[^\.]*\.)*)\{(.*)\}$/;
+var SPLIT_REGEX = /\{|\}/;
 
 /**
   Expands `pattern`, invoking `callback` for each expansion.
@@ -62,8 +62,8 @@ function oldExpandProperties(pattern, callback) {
 
 function newExpandProperties(pattern, callback) {
   if ('string' === Ember.typeOf(pattern)) {
-    var parts = pattern.split(SPLIT_REGEX),
-        properties = [parts];
+    var parts = pattern.split(SPLIT_REGEX);
+    var properties = [parts];
 
     forEach(parts, function(part, index) {
       if (part.indexOf(',') >= 0) {

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -47,7 +47,8 @@ import { tryCatchFinally } from "ember-metal/utils";
   @namespace Ember
   @static
 */
-var subscribers = [], cache = {};
+var subscribers = [];
+var cache = {};
 
 var populateListeners = function(name) {
   var listeners = [], subscriber;

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -36,13 +36,13 @@ import {
   removeListener
 } from "ember-metal/events";
 
-var REQUIRED,
-    a_map = map,
-    a_indexOf = indexOf,
-    a_forEach = forEach,
-    a_slice = [].slice,
-    o_create = create,
-    metaFor = meta;
+var REQUIRED;
+var a_map = map;
+var a_indexOf = indexOf;
+var a_forEach = forEach;
+var a_slice = [].slice;
+var o_create = create;
+var metaFor = meta;
 
 function superFunction(){
   var ret, func = this.__nextSuper;
@@ -55,7 +55,8 @@ function superFunction(){
 }
 
 function mixinsMeta(obj) {
-  var m = metaFor(obj, true), ret = m.mixins;
+  var m = metaFor(obj, true);
+  var ret = m.mixins;
   if (!ret) {
     ret = m.mixins = {};
   } else if (!m.hasOwnProperty('mixins')) {
@@ -179,8 +180,8 @@ function applyMergedProperties(obj, key, value, values) {
 
   if (!baseValue) { return value; }
 
-  var newBase = merge({}, baseValue),
-      hasFunction = false;
+  var newBase = merge({}, baseValue);
+  var hasFunction = false;
 
   for (var prop in value) {
     if (!value.hasOwnProperty(prop)) { continue; }
@@ -352,8 +353,11 @@ function replaceObserversAndListeners(obj, key, observerOrListener) {
 }
 
 function applyMixin(obj, mixins, partial) {
-  var descs = {}, values = {}, m = metaFor(obj),
-      key, value, desc, keys = [];
+  var descs = {};
+  var values = {};
+  var m = metaFor(obj);
+  var keys = [];
+  var key, value, desc;
 
   obj._super = superFunction;
 
@@ -512,7 +516,8 @@ MixinPrototype.reopen = function() {
     this.mixins = [];
   }
 
-  var len = arguments.length, mixins = this.mixins, idx;
+  var len = arguments.length;
+  var mixins = this.mixins, idx;
 
   for(idx=0; idx < len; idx++) {
     mixin = arguments[idx];
@@ -551,7 +556,8 @@ function _detect(curMixin, targetMixin, seen) {
   seen[guid] = true;
 
   if (curMixin === targetMixin) { return true; }
-  var mixins = curMixin.mixins, loc = mixins ? mixins.length : 0;
+  var mixins = curMixin.mixins;
+  var loc = mixins ? mixins.length : 0;
   while (--loc >= 0) {
     if (_detect(mixins[loc], targetMixin, seen)) { return true; }
   }
@@ -566,8 +572,8 @@ function _detect(curMixin, targetMixin, seen) {
 MixinPrototype.detect = function(obj) {
   if (!obj) { return false; }
   if (obj instanceof Mixin) { return _detect(obj, this, {}); }
-  var m = obj['__ember_meta__'],
-      mixins = m && m.mixins;
+  var m = obj['__ember_meta__'];
+  var mixins = m && m.mixins;
   if (mixins) {
     return !!mixins[guidFor(this)];
   }
@@ -595,7 +601,9 @@ function _keys(ret, mixin, seen) {
 }
 
 MixinPrototype.keys = function() {
-  var keys = {}, seen = {}, ret = [];
+  var keys = {};
+  var seen = {};
+  var ret = [];
   _keys(keys, this, seen);
   for(var key in keys) {
     if (keys.hasOwnProperty(key)) { ret.push(key); }
@@ -606,8 +614,9 @@ MixinPrototype.keys = function() {
 // returns the mixins currently applied to the specified object
 // TODO: Make Ember.mixin
 Mixin.mixins = function(obj) {
-  var m = obj['__ember_meta__'],
-      mixins = m && m.mixins, ret = [];
+  var m = obj['__ember_meta__'];
+  var mixins = m && m.mixins;
+  var ret = [];
 
   if (!mixins) { return ret; }
 

--- a/packages/ember-metal/lib/observer_set.js
+++ b/packages/ember-metal/lib/observer_set.js
@@ -26,11 +26,11 @@ function ObserverSet() {
 
 
 ObserverSet.prototype.add = function(sender, keyName, eventName) {
-  var observerSet = this.observerSet,
-      observers = this.observers,
-      senderGuid = guidFor(sender),
-      keySet = observerSet[senderGuid],
-      index;
+  var observerSet = this.observerSet;
+  var observers = this.observers;
+  var senderGuid = guidFor(sender);
+  var keySet = observerSet[senderGuid];
+  var index;
 
   if (!keySet) {
     observerSet[senderGuid] = keySet = {};

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -88,7 +88,8 @@ function dependentKeysWillChange(obj, depKey, meta) {
 
   var deps;
   if (meta && meta.deps && (deps = meta.deps[depKey])) {
-    var seen = WILL_SEEN, top = !seen;
+    var seen = WILL_SEEN;
+    var top = !seen;
     if (top) { seen = WILL_SEEN = {}; }
     iterDeps(propertyWillChange, obj, deps, depKey, seen, meta);
     if (top) { WILL_SEEN = null; }
@@ -101,7 +102,8 @@ function dependentKeysDidChange(obj, depKey, meta) {
 
   var deps;
   if (meta && meta.deps && (deps = meta.deps[depKey])) {
-    var seen = DID_SEEN, top = !seen;
+    var seen = DID_SEEN;
+    var top = !seen;
     if (top) { seen = DID_SEEN = {}; }
     iterDeps(propertyDidChange, obj, deps, depKey, seen, meta);
     if (top) { DID_SEEN = null; }

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -67,7 +67,8 @@ var get = function get(obj, keyName) {
     return value;
   }
 
-  var meta = obj['__ember_meta__'], desc = meta && meta.descs[keyName], ret;
+  var meta = obj['__ember_meta__'];
+  var desc = meta && meta.descs[keyName], ret;
 
   if (desc === undefined && isPath(keyName)) {
     return _getPath(obj, keyName);

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -41,7 +41,8 @@ var set = function set(obj, keyName, value, tolerant) {
     return setPath(obj, keyName, value, tolerant);
   }
 
-  var meta = obj['__ember_meta__'], desc = meta && meta.descs[keyName],
+  var meta = obj['__ember_meta__'];
+  var desc = meta && meta.descs[keyName],
       isUnknown, currentValue;
 
   if (desc === undefined && isPath(keyName)) {

--- a/packages/ember-metal/lib/watch_path.js
+++ b/packages/ember-metal/lib/watch_path.js
@@ -10,7 +10,8 @@ var metaFor = meta;
 // chains inherited from the proto they will be cloned and reconfigured for
 // the current object.
 function chainsFor(obj, meta) {
-  var m = meta || metaFor(obj), ret = m.chains;
+  var m = meta || metaFor(obj);
+  var ret = m.chains;
   if (!ret) {
     ret = m.chains = new ChainNode(null, null, obj);
   } else if (ret.value() !== obj) {
@@ -23,7 +24,8 @@ export function watchPath(obj, keyPath, meta) {
   // can't watch length on Array - it is special...
   if (keyPath === 'length' && typeOf(obj) === 'array') { return; }
 
-  var m = meta || metaFor(obj), watching = m.watching;
+  var m = meta || metaFor(obj);
+  var watching = m.watching;
 
   if (!watching[keyPath]) { // activate watching first time
     watching[keyPath] = 1;
@@ -34,7 +36,8 @@ export function watchPath(obj, keyPath, meta) {
 }
 
 export function unwatchPath(obj, keyPath, meta) {
-  var m = meta || metaFor(obj), watching = m.watching;
+  var m = meta || metaFor(obj);
+  var watching = m.watching;
 
   if (watching[keyPath] === 1) {
     watching[keyPath] = 0;

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -14,7 +14,9 @@ import { defineProperty } from "ember-metal/properties";
 QUnit.module("system/binding/sync_test.js");
 
 testBoth("bindings should not sync twice in a single run loop", function(get, set) {
-  var a, b, setValue, setCalled=0, getCalled=0;
+  var a, b, setValue;
+  var setCalled=0;
+  var getCalled=0;
 
   run(function() {
     a = {};

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -610,7 +610,8 @@ test('adding a computed property should show up in key iteration',function() {
 });
 
 testBoth("when setting a value after it had been retrieved empty don't pass function UNDEFINED as oldValue", function(get, set) {
-    var obj = {}, oldValueIsNoFunction = true;
+    var obj = {};
+    var oldValueIsNoFunction = true;
 
     defineProperty(obj, 'foo', computed(function(key, value, oldValue) {
         if(typeof oldValue === 'function') {
@@ -644,12 +645,12 @@ testBoth('setting a watched computed property', function(get, set) {
       return get(this, 'firstName') + ' ' + get(this, 'lastName');
     }).property('firstName', 'lastName')
   );
-  var fullNameWillChange = 0,
-      fullNameDidChange = 0,
-      firstNameWillChange = 0,
-      firstNameDidChange = 0,
-      lastNameWillChange = 0,
-      lastNameDidChange = 0;
+  var fullNameWillChange = 0;
+  var fullNameDidChange = 0;
+  var firstNameWillChange = 0;
+  var firstNameDidChange = 0;
+  var lastNameWillChange = 0;
+  var lastNameDidChange = 0;
   addBeforeObserver(obj, 'fullName', function () {
     fullNameWillChange++;
   });
@@ -700,8 +701,8 @@ testBoth('setting a cached computed property that modifies the value you give it
       return get(this, 'foo') + 1;
     }).property('foo')
   );
-  var plusOneWillChange = 0,
-      plusOneDidChange = 0;
+  var plusOneWillChange = 0;
+  var plusOneDidChange = 0;
   addBeforeObserver(obj, 'plusOne', function () {
     plusOneWillChange++;
   });
@@ -728,7 +729,8 @@ testBoth('setting a cached computed property that modifies the value you give it
 QUnit.module('computed - default setter');
 
 testBoth("when setting a value on a computed property that doesn't handle sets", function(get, set) {
-  var obj = {}, observerFired = false;
+  var obj = {};
+  var observerFired = false;
 
   defineProperty(obj, 'foo', computed(function() {
     return 'foo';

--- a/packages/ember-metal/tests/enumerable_utils_test.js
+++ b/packages/ember-metal/tests/enumerable_utils_test.js
@@ -3,7 +3,8 @@ import EnumerableUtils from 'ember-metal/enumerable_utils';
 QUnit.module('Ember.EnumerableUtils.intersection');
 
 test('returns an array of objects that appear in both enumerables', function() {
-  var a = [1,2,3], b = [2,3,4], result;
+  var a = [1,2,3];
+  var b = [2,3,4], result;
 
   result = EnumerableUtils.intersection(a, b);
 

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -19,7 +19,8 @@ import {
 QUnit.module('system/props/events_test');
 
 test('listener should receive event - removing should remove', function() {
-  var obj = {}, count = 0;
+  var obj = {};
+  var count = 0;
   var F = function() { count++; };
 
   addListener(obj, 'event!', F);
@@ -36,7 +37,8 @@ test('listener should receive event - removing should remove', function() {
 });
 
 test('listeners should be inherited', function() {
-  var obj = {}, count = 0;
+  var obj = {};
+  var count = 0;
   var F = function() { count++; };
 
   addListener(obj, 'event!', F);
@@ -62,7 +64,8 @@ test('listeners should be inherited', function() {
 
 test('adding a listener more than once should only invoke once', function() {
 
-  var obj = {}, count = 0;
+  var obj = {};
+  var count = 0;
   var F = function() { count++; };
   addListener(obj, 'event!', F);
   addListener(obj, 'event!', F);
@@ -138,7 +141,8 @@ test('adding a listener with string method should lookup method on event deliver
 
 test('calling sendEvent with extra params should be passed to listeners', function() {
 
-  var obj = {}, params = null;
+  var obj = {};
+  var params = null;
   addListener(obj, 'event!', function() {
     params = Array.prototype.slice.call(arguments);
   });
@@ -166,7 +170,9 @@ test('implementing sendEvent on object should invoke', function() {
 
 test('hasListeners tells you if there are listeners for a given event', function() {
 
-  var obj = {}, F = function() {}, F2 = function() {};
+  var obj = {};
+  var F = function() {};
+  var F2 = function() {};
 
   equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
 
@@ -186,7 +192,9 @@ test('hasListeners tells you if there are listeners for a given event', function
 });
 
 test('calling removeListener without method should remove all listeners', function() {
-  var obj = {}, F = function() {}, F2 = function() {};
+  var obj = {};
+  var F = function() {};
+  var F2 = function() {};
 
   equal(hasListeners(obj, 'event!'), false, 'no listeners at first');
 

--- a/packages/ember-metal/tests/instrumentation_test.js
+++ b/packages/ember-metal/tests/instrumentation_test.js
@@ -17,7 +17,8 @@ QUnit.module("Ember Instrumentation", {
 test("subscribing to a simple path receives the listener", function() {
   expect(12);
 
-  var sentPayload = {}, count = 0;
+  var sentPayload = {};
+  var count = 0;
 
   subscribe("render", {
     before: function(name, timestamp, payload) {
@@ -57,7 +58,8 @@ test("subscribing to a simple path receives the listener", function() {
 test("returning a value from the before callback passes it to the after callback", function() {
   expect(2);
 
-  var passthru1 = {}, passthru2 = {};
+  var passthru1 = {};
+  var passthru2 = {};
 
   subscribe("render", {
     before: function(name, timestamp, payload) {

--- a/packages/ember-metal/tests/is_blank_test.js
+++ b/packages/ember-metal/tests/is_blank_test.js
@@ -3,8 +3,9 @@ import isBlank from 'ember-metal/is_blank';
 QUnit.module("Ember.isBlank");
 
 test("Ember.isBlank", function() {
-  var string = "string", fn = function() {},
-  object = {length: 0};
+  var string = "string";
+  var fn = function() {};
+  var object = {length: 0};
 
   equal(true,  isBlank(null),      "for null");
   equal(true,  isBlank(undefined), "for undefined");

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -3,8 +3,9 @@ import isEmpty from 'ember-metal/is_empty';
 QUnit.module("Ember.isEmpty");
 
 test("Ember.isEmpty", function() {
-  var string = "string", fn = function() {},
-      object = {length: 0};
+  var string = "string";
+  var fn = function() {};
+  var object = {length: 0};
 
   equal(true,  isEmpty(null),      "for null");
   equal(true,  isEmpty(undefined), "for undefined");

--- a/packages/ember-metal/tests/is_none_test.js
+++ b/packages/ember-metal/tests/is_none_test.js
@@ -3,7 +3,8 @@ import isNone from 'ember-metal/is_none';
 QUnit.module("Ember.isNone");
 
 test("Ember.isNone", function() {
-  var string = "string", fn = function() {};
+  var string = "string";
+  var fn = function() {};
 
   equal(true,  isNone(null),      "for null");
   equal(true,  isNone(undefined), "for undefined");

--- a/packages/ember-metal/tests/is_present_test.js
+++ b/packages/ember-metal/tests/is_present_test.js
@@ -4,8 +4,9 @@ if (Ember.FEATURES.isEnabled('ember-metal-is-present')) {
   QUnit.module("Ember.isPresent");
 
   test("Ember.isPresent", function() {
-    var string = "string", fn = function() {},
-    object = {length: 0};
+    var string = "string";
+    var fn = function() {};
+    var object = {length: 0};
 
     equal(false, isPresent(),          "for no params");
     equal(false, isPresent(null),      "for null");

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -61,8 +61,8 @@ test('calling set on overridden computed properties', function() {
   var SuperMixin, SubMixin;
   var obj;
 
-  var superGetOccurred = false,
-      superSetOccurred = false;
+  var superGetOccurred = false;
+  var superSetOccurred = false;
 
   SuperMixin = Mixin.create({
     aProp: computed(function(key, val) {

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -75,7 +75,8 @@ testBoth('observer should fire when dependent property is modified', function(ge
 });
 
 testBoth('observer should continue to fire after dependent properties are accessed', function(get, set) {
-  var observerCount = 0, obj = {};
+  var observerCount = 0;
+  var obj = {};
 
   defineProperty(obj, 'prop', Ember.computed(function () { return Math.random(); }));
   defineProperty(obj, 'anotherProp', Ember.computed('prop', function () { return get(this, 'prop') + Math.random(); }));
@@ -190,7 +191,8 @@ testBoth('observers watching multiple properties via brace expansion should fire
 
 testBoth('nested observers should fire in order', function(get,set) {
   var obj = { foo: 'foo', bar: 'bar' };
-  var fooCount = 0, barCount = 0;
+  var fooCount = 0;
+  var barCount = 0;
 
   addObserver(obj, 'foo' ,function() { fooCount++; });
   addObserver(obj, 'bar', function() {
@@ -206,9 +208,16 @@ testBoth('nested observers should fire in order', function(get,set) {
 });
 
 testBoth('removing an chain observer on change should not fail', function(get,set) {
-  var foo = { bar: 'bar' },
-    obj1 = { foo: foo }, obj2 = { foo: foo }, obj3 = { foo: foo }, obj4 = { foo: foo },
-    count1=0, count2=0, count3=0, count4=0;
+  var foo = { bar: 'bar' };
+  var obj1 = { foo: foo };
+  var obj2 = { foo: foo };
+  var obj3 = { foo: foo };
+  var obj4 = { foo: foo };
+  var count1=0;
+  var count2=0;
+  var count3=0;
+  var count4=0;
+
   function observer1() { count1++; }
   function observer2() { count2++; }
   function observer3() {
@@ -233,9 +242,16 @@ testBoth('removing an chain observer on change should not fail', function(get,se
 });
 
 testBoth('removing an chain before observer on change should not fail', function(get,set) {
-  var foo = { bar: 'bar' },
-    obj1 = { foo: foo }, obj2 = { foo: foo }, obj3 = { foo: foo }, obj4 = { foo: foo },
-    count1=0, count2=0, count3=0, count4=0;
+  var foo = { bar: 'bar' };
+  var obj1 = { foo: foo };
+  var obj2 = { foo: foo };
+  var obj3 = { foo: foo };
+  var obj4 = { foo: foo };
+  var count1=0;
+  var count2=0;
+  var count3=0;
+  var count4=0;
+
   function observer1() { count1++; }
   function observer2() { count2++; }
   function observer3() {
@@ -464,7 +480,8 @@ testBoth('deferring property change notifications will not defer before observer
 });
 
 testBoth('implementing sendEvent on object should invoke when deferring property change notifications ends', function(get, set) {
-  var count = 0, events = [];
+  var count = 0;
+  var events = [];
   var obj = {
     sendEvent: function(eventName) {
       events.push(eventName);
@@ -1032,9 +1049,8 @@ testBoth('setting a cached computed property whose value has changed should trig
 QUnit.module("Ember.immediateObserver");
 
 testBoth("immediate observers should fire synchronously", function(get, set) {
-  var obj = {},
-      observerCalled = 0,
-      mixin;
+  var obj = {};
+  var observerCalled = 0, mixin;
 
   // explicitly create a run loop so we do not inadvertently
   // trigger deferred behavior
@@ -1067,9 +1083,8 @@ testBoth("immediate observers should fire synchronously", function(get, set) {
 
 if (Ember.EXTEND_PROTOTYPES) {
   testBoth('immediate observers added declaratively via brace expansion fire synchronously', function (get, set) {
-    var obj = {},
-    observerCalled = 0,
-    mixin;
+    var obj = {};
+    var observerCalled = 0, mixin;
 
     // explicitly create a run loop so we do not inadvertently
     // trigger deferred behavior
@@ -1101,9 +1116,8 @@ if (Ember.EXTEND_PROTOTYPES) {
 }
 
 testBoth('immediate observers watching multiple properties via brace expansion fire synchronously', function (get, set) {
-  var obj = {},
-  observerCalled = 0,
-  mixin;
+  var obj = {};
+  var observerCalled = 0, mixin;
 
   // explicitly create a run loop so we do not inadvertently
   // trigger deferred behavior

--- a/packages/ember-metal/tests/performance_test.js
+++ b/packages/ember-metal/tests/performance_test.js
@@ -20,7 +20,8 @@ QUnit.module("Computed Properties - Number of times evaluated");
 
 test("computed properties that depend on multiple properties should run only once per run loop", function() {
   var obj = {a: 'a', b: 'b', c: 'c'};
-  var cpCount = 0, obsCount = 0;
+  var cpCount = 0;
+  var obsCount = 0;
 
   defineProperty(obj, 'abc', computed(function(key) {
     cpCount++;

--- a/packages/ember-metal/tests/platform/defineProperty_test.js
+++ b/packages/ember-metal/tests/platform/defineProperty_test.js
@@ -71,7 +71,10 @@ test('defining a non enumerable property', function() {
 // and setters don't do anything
 if (platform.hasPropertyAccessors) {
   test('defining a getter/setter', function() {
-    var obj = {}, getCnt = 0, setCnt = 0, v = 'FOO';
+    var obj = {};
+    var getCnt = 0;
+    var setCnt = 0;
+    var v = 'FOO';
 
     var desc = {
       enumerable: true,

--- a/packages/ember-metal/tests/run_loop/once_test.js
+++ b/packages/ember-metal/tests/run_loop/once_test.js
@@ -17,7 +17,8 @@ test('calling invokeOnce more than once invokes only once', function() {
 
 test('should differentiate based on target', function() {
 
-  var A = { count: 0 }, B = { count: 0 };
+  var A = { count: 0 };
+  var B = { count: 0 };
   run(function() {
     var F = function() { this.count++; };
     run.once(A, F);
@@ -33,7 +34,8 @@ test('should differentiate based on target', function() {
 
 test('should ignore other arguments - replacing previous ones', function() {
 
-  var A = { count: 0 }, B = { count: 0 };
+  var A = { count: 0 };
+  var B = { count: 0 };
   run(function() {
     var F = function(amt) { this.count += amt; };
     run.once(A, F, 10);

--- a/packages/ember-metal/tests/utils/guidFor_test.js
+++ b/packages/ember-metal/tests/utils/guidFor_test.js
@@ -20,7 +20,8 @@ var nanGuid = function(obj) {
 };
 
 test("Object", function() {
-  var a = {}, b = {};
+  var a = {};
+  var b = {};
 
   sameGuid( a, a, "same object always yields same guid" );
   diffGuid( a, b, "different objects yield different guids" );
@@ -44,7 +45,9 @@ test("Object with prototype", function() {
 });
 
 test("strings", function() {
-  var a = "string A", aprime = "string A", b = "String B";
+  var a = "string A";
+  var aprime = "string A";
+  var b = "String B";
 
   sameGuid( a, a,      "same string always yields same guid" );
   sameGuid( a, aprime, "identical strings always yield the same guid" );
@@ -53,7 +56,9 @@ test("strings", function() {
 });
 
 test("numbers", function() {
-  var a = 23, aprime = 23, b = 34;
+  var a = 23;
+  var aprime = 23;
+  var b = 34;
 
   sameGuid( a, a,      "same numbers always yields same guid" );
   sameGuid( a, aprime, "identical numbers always yield the same guid" );
@@ -62,7 +67,9 @@ test("numbers", function() {
 });
 
 test("numbers", function() {
-  var a = true, aprime = true, b = false;
+  var a = true;
+  var aprime = true;
+  var b = false;
 
   sameGuid( a, a,      "same booleans always yields same guid" );
   sameGuid( a, aprime, "identical booleans always yield the same guid" );
@@ -72,7 +79,9 @@ test("numbers", function() {
 });
 
 test("null and undefined", function() {
-  var a = null, aprime = null, b;
+  var a = null;
+  var aprime = null;
+  var b;
 
   sameGuid( a, a,      "null always returns the same guid" );
   sameGuid( b, b,      "undefined always returns the same guid" );
@@ -83,7 +92,9 @@ test("null and undefined", function() {
 });
 
 test("arrays", function() {
-  var a = ["a", "b", "c"], aprime = ["a", "b", "c"], b = ["1", "2", "3"];
+  var a = ["a", "b", "c"];
+  var aprime = ["a", "b", "c"];
+  var b = ["1", "2", "3"];
 
   sameGuid( a, a,      "same instance always yields same guid" );
   diffGuid( a, aprime, "identical arrays always yield the same guid" );

--- a/packages/ember-metal/tests/utils/is_array_test.js
+++ b/packages/ember-metal/tests/utils/is_array_test.js
@@ -4,13 +4,13 @@ QUnit.module("Ember Type Checking");
 var global = this;
 
 test("Ember.isArray" ,function() {
-  var numarray      = [1,2,3],
-      number        = 23,
-      strarray      = ["Hello", "Hi"],
-      string        = "Hello",
-      object        = {},
-      length        = {length: 12},
-      fn            = function() {};
+  var numarray      = [1,2,3];
+  var number        = 23;
+  var strarray      = ["Hello", "Hi"];
+  var string        = "Hello";
+  var object        = {};
+  var length        = {length: 12};
+  var fn            = function() {};
 
   equal( isArray(numarray), true,  "[1,2,3]" );
   equal( isArray(number),   false, "23" );

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -6,10 +6,10 @@ test("Ember.typeOf", function() {
   var MockedDate = function() { };
   MockedDate.prototype = new Date();
 
-  var mockedDate  = new MockedDate(),
-      date        = new Date(),
-      error       = new Error('boum'),
-      object      = {a: 'b'};
+  var mockedDate  = new MockedDate();
+  var date        = new Date();
+  var error       = new Error('boum');
+  var object      = {a: 'b'};
 
   equal( typeOf(),            'undefined',  "undefined");
   equal( typeOf(null),        'null',       "null");
@@ -24,8 +24,8 @@ test("Ember.typeOf", function() {
   equal( typeOf(object),      'object',     "object");
 
   if(Ember.Object) {
-    var klass       = Ember.Object.extend(),
-        instance    = Ember.Object.create();
+    var klass       = Ember.Object.extend();
+    var instance    = Ember.Object.create();
 
     equal( Ember.typeOf(klass),     'class',      "class");
     equal( Ember.typeOf(instance),  'instance',   "instance");

--- a/packages/ember-metal/tests/watching/isWatching_test.js
+++ b/packages/ember-metal/tests/watching/isWatching_test.js
@@ -13,7 +13,8 @@ import { isWatching } from 'ember-metal/watching';
 QUnit.module('isWatching');
 
 function testObserver(setup, teardown, key) {
-  var obj = {}, fn = function() {};
+  var obj = {};
+  var fn = function() {};
   key = key || 'foo';
 
   equal(isWatching(obj, key), false, "precond - isWatching is false by default");


### PR DESCRIPTION
I am working through a code style cleanup effort using [jscs](https://github.com/mdevils/node-jscs) rules. 

You can see the script and rules in: https://github.com/rwjblue/ember.js/compare/code-style-rules

---

This applies the `disallowMultipleVarDeclWithAssignment` rule to `ember-metal`.
