### PR TITLE
Use bind instead of apply in logger

### DIFF
--- a/packages/ember-metal/lib/logger.js
+++ b/packages/ember-metal/lib/logger.js
@@ -14,11 +14,9 @@ function consoleMethod(name) {
   var method = typeof consoleObj === 'object' ? consoleObj[name] : null;
 
   if (method) {
-    // Older IE doesn't support apply, but Chrome needs it
-    if (typeof method.apply === 'function') {
-      logToConsole = function() {
-        method.apply(consoleObj, arguments);
-      };
+    // Older IE doesn't support bind, but Chrome needs it
+    if (typeof method.bind === 'function') {
+      logToConsole = method.bind(consoleObj);
       logToConsole.displayName = 'console.' + name;
       return logToConsole;
     } else {

--- a/packages/ember-metal/lib/logger.js
+++ b/packages/ember-metal/lib/logger.js
@@ -19,6 +19,12 @@ function consoleMethod(name) {
       logToConsole = method.bind(consoleObj);
       logToConsole.displayName = 'console.' + name;
       return logToConsole;
+    } else if (typeof method.apply === 'function') {
+      logToConsole = function() {
+        method.apply(consoleObj, arguments);
+      };
+      logToConsole.displayName = 'console.' + name;
+      return logToConsole;
     } else {
       return function() {
         var message = Array.prototype.join.call(arguments, ', ');


### PR DESCRIPTION
This small change makes a difference to users of Chrome (and possibly other Webkit users). Under the old code, the "line number" for log messages reported in Chrome's console was always the line from this file, invoking `method.apply`. After this change, the line number matches the file and line where `Ember.Logger.method` was actually called, speeding diagnoses.

Tests all pass after this change.
