### PR TITLE
[BUGFIX release] Fix htmlSafe to accept numbers

### DIFF
--- a/packages/ember-handlebars/lib/string.js
+++ b/packages/ember-handlebars/lib/string.js
@@ -16,6 +16,9 @@ import EmberStringUtils from "ember-runtime/system/string";
   @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
 */
 function htmlSafe(str) {
+  if (typeof str !== 'string') {
+    str = ''+str;
+  }
   return new Handlebars.SafeString(str);
 }
 

--- a/packages/ember-handlebars/lib/views/handlebars_bound_view.js
+++ b/packages/ember-handlebars/lib/views/handlebars_bound_view.js
@@ -16,6 +16,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
+import htmlSafe from "ember-handlebars/string";
 import {
   cloneStates,
   states as viewStates
@@ -62,7 +63,7 @@ SimpleHandlebarsView.prototype = {
     if (result === null || result === undefined) {
       result = "";
     } else if (!this.isEscaped && !(result instanceof EmberHandlebars.SafeString)) {
-      result = new EmberHandlebars.SafeString(result);
+      result = htmlSafe(result);
     }
 
     return result;

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -258,6 +258,38 @@ test("should read from a global-ish simple local path without deprecation", func
   equal(view.$().text(), 'Gwar');
 });
 
+test("should read a number value", function() {
+  var context = { aNumber: 1 };
+  view = EmberView.create({
+    context: context,
+    template: EmberHandlebars.compile('{{aNumber}}')
+  });
+
+  appendView();
+  equal(view.$().text(), '1');
+
+  Ember.run(function(){
+    Ember.set(context, 'aNumber', 2);
+  });
+  equal(view.$().text(), '2');
+});
+
+test("should read an escaped number value", function() {
+  var context = { aNumber: 1 };
+  view = EmberView.create({
+    context: context,
+    template: EmberHandlebars.compile('{{{aNumber}}}')
+  });
+
+  appendView();
+  equal(view.$().text(), '1');
+
+  Ember.run(function(){
+    Ember.set(context, 'aNumber', 2);
+  });
+  equal(view.$().text(), '2');
+});
+
 test("htmlSafe should return an instance of Handlebars.SafeString", function() {
   var safeString = htmlSafe("you need to be more <b>bold</b>");
 

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -507,6 +507,8 @@ _RenderBuffer.prototype = {
   */
   element: function() {
     var content = this.innerContent();
+    // No content means a text node buffer, with the content
+    // in _element. HandlebarsBoundView is an example.
     if (content === null)  {
       return this._element;
     }


### PR DESCRIPTION
Handlebars SafeString does not ensure unescaped strings are actually
strings. Morph expects that they are.

Convert content to a string before passing it to SafeString.

Fixes #9445 
