### PR TITLE
SelectView should work properly with optionValuePath and selection

### DIFF
--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -198,3 +198,90 @@ test("select element should correctly initialize and update selectedIndex and bo
     '    value=view.val}}'
   );
 });
+
+function testSelectionBinding(templateString) {
+  view = EmberView.create({
+    collection: Ember.A([{name: 'Wes', value: 'w'}, {name: 'Gordon', value: 'g'}]),
+    selection: {name: 'Gordon', value: 'g'},
+    selectView: SelectView,
+    template: compile(templateString)
+  });
+
+  runAppend(view);
+
+  var select = view.get('select');
+  var selectEl = select.$()[0];
+
+  equal(view.get('selection.value'), 'g', "Precond: Initial bound property is correct");
+  equal(select.get('selection.value'), 'g', "Precond: Initial selection is correct");
+  equal(selectEl.selectedIndex, 2, "Precond: The DOM reflects the correct selection");
+  equal(select.$('option:eq(2)').prop('selected'), true, "Precond: selected proprty is set to proper option");
+
+  select.$('option:eq(2)').removeAttr('selected');
+  select.$('option:eq(1)').prop('selected', true);
+  select.$().trigger('change');
+
+  equal(view.get('selection.value'), 'w', "Updated bound property is correct");
+  equal(select.get('selection.value'), 'w', "Updated selection is correct");
+  equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
+  equal(select.$('option:eq(1)').prop('selected'), true, "Selected proprty is set to proper option");
+}
+
+test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (old xBinding='' syntax)", function() {
+  testSelectionBinding(
+    '{{view view.selectView viewName="select"' +
+    '    contentBinding="view.collection"' +
+    '    optionLabelPath="content.name"' +
+    '    optionValuePath="content.value"' +
+    '    prompt="Please wait..."' +
+    '    selectionBinding="view.selection"}}'
+  );
+});
+
+test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (new quoteless binding shorthand)", function() {
+  testSelectionBinding(
+    '{{view view.selectView viewName="select"' +
+    '    content=view.collection' +
+    '    optionLabelPath="content.name"' +
+    '    optionValuePath="content.value"' +
+    '    prompt="Please wait..."' +
+    '    selection=view.selection}}'
+  );
+});
+
+test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding and optionValuePath with custom path", function() {
+  var templateString = '{{view view.selectView viewName="select"' +
+    '    content=view.collection' +
+    '    optionLabelPath="content.name"' +
+    '    optionValuePath="content.val"' +
+    '    prompt="Please wait..."' +
+    '    selection=view.selection}}';
+
+  view = EmberView.create({
+    collection: Ember.A([{name: 'Wes', val: 'w'}, {name: 'Gordon', val: 'g'}]),
+    selection: {name: 'Gordon', val: 'g'},
+    selectView: SelectView,
+    template: Ember.Handlebars.compile(templateString)
+  });
+
+  run(function() {
+    view.appendTo('#qunit-fixture');
+  });
+
+  var select = view.get('select');
+  var selectEl = select.$()[0];
+
+  equal(view.get('selection.val'), 'g', "Precond: Initial bound property is correct");
+  equal(select.get('selection.val'), 'g', "Precond: Initial selection is correct");
+  equal(selectEl.selectedIndex, 2, "Precond: The DOM reflects the correct selection");
+  equal(select.$('option:eq(1)').prop('selected'), false, "Precond: selected proprty is set to proper option");
+
+  select.$('option:eq(2)').removeAttr('selected');
+  select.$('option:eq(1)').prop('selected', true);
+  select.$().trigger('change');
+
+  equal(view.get('selection.val'), 'w', "Updated bound property is correct");
+  equal(select.get('selection.val'), 'w', "Updated selection is correct");
+  equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
+  equal(select.$('option:eq(1)').prop('selected'), true, "selected proprty is set to proper option");
+});

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -21,6 +21,7 @@ import { A as emberA } from "ember-runtime/system/native_array";
 import { observer } from "ember-metal/mixin";
 import { defineProperty } from "ember-metal/properties";
 import run from "ember-metal/run_loop";
+import { map } from "ember-metal/enumerable_utils";
 
 import htmlbarsTemplate from "ember-htmlbars/templates/select";
 
@@ -55,35 +56,25 @@ var SelectOption = View.extend({
   },
 
   selected: computed(function() {
-    var content = get(this, 'content');
+    var value = get(this, 'value');
     var selection = get(this, 'parentView.selection');
     if (get(this, 'parentView.multiple')) {
-      return selection && indexOf(selection, content.valueOf()) > -1;
+      return selection && indexOf(selection, value) > -1;
     } else {
       // Primitives get passed through bindings as objects... since
       // `new Number(4) !== 4`, we use `==` below
-      return content == selection; // jshint ignore:line
+      return value === get(this, 'parentView.value');
     }
   }).property('content', 'parentView.selection'),
 
   labelPathDidChange: observer('parentView.optionLabelPath', function() {
     var labelPath = get(this, 'parentView.optionLabelPath');
-
-    if (!labelPath) { return; }
-
-    defineProperty(this, 'label', computed(function() {
-      return get(this, labelPath);
-    }).property(labelPath));
+    defineProperty(this, 'label', computed.alias(labelPath));
   }),
 
   valuePathDidChange: observer('parentView.optionValuePath', function() {
     var valuePath = get(this, 'parentView.optionValuePath');
-
-    if (!valuePath) { return; }
-
-    defineProperty(this, 'value', computed(function() {
-      return get(this, valuePath);
-    }).property(valuePath));
+    defineProperty(this, 'value', computed.alias(valuePath));
   })
 });
 
@@ -429,11 +420,11 @@ var Select = View.extend({
     @type String
     @default null
   */
-  value: computed(function(key, value) {
+  value: computed('_valuePath', 'selection', function(key, value) {
     if (arguments.length === 2) { return value; }
-    var valuePath = get(this, 'optionValuePath').replace(/^content\.?/, '');
+    var valuePath = get(this, '_valuePath');
     return valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection');
-  }).property('selection'),
+  }),
 
   /**
     If given, a top-most dummy option will be rendered to serve as a user
@@ -595,31 +586,47 @@ var Select = View.extend({
   },
 
   _selectionDidChangeSingle: function() {
-    var content = get(this, 'content');
-    var selection = get(this, 'selection');
+    var value = get(this, 'value');
     var self = this;
-    if (selection && selection.then) {
-      selection.then(function(resolved) {
-        // Ensure that we don't overwrite a new selection
-        if (self.get('selection') === selection) {
-          self._setSelectionIndex(content, resolved);
+    if(value && value.then) {
+      value.then(function (resolved) {
+        // Ensure that we don't overwrite new value
+        if(get(self, 'value') === value) {
+          self._setSelectedIndex(resolved);
         }
       });
     } else {
-      this._setSelectionIndex(content, selection);
+      this._setSelectedIndex(value);
     }
   },
 
-  _setSelectionIndex: function(content, selection) {
+  _setSelectedIndex: function (selectionValue) {
     var el = get(this, 'element');
+    var content = get(this, 'contentValues');
     if (!el) { return; }
 
-    var selectionIndex = content ? indexOf(content, selection) : -1;
+    var selectionIndex = content.indexOf(selectionValue);
     var prompt = get(this, 'prompt');
 
     if (prompt) { selectionIndex += 1; }
     if (el) { el.selectedIndex = selectionIndex; }
   },
+
+  _valuePath: computed('optionValuePath', function () {
+    var optionValuePath = get(this, 'optionValuePath');
+    return optionValuePath.replace(/^content\.?/, '');
+  }),
+
+  contentValues: computed('content.[]', '_valuePath', function () {
+    var valuePath = get(this, '_valuePath');
+    var content = get(this, 'content') || [];
+
+    if (valuePath) {
+      return map(content, function (el) { return get(el, valuePath); });
+    } else {
+      return map(content, function (el) { return el; });
+    }
+  }),
 
   _selectionDidChangeMultiple: function() {
     var content = get(this, 'content');


### PR DESCRIPTION
SelectView was not working property when `optionValuePath` and `selection` properties were set. 
`selection` and `value` properties did not update, also `selected` attribute was not set on option tag. 

Typical use case in which SelectView content was bound to ember-data records array and selection was bound to some ember-data object fail to set Select into proper state. Example: http://emberjs.jsbin.com/zemomorunu/1/

This PR aims to improve SelectView so its content can be bound to array of any Ember objects.

TODO:
- support for `multiple=true`
