### PR TITLE
Adding dir & lang attribute bindings to allow for easier bidirectional support

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_area.js
+++ b/packages/ember-handlebars/lib/controls/text_area.js
@@ -31,7 +31,7 @@ export default Component.extend(TextSupport, {
   classNames: ['ember-text-area'],
 
   tagName: "textarea",
-  attributeBindings: ['rows', 'cols', 'name', 'selectionEnd', 'selectionStart', 'wrap'],
+  attributeBindings: ['rows', 'cols', 'name', 'selectionEnd', 'selectionStart', 'wrap', 'lang', 'dir'],
   rows: null,
   cols: null,
 

--- a/packages/ember-handlebars/lib/controls/text_field.js
+++ b/packages/ember-handlebars/lib/controls/text_field.js
@@ -31,7 +31,7 @@ export default Component.extend(TextSupport, {
   attributeBindings: ['type', 'value', 'size', 'pattern', 'name', 'min', 'max',
                       'accept', 'autocomplete', 'autosave', 'formaction',
                       'formenctype', 'formmethod', 'formnovalidate', 'formtarget',
-                      'height', 'inputmode', 'list', 'multiple', 'step',
+                      'height', 'inputmode', 'list', 'multiple', 'step', 'lang', 'dir',
                       'width'],
 
   /**


### PR DESCRIPTION
For languages like Arabic you want to be able to flip the text fields to right-to-left.  Lang brings language meta data about the contents of the field.
