### PR TITLE
cleanup core object init argument passing

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -170,16 +170,22 @@ function makeCtor() {
         }
       }
     }
+
     finishPartial(this, m);
+
     var length = arguments.length;
-    var args = new Array(length);
-    for (var x = 0; x < length; x++) {
-      args[x] = arguments[x];
+
+    if (length === 0) {
+      this.init();
+    } else if (length === 1) {
+      this.init(arguments[0]);
+    } else {
+      this.init.apply(this, arguments);
     }
-    apply(this, this.init, args);
+
     m.proto = proto;
     finishChains(this);
-    sendEvent(this, "init");
+    sendEvent(this, 'init');
   };
 
   Class.toString = Mixin.prototype.toString;


### PR DESCRIPTION
- don't allocate new array if no arguments exist
- don't do costly apply, if there are not multiple (or any) arguments to apply to

test run stats:

1 arguments 10153
2 arguments   490
3 arguments     0
4 arguments     5

(yes apps may use this differently, but ultimately the 1 argument case is the most common, and most hot-paths are in ember-corec)
