### PR TITLE
Transform dasherized properties to camelized in {{view}}.

### DIFF
--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -229,3 +229,91 @@ test("Should apply class without condition always", function() {
   ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
 
 });
+
+test("Should allow `class-binding` (move dasherized properties to camelized)", function() {
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" class-binding=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "applied class binding");
+});
+
+test("Should allow `class-binding` (move dasherized properties to camelized)", function() {
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" class-binding=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "applied class binding");
+});
+
+test("Should allow `class-binding` (move dasherized properties to camelized)", function() {
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" class-binding=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "applied class binding");
+});
+
+test("Should allow `class-name-bindings` (move dasherized properties to camelized)", function() {
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" class-name-bindings=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "applied class binding");
+});
+
+test("Should move dasherized properties to camelized", function() {
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" foo-bar="yippie"}}{{view.fooBar}}{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#foo').text(), 'yippie', "moves dasherized to camelized props");
+});
+
+test('Should allow access to dasherized property in view with a deprecation', function() {
+  expectDeprecation('Usage of `foo-bar` is deprecated, use `fooBar` instead.');
+
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" foo-bar="yippie"}}{{view.foo-bar}}{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#foo').text(), 'yippie', "moves dasherized to camelized props");
+});
+
+test('Should not throw deprecation if dasherized property is not accessed', function() {
+  expectNoDeprecation();
+
+  view = EmberView.create({
+    context: [],
+    controller: Ember.Object.create(),
+    template: Ember.Handlebars.compile('{{#view id="foo" foo-bar="yippie"}}{{view.fooBar}}{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#foo').text(), 'yippie', "moves dasherized to camelized props");
+});

--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -70,17 +70,11 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
   tagName: 'a',
 
   /**
-    @deprecated Use current-when instead.
-    @property currentWhen
-  */
-  currentWhen: null,
-
-  /**
     Used to determine when this LinkView is active.
 
     @property currentWhen
   */
-  'current-when': null,
+  currentWhen: null,
 
   /**
     Sets the `title` attribute of the `LinkView`'s HTML element.
@@ -211,8 +205,6 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
   init: function() {
     this._super.apply(this, arguments);
 
-    Ember.deprecate('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.', !this.currentWhen);
-
     // Map desired event name to invoke function
     var eventName = get(this, 'eventName');
     this.on(eventName, this, this._invoke);
@@ -315,7 +307,7 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
     var router = get(this, 'router');
     var loadedParams = get(this, 'loadedParams');
     var contexts = loadedParams.models;
-    var currentWhen = this['current-when'] || this.currentWhen;
+    var currentWhen = this.currentWhen;
     var isCurrentWhenSpecified = Boolean(currentWhen);
     currentWhen = currentWhen || loadedParams.targetRouteName;
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1871,6 +1871,8 @@ var View = CoreView.extend({
 
     Ember.assert("Only arrays are allowed for 'classNames'", typeOf(this.classNames) === 'array');
     this.classNames = emberA(this.classNames.slice());
+
+    this._setupDeprecatedProperties();
   },
 
   appendChild: function(view, options) {
@@ -2025,11 +2027,19 @@ var View = CoreView.extend({
       }
 
       setProperties(view, attrs);
-
     }
 
     return view;
   },
+
+  _setupDeprecatedProperties: function setupDeprecatedProperties() {
+    if (!this._deprecatedProperties) { return; }
+
+    for (var prop in this._deprecatedProperties) {
+      deprecateProperty(this, prop, this._deprecatedProperties[prop]);
+    }
+  },
+
 
   becameVisible: Ember.K,
   becameHidden: Ember.K,

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -267,9 +267,7 @@ test("The {{link-to}} helper supports leaving off .index for nested routes", fun
   equal(normalizeUrl(Ember.$('#item a', '#qunit-fixture').attr('href')), '/about');
 });
 
-test("The {{link-to}} helper supports currentWhen (DEPRECATED)", function() {
-  expectDeprecation('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.');
-
+test("The {{link-to}} helper supports currentWhen", function() {
   Router.map(function(match) {
     this.resource("index", { path: "/" }, function() {
       this.route("about");


### PR DESCRIPTION
After discussing the deprecations in https://github.com/emberjs/ember.js/pull/5388 with @mixonic, I believe that we actually need to allow consistent usage of dasherized property names from within Handlebars templates.

Dasherized properties are preferred for usage in HTML (and Handlebars).  This change allows the following:

``` handlebars
{{some-component foo-bar="yeah"}}

{{! The component will have this.fooBar as "yeah" from above }}
```

This paves the way for a much more normal looking HTMLBars world:

``` html
<some-component foo-bar="yeah" />

<!-- The component will have this.fooBar as "yeah" from above -->
```

---

Once this is merged I will work on deprecating camelized usage in templates.  I have the deprecation ready, but will need to update a number of test templates to use the newly available dasherized versions.

The goal is a single clear rule: Use dasherized properties in templates/HTML, and camelized properties in JavaScript.
