### PR TITLE
[BUGFIX beta] Fix regression in setProperties

### DIFF
--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -18,20 +18,20 @@ import keys from "ember-metal/keys";
   ```
 
   @method setProperties
-  @param self
-  @param {Object} hash
-  @return self
+  @param obj
+  @param {Object} properties
+  @return obj
 */
-export default function setProperties(self, hash) {
+export default function setProperties(obj, properties) {
   changeProperties(function() {
-    var props = keys(hash);
-    var prop;
+    var props = keys(properties);
+    var propertyName;
 
     for (var i = 0, l = props.length; i < l; i++) {
-      prop = props[i];
+      propertyName = props[i];
 
-      set(self, prop, hash[prop]);
+      set(obj, propertyName, properties[propertyName]);
     }
   });
-  return self;
+  return obj;
 }

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -23,6 +23,7 @@ import keys from "ember-metal/keys";
   @return obj
 */
 export default function setProperties(obj, properties) {
+  if (!properties || typeof properties !== "object") { return obj; }
   changeProperties(function() {
     var props = keys(properties);
     var propertyName;

--- a/packages/ember-metal/tests/set_properties_test.js
+++ b/packages/ember-metal/tests/set_properties_test.js
@@ -1,0 +1,26 @@
+import setProperties from 'ember-metal/set_properties';
+
+QUnit.module('Ember.setProperties');
+
+test("supports setting multiple attributes at once", function() {
+  deepEqual(setProperties(null, null),    null, 'noop for null properties and null object');
+  deepEqual(setProperties(undefined, undefined),    undefined, 'noop for undefined properties and undefined object');
+
+  deepEqual(setProperties({}),            {}, 'noop for no properties');
+  deepEqual(setProperties({}, undefined), {}, 'noop for undefined');
+  deepEqual(setProperties({}, null),      {}, 'noop for null');
+  deepEqual(setProperties({}, NaN),       {}, 'noop for NaN');
+  deepEqual(setProperties({}, {}),        {}, 'meh');
+
+  deepEqual(setProperties({}, {foo: 1}),  {foo: 1}, 'Set a single property');
+
+  deepEqual(setProperties({}, {foo:1, bar: 1}), {foo: 1, bar: 1}, 'Set multiple properties');
+
+  deepEqual(setProperties({foo: 2, baz: 2}, {foo: 1}), {foo: 1, baz: 2}, 'Set one of multiple properties');
+
+  deepEqual(setProperties({foo: 2, baz: 2}, {bar: 2}), {
+    bar: 2,
+    foo: 2,
+    baz: 2
+  }, 'Set an additional, previously unset property');
+});


### PR DESCRIPTION
The switch to Object.keys caused a regression because `for x in y` works for non-objects as well. All credit to @stefanpenner 
