### PR TITLE
Ensure that variable assigning declarations are single line

### DIFF
--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -76,7 +76,8 @@ var indexOf = defineNativeShim(ArrayPrototype.indexOf, function (obj, fromIndex)
 });
 
 var lastIndexOf = defineNativeShim(ArrayPrototype.lastIndexOf, function(obj, fromIndex) {
-    var idx, len = this.length;
+    var len = this.length;
+    var idx;
 
     if (fromIndex === undefined) fromIndex = len-1;
     else fromIndex = (fromIndex < 0) ? Math.ceil(fromIndex) : Math.floor(fromIndex);

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -210,7 +210,8 @@ ChainNodePrototype.remove = function(path) {
 ChainNodePrototype.count = 0;
 
 ChainNodePrototype.chain = function(key, path, src) {
-  var chains = this._chains, node;
+  var chains = this._chains;
+  var node;
   if (!chains) { chains = this._chains = {}; }
 
   node = chains[key];

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -50,8 +50,8 @@ function indexOf(array, target, method) {
 }
 
 function actionsFor(obj, eventName) {
-  var meta = metaFor(obj, true),
-      actions;
+  var meta = metaFor(obj, true);
+  var actions;
 
   if (!meta.listeners) { meta.listeners = {}; }
 

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -51,7 +51,8 @@ var subscribers = [];
 var cache = {};
 
 var populateListeners = function(name) {
-  var listeners = [], subscriber;
+  var listeners = [];
+  var subscriber;
 
   for (var i=0, l=subscribers.length; i<l; i++) {
     subscriber = subscribers[i];

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -45,7 +45,8 @@ var o_create = create;
 var metaFor = meta;
 
 function superFunction(){
-  var ret, func = this.__nextSuper;
+  var func = this.__nextSuper;
+  var ret;
   if (func) {
     this.__nextSuper = null;
     ret = apply(this, func, arguments);
@@ -284,7 +285,8 @@ function detectBinding(obj, key, value, m) {
 
 function connectBindings(obj, m) {
   // TODO Mixin.apply(instance) should disconnect binding if exists
-  var bindings = m.bindings, key, binding, to;
+  var bindings = m.bindings;
+  var key, binding, to;
   if (bindings) {
     for (key in bindings) {
       binding = bindings[key];
@@ -311,7 +313,8 @@ function finishPartial(obj, m) {
 }
 
 function followAlias(obj, desc, m, descs, values) {
-  var altKey = desc.methodName, value;
+  var altKey = desc.methodName;
+  var value;
   if (descs[altKey] || values[altKey]) {
     value = values[altKey];
     desc  = descs[altKey];
@@ -517,7 +520,8 @@ MixinPrototype.reopen = function() {
   }
 
   var len = arguments.length;
-  var mixins = this.mixins, idx;
+  var mixins = this.mixins;
+  var idx;
 
   for(idx=0; idx < len; idx++) {
     mixin = arguments[idx];

--- a/packages/ember-metal/lib/observer_set.js
+++ b/packages/ember-metal/lib/observer_set.js
@@ -49,7 +49,8 @@ ObserverSet.prototype.add = function(sender, keyName, eventName) {
 };
 
 ObserverSet.prototype.flush = function() {
-  var observers = this.observers, i, len, observer, sender;
+  var observers = this.observers;
+  var i, len, observer, sender;
   this.clear();
   for (i=0, len=observers.length; i < len; ++i) {
     observer = observers[i];

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -226,7 +226,8 @@ function changeProperties(cb, binding) {
 function notifyBeforeObservers(obj, keyName) {
   if (obj.isDestroying) { return; }
 
-  var eventName = keyName + ':before', listeners, diff;
+  var eventName = keyName + ':before';
+  var listeners, diff;
   if (deferred) {
     listeners = beforeObserverSet.add(obj, keyName, eventName);
     diff = listenersDiff(obj, eventName, listeners);
@@ -239,7 +240,8 @@ function notifyBeforeObservers(obj, keyName) {
 function notifyObservers(obj, keyName) {
   if (obj.isDestroying) { return; }
 
-  var eventName = keyName + ':change', listeners;
+  var eventName = keyName + ':change';
+  var listeners;
   if (deferred) {
     listeners = observerSet.add(obj, keyName, eventName);
     listenersUnion(obj, eventName, listeners);

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -68,7 +68,8 @@ var get = function get(obj, keyName) {
   }
 
   var meta = obj['__ember_meta__'];
-  var desc = meta && meta.descs[keyName], ret;
+  var desc = meta && meta.descs[keyName];
+  var ret;
 
   if (desc === undefined && isPath(keyName)) {
     return _getPath(obj, keyName);

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -42,8 +42,8 @@ var set = function set(obj, keyName, value, tolerant) {
   }
 
   var meta = obj['__ember_meta__'];
-  var desc = meta && meta.descs[keyName],
-      isUnknown, currentValue;
+  var desc = meta && meta.descs[keyName];
+  var isUnknown, currentValue;
 
   if (desc === undefined && isPath(keyName)) {
     return setPath(obj, keyName, value, tolerant);

--- a/packages/ember-metal/tests/accessors/getPath_test.js
+++ b/packages/ember-metal/tests/accessors/getPath_test.js
@@ -2,7 +2,8 @@
 
 import { get } from 'ember-metal/property_get';
 
-var obj, moduleOpts = {
+var obj;
+var moduleOpts = {
   setup: function() {
     obj = {
       foo: {

--- a/packages/ember-metal/tests/accessors/normalizeTuple_test.js
+++ b/packages/ember-metal/tests/accessors/normalizeTuple_test.js
@@ -1,7 +1,8 @@
 /*globals Foo:true, $foo:true */
 import { normalizeTuple } from "ember-metal/property_get";
 
-var obj, moduleOpts = {
+var obj;
+var moduleOpts = {
   setup: function() {
     obj = {
       foo: {

--- a/packages/ember-metal/tests/accessors/setPath_test.js
+++ b/packages/ember-metal/tests/accessors/setPath_test.js
@@ -6,7 +6,8 @@ import { get } from 'ember-metal/property_get';
 
 var originalLookup = Ember.lookup;
 
-var obj, moduleOpts = {
+var obj;
+var moduleOpts = {
   setup: function() {
     obj = {
       foo: {

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -51,7 +51,8 @@ testBoth("bindings should not sync twice in a single run loop", function(get, se
 });
 
 testBoth("bindings should not infinite loop if computed properties return objects", function(get, set) {
-  var a, b, getCalled=0;
+  var a, b;
+  var getCalled=0;
 
   run(function() {
     a = {};

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -20,8 +20,8 @@ import {
 } from "ember-metal/observer";
 import { indexOf } from 'ember-metal/enumerable_utils';
 
-var originalLookup = Ember.lookup, lookup;
-var obj, count, Global;
+var originalLookup = Ember.lookup;
+var obj, count, Global, lookup;
 
 QUnit.module('computed');
 
@@ -449,7 +449,8 @@ testBoth('throws assertion if brace expansion notation has spaces', function (ge
 //
 
 
-var func, moduleOpts = {
+var func;
+var moduleOpts = {
   setup: function() {
     originalLookup = Ember.lookup;
     lookup = Ember.lookup = {};

--- a/packages/ember-metal/tests/enumerable_utils_test.js
+++ b/packages/ember-metal/tests/enumerable_utils_test.js
@@ -4,7 +4,8 @@ QUnit.module('Ember.EnumerableUtils.intersection');
 
 test('returns an array of objects that appear in both enumerables', function() {
   var a = [1,2,3];
-  var b = [2,3,4], result;
+  var b = [2,3,4];
+  var result;
 
   result = EnumerableUtils.intersection(a, b);
 

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -75,7 +75,8 @@ test('adding a listener more than once should only invoke once', function() {
 });
 
 test('adding a listener with a target should invoke with target', function() {
-  var obj = {}, target;
+  var obj = {};
+  var target;
 
   target = {
     count: 0,
@@ -88,7 +89,8 @@ test('adding a listener with a target should invoke with target', function() {
 });
 
 test('suspending a listener should not invoke during callback', function() {
-  var obj = {}, target, otherTarget;
+  var obj = {};
+  var target, otherTarget;
 
   target = {
     count: 0,
@@ -123,7 +125,8 @@ test('suspending a listener should not invoke during callback', function() {
 });
 
 test('adding a listener with string method should lookup method on event delivery', function() {
-  var obj = {}, target;
+  var obj = {};
+  var target;
 
   target = {
     count: 0,
@@ -209,7 +212,8 @@ test('calling removeListener without method should remove all listeners', functi
 });
 
 test('while suspended, it should not be possible to add a duplicate listener', function() {
-  var obj = {}, target;
+  var obj = {};
+  var target;
 
   target = {
     count: 0,

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember-metal/core';
 
-var isEnabled = Ember.FEATURES.isEnabled,
-    origFeatures, origEnableAll, origEnableOptional;
+var isEnabled = Ember.FEATURES.isEnabled;
+var origFeatures, origEnableAll, origEnableOptional;
 
 QUnit.module("Ember.FEATURES.isEnabled", {
   setup: function(){

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -4,9 +4,8 @@ import {
   MapWithDefault
 } from "ember-metal/map";
 
-var object, number, string, map;
-
-var varieties = [['Map', Map], ['MapWithDefault', MapWithDefault]], variety;
+var object, number, string, map, variety;
+var varieties = [['Map', Map], ['MapWithDefault', MapWithDefault]];
 
 function testMap(nameAndFunc) {
   variety = nameAndFunc[0];

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -276,7 +276,8 @@ testBoth('removing an chain before observer on change should not fail', function
 });
 
 testBoth('suspending an observer should not fire during callback', function(get,set) {
-  var obj = {}, target, otherTarget;
+  var obj = {};
+  var target, otherTarget;
 
   target = {
     values: [],
@@ -312,7 +313,8 @@ testBoth('suspending an observer should not fire during callback', function(get,
 
 
 testBoth('suspending an observer should not defer change notifications during callback', function(get,set) {
-  var obj = {}, target, otherTarget;
+  var obj = {};
+  var target, otherTarget;
 
   target = {
     values: [],
@@ -349,7 +351,8 @@ testBoth('suspending an observer should not defer change notifications during ca
 });
 
 testBoth('suspending observers should not fire during callback', function(get,set) {
-  var obj = {}, target, otherTarget;
+  var obj = {};
+  var target, otherTarget;
 
   target = {
     values: [],
@@ -385,7 +388,8 @@ testBoth('suspending observers should not fire during callback', function(get,se
 
 
 testBoth('suspending observers should not defer change notifications during callback', function(get,set) {
-  var obj = {}, target, otherTarget;
+  var obj = {};
+  var target, otherTarget;
 
   target = {
     values: [],
@@ -506,7 +510,8 @@ testBoth('implementing sendEvent on object should invoke when deferring property
 });
 
 testBoth('addObserver should propagate through prototype', function(get,set) {
-  var obj = { foo: 'foo', count: 0 }, obj2;
+  var obj = { foo: 'foo', count: 0 };
+  var obj2;
 
   addObserver(obj, 'foo', function() { this.count++; });
   obj2 = create(obj);
@@ -805,7 +810,8 @@ testBoth('before observer watching multiple properties via brace expansion shoul
 });
 
 testBoth('addBeforeObserver should propagate through prototype', function(get,set) {
-  var obj = { foo: 'foo', count: 0 }, obj2;
+  var obj = { foo: 'foo', count: 0 };
+  var obj2;
 
   addBeforeObserver(obj, 'foo', function() { this.count++; });
   obj2 = create(obj);
@@ -862,8 +868,8 @@ testBoth('addBeforeObserver should respect targets with methods', function(get,s
 // CHAINED OBSERVERS
 //
 
-var obj, count;
-var originalLookup = Ember.lookup, lookup;
+var obj, count, lookup;
+var originalLookup = Ember.lookup;
 
 QUnit.module('addObserver - dependentkey with chained properties', {
   setup: function() {
@@ -955,7 +961,8 @@ testBoth('depending on a simple chain', function(get, set) {
 });
 
 testBoth('depending on a Global chain', function(get, set) {
-  var Global = lookup.Global, val;
+  var Global = lookup.Global;
+  var val;
 
   addObserver(obj, 'Global.foo.bar.baz.biff', function(target, key) {
     val = get(lookup, key);
@@ -1050,7 +1057,8 @@ QUnit.module("Ember.immediateObserver");
 
 testBoth("immediate observers should fire synchronously", function(get, set) {
   var obj = {};
-  var observerCalled = 0, mixin;
+  var observerCalled = 0;
+  var mixin;
 
   // explicitly create a run loop so we do not inadvertently
   // trigger deferred behavior
@@ -1084,7 +1092,8 @@ testBoth("immediate observers should fire synchronously", function(get, set) {
 if (Ember.EXTEND_PROTOTYPES) {
   testBoth('immediate observers added declaratively via brace expansion fire synchronously', function (get, set) {
     var obj = {};
-    var observerCalled = 0, mixin;
+    var observerCalled = 0;
+    var mixin;
 
     // explicitly create a run loop so we do not inadvertently
     // trigger deferred behavior
@@ -1117,7 +1126,8 @@ if (Ember.EXTEND_PROTOTYPES) {
 
 testBoth('immediate observers watching multiple properties via brace expansion fire synchronously', function (get, set) {
   var obj = {};
-  var observerCalled = 0, mixin;
+  var observerCalled = 0;
+  var mixin;
 
   // explicitly create a run loop so we do not inadvertently
   // trigger deferred behavior

--- a/packages/ember-metal/tests/run_loop/join_test.js
+++ b/packages/ember-metal/tests/run_loop/join_test.js
@@ -37,8 +37,8 @@ test('run.join returns a value if creating a new run-loop', function() {
 });
 
 test('run.join returns undefined if joining another run-loop', function() {
-  var value = 'returned value',
-  result;
+  var value = 'returned value';
+  var result;
 
   run(function() {
     var result = run.join(function() {

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -68,7 +68,8 @@ asyncTest('should invoke after specified period of time - target/method/args', f
 });
 
 asyncTest('should always invoke within a separate runloop', function() {
-  var obj = { invoked: 0 }, firstRunLoop, secondRunLoop;
+  var obj = { invoked: 0 };
+  var firstRunLoop, secondRunLoop;
 
   run(function() {
     firstRunLoop = run.currentRunLoop;

--- a/packages/ember-metal/tests/run_loop/onerror_test.js
+++ b/packages/ember-metal/tests/run_loop/onerror_test.js
@@ -4,8 +4,8 @@ import run from 'ember-metal/run_loop';
 QUnit.module('system/run_loop/onerror_test');
 
 test('With Ember.onerror undefined, errors in Ember.run are thrown', function () {
-  var thrown = new Error('Boom!'),
-      caught;
+  var thrown = new Error('Boom!');
+  var caught;
 
   try {
     run(function() { throw thrown; });
@@ -17,8 +17,8 @@ test('With Ember.onerror undefined, errors in Ember.run are thrown', function ()
 });
 
 test('With Ember.onerror set, errors in Ember.run are caught', function () {
-  var thrown = new Error('Boom!'),
-      caught;
+  var thrown = new Error('Boom!');
+  var caught;
 
   Ember.onerror = function(error) { caught = error; };
 


### PR DESCRIPTION
I am working through a code style cleanup effort using [jscs](https://github.com/mdevils/node-jscs) rules. 

You can see the script and rules in: https://github.com/rwjblue/ember.js/compare/code-style-rules

---

As referenced in #5351, this tweaks the rule to require all assignments to be in a `var` declaration by itself.
