### PR TITLE
removed unreachable code

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -50,11 +50,6 @@ var get = function get(obj, keyName) {
     return obj;
   }
 
-  if (!keyName && 'string' === typeof obj) {
-    keyName = obj;
-    obj = null;
-  }
-
   Ember.assert("Cannot call get with "+ keyName +" key.", !!keyName);
   Ember.assert("Cannot call get with '"+ keyName +"' on an undefined object.", obj !== undefined);
 


### PR DESCRIPTION
After line 52 we can assume `keyname !== ''`. The only value that satisfies `(!keyName && 'string' === typeof obj)` is `''`, therefore this code is unreachable.

EDIT: derp. keyName !== obj
