### PR TITLE
[Bugfix beta] Prevent churn cause during Route#deactivate

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -321,8 +321,9 @@ var Route = EmberObject.extend(ActionHandler, {
     @method exit
   */
   exit: function() {
-    this.deactivate();
     this.teardownViews();
+    // ensure we teardown views before we teardown state, this prevents churn
+    this.deactivate();
   },
 
   /**

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -198,4 +198,3 @@ test("controllerFor uses route's controllerName if specified", function() {
 
   equal(routeTwo.controllerFor('one'), testController);
 });
-


### PR DESCRIPTION
by changing the order we prevent soon to be destroyed view bindings from trying to synchronize changes that where a result of cleanup that occurred in Route#deactivate
