### PR TITLE
[BUGFIX beta] Fix QP link issue upon app reload

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -710,13 +710,15 @@ var Route = EmberObject.extend(ActionHandler, {
         var states = get(this, '_qp.states');
         if (transition) {
           // Update the model dep values used to calculate cache keys.
+          stashParamNames(this.router, transition.state.handlerInfos);
           controller._qpDelegate = states.changingKeys;
           controller._updateCacheParams(transition.params);
         }
         controller._qpDelegate = states.allowOverrides;
 
         if (transition) {
-          controller.setProperties(getQueryParamsFor(this, transition.state));
+          var qpValues = getQueryParamsFor(this, transition.state);
+          controller.setProperties(qpValues);
         }
 
         this.setupController(controller, context, transition);

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -5,6 +5,7 @@ import {
 }  from "ember-metal/enumerable_utils";
 import { computed } from "ember-metal/computed";
 import { platform } from 'ember-metal/platform';
+import { capitalize } from "ember-runtime/system/string";
 
 var Router, App, AppView, templates, router, container;
 var get = Ember.get;
@@ -1188,6 +1189,27 @@ if (Ember.FEATURES.isEnabled("query-params-new")) {
     startingURL = '/?foo=YEAH';
     bootApplication();
   });
+
+  var testParamlessLinks = function(routeName) {
+    test("param-less links in an app booted with query params in the URL don't reset the query params: " + routeName, function() {
+      expect(1);
+
+      Ember.TEMPLATES[routeName] = compile("{{link-to 'index' 'index' id='index-link'}}");
+
+      App[capitalize(routeName) + "Controller"] = Ember.Controller.extend({
+        queryParams: ['foo'],
+        foo: "wat"
+      });
+
+      startingURL = '/?foo=YEAH';
+      bootApplication();
+
+      equal(Ember.$('#index-link').attr('href'), '/?foo=YEAH');
+    });
+  };
+
+  testParamlessLinks('application');
+  testParamlessLinks('index');
 
   QUnit.module("Model Dep Query Params", {
     setup: function() {


### PR DESCRIPTION
Fixes a bug reported by @mixonic where some links that didn’t specify query
params were resetting query params set from the URL at boot time.
