### PR TITLE
Removed redundant conditional

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -39,7 +39,7 @@ DSL.prototype = {
       route(dsl, 'loading');
       route(dsl, 'error', { path: "/_unused_dummy_error_path_route_" + name + "/:error" });
 
-      if (callback) { callback.call(dsl); }
+      callback.call(dsl);
 
       this.push(options.path, name, dsl.generate());
     } else {


### PR DESCRIPTION
The current block it was in already guarantees `callback` is truthy so it was frivolous.
