### PR TITLE
Clarify that SHIM_ES5 only adds Array methods

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -167,7 +167,7 @@ if (typeof Ember.EXTEND_PROTOTYPES === 'undefined') {
 Ember.LOG_STACKTRACE_ON_DEPRECATION = (Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION !== false);
 
 /**
-  Determines whether Ember should add ECMAScript 5 shims to older browsers.
+  Determines whether Ember should add ECMAScript 5 Array shims to older browsers.
 
   @property SHIM_ES5
   @type Boolean


### PR DESCRIPTION
I spent a little time today trying to figure out why the SHIM_ES5 setting wasn't shimming Function#bind — and its because this flag only enables Array method shims. Added clarification.
