### PR TITLE
es6 lint to improve ES6 compatability

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -20,7 +20,6 @@ import { isGlobalPath } from "ember-metal/binding";
 import { bind as emberBind } from "ember-metal/binding";
 import jQuery from "ember-views/system/jquery";
 import { isArray } from "ember-metal/utils";
-import { getEscaped } from "ember-handlebars/ext";
 import keys from "ember-metal/keys";
 import Cache from "ember-metal/cache";
 

--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -80,7 +80,6 @@ import {
   SimpleHandlebarsView
 } from "ember-handlebars/views/handlebars_bound_view";
 import {
-  _wrapMap,
   _SimpleMetamorphView,
   _MetamorphView,
   _Metamorph
@@ -123,7 +122,6 @@ Ember._HandlebarsBoundView = _HandlebarsBoundView;
 Ember._SimpleMetamorphView = _SimpleMetamorphView;
 Ember._MetamorphView = _MetamorphView;
 Ember._Metamorph = _Metamorph;
-Ember._metamorphWrapMap = _wrapMap;
 Ember.TextSupport = TextSupport;
 Ember.Checkbox = Checkbox;
 Ember.Select = Select;

--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -28,7 +28,7 @@ function isEmpty(obj) {
   return isNone(obj) || (obj.length === 0 && typeof obj !== 'function') || (typeof obj === 'object' && get(obj, 'length') === 0);
 }
 
-export var empty = Ember.deprecateFunc("Ember.empty is deprecated. Please use Ember.isEmpty instead.", isEmpty);
+var empty = Ember.deprecateFunc("Ember.empty is deprecated. Please use Ember.isEmpty instead.", isEmpty);
 
 export default isEmpty;
 export {

--- a/packages/ember-runtime/lib/system/container.js
+++ b/packages/ember-runtime/lib/system/container.js
@@ -1,4 +1,4 @@
-import set from "ember-metal/property_set";
+import { set } from "ember-metal/property_set";
 
 var Container = requireModule('container')["default"];
 Container.set = set;


### PR DESCRIPTION
After building the code with Traceur I found there are some minor lint issues.
like duplicate imports / exports or importing none existing values this changes solve some of this issues;
