### PR TITLE
[BUGFIX release] Throws an assertion if `classNameBindings` are specified on a tag-less view

### DIFF
--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -1,3 +1,4 @@
+import Ember from "ember-metal/core";
 import Renderer from 'ember-metal-views/renderer';
 import { create } from 'ember-metal/platform';
 import renderBuffer from "ember-views/system/render_buffer";
@@ -34,9 +35,14 @@ EmberRenderer.prototype.createElement =
     // provided buffer operation (for example, `insertAfter` will
     // insert a new buffer after the "parent buffer").
     var tagName = view.tagName;
+    var classNameBindings = view.classNameBindings;
+    var taglessViewWithClassBindings = tagName === '' && classNameBindings.length > 0;
+
     if (tagName === null || tagName === undefined) {
       tagName = 'div';
     }
+
+    Ember.assert('You cannot use `classNameBindings` on a tag-less view: ' + view.toString(), !taglessViewWithClassBindings);
 
     var buffer = view.buffer = this.buffer;
     buffer.reset(tagName, contextualElement);
@@ -45,7 +51,7 @@ EmberRenderer.prototype.createElement =
       view.beforeRender(buffer);
     }
 
-    if (view.tagName !== '') {
+    if (tagName !== '') {
       if (view.applyAttributesToBuffer) {
         view.applyAttributesToBuffer(buffer);
       }

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -26,6 +26,22 @@ test("returns the receiver", function() {
   equal(ret, view, 'returns receiver');
 });
 
+test('should assert if `tagName` is an empty string and `classNameBindings` are specified', function() {
+  expect(1);
+
+  view = EmberView.create({
+    tagName: '',
+    foo: true,
+    classNameBindings: ['foo:is-foo:is-bar']
+  });
+
+  expectAssertion(function(){
+    run(function(){
+      view.createElement();
+    });
+  }, /You cannot use `classNameBindings` on a tag-less view/);
+});
+
 test("calls render and turns resultant string into element", function() {
   view = EmberView.create({
     tagName: 'span',


### PR DESCRIPTION
Fixes #9418
