### PR TITLE
[BUGFIX beta] IE9 Fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
     "router.js": "https://github.com/tildeio/router.js.git#f7b4b11543222c52d91df861544592a8c1dcea8a",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
-    "htmlbars": "https://github.com/tildeio/htmlbars.git#a3e2369f1859f4993a9b64a80d50556ef2ebe246",
+    "htmlbars": "https://github.com/tildeio/htmlbars.git#87c7635744aa258c05bb88a432a69dd88ecb6f57",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be"
   }
 }

--- a/packages/ember-handlebars/tests/controls/select_test.js
+++ b/packages/ember-handlebars/tests/controls/select_test.js
@@ -61,29 +61,29 @@ test("should begin required if the required attribute is true", function() {
   select.set('required', true);
   append();
 
-  equal(select.$().attr('required'), 'required');
+  ok(select.element.required, 'required property is truthy');
 });
 
 test("should become required if the required attribute is changed", function() {
   append();
-  equal(select.$().attr('required'), undefined);
+  ok(!select.element.required, 'required property is falsy');
 
   run(function() { select.set('required', true); });
-  equal(select.$().attr('required'), 'required');
+  ok(select.element.required, 'required property is truthy');
 
   run(function() { select.set('required', false); });
-  equal(select.$().attr('required'), undefined);
+  ok(!select.element.required, 'required property is falsy');
 });
 
 test("should become disabled if the disabled attribute is changed", function() {
   append();
-  ok(select.$().is(":not(:disabled)"));
+  ok(!select.element.disabled, 'disabled property is falsy');
 
   run(function() { select.set('disabled', true); });
-  ok(select.$().is(":disabled"));
+  ok(select.element.disabled, 'disabled property is truthy');
 
   run(function() { select.set('disabled', false); });
-  ok(select.$().is(":not(:disabled)"));
+  ok(!select.element.disabled, 'disabled property is falsy');
 });
 
 test("can have options", function() {

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -67,8 +67,10 @@ test("calls render and parses the buffer string in the right context", function(
 
   var elem = get(view, 'element');
   ok(elem, 'has element now');
-  equalHTML(elem.childNodes, '<script></script><tr><td>snorfblax</td></tr>', 'has innerHTML from context');
   equal(elem.tagName.toString().toLowerCase(), 'table', 'has tagName from view');
+  equal(elem.childNodes[0].tagName, 'SCRIPT', 'script tag first');
+  equal(elem.childNodes[1].tagName, 'TR', 'tr tag second');
+  equalHTML(elem.childNodes, '<script></script><tr><td>snorfblax</td></tr>', 'has innerHTML from context');
 });
 
 test("does not wrap many tr children in tbody elements", function() {


### PR DESCRIPTION
Bump HTMLBars to get some IE9 and FF fixes:

https://github.com/tildeio/htmlbars/pull/102

Additionally refactor a test in `create_element_test.js` to be easier to debug, and several tests in `select_test.js` to support assert against properties (instead of asserting jQuery behavior).
