### PR TITLE
Import keys, and bring back Ember.keys tests lost in shuffle.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-metal/core'; // Ember.assert
+import emberKeys from "ember-metal/keys";
 import dictionary from 'ember-metal/dictionary';
 
 // A lightweight container that helps to assemble and decouple components.
@@ -796,7 +797,7 @@ function instantiate(container, fullName) {
 
 function eachDestroyable(container, callback) {
   var cache = container.cache;
-  var keys = Ember.keys(cache);
+  var keys = emberKeys(cache);
   var key, value;
 
   for (var i = 0, l = keys.length; i < l; i++) {


### PR DESCRIPTION
These tests were deleted in https://github.com/emberjs/ember.js/pull/5411.
