### PR TITLE
[BUGFIX release] Ensure exports are setup for node build.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -581,7 +581,14 @@ function buildRuntimeTree() {
     destFile: '/ember-runtime.js'
   });
 
-  return compiledRuntime;
+
+  var exportsTree = writeFile('export-ember', ';module.exports = Ember;\n');
+
+  return concat(mergeTrees([compiledRuntime, exportsTree]), {
+    wrapInEval: false,
+    inputFiles: ['ember-runtime.js', 'export-ember'],
+    outputFile: '/ember-runtime.js'
+  });
 }
 
 // Takes original source file and removes the ember-debug package.


### PR DESCRIPTION
With this you can more easily use the Ember object system in node.

Generate with `npm run build`.

Then you can run the following in a `node` REPL:

``` javascript
Ember = require('./dist/ember-runtime');

var Person = Ember.Object.extend({
  firstName: null,
  lastName: null,
  fullName: Ember.computed('firstName', 'lastName', function() {
    return this.get('lastName') + ', ' + this.get('firstName');
  })
});

var max   = Person.create({ firstName: 'Max', lastName: 'Jackson'});
var james = Person.create({ firstName: 'James', lastName: 'Jackson'});

max.get('fullName'); //=> Jackson, Max
james.get('fullName'); //=> Jackson, James
```
