### PR TITLE
Make _view a special prefix instead of a keyword

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -18,6 +18,8 @@ import {
   handlebarsGetView
 } from "ember-handlebars/ext";
 
+var SELF_BINDING = /^_view\./;
+
 function makeBindings(thisContext, options) {
   var hash = options.hash;
   var hashType = options.hashTypes;
@@ -139,9 +141,10 @@ export var ViewHelper = EmberObject.create({
 
   // Transform bindings from the current context to a context that can be evaluated within the view.
   // Returns null if the path shouldn't be changed.
-  //
-  // TODO: consider the addition of a prefix that would allow this method to return `path`.
   contextualizeBindingPath: function(path, data) {
+    if (SELF_BINDING.test(path)) {
+      return path.slice(6); // Lop off "_view."
+    }
     var normalized = normalizePath(null, path, data);
     if (normalized.isKeyword) {
       return 'templateData.keywords.' + path;

--- a/packages/ember-routing-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-routing-handlebars/lib/helpers/outlet.js
@@ -108,7 +108,7 @@ export function outletHelper(property, options) {
 
   viewClass = viewName ? container.lookupFactory(viewFullName) : options.hash.viewClass || OutletView;
 
-  options.data.view.set('outletSource', outletSource);
+  options.hash.outletSource = outletSource;
   options.hash.currentViewBinding = '_view.outletSource._outlets.' + property;
 
   options.helperName = options.helperName || 'outlet';

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1014,7 +1014,6 @@ var View = CoreView.extend({
 
     var keywords = templateData ? copy(templateData.keywords) : {};
     set(keywords, 'view', this.isVirtual ? keywords.view : this);
-    set(keywords, '_view', this);
     set(keywords, 'controller', get(this, 'controller'));
 
     return keywords;


### PR DESCRIPTION
Changes:
- The `_view` keyword is removed completely.
- `_view.some.path` is contextualized to `some.path` rather than `templateData.keywords._view.some.path`.
- Binding to `_view` alone is no longer possible.

Internally we used `_view` for hooking up outlets. I've rearranged things a bit to work with the new prefix:
- `outletSource` is now stored on the OutletView instance rather than on the (parent) view that invoked the `{{outlet}}` helper.
