### PR TITLE
Add findOneWithAssert to ember-testing

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -47,7 +47,7 @@ function visit(app, url) {
 }
 
 function click(app, selector, context) {
-  var $el = app.testHelpers.findWithAssert(selector, context);
+  var $el = app.testHelpers.findOneWithAssert(selector, context);
   run($el, 'mousedown');
 
   if ($el.is(':input')) {
@@ -101,7 +101,7 @@ function triggerEvent(app, selector, contextOrType, typeOrOptions, possibleOptio
     options = possibleOptions;
   }
 
-  var $el = app.testHelpers.findWithAssert(selector, context);
+  var $el = app.testHelpers.findOneWithAssert(selector, context);
 
   var event = jQuery.Event(type, options);
 
@@ -132,7 +132,7 @@ function fillIn(app, selector, contextOrText, text) {
   } else {
     context = contextOrText;
   }
-  $el = app.testHelpers.findWithAssert(selector, context);
+  $el = app.testHelpers.findOneWithAssert(selector, context);
   run(function() {
     $el.val(text).change();
   });
@@ -143,6 +143,14 @@ function findWithAssert(app, selector, context) {
   var $el = app.testHelpers.find(selector, context);
   if ($el.length === 0) {
     throw new EmberError("Element " + selector + " not found.");
+  }
+  return $el;
+}
+
+function findOneWithAssert(app, selector, context) {
+  var $el = app.testHelpers.findWithAssert(selector, context);
+  if ($el.length > 1) {
+    throw new EmberError("More then one element was found for " + selector);
   }
   return $el;
 }
@@ -306,6 +314,27 @@ helper('find', find);
 * @throws {Error} throws error if jQuery object returned has a length of 0
 */
 helper('findWithAssert', findWithAssert);
+
+/**
+* Like `find`, but throws an error if the element selector returns no results or
+* returns more than one result.
+*
+* Example:
+*
+* ```javascript
+* var $el = findOneWithAssert('.doesnt-exist'); // throws error
+* // or
+* var $el = findOneWithAssert('li.multiple-items'); // throws error
+* ```
+*
+* @method findOneWithAssert
+* @param {String} selector jQuery selector string for finding an element within
+* the DOM
+* @return {Object} jQuery object representing the results of the query
+* @throws {Error} throws error if jQuery object returned has a length of 0
+* or greater than 1
+*/
+helper('findOneWithAssert', findOneWithAssert);
 
 /**
   Causes the run loop to process any pending events. This is used to ensure that


### PR DESCRIPTION
and make click, fillIn, triggerEvent (and hence
keyEvent) make use of it.

This change will cause your test suite to loudly
break if the selectors you provide to the above
helpers match more than one element.

Note: I tried and failed to add test cases. It's very difficult to test a failing assert given QUnit + async, which is likely the same reason that no failing-assertion test cases exist for the original `testWithAssert`.

Also note that `find` is untouched; it's only the above listed helpers that will throw when supplied that helper that matches more than one el..
