### PR TITLE
Split up single line functions in Ember.Route.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1988,11 +1988,15 @@ function appendView(route, view, options) {
 }
 
 function generateTopLevelTeardown(view) {
-  return function() { view.destroy(); };
+  return function() {
+    view.destroy();
+  };
 }
 
 function generateOutletTeardown(parentView, outlet) {
-  return function() { parentView.disconnectOutlet(outlet); };
+  return function() {
+    parentView.disconnectOutlet(outlet);
+  };
 }
 
 function getFullQueryParams(router, state) {


### PR DESCRIPTION
Makes debugging much easier (allows you to put a breakpoint on the actual body of the function).
