### PR TITLE
Update Morph to latest version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.13",
     "router.js": "https://github.com/tildeio/router.js.git#1562462f120156a140b9153bf36f1046f85e7812",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
-    "htmlbars": "https://github.com/tildeio/htmlbars.git#1a4d5985824f4df23bb6e78829e442fe368937aa"
+    "htmlbars": "https://github.com/tildeio/htmlbars.git#7889d3f4d2a979f8e32648c92afa033f1f32b434"
   }
 }


### PR DESCRIPTION
Compare view:

https://github.com/tildeio/htmlbars/compare/1a4d5985824f4df23bb6e78829e442fe368937aa...7889d3f4d2a979f8e32648c92afa033f1f32b434

This includes some perf fixes (in https://github.com/tildeio/htmlbars/pull/79) by Stef to allow Morph's constructor to be inlineable.
