### PR TITLE
Fixes classNameBindings regression

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -51,13 +51,13 @@ function makeBindings(thisContext, options) {
 
 export var ViewHelper = EmberObject.create({
   propertiesFromHTMLOptions: function(options) {
-    var hash = options.hash;
-    var data = options.data;
-    var extensions = {
-      classNameBindings: [],
-      helperName:        options.helperName || ''
-    };
+    var hash    = options.hash;
+    var data    = options.data;
     var classes = hash['class'];
+
+    var extensions = {
+      helperName: options.helperName || ''
+    };
 
     if (hash.id) {
       extensions.elementId = hash.id;
@@ -77,6 +77,9 @@ export var ViewHelper = EmberObject.create({
     }
 
     if (hash.classNameBindings) {
+      if (extensions.classNameBindings === undefined) {
+        extensions.classNameBindings = [];
+      }
       extensions.classNameBindings = extensions.classNameBindings.concat(hash.classNameBindings.split(' '));
     }
 
@@ -108,23 +111,25 @@ export var ViewHelper = EmberObject.create({
       }
     }
 
-    // Evaluate the context of class name bindings:
-    for (var j = 0, k = extensions.classNameBindings.length; j < k; j++) {
-      var full = extensions.classNameBindings[j];
+    if (extensions.classNameBindings) {
+      // Evaluate the context of class name bindings:
+      for (var j = 0, k = extensions.classNameBindings.length; j < k; j++) {
+        var full = extensions.classNameBindings[j];
 
-      if (typeof full === 'string') {
-        // Contextualize the path of classNameBinding so this:
-        //
-        //     classNameBinding="isGreen:green"
-        //
-        // is converted to this:
-        //
-        //     classNameBinding="_parentView.context.isGreen:green"
-        var parsedPath = View._parsePropertyPath(full);
-        if (parsedPath.path !== '') {
-          path = this.contextualizeBindingPath(parsedPath.path, data);
-          if (path) {
-            extensions.classNameBindings[j] = path + parsedPath.classNames;
+        if (typeof full === 'string') {
+          // Contextualize the path of classNameBinding so this:
+          //
+          //     classNameBinding="isGreen:green"
+          //
+          // is converted to this:
+          //
+          //     classNameBinding="_parentView.context.isGreen:green"
+          var parsedPath = View._parsePropertyPath(full);
+          if (parsedPath.path !== '') {
+            path = this.contextualizeBindingPath(parsedPath.path, data);
+            if (path) {
+              extensions.classNameBindings[j] = path + parsedPath.classNames;
+            }
           }
         }
       }

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -131,6 +131,32 @@ test("template view should call the function of the associated template", functi
   ok(view.$('#twas-called').length, "the named template was called");
 });
 
+test("{{view}} should not override class bindings defined on a child view", function() {
+  var LabelView = EmberView.extend({
+    container:         container,
+    templateName:      'nested',
+    classNameBindings: ['something'],
+    something:         'visible'
+  });
+
+  container.register('controller:label', ObjectController, { instantiate: true });
+  container.register('view:label',       LabelView);
+  container.register('template:label',   EmberHandlebars.compile('<div id="child-view"></div>'));
+  container.register('template:nester', EmberHandlebars.compile('{{render "label"}}'));
+
+  view = EmberView.create({
+    container:    container,
+    templateName: 'nester',
+    controller:   ObjectController.create({
+      container: container
+    })
+  });
+
+  appendView();
+
+  ok(view.$('.visible').length > 0, 'class bindings are not overriden');
+});
+
 test("template view should call the function of the associated template with itself as the context", function() {
   container.register('template:testTemplate', EmberHandlebars.compile("<h1 id='twas-called'>template was called for {{view.personName}}. Yea {{view.personName}}</h1>"));
 


### PR DESCRIPTION
`classNameBindings` was initialized as an empty array inside `propertiesFromHTMLOptions` so we could maintain the same shape of the object via this [PR](https://github.com/emberjs/ember.js/pull/5559).

When the view is [created](https://github.com/emberjs/ember.js/blob/master/packages/ember-views/lib/views/states/in_buffer.js#L38), `options.classNameBindings` is an empty array and the view gets confused about its classes.

Scumbag @twokul.

Fixes #5660
