### PR TITLE
Deprecate setting ContainerView#childViews

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -2406,6 +2406,8 @@ test("should update bound values after the view is removed and then re-appended"
 });
 
 test("should update bound values after view's parent is removed and then re-appended", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   var controller = EmberObject.create();
 
   var parentView = ContainerView.create({

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember-metal/core'; // A, FEATURES, assert, TESTING_DEPRECATION
+import Ember from 'ember-metal/core'; // A, FEATURES, assert
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EventDispatcher from "ember-views/system/event_dispatcher";

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -198,6 +198,7 @@ var ContainerView = View.extend(MutableArray, {
     this._super();
 
     var childViews = get(this, 'childViews');
+    Ember.deprecate('Setting `childViews` on a Container is deprecated.', Ember.isEmpty(childViews));
 
     // redefine view's childViews property that was obliterated
     defineProperty(this, 'childViews', View.childViewsProperty);

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember-metal/core'; // A, FEATURES, assert, TESTING_DEPRECATION
+import Ember from 'ember-metal/core'; // A, FEATURES, assert
 import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -228,6 +228,7 @@ test("should dispatch events to nearest event manager", function() {
 });
 
 test("event manager should be able to re-dispatch events to view", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var receivedEvent=0;
   view = ContainerView.createWithMixins({

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -52,6 +52,8 @@ test("should be able to insert views after the DOM representation is created", f
 });
 
 test("should be able to observe properties that contain child views", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   run(function() {
     var Container = ContainerView.extend({
       childViews: ['displayView'],
@@ -663,6 +665,8 @@ test("should be able to modify childViews then rerender again the ContainerView 
 });
 
 test("should invalidate `element` on itself and childViews when being rendered by ensureChildrenAreInDOM", function () {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   var root = ContainerView.create();
 
   view = View.create({ template: function() {} });

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -150,6 +150,8 @@ test("destroy more forcibly removes the view", function() {
 
 QUnit.module("EmberView - append() and appendTo() in a view hierarchy", {
   setup: function() {
+    expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
     View = ContainerView.extend({
       childViews: ['child'],
       child: EmberView.extend({
@@ -197,6 +199,8 @@ test("should be added to the document body when calling append()", function() {
 
 QUnit.module("EmberView - removing views in a view hierarchy", {
   setup: function() {
+    expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
     willDestroyCalled = 0;
 
     view = ContainerView.create({

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -64,6 +64,8 @@ test("calls render and turns resultant string into element", function() {
 });
 
 test("calls render and parses the buffer string in the right context", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   view = ContainerView.create({
     tagName: 'table',
     childViews: [ EmberView.create({
@@ -90,6 +92,8 @@ test("calls render and parses the buffer string in the right context", function(
 });
 
 test("does not wrap many tr children in tbody elements", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   view = ContainerView.create({
     tagName: 'table',
     childViews: [
@@ -121,6 +125,8 @@ test("does not wrap many tr children in tbody elements", function() {
 });
 
 test("generated element include HTML from child views as well", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   view = ContainerView.create({
     childViews: [ EmberView.create({ elementId: "foo" })]
   });

--- a/packages/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages/ember-views/tests/views/view/destroy_element_test.js
@@ -29,6 +29,8 @@ test("if it has no element, does nothing", function() {
 });
 
 test("if it has a element, calls willDestroyElement on receiver and child views then deletes the element", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   var parentCount = 0;
   var childCount = 0;
 

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -23,6 +23,8 @@ test("returns null if the view has no element and no parent view", function() {
 });
 
 test("returns null if the view has no element and parent view has no element", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   parentView = ContainerView.create({
     childViews: [ EmberView.extend() ]
   });

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -8,33 +8,6 @@ var View, view, parentBecameVisible, childBecameVisible, grandchildBecameVisible
 var parentBecameHidden, childBecameHidden, grandchildBecameHidden;
 
 QUnit.module("EmberView#isVisible", {
-  setup: function() {
-    parentBecameVisible=0;
-    childBecameVisible=0;
-    grandchildBecameVisible=0;
-    parentBecameHidden=0;
-    childBecameHidden=0;
-    grandchildBecameHidden=0;
-
-    View = ContainerView.extend({
-      childViews: ['child'],
-      becameVisible: function() { parentBecameVisible++; },
-      becameHidden: function() { parentBecameHidden++; },
-
-      child: ContainerView.extend({
-        childViews: ['grandchild'],
-        becameVisible: function() { childBecameVisible++; },
-        becameHidden: function() { childBecameHidden++; },
-
-        grandchild: EmberView.extend({
-          template: function() { return "seems weird bro"; },
-          becameVisible: function() { grandchildBecameVisible++; },
-          becameHidden: function() { grandchildBecameHidden++; }
-        })
-      })
-    });
-  },
-
   teardown: function() {
     if (view) {
       run(function() { view.destroy(); });
@@ -95,6 +68,43 @@ test("should hide element if isVisible is false before element is created", func
   run(function() {
     view.remove();
   });
+});
+
+QUnit.module("EmberView#isVisible with Container", {
+  setup: function() {
+    expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
+    parentBecameVisible=0;
+    childBecameVisible=0;
+    grandchildBecameVisible=0;
+    parentBecameHidden=0;
+    childBecameHidden=0;
+    grandchildBecameHidden=0;
+
+    View = ContainerView.extend({
+      childViews: ['child'],
+      becameVisible: function() { parentBecameVisible++; },
+      becameHidden: function() { parentBecameHidden++; },
+
+      child: ContainerView.extend({
+        childViews: ['grandchild'],
+        becameVisible: function() { childBecameVisible++; },
+        becameHidden: function() { childBecameHidden++; },
+
+        grandchild: EmberView.extend({
+          template: function() { return "seems weird bro"; },
+          becameVisible: function() { grandchildBecameVisible++; },
+          becameHidden: function() { grandchildBecameHidden++; }
+        })
+      })
+    });
+  },
+
+  teardown: function() {
+    if (view) {
+      run(function() { view.destroy(); });
+    }
+  }
 });
 
 test("view should be notified after isVisible is set to false and the element has been hidden", function() {

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -12,6 +12,8 @@ import ContainerView from "ember-views/views/container_view";
 var parentView, child;
 QUnit.module("View#removeChild", {
   setup: function() {
+    expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
     parentView = ContainerView.create({ childViews: [View] });
     child = get(parentView, 'childViews').objectAt(0);
   },
@@ -45,6 +47,8 @@ test("sets parentView property to null", function() {
 var view, childViews;
 QUnit.module("View#removeAllChildren", {
   setup: function() {
+    expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
     view = ContainerView.create({
       childViews: [View, View, View]
     });
@@ -83,6 +87,8 @@ QUnit.module("View#removeFromParent", {
 });
 
 test("removes view from parent view", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   parentView = ContainerView.create({ childViews: [View] });
   child = get(parentView, 'childViews').objectAt(0);
   ok(get(child, 'parentView'), 'precond - has parentView');
@@ -103,6 +109,8 @@ test("removes view from parent view", function() {
 });
 
 test("returns receiver", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   parentView = ContainerView.create({ childViews: [View] });
   child = get(parentView, 'childViews').objectAt(0);
   var removed = run(function() {

--- a/packages/ember-views/tests/views/view/render_test.js
+++ b/packages/ember-views/tests/views/view/render_test.js
@@ -18,6 +18,8 @@ QUnit.module("EmberView#render", {
 });
 
 test("default implementation does not render child views", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   var rendered = 0;
   var parentRendered = 0;
 
@@ -47,6 +49,8 @@ test("default implementation does not render child views", function() {
 });
 
 test("should invoke renderChildViews if layer is destroyed then re-rendered", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   var rendered = 0;
   var parentRendered = 0;
 
@@ -88,6 +92,8 @@ test("should invoke renderChildViews if layer is destroyed then re-rendered", fu
 });
 
 test("should render child views with a different tagName", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   view = ContainerView.create({
     childViews: ["child"],
 
@@ -114,6 +120,7 @@ test("should add ember-view to views", function() {
 });
 
 test("should allow hX tags as tagName", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.create({
     childViews: ["child"],
@@ -166,6 +173,8 @@ test("should re-render if the context is changed", function() {
 });
 
 test("renders contained view with omitted start tag and parent view context", function() {
+  expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
   view = ContainerView.createWithMixins({
     tagName: 'table',
     childViews: ["row"],

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -73,6 +73,8 @@ test("should move the view to the inDOM state after replacing", function() {
 
 QUnit.module("EmberView - replaceIn() in a view hierarchy", {
   setup: function() {
+    expectDeprecation("Setting `childViews` on a Container is deprecated.");
+
     View = ContainerView.extend({
       childViews: ['child'],
       child: EmberView.extend({


### PR DESCRIPTION
We may want to clean up some of the usages in tests before merging.
