### PR TITLE
Minor cleanup in ChainNode.unchain.

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -231,10 +231,10 @@ ChainNodePrototype.unchain = function(key, path) {
   var node = chains[key];
 
   // unchain rest of path first...
-  if (path && path.length>1) {
-    key  = firstKey(path);
-    path = path.slice(key.length+1);
-    node.unchain(key, path);
+  if (path && path.length > 1) {
+    var nextKey  = firstKey(path);
+    var nextPath = path.slice(nextKey.length + 1);
+    node.unchain(nextKey, nextPath);
   }
 
   // delete node if needed.


### PR DESCRIPTION
Do not reassign passed in variable. Makes debugging quite painful.
