### PR TITLE
[BUGFIX beta] Fix ember-routing-inherits-parent-model for nestable routes.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1252,7 +1252,7 @@ var Route = EmberObject.extend(ActionHandler, {
 
     if (!name && sawParams) { return copy(params); }
     else if (!name) {
-      if (transition.resolveIndex !== transition.state.handlerInfos.length-1) { return; }
+      if (transition.resolveIndex < 1) { return; }
 
       var parentModel = transition.state.handlerInfos[transition.resolveIndex-1].context;
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1624,7 +1624,7 @@ test("Route inherits model from parent route", function() {
   handleURL("/posts/3/shares/3");
 });
 
-test("Resource does not inherit model from parent resource", function() {
+test("Resource inherits model from parent resource", function() {
   expect(6);
 
   Router.map(function() {
@@ -1652,7 +1652,7 @@ test("Resource does not inherit model from parent resource", function() {
     afterModel: function(post, transition) {
       var parent_model = this.modelFor('thePost');
 
-      notEqual(post, parent_model);
+      equal(post, parent_model);
     }
   });
 


### PR DESCRIPTION
When the original [ember-routing-inherits-parent-model feature](https://github.com/emberjs/ember.js/pull/4246) was accepted, it was decided that routes could inherit their parent's model but resources couldn't.

But now the distinction between those two is smaller than ever, and the existing check is actually wrong, since it excludes routes with children.

I'm proposing we scrap this legacy distinction and just let any route inherit.
