### PR TITLE
[DOC] fix typo in computed_macros.js

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -258,7 +258,7 @@ registerComputed('equal', function(dependentKey, value) {
 });
 
 /**
-  A computed property that returns true if the provied dependent property
+  A computed property that returns true if the provided dependent property
   is greater than the provided value.
 
   Example


### PR DESCRIPTION
change 'provied' to 'provided' to improve API doc readability.
