### PR TITLE
[DEPRECATION beta] Deprecate context switching form of {{each}}.

### DIFF
--- a/packages/ember-handlebars/lib/controls/select.js
+++ b/packages/ember-handlebars/lib/controls/select.js
@@ -335,7 +335,7 @@ var Select = View.extend({
 
   tagName: 'select',
   classNames: ['ember-select'],
-  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each view.groupedContent}}{{view view.groupView content=content label=label}}{{/each}}{{else}}{{#each view.content}}{{view view.optionView content=this}}{{/each}}{{/if}}'),
+  defaultTemplate: precompileTemplate('{{#if view.prompt}}<option value="">{{view.prompt}}</option>{{/if}}{{#if view.optionGroupPath}}{{#each group in view.groupedContent}}{{view view.groupView content=group.content label=group.label}}{{/each}}{{else}}{{#each item in view.content}}{{view view.optionView content=item}}{{/each}}{{/if}}'),
   attributeBindings: ['multiple', 'disabled', 'tabindex', 'name', 'required', 'autofocus',
                       'form', 'size'],
 

--- a/packages/ember-handlebars/lib/helpers/each.js
+++ b/packages/ember-handlebars/lib/helpers/each.js
@@ -122,21 +122,11 @@ var EachView = CollectionView.extend(_Metamorph, {
   of the base Handlebars `{{#each}}` helper.
 
   The default behavior of `{{#each}}` is to yield its inner block once for every
-  item in an array. Each yield will provide the item as the context of the block.
+  item in an array.
 
   ```javascript
   var developers = [{name: 'Yehuda'},{name: 'Tom'}, {name: 'Paul'}];
   ```
-
-  ```handlebars
-  {{#each developers}}
-    {{name}}
-    {{! `this` is each developer }}
-  {{/each}}
-  ```
-
-  `{{#each}}` supports an alternative syntax with element naming. This preserves
-  context of the yielded block:
 
   ```handlebars
   {{#each person in developers}}
@@ -153,8 +143,8 @@ var EachView = CollectionView.extend(_Metamorph, {
   ```
 
   ```handlebars
-  {{#each developerNames}}
-    {{this}}
+  {{#each name in developerNames}}
+    {{name}}
   {{/each}}
   ```
 
@@ -180,8 +170,8 @@ var EachView = CollectionView.extend(_Metamorph, {
 
   ```handlebars
   <ul>
-  {{#each developers itemViewClass="person"}}
-    {{name}}
+  {{#each developer in developers itemViewClass="person"}}
+    {{developer.name}}
   {{/each}}
   </ul>
   ```
@@ -212,13 +202,13 @@ var EachView = CollectionView.extend(_Metamorph, {
   ```javascript
   App.PersonView = Ember.View.extend({
     tagName: 'li',
-    template: '{{name}}'
+    template: '{{developer.name}}'
   });
   ```
 
   ```handlebars
   <ul>
-    {{each developers itemViewClass="person"}}
+    {{each developer in developers itemViewClass="person"}}
   </ul>
   ```
 
@@ -236,8 +226,8 @@ var EachView = CollectionView.extend(_Metamorph, {
 
   ```handlebars
   <ul>
-  {{#each developers emptyViewClass="no-people"}}
-    <li>{{name}}</li>
+  {{#each developer in developers emptyViewClass="no-people"}}
+    <li>{{developer.name}}</li>
   {{/each}}
   </ul>
   ```
@@ -280,12 +270,13 @@ var EachView = CollectionView.extend(_Metamorph, {
 function eachHelper(path) {
   var options = arguments[arguments.length - 1];
   var helperName = 'each';
+  var keywordName;
 
   if (arguments.length === 4) {
     Ember.assert("If you pass more than one argument to the each helper," +
                  " it must be in the form #each foo in bar", arguments[1] === "in");
 
-    var keywordName = arguments[0];
+    keywordName = arguments[0];
     path = arguments[2];
 
     helperName += ' ' + keywordName + ' in ' + path;
@@ -296,6 +287,8 @@ function eachHelper(path) {
   } else {
     helperName += ' ' + path;
   }
+
+  Ember.deprecate('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.', keywordName);
 
   options.hash.emptyViewClass = Ember._MetamorphView;
   options.hash.dataSourceBinding = path;

--- a/packages/ember-handlebars/tests/bind_attr_test.js
+++ b/packages/ember-handlebars/tests/bind_attr_test.js
@@ -393,7 +393,9 @@ test("should be able to bind classes to globals with {{bind-attr class}} (DEPREC
   ok(view.$('img').hasClass('is-open'), "sets classname to the dasherized value of the global property");
 });
 
-test("should be able to bind-attr to 'this' in an {{#each}} block", function() {
+test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]", function() {
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
   view = EmberView.create({
     template: EmberHandlebars.compile('{{#each view.images}}<img {{bind-attr src="this"}}>{{/each}}'),
     images: A(['one.png', 'two.jpg', 'three.gif'])
@@ -407,7 +409,9 @@ test("should be able to bind-attr to 'this' in an {{#each}} block", function() {
   ok(/three\.gif$/.test(images[2].src));
 });
 
-test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}}", function() {
+test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}} [DEPRECATED]", function() {
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
   view = EmberView.create({
     template: EmberHandlebars.compile('{{#each view.items}}<li {{bind-attr class="this"}}>Item</li>{{/each}}'),
     items: A(['a', 'b', 'c'])

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1498,7 +1498,7 @@ test("should be able to use unbound helper in #each helper", function() {
   view = EmberView.create({
     items: A(['a', 'b', 'c', 1, 2, 3]),
     template: EmberHandlebars.compile(
-      "<ul>{{#each view.items}}<li>{{unbound this}}</li>{{/each}}</ul>")
+      "<ul>{{#each item in view.items}}<li>{{unbound item}}</li>{{/each}}</ul>")
   });
 
   appendView();
@@ -1511,7 +1511,7 @@ test("should be able to use unbound helper in #each helper (with objects)", func
   view = EmberView.create({
     items: A([{wham: 'bam'}, {wham: 1}]),
     template: EmberHandlebars.compile(
-      "<ul>{{#each view.items}}<li>{{unbound wham}}</li>{{/each}}</ul>")
+      "<ul>{{#each item in view.items}}<li>{{unbound item.wham}}</li>{{/each}}</ul>")
   });
 
   appendView();
@@ -1668,30 +1668,33 @@ test("should be able to explicitly set a view's context", function() {
 
 test("should escape HTML in primitive value contexts when using normal mustaches", function() {
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#each view.kiddos}}{{this}}{{/each}}'),
-    kiddos: A(['<b>Max</b>', '<b>James</b>'])
+    context: '<b>Max</b><b>James</b>',
+    template: EmberHandlebars.compile('{{this}}'),
   });
 
   appendView();
+
   equal(view.$('b').length, 0, "does not create an element");
   equal(view.$().text(), '<b>Max</b><b>James</b>', "inserts entities, not elements");
 
-  run(function() { set(view, 'kiddos', A(['<i>Max</i>','<i>James</i>'])); });
+  run(function() { set(view, 'context', '<i>Max</i><i>James</i>'); });
+
   equal(view.$().text(), '<i>Max</i><i>James</i>', "updates with entities, not elements");
   equal(view.$('i').length, 0, "does not create an element when value is updated");
 });
 
 test("should not escape HTML in primitive value contexts when using triple mustaches", function() {
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#each view.kiddos}}{{{this}}}{{/each}}'),
-    kiddos: A(['<b>Max</b>', '<b>James</b>'])
+    context: '<b>Max</b><b>James</b>',
+    template: EmberHandlebars.compile('{{{this}}}'),
   });
 
   appendView();
 
   equal(view.$('b').length, 2, "creates an element");
 
-  run(function() { set(view, 'kiddos', A(['<i>Max</i>','<i>James</i>'])); });
+  run(function() { set(view, 'context', '<i>Max</i><i>James</i>'); });
+
   equal(view.$('i').length, 2, "creates an element when value is updated");
 });
 
@@ -1747,15 +1750,14 @@ test("should be able to log a view property", function() {
 
 test("should be able to log `this`", function() {
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#each view.items}}{{log this}}{{/each}}'),
-    items: A(['one', 'two'])
+    context: 'one',
+    template: EmberHandlebars.compile('{{log this}}'),
   });
 
   appendView();
 
   equal(view.$().text(), "", "shouldn't render any text");
   equal(logCalls[0], 'one', "should call log with item one");
-  equal(logCalls[1], 'two', "should call log with item two");
 });
 
 var MyApp;
@@ -1863,9 +1865,9 @@ test("views within an if statement should be sane on re-render", function() {
 
 test("the {{this}} helper should not fail on removal", function() {
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#if view.show}}{{#each view.list}}{{this}}{{/each}}{{/if}}'),
-    show: true,
-    list: A(['a', 'b', 'c'])
+    context: 'abc',
+    template: EmberHandlebars.compile('{{#if view.show}}{{this}}{{/if}}'),
+    show: true
   });
 
   appendView();

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -44,14 +44,16 @@ QUnit.module("Handlebars bound helpers", {
   }
 });
 
-test("primitives should work correctly", function() {
+test("primitives should work correctly [DEPRECATED]", function() {
   view = EmberView.create({
     prims: Ember.A(["string", 12]),
 
     template: compile('{{#each view.prims}}{{#if this}}inside-if{{/if}}{{#with this}}inside-with{{/with}}{{/each}}')
   });
 
-  appendView(view);
+  expectDeprecation(function() {
+    appendView(view);
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), 'inside-ifinside-withinside-ifinside-with');
 });
@@ -387,7 +389,7 @@ test("shouldn't treat quoted strings as bound paths", function() {
   equal(helperCount, 5, "changing controller property with same name as quoted string doesn't re-render helper");
 });
 
-test("bound helpers can handle nulls in array (with primitives)", function() {
+test("bound helpers can handle nulls in array (with primitives) [DEPRECATED]", function() {
   EmberHandlebars.helper('reverse', function(val) {
     return val ? val.split('').reverse().join('') : "NOPE";
   });
@@ -399,7 +401,9 @@ test("bound helpers can handle nulls in array (with primitives)", function() {
     template: compile("{{#each things}}{{this}}|{{reverse this}} {{/each}}{{#each thing in things}}{{thing}}|{{reverse thing}} {{/each}}")
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), '|NOPE 0|NOPE |NOPE false|NOPE OMG|GMO |NOPE 0|NOPE |NOPE false|NOPE OMG|GMO ', "helper output is correct");
 
@@ -423,7 +427,9 @@ test("bound helpers can handle nulls in array (with objects)", function() {
     template: compile("{{#each things}}{{foo}}|{{print-foo this}} {{/each}}{{#each thing in things}}{{thing.foo}}|{{print-foo thing}} {{/each}}")
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), '|NOPE 5|5 |NOPE 5|5 ', "helper output is correct");
 
@@ -439,20 +445,24 @@ test("bound helpers can handle `this` keyword when it's a non-object", function(
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({
-      things: A(['alex'])
-    }),
-    template: compile("{{#each things}}{{shout this}}{{/each}}")
+    context: 'alex',
+    template: compile("{{shout this}}")
   });
 
   appendView();
 
   equal(view.$().text(), 'alex!', "helper output is correct");
 
-  run(view.controller.things, 'shiftObject');
-  equal(view.$().text(), '', "helper output is correct");
+  run(function() {
+    set(view, 'context', '');
+  });
 
-  run(view.controller.things, 'pushObject', 'wallace');
+  equal(view.$().text(), '!', "helper output is correct");
+
+  run(function() {
+    set(view, 'context', 'wallace');
+  });
+
   equal(view.$().text(), 'wallace!', "helper output is correct");
 });
 

--- a/packages/ember-handlebars/tests/helpers/each_test.js
+++ b/packages/ember-handlebars/tests/helpers/each_test.js
@@ -26,7 +26,7 @@ function templateFor(template) {
 var originalLookup = Ember.lookup;
 var lookup;
 
-QUnit.module("the #each helper", {
+QUnit.module("the #each helper [DEPRECATED]", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
 
@@ -48,7 +48,9 @@ QUnit.module("the #each helper", {
       template: templateMyView
     });
 
-    append(view);
+    expectDeprecation(function() {
+      append(view);
+    },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
   },
 
   teardown: function() {
@@ -552,6 +554,8 @@ test("it supports {{else}}", function() {
 });
 
 test("it works with the controller keyword", function() {
+  run(view, 'destroy'); // destroy existing view
+
   var controller = ArrayController.create({
     model: A(["foo", "bar", "baz"])
   });
@@ -566,6 +570,55 @@ test("it works with the controller keyword", function() {
   append(view);
 
   equal(view.$().text(), "foobarbaz");
+});
+
+test("views inside #each preserve the new context [DEPRECATED]", function() {
+  run(view, 'destroy'); // destroy existing view
+
+  var controller = A([ { name: "Adam" }, { name: "Steve" } ]);
+
+  view = EmberView.create({
+    container: container,
+    controller: controller,
+    template: templateFor('{{#each controller}}{{#view}}{{name}}{{/view}}{{/each}}')
+  });
+
+
+  expectDeprecation(function() {
+    append(view);
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
+  equal(view.$().text(), "AdamSteve");
+});
+
+test("single-arg each defaults to current context [DEPRECATED]", function() {
+  run(view, 'destroy'); // destroy existing view
+
+  view = EmberView.create({
+    context: A([ { name: "Adam" }, { name: "Steve" } ]),
+    template: templateFor('{{#each}}{{name}}{{/each}}')
+  });
+
+  expectDeprecation(function() {
+    append(view);
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
+  equal(view.$().text(), "AdamSteve");
+});
+
+test("single-arg each will iterate over controller if present [DEPRECATED]", function() {
+  run(view, 'destroy'); // destroy existing view
+
+  view = EmberView.create({
+    controller: A([ { name: "Adam" }, { name: "Steve" } ]),
+    template: templateFor('{{#each}}{{name}}{{/each}}')
+  });
+
+  expectDeprecation(function() {
+    append(view);
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
+  equal(view.$().text(), "AdamSteve");
 });
 
 QUnit.module("{{#each foo in bar}}", {
@@ -644,7 +697,7 @@ test("#each accepts 'this' as the right hand side", function() {
   equal(view.$().text(), "My Cool Each Test 1My Cool Each Test 2");
 });
 
-test("views inside #each preserve the new context", function() {
+test("views inside #each preserve the new context [DEPRECATED]", function() {
   var controller = A([ { name: "Adam" }, { name: "Steve" } ]);
 
   view = EmberView.create({
@@ -653,7 +706,9 @@ test("views inside #each preserve the new context", function() {
     template: templateFor('{{#each controller}}{{#view}}{{name}}{{/view}}{{/each}}')
   });
 
-  append(view);
+  expectDeprecation(function() {
+    append(view);
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -674,32 +729,10 @@ test("controller is assignable inside an #each", function() {
   equal(view.$().text(), "AdamSteve");
 });
 
-test("single-arg each defaults to current context", function() {
-  view = EmberView.create({
-    context: A([ { name: "Adam" }, { name: "Steve" } ]),
-    template: templateFor('{{#each}}{{name}}{{/each}}')
-  });
-
-  append(view);
-
-  equal(view.$().text(), "AdamSteve");
-});
-
-test("single-arg each will iterate over controller if present", function() {
-  view = EmberView.create({
-    controller: A([ { name: "Adam" }, { name: "Steve" } ]),
-    template: templateFor('{{#each}}{{name}}{{/each}}')
-  });
-
-  append(view);
-
-  equal(view.$().text(), "AdamSteve");
-});
-
 test("it doesn't assert when the morph tags have the same parent", function() {
   view = EmberView.create({
     controller: A(['Cyril', 'David']),
-    template: templateFor('<table><tbody>{{#each}}<tr><td>{{this}}</td></tr>{{/each}}<tbody></table>')
+    template: templateFor('<table><tbody>{{#each name in this}}<tr><td>{{name}}</td></tr>{{/each}}<tbody></table>')
   });
 
   append(view);
@@ -782,4 +815,34 @@ test("itemController specified in ArrayController with name binding does not cha
   append(view);
 
   equal(view.$().text(), "controller:people - controller:Steve Holt of Yapp - controller:people - controller:Annabelle of Yapp - ");
+});
+
+test("{{each}} without arguments [DEPRECATED]", function() {
+  expect(2);
+
+  view = EmberView.create({
+    controller: A([ { name: "Adam" }, { name: "Steve" } ]),
+    template: templateFor('{{#each}}{{name}}{{/each}}')
+  });
+
+  expectDeprecation(function() {
+    append(view);
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
+  equal(view.$().text(), "AdamSteve");
+});
+
+test("{{each this}} without keyword [DEPRECATED]", function() {
+  expect(2);
+
+  view = EmberView.create({
+    controller: A([ { name: "Adam" }, { name: "Steve" } ]),
+    template: templateFor('{{#each this}}{{name}}{{/each}}')
+  });
+
+  expectDeprecation(function() {
+    append(view);
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
+  equal(view.$().text(), "AdamSteve");
 });

--- a/packages/ember-handlebars/tests/helpers/group_test.js
+++ b/packages/ember-handlebars/tests/helpers/group_test.js
@@ -129,7 +129,7 @@ test("should work with the #if helper", function() {
 test("#each with no content", function() {
   expect(0);
   createGroupedView(
-    "{{#each missing}}{{this}}{{/each}}"
+    "{{#each item in missing}}{{item}}{{/each}}"
   );
   appendView();
 });
@@ -138,7 +138,7 @@ test("#each's content can be changed right before a destroy", function() {
   expect(0);
 
   createGroupedView(
-    "{{#each numbers}}{{this}}{{/each}}",
+    "{{#each number in numbers}}{{number}}{{/each}}",
     {numbers: A([1,2,3])}
   );
   appendView();
@@ -151,7 +151,7 @@ test("#each's content can be changed right before a destroy", function() {
 
 test("#each can be nested", function() {
   createGroupedView(
-    "{{#each numbers}}{{this}}{{/each}}",
+    "{{#each number in numbers}}{{number}}{{/each}}",
     {numbers: A([1, 2, 3])}
   );
   appendView();
@@ -172,7 +172,7 @@ test("#each can be nested", function() {
 
 test("#each can be used with an ArrayProxy", function() {
   createGroupedView(
-    "{{#each numbers}}{{this}}{{/each}}",
+    "{{#each number in numbers}}{{number}}{{/each}}",
     {numbers: ArrayProxy.create({content: A([1, 2, 3])})}
   );
   appendView();
@@ -208,7 +208,7 @@ test("should allow `#each item in array` format", function() {
 test("an #each can be nested with a view inside", function() {
   var yehuda = {name: 'Yehuda'};
   createGroupedView(
-    '{{#each people}}{{#view}}{{name}}{{/view}}{{/each}}',
+    '{{#each person in people}}{{#view}}{{person.name}}{{/view}}{{/each}}',
     {people: A([yehuda, {name: 'Tom'}])}
   );
   appendView();
@@ -225,7 +225,7 @@ test("an #each can be nested with a component inside", function() {
   var yehuda = {name: 'Yehuda'};
   container.register('view:test', Component.extend());
   createGroupedView(
-    '{{#each people}}{{#view "test"}}{{name}}{{/view}}{{/each}}',
+    '{{#each person in people}}{{#view "test"}}{{person.name}}{{/view}}{{/each}}',
     {people: A([yehuda, {name: 'Tom'}])}
   );
 
@@ -241,7 +241,7 @@ test("an #each can be nested with a component inside", function() {
 
 test("#each with groupedRows=true behaves like a normal bound #each", function() {
   createGroupedView(
-    '{{#each numbers groupedRows=true}}{{this}}{{/each}}',
+    '{{#each number in numbers groupedRows=true}}{{number}}{{/each}}',
     {numbers: A([1, 2, 3])}
   );
   appendView();
@@ -257,7 +257,7 @@ test("#each with groupedRows=true behaves like a normal bound #each", function()
 test("#each with itemViewClass behaves like a normal bound #each", function() {
   container.register('view:nothing-special-view', Ember.View);
   createGroupedView(
-    '{{#each people itemViewClass="nothing-special-view"}}{{name}}{{/each}}',
+    '{{#each person in people itemViewClass="nothing-special-view"}}{{person.name}}{{/each}}',
     {people: A([{name: 'Erik'}, {name: 'Peter'}])}
   );
   appendView();

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -68,7 +68,7 @@ test("block should work properly even when templates are not hard-coded", functi
 
 test("templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
   var TimesView = EmberView.extend({
-    layout: EmberHandlebars.compile('<div class="times">{{#each view.index}}{{yield}}{{/each}}</div>'),
+    layout: EmberHandlebars.compile('<div class="times">{{#each item in view.index}}{{yield}}{{/each}}</div>'),
     n: null,
     index: computed(function() {
       var n = get(this, 'n');

--- a/packages/ember-handlebars/tests/views/collection_view_test.js
+++ b/packages/ember-handlebars/tests/views/collection_view_test.js
@@ -391,7 +391,7 @@ test("should work inside a bound {{#if}}", function() {
   equal(view.$('ul li').length, 3, "collection renders when conditional changes to true");
 });
 
-test("should pass content as context when using {{#each}} helper", function() {
+test("should pass content as context when using {{#each}} helper [DEPRECATED]", function() {
   view = EmberView.create({
     template: EmberHandlebars.compile('{{#each view.releases}}Mac OS X {{version}}: {{name}} {{/each}}'),
 
@@ -405,7 +405,9 @@ test("should pass content as context when using {{#each}} helper", function() {
               ])
   });
 
-  run(function() { view.appendTo('#qunit-fixture'); });
+  expectDeprecation(function() {
+    run(view, 'appendTo', '#qunit-fixture');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "Mac OS X 10.7: Lion Mac OS X 10.6: Snow Leopard Mac OS X 10.5: Leopard ", "prints each item in sequence");
 });

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -148,7 +148,7 @@ test("Inside a yield, the target points at the original target", function() {
   equal(watted, true, "The action was called on the right context");
 });
 
-test("should target the current controller inside an {{each}} loop", function() {
+test("should target the current controller inside an {{each}} loop [DEPRECATED]", function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -173,7 +173,9 @@ test("should target the current controller inside an {{each}} loop", function() 
     template: EmberHandlebars.compile('{{#each controller}}{{action "editTodo"}}{{/each}}')
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(registeredTarget, itemController, "the item controller is the target of action");
 
@@ -209,7 +211,7 @@ test("should target the with-controller inside an {{#with controller='person'}}"
   ActionHelper.registerAction = originalRegisterAction;
 });
 
-test("should target the with-controller inside an {{each}} in a {{#with controller='person'}}", function() {
+test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
   var eventsCalled = [];
 
   var PeopleController = EmberArrayController.extend({
@@ -236,7 +238,9 @@ test("should target the with-controller inside an {{each}} in a {{#with controll
 
   container.register('controller:people', PeopleController);
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   view.$('a').trigger('click');
 
@@ -467,7 +471,7 @@ test("should work properly in an #each block", function() {
   view = EmberView.create({
     controller: controller,
     items: Ember.A([1, 2, 3, 4]),
-    template: EmberHandlebars.compile('{{#each view.items}}<a href="#" {{action "edit"}}>click me</a>{{/each}}')
+    template: EmberHandlebars.compile('{{#each item in view.items}}<a href="#" {{action "edit"}}>click me</a>{{/each}}')
   });
 
   appendView();
@@ -527,7 +531,7 @@ test("should unregister event handlers on inside virtual views", function() {
     }
   ]);
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#each view.things}}<a href="#" {{action "edit"}}>click me</a>{{/each}}'),
+    template: EmberHandlebars.compile('{{#each thing in view.things}}<a href="#" {{action "edit"}}>click me</a>{{/each}}'),
     things: things
   });
 
@@ -964,8 +968,8 @@ test("a quoteless parameter should allow dynamic lookup of the actionName", func
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
-test("a quoteless parameter should lookup actionName in context", function(){
-  expect(4);
+test("a quoteless parameter should lookup actionName in context [DEPRECATED]", function(){
+  expect(5);
   var lastAction;
   var actionOrder = [];
 
@@ -993,10 +997,12 @@ test("a quoteless parameter should lookup actionName in context", function(){
     }
   }).create();
 
-  run(function() {
-    view.set('controller', controller);
-    view.appendTo('#qunit-fixture');
-  });
+  expectDeprecation(function() {
+    run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   var testBoundAction = function(propertyValue){
     run(function(){

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -39,8 +39,8 @@ import EmberError from 'ember-metal/error';
   Then, create a view that binds to your new controller:
 
   ```handlebars
-  {{#each MyApp.listController}}
-    {{firstName}} {{lastName}}
+  {{#each person in MyApp.listController}}
+    {{person.firstName}} {{person.lastName}}
   {{/each}}
   ```
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -447,7 +447,7 @@ test("The {{link-to}} helper moves into the named route with context", function(
     this.resource("item", { path: "/item/:id" });
   });
 
-  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each controller}}<li>{{#link-to 'item' this}}{{name}}{{/link-to}}</li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
+  Ember.TEMPLATES.about = Ember.Handlebars.compile("<h3>List</h3><ul>{{#each person in controller}}<li>{{#link-to 'item' person}}{{person.name}}{{/link-to}}</li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
   App.AboutRoute = Ember.Route.extend({
     model: function() {
@@ -927,7 +927,9 @@ test("The {{link-to}} helper works in an #each'd array of string route names", f
     index: compile('{{#each routeName in routeNames}}{{#link-to routeName}}{{routeName}}{{/link-to}}{{/each}}{{#each routeNames}}{{#link-to this}}{{this}}{{/link-to}}{{/each}}{{#link-to route1}}a{{/link-to}}{{#link-to route2}}b{{/link-to}}')
   };
 
-  bootApplication();
+  expectDeprecation(function() {
+    bootApplication();
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   function linksEqual($links, expected) {
     equal($links.length, expected.length, "Has correct number of links");
@@ -1042,7 +1044,7 @@ test("The non-block form {{link-to}} helper moves into the named route with cont
     }
   });
 
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3><ul>{{#each controller}}<li>{{link-to name 'item' this}}</li>{{/each}}</ul>");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h3>Home</h3><ul>{{#each person in controller}}<li>{{link-to person.name 'item' person}}</li>{{/each}}</ul>");
   Ember.TEMPLATES.item = Ember.Handlebars.compile("<h3>Item</h3><p>{{name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
   bootApplication();

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -5,7 +5,7 @@ var App, $fixture;
 function setupExample() {
   // setup templates
   Ember.TEMPLATES.application = Ember.Handlebars.compile("{{outlet}}");
-  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h1>People</h1><ul>{{#each model}}<li>Hello, <b>{{fullName}}</b>!</li>{{/each}}</ul>");
+  Ember.TEMPLATES.index = Ember.Handlebars.compile("<h1>People</h1><ul>{{#each person in model}}<li>Hello, <b>{{person.fullName}}</b>!</li>{{/each}}</ul>");
 
 
   App.Person = Ember.Object.extend({

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -647,7 +647,7 @@ test("The Homepage with a computed context that does not get overridden", functi
   });
 
   Ember.TEMPLATES.home = Ember.Handlebars.compile(
-    "<ul>{{#each}}<li>{{this}}</li>{{/each}}</ul>"
+    "<ul>{{#each passage in model}}<li>{{passage}}</li>{{/each}}</ul>"
   );
 
   bootApplication();


### PR DESCRIPTION
Deprecate the context switching form of `{{each}}`.

Will be updating the website and guides to remove old references.

From the 2.0 RFC:

---
## More Consistent Handlebars Scope

In today's Ember, the `each` and `with` helpers come in two flavors: a "context-switching" flavor and a "named-parameter" flavor.

``` handlebars
{{#each post in posts}}
  {{!-- the context in here is the same as the outside context,
        and `post` references the current iteration --}}
{{/each}}

{{#each posts}}
  {{!-- the context in here has shifted to the individual post.
        the outer context is no longer accessible --}}
{{/each}}
```

This has proven to be one of the more confusing parts of the Ember templating system. It is also not clear to beginners which to use, and when they choose the context-shifting form, they lose access to values in the outer context that may be important.

Because the helper itself offers no clue about the context-shifting behavior, it is easy (even for more experienced Ember developers) to get confused when skimming a template about which object a value refers to.

In Ember 1.10, we will deprecate the context-shifting forms of `#each` and `#with` in favor of the named-parameter forms.
### Transition Plan

To transition your code to the new syntax, you can change templates that look like this:

``` hbs
{{#each people}}
  <p>{{firstName}} {{lastName}}</p>
  <p>{{address}}</p>
{{/each}}
```

with:

``` hbs
{{#each people as |person|}}
  <p>{{person.firstName}} {{person.lastName}}</p>
  <p>{{person.address}}</p>
{{/each}}
```

**We plan to deprecate support for the context-shifting helpers in Ember 1.9 and remove support in Ember 2.0.** This change should be entirely mechanical.
