### PR TITLE
[BUGFIX beta] Fix bound helper argument types

### DIFF
--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -81,9 +81,7 @@ SimpleHandlebarsView.prototype = {
       result = handlebarsGet(pathRoot, path, { data: templateData });
     }
 
-    if (result === null || result === undefined) {
-      result = "";
-    } else if (!escape && !(result instanceof SafeString)) {
+    if (!escape && !(result instanceof SafeString)) {
       result = new SafeString(result);
     }
 

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -435,4 +435,17 @@ test("bound helpers can handle `this` keyword when it's a non-object", function(
   equal(view.$().text(), 'wallace!', "helper output is correct");
 });
 
+test("should have correct argument types", function() {
+  EmberHandlebars.helper('getType', function(value) {
+    return typeof value;
+  });
 
+  view = EmberView.create({
+    controller: EmberObject.create(),
+    template: EmberHandlebars.compile('{{getType null}}, {{getType undefProp}}, {{getType "string"}}, {{getType 1}}, {{getType}}')
+  });
+
+  appendView();
+
+  equal(view.$().text(), 'undefined, undefined, string, number, object', "helper output is correct");
+});


### PR DESCRIPTION
_This is a PR against `beta`, not `master`, because it is not an issue on canary. It does, however, affect the upcoming 1.8 release._

Fixes #9280.

I was able to track down the [commit](https://github.com/emberjs/ember.js/commit/b87696b07b5ef7d585225ca1b375d5a528c379f3) where this issue got introduced, in [`handlebars_bound_view.js`](https://github.com/emberjs/ember.js/commit/b87696b07b5ef7d585225ca1b375d5a528c379f3#diff-3) more specifically.

Essentially, `render` used to have this logic:

``` javascript
render: function(value) {
  var result = value || this.normalizedValue();
  if (result === null || result === undefined) {
    result = "";
  }
  // ...
}
```

`this.normalizedValue()` internally called `SimpleHandlebarsView.prototype.normalizedValue` in [`makeBoundHelper`](https://github.com/emberjs/ember.js/blob/b87696b07b5ef7d585225ca1b375d5a528c379f3/packages/ember-handlebars/lib/ext.js#L544), and the value returned would get pushed as an argument to the helper function.

The changes in the breaking commit moved that logic to `SimpleHandlebarsView.prototype.normalizedValue`:

``` javascript
normalizedValue: function() {
  // ...
  if (result === null || result === undefined) {
    result = "";
  }
  // ...

  return result;
}
```

Setting `result` to `""` is what causes the arguments to the bound helpers to change as described in #9280 (`null` and `undefined` are now passed in as `""`).

**How is this fixed in `master`?**

The problem was removed with this [stream-related PR](https://github.com/emberjs/ember.js/commit/f839dcd89ad5ecc50d5403a06f507449380557b0#diff-11).

While `normalizedValue` still returns an empty string if `result` is `null` or `undefined`, it is no longer being called by `makeBoundHelper`, as least not directly as far as I can tell.

What I have for now removes the block that sets `result` to an empty string in `normalizedValue`. All of the existing tests are passing, and I've added @kategengler's [test](https://github.com/emberjs/ember.js/issues/9280#issuecomment-59881757) as well.

I'm unable to completely verify that this will not have adverse effects not covered by the tests, however. It would be great if someone who knows this code well could take a look. Thanks!
