### PR TITLE
Add controller model property to documentation.

### DIFF
--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -45,7 +45,18 @@ export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecatio
 
   store: null,
 
+  /**
+    The controller's current model. When retrieving or modifying a controller's
+    model, this property should be used instead of the `content` property.
+
+    @property model
+    @public
+   */
   model: null,
+
+  /**
+    @private
+   */
   content: computed.alias('model')
 
 });


### PR DESCRIPTION
This is just a small documentation addition to ensure that the `model` property of the `ControllerMixin` shows up in the API docs. It also warns against using the `content` property directly, since the documentation for `ControllerContentModelAliasDeprecation` states:

> This change reduces many caveats with model/content, and also sets a simple ground rule: Never set a controllers content, rather always set it's model and ember will do the right thing.

There's already quite a bit of confusion about whether to use `model` or `content`, and I think it would help if `model` was publicly documented.
