### PR TITLE
[Bugfix Beta] Container.options populate options

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -372,11 +372,13 @@ Container.prototype = {
 
   /**
     @method options
-    @param {String} type
+    @param {String} fullName
     @param {Object} options
   */
-  options: function(type, options) {
-    this.optionsForType(type, options);
+  options: function(fullName, options) {
+    options = options || {};
+    var normalizedName = this.normalize(fullName);
+    this._options[normalizedName] = options;
   },
 
   /**

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -473,6 +473,28 @@ test("The container normalizes names when injecting", function() {
   deepEqual(container.lookup('controller:post'), user, "Normalizes the name when injecting");
 });
 
+test("The container can get options that should be applied to a given factory", function(){
+  var container = new Container();
+
+  var PostView = factory();
+
+  container.resolver = function(fullName) {
+    if (fullName === 'view:post') {
+      return PostView;
+    }
+  };
+
+  container.options('view:post', {instantiate: true, singleton: false});
+
+  var postView1 = container.lookup('view:post');
+  var postView2 = container.lookup('view:post');
+
+  ok(postView1 instanceof PostView, "The correct factory was provided");
+  ok(postView2 instanceof PostView, "The correct factory was provided");
+
+  ok(postView1 !== postView2, "The two lookups are different");
+});
+
 test("The container can get options that should be applied to all factories for a given type", function() {
   var container = new Container();
   var PostView = factory();


### PR DESCRIPTION
As has been highlighted here: https://github.com/emberjs/ember.js/issues/9371 by @stefanpenner Container.options was actually populating the _typeOptions object.

I assume that Container.options should set the options for a given factory specified by its full name, so the fix and the test apply/verify that logic: The test would fail without the fix because by default the `singleton` option is `true`, so both `postView`'s would be identical if we were not able to set options for that factory.
