### PR TITLE
Serve documentation live from /docs endpont (optional)

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -18,6 +18,7 @@ var useStrictRemover = require('broccoli-use-strict-remover');
 var derequire = require('broccoli-derequire');
 
 var getVersion = require('git-repo-version');
+var yuidocPlugin = require('ember-cli-yuidoc');
 
 // To create fast production builds (without ES3 support, minification, derequire, or JSHint)
 // run the following:
@@ -28,6 +29,7 @@ var env = process.env.EMBER_ENV || 'development';
 var disableJSHint = !!process.env.DISABLE_JSHINT || false;
 var disableES3    = !!process.env.DISABLE_ES3 || false;
 var disableMin    = !!process.env.DISABLE_MIN || false;
+var enableDocs    = !!process.env.ENABLE_DOCS || false;
 var disableDefeatureify;
 
 var disableDerequire = !!process.env.DISABLE_DEREQUIRE || false;
@@ -730,6 +732,11 @@ if (env !== 'development') {
 
 // merge distTrees and sub out version placeholders for distribution
 distTrees = mergeTrees(distTrees);
+
+if (enableDocs && process.argv[2] === "serve") {
+  distTrees = yuidocPlugin.addDocsToTree(distTrees);
+}
+
 distTrees = replace(distTrees, {
   files: [ '**/*.js', '**/*.json' ],
   patterns: [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chalk": "~0.4.0",
     "defeatureify": "~0.2.0",
     "ember-cli": "0.0.46",
-    "ember-cli-yuidoc": "0.1.1",
+    "ember-cli-yuidoc": "0.3.1",
     "ember-publisher": "0.0.6",
     "es6-module-transpiler": "~0.4.0",
     "express": "^4.5.0",


### PR DESCRIPTION
I've been using this in ember cpm for edit documentation quickly and see the result instantly. I liked it, maybe you too.

When you run `ENABLE_DOCS=true ember serve` you can access the documentation going to the `/docs` url in the browser. It watch for changes so its always up to date.

This is disabled by default. Since generating the documentation is an expensive task and most likely you don't want to add ~4s to each rebuild, you need enable it with an environment variable.

Usually in ember-cli apps just installing the addon `ember-cli-yuidoc` adds this behavior out of the box, but in this case it had to be invoked manually in the brocfile.
