### PR TITLE
Make attribute and concat regular helpers

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/attribute.js
+++ b/packages/ember-htmlbars/lib/helpers/attribute.js
@@ -1,0 +1,10 @@
+export function attribute(element, params, options) {
+  var name = params[0];
+  var value = params[1];
+
+  value.subscribe(function(lazyValue) {
+    element.setAttribute(name, lazyValue.value());
+  });
+
+  element.setAttribute(name, value.value());
+}

--- a/packages/ember-htmlbars/lib/helpers/concat.js
+++ b/packages/ember-htmlbars/lib/helpers/concat.js
@@ -1,0 +1,18 @@
+import Stream from "ember-metal/streams/stream";
+import {readArray} from "ember-metal/streams/read";
+
+export function concat(params, options) {
+  var stream = new Stream(function() {
+    return readArray(params).join('');
+  });
+
+  for (var i = 0, l = params.length; i < l; i++) {
+    var param = params[i];
+
+    if (param && param.isStream) {
+      param.subscribe(stream.notifyAll, stream);
+    }
+  }
+
+  return stream;
+}

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -1,6 +1,3 @@
-import Stream from "ember-metal/streams/stream";
-import {readArray} from "ember-metal/streams/read";
-
 function streamifyArgs(view, params, options, env) {
   if (params.length === 3 && params[1] === "as") {
     params.splice(0, 3, {
@@ -70,34 +67,5 @@ export function subexpr(path, view, params, options, env) {
 }
 
 export function lookupHelper(name, env) {
-  if (name === 'concat') { return concat; }
-  if (name === 'attribute') { return attribute; }
   return env.helpers[name];
-}
-
-function attribute(element, params, options) {
-  var name = params[0];
-  var value = params[1];
-
-  value.subscribe(function(lazyValue) {
-    element.setAttribute(name, lazyValue.value());
-  });
-
-  element.setAttribute(name, value.value());
-}
-
-function concat(params, options) {
-  var stream = new Stream(function() {
-    return readArray(params).join('');
-  });
-
-  for (var i = 0, l = params.length; i < l; i++) {
-    var param = params[i];
-
-    if (param && param.isStream) {
-      param.subscribe(stream.notifyAll, stream);
-    }
-  }
-
-  return stream;
 }

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -5,6 +5,8 @@ import {
   registerHelper,
   default as helpers
 } from "ember-htmlbars/helpers";
+import { concat } from "ember-htmlbars/helpers/concat";
+import { attribute } from "ember-htmlbars/helpers/attribute";
 import { bindHelper } from "ember-htmlbars/helpers/binding";
 import { viewHelper } from "ember-htmlbars/helpers/view";
 import { yieldHelper } from "ember-htmlbars/helpers/yield";
@@ -18,6 +20,8 @@ import {
   boundIfHelper
 } from "ember-htmlbars/helpers/if_unless";
 
+registerHelper('concat', concat);
+registerHelper('attribute', attribute);
 registerHelper('bindHelper', bindHelper);
 registerHelper('bind', bindHelper);
 registerHelper('view', viewHelper);


### PR DESCRIPTION
Removes special casing in `lookupHelper`, and allows other helpers to utilize `attribute` and `concat` helpers.

/cc @mixonic @mmun
