### PR TITLE
Add deprecation for old usages of cachable and readOnly in CPs

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -120,9 +120,11 @@ function ComputedProperty(func, opts) {
   this._suspended = undefined;
   this._meta = undefined;
 
-  this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : true;
+  Ember.deprecate("Passing opts.cacheable to the CP constructor is deprecated. Invoke `volatile()` on the CP instead.", !opts || !opts.hasOwnProperty('cacheable'));
+  this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : true;   // TODO: Set always to `true` once this deprecation is gone.
   this._dependentKeys = opts && opts.dependentKeys;
-  this._readOnly = opts && (opts.readOnly !== undefined || !!opts.readOnly) || false;
+  Ember.deprecate("Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. Yo can invoke `readOnly()` on the CP to change this.", !opts || !opts.hasOwnProperty('readOnly'));
+  this._readOnly = opts && (opts.readOnly !== undefined || !!opts.readOnly) || false; // TODO: Set always to `false` once this deprecation is gone.
 }
 
 ComputedProperty.prototype = new Descriptor();
@@ -143,8 +145,10 @@ var ComputedPropertyPrototype = ComputedProperty.prototype;
   @param {Boolean} aFlag optional set to `false` to disable caching
   @return {Ember.ComputedProperty} this
   @chainable
+  @deprecated All computed properties are cacheble by default. Use `volatile()` instead to opt-out to caching.
 */
 ComputedPropertyPrototype.cacheable = function(aFlag) {
+  Ember.deprecate('ComputedProperty.cacheable() is deprecated. All computed properties are cacheable by default.');
   this._cacheable = aFlag !== false;
   return this;
 };
@@ -166,7 +170,8 @@ ComputedPropertyPrototype.cacheable = function(aFlag) {
   @chainable
 */
 ComputedPropertyPrototype.volatile = function() {
-  return this.cacheable(false);
+  this._cacheable = false;
+  return this;
 };
 
 /**
@@ -190,7 +195,8 @@ ComputedPropertyPrototype.volatile = function() {
   @chainable
 */
 ComputedPropertyPrototype.readOnly = function(readOnly) {
-  this._readOnly = readOnly === undefined || !!readOnly;
+  Ember.deprecate('Passing arguments to ComputedProperty.readOnly() is deprecated.', arguments.length === 0);
+  this._readOnly = readOnly === undefined || !!readOnly; // Force to true once this deprecation is gone
   return this;
 };
 
@@ -502,7 +508,7 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
   The function should accept two parameters, key and value. If value is not
   undefined you should set the value first. In either case return the
   current value of the property.
-  
+
   A computed property defined in this way might look like this:
 
   ```js
@@ -518,7 +524,7 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
   var client = Person.create();
 
   client.get('fullName'); // 'Betty Jones'
-  
+
   client.set('lastName', 'Fuller');
   client.get('fullName'); // 'Betty Fuller'
   ```

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -26,7 +26,8 @@ function InjectedProperty(type, name) {
                  "instantiated via a container.", this.container);
 
     return this.container.lookup(type + ':' + (name || keyName));
-  }, { readOnly: true });
+  });
+  this.readOnly();
 }
 
 InjectedProperty.prototype = create(Descriptor.prototype);
@@ -37,6 +38,7 @@ var ComputedPropertyPrototype = ComputedProperty.prototype;
 InjectedPropertyPrototype._super$Constructor = ComputedProperty;
 
 InjectedPropertyPrototype.get = ComputedPropertyPrototype.get;
+InjectedPropertyPrototype.readOnly = ComputedPropertyPrototype.readOnly;
 
 InjectedPropertyPrototype.set = function(obj, keyName) {
   throw new EmberError("Cannot set injected property '" + keyName + "' on object: " + inspect(obj));

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -222,6 +222,32 @@ testBoth('modifying a cacheable property should update cache', function(get, set
   equal(count, 2, 'should not invoke again');
 });
 
+test('calling cacheable() on a computed property raises a deprecation', function(){
+  var cp = new ComputedProperty(function(){});
+  expectDeprecation(function(){
+    cp.cacheable();
+  }, 'ComputedProperty.cacheable() is deprecated. All computed properties are cacheable by default.');
+});
+
+test('passing cacheable in a the options to the CP constructor raises a deprecation', function(){
+  expectDeprecation(function(){
+    new ComputedProperty(function(){}, { cacheable: true });
+  }, "Passing opts.cacheable to the CP constructor is deprecated. Invoke `volatile()` on the CP instead.");
+});
+
+test('calling readOnly() on a computed property with arguments raises a deprecation', function(){
+  var cp = new ComputedProperty(function(){});
+  expectDeprecation(function(){
+    cp.readOnly(true);
+  }, 'Passing arguments to ComputedProperty.readOnly() is deprecated.');
+});
+
+test('passing readOnly in a the options to the CP constructor raises a deprecation', function(){
+  expectDeprecation(function(){
+    new ComputedProperty(function(){}, { readOnly: false });
+  }, "Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. Yo can invoke `readOnly()` on the CP to change this.");
+});
+
 testBoth('inherited property should not pick up cache', function(get, set) {
   var objB = create(obj);
 

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -476,13 +476,13 @@ function ReduceComputedProperty(options) {
 
   this.options = options;
   this._dependentKeys = null;
+  this._cacheable = true;
   // A map of dependentKey -> [itemProperty, ...] that tracks what properties of
   // items in the array we must track to update this property.
   this._itemPropertyKeys = {};
   this._previousItemPropertyKeys = {};
 
   this.readOnly();
-  this.cacheable();
 
   this.recomputeOnce = function(propertyName) {
     // What we really want to do is coalesce by <cp, propertyName>.


### PR DESCRIPTION
- Passing opts.cacheable to the constructor of ComputedProperty is deprecated
- Passing opts.readOnly to the constructor of ComputedProperty is deprecated
- Invoking `cacheable` in a computed property is preprecated.
- Invoking `readOnly` with aany params in a computed property is deprecated.

-- UPDATE --

After reading #9290 and https://github.com/emberjs/rfcs/pull/12, seems that this PR is the first step to make CP read only by default.

Steps done in this PR:
- [x] Raise deprecation warnings when passing `cacheable` or `readOnly` to the constructor. No extrictly necessary, but is not used anywhere in the code since 2012 and simplifies things.
- [x] Deprecate usage of `cacheable()` and `readOnly()`. Are the default.

Steps pending:
- [ ] Modify CPs to work internally with setter and getters. A way of doing that gracefully without people even noticing it could be count the arity of the function passed to `Ember.computed`. If is arity <=1, create only a setter. If has arity > 1, assign the same function to getter and setter. Passing an object also works. No deprecations yet.
- [ ] Deprecate passing functions with arity > 1. Recommend user `{get, set}` instead.
- [ ] Implement logic in this RFC: Create `writable` and/or `overridable` and determina default values as explained in the code example above.
- [ ] Deprecate all the things!
- [ ] Ember 2.0. Delete all the things!

This steps don't need to happen in this PR. I fact I would merge things one step at a time.
