### PR TITLE
[BUGFIX beta] Do not use defineProperty on each View instance.

### DIFF
--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -176,8 +176,8 @@ export function deprecateProperty(object, deprecatedKey, newKey) {
     defineProperty(object, deprecatedKey, {
         configurable: true,
         enumerable: false,
-        set: function(value) { deprecate(); set(object, newKey, value); },
-        get: function() { deprecate(); return get(object, newKey); }
+        set: function(value) { deprecate(); set(this, newKey, value); },
+        get: function() { deprecate(); return get(this, newKey); }
     });
   }
 }

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -8,7 +8,6 @@ import EmberObject from "ember-runtime/system/object";
 import Evented from "ember-runtime/mixins/evented";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 
-import { deprecateProperty } from "ember-metal/properties";
 import { get } from "ember-metal/property_get";
 import { computed } from "ember-metal/computed";
 
@@ -38,9 +37,6 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     this._super();
     this._transitionTo('preRender');
     this._isVisible = get(this, 'isVisible');
-
-    deprecateProperty(this, 'states', '_states');
-    deprecateProperty(this, 'state', '_state');
   },
 
   /**

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -24,6 +24,7 @@ import {
 } from "ember-metal/utils";
 import { isNone } from 'ember-metal/is_none';
 import { Mixin } from 'ember-metal/mixin';
+import { deprecateProperty } from "ember-metal/properties";
 import { A as emberA } from "ember-runtime/system/native_array";
 
 import { dasherize } from "ember-runtime/system/string";
@@ -1971,6 +1972,8 @@ var View = CoreView.extend({
   }
 
 });
+deprecateProperty(View.prototype, 'state', '_state');
+deprecateProperty(View.prototype, 'states', '_states');
 
 /*
   Describe how the specified actions should behave in the various


### PR DESCRIPTION
On my initial implementation, I had a call to `defineProperty` (for the `state` -> `_state` deprecation) on EACH `Ember.View` instance which is **very bad** performance wise.

/cc @krisselden
