### PR TITLE
Cleaning up `{{loc}}`

### DIFF
--- a/packages/ember-handlebars/lib/helpers/loc.js
+++ b/packages/ember-handlebars/lib/helpers/loc.js
@@ -5,24 +5,29 @@ import { loc } from "ember-runtime/system/string";
 @submodule ember-handlebars
 */
 
-// ES6TODO:
-// Pretty sure this can be expressed as
-// var locHelper EmberStringUtils.loc ?
-
 /**
   Calls [Ember.String.loc](/api/classes/Ember.String.html#method_loc) with the
   provided string.
 
-  This is a convenient way to localize text. For example:
+  This is a convenient way to localize text within a template:
 
-  ```html
-  <script type="text/x-handlebars" data-template-name="home">
-    {{loc "welcome"}}
-  </script>
+  ```javascript
+  Ember.STRINGS = {
+    '_welcome_': 'Bonjour'
+  };
   ```
 
-  Take note that `"welcome"` is a string and not an object
-  reference.
+  ```handlebars
+  <div class='message'>
+    {{loc '_welcome_'}}
+  </div>
+  ```
+
+  ```html
+  <div class='message'>
+    Bonjour
+  </div>
+  ```
 
   See [Ember.String.loc](/api/classes/Ember.String.html#method_loc) for how to
   set up localized string references.
@@ -32,6 +37,4 @@ import { loc } from "ember-runtime/system/string";
   @param {String} str The string to format
   @see {Ember.String#loc}
 */
-export default function locHelper(str) {
-  return loc(str);
-}
+export default loc;


### PR DESCRIPTION
- Simplify helper by just re-exporting StringUtils.loc
- Removes inline script style example
- Adds example Ember.String setup and resulting output
