### PR TITLE
[Bugfix Beta] detect if we can use toString to analyze functions

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -145,6 +145,10 @@ function giveDescriptorSuper(meta, key, property, values, descs) {
   return property;
 }
 
+var sourceAvailable = (function() {
+  return this;
+}).toString().indexOf('return this;') > -1;
+
 function giveMethodSuper(obj, key, method, values, descs) {
   var superMethod;
 
@@ -163,14 +167,17 @@ function giveMethodSuper(obj, key, method, values, descs) {
     return method;
   }
 
-  var hasSuper = method.__hasSuper;
+  var hasSuper;
+  if (sourceAvailable) {
+    hasSuper = method.__hasSuper;
 
-  if (hasSuper === undefined) {
-    hasSuper = method.toString().indexOf('_super') > -1;
-    method.__hasSuper = hasSuper;
+    if (hasSuper === undefined) {
+      hasSuper = method.toString().indexOf('_super') > -1;
+      method.__hasSuper = hasSuper;
+    }
   }
 
-  if (hasSuper) {
+  if (sourceAvailable === false || hasSuper) {
     return wrap(method, superMethod);
   } else {
     return method;


### PR DESCRIPTION
In some modes platforms like PS3 + FireFox OS will discard these sources to save on memory. Instead we will opt into this perf only after we detect the ability.

cc @krisselden @mixonic @twokul

I tested this in the Firefox OS WebIDE and all seems well. The feature detection appears to work, and our test suite appears 100% green.

Unfortunately I don't have a real firefox OS device, or a PS3 so I can't test further.

Closes #5601.
