### PR TITLE
Allow more configurability in production builds.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -18,8 +18,15 @@ var es3recast = require('broccoli-es3-safe-recast');
 
 var getVersion = require('git-repo-version');
 
+// To create fast production builds (without ES3 support, minification, or JSHint)
+// run the following:
+//
+// DISABLE_ES3=true DISABLE_JSHINT=true DISABLE_MIN=true ember serve --environment=production
+
 var env = process.env.EMBER_ENV || 'development';
-var disableJSHint = !!process.env.NO_JSHINT || false;
+var disableJSHint = !!process.env.DISABLE_JSHINT || false;
+var disableES3    = !!process.env.DISABLE_ES3 || false;
+var disableMin    = !!process.env.DISABLE_MIN || false;
 var disableDefeatureify;
 
 if (process.env.DEFEATUREIFY === 'true') {
@@ -102,7 +109,7 @@ function vendoredPackage(packageName) {
     destFile: '/' + packageName + '.js'
   });
 
-  if (env !== 'development') {
+  if (env !== 'development' && !disableES3) {
     sourceTree = es3recast(sourceTree);
   }
 
@@ -144,7 +151,7 @@ error:
      {default: "something"}['default']
     ```
    */
-  if (options.es3Safe) {
+  if (options.es3Safe && !disableES3) {
     sourceTrees = es3recast(sourceTrees);
   }
 
@@ -565,7 +572,7 @@ function vendoredEs6Package(packageName) {
     moduleName: true
   });
 
-  if (env !== 'development') {
+  if (env !== 'development' && !disableES3) {
     sourceTree = es3recast(sourceTree);
   }
 
@@ -678,7 +685,10 @@ var distTrees = [templateCompilerTree, compiledSource, compiledTests, testConfig
 if (env !== 'development') {
   distTrees.push(prodCompiledSource);
   distTrees.push(prodCompiledTests);
-  distTrees.push(minCompiledSource);
+
+  if (!disableMin) {
+    distTrees.push(minCompiledSource);
+  }
   distTrees.push(buildRuntimeTree());
 }
 


### PR DESCRIPTION
```
DISABLE_ES3=true DISABLE_JSHINT=true DISABLE_MIN=true ember serve --environment=production
```

Takes initial production build time from 70s to 21s, and rebuilds from 6s to 2s.

``` bash
% DISABLE_ES3=true DISABLE_JSHINT=true DISABLE_MIN=true ember serve --environment=production
version: 0.0.46
Livereload server on port 35729
Serving on http://0.0.0.0:4200

Build successful - 21433ms.

Slowest Trees                  | Total
-------------------------------+----------------
DefeatureifyFilter             | 4363ms
DefeatureifyFilter             | 4308ms
TranspilerFilter               | 2773ms
TranspilerFilter               | 2001ms
DefeatureifyFilter             | 1860ms
DefeatureifyFilter             | 1644ms

file changed main.js

Build successful - 2355ms.

Slowest Trees                  | Total
-------------------------------+----------------
ReplaceFilter                  | 159ms
DefeatureifyFilter             | 119ms
```

@stefanpenner - Your wish is my command. ;)
