### PR TITLE
HTMLBars: Initial Helper Integration

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -86,7 +86,11 @@ function defeatureifyConfig(opts) {
 /*
   Returns a tree picked from `packages/#{packageName}/lib` and then move `main.js` to `/#{packageName}.js`.
  */
-function vendoredPackage(packageName) {
+function vendoredPackage(packageName, options) {
+  if (!options) { options = {}; }
+
+  var libPath = options.libPath || 'packages/' + packageName + '/lib';
+  var mainFile = options.mainFile || 'main.js';
   /*
     For example:
       Given the following dir:
@@ -97,8 +101,8 @@ function vendoredPackage(packageName) {
         /metamorph
           └── main.js
    */
-  var libTree = pickFiles('packages/' + packageName + '/lib', {
-    files: ['main.js'],
+  var libTree = pickFiles(libPath, {
+    files: [ mainFile ],
     srcDir: '/',
     destDir: '/' + packageName
   });
@@ -113,7 +117,7 @@ function vendoredPackage(packageName) {
         └── metamorph.js
    */
   var sourceTree = moveFile(libTree, {
-    srcFile: packageName + '/main.js',
+    srcFile: packageName + '/' + mainFile,
     destFile: '/' + packageName + '.js'
   });
 
@@ -337,14 +341,23 @@ var iifeStop  = writeFile('iife-stop', '})();');
       'ember-metal': {trees: null,  vendorRequirements: ['backburner']}
     ```
  */
+var handlebarsConfig = {
+  libPath: 'node_modules/handlebars/dist',
+  mainFile: 'handlebars.amd.js'
+};
+
 var vendoredPackages = {
-  'loader':           vendoredPackage('loader'),
-  'rsvp':             vendoredEs6Package('rsvp'),
-  'backburner':       vendoredEs6Package('backburner'),
-  'router':           vendoredEs6Package('router.js'),
-  'route-recognizer': vendoredEs6Package('route-recognizer'),
-  'dag-map':          vendoredEs6Package('dag-map'),
-  'morph':            htmlbarsPackage('morph')
+  'loader':                vendoredPackage('loader'),
+  'rsvp':                  vendoredEs6Package('rsvp'),
+  'backburner':            vendoredEs6Package('backburner'),
+  'router':                vendoredEs6Package('router.js'),
+  'route-recognizer':      vendoredEs6Package('route-recognizer'),
+  'dag-map':               vendoredEs6Package('dag-map'),
+  'morph':                 htmlbarsPackage('morph'),
+  'htmlbars':              htmlbarsPackage('htmlbars-runtime'),
+  'htmlbars-compiler':     htmlbarsPackage('htmlbars-compiler'),
+  'simple-html-tokenizer': vendoredEs6Package('simple-html-tokenizer'),
+  'handlebars':            vendoredPackage('handlebars', handlebarsConfig)
 };
 
 var emberHandlebarsCompiler = pickFiles('packages/ember-handlebars-compiler/lib', {

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -86,8 +86,8 @@ function defeatureifyConfig(opts) {
 /*
   Returns a tree picked from `packages/#{packageName}/lib` and then move `main.js` to `/#{packageName}.js`.
  */
-function vendoredPackage(packageName, options) {
-  if (!options) { options = {}; }
+function vendoredPackage(packageName, _options) {
+  var options = _options || {};
 
   var libPath = options.libPath || 'packages/' + packageName + '/lib';
   var mainFile = options.mainFile || 'main.js';
@@ -315,7 +315,7 @@ var bowerFiles = [
     files: ['handlebars.js'],
     srcDir: '/',
     destDir: '/handlebars'
-  }),
+  })
 ];
 
 bowerFiles = mergeTrees(bowerFiles);
@@ -582,6 +582,7 @@ var devSourceTrees       = [];
 var prodSourceTrees      = [];
 var testingSourceTrees   = [];
 var testTrees            = [emberDevTestHelpers];
+var testHelpers          = [];
 var compiledPackageTrees = [];
 
 for (var packageName in packages) {
@@ -617,6 +618,11 @@ for (var packageName in packages) {
 compiledPackageTrees = mergeTrees(compiledPackageTrees);
 vendorTrees = mergeTrees(vendorTrees);
 devSourceTrees = mergeTrees(devSourceTrees);
+
+// Grab the HTMLBars test helpers and make them appear they are coming from
+// the ember-htmlbars package.
+testHelpers = htmlbarsTestHelpers('assertions', 'ember-htmlbars/tests/helpers');
+testTrees.push(testHelpers);
 testTrees   = mergeTrees(testTrees);
 
 
@@ -636,6 +642,19 @@ function htmlbarsPackage(packageName) {
   });
 
   return useStrictRemover(tree);
+}
+
+function htmlbarsTestHelpers(helper, rename) {
+  var tree = pickFiles('bower_components/htmlbars/test/support', {
+    files: [helper + '.js'],
+    srcDir: '/',
+    destDir: '/'
+  });
+
+  return moveFile(tree, {
+    srcFile: '/' + helper + '.js',
+    destFile: '/' + rename + '.js'
+  });
 }
 
 /*

--- a/features.json
+++ b/features.json
@@ -15,7 +15,8 @@
     "ember-metal-injected-properties": null,
     "mandatory-setter": "development-only",
     "ember-routing-fire-activate-deactivate-events": true,
-    "ember-testing-pause-test": true
+    "ember-testing-pause-test": true,
+    "ember-htmlbars": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -9,6 +9,7 @@ module.exports = {
   'ember-testing':              {trees: null,  requirements: ['ember-application', 'ember-routing'], developmentOnly: true},
   'ember-handlebars-compiler':  {trees: null,  requirements: ['ember-views']},
   'ember-handlebars':           {trees: null,  requirements: ['ember-views', 'ember-handlebars-compiler']},
+  'ember-htmlbars':             {trees: null,  vendorRequirements: ['htmlbars', 'handlebars', 'simple-html-tokenizer', 'htmlbars-compiler'], requirements: ['ember-metal-views']},
   'ember-routing':              {trees: null,  vendorRequirements: ['router', 'route-recognizer'],
                                                requirements: ['ember-runtime', 'ember-views']},
   'ember-routing-handlebars':   {trees: null,  requirements: ['ember-routing', 'ember-handlebars']},

--- a/packages/ember-htmlbars/lib/helpers.js
+++ b/packages/ember-htmlbars/lib/helpers.js
@@ -1,0 +1,82 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import View from "ember-views/views/view";
+import Component from "ember-views/views/component";
+import makeViewHelper from "./system/make-view-helper";
+
+var helpers = { };
+
+/**
+  Register a bound helper or custom view helper.
+
+  ## Simple bound helper example
+
+  ```javascript
+  Ember.HTMLBars.helper('capitalize', function(value) {
+    return value.toUpperCase();
+  });
+  ```
+
+  The above bound helper can be used inside of templates as follows:
+
+  ```handlebars
+  {{capitalize name}}
+  ```
+
+  In this case, when the `name` property of the template's context changes,
+  the rendered value of the helper will update to reflect this change.
+
+  For more examples of bound helpers, see documentation for
+  `Ember.HTMLBars.registerBoundHelper`.
+
+  ## Custom view helper example
+
+  Assuming a view subclass named `App.CalendarView` were defined, a helper
+  for rendering instances of this view could be registered as follows:
+
+  ```javascript
+  Ember.HTMLBars.helper('calendar', App.CalendarView):
+  ```
+
+  The above bound helper can be used inside of templates as follows:
+
+  ```handlebars
+  {{calendar}}
+  ```
+
+  Which is functionally equivalent to:
+
+  ```handlebars
+  {{view 'calendar'}}
+  ```
+
+  Options in the helper will be passed to the view in exactly the same
+  manner as with the `view` helper.
+
+  @method helper
+  @for Ember.HTMLBars
+  @param {String} name
+  @param {Function|Ember.View} function or view class constructor
+  @param {String} dependentKeys*
+*/
+export function helper(name, value) {
+  Ember.assert("You tried to register a component named '" + name +
+               "', but component names must include a '-'", !Component.detect(value) || name.match(/-/));
+
+  if (View.detect(value)) {
+    registerHelper(name, makeViewHelper(value));
+  } else {
+    // HTMLBars TODO: Support bound helpers
+    // EmberHandlebars.registerBoundHelper.apply(null, arguments);
+    throw new Error('unimplemented');
+  }
+}
+
+export function registerHelper(name, value) {
+  helpers[name] = value;
+}
+
+export default helpers;

--- a/packages/ember-htmlbars/lib/helpers/binding.js
+++ b/packages/ember-htmlbars/lib/helpers/binding.js
@@ -1,0 +1,131 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import isNone from 'ember-metal/is_none';
+import run from "ember-metal/run_loop";
+import SimpleStream from "ember-metal/streams/simple";
+
+import {
+  _HandlebarsBoundView,
+  SimpleHandlebarsView
+} from "ember-handlebars/views/handlebars_bound_view";
+
+function exists(value) {
+  return !isNone(value);
+}
+
+// Binds a property into the DOM. This will create a hook in DOM that the
+// KVO system will look for and update if the property changes.
+function bind(property, options, env, preserveContext, shouldDisplay, valueNormalizer, childProperties, _viewClass) {
+  var valueStream = property.isStream ? property : this.getStream(property);
+  var lazyValue;
+
+  if (childProperties) {
+    lazyValue = new SimpleStream(valueStream);
+
+    var subscriber = function(childStream) {
+      childStream.value();
+      lazyValue.notify();
+    };
+
+    for (var i = 0; i < childProperties.length; i++) {
+      var childStream = valueStream.get(childProperties[i]);
+      childStream.value();
+      childStream.subscribe(subscriber);
+    }
+  } else {
+    lazyValue = valueStream;
+  }
+
+  // Set up observers for observable objects
+  var viewClass = _viewClass || _HandlebarsBoundView;
+  var viewOptions = {
+    _morph: options.morph,
+    preserveContext: preserveContext,
+    shouldDisplayFunc: shouldDisplay,
+    valueNormalizerFunc: valueNormalizer,
+    displayTemplate: options.render,
+    inverseTemplate: options.inverse,
+    lazyValue: lazyValue,
+    previousContext: this.get('context'),
+    isEscaped: !options.hash.unescaped,
+    templateData: env.data,
+    templateHash: options.hash,
+    helperName: options.helperName
+  };
+
+  if (options.keywords) {
+    viewOptions._keywords = options.keywords;
+  }
+
+  // Create the view that will wrap the output of this template/property
+  // and add it to the nearest view's childViews array.
+  // See the documentation of Ember._HandlebarsBoundView for more.
+  var bindView = this.createChildView(viewClass, viewOptions);
+
+  this.appendChild(bindView);
+
+  lazyValue.subscribe(this._wrapAsScheduled(function() {
+    run.scheduleOnce('render', bindView, 'rerenderIfNeeded');
+  }));
+}
+
+function simpleBind(params, options, env) {
+  var lazyValue = params[0];
+
+  var view = new SimpleHandlebarsView(
+    lazyValue, options.escaped
+  );
+
+  view._parentView = this;
+  view._morph = options.morph;
+  this.appendChild(view);
+
+  lazyValue.subscribe(this._wrapAsScheduled(function() {
+    run.scheduleOnce('render', view, 'rerender');
+  }));
+}
+
+/**
+  `bind` can be used to display a value, then update that value if it
+  changes. For example, if you wanted to print the `title` property of
+  `content`:
+
+  ```handlebars
+  {{bind "content.title"}}
+  ```
+
+  This will return the `title` property as a string, then create a new observer
+  at the specified path. If it changes, it will update the value in DOM. Note
+  that if you need to support IE7 and IE8 you must modify the model objects
+  properties using `Ember.get()` and `Ember.set()` for this to work as it
+  relies on Ember's KVO system. For all other browsers this will be handled for
+  you automatically.
+
+  @private
+  @method bind
+  @for Ember.Handlebars.helpers
+  @param {String} property Property to bind
+  @param {Function} fn Context to provide for rendering
+  @return {String} HTML string
+*/
+function bindHelper(params, options, env) {
+  Ember.assert("You must pass exactly one argument to the bind helper", params.length === 1);
+
+  var property = params[0];
+
+  if (options.fn) {
+    options.helperName = 'bind';
+    bind.call(this, property, options, env, false, exists);
+  } else {
+    simpleBind.call(this, params, options, env);
+  }
+}
+
+export {
+  bind,
+  simpleBind,
+  bindHelper
+};

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -1,0 +1,135 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import Ember from "ember-metal/core"; // Ember.assert
+import { default as helpers } from "ember-htmlbars/helpers";
+import { bind } from "ember-htmlbars/helpers/binding";
+
+import { get } from "ember-metal/property_get";
+import { isArray } from "ember-metal/utils";
+
+function shouldDisplayIfHelperContent(result) {
+  var truthy = result && get(result, 'isTruthy');
+  if (typeof truthy === 'boolean') { return truthy; }
+
+  if (isArray(result)) {
+    return get(result, 'length') !== 0;
+  } else {
+    return !!result;
+  }
+}
+
+/**
+  Use the `boundIf` helper to create a conditional that re-evaluates
+  whenever the truthiness of the bound value changes.
+
+  ```handlebars
+  {{#boundIf "content.shouldDisplayTitle"}}
+    {{content.title}}
+  {{/boundIf}}
+  ```
+
+  @private
+  @method boundIf
+  @for Ember.Handlebars.helpers
+  @param {String} property Property to bind
+  @param {Function} fn Context to provide for rendering
+  @return {String} HTML string
+*/
+function boundIfHelper(params, options, env) {
+  options.helperName = options.helperName || 'boundIf';
+  return bind.call(this, params[0], options, env, true, shouldDisplayIfHelperContent, shouldDisplayIfHelperContent, [
+   'isTruthy',
+   'length'
+ ]);
+}
+
+/**
+  @private
+
+  Use the `unboundIf` helper to create a conditional that evaluates once.
+
+  ```handlebars
+  {{#unboundIf "content.shouldDisplayTitle"}}
+    {{content.title}}
+  {{/unboundIf}}
+  ```
+
+  @method unboundIf
+  @for Ember.Handlebars.helpers
+  @param {String} property Property to bind
+  @param {Function} fn Context to provide for rendering
+  @return {String} HTML string
+  @since 1.4.0
+*/
+function unboundIfHelper(params, options, env) {
+  var template = options.render;
+
+  if (!shouldDisplayIfHelperContent(params[0].value())) {
+    template = options.inverse;
+  }
+
+  var result = template(options.context, env, options.morph.contextualElement);
+  options.morph.update(result);
+}
+
+/**
+  See [boundIf](/api/classes/Ember.Handlebars.helpers.html#method_boundIf)
+  and [unboundIf](/api/classes/Ember.Handlebars.helpers.html#method_unboundIf)
+
+  @method if
+  @for Ember.Handlebars.helpers
+  @param {Function} context
+  @param {Hash} options
+  @return {String} HTML string
+*/
+function ifHelper(params, options, env) {
+  Ember.assert("You must pass exactly one argument to the if helper", params.length === 1);
+  Ember.assert("You must pass a block to the if helper", options.render);
+
+  options.helperName = options.helperName || ('if ');
+
+  options.inverse = options.inverse || function(){ return ''; };
+
+  if (options.isUnbound) {
+    return helpers.unboundIf.call(this, params, options, env);
+  } else {
+    return helpers.boundIf.call(this, params, options, env);
+  }
+}
+
+/**
+  @method unless
+  @for Ember.Handlebars.helpers
+  @param {Function} context
+  @param {Hash} options
+  @return {String} HTML string
+*/
+function unlessHelper(params, options, env) {
+  Ember.assert("You must pass exactly one argument to the unless helper", params.length === 1);
+  Ember.assert("You must pass a block to the unless helper", options.render);
+
+  var fn = options.render;
+  var inverse = options.inverse || function(){ return ''; };
+  var helperName = 'unless';
+
+  options.render = inverse;
+  options.inverse = fn;
+
+  options.helperName = options.helperName || helperName;
+
+  if (options.isUnbound) {
+    return helpers.unboundIf.call(this, params, options, env);
+  } else {
+    return helpers.boundIf.call(this, params, options, env);
+  }
+}
+
+export {
+  ifHelper,
+  boundIfHelper,
+  unboundIfHelper,
+  unlessHelper
+};

--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -1,0 +1,377 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import Ember from "ember-metal/core"; // Ember.warn, Ember.assert
+// var emberWarn = Ember.warn, emberAssert = Ember.assert;
+
+import EmberObject from "ember-runtime/system/object";
+import { get } from "ember-metal/property_get";
+import keys from "ember-metal/keys";
+import { IS_BINDING } from "ember-metal/mixin";
+import { read } from "ember-metal/streams/read";
+import { readViewFactory } from "ember-views/streams/read";
+import View from "ember-views/views/view";
+import SimpleStream from "ember-metal/streams/simple";
+
+function makeBindings(options, view) {
+  var hash = options.hash;
+  var hashTypes = options.hashTypes;
+
+  for (var prop in hash) {
+    var hashType = hashTypes[prop];
+    var valueOrStream = hash[prop];
+
+    if (IS_BINDING.test(prop)) {
+      // classBinding is processed separately
+      if (prop === 'classBinding') {
+        continue;
+      }
+
+      if (hashType === 'id') {
+        // valueOrStream is a stream, streamifyArgs took care of it
+        Ember.warn("You're attempting to render a view by passing " +
+                   prop + " " +
+                   "to a view helper without a quoted value, " +
+                   "but this syntax is ambiguous. You should either surround " +
+                   prop + "'s value in quotes or remove `Binding` " +
+                   "from " + prop + ".");
+      } else if (typeof valueOrStream === 'string') {
+        hash[prop] = view._getBindingForStream(valueOrStream);
+      }
+    }
+  }
+}
+
+export var ViewHelper = EmberObject.create({
+  propertiesFromHTMLOptions: function(options, env) {
+    var view    = env.data.view;
+    var hash    = options.hash || {};
+    var classes = read(hash['class']);
+
+    var extensions = {
+      helperName: options.helperName || ''
+    };
+
+    if (hash.id) {
+      extensions.elementId = read(hash.id);
+    }
+
+    if (hash.tag) {
+      extensions.tagName = hash.tag;
+    }
+
+    if (classes) {
+      classes = classes.split(' ');
+      extensions.classNames = classes;
+    }
+
+    if (hash.classBinding) {
+      extensions.classNameBindings = hash.classBinding.split(' ');
+    }
+
+    if (hash.classNameBindings) {
+      if (extensions.classNameBindings === undefined) {
+        extensions.classNameBindings = [];
+      }
+      extensions.classNameBindings = extensions.classNameBindings.concat(hash.classNameBindings.split(' '));
+    }
+
+    if (hash.attributeBindings) {
+      Ember.assert("Setting 'attributeBindings' via template helpers is not allowed." +
+                   " Please subclass Ember.View and set it there instead.");
+      extensions.attributeBindings = null;
+    }
+
+    // Set the proper context for all bindings passed to the helper. This applies to regular attribute bindings
+    // as well as class name bindings. If the bindings are local, make them relative to the current context
+    // instead of the view.
+
+    var hashKeys = keys(hash);
+
+    for (var i = 0, l = hashKeys.length; i < l; i++) {
+      var prop = hashKeys[i];
+
+      if (prop !== 'classNameBindings') {
+        extensions[prop] = hash[prop];
+      }
+    }
+
+    var classNameBindings = extensions.classNameBindings;
+    if (classNameBindings) {
+      for (var j = 0; j < classNameBindings.length; j++) {
+        var parsedPath = View._parsePropertyPath(classNameBindings[j]);
+        if (parsedPath.path === '') {
+          parsedPath.stream = new SimpleStream(true);
+        } else {
+          parsedPath.stream = view.getStream(parsedPath.path);
+        }
+        classNameBindings[j] = parsedPath;
+      }
+    }
+
+    return extensions;
+  },
+
+  helper: function(newView, options, env) {
+    var data = env.data;
+    var fn   = options.render;
+
+    makeBindings(options, env.data.view);
+
+    var viewOptions = this.propertiesFromHTMLOptions(options, env);
+    var currentView = data.view;
+    viewOptions.templateData = data;
+    var newViewProto = newView.proto();
+
+    if (fn) {
+      Ember.assert("You cannot provide a template block if you also specified a templateName",
+                   !get(viewOptions, 'templateName') && !get(newViewProto, 'templateName'));
+      viewOptions.template = fn;
+    }
+
+    // We only want to override the `_context` computed property if there is
+    // no specified controller. See View#_context for more information.
+    if (!newViewProto.controller && !newViewProto.controllerBinding && !viewOptions.controller && !viewOptions.controllerBinding) {
+      viewOptions._context = get(currentView, 'context'); // TODO: is this right?!
+    }
+
+    viewOptions._morph = options.morph;
+
+    currentView.appendChild(newView, viewOptions);
+  },
+
+  instanceHelper: function(newView, options, env) {
+    var data = env.data;
+    var fn   = options.render;
+
+    makeBindings(options, env.data.view);
+
+    Ember.assert(
+      'Only a instance of a view may be passed to the ViewHelper.instanceHelper',
+      View.detectInstance(newView)
+    );
+
+    var viewOptions = this.propertiesFromHTMLOptions(options, env);
+    var currentView = data.view;
+    viewOptions.templateData = data;
+
+    if (fn) {
+      Ember.assert("You cannot provide a template block if you also specified a templateName",
+                   !get(viewOptions, 'templateName') && !get(newView, 'templateName'));
+      viewOptions.template = fn;
+    }
+
+    // We only want to override the `_context` computed property if there is
+    // no specified controller. See View#_context for more information.
+    if (!newView.controller && !newView.controllerBinding &&
+        !viewOptions.controller && !viewOptions.controllerBinding) {
+      viewOptions._context = get(currentView, 'context'); // TODO: is this right?!
+    }
+
+    currentView.appendChild(newView, viewOptions);
+  }
+});
+
+/**
+  `{{view}}` inserts a new instance of an `Ember.View` into a template passing its
+  options to the `Ember.View`'s `create` method and using the supplied block as
+  the view's own template.
+
+  An empty `<body>` and the following template:
+
+  ```handlebars
+  A span:
+  {{#view tagName="span"}}
+    hello.
+  {{/view}}
+  ```
+
+  Will result in HTML structure:
+
+  ```html
+  <body>
+    <!-- Note: the handlebars template script
+         also results in a rendered Ember.View
+         which is the outer <div> here -->
+
+    <div class="ember-view">
+      A span:
+      <span id="ember1" class="ember-view">
+        Hello.
+      </span>
+    </div>
+  </body>
+  ```
+
+  ### `parentView` setting
+
+  The `parentView` property of the new `Ember.View` instance created through
+  `{{view}}` will be set to the `Ember.View` instance of the template where
+  `{{view}}` was called.
+
+  ```javascript
+  aView = Ember.View.create({
+    template: Ember.Handlebars.compile("{{#view}} my parent: {{parentView.elementId}} {{/view}}")
+  });
+
+  aView.appendTo('body');
+  ```
+
+  Will result in HTML structure:
+
+  ```html
+  <div id="ember1" class="ember-view">
+    <div id="ember2" class="ember-view">
+      my parent: ember1
+    </div>
+  </div>
+  ```
+
+  ### Setting CSS id and class attributes
+
+  The HTML `id` attribute can be set on the `{{view}}`'s resulting element with
+  the `id` option. This option will _not_ be passed to `Ember.View.create`.
+
+  ```handlebars
+  {{#view tagName="span" id="a-custom-id"}}
+    hello.
+  {{/view}}
+  ```
+
+  Results in the following HTML structure:
+
+  ```html
+  <div class="ember-view">
+    <span id="a-custom-id" class="ember-view">
+      hello.
+    </span>
+  </div>
+  ```
+
+  The HTML `class` attribute can be set on the `{{view}}`'s resulting element
+  with the `class` or `classNameBindings` options. The `class` option will
+  directly set the CSS `class` attribute and will not be passed to
+  `Ember.View.create`. `classNameBindings` will be passed to `create` and use
+  `Ember.View`'s class name binding functionality:
+
+  ```handlebars
+  {{#view tagName="span" class="a-custom-class"}}
+    hello.
+  {{/view}}
+  ```
+
+  Results in the following HTML structure:
+
+  ```html
+  <div class="ember-view">
+    <span id="ember2" class="ember-view a-custom-class">
+      hello.
+    </span>
+  </div>
+  ```
+
+  ### Supplying a different view class
+
+  `{{view}}` can take an optional first argument before its supplied options to
+  specify a path to a custom view class.
+
+  ```handlebars
+  {{#view "custom"}}{{! will look up App.CustomView }}
+    hello.
+  {{/view}}
+  ```
+
+  The first argument can also be a relative path accessible from the current
+  context.
+
+  ```javascript
+  MyApp = Ember.Application.create({});
+  MyApp.OuterView = Ember.View.extend({
+    innerViewClass: Ember.View.extend({
+      classNames: ['a-custom-view-class-as-property']
+    }),
+    template: Ember.Handlebars.compile('{{#view view.innerViewClass}} hi {{/view}}')
+  });
+
+  MyApp.OuterView.create().appendTo('body');
+  ```
+
+  Will result in the following HTML:
+
+  ```html
+  <div id="ember1" class="ember-view">
+    <div id="ember2" class="ember-view a-custom-view-class-as-property">
+      hi
+    </div>
+  </div>
+  ```
+
+  ### Blockless use
+
+  If you supply a custom `Ember.View` subclass that specifies its own template
+  or provide a `templateName` option to `{{view}}` it can be used without
+  supplying a block. Attempts to use both a `templateName` option and supply a
+  block will throw an error.
+
+  ```javascript
+  var App = Ember.Application.create();
+  App.WithTemplateDefinedView = Ember.View.extend({
+    templateName: 'defined-template'
+  });
+  ```
+
+  ```handlebars
+  {{! application.hbs }}
+  {{view 'with-template-defined'}}
+  ```
+
+  ```handlebars
+  {{! defined-template.hbs }}
+  Some content for the defined template view.
+  ```
+
+  ### `viewName` property
+
+  You can supply a `viewName` option to `{{view}}`. The `Ember.View` instance
+  will be referenced as a property of its parent view by this name.
+
+  ```javascript
+  aView = Ember.View.create({
+    template: Ember.Handlebars.compile('{{#view viewName="aChildByName"}} hi {{/view}}')
+  });
+
+  aView.appendTo('body');
+  aView.get('aChildByName') // the instance of Ember.View created by {{view}} helper
+  ```
+
+  @method view
+  @for Ember.Handlebars.helpers
+  @param {String} path
+  @param {Hash} options
+  @return {String} HTML string
+*/
+export function viewHelper(params, options, env) {
+  Ember.assert("The view helper only takes a single argument", params.length <= 2);
+
+  var container = this.container || this._keywords.view.value().container;
+  var viewClass;
+
+  // If no path is provided, treat path param as options
+  // and get an instance of the registered `view:toplevel`
+  if (params.length === 0) {
+    if (container) {
+      viewClass = container.lookupFactory('view:toplevel');
+    } else {
+      viewClass = View;
+    }
+  } else {
+    var pathStream = params[0];
+    viewClass = readViewFactory(pathStream, container);
+  }
+
+  options.helperName = options.helperName || 'view';
+
+  return ViewHelper.helper(viewClass, options, env);
+}

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -1,0 +1,171 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import Ember from "ember-metal/core"; // Ember.assert
+
+import { set } from "ember-metal/property_set";
+import { apply } from "ember-metal/utils";
+import { create as o_create } from "ember-metal/platform";
+import isNone from 'ember-metal/is_none';
+import { bind } from "ember-htmlbars/helpers/binding";
+import { _HandlebarsBoundView } from "ember-handlebars/views/handlebars_bound_view";
+
+function exists(value) {
+  return !isNone(value);
+}
+
+var WithView = _HandlebarsBoundView.extend({
+  init: function() {
+    apply(this, this._super, arguments);
+
+    var keywordName     = this.templateHash.keywordName;
+    var controllerName  = this.templateHash.controller;
+
+    if (controllerName) {
+      var previousContext = this.previousContext;
+      var controller = this.container.lookupFactory('controller:'+controllerName).create({
+        parentController: previousContext,
+        target: previousContext
+      });
+
+      this._generatedController = controller;
+
+      if (this.preserveContext) {
+        this._keywords[keywordName] = controller;
+        this.lazyValue.subscribe(function(modelStream) {
+          set(controller, 'model', modelStream.value());
+        });
+      } else {
+        set(this, 'controller', controller);
+        this.valueNormalizerFunc = function(result) {
+          controller.set('model', result);
+          return controller;
+        };
+      }
+
+      set(controller, 'model', this.lazyValue.value());
+    }
+  },
+
+  willDestroy: function() {
+    this._super();
+
+    if (this._generatedController) {
+      this._generatedController.destroy();
+    }
+  }
+});
+
+/**
+  Use the `{{with}}` helper when you want to scope context. Take the following code as an example:
+
+  ```handlebars
+  <h5>{{user.name}}</h5>
+
+  <div class="role">
+    <h6>{{user.role.label}}</h6>
+    <span class="role-id">{{user.role.id}}</span>
+
+    <p class="role-desc">{{user.role.description}}</p>
+  </div>
+  ```
+
+  `{{with}}` can be our best friend in these cases,
+  instead of writing `user.role.*` over and over, we use `{{#with user.role}}`.
+  Now the context within the `{{#with}} .. {{/with}}` block is `user.role` so you can do the following:
+
+  ```handlebars
+  <h5>{{user.name}}</h5>
+
+  <div class="role">
+    {{#with user.role}}
+      <h6>{{label}}</h6>
+      <span class="role-id">{{id}}</span>
+
+      <p class="role-desc">{{description}}</p>
+    {{/with}}
+  </div>
+  ```
+
+  ### `as` operator
+
+  This operator aliases the scope to a new name. It's helpful for semantic clarity and to retain
+  default scope or to reference from another `{{with}}` block.
+
+  ```handlebars
+  // posts might not be
+  {{#with user.posts as blogPosts}}
+    <div class="notice">
+      There are {{blogPosts.length}} blog posts written by {{user.name}}.
+    </div>
+
+    {{#each post in blogPosts}}
+      <li>{{post.title}}</li>
+    {{/each}}
+  {{/with}}
+  ```
+
+  Without the `as` operator, it would be impossible to reference `user.name` in the example above.
+
+  NOTE: The alias should not reuse a name from the bound property path.
+  For example: `{{#with foo.bar as foo}}` is not supported because it attempts to alias using
+  the first part of the property path, `foo`. Instead, use `{{#with foo.bar as baz}}`.
+
+  ### `controller` option
+
+  Adding `controller='something'` instructs the `{{with}}` helper to create and use an instance of
+  the specified controller with the new context as its content.
+
+  This is very similar to using an `itemController` option with the `{{each}}` helper.
+
+  ```handlebars
+  {{#with users.posts controller='userBlogPosts'}}
+    {{!- The current context is wrapped in our controller instance }}
+  {{/with}}
+  ```
+
+  In the above example, the template provided to the `{{with}}` block is now wrapped in the
+  `userBlogPost` controller, which provides a very elegant way to decorate the context with custom
+  functions/properties.
+
+  @method with
+  @for Ember.Handlebars.helpers
+  @param {Function} context
+  @param {Hash} options
+  @return {String} HTML string
+*/
+export function withHelper(params, options, env) {
+
+  Ember.assert(
+    '{{#with foo}} must be called with a single argument or the use the '+
+    '{{#with foo as bar}} syntax',
+    params.length === 1
+  );
+
+  Ember.assert("The {{#with}} helper must be called with a block", options.render);
+
+  var source, keyword;
+  var preserveContext, context;
+  if (options.types[0] === 'id') {
+    source = params[0];
+    preserveContext = false;
+    context = source.value();
+  } else if (options.types[0] === 'keyword') {
+    source = params[0].stream;
+    keyword = params[0].to;
+    context = this.get('context');
+
+    var localizedOptions = o_create(options);
+
+    localizedOptions.keywords = {};
+    localizedOptions.keywords[keyword] = source;
+    localizedOptions.hash.keywordName = keyword;
+
+    options = localizedOptions;
+    preserveContext = true;
+  }
+
+  bind.call(this, source, options, env, preserveContext, exists, undefined, undefined, WithView);
+}

--- a/packages/ember-htmlbars/lib/helpers/yield.js
+++ b/packages/ember-htmlbars/lib/helpers/yield.js
@@ -1,0 +1,108 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import Ember from "ember-metal/core";
+// var emberAssert = Ember.assert;
+
+import { get } from "ember-metal/property_get";
+
+/**
+  `{{yield}}` denotes an area of a template that will be rendered inside
+  of another template. It has two main uses:
+
+  ### Use with `layout`
+  When used in a Handlebars template that is assigned to an `Ember.View`
+  instance's `layout` property Ember will render the layout template first,
+  inserting the view's own rendered output at the `{{yield}}` location.
+
+  An empty `<body>` and the following application code:
+
+  ```javascript
+  AView = Ember.View.extend({
+    classNames: ['a-view-with-layout'],
+    layout: Ember.Handlebars.compile('<div class="wrapper">{{yield}}</div>'),
+    template: Ember.Handlebars.compile('<span>I am wrapped</span>')
+  });
+
+  aView = AView.create();
+  aView.appendTo('body');
+  ```
+
+  Will result in the following HTML output:
+
+  ```html
+  <body>
+    <div class='ember-view a-view-with-layout'>
+      <div class="wrapper">
+        <span>I am wrapped</span>
+      </div>
+    </div>
+  </body>
+  ```
+
+  The `yield` helper cannot be used outside of a template assigned to an
+  `Ember.View`'s `layout` property and will throw an error if attempted.
+
+  ```javascript
+  BView = Ember.View.extend({
+    classNames: ['a-view-with-layout'],
+    template: Ember.Handlebars.compile('{{yield}}')
+  });
+
+  bView = BView.create();
+  bView.appendTo('body');
+
+  // throws
+  // Uncaught Error: assertion failed:
+  // You called yield in a template that was not a layout
+  ```
+
+  ### Use with Ember.Component
+  When designing components `{{yield}}` is used to denote where, inside the component's
+  template, an optional block passed to the component should render:
+
+  ```handlebars
+  <!-- application.hbs -->
+  {{#labeled-textfield value=someProperty}}
+    First name:
+  {{/labeled-textfield}}
+  ```
+
+  ```handlebars
+  <!-- components/labeled-textfield.hbs -->
+  <label>
+    {{yield}} {{input value=value}}
+  </label>
+  ```
+
+  Result:
+
+  ```html
+  <label>
+    First name: <input type="text" />
+  </label>
+  ```
+
+  @method yield
+  @for Ember.Handlebars.helpers
+  @param {Hash} options
+  @return {String} HTML string
+*/
+export function yieldHelper(params, options, env) {
+  var view = this;
+
+  // Yea gods
+  while (view && !get(view, 'layout')) {
+    if (view._contextView) {
+      view = view._contextView;
+    } else {
+      view = get(view, '_parentView');
+    }
+  }
+
+  Ember.assert("You called yield in a template that was not a layout", !!view);
+
+  view._yield(null, env, options.morph);
+}

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -1,0 +1,112 @@
+import Stream from "ember-metal/streams/stream";
+import {readArray} from "ember-metal/streams/read";
+
+function streamifyArgs(context, params, options, env) {
+  var hooks = env.hooks;
+
+  // TODO: Revisit keyword rewriting approach
+  if (params.length === 3 && params[1] === "in") {
+    params.splice(0, 3, {isKeyword: true, from: params[2], to: params[0]});
+    options.types.splice(0, 3, 'keyword');
+  }
+
+  if (params.length === 3 && params[1] === "as") {
+    params.splice(0, 3, {isKeyword: true, from: params[0], to: params[2]});
+    options.types.splice(0, 3, 'keyword');
+  }
+
+  // Convert ID params to streams
+  for (var i = 0, l = params.length; i < l; i++) {
+    if (options.types[i] === 'id') {
+      params[i] = hooks.streamFor(context, params[i]);
+    } else if (options.types[i] === 'keyword') {
+      params[i].lazyValue = hooks.streamFor(context, params[i].from);
+    }
+  }
+
+  // Convert hash ID values to streams
+  var hash = options.hash,
+      hashTypes = options.hashTypes;
+  for (var key in hash) {
+    if (hashTypes[key] === 'id') {
+      hash[key] = hooks.streamFor(context, hash[key]);
+    }
+  }
+}
+
+export function content(morph, path, context, params, options, env) {
+  var hooks = env.hooks;
+
+  // TODO: just set escaped on the morph in HTMLBars
+  morph.escaped = options.escaped;
+  var lazyValue;
+  var helper = hooks.lookupHelper(path, env);
+  if (helper) {
+    streamifyArgs(context, params, options, env);
+    lazyValue = helper(params, options, env);
+  } else {
+    lazyValue = hooks.streamFor(context, path);
+  }
+  if (lazyValue) {
+    lazyValue.subscribe(function(sender) {
+      morph.update(sender.value());
+    });
+
+    morph.update(lazyValue.value());
+  }
+}
+
+export function element(element, path, context, params, options, env) { //jshint ignore:line
+  var hooks = env.hooks;
+  var helper = hooks.lookupHelper(path, env);
+
+  if (helper) {
+    streamifyArgs(context, params, options, env);
+    return helper(element, params, options, env);
+  } else {
+    return hooks.streamFor(context, path);
+  }
+}
+
+export function subexpr(path, context, params, options, env) {
+  var hooks = env.hooks;
+  var helper = hooks.lookupHelper(path, env);
+
+  if (helper) {
+    streamifyArgs(context, params, options, env);
+    return helper(params, options, env);
+  } else {
+    return hooks.streamFor(context, path);
+  }
+}
+
+export function lookupHelper(name, env) {
+  if (name === 'concat') { return concat; }
+  if (name === 'attribute') { return attribute; }
+  return env.helpers[name];
+}
+
+function attribute(element, params, options) {
+  var name = params[0],
+      value = params[1];
+
+  value.subscribe(function(lazyValue) {
+    element.setAttribute(name, lazyValue.value());
+  });
+
+  element.setAttribute(name, value.value());
+}
+
+function concat(params, options) {
+  var stream = new Stream(function() {
+    return readArray(params).join('');
+  });
+
+  params.forEach(function(param) {
+    if (param && param.isStream) {
+      param.subscribe(stream.notifyAll, stream);
+    }
+  });
+
+  return stream;
+}

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -1,82 +1,71 @@
 import Stream from "ember-metal/streams/stream";
 import {readArray} from "ember-metal/streams/read";
 
-function streamifyArgs(context, params, options, env) {
-  var hooks = env.hooks;
-
-  // TODO: Revisit keyword rewriting approach
-  if (params.length === 3 && params[1] === "in") {
-    params.splice(0, 3, {isKeyword: true, from: params[2], to: params[0]});
-    options.types.splice(0, 3, 'keyword');
-  }
-
+function streamifyArgs(view, params, options, env) {
   if (params.length === 3 && params[1] === "as") {
-    params.splice(0, 3, {isKeyword: true, from: params[0], to: params[2]});
+    params.splice(0, 3, {
+      from: params[0],
+      to: params[2],
+      stream: view.getStream(params[0])
+    });
     options.types.splice(0, 3, 'keyword');
-  }
-
-  // Convert ID params to streams
-  for (var i = 0, l = params.length; i < l; i++) {
-    if (options.types[i] === 'id') {
-      params[i] = hooks.streamFor(context, params[i]);
-    } else if (options.types[i] === 'keyword') {
-      params[i].lazyValue = hooks.streamFor(context, params[i].from);
+  } else {
+    // Convert ID params to streams
+    for (var i = 0, l = params.length; i < l; i++) {
+      if (options.types[i] === 'id') {
+        params[i] = view.getStream(params[i]);
+      }
     }
   }
 
   // Convert hash ID values to streams
-  var hash = options.hash,
-      hashTypes = options.hashTypes;
+  var hash = options.hash;
+  var hashTypes = options.hashTypes;
   for (var key in hash) {
-    if (hashTypes[key] === 'id') {
-      hash[key] = hooks.streamFor(context, hash[key]);
+    if (hashTypes[key] === 'id' && key !== 'classBinding') {
+      hash[key] = view.getStream(hash[key]);
     }
   }
 }
 
-export function content(morph, path, context, params, options, env) {
+export function content(morph, path, view, params, options, env) {
   var hooks = env.hooks;
 
   // TODO: just set escaped on the morph in HTMLBars
   morph.escaped = options.escaped;
-  var lazyValue;
   var helper = hooks.lookupHelper(path, env);
-  if (helper) {
-    streamifyArgs(context, params, options, env);
-    lazyValue = helper(params, options, env);
-  } else {
-    lazyValue = hooks.streamFor(context, path);
+  if (!helper) {
+    helper = hooks.lookupHelper('bindHelper', env);
+    // Modify params to include the first word
+    params.unshift(path);
+    options.types = ['id'];
   }
-  if (lazyValue) {
-    lazyValue.subscribe(function(sender) {
-      morph.update(sender.value());
-    });
 
-    morph.update(lazyValue.value());
-  }
+  streamifyArgs(view, params, options, env);
+  return helper.call(view, params, options, env);
 }
 
-export function element(element, path, context, params, options, env) { //jshint ignore:line
+export function element(element, path, view, params, options, env) { //jshint ignore:line
   var hooks = env.hooks;
   var helper = hooks.lookupHelper(path, env);
 
   if (helper) {
-    streamifyArgs(context, params, options, env);
-    return helper(element, params, options, env);
+    streamifyArgs(view, params, options, env);
+    return helper.call(view, element, params, options, env);
   } else {
-    return hooks.streamFor(context, path);
+    return view.getStream(path);
   }
 }
 
-export function subexpr(path, context, params, options, env) {
+export function subexpr(path, view, params, options, env) {
   var hooks = env.hooks;
   var helper = hooks.lookupHelper(path, env);
 
   if (helper) {
-    streamifyArgs(context, params, options, env);
-    return helper(params, options, env);
+    streamifyArgs(view, params, options, env);
+    return helper.call(view, params, options, env);
   } else {
-    return hooks.streamFor(context, path);
+    return view.getStream(path);
   }
 }
 
@@ -87,8 +76,8 @@ export function lookupHelper(name, env) {
 }
 
 function attribute(element, params, options) {
-  var name = params[0],
-      value = params[1];
+  var name = params[0];
+  var value = params[1];
 
   value.subscribe(function(lazyValue) {
     element.setAttribute(name, lazyValue.value());
@@ -102,11 +91,13 @@ function concat(params, options) {
     return readArray(params).join('');
   });
 
-  params.forEach(function(param) {
+  for (var i = 0, l = params.length; i < l; i++) {
+    var param = params[i];
+
     if (param && param.isStream) {
       param.subscribe(stream.notifyAll, stream);
     }
-  });
+  }
 
   return stream;
 }

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,0 +1,24 @@
+import { content, element, subexpr, lookupHelper } from "ember-htmlbars/hooks";
+import { DOMHelper } from "morph";
+import Stream from "ember-metal/streams/stream";
+
+export var defaultEnv = {
+  dom: new DOMHelper(),
+
+  hooks: {
+    content: content,
+    element: element,
+    subexpr: subexpr,
+    lookupHelper: lookupHelper,
+
+    streamFor: function(context, path) {
+      return new Stream(function() {
+        return context[path];
+      });
+    }
+  },
+
+  helpers: {
+
+  }
+};

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,6 +1,30 @@
 import { content, element, subexpr, lookupHelper } from "ember-htmlbars/hooks";
 import { DOMHelper } from "morph";
-import Stream from "ember-metal/streams/stream";
+
+import {
+  registerHelper,
+  default as helpers
+} from "ember-htmlbars/helpers";
+import { bindHelper } from "ember-htmlbars/helpers/binding";
+import { viewHelper } from "ember-htmlbars/helpers/view";
+import { yieldHelper } from "ember-htmlbars/helpers/yield";
+import { withHelper } from "ember-htmlbars/helpers/with";
+import {
+  ifHelper,
+  unlessHelper,
+  unboundIfHelper,
+  boundIfHelper
+} from "ember-htmlbars/helpers/if_unless";
+
+registerHelper('bindHelper', bindHelper);
+registerHelper('bind', bindHelper);
+registerHelper('view', viewHelper);
+registerHelper('yield', yieldHelper);
+registerHelper('with', withHelper);
+registerHelper('if', ifHelper);
+registerHelper('unless', unlessHelper);
+registerHelper('unboundIf', unboundIfHelper);
+registerHelper('boundIf', boundIfHelper);
 
 export var defaultEnv = {
   dom: new DOMHelper(),
@@ -9,16 +33,9 @@ export var defaultEnv = {
     content: content,
     element: element,
     subexpr: subexpr,
-    lookupHelper: lookupHelper,
-
-    streamFor: function(context, path) {
-      return new Stream(function() {
-        return context[path];
-      });
-    }
+    lookupHelper: lookupHelper
   },
 
-  helpers: {
-
-  }
+  helpers: helpers
 };
+

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -1,0 +1,22 @@
+import Ember from "ember-metal/core"; // Ember.assert
+import { viewHelper } from "ember-htmlbars/helpers/view";
+
+/**
+  Returns a helper function that renders the provided ViewClass.
+
+  Used internally by Ember.Handlebars.helper and other methods
+  involving helper/component registration.
+
+  @private
+  @method makeViewHelper
+  @param {Function} ViewClass view class constructor
+  @since 1.2.0
+*/
+export default function makeViewHelper(ViewClass) {
+  return function(params, options, env) {
+    Ember.assert("You can only pass attributes (such as name=value) not bare " +
+                 "values to a helper for a View found in '" + ViewClass.toString() + "'", params.length === 0);
+
+    return viewHelper.call(this, [ViewClass], options, env);
+  };
+}

--- a/packages/ember-htmlbars/tests/helpers/bind_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_test.js
@@ -1,0 +1,59 @@
+import EmberView from "ember-views/views/view";
+import EmberObject from "ember-runtime/system/object";
+import run from "ember-metal/run_loop";
+import { compile } from "htmlbars-compiler/compiler";
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+var view;
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module("ember-htmlbars: {{#bind}} helper", {
+  teardown: function() {
+    if (view) {
+      run(view, view.destroy);
+      view = null;
+    }
+  }
+});
+
+test("it should render the current value of a property on the context", function() {
+  view = EmberView.create({
+    template: compile('{{bind foo}}'),
+    context: EmberObject.create({
+      foo: "BORK"
+    })
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "BORK", "initial value is rendered");
+
+  run(view, view.set, 'context.foo', 'MWEEER');
+
+  equal(view.$().text(), "MWEEER", "value can be updated");
+});
+
+test("it should render the current value of a path on the context", function() {
+  view = EmberView.create({
+    template: compile('{{bind foo.bar}}'),
+    context: EmberObject.create({
+      foo: {
+        bar: "BORK"
+      }
+    })
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "BORK", "initial value is rendered");
+
+  run(view, view.set, 'context.foo.bar', 'MWEEER');
+
+  equal(view.$().text(), "MWEEER", "value can be updated");
+});
+
+}

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -1,0 +1,188 @@
+import EmberObject from "ember-runtime/system/object";
+import run from "ember-metal/run_loop";
+import EmberView from "ember-views/views/view";
+import ObjectProxy from "ember-runtime/system/object_proxy";
+import { compile } from "htmlbars-compiler/compiler";
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+var view;
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module("Handlebars {{#if}} and {{#unless}} helpers", {
+  teardown: function() {
+    run(function() {
+      if (view) {
+        view.destroy();
+      }
+    });
+  }
+});
+
+/* requires with
+test("unless should keep the current context (#784)", function() {
+  view = EmberView.create({
+    o: EmberObject.create({foo: '42'}),
+
+    template: compile('{{#with view.o}}{{#view}}{{#unless view.doesNotExist}}foo: {{foo}}{{/unless}}{{/view}}{{/with}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'foo: 42');
+});
+*/
+
+test("The `if` helper tests for `isTruthy` if available", function() {
+  view = EmberView.create({
+    truthy: EmberObject.create({ isTruthy: true }),
+    falsy: EmberObject.create({ isTruthy: false }),
+
+    template: compile('{{#if view.truthy}}Yep{{/if}}{{#if view.falsy}}Nope{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'Yep');
+});
+
+test("The `if` helper does not print the contents for an object proxy without content", function() {
+  view = EmberView.create({
+    truthy: ObjectProxy.create({ content: {} }),
+    falsy: ObjectProxy.create({ content: null }),
+
+    template: compile('{{#if view.truthy}}Yep{{/if}}{{#if view.falsy}}Nope{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'Yep');
+});
+
+test("The `if` helper updates if an object proxy gains or loses context", function() {
+  view = EmberView.create({
+    proxy: ObjectProxy.create({ content: null }),
+
+    template: compile('{{#if view.proxy}}Yep{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), '');
+
+  run(function() {
+    view.set('proxy.content', {});
+  });
+
+  equal(view.$().text(), 'Yep');
+
+  run(function() {
+    view.set('proxy.content', null);
+  });
+
+  equal(view.$().text(), '');
+});
+
+test("The `if` helper updates if an array is empty or not", function() {
+  view = EmberView.create({
+    array: Ember.A(),
+
+    template: compile('{{#if view.array}}Yep{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), '');
+
+  run(function() {
+    view.get('array').pushObject(1);
+  });
+
+  equal(view.$().text(), 'Yep');
+
+  run(function() {
+    view.get('array').removeObject(1);
+  });
+
+  equal(view.$().text(), '');
+});
+
+test("The `if` helper updates when the value changes", function() {
+  view = EmberView.create({
+    conditional: true,
+    template: compile('{{#if view.conditional}}Yep{{/if}}')
+  });
+  appendView(view);
+  equal(view.$().text(), 'Yep');
+  run(function(){
+    view.set('conditional', false);
+  });
+  equal(view.$().text(), '');
+});
+
+/* requires unbound helper
+test("The `unbound if` helper does not update when the value changes", function() {
+  view = EmberView.create({
+    conditional: true,
+    template: compile('{{#unbound if view.conditional}}Yep{{/unbound}}')
+  });
+  appendView(view);
+  equal(view.$().text(), 'Yep');
+  run(function(){
+    view.set('conditional', false);
+  });
+  equal(view.$().text(), 'Yep');
+});
+*/
+
+test("The `unless` helper updates when the value changes", function() {
+  view = EmberView.create({
+    conditional: false,
+    template: compile('{{#unless view.conditional}}Nope{{/unless}}')
+  });
+  appendView(view);
+  equal(view.$().text(), 'Nope');
+  run(function(){
+    view.set('conditional', true);
+  });
+  equal(view.$().text(), '');
+});
+
+/* requires unbound helper
+test("The `unbound if` helper does not update when the value changes", function() {
+  view = EmberView.create({
+    conditional: false,
+    template: compile('{{#unbound unless view.conditional}}Nope{{/unbound}}')
+  });
+  appendView(view);
+  equal(view.$().text(), 'Nope');
+  run(function(){
+    view.set('conditional', true);
+  });
+  equal(view.$().text(), 'Nope');
+});
+*/
+
+test("The `if` helper ignores a controller option", function() {
+  var lookupCalled = false;
+
+  view = EmberView.create({
+    container: {
+      lookup: function() {
+        lookupCalled = true;
+      }
+    },
+    truthy: true,
+
+    template: compile('{{#if view.truthy controller="foo"}}Yep{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(lookupCalled, false, 'controller option should NOT be used');
+});
+
+}

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -1,0 +1,267 @@
+/*globals EmberDev */
+import EmberView from "ember-views/views/view";
+import Container from 'container/container';
+import run from "ember-metal/run_loop";
+import jQuery from "ember-views/system/jquery";
+import { compile } from "htmlbars-compiler/compiler";
+
+var view, originalLookup;
+
+var container = {
+  lookupFactory: function() { }
+};
+
+function viewClass(options) {
+  options.container = options.container || container;
+  return EmberView.extend(options);
+}
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module("ember-htmlbars: {{#view}} helper", {
+  setup: function() {
+    originalLookup = Ember.lookup;
+  },
+
+  teardown: function() {
+    Ember.lookup = originalLookup;
+
+    if (view) {
+      run(view, 'destroy');
+    }
+  }
+});
+
+test("By default view:toplevel is used", function() {
+  var DefaultView = viewClass({
+    elementId: 'toplevel-view',
+    template: compile('hello world')
+  });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:toplevel');
+
+    return DefaultView;
+  }
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: compile('{{view}}'),
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#toplevel-view').text(), 'hello world');
+});
+
+test("By default, without a container, EmberView is used", function() {
+  view = EmberView.extend({
+    template: compile('{{view tagName="span"}}')
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#qunit-fixture').html().toUpperCase().match(/<SPAN/), 'contains view with span');
+});
+
+test("View lookup - App.FuView (DEPRECATED)", function() {
+  Ember.lookup = {
+    App: {
+      FuView: viewClass({
+        elementId: "fu",
+        template: compile("bro")
+      })
+    }
+  };
+
+  view = viewClass({
+    template: compile("{{view App.FuView}}")
+  }).create();
+
+  expectDeprecation(function(){
+    run(view, 'appendTo', '#qunit-fixture');
+  }, /Global lookup of App.FuView from a Handlebars template is deprecated./);
+
+  equal(jQuery('#fu').text(), 'bro');
+});
+
+test("View lookup - 'fu'", function() {
+  var FuView = viewClass({
+    elementId: "fu",
+    template: compile("bro")
+  });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: compile("{{view 'fu'}}"),
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#fu').text(), 'bro');
+});
+
+test("View lookup - 'fu' when fu is a property and a view name", function() {
+  var FuView = viewClass({
+    elementId: "fu",
+    template: compile("bro")
+  });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: compile("{{view 'fu'}}"),
+    context: {fu: 'boom!'},
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#fu').text(), 'bro');
+});
+
+test("View lookup - view.computed", function() {
+  var FuView = viewClass({
+    elementId: "fu",
+    template: compile("bro")
+  });
+
+  function lookupFactory(fullName) {
+    equal(fullName, 'view:fu');
+
+    return FuView;
+  }
+
+  var container = {
+    lookupFactory: lookupFactory
+  };
+
+  view = EmberView.extend({
+    template: compile("{{view view.computed}}"),
+    container: container,
+    computed: 'fu'
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#fu').text(), 'bro');
+});
+
+test("id bindings downgrade to one-time property lookup", function() {
+  view = EmberView.extend({
+    template: compile("{{#view id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}"),
+    meshuggah: 'stengah'
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#stengah').text(), 'stengah', "id binding performed property lookup");
+  run(view, 'set', 'meshuggah', 'omg');
+  equal(jQuery('#stengah').text(), 'omg', "id didn't change");
+});
+
+test("mixing old and new styles of property binding fires a warning, treats value as if it were quoted", function() {
+  if (EmberDev && EmberDev.runningProdBuild){
+    ok(true, 'Logging does not occur in production builds');
+    return;
+  }
+
+  expect(2);
+
+  var oldWarn = Ember.warn;
+
+  Ember.warn = function(msg) {
+    equal(msg, "You're attempting to render a view by passing borfBinding to a view helper without a quoted value, but this syntax is ambiguous. You should either surround borfBinding's value in quotes or remove `Binding` from borfBinding.");
+  };
+
+  view = EmberView.extend({
+    template: compile("{{#view borfBinding=view.snork}}<p id='lol'>{{view.borf}}</p>{{/view}}"),
+    snork: "nerd"
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  equal(jQuery('#lol').text(), "nerd", "awkward mixed syntax treated like binding");
+
+  Ember.warn = oldWarn;
+});
+
+test("allows you to pass attributes that will be assigned to the class instance, like class=\"foo\"", function() {
+  expect(4);
+
+  var container = new Container();
+  container.register('view:toplevel', EmberView.extend());
+
+  view = EmberView.extend({
+    template: compile('{{view id="foo" tagName="h1" class="foo"}}{{#view id="bar" class="bar"}}Bar{{/view}}'),
+    container: container
+  }).create();
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'));
+  ok(jQuery('#foo').is('h1'));
+  ok(jQuery('#bar').hasClass('bar'));
+  equal(jQuery('#bar').text(), 'Bar');
+});
+
+test("Should apply class without condition always", function() {
+  view = EmberView.create({
+    controller: Ember.Object.create(),
+    template: compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
+});
+
+test("Should apply classes when bound controller.* property specified", function() {
+  view = EmberView.create({
+    controller: {
+      someProp: 'foo'
+    },
+    template: compile('{{#view id="foo" class=controller.someProp}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
+});
+
+test("Should apply classes when bound property specified", function() {
+  view = EmberView.create({
+    controller: {
+      someProp: 'foo'
+    },
+    template: compile('{{#view id="foo" class=someProp}} Foo{{/view}}')
+  });
+
+  run(view, 'appendTo', '#qunit-fixture');
+
+  ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
+});
+
+}

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -1,0 +1,484 @@
+/*jshint newcap:false*/
+import EmberView from "ember-views/views/view";
+import run from "ember-metal/run_loop";
+import EmberObject from "ember-runtime/system/object";
+import { computed } from "ember-metal/computed";
+import { set } from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
+import ObjectController from "ember-runtime/controllers/object_controller";
+import Container from "ember-runtime/system/container";
+// import { A } from "ember-runtime/system/native_array";
+import { compile } from "htmlbars-compiler/compiler";
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+var view, lookup;
+var originalLookup = Ember.lookup;
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module("ember-htmlbars: {{#with}} helper", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    view = EmberView.create({
+      template: compile("{{#with person as tom}}{{title}}: {{tom.name}}{{/with}}"),
+      context: {
+        title: "Señor Engineer",
+        person: { name: "Tom Dale" }
+      }
+    });
+
+    appendView(view);
+  },
+
+  teardown: function() {
+    run(function() {
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("it should support #with foo as bar", function() {
+  equal(view.$().text(), "Señor Engineer: Tom Dale", "should be properly scoped");
+});
+
+test("updating the context should update the alias", function() {
+  run(function() {
+    view.set('context.person', {
+      name: "Yehuda Katz"
+    });
+  });
+
+  equal(view.$().text(), "Señor Engineer: Yehuda Katz", "should be properly scoped after updating");
+});
+
+test("updating a property on the context should update the HTML", function() {
+  run(function() {
+    set(view, 'context.person.name', "Yehuda Katz");
+  });
+
+  equal(view.$().text(), "Señor Engineer: Yehuda Katz", "should be properly scoped after updating");
+});
+
+test("updating a property on the view should update the HTML", function() {
+  run(function() {
+    view.set('context.title', "Señorette Engineer");
+  });
+
+  equal(view.$().text(), "Señorette Engineer: Tom Dale", "should be properly scoped after updating");
+});
+
+QUnit.module("Multiple Handlebars {{with}} helpers with 'as'", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    view = EmberView.create({
+      template: compile("Admin: {{#with admin as person}}{{person.name}}{{/with}} User: {{#with user as person}}{{person.name}}{{/with}}"),
+      context: {
+        admin: { name: "Tom Dale" },
+        user: { name: "Yehuda Katz"}
+      }
+    });
+
+    appendView(view);
+  },
+
+  teardown: function() {
+    run(function() {
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("re-using the same variable with different #with blocks does not override each other", function(){
+  equal(view.$().text(), "Admin: Tom Dale User: Yehuda Katz", "should be properly scoped");
+});
+
+test("the scoped variable is not available outside the {{with}} block.", function(){
+  run(function() {
+    view.set('template', compile("{{name}}-{{#with other as name}}{{name}}{{/with}}-{{name}}"));
+    view.set('context', {
+      name: 'Stef',
+      other: 'Yehuda'
+    });
+  });
+
+  equal(view.$().text(), "Stef-Yehuda-Stef", "should be properly scoped after updating");
+});
+
+test("nested {{with}} blocks shadow the outer scoped variable properly.", function(){
+  run(function() {
+    view.set('template', compile("{{#with first as ring}}{{ring}}-{{#with fifth as ring}}{{ring}}-{{#with ninth as ring}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}{{/with}}"));
+    view.set('context', {
+      first: 'Limbo',
+      fifth: 'Wrath',
+      ninth: 'Treachery'
+    });
+  });
+
+  equal(view.$().text(), "Limbo-Wrath-Treachery-Wrath-Limbo", "should be properly scoped after updating");
+});
+
+QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    lookup.Foo = { bar: 'baz' };
+    view = EmberView.create({
+      template: compile("{{#with Foo.bar as qux}}{{qux}}{{/with}}")
+    });
+  },
+
+  teardown: function() {
+    run(function() {
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
+  expectDeprecation(function() {
+    appendView(view);
+  }, /Global lookup of Foo.bar from a Handlebars template is deprecated/);
+
+  equal(view.$().text(), "baz", "should be properly scoped");
+
+  run(function() {
+    set(lookup.Foo, 'bar', 'updated');
+  });
+
+  equal(view.$().text(), "updated", "should update");
+});
+
+QUnit.module("Handlebars {{#with keyword as foo}}");
+
+test("it should support #with view as foo", function() {
+  var view = EmberView.create({
+    template: compile("{{#with view as myView}}{{myView.name}}{{/with}}"),
+    name: "Sonics"
+  });
+
+  appendView(view);
+  equal(view.$().text(), "Sonics", "should be properly scoped");
+
+  run(function() {
+    set(view, 'name', "Thunder");
+  });
+
+  equal(view.$().text(), "Thunder", "should update");
+
+  run(function() {
+    view.destroy();
+  });
+});
+
+test("it should support #with name as food, then #with foo as bar", function() {
+  var view = EmberView.create({
+    template: compile("{{#with name as foo}}{{#with foo as bar}}{{bar}}{{/with}}{{/with}}"),
+    context: { name: "caterpillar" }
+  });
+
+  appendView(view);
+  equal(view.$().text(), "caterpillar", "should be properly scoped");
+
+  run(function() {
+    set(view, 'context.name', "butterfly");
+  });
+
+  equal(view.$().text(), "butterfly", "should update");
+
+  run(function() {
+    view.destroy();
+  });
+});
+
+QUnit.module("Handlebars {{#with this as foo}}");
+
+test("it should support #with this as qux", function() {
+  var view = EmberView.create({
+    template: compile("{{#with this as person}}{{person.name}}{{/with}}"),
+    controller: EmberObject.create({ name: "Los Pivots" })
+  });
+
+  appendView(view);
+  equal(view.$().text(), "Los Pivots", "should be properly scoped");
+
+  run(function() {
+    set(view, 'controller.name', "l'Pivots");
+  });
+
+  equal(view.$().text(), "l'Pivots", "should update");
+
+  run(function() {
+    view.destroy();
+  });
+});
+
+QUnit.module("Handlebars {{#with foo}} insideGroup");
+
+test("it should render without fail", function() {
+  var View = EmberView.extend({
+    template: compile("{{#view view.childView}}{{#with person}}{{name}}{{/with}}{{/view}}"),
+    controller: EmberObject.create({ person: { name: "Ivan IV Vasilyevich" } }),
+    childView: EmberView.extend({
+      render: function(){
+        this.set('templateData.insideGroup', true);
+        return this._super.apply(this, arguments);
+      }
+    })
+  });
+
+  var view = View.create();
+  appendView(view);
+  equal(view.$().text(), "Ivan IV Vasilyevich", "should be properly scoped");
+
+  run(function() {
+    set(view, 'controller.person.name', "Ivan the Terrible");
+  });
+
+  equal(view.$().text(), "Ivan the Terrible", "should update");
+
+  run(function() {
+    view.destroy();
+  });
+});
+
+QUnit.module("Handlebars {{#with foo}} with defined controller");
+
+test("it should wrap context with object controller", function() {
+  var Controller = ObjectController.extend({
+    controllerName: computed(function() {
+      return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
+    })
+  });
+
+  var person = EmberObject.create({name: 'Steve Holt'});
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    name: 'Bob Loblaw'
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{#with view.person controller="person"}}{{controllerName}}{{/with}}'),
+    person: person,
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  appendView(view);
+
+  equal(view.$().text(), "controller:Steve Holt and Bob Loblaw");
+
+  run(function() {
+    view.rerender();
+  });
+
+  equal(view.$().text(), "controller:Steve Holt and Bob Loblaw");
+
+  run(function() {
+    parentController.set('name', 'Carl Weathers');
+    view.rerender();
+  });
+
+  equal(view.$().text(), "controller:Steve Holt and Carl Weathers");
+
+  run(function() {
+    person.set('name', 'Gob');
+    view.rerender();
+  });
+
+  equal(view.$().text(), "controller:Gob and Carl Weathers");
+
+  strictEqual(view.get('_childViews')[0].get('controller.target'), parentController, "the target property of the child controllers are set correctly");
+
+  run(function() { view.destroy(); }); // destroy existing view
+});
+
+/* requires each
+test("it should still have access to original parentController within an {{#each}}", function() {
+  var Controller = ObjectController.extend({
+    controllerName: computed(function() {
+      return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
+    })
+  });
+
+  var people = A([{ name: "Steve Holt" }, { name: "Carl Weathers" }]);
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    name: 'Bob Loblaw',
+    people: people
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{#each person in people}}{{#with person controller="person"}}{{controllerName}}{{/with}}{{/each}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  appendView(view);
+
+  equal(view.$().text(), "controller:Steve Holt and Bob Loblawcontroller:Carl Weathers and Bob Loblaw");
+
+  run(function() { view.destroy(); }); // destroy existing view
+});
+*/
+
+test("it should wrap keyword with object controller", function() {
+  var PersonController = ObjectController.extend({
+    name: computed('model.name', function() {
+      return get(this, 'model.name').toUpperCase();
+    })
+  });
+
+  var person = EmberObject.create({name: 'Steve Holt'});
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    person: person,
+    name: 'Bob Loblaw'
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{#with person as steve controller="person"}}{{name}} - {{steve.name}}{{/with}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', PersonController);
+
+  appendView(view);
+
+  equal(view.$().text(), "Bob Loblaw - STEVE HOLT");
+
+  run(function() {
+    view.rerender();
+  });
+
+  equal(view.$().text(), "Bob Loblaw - STEVE HOLT");
+
+  run(function() {
+    parentController.set('name', 'Carl Weathers');
+    view.rerender();
+  });
+
+  equal(view.$().text(), "Carl Weathers - STEVE HOLT");
+
+  run(function() {
+    person.set('name', 'Gob');
+    view.rerender();
+  });
+
+  equal(view.$().text(), "Carl Weathers - GOB");
+
+  run(function() { view.destroy(); }); // destroy existing view
+});
+
+test("destroys the controller generated with {{with foo controller='blah'}}", function() {
+  var destroyed = false;
+  var Controller = ObjectController.extend({
+    willDestroy: function() {
+      this._super();
+      destroyed = true;
+    }
+  });
+
+  var person = EmberObject.create({name: 'Steve Holt'});
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    person: person,
+    name: 'Bob Loblaw'
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{#with person controller="person"}}{{controllerName}}{{/with}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  appendView(view);
+
+  run(view, 'destroy'); // destroy existing view
+
+  ok(destroyed, 'controller was destroyed properly');
+});
+
+test("destroys the controller generated with {{with foo as bar controller='blah'}}", function() {
+  var destroyed = false;
+  var Controller = ObjectController.extend({
+    willDestroy: function() {
+      this._super();
+      destroyed = true;
+    }
+  });
+
+  var person = EmberObject.create({name: 'Steve Holt'});
+  var container = new Container();
+
+  var parentController = EmberObject.create({
+    container: container,
+    person: person,
+    name: 'Bob Loblaw'
+  });
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{#with person as steve controller="person"}}{{controllerName}}{{/with}}'),
+    controller: parentController
+  });
+
+  container.register('controller:person', Controller);
+
+  appendView(view);
+
+  run(view, 'destroy'); // destroy existing view
+
+  ok(destroyed, 'controller was destroyed properly');
+});
+
+QUnit.module("{{#with}} helper binding to view keyword", {
+  setup: function() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    view = EmberView.create({
+      template: compile("We have: {{#with view.thing as fromView}}{{fromView.name}} and {{fromContext.name}}{{/with}}"),
+      thing: { name: 'this is from the view' },
+      context: {
+        fromContext: { name: "this is from the context" }
+      }
+    });
+
+    appendView(view);
+  },
+
+  teardown: function() {
+    run(function() {
+      view.destroy();
+    });
+    Ember.lookup = originalLookup;
+  }
+});
+
+test("{{with}} helper can bind to keywords with 'as'", function(){
+  equal(view.$().text(), "We have: this is from the view and this is from the context", "should render");
+});
+
+}

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -1,0 +1,418 @@
+/*jshint newcap:false*/
+import run from "ember-metal/run_loop";
+import EmberView from "ember-views/views/view";
+// import { computed } from "ember-metal/computed";
+import Container from "ember-runtime/system/container";
+// import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+// import { A } from "ember-runtime/system/native_array";
+import Component from "ember-views/views/component";
+import EmberError from "ember-metal/error";
+import { compile } from "htmlbars-compiler/compiler";
+import {
+  helper,
+  default as helpers
+} from "ember-htmlbars/helpers";
+
+var view, container;
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module("ember-htmlbars: Support for {{yield}} helper", {
+  setup: function() {
+    container = new Container();
+    container.optionsForType('template', { instantiate: false });
+  },
+  teardown: function() {
+    run(function() {
+      Ember.TEMPLATES = {};
+      if (view) {
+        view.destroy();
+      }
+    });
+  }
+});
+
+test("a view with a layout set renders its template where the {{yield}} helper appears", function() {
+  var ViewWithLayout = EmberView.extend({
+    layout: compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>')
+  });
+
+  view = EmberView.create({
+    withLayout: ViewWithLayout,
+    template: compile('{{#view view.withLayout title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
+});
+
+test("block should work properly even when templates are not hard-coded", function() {
+  container.register('template:nester', compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>'));
+  container.register('template:nested', compile('{{#view "with-layout" title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}'));
+
+  container.register('view:with-layout', EmberView.extend({
+    container: container,
+    layoutName: 'nester'
+  }));
+
+  view = EmberView.create({
+    container: container,
+    templateName: 'nested'
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
+
+});
+
+/* NOPE
+test("templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
+  var TimesView = EmberView.extend({
+    layout: compile('<div class="times">{{#each view.index}}{{yield}}{{/each}}</div>'),
+    n: null,
+    index: computed(function() {
+      var n = get(this, 'n');
+      var indexArray = A();
+      for (var i=0; i < n; i++) {
+        indexArray[i] = i;
+      }
+      return indexArray;
+    })
+  });
+
+  view = EmberView.create({
+    timesView: TimesView,
+    template: compile('<div id="container"><div class="title">Counting to 5</div>{{#view view.timesView n=5}}<div class="times-item">Hello</div>{{/view}}</div>')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div#container div.times-item').length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
+});
+
+*/
+test("templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
+  var NestingView = EmberView.extend({
+    layout: compile('{{#view tagName="div" classNames="nesting"}}{{yield}}{{/view}}')
+  });
+
+  view = EmberView.create({
+    nestingView: NestingView,
+    template: compile('<div id="container">{{#view view.nestingView}}<div id="block">Hello</div>{{/view}}</div>')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div#container div.nesting div#block').length, 1, 'nesting view yields correctly even within a view hierarchy in the nesting view');
+});
+
+test("block should not be required", function() {
+  var YieldingView = EmberView.extend({
+    layout: compile('{{#view tagName="div" classNames="yielding"}}{{yield}}{{/view}}')
+  });
+
+  view = EmberView.create({
+    yieldingView: YieldingView,
+    template: compile('<div id="container">{{view view.yieldingView}}</div>')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div#container div.yielding').length, 1, 'yielding view is rendered as expected');
+});
+
+test("yield uses the outer context", function() {
+  var component = Component.extend({
+    boundText: "inner",
+    layout: compile("<p>{{boundText}}</p><p>{{yield}}</p>")
+  });
+
+  view = EmberView.create({
+    controller: { boundText: "outer", component: component },
+    template: compile('{{#view component}}{{boundText}}{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "Yield points at the right context");
+});
+
+/* requires with helper
+test("yield inside a conditional uses the outer context", function() {
+  var component = Component.extend({
+    boundText: "inner",
+    truthy: true,
+    obj: {},
+    layout: compile("<p>{{boundText}}</p><p>{{#if truthy}}{{#with obj}}{{yield}}{{/with}}{{/if}}</p>")
+  });
+
+  view = EmberView.create({
+    controller: { boundText: "outer", truthy: true, obj: { component: component, truthy: true, boundText: 'insideWith' } },
+    template: compile('{{#with obj}}{{#if truthy}}{{#view component}}{{#if truthy}}{{boundText}}{{/if}}{{/view}}{{/if}}{{/with}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, "Yield points at the right context");
+});
+*/
+
+/* requires with helper
+test("outer keyword doesn't mask inner component property", function () {
+  var component = Component.extend({
+    item: "inner",
+    layout: compile("<p>{{item}}</p><p>{{yield}}</p>")
+  });
+
+  view = EmberView.create({
+    controller: { boundText: "outer", component: component },
+    template: compile('{{#with boundText as item}}{{#view component}}{{item}}{{/view}}{{/with}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "inner component property isn't masked by outer keyword");
+});
+*/
+
+/* requires with helper
+test("inner keyword doesn't mask yield property", function() {
+  var component = Component.extend({
+    boundText: "inner",
+    layout: compile("{{#with boundText as item}}<p>{{item}}</p><p>{{yield}}</p>{{/with}}")
+  });
+
+  view = EmberView.create({
+    controller: { item: "outer", component: component },
+    template: compile('{{#view component}}{{item}}{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "outer property isn't masked by inner keyword");
+});
+*/
+
+/* requires with helper
+test("can bind a keyword to a component and use it in yield", function() {
+  var component = Component.extend({
+    content: null,
+    layout: compile("<p>{{content}}</p><p>{{yield}}</p>")
+  });
+
+  view = EmberView.create({
+    controller: { boundText: "outer", component: component },
+    template: compile('{{#with boundText as item}}{{#view component contentBinding="item"}}{{item}}{{/view}}{{/with}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div p:contains(outer) + p:contains(outer)').length, 1, "component and yield have keyword");
+
+  run(function() {
+    view.set('controller.boundText', 'update');
+  });
+
+  equal(view.$('div p:contains(update) + p:contains(update)').length, 1, "keyword has correctly propagated update");
+});
+*/
+
+/* requires with helper
+test("yield uses the layout context for non component", function() {
+  view = EmberView.create({
+    controller: {
+      boundText: "outer",
+      inner: {
+        boundText: "inner"
+      }
+    },
+    layout: compile("<p>{{boundText}}</p>{{#with inner}}<p>{{yield}}</p>{{/with}}"),
+    template: compile('{{boundText}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal('outerinner', view.$('p').text(), "Yield points at the right context");
+});
+*/
+
+test("yield view should be a virtual view", function() {
+  var component = Component.extend({
+    isParentComponent: true,
+
+    layout: compile('{{yield}}')
+  });
+
+  view = EmberView.create({
+    template: compile('{{#view component}}{{view includedComponent}}{{/view}}'),
+    controller: {
+      component: component,
+      includedComponent: Component.extend({
+        didInsertElement: function() {
+          var parentView = this.get('parentView');
+
+          ok(parentView.get('isParentComponent'), "parent view is the parent component");
+        }
+      })
+    }
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+});
+
+
+test("adding a layout should not affect the context of normal views", function() {
+  var parentView = EmberView.create({
+    context: "ParentContext"
+  });
+
+  view = EmberView.create({
+    template:     compile("View context: {{this}}"),
+    context:      "ViewContext",
+    _parentView:  parentView
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().text(), "View context: ViewContext");
+
+
+  set(view, 'layout', compile("Layout: {{yield}}"));
+
+  run(function() {
+    view.destroyElement();
+    view.createElement();
+  });
+
+  equal(view.$().text(), "Layout: View context: ViewContext");
+
+  run(function() {
+    parentView.destroy();
+  });
+});
+
+test("yield should work for views even if _parentView is null", function() {
+  view = EmberView.create({
+    layout:   compile('Layout: {{yield}}'),
+    template: compile("View Content")
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().text(), "Layout: View Content");
+
+});
+
+QUnit.module("ember-htmlbars: Component {{yield}}", {
+  setup: function() {},
+  teardown: function() {
+    run(function() {
+      if (view) {
+        view.destroy();
+      }
+      delete helpers['inner-component'];
+      delete helpers['outer-component'];
+    });
+  }
+});
+
+test("yield with nested components (#3220)", function(){
+  var count = 0;
+  var InnerComponent = Component.extend({
+    layout: compile("{{yield}}"),
+    _yield: function (context, options, morph) {
+      count++;
+      if (count > 1) throw new EmberError('is looping');
+      return this._super(context, options, morph);
+    }
+  });
+
+  helper('inner-component', InnerComponent);
+
+  var OuterComponent = Component.extend({
+    layout: compile("{{#inner-component}}<span>{{yield}}</span>{{/inner-component}}")
+  });
+
+  helper('outer-component', OuterComponent);
+
+  view = EmberView.create({
+    template: compile(
+      "{{#outer-component}}Hello world{{/outer-component}}"
+    )
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div > span').text(), "Hello world");
+});
+
+test("yield works inside a conditional in a component that has Ember._Metamorph mixed in", function() {
+  var component = Component.extend(Ember._Metamorph, {
+    item: "inner",
+    layout: compile("<p>{{item}}</p>{{#if item}}<p>{{yield}}</p>{{/if}}")
+  });
+
+  view = Ember.View.create({
+    controller: { item: "outer", component: component },
+    template: compile('{{#view component}}{{item}}{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$().text(), 'innerouter', "{{yield}} renders yielded content inside metamorph component");
+});
+
+test("view keyword works inside component yield", function () {
+  var component = Component.extend({
+    layout: compile("<p>{{yield}}</p>")
+  });
+
+  view = EmberView.create({
+    dummyText: 'hello',
+    component: component,
+    template: compile('{{#view view.component}}{{view.dummyText}}{{/view}}')
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  equal(view.$('div > p').text(), "hello", "view keyword inside component yield block should refer to the correct view");
+});
+
+}

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -1,0 +1,56 @@
+import EmberView from "ember-views/views/view";
+import run from "ember-metal/run_loop";
+import EmberObject from "ember-runtime/system/object";
+import { compile } from "htmlbars-compiler/compiler";
+import { equalInnerHTML } from "../helpers";
+
+var view;
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  QUnit.module("ember-htmlbars: basic/text_node_test", {
+    teardown: function(){
+      if (view) {
+        run(view, view.destroy);
+      }
+    }
+  });
+
+  test("property is output", function() {
+    view = EmberView.create({
+      context: {name: 'erik'},
+      template: compile("ohai {{name}}")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, 'ohai erik', "property is output");
+  });
+
+  test("path is output", function() {
+    view = EmberView.create({
+      context: {name: {firstName: 'erik'}},
+      template: compile("ohai {{name.firstName}}")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, 'ohai erik', "path is output");
+  });
+
+  test("changed property updates", function() {
+    var context = EmberObject.create({name: 'erik'});
+    view = EmberView.create({
+      context: context,
+      template: compile("ohai {{name}}")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, 'ohai erik', "precond - original property is output");
+
+    run(context, context.set, 'name', 'mmun');
+
+    equalInnerHTML(view.element, 'ohai mmun', "new property is output");
+  });
+}

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -1,0 +1,23 @@
+import { compile } from "htmlbars-compiler/compiler";
+import { defaultEnv } from "ember-htmlbars";
+
+function fragmentHTML(fragment) {
+  var html = '', node;
+  for (var i = 0, l = fragment.childNodes.length; i < l; i++) {
+    node = fragment.childNodes[i];
+    if (node.nodeType === 3) {
+      html += node.nodeValue;
+    } else {
+      html += node.outerHTML;
+    }
+  }
+  return html;
+}
+
+QUnit.module("ember-htmlbars");
+
+test("hello world", function() {
+  var template = compile("ohai {{name}}");
+  var output = template({name: 'erik'}, defaultEnv, document.body);
+  equal(fragmentHTML(output), "ohai erik");
+});

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -1,23 +1,14 @@
 import { compile } from "htmlbars-compiler/compiler";
 import { defaultEnv } from "ember-htmlbars";
+import { equalHTML } from "./helpers";
 
-function fragmentHTML(fragment) {
-  var html = '', node;
-  for (var i = 0, l = fragment.childNodes.length; i < l; i++) {
-    node = fragment.childNodes[i];
-    if (node.nodeType === 3) {
-      html += node.nodeValue;
-    } else {
-      html += node.outerHTML;
-    }
-  }
-  return html;
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+  QUnit.module("ember-htmlbars: main");
+
+  test("HTMLBars is present and can be executed", function() {
+    var template = compile("ohai");
+    var output = template({}, defaultEnv, document.body);
+    equalHTML(output, "ohai");
+  });
 }
-
-QUnit.module("ember-htmlbars");
-
-test("hello world", function() {
-  var template = compile("ohai {{name}}");
-  var output = template({name: 'erik'}, defaultEnv, document.body);
-  equal(fragmentHTML(output), "ohai erik");
-});

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -303,10 +303,16 @@ _RenderBuffer.prototype = {
     @chainable
   */
   push: function(content) {
-    if (this.buffer === null) {
-      this.buffer = '';
+    if (content.nodeType) {
+      Ember.assert("A fragment cannot be pushed into a buffer that contains content", !this.buffer);
+      this.buffer = content;
+    } else {
+      if (this.buffer === null) {
+        this.buffer = '';
+      }
+      Ember.assert("A string cannot be pushed into the buffer after a fragment", !this.buffer.nodeType);
+      this.buffer += content;
     }
-    this.buffer += content;
     return this;
   },
 
@@ -520,9 +526,14 @@ _RenderBuffer.prototype = {
       this._element = document.createDocumentFragment();
     }
 
-    var nodes = this.dom.parseHTML(content, contextualElement);
-    while (nodes[0]) {
-      this._element.appendChild(nodes[0]);
+    if (content.nodeType) {
+      this._element.appendChild(content);
+    } else {
+      var nodes;
+      nodes = this.dom.parseHTML(content, contextualElement);
+      while (nodes[0]) {
+        this._element.appendChild(nodes[0]);
+      }
     }
     this.hydrateMorphs(contextualElement);
 

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -163,7 +163,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     this._keywords.view.setSource(this);
   },
 
-  _yield: function(context, options) {
+  _yield: function(context, options, morph) {
     var view = options.data.view;
     var parentView = this._parentView;
     var template = get(this, 'template');
@@ -174,8 +174,9 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
       view.appendChild(View, {
         isVirtual: true,
         tagName: '',
-        _contextView: parentView,
         template: template,
+        _contextView: parentView,
+        _morph: morph,
         context: get(parentView, 'context'),
         controller: get(parentView, 'controller'),
         templateData: { keywords: {} }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -54,6 +54,15 @@ import CoreView from "ember-views/views/core_view";
 
 function K() { return this; }
 
+// Circular dep
+var _htmlbarsDefaultEnv;
+function buildHTMLBarsDefaultEnv(){
+  if (!_htmlbarsDefaultEnv) {
+    _htmlbarsDefaultEnv = require('ember-htmlbars').defaultEnv;
+  }
+  return create(_htmlbarsDefaultEnv);
+}
+
 /**
 @module ember
 @submodule ember-views
@@ -791,9 +800,25 @@ var View = CoreView.extend({
     return layout || get(this, 'defaultLayout');
   }).property('layoutName'),
 
-  _yield: function(context, options) {
+  _yield: function(context, options, morph) {
     var template = get(this, 'template');
-    if (template) { template(context, options); }
+    var result;
+
+    if (template) {
+      var useHTMLBars = false;
+      if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+        useHTMLBars = template.length === 3;
+      }
+
+      if (useHTMLBars) {
+        result = template(this, options, morph.contextualElement);
+      } else {
+        result = template(context, options);
+      }
+    }
+    if (morph) {
+      morph.update(result);
+    }
   },
 
   templateForName: function(name, type) {
@@ -1067,7 +1092,19 @@ var View = CoreView.extend({
       Ember.assert('template must be a function. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'function');
       // The template should write directly to the render buffer instead
       // of returning a string.
-      output = template(context, { data: data });
+      var options = { data: data };
+      var useHTMLBars = false;
+
+      if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+        useHTMLBars = template.length === 3;
+      }
+
+      if (useHTMLBars) {
+        var env = Ember.merge(buildHTMLBarsDefaultEnv(), options);
+        output = template(this, env, buffer.innerContextualElement());
+      } else {
+        output = template(context, options);
+      }
 
       // If the template returned a string instead of writing to the buffer,
       // push the string onto the buffer.

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -41,6 +41,41 @@ test("RenderBuffers combine strings", function() {
   equal(el.childNodes[0].nodeValue, 'ab', "Multiple pushes should concatenate");
 });
 
+test("RenderBuffers push fragments", function() {
+  var buffer = new RenderBuffer('div', document.body);
+  var fragment = document.createElement('span');
+  buffer.generateElement();
+
+  buffer.push(fragment);
+
+  var el = buffer.element();
+  equal(el.tagName.toLowerCase(), 'div');
+  console.log('el.', el.childNodes);
+  equal(el.childNodes[0].tagName, 'SPAN', "Fragment is pushed into the buffer");
+});
+
+test("RenderBuffers cannot push fragments when something else is in the buffer", function() {
+  var buffer = new RenderBuffer('div', document.body);
+  var fragment = document.createElement('span');
+  buffer.generateElement();
+
+  buffer.push(fragment);
+  expectAssertion(function(){
+    buffer.push(fragment);
+  });
+});
+
+test("RenderBuffers cannot push strings after fragments", function() {
+  var buffer = new RenderBuffer('div', document.body);
+  var fragment = document.createElement('span');
+  buffer.generateElement();
+
+  buffer.push(fragment);
+  expectAssertion(function(){
+    buffer.push('howdy');
+  });
+});
+
 test("value of 0 is included in output", function() {
   var buffer, el;
   buffer = new RenderBuffer('input', document.body);


### PR DESCRIPTION
Build TODO:
- [x] Refactor the build pipeline to pull in HTMLBars via ES6.
- [x] Have the ember-htmlbars test helper come out of htmlbars via ES6 (is this a new htmlbars package that doesn't ship in the main build?).
- [x] Ensure the ember-htmlbars package in Ember is not included in the Ember build.
- [x] simple-html-tokenizer should not be needed in Ember (it comes with HTMLBars already). (talked to robert- we should make the sht a dep in htmlbars instead of a dev dep, then import it via ES6 in Ember)

TODO:
- [x] `view` helper must be implemented, tested.
- [x] Components and yielding must be implemented, tested.
- [x] ~~Move Handlebars views used in HTMLBars into ember-views. Rename, refactor along the way.~~
- [x] ~~Upstream commit to HTMLBars for to emit blank array types.~~
- [x] Upstream commit to HTMLBars to fix the equalHTML helper on bare text nodes.
- [x] unrelated, but the refactor of buffer should go into beta. Must confirm it fixes an issue with rerender of TRs. In #9361.
- [x] Refactor the  `Object.create` out of `views/view`.
- [x] Add a feature flag around the template arity check in `views/view`.  PR pending in https://github.com/mixonic/ember.js/pull/5.
- [x] Rebase shizzit (after some other things get fixed)
- [x] ~~Rebase on top of Handlebars 2 (requires upstream fix for Handlebars 2)~~
- [x] Implement `{{with}}` helper (needed for yield tests to be completed)
- [x] Implement a basic version of registering helpers/components (Needed for yield tests to be completed)
