### PR TITLE
[FEATURE ember-routing-linkto-tabindex-attribute]

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -136,7 +136,7 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
     @type Array | String
     @default ['href', 'title', 'rel']
    **/
-  attributeBindings: ['href', 'title', 'rel'],
+  attributeBindings: ['href', 'title', 'rel', 'tabindex'],
 
   /**
     By default the `{{link-to}}` helper will bind to the `active`, `loading`, and

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -474,7 +474,7 @@ test("The {{link-to}} helper moves into the named route with context", function(
 });
 
 test("The {{link-to}} helper binds some anchor html tag common attributes", function() {
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'index' id='self-link' title='title-attr' rel='rel-attr'}}Self{{/link-to}}");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#link-to 'index' id='self-link' title='title-attr' rel='rel-attr' tabindex='-1'}}Self{{/link-to}}");
   bootApplication();
 
   Ember.run(function() {
@@ -484,6 +484,7 @@ test("The {{link-to}} helper binds some anchor html tag common attributes", func
   var link = Ember.$('#self-link', '#qunit-fixture');
   equal(link.attr('title'), 'title-attr', "The self-link contains title attribute");
   equal(link.attr('rel'), 'rel-attr', "The self-link contains rel attribute");
+  equal(link.attr('tabindex'), '-1', "The self-link contains tabindex attribute");
 });
 
 if(Ember.FEATURES.isEnabled('ember-routing-linkto-target-attribute')) {


### PR DESCRIPTION
The link-to helper should support the tabindex attribute. I added tests in to verify the change.
