### PR TITLE
[BUGFIX beta] Add assertion when morph is not found in RenderBuffer.

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -2494,3 +2494,15 @@ test("should teardown observers from bind-attr on rerender", function() {
 
   equal(observersFor(view, 'foo').length, 1);
 });
+
+test("should provide a helpful assertion for bindings within HTML comments", function() {
+  view = EmberView.create({
+    template: EmberHandlebars.compile('<!-- {{view.someThing}} -->'),
+    someThing: 'foo',
+    _debugTemplateName: 'blahzorz'
+  });
+
+  expectAssertion(function() {
+    appendView();
+  }, 'An error occured while setting up template bindings. Please check "blahzorz" template for invalid markup or bindings within HTML comments.');
+});

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -275,6 +275,14 @@ _RenderBuffer.prototype = {
     for (var i=0,l=childViews.length; i<l; i++) {
       var childView = childViews[i];
       var ref = el.querySelector('#morph-'+i);
+
+      Ember.assert('An error occured while setting up template bindings. Please check ' +
+                   (childView && childView._parentView && childView._parentView._debugTemplateName ?
+                        '"' + childView._parentView._debugTemplateName + '" template ' :
+                        ''
+                   )  + 'for invalid markup or bindings within HTML comments.',
+                   ref);
+
       var parent = ref.parentNode;
 
       childView._morph = this.dom.insertMorphBefore(


### PR DESCRIPTION
When `_debugTemplateName` is present, the assertion is the following:

```
Assertion Failed: An error occured while setting up template bindings.  Please check "application" template for invalid markup or bindings within HTML comments.
```

When it is not present the following is asserted:

```
Assertion Failed: An error occured while setting up template bindings. Please check for invalid markup or bindings within HTML comments.
```

Closes #9365.
