### PR TITLE
Make the action helper examples syntax hilight correctly.

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/action.js
+++ b/packages/ember-routing-handlebars/lib/helpers/action.js
@@ -140,7 +140,6 @@ ActionHelper.registerAction = function(actionNameOrStream, options, allowedKeys)
 };
 
 /**
-
   The `{{action}}` helper provides a useful shortcut for registering an HTML
   element within a template for a single DOM event and forwarding that
   interaction to the template's controller or specified `target` option.


### PR DESCRIPTION
Don't ask me why this works...
#### http://emberjs.com/api/classes/Ember.Handlebars.helpers.html#method_action
#### Before

![screen shot 2014-11-05 at 5 14 10 pm](https://cloud.githubusercontent.com/assets/54056/4927159/1fae5b52-6539-11e4-9937-e5a984fb65ae.png)
#### After

![screen shot 2014-11-05 at 5 07 07 pm](https://cloud.githubusercontent.com/assets/54056/4927161/22445ec0-6539-11e4-8467-a009845b5133.png)
