### PR TITLE
Avoid if statements useful only for Ember.deprecate calls.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1036,9 +1036,7 @@ Application.reopenClass({
   @return {*} the resolved value for a given lookup
 */
 function resolverFor(namespace) {
-  if (namespace.get('resolver')) {
-    Ember.deprecate('Application.resolver is deprecated in favor of Application.Resolver', false);
-  }
+  Ember.deprecate('Application.resolver is deprecated in favor of Application.Resolver', !namespace.get('resolver'));
 
   var ResolverClass = namespace.get('resolver') || namespace.get('Resolver') || DefaultResolver;
   var resolver = ResolverClass.create({

--- a/packages/ember-views/lib/mixins/component_template_deprecation.js
+++ b/packages/ember-views/lib/mixins/component_template_deprecation.js
@@ -55,8 +55,6 @@ export default Mixin.create({
       delete props['template'];
     }
 
-    if (deprecatedProperty) {
-      Ember.deprecate('Do not specify ' + deprecatedProperty + ' on a Component, use ' + replacementProperty + ' instead.', false);
-    }
+    Ember.deprecate('Do not specify ' + deprecatedProperty + ' on a Component, use ' + replacementProperty + ' instead.', !deprecatedProperty);
   }
 });


### PR DESCRIPTION
This removes empty if blocks in `ember.prod.js`.

/cc @rwjblue
