### PR TITLE
Prevents arguments from leaking

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -48,8 +48,12 @@ function superFunction(){
   var func = this.__nextSuper;
   var ret;
   if (func) {
+    var args = new Array(arguments.length);
+    for (var i = 0, l = args.length; i < l; i++) {
+      args[i] = arguments[i];
+    }
     this.__nextSuper = null;
-    ret = apply(this, func, arguments);
+    ret = apply(this, func, args);
     this.__nextSuper = func;
   }
   return ret;

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -394,9 +394,13 @@ export function metaPath(obj, path, writable) {
 export function wrap(func, superFunc) {
   function superWrapper() {
     var ret;
-    var sup = this && this.__nextSuper;
+    var sup  = this && this.__nextSuper;
+    var args = new Array(arguments.length);
+    for (var i = 0, l = args.length; i < l; i++) {
+      args[i] = arguments[i];
+    }
     if(this) { this.__nextSuper = superFunc; }
-    ret = apply(this, func, arguments);
+    ret = apply(this, func, args);
     if(this) { this.__nextSuper = sup; }
     return ret;
   }


### PR DESCRIPTION
The context for this fix is "Bad value context for arguments value" deoptimization. (when you try to materialize `arguments` object inside your function). This PR fixes it.

The example app I tested it on is [here](https://github.com/stefanpenner/perf-stress).

before  `superWrapper`:
![full-profile-super-wrapper-before](https://cloud.githubusercontent.com/assets/1131196/3976533/50b2a0ba-2825-11e4-9d61-b42fa81e4e45.png)

after  `superWrapper`:
![full-profile-super-wrapper-after](https://cloud.githubusercontent.com/assets/1131196/3976535/6b8c4918-2825-11e4-88a8-e4d73429c2f1.png)

before  `superFunction`:
![full-profile-super-function-before](https://cloud.githubusercontent.com/assets/1131196/3976539/791d3e52-2825-11e4-8ff0-64af41532b4d.png)

after  `superFunction`:
![full-profile-super-function-after](https://cloud.githubusercontent.com/assets/1131196/3976544/840bef34-2825-11e4-9efd-67d0489e6e72.png)
