### PR TITLE
Makes sure that `{{view}}` can take instance view as an argument

### DIFF
--- a/packages/ember-handlebars/lib/ext.js
+++ b/packages/ember-handlebars/lib/ext.js
@@ -211,8 +211,8 @@ function handlebarsGetView(context, path, container, options) {
   }
 
   Ember.assert(
-    fmt(path+" must be a subclass of Ember.View, not %@", [viewClass]),
-    View.detect(viewClass)
+    fmt(path+" must be a subclass or an instance of Ember.View, not %@", [viewClass]),
+    View.detect(viewClass) || View.detectInstance(viewClass)
   );
 
   return viewClass;

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -166,16 +166,22 @@ export var ViewHelper = EmberObject.create({
     var data = options.data;
     var fn   = options.fn;
     var newView;
+    var newViewProto;
 
     makeBindings(thisContext, options);
 
     var container = this.container || (data && data.view && data.view.container);
     newView = handlebarsGetView(thisContext, path, container, options);
 
+    if (View.detectInstance(newView)) {
+      newViewProto = newView;
+    } else {
+      newViewProto = newView.proto();
+    }
+
     var viewOptions = this.propertiesFromHTMLOptions(options, thisContext);
     var currentView = data.view;
     viewOptions.templateData = data;
-    var newViewProto = newView.proto();
 
     if (fn) {
       Ember.assert("You cannot provide a template block if you also specified a templateName", !get(viewOptions, 'templateName') && !get(newViewProto, 'templateName'));

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1211,6 +1211,108 @@ test("{{view}} id attribute should set id on layer", function() {
   equal(view.$('#bar').text(), 'baz', "emits content");
 });
 
+test("{{view}} should be able to point to a local instance of view", function() {
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view view.common}}"),
+
+    common: EmberView.create({
+      template: EmberHandlebars.compile("common")
+    })
+  });
+
+  appendView();
+
+  equal(view.$().text(), "common", "tries to look up view name locally");
+});
+
+test("{{view}} should be able to point to a local subclass of view", function() {
+  var MyView = EmberView.extend();
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view view.subclassed}}"),
+    subclassed: MyView.extend({
+      template: EmberHandlebars.compile("subclassed")
+    })
+  });
+
+  appendView();
+
+  equal(view.$().text(), "subclassed", "tries to look up view name locally");
+});
+
+test("{{view}} should be able to point to a local instance of subclass of view", function() {
+  var MyView = EmberView.extend();
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view view.subclassed}}"),
+    subclassed: MyView.create({
+      template: EmberHandlebars.compile("subclassed")
+    })
+  });
+
+  appendView();
+
+  equal(view.$().text(), "subclassed", "tries to look up view name locally");
+});
+
+test("{{view}} asserts that a view class is present", function() {
+  var MyView = EmberObject.extend();
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view view.notView}}"),
+    notView: MyView.extend({
+      template: EmberHandlebars.compile("notView")
+    })
+  });
+
+  expectAssertion(function(){
+    appendView();
+  }, /must be a subclass or an instance of Ember.View/);
+});
+
+test("{{view}} asserts that a view class is present off controller", function() {
+  var MyView = EmberObject.extend();
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view notView}}"),
+    controller: EmberObject.create({
+      notView: MyView.extend({
+        template: EmberHandlebars.compile("notView")
+      })
+    })
+  });
+
+  expectAssertion(function(){
+    appendView();
+  }, /must be a subclass or an instance of Ember.View/);
+});
+
+test("{{view}} asserts that a view instance is present", function() {
+  var MyView = EmberObject.extend();
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view view.notView}}"),
+    notView: MyView.create({
+      template: EmberHandlebars.compile("notView")
+    })
+  });
+
+  expectAssertion(function(){
+    appendView();
+  }, /must be a subclass or an instance of Ember.View/);
+});
+
+test("{{view}} asserts that a view subclass instance is present off controller", function() {
+  var MyView = EmberObject.extend();
+  view = EmberView.create({
+    template: EmberHandlebars.compile("{{view notView}}"),
+    controller: EmberObject.create({
+      notView: MyView.create({
+        template: EmberHandlebars.compile("notView")
+      })
+    })
+  });
+
+  expectAssertion(function(){
+    appendView();
+  }, /must be a subclass or an instance of Ember.View/);
+});
+
 test("{{view}} tag attribute should set tagName of the view", function() {
   container.register('template:foo', EmberHandlebars.compile('{{#view view.tagView tag="span"}}baz{{/view}}'));
 


### PR DESCRIPTION
Related to #9427
