### PR TITLE
Fix publishing of canary builds.

### DIFF
--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -6,7 +6,7 @@ fileMap = function(revision,tag,date) {
     "ember-runtime.js":           fileObject("ember-runtime",           ".js",   "text/javascript",  revision, tag, date),
     "ember.min.js":               fileObject("ember.min",               ".js",   "text/javascript",  revision, tag, date),
     "ember.prod.js":              fileObject("ember.prod",              ".js",   "text/javascript",  revision, tag, date),
-    "../docs/build/data.json":    fileObject("ember-docs",              ".json", "application/json", revision, tag, date)
+//    "../docs/build/data.json":    fileObject("ember-docs",              ".json", "application/json", revision, tag, date)
   };
 };
 


### PR DESCRIPTION
Broken since #9384. This simply disables publishing of the YUIDoc data file so that auto-publishing of canary builds will continue.

Added https://github.com/emberjs/ember.js/issues/9450 to fix the underlying issue.
