### PR TITLE
[BUGFIX release] Prevent mandatory-setter assertion from classNames in Ember.View.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1031,6 +1031,16 @@ var View = CoreView.extend({
     }
   },
 
+  _setupClasses: function() {
+    var classNameBindings = this.classNameBindings;
+    Ember.assert("Only arrays are allowed for 'classNameBindings'", typeOf(classNameBindings) === 'array');
+    set(this, 'classNameBindings', emberA(classNameBindings.slice()));
+
+    var classNames = this.classNames;
+    Ember.assert("Only arrays are allowed for 'classNames'", typeOf(classNames) === 'array');
+    set(this, 'classNames', emberA(classNames.slice()));
+  },
+
   /**
     Called on your view when it should push strings of HTML into a
     `Ember.RenderBuffer`. Most users will want to override the `template`
@@ -1718,12 +1728,7 @@ var View = CoreView.extend({
     this._keywords._view = this;
     this._keywords.controller = new KeyStream(this, 'controller');
     this._setupKeywords();
-
-    Ember.assert("Only arrays are allowed for 'classNameBindings'", typeOf(this.classNameBindings) === 'array');
-    this.classNameBindings = emberA(this.classNameBindings.slice());
-
-    Ember.assert("Only arrays are allowed for 'classNames'", typeOf(this.classNames) === 'array');
-    this.classNames = emberA(this.classNames.slice());
+    this._setupClasses();
   },
 
   appendChild: function(view, options) {

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -12,9 +12,9 @@ QUnit.module("EmberView.create", {
     Ember.lookup = lookup = {};
   },
   teardown: function() {
-    run(function() {
-      view.destroy();
-    });
+    if (view) {
+      run(view, 'destroy');
+    }
 
     Ember.lookup = originalLookup;
   }
@@ -28,11 +28,9 @@ test("registers view in the global views hash using layerId for event targeted",
   equal(EmberView.views[get(view, 'elementId')], view, 'registers view');
 });
 
-QUnit.module("EmberView.createWithMixins");
-
 test("should warn if a non-array is used for classNames", function() {
   expectAssertion(function() {
-    EmberView.createWithMixins({
+    view = EmberView.createWithMixins({
       elementId: 'test',
       classNames: computed(function() {
         return ['className'];
@@ -43,11 +41,38 @@ test("should warn if a non-array is used for classNames", function() {
 
 test("should warn if a non-array is used for classNamesBindings", function() {
   expectAssertion(function() {
-    EmberView.createWithMixins({
+    view = EmberView.createWithMixins({
       elementId: 'test',
       classNameBindings: computed(function() {
         return ['className'];
       }).volatile()
     });
   }, /Only arrays are allowed/i);
+});
+
+test("setting classNameBindings does not trigger a mandatory-setter assertion", function() {
+  view = EmberView.create({
+    elementId: 'test',
+    classNameBindings: ['foo'],
+    foo: true
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  ok(view.$().hasClass('foo'), 'proper class was applied');
+});
+
+test("setting classNames does not trigger a mandatory-setter assertion", function() {
+  view = EmberView.create({
+    elementId: 'test',
+    classNames: ['foo']
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  ok(view.$().hasClass('foo'), 'proper class was applied');
 });


### PR DESCRIPTION
Failing JSBin: http://emberjs.jsbin.com/xibom/1/edit?html,js.
