### PR TITLE
Remove isContainer flag

### DIFF
--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -37,25 +37,6 @@ EmberRenderer.prototype.cancelRender =
     run.cancel(id);
   };
 
-EmberRenderer.prototype.createChildViewsMorph =
-  function EmberRenderer_createChildViewsMorph(view, _element) {
-    if (view.createChildViewsMorph) {
-      return view.createChildViewsMorph(_element);
-    }
-    var element = _element;
-    if (view.tagName === '') {
-      if (view._morph) {
-        view._childViewsMorph = view._morph;
-      } else {
-        element = document.createDocumentFragment();
-        view._childViewsMorph = this._dom.appendMorph(element);
-      }
-    } else {
-      view._childViewsMorph = this._dom.createMorph(element, element.lastChild, null);
-    }
-    return element;
-  };
-
 EmberRenderer.prototype.createElement =
   function EmberRenderer_createElement(view) {
     // If this is the top-most view, start a new buffer. Otherwise,
@@ -90,10 +71,6 @@ EmberRenderer.prototype.createElement =
     }
 
     var element = buffer.element();
-
-    if (view.isContainer) {
-      this.createChildViewsMorph(view, element);
-    }
 
     view.buffer = null;
     if (element && element.nodeType === 1) {

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -184,7 +184,6 @@ var states = cloneStates(EmberViewStates);
   @extends Ember.View
 */
 var ContainerView = View.extend(MutableArray, {
-  isContainer: true,
   _states: states,
 
   willWatchProperty: function(prop){
@@ -263,6 +262,21 @@ var ContainerView = View.extend(MutableArray, {
     @param {Ember.RenderBuffer} buffer the buffer to render to
   */
   render: function(buffer) {
+    var element = buffer.element();
+    var dom = buffer.dom;
+
+    if (this.tagName === '') {
+      if (this._morph) {
+        this._childViewsMorph = this._morph;
+      } else {
+        element = dom.createDocumentFragment();
+        this._childViewsMorph = dom.appendMorph(element);
+      }
+    } else {
+      this._childViewsMorph = dom.createMorph(element, element.lastChild, null);
+    }
+
+    return element;
   },
 
   instrumentName: 'container',

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -35,7 +35,6 @@ import { instrument } from "ember-metal/instrumentation";
 var CoreView = EmberObject.extend(Evented, ActionHandler, {
   isView: true,
   isVirtual: false,
-  isContainer: false,
 
   _states: cloneStates(states),
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -35,24 +35,22 @@ test("should dispatch events to views", function() {
   var childKeyDownCalled = 0;
   var parentKeyDownCalled = 0;
 
-  view = ContainerView.createWithMixins({
-    childViews: ['child'],
+  var childView = View.createWithMixins({
+    render: function(buffer) {
+      buffer.push('<span id="wot">ewot</span>');
+    },
 
-    child: View.extend({
-      render: function(buffer) {
-        buffer.push('<span id="wot">ewot</span>');
-      },
+    keyDown: function(evt) {
+      childKeyDownCalled++;
 
-      keyDown: function(evt) {
-        childKeyDownCalled++;
+      return false;
+    }
+  });
 
-        return false;
-      }
-    }),
-
+  view = View.createWithMixins({
     render: function(buffer) {
       buffer.push('some <span id="awesome">awesome</span> content');
-      this._super(buffer);
+      this.appendChild(childView);
     },
 
     mouseDown: function(evt) {


### PR DESCRIPTION
The ember renderer no longer special cases the container view. The metal renderer still contains logic related to `_childViewsMorph`.

I had to modify an old test that was modifying a container view's buffer directly.
