### PR TITLE
[BUGFIX beta] contextualElements, clean omitted start tags

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -226,7 +226,7 @@ test("should read from a global-ish simple local path without deprecation", func
     template: EmberHandlebars.compile('{{NotGlobal}}')
   });
 
-  expectNoDeprecation();
+  expectNoDeprecation(/Global lookup/);
   appendView();
 
   equal(view.$().text(), 'Gwar');

--- a/packages/ember-metal-views/tests/main_test.js
+++ b/packages/ember-metal-views/tests/main_test.js
@@ -11,6 +11,7 @@ testsFor("ember-metal-views", {
   }
 });
 
+// Test the behavior of the helper createElement stub
 test("by default, view renders as a div", function() {
   view = {isView: true};
 
@@ -18,6 +19,7 @@ test("by default, view renders as a div", function() {
   equalHTML('qunit-fixture', "<div></div>");
 });
 
+// Test the behavior of the helper createElement stub
 test("tagName can be specified", function() {
   view = {
     isView: true,
@@ -29,6 +31,7 @@ test("tagName can be specified", function() {
   equalHTML('qunit-fixture', "<span></span>");
 });
 
+// Test the behavior of the helper createElement stub
 test("textContent can be specified", function() {
   view = {
     isView: true,
@@ -40,6 +43,7 @@ test("textContent can be specified", function() {
   equalHTML('qunit-fixture', "<div>ohai &lt;a&gt;derp&lt;/a&gt;</div>");
 });
 
+// Test the behavior of the helper createElement stub
 test("innerHTML can be specified", function() {
   view = {
     isView: true,
@@ -51,6 +55,20 @@ test("innerHTML can be specified", function() {
   equalHTML('qunit-fixture', "<div>ohai <a>derp</a></div>");
 });
 
+// Test the behavior of the helper createElement stub
+test("innerHTML tr can be specified", function() {
+  view = {
+    isView: true,
+    tagName: 'table',
+    innerHTML: '<tr><td>ohai</td></tr>'
+  };
+
+  appendTo(view);
+
+  equalHTML('qunit-fixture', "<table><tbody><tr><td>ohai</td></tr></tbody></table>");
+});
+
+// Test the behavior of the helper createElement stub
 test("element can be specified", function() {
   view = {
     isView: true,

--- a/packages/ember-metal-views/tests/test_helpers.js
+++ b/packages/ember-metal-views/tests/test_helpers.js
@@ -46,7 +46,7 @@ MetalRenderer.prototype.createElement = function (view) {
     }
   }
   if (view.childViews) {
-    view._childViewsMorph = this._dom.createMorph(el, null, null);
+    view._childViewsMorph = this._dom.createMorph(el, null, null, el);
   } else if (view.textContent) {
     el.textContent = view.textContent;
   } else if (view.innerHTML) {

--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -25,7 +25,7 @@ EmberRenderer.prototype.cancelRender =
   };
 
 EmberRenderer.prototype.createElement =
-  function EmberRenderer_createElement(view) {
+  function EmberRenderer_createElement(view, contextualElement) {
     // If this is the top-most view, start a new buffer. Otherwise,
     // create a new buffer relative to the original using the
     // provided buffer operation (for example, `insertAfter` will
@@ -36,7 +36,7 @@ EmberRenderer.prototype.createElement =
     }
 
     var buffer = view.buffer = this.buffer;
-    buffer.reset(tagName);
+    buffer.reset(tagName, contextualElement);
 
     if (view.beforeRender) {
       view.beforeRender(buffer);

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -269,10 +269,10 @@ var ContainerView = View.extend(MutableArray, {
         this._childViewsMorph = this._morph;
       } else {
         element = dom.createDocumentFragment();
-        this._childViewsMorph = dom.appendMorph(element);
+        this._childViewsMorph = dom.appendMorph(element, element);
       }
     } else {
-      this._childViewsMorph = dom.createMorph(element, element.lastChild, null);
+      this._childViewsMorph = dom.createMorph(element, element.lastChild, null, element);
     }
 
     return element;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1439,6 +1439,7 @@ var View = CoreView.extend({
   createElement: function() {
     if (this.element) { return this; }
 
+    this._didCreateElementWithoutMorph = true;
     this.constructor.renderer.renderTree(this);
 
     return this;

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -8,8 +8,27 @@ var trim = jQuery.trim;
 //
 QUnit.module("RenderBuffer");
 
-test("RenderBuffers combine strings", function() {
+test("RenderBuffers raise a deprecation warning without a contextualElement", function() {
   var buffer = new RenderBuffer('div');
+  buffer.generateElement();
+  expectDeprecation(function(){
+    var el = buffer.element();
+    equal(el.tagName.toLowerCase(), 'div');
+  }, /buffer.element expects a contextualElement to exist/);
+});
+
+test("reset RenderBuffers raise a deprecation warning without a contextualElement", function() {
+  var buffer = new RenderBuffer('div', document.body);
+  buffer.reset('span');
+  buffer.generateElement();
+  expectDeprecation(function(){
+    var el = buffer.element();
+    equal(el.tagName.toLowerCase(), 'span');
+  }, /buffer.element expects a contextualElement to exist/);
+});
+
+test("RenderBuffers combine strings", function() {
+  var buffer = new RenderBuffer('div', document.body);
   buffer.generateElement();
 
   buffer.push('a');
@@ -22,7 +41,7 @@ test("RenderBuffers combine strings", function() {
 
 test("value of 0 is included in output", function() {
   var buffer, el;
-  buffer = new RenderBuffer('input');
+  buffer = new RenderBuffer('input', document.body);
   buffer.prop('value', 0);
   buffer.generateElement();
   el = buffer.element();
@@ -30,7 +49,7 @@ test("value of 0 is included in output", function() {
 });
 
 test("prevents XSS injection via `id`", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
 
   buffer.id('hacked" megahax="yes');
   buffer.generateElement();
@@ -40,7 +59,7 @@ test("prevents XSS injection via `id`", function() {
 });
 
 test("prevents XSS injection via `attr`", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
 
   buffer.attr('id', 'trololol" onmouseover="pwn()');
   buffer.attr('class', "hax><img src=\"trollface.png\"");
@@ -54,7 +73,7 @@ test("prevents XSS injection via `attr`", function() {
 });
 
 test("prevents XSS injection via `addClass`", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
 
   buffer.addClass('megahax" xss="true');
   buffer.generateElement();
@@ -64,7 +83,7 @@ test("prevents XSS injection via `addClass`", function() {
 });
 
 test("prevents XSS injection via `style`", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
 
   buffer.style('color', 'blue;" xss="true" style="color:red');
   buffer.generateElement();
@@ -83,7 +102,7 @@ test("prevents XSS injection via `style`", function() {
 });
 
 test("prevents XSS injection via `tagName`", function() {
-  var buffer = new RenderBuffer('cool-div><div xss="true"');
+  var buffer = new RenderBuffer('cool-div><div xss="true"', document.body);
   try {
     buffer.generateElement();
     equal(buffer.string(), '<cool-divdivxsstrue></cool-divdivxsstrue>');
@@ -93,7 +112,7 @@ test("prevents XSS injection via `tagName`", function() {
 });
 
 test("handles null props - Issue #2019", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
 
   buffer.prop('value', null);
   buffer.generateElement();
@@ -101,7 +120,7 @@ test("handles null props - Issue #2019", function() {
 });
 
 test("handles browsers like Firefox < 11 that don't support outerHTML Issue #1952", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
   buffer.generateElement();
   // Make sure element.outerHTML is falsy to trigger the fallback.
   var elementStub = '<div></div>';
@@ -111,7 +130,7 @@ test("handles browsers like Firefox < 11 that don't support outerHTML Issue #195
 });
 
 test("lets `setClasses` and `addClass` work together", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
   buffer.setClasses(['foo', 'bar']);
   buffer.addClass('baz');
   buffer.generateElement();
@@ -121,10 +140,68 @@ test("lets `setClasses` and `addClass` work together", function() {
   equal(el.getAttribute('class'), 'foo bar baz');
 });
 
+test("generates text and a div and text", function() {
+  var div = document.createElement('div');
+  var buffer = new RenderBuffer(undefined, div);
+  buffer.buffer = 'Howdy<div>Nick</div>Cage';
+
+  var el = buffer.element();
+  equal(el.childNodes[0].data, 'Howdy');
+  equal(el.childNodes[1].tagName.toLowerCase(), 'div');
+  equal(el.childNodes[1].childNodes[0].data, 'Nick');
+  equal(el.childNodes[2].data, 'Cage');
+});
+
+
+test("generates a tr from a tr innerString", function() {
+  var table = document.createElement('table');
+  var buffer = new RenderBuffer(undefined, table);
+  buffer.buffer = '<tr></tr>';
+
+  var el = buffer.element();
+  equal(el.childNodes[0].tagName.toLowerCase(), 'tr');
+});
+
+test("generates a tr from a tr innerString with leading <script", function() {
+  var table = document.createElement('table');
+  var buffer = new RenderBuffer(undefined, table);
+  buffer.buffer = '<script></script><tr></tr>';
+
+  var el = buffer.element();
+  equal(el.childNodes[1].tagName.toLowerCase(), 'tr');
+});
+
+test("generates a tr from a tr innerString with leading comment", function() {
+  var table = document.createElement('table');
+  var buffer = new RenderBuffer(undefined, table);
+  buffer.buffer = '<!-- blargh! --><tr></tr>';
+
+  var el = buffer.element();
+  equal(el.childNodes[1].tagName.toLowerCase(), 'tr');
+});
+
+test("generates a tbody from a tbody innerString", function() {
+  var table = document.createElement('table');
+  var buffer = new RenderBuffer(undefined, table);
+  buffer.buffer = '<tbody><tr></tr></tbody>';
+
+  var el = buffer.element();
+  equal(el.childNodes[0].tagName.toLowerCase(), 'tbody');
+});
+
+test("generates a col from a col innerString", function() {
+  var table = document.createElement('table');
+  var buffer = new RenderBuffer(undefined, table);
+  buffer.buffer = '<col></col>';
+
+  var el = buffer.element();
+  equal(el.childNodes[0].tagName.toLowerCase(), 'col');
+});
+
 QUnit.module("RenderBuffer - without tagName");
 
 test("It is possible to create a RenderBuffer without a tagName", function() {
-  var buffer = new RenderBuffer();
+  var buffer = new RenderBuffer(undefined, document.body);
   buffer.push('a');
   buffer.push('b');
   buffer.push('c');
@@ -139,7 +216,7 @@ test("It is possible to create a RenderBuffer without a tagName", function() {
 QUnit.module("RenderBuffer#element");
 
 test("properly handles old IE's zero-scope bug", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = new RenderBuffer('div', document.body);
   buffer.generateElement();
   buffer.push('<script></script>foo');
 

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -46,6 +46,61 @@ test("calls render and turns resultant string into element", function() {
   equal(elem.tagName.toString().toLowerCase(), 'span', 'has tagName from view');
 });
 
+test("calls render and parses the buffer string in the right context", function() {
+  view = ContainerView.create({
+    tagName: 'table',
+    childViews: [ EmberView.create({
+      tagName: '',
+      render: function(buffer) {
+        // Emulate a metamorph
+        buffer.push("<script></script><tr><td>snorfblax</td></tr>");
+      }
+    })]
+  });
+
+  equal(get(view, 'element'), null, 'precondition - has no element');
+  run(function() {
+    view.createElement();
+  });
+
+
+  var elem = get(view, 'element');
+  ok(elem, 'has element now');
+  equal(elem.innerHTML, '<script></script><tr><td>snorfblax</td></tr>', 'has innerHTML from context');
+  equal(elem.tagName.toString().toLowerCase(), 'table', 'has tagName from view');
+});
+
+test("does not wrap many tr children in tbody elements", function() {
+  view = ContainerView.create({
+    tagName: 'table',
+    childViews: [
+      EmberView.create({
+        tagName: '',
+        render: function(buffer) {
+          // Emulate a metamorph
+          buffer.push("<script></script><tr><td>snorfblax</td></tr>");
+        } }),
+      EmberView.create({
+        tagName: '',
+        render: function(buffer) {
+          // Emulate a metamorph
+          buffer.push("<script></script><tr><td>snorfblax</td></tr>");
+        } })
+    ]
+  });
+
+  equal(get(view, 'element'), null, 'precondition - has no element');
+  run(function() {
+    view.createElement();
+  });
+
+
+  var elem = get(view, 'element');
+  ok(elem, 'has element now');
+  equal(elem.innerHTML, '<script></script><tr><td>snorfblax</td></tr><script></script><tr><td>snorfblax</td></tr>', 'has innerHTML from context');
+  equal(elem.tagName.toString().toLowerCase(), 'table', 'has tagName from view');
+});
+
 test("generated element include HTML from child views as well", function() {
   view = ContainerView.create({
     childViews: [ EmberView.create({ elementId: "foo" })]

--- a/tests/qunit_configuration.js
+++ b/tests/qunit_configuration.js
@@ -334,9 +334,11 @@
     if (expecteds === EmberDev.deprecations.NONE) {
       var actualMessages = [];
       for (var i=0;i<actuals.length;i++) {
-        actualMessages.push(actuals[i][0]);
+        if (!actuals[i][1]) {
+          actualMessages.push(actuals[i][0]);
+        }
       }
-      ok(actuals.length === 0, "Expected no deprecation calls, got "+actuals.length+": "+actualMessages.join(', '));
+      ok(actualMessages.length === 0, "Expected no deprecation calls, got "+actualMessages.length+": "+actualMessages.join(', '));
     } else {
       for (var o=0;o < expecteds.length; o++) {
         var expected = expecteds[o], match;


### PR DESCRIPTION
During a renderTree call, look to the morphs for information about the contextualElement. Pass this to the Ember renderer, which in turn passes it to the buffer for use when generating an element.

Here I've changed the morph creation points to explicitly pass a contextualElement. This avoids the possibility of createMorph's fallback to document.body happening.

Additionally, strip omitted start tags even if the child node causing their generation is after a script tag. See the long comment in `render_buffer`.

Fixes #5476
