### PR TITLE
Pass depKey and old/new value to will/didChange

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -152,7 +152,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
   // if key is being watched, override chains that
   // were initialized with the prototype
-  if (watching) { overrideChains(obj, keyName, meta); }
+  if (watching) { overrideChains(obj, keyName, meta, undefined, data); }
 
   // The `value` passed to the `didDefineProperty` hook is
   // either the descriptor or data, whichever was passed.

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -30,9 +30,11 @@ var deferred = 0;
   @for Ember
   @param {Object} obj The object with the property that will change
   @param {String} keyName The property key (or path) that will change.
+  @param {String} depKey The named of the dependent key that fires the change (if any).
+  @param          newValue The new value of the property.
   @return {void}
 */
-function propertyWillChange(obj, keyName) {
+function propertyWillChange(obj, keyName, depKey, changeInfo) {
   var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
@@ -40,9 +42,9 @@ function propertyWillChange(obj, keyName) {
 
   if (!watching) { return; }
   if (proto === obj) { return; }
-  if (desc && desc.willChange) { desc.willChange(obj, keyName); }
-  dependentKeysWillChange(obj, keyName, m);
-  chainsWillChange(obj, keyName, m);
+  if (desc && desc.willChange) { desc.willChange(obj, keyName, depKey, changeInfo); }
+  dependentKeysWillChange(obj, keyName, changeInfo, m);
+  chainsWillChange(obj, keyName, m, depKey, changeInfo);
   notifyBeforeObservers(obj, keyName);
 }
 
@@ -57,11 +59,13 @@ function propertyWillChange(obj, keyName) {
 
   @method propertyDidChange
   @for Ember
-  @param {Object} obj The object with the property that will change
+  @param {Object} obj The object with the property that will change.
   @param {String} keyName The property key (or path) that will change.
+  @param {String} depKey The named of the dependent key that fires the change (if any).
+  @param          changeInfo Information about the change being made.
   @return {void}
 */
-function propertyDidChange(obj, keyName) {
+function propertyDidChange(obj, keyName, depKey, changeInfo) {
   var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
@@ -70,20 +74,20 @@ function propertyDidChange(obj, keyName) {
   if (proto === obj) { return; }
 
   // shouldn't this mean that we're watching this key?
-  if (desc && desc.didChange) { desc.didChange(obj, keyName); }
+  if (desc && desc.didChange) { desc.didChange(obj, keyName, depKey, changeInfo); }
   if (!watching && keyName !== 'length') { return; }
 
   if (m && m.deps && m.deps[keyName]) {
-    dependentKeysDidChange(obj, keyName, m);
+    dependentKeysDidChange(obj, keyName, changeInfo, m);
   }
 
-  chainsDidChange(obj, keyName, m, false);
+  chainsDidChange(obj, keyName, m, false, depKey, changeInfo);
   notifyObservers(obj, keyName);
 }
 
 var WILL_SEEN, DID_SEEN;
 // called whenever a property is about to change to clear the cache of any dependent keys (and notify those properties of changes, etc...)
-function dependentKeysWillChange(obj, depKey, meta) {
+function dependentKeysWillChange(obj, depKey, changeInfo, meta) {
   if (obj.isDestroying) { return; }
 
   var deps;
@@ -91,13 +95,13 @@ function dependentKeysWillChange(obj, depKey, meta) {
     var seen = WILL_SEEN;
     var top = !seen;
     if (top) { seen = WILL_SEEN = {}; }
-    iterDeps(propertyWillChange, obj, deps, depKey, seen, meta);
+    iterDeps(propertyWillChange, obj, deps, depKey, changeInfo, seen, meta);
     if (top) { WILL_SEEN = null; }
   }
 }
 
 // called whenever a property has just changed to update dependent keys
-function dependentKeysDidChange(obj, depKey, meta) {
+function dependentKeysDidChange(obj, depKey, changeInfo, meta) {
   if (obj.isDestroying) { return; }
 
   var deps;
@@ -105,7 +109,7 @@ function dependentKeysDidChange(obj, depKey, meta) {
     var seen = DID_SEEN;
     var top = !seen;
     if (top) { seen = DID_SEEN = {}; }
-    iterDeps(propertyDidChange, obj, deps, depKey, seen, meta);
+    iterDeps(propertyDidChange, obj, deps, depKey, changeInfo, seen, meta);
     if (top) { DID_SEEN = null; }
   }
 }
@@ -116,7 +120,7 @@ function keysOf(obj) {
   return keys;
 }
 
-function iterDeps(method, obj, deps, depKey, seen, meta) {
+function iterDeps(method, obj, deps, depKey, changeInfo, seen, meta) {
   var keys, key, i, desc;
   var guid = guidFor(obj);
   var current = seen[guid];
@@ -131,12 +135,12 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
       key = keys[i];
       desc = descs[key];
       if (desc && desc._suspended === obj) continue;
-      method(obj, key);
+      method(obj, key, depKey, changeInfo);
     }
   }
 }
 
-function chainsWillChange(obj, keyName, m) {
+function chainsWillChange(obj, keyName, m, depKey, changeInfo) {
   if (!(m.hasOwnProperty('chainWatchers') &&
         m.chainWatchers[keyName])) {
     return;
@@ -151,11 +155,11 @@ function chainsWillChange(obj, keyName, m) {
   }
 
   for (i = 0, l = events.length; i < l; i += 2) {
-    propertyWillChange(events[i], events[i+1]);
+    propertyWillChange(events[i], events[i+1], depKey, changeInfo);
   }
 }
 
-function chainsDidChange(obj, keyName, m, suppressEvents) {
+function chainsDidChange(obj, keyName, m, suppressEvents, depKey, changeInfo) {
   if (!(m && m.hasOwnProperty('chainWatchers') &&
         m.chainWatchers[keyName])) {
     return;
@@ -174,12 +178,12 @@ function chainsDidChange(obj, keyName, m, suppressEvents) {
   }
 
   for (i = 0, l = events.length; i < l; i += 2) {
-    propertyDidChange(events[i], events[i+1]);
+    propertyDidChange(events[i], events[i+1], depKey, changeInfo);
   }
 }
 
-function overrideChains(obj, keyName, m) {
-  chainsDidChange(obj, keyName, m, true);
+function overrideChains(obj, keyName, m, depKey, changeInfo) {
+  chainsDidChange(obj, keyName, m, true, depKey, changeInfo);
 }
 
 /**

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -78,7 +78,7 @@ var set = function set(obj, keyName, value, tolerant) {
       }
       // only trigger a change if the value has changed
       if (value !== currentValue) {
-        propertyWillChange(obj, keyName);
+        propertyWillChange(obj, keyName, undefined, value);
         if (Ember.FEATURES.isEnabled('mandatory-setter')) {
           if (hasPropertyAccessors) {
             if ((currentValue === undefined && !(keyName in obj)) || !obj.propertyIsEnumerable(keyName)) {
@@ -92,7 +92,7 @@ var set = function set(obj, keyName, value, tolerant) {
         } else {
           obj[keyName] = value;
         }
-        propertyDidChange(obj, keyName);
+        propertyDidChange(obj, keyName, undefined, currentValue);
       }
     } else {
       obj[keyName] = value;

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -221,7 +221,7 @@ export default Mixin.create({
     var found = this.find(function(item) {
       return item === obj;
     });
-    
+
     return found !== undefined;
   },
 
@@ -987,7 +987,7 @@ export default Mixin.create({
     var didChange  = (opts && opts.didChange) || 'enumerableDidChange';
     var hasObservers = get(this, 'hasEnumerableObservers');
 
-    if (!hasObservers) { 
+    if (!hasObservers) {
       propertyWillChange(this, 'hasEnumerableObservers');
     }
 
@@ -1081,7 +1081,7 @@ export default Mixin.create({
       adding = null;
     }
 
-    propertyWillChange(this, '[]');
+    propertyWillChange(this, '[]', undefined, {removing: removing, adding: adding});
 
     if (hasDelta) {
       propertyWillChange(this, 'length');
@@ -1141,7 +1141,7 @@ export default Mixin.create({
       propertyDidChange(this, 'length');
     }
 
-    propertyDidChange(this, '[]');
+    propertyDidChange(this, '[]', undefined, {removing: removing, adding: adding});
 
     return this ;
   },


### PR DESCRIPTION
Some context:
I found myself in a situation where I needed to store, inside the `didChange` hook of a reduceComputed property, which dependency has changed and its previous valued, but there was no way of knowing this.

When a property is `set`, we invalidate the cache and propagate invoke `willChange` and `didChange` of properties that depend on the property being modified, but the only information we pass is the object and the name of the property in that object. That's not very useful. I don't see the reason to be so selective, since we have the information available. The code just don't passed it. 

Now it does.
- `willChange`  now receives the new value about to be set.
- `didChange`  now receives the old value just overwritten. 
- Both, when being invoked by `dependentKeysWillChange` receive the name of the dependent key.

Since the values where there all the time, I don't think there is any performance penalty at all for passing along 2 values.

I don't have still a clear idea of how should a place tests for this improvement.

Makes sense? I can point you to what I am doing if you want to see a use case for this.
