### PR TITLE
[BUGFIX beta] Move __nextSuper onto meta

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -45,12 +45,13 @@ var o_create = create;
 var metaFor = meta;
 
 function superFunction(){
-  var func = this.__nextSuper;
+  var m = metaFor(this);
+  var func = m.nextSuper;
   var ret;
-  if (func) {
-    this.__nextSuper = null;
+  if (func && func !== Ember.K) {
+    m.nextSuper = Ember.K;
     ret = apply(this, func, arguments);
-    this.__nextSuper = func;
+    m.nextSuper = func;
   }
   return ret;
 }
@@ -154,7 +155,7 @@ function giveMethodSuper(obj, key, method, values, descs) {
   // the original object
   superMethod = superMethod || obj[key];
 
-  // Only wrap the new method if the original method was a function
+  // Don't wrap the method if the parent is not a function
   if ('function' !== typeof superMethod) {
     return method;
   }
@@ -208,8 +209,7 @@ function addNormalizedProperty(base, key, value, meta, descs, values, concats, m
   if (value instanceof Descriptor) {
     if (value === REQUIRED && descs[key]) { return CONTINUE; }
 
-    // Wrap descriptor function to implement
-    // __nextSuper() if needed
+    // Wrap descriptor function to set meta.nextSuper if needed
     if (value.func) {
       value = giveDescriptorSuper(meta, key, value, values, descs);
     }

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -224,6 +224,7 @@ function Meta(obj) {
   this.cache = {};
   this.cacheMeta = {};
   this.source = obj;
+  this.nextSuper = Ember.K;
 }
 
 Meta.prototype = {
@@ -392,10 +393,16 @@ export function metaPath(obj, path, writable) {
 */
 export function wrap(func, superFunc) {
   function superWrapper() {
-    var ret, sup = this && this.__nextSuper;
-    if(this) { this.__nextSuper = superFunc; }
-    ret = apply(this, func, arguments);
-    if(this) { this.__nextSuper = sup; }
+    var ret;
+    if (this) {
+      var m = meta(this);
+      var sup = m.nextSuper;
+      m.nextSuper = superFunc;
+      ret = apply(this, func, arguments);
+      m.nextSuper = sup;
+    } else {
+      ret = apply(this, func, arguments);
+    }
     return ret;
   }
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -79,7 +79,6 @@ function makeCtor() {
       Class.proto(); // prepare prototype...
     }
     o_defineProperty(this, GUID_KEY, nullDescriptor);
-    o_defineProperty(this, '__nextSuper', undefinedDescriptor);
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -67,6 +67,8 @@ ArrayTests.extend({
 
 }).run();
 
+QUnit.module("Basic Mutable Array - misc");
+
 test("the return value of slice has Ember.Array applied", function() {
   var x = EmberObject.createWithMixins(EmberArray, {
     length: 0
@@ -74,6 +76,21 @@ test("the return value of slice has Ember.Array applied", function() {
   var y = x.slice(1);
   equal(EmberArray.detect(y), true, "mixin should be applied");
 });
+
+if (Object.freeze) {
+  test("contains on a froze array does not raise", function() {
+    var testArray = EmberArray.apply([]);
+    var throws = false;
+    Object.freeze(testArray);
+    try {
+      testArray.contains('whatever');
+    } catch(e) {
+      throws = true;
+    }
+
+    ok(!throws, "No exception thrown calling contains");
+  });
+}
 
 test("slice supports negative index arguments", function() {
   var testArray = new TestArray([1,2,3,4]);


### PR DESCRIPTION
Properties cannot be modified on a frozen object, which means even if the functions to not alter the context, the super implementation itself will raise an exception when a wrapped method calls (and changes `__nextSuper`).

Part of the challenge here is that Ember wraps functions defensively- it has no insight into if super will be called by a function and no tools for hinting about non-super-calling functions. Ember also follows a pattern of using hooks, so many methods are intended to be overridden even if the override will never call super. Unfortunately this pattern costs us. With either hinting or a new internals-only super syntax, we can improve the performance regardless.

But putting super on the meta we kill two birds with one stone. The property does not need to use slow defineProperty (it is already not enumerable on the object) and it can still be set regardless of an object being frozen.

This is not expected to have an impact on performance. The number of meta objects created during a run of the tests remains steady at about 22000 objects, and the number of requests for meta triples from 30k to 90k.

Fixes #4970, Fixes #5324, Fixes #5374
