### PR TITLE
ES6 circulare dependencies in ember-metal properties and property_set

### DIFF
--- a/packages/ember-metal/lib/deprecate_property.js
+++ b/packages/ember-metal/lib/deprecate_property.js
@@ -1,0 +1,37 @@
+/**
+@module ember-metal
+*/
+
+import Ember from "ember-metal/core";
+import { hasPropertyAccessors } from "ember-metal/platform";
+import { defineProperty } from "ember-metal/properties";
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+
+
+/**
+  Used internally to allow changing properties in a backwards compatible way, and print a helpful
+  deprecation warning.
+
+  @method deprecateProperty
+  @param {Object} object The object to add the deprecated property to.
+  @param {String} deprecatedKey The property to add (and print deprecation warnings upon accessing).
+  @param {String} newKey The property that will be aliased.
+  @private
+  @since 1.7.0
+*/
+
+export function deprecateProperty(object, deprecatedKey, newKey) {
+  function deprecate() {
+    Ember.deprecate('Usage of `' + deprecatedKey + '` is deprecated, use `' + newKey + '` instead.');
+  }
+
+  if (hasPropertyAccessors) {
+    defineProperty(object, deprecatedKey, {
+        configurable: true,
+        enumerable: false,
+        set: function(value) { deprecate(); set(this, newKey, value); },
+        get: function() { deprecate(); return get(this, newKey); }
+    });
+  }
+}

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -9,9 +9,6 @@ import {
   hasPropertyAccessors
 } from "ember-metal/platform";
 import { overrideChains } from "ember-metal/property_events";
-import { get } from "ember-metal/property_get";
-import { set } from "ember-metal/property_set";
-
 // ..........................................................
 // DESCRIPTOR
 //
@@ -159,31 +156,4 @@ export function defineProperty(obj, keyName, desc, data, meta) {
   if (obj.didDefineProperty) { obj.didDefineProperty(obj, keyName, value); }
 
   return this;
-}
-
-/**
-  Used internally to allow changing properties in a backwards compatible way, and print a helpful
-  deprecation warning.
-
-  @method deprecateProperty
-  @param {Object} object The object to add the deprecated property to.
-  @param {String} deprecatedKey The property to add (and print deprecation warnings upon accessing).
-  @param {String} newKey The property that will be aliased.
-  @private
-  @since 1.7.0
-*/
-
-export function deprecateProperty(object, deprecatedKey, newKey) {
-  function deprecate() {
-    Ember.deprecate('Usage of `' + deprecatedKey + '` is deprecated, use `' + newKey + '` instead.');
-  }
-
-  if (hasPropertyAccessors) {
-    defineProperty(object, deprecatedKey, {
-        configurable: true,
-        enumerable: false,
-        set: function(value) { deprecate(); set(this, newKey, value); },
-        get: function() { deprecate(); return get(this, newKey); }
-    });
-  }
 }

--- a/packages/ember-metal/tests/properties_test.js
+++ b/packages/ember-metal/tests/properties_test.js
@@ -1,9 +1,8 @@
 import Ember from 'ember-metal/core';
 import { hasPropertyAccessors } from "ember-metal/platform";
 import { computed } from 'ember-metal/computed';
-import { defineProperty,
-         deprecateProperty
-} from "ember-metal/properties";
+import { defineProperty } from "ember-metal/properties";
+import { deprecateProperty } from "ember-metal/deprecate_property";
 
 QUnit.module('Ember.defineProperty');
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -24,7 +24,7 @@ import {
 } from "ember-metal/utils";
 import { isNone } from 'ember-metal/is_none';
 import { Mixin } from 'ember-metal/mixin';
-import { deprecateProperty } from "ember-metal/properties";
+import { deprecateProperty } from "ember-metal/deprecate_property";
 import { A as emberA } from "ember-runtime/system/native_array";
 
 import { dasherize } from "ember-runtime/system/string";


### PR DESCRIPTION
For the deprecateProperty method we need to have access to the set and get method
but the property_set method also relies on the defineProperty method which is in the same file
I think the good and easy way to solve it is to move deprecateProperty so thats what this fix does.
