### PR TITLE
[BUGFIX beta] SVG support for metal-views

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
     "router.js": "https://github.com/tildeio/router.js.git#f7b4b11543222c52d91df861544592a8c1dcea8a",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
-    "htmlbars": "https://github.com/tildeio/htmlbars.git#e0e65c321d48f294b874c403823d2285bb05525a"
+    "htmlbars": "https://github.com/tildeio/htmlbars.git#a3e2369f1859f4993a9b64a80d50556ef2ebe246"
   }
 }

--- a/packages/ember-metal-views/tests/test_helpers.js
+++ b/packages/ember-metal-views/tests/test_helpers.js
@@ -25,7 +25,7 @@ MetalRenderer.prototype.createElement = function (view, contextualElement) {
   if (view.element) {
     el = view.element;
   } else {
-    el = view.element = this._dom.createElement(view.tagName || 'div');
+    el = view.element = this._dom.createElement(view.tagName || 'div', contextualElement);
   }
   var classNames = view.classNames;
   if (typeof classNames === 'string') {
@@ -50,6 +50,7 @@ MetalRenderer.prototype.createElement = function (view, contextualElement) {
   } else if (view.textContent) {
     setElementText(el, view.textContent);
   } else if (view.innerHTML) {
+    this._dom.detectNamespace(el);
     var nodes = this._dom.parseHTML(view.innerHTML, el);
     while (nodes[0]) {
       el.appendChild(nodes[0]);

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -451,11 +451,11 @@ _RenderBuffer.prototype = {
     var $element = jQuery(element);
 
     if (id) {
-      $element.attr('id', id);
+      this.dom.setAttribute(element, 'id', id);
       this.elementId = null;
     }
     if (classes) {
-      $element.attr('class', classes.join(' '));
+      this.dom.setAttribute(element, 'class', classes.join(' '));
       this.classes = null;
       this.elementClasses = null;
     }
@@ -467,7 +467,7 @@ _RenderBuffer.prototype = {
         }
       }
 
-      $element.attr('style', styleBuffer);
+      this.dom.setAttribute(element, 'style', styleBuffer);
 
       this.elementStyle = null;
     }
@@ -475,7 +475,7 @@ _RenderBuffer.prototype = {
     if (attrs) {
       for (attr in attrs) {
         if (attrs.hasOwnProperty(attr)) {
-          $element.attr(attr, attrs[attr]);
+          this.dom.setAttribute(element, attr, attrs[attr]);
         }
       }
 

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -447,7 +447,7 @@ _RenderBuffer.prototype = {
       tagString = tagName;
     }
 
-    var element = this.dom.createElement(tagString);
+    var element = this.dom.createElement(tagString, this._contextualElement);
     var $element = jQuery(element);
 
     if (id) {
@@ -510,6 +510,7 @@ _RenderBuffer.prototype = {
     var nodes;
     if (this._element) {
       if (html) {
+        this.dom.detectNamespace(this._element);
         nodes = this.dom.parseHTML(html, this._element);
         while (nodes[0]) {
           this._element.appendChild(nodes[0]);
@@ -520,6 +521,7 @@ _RenderBuffer.prototype = {
       if (html) {
         var omittedStartTag = detectOmittedStartTag(html, this._contextualElement);
         var contextualElement = omittedStartTag || this._contextualElement;
+        this.dom.detectNamespace(contextualElement);
         nodes = this.dom.parseHTML(html, contextualElement);
         var frag = this._element = document.createDocumentFragment();
         while (nodes[0]) {

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -1,6 +1,8 @@
 import jQuery from "ember-views/system/jquery";
 import RenderBuffer from "ember-views/system/render_buffer";
 
+var svgNamespace = "http://www.w3.org/2000/svg";
+var xhtmlNamespace = "http://www.w3.org/1999/xhtml";
 var trim = jQuery.trim;
 
 // .......................................................
@@ -224,3 +226,61 @@ test("properly handles old IE's zero-scope bug", function() {
   ok(jQuery(element).html().match(/script/i), "should have script tag");
   ok(!jQuery(element).html().match(/&shy;/), "should not have &shy;");
 });
+
+if ('namespaceURI' in document.createElement('div')) {
+
+QUnit.module("RenderBuffer namespaces");
+
+test("properly makes a content string SVG namespace inside an SVG tag", function() {
+  var buffer = new RenderBuffer('svg', document.body);
+  buffer.generateElement();
+  buffer.push('<path></path>foo');
+
+  var element = buffer.element();
+  ok(element.tagName, 'SVG', 'element is svg');
+  equal(element.namespaceURI, svgNamespace, 'element is svg namespace');
+
+  ok(element.childNodes[0].tagName, 'PATH', 'element is path');
+  equal(element.childNodes[0].namespaceURI, svgNamespace, 'element is svg namespace');
+});
+
+test("properly makes a path element svg namespace inside SVG context", function() {
+  var buffer = new RenderBuffer('path', document.createElementNS(svgNamespace, 'svg'));
+  buffer.generateElement();
+  buffer.push('<g></g>');
+
+  var element = buffer.element();
+  ok(element.tagName, 'PATH', 'element is PATH');
+  equal(element.namespaceURI, svgNamespace, 'element is svg namespace');
+
+  ok(element.childNodes[0].tagName, 'G', 'element is g');
+  equal(element.childNodes[0].namespaceURI, svgNamespace, 'element is svg namespace');
+});
+
+test("properly makes a foreignObject svg namespace inside SVG context", function() {
+  var buffer = new RenderBuffer('foreignObject', document.createElementNS(svgNamespace, 'svg'));
+  buffer.generateElement();
+  buffer.push('<div></div>');
+
+  var element = buffer.element();
+  ok(element.tagName, 'FOREIGNOBJECT', 'element is foreignObject');
+  equal(element.namespaceURI, svgNamespace, 'element is svg namespace');
+
+  ok(element.childNodes[0].tagName, 'DIV', 'element is div');
+  equal(element.childNodes[0].namespaceURI, xhtmlNamespace, 'element is xhtml namespace');
+});
+
+test("properly makes a div xhtml namespace inside foreignObject context", function() {
+  var buffer = new RenderBuffer('div', document.createElementNS(svgNamespace, 'foreignObject'));
+  buffer.generateElement();
+  buffer.push('<div></div>');
+
+  var element = buffer.element();
+  ok(element.tagName, 'DIV', 'element is div');
+  equal(element.namespaceURI, xhtmlNamespace, 'element is xhtml namespace');
+
+  ok(element.childNodes[0].tagName, 'DIV', 'element is div');
+  equal(element.childNodes[0].namespaceURI, xhtmlNamespace, 'element is xhtml namespace');
+});
+
+}

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -50,6 +50,16 @@ test("value of 0 is included in output", function() {
   strictEqual(el.value, '0', "generated element has value of '0'");
 });
 
+test("sets attributes with camelCase", function() {
+  var buffer = new RenderBuffer('div', document.body);
+  var content = "javascript:someCode()"; //jshint ignore:line
+
+  buffer.attr('onClick', content);
+  buffer.generateElement();
+  var el = buffer.element();
+  strictEqual(el.getAttribute('onClick'), content, "attribute with camelCase was set");
+});
+
 test("prevents XSS injection via `id`", function() {
   var buffer = new RenderBuffer('div', document.body);
 

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -107,6 +107,25 @@ test("should update attribute bindings", function() {
   ok(!view.$().attr('notNumber'), "removes notNumber attribute when NaN");
 });
 
+test("should update attribute bindings on svg", function() {
+  view = EmberView.create({
+    attributeBindings: ['viewBox'],
+    viewBox: null
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().attr('viewBox'), null, "viewBox can be null");
+
+  run(function() {
+    view.set('viewBox', '0 0 100 100');
+  });
+
+  equal(view.$().attr('viewBox'), '0 0 100 100', "viewBox can be updated");
+});
+
 // This comes into play when using the {{#each}} helper. If the
 // passed array item is a String, it will be converted into a
 // String object instead of a normal string.


### PR DESCRIPTION
This greatly improves SVG support in metal-view by basing the current namespace off the contextual element. SVG components like `{{somePath` should be viable with this change.

TODO
- [x] Make some demo JSBins to test this visually, SVG can be tricky
- [x] Fix someCapsAttributes, stop using jQuery `attr` 0_p
- [x] Confirm it in a real app

Binding to a class attribute on an svg is probably still broken. We must write a few more replacements for jQuery methods before we have that.

/cc @bantic @heyjinkim @blesh for you all to try out, if you please.

Builds: [dev](http://uni.madhatted.com.s3.amazonaws.com/svg-ember/ember.js) [prod](http://uni.madhatted.com.s3.amazonaws.com/svg-ember/ember.prod.js) [min](http://uni.madhatted.com.s3.amazonaws.com/svg-ember/ember.min.js)

A Very Ugly Demo: [source](http://emberjs.jsbin.com/woxes/7/edit?html,css,js) [demo](http://emberjs.jsbin.com/woxes/7)
