### PR TITLE
Ensure defineProperties shim has a defineProperty to use.

### DIFF
--- a/packages/ember-metal/lib/platform.js
+++ b/packages/ember-metal/lib/platform.js
@@ -213,7 +213,7 @@ platform.hasPropertyAccessors = true;
 if (!platform.defineProperty) {
   platform.hasPropertyAccessors = false;
 
-  platform.defineProperty = function(obj, keyName, desc) {
+  defineProperty = platform.defineProperty = function(obj, keyName, desc) {
     if (!desc.get) { obj[keyName] = desc.value; }
   };
 


### PR DESCRIPTION
The Object.create shim uses a `defineProperty` local function, but in the case of IE8 we nullify the `defineProperty` local function and never reset it to what we use for `platform.defineProperty`.
