### PR TITLE
Fix for {{view class=someBoundProp}}.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -40,7 +40,11 @@ function makeBindings(options) {
       }
     } else {
       if (hashType === 'ID') {
-        hash[prop + 'Binding'] = view._getBindingForStream(value);
+        if (prop === 'class') {
+          hash.classBinding = value;
+        } else {
+          hash[prop + 'Binding'] = view._getBindingForStream(value);
+        }
         delete hash[prop];
         delete hashTypes[prop];
       }

--- a/packages/ember-handlebars/tests/helpers/view_test.js
+++ b/packages/ember-handlebars/tests/helpers/view_test.js
@@ -199,9 +199,34 @@ test("allows you to pass attributes that will be assigned to the class instance,
 
 test("Should apply class without condition always", function() {
   view = EmberView.create({
-    context: [],
     controller: Ember.Object.create(),
     template: Ember.Handlebars.compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
+});
+
+test("Should apply classes when bound controller.* property specified", function() {
+  view = EmberView.create({
+    controller: {
+      someProp: 'foo'
+    },
+    template: Ember.Handlebars.compile('{{#view id="foo" class=controller.someProp}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
+});
+
+test("Should apply classes when bound property specified", function() {
+  view = EmberView.create({
+    controller: {
+      someProp: 'foo'
+    },
+    template: Ember.Handlebars.compile('{{#view id="foo" class=someProp}} Foo{{/view}}')
   });
 
   run(view, 'appendTo', '#qunit-fixture');


### PR DESCRIPTION
Error happens in [packages/ember-handlebars/lib/helpers/view.js#L83](https://github.com/emberjs/ember.js/blob/master/packages/ember-handlebars/lib/helpers/view.js#L83), which is:

``` javascript
    if (hash.classBinding) {
      extensions.classNameBindings = hash.classBinding.split(' ');
    }
```

Where `classBinding` there is a `StreamBinding` instance (which does not have a `split` method).

---

**Update:** Whitelist `classBinding` to allow it to be transformed into a stream later.
