### PR TITLE
[BUGFIX beta] Use the jQuery polyfill for Node.prototype.contains

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -3,29 +3,13 @@
 import _default from "ember-views/views/states/default";
 import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
+import jQuery from "ember-views/system/jquery";
 
 /**
 @module ember
 @submodule ember-views
 */
 var preRender = create(_default);
-
-var containsElement;
-if (typeof Node === 'object') {
-  containsElement = Node.prototype.contains;
-
-  if (!containsElement && Node.prototype.compareDocumentPosition) {
-    // polyfill for older Firefox.
-    // http://compatibility.shwups-cms.ch/en/polyfills/?&id=52
-    containsElement = function(node){
-      return !!(this.compareDocumentPosition(node) & 16);
-    };
-  }
-} else {
-  containsElement = function(element) {
-    return this.contains(element);
-  };
-}
 
 merge(preRender, {
   // a view leaves the preRender state once its element has been
@@ -40,7 +24,7 @@ merge(preRender, {
 
     // We transition to `inDOM` if the element exists in the DOM
     var element = view.get('element');
-    if (containsElement.call(document.body, element)) {
+    if (jQuery.contains(document.body, element)) {
       viewCollection.transitionTo('inDOM', false);
       viewCollection.trigger('didInsertElement');
     }


### PR DESCRIPTION
Currently Ember is broken in FF17 (I'm not sure if others) because both `Node.contains` and `Node. compareDocumentPosition` are missing.

This swaps out the polyfill for the jQuery version.

Technically it's a BUGFIX release, but because of FF being evergreen and no other open bug reports, it's probably safe to wait.

ping @rwjblue
