### PR TITLE
[workaround for #5606] o_0) iOS 8 non-64bit Object.create bug...

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -281,6 +281,12 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
     the meta hash, allowing the method to avoid making an unnecessary copy.
   @return {Object} the meta hash for an object
 */
+var agent = window.navigator.userAgent;
+
+var mayNeedFix = agent.indexOf('iPhone') > -1 &&
+  agent.indexOf('Version/8.0 Mobile') > -1 &&
+  ({ '__proto__': []} instanceof Array);
+
 function meta(obj, writable) {
 
   var ret = obj['__ember_meta__'];
@@ -305,18 +311,30 @@ function meta(obj, writable) {
   } else if (ret.source !== obj) {
     if (canDefineNonEnumerableProperties) o_defineProperty(obj, '__ember_meta__', META_DESC);
 
-    ret = o_create(ret);
-    ret.descs     = o_create(ret.descs);
-    ret.watching  = o_create(ret.watching);
-    ret.cache     = {};
-    ret.cacheMeta = {};
-    ret.source    = obj;
+    var newRet;
+    if (mayNeedFix) {
+      newRet = { };
+    } else {
+      newRet = o_create(ret);
+
+    }
+    newRet.descs     = o_create(ret.descs);
+    newRet.watching  = o_create(ret.watching);
+    newRet.cache     = {};
+    newRet.cacheMeta = {};
+    newRet.source    = obj;
 
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       if (hasPropertyAccessors) {
-        ret.values = o_create(ret.values);
+        newRet.values = o_create(ret.values);
       }
     }
+
+    if (mayNeedFix) {
+      newRet['__proto__'] = ret;
+    }
+
+    ret = newRet;
 
     obj['__ember_meta__'] = ret;
   }


### PR DESCRIPTION
ghetto hack for https://github.com/emberjs/ember.js/issues/5606 – o_0) that is all
- [x] properly analyze what is unique about #5606 to better understand this issue 
- [x] after ^^ try to isolate and report the issue to apple as it does appear unique to other similar issues
- [x] think about this when I'm not tired (in the morning)
- [ ] sanity check with others ( @krisselden et al i could use some cycles)
- [ ] release 1.7.1 (maybe more?)
- [ ] release new beta or get something into canary

---

other issues that have popped up turn out to be slightly different, an example of there test is attached bellow but it seems to cause issues for all Safari 8 Versions and platforms, whereas ours seems to only affect some devices.

see: https://github.com/emberjs/ember.js/issues/5606 for more details (I will continue to flesh this out after I sleep)

a more accurate test for something similar... they symptoms are so close i assume it is the same problem, but our scenario is different. But maybe it is a better check?

this test **needs** 'use strict' and the parentClass to be `window.HTMLElement.prototype` maybe our scenario touches a native object as well?

``` js
function test() {
  var broken;
  (function(){
    "use strict";
    var proto = Object.create(window.HTMLElement.prototype);
    try { 
      proto.constructor = function () {
      };

      broken = false;
    } catch(e) {
      broken = true;
    }
  }());

  return broken;
}
```
