### PR TITLE
[Fixes #9541] components which subscribe to actions now must handle them

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -302,6 +302,30 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
       action: actionName,
       actionContext: contexts
     });
+  },
+
+  send: function(actionName) {
+    var args = [].slice.call(arguments, 1);
+    var target;
+    var hasAction = this._actions && this._actions[actionName];
+
+    if (hasAction) {
+      if (this._actions[actionName].apply(this, args) === true) {
+        // handler returned true, so this action will bubble
+      } else {
+        return;
+      }
+    }
+
+    if (target = get(this, 'target')) {
+      Ember.assert("The `target` for " + this + " (" + target +
+                   ") does not have a `send` method", typeof target.send === 'function');
+      target.send.apply(target, arguments);
+    } else {
+      if (!hasAction) {
+        throw new Error(Ember.inspect(this) + ' had no action handler for: ' + actionName);
+      }
+    }
   }
 });
 

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -208,3 +208,41 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     equal(profilerService, appComponent.get('profilerService'), "service.profiler is injected");
   });
 }
+
+
+QUnit.module('Ember.Component - subscribed and sent actions trigger errors');
+
+test('something', function() {
+  expect(2);
+
+  var appComponent = Component.extend({
+    actions: {
+      foo: function(message) {
+        equal('bar', message);
+      }
+    }
+  }).create();
+
+  appComponent.send('foo', 'bar');
+ 
+  throws(function() {
+    appComponent.send('baz', 'bar');
+  }, /had no action handler for: baz/, 'asdf');
+});
+
+test('component with target', function() {
+  expect(2);
+
+  var target = {
+    send: function(message, payload) {
+      equal('foo', message);
+      equal('baz', payload);
+    }
+  };
+
+  var appComponent = Component.create({
+    target: target
+  });
+
+  appComponent.send('foo', 'baz');
+});


### PR DESCRIPTION
Components which subscribe to actions now must handle them, if they do not handle them, nothing changes.
## Example:

``` js
// component-a.js
export default Ember.Component.extend({
   actions:  {  }
})
```

``` hbs
{{!component-a.hbs}}
<h1> Title </h1>
{{some-other-component action="saveMe"}}
```

We clearly have subscribed to `some-other-component`'s `action`. Currently, when action is emitted this results in silence, but my intent is absolutely clear. I am subscribing to be notified, I merely have not completed the contract.

This patch provides us with:

``` js
throw new Error('component:component-a:4123 had no action handler for: `saveMe`');
```

---

Component isolation continues to be in play:

when given:

``` hbs
{{!component-a.hbs}}
<h1> Title </h1>
{{some-other-component}}
```

the `action` is not subscribed to, and as such will continue to remain isolated in the component.

---

target dispatch also remains correct

when given:

``` hbs
{{!component-a.hbs}}
<h1> Title </h1>
{{some-other-component action="foo" target=somethingElse}}
```

as expected `somethingElse` will be notified of `action`
