### PR TITLE
[BUGFIX beta] Computed not empty array does not require brackets

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -78,15 +78,11 @@ computed.empty = function (dependentKey) {
   A computed property that returns true if the value of the dependent
   property is NOT null, an empty string, empty array, or empty function.
 
-  Note: When using `computed.notEmpty` to watch an array make sure to
-  use the `array.[]` syntax so the computed can subscribe to transitions
-  from empty to non-empty states.
-
   Example
 
   ```javascript
   var Hamster = Ember.Object.extend({
-    hasStuff: Ember.computed.notEmpty('backpack.[]')
+    hasStuff: Ember.computed.notEmpty('backpack')
   });
 
   var hamster = Hamster.create({ backpack: ['Food', 'Sleeping Bag', 'Tent'] });
@@ -102,9 +98,11 @@ computed.empty = function (dependentKey) {
   @return {Ember.ComputedProperty} computed property which returns true if
   original value for property is not empty.
 */
-registerComputed('notEmpty', function(dependentKey) {
-  return !isEmpty(get(this, dependentKey));
-});
+computed.notEmpty = function(dependentKey) {
+  return computed(dependentKey + '.length', function () {
+    return !isEmpty(get(this, dependentKey));
+  });
+};
 
 /**
   A computed property that returns true if the value of the dependent

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -24,3 +24,24 @@ testBoth('Ember.computed.empty', function (get, set) {
   equal(get(obj, 'bestLannisterUnspecified'), false, "empty respects strings");
   equal(get(obj, 'noLannistersKnown'), false, "empty respects array mutations");
 });
+
+testBoth('Ember.computed.notEmpty', function(get, set) {
+  var obj = EmberObject.extend({
+    bestLannister: null,
+    lannisters: null,
+
+    bestLannisterSpecified: computed.notEmpty('bestLannister'),
+    LannistersKnown: computed.notEmpty('lannisters')
+  }).create({
+    lannisters: Ember.A([])
+  });
+
+  equal(get(obj, 'bestLannisterSpecified'), false, "bestLannister initially empty");
+  equal(get(obj, 'LannistersKnown'), false, "lannisters initially empty");
+
+  get(obj, 'lannisters').pushObject('Tyrion');
+  set(obj, 'bestLannister', 'Tyrion');
+
+  equal(get(obj, 'bestLannisterSpecified'), true, "empty respects strings");
+  equal(get(obj, 'LannistersKnown'), true, "empty respects array mutations");
+});


### PR DESCRIPTION
In 1.6 Ember.computed.empty was updated to automatically respect arrays without forcing users to use array.[] as the dependent key.

Ember.computed.notEmpty was not updated with this behavior.  
