### PR TITLE
StreamBindings should always notify on sync

### DIFF
--- a/packages/ember-metal/lib/streams/stream_binding.js
+++ b/packages/ember-metal/lib/streams/stream_binding.js
@@ -58,6 +58,9 @@ merge(StreamBinding.prototype, {
     this.senderContext = undefined;
     this.senderValue = undefined;
 
+    // Force StreamBindings to always notify
+    this.cache = undefined;
+
     this.notify(senderCallback, senderContext);
   },
 

--- a/packages/ember-metal/tests/streams/stream_binding_test.js
+++ b/packages/ember-metal/tests/streams/stream_binding_test.js
@@ -119,3 +119,30 @@ test('the last value sent by the source wins', function() {
   equal(source.value(), "hoopla", "value has synced after run loop");
   equal(get(obj, 'to'), "hoopla", "value has synced after run loop");
 });
+
+test('continues to notify subscribers after first consumption, even if not consumed', function() {
+  var counter = 0;
+  var binding = new StreamBinding(source);
+
+  binding.value();
+
+  binding.subscribe(function() {
+    source.value();
+    counter++;
+  });
+
+  equal(counter, 0);
+
+  run(function() {
+    source.setValue("blorg");
+    equal(counter, 0);
+  });
+  equal(counter, 1);
+
+  run(function() {
+    source.setValue("hoopla");
+    source.setValue("zlurp");
+    equal(counter, 1);
+  });
+  equal(counter, 2);
+});


### PR DESCRIPTION
Fixes #9337.

This is one possible solution to the issue. Another solution is to drop registerObserver in attribute bindings, because those code paths don't consume the stream binding, but this PR provides a sufficient stopgap.

In Ember 2.0 we can do better by giving bindings CP/Stream-like semantics, i.e. notify+pull instead of push.

cc @rlivsey 
