### PR TITLE
Only instrument views with `instrumentDetails` defined

### DIFF
--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -115,7 +115,7 @@ EmberRenderer.prototype.childViews = function childViews(view) {
 };
 
 Renderer.prototype.willCreateElement = function (view) {
-  if (subscribers.length) {
+  if (subscribers.length && view.instrumentDetails) {
     view._instrumentEnd = _instrumentStart('render.'+view.instrumentName, function viewInstrumentDetails() {
       var details = {};
       view.instrumentDetails(details);


### PR DESCRIPTION
`SimpleHandlebarsView` does not define `instrumentDetails` because it is not intended to be instrumented.

Thanks to @cibernox for catching it. See http://pasteboard.co/2prLeL7b.png
