### PR TITLE
bug: cannot call childView.destroy() on an undefined value

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -325,7 +325,8 @@ var CollectionView = ContainerView.extend({
 
     for (idx = start + removedCount - 1; idx >= start; idx--) {
       childView = childViews[idx];
-      childView.destroy();
+      if(childView)
+        childView.destroy();
     }
   },
 


### PR DESCRIPTION
Just a small bug I came across. In my app scenario the childView list length was 0 but the output of "start + removedCount - 1" was 0. Consequently it was trying to destroy a childView that did not exist. After the error was thrown, the Ember app became unresponsive.

This only seemed to happen when the view was loaded for the first time. Please let me know if you need any other help. The guidelines mention writing tests, I think I could get a small test for this change but to be totally honest I have no idea where the tests are located. I see the tests directory but it only contains config and setup code.
