### PR TITLE
[FEATURE ember-handlebars-compiler-ast-to-precompile] Revert.

### DIFF
--- a/features.json
+++ b/features.json
@@ -10,8 +10,7 @@
     "ember-metal-is-present": true,
     "property-brace-expansion-improvement": true,
     "ember-routing-handlebars-action-with-key-code": null,
-    "ember-runtime-item-controller-inline-class": null,
-    "ember-handlebars-compiler-ast-to-precompile": null
+    "ember-runtime-item-controller-inline-class": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -271,20 +271,7 @@ EmberHandlebars.Compiler.prototype.mustache = function(mustache) {
                             compiled template should be returned as an Object or a String
 */
 EmberHandlebars.precompile = function(value, asObject) {
-  var ast;
-
-  if (Ember.FEATURES.isEnabled("ember-handlebars-compiler-ast-to-precompile")) {
-
-    if ( typeof value === 'string' ) {
-      ast = Handlebars.parse(value);
-    } else if ( typeof value === 'object' ) {
-      ast = value;
-    }
-
-    Ember.assert("You can only pass a template string or a Handlebars AST to precompiled. You passed an item that has the type of " + typeof value + " which is not a template or AST.", typeof value !== "string" || typeof value !== "object");
-  } else {
-    ast = Handlebars.parse(value);
-  }
+  var ast = Handlebars.parse(value);
 
   var options = {
     knownHelpers: {

--- a/packages/ember-handlebars-compiler/tests/precompile_type_test.js
+++ b/packages/ember-handlebars-compiler/tests/precompile_type_test.js
@@ -21,12 +21,8 @@ test("precompile creates a string when asObject is false", function(){
   equal(typeof(result), "string");
 });
 
-if (Ember.FEATURES.isEnabled("ember-handlebars-compiler-ast-to-precompile")) {
-  test("precompile creates a function when passed an AST", function(){
-    var ast = parse(template);
-    result = precompile(ast);
-    equal(typeof(result), "function");
-  });
-}
-
-
+test("precompile creates a function when passed an AST", function(){
+  var ast = parse(template);
+  result = precompile(ast);
+  equal(typeof(result), "function");
+});


### PR DESCRIPTION
Apparently, the changes in ember-handlebars-compiler were not needed.

I left the test in place (unflagged) to confirm we do not regress.

/cc @chadhietala
