### PR TITLE
[BUGFIX release] attributeBinding on class triggers assertion.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1202,6 +1202,8 @@ var View = CoreView.extend({
       var property = split[0];
       var attributeName = split[1] || property;
 
+      Ember.assert('You cannot use class as an attributeBinding, use classNameBindings instead.', attributeName !== 'class');
+
       if (property in this) {
         this._setupAttributeBindingObservation(property, attributeName);
 

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -291,3 +291,13 @@ test("attributeBindings should not fail if view has been destroyed", function() 
   }
   ok(!error, error);
 });
+
+test("asserts if an attributeBinding is setup on class", function() {
+  view = EmberView.create({
+    attributeBindings: ['class']
+  });
+
+  expectAssertion(function() {
+    appendView();
+  }, 'You cannot use class as an attributeBinding, use classNameBindings instead.');
+});


### PR DESCRIPTION
Using `attributeBinding: ['class']` will render your view unable to handle DOM events (`EventDispatcher` uses `.ember-view` class for events), `classNameBindings` is the more appropriate place to do this.

Closes #9424.
