### PR TITLE
[BUGFIX] HashLocation no longer assumes any hash is a route, uses forward slash prefix convention #/foo

### DIFF
--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -39,15 +39,33 @@ export default EmberObject.extend({
   getHash: EmberLocation._getHash,
 
   /**
-    Returns the current `location.hash`, minus the '#' at the front.
+    Returns the normalized URL, constructed from `location.hash`.
+
+    e.g. `#/foo` => `/foo` as well as `#/foo#bar` => `/foo#bar`.
+
+    By convention, hashed paths must begin with a forward slash, otherwise they
+    are not treated as a path so we can distinguish intent.
 
     @private
     @method getURL
   */
   getURL: function() {
-    var path = this.getHash().substr(1);
-    Ember.deprecate('location.hash value is ambiguous. Support for this will be removed soon. When using location: "hash|auto" your hash paths MUST begin with a forward slash. e.g. #/' + path + ' NOT #' + path, path.length === 0 || path.charAt(0) === '/');
-    return path;
+    var originalPath = this.getHash().substr(1);
+    var outPath = originalPath;
+    
+    if (outPath.charAt(0) !== '/') {
+      outPath = '/';
+
+      // Only add the # if the path isn't empty.
+      // We do NOT want `/#` since the ampersand
+      // is only included (conventionally) when
+      // the location.hash has a value
+      if (originalPath) {
+        outPath += '#' + originalPath;
+      }
+    }
+
+    return outPath;
   },
 
   /**

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -65,16 +65,16 @@ QUnit.module("Ember.AutoLocation", {
       hash: '',
       search: '',
       replace: function () {
-        ok(false, 'location.replace should not be called');
+        ok(false, 'location.replace should not be called during testing');
       }
     };
 
     AutoTestLocation._history = {
       pushState: function () {
-        ok(false, 'history.pushState should not be called');
+        ok(false, 'history.pushState should not be called during testing');
       },
       replaceState: function () {
-        ok(false, 'history.replaceState should not be called');
+        ok(false, 'history.replaceState should not be called during testing');
       }
     };
   },

--- a/packages/ember-routing/tests/location/hash_location_test.js
+++ b/packages/ember-routing/tests/location/hash_location_test.js
@@ -74,28 +74,24 @@ test("HashLocation.getURL() includes extra hashes", function() {
     equal(location.getURL(), '/foo#bar#car');
 });
 
-test("HashLocation.getURL() a non-empty location.hash without #/ signals deprecation warning", function() {
-    expect(2);
+test("HashLocation.getURL() assumes location.hash without #/ prefix is not a route path", function() {
+    expect(1);
 
     createLocation({
-      _location: mockBrowserLocation('/#foo')
+      _location: mockBrowserLocation('/#foo#bar')
     });
 
-    expectDeprecation(function() {
-      equal(location.getURL(), 'foo');
-    }, /location.hash value is ambiguous. Support for this will be removed soon. When using location: "hash|auto" your hash paths MUST begin with a forward slash. e.g. #\/foo NOT #foo/);
+    equal(location.getURL(), '/#foo#bar');
 });
 
-
-test("HashLocation.getURL() an empty location.hash does NOT trigger deprecation warning related to missing forward slash", function() {
-    expect(2);
-    expectNoDeprecation();
+test("HashLocation.getURL() returns a normal forward slash when there is no location.hash", function() {
+    expect(1);
 
     createLocation({
       _location: mockBrowserLocation('/')
     });
-
-    equal(location.getURL(), '');
+    
+    equal(location.getURL(), '/');
 });
 
 test("HashLocation.setURL() correctly sets the url", function() {


### PR DESCRIPTION
We first deprecated this behavior here #9388, this PR removes that deprecated behavior.

Up until this PR, `HashLocation` returns `#foo` => `foo` as the "url" when the router asks for it, which means any hash gets considered by the router as a possible route. This prevents you from linking to element's with id's, like `<div id="foo">` as well as using normal `<a href="#foo">` in your app will incorrectly try to transition the app to a `foo` route. Also--If someone relies on this bug, it has the negative effect of causing duplicate history states if someone clicks a link to that same route inside the app since `#/foo` and `#foo` aren't the same URL, but resolve to the same route.

This bug has been [reported in the wild](https://stackoverflow.com/questions/16164566/section-links-with-ember-js).

This PR is also needed as part of a bigger solution to support auto-scrolling to id after route's finish transitioning to mimic the default browser behavior.

Related: https://github.com/emberjs/ember.js/issues/4098#issuecomment-59674832

Because this has existed since day one, I realize some people may unfortunately be relying on it for some reason...If we want to continue to support this behavior until 2.0, we can put this correction behind some sort of property flag that users can opt-into. e.g. `Ember.ENV.STRICT_HASH_LOCATION = true` or something. It might be worth noting that `AutoLocation` [didn't make this assumption](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/location/auto_location.js#L275).

p.s. this also adds much needed tests for `HashLocation` in general. woot.
