### PR TITLE
[Bugfix Beta] Improve Ember.Map

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -244,7 +244,7 @@ Binding.prototype = {
     var fromPath = this._from;
     var toPath = this._to;
 
-    directionMap.remove(obj);
+    directionMap.delete(obj);
 
     // if we're synchronizing from the remote object...
     if (direction === 'fwd') {

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core"; // Ember.Logger, Ember.LOG_BINDINGS, asser
 import { get } from "ember-metal/property_get";
 import { trySet } from "ember-metal/property_set";
 import { guidFor } from "ember-metal/utils";
-import { Map } from "ember-metal/map";
+import Map from "ember-metal/map";
 import {
   addObserver,
   removeObserver,
@@ -58,7 +58,7 @@ function Binding(toPath, fromPath) {
   this._direction = 'fwd';
   this._from = fromPath;
   this._to   = toPath;
-  this._directionMap = Map.create();
+  this._directionMap = new Map();
   this._readyToSync = undefined;
   this._oneWay = undefined;
 }

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -173,6 +173,8 @@ OrderedSet.prototype = {
     @return {Boolean}
   */
   has: function(obj) {
+    if (this.size === 0) { return; }
+
     var guid = guidFor(obj);
     var presenceSet = this.presenceSet;
 
@@ -185,6 +187,8 @@ OrderedSet.prototype = {
     @param self
   */
   forEach: function(fn, thisArg) {
+    if (this.size === 0) { return; }
+
     var list = this.list;
     var length = arguments.length;
     var i;
@@ -219,6 +223,7 @@ OrderedSet.prototype = {
     set._silenceRemoveDeprecation = this._silenceRemoveDeprecation;
     set.presenceSet = copyNull(this.presenceSet);
     set.list = this.toArray();
+    set.size = this.size;
 
     return set;
   }
@@ -288,6 +293,8 @@ Map.prototype = {
     @return {*} the value associated with the key, or `undefined`
   */
   get: function(key) {
+    if (this.size === 0) { return; }
+
     var values = this.values;
     var guid = guidFor(key);
 
@@ -338,6 +345,7 @@ Map.prototype = {
     @return {Boolean} true if an item was removed, false otherwise
   */
   'delete': function(key) {
+    if (this.size === 0) { return false; }
     // don't use ES6 "delete" because it will be annoying
     // to use in browsers that are not ES6 friendly;
     var keys = this.keys;
@@ -362,6 +370,7 @@ Map.prototype = {
     @return {Boolean} true if the item was present, false otherwise
   */
   has: function(key) {
+    if (this.size === 0) { return; }
     return this.keys.has(key);
   },
 
@@ -380,6 +389,8 @@ Map.prototype = {
     if (typeof callback !== 'function') {
       missingFunction(callback);
     }
+
+    if (this.size === 0) { return; }
 
     var length = arguments.length;
     var map = this;
@@ -475,6 +486,7 @@ MapWithDefault.prototype.copy = function() {
 };
 
 export default Map;
+
 export {
   OrderedSet,
   Map,

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -474,6 +474,7 @@ MapWithDefault.prototype.copy = function() {
   }));
 };
 
+export default Map;
 export {
   OrderedSet,
   Map,

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -25,6 +25,7 @@
 import { guidFor } from "ember-metal/utils";
 import { indexOf } from "ember-metal/array";
 import { create } from "ember-metal/platform";
+import { deprecateProperty } from "ember-metal/deprecate_property";
 
 function missingFunction(fn) {
   throw new TypeError('' + Object.prototype.toString.call(fn) + " is not a function");
@@ -70,6 +71,7 @@ function OrderedSet() {
 
   if (this instanceof OrderedSet) {
     this.clear();
+    this._silenceRemoveDeprecation = false;
   } else {
     missingNew("OrderedSet");
   }
@@ -128,6 +130,8 @@ OrderedSet.prototype = {
     @return {Boolean}
   */
   remove: function(obj, _guid) {
+    Ember.deprecate('Calling `OrderedSet.prototype.remove` has been deprecated, please use `OrderedSet.prototype.delete` instead.', this._silenceRemoveDeprecation);
+
     return this['delete'](obj, _guid);
   },
 
@@ -212,12 +216,15 @@ OrderedSet.prototype = {
     var Constructor = this.constructor;
     var set = new Constructor();
 
+    set._silenceRemoveDeprecation = this._silenceRemoveDeprecation;
     set.presenceSet = copyNull(this.presenceSet);
     set.list = this.toArray();
 
     return set;
   }
 };
+
+deprecateProperty(OrderedSet.prototype, 'length', 'size');
 
 /**
   A Map stores values indexed by keys. Unlike JavaScript's
@@ -242,6 +249,7 @@ OrderedSet.prototype = {
 function Map() {
   if (this instanceof this.constructor) {
     this.keys = OrderedSet.create();
+    this.keys._silenceRemoveDeprecation = true;
     this.values = Object.create(null);
     this.size = 0;
   } else {
@@ -317,6 +325,8 @@ Map.prototype = {
     @return {Boolean} true if an item was removed, false otherwise
   */
   remove: function(key) {
+    Ember.deprecate('Calling `Map.prototype.remove` has been deprecated, please use `Map.prototype.delete` instead.');
+
     return this['delete'](key);
   },
 
@@ -396,6 +406,8 @@ Map.prototype = {
     return copyMap(this, new Map());
   }
 };
+
+deprecateProperty(Map.prototype, 'length', 'size');
 
 /**
   @class MapWithDefault

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -41,7 +41,13 @@ function testMap(nameAndFunc) {
     mapHasLength(entries.length, theMap);
   };
 
-  test("add", function() {
+  var unboundThis;
+
+  (function() {
+    unboundThis = this;
+  }());
+
+  test("set", function() {
     map.set(object, "winning");
     map.set(number, "winning");
     map.set(string, "winning");
@@ -62,8 +68,46 @@ function testMap(nameAndFunc) {
       [ string, "losing" ]
     ]);
 
-    equal(map.has("nope"), false);
-    equal(map.has({}), false);
+    equal(map.has("nope"), false, "expected the key `nope` to not be present");
+    equal(map.has({}), false, "expected they key `{}` to not be present");
+  });
+
+  test("set chaining", function() {
+    map.set(object, "winning").
+        set(number, "winning").
+        set(string, "winning");
+
+    mapHasEntries([
+      [ object, "winning" ],
+      [ number, "winning" ],
+      [ string, "winning" ]
+    ]);
+
+    map.set(object, "losing").
+        set(number, "losing").
+        set(string, "losing");
+
+    mapHasEntries([
+      [ object, "losing" ],
+      [ number, "losing" ],
+      [ string, "losing" ]
+    ]);
+
+    equal(map.has("nope"), false, "expected the key `nope` to not be present");
+    equal(map.has({}), false, "expected they key `{}` to not be present");
+  });
+
+  test("with key with undefined value", function() {
+    map.set("foo", undefined);
+
+    map.forEach(function(value, key) {
+      equal(value, undefined);
+      equal(key, 'foo');
+    });
+
+    ok(map.has("foo"), "has key foo, even with undefined value");
+
+    equal(map.size, 1);
   });
 
   test("remove", function() {
@@ -125,37 +169,169 @@ function testMap(nameAndFunc) {
     mapHasEntries([ ], map2);
   });
 
-  test("length", function() {
+  test("size", function() {
     //Add a key twice
-    equal(map.length, 0);
+    equal(map.size, 0);
     map.set(string, "a string");
-    equal(map.length, 1);
+    equal(map.size, 1);
     map.set(string, "the same string");
-    equal(map.length, 1);
+    equal(map.size, 1);
 
     //Add another
     map.set(number, "a number");
-    equal(map.length, 2);
+    equal(map.size, 2);
 
     //Remove one that doesn't exist
     map.remove('does not exist');
-    equal(map.length, 2);
+    equal(map.size, 2);
 
     //Check copy
     var copy = map.copy();
-    equal(copy.length, 2);
+    equal(copy.size, 2);
 
     //Remove a key twice
     map.remove(number);
-    equal(map.length, 1);
+    equal(map.size, 1);
     map.remove(number);
-    equal(map.length, 1);
+    equal(map.size, 1);
 
     //Remove the last key
     map.remove(string);
-    equal(map.length, 0);
+    equal(map.size, 0);
     map.remove(string);
-    equal(map.length, 0);
+    equal(map.size, 0);
+  });
+
+  test("forEach without proper callback", function() {
+    QUnit.throws(function() {
+      map.forEach();
+    }, '[object Undefined] is not a function');
+
+    QUnit.throws(function() {
+      map.forEach(undefined);
+    }, '[object Undefined] is not a function');
+
+    QUnit.throws(function() {
+      map.forEach(1);
+    }, '[object Number] is not a function');
+
+    QUnit.throws(function() {
+      map.forEach({});
+    }, '[object Object] is not a function');
+  });
+
+  test("forEach basic", function() {
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    var iteration = 0;
+
+    var expectations = [
+      { value: 1, key: "a", context: unboundThis },
+      { value: 2, key: "b", context: unboundThis },
+      { value: 3, key: "c", context: unboundThis },
+    ];
+
+    map.forEach(function(value, key) {
+      var expectation = expectations[iteration];
+
+      equal(value, expectation.value, 'value should be correct');
+      equal(key, expectation.key, 'key should be correct');
+      equal(this, expectation.context, 'context should be as if it was unbound');
+
+      iteration++;
+    });
+
+    equal(iteration, 3, 'expected 3 iterations');
+
+  });
+
+  test("forEach basic /w context", function() {
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    var iteration = 0;
+    var context = {};
+    var expectations = [
+      { value: 1, key: "a", context: context },
+      { value: 2, key: "b", context: context },
+      { value: 3, key: "c", context: context },
+    ];
+
+    map.forEach(function(value, key) {
+      var expectation = expectations[iteration];
+
+      equal(value, expectation.value, 'value should be correct');
+      equal(key, expectation.key, 'key should be correct');
+      equal(this, expectation.context, 'context should be as if it was unbound');
+
+      iteration++;
+
+    }, context);
+
+    equal(iteration, 3, 'expected 3 iterations');
+  });
+
+  test("forEach basic /w deletion while enumerating", function() {
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    var iteration = 0;
+
+    var expectations = [
+      { value: 1, key: "a", context: unboundThis },
+      { value: 2, key: "b", context: unboundThis }
+    ];
+
+    map.forEach(function(value, key) {
+      if (iteration === 0) {
+        map.delete("c");
+      }
+
+      var expectation = expectations[iteration];
+
+      equal(value, expectation.value, 'value should be correct');
+      equal(key, expectation.key, 'key should be correct');
+      equal(this, expectation.context, 'context should be as if it was unbound');
+
+      iteration++;
+    });
+
+    equal(iteration, 2, 'expected 3 iterations');
+  });
+
+  test("forEach basic /w addition while enumerating", function() {
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    var iteration = 0;
+
+    var expectations = [
+      { value: 1, key: "a", context: unboundThis },
+      { value: 2, key: "b", context: unboundThis },
+      { value: 3, key: "c", context: unboundThis },
+      { value: 4, key: "d", context: unboundThis },
+    ];
+
+    map.forEach(function(value, key) {
+      if (iteration === 0) {
+        map.set('d', 4);
+      }
+
+      var expectation = expectations[iteration];
+
+      equal(value, expectation.value, 'value should be correct');
+      equal(key, expectation.key, 'key should be correct');
+      equal(this, expectation.context, 'context should be as if it was unbound');
+
+      iteration++;
+    });
+
+    equal(iteration, 4, 'expected 3 iterations');
   });
 }
 

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -115,12 +115,31 @@ function testMap(nameAndFunc) {
     map.set(number, "winning");
     map.set(string, "winning");
 
-    map.remove(object);
-    map.remove(number);
-    map.remove(string);
+    expectDeprecation(function() {
+      map.remove(object);
+      map.remove(number);
+      map.remove(string);
+
+      // doesn't explode
+      map.remove({});
+    }, 'Calling `Map.prototype.remove` has been deprecated, please use `Map.prototype.delete` instead.');
+
+    mapHasEntries([]);
+  });
+
+  test("delete", function() {
+    expectNoDeprecation();
+
+    map.set(object, "winning");
+    map.set(number, "winning");
+    map.set(string, "winning");
+
+    map.delete(object);
+    map.delete(number);
+    map.delete(string);
 
     // doesn't explode
-    map.remove({});
+    map.delete({});
 
     mapHasEntries([]);
   });
@@ -149,16 +168,16 @@ function testMap(nameAndFunc) {
     ], map2);
   });
 
-  test("copy and then remove", function() {
+  test("copy and then delete", function() {
     map.set(object, "winning");
     map.set(number, "winning");
     map.set(string, "winning");
 
     var map2 = map.copy();
 
-    map2.remove(object);
-    map2.remove(number);
-    map2.remove(string);
+    map2.delete(object);
+    map2.delete(number);
+    map2.delete(string);
 
     mapHasEntries([
       [ object, "winning" ],
@@ -167,6 +186,41 @@ function testMap(nameAndFunc) {
     ]);
 
     mapHasEntries([ ], map2);
+  });
+
+  test("length", function() {
+    expectDeprecation('Usage of `length` is deprecated, use `size` instead.');
+
+    //Add a key twice
+    equal(map.length, 0);
+    map.set(string, "a string");
+    equal(map.length, 1);
+    map.set(string, "the same string");
+    equal(map.length, 1);
+
+    //Add another
+    map.set(number, "a number");
+    equal(map.length, 2);
+
+    //Remove one that doesn't exist
+    map.delete('does not exist');
+    equal(map.length, 2);
+
+    //Check copy
+    var copy = map.copy();
+    equal(copy.length, 2);
+
+    //Remove a key twice
+    map.delete(number);
+    equal(map.length, 1);
+    map.delete(number);
+    equal(map.length, 1);
+
+    //Remove the last key
+    map.delete(string);
+    equal(map.length, 0);
+    map.delete(string);
+    equal(map.length, 0);
   });
 
   test("size", function() {
@@ -182,7 +236,7 @@ function testMap(nameAndFunc) {
     equal(map.size, 2);
 
     //Remove one that doesn't exist
-    map.remove('does not exist');
+    map.delete('does not exist');
     equal(map.size, 2);
 
     //Check copy
@@ -190,15 +244,15 @@ function testMap(nameAndFunc) {
     equal(copy.size, 2);
 
     //Remove a key twice
-    map.remove(number);
+    map.delete(number);
     equal(map.size, 1);
-    map.remove(number);
+    map.delete(number);
     equal(map.size, 1);
 
     //Remove the last key
-    map.remove(string);
+    map.delete(string);
     equal(map.size, 0);
-    map.remove(string);
+    map.delete(string);
     equal(map.size, 0);
   });
 

--- a/tests/qunit_configuration.js
+++ b/tests/qunit_configuration.js
@@ -243,7 +243,9 @@
       }
       Ember.deprecate = function(msg, test) {
         EmberDev.deprecations.actuals = EmberDev.deprecations.actuals || [];
-        EmberDev.deprecations.actuals.push([msg, test]);
+        if (!test) {
+          EmberDev.deprecations.actuals.push([msg, test]);
+        }
       };
     },
     restoreEmber: function(){


### PR DESCRIPTION
- [Perf + ES6] no longer clone array before enumeration (dramatically reduce allocations)
- [Perf] Don’t rebind the callback of forEach if not needed
- [Perf + ES6] no longer allow Map#length to be bindable
- [Perf] don’t double guid keys, as they are passed from map to ordered set (add/remove)
- [ES6] deprecate Map#remove in-favor of the es6 Map#delete
- [ES6] deprecate OrderedSet#remove in-favor of the es6 OrderedSet#delete (to be aligned with es6 set)
- [ES6] error if callback is not a function
- [ES6] Map#set should return the map. This enables chaining map.`map.set(‘foo’,1).set(‘bar’,3);` etc
- [ES6] remove length in-favor of size.
- [x] we have some extra functionality not in es6 such as clear + copy (what do @wycats r?)
- [x] removed length in-favour of size (breaking change) I can support length if needed, someone tell me (@wycats r?)
- [x] removed observable length entirely (it can be restored, but it was 1. a mistake 2. slowish) (@wycats r?)
