### PR TITLE
[FEATURE conditional-observers-and-listeners]

### DIFF
--- a/features.json
+++ b/features.json
@@ -10,7 +10,8 @@
     "ember-metal-is-present": true,
     "property-brace-expansion-improvement": true,
     "ember-routing-handlebars-action-with-key-code": null,
-    "ember-runtime-item-controller-inline-class": null
+    "ember-runtime-item-controller-inline-class": null,
+    "conditional-observers-and-listeners": true
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -407,6 +407,9 @@ export function wrap(func, superFunc) {
 
   superWrapper.wrappedFunction = func;
   superWrapper.wrappedFunction.__ember_arity__ = func.length;
+  if (Ember.FEATURES.isEnabled("conditional-observers-and-listeners")) {
+    superWrapper.__ember_conditions__ = func.__ember_conditions__;
+  }
   superWrapper.__ember_observes__ = func.__ember_observes__;
   superWrapper.__ember_observesBefore__ = func.__ember_observesBefore__;
   superWrapper.__ember_listens__ = func.__ember_listens__;

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -6,7 +6,7 @@
 import Ember from 'ember-metal/core'; // Ember.EXTEND_PROTOTYPES, Ember.assert
 import expandProperties from 'ember-metal/expand_properties';
 import { computed } from 'ember-metal/computed';
-import { observer } from "ember-metal/mixin";
+import { observer, when } from "ember-metal/mixin";
 
 var a_slice = Array.prototype.slice;
 var FunctionPrototype = Function.prototype;
@@ -212,4 +212,42 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
     return this;
   };
+
+  if (Ember.FEATURES.isEnabled("conditional-observers-and-listeners")) {
+    /**
+     The `when` extension of JavaScript's Function prototype is
+     available when `Ember.EXTEND_PROTOTYPES` or
+     `Ember.EXTEND_PROTOTYPES.Function` is true, which is the default.
+
+     You can specify conditions that control when an observer and/or listener
+     should fire. For example:
+
+     ```javascript
+     Ember.TextField.extend({
+
+       isSelectAllTextEnabled: true,
+
+       selectAllText: function() {
+         // Executes whenever the "focusIn" event occurs
+         // and isSelectAllTextEnabled is true
+         this.$().select();
+       }.on('focusIn').when('isSelectAllTextEnabled')
+    });
+     ```
+
+     See `Ember.when`.
+
+     @method when
+     @for Function
+     */
+    FunctionPrototype.when = function () {
+      var length = arguments.length;
+      var args = new Array(length);
+      for (var x = 0; x < length; x++) {
+        args[x] = arguments[x];
+      }
+
+      return when.apply(this, args.concat(this));
+    };
+  }
 }

--- a/packages/ember-runtime/tests/ext/function_test.js
+++ b/packages/ember-runtime/tests/ext/function_test.js
@@ -104,3 +104,117 @@ testBoth('sets up a ComputedProperty', function(get, set) {
   set(obj, 'lastName', "");
   equal(get(obj, 'fullName'), 'Wilma ', 'should return the new computed value');
 });
+
+if (Ember.FEATURES.isEnabled("conditional-observers-and-listeners")) {
+  QUnit.module('Function.prototype.when() helper');
+
+  testBoth('conditional listener initially enabled', function (get, set) {
+
+    if (Ember.EXTEND_PROTOTYPES === false) {
+      ok("undefined" === typeof Function.prototype.property, 'Function.prototype helper disabled');
+      return;
+    }
+
+    var triggered = 0;
+    var obj = Ember.Object.createWithMixins(Ember.Evented, {
+      foo: function () { triggered++; }.on('bar').when('baz'),
+      baz: true
+    });
+
+    equal(triggered, 0, 'listener is enabled; should not invoke listener immediately');
+
+    obj.trigger('bar');
+    equal(triggered, 1, 'listener is enabled; should invoke listener on event');
+
+    set(obj, 'baz', false);
+    obj.trigger('bar');
+    equal(triggered, 1, 'listener is disabled; should not invoke listener on event');
+
+    set(obj, 'baz', true);
+    obj.trigger('bar');
+    equal(triggered, 2, 'listener is re-enabled; should invoke listener on event');
+  });
+
+  testBoth('conditional listener initially disabled', function (get, set) {
+
+    if (Ember.EXTEND_PROTOTYPES === false) {
+      ok("undefined" === typeof Function.prototype.property, 'Function.prototype helper disabled');
+      return;
+    }
+
+    var triggered = 0;
+    var obj = Ember.Object.createWithMixins(Ember.Evented, {
+      foo: function () { triggered++; }.on('bar').when('baz'),
+      baz: false
+    });
+
+    equal(triggered, 0, 'listener is disabled; should not invoke listener immediately');
+
+    obj.trigger('bar');
+    equal(triggered, 0, 'listener is disabled; should not invoke listener on event');
+
+    set(obj, 'baz', true);
+    obj.trigger('bar');
+    equal(triggered, 1, 'listener is enabled; should invoke listener on event');
+
+    set(obj, 'baz', false);
+    obj.trigger('bar');
+    equal(triggered, 1, 'listener is re-disabled; should not invoke listener on event');
+  });
+
+  testBoth('conditional observer initially enabled', function (get, set) {
+
+    if (Ember.EXTEND_PROTOTYPES === false) {
+      ok("undefined" === typeof Function.prototype.property, 'Function.prototype helper disabled');
+      return;
+    }
+
+    var triggered = 0;
+    var obj = Ember.Object.createWithMixins({
+      foo: function () { triggered++; }.observes('bar').when('baz'),
+      bar: undefined,
+      baz: true
+    });
+
+    equal(triggered, 0, 'observer is enabled; should not invoke observer immediately');
+
+    set(obj, 'bar', 'QUX');
+    equal(triggered, 1, 'observer is enabled; should invoke observer after change');
+
+    set(obj, 'baz', false);
+    set(obj, 'bar', 'QUUX');
+    equal(triggered, 1, 'observer is disabled; should not invoke observer after change');
+
+    set(obj, 'baz', true);
+    set(obj, 'bar', 'QUX');
+    equal(triggered, 2, 'observer is re-enabled; should invoke observer after change');
+  });
+
+  testBoth('conditional observer initially disabled', function (get, set) {
+
+    if (Ember.EXTEND_PROTOTYPES === false) {
+      ok("undefined" === typeof Function.prototype.property, 'Function.prototype helper disabled');
+      return;
+    }
+
+    var triggered = 0;
+    var obj = Ember.Object.createWithMixins({
+      foo: function () { triggered++; }.observes('bar').when('baz'),
+      bar: undefined,
+      baz: false
+    });
+
+    equal(triggered, 0, 'observer is disabled; should not invoke observer immediately');
+
+    set(obj, 'bar', 'QUX');
+    equal(triggered, 0, 'observer is disabled; should not invoke observer after change');
+
+    set(obj, 'baz', true);
+    set(obj, 'bar', 'QUUX');
+    equal(triggered, 1, 'observer is enabled; should invoke observer after change');
+
+    set(obj, 'baz', false);
+    set(obj, 'bar', 'QUX');
+    equal(triggered, 1, 'observer is re-disabled; should not invoke observer after change');
+  });
+}

--- a/packages/ember-runtime/tests/system/object/events_test.js
+++ b/packages/ember-runtime/tests/system/object/events_test.js
@@ -1,5 +1,7 @@
 import EmberObject from "ember-runtime/system/object";
 import Evented from "ember-runtime/mixins/evented";
+import { on } from "ember-metal/events";
+import { when } from 'ember-metal/mixin';
 
 QUnit.module("Object events");
 
@@ -140,3 +142,33 @@ test("adding and removing listeners should be chainable", function() {
   ret = obj.one('event!', F);
   equal(ret, obj, '#one returns self');
 });
+
+if (Ember.FEATURES.isEnabled("conditional-observers-and-listeners")) {
+  test('conditional listener respects initial condition: true', function () {
+
+    var triggered = 0;
+    var obj = EmberObject.createWithMixins(Evented, {
+      foo: on('bar', when('baz', function () { triggered++; })),
+      baz: true
+    });
+
+    equal(triggered, 0, 'listener is enabled; should not invoke listener immediately');
+
+    obj.trigger('bar');
+    equal(triggered, 1, 'listener is enabled; should invoke listener on event');
+  });
+
+  test('conditional listener respects initial condition: false', function () {
+
+    var triggered = 0;
+    var obj = EmberObject.createWithMixins(Evented, {
+      foo: on('bar', when('baz', function () { triggered++; })),
+      baz: false
+    });
+
+    equal(triggered, 0, 'listener is disabled; should not invoke listener immediately');
+
+    obj.trigger('bar');
+    equal(triggered, 0, 'listener is disabled; should not invoke listener on event');
+  });
+}

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -3,6 +3,7 @@ import {observer} from "ember-metal/mixin";
 import run from "ember-metal/run_loop";
 import {testBoth} from 'ember-runtime/tests/props_helper';
 import EmberObject from "ember-runtime/system/object";
+import { when } from 'ember-metal/mixin';
 
 QUnit.module('EmberObject observer');
 
@@ -199,3 +200,35 @@ testBoth('chain observer on class', function(get, set) {
   equal(get(obj1, 'count'), 1, 'should not invoke again');
   equal(get(obj2, 'count'), 1, 'should invoke observer on obj2');
 });
+
+if (Ember.FEATURES.isEnabled("conditional-observers-and-listeners")) {
+  testBoth('conditional observer respects initial condition: true', function (get, set) {
+
+    var triggered = 0;
+    var obj = EmberObject.createWithMixins({
+      foo: observer('bar', when('baz', function () { triggered++; })),
+      bar: undefined,
+      baz: true
+    });
+
+    equal(triggered, 0, 'observer is enabled; should not invoke observer immediately');
+
+    set(obj, 'bar', 'QUX');
+    equal(triggered, 1, 'observer is enabled; should invoke observer after change');
+  });
+
+  testBoth('conditional observer respects initial condition: false', function (get, set) {
+
+    var triggered = 0;
+    var obj = EmberObject.createWithMixins({
+      foo: observer('bar', when('baz', function () { triggered++; })),
+      bar: undefined,
+      baz: false
+    });
+
+    equal(triggered, 0, 'observer is disabled; should not invoke observer immediately');
+
+    set(obj, 'bar', 'QUX');
+    equal(triggered, 0, 'observer is disabled; should not invoke observer after change');
+  });
+}


### PR DESCRIPTION
I find myself doing the following a lot:

``` js
SomeClass = Ember.Object.extend({

  enabled: true,

  value: 'foo',

  valueDidChange: function() {
    if (this.get('enabled')) {
      // do something after value changes only when enabled is true
    }
  }.observes('enabled', 'value')
});
```

That works fine under normal circumstances but what happens when your dealing with a large number of these objects and `value` changes frequently when `enabled` is `false`? The `valueDidChange` observer fires needlessly on all of those objects, basically it adds additional overhead that accomplishes nothing.

If we refactor the code a bit, we can avoid this:

``` js
SomeClass = Ember.Object.extend({

  enabled: true,

  enabledDidChange: function() {
    if (this.get('enabled')) {
      Ember.addObserver(this, 'value', null, 'valueDidChangeWhenEnabled');
    } else {
      Ember.removeObserver(this, 'value', null, 'valueDidChangeWhenEnabled');
    }
  }.observes('enabled'),

  value: 'foo',

  valueDidChangeWhenEnabled: function() {
    // do something after value changes only when enabled is true
  }
});
```

Now the `value` observer will only fire when `enabled` is `true` because it only exists when `enabled` is `true`. Basically, we've introduced a conditional observer. There were quite a few places where I found this sort of thing useful. So I came up with this commit that essentially allows one to do the same thing in a bit more declarative way:

``` js
SomeClass = Ember.Object.extend({

  enabled: true,

  value: 'foo',

  doSomething: function() {
    // do something after value changes only when enabled is true
  }.observes('value').when('enabled')
});
```

This commit also allows `when` to work with listeners:

``` javascript
Ember.TextField.extend({

  selectIsEnabled: true,

  select: function() {
    // Executes on "focusIn" only when selectIsEnabled is true
    this.$().select();
  }.on('focusIn').when('selectIsEnabled')
});
```

Thoughts?
