### PR TITLE
Fix for ES3 browsers in development mode.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.13",
     "router.js": "https://github.com/tildeio/router.js.git#1562462f120156a140b9153bf36f1046f85e7812",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
-    "htmlbars": "https://github.com/tildeio/htmlbars.git#6582d5584146c657dc61de8f5c5d00438d0e248d"
+    "htmlbars": "https://github.com/tildeio/htmlbars.git#3f0176fd3d800de25dd3db0c0a4347488401f080"
   }
 }

--- a/packages/ember-metal/lib/platform.js
+++ b/packages/ember-metal/lib/platform.js
@@ -1,7 +1,5 @@
 /*globals Node */
 
-import Ember from "ember-metal/core";
-
 /**
 @module ember-metal
 */
@@ -184,10 +182,6 @@ if (!(Object.create && !Object.create(null).hasOwnProperty)) {
   };
 } else {
   create = Object.create;
-}
-
-if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-  Ember.FEATURES['mandatory-setter'] = hasES5CompliantDefineProperty;
 }
 
 var hasPropertyAccessors = hasES5CompliantDefineProperty;

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -33,16 +33,16 @@ export function Descriptor() {}
 // DEFINING PROPERTIES API
 //
 
-var MANDATORY_SETTER_FUNCTION = Ember.MANDATORY_SETTER_FUNCTION = function(value) {
+export function MANDATORY_SETTER_FUNCTION(value) {
   Ember.assert("You must use Ember.set() to access this property (of " + this + ")", false);
-};
+}
 
-var DEFAULT_GETTER_FUNCTION = Ember.DEFAULT_GETTER_FUNCTION = function DEFAULT_GETTER_FUNCTION(name) {
-  return function() {
+export function DEFAULT_GETTER_FUNCTION(name) {
+  return function GETTER_FUNCTION() {
     var meta = this['__ember_meta__'];
     return meta && meta.values[name];
   };
-};
+}
 
 /**
   NOTE: This is a low-level method used by other parts of the API. You almost
@@ -108,7 +108,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
 
     descs[keyName] = desc;
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-      if (watching) {
+      if (watching && hasPropertyAccessors) {
         objectDefineProperty(obj, keyName, {
           configurable: true,
           enumerable: true,
@@ -128,7 +128,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
       value = data;
 
       if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-        if (watching) {
+        if (watching && hasPropertyAccessors) {
           meta.values[keyName] = data;
           objectDefineProperty(obj, keyName, {
             configurable: true,

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -9,6 +9,7 @@ import {
   isPath,
   hasThis as pathHasThis
 } from "ember-metal/path_cache";
+import { hasPropertyAccessors } from "ember-metal/platform";
 
 var FIRST_KEY = /^([^\.]+)/;
 
@@ -78,7 +79,7 @@ var get = function get(obj, keyName) {
     return desc.get(obj, keyName);
   } else {
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-      if (meta && meta.watching[keyName] > 0) {
+      if (hasPropertyAccessors && meta && meta.watching[keyName] > 0) {
         ret = meta.values[keyName];
       } else {
         ret = obj[keyName];

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -2,6 +2,7 @@ import Ember from "ember-metal/core";
 import {
   defineProperty as o_defineProperty,
   canDefineNonEnumerableProperties,
+  hasPropertyAccessors,
   create
 } from "ember-metal/platform";
 
@@ -255,7 +256,9 @@ if (!canDefineNonEnumerableProperties) {
 var EMPTY_META = new Meta(null);
 
 if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-  EMPTY_META.values = {};
+  if (hasPropertyAccessors) {
+    EMPTY_META.values = {};
+  }
 }
 
 /**
@@ -287,7 +290,9 @@ function meta(obj, writable) {
     ret = new Meta(obj);
 
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-      ret.values = {};
+      if (hasPropertyAccessors) {
+        ret.values = {};
+      }
     }
 
     obj['__ember_meta__'] = ret;
@@ -306,7 +311,9 @@ function meta(obj, writable) {
     ret.source    = obj;
 
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-      ret.values = o_create(ret.values);
+      if (hasPropertyAccessors) {
+        ret.values = o_create(ret.values);
+      }
     }
 
     obj['__ember_meta__'] = ret;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -39,10 +39,11 @@ import { ComputedProperty } from "ember-metal/computed";
 import InjectedProperty from "ember-metal/injected_property";
 import run from 'ember-metal/run_loop';
 import { destroy } from "ember-metal/watching";
-
 import {
   K
 } from 'ember-metal/core';
+import { hasPropertyAccessors } from "ember-metal/platform";
+
 var schedule = run.schedule;
 var applyMixin = Mixin._apply;
 var finishPartial = Mixin.finishPartial;
@@ -152,7 +153,11 @@ function makeCtor() {
               this.setUnknownProperty(keyName, value);
             } else {
               if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-                defineProperty(this, keyName, null, value); // setup mandatory setter
+                if (hasPropertyAccessors) {
+                  defineProperty(this, keyName, null, value); // setup mandatory setter
+                } else {
+                  this[keyName] = value;
+                }
               } else {
                 this[keyName] = value;
               }


### PR DESCRIPTION
Still need to conditionally switch on browsers that do not have ES5 compliant accessors, because isEnabled is compiled out based on development vs production build.

Still needs to be tested in old IE, was having some issues running the tests. Will do later.

@rwjblue 
