### PR TITLE
[BUGFIX beta] Start on mergedProperties fix for #5182

### DIFF
--- a/packages/ember-metal/tests/mixin/mergedProperties_test.js
+++ b/packages/ember-metal/tests/mixin/mergedProperties_test.js
@@ -91,6 +91,28 @@ test('mergedProperties should be concatenated', function() {
   deepEqual(get(obj, 'bar'), { a: true, l: true, e: true, x: true }, "get bar");
 });
 
+test("mergedProperties should exist even if not explicitly set on create", function(){
+
+  var AnObj = Ember.Object.extend({
+    mergedProperties: ['options'],
+    options: {
+      a: 'a',
+      b: {
+        c: 'ccc',
+      }
+    }
+  });
+
+  var obj = AnObj.create({
+    options: {
+      a: 'A'
+    }
+  });
+
+  equal(get(obj, "options").a, 'A');
+  equal(get(obj, "options").b.c, 'ccc');
+});
+
 test("mergedProperties' overwriting methods can call _super", function() {
 
   expect(4);

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -9,6 +9,7 @@
 */
 
 import Ember from "ember-metal/core";
+import merge from "ember-metal/merge";
 // Ember.assert, Ember.K, Ember.config
 
 // NOTE: this object should never be included directly. Instead use `Ember.Object`.
@@ -98,6 +99,7 @@ function makeCtor() {
       initProperties = null;
 
       var concatenatedProperties = this.concatenatedProperties;
+      var mergedProperties = this.mergedProperties;
 
       for (var i = 0, l = props.length; i < l; i++) {
         var properties = props[i];
@@ -134,7 +136,7 @@ function makeCtor() {
                        "time, when Ember.ActionHandler is used (i.e. views, " +
                        "controllers & routes).", !((keyName === 'actions') && ActionHandler.detect(this)));
 
-          if (concatenatedProperties && 
+          if (concatenatedProperties &&
               concatenatedProperties.length > 0 &&
               indexOf(concatenatedProperties, keyName) >= 0) {
             var baseValue = this[keyName];
@@ -148,6 +150,12 @@ function makeCtor() {
             } else {
               value = makeArray(value);
             }
+          }
+
+          if (mergedProperties && indexOf(mergedProperties, keyName) >= 0) {
+            var originalValue = this[keyName];
+
+            value = merge(originalValue, value);
           }
 
           if (desc) {


### PR DESCRIPTION
This provides a partial fix for #5182 (https://github.com/emberjs/ember.js/issues/5182). The reason it's currently a partial fix is due to the fact that Ember.merge does not perform a "deep" merge. I poked around a bit and did not see a supported way to perform a deep merge on objects so I figured I'd submit at least this as a good starting point. Is there something else I should be using here, other than "Ember.merge"?
