### PR TITLE
[BUGFIX beta] Fix serialize *_id case. Closes #5594

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1427,8 +1427,12 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     var name = params[0];
     var object = {};
 
-    if (/_id$/.test(name) && params.length === 1) {
-      object[name] = get(model, "id");
+    if (params.length === 1) {
+      if (name in model) {
+        object[name] = get(model, name);
+      } else if (/_id$/.test(name)) {
+        object[name] = get(model, "id");
+      }
     } else {
       object = getProperties(model, params);
     }

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -194,6 +194,12 @@ test("returns model.id if params include *_id", function() {
   deepEqual(route.serialize(model, ['post_id']), { post_id: 2 }, "serialized correctly");
 });
 
+test("returns checks for existence of model.post_id before trying model.id", function() {
+  var model = { post_id: 3 };
+
+  deepEqual(route.serialize(model, ['post_id']), { post_id: 3 }, "serialized correctly");
+});
+
 test("returns undefined if model is not set", function() {
   equal(route.serialize(undefined, ['post_id']), undefined, "serialized correctly");
 });


### PR DESCRIPTION
This isn't perfect; technically it's still possible for someone to have defined an `unknownProperty` that returns a meaningful value for `post_id` even if `!('post_id' in model)`. But that seems really bizarre if anyone's doing that.
