### PR TITLE
perf: only wrap methods that container _super in the function body

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -159,7 +159,17 @@ function giveMethodSuper(obj, key, method, values, descs) {
     return method;
   }
 
-  return wrap(method, superMethod);
+  var hasSuper = method.__hasSuper;
+
+  if (hasSuper === undefined) {
+    hasSuper = method.toString().indexOf('_super');
+  }
+
+  if (hasSuper) {
+    return wrap(method, superMethod);
+  } else {
+    return method;
+  }
 }
 
 function applyConcatenatedProperties(obj, key, value, values) {


### PR DESCRIPTION
Some statistics:

50 / 122 only 40% of methods currently being superWrapped need to be.

It also appears to have negligible negative performance impact (didn't even show up as a 0.01%)

stress app boot: superWrapper calls before: 48746 after: 21094

This seems to reduce the cost of total consumed superWrapper time by the same ratio (about 40%) but also has have a net positive impact on all functions that now don't need go through the wrapper. This allows those traces to be optimized and further inlined.

Another nice bonus, is that methods not needing to be wrapped are also now much more debuggable.

my stress test app (which ends up with like 50,000 bindings or something): https://github.com/stefanpenner/perf-stress

before;
![screenshot 2014-08-19 22 50 57](https://cloud.githubusercontent.com/assets/1377/3976326/f1148af2-281e-11e4-91fb-256918c23a50.png)

after:
![screenshot 2014-08-19 22 53 08](https://cloud.githubusercontent.com/assets/1377/3976327/f44ecc14-281e-11e4-8bb9-3739134bf51c.png)
