### PR TITLE
Handlebars 2.x Update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember",
   "dependencies": {
-    "handlebars": "~1.3.0",
+    "handlebars": "~2.0.0",
     "jquery": "~1.11.1",
     "qunit": "~1.12.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"

--- a/lib/broccoli-ember-inline-template-precompiler.js
+++ b/lib/broccoli-ember-inline-template-precompiler.js
@@ -35,7 +35,7 @@ EmberInlineTemplatePrecompiler.prototype.processFile = function (srcDir, destDir
 
     while (nextIndex > -1) {
       var match = inputString.match(self.inlineTemplateRegExp);
-      var template = "Ember.Handlebars.template(" + compiler.precompile(match[1]).toString() + ")";
+      var template = "Ember.Handlebars.template(" + compiler.precompile(match[1], false) + ")";
 
       inputString = inputString.replace(match[0], template);
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "es6-module-transpiler": "~0.4.0",
     "express": "^4.5.0",
     "glob": "~3.2.8",
-    "handlebars": "^1.3",
+    "handlebars": "^2.0",
     "mocha": "1.20.1",
     "ncp": "~0.5.1",
     "rimraf": "~2.2.8",

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -34,7 +34,7 @@ Ember.assert("Ember Handlebars requires Handlebars version 1.0 or 1.1. Include "
 Ember.assert("Ember Handlebars requires Handlebars version 1.0 or 1.1, " +
              "COMPILER_REVISION expected: 4, got: " +  Handlebars.COMPILER_REVISION +
              " - Please note: Builds of master may have other COMPILER_REVISION values.",
-             Handlebars.COMPILER_REVISION === 4);
+             Handlebars.COMPILER_REVISION === 6);
 
 /**
   Prepares the Handlebars templating library for use inside Ember's view

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -50,7 +50,7 @@ Ember.assert("Ember Handlebars requires Handlebars version 1.0 or 1.1, " +
   @class Handlebars
   @namespace Ember
 */
-var EmberHandlebars = Ember.Handlebars = objectCreate(Handlebars);
+var EmberHandlebars = Ember.Handlebars = Handlebars.create();
 
 /**
   Register a bound helper or custom view helper.

--- a/packages/ember-handlebars-compiler/lib/main.js
+++ b/packages/ember-handlebars-compiler/lib/main.js
@@ -27,12 +27,12 @@ if (!Handlebars && typeof require === 'function') {
   Handlebars = require('handlebars');
 }
 
-Ember.assert("Ember Handlebars requires Handlebars version 1.0 or 1.1. Include " +
+Ember.assert("Ember Handlebars requires Handlebars version 2.0. Include " +
              "a SCRIPT tag in the HTML HEAD linking to the Handlebars file " +
              "before you link to Ember.", Handlebars);
 
-Ember.assert("Ember Handlebars requires Handlebars version 1.0 or 1.1, " +
-             "COMPILER_REVISION expected: 4, got: " +  Handlebars.COMPILER_REVISION +
+Ember.assert("Ember Handlebars requires Handlebars version 2.0, " +
+             "COMPILER_REVISION expected: 6, got: " +  Handlebars.COMPILER_REVISION +
              " - Please note: Builds of master may have other COMPILER_REVISION values.",
              Handlebars.COMPILER_REVISION === 6);
 

--- a/packages/ember-handlebars-compiler/tests/precompile_type_test.js
+++ b/packages/ember-handlebars-compiler/tests/precompile_type_test.js
@@ -6,14 +6,14 @@ var result;
 
 QUnit.module("Ember.Handlebars.precompileType");
 
-test("precompile creates a function when asObject isn't defined", function(){
+test("precompile creates an object when asObject isn't defined", function(){
   result = precompile(template);
-  equal(typeof(result), "function");
+  equal(typeof(result), "object");
 });
 
-test("precompile creates a function when asObject is true", function(){
+test("precompile creates an object when asObject is true", function(){
   result = precompile(template, true);
-  equal(typeof(result), "function");
+  equal(typeof(result), "object");
 });
 
 test("precompile creates a string when asObject is false", function(){
@@ -21,8 +21,8 @@ test("precompile creates a string when asObject is false", function(){
   equal(typeof(result), "string");
 });
 
-test("precompile creates a function when passed an AST", function(){
+test("precompile creates an object when passed an AST", function(){
   var ast = parse(template);
   result = precompile(ast);
-  equal(typeof(result), "function");
+  equal(typeof(result), "object");
 });

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -4,7 +4,6 @@ import Ember from "ember-metal/core"; // Ember.FEATURES, Ember.assert, Ember.Han
 import { fmt } from "ember-runtime/system/string";
 
 import EmberHandlebars from "ember-handlebars-compiler";
-var helpers = EmberHandlebars.helpers;
 
 import { get } from "ember-metal/property_get";
 import EmberError from "ember-metal/error";

--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -22,7 +22,6 @@ var resolveHelper, SimpleHandlebarsView;
 import isEmpty from 'ember-metal/is_empty';
 
 var slice = [].slice;
-var originalTemplate = EmberHandlebars.template;
 
 /**
   If a path starts with a reserved keyword, returns the root
@@ -621,21 +620,6 @@ function evaluateUnboundHelper(context, fn, normalizedProperties, options) {
   }
   args.push(options);
   return fn.apply(context, args);
-}
-
-/**
-  Overrides Handlebars.template so that we can distinguish
-  user-created, top-level templates from inner contexts.
-
-  @private
-  @method template
-  @for Ember.Handlebars
-  @param {String} spec
-*/
-export function template(spec) {
-  var t = originalTemplate(spec);
-  t.isTop = true;
-  return t;
 }
 
 export {

--- a/packages/ember-handlebars/lib/helpers/unbound.js
+++ b/packages/ember-handlebars/lib/helpers/unbound.js
@@ -43,6 +43,10 @@ export default function unboundHelper(property, fn) {
     // Unbound helper call.
     options.data.isUnbound = true;
     helper = resolveHelper(container, property) || helpers.helperMissing;
+
+    // Attempt to exec the first field as a helper
+    options.name = arguments[0];
+
     out = helper.apply(ctx, slice.call(arguments, 1));
     delete options.data.isUnbound;
     return out;

--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -6,7 +6,6 @@ import bootstrap from "ember-handlebars/loader";
 
 import {
   normalizePath,
-  template,
   makeBoundHelper,
   registerBoundHelper,
   resolveHash,
@@ -97,7 +96,6 @@ Ember Handlebars
 
 // Ember.Handlebars.Globals
 EmberHandlebars.bootstrap = bootstrap;
-EmberHandlebars.template = template;
 EmberHandlebars.makeBoundHelper = makeBoundHelper;
 EmberHandlebars.registerBoundHelper = registerBoundHelper;
 EmberHandlebars.resolveHash = resolveHash;


### PR DESCRIPTION
Updates the library to run with Handlebars 2.x codebase.

These changes made no attempt at backwards compatibility between the versions, but it seems like it would be possible if these are the project requirements.

Tests are passing locally but are pending the release of the beta (and the bower/npm updates tied to that). I'll be releasing the code that is master tomorrow evening or Weds as 2.0.0-beta.1.
