### PR TITLE
[BUGFIX] Use view's template in render helper, if defined

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/render.js
+++ b/packages/ember-routing-handlebars/lib/helpers/render.js
@@ -114,7 +114,8 @@ export default function renderHelper(name, contextString, options) {
   // \ legacy slash as namespace support
 
 
-  view = container.lookup('view:' + name) || container.lookup('view:default');
+  var lookupView = container.lookup('view:' + name);
+  view = lookupView || container.lookup('view:default');
 
   // provide controller override
   var controllerName = options.hash.controller || name;
@@ -162,7 +163,7 @@ export default function renderHelper(name, contextString, options) {
 
   var templateName = 'template:' + name;
   Ember.assert("You used `{{render '" + name + "'}}`, but '" + name + "' can not be found as either a template or a view.", container.has("view:" + name) || container.has(templateName) || options.fn);
-  options.hash.template = container.lookup(templateName);
+  options.hash.template = (lookupView && lookupView.template) ? lookupView.template : container.lookup(templateName);
 
   options.hash.controller = controller;
 

--- a/packages/ember-routing-handlebars/tests/helpers/render_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/render_test.js
@@ -183,6 +183,25 @@ test("{{render}} helper should not have assertion if view exists without a templ
   equal(view.$().text(), 'HI');
 });
 
+test("{{render}} helper should prefer view's directly assigned template", function() {
+  var template = "{{render 'templated'}}";
+  var controller = EmberController.extend({container: container});
+  view = EmberView.create({
+    controller: controller.create(),
+    template: compile(template)
+  });
+
+  var directTemplate = 'DIRECT';
+  Ember.TEMPLATES['templated'] = compile("FROM_EM_TEMPLATES");
+  container.register('view:templated', EmberView.extend({
+    template: compile(directTemplate)
+  }));
+
+  appendView(view);
+
+  equal(view.$().text(), 'DIRECT');
+});
+
 test("{{render}} helper should render given template with a supplied model", function() {
   var template = "<h1>HI</h1>{{render 'post' post}}";
   var post = {


### PR DESCRIPTION
Prefer over default and also over what is set in Ember.TEMPLATES.
Demonstration jsfiddle: http://jsfiddle.net/NQKvy/1247/
