### PR TITLE
Remove QUnit option for `raiseonunhandleddeprecation`.

### DIFF
--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -75,10 +75,10 @@ function generateEachPackageTests() {
     if (packages[packageName].skipTests) { return; }
 
     testFunctions.push(function() {
-      return run('package=' + packageName + '&raiseonunhandleddeprecation=true');
+      return run('package=' + packageName);
     });
     testFunctions.push(function() {
-      return run('package=' + packageName + '&enableoptionalfeatures=true&raiseonunhandleddeprecation=true');
+      return run('package=' + packageName + '&enableoptionalfeatures=true');
     });
   });
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -56,8 +56,7 @@
         // Don't worry about jQuery version
         ENV['FORCE_JQUERY'] = true;
 
-        // Don't worry about jQuery version
-        ENV['RAISE_ON_DEPRECATION'] = !!QUnit.urlParams.raiseonunhandleddeprecation;
+        ENV['RAISE_ON_DEPRECATION'] = true;
       })();
     </script>
 
@@ -119,8 +118,6 @@
         QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features"});
         // Handle extending prototypes
         QUnit.config.urlConfig.push({ id: 'extendprototypes', label: 'Extend Prototypes'});
-        // Raise on unhandled deprecation
-        QUnit.config.urlConfig.push({ id: 'raiseonunhandleddeprecation', label: 'Raise on Deprecation'});
         // Handle JSHint
         QUnit.config.urlConfig.push('nojshint');
       })();


### PR DESCRIPTION
This is now required to pass Travis runs so it should just be enabled all the time internally.  It has been a point of confusion for some contributors (why do the tests pass locally but not on Travis).
