### PR TITLE
Remove outdated model documentation

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1176,7 +1176,7 @@ var Route = EmberObject.extend(ActionHandler, {
     });
     ```
 
-    The model for the `post` route is `App.Post.find(params.post_id)`.
+    The model for the `post` route is `store.find('post', params.post_id)`.
 
     By default, if your route has a dynamic segment ending in `_id`:
 
@@ -1219,7 +1219,7 @@ var Route = EmberObject.extend(ActionHandler, {
     ```js
     App.PostRoute = Ember.Route.extend({
       model: function(params) {
-        return App.Post.find(params.post_id);
+        return this.store.find('post', params.post_id);
       }
     });
     ```
@@ -1390,7 +1390,7 @@ var Route = EmberObject.extend(ActionHandler, {
     ```js
     App.PhotosRoute = Ember.Route.extend({
       model: function() {
-        return App.Photo.find();
+        return this.store.find('photo');
       },
 
       setupController: function (controller, model) {


### PR DESCRIPTION
Since the static `find` method on models was [removed over a year ago](https://github.com/emberjs/data/commit/d96327c30a74a55aa75ed42b73b95198e5f9f024#diff-4cc9f4885e8425eeaa555ef3648588ae), I removed some of the references to it and used the store's `find` method instead.
