### PR TITLE
make run.later return val consistent with other run methods

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -312,8 +312,7 @@ run.sync = function() {
     target at the time the method is invoked.
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @param {Number} wait Number of milliseconds to wait.
-  @return {String} a string you can use to cancel the timer in
-    `run.cancel` later.
+  @return {Object} Timer information for use in cancelling, see `run.cancel`.
 */
 run.later = function(target, method) {
   return apply(backburner, backburner.later, arguments);


### PR DESCRIPTION
This fixes #5667.
