### PR TITLE
Allow all rejection types.

### DIFF
--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -42,7 +42,7 @@ RSVP.Promise.prototype.fail = function(callback, label){
 };
 
 RSVP.onerrorDefault = function (error) {
-  if (error instanceof Error) {
+  if (error && error.name !== 'TransitionAborted') {
     if (Ember.testing) {
       // ES6TODO: remove when possible
       if (!Test && Ember.__loader.registry[testModuleName]) {

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -108,3 +108,12 @@ test("given `Ember.testing = true`, correctly informs the test suite about async
     equal(asyncEnded, 2);
   });
 });
+
+test('TransitionAborted errors are not re-thrown', function() {
+  expect(1);
+  var fakeTransitionAbort = { name: 'TransitionAborted' };
+
+  run(RSVP, 'reject', fakeTransitionAbort);
+
+  ok(true, 'did not throw an error when dealing with TransitionAborted');
+});

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -244,6 +244,7 @@ test("should have content when isFulfilled is set", function() {
 });
 
 test("should have reason when isRejected is set", function() {
+  var error = new Error('Y U REJECT?!?');
   var deferred = EmberRSVP.defer();
 
   var proxy = ObjectPromiseProxy.create({
@@ -251,8 +252,12 @@ test("should have reason when isRejected is set", function() {
   });
 
   proxy.addObserver('isRejected', function() {
-    equal(get(proxy, 'reason'), true);
+    equal(get(proxy, 'reason'), error);
   });
 
-  run(deferred, 'reject', true);
+  try {
+    run(deferred, 'reject', error);
+  } catch(e) {
+    equal(e, error);
+  }
 });


### PR DESCRIPTION
In `RSVP.onerrorDefault` we only handled `instanceof Error`, but we really only care about ignoring `TransitionAborted` (because that is the only acceptable rejection).

This ensures that `String` errors are still handled by `RSVP.onerrorDefault`.
