### PR TITLE
Allow development only feature flags.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -657,6 +657,18 @@ var compiledTests = concatES6(testTrees, {
   destFile: '/ember-tests.js'
 });
 
+// Take testsTrees and compile them for consumption in the browser test suite
+// to be used by production builds
+var prodCompiledTests = concatES6(testTrees, {
+  es3Safe: env !== 'development',
+  includeLoader: true,
+  inputFiles: ['**/*.js'],
+  destFile: '/ember-tests.prod.js',
+  defeatureifyOptions: {
+    environment: 'production'
+  }
+});
+
 var distTrees = [templateCompilerTree, compiledSource, compiledTests, testConfig, bowerFiles];
 
 // If you are not running in dev add Production and Minify build to distTrees.
@@ -664,6 +676,7 @@ var distTrees = [templateCompilerTree, compiledSource, compiledTests, testConfig
 // minification and defeaturification
 if (env !== 'development') {
   distTrees.push(prodCompiledSource);
+  distTrees.push(prodCompiledTests);
   distTrees.push(minCompiledSource);
   distTrees.push(buildRuntimeTree());
 }

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -204,7 +204,22 @@ var testConfig = pickFiles('tests', {
 testConfig = replace(testConfig, {
   files: [ 'tests/ember_configuration.js' ],
   patterns: [
-    { match: /\{\{FEATURES\}\}/g, replacement: JSON.stringify(defeatureifyConfig().enabled) }
+    { match: /\{\{DEV_FEATURES\}\}/g,
+      replacement: function() {
+        var features = defeatureifyConfig().enabled;
+
+        return JSON.stringify(features);
+      }
+    },
+    { match: /\{\{PROD_FEATURES\}\}/g,
+      replacement: function() {
+        var features = defeatureifyConfig({
+          environment: 'production'
+        }).enabled;
+
+        return JSON.stringify(features);
+      }
+    },
   ]
 });
 

--- a/features.json
+++ b/features.json
@@ -11,7 +11,8 @@
     "property-brace-expansion-improvement": true,
     "ember-routing-handlebars-action-with-key-code": null,
     "ember-runtime-item-controller-inline-class": null,
-    "ember-metal-injected-properties": null
+    "ember-metal-injected-properties": null,
+    "mandatory-setter": "development-only"
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -38,7 +38,7 @@ export function watchKey(obj, keyName, meta) {
 
 
 if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-  var handleMandatorySetter = function handleMandatorySetter(m, keyName, obj) {
+  var handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
     // this x in Y deopts, so keeping it in this function is better;
     if (keyName in obj) {
       m.values[keyName] = obj[keyName];

--- a/tests/ember_configuration.js
+++ b/tests/ember_configuration.js
@@ -5,7 +5,6 @@
     testing: true
   };
   window.ENV = window.ENV || {};
-  ENV.FEATURES = {{FEATURES}};
 
   // Test for "hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed"
   ENV.EMBER_LOAD_HOOKS = ENV.EMBER_LOAD_HOOKS || {};
@@ -14,6 +13,8 @@
   ENV.EMBER_LOAD_HOOKS.__before_ember_test_hook__.push(function(object) {
     ENV.__test_hook_count__ += object;
   });
+
+  window.ENV.FEATURES = !!QUnit.urlParams.prod ? {{PROD_FEATURES}} : {{DEV_FEATURES}};
 
   // Handle extending prototypes
   ENV['EXTEND_PROTOTYPES'] = !!QUnit.urlParams.extendprototypes;

--- a/tests/index.html
+++ b/tests/index.html
@@ -43,7 +43,15 @@
       }
     </script>
 
-    <script src="../ember-tests.js"></script>
+    <script>
+      var prod = QUnit.urlParams.prod;
+
+      if (prod) {
+        loadScript('../ember-tests.prod.js');
+      } else {
+        loadScript('../ember-tests.js');
+      }
+    </script>
     <script>
       var packages     = QUnit.urlParams.package;
       packages = (packages && packages.split(',')) || [".*"];


### PR DESCRIPTION
When a flag with `development-only` is found in `features.json` it will be enabled (flags stripped) for `ember.js`, and disabled (flags stripped) for `ember.prod.js`.

Used for changes in #5529.
