### PR TITLE
[BUGFIX beta] Fix isEmpty for map

### DIFF
--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -25,8 +25,36 @@ import isNone from 'ember-metal/is_none';
   @return {Boolean}
 */
 function isEmpty(obj) {
-  return isNone(obj) || (obj.length === 0 && typeof obj !== 'function') ||
-    (typeof obj === 'object' && get(obj, 'length') === 0);
+  var none = isNone(obj);
+  if (none) {
+    return none;
+  }
+
+  if (typeof obj.size === 'number') {
+    return !obj.size;
+  }
+
+  var objectType = typeof obj;
+
+  if (objectType === 'object') {
+    var size = get(obj, 'size');
+    if (typeof size === 'number') {
+      return !size;
+    }
+  }
+
+  if (typeof obj.length === 'number' && objectType !== 'function') {
+    return !obj.length;
+  }
+
+  if (objectType === 'object') {
+    var length = get(obj, 'length');
+    if (typeof length === 'number') {
+      return !length;
+    }
+  }
+
+  return false;
 }
 
 var empty = Ember.deprecateFunc("Ember.empty is deprecated. Please use Ember.isEmpty instead.", isEmpty);

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -1,4 +1,8 @@
 import isEmpty from 'ember-metal/is_empty';
+import {
+  Map,
+  OrderedSet
+} from 'ember-metal/map';
 
 QUnit.module("Ember.isEmpty");
 
@@ -18,4 +22,18 @@ test("Ember.isEmpty", function() {
   equal(true,  isEmpty([]),        "for an empty Array");
   equal(false, isEmpty({}),        "for an empty Object");
   equal(true,  isEmpty(object),     "for an Object that has zero 'length'");
+});
+
+test("Ember.isEmpty Ember.Map", function() {
+  var map = new Map();
+  equal(true, isEmpty(map), "Empty map is empty");
+  map.set('foo', 'bar');
+  equal(false, isEmpty(map), "Map is not empty");
+});
+
+test("Ember.isEmpty Ember.OrderedSet", function() {
+  var orderedSet = new OrderedSet();
+  equal(true, isEmpty(orderedSet), "Empty ordered set is empty");
+  orderedSet.add('foo');
+  equal(false, isEmpty(orderedSet), "Ordered set is not empty");
 });


### PR DESCRIPTION
Fixes #9412 (`isEmpty` raises a deprecation in beta), with the cost of far more complexity in `isEmpty`. Tried to avoid `typeof` calls as much as possible.

@stefanpenner for you.
