### PR TITLE
Adds `unbound` htmlbars helper

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/unbound.js
+++ b/packages/ember-htmlbars/lib/helpers/unbound.js
@@ -1,0 +1,53 @@
+import { lookupHelper } from 'ember-htmlbars/system/lookup-helper';
+import { read } from 'ember-metal/streams/read';
+
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+/**
+  `unbound` allows you to output a property without binding. *Important:* The
+  output will not be updated if the property changes. Use with caution.
+
+  ```handlebars
+  <div>{{unbound somePropertyThatDoesntChange}}</div>
+  ```
+
+  `unbound` can also be used in conjunction with a bound helper to
+  render it in its unbound form:
+
+  ```handlebars
+  <div>{{unbound helperName somePropertyThatDoesntChange}}</div>
+  ```
+
+  @method unbound
+  @for Ember.Handlebars.helpers
+  @param {String} property
+  @return {String} HTML string
+*/
+export function unboundHelper(params, hash, options, env) {
+  var length = params.length;
+  var result;
+
+  options.helperName = options.helperName || 'unbound';
+
+  if (length === 1) {
+    result = params[0].value();
+  } else if (length >= 2) {
+    var helperName = params[0];
+    var args = [];
+
+    for (var i = 1, l = params.length; i < l; i++) {
+      var value = read(params[i]);
+
+      args.push(value);
+    }
+
+    var helper = lookupHelper(helperName, this, env);
+
+    result = helper.call(this, args, hash, options, env);
+  }
+
+  options.morph.update(result);
+}

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -37,6 +37,7 @@ import { inputHelper } from "ember-htmlbars/helpers/input";
 import { textareaHelper } from "ember-htmlbars/helpers/text_area";
 import { collectionHelper } from "ember-htmlbars/helpers/collection";
 import { eachHelper } from "ember-htmlbars/helpers/each";
+import { unboundHelper } from "ember-htmlbars/helpers/unbound";
 
 registerHelper('bindHelper', bindHelper);
 registerHelper('bind', bindHelper);
@@ -58,6 +59,7 @@ registerHelper('input', inputHelper);
 registerHelper('textarea', textareaHelper);
 registerHelper('collection', collectionHelper);
 registerHelper('each', eachHelper);
+registerHelper('unbound', unboundHelper);
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   Ember.HTMLBars = {
@@ -81,4 +83,3 @@ export var defaultEnv = {
 
   helpers: helpers
 };
-


### PR DESCRIPTION
Most of the tests got hidden behind a feature flag because they depend on `makeBoundHelper` and `registerBoundHelper`.
