### PR TITLE
Update bb fast push unique

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },
   "devDependencies": {
-    "backburner": "https://github.com/ebryn/backburner.js.git#bf91c46978cced9aa130ca0793c5a72107e649db",
+    "backburner": "https://github.com/ebryn/backburner.js.git#30d4f505e935f7b588317f94a489dbdf44ec3a0b",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.13",
     "router.js": "https://github.com/tildeio/router.js.git#1562462f120156a140b9153bf36f1046f85e7812",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -159,7 +159,17 @@ function giveMethodSuper(obj, key, method, values, descs) {
     return method;
   }
 
-  return wrap(method, superMethod);
+  var hasSuper = method.__hasSuper;
+
+  if (hasSuper === undefined) {
+    hasSuper = method.toString().indexOf('_super');
+  }
+
+  if (hasSuper) {
+    return wrap(method, superMethod);
+  } else {
+    return method;
+  }
 }
 
 function applyConcatenatedProperties(obj, key, value, values) {

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -1,10 +1,14 @@
 import Ember from 'ember-metal/core';
-import { apply } from 'ember-metal/utils';
+import {
+  apply,
+  GUID_KEY
+} from 'ember-metal/utils';
 import { indexOf } from "ember-metal/array";
 import {
   beginPropertyChanges,
   endPropertyChanges
 } from 'ember-metal/property_events';
+import Backburner from 'backburner';
 
 function onBegin(current) {
   run.currentRunLoop = current;
@@ -15,8 +19,8 @@ function onEnd(current, next) {
 }
 
 // ES6TODO: should Backburner become es6?
-var Backburner = requireModule('backburner').Backburner;
 var backburner = new Backburner(['sync', 'actions', 'destroy'], {
+  GUID_KEY: GUID_KEY,
   sync: {
     before: beginPropertyChanges,
     after: endPropertyChanges


### PR DESCRIPTION
dirty 1000 ember data models with 5 active and rendered bindings each.

before:
![screenshot 2014-08-20 01 04 53](https://cloud.githubusercontent.com/assets/1377/3977013/24ed30ac-2830-11e4-9046-1ef2337393f2.png)
![screenshot 2014-08-20 01 07 37](https://cloud.githubusercontent.com/assets/1377/3977027/5a02699c-2830-11e4-86ff-93d5c8a5c3c3.png)

after:

![screenshot 2014-08-20 01 04 48](https://cloud.githubusercontent.com/assets/1377/3977015/2aadd4f6-2830-11e4-8f94-5ea976e97e4c.png)
![screenshot 2014-08-20 01 07 31](https://cloud.githubusercontent.com/assets/1377/3977030/5e43bb28-2830-11e4-9ddf-bef627e62877.png)

Another pathological churn example:

before:

![screenshot 2014-08-20 01 08 55](https://cloud.githubusercontent.com/assets/1377/3977037/88be51f6-2830-11e4-8909-582b2762d74e.png)

after:
![screenshot 2014-08-20 01 09 01](https://cloud.githubusercontent.com/assets/1377/3977040/9342f924-2830-11e4-9081-6cea52bf70ed.png)
