### PR TITLE
fix failing test on IE11.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -89,7 +89,7 @@ function vendoredPackage(packageName) {
     destFile: '/' + packageName + '.js'
   });
 
-  if (env !== 'development') {
+  if (true) {
     sourceTree = es3recast(sourceTree);
   }
 
@@ -599,7 +599,7 @@ var prodCompiledSource = removeFile(sourceTrees, {
 // Generates prod build.  defeatureify increases the overall runtime speed of ember.js by
 // ~10%.  See defeatureify.
 prodCompiledSource = concatES6(prodCompiledSource, {
-  es3Safe: env !== 'development',
+  es3Safe: true, // env !== 'development',
   includeLoader: true,
   bootstrapModule: 'ember',
   vendorTrees: vendorTrees,
@@ -620,7 +620,7 @@ minCompiledSource = uglifyJavaScript(minCompiledSource, {
 
 // Take testsTrees and compile them for consumption in the browser test suite.
 var compiledTests = concatES6(testTrees, {
-  es3Safe: env !== 'development',
+  es3Safe: true, //env !== 'development',
   includeLoader: true,
   inputFiles: ['**/*.js'],
   destFile: '/ember-tests.js'

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -70,7 +70,16 @@ test("prevents XSS injection via `style`", function() {
   buffer.generateElement();
 
   var el = buffer.element();
-  equal(el.getAttribute('style'), 'color:blue;" xss="true" style="color:red;');
+  var div = document.createElement('div');
+
+  // some browsers have different escaping strageties
+  // we should ensure the outcome is consistent. Ultimately we now use
+  // setAttribute under the hood, so we should always do the right thing.  But
+  // this test should be kept to ensure we do. Also, I believe/hope it is
+  // alright to assume the browser escapes setAttribute correctly...
+  div.setAttribute('style', 'color:blue;" xss="true" style="color:red;');
+
+  equal(el.getAttribute('style'), div.getAttribute('style'));
 });
 
 test("prevents XSS injection via `tagName`", function() {


### PR DESCRIPTION
turns out the internal escaping stragety can differ between browsers. We
should defer to the browsers defaults
