### PR TITLE
Symbol spike

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -3,7 +3,7 @@ import {get, normalizeTuple} from "ember-metal/property_get";
 import {meta as metaFor} from "ember-metal/utils";
 import {forEach} from "ember-metal/array";
 import {watchKey, unwatchKey} from "ember-metal/watch_key";
-
+import { META_KEY } from "ember-metal/utils";
 var warn = Ember.warn;
 var FIRST_KEY = /^([^\.]+)/;
 
@@ -46,7 +46,7 @@ function addChainWatcher(obj, keyName, node) {
 function removeChainWatcher(obj, keyName, node) {
   if (!obj || 'object' !== typeof obj) { return; } // nothing to do
 
-  var m = obj['__ember_meta__'];
+  var m = obj[META_KEY];
   if (m && !m.hasOwnProperty('chainWatchers')) { return; } // nothing to do
 
   var nodes = m && m.chainWatchers;
@@ -100,7 +100,7 @@ var ChainNodePrototype = ChainNode.prototype;
 function lazyGet(obj, key) {
   if (!obj) return undefined;
 
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   // check if object meant only to be a prototype
   if (meta && meta.proto === obj) return undefined;
 
@@ -324,7 +324,7 @@ ChainNodePrototype.didChange = function(events) {
 
 export function finishChains(obj) {
   // We only create meta if we really have to
-  var m = obj['__ember_meta__'],
+  var m = obj[META_KEY],
     chains, chainWatchers, chainNodes;
   if (m) {
     // finish any current chains node watchers that reference obj

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -2,7 +2,8 @@ import Ember from "ember-metal/core";
 import { set } from "ember-metal/property_set";
 import {
   meta,
-  inspect
+  inspect,
+  META_KEY
 } from "ember-metal/utils";
 import expandProperties from "ember-metal/expand_properties";
 import EmberError from "ember-metal/error";
@@ -581,7 +582,7 @@ function computed(func) {
   @return {Object} the cached value
 */
 function cacheFor(obj, key) {
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var cache = meta && meta.cache;
   var ret = cache && cache[key];
 

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -6,7 +6,8 @@ import {
   meta as metaFor,
   tryFinally,
   apply,
-  applyStr
+  applyStr,
+  META_KEY
 } from "ember-metal/utils";
 import { create } from "ember-metal/platform";
 
@@ -77,7 +78,7 @@ function actionsFor(obj, eventName) {
 }
 
 export function listenersUnion(obj, eventName, otherActions) {
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var actions = meta && meta.listeners && meta.listeners[eventName];
 
   if (!actions) { return; }
@@ -94,7 +95,7 @@ export function listenersUnion(obj, eventName, otherActions) {
 }
 
 export function listenersDiff(obj, eventName, otherActions) {
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var actions = meta && meta.listeners && meta.listeners[eventName];
   var diffActions = [];
 
@@ -185,7 +186,7 @@ function removeListener(obj, eventName, target, method) {
   if (method) {
     _removeListener(target, method);
   } else {
-    var meta = obj['__ember_meta__'];
+    var meta = obj[META_KEY];
     var actions = meta && meta.listeners && meta.listeners[eventName];
 
     if (!actions) { return; }
@@ -288,7 +289,7 @@ export function suspendListeners(obj, eventNames, target, method, callback) {
   @param obj
 */
 export function watchedEvents(obj) {
-  var listeners = obj['__ember_meta__'].listeners, ret = [];
+  var listeners = obj[META_KEY].listeners, ret = [];
 
   if (listeners) {
     for (var eventName in listeners) {
@@ -322,7 +323,7 @@ export function sendEvent(obj, eventName, params, actions) {
   }
 
   if (!actions) {
-    var meta = obj['__ember_meta__'];
+    var meta = obj[META_KEY];
     actions = meta && meta.listeners && meta.listeners[eventName];
   }
 
@@ -359,7 +360,7 @@ export function sendEvent(obj, eventName, params, actions) {
   @param {String} eventName
 */
 export function hasListeners(obj, eventName) {
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var actions = meta && meta.listeners && meta.listeners[eventName];
 
   return !!(actions && actions.length);
@@ -374,7 +375,7 @@ export function hasListeners(obj, eventName) {
 */
 export function listenersFor(obj, eventName) {
   var ret = [];
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var actions = meta && meta.listeners && meta.listeners[eventName];
 
   if (!actions) { return ret; }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -20,7 +20,8 @@ import {
   meta as metaFor,
   wrap,
   makeArray,
-  apply
+  apply,
+  META_KEY
 } from "ember-metal/utils";
 import expandProperties from "ember-metal/expand_properties";
 import {
@@ -632,7 +633,7 @@ function _detect(curMixin, targetMixin, seen) {
 MixinPrototype.detect = function(obj) {
   if (!obj) { return false; }
   if (obj instanceof Mixin) { return _detect(obj, this, {}); }
-  var m = obj['__ember_meta__'];
+  var m = obj[META_KEY];
   var mixins = m && m.mixins;
   if (mixins) {
     return !!mixins[guidFor(this)];
@@ -674,7 +675,7 @@ MixinPrototype.keys = function() {
 // returns the mixins currently applied to the specified object
 // TODO: Make Ember.mixin
 Mixin.mixins = function(obj) {
-  var m = obj['__ember_meta__'];
+  var m = obj[META_KEY];
   var mixins = m && m.mixins;
   var ret = [];
 

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -3,7 +3,10 @@
 */
 
 import Ember from "ember-metal/core";
-import { meta as metaFor } from "ember-metal/utils";
+import {
+  meta as metaFor,
+  META_KEY
+} from "ember-metal/utils";
 import {
   defineProperty as objectDefineProperty,
   hasPropertyAccessors
@@ -36,7 +39,7 @@ export function MANDATORY_SETTER_FUNCTION(value) {
 
 export function DEFAULT_GETTER_FUNCTION(name) {
   return function GETTER_FUNCTION() {
-    var meta = this['__ember_meta__'];
+    var meta = this[META_KEY];
     return meta && meta.values[name];
   };
 }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -1,6 +1,7 @@
 import {
   guidFor,
-  tryFinally
+  tryFinally,
+  META_KEY
 } from "ember-metal/utils";
 import {
   sendEvent,
@@ -33,7 +34,7 @@ var deferred = 0;
   @return {void}
 */
 function propertyWillChange(obj, keyName) {
-  var m = obj['__ember_meta__'];
+  var m = obj[META_KEY];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
   var desc = m && m.descs[keyName];
@@ -62,7 +63,7 @@ function propertyWillChange(obj, keyName) {
   @return {void}
 */
 function propertyDidChange(obj, keyName) {
-  var m = obj['__ember_meta__'];
+  var m = obj[META_KEY];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
   var desc = m && m.descs[keyName];

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -9,6 +9,9 @@ import {
   isPath,
   hasThis as pathHasThis
 } from "ember-metal/path_cache";
+import {
+  META_KEY
+} from "ember-metal/utils";
 import { hasPropertyAccessors } from "ember-metal/platform";
 
 var FIRST_KEY = /^([^\.]+)/;
@@ -67,7 +70,7 @@ var get = function get(obj, keyName) {
     return value;
   }
 
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var desc = meta && meta.descs[keyName];
   var ret;
 

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -4,6 +4,9 @@ import {
   propertyWillChange,
   propertyDidChange
 } from "ember-metal/property_events";
+import {
+  META_KEY
+} from "ember-metal/utils";
 import { defineProperty } from "ember-metal/properties";
 import EmberError from "ember-metal/error";
 import {
@@ -40,7 +43,7 @@ var set = function set(obj, keyName, value, tolerant) {
     return setPath(obj, keyName, value, tolerant);
   }
 
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   var desc = meta && meta.descs[keyName];
   var isUnknown, currentValue;
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -396,17 +396,19 @@ export function metaPath(obj, path, writable) {
   @param {Function} superFunc The super function.
   @return {Function} wrapped function.
 */
+
+export var NEXT_SUPER = Symbole("next super");
 export function wrap(func, superFunc) {
   function superWrapper() {
     var ret;
-    var sup  = this && this.__nextSuper;
+    var sup  = this && this[NEXT_SUPER];
     var args = new Array(arguments.length);
     for (var i = 0, l = args.length; i < l; i++) {
       args[i] = arguments[i];
     }
-    if(this) { this.__nextSuper = superFunc; }
+    if(this) { this[NEXT_SUPER] = superFunc; }
     ret = apply(this, func, args);
-    if(this) { this.__nextSuper = sup; }
+    if(this) { this[NEXT_SUPER] = sup; }
     return ret;
   }
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -112,7 +112,7 @@ function intern(str) {
   @type String
   @final
 */
-var GUID_KEY = intern('__ember' + (+ new Date()));
+var GUID_KEY = Symbol('GUID_KEY'); //intern('__ember' + (+ new Date()));
 
 var GUID_DESC = {
   writable:    false,
@@ -145,8 +145,7 @@ export function generateGuid(obj, prefix) {
     if (obj[GUID_KEY] === null) {
       obj[GUID_KEY] = ret;
     } else {
-      GUID_DESC.value = ret;
-      o_defineProperty(obj, GUID_KEY, GUID_DESC);
+      obj[GUID_KEY] = ret;
     }
   }
   return ret;
@@ -166,6 +165,9 @@ export function generateGuid(obj, prefix) {
   @param {Object} obj any object, string, number, Element, or primitive
   @return {String} the unique guid for this instance.
 */
+
+var guids = new WeakMap();
+
 export function guidFor(obj) {
 
   // special cases where we don't want to add a key to object
@@ -191,17 +193,11 @@ export function guidFor(obj) {
       return obj ? '(true)' : '(false)';
 
     default:
-      if (obj[GUID_KEY]) return obj[GUID_KEY];
       if (obj === Object) return '(Object)';
       if (obj === Array)  return '(Array)';
+      if (guids.has(obj)) return guids.get(obj);
       ret = GUID_PREFIX + uuid();
-
-      if (obj[GUID_KEY] === null) {
-        obj[GUID_KEY] = ret;
-      } else {
-        GUID_DESC.value = ret;
-        o_defineProperty(obj, GUID_KEY, GUID_DESC);
-      }
+      guids.set(obj, ret);
       return ret;
   }
 }
@@ -280,13 +276,13 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
     the meta hash, allowing the method to avoid making an unnecessary copy.
   @return {Object} the meta hash for an object
 */
+
+export var META_KEY = Symbol("ember meta");
 function meta(obj, writable) {
-  var ret = obj['__ember_meta__'];
+  var ret = obj[META_KEY];
   if (writable===false) return ret || EMPTY_META;
 
   if (!ret) {
-    if (canDefineNonEnumerableProperties) o_defineProperty(obj, '__ember_meta__', META_DESC);
-
     ret = new Meta(obj);
 
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
@@ -295,13 +291,12 @@ function meta(obj, writable) {
       }
     }
 
-    obj['__ember_meta__'] = ret;
+    obj[META_KEY] = ret;
 
     // make sure we don't accidentally try to create constructor like desc
     ret.descs.constructor = null;
 
   } else if (ret.source !== obj) {
-    if (canDefineNonEnumerableProperties) o_defineProperty(obj, '__ember_meta__', META_DESC);
 
     ret = o_create(ret);
     ret.descs     = o_create(ret.descs);
@@ -316,7 +311,7 @@ function meta(obj, writable) {
       }
     }
 
-    obj['__ember_meta__'] = ret;
+    obj[META_KEY] = ret;
   }
   return ret;
 }

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -3,7 +3,8 @@
 */
 
 import {
-  typeOf
+  typeOf,
+  META_KEY
 } from "ember-metal/utils";
 import {
   removeChainWatcher,
@@ -49,7 +50,7 @@ function watch(obj, _keyPath, m) {
 export { watch };
 
 export function isWatching(obj, key) {
-  var meta = obj['__ember_meta__'];
+  var meta = obj[META_KEY];
   return (meta && meta.watching[key]) > 0;
 }
 
@@ -78,9 +79,9 @@ var NODE_STACK = [];
   @return {void}
 */
 export function destroy(obj) {
-  var meta = obj['__ember_meta__'], node, nodes, key, nodeObject;
+  var meta = obj[META_KEY], node, nodes, key, nodeObject;
   if (meta) {
-    obj['__ember_meta__'] = null;
+    obj[META_KEY] = null;
     // remove chainWatchers to remove circular references that would prevent GC
     node = meta.chains;
     if (node) {

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -3,9 +3,7 @@
 */
 
 import {
-  GUID_KEY,
-  typeOf,
-  generateGuid
+  typeOf
 } from "ember-metal/utils";
 import {
   removeChainWatcher,
@@ -65,30 +63,6 @@ export function unwatch(obj, _keyPath, m) {
     unwatchKey(obj, _keyPath, m);
   } else {
     unwatchPath(obj, _keyPath, m);
-  }
-}
-
-/**
-  Call on an object when you first beget it from another object. This will
-  setup any chained watchers on the object instance as needed. This method is
-  safe to call multiple times.
-
-  @private
-  @method rewatch
-  @for Ember
-  @param obj
-*/
-export function rewatch(obj) {
-  var m = obj['__ember_meta__'], chains = m && m.chains;
-
-  // make sure the object has its own guid.
-  if (GUID_KEY in obj && !obj.hasOwnProperty(GUID_KEY)) {
-    generateGuid(obj);
-  }
-
-  // make sure any chained watchers update.
-  if (chains && chains.value() !== obj) {
-    m.chains = chains.copy(obj);
   }
 }
 

--- a/packages/ember-metal/tests/binding/connect_test.js
+++ b/packages/ember-metal/tests/binding/connect_test.js
@@ -5,10 +5,8 @@ import {
   bind
 } from "ember-metal/binding";
 import run from 'ember-metal/run_loop';
-import { create } from 'ember-metal/platform';
 import { set } from 'ember-metal/property_set';
 import { get } from 'ember-metal/property_get';
-import { rewatch } from "ember-metal/watching";
 
 function performTest(binding, a, b, get, set, connect) {
   if (connect === undefined) connect = function() {binding.connect(a);};
@@ -102,31 +100,6 @@ testBoth('Calling connect more than once', function(get, set) {
 
     binding.connect(a);
   });
-});
-
-testBoth('Bindings should be inherited', function(get, set) {
-
-  var a = { foo: 'FOO', b: { bar: 'BAR' } };
-  var binding = new Binding('foo', 'b.bar');
-  var a2;
-
-  run(function () {
-    binding.connect(a);
-
-    a2 = create(a);
-    rewatch(a2);
-  });
-
-  equal(get(a2, 'foo'), "BAR", "Should have synced binding on child");
-  equal(get(a,  'foo'), "BAR", "Should NOT have synced binding on parent");
-
-  run(function () {
-    set(a2, 'b', { bar: 'BAZZ' });
-  });
-
-  equal(get(a2, 'foo'), "BAZZ", "Should have synced binding on child");
-  equal(get(a,  'foo'), "BAR", "Should NOT have synced binding on parent");
-
 });
 
 test('inherited bindings should sync on create', function() {

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -1,6 +1,7 @@
 import { addObserver } from "ember-metal/observer";
 import { finishChains } from "ember-metal/chains";
 import { create } from 'ember-metal/platform';
+import { META_KEY } from 'ember-metal/utils';
 
 QUnit.module("Chains");
 
@@ -13,5 +14,5 @@ test("finishChains should properly copy chains from prototypes to instances", fu
   var childObj = create(obj);
   finishChains(childObj);
 
-  ok(obj['__ember_meta__'].chains !== childObj['__ember_meta__'].chains, "The chains object is copied");
+  ok(obj[META_KEY].chains !== childObj[META_KEY].chains, "The chains object is copied");
 });

--- a/packages/ember-metal/tests/utils/guidFor_test.js
+++ b/packages/ember-metal/tests/utils/guidFor_test.js
@@ -1,7 +1,6 @@
 import {
   guidFor
 } from "ember-metal/utils";
-import { rewatch } from "ember-metal/watching";
 
 QUnit.module("guidFor");
 
@@ -25,22 +24,6 @@ test("Object", function() {
   sameGuid( a, a, "same object always yields same guid" );
   diffGuid( a, b, "different objects yield different guids" );
   nanGuid( a );
-});
-
-test("Object with prototype", function() {
-  var Class = function() { };
-
-  guidFor(Class.prototype);
-
-  var a = new Class();
-  var b = new Class();
-
-  sameGuid( a, b , "without calling rewatch, objects copy the guid from their prototype");
-
-  rewatch(a);
-  rewatch(b);
-
-  diffGuid( a, b, "after calling rewatch, objects don't share guids" );
 });
 
 test("strings", function() {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -20,7 +20,6 @@ import {
   meta,
   makeArray
 } from "ember-metal/utils";
-import { rewatch } from "ember-metal/watching";
 import { finishChains } from "ember-metal/chains";
 import { sendEvent } from "ember-metal/events";
 import {
@@ -196,7 +195,6 @@ function makeCtor() {
     if (!wasApplied) {
       wasApplied = true;
       Class.PrototypeMixin.applyPartial(Class.prototype);
-      rewatch(Class.prototype);
     }
 
     return this.prototype;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -18,7 +18,8 @@ import {
   generateGuid,
   GUID_KEY,
   meta,
-  makeArray
+  makeArray,
+  META_KEY
 } from "ember-metal/utils";
 import { finishChains } from "ember-metal/chains";
 import { sendEvent } from "ember-metal/events";
@@ -76,8 +77,8 @@ function makeCtor() {
     if (!wasApplied) {
       Class.proto(); // prepare prototype...
     }
-    o_defineProperty(this, GUID_KEY, nullDescriptor);
-    o_defineProperty(this, '__nextSuper', undefinedDescriptor);
+
+    this[GUID_KEY] = null;
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;
@@ -785,7 +786,7 @@ var ClassMixinProps = {
     @param key {String} property name
   */
   metaForProperty: function(key) {
-    var meta = this.proto()['__ember_meta__'];
+    var meta = this.proto()[META_KEY];
     var desc = meta && meta.descs[key];
 
     Ember.assert("metaForProperty() could not find a computed property with key '"+key+"'.", !!desc && desc instanceof ComputedProperty);

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -11,16 +11,15 @@ import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import {
   guidFor,
-  apply
-} from "ember-metal/utils";
-import { create as o_create } from "ember-metal/platform";
-import {
+  apply,
+  NEXT_SUPER,
   generateGuid,
   GUID_KEY,
   meta,
   makeArray,
   META_KEY
 } from "ember-metal/utils";
+import { create as o_create } from "ember-metal/platform";
 import { finishChains } from "ember-metal/chains";
 import { sendEvent } from "ember-metal/events";
 import {
@@ -79,6 +78,7 @@ function makeCtor() {
     }
 
     this[GUID_KEY] = null;
+    this[NEXT_SUPER] = undefined;
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -154,7 +154,7 @@ function findNamespaces() {
   }
 }
 
-var NAME_KEY = Ember.NAME_KEY = GUID_KEY + '_name';
+var NAME_KEY = Ember.NAME_KEY = String(GUID_KEY) + '_name';
 
 function superClassString(mixin) {
   var superclass = mixin.superclass;

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -7,6 +7,9 @@ import {
   beginPropertyChanges,
   endPropertyChanges
 } from "ember-metal/property_events";
+import {
+  META_KEY
+} from "ember-metal/utils";
 import objectKeys from "ember-metal/keys";
 import { testBoth } from 'ember-runtime/tests/props_helper';
 import EmberObject from 'ember-runtime/system/object';
@@ -19,13 +22,13 @@ testBoth("should schedule objects to be destroyed at the end of the run loop", f
 
   run(function() {
     obj.destroy();
-    meta = obj['__ember_meta__'];
+    meta = obj[META_KEY];
     ok(meta, "meta is not destroyed immediately");
     ok(get(obj, 'isDestroying'), "object is marked as destroying immediately");
     ok(!get(obj, 'isDestroyed'), "object is not destroyed immediately");
   });
 
-  meta = obj['__ember_meta__'];
+  meta = obj[META_KEY];
   ok(!meta, "meta is destroyed after run loop finishes");
   ok(get(obj, 'isDestroyed'), "object is destroyed after run loop finishes");
 });

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -89,8 +89,8 @@ test('toString includes toStringExtension if defined', function() {
   var bar = Bar.create();
 
   // simulate these classes being defined on a Namespace
-  Foo[GUID_KEY+'_name'] = 'Foo';
-  Bar[GUID_KEY+'_name'] = 'Bar';
+  Foo[String(GUID_KEY)+'_name'] = 'Foo';
+  Bar[String(GUID_KEY)+'_name'] = 'Bar';
 
   equal(bar.toString(), '<Bar:'+guidFor(bar)+'>', 'does not include toStringExtension part');
   equal(foo.toString(), '<Foo:'+guidFor(foo)+':fooey>', 'Includes toStringExtension result');

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -2,6 +2,7 @@ import "ember";
 import { computed } from "ember-metal/computed";
 import { canDefineNonEnumerableProperties } from 'ember-metal/platform';
 import { capitalize } from "ember-runtime/system/string";
+import { META_KEY } from "ember-meta/utils";
 
 var Router, App, router, container;
 var get = Ember.get;
@@ -12,7 +13,7 @@ function withoutMeta(object) {
     return object;
   }
   var newObject = Ember.$.extend(true, {}, object);
-  delete newObject['__ember_meta__'];
+  delete newObject[META_KEY];
   return newObject;
 }
 


### PR DESCRIPTION
this is just a spike, experimenting with symbols over defProp
- [ ] make this work with non-symbol supporting browsers
- [ ] evaluate the impact of slower property lookups but much faster object allocation.. (until they make symbol lookups faster)
- [ ] fix jshint
- [ ] test both paths.

this reduces the cost of ember object allocations by 4x-6x and seems to improve perf-stress render time by 10% or so.
