### PR TITLE
Remove unused container method set()

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -104,20 +104,6 @@ Container.prototype = {
   },
 
   /**
-    Sets a key-value pair on the current container. If a parent container,
-    has the same key, once set on a child, the parent and child will diverge
-    as expected.
-
-    @method set
-    @param {Object} object
-    @param {String} key
-    @param {any} value
-  */
-  set: function(object, key, value) {
-    object[key] = value;
-  },
-
-  /**
     Registers a factory for later injection.
 
     Example:


### PR DESCRIPTION
This method seems to have been left behind when the code that used it was modified and was no longer using it.  All the tests pass without it, and it's not described as a hook like some other methods in `Container`.  In looking into the history I found:

(a) It was added (line 13) in https://github.com/emberjs/ember.js/commit/25f444603b660976c00eb4cb4b7be31d1da01f86 and was being used (line 85) in `applyInjections`, which itself was being used (line 122) in `instantiate`.
(b) This use was removed in https://github.com/emberjs/ember.js/commit/179744aca0557c53e4c38fd5e6d8dc7f38a2348a , with the function being renamed from `applyInjections` to `buildInjections` and what `set` was doing now being done directly (`hash` is also a new addition):

```
- container.set(value, injection.property, lookup);
+ hash[injection.property] = lookup;
```

So I'm confident that `set` should be deleted, but of course this should be verified by people more familiar with the code and its history, and if I'm wrong please go easy on me :-)
