### PR TITLE
[FIX] Prevent setting of __nextSuper on frozen objects

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -393,9 +393,9 @@ export function metaPath(obj, path, writable) {
 export function wrap(func, superFunc) {
   function superWrapper() {
     var ret, sup = this && this.__nextSuper;
-    if(this) { this.__nextSuper = superFunc; }
+    setSuper(this, superFunc);
     ret = apply(this, func, arguments);
-    if(this) { this.__nextSuper = sup; }
+    setSuper(this, sup);
     return ret;
   }
 
@@ -406,6 +406,10 @@ export function wrap(func, superFunc) {
   superWrapper.__ember_listens__ = func.__ember_listens__;
 
   return superWrapper;
+
+  function setSuper(obj, superFunc) {
+    if(obj && !Object.isFrozen(obj)) { obj.__nextSuper = superFunc; }
+  }
 }
 
 var EmberArray;

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -158,6 +158,12 @@ test('every', function() {
   equal(allWhite, true);
 });
 
+test('contains on frozen array', function(){
+  var arr = Ember.A(["foo", "bar", "baz"]);
+  Object.freeze(arr);
+  equal(arr.contains("foo"), true);
+});
+
 // ..........................................................
 // CONTENT DID CHANGE
 //


### PR DESCRIPTION
This fixes #5324

If the object is frozen we should not modify it.  This includes the setting of `__nextSuper` which is used by `_super`.
