### PR TITLE
Remove documentation for {{template}}

### DIFF
--- a/packages/ember-handlebars/lib/helpers/template.js
+++ b/packages/ember-handlebars/lib/helpers/template.js
@@ -1,5 +1,4 @@
-import Ember from "ember-metal/core";
-// var emberDeprecate = Ember.deprecate;
+import Ember from "ember-metal/core"; // Ember.deprecate;
 
 import EmberHandlebars from "ember-handlebars-compiler";
 /**
@@ -8,43 +7,6 @@ import EmberHandlebars from "ember-handlebars-compiler";
 */
 
 /**
-  `template` allows you to render a template from inside another template.
-  This allows you to re-use the same template in multiple places. For example:
-
-  ```html
-  <script type="text/x-handlebars" data-template-name="logged_in_user">
-    {{#with loggedInUser}}
-      Last Login: {{lastLogin}}
-      User Info: {{template "user_info"}}
-    {{/with}}
-  </script>
-  ```
-
-  ```html
-  <script type="text/x-handlebars" data-template-name="user_info">
-    Name: <em>{{name}}</em>
-    Karma: <em>{{karma}}</em>
-  </script>
-  ```
-
-  ```handlebars
-  {{#if isUser}}
-    {{template "user_info"}}
-  {{else}}
-    {{template "unlogged_user_info"}}
-  {{/if}}
-  ```
-
-  This helper looks for templates in the global `Ember.TEMPLATES` hash. If you
-  add `<script>` tags to your page with the `data-template-name` attribute set,
-  they will be compiled and placed in this hash automatically.
-
-  You can also manually register templates by adding them to the hash:
-
-  ```javascript
-  Ember.TEMPLATES["my_cool_template"] = Ember.Handlebars.compile('<b>{{user}}</b>');
-  ```
-
   @deprecated
   @method template
   @for Ember.Handlebars.helpers


### PR DESCRIPTION
`{{template}}` was deprecated in favor or `{{partial}}` before 1.0 in ea5456ac on 2013-07-19.
