### PR TITLE
[BUGFIX release] Remove 'use strict' for Ember.create usage in hotspots.

### DIFF
--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -1,3 +1,8 @@
+// Remove "use strict"; from transpiled module until
+// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
+//
+// REMOVE_USE_STRICT: true
+
 import {
   create as o_create
 } from "ember-metal/platform";

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -1,3 +1,8 @@
+// Remove "use strict"; from transpiled module until
+// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
+//
+// REMOVE_USE_STRICT: true
+
 /**
 @module ember-metal
 */

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -1,3 +1,8 @@
+// Remove "use strict"; from transpiled module until
+// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
+//
+// REMOVE_USE_STRICT: true
+
 /**
 @module ember
 @submodule ember-metal

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -1,3 +1,8 @@
+// Remove "use strict"; from transpiled module until
+// https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
+//
+// REMOVE_USE_STRICT: true
+
 import Ember from "ember-metal/core";
 import {
   defineProperty as o_defineProperty,


### PR DESCRIPTION
Closes #9441.
