### PR TITLE
Fixed a Cannot read property of undefined error in chains.js

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -228,7 +228,13 @@ ChainNodePrototype.chain = function(key, path, src) {
 
 ChainNodePrototype.unchain = function(key, path) {
   var chains = this._chains;
-  var node = chains[key];
+  var node = chains ? chains[key] : null;
+  
+  // if we don't have a node then the chain must have already been broken.
+  // this happens with handlebars templates that refer to sub-objects.
+  if ( !node ){
+    return;
+  }
 
   // unchain rest of path first...
   if (path && path.length>1) {


### PR DESCRIPTION
Fixed an error in chains.js that happens when switching routes from one that uses an object's sub-objects in handlebars templates. Upon destruction of the previous route Ember will destroy the parent object before destroying its children in the chain. This will cause Ember to error when it reaches the children because there is no chain to destroy. This affects Ember versions 1.3.0-1.7.0+. See example here: http://plnkr.co/edit/5nbJ6h0m3RCKnv6geKfi?p=preview
