### PR TITLE
[BUGFIX] attributeBindings handles names with ':'

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1181,7 +1181,7 @@ var View = CoreView.extend({
     forEach(attributeBindings, function(binding) {
       var split = binding.split(':');
       var property = split[0];
-      var attributeName = split[1] || property;
+      var attributeName = binding.substring(binding.indexOf(':') + 1);
 
       if (property in this) {
         this._setupAttributeBindingObservation(property, attributeName);

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -291,3 +291,16 @@ test("attributeBindings should not fail if view has been destroyed", function() 
   }
   ok(!error, error);
 });
+
+test("should handle attribute names containing ':'", function() {
+  view = EmberView.create({
+    attributeBindings: ['href:xlink:href'],
+    href: "foo"
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().attr('xlink:href'), "foo", "attribute is set");
+});


### PR DESCRIPTION
Fixes bug that prevented using attributeBindings for attribute names containing ':'  - e.g. attributeBindings: ['href:xlink:href']
