### PR TITLE
Cleanup deprecations in test run.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/binding.js
+++ b/packages/ember-handlebars/lib/helpers/binding.js
@@ -726,7 +726,8 @@ function bindAttrHelper(options) {
   @return {String} HTML string
 */
 function bindAttrHelperDeprecated() {
-  Ember.warn("The 'bindAttr' view helper is deprecated in favor of 'bind-attr'");
+  Ember.deprecate("The 'bindAttr' view helper is deprecated in favor of 'bind-attr'");
+
   return helpers['bind-attr'].apply(this, arguments);
 }
 

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -100,12 +100,6 @@ test("collection helper should accept relative paths", function() {
 });
 
 test("empty views should be removed when content is added to the collection (regression, ht: msofaer)", function() {
-  var App;
-
-  run(function() {
-    lookup.App = App = Namespace.create();
-  });
-
   var EmptyView = EmberView.extend({
     template : EmberHandlebars.compile("<td>No Rows Yet</td>")
   });
@@ -114,13 +108,14 @@ test("empty views should be removed when content is added to the collection (reg
     emptyView: EmptyView
   });
 
-  App.listController = ArrayProxy.create({
+  var listController = ArrayProxy.create({
     content : A()
   });
 
   view = EmberView.create({
     listView: ListView,
-    template: EmberHandlebars.compile('{{#collection view.listView contentBinding="App.listController" tagName="table"}} <td>{{view.content.title}}</td> {{/collection}}')
+    listController: listController,
+    template: EmberHandlebars.compile('{{#collection view.listView content=view.listController tagName="table"}} <td>{{view.content.title}}</td> {{/collection}}')
   });
 
   run(function() {
@@ -130,13 +125,11 @@ test("empty views should be removed when content is added to the collection (reg
   equal(view.$('tr').length, 1, 'Make sure the empty view is there (regression)');
 
   run(function() {
-    App.listController.pushObject({title : "Go Away, Placeholder Row!"});
+    listController.pushObject({title : "Go Away, Placeholder Row!"});
   });
 
   equal(view.$('tr').length, 1, 'has one row');
   equal(view.$('tr:nth-child(1) td').text(), 'Go Away, Placeholder Row!', 'The content is the updated data.');
-
-  run(function() { App.destroy(); });
 });
 
 test("should be able to specify which class should be used for the empty view", function() {
@@ -615,15 +608,11 @@ test("should allow view objects to be swapped out without throwing an error (#78
 });
 
 test("context should be content", function() {
-  var App, view;
-
-  run(function() {
-    lookup.App = App = Namespace.create();
-  });
+  var view;
 
   var container = new Container();
 
-  App.items = A([
+  var items = A([
     EmberObject.create({name: 'Dave'}),
     EmberObject.create({name: 'Mary'}),
     EmberObject.create({name: 'Sara'})
@@ -633,14 +622,12 @@ test("context should be content", function() {
     template: EmberHandlebars.compile("Greetings {{name}}")
   }));
 
-  App.AView = EmberView.extend({
-    template: EmberHandlebars.compile('{{collection contentBinding="App.items" itemViewClass="an-item"}}')
-  });
-
-  run(function() {
-    view = App.AView.create({
-      container: container
-    });
+  view = EmberView.create({
+    container: container,
+    controller: {
+      items: items
+    },
+    template: EmberHandlebars.compile('{{collection contentBinding="items" itemViewClass="an-item"}}')
   });
 
   run(function() {
@@ -649,8 +636,5 @@ test("context should be content", function() {
 
   equal(view.$().text(), "Greetings DaveGreetings MaryGreetings Sara");
 
-  run(function() {
-    view.destroy();
-    App.destroy();
-  });
+  run(view, 'destroy');
 });

--- a/packages/ember-routing-handlebars/lib/helpers/link_to.js
+++ b/packages/ember-routing-handlebars/lib/helpers/link_to.js
@@ -959,7 +959,8 @@ export function queryParamsHelper(options) {
   @return {String} HTML string
 */
 function deprecatedLinkToHelper() {
-  Ember.warn("The 'linkTo' view helper is deprecated in favor of 'link-to'");
+  Ember.deprecate("The 'linkTo' view helper is deprecated in favor of 'link-to'");
+
   return linkToHelper.apply(this, arguments);
 }
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -567,7 +567,7 @@ test("a array_proxy that backs an sorted array_controller that backs a collectio
 test("when a collection view is emptied, deeply nested views elements are not removed from the DOM and then destroyed again", function() {
   var assertProperDestruction = Mixin.create({
     destroyElement: function() {
-      if (this.state === 'inDOM') {
+      if (this._state === 'inDOM') {
         ok(this.get('element'), this + ' still exists in DOM');
       }
       return this._super();

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -552,7 +552,7 @@ if(Ember.FEATURES.isEnabled('ember-routing-linkto-target-attribute')) {
   });
 
   test("The {{link-to}} helper should not transition if target is not equal to _self or empty", function() {
-    Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#linkTo 'about' id='about-link' replace=true target='_blank'}}About{{/linkTo}}");
+    Ember.TEMPLATES.index = Ember.Handlebars.compile("{{#link-to 'about' id='about-link' replace=true target='_blank'}}About{{/link-to}}");
 
     Router.map(function() {
       this.route("about");
@@ -864,19 +864,15 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
 });
 
 test("{{linkTo}} is aliased", function() {
-  var originalWarn = Ember.warn;
-
-  Ember.warn = function(msg) {
-    equal(msg, "The 'linkTo' view helper is deprecated in favor of 'link-to'", 'Warning called');
-  };
-
   Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3>{{#linkTo 'about' id='about-link' replace=true}}About{{/linkTo}}");
 
   Router.map(function() {
     this.route("about");
   });
 
-  bootApplication();
+  expectDeprecation(function() {
+    bootApplication();
+  }, "The 'linkTo' view helper is deprecated in favor of 'link-to'");
 
   Ember.run(function() {
     router.handleURL("/");
@@ -887,8 +883,6 @@ test("{{linkTo}} is aliased", function() {
   });
 
   equal(container.lookup('controller:application').get('currentRouteName'), 'about', 'linkTo worked properly');
-
-  Ember.warn = originalWarn;
 });
 
 test("The {{link-to}} helper is active when a resource is active", function() {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -970,7 +970,9 @@ test("ApplicationRoute's default error handler can be overridden", function() {
 });
 
 test("ApplicationRoute's default error handler can be overridden (with DEPRECATED `events`)", function() {
-  testOverridableErrorHandler('events');
+  ignoreDeprecation(function() {
+    testOverridableErrorHandler('events');
+  });
 });
 
 asyncTest("Moving from one page to another triggers the correct callbacks", function() {


### PR DESCRIPTION
- Silence deprecations when testing that something is deprecated.
- Refactor to not trigger deprecation warnings if not testing something that was deprecated (i.e. old tests that just happened to use deprecated behaviors).

All tests pass when running with "Raise on Deprecation":

![screenshot](http://monosnap.com/image/TxurBA6SLgTxmBaha1xfCjEJeld5Zw.png)

I dedicate this PR to @mixonic. :birthday: :gift:
