### PR TITLE
[perf] “keys” or “hasOwnProperty” in for in loops

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,6 +1,7 @@
 import Ember from 'ember-metal/core'; // Ember.assert
 import emberKeys from "ember-metal/keys";
 import dictionary from 'ember-metal/dictionary';
+import { iterateObject } from 'ember-metal/utils';
 
 // A lightweight container that helps to assemble and decouple components.
 // Public api for the container is still in flux.
@@ -785,13 +786,10 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   var normalizeInjectionsHash = function(hash) {
     var injections = [];
 
-    for (var key in hash) {
-      if (hash.hasOwnProperty(key)) {
-        Ember.assert("Expected a proper full name, given '" + hash[key] + "'", validateFullName(hash[key]));
-
-        addInjection(injections, key, hash[key]);
-      }
-    }
+    iterateObject(hash, function(key, value){
+      Ember.assert("Expected a proper full name, given '" + hash[key] + "'", validateFullName(hash[key]));
+      addInjection(injections, key, value);
+    });
 
     return injections;
   };

--- a/packages/ember-application/lib/system/dag.js
+++ b/packages/ember-application/lib/system/dag.js
@@ -13,7 +13,7 @@ function visit(vertex, fn, visited, path) {
   if (!path) {
     path = [];
   }
-  if (visited.hasOwnProperty(name)) {
+  if (Object.hasOwnProperty.call(visited, name)) {
     return;
   }
   path.push(name);

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -7,6 +7,7 @@ import {
 } from "ember-runtime/system/string";
 import Namespace from "ember-runtime/system/namespace";
 import EmberObject from "ember-runtime/system/object";
+import { iterateObject } from "ember-metal/utils";
 
 /**
 @module ember
@@ -94,15 +95,11 @@ export default EmberObject.extend({
 
     namespaces.forEach(function(namespace) {
       if (namespace !== Ember) {
-        for (var key in namespace) {
-          if (!namespace.hasOwnProperty(key)) { continue; }
-          if (typeSuffixRegex.test(key)) {
-            var klass = namespace[key];
-            if (typeOf(klass) === 'class') {
-              types.push(dasherize(key.replace(typeSuffixRegex, '')));
-            }
+        iterateObject(namespace, function(key, klass){
+          if (typeSuffixRegex.test(key) && typeOf(klass) === 'class') {
+            types.push(dasherize(key.replace(typeSuffixRegex, '')));
           }
-        }
+        });
       }
     });
     return types;

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -6,6 +6,7 @@ import Namespace from "ember-runtime/system/namespace";
 import EmberObject from "ember-runtime/system/object";
 import { A as emberA } from "ember-runtime/system/native_array";
 import Application from "ember-application/system/application";
+import { iterateObject } from "ember-metal/utils";
 
 /**
 @module ember
@@ -378,18 +379,17 @@ export default EmberObject.extend({
     var self = this;
 
     namespaces.forEach(function(namespace) {
-      for (var key in namespace) {
-        if (!namespace.hasOwnProperty(key)) { continue; }
+      iterateObject(namespace, function(key, value){
         // Even though we will filter again in `getModelTypes`,
         // we should not call `lookupContainer` on non-models
         // (especially when `Ember.MODEL_FACTORY_INJECTIONS` is `true`)
-        if (!self.detect(namespace[key])) { continue; }
+        if (!self.detect(namespace[key])) { return; }
         var name = dasherize(key);
         if (!(namespace instanceof Application) && namespace.toString()) {
           name = namespace + '/' + name;
         }
         types.push(name);
-      }
+      });
     });
     return types;
   },

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -17,6 +17,7 @@ import { handlebarsGetView } from "ember-handlebars/ext";
 import { ViewHelper } from "ember-handlebars/helpers/view";
 import { computed } from "ember-metal/computed";
 import CollectionView from "ember-views/views/collection_view";
+import { iterateObject } from "ember-metal/utils";
 
 var alias = computed.alias;
 /**
@@ -199,19 +200,17 @@ function collectionHelper(path, options) {
 
   // Go through options passed to the {{collection}} helper and extract options
   // that configure item views instead of the collection itself.
-  for (var prop in hash) {
-    if (hash.hasOwnProperty(prop)) {
-      match = prop.match(/^item(.)(.*)$/);
+  iterateObject(hash, function(prop, value){
+    match = prop.match(/^item(.)(.*)$/);
 
-      if (match && prop !== 'itemController') {
-        // Convert itemShouldFoo -> shouldFoo
-        itemHash[match[1].toLowerCase() + match[2]] = hash[prop];
-        // Delete from hash as this will end up getting passed to the
-        // {{view}} helper method.
-        delete hash[prop];
-      }
+    if (match && prop !== 'itemController') {
+      // Convert itemShouldFoo -> shouldFoo
+      itemHash[match[1].toLowerCase() + match[2]] = hash[prop];
+      // Delete from hash as this will end up getting passed to the
+      // {{view}} helper method.
+      delete hash[prop];
     }
-  }
+  });
 
   if (fn) {
     itemHash.template = fn;

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -17,6 +17,7 @@ import {
   handlebarsGet,
   handlebarsGetView
 } from "ember-handlebars/ext";
+import { iterateObject } from "ember-metal/utils";
 
 var SELF_BINDING = /^_view\./;
 
@@ -24,7 +25,7 @@ function makeBindings(thisContext, options) {
   var hash = options.hash;
   var hashType = options.hashTypes;
 
-  for (var prop in hash) {
+  iterateObject(hash, function(prop, _){
     if (hashType[prop] === 'ID') {
 
       var value = hash[prop];
@@ -38,9 +39,9 @@ function makeBindings(thisContext, options) {
         delete hashType[prop];
       }
     }
-  }
+  });
 
-  if (hash.hasOwnProperty('idBinding')) {
+  if (Object.hasOwnProperty.call(hash, 'idBinding')) {
     // id can't be bound, so just perform one-time lookup.
     hash.id = handlebarsGet(thisContext, hash.idBinding, options);
     hashType.id = 'STRING';
@@ -105,15 +106,14 @@ export var ViewHelper = EmberObject.create({
     var path;
 
     // Evaluate the context of regular attribute bindings:
-    for (var prop in hash) {
-      if (!hash.hasOwnProperty(prop)) { continue; }
-
+    var self = this;
+    iterateObject(hash, function(prop, value){
       // Test if the property ends in "Binding"
       if (IS_BINDING.test(prop) && typeof hash[prop] === 'string') {
-        path = this.contextualizeBindingPath(hash[prop], data);
+        path = self.contextualizeBindingPath(hash[prop], data);
         if (path) { hash[prop] = path; }
       }
-    }
+    });
 
     // Evaluate the context of class name bindings:
     if (extensions.classNameBindings) {

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -12,6 +12,7 @@ import run from "ember-metal/run_loop";
 import {
   isGlobal as isGlobalPath
 } from "ember-metal/path_cache";
+import { iterateObject } from "ember-metal/utils";
 
 
 // ES6TODO: where is Ember.lookup defined?
@@ -274,11 +275,9 @@ Binding.prototype = {
 };
 
 function mixinProperties(to, from) {
-  for (var key in from) {
-    if (from.hasOwnProperty(key)) {
-      to[key] = from[key];
-    }
-  }
+  iterateObject(from, function(key, value){
+    to[key] = value;
+  });
 }
 
 mixinProperties(Binding, {

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -5,6 +5,9 @@ import { computed } from "ember-metal/computed";
 import isEmpty from 'ember-metal/is_empty';
 import { isNone } from 'ember-metal/is_none';
 import { alias } from 'ember-metal/alias';
+import keys from "ember-metal/keys";
+import { iterateObject } from "ember-metal/utils";
+import { create as o_create } from "ember-metal/platform";
 
 /**
 @module ember-metal
@@ -13,7 +16,7 @@ import { alias } from 'ember-metal/alias';
 var a_slice = [].slice;
 
 function getProperties(self, propertyNames) {
-  var ret = {};
+  var ret = o_create(null);
   for(var i = 0; i < propertyNames.length; i++) {
     ret[propertyNames[i]] = get(self, propertyNames[i]);
   }
@@ -408,8 +411,12 @@ registerComputed('lte', function(dependentKey, value) {
   a logical `and` on the values of all the original values for properties.
 */
 registerComputedWithProperties('and', function(properties) {
-  for (var key in properties) {
-    if (properties.hasOwnProperty(key) && !properties[key]) {
+  var propKeys = keys(properties);
+  var length = propKeys.length;
+  var i;
+
+  for (i = 0; i < length; i++){
+    if (!properties[propKeys[i]]){
       return false;
     }
   }
@@ -441,8 +448,12 @@ registerComputedWithProperties('and', function(properties) {
   a logical `or` on the values of all the original values for properties.
 */
 registerComputedWithProperties('or', function(properties) {
-  for (var key in properties) {
-    if (properties.hasOwnProperty(key) && properties[key]) {
+  var propKeys = keys(properties);
+  var length = propKeys.length;
+  var i;
+
+  for (i = 0; i < length; i++){
+    if (properties[propKeys[i]]){
       return true;
     }
   }
@@ -474,9 +485,15 @@ registerComputedWithProperties('or', function(properties) {
   the first truthy value of given list of properties.
 */
 registerComputedWithProperties('any', function(properties) {
-  for (var key in properties) {
-    if (properties.hasOwnProperty(key) && properties[key]) {
-      return properties[key];
+  var propKeys = keys(properties);
+  var length = propKeys.length;
+  var i, key, value;
+
+  for (i = 0; i < length; i++){
+    key = propKeys[i];
+    value = properties[key];
+    if (value) {
+      return  value;
     }
   }
   return null;
@@ -509,15 +526,13 @@ registerComputedWithProperties('any', function(properties) {
 */
 registerComputedWithProperties('collect', function(properties) {
   var res = Ember.A();
-  for (var key in properties) {
-    if (properties.hasOwnProperty(key)) {
-      if (isNone(properties[key])) {
-        res.push(null);
-      } else {
-        res.push(properties[key]);
-      }
+  iterateObject(properties, function(key, value){
+    if (isNone(value)){
+      res.push(null);
+    } else {
+      res.push(value);
     }
-  }
+  });
   return res;
 });
 

--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -1,5 +1,6 @@
 import { create } from "ember-metal/platform";
 import { watch, unwatch } from "ember-metal/watching";
+import { hasOwn } from "ember-metal/utils";
 
 /**
 @module ember-metal
@@ -28,7 +29,7 @@ function keysForDep(depsMeta, depKey) {
     // if there are no dependencies yet for a the given key
     // create a new empty list of dependencies for the key
     keys = depsMeta[depKey] = {};
-  } else if (!depsMeta.hasOwnProperty(depKey)) {
+  } else if (!hasOwn(depsMeta, depKey)) {
     // otherwise if the dependency list is inherited from
     // a superclass, clone the hash
     keys = depsMeta[depKey] = o_create(keys);

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -1,3 +1,4 @@
+import { iterateObject } from "ember-metal/utils";
 /**
   Merge the contents of two objects together into the first object.
 
@@ -14,9 +15,8 @@
   @return {Object}
 */
 export default function merge(original, updates) {
-  for (var prop in updates) {
-    if (!updates.hasOwnProperty(prop)) { continue; }
-    original[prop] = updates[prop];
-  }
+  iterateObject(updates, function(key, value){
+    original[key] = value;
+  });
   return original;
 }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -8,6 +8,7 @@ import {
   listenersDiff
 } from "ember-metal/events";
 import ObserverSet from "ember-metal/observer_set";
+import { hasOwn } from "ember-metal/utils";
 
 var beforeObserverSet = new ObserverSet();
 var observerSet = new ObserverSet();
@@ -137,7 +138,7 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
 }
 
 function chainsWillChange(obj, keyName, m) {
-  if (!(m.hasOwnProperty('chainWatchers') &&
+  if (!(hasOwn(m, 'chainWatchers') &&
         m.chainWatchers[keyName])) {
     return;
   }
@@ -156,7 +157,7 @@ function chainsWillChange(obj, keyName, m) {
 }
 
 function chainsDidChange(obj, keyName, m, suppressEvents) {
-  if (!(m && m.hasOwnProperty('chainWatchers') &&
+  if (!(m && hasOwn(m, 'chainWatchers') &&
         m.chainWatchers[keyName])) {
     return;
   }

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -1,5 +1,6 @@
 import { changeProperties } from "ember-metal/property_events";
 import { set } from "ember-metal/property_set";
+import { iterateObject } from "ember-metal/utils";
 
 /**
   Set a list of properties on an object. These properties are set inside
@@ -23,9 +24,9 @@ import { set } from "ember-metal/property_set";
 */
 export default function setProperties(self, hash) {
   changeProperties(function() {
-    for(var prop in hash) {
-      if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
-    }
+    iterateObject(hash, function setProps(key, value){
+      set(self, key, value);
+    });
   });
   return self;
 }

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -10,6 +10,7 @@ import {
   forEach
 } from "ember-metal/array";
 
+import keys from "ember-metal/keys";
 /**
 @module ember-metal
 */
@@ -862,6 +863,24 @@ export function applyStr(t /* target */, m /* method */, a /* args */) {
   }
 }
 
+function iterateObject(object, callback){
+  if (typeof object !== 'object') {
+    return;
+  }
+  var objectKeys = keys(object);
+  var length = objectKeys.length;
+  var i, key;
+
+  for(i = 0; i < length; i++){
+    key = objectKeys[i];
+    callback(key, object[key]);
+  }
+}
+
+function hasOwn(object, property){
+  return Object.prototype.hasOwnProperty.call(object, property);
+}
+
 export {
   GUID_KEY,
   META_DESC,
@@ -871,5 +890,7 @@ export {
   tryCatchFinally,
   isArray,
   canInvoke,
-  tryFinally
+  tryFinally,
+  iterateObject,
+  hasOwn
 };

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -12,7 +12,9 @@ import { computed } from "ember-metal/computed";
 import merge from "ember-metal/merge";
 import {
   isArray,
-  typeOf
+  typeOf,
+  iterateObject,
+  hasOwn
 } from "ember-metal/utils";
 import run from "ember-metal/run_loop";
 import keys from "ember-metal/keys";
@@ -96,11 +98,8 @@ var Route = EmberObject.extend(ActionHandler, {
     var cacheMeta = get(controllerProto, '_cacheMeta');
 
     var qps = [], map = {}, self = this;
-    for (var propName in qpProps) {
-      if (!qpProps.hasOwnProperty(propName)) { continue; }
-
-      var desc = qpProps[propName];
-      var urlKey = desc.as || this.serializeQueryParamKey(propName);
+    iterateObject(qpProps, function(propName, desc){
+      var urlKey = desc.as || self.serializeQueryParamKey(propName);
       var defaultValue = get(controllerProto, propName);
 
       if (isArray(defaultValue)) {
@@ -108,7 +107,7 @@ var Route = EmberObject.extend(ActionHandler, {
       }
 
       var type = typeOf(defaultValue);
-      var defaultValueSerialized = this.serializeQueryParam(defaultValue, urlKey, type);
+      var defaultValueSerialized = self.serializeQueryParam(defaultValue, urlKey, type);
       var fprop = controllerName + ':' + propName;
       var qp = {
         def: defaultValue,
@@ -121,13 +120,13 @@ var Route = EmberObject.extend(ActionHandler, {
         cProto: controllerProto,
         svalue: defaultValueSerialized,
         cacheType: desc.scope,
-        route: this,
+        route: self,
         cacheMeta: cacheMeta[propName]
       };
 
       map[propName] = map[urlKey] = map[fprop] = qp;
       qps.push(qp);
-    }
+    });
 
     return {
       qps: qps,
@@ -1555,7 +1554,7 @@ var Route = EmberObject.extend(ActionHandler, {
     // resolved parent contexts on the current transitionEvent.
     if (transition) {
       var modelLookupName = (route && route.routeName) || name;
-      if (transition.resolvedModels.hasOwnProperty(modelLookupName)) {
+      if (hasOwn(transition.resolvedModels, modelLookupName)) {
         return transition.resolvedModels[modelLookupName];
       }
     }

--- a/packages/ember-runtime/lib/copy.js
+++ b/packages/ember-runtime/lib/copy.js
@@ -2,9 +2,10 @@ import { indexOf } from 'ember-metal/enumerable_utils';
 import { typeOf } from 'ember-metal/utils';
 import EmberObject from 'ember-runtime/system/object';
 import Copyable from 'ember-runtime/mixins/copyable';
+import { iterateObject } from 'ember-metal/utils';
 
 function _copy(obj, deep, seen, copies) {
-  var ret, loc, key;
+  var ret, loc;
 
   // primitive data types are immutable, just return them.
   if (typeof obj !== 'object' || obj === null) {
@@ -38,20 +39,14 @@ function _copy(obj, deep, seen, copies) {
   } else {
     ret = {};
 
-    for (key in obj) {
-      // support Null prototype
-      if (!Object.prototype.hasOwnProperty.call(obj, key)) {
-        continue;
-      }
-
+    iterateObject(obj, function(key, value){
       // Prevents browsers that don't respect non-enumerability from
       // copying internal Ember properties
       if (key.substring(0, 2) === '__') {
-        continue;
+        return;
       }
-
       ret[key] = deep ? _copy(obj[key], deep, seen, copies) : obj[key];
-    }
+    });
   }
 
   if (deep) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -11,7 +11,8 @@ import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import {
   guidFor,
-  apply
+  apply,
+  hasOwn
 } from "ember-metal/utils";
 import { create as o_create } from "ember-metal/platform";
 import {
@@ -110,7 +111,7 @@ function makeCtor() {
 
         for (var j = 0, ll = keyNames.length; j < ll; j++) {
           var keyName = keyNames[j];
-          if (!properties.hasOwnProperty(keyName)) { continue; }
+          if (!hasOwn(properties, keyName)) { continue; }
 
           var value = properties[keyName];
 
@@ -118,7 +119,7 @@ function makeCtor() {
             var bindings = m.bindings;
             if (!bindings) {
               bindings = m.bindings = {};
-            } else if (!m.hasOwnProperty('bindings')) {
+            } else if (!hasOwn(m, 'bindings')) {
               bindings = m.bindings = o_create(m.bindings);
             }
             bindings[keyName] = value;

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -8,7 +8,10 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { isNone } from 'ember-metal/is_none';
 import run from "ember-metal/run_loop";
-import { typeOf } from "ember-metal/utils";
+import {
+  typeOf,
+  iterateObject
+} from "ember-metal/utils";
 import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
@@ -131,7 +134,7 @@ export default EmberObject.extend({
     @param addedEvents {Hash}
   */
   setup: function(addedEvents, rootElement) {
-    var event, events = get(this, 'events');
+    var events = get(this, 'events');
 
     merge(events, addedEvents || {});
 
@@ -149,11 +152,10 @@ export default EmberObject.extend({
 
     Ember.assert('Unable to add "ember-application" class to rootElement. Make sure you set rootElement to the body or an element in the body.', rootElement.is('.ember-application'));
 
-    for (event in events) {
-      if (events.hasOwnProperty(event)) {
-        this.setupHandler(rootElement, event, events[event]);
-      }
-    }
+    var self = this;
+    iterateObject(events, function(eventName, event){
+      self.setupHandler(rootElement, eventName, event);
+    });
   },
 
   /**

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -6,6 +6,7 @@
 import { setInnerHTML } from "ember-views/system/utils";
 import jQuery from "ember-views/system/jquery";
 import {DOMHelper} from "morph";
+import { iterateObject } from "ember-metal/utils";
 
 function ClassSet() {
   this.seen = {};
@@ -383,7 +384,7 @@ _RenderBuffer.prototype = {
     var props = this.elementProperties;
     var style = this.elementStyle;
     var styleBuffer = '';
-    var attr, prop, tagString;
+    var tagString;
 
     if (attrs && attrs.name && !canSetNameOnInputs) {
       // IE allows passing a tag to createElement. See note on `canSetNameOnInputs` above as well.
@@ -406,11 +407,9 @@ _RenderBuffer.prototype = {
     }
 
     if (style) {
-      for (prop in style) {
-        if (style.hasOwnProperty(prop)) {
-          styleBuffer += (prop + ':' + style[prop] + ';');
-        }
-      }
+      iterateObject(style, function(prop, styleValue){
+        styleBuffer += (prop + ':' + styleValue + ';');
+      });
 
       $element.attr('style', styleBuffer);
 
@@ -418,21 +417,17 @@ _RenderBuffer.prototype = {
     }
 
     if (attrs) {
-      for (attr in attrs) {
-        if (attrs.hasOwnProperty(attr)) {
-          $element.attr(attr, attrs[attr]);
-        }
-      }
+      iterateObject(attrs, function(key, attr){
+        $element.attr(key, attr);
+      });
 
       this.elementAttributes = null;
     }
 
     if (props) {
-      for (prop in props) {
-        if (props.hasOwnProperty(prop)) {
-          $element.prop(prop, props[prop]);
-        }
-      }
+      iterateObject(props, function(propName, prop){
+        $element.prop(propName, prop);
+      });
 
       this.elementProperties = null;
     }

--- a/packages/ember-views/lib/views/states.js
+++ b/packages/ember-views/lib/views/states.js
@@ -6,6 +6,7 @@ import inBuffer from "ember-views/views/states/in_buffer";
 import hasElement from "ember-views/views/states/has_element";
 import inDOM from "ember-views/views/states/in_dom";
 import destroying from "ember-views/views/states/destroying";
+import { iterateObject } from "ember-metal/utils";
 
 export function cloneStates(from) {
   var into = {};
@@ -17,10 +18,9 @@ export function cloneStates(from) {
   into.hasElement = create(into._default);
   into.inDOM = create(into.hasElement);
 
-  for (var stateName in from) {
-    if (!from.hasOwnProperty(stateName)) { continue; }
+  iterateObject(from, function(stateName, _){
     merge(into[stateName], from[stateName]);
-  }
+  });
 
   return into;
 }


### PR DESCRIPTION
adds a iterateObject helper in ember-metal/utils to help with for/in loop optimizations we usually do.
Normalizes many of the for in calls we have
to use Object.keys(or a polyfill) to loop
through the object instead of for in (which
is slower). Also handles cases where
hasOwnProperty could get called on an object
with a null prototype.

fixes github #5607
