### PR TITLE
[BUGFIX beta] Object.create(null) in Ember.inspect

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -820,7 +820,12 @@ export function inspect(obj) {
       v = obj[key];
       if (v === 'toString') { continue; } // ignore useless items
       if (typeOf(v) === 'function') { v = "function() { ... }"; }
-      ret.push(key + ": " + v);
+
+      if (v && typeof v.toString !== 'function') {
+        ret.push(key + ": " + toString.call(v));
+      } else {
+        ret.push(key + ": " + v);
+      }
     }
   }
   return "{" + ret.join(", ") + "}";

--- a/packages/ember-metal/tests/core/inspect_test.js
+++ b/packages/ember-metal/tests/core/inspect_test.js
@@ -1,4 +1,6 @@
 import { inspect } from "ember-metal/utils";
+import { create } from "ember-metal/platform";
+
 import Ember from 'ember-metal/core';
 
 QUnit.module("Ember.inspect");
@@ -31,6 +33,11 @@ test("object", function() {
   equal(inspect({}), "{}");
   equal(inspect({ foo: 'bar' }), "{foo: bar}");
   equal(inspect({ foo: Ember.K }), "{foo: function() { ... }}");
+});
+
+test("objects without a prototype", function() {
+  var prototypelessObj = create(null);
+  equal(inspect({ foo: prototypelessObj }), "{foo: [object Object]}");
 });
 
 test("array", function() {


### PR DESCRIPTION
This commit resolves an issue where objects passed to Ember.inspect that contained an `Object.create(null)` object as a property would cause an exception to be thrown.

I hit this in my app because we were `Ember.inspect`ing objects (a model in this case) that had their container property set. The container’s registry as of 1.8.0 is (you guessed it) an object with a null prototype.
