### PR TITLE
Do not use trim() in fillIn tests.

### DIFF
--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -724,8 +724,8 @@ test("`fillIn` takes context into consideration", function() {
   visit('/');
   fillIn('.current', '#parent', 'current value');
   andThen(function() {
-    equal(find('#first').val().trim(), 'current value');
-    equal(find('#second').val().trim(), '');
+    equal(find('#first').val(), 'current value');
+    equal(find('#second').val(), '');
   });
 });
 


### PR DESCRIPTION
`find('#first').val().trim()` causes an error in IE8 (not sure why), but
we don't actually need to trim at all.
