### PR TITLE
Ensure options are consistent for helpers.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -1,4 +1,5 @@
 import { lookupHelper } from "ember-htmlbars/system/lookup-helper";
+import { sanitizeOptionsForHelper } from "ember-htmlbars/system/sanitize-for-helper";
 
 function streamifyArgs(view, params, options, env) {
   if (params.length === 3 && params[1] === "as") {
@@ -39,6 +40,7 @@ export function content(morph, path, view, params, options, env) {
   }
 
   streamifyArgs(view, params, options, env);
+  sanitizeOptionsForHelper(options);
   return helper.call(view, params, options, env);
 }
 
@@ -47,6 +49,7 @@ export function element(element, path, view, params, options, env) { //jshint ig
 
   if (helper) {
     streamifyArgs(view, params, options, env);
+    sanitizeOptionsForHelper(options);
     return helper.call(view, element, params, options, env);
   } else {
     return view.getStream(path);
@@ -58,6 +61,7 @@ export function subexpr(path, view, params, options, env) {
 
   if (helper) {
     streamifyArgs(view, params, options, env);
+    sanitizeOptionsForHelper(options);
     return helper.call(view, params, options, env);
   } else {
     return view.getStream(path);

--- a/packages/ember-htmlbars/lib/system/sanitize-for-helper.js
+++ b/packages/ember-htmlbars/lib/system/sanitize-for-helper.js
@@ -1,0 +1,22 @@
+/**
+  Sanitize options so that all helpers have `types`, `hash`, and `hashTypes`.
+
+  @private
+  @method sanitizeOptionsForHelper
+  @param {Object} options The options hash provided by the template engine.
+*/
+export function sanitizeOptionsForHelper(options) {
+  if (!options.types) {
+    options.types = [];
+  }
+
+  if (!options.hash) {
+    options.hash = {};
+  }
+
+  if (!options.hashTypes) {
+    options.hashTypes = {};
+  }
+
+  return options;
+}

--- a/packages/ember-htmlbars/tests/system/sanitize-for-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/sanitize-for-helper_test.js
@@ -1,0 +1,71 @@
+import { sanitizeOptionsForHelper } from "ember-htmlbars/system/sanitize-for-helper";
+
+var options;
+QUnit.module('ember-htmlbars: sanitize-for-helper', {
+  setup: function() {
+    options = {};
+  },
+
+  teardown: function() {
+    ok(options.types, 'types is present');
+    ok(options.hash, 'hash is present');
+    ok(options.hashTypes, 'hashTypes is present');
+  }
+});
+
+test('will not override `types` if present', function() {
+  expect(4);
+
+  var types = [];
+  options.types = types;
+
+  sanitizeOptionsForHelper(options);
+
+  equal(options.types, types, 'types is not changed when present');
+});
+
+test('will add `types` if not present', function() {
+  expect(4);
+
+  sanitizeOptionsForHelper(options);
+
+  deepEqual(options.types, [], 'types is added when not present');
+});
+
+test('will not override `hash` if present', function() {
+  expect(4);
+
+  var hash = {};
+  options.hash = hash;
+
+  sanitizeOptionsForHelper(options);
+
+  equal(options.hash, hash, 'hash is not changed when present');
+});
+
+test('will add `hash` if not present', function() {
+  expect(4);
+
+  sanitizeOptionsForHelper(options);
+
+  deepEqual(options.hash, {}, 'hash is added when not present');
+});
+
+test('will not override `hashTypes` if present', function() {
+  expect(4);
+
+  var hashTypes = {};
+  options.hashTypes = hashTypes;
+
+  sanitizeOptionsForHelper(options);
+
+  equal(options.hashTypes, hashTypes, 'hashTypes is not changed when present');
+});
+
+test('will add `hashTypes` if not present', function() {
+  expect(4);
+
+  sanitizeOptionsForHelper(options);
+
+  deepEqual(options.hashTypes, {}, 'hashTypes is added when not present');
+});


### PR DESCRIPTION
Helpers like `{{yield}}` and `{{outlet}}` will not automatically have `types`, `hash`, and `hashTypes` populated. This ensures that all helpers can expect them to exist.

Originally from https://github.com/tildeio/htmlbars/issues/115.
