### PR TITLE
Ember presence

### DIFF
--- a/features.json
+++ b/features.json
@@ -12,7 +12,8 @@
     "ember-routing-handlebars-action-with-key-code": null,
     "ember-runtime-item-controller-inline-class": null,
     "ember-metal-injected-properties": null,
-    "mandatory-setter": "development-only"
+    "mandatory-setter": "development-only",
+    "ember-metal-presence": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -153,6 +153,7 @@ import {
 import isBlank from 'ember-metal/is_blank';
 import isPresent from 'ember-metal/is_present';
 import keys from 'ember-metal/keys';
+import presence from 'ember-metal/presence';
 
 // END IMPORTS
 
@@ -308,6 +309,10 @@ Ember.isBlank = isBlank;
 
 if (Ember.FEATURES.isEnabled('ember-metal-is-present')) {
   Ember.isPresent = isPresent;
+}
+
+if (Ember.FEATURES.isEnabled('ember-metal-presence')) {
+  Ember.presence = presence;
 }
 
 Ember.merge = merge;

--- a/packages/ember-metal/lib/presence.js
+++ b/packages/ember-metal/lib/presence.js
@@ -1,0 +1,10 @@
+import isPresent from 'ember-metal/is_present';
+var presence;
+
+if (Ember.FEATURES.isEnabled('ember-metal-presence')) {
+  presence = function(obj) {
+    if ( isPresent(obj) ) { return obj; }
+  };
+}
+
+export default presence;

--- a/packages/ember-metal/tests/presence_test.js
+++ b/packages/ember-metal/tests/presence_test.js
@@ -1,0 +1,31 @@
+import presence from 'ember-metal/presence';
+
+if (Ember.FEATURES.isEnabled('ember-metal-presence')) {
+  QUnit.module("Ember.presence");
+
+  test("Ember.presence", function() {
+    var string = "This is present",
+        fn = function() {},
+        arr = [1,2,3],
+        object = {ember: 'Rocks'},
+        zeroLengthObject = {length: 0};
+
+    equal(null, presence(),                    "for no params");
+    equal(null, presence(null),                "for null");
+    equal(null, presence(undefined),           "for undefined");
+    equal(null, presence(""),                  "for an empty String");
+    equal(null, presence("  "),                "for a whitespace String");
+    equal(null, presence("\n\t"),              "for another whitespace String");
+    equal("\n\t Hi", presence("\n\t Hi"),      "for a String with whitespaces");
+    equal(true, presence(true),                "for true");
+    equal(false, presence(false),              "for false");
+    equal(string, presence(string),            "for a String");
+    equal(fn, presence(fn),                    "for a Function");
+    equal(0, presence(0),                      "for 0");
+    equal(null, presence([]),                  "for an empty Array");
+    //equal(null, presence({}),                  "for an empty Object"); // still not sure what the output here should be
+    equal(null, presence(zeroLengthObject),    "for an Object that has zero 'length'");
+    equal(object, presence(object),            "for an Object that a length > 0");
+    equal(arr, presence(arr),                  "for a non-empty array");
+  });
+}


### PR DESCRIPTION
I'm still learning Ember, and coming from Rails, I've found [Object#presence](http://api.rubyonrails.org/classes/Object.html#method-i-presence) really useful.
Searching through the issues and API, I couldn't find anything like this, so I thought it might be nice to have it.

Also, I commented out a spec since I wanted some feedback on that specific case. 
In Rails, if you call `#presence` on an empty Hash , it returns `nil`, but in this case, `Ember.presence({})` returns `{}` instead of null, and `Ember.presence([])` does return `null` (I assume that it might be because `[]` responds to the length method and `{}` doesn't, also I'm using the isPresent method, which uses the isBlank method).

So my question is, is this behavior okay, or should it return null?

Thanks!

BTW I still need to add some documentation to the presence.js file, but I wanted to open the PR to get some feedback
