### PR TITLE
Remove dead code and polyfill for containsElement.

### DIFF
--- a/packages/ember-views/lib/views/states/pre_render.js
+++ b/packages/ember-views/lib/views/states/pre_render.js
@@ -1,5 +1,3 @@
-/* global Node */
-
 import _default from "ember-views/views/states/default";
 import { create } from "ember-metal/platform";
 import merge from "ember-metal/merge";
@@ -10,22 +8,5 @@ import jQuery from "ember-views/system/jquery";
 @submodule ember-views
 */
 var preRender = create(_default);
-
-var containsElement;
-if (typeof Node === 'object') {
-  containsElement = Node.prototype.contains;
-
-  if (!containsElement && Node.prototype.compareDocumentPosition) {
-    // polyfill for older Firefox.
-    // http://compatibility.shwups-cms.ch/en/polyfills/?&id=52
-    containsElement = function(node){
-      return !!(this.compareDocumentPosition(node) & 16);
-    };
-  }
-} else {
-  containsElement = function(element) {
-    return this.contains(element);
-  };
-}
 
 export default preRender;


### PR DESCRIPTION
This is not used since the metal-views merge.
