### PR TITLE
[BUGFIX beta] Fixes V8 bailouts for `propertiesFromHTMLOptions` function

### DIFF
--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -239,8 +239,6 @@ function collectionHelper(path, options) {
   var viewOptions = ViewHelper.propertiesFromHTMLOptions({ data: data, hash: itemHash }, this);
   hash.itemViewClass = itemViewClass.extend(viewOptions);
 
-  options.helperName = options.helperName || 'collection';
-
   return helpers.view.call(this, collectionClass, options);
 }
 

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -11,7 +11,7 @@ import { get } from "ember-metal/property_get";
 import { IS_BINDING } from "ember-metal/mixin";
 import View from "ember-views/views/view";
 import { isGlobalPath } from "ember-metal/binding";
-import merge from "ember-metal/merge";
+import keys  from 'ember-metal/keys';
 import {
   normalizePath,
   handlebarsGet,
@@ -50,93 +50,90 @@ function makeBindings(thisContext, options) {
 }
 
 export var ViewHelper = EmberObject.create({
-
   propertiesFromHTMLOptions: function(options) {
     var hash = options.hash;
     var data = options.data;
-    var extensions = {};
+    var extensions = {
+      classNameBindings: [],
+      helperName:        options.helperName || ''
+    };
     var classes = hash['class'];
-    var dup = false;
 
     if (hash.id) {
       extensions.elementId = hash.id;
-      dup = true;
     }
 
     if (hash.tag) {
       extensions.tagName = hash.tag;
-      dup = true;
     }
 
     if (classes) {
       classes = classes.split(' ');
       extensions.classNames = classes;
-      dup = true;
     }
 
     if (hash.classBinding) {
       extensions.classNameBindings = hash.classBinding.split(' ');
-      dup = true;
     }
 
     if (hash.classNameBindings) {
-      if (extensions.classNameBindings === undefined) extensions.classNameBindings = [];
       extensions.classNameBindings = extensions.classNameBindings.concat(hash.classNameBindings.split(' '));
-      dup = true;
     }
 
     if (hash.attributeBindings) {
       Ember.assert("Setting 'attributeBindings' via Handlebars is not allowed. Please subclass Ember.View and set it there instead.");
       extensions.attributeBindings = null;
-      dup = true;
-    }
-
-    if (dup) {
-      hash = merge({}, hash);
-      delete hash.id;
-      delete hash.tag;
-      delete hash['class'];
-      delete hash.classBinding;
     }
 
     // Set the proper context for all bindings passed to the helper. This applies to regular attribute bindings
     // as well as class name bindings. If the bindings are local, make them relative to the current context
     // instead of the view.
     var path;
+    var hashKeys = keys(hash);
 
-    // Evaluate the context of regular attribute bindings:
-    for (var prop in hash) {
-      if (!hash.hasOwnProperty(prop)) { continue; }
+    for (var i = 0, l = hashKeys.length; i < l; i++) {
+      var prop      = hashKeys[i];
+      var isBinding = IS_BINDING.test(prop);
+
+      if (prop !== 'classNameBindings') {
+        extensions[prop] = hash[prop];
+      }
 
       // Test if the property ends in "Binding"
-      if (IS_BINDING.test(prop) && typeof hash[prop] === 'string') {
+      if (isBinding && typeof extensions[prop] === 'string') {
         path = this.contextualizeBindingPath(hash[prop], data);
-        if (path) { hash[prop] = path; }
+        if (path) {
+          extensions[prop] = path;
+        }
       }
     }
 
     // Evaluate the context of class name bindings:
-    if (extensions.classNameBindings) {
-      for (var b in extensions.classNameBindings) {
-        var full = extensions.classNameBindings[b];
-        if (typeof full === 'string') {
-          // Contextualize the path of classNameBinding so this:
-          //
-          //     classNameBinding="isGreen:green"
-          //
-          // is converted to this:
-          //
-          //     classNameBinding="_parentView.context.isGreen:green"
-          var parsedPath = View._parsePropertyPath(full);
-          if(parsedPath.path !== '') {
-            path = this.contextualizeBindingPath(parsedPath.path, data);
-            if (path) { extensions.classNameBindings[b] = path + parsedPath.classNames; }
+    var classNameBindingsKeys = keys(extensions.classNameBindings);
+
+    for (var j = 0, k = classNameBindingsKeys.length; j < k; j++) {
+      var classKey = classNameBindingsKeys[j];
+      var full     = extensions.classNameBindings[classKey];
+
+      if (typeof full === 'string') {
+        // Contextualize the path of classNameBinding so this:
+        //
+        //     classNameBinding="isGreen:green"
+        //
+        // is converted to this:
+        //
+        //     classNameBinding="_parentView.context.isGreen:green"
+        var parsedPath = View._parsePropertyPath(full);
+        if (parsedPath.path !== '') {
+          path = this.contextualizeBindingPath(parsedPath.path, data);
+          if (path) {
+            extensions.classNameBindings[classKey] = path + parsedPath.classNames;
           }
         }
       }
     }
 
-    return merge(hash, extensions);
+    return extensions;
   },
 
   // Transform bindings from the current context to a context that can be evaluated within the view.
@@ -159,7 +156,7 @@ export var ViewHelper = EmberObject.create({
 
   helper: function(thisContext, path, options) {
     var data = options.data;
-    var fn = options.fn;
+    var fn   = options.fn;
     var newView;
 
     makeBindings(thisContext, options);
@@ -183,17 +180,12 @@ export var ViewHelper = EmberObject.create({
       viewOptions._context = thisContext;
     }
 
-    // for instrumentation
-    if (options.helperName) {
-      viewOptions.helperName = options.helperName;
-    }
-
     currentView.appendChild(newView, viewOptions);
   },
 
   instanceHelper: function(thisContext, newView, options) {
-    var data = options.data,
-        fn = options.fn;
+    var data = options.data;
+    var fn   = options.fn;
 
     makeBindings(thisContext, options);
 
@@ -215,11 +207,6 @@ export var ViewHelper = EmberObject.create({
     // no specified controller. See View#_context for more information.
     if (!newView.controller && !newView.controllerBinding && !viewOptions.controller && !viewOptions.controllerBinding) {
       viewOptions._context = thisContext;
-    }
-
-    // for instrumentation
-    if (options.helperName) {
-      viewOptions.helperName = options.helperName;
     }
 
     currentView.appendChild(newView, viewOptions);


### PR DESCRIPTION
Before:

![bailouts](https://cloud.githubusercontent.com/assets/1131196/4175916/51e9079c-35ec-11e4-9de0-a83abb8c2c22.png)

After:

![bailouts-fix](https://cloud.githubusercontent.com/assets/1131196/4175920/6b51211a-35ec-11e4-9423-271910496a9c.png)

Bailout reason: "ForIn is not fast case"

It turns out that we can use `Object.keys` instead of using `for-in`.

`for-in` is actually more expensive as it will enumerate properties in the prototype chain as well (you have to use `hasOwnProperty` check which is not cheap). More about [`for-in`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in) for the curious.

`Object.keys` will return an array of a given object's own enumerable properties. That is very handy because we can avoid `hasOwnProperty` check and looking up properties on the prototype chain.

``` javascript
var a = { bar: 'foo', baz: 'blah' };
Object.keys(a);
// ["bar", "baz"]
Object.getOwnPropertyDescriptor(a, 'bar');
// Object {value: "foo", writable: true, enumerable: true, configurable: true}
```
#### normalizePath

Before:

![normalizepath-old](https://cloud.githubusercontent.com/assets/1131196/4312974/2c6d134a-3ec1-11e4-97c9-6eec3bdebf46.png)

After:

![normalizepath-new](https://cloud.githubusercontent.com/assets/1131196/4312977/3a00b89a-3ec1-11e4-8bd6-20d032f79792.png)
#### collectionHelper

Before:

![collectionhelper-before](https://cloud.githubusercontent.com/assets/1131196/4362326/f306fe58-428b-11e4-8d1f-f6d2c2d85065.png)

After:

![collectionhelper-after](https://cloud.githubusercontent.com/assets/1131196/4362334/0284664a-428c-11e4-97d9-fa9a4f3c9d75.png)
- [x] remove `for-in` loops and `delete`s to fix the deoptimizations
- [x] remove `merge` function because it is unnecessary
