### PR TITLE
[BUGFIX release] make GUID_KEY = intern(GUID_KEY) actually work on ES3.

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -10,7 +10,6 @@ import {
   forEach
 } from "ember-metal/array";
 
-import keys from "ember-metal/keys";
 /**
 @module ember-metal
 */
@@ -91,10 +90,13 @@ var stringCache  = {};
   @private
   @return {String} interned version of the provided string
 */
-function intern(string) {
-  var obj = Object.create(null);
-  obj[string] = true;
-  return keys(obj)[0];
+function intern(str) {
+  var obj = {};
+  obj[str] = 1;
+  for (var key in obj) {
+    if (key === str) return key;
+  }
+  return str;
 }
 
 /**


### PR DESCRIPTION
Ember.keys() filters out __ leading underscores so it returns undefined for GUID_KEY. This change not only works in ES3 browsers but is faster across all browsers I benchmarked.
