### PR TITLE
[DEPRECATE beta] Deprecate context switching form of {{with}}.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -43,16 +43,6 @@ import { bind } from "ember-handlebars/helpers/binding";
   changes, the partial will be re-rendered using the new template
   name.
 
-  ## Setting the partial's context with `with`
-
-  The `partial` helper can be used in conjunction with the `with`
-  helper to set a context that will be used by the partial:
-
-  ```handlebars
-  {{#with currentUser}}
-    {{partial "user_info"}}
-  {{/with}}
-  ```
 
   @method partial
   @for Ember.Handlebars.helpers

--- a/packages/ember-handlebars/lib/helpers/with.js
+++ b/packages/ember-handlebars/lib/helpers/with.js
@@ -59,40 +59,9 @@ var WithView = _HandlebarsBoundView.extend({
 });
 
 /**
-  Use the `{{with}}` helper when you want to scope context. Take the following code as an example:
-
-  ```handlebars
-  <h5>{{user.name}}</h5>
-
-  <div class="role">
-    <h6>{{user.role.label}}</h6>
-    <span class="role-id">{{user.role.id}}</span>
-
-    <p class="role-desc">{{user.role.description}}</p>
-  </div>
-  ```
-
-  `{{with}}` can be our best friend in these cases,
-  instead of writing `user.role.*` over and over, we use `{{#with user.role}}`.
-  Now the context within the `{{#with}} .. {{/with}}` block is `user.role` so you can do the following:
-
-  ```handlebars
-  <h5>{{user.name}}</h5>
-
-  <div class="role">
-    {{#with user.role}}
-      <h6>{{label}}</h6>
-      <span class="role-id">{{id}}</span>
-
-      <p class="role-desc">{{description}}</p>
-    {{/with}}
-  </div>
-  ```
-
-  ### `as` operator
-
-  This operator aliases the scope to a new name. It's helpful for semantic clarity and to retain
-  default scope or to reference from another `{{with}}` block.
+  Use the `{{with}}` helper when you want to aliases the to a new name. It's helpful
+  for semantic clarity and to retain default scope or to reference from another
+  `{{with}}` block.
 
   ```handlebars
   // posts might not be
@@ -116,18 +85,18 @@ var WithView = _HandlebarsBoundView.extend({
   ### `controller` option
 
   Adding `controller='something'` instructs the `{{with}}` helper to create and use an instance of
-  the specified controller with the new context as its content.
+  the specified controller wrapping the aliased keyword.
 
   This is very similar to using an `itemController` option with the `{{each}}` helper.
 
   ```handlebars
-  {{#with users.posts controller='userBlogPosts'}}
-    {{!- The current context is wrapped in our controller instance }}
+  {{#with users.posts as posts controller='userBlogPosts'}}
+    {{!- `posts` is wrapped in our controller instance }}
   {{/with}}
   ```
 
-  In the above example, the template provided to the `{{with}}` block is now wrapped in the
-  `userBlogPost` controller, which provides a very elegant way to decorate the context with custom
+  In the above example, the `posts` keyword is now wrapped in the `userBlogPost` controller,
+  which provides an elegant way to decorate the context with custom
   functions/properties.
 
   @method with
@@ -166,6 +135,8 @@ export default function withHelper(contextPath) {
     options = localizedOptions;
     preserveContext = true;
   } else {
+    Ember.deprecate('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
     Ember.assert("You must pass exactly one argument to the with helper", arguments.length === 2);
     Ember.assert("You must pass a block to the with helper", options.fn && options.fn !== Handlebars.VM.noop);
 

--- a/packages/ember-handlebars/tests/bind_attr_test.js
+++ b/packages/ember-handlebars/tests/bind_attr_test.js
@@ -227,7 +227,7 @@ test("{{bindAttr}} is aliased to {{bind-attr}}", function() {
 });
 
 test("should be able to bind element attributes using {{bind-attr}} inside a block", function() {
-  var template = EmberHandlebars.compile('{{#with view.content}}<img {{bind-attr src="url" alt="title"}}>{{/with}}');
+  var template = EmberHandlebars.compile('{{#with view.content as image}}<img {{bind-attr src=image.url alt=image.title}}>{{/with}}');
 
   view = EmberView.create({
     template: template,

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -181,7 +181,7 @@ test("template view should call the function of the associated template with its
 
 test("should allow values from normal JavaScript hash objects to be used", function() {
   view = EmberView.create({
-    template: EmberHandlebars.compile('{{#with view.person}}{{firstName}} {{lastName}} (and {{pet.name}}){{/with}}'),
+    template: EmberHandlebars.compile('{{#with view.person as person}}{{person.firstName}} {{person.lastName}} (and {{person.pet.name}}){{/with}}'),
 
     person: {
       firstName: 'Señor',
@@ -396,7 +396,7 @@ test("child views can be inserted using the {{view}} Handlebars helper", functio
 
 test("child views can be inserted inside a bind block", function() {
   container.register('template:nester', EmberHandlebars.compile("<h1 id='hello-world'>Hello {{world}}</h1>{{view view.bqView}}"));
-  container.register('template:nested', EmberHandlebars.compile("<div id='child-view'>Goodbye {{#with content}}{{blah}} {{view view.otherView}}{{/with}} {{world}}</div>"));
+  container.register('template:nested', EmberHandlebars.compile("<div id='child-view'>Goodbye {{#with content as thing}}{{thing.blah}} {{view view.otherView}}{{/with}} {{world}}</div>"));
   container.register('template:other', EmberHandlebars.compile("cruel"));
 
   var context = {
@@ -447,7 +447,7 @@ test("using Handlebars helper that doesn't exist should result in an error", fun
 });
 
 test("View should update when a property changes and the bind helper is used", function() {
-  container.register('template:foo', EmberHandlebars.compile('<h1 id="first">{{#with view.content}}{{bind "wham"}}{{/with}}</h1>'));
+  container.register('template:foo', EmberHandlebars.compile('<h1 id="first">{{#with view.content as thing}}{{bind "thing.wham"}}{{/with}}</h1>'));
 
   view = EmberView.create({
     container: container,
@@ -487,7 +487,7 @@ test("View should not use keyword incorrectly - Issue #1315", function() {
 });
 
 test("View should update when a property changes and no bind helper is used", function() {
-  container.register('template:foo', EmberHandlebars.compile('<h1 id="first">{{#with view.content}}{{wham}}{{/with}}</h1>'));
+  container.register('template:foo', EmberHandlebars.compile('<h1 id="first">{{#with view.content as thing}}{{thing.wham}}{{/with}}</h1>'));
 
   view = EmberView.create({
     container: container,
@@ -508,7 +508,7 @@ test("View should update when a property changes and no bind helper is used", fu
   equal(view.$('#first').text(), "bazam", "view updates when a bound property changes");
 });
 
-test("View should update when the property used with the #with helper changes", function() {
+test("View should update when the property used with the #with helper changes [DEPRECATED]", function() {
   container.register('template:foo', EmberHandlebars.compile('<h1 id="first">{{#with view.content}}{{wham}}{{/with}}</h1>'));
 
   view = EmberView.create({
@@ -521,7 +521,9 @@ test("View should update when the property used with the #with helper changes", 
     })
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$('#first').text(), "bam", "precond - view renders Handlebars template");
 
@@ -877,7 +879,7 @@ test("views set the template of their children to a passed block", function() {
 });
 
 test("views render their template in the context of the parent view's context", function() {
-  container.register('template:parent', EmberHandlebars.compile('<h1>{{#with content}}{{#view}}{{firstName}} {{lastName}}{{/view}}{{/with}}</h1>'));
+  container.register('template:parent', EmberHandlebars.compile('<h1>{{#with content as person}}{{#view}}{{person.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
 
   var context = {
     content: {
@@ -897,7 +899,7 @@ test("views render their template in the context of the parent view's context", 
 });
 
 test("views make a view keyword available that allows template to reference view context", function() {
-  container.register('template:parent', EmberHandlebars.compile('<h1>{{#with view.content}}{{#view subview}}{{view.firstName}} {{lastName}}{{/view}}{{/with}}</h1>'));
+  container.register('template:parent', EmberHandlebars.compile('<h1>{{#with view.content as person}}{{#view person.subview}}{{view.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
 
   view = EmberView.create({
     container: container,
@@ -1625,7 +1627,7 @@ test("should expose a controller keyword that persists through Ember.ContainerVi
   equal(trim(viewInstanceToBeInserted.$().text()), "bar", "renders value from parent's controller");
 });
 
-test("should expose a view keyword", function() {
+test("should expose a view keyword [DEPRECATED]", function() {
   var templateString = '{{#with view.differentContent}}{{view.foo}}{{#view baz="bang"}}{{view.baz}}{{/view}}{{/with}}';
   view = EmberView.create({
     container: container,
@@ -1641,7 +1643,9 @@ test("should expose a view keyword", function() {
     template: EmberHandlebars.compile(templateString)
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "barbang", "renders values from view and child view");
 });
@@ -1926,7 +1930,7 @@ test("bindings should respect keywords", function() {
   equal(trim(view.$().text()), "Name: SFMoMA Price: $20", "should print baz twice");
 });
 
-test("bindings can be 'this', in which case they *are* the current context", function() {
+test("bindings can be 'this', in which case they *are* the current context [DEPRECATED]", function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -1939,10 +1943,12 @@ test("bindings can be 'this', in which case they *are* the current context", fun
     }),
 
 
-    template: EmberHandlebars.compile('{{#if view.museumOpen}} {{#with view.museumDetails}}{{view museumView museumBinding="this"}} {{/with}}{{/if}}')
+    template: EmberHandlebars.compile('{{#if view.museumOpen}} {{#with view.museumDetails}}{{view museumView museum=this}} {{/with}}{{/if}}')
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(trim(view.$().text()), "Name: SFMoMA Price: $20", "should print baz twice");
 });

--- a/packages/ember-handlebars/tests/helpers/bound_helper_test.js
+++ b/packages/ember-handlebars/tests/helpers/bound_helper_test.js
@@ -45,15 +45,16 @@ QUnit.module("Handlebars bound helpers", {
 });
 
 test("primitives should work correctly [DEPRECATED]", function() {
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
   view = EmberView.create({
     prims: Ember.A(["string", 12]),
 
     template: compile('{{#each view.prims}}{{#if this}}inside-if{{/if}}{{#with this}}inside-with{{/with}}{{/each}}')
   });
 
-  expectDeprecation(function() {
-    appendView(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  appendView(view);
 
   equal(view.$().text(), 'inside-ifinside-withinside-ifinside-with');
 });

--- a/packages/ember-handlebars/tests/helpers/if_unless_test.js
+++ b/packages/ember-handlebars/tests/helpers/if_unless_test.js
@@ -21,14 +21,16 @@ QUnit.module("Handlebars {{#if}} and {{#unless}} helpers", {
   }
 });
 
-test("unless should keep the current context (#784)", function() {
+test("unless should keep the current context (#784) [DEPRECATED]", function() {
   view = EmberView.create({
     o: EmberObject.create({foo: '42'}),
 
     template: compile('{{#with view.o}}{{#view}}{{#unless view.doesNotExist}}foo: {{foo}}{{/unless}}{{/view}}{{/with}}')
   });
 
-  appendView(view);
+  expectDeprecation(function() {
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), 'foo: 42');
 });

--- a/packages/ember-handlebars/tests/helpers/with_test.js
+++ b/packages/ember-handlebars/tests/helpers/with_test.js
@@ -220,7 +220,7 @@ test("it should support #with this as qux", function() {
 
 QUnit.module("Handlebars {{#with foo}} insideGroup");
 
-test("it should render without fail", function() {
+test("it should render without fail [DEPRECATED]", function() {
   var View = EmberView.extend({
     template: EmberHandlebars.compile("{{#view view.childView}}{{#with person}}{{name}}{{/with}}{{/view}}"),
     controller: EmberObject.create({ person: { name: "Ivan IV Vasilyevich" } }),
@@ -233,7 +233,11 @@ test("it should render without fail", function() {
   });
 
   var view = View.create();
-  appendView(view);
+
+  expectDeprecation(function(){
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
   equal(view.$().text(), "Ivan IV Vasilyevich", "should be properly scoped");
 
   run(function() {
@@ -249,7 +253,7 @@ test("it should render without fail", function() {
 
 QUnit.module("Handlebars {{#with foo}} with defined controller");
 
-test("it should wrap context with object controller", function() {
+test("it should wrap context with object controller [DEPRECATED]", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
@@ -273,7 +277,9 @@ test("it should wrap context with object controller", function() {
 
   container.register('controller:person', Controller);
 
-  appendView(view);
+  expectDeprecation(function(){
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblaw");
 
@@ -302,7 +308,7 @@ test("it should wrap context with object controller", function() {
   run(function() { view.destroy(); }); // destroy existing view
 });
 
-test("it should still have access to original parentController within an {{#each}}", function() {
+test("it should still have access to original parentController within an {{#each}} [DEPRECATED]", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
@@ -326,7 +332,9 @@ test("it should still have access to original parentController within an {{#each
 
   container.register('controller:person', Controller);
 
-  appendView(view);
+  expectDeprecation(function() {
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblawcontroller:Carl Weathers and Bob Loblaw");
 
@@ -384,7 +392,7 @@ test("it should wrap keyword with object controller", function() {
   run(function() { view.destroy(); }); // destroy existing view
 });
 
-test("destroys the controller generated with {{with foo controller='blah'}}", function() {
+test("destroys the controller generated with {{with foo as bar controller='blah'}}", function() {
   var destroyed = false;
   var Controller = ObjectController.extend({
     willDestroy: function() {
@@ -404,7 +412,7 @@ test("destroys the controller generated with {{with foo controller='blah'}}", fu
 
   view = EmberView.create({
     container: container,
-    template: EmberHandlebars.compile('{{#with person controller="person"}}{{controllerName}}{{/with}}'),
+    template: EmberHandlebars.compile('{{#with person as otherPerson controller="person"}}{{controllerName}}{{/with}}'),
     controller: parentController
   });
 

--- a/packages/ember-handlebars/tests/helpers/yield_test.js
+++ b/packages/ember-handlebars/tests/helpers/yield_test.js
@@ -144,7 +144,7 @@ test("yield uses the outer context", function() {
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "Yield points at the right context");
 });
 
-test("yield inside a conditional uses the outer context", function() {
+test("yield inside a conditional uses the outer context [DEPRECATED]", function() {
   var component = Component.extend({
     boundText: "inner",
     truthy: true,
@@ -157,9 +157,9 @@ test("yield inside a conditional uses the outer context", function() {
     template: EmberHandlebars.compile('{{#with obj}}{{#if truthy}}{{#view component}}{{#if truthy}}{{boundText}}{{/if}}{{/view}}{{/if}}{{/with}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  expectDeprecation(function() {
+    run(view, 'appendTo', '#qunit-fixture');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, "Yield points at the right context");
 });
@@ -224,7 +224,7 @@ test("can bind a keyword to a component and use it in yield", function() {
   equal(view.$('div p:contains(update) + p:contains(update)').length, 1, "keyword has correctly propagated update");
 });
 
-test("yield uses the layout context for non component", function() {
+test("yield uses the layout context for non component [DEPRECATED]", function() {
   view = EmberView.create({
     controller: {
       boundText: "outer",
@@ -236,9 +236,9 @@ test("yield uses the layout context for non component", function() {
     template: EmberHandlebars.compile('{{boundText}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  expectDeprecation(function() {
+    run(view, 'appendTo', '#qunit-fixture');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal('outerinner', view.$('p').text(), "Yield points at the right context");
 });

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -59,40 +59,9 @@ var WithView = _HandlebarsBoundView.extend({
 });
 
 /**
-  Use the `{{with}}` helper when you want to scope context. Take the following code as an example:
-
-  ```handlebars
-  <h5>{{user.name}}</h5>
-
-  <div class="role">
-    <h6>{{user.role.label}}</h6>
-    <span class="role-id">{{user.role.id}}</span>
-
-    <p class="role-desc">{{user.role.description}}</p>
-  </div>
-  ```
-
-  `{{with}}` can be our best friend in these cases,
-  instead of writing `user.role.*` over and over, we use `{{#with user.role}}`.
-  Now the context within the `{{#with}} .. {{/with}}` block is `user.role` so you can do the following:
-
-  ```handlebars
-  <h5>{{user.name}}</h5>
-
-  <div class="role">
-    {{#with user.role}}
-      <h6>{{label}}</h6>
-      <span class="role-id">{{id}}</span>
-
-      <p class="role-desc">{{description}}</p>
-    {{/with}}
-  </div>
-  ```
-
-  ### `as` operator
-
-  This operator aliases the scope to a new name. It's helpful for semantic clarity and to retain
-  default scope or to reference from another `{{with}}` block.
+  Use the `{{with}}` helper when you want to aliases the to a new name. It's helpful
+  for semantic clarity and to retain default scope or to reference from another
+  `{{with}}` block.
 
   ```handlebars
   // posts might not be
@@ -116,18 +85,18 @@ var WithView = _HandlebarsBoundView.extend({
   ### `controller` option
 
   Adding `controller='something'` instructs the `{{with}}` helper to create and use an instance of
-  the specified controller with the new context as its content.
+  the specified controller wrapping the aliased keyword.
 
   This is very similar to using an `itemController` option with the `{{each}}` helper.
 
   ```handlebars
-  {{#with users.posts controller='userBlogPosts'}}
-    {{!- The current context is wrapped in our controller instance }}
+  {{#with users.posts as posts controller='userBlogPosts'}}
+    {{!- `posts` is wrapped in our controller instance }}
   {{/with}}
   ```
 
-  In the above example, the template provided to the `{{with}}` block is now wrapped in the
-  `userBlogPost` controller, which provides a very elegant way to decorate the context with custom
+  In the above example, the `posts` keyword is now wrapped in the `userBlogPost` controller,
+  which provides an elegant way to decorate the context with custom
   functions/properties.
 
   @method with
@@ -149,6 +118,8 @@ export function withHelper(params, options, env) {
   var source, keyword;
   var preserveContext, context;
   if (options.types[0] === 'id') {
+    Ember.deprecate('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
     source = params[0];
     preserveContext = false;
     context = source.value();

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -222,7 +222,7 @@ test("it should support #with this as qux", function() {
 
 QUnit.module("Handlebars {{#with foo}} insideGroup");
 
-test("it should render without fail", function() {
+test("it should render without fail [DEPRECATED]", function() {
   var View = EmberView.extend({
     template: compile("{{#view view.childView}}{{#with person}}{{name}}{{/with}}{{/view}}"),
     controller: EmberObject.create({ person: { name: "Ivan IV Vasilyevich" } }),
@@ -235,7 +235,9 @@ test("it should render without fail", function() {
   });
 
   var view = View.create();
-  appendView(view);
+  expectDeprecation(function(){
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
   equal(view.$().text(), "Ivan IV Vasilyevich", "should be properly scoped");
 
   run(function() {
@@ -251,7 +253,7 @@ test("it should render without fail", function() {
 
 QUnit.module("Handlebars {{#with foo}} with defined controller");
 
-test("it should wrap context with object controller", function() {
+test("it should wrap context with object controller [DEPRECATED]", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
@@ -275,7 +277,9 @@ test("it should wrap context with object controller", function() {
 
   container.register('controller:person', Controller);
 
-  appendView(view);
+  expectDeprecation(function(){
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblaw");
 
@@ -388,7 +392,7 @@ test("it should wrap keyword with object controller", function() {
   run(function() { view.destroy(); }); // destroy existing view
 });
 
-test("destroys the controller generated with {{with foo controller='blah'}}", function() {
+test("destroys the controller generated with {{with foo controller='blah'}} [DEPRECATED]", function() {
   var destroyed = false;
   var Controller = ObjectController.extend({
     willDestroy: function() {
@@ -414,7 +418,9 @@ test("destroys the controller generated with {{with foo controller='blah'}}", fu
 
   container.register('controller:person', Controller);
 
-  appendView(view);
+  expectDeprecation(function(){
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   run(view, 'destroy'); // destroy existing view
 

--- a/packages/ember-routing-handlebars/tests/helpers/action_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/action_test.js
@@ -120,7 +120,7 @@ test("Inside a yield, the target points at the original target", function() {
     boundText: "inner",
     truthy: true,
     obj: {},
-    layout: EmberHandlebars.compile("<div>{{boundText}}</div><div>{{#if truthy}}{{#with obj}}{{yield}}{{/with}}{{/if}}</div>")
+    layout: EmberHandlebars.compile("<div>{{boundText}}</div><div>{{#if truthy}}{{yield}}{{/if}}</div>")
   });
 
   view = EmberView.create({
@@ -130,13 +130,9 @@ test("Inside a yield, the target points at the original target", function() {
       wat: function() {
         watted = true;
       },
-      obj: {
-        component: component,
-        truthy: true,
-        boundText: 'insideWith'
-      }
+      component: component
     },
-    template: EmberHandlebars.compile('{{#with obj}}{{#if truthy}}{{#view component}}{{#if truthy}}<div {{action "wat"}} class="wat">{{boundText}}</div>{{/if}}{{/view}}{{/if}}{{/with}}')
+    template: EmberHandlebars.compile('{{#if truthy}}{{#view component}}{{#if truthy}}<div {{action "wat"}} class="wat">{{boundText}}</div>{{/if}}{{/view}}{{/if}}')
   });
 
   appendView();
@@ -182,7 +178,7 @@ test("should target the current controller inside an {{each}} loop [DEPRECATED]"
   ActionHelper.registerAction = originalRegisterAction;
 });
 
-test("should target the with-controller inside an {{#with controller='person'}}", function() {
+test("should target the with-controller inside an {{#with controller='person'}} [DEPRECATED]", function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -204,7 +200,9 @@ test("should target the with-controller inside an {{#with controller='person'}}"
 
   container.register('controller:person', PersonController);
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   ok(registeredTarget instanceof PersonController, "the with-controller is the target of action");
 
@@ -212,6 +210,9 @@ test("should target the with-controller inside an {{#with controller='person'}}"
 });
 
 test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+
   var eventsCalled = [];
 
   var PeopleController = EmberArrayController.extend({
@@ -238,9 +239,7 @@ test("should target the with-controller inside an {{each}} in a {{#with controll
 
   container.register('controller:people', PeopleController);
 
-  expectDeprecation(function() {
-    appendView();
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  appendView();
 
   view.$('a').trigger('click');
 
@@ -481,7 +480,27 @@ test("should work properly in an #each block", function() {
   ok(eventHandlerWasCalled, "The event handler was called");
 });
 
-test("should work properly in a #with block", function() {
+test("should work properly in a {{#with foo as bar}} block", function() {
+  var eventHandlerWasCalled = false;
+
+  var controller = EmberController.extend({
+    actions: { edit: function() { eventHandlerWasCalled = true; } }
+  }).create();
+
+  view = EmberView.create({
+    controller: controller,
+    something: {ohai: 'there'},
+    template: EmberHandlebars.compile('{{#with view.something as somethingElse}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
+  });
+
+  appendView();
+
+  view.$('a').trigger('click');
+
+  ok(eventHandlerWasCalled, "The event handler was called");
+});
+
+test("should work properly in a #with block [DEPRECATED]", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -494,7 +513,9 @@ test("should work properly in a #with block", function() {
     template: EmberHandlebars.compile('{{#with view.something}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
   });
 
-  appendView();
+  expectDeprecation(function() {
+    appendView();
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   view.$('a').trigger('click');
 
@@ -644,8 +665,8 @@ test("should send the view, event and current Handlebars context to the action",
   var aContext = { aTarget: aTarget };
 
   view = EmberView.create({
-    aContext: aContext,
-    template: EmberHandlebars.compile('{{#with view.aContext}}<a id="edit" href="#" {{action "edit" this target="aTarget"}}>edit</a>{{/with}}')
+    context: aContext,
+    template: EmberHandlebars.compile('<a id="edit" href="#" {{action "edit" this target="aTarget"}}>edit</a>')
   });
 
   appendView();

--- a/packages/ember-routing-handlebars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-handlebars/tests/helpers/outlet_test.js
@@ -310,7 +310,7 @@ test("view should support disconnectOutlet for the main outlet", function() {
   equal(trim(view.$().text()), 'HI');
 });
 
-test("Outlets bind to the current template's view, not inner contexts", function() {
+test("Outlets bind to the current template's view, not inner contexts [DEPRECATED]", function() {
   var parentTemplate = "<h1>HI</h1>{{#if view.alwaysTrue}}{{#with this}}{{outlet}}{{/with}}{{/if}}";
   var bottomTemplate = "<h3>BOTTOM</h3>";
 
@@ -323,7 +323,9 @@ test("Outlets bind to the current template's view, not inner contexts", function
     template: compile(bottomTemplate)
   });
 
-  appendView(view);
+  expectDeprecation(function() {
+    appendView(view);
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   run(function() {
     view.connectOutlet('main', bottomView);


### PR DESCRIPTION
From the 2.0 RFC:

---
## More Consistent Handlebars Scope

In today's Ember, the `each` and `with` helpers come in two flavors: a "context-switching" flavor and a "named-parameter" flavor.

``` handlebars
{{#each post in posts}}
  {{!-- the context in here is the same as the outside context,
        and `post` references the current iteration --}}
{{/each}}

{{#each posts}}
  {{!-- the context in here has shifted to the individual post.
        the outer context is no longer accessible --}}
{{/each}}
```

This has proven to be one of the more confusing parts of the Ember templating system. It is also not clear to beginners which to use, and when they choose the context-shifting form, they lose access to values in the outer context that may be important.

Because the helper itself offers no clue about the context-shifting behavior, it is easy (even for more experienced Ember developers) to get confused when skimming a template about which object a value refers to.

In Ember 1.10, we will deprecate the context-shifting forms of `#each` and `#with` in favor of the named-parameter forms.
### Transition Plan

To transition your code to the new syntax, you can change templates that look like this:

``` hbs
{{#each people}}
  <p>{{firstName}} {{lastName}}</p>
  <p>{{address}}</p>
{{/each}}
```

with:

``` hbs
{{#each people as |person|}}
  <p>{{person.firstName}} {{person.lastName}}</p>
  <p>{{person.address}}</p>
{{/each}}
```

**We plan to deprecate support for the context-shifting helpers in Ember 1.9 and remove support in Ember 2.0.** This change should be entirely mechanical.
