### PR TITLE
[BUGFIX] Ensure Ember.A methods return an Ember.A

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -134,7 +134,29 @@ if (ignore.length > 0) {
 */
 var A = function(arr) {
   if (arr === undefined) { arr = []; }
-  return EmberArray.detect(arr) ? arr : NativeArray.apply(arr);
+
+  if (EmberArray.detect(arr)) {
+    return arr;
+  }
+
+  NativeArray.apply(arr);
+
+  var arrayReturners = ['sort', 'splice', 'concat', 'slice', 'filter', 'map'];
+
+  // make sure that native methods that return arrays are wrapped to return an Ember.A
+  forEach(arrayReturners, function (fn) {
+    if (!arr[fn]) {
+      return;
+    }
+
+    var nativeFn = arr[fn];
+
+    arr[fn] = function () {
+      return Ember.A(nativeFn.apply(this, arguments));
+    };
+  });
+
+  return arr;
 };
 
 /**

--- a/packages/ember-runtime/tests/system/native_array/return_test.js
+++ b/packages/ember-runtime/tests/system/native_array/return_test.js
@@ -1,0 +1,39 @@
+import EmberArray from 'ember-runtime/mixins/array';
+
+QUnit.module("NativeArray methods return an Array with the correct methods");
+
+test("concat returns a NativeArray", function () {
+    var returnedArray = Ember.A().concat();
+
+    ok(EmberArray.detect(returnedArray), "returned value should be an EmberArray");
+});
+
+test("filter returns a NativeArray", function () {
+    var returnedArray = Ember.A().filter(function () {});
+
+    ok(EmberArray.detect(returnedArray), "returned value should be an EmberArray");
+});
+
+test("map returns a NativeArray", function () {
+    var returnedArray = Ember.A().map(function () {});
+
+    ok(EmberArray.detect(returnedArray), "returned value should be an EmberArray");
+});
+
+test("slice returns a NativeArray", function () {
+    var returnedArray = Ember.A().slice();
+
+    ok(EmberArray.detect(returnedArray), "returned value should be an EmberArray");
+});
+
+test("sort returns a NativeArray", function () {
+    var returnedArray = Ember.A().sort();
+
+    ok(EmberArray.detect(returnedArray), "returned value should be an EmberArray");
+});
+
+test("splice returns a NativeArray", function () {
+    var returnedArray = Ember.A().splice();
+
+    ok(EmberArray.detect(returnedArray), "returned value should be an EmberArray");
+});


### PR DESCRIPTION
Closes #4921
- Wrap native methods that return arrays so that they return
  Ember.A.
