### PR TITLE
Remove duplicate _MetamorphView

### DIFF
--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -27,10 +27,8 @@ import {
   removeBeforeObserver
 } from "ember-metal/observer";
 
-import {
-  _Metamorph,
-  _MetamorphView
-} from "ember-handlebars/views/metamorph_view";
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
+import { _Metamorph } from "ember-handlebars/views/metamorph_view";
 
 var EachView = CollectionView.extend(_Metamorph, {
 

--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -79,9 +79,9 @@ import {
   _HandlebarsBoundView,
   SimpleHandlebarsView
 } from "ember-handlebars/views/handlebars_bound_view";
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
 import {
   _SimpleMetamorphView,
-  _MetamorphView,
   _Metamorph
 } from "ember-handlebars/views/metamorph_view";
 

--- a/packages/ember-handlebars/lib/views/metamorph_view.js
+++ b/packages/ember-handlebars/lib/views/metamorph_view.js
@@ -37,7 +37,7 @@ export var _Metamorph = Mixin.create({
   @uses Ember._Metamorph
   @private
 */
-export var _MetamorphView = View.extend(_Metamorph);
+export default View.extend(_Metamorph);
 
 /**
   @class _SimpleMetamorphView
@@ -47,4 +47,3 @@ export var _MetamorphView = View.extend(_Metamorph);
   @private
 */
 export var _SimpleMetamorphView = CoreView.extend(_Metamorph);
-export default View.extend(_Metamorph);

--- a/packages/ember-routing-handlebars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/outlet_test.js
@@ -17,7 +17,7 @@ import EmberRouter from "ember-routing/system/router";
 import HashLocation from "ember-routing/location/hash_location";
 
 import EmberHandlebars from "ember-handlebars";
-import {_MetamorphView} from "ember-handlebars/views/metamorph_view";
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
 import EmberView from "ember-routing/ext/view";
 import EmberContainerView from "ember-views/views/container_view";
 import jQuery from "ember-views/system/jquery";


### PR DESCRIPTION
We had two separate copies of `View.extend(_Metamorph)`
