### PR TITLE
Set previousValues on ChangeMeta in dependentArrayWillChange

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -248,7 +248,7 @@ DependentArraysObserver.prototype = {
     if (this.suspended) { return; }
 
     var removedItem = this.callbacks.removedItem;
-    var changeMeta;
+    var changeMeta, changedItem, previousValues;
     var guid = guidFor(dependentArray);
     var dependentKey = this.dependentKeysByGuid[guid];
     var itemPropertyKeys = this.cp._itemPropertyKeys[dependentKey] || [];
@@ -273,7 +273,10 @@ DependentArraysObserver.prototype = {
 
       forEach(itemPropertyKeys, removeObservers, this);
 
-      changeMeta = new ChangeMeta(dependentArray, item, itemIndex, this.instanceMeta.propertyName, this.cp, normalizedRemoveCount);
+      if(changedItem = this.changedItems[guidFor(item)]) {
+        previousValues = changedItem.previousValues;
+      }
+      changeMeta = new ChangeMeta(dependentArray, item, itemIndex, this.instanceMeta.propertyName, this.cp, normalizedRemoveCount, previousValues);
       this.setValue(removedItem.call(
         this.instanceMeta.context, this.getValue(), item, changeMeta, this.instanceMeta.sugarMeta));
     }
@@ -290,7 +293,7 @@ DependentArraysObserver.prototype = {
     var length = get(dependentArray, 'length');
     var normalizedIndex = normalizeIndex(index, length, addedCount);
     var endIndex = normalizedIndex + addedCount;
-    var changeMeta, observerContext;
+    var changeMeta, observerContext, changedItem, previousValues;
 
     forEach(dependentArray.slice(normalizedIndex, endIndex), function (item, sliceIndex) {
       if (itemPropertyKeys) {
@@ -304,7 +307,10 @@ DependentArraysObserver.prototype = {
         }, this);
       }
 
-      changeMeta = new ChangeMeta(dependentArray, item, normalizedIndex + sliceIndex, this.instanceMeta.propertyName, this.cp, addedCount);
+      if(changedItem = this.changedItems[guidFor(item)]) {
+        previousValues = changedItem.previousValues;
+      }
+      changeMeta = new ChangeMeta(dependentArray, item, normalizedIndex + sliceIndex, this.instanceMeta.propertyName, this.cp, addedCount, previousValues);
       this.setValue(addedItem.call(
         this.instanceMeta.context, this.getValue(), item, changeMeta, this.instanceMeta.sugarMeta));
     }, this);

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -1018,3 +1018,69 @@ test("item property change flushes are gated by a semaphore", function() {
   shared.set('flag', true);
   deepEqual(callbackItems, ['remove:true', 'add:true', 'remove:true', 'add:true'], "item property flushes that depend on a shared prop are gated by a semaphore");
 });
+
+QUnit.module('arrayComputed - changeMeta property observers, previousValues', {
+  setup: function() {
+    callbackItems = [];
+    run(function() {
+      obj = EmberObject.createWithMixins({
+        items: Ember.A([EmberObject.create({ n: 'one' })]),
+        itemsChanged: arrayComputed('items.@each.n', {
+          addedItem: function(array, item, changeMeta, instanceMeta) {
+            array.insertAt(changeMeta.index, item);
+            return array;
+          },
+          removedItem: function(array, item, changeMeta, instanceMeta) {
+            array.removeAt(changeMeta.index);
+            return array;
+          }
+        }),
+        itemsN: arrayComputed('itemsChanged.@each.n', {
+          addedItem: function(array, item, changeMeta, instanceMeta) {
+            var previousNValue = null;
+            if(changeMeta.previousValues) {
+              previousNValue = changeMeta.previousValues.n;
+            }
+            callbackItems.push('add:' + previousNValue + ":" + get(changeMeta.item, 'n'));
+
+          },
+          removedItem: function (array, item, changeMeta, instanceMeta) {
+            var previousNValue = null;
+            if(changeMeta.previousValues) {
+              previousNValue = changeMeta.previousValues.n;
+            }
+            callbackItems.push('remove:' + previousNValue + ":" + get(changeMeta.item, 'n'));
+          }
+        })
+      });
+    });
+  },
+  teardown: function() {
+    run(function() {
+      obj.destroy();
+    });
+  }
+});
+
+test("previousValues are passed to removedItem and addedItem callbacks", function() {
+  var expected, items, anotherObj;
+
+  items = get(obj, 'items');
+
+  anotherObj = Ember.Object.create({
+    item: obj.get('items.firstObject'),
+    nBinding: 'item.n'
+  });
+
+  run(function() {
+    obj.get('itemsN');
+  });
+
+  callbackItems = [];
+  run(function() {
+    set(anotherObj, 'n', "two");
+  });
+
+  expected = ['remove:one:two', 'add:one:two'];
+  deepEqual(callbackItems, expected, "changeMeta includes previous values");
+});


### PR DESCRIPTION
This is an attempt to fix #5558. The problem is described there.

One thing that I'm not sure about here is if the same code should be also added to `dependentArrayDidChange`. I'm also not sure if there's any better way to test it.
