### PR TITLE
click test helper blurs active element

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -50,7 +50,7 @@ function click(app, selector, context) {
   var $el = app.testHelpers.findWithAssert(selector, context);
   run($el, 'mousedown');
   if(document.activeElement){
-    Ember.run(app.$(document.activeElement), 'trigger', 'focusout');    
+    Ember.run(app.$(document.activeElement), 'blur');    
   }
 
   if ($el.is(':input')) {

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -49,6 +49,9 @@ function visit(app, url) {
 function click(app, selector, context) {
   var $el = app.testHelpers.findWithAssert(selector, context);
   run($el, 'mousedown');
+  if(document.activeElement){
+    Ember.run(app.$(document.activeElement), 'trigger', 'focusout');    
+  }
 
   if ($el.is(':input')) {
     var type = $el.prop('type');


### PR DESCRIPTION
otherwise views that define focusOut may not have their side effects run correctly
