### PR TITLE
Move routing helper methods to more appropriate package

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -11,10 +11,10 @@ import { isSimpleClick } from "ember-views/system/utils";
 import EmberComponent from "ember-views/views/component";
 import EmberHandlebars from "ember-handlebars";
 import { viewHelper } from "ember-handlebars/helpers/view";
+import { routeArgs } from "ember-routing/utils";
 import {
   resolveParams,
-  resolvePaths,
-  routeArgs
+  resolvePaths
 } from "ember-routing-handlebars/helpers/shared";
 
 /**

--- a/packages/ember-routing-handlebars/lib/helpers/shared.js
+++ b/packages/ember-routing-handlebars/lib/helpers/shared.js
@@ -5,25 +5,6 @@ import {
   resolveParams as handlebarsResolve,
   handlebarsGet
 } from "ember-handlebars/ext";
-import { typeOf } from 'ember-metal/utils';
-import { get } from "ember-metal/property_get";
-
-export function routeArgs(targetRouteName, models, queryParams) {
-  var args = [];
-  if (typeOf(targetRouteName) === 'string') {
-    args.push('' + targetRouteName);
-  }
-  args.push.apply(args, models);
-  args.push({ queryParams: queryParams });
-  return args;
-}
-
-export function getActiveTargetName(router) {
-  var handlerInfos = router.activeTransition ?
-                     router.activeTransition.state.handlerInfos :
-                     router.state.handlerInfos;
-  return handlerInfos[handlerInfos.length - 1].name;
-}
 
 export function resolveParams(context, params, options) {
   return map.call(resolvePaths(context, params, options), function(path, i) {
@@ -34,34 +15,6 @@ export function resolveParams(context, params, options) {
       return handlebarsGet(context, path, options);
     }
   });
-}
-
-export function stashParamNames(router, handlerInfos) {
-  if (handlerInfos._namesStashed) { return; }
-
-  // This helper exists because router.js/route-recognizer.js awkwardly
-  // keeps separate a handlerInfo's list of parameter names depending
-  // on whether a URL transition or named transition is happening.
-  // Hopefully we can remove this in the future.
-  var targetRouteName = handlerInfos[handlerInfos.length-1].name;
-  var recogHandlers = router.router.recognizer.handlersFor(targetRouteName);
-  var dynamicParent = null;
-
-  for (var i = 0, len = handlerInfos.length; i < len; ++i) {
-    var handlerInfo = handlerInfos[i];
-    var names = recogHandlers[i].names;
-
-    if (names.length) {
-      dynamicParent = handlerInfo;
-    }
-
-    handlerInfo._names = names;
-
-    var route = handlerInfo.handler;
-    route._stashNames(handlerInfo, dynamicParent);
-  }
-
-  handlerInfos._namesStashed = true;
 }
 
 export function resolvePaths(context, params, options) {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -23,7 +23,7 @@ import {
 import EmberObject from "ember-runtime/system/object";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import generateController from "ember-routing/system/generate_controller";
-import { stashParamNames } from "ember-routing-handlebars/helpers/shared";
+import { stashParamNames } from "ember-routing/utils";
 
 /**
 @module ember

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -18,7 +18,7 @@ import {
   routeArgs,
   getActiveTargetName,
   stashParamNames
-} from "ember-routing-handlebars/helpers/shared";
+} from "ember-routing/utils";
 
 // requireModule("ember-handlebars");
 // requireModule("ember-runtime");

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -1,0 +1,46 @@
+import { typeOf } from 'ember-metal/utils';
+
+export function routeArgs(targetRouteName, models, queryParams) {
+  var args = [];
+  if (typeOf(targetRouteName) === 'string') {
+    args.push('' + targetRouteName);
+  }
+  args.push.apply(args, models);
+  args.push({ queryParams: queryParams });
+  return args;
+}
+
+export function getActiveTargetName(router) {
+  var handlerInfos = router.activeTransition ?
+                     router.activeTransition.state.handlerInfos :
+                     router.state.handlerInfos;
+  return handlerInfos[handlerInfos.length - 1].name;
+}
+
+export function stashParamNames(router, handlerInfos) {
+  if (handlerInfos._namesStashed) { return; }
+
+  // This helper exists because router.js/route-recognizer.js awkwardly
+  // keeps separate a handlerInfo's list of parameter names depending
+  // on whether a URL transition or named transition is happening.
+  // Hopefully we can remove this in the future.
+  var targetRouteName = handlerInfos[handlerInfos.length-1].name;
+  var recogHandlers = router.router.recognizer.handlersFor(targetRouteName);
+  var dynamicParent = null;
+
+  for (var i = 0, len = handlerInfos.length; i < len; ++i) {
+    var handlerInfo = handlerInfos[i];
+    var names = recogHandlers[i].names;
+
+    if (names.length) {
+      dynamicParent = handlerInfo;
+    }
+
+    handlerInfo._names = names;
+
+    var route = handlerInfo.handler;
+    route._stashNames(handlerInfo, dynamicParent);
+  }
+
+  handlerInfos._namesStashed = true;
+}


### PR DESCRIPTION
routeArgs, getActiveTargetName and stashParamNames don't have to do with the handlebars integration so I pulled them back into ember-routing.
