### PR TITLE
Remove Ember.empty and Ember.none.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core"; // Ember.assert
 // var emberAssert = Ember.assert;
 
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import { bind } from "ember-handlebars/helpers/binding";
 
 /**

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -1,4 +1,3 @@
-import Ember from "ember-metal/core";
 import { set } from "ember-metal/property_set";
 import {
   meta,

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -3,7 +3,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { computed } from "ember-metal/computed";
 import isEmpty from 'ember-metal/is_empty';
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import alias from 'ember-metal/alias';
 
 /**

--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -1,4 +1,3 @@
-import Ember from 'ember-metal/core'; // deprecateFunc
 import { get } from 'ember-metal/property_get';
 import isNone from 'ember-metal/is_none';
 
@@ -57,10 +56,4 @@ function isEmpty(obj) {
   return false;
 }
 
-var empty = Ember.deprecateFunc("Ember.empty is deprecated. Please use Ember.isEmpty instead.", isEmpty);
-
 export default isEmpty;
-export {
-  isEmpty,
-  empty
-};

--- a/packages/ember-metal/lib/is_none.js
+++ b/packages/ember-metal/lib/is_none.js
@@ -1,5 +1,3 @@
-import Ember from 'ember-metal/core'; // deprecateFunc
-
 /**
   Returns true if the passed value is null or undefined. This avoids errors
   from JSLint complaining about use of ==, which can be technically
@@ -23,7 +21,4 @@ function isNone(obj) {
   return obj === null || obj === undefined;
 }
 
-export var none = Ember.deprecateFunc("Ember.none is deprecated. Please use Ember.isNone instead.", isNone);
-
 export default isNone;
-export { isNone };

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -161,14 +161,8 @@ import {
 } from "ember-metal/binding";
 import run from "ember-metal/run_loop";
 import libraries from "ember-metal/libraries";
-import {
-  isNone,
-  none
-} from 'ember-metal/is_none';
-import {
-  isEmpty,
-  empty
-} from 'ember-metal/is_empty';
+import isNone from 'ember-metal/is_none';
+import isEmpty from 'ember-metal/is_empty';
 import isBlank from 'ember-metal/is_blank';
 import isPresent from 'ember-metal/is_present';
 import keys from 'ember-metal/keys';
@@ -321,11 +315,7 @@ Ember.libraries = libraries;
 Ember.libraries.registerCoreLibrary('Ember', Ember.VERSION);
 
 Ember.isNone = isNone;
-Ember.none = none;
-
 Ember.isEmpty = isEmpty;
-Ember.empty = empty;
-
 Ember.isBlank = isBlank;
 
 if (Ember.FEATURES.isEnabled('ember-metal-is-present')) {

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -7,7 +7,7 @@ import {
   forEach,
   replace
 }from "ember-metal/enumerable_utils";
-import { isNone } from "ember-metal/is_none";
+import isNone from "ember-metal/is_none";
 import { computed } from "ember-metal/computed";
 import merge from "ember-metal/merge";
 import {

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -13,9 +13,7 @@ import {
   computed,
   cacheFor
 } from 'ember-metal/computed';
-import {
-  isNone
-} from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import Enumerable from 'ember-runtime/mixins/enumerable';
 import { map } from 'ember-metal/enumerable_utils';
 import {

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -27,7 +27,7 @@ import {
   observersFor
 } from "ember-metal/observer";
 import { cacheFor } from "ember-metal/computed";
-import { isNone } from "ember-metal/is_none";
+import isNone from "ember-metal/is_none";
 
 
 var slice = Array.prototype.slice;

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -7,7 +7,7 @@ import Ember from "ember-metal/core"; // Ember.isNone, Ember.A
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { guidFor } from "ember-metal/utils";
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import { fmt } from "ember-runtime/system/string";
 import CoreObject from "ember-runtime/system/core_object";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";

--- a/packages/ember-runtime/tests/core/is_empty_test.js
+++ b/packages/ember-runtime/tests/core/is_empty_test.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core";
-import {isEmpty} from 'ember-metal/is_empty';
+import isEmpty from 'ember-metal/is_empty';
 import ArrayProxy from "ember-runtime/system/array_proxy";
 
 QUnit.module("Ember.isEmpty");

--- a/packages/ember-runtime/tests/legacy_1x/system/set_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/set_test.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core";
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import Set from "ember-runtime/system/set";
 import EmberObject from 'ember-runtime/system/object';
 import EmberArray from "ember-runtime/mixins/array";

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -6,7 +6,7 @@ import Ember from "ember-metal/core"; // Ember.assert
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import run from "ember-metal/run_loop";
 import { typeOf } from "ember-metal/utils";
 import { fmt } from "ember-runtime/system/string";

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -6,7 +6,7 @@ import View from "ember-views/views/view";
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 
 import { computed } from "ember-metal/computed";
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -26,7 +26,7 @@ import {
   typeOf,
   isArray
 } from "ember-metal/utils";
-import { isNone } from 'ember-metal/is_none';
+import isNone from 'ember-metal/is_none';
 import { Mixin } from 'ember-metal/mixin';
 import { deprecateProperty } from "ember-metal/deprecate_property";
 import { A as emberA } from "ember-runtime/system/native_array";


### PR DESCRIPTION
These have been deprecated since before 1.0.0, and serve no purpose now.
