### PR TITLE
[BUGFIX beta] deprecate location: 'hash' paths that don't have a forward slash. e.g. #foo vs. #/foo

### DIFF
--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -1,3 +1,4 @@
+import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
@@ -5,7 +6,6 @@ import { guidFor } from "ember-metal/utils";
 
 import EmberObject from "ember-runtime/system/object";
 import EmberLocation from "ember-routing/location/api";
-import jQuery from "ember-views/system/jquery";
 
 /**
 @module ember
@@ -45,7 +45,9 @@ export default EmberObject.extend({
     @method getURL
   */
   getURL: function() {
-    return this.getHash().substr(1);
+    var path = this.getHash().substr(1);
+    Ember.deprecate('location.hash value is ambiguous. Support for this will be removed soon. When using location: "hash|auto" your hash paths MUST begin with a forward slash. e.g. #/' + path + ' NOT #' + path, path.length === 0 || path.charAt(0) === '/');
+    return path;
   },
 
   /**
@@ -88,7 +90,7 @@ export default EmberObject.extend({
     var self = this;
     var guid = guidFor(this);
 
-    jQuery(window).on('hashchange.ember-location-'+guid, function() {
+    Ember.$(window).on('hashchange.ember-location-'+guid, function() {
       run(function() {
         var path = self.getURL();
         if (get(self, 'lastSetURL') === path) { return; }
@@ -124,6 +126,6 @@ export default EmberObject.extend({
   willDestroy: function() {
     var guid = guidFor(this);
 
-    jQuery(window).off('hashchange.ember-location-'+guid);
+    Ember.$(window).off('hashchange.ember-location-'+guid);
   }
 });

--- a/packages/ember-routing/tests/location/hash_location_test.js
+++ b/packages/ember-routing/tests/location/hash_location_test.js
@@ -1,0 +1,190 @@
+import Ember from "ember-metal/core";
+import { get } from "ember-metal/property_get";
+import { guidFor } from "ember-metal/utils";
+import run from "ember-metal/run_loop";
+import HashLocation from "ember-routing/location/hash_location";
+
+var HashTestLocation, location;
+
+function createLocation(options){
+  if (!options) { options = {}; }
+  location = HashTestLocation.create(options);
+}
+
+function mockBrowserLocation(path) {
+  // This is a neat trick to auto-magically extract the hostname from any
+  // url by letting the browser do the work ;)
+  var tmp = document.createElement ('a');
+  tmp.href = path;
+
+  var protocol = (!tmp.protocol || tmp.protocol === ':') ? 'http' : tmp.protocol;
+  var pathname = (tmp.pathname.match(/^\//)) ? tmp.pathname : '/' + tmp.pathname;
+
+  return {
+      hash: tmp.hash,
+      host: tmp.host || 'localhost',
+      hostname: tmp.hostname || 'localhost',
+      href: tmp.href,
+      pathname: pathname,
+      port: tmp.port || '',
+      protocol: protocol,
+      search: tmp.search
+  };
+}
+
+QUnit.module("Ember.HashLocation", {
+  setup: function() {
+    HashTestLocation = HashLocation.extend({
+      _location: {
+        href: 'http://test.com/',
+        pathname: '/',
+        hash: '',
+        search: '',
+        replace: function () {
+          ok(false, 'location.replace should not be called during testing');
+        }
+      }
+    });
+  },
+
+  teardown: function() {
+    run(function() {
+      if (location) { location.destroy(); }
+    });
+  }
+});
+
+test("HashLocation.getURL() returns the current url", function() {
+    expect(1);
+
+    createLocation({
+      _location: mockBrowserLocation('/#/foo/bar')
+    });
+
+    equal(location.getURL(), '/foo/bar');
+});
+
+test("HashLocation.getURL() includes extra hashes", function() {
+    expect(1);
+
+    createLocation({
+      _location: mockBrowserLocation('/#/foo#bar#car')
+    });
+
+    equal(location.getURL(), '/foo#bar#car');
+});
+
+test("HashLocation.getURL() a non-empty location.hash without #/ signals deprecation warning", function() {
+    expect(2);
+
+    createLocation({
+      _location: mockBrowserLocation('/#foo')
+    });
+
+    expectDeprecation(function() {
+      equal(location.getURL(), 'foo');
+    }, /location.hash value is ambiguous. Support for this will be removed soon. When using location: "hash|auto" your hash paths MUST begin with a forward slash. e.g. #\/foo NOT #foo/);
+});
+
+
+test("HashLocation.getURL() an empty location.hash does NOT trigger deprecation warning related to missing forward slash", function() {
+    expect(2);
+    expectNoDeprecation();
+
+    createLocation({
+      _location: mockBrowserLocation('/')
+    });
+
+    equal(location.getURL(), '');
+});
+
+test("HashLocation.setURL() correctly sets the url", function() {
+    expect(2);
+
+    createLocation();
+
+    location.setURL('/bar');
+
+    equal(get(location, 'location.hash'), '/bar');
+    equal(get(location, 'lastSetURL'), '/bar');
+});
+
+test("HashLocation.replaceURL() correctly replaces to the path with a page reload", function() {
+    expect(2);
+
+    createLocation({
+      _location: {
+        replace: function(path) {
+          equal(path, '#/foo');
+        }
+      }
+    });
+
+    location.replaceURL('/foo');
+
+    equal(get(location, 'lastSetURL'), '/foo');
+});
+
+test("HashLocation.onUpdateURL() registers a hashchange callback", function() {
+    expect(3);
+
+    var oldJquery = Ember.$;
+
+    Ember.$ = function (element) {
+      equal(element, window);
+      return {
+        on: function(eventName, callback) {
+          equal(eventName, 'hashchange.ember-location-' + guid);
+          equal(Object.prototype.toString.call(callback), '[object Function]');
+        }
+      };
+    };
+
+    createLocation({
+      // Mock so test teardown doesn't fail
+      willDestroy: function () {}
+    });
+
+    var guid = guidFor(location);
+
+    location.onUpdateURL(function () {});
+
+    // clean up
+    Ember.$ = oldJquery;
+});
+
+test("HashLocation.formatURL() prepends a # to the provided string", function() {
+    expect(1);
+
+    createLocation();
+
+    equal(location.formatURL('/foo#bar'), '#/foo#bar');
+});
+
+test("HashLocation.willDestroy() cleans up hashchange event listener", function() {
+    expect(2);
+
+    var oldJquery = Ember.$;
+
+    Ember.$ = function (element) {
+      equal(element, window);
+
+      return {
+        off: function(eventName) {
+          equal(eventName, 'hashchange.ember-location-' + guid);
+        }
+      };
+    };
+
+    createLocation();
+
+    var guid = guidFor(location);
+
+    location.willDestroy();
+
+    // noop so test teardown doesn't call our mocked jQuery again
+    location.willDestroy = function() {};
+
+    // clean up
+    Ember.$ = oldJquery;
+});


### PR DESCRIPTION
Also adds much needed test coverage for HashLocation in general.

Requested by @rwjblue before we merge #9367
