### PR TITLE
[DOC beta] Fix typo, change 'they' to just 'the', per #9373

### DIFF
--- a/packages/ember-handlebars/lib/controls/text_support.js
+++ b/packages/ember-handlebars/lib/controls/text_support.js
@@ -74,7 +74,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
   onEvent: 'enter',
 
   /**
-    Whether they `keyUp` event that triggers an `action` to be sent continues
+    Whether the `keyUp` event that triggers an `action` to be sent continues
     propagating to other views.
 
     By default, when the user presses the return key on their keyboard and


### PR DESCRIPTION
Just fixing a really minor typo. 
