### PR TITLE
[Bugfix beta] RSVP.onerrordefault now unwraps reason like jqXHR to be it...

### DIFF
--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -41,7 +41,17 @@ RSVP.Promise.prototype.fail = function(callback, label){
   return this['catch'](callback, label);
 };
 
-RSVP.onerrorDefault = function (error) {
+RSVP.onerrorDefault = function (e) {
+  var error;
+
+  if (e && e.errorThrown) {
+    // jqXHR provides this
+    error = e.errorThrown;
+    error.__reason_with_error_thrown__ = e;
+  } else {
+    error = e;
+  }
+
   if (error && error.name !== 'TransitionAborted') {
     if (Ember.testing) {
       // ES6TODO: remove when possible

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -117,3 +117,28 @@ test('TransitionAborted errors are not re-thrown', function() {
 
   ok(true, 'did not throw an error when dealing with TransitionAborted');
 });
+
+test('rejections like jqXHR which have errorThrown property work', function() {
+  expect(2);
+
+  var wasEmberTesting = Ember.testing;
+  var wasOnError      = Ember.onerror;
+
+  try {
+    Ember.testing = false;
+    Ember.onerror = function(error) {
+      equal(error, actualError, 'expected the real error on the jqXHR');
+      equal(error.__reason_with_error_thrown__, jqXHR, 'also retains a helpful reference to the rejection reason');
+    };
+
+    var actualError = new Error("OMG what really happend");
+    var jqXHR = {
+      errorThrown: actualError
+    };
+
+    run(RSVP, 'reject', jqXHR);
+  } finally {
+    Ember.onerror = wasOnError;
+    Ember.testing = wasEmberTesting ;
+  }
+});


### PR DESCRIPTION
...s errorThrown.

This should provide much more actionable errors.

previously I had  the result of `console.log(undefined)` now i get:

![screenshot 2014-11-13 12 15 00](https://cloud.githubusercontent.com/assets/1377/5032822/c92d71e0-6b2e-11e4-959e-34d3d2786d4c.png)
