### PR TITLE
Adds an ability to pass functions to `assert` and `deprecate`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "router.js": "https://github.com/tildeio/router.js.git#f7b4b11543222c52d91df861544592a8c1dcea8a",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
-    "ember-dev": "https://github.com/emberjs/ember-dev.git#fb788b5367a592ac39165416d05a39e78b50a520",
+    "ember-dev": "https://github.com/emberjs/ember-dev.git#1c30a1666273ab2a9b134a42bad28c774f9ecdfc",
     "simple-html-tokenizer": "tildeio/simple-html-tokenizer#83952381ed525eaff9b81c79ccd2ae5af1c9ed9f"
   },
   "resolutions": {

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -685,7 +685,7 @@ var Application = Namespace.extend(DeferredMixin, {
 
     graph.topsort(function (vertex) {
       var initializer = vertex.value;
-      Ember.assert("No application initializer named '" + vertex.name + "'", initializer);
+      Ember.assert("No application initializer named '" + vertex.name + "'", !!initializer);
       initializer(container, namespace);
     });
   },

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -35,7 +35,15 @@ Ember Debug
     falsy, an exception will be thrown.
 */
 Ember.assert = function(desc, test) {
-  if (!test) {
+  var throwAssertion;
+
+  if (typeof test === 'function') {
+    throwAssertion = !test();
+  } else {
+    throwAssertion = !test;
+  }
+
+  if (throwAssertion) {
     throw new EmberError("Assertion Failed: " + desc);
   }
 };
@@ -83,7 +91,15 @@ Ember.debug = function(message) {
     will be displayed.
 */
 Ember.deprecate = function(message, test) {
-  if (test) { return; }
+  var noDeprecation;
+
+  if (typeof test === 'function') {
+    noDeprecation = test();
+  } else {
+    noDeprecation = test;
+  }
+
+  if (noDeprecation) { return; }
 
   if (Ember.ENV.RAISE_ON_DEPRECATION) { throw new EmberError(message); }
 

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -1,0 +1,95 @@
+import Ember from 'ember-metal/core';
+
+QUnit.module('ember-debug');
+
+test('Ember.deprecate throws deprecation if second argument is falsy', function() {
+  expect(3);
+
+  throws(function() {
+    Ember.deprecate('Deprecation is thrown', false);
+  });
+
+  throws(function() {
+    Ember.deprecate('Deprecation is thrown', '');
+  });
+
+  throws(function() {
+    Ember.deprecate('Deprecation is thrown', 0);
+  });
+});
+
+test('Ember.deprecate does not throw deprecation if second argument is a function and it returns true', function() {
+  expect(1);
+
+  Ember.deprecate('Deprecation is thrown', function() {
+    return true;
+  });
+
+  ok(true, 'deprecation was not thrown');
+});
+
+test('Ember.deprecate throws if second argument is a function and it returns false', function() {
+  expect(1);
+
+  throws(function() {
+    Ember.deprecate('Deprecation is thrown', function() {
+      return false;
+    });
+  });
+});
+
+test('Ember.deprecate does not throw deprecations if second argument is truthy', function() {
+  expect(1);
+
+  Ember.deprecate('Deprecation is thrown', true);
+  Ember.deprecate('Deprecation is thrown', '1');
+  Ember.deprecate('Deprecation is thrown', 1);
+
+  ok(true, 'deprecations were not thrown');
+});
+
+test('Ember.assert throws if second argument is falsy', function() {
+  expect(3);
+
+  throws(function() {
+    Ember.assert('Assertion is thrown', false);
+  });
+
+  throws(function() {
+    Ember.assert('Assertion is thrown', '');
+  });
+
+  throws(function() {
+    Ember.assert('Assertion is thrown', 0);
+  });
+});
+
+test('Ember.assert does not throw if second argument is a function and it returns true', function() {
+  expect(1);
+
+  Ember.assert('Assertion is thrown', function() {
+    return true;
+  });
+
+  ok(true, 'assertion was not thrown');
+});
+
+test('Ember.assert throws if second argument is a function and it returns false', function() {
+  expect(1);
+
+  throws(function() {
+    Ember.assert('Assertion is thrown', function() {
+      return false;
+    });
+  });
+});
+
+test('Ember.assert does not throw if second argument is truthy', function() {
+  expect(1);
+
+  Ember.assert('Assertion is thrown', true);
+  Ember.assert('Assertion is thrown', '1');
+  Ember.assert('Assertion is thrown', 1);
+
+  ok(true, 'assertions were not thrown');
+});

--- a/packages/ember-handlebars/lib/helpers/partial.js
+++ b/packages/ember-handlebars/lib/helpers/partial.js
@@ -87,7 +87,7 @@ function renderPartial(context, name, options) {
   var template = view.templateForName(underscoredName);
   var deprecatedTemplate = !template && view.templateForName(name);
 
-  Ember.assert("Unable to find partial with name '"+name+"'.", template || deprecatedTemplate);
+  Ember.assert("Unable to find partial with name '"+name+"'.", !!template || !!deprecatedTemplate);
 
   template = template || deprecatedTemplate;
 

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -87,7 +87,7 @@ function unboundIfHelper(params, options, env) {
 */
 function ifHelper(params, options, env) {
   Ember.assert("You must pass exactly one argument to the if helper", params.length === 1);
-  Ember.assert("You must pass a block to the if helper", options.render);
+  Ember.assert("You must pass a block to the if helper", !!options.render);
 
   options.helperName = options.helperName || ('if ');
 
@@ -109,7 +109,7 @@ function ifHelper(params, options, env) {
 */
 function unlessHelper(params, options, env) {
   Ember.assert("You must pass exactly one argument to the unless helper", params.length === 1);
-  Ember.assert("You must pass a block to the unless helper", options.render);
+  Ember.assert("You must pass a block to the unless helper", !!options.render);
 
   var fn = options.render;
   var inverse = options.inverse || function(){ return ''; };

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -39,16 +39,14 @@ import { loc } from 'ember-runtime/system/string';
   @see {Ember.String#loc}
 */
 export function locHelper(params, options, env) {
-  function ifParamsContainBindings() {
+  Ember.assert('You cannot pass bindings to `loc` helper', function ifParamsContainBindings() {
     for (var i = 0, l = params.length; i < l; i++) {
       if (options.types[i] === 'id') {
         return false;
       }
     }
     return true;
-  }
-
-  Ember.assert('You cannot pass bindings to `loc` helper', ifParamsContainBindings());
+  });
 
   options.morph.update(loc.apply(this, params));
 }

--- a/packages/ember-htmlbars/lib/helpers/partial.js
+++ b/packages/ember-htmlbars/lib/helpers/partial.js
@@ -85,7 +85,7 @@ function lookupPartial(view, templateName) {
     template = view.templateForName(templateName);
   }
 
-  Ember.assert('Unable to find partial with name "'+templateName+'"', template);
+  Ember.assert('Unable to find partial with name "'+templateName+'"', !!template);
 
   return template;
 }

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -65,7 +65,7 @@ export function withHelper(params, options, env) {
     params.length === 1
   );
 
-  Ember.assert("The {{#with}} helper must be called with a block", options.render);
+  Ember.assert("The {{#with}} helper must be called with a block", !!options.render);
 
   var source, keyword;
   var preserveContext, context;

--- a/packages/ember-routing-handlebars/lib/helpers/render.js
+++ b/packages/ember-routing-handlebars/lib/helpers/render.js
@@ -151,7 +151,7 @@ export default function renderHelper(name, contextString, options) {
 
   var templateName = 'template:' + name;
   Ember.assert("You used `{{render '" + name + "'}}`, but '" + name + "' can not be found as either" +
-               " a template or a view.", container.has("view:" + name) || container.has(templateName) || options.fn);
+               " a template or a view.", container.has("view:" + name) || container.has(templateName) || !!options.fn);
   options.hash.template = container.lookup(templateName);
 
   options.hash.controller = controller;

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1332,7 +1332,7 @@ var Route = EmberObject.extend(ActionHandler, {
         Ember.assert("You used the dynamic segment " + name + "_id in your route " +
                      routeName + ", but " + namespace + "." + classify(name) +
                      " did not exist and you did not override your route's `model` " +
-                     "hook.", modelClass);
+                     "hook.", !!modelClass);
 
         if (!modelClass) { return; }
 

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -145,7 +145,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     var templateName = get(this, 'templateName');
     var template = this.templateForName(templateName, 'template');
 
-    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || template);
+    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
 
     return template || get(this, 'defaultTemplate');
   }).property('templateName'),

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -760,7 +760,7 @@ var View = CoreView.extend({
     var templateName = get(this, 'templateName');
     var template = this.templateForName(templateName, 'template');
 
-    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || template);
+    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
 
     return template || get(this, 'defaultTemplate');
   }),
@@ -795,7 +795,7 @@ var View = CoreView.extend({
     var layoutName = get(this, 'layoutName');
     var layout = this.templateForName(layoutName, 'layout');
 
-    Ember.assert("You specified the layoutName " + layoutName + " for " + this + ", but it did not exist.", !layoutName || layout);
+    Ember.assert("You specified the layoutName " + layoutName + " for " + this + ", but it did not exist.", !layoutName || !!layout);
 
     return layout || get(this, 'defaultLayout');
   }).property('layoutName'),


### PR DESCRIPTION
It depends on the [ember-dev PR](https://github.com/emberjs/ember-dev/pull/148).

The use case surfaced when I was [re-writing](https://github.com/emberjs/ember.js/pull/9537) `loc` helper.

It would be nice to replace this code:

``` javascript
export function locHelper(params, options, env) {
  function ifParamsContainBindings() {
    for (var i = 0, l = params.length; i < l; i++) {
      if (options.types[i] === 'id') {
        return false;
      }
    }
    return true;
  }

  Ember.assert('You cannot pass bindings to `loc` helper', ifParamsContainBindings());

  options.morph.update(loc.apply(this, params));
}
```

with this:

``` javascript
export function locHelper(params, options, env) {
  Ember.assert('You cannot pass bindings to `loc` helper', function ifParamsContainBindings() {
    for (var i = 0, l = params.length; i < l; i++) {
      if (options.types[i] === 'id') {
        return false;
      }
    }
    return true;
  });

  options.morph.update(loc.apply(this, params));
}
```

`Ember.assert` is going to be stripped all together and file size of Ember production build won't be changed at all.

Let me know if you want to hide this feature behind a feature flag.
