### PR TITLE
Make Ember.Namespace#toString ember-cli aware

### DIFF
--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -41,7 +41,7 @@ var Namespace = EmberObject.extend({
   },
 
   toString: function() {
-    var name = get(this, 'name');
+    var name = get(this, 'name') || get(this, 'modulePrefix');
     if (name) { return name; }
 
     findNamespaces();

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -72,6 +72,12 @@ test("toString on a namespace finds the namespace in Ember.lookup", function() {
   equal(obj.toString(), "<Foo.Bar:" + guidFor(obj) + ">");
 });
 
+test("toString on a namespace falls back to modulePrefix, if defined", function() {
+  var Foo = Namespace.create({ modulePrefix: 'foo' });
+
+  equal(Foo.toString(), "foo");
+});
+
 test('toString includes toStringExtension if defined', function() {
   var Foo = EmberObject.extend({
         toStringExtension: function() {


### PR DESCRIPTION
Since ember-cli [no longer assigns](https://github.com/stefanpenner/ember-cli/pull/2058) a `window.App` global, your app's `Ember.Namespace` is incorrectly registered as an empty string. i.e. `Ember.Namespace.NAMESPACES_BY_ID['']`. To fix this and allow for easier debugging, this makes it so ember is ember-cli "aware", using the `modulePrefix` property if available.

You can then get a reference to your app via `Ember.Namespace.NAMESPACES_BY_ID['app']` or whatever your name is.

*Alternatively, ember-cli could stop using `modulePrefix` and use `name` instead, and define _that_ in the `app.js`. IMO that's better to me, but figured there was some legit reason for using `modulePrefix` instead?
