### PR TITLE
"Bad value context for arguments value" deoptimization in `String.fmt`.

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -55,15 +55,21 @@ var STRING_UNDERSCORE_REGEXP_1 = (/([a-z\d])([A-Z]+)/g);
 var STRING_UNDERSCORE_REGEXP_2 = (/\-|\s+/g);
 
 function fmt(str, formats) {
-  if (!isArray(formats) || arguments.length > 2) {
-    formats = Array.prototype.slice.call(arguments, 1);
+  var cachedFormats = formats;
+
+  if (!isArray(cachedFormats) || arguments.length > 2) {
+    cachedFormats = new Array(arguments.length - 1);
+
+    for (var i = 1, l = arguments.length; i < l; i++) {
+      cachedFormats[i - 1] = arguments[i];
+    }
   }
 
   // first, replace any ORDERED replacements.
   var idx  = 0; // the current index for non-numerical replacements
   return str.replace(/%@([0-9]+)?/g, function(s, argIndex) {
     argIndex = (argIndex) ? parseInt(argIndex, 10) - 1 : idx++;
-    s = formats[argIndex];
+    s = cachedFormats[argIndex];
     return (s === null) ? '(null)' : (s === undefined) ? '' : emberInspect(s);
   });
 }


### PR DESCRIPTION
This deoptimization occurs when you try to re-assign arguments passed into the function.

Also, this change swaps slow `Array.prototype.slice` with `for loop`, here's a related [benchmark](https://gist.github.com/twokul/2632ed3df1d3e6d49000).

before:
![fmt-before](https://cloud.githubusercontent.com/assets/1131196/3981272/36463740-286c-11e4-8bbc-8d3dd80448e0.png)

after:
![fmt-after](https://cloud.githubusercontent.com/assets/1131196/3981279/410d61bc-286c-11e4-92d1-52bdb2d98f74.png)
