### PR TITLE
String.prototype.indexOf returns -1 for non-matches.

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -166,7 +166,7 @@ function giveMethodSuper(obj, key, method, values, descs) {
   var hasSuper = method.__hasSuper;
 
   if (hasSuper === undefined) {
-    hasSuper = method.toString().indexOf('_super');
+    hasSuper = method.toString().indexOf('_super') > -1;
     method.__hasSuper = hasSuper;
   }
 


### PR DESCRIPTION
Previous check would wrap everything (unless `_super` was at position `0` which is not possible).
