### PR TITLE
fix reduce computed

### DIFF
--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -10,27 +10,7 @@ import EmberError from 'ember-metal/error';
 var a_slice = [].slice;
 
 function ArrayComputedProperty() {
-  var cp = this;
-
   ReduceComputedProperty.apply(this, arguments);
-
-  this.func = (function(reduceFunc) {
-    return function (propertyName) {
-      if (!cp._hasInstanceMeta(this, propertyName)) {
-        // When we recompute an array computed property, we need already
-        // retrieved arrays to be updated; we can't simply empty the cache and
-        // hope the array is re-retrieved.
-        forEach(cp._dependentKeys, function(dependentKey) {
-          addObserver(this, dependentKey, function() {
-            cp.recomputeOnce.call(this, propertyName);
-          });
-        }, this);
-      }
-
-      return reduceFunc.apply(this, arguments);
-    };
-  })(this.func);
-
   return this;
 }
 

--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -2,9 +2,7 @@ import Ember from 'ember-metal/core';
 import {
   ReduceComputedProperty
 } from 'ember-runtime/computed/reduce_computed';
-import { forEach } from 'ember-metal/enumerable_utils';
 import { create as o_create } from 'ember-metal/platform';
-import { addObserver } from 'ember-metal/observer';
 import EmberError from 'ember-metal/error';
 
 var a_slice = [].slice;

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -550,7 +550,7 @@ function ReduceComputedProperty(options) {
       }, this);
       recompute.call(this, propertyName);
     }
-    if(cp._instanceMeta(this, propertyName).value == undefined){
+    if(cp._instanceMeta(this, propertyName).value === undefined){
       recompute.call(this, propertyName);
     }
     return cp._instanceMeta(this, propertyName).getValue();

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -550,6 +550,9 @@ function ReduceComputedProperty(options) {
       }, this);
       recompute.call(this, propertyName);
     }
+    if(cp._instanceMeta(this, propertyName).value == undefined){
+      recompute.call(this, propertyName);
+    }
     return cp._instanceMeta(this, propertyName).getValue();
  };
 }

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -555,7 +555,8 @@ function ReduceComputedProperty(options) {
       recompute.call(this, propertyName);
     }
     return cp._instanceMeta(this, propertyName).getValue();
- }
+ };
+}
 
 ReduceComputedProperty.prototype = o_create(ComputedProperty.prototype);
 

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -17,8 +17,7 @@ import {
   removeBeforeObserver
 } from 'ember-metal/observer';
 import {
-  ComputedProperty,
-  cacheFor
+  ComputedProperty
 } from 'ember-metal/computed';
 import { create as o_create } from 'ember-metal/platform';
 import { forEach } from 'ember-metal/enumerable_utils';
@@ -27,9 +26,6 @@ import EmberArray from 'ember-runtime/mixins/array';
 import run from 'ember-metal/run_loop';
 import { isArray } from 'ember-metal/utils';
 
-var cacheSet = cacheFor.set;
-var cacheGet = cacheFor.get;
-var cacheRemove = cacheFor.remove;
 var a_slice = [].slice;
 // Here we explicitly don't allow `@each.foo`; it would require some special
 // testing, but there's no particular reason why it should be disallowed.

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -620,9 +620,11 @@ QUnit.module('arrayComputed - changeMeta property observers', {
         itemsN: arrayComputed('items.@each.n', {
           addedItem: function (array, item, changeMeta, instanceMeta) {
             callbackItems.push('add:' + changeMeta.index + ":" + get(changeMeta.item, 'n'));
+            return array;
           },
           removedItem: function (array, item, changeMeta, instanceMeta) {
             callbackItems.push('remove:' + changeMeta.index + ":" + get(changeMeta.item, 'n'));
+            return array;
           }
         })
       });
@@ -720,9 +722,11 @@ test("changeMeta includes changedCount and arrayChanged", function() {
     lettersArrayComputed: arrayComputed('letters', {
       addedItem: function (array, item, changeMeta, instanceMeta) {
         callbackItems.push('add:' + changeMeta.changedCount + ":" + changeMeta.arrayChanged.join(''));
+        return array;
       },
       removedItem: function (array, item, changeMeta, instanceMeta) {
         callbackItems.push('remove:' + changeMeta.changedCount + ":" + changeMeta.arrayChanged.join(''));
+        return array;
       }
     })
   });


### PR DESCRIPTION
This fixes computed properties that depend on other computed properties.
issue: https://github.com/emberjs/ember.js/issues/4941
Maybe would fix other issues.
Or introduce more... didnt run the tests yet.

From what i saw through debugging is that `cacheSet` only works if `propertyDidChange` is not called. It will just be set to `undefined` when calling `propertyDidChange`

also fixes: #9313
http://emberjs.jsbin.com/hotilafamu/1/edit?html,css,js,console,output

I've made a gist with the fixed code, it can be included in jsbins to test:
https://rawgit.com/patricklx/641946978a1e3bac833d/raw/6f0d5e84db8a5b04939b30350e211e071a378485/reduced-computed-fix.js

currenly there are some problems related to changeMeta
