### PR TITLE
Prevent extra method.toString checks.

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -167,6 +167,7 @@ function giveMethodSuper(obj, key, method, values, descs) {
 
   if (hasSuper === undefined) {
     hasSuper = method.toString().indexOf('_super');
+    method.__hasSuper = hasSuper;
   }
 
   if (hasSuper) {


### PR DESCRIPTION
It appears that the intent here was to only check the `method.toString().indexOf('_super')` once, and store the result so that we do not need to check the same method twice, but we were never actual storing `__hasSuper` on the method so it was just always going to check the `toString`.

@stefanpenner - Can you confirm this was your original intent?
