### PR TITLE
Get firstObject/lastObject notification only when cached

### DIFF
--- a/packages/ember-runtime/tests/suites/mutable_array/replace.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/replace.js
@@ -22,6 +22,23 @@ suite.test('[].replace(0,0,\'X\') => [\'X\'] + notify', function() {
   equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
 });
 
+suite.test('[].replace(0,0,"X") => ["X"] + avoid calling objectAt and notifying fistObject/lastObject when not in cache', function() {
+  var obj, exp, observer;
+  var called = 0;
+  exp = this.newFixture(1);
+  obj = this.newObject([]);
+  obj.objectAt = function() {
+    called++;
+  };
+  observer = this.newObserver(obj, 'firstObject', 'lastObject');
+
+  obj.replace(0, 0, exp);
+
+  equal(called, 0, 'should NOT have called objectAt upon replace when firstObject/lastObject are not cached');
+  equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject since not cached');
+  equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject since not cached');
+});
+
 suite.test('[A,B,C,D].replace(1,2,X) => [A,X,D] + notify', function() {
   var obj, observer, before, replace, after;
 


### PR DESCRIPTION
Created Em.Array#arrayFirstLastObjectChange abstraction in order to be able to override the Em.Array#firstObject/lastObject notification implementation which by default calls #objectAt(0) and #objectAt(length-1).

These calls are not optimal in case of e.g. sparse RecordArrays which would trigger unnecessary content[index] requests.

Consider an example of using Ember.ListView which only pulls the rendered items out of the content array. In case the content is an ArrayController which dynamically loads items as rendered the Em.Array would actually request the index of 0 and length-1 even in cases where those index content items are not to be rendered at all and therefore trigger unnecessary store layer roundtrips.
