### PR TITLE
Fix jQuery dependency in component.json

### DIFF
--- a/config/package_manager_files/component.json
+++ b/config/package_manager_files/component.json
@@ -7,7 +7,7 @@
     "ember.js"
   ],
   "dependencies": {
-    "component/jquery": ">= 1.7.0 <= 2.1.0",
+    "components/jquery": ">= 1.7.0 <= 2.1.0",
     "components/handlebars.js": ">= 2.0.0 < 3.0.0"
   }
 }


### PR DESCRIPTION
The jQuery dependency in component.json is pointing at the [wrong repository](https://github.com/component/jquery). This causes component and duo to fail when they try to install `components/ember`. Changing the dependency from `component/jquery` to `components/jquery` fixes the problem.
