### PR TITLE
[DOC beta] Fix link to guides

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -74,7 +74,7 @@ function handlebarsGetView(context, path, container, data) {
       var globalViewClass = get(path);
       Ember.deprecate('Resolved the view "'+path+'" on the global context. Pass a view name to be looked' +
                       ' up on the container instead, such as {{view "select"}}.' +
-                      ' http://emberjs.com/guides/deprecations#toc_global-lookup-of-views-since-1-8', !globalViewClass);
+                      ' http://emberjs.com/guides/deprecations#toc_global-lookup-of-views', !globalViewClass);
       if (globalViewClass) {
         viewClass = globalViewClass;
       }

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -192,7 +192,7 @@ function collectionHelper(path, options) {
   } else if (hash.itemViewClass) {
     if (hashTypes.itemViewClass === 'ID') {
       var itemViewClassStream = view.getStream(hash.itemViewClass);
-      Ember.deprecate('Resolved the view "'+hash.itemViewClass+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views-since-1-8', !itemViewClassStream.isGlobal());
+      Ember.deprecate('Resolved the view "'+hash.itemViewClass+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views', !itemViewClassStream.isGlobal());
       itemViewClass = itemViewClassStream.value();
     } else {
       itemViewClass = hash.itemViewClass;

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -387,7 +387,7 @@ export function viewHelper(path) {
     var pathStream;
     if (typeof path === 'string' && types[0] === 'ID') {
       pathStream = view.getStream(path);
-      Ember.deprecate('Resolved the view "'+path+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views-since-1-8', !pathStream.isGlobal());
+      Ember.deprecate('Resolved the view "'+path+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views', !pathStream.isGlobal());
     } else {
       pathStream = path;
     }

--- a/packages/ember-views/lib/streams/read.js
+++ b/packages/ember-views/lib/streams/read.js
@@ -13,7 +13,7 @@ export function readViewFactory(object, container) {
   if (typeof value === 'string') {
     if (isGlobal(value)) {
       viewClass = get(null, value);
-      Ember.deprecate('Resolved the view "'+value+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views-since-1-8', !viewClass);
+      Ember.deprecate('Resolved the view "'+value+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views', !viewClass);
     } else {
       Ember.assert("View requires a container to resolve views not passed in through the context", !!container);
       viewClass = container.lookupFactory('view:'+value);


### PR DESCRIPTION
The "Global lookup of view" section is linked as:
- http://emberjs.com/guides/deprecations/#toc_global-lookup-of-views

'-since-1-8' suffix is unnecessary.
