### PR TITLE
Log unhandled promise rejections in testing #9376

### DIFF
--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -51,6 +51,7 @@ RSVP.onerrorDefault = function (error) {
 
       if (Test && Test.adapter) {
         Test.adapter.exception(error);
+        Logger.error(error.stack);
       } else {
         throw error;
       }


### PR DESCRIPTION
Added a log of the error stack.

Are tests typically written for log statements? I attempted to add a test but struggled; I would need some guidance to set up the scenario in which this log statement appears. 
