### PR TITLE
Publish test index.html for easier testing from S3.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -249,6 +249,45 @@ testConfig = replace(testConfig, {
   ]
 });
 
+var s3TestRunner = pickFiles(testConfig, {
+  srcDir: '/tests',
+  destDir: '/ember-tests',
+  files: ['index.html']
+});
+
+s3TestRunner = replace(s3TestRunner, {
+  files: ['ember-tests/index.html'],
+  patterns: [
+    { match: new RegExp('../ember', 'g'), replacement: './ember' },
+    { match: new RegExp('../qunit/qunit.css', 'g'), replacement: 'http://code.jquery.com/qunit/qunit-1.15.0.css' },
+    { match: new RegExp('../qunit/qunit.js', 'g'), replacement: 'http://code.jquery.com/qunit/qunit-1.15.0.js' },
+    { match: new RegExp('../handlebars/handlebars.js', 'g'), replacement: 'http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v2.0.0.js' },
+    { match: new RegExp('../jquery/jquery.js', 'g'), replacement: 'http://code.jquery.com/jquery-1.11.1.js'}
+  ]
+});
+
+testConfig = replace(testConfig, {
+  files: [ 'tests/index.html' ],
+  patterns: [
+    { match: /\{\{DEV_FEATURES\}\}/g,
+      replacement: function() {
+        var features = defeatureifyConfig().enabled;
+
+        return JSON.stringify(features);
+      }
+    },
+    { match: /\{\{PROD_FEATURES\}\}/g,
+      replacement: function() {
+        var features = defeatureifyConfig({
+          environment: 'production'
+        }).enabled;
+
+        return JSON.stringify(features);
+      }
+    },
+  ]
+});
+
 // List of bower component trees that require no special handling.  These will
 // be included in the distTrees for use within testsConfig/index.html
 var bowerFiles = [
@@ -727,6 +766,7 @@ var distTrees = [templateCompilerTree, compiledSource, compiledTests, testingCom
 // This ensures development build speed is not affected by unnecessary
 // minification and defeaturification
 if (env !== 'development') {
+  distTrees.push(s3TestRunner);
   distTrees.push(prodCompiledSource);
   distTrees.push(prodCompiledTests);
 

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,12 +1,13 @@
 fileMap = function(revision,tag,date) {
   return {
     "ember.js":                   fileObject("ember",                   ".js",   "text/javascript",  revision, tag, date),
-    "ember-tests.js":             fileObject("ember-test",              ".js",   "text/javascript",  revision, tag, date),
+    "ember-tests.js":             fileObject("ember-tests",             ".js",   "text/javascript",  revision, tag, date),
     "ember-template-compiler.js": fileObject("ember-template-compiler", ".js",   "text/javascript",  revision, tag, date),
     "ember-runtime.js":           fileObject("ember-runtime",           ".js",   "text/javascript",  revision, tag, date),
     "ember.min.js":               fileObject("ember.min",               ".js",   "text/javascript",  revision, tag, date),
     "ember.prod.js":              fileObject("ember.prod",              ".js",   "text/javascript",  revision, tag, date),
-    "../docs/data.json":          fileObject("ember-docs",              ".json", "application/json", revision, tag, date)
+    "../docs/data.json":          fileObject("ember-docs",              ".json", "application/json", revision, tag, date),
+    "ember-tests/index.html":     fileObject("ember-tests-index",       ".html", "text/html",        revision, tag, date)
   };
 };
 
@@ -16,7 +17,6 @@ function fileObject(baseName, extension, contentType, currentRevision, tag, date
     contentType: contentType,
       destinations: {
         canary: [
-          baseName + "-latest" + extension,
           "latest" + fullName,
           "canary" + fullName,
           "canary/daily/" + date + fullName,


### PR DESCRIPTION
Enables testing from the published S3 builds.  Sample output (tested with internal build publisher to confirm):

http://assets.rwjblue.com/canary/ember-test-index.html
