### PR TITLE
Fix for #5579

### DIFF
--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -112,6 +112,33 @@ test("View lookup - 'fu'", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
+test("View lookup - 'fu' when fu is a property and a view name", function() {
+  var FuView = viewClass({
+    elementId: "fu",
+    template: Ember.Handlebars.compile("bro")
+  });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: Ember.Handlebars.compile("{{view 'fu'}}"),
+    context: {fu: 'boom!'},
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#fu').text(), 'bro');
+});
+
 test("View lookup - view.computed", function() {
   var FuView = viewClass({
     elementId: "fu",


### PR DESCRIPTION
If the view is named by a string try to look that up first.
