### PR TITLE
Add a checkbox to raise on deprecation to the tests

### DIFF
--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -24,6 +24,9 @@
   // Don't worry about jQuery version
   ENV['FORCE_JQUERY'] = true;
 
+  // Don't worry about jQuery version
+  ENV['RAISE_ON_DEPRECATION'] = !!QUnit.urlParams.raiseonunhandleddeprecation;
+
   if (EmberDev.jsHint) {
     // jsHint makes its own Object.create stub, we don't want to use this
     ENV['STUB_OBJECT_CREATE'] = !Object.create;

--- a/tests/qunit_configuration.js
+++ b/tests/qunit_configuration.js
@@ -104,6 +104,8 @@
   // Handle extending prototypes
   QUnit.config.urlConfig.push({ id: 'extendprototypes', label: 'Extend Prototypes'});
 
+  // Raise on unhandled deprecation
+  QUnit.config.urlConfig.push({ id: 'raiseonunhandleddeprecation', label: 'Raise on Deprecation'});
 
   // Handle JSHint
   QUnit.config.urlConfig.push('nojshint');


### PR DESCRIPTION
![](https://api.monosnap.com/image/download?id=XykMzGNnBTxgGdTUSGcW1IU7kvgaer)
![](http://stream1.gifsoup.com/view/338920/mister-trololo-sez-hi-o.gif)

I [complained about deprecation noise in the tests](https://github.com/emberjs/ember.js/pull/5388#issuecomment-52389452), but really there isn't an easy way to see that you have caught all occurrences of a deprecated behavior. This is a start, and once the notices are clean we can maybe add this flag to the test runs on CI.

Refs #4748
