### PR TITLE
Remove binding direction map

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -285,10 +285,9 @@ mixinProperties(Binding, {
     @method from
     @static
   */
-  from: function() {
+  from: function(from) {
     var C = this;
-    var binding = new C();
-    return binding.from.apply(binding, arguments);
+    return new C(undefined, from);
   },
 
   /*
@@ -297,10 +296,9 @@ mixinProperties(Binding, {
     @method to
     @static
   */
-  to: function() {
+  to: function(to) {
     var C = this;
-    var binding = new C();
-    return binding.to.apply(binding, arguments);
+    return new C(to, undefined);
   },
 
   /**
@@ -321,8 +319,7 @@ mixinProperties(Binding, {
   */
   oneWay: function(from, flag) {
     var C = this;
-    var binding = new C(null, from);
-    return binding.oneWay(flag);
+    return new C(undefined, from).oneWay(flag);
   }
 
 });

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -3,9 +3,7 @@ import run from 'ember-metal/run_loop';
 import {
   addObserver
 } from "ember-metal/observer";
-import { create }  from 'ember-metal/platform';
 import { bind } from "ember-metal/binding";
-import { rewatch } from "ember-metal/watching";
 import { computed } from "ember-metal/computed";
 import { defineProperty } from "ember-metal/properties";
 

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -101,49 +101,6 @@ testBoth("bindings should do the right thing when observers trigger bindings in 
   equal(get(a, 'foo'), "what is going on");
 });
 
-testBoth("bindings should do the right thing when binding is in prototype", function(get, set) {
-  var obj, proto, a, b, selectionChanged;
-  run(function() {
-    obj = {
-      selection: null
-    };
-
-    selectionChanged = 0;
-
-    addObserver(obj, 'selection', function () {
-      selectionChanged++;
-    });
-
-    proto = {
-      obj: obj,
-      changeSelection: function (value) {
-        set(this, 'selection', value);
-      }
-    };
-    bind(proto, 'selection', 'obj.selection');
-
-    a = create(proto);
-    b = create(proto);
-    rewatch(a);
-    rewatch(b);
-  });
-
-  run(function () {
-    set(a, 'selection', 'a');
-  });
-
-  run(function () {
-    set(b, 'selection', 'b');
-  });
-
-  run(function () {
-    set(a, 'selection', 'a');
-  });
-
-  equal(selectionChanged, 3);
-  equal(get(obj, 'selection'), 'a');
-});
-
 testBoth("bindings should not try to sync destroyed objects", function(get, set) {
   var a, b;
 


### PR DESCRIPTION
@krisselden two test failures are test that explicitly test binding to a prototype.

https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/tests/binding/sync_test.js#L106
