### PR TITLE
Ensure Ember.Handlebars.get is exported.

### DIFF
--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -8,7 +8,8 @@ import {
   makeBoundHelper,
   registerBoundHelper,
   helperMissingHelper,
-  blockHelperMissingHelper
+  blockHelperMissingHelper,
+  handlebarsGet
 } from "ember-handlebars/ext";
 
 
@@ -97,6 +98,7 @@ EmberHandlebars.ViewHelper = ViewHelper;
 
 // Ember Globals
 Ember.Handlebars = EmberHandlebars;
+EmberHandlebars.get = handlebarsGet;
 Ember.ComponentLookup = ComponentLookup;
 Ember._SimpleHandlebarsView = SimpleHandlebarsView;
 Ember._HandlebarsBoundView = _HandlebarsBoundView;


### PR DESCRIPTION
It was brought back earlier, but not re-exported properly.
