### PR TITLE
[FEATURE ember-metal-get-properties-rename-keys] Allow keys to be renamed in the object returned by getProperties

### DIFF
--- a/features.json
+++ b/features.json
@@ -16,7 +16,8 @@
     "mandatory-setter": "development-only",
     "ember-routing-fire-activate-deactivate-events": true,
     "ember-testing-pause-test": true,
-    "ember-htmlbars": null
+    "ember-htmlbars": null,
+    "ember-metal-get-properties-rename-keys": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/tests/accessors/getProperties_test.js
+++ b/packages/ember-metal/tests/accessors/getProperties_test.js
@@ -17,3 +17,21 @@ test('can retrieve a hash of properties from an object via an argument list or a
   deepEqual(getProperties(obj, ["firstName"]), { firstName: 'Steve' });
   deepEqual(getProperties(obj, []), {});
 });
+
+if (Ember.FEATURES.isEnabled("ember-metal-get-properties-rename-keys")) {
+  test('can transform property names in returned object', function() {
+    expect(4);
+
+    var obj = {
+      firstName: "Steve",
+      lastName: "Jobs"
+    };
+
+    deepEqual(getProperties(obj, "firstName:first", "lastName:last"), { first: 'Steve', last: 'Jobs' });
+    deepEqual(getProperties(obj, ":"), {});
+
+    obj['application:main'] = 'app';
+    deepEqual(getProperties(obj, "application:main"), { 'application:main': 'app' });
+    deepEqual(getProperties(obj, "application:main:application"), { 'application': 'app' });
+  });
+}


### PR DESCRIPTION
In a number of places in our application, we call `getProperties` but end up having to rename the keys of the object that is returned.  I figured throwing out some failing tests to demonstrate the syntax would be the easiest way to get feedback on whether this feature is desirable or not.
