### PR TITLE
Remove duplicate bindHelper helper.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -35,7 +35,7 @@ export function content(morph, path, view, params, options, env) {
   morph.escaped = options.escaped;
   var helper = hooks.lookupHelper(path, env);
   if (!helper) {
-    helper = hooks.lookupHelper('bindHelper', env);
+    helper = hooks.lookupHelper('bind', env);
     // Modify params to include the first word
     params.unshift(path);
     options.types = ['id'];

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -21,7 +21,6 @@ import { locHelper } from "ember-htmlbars/helpers/loc";
 import { partialHelper } from "ember-htmlbars/helpers/partial";
 import { templateHelper } from "ember-htmlbars/helpers/template";
 
-registerHelper('bindHelper', bindHelper);
 registerHelper('bind', bindHelper);
 registerHelper('view', viewHelper);
 registerHelper('yield', yieldHelper);


### PR DESCRIPTION
We already have `bind` registered, we don't need both `bindHelper` and `bind` as registered helpers.
