### PR TITLE
[BUGFIX release] Add support for null prototype object to mandatory setter

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -21,6 +21,7 @@ import { Binding } from "ember-metal/binding";
 import { observersFor } from "ember-metal/observer";
 import TextField from "ember-handlebars/controls/text_field";
 import Container from "ember-runtime/system/container";
+import { create as o_create } from "ember-metal/platform";
 
 import htmlSafe from "ember-handlebars/string";
 
@@ -288,6 +289,24 @@ test("should read an escaped number value", function() {
     Ember.set(context, 'aNumber', 2);
   });
   equal(view.$().text(), '2');
+});
+
+test("should read from an Object.create(null)", function() {
+  // Use ember's polyfill for Object.create
+  var nullObject = o_create(null);
+  nullObject['foo'] = 'bar';
+  view = EmberView.create({
+    context: { nullObject: nullObject },
+    template: EmberHandlebars.compile('{{nullObject.foo}}')
+  });
+
+  appendView();
+  equal(view.$().text(), 'bar');
+
+  Ember.run(function(){
+    Ember.set(nullObject, 'foo', 'baz');
+  });
+  equal(view.$().text(), 'baz');
 });
 
 test("htmlSafe should return an instance of Handlebars.SafeString", function() {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -81,7 +81,10 @@ var set = function set(obj, keyName, value, tolerant) {
         propertyWillChange(obj, keyName);
         if (Ember.FEATURES.isEnabled('mandatory-setter')) {
           if (hasPropertyAccessors) {
-            if ((currentValue === undefined && !(keyName in obj)) || !obj.propertyIsEnumerable(keyName)) {
+            if (
+              (currentValue === undefined && !(keyName in obj)) ||
+              !Object.prototype.propertyIsEnumerable.call(obj, keyName)
+            ) {
               defineProperty(obj, keyName, null, value); // setup mandatory setter
             } else {
               meta.values[keyName] = value;

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -47,7 +47,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       m.values[keyName] = obj[keyName];
       o_defineProperty(obj, keyName, {
         configurable: true,
-        enumerable: obj.propertyIsEnumerable(keyName),
+        enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),
         set: MANDATORY_SETTER_FUNCTION(keyName),
         get: DEFAULT_GETTER_FUNCTION(keyName)
       });
@@ -72,7 +72,7 @@ export function unwatchKey(obj, keyName, meta) {
       if (hasPropertyAccessors && keyName in obj) {
         o_defineProperty(obj, keyName, {
           configurable: true,
-          enumerable: obj.propertyIsEnumerable(keyName),
+          enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),
           set: function(val) {
             // redefine to set as enumerable
             o_defineProperty(obj, keyName, {


### PR DESCRIPTION
Objects created with Object.create(null) do not have the method
propertyIsEnumerable. Mandatory setter expects this.

Here is choose to presume any object not having the detection method
would return true. This is inline with the output of:

```
var nullObject = Object.create(null);
nullObject['foo'] = 'bar';
Object.prototype.propertyIsEnumerable.call(nullObject, 'foo');
// ^ is true
```

Fixes #9433 (applied cleanly to master, I expect to stable too)
