### PR TITLE
Route query params configured by property name

### DIFF
--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -599,6 +599,31 @@ test("can opt into a replace query by specifying replace:true in the Router conf
   setAndFlush(appController, 'alex', 'wallace');
 });
 
+test("Route query params config can be configured using property name instead of URL key", function() {
+  expect(2);
+  App.ApplicationController = Ember.Controller.extend({
+    queryParams: [
+      {commitBy: "commit_by"}
+    ]
+  });
+
+  App.ApplicationRoute = Ember.Route.extend({
+    queryParams: {
+      commitBy: {
+        replace: true
+      }
+    }
+  });
+
+  bootApplication();
+
+  equal(router.get('location.path'), "");
+
+  var appController = container.lookup('controller:application');
+  expectedReplaceURL = "/?commit_by=igor_seb";
+  setAndFlush(appController, 'commitBy', 'igor_seb');
+});
+
 test("An explicit replace:false on a changed QP always wins and causes a pushState", function() {
   expect(3);
   App.ApplicationController = Ember.Controller.extend({


### PR DESCRIPTION
Route query params configuration currently requires using the URL form of the query param key instead of its property name as used in the model hook in the route and in the controller. This patch adds a fallback to the property name for query params configuration.
