### PR TITLE
Trigger actions for TextField & TextArea on keyUp and keyDown.

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -29,12 +29,9 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
   init: function() {
     this._super();
-    this.on("focusOut", this, this._elementValueDidChange);
-    this.on("change", this, this._elementValueDidChange);
     this.on("paste", this, this._elementValueDidChange);
     this.on("cut", this, this._elementValueDidChange);
     this.on("input", this, this._elementValueDidChange);
-    this.on("keyUp", this, this.interpretKeyEvents);
   },
 
   /**
@@ -120,6 +117,10 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     sendAction('escape-press', this, event);
   },
 
+  change: function(event) {
+    this._elementValueDidChange(event);
+  },
+
   /**
     Called when the text area is focused.
 
@@ -141,6 +142,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     @param {Event} event
   */
   focusOut: function(event) {
+    this._elementValueDidChange(event);
     sendAction('focus-out', this, event);
   },
 
@@ -155,8 +157,36 @@ var TextSupport = Mixin.create(TargetActionSupport, {
   */
   keyPress: function(event) {
     sendAction('key-press', this, event);
-  }
+  },
 
+  /**
+    Called when the browser triggers a `keyup` event on the element.
+
+    Uses sendAction to send the `key-up` action passing the current value
+    and event as parameters.
+
+    @method keyUp
+    @param {Event} event
+  */
+  keyUp: function(event) {
+    this.interpretKeyEvents(event);
+
+    this.sendAction('key-up', get(this, 'value'), event);
+  },
+
+  /**
+    Called when the browser triggers a `keydown` event on the element.
+
+    Uses sendAction to send the `key-down` action passing the current value
+    and event as parameters. Note that generally in key-down the value is unchanged
+    (as the key pressing has not completed yet).
+
+    @method keyDown
+    @param {Event} event
+  */
+  keyDown: function(event) {
+    this.sendAction('key-down', get(this, 'value'), event);
+  }
 });
 
 TextSupport.KEY_EVENTS = {

--- a/packages/ember-handlebars/tests/controls/text_field_test.js
+++ b/packages/ember-handlebars/tests/controls/text_field_test.js
@@ -632,3 +632,52 @@ test("when the user hits escape, the `escape-press` action is sent to the contro
 
 });
 
+test("when the user presses a key, the `key-down` action is sent to the controller", function() {
+  expect(3);
+  var event;
+
+  textField = TextField.create({
+    'key-down': 'doSomething',
+    targetObject: StubController.create({
+      send: function(actionName, value, evt) {
+        equal(actionName, 'doSomething', "text field sent correct action name");
+        equal(value, '', 'value was blank in key-down');
+        equal(evt, event, 'event was received as param');
+      }
+    })
+  });
+
+  append();
+
+  run(function() {
+    event = jQuery.Event("keydown");
+    event.keyCode = event.which = 65;
+    textField.$().val('foo');
+    textField.$().trigger(event);
+  });
+});
+
+test("when the user releases a key, the `key-up` action is sent to the controller", function() {
+  expect(3);
+  var event;
+
+  textField = TextField.create({
+    'key-up': 'doSomething',
+    targetObject: StubController.create({
+      send: function(actionName, value, evt) {
+        equal(actionName, 'doSomething', "text field sent correct action name");
+        equal(value, 'bar', 'value was received');
+        equal(evt, event, 'event was received as param');
+      }
+    })
+  });
+
+  append();
+
+  run(function() {
+    event = jQuery.Event("keyup");
+    event.keyCode = event.which = 65;
+    textField.$().val('bar');
+    textField.$().trigger(event);
+  });
+});


### PR DESCRIPTION
- Trigger `key-up` and `key-down` actions.
- Remove extraneous event listeners.

As mentioned in the W3C [DOM Level 3 Events Specification](http://www.w3.org/TR/DOM-Level-3-Events/#event-type-keypress), `keypress` is being deprecated (and does not work properly on android)..

> The keypress event type is defined in this specification for reference and completeness, but this specification deprecates the use of this event type. When in editing contexts, authors can subscribe to the beforeinput event instead.
