### PR TITLE
[BUGFIX] location: 'history' no longer blows away location.hash

### DIFF
--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -3,6 +3,7 @@ import {set} from "ember-metal/property_set";
 import {guidFor} from "ember-metal/utils";
 
 import EmberObject from "ember-runtime/system/object";
+import EmberLocation from "ember-routing/location/api";
 import jQuery from "ember-views/system/jquery";
 
 /**
@@ -68,6 +69,7 @@ export default EmberObject.extend({
     var search = location.search || '';
 
     url += search;
+    url += this.getHash();
 
     return url;
   },
@@ -149,7 +151,6 @@ export default EmberObject.extend({
   */
   replaceState: function(path) {
     var state = { path: path };
-
     get(this, 'history').replaceState(state, null, path);
 
     // store state if browser doesn't support `history.state`
@@ -215,5 +216,14 @@ export default EmberObject.extend({
     var guid = guidFor(this);
 
     jQuery(window).off('popstate.ember-location-'+guid);
-  }
+  },
+
+  /**
+    @private
+
+    Returns normalized location.hash
+
+    @method getHash
+  */
+  getHash: EmberLocation._getHash,
 });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -154,6 +154,9 @@ var EmberRouter = EmberObject.extend(Evented, {
   },
 
   handleURL: function(url) {
+    // Until we have an ember-idiomatic way of accessing #hashes, we need to
+    // remove it because router.js doesn't know how to handle it.
+    url = url.split(/#(.+)?/)[0];
     return this._doURLTransition('handleURL', url);
   },
 

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -9,6 +9,27 @@ function createLocation(options){
   location = HistoryTestLocation.create(options);
 }
 
+function mockBrowserLocation(path) {
+  // This is a neat trick to auto-magically extract the hostname from any
+  // url by letting the browser do the work ;)
+  var tmp = document.createElement ('a');
+  tmp.href = path;
+
+  var protocol = (!tmp.protocol || tmp.protocol === ':') ? 'http' : tmp.protocol;
+  var pathname = (tmp.pathname.match(/^\//)) ? tmp.pathname : '/' + tmp.pathname;
+
+  return {
+      hash: tmp.hash,
+      host: tmp.host || 'localhost',
+      hostname: tmp.hostname || 'localhost',
+      href: tmp.href,
+      pathname: pathname,
+      port: tmp.port || '',
+      protocol: protocol,
+      search: tmp.search
+  };
+}
+
 QUnit.module("Ember.HistoryLocation", {
   setup: function() {
     FakeHistory = {
@@ -75,7 +96,7 @@ test("base URL is removed when retrieving the current pathname", function() {
         init: function() {
             this._super();
 
-            set(this, 'location', { pathname: '/base/foo/bar' });
+            set(this, 'location', mockBrowserLocation('/base/foo/bar'));
             set(this, 'baseURL', '/base/');
         },
 
@@ -97,7 +118,7 @@ test("base URL is preserved when moving around", function() {
         init: function() {
             this._super();
 
-            set(this, 'location', { pathname: '/base/foo/bar' });
+            set(this, 'location', mockBrowserLocation('/base/foo/bar'));
             set(this, 'baseURL', '/base/');
         }
     });
@@ -137,16 +158,61 @@ test("HistoryLocation.getURL() returns the current url, excluding both rootURL a
     expect(1);
 
     HistoryTestLocation.reopen({
-        init: function() {
-            this._super();
+      init: function() {
+        this._super();
 
-            set(this, 'location', { pathname: '/base/foo/bar' });
-            set(this, 'rootURL', '/app/');
-            set(this, 'baseURL', '/base/');
-        }
+        set(this, 'location', mockBrowserLocation('/base/foo/bar'));
+        set(this, 'rootURL', '/app/');
+        set(this, 'baseURL', '/base/');
+      }
     });
 
     createLocation();
 
     equal(location.getURL(), '/foo/bar');
+});
+
+test("HistoryLocation.getURL() includes location.search", function() {
+    expect(1);
+
+    HistoryTestLocation.reopen({  
+      init: function() {
+        this._super();
+        set(this, 'location', mockBrowserLocation('/foo/bar?time=morphin'));
+      }
+    });
+
+    createLocation();
+
+    equal(location.getURL(), '/foo/bar?time=morphin');
+});
+
+test("HistoryLocation.getURL() includes location.hash", function() {
+    expect(1);
+
+    HistoryTestLocation.reopen({  
+      init: function() {
+        this._super();
+        set(this, 'location', mockBrowserLocation('/foo/bar#pink-power-ranger'));
+      }
+    });
+
+    createLocation();
+
+    equal(location.getURL(), '/foo/bar#pink-power-ranger');
+});
+
+test("HistoryLocation.getURL() includes location.hash and location.search", function() {
+    expect(1);
+
+    HistoryTestLocation.reopen({  
+      init: function() {
+        this._super();
+        set(this, 'location', mockBrowserLocation('/foo/bar?time=morphin#pink-power-ranger'));
+      }
+    });
+
+    createLocation();
+
+    equal(location.getURL(), '/foo/bar?time=morphin#pink-power-ranger');
 });

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -162,3 +162,18 @@ test("AutoLocation should replace the url when it's not in the preferred format"
     rootURL: '/rootdir/'
   });
 });
+
+test("Router#handleURL should remove any #hashes before doing URL transition", function() {
+  expect(2);
+
+  router = Router.create({
+    container: container,
+
+    _doURLTransition: function (routerJsMethod, url) {
+      equal(routerJsMethod, 'handleURL');
+      equal(url, '/foo/bar?time=morphin');
+    }
+  });
+
+  router.handleURL('/foo/bar?time=morphin#pink-power-ranger');
+});

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2098,7 +2098,8 @@ test("Router accounts for rootURL on page load when using history location", fun
 
       setHistory(this, path);
       this.set('location', {
-        pathname: path
+        pathname: path,
+        href: 'http://localhost/' + path
       });
     },
 


### PR DESCRIPTION
This is Phase 2 of https://github.com/emberjs/ember.js/issues/4098.

Currently, if you're using `location: 'history'` and someone navigates to a URL with a hash in it (e.g. `/foo#bar`) `HistoryLocation` will call `history.replaceState()` without the `location.hash`, which immediately strips it from the URL and prevents the browser from natively scrolling the page to any HTML element with that id, (e.g. `<div id="bar">`) as well as let devs access `location.hash` for other reasons.

Because providing an ember-idiomatic way of getting/setting `location.hash` is probably quite a large under taking like query params were, this phase has the router internally strip the hash before passing it along to `router.js` library, since it is not hash-aware yet either.

(Note: This PR doesn't let the browser auto-scroll to any `#id` that's inside an ember-backed template because routes defer rendering until their model is resolved. That's a separate, more controversial PR to manually do so for all location classes)
