### PR TITLE
[BUGFIX release] Allow for bound property {{input}} type.

### DIFF
--- a/packages/ember-handlebars/lib/controls.js
+++ b/packages/ember-handlebars/lib/controls.js
@@ -204,14 +204,16 @@ export function inputHelper(options) {
   var inputType = _resolveOption(this, options, 'type');
   var onEvent = hash.on;
 
-  delete hash.type;
-  delete hash.on;
-
   if (inputType === 'checkbox') {
+    delete hash.type;
+    delete types.type;
+
     Ember.assert("{{input type='checkbox'}} does not support setting `value=someBooleanValue`; you must use `checked=someBooleanValue` instead.", options.hashTypes.value !== 'ID');
+
     return helpers.view.call(this, Checkbox, options);
   } else {
-    if (inputType) { hash.type = inputType; }
+    delete hash.on;
+
     hash.onEvent = onEvent || 'enter';
     return helpers.view.call(this, TextField, options);
   }

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -158,6 +158,29 @@ test("input tabindex is updated when setting tabindex property of view", functio
   equal(textField.$('input').attr('tabindex'), "5", "renders text field with the tabindex");
 });
 
+QUnit.module("{{input type='text'}} - dynamic type", {
+  setup: function() {
+    controller = {
+      someProperty: 'password'
+    };
+
+    textField = View.extend({
+      controller: controller,
+      template: compile('{{input type=someProperty}}')
+    }).create();
+
+    append();
+  },
+
+  teardown: function() {
+    destroy(textField);
+  }
+});
+
+test("should insert a text field into DOM", function() {
+  equal(textField.$('input').attr('type'), 'password', "a bound property can be used to determine type.");
+});
+
 QUnit.module("{{input}} - default type", {
   setup: function() {
     controller = {};


### PR DESCRIPTION
Closes #5348.
