### PR TITLE
Fix some.path dependent keys on bound helpers

### DIFF
--- a/packages/ember-handlebars/tests/helpers/bind_test.js
+++ b/packages/ember-handlebars/tests/helpers/bind_test.js
@@ -1,0 +1,55 @@
+import EmberView from "ember-views/views/view";
+import EmberObject from "ember-runtime/system/object";
+import run from "ember-metal/run_loop";
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+var view;
+
+QUnit.module("Handlebars {{#bind}} helper", {
+  teardown: function() {
+    if (view) {
+      run(view, view.destroy);
+      view = null;
+    }
+  }
+});
+
+test("it should render the current value of a property on the context", function() {
+  view = EmberView.create({
+    template: Ember.Handlebars.compile('{{bind "foo"}}'),
+    context: EmberObject.create({
+      foo: "BORK"
+    })
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "BORK", "initial value is rendered");
+
+  run(view, view.set, 'context.foo', 'MWEEER');
+
+  equal(view.$().text(), "MWEEER", "value can be updated");
+});
+
+test("it should render the current value of a path on the context", function() {
+  view = EmberView.create({
+    template: Ember.Handlebars.compile('{{bind "foo.bar"}}'),
+    context: EmberObject.create({
+      foo: {
+        bar: "BORK"
+      }
+    })
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "BORK", "initial value is rendered");
+
+  run(view, view.set, 'context.foo.bar', 'MWEEER');
+
+  equal(view.$().text(), "MWEEER", "value can be updated");
+});
+

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -295,28 +295,38 @@ test("bound helpers should not be invoked with blocks", function() {
 
 test("should observe dependent keys passed to registerBoundHelper", function() {
   try {
-    expect(2);
+    expect(3);
 
-    var SimplyObject = EmberObject.create({
+    var simplyObject = EmberObject.create({
       firstName: 'Jim',
-      lastName: 'Owen'
+      lastName: 'Owen',
+      birthday: EmberObject.create({
+        year: '2009'
+      })
     });
 
     EmberHandlebars.registerBoundHelper('fullName', function(value){
-      return value.get('firstName') + ' ' + value.get('lastName');
-    }, 'firstName', 'lastName');
+      return [
+        value.get('firstName'),
+        value.get('lastName'),
+        value.get('birthday.year') ].join(' ');
+    }, 'firstName', 'lastName', 'birthday.year');
 
     view = EmberView.create({
       template: compile('{{fullName this}}'),
-      context: SimplyObject
+      context: simplyObject
     });
     appendView(view);
 
-    equal(view.$().text(), 'Jim Owen', 'simply render the helper');
+    equal(view.$().text(), 'Jim Owen 2009', 'simply render the helper');
 
-    run(SimplyObject, SimplyObject.set, 'firstName', 'Tom');
+    run(simplyObject, simplyObject.set, 'firstName', 'Tom');
 
-    equal(view.$().text(), 'Tom Owen', 'simply render the helper');
+    equal(view.$().text(), 'Tom Owen 2009', 'render the helper after prop change');
+
+    run(simplyObject, simplyObject.set, 'birthday.year', '1692');
+
+    equal(view.$().text(), 'Tom Owen 1692', 'render the helper after path change');
   } finally {
     delete EmberHandlebars.helpers['fullName'];
   }


### PR DESCRIPTION
The original version of dependent key binding in bound helpers raised an exception when depending on a `complex.path`. Here is a fix with protips from @mmun 
