### PR TITLE
Prevent unhandled testing deprecations from being added.

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -75,10 +75,10 @@ function generateEachPackageTests() {
     if (packages[packageName].skipTests) { return; }
 
     testFunctions.push(function() {
-      return run('package=' + packageName);
+      return run('package=' + packageName + '&raiseonunhandleddeprecation=true');
     });
     testFunctions.push(function() {
-      return run('package=' + packageName + '&enableoptionalfeatures=true');
+      return run('package=' + packageName + '&enableoptionalfeatures=true&raiseonunhandleddeprecation=true');
     });
   });
 }


### PR DESCRIPTION
This makes it so that any unhandled deprecations will fail the Travis build and therefore ensures that we continue to control the deprecations that are added.
