### PR TITLE
ES6 fixes

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -36,7 +36,7 @@ import BucketCache from "ember-routing/system/cache";
 // `import ContainerDebugAdapter from 'ember-extension-support/container_debug_adapter';` but
 // es6-module-transpiler 0.4.0 eagerly grabs the module (which is undefined)
 
-module ContainerDebugAdapterModule from "ember-extension-support/container_debug_adapter";
+import ContainerDebugAdapter from "ember-extension-support/container_debug_adapter";
 
 import {
   K
@@ -1008,7 +1008,7 @@ Application.reopenClass({
     container.injection('data-adapter:main', 'containerDebugAdapter', 'container-debug-adapter:main');
     // Custom resolver authors may want to register their own ContainerDebugAdapter with this key
 
-    container.register('container-debug-adapter:main', ContainerDebugAdapterModule['default']);
+    container.register('container-debug-adapter:main', ContainerDebugAdapter);
 
     return container;
   }

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -191,10 +191,10 @@ Ember.LOG_VERSION = (Ember.ENV.LOG_VERSION === false) ? false : true;
   @private
   @return {Object}
 */
-var K = function() { return this; };
-export var K = K;
+function K() { return this; }
+export { K };
 Ember.K = K;
-//TODO: ES6 GLOBL TODO
+//TODO: ES6 GLOBAL TODO
 
 // Stub out the methods defined by the ember-debug package in case it's not loaded
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -35,7 +35,7 @@ import keys from "ember-metal/keys";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 import { defineProperty } from "ember-metal/properties";
 import { Binding } from "ember-metal/binding";
-import { ComputedProperty } from "ember-metal/computed";
+import { ComputedProperty, computed } from "ember-metal/computed";
 import InjectedProperty from "ember-metal/injected_property";
 import run from 'ember-metal/run_loop';
 import { destroy } from "ember-metal/watching";
@@ -794,7 +794,7 @@ var ClassMixinProps = {
     return desc._meta || {};
   },
 
-  _computedProperties: Ember.computed(function() {
+  _computedProperties: computed(function() {
     hasCachedComputedProperties = true;
     var proto = this.proto();
     var descs = meta(proto).descs;


### PR DESCRIPTION
Another round of ES6 fixes taken from my [work-in-progress branch](https://github.com/eventualbuddha/ember.js/tree/es6-module-transpiler-update) to get Ember on the latest module transpiler release.
