### PR TITLE
RFC: Improved CP Syntax

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -67,7 +67,7 @@ for a detailed explanation.
 
 * `ember-htmlbars-inline-if-helper`
 
-  Enables the use of the if helper in inline form. The truthy 
+  Enables the use of the if helper in inline form. The truthy
   and falsy values are passed as params, instead of using the block form.
 
   Added in [#9718](https://github.com/emberjs/ember.js/pull/9718).
@@ -100,3 +100,12 @@ for a detailed explanation.
   - `transitioning-out`: link-to is currently active, but will no longer
     be active when the current underway (slow) transition completes.
 
+* `new-computed-syntax`
+
+  Enables the new computed property syntax. In this new syntax, instead of passing
+  a function that acts both as getter and setter for the property, `Ember.computed`
+  receives an object with `get` and `set` keys, each one containing a function.
+  If the object does not contain a `set` key, the property will simply be overrided.
+  Passing just function is still supported, and is equivalent to pass only a getter.
+
+  Added in [#9527](https://github.com/emberjs/ember.js/pull/9527).

--- a/features.json
+++ b/features.json
@@ -9,7 +9,8 @@
     "ember-htmlbars-component-generation": null,
     "ember-htmlbars-inline-if-helper": true,
     "ember-htmlbars-attribute-syntax": null,
-    "ember-routing-transitioning-classes": true
+    "ember-routing-transitioning-classes": true,
+    "new-computed-syntax": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -151,7 +151,14 @@ function giveDescriptorSuper(meta, key, property, values, descs) {
   // to clone the computed property so that other mixins do not receive
   // the wrapped version.
   property = o_create(property);
-  property.func = wrap(property.func, superProperty.func);
+  property._getter = wrap(property._getter, superProperty._getter);
+  if (superProperty._setter) {
+    if (property._setter) {
+      property._setter = wrap(property._setter, superProperty._setter);
+    } else {
+      property._setter = superProperty._setter;
+    }
+  }
 
   return property;
 }
@@ -250,7 +257,7 @@ function addNormalizedProperty(base, key, value, meta, descs, values, concats, m
 
     // Wrap descriptor function to implement
     // __nextSuper() if needed
-    if (value.func) {
+    if (value._getter) {
       value = giveDescriptorSuper(meta, key, value, values, descs);
     }
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -511,7 +511,6 @@ export function wrap(func, superFunc) {
   }
 
   superWrapper.wrappedFunction = func;
-  superWrapper.wrappedFunction.__ember_arity__ = func.length;
   superWrapper.__ember_observes__ = func.__ember_observes__;
   superWrapper.__ember_observesBefore__ = func.__ember_observesBefore__;
   superWrapper.__ember_listens__ = func.__ember_listens__;

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -616,6 +616,56 @@ testBoth('chained dependent keys should evaluate computed properties lazily', fu
   equal(count, 0, 'b should not run');
 });
 
+// ..........................................................
+// improved-cp-syntax
+//
+
+if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
+  QUnit.module('computed - improved cp syntax');
+
+  test('setter and getters are passed using an object', function() {
+    var testObj = Ember.Object.extend({
+      a: '1',
+      b: '2',
+      aInt: computed('a', {
+        get: function(keyName) {
+          equal(keyName, 'aInt', 'getter receives the keyName');
+          return parseInt(this.get('a'));
+        },
+        set: function(keyName, value, oldValue) {
+          equal(keyName, 'aInt', 'setter receives the keyName');
+          equal(value, 123, 'setter receives the new value');
+          equal(oldValue, 1, 'setter receives the old value');
+          this.set('a', ""+value); // side effect
+          return parseInt(this.get('a'));
+        }
+      })
+    }).create();
+
+    ok(testObj.get('aInt') === 1, 'getter works');
+    testObj.set('aInt', 123);
+    ok(testObj.get('a') === '123', 'setter works');
+    ok(testObj.get('aInt') === 123, 'cp has been updated too');
+  });
+
+  test('setter can be omited', function() {
+    var testObj = Ember.Object.extend({
+      a: '1',
+      b: '2',
+      aInt: computed('a', {
+        get: function(keyName) {
+          equal(keyName, 'aInt', 'getter receives the keyName');
+          return parseInt(this.get('a'));
+        }
+      })
+    }).create();
+
+    ok(testObj.get('aInt') === 1, 'getter works');
+    ok(testObj.get('a') === '1');
+    testObj.set('aInt', '123');
+    ok(testObj.get('aInt') === '123', 'cp has been updated too');
+  });
+}
 
 // ..........................................................
 // BUGS

--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -14,7 +14,7 @@ function ArrayComputedProperty() {
 
   ReduceComputedProperty.apply(this, arguments);
 
-  this.func = (function(reduceFunc) {
+  this._getter = (function(reduceFunc) {
     return function (propertyName) {
       if (!cp._hasInstanceMeta(this, propertyName)) {
         // When we recompute an array computed property, we need already
@@ -29,7 +29,7 @@ function ArrayComputedProperty() {
 
       return reduceFunc.apply(this, arguments);
     };
-  })(this.func);
+  })(this._getter);
 
   return this;
 }

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -544,7 +544,7 @@ function ReduceComputedProperty(options) {
   };
 
 
-  this.func = function (propertyName) {
+  this._getter = function (propertyName) {
     Ember.assert('Computed reduce values require at least one dependent key', cp._dependentKeys);
 
     recompute.call(this, propertyName);

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -12,9 +12,7 @@ test("The `contentArrayDidChange` method is invoked after `content` is updated."
   proxy = ArrayProxy.createWithMixins({
     content: Ember.A(),
 
-    arrangedContent: computed('content', function(key, value) {
-      // setup arrangedContent as a different object than content,
-      // which is the default
+    arrangedContent: computed('content', function(key) {
       return Ember.A(this.get('content').slice());
     }),
 


### PR DESCRIPTION
This PR implements https://github.com/emberjs/rfcs/pull/11

It is based on #9489, which will be merge soon. Also supersedes #9478 (I'll close it in a minute).

There is no feature flags for this because it mostly a refactor that does not change current semantics. It could be done though.
### Tasks

Done in #9489 
- [x] Raise deprecation warnings when passing `cacheable` or `readOnly` to the constructor. No extrictly necessary, but is not used anywhere in the code since 2012 and simplifies things.
- [x] Deprecate usage of `cacheable()` and `readOnly()`. Are the default.

Done in this PR:
- [x] Refactor CPs to work internally with setter and getters. Passing a function still works: If the function has arity < 2 its considered a getter. If arity is >=2 is considered both setter and getter. 

Steps in futures PRs:
- [x] Use new cp syntax all iver the place in ember internals.
- [x] Although passing functions with arity >= 2 is still allowed, is deprecated. Recommend user {get, set} instead.
- [ ] Implement logic in https://github.com/emberjs/rfcs/pull/12
- [ ] Deprecate all the things!
- [ ] Ember 2.0. Delete all the things!
