### PR TITLE
[FEATURE ember-routing-fire-activate-deactivate-events] Fire `activate` and `deactivate` events on `Ember.Route`

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -68,3 +68,10 @@ for a detailed explanation.
   property of an `array controller`.
 
   Added in [#5301](https://github.com/emberjs/ember.js/pull/5301)
+
+* `ember-routing-fire-activate-deactivate-events`
+
+  Fire `activate` and `deactivate` events, additionally to the corresponding
+  `Ember.Route` hooks.
+
+  Added in [#5569](https://github.com/emberjs/ember.js/pull/5569)

--- a/features.json
+++ b/features.json
@@ -12,7 +12,8 @@
     "ember-routing-handlebars-action-with-key-code": null,
     "ember-runtime-item-controller-inline-class": null,
     "ember-metal-injected-properties": null,
-    "mandatory-setter": "development-only"
+    "mandatory-setter": "development-only",
+    "ember-routing-fire-activate-deactivate-events": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -21,6 +21,7 @@ import {
   classify
 } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
+import Evented from "ember-runtime/mixins/evented";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import generateController from "ember-routing/system/generate_controller";
 import { stashParamNames } from "ember-routing/utils";
@@ -340,6 +341,9 @@ var Route = EmberObject.extend(ActionHandler, {
   */
   exit: function() {
     this.deactivate();
+    if (Ember.FEATURES.isEnabled("ember-routing-fire-activate-deactivate-events")) {
+      this.trigger('deactivate');
+    }
     this.teardownViews();
   },
 
@@ -364,6 +368,9 @@ var Route = EmberObject.extend(ActionHandler, {
   */
   enter: function() {
     this.activate();
+    if (Ember.FEATURES.isEnabled("ember-routing-fire-activate-deactivate-events")) {
+      this.trigger('activate');
+    }
   },
 
   /**
@@ -1844,6 +1851,12 @@ var Route = EmberObject.extend(ActionHandler, {
     delete this.lastRenderedTemplate;
   }
 });
+
+if (Ember.FEATURES.isEnabled("ember-routing-fire-activate-deactivate-events")) {
+  // TODO add mixin directly to `Route` class definition above, once this
+  // feature is merged:
+  Route.reopen(Evented);
+}
 
 var defaultQPMeta = {
   qps: [],

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2815,6 +2815,66 @@ test("`didTransition` can be reopened", function() {
   bootApplication();
 });
 
+if (Ember.FEATURES.isEnabled("ember-routing-fire-activate-deactivate-events")) {
+  test("`activate` event fires on the route", function() {
+    expect(2);
+
+    var eventFired = 0;
+
+    Router.map(function(){
+      this.route("nork");
+    });
+
+    App.NorkRoute = Ember.Route.extend({
+      init: function() {
+        this._super();
+
+        this.on("activate", function() {
+          equal(++eventFired, 1, "activate event is fired once");
+        });
+      },
+
+      activate: function() {
+        ok(true, "activate hook is called");
+      }
+    });
+
+    bootApplication();
+
+    Ember.run(router, 'transitionTo', 'nork');
+  });
+
+  test("`deactivate` event fires on the route", function() {
+    expect(2);
+
+    var eventFired = 0;
+
+    Router.map(function(){
+      this.route("nork");
+      this.route("dork");
+    });
+
+    App.NorkRoute = Ember.Route.extend({
+      init: function() {
+        this._super();
+
+        this.on("deactivate", function() {
+          equal(++eventFired, 1, "deactivate event is fired once");
+        });
+      },
+
+      deactivate: function() {
+        ok(true, "deactivate hook is called");
+      }
+    });
+
+    bootApplication();
+
+    Ember.run(router, 'transitionTo', 'nork');
+    Ember.run(router, 'transitionTo', 'dork');
+  });
+}
+
 test("Actions can be handled by inherited action handlers", function() {
 
   expect(4);


### PR DESCRIPTION
Additionally to the existing `activate` and `deactivate` hooks on
`Ember.Route`, this feature adds the firing of events with the same name
on the route.

This closes #4923
