### PR TITLE
Remove warning about nesting resources only

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -94,8 +94,6 @@ function canNest(dsl) {
 }
 
 function route(dsl, name, options) {
-  Ember.assert("You must use `this.resource` to nest", typeof options !== 'function');
-
   options = options || {};
 
   if (typeof options.path !== 'string') {


### PR DESCRIPTION
Nested routes are now supported, this warning then feels ready to remove.
