### PR TITLE
[BUGFIX beta] Assert name property exists when registering an application initializer

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -929,6 +929,7 @@ Application.reopenClass({
 
     Ember.assert("The initializer '" + initializer.name + "' has already been registered", !this.initializers[initializer.name]);
     Ember.assert("An initializer cannot be registered without an initialize function", canInvoke(initializer, 'initialize'));
+    Ember.assert("An initializer cannot be registered without a name property", initializer.name !== undefined);
 
     this.initializers[initializer.name] = initializer;
   },

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -16,6 +16,23 @@ QUnit.module("Ember.Application initializers", {
   }
 });
 
+test("initializers require proper 'name' and 'initialize' properties", function() {
+  var MyApplication = Application.extend();
+
+  expectAssertion(function() {
+    run(function() {
+      MyApplication.initializer({name:'initializer'});
+    });
+  });
+
+  expectAssertion(function() {
+    run(function() {
+      MyApplication.initializer({initialize:Ember.K});
+    });
+  });
+
+});
+
 test("initializers can be registered in a specified order", function() {
   var order = [];
   var MyApplication = Application.extend();


### PR DESCRIPTION
otherwise if someone tries to register an unnamed initializer a cryptic exception gets raised [1]

[1] http://jsfiddle.net/vinilios/pk3r5x36/
