### PR TITLE
SimpleBinding should relay setValue

### DIFF
--- a/packages/ember-metal/lib/streams/simple.js
+++ b/packages/ember-metal/lib/streams/simple.js
@@ -18,6 +18,14 @@ merge(SimpleStream.prototype, {
     return read(this.source);
   },
 
+  setValue: function(value) {
+    var source = this.source;
+
+    if (source && source.isStream) {
+      source.setValue(value);
+    }
+  },
+
   setSource: function(nextSource) {
     var prevSource = this.source;
     if (nextSource !== prevSource) {

--- a/packages/ember-metal/tests/streams/simple_stream_test.js
+++ b/packages/ember-metal/tests/streams/simple_stream_test.js
@@ -1,0 +1,39 @@
+import Stream from "ember-metal/streams/stream";
+import SimpleStream from "ember-metal/streams/simple";
+
+var source, value;
+
+QUnit.module('Simple Stream', {
+  setup: function() {
+    value = "zlurp";
+
+    source = new Stream(function() {
+      return value;
+    });
+
+    source.setValue = function(_value, callback, context) {
+      value = _value;
+      this.notify(callback, context);
+    };
+  },
+  teardown: function() {
+    value = undefined;
+    source = undefined;
+  }
+});
+
+test('supports a stream argument', function() {
+  var stream = new SimpleStream(source);
+  equal(stream.value(), "zlurp");
+
+  stream.setValue("blorg");
+  equal(stream.value(), "blorg");
+});
+
+test('supports a non-stream argument', function() {
+  var stream = new SimpleStream(value);
+  equal(stream.value(), "zlurp");
+
+  stream.setValue("blorg");
+  equal(stream.value(), "zlurp");
+});


### PR DESCRIPTION
Previously `{{input value=foo.bar}}` worked but `{{input value=baz}}` did not. This is because root keys on the context are proxied through a SimpleStream which did not implement setValue.
