### PR TITLE
Bring back Ember.Handlebars.get.

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -28,6 +28,24 @@ var slice = [].slice;
 var originalTemplate = EmberHandlebars.template;
 
 /**
+  Lookup both on root and on window. If the path starts with
+  a keyword, the corresponding object will be looked up in the
+  template's data hash and used to resolve the path.
+
+  @method get
+  @for Ember.Handlebars
+  @param {Object} root The object to look up the property on
+  @param {String} path The path to be lookedup
+  @param {Object} options The template's option hash
+  @deprecated
+*/
+function handlebarsGet(root, path, options) {
+  Ember.deprecate('Usage of Ember.Handlebars.get is deprecated, use a Component or Ember.Handlebars.makeBoundHelper instead.');
+
+  return options.data.view.getStream(path).value();
+}
+
+/**
   handlebarsGetView resolves a view based on strings passed into a template.
   For example:
 
@@ -435,5 +453,6 @@ export function template(spec) {
 
 export {
   makeBoundHelper,
-  handlebarsGetView
+  handlebarsGetView,
+  handlebarsGet
 };

--- a/packages/ember-handlebars/tests/handlebars_get_test.js
+++ b/packages/ember-handlebars/tests/handlebars_get_test.js
@@ -1,0 +1,128 @@
+import Ember from "ember-metal/core"; // Ember.lookup
+import _MetamorphView from "ember-handlebars/views/metamorph_view";
+import EmberView from "ember-views/views/view";
+import run from "ember-metal/run_loop";
+import EmberHandlebars from "ember-handlebars";
+import { handlebarsGet } from "ember-handlebars/ext";
+import Container from "ember-runtime/system/container";
+
+var compile = EmberHandlebars.compile;
+var originalLookup = Ember.lookup;
+var TemplateTests, container, lookup, view;
+
+function appendView() {
+  run(view, 'appendTo', '#qunit-fixture');
+}
+
+QUnit.module("Ember.Handlebars.get", {
+  setup: function() {
+    Ember.lookup = lookup = {};
+    container = new Container();
+    container.optionsForType('template', { instantiate: false });
+    container.optionsForType('helper', { instantiate: false });
+    container.register('view:default', _MetamorphView);
+    container.register('view:toplevel', EmberView.extend());
+  },
+
+  teardown: function() {
+    run(function() {
+        if (container) {
+          container.destroy();
+        }
+        if (view) {
+          view.destroy();
+        }
+        container = view = null;
+    });
+    Ember.lookup = lookup = originalLookup;
+    TemplateTests = null;
+  }
+});
+
+test('it can lookup a path from the current context', function() {
+  expect(1);
+
+  container.register('helper:handlebars-get', function(path, options) {
+    var context = options.contexts && options.contexts[0] || this;
+
+    ignoreDeprecation(function() {
+      equal(handlebarsGet(context, path, options), 'bar');
+    });
+  });
+
+  view = EmberView.create({
+    container: container,
+    controller: {
+      foo: 'bar'
+    },
+    template: compile('{{handlebars-get "foo"}}')
+  });
+
+  appendView();
+});
+
+test('it can lookup a path from the current keywords', function() {
+  expect(1);
+
+  container.register('helper:handlebars-get', function(path, options) {
+    var context = options.contexts && options.contexts[0] || this;
+
+    ignoreDeprecation(function() {
+      equal(handlebarsGet(context, path, options), 'bar');
+    });
+  });
+
+  view = EmberView.create({
+    container: container,
+    controller: {
+      foo: 'bar'
+    },
+    template: compile('{{#with foo as bar}}{{handlebars-get "bar"}}{{/with}}')
+  });
+
+  appendView();
+});
+
+test('it can lookup a path from globals', function() {
+  expect(1);
+
+  lookup.Blammo = { foo: 'blah'};
+
+  container.register('helper:handlebars-get', function(path, options) {
+    var context = options.contexts && options.contexts[0] || this;
+
+    ignoreDeprecation(function() {
+      equal(handlebarsGet(context, path, options), lookup.Blammo.foo);
+    });
+  });
+
+  view = EmberView.create({
+    container: container,
+    controller: { },
+    template: compile('{{handlebars-get "Blammo.foo"}}')
+  });
+
+  appendView();
+});
+
+test('it raises a deprecation warning on use', function() {
+  expect(1);
+
+  container.register('helper:handlebars-get', function(path, options) {
+    var context = options.contexts && options.contexts[0] || this;
+
+    expectDeprecation(function() {
+      handlebarsGet(context, path, options);
+    }, 'Usage of Ember.Handlebars.get is deprecated, use a Component or Ember.Handlebars.makeBoundHelper instead.');
+  });
+
+  view = EmberView.create({
+    container: container,
+    controller: {
+      foo: 'bar'
+    },
+    template: compile('{{handlebars-get "foo"}}')
+  });
+
+  appendView();
+});


### PR DESCRIPTION
Credit to @mmun for the implementation (thank you).

Closes #9336.
