### PR TITLE
WIP explore alternative build+ runtime super approach.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -261,7 +261,7 @@ var Application = Namespace.extend(DeferredMixin, {
 
     this.Router = this.defaultRouter();
 
-    this._super();
+    this._super$application_init();
 
     this.scheduleInitialize();
 
@@ -778,10 +778,10 @@ var Application = Namespace.extend(DeferredMixin, {
     @private
     @deprecated
   */
-  then: function() {
+  then: function(fulfillment, rejection, label) {
     Ember.deprecate('Do not use `.then` on an instance of Ember.Application.  Please use the `.ready` hook instead.');
 
-    this._super.apply(this, arguments);
+    this._super$application_then(fulfillment, rejection, label);
   }
 });
 

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -55,7 +55,7 @@ import Application from "ember-application/system/application";
 */
 export default EmberObject.extend({
   init: function() {
-    this._super();
+    this._super$dataAdapter_init();
     this.releaseMethods = emberA();
   },
 
@@ -230,7 +230,7 @@ export default EmberObject.extend({
     @method willDestroy
   */
   willDestroy: function() {
-    this._super();
+    this._super$dataAdapter_willDestroy();
     this.releaseMethods.forEach(function(fn) {
       fn();
     });

--- a/packages/ember-handlebars/lib/controls/checkbox.js
+++ b/packages/ember-handlebars/lib/controls/checkbox.js
@@ -56,12 +56,12 @@ export default View.extend({
   indeterminate: false,
 
   init: function() {
-    this._super();
+    this._super$checkBox_init();
     this.on('change', this, this._updateElementValue);
   },
 
   didInsertElement: function() {
-    this._super();
+    this._super$checkBox_didInsertElement();
     get(this, 'element').indeterminate = !!get(this, 'indeterminate');
   },
 

--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -40,7 +40,7 @@ var SelectOption = View.extend({
     this.labelPathDidChange();
     this.valuePathDidChange();
 
-    this._super();
+    this._super$selectOption_init();
   },
 
   selected: computed(function() {
@@ -615,7 +615,7 @@ var Select = View.extend({
   },
 
   init: function() {
-    this._super();
+    this._super$select_init();
     this.on("didInsertElement", this, this._triggerChange);
     this.on("change", this, this._change);
   }

--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -45,7 +45,7 @@ export default Component.extend(TextSupport, {
   }),
 
   init: function() {
-    this._super();
+    this._super$textArea_init();
     this.on("didInsertElement", this, this._updateElementValue);
   }
 });

--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -8,7 +8,7 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.warn, uuid
 
 import EmberHandlebars from "ember-handlebars-compiler";
 import { get } from "ember-metal/property_get";
-import { apply, uuid } from "ember-metal/utils";
+import { uuid } from "ember-metal/utils";
 import { fmt } from "ember-runtime/system/string";
 import { create as o_create } from "ember-metal/platform";
 import isNone from 'ember-metal/is_none';
@@ -51,7 +51,7 @@ var WithView = _HandlebarsBoundView.extend({
   init: function() {
     var controller;
 
-    apply(this, this._super, arguments);
+    this._super$withView();
 
     var keywords        = this.templateData.keywords;
     var keywordName     = this.templateHash.keywordName;
@@ -89,7 +89,7 @@ var WithView = _HandlebarsBoundView.extend({
 
   },
   willDestroy: function() {
-    this._super();
+    this._super$withView_willDestroy();
 
     if (this._generatedController) {
       this._generatedController.destroy();

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -62,7 +62,7 @@ var EachView = CollectionView.extend(_Metamorph, {
       });
     }
 
-    return this._super();
+    return this._super$eachView_init();
   },
 
   _assertArrayLike: function(content) {
@@ -89,7 +89,7 @@ var EachView = CollectionView.extend(_Metamorph, {
   emptyViewClass: _MetamorphView,
 
   createChildView: function(view, attrs) {
-    view = this._super(view, attrs);
+    view = this._super$eachView_createChildView(view, attrs);
 
     // At the moment, if a container view subclass wants
     // to insert keywords, it is responsible for cloning
@@ -119,7 +119,7 @@ var EachView = CollectionView.extend(_Metamorph, {
   },
 
   destroy: function() {
-    if (!this._super()) { return; }
+    if (!this._super$eachView_destroy()) { return; }
 
     var arrayController = get(this, '_arrayController');
 

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -333,7 +333,7 @@ var _HandlebarsBoundView = _MetamorphView.extend({
       set(this, 'template', function() { return ''; });
     }
 
-    return this._super(buffer);
+    return this._super$handlebarsBoundView_render(buffer);
   }
 });
 

--- a/packages/ember-metal/lib/keys.js
+++ b/packages/ember-metal/lib/keys.js
@@ -30,7 +30,7 @@ if (!keys || !canDefineNonEnumerableProperties) {
       return;
     }
 
-    if (key === '_super') {
+    if (key === '_super' || key.indexOf('__super') > -1) {
       return;
     }
 

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -164,14 +164,37 @@ function giveMethodSuper(obj, key, method, values, descs) {
   }
 
   var hasSuper = method.__hasSuper;
+  var methodToString;
+  var superName;
 
   if (hasSuper === undefined) {
-    hasSuper = method.toString().indexOf('_super') > -1;
+    methodToString = method.toString();
+    hasSuper = methodToString.indexOf('_super') > -1;
+
+    if (hasSuper) {
+      var match = methodToString.match(/(_super\$\w+)/);
+      if (match) {
+        superName = match[0];
+      }
+    }
+
     method.__hasSuper = hasSuper;
   }
 
   if (hasSuper) {
-    return wrap(method, superMethod);
+    if (superName) {
+      if (obj[superName] === undefined) {
+        Ember.defineProperty(obj, superName, {
+         value: superMethod,
+         enumerable: false
+        });
+      } else {
+        throw new Error('Conflicting super');
+      }
+      return method;
+    } else {
+      return wrap(method, superMethod);
+    }
   } else {
     return method;
   }

--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -206,7 +206,7 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
     @method init
   */
   init: function() {
-    this._super.apply(this, arguments);
+    this._super$linkTo_init();
 
     Ember.deprecate('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.', !this.currentWhen);
 
@@ -275,7 +275,7 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
   },
 
   afterRender: function(){
-    this._super.apply(this, arguments);
+    this._super$linkTo_afterRender();
     this._setupPathObservers();
   },
 

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -17,7 +17,7 @@ ControllerMixin.reopen({
   concatenatedProperties: ['queryParams', '_pCacheMeta'],
 
   init: function() {
-    this._super.apply(this, arguments);
+    this._super();
     listenForQueryParamChanges(this);
   },
 

--- a/packages/ember-routing/lib/ext/view.js
+++ b/packages/ember-routing/lib/ext/view.js
@@ -17,7 +17,7 @@ EmberView.reopen({
    */
   init: function() {
     set(this, '_outlets', {});
-    this._super();
+    this._super$routingView_init();
   },
 
   /**

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -177,7 +177,7 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
   },
 
   arrangedContentDidChange: function() {
-    this._super();
+    this._super$arraController_arrangedContentDidChange();
     this._resetSubControllers();
   },
 
@@ -199,11 +199,11 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
     // The shadow array of subcontrollers must be updated before we trigger
     // observers, otherwise observers will get the wrong subcontainer when
     // calling `objectAt`
-    this._super(idx, removedCnt, addedCnt);
+    this._super$arrayController_arrayContentDidChange(idx, removedCnt, addedCnt);
   },
 
   init: function() {
-    this._super();
+    this._super$arrayController_init();
     this._subControllers = [];
   },
 
@@ -301,6 +301,6 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
 
   willDestroy: function() {
     this._resetSubControllers();
-    this._super();
+    this._super$arrayController_willDestroy();
   }
 });

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -363,7 +363,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
   },
 
   init: function() {
-    this._super();
+    this._super$arrayProxy_init();
     this._setupContent();
     this._setupArrangedContent();
   },

--- a/packages/ember-runtime/lib/system/deferred.js
+++ b/packages/ember-runtime/lib/system/deferred.js
@@ -5,7 +5,7 @@ import EmberObject from "ember-runtime/system/object";
 var Deferred = EmberObject.extend(DeferredMixin, {
   init: function() {
     Ember.deprecate('Usage of Ember.Deferred is deprecated.');
-    this._super();
+    this._super$deferred_init();
   }
 });
 

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -32,7 +32,7 @@ import {
 var EachArray = EmberObject.extend(EmberArray, {
 
   init: function(content, keyName, owner) {
-    this._super();
+    this._super$eachArray_init();
     this._keyName = keyName;
     this._owner   = owner;
     this._content = content;
@@ -104,7 +104,7 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
 var EachProxy = EmberObject.extend({
 
   init: function(content) {
-    this._super();
+    this._super$eachProxy_init();
     this._content = content;
     content.addArrayObserver(this);
 

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -61,7 +61,7 @@ var Namespace = EmberObject.extend({
       delete Namespace.NAMESPACES_BY_ID[toString];
     }
     namespaces.splice(indexOf.call(namespaces, this), 1);
-    this._super();
+    this._super$namespace_destroy();
   }
 });
 

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -359,7 +359,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
   init: function(items) {
     Ember.deprecate('Ember.Set is deprecated and will be removed in a future release.');
-    this._super();
+    this._super$Set_init();
     if (items) this.addObjects(items);
   },
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -237,7 +237,7 @@ export default EmberObject.extend({
   destroy: function() {
     var rootElement = get(this, 'rootElement');
     jQuery(rootElement).off('.ember', '**').removeClass('ember-application');
-    return this._super();
+    return this._super$EventDispatcher_destroy();
   },
 
   toString: function() {

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -227,7 +227,7 @@ var CollectionView = ContainerView.extend({
     @method init
   */
   init: function() {
-    var ret = this._super();
+    var ret = this._super$CollectionView_init();
     this._contentDidChange();
     return ret;
   },
@@ -284,7 +284,7 @@ var CollectionView = ContainerView.extend({
     @method destroy
   */
   destroy: function() {
-    if (!this._super()) { return; }
+    if (!this._super$CollectionView_destroy()) { return; }
 
     var content = get(this, 'content');
     if (content) { content.removeArrayObserver(this); }
@@ -400,7 +400,7 @@ var CollectionView = ContainerView.extend({
     @return {Ember.View} new instance
   */
   createChildView: function(view, attrs) {
-    view = this._super(view, attrs);
+    view = this._super$CollectionView_createChildView(view, attrs);
 
     var itemTagName = get(view, 'tagName');
 

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -111,7 +111,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
   }),
 
   init: function() {
-    this._super();
+    this._super$Component_init();
     set(this, 'origContext', get(this, 'context'));
     set(this, 'context', this);
     set(this, 'controller', this);

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -193,7 +193,7 @@ var ContainerView = View.extend(MutableArray, {
   },
 
   init: function() {
-    this._super();
+    this._super$ContainerView_init();
 
     var childViews = get(this, 'childViews');
 

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -34,7 +34,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   _states: cloneStates(states),
 
   init: function() {
-    this._super();
+    this._super$CoreView_init();
     this._transitionTo('preRender');
     this._isVisible = get(this, 'isVisible');
   },
@@ -84,7 +84,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     @private
   */
   trigger: function() {
-    this._super.apply(this, arguments);
+    this._super$CoreView_trigger.apply(this, arguments);
     var name = arguments[0];
     var method = this[name];
     if (method) {
@@ -98,13 +98,13 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   },
 
   has: function(name) {
-    return typeOf(this[name]) === 'function' || this._super(name);
+    return typeOf(this[name]) === 'function' || this._super$CoreView_has(name);
   },
 
   destroy: function() {
     var parent = this._parentView;
 
-    if (!this._super()) { return; }
+    if (!this._super$CoreView_destroy()) { return; }
 
 
     // destroy the element -- this will avoid each child view destroying

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1515,7 +1515,7 @@ var View = CoreView.extend({
 
   instrumentDetails: function(hash) {
     hash.template = get(this, 'templateName');
-    this._super(hash);
+    this._super$View_instrumentDetails(hash);
   },
 
   beforeRender: function(buffer) {},
@@ -1687,7 +1687,7 @@ var View = CoreView.extend({
       this.elementId = guidFor(this);
     }
 
-    this._super();
+    this._super$View_init();
 
     // setup child views. be sure to clone the child views array first
     this._childViews = this._childViews.slice();
@@ -1777,7 +1777,7 @@ var View = CoreView.extend({
     var nonVirtualParentView = get(this, 'parentView');
     var viewName = this.viewName;
 
-    if (!this._super()) { return; }
+    if (!this._super$View_destroy()) { return; }
 
     // remove from non-virtual parent view if viewName was specified
     if (viewName && nonVirtualParentView) {


### PR DESCRIPTION
- [ ] if we do this it needs to be a build step (so firefox OS certified and PS3 certified apps can use it)
- [ ] make it work with super in mixins
- [ ] broccoli filter for ember-cli apps, so they can opt into the faster/better super.

build tool could inline something like, this could enable us to drop the need for toString entirely.

``` js
__superFunctions: [
  ['init', 'EmberView_init']
]
```

Specific improvements doesn't really seem like much as we have already reduced superWrapper. But in terms of reducing overall cost of super, it is a really nice step. As this doesn't require a rebind, nor a super wrapper. 

This should allow and enable further runtime optimizations as well as fix some existing super issues.

For example, if an error is thrown __nextSuper may not be restored correctly.

This may still have other implications I have not thought about yet.

before:

![screenshot 2014-09-18 01 58 59](https://cloud.githubusercontent.com/assets/1377/4315619/72ec7c9c-3ef9-11e4-85c6-b1a4d936ed17.png)

after:

![screenshot 2014-09-18 01 59 13](https://cloud.githubusercontent.com/assets/1377/4315620/788b73f6-3ef9-11e4-8009-d278a44056eb.png)
