### PR TITLE
Add {{log}} and {{debugger}} helper for HTMLBars.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/debugger.js
+++ b/packages/ember-htmlbars/lib/helpers/debugger.js
@@ -1,0 +1,51 @@
+/*jshint debug:true*/
+
+/**
+@module ember
+@submodule ember-handlebars
+*/
+import Logger from "ember-metal/logger";
+
+/**
+  Execute the `debugger` statement in the current context.
+
+  ```handlebars
+  {{debugger}}
+  ```
+
+  Before invoking the `debugger` statement, there
+  are a few helpful variables defined in the
+  body of this helper that you can inspect while
+  debugging that describe how and where this
+  helper was invoked:
+
+  - templateContext: this is most likely a controller
+    from which this template looks up / displays properties
+  - typeOfTemplateContext: a string description of
+    what the templateContext is
+
+  For example, if you're wondering why a value `{{foo}}`
+  isn't rendering as expected within a template, you
+  could place a `{{debugger}}` statement, and when
+  the `debugger;` breakpoint is hit, you can inspect
+  `templateContext`, determine if it's the object you
+  expect, and/or evaluate expressions in the console
+  to perform property lookups on the `templateContext`:
+
+  ```
+    > templateContext.get('foo') // -> "<value of {{foo}}>"
+  ```
+
+  @method debugger
+  @for Ember.Handlebars.helpers
+  @param {String} property
+*/
+export function debuggerHelper(options) {
+
+  // These are helpful values you can inspect while debugging.
+  /* jshint unused: false */
+  var view = this;
+  Logger.info('Use `this` to access the view context.');
+
+  debugger;
+}

--- a/packages/ember-htmlbars/lib/helpers/log.js
+++ b/packages/ember-htmlbars/lib/helpers/log.js
@@ -1,0 +1,33 @@
+/**
+@module ember
+@submodule ember-handlebars
+*/
+import Logger from "ember-metal/logger";
+
+/**
+  `log` allows you to output the value of variables in the current rendering
+  context. `log` also accepts primitive types such as strings or numbers.
+
+  ```handlebars
+  {{log "myVariable:" myVariable }}
+  ```
+
+  @method log
+  @for Ember.Handlebars.helpers
+  @param {String} property
+*/
+export function logHelper(params, options, env) {
+  var logger = Logger.log;
+  var values = [];
+
+  for (var i = 0; i < params.length; i++) {
+    if (options.types[i] === 'id') {
+      var stream = params[i];
+      values.push(stream.value());
+    } else {
+      values.push(params[i]);
+    }
+  }
+
+  logger.apply(logger, values);
+}

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -10,6 +10,7 @@ import { viewHelper } from "ember-htmlbars/helpers/view";
 import { yieldHelper } from "ember-htmlbars/helpers/yield";
 import { withHelper } from "ember-htmlbars/helpers/with";
 import { logHelper } from "ember-htmlbars/helpers/log";
+import { debuggerHelper } from "ember-htmlbars/helpers/debugger";
 import {
   ifHelper,
   unlessHelper,
@@ -27,6 +28,7 @@ registerHelper('unless', unlessHelper);
 registerHelper('unboundIf', unboundIfHelper);
 registerHelper('boundIf', boundIfHelper);
 registerHelper('log', logHelper);
+registerHelper('debugger', debuggerHelper);
 
 export var defaultEnv = {
   dom: new DOMHelper(),

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -9,6 +9,7 @@ import { bindHelper } from "ember-htmlbars/helpers/binding";
 import { viewHelper } from "ember-htmlbars/helpers/view";
 import { yieldHelper } from "ember-htmlbars/helpers/yield";
 import { withHelper } from "ember-htmlbars/helpers/with";
+import { logHelper } from "ember-htmlbars/helpers/log";
 import {
   ifHelper,
   unlessHelper,
@@ -25,6 +26,7 @@ registerHelper('if', ifHelper);
 registerHelper('unless', unlessHelper);
 registerHelper('unboundIf', unboundIfHelper);
 registerHelper('boundIf', boundIfHelper);
+registerHelper('log', logHelper);
 
 export var defaultEnv = {
   dom: new DOMHelper(),

--- a/packages/ember-htmlbars/tests/helpers/debug_test.js
+++ b/packages/ember-htmlbars/tests/helpers/debug_test.js
@@ -4,6 +4,14 @@ import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
 import { logHelper } from "ember-handlebars/helpers/debug";
+import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+
+var compile;
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  compile = htmlbarsCompile;
+} else {
+  compile = EmberHandlebars.compile;
+}
 
 var originalLookup = Ember.lookup;
 var lookup;
@@ -49,7 +57,7 @@ test("should be able to log multiple properties", function() {
 
   view = EmberView.create({
     context: context,
-    template: EmberHandlebars.compile('{{log value valueTwo}}')
+    template: compile('{{log value valueTwo}}')
   });
 
   appendView();
@@ -67,7 +75,7 @@ test("should be able to log primitives", function() {
 
   view = EmberView.create({
     context: context,
-    template: EmberHandlebars.compile('{{log value "foo" 0 valueTwo true}}')
+    template: compile('{{log value "foo" 0 valueTwo true}}')
   });
 
   appendView();


### PR DESCRIPTION
Updated to use new HTMLBars build from tildeio/htmlbars#113. No longer gets Handlebars 2.0 compiler.
