### PR TITLE
[DOC release] Minor route template render doc change

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1649,7 +1649,7 @@ var Route = EmberObject.extend(ActionHandler, {
     // posts route
     Ember.Route.extend({
       renderTemplate: function(){
-        this.render('posts', {
+        this.render('photos', {
           into: 'application',
           outlet: 'anOutletName'
         })


### PR DESCRIPTION
Docs said 

> You can render `photos.hbs` into the `"anOutletName"` outlet of `application.hbs` by calling `render`

But passed in the `posts` template. 
