### PR TITLE
[BUGIFX beta] Fix failing test from recent contextualElements (74203e9)

### DIFF
--- a/packages/ember-metal-views/tests/main_test.js
+++ b/packages/ember-metal-views/tests/main_test.js
@@ -68,7 +68,7 @@ test("innerHTML tr can be specified", function() {
 
   appendTo(view);
 
-  equalHTML('qunit-fixture', "<table><tr><td>ohai</td></tr></table>");
+  equalHTML('qunit-fixture', "<table><tbody><tr><td>ohai</td></tr></tbody></table>");
 });
 
 // Test the behavior of the helper createElement stub


### PR DESCRIPTION
Recent contextualElements commit (74203e9) causes a test to fail.
