### PR TITLE
[WIP] Add an assertion when watched props are are written to without Em.set.

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -81,6 +81,10 @@ var get = function get(obj, keyName) {
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       if (hasPropertyAccessors && meta && meta.watching[keyName] > 0) {
         ret = meta.values[keyName];
+
+        if (ret === undefined && keyName in obj && !(keyName in meta.values)) {
+          Ember.assert('You must use Ember.set to set `' + keyName + '` (on `' + obj + '`).');
+        }
       } else {
         ret = obj[keyName];
       }

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -32,6 +32,22 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
     }, 'You must use Ember.set() to set the `someProp` property (of custom-object) to `foo-bar`.');
   });
 
+  test('should assert if get a watched property (not on the prototype) that is not set by Ember.set', function() {
+    var obj = {
+      toString: function() {
+        return 'custom-object';
+      }
+    };
+
+    watch(obj, 'someProp');
+
+    obj.someProp = 'foo-bar';
+
+    expectAssertion(function() {
+      get(obj, 'someProp');
+    }, 'You must use Ember.set to set `someProp` (on `custom-object`).');
+  });
+
   test('should not assert if set with Ember.set when property is being watched', function() {
     var obj = {
       someProp: null,
@@ -45,6 +61,20 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
 
     equal(get(obj, 'someProp'), 'foo-bar');
   });
+
+  test('prints a helpful assertion if a watched property (not present at watch time) was not set with Ember.set', function() {
+    var obj = {
+      toString: function() {
+        return 'custom-object';
+      }
+    };
+
+    watch(obj, 'someProp');
+    obj.someProp = 'blastix';
+
+    equal(get(obj, 'someProp'), 'blastix');
+  });
+
 } else {
   test('does not assert', function() {
     var obj = {


### PR DESCRIPTION
If a property that is being watched (but was not available on the object at the time the watching was setup) is set directly (without `Ember.set`), no assertion will be fired and any `Ember.get`'s on that property will return `undefined` (see [explanation](https://github.com/emberjs/ember.js/issues/9387#issuecomment-60487275)). This PR adds an assertion to provide a path forward (basically use `Ember.set`).

Closes #9387.

This is still a WIP, as it fails a [single test](https://github.com/rwjblue/ember.js/blob/provide-assertion-when-setting-watched-property/packages/ember-runtime/tests/system/object/destroy_test.js#L75) that is actually relying on this behavior (setting a plain prop). Would love input on that test to see if it is possible to maintain its intent while refactoring to allow this PR/assertion.
