### PR TITLE
[Bugfix beta] slightly defensive perf

### DIFF
--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -1,3 +1,5 @@
+import keys from 'ember-metal/keys';
+
 /**
   Merge the contents of two objects together into the first object.
 
@@ -14,9 +16,18 @@
   @return {Object}
 */
 export default function merge(original, updates) {
-  for (var prop in updates) {
-    if (!updates.hasOwnProperty(prop)) { continue; }
+  if (!updates || typeof updates !== 'object') { 
+    return original;
+  }
+
+  var props = keys(updates);
+  var prop;
+  var length = props.length;
+
+  for (var i = 0; i < length; i++) {
+    prop = props[i];
     original[prop] = updates[prop];
   }
+
   return original;
 }


### PR DESCRIPTION
Ember.merge is global and as such if merge(x, y) ever happens where y is not safe for enumeration, it can deopt the function (in v8) for all other users.

Since functions are shared, deopting merge can cause inlining bailout cascades throughout the framework. Now it is still possible to deopt it by for example passing a global like window to it, but at least it wont happen more unexpectedly.

example inlining bailout cascade

![screenshot 2014-09-27 01 21 48](https://cloud.githubusercontent.com/assets/1377/4429852/54291452-4609-11e4-89d8-d2ab119a2e95.png)
