### PR TITLE
Add template & compile functions for HTMLBars.

### DIFF
--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,5 +1,8 @@
+import Ember from "ember-metal/core";
 import { content, element, subexpr } from "ember-htmlbars/hooks";
 import { DOMHelper } from "morph";
+import template from "ember-htmlbars/system/template";
+import compile from "ember-htmlbars/system/compile";
 
 import {
   registerHelper,
@@ -41,6 +44,13 @@ registerHelper('partial', partialHelper);
 registerHelper('template', templateHelper);
 registerHelper('bind-attr', bindAttrHelper);
 registerHelper('bindAttr', bindAttrHelperDeprecated);
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  Ember.HTMLBars = {
+    template: template,
+    compile: compile
+  };
+}
 
 export var defaultEnv = {
   dom: new DOMHelper(),

--- a/packages/ember-htmlbars/lib/system/compile.js
+++ b/packages/ember-htmlbars/lib/system/compile.js
@@ -1,0 +1,18 @@
+import { compile } from "htmlbars-compiler/compiler";
+import template from "ember-htmlbars/system/template";
+
+/**
+  Uses HTMLBars `compile` function to process a string into a compiled template.
+
+  This is not present in production builds.
+
+  @private
+  @method template
+  @param {String} templateString This is the string to be compiled by HTMLBars.
+*/
+
+export default function(templateString) {
+  var templateSpec = compile(templateString);
+
+  return template(templateSpec);
+}

--- a/packages/ember-htmlbars/lib/system/template.js
+++ b/packages/ember-htmlbars/lib/system/template.js
@@ -1,0 +1,15 @@
+/**
+  Augments the detault precompiled output of an HTMLBars template with
+  additional information needed by Ember.
+
+  @private
+  @method template
+  @param {Function} templateSpec This is the compiled HTMLBars template spec.
+*/
+
+export default function(templateSpec) {
+  templateSpec.isTop = true;
+  templateSpec.isMethod = false;
+
+  return templateSpec;
+}

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -15,9 +15,7 @@ import { set } from "ember-metal/property_set";
 import {
   default as htmlbarsHelpers
 } from "ember-htmlbars/helpers";
-import {
-  compile as htmlbarsCompile
-} from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile, helpers;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/helpers/bind_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_test.js
@@ -2,7 +2,7 @@ import EmberView from "ember-views/views/view";
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
 import EmberHandlebars from "ember-handlebars";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 function appendView(view) {
   run(function() { view.appendTo('#qunit-fixture'); });

--- a/packages/ember-htmlbars/tests/helpers/debug_test.js
+++ b/packages/ember-htmlbars/tests/helpers/debug_test.js
@@ -4,7 +4,7 @@ import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
 import { logHelper } from "ember-handlebars/helpers/debug";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -3,7 +3,7 @@ import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 import EmberHandlebars from "ember-handlebars";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/helpers/loc_test.js
+++ b/packages/ember-htmlbars/tests/helpers/loc_test.js
@@ -1,7 +1,7 @@
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 import EmberHandlebars from 'ember-handlebars-compiler';
-import { compile as htmlbarsCompile } from 'htmlbars-compiler/compiler';
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/helpers/partial_test.js
+++ b/packages/ember-htmlbars/tests/helpers/partial_test.js
@@ -5,7 +5,7 @@ import jQuery from "ember-views/system/jquery";
 var trim = jQuery.trim;
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var MyApp, lookup, view, container;
 var originalLookup = Ember.lookup;

--- a/packages/ember-htmlbars/tests/helpers/template_test.js
+++ b/packages/ember-htmlbars/tests/helpers/template_test.js
@@ -6,7 +6,7 @@ var trim = jQuery.trim;
 
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var MyApp, lookup, view, container;
 var originalLookup = Ember.lookup;

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -4,7 +4,7 @@ import Container from 'container/container';
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 import EmberHandlebars from "ember-handlebars";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -9,7 +9,7 @@ import ObjectController from "ember-runtime/controllers/object_controller";
 import Container from "ember-runtime/system/container";
 // import { A } from "ember-runtime/system/native_array";
 import EmberHandlebars from "ember-handlebars";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -14,7 +14,7 @@ import {
 } from "ember-htmlbars/helpers";
 
 import EmberHandlebars from "ember-handlebars";
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile, helper;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-htmlbars/tests/system/compile_test.js
+++ b/packages/ember-htmlbars/tests/system/compile_test.js
@@ -1,0 +1,28 @@
+import compile from "ember-htmlbars/system/compile";
+import {
+  compile as htmlbarsCompile
+} from "htmlbars-compiler/compiler";
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module('ember-htmlbars: compile');
+
+test('compiles the provided template with htmlbars', function() {
+  var templateString = "{{foo}} -- {{some-bar blah='foo'}}";
+
+  var actual = compile(templateString);
+  var expected = htmlbarsCompile(templateString);
+
+  equal(actual.toString(), expected.toString(), 'compile function matches content with htmlbars compile');
+});
+
+test('calls template on the compiled function', function() {
+  var templateString = "{{foo}} -- {{some-bar blah='foo'}}";
+
+  var actual = compile(templateString);
+
+  ok(actual.isTop, 'sets isTop via template function');
+  ok(actual.isMethod === false, 'sets isMethod via template function');
+});
+
+}

--- a/packages/ember-htmlbars/tests/system/template_test.js
+++ b/packages/ember-htmlbars/tests/system/template_test.js
@@ -1,0 +1,23 @@
+import template from "ember-htmlbars/system/template";
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module('ember-htmlbars: template');
+
+test('sets `isTop` on the provided function', function() {
+  function test() { }
+
+  template(test);
+
+  equal(test.isTop, true, 'sets isTop on the provided function');
+});
+
+test('sets `isMethod` on the provided function', function() {
+  function test() { }
+
+  template(test);
+
+  equal(test.isMethod, false, 'sets isMethod on the provided function');
+});
+
+}


### PR DESCRIPTION
This provides a central location for any customizations we need to do to the compiled templates from htmlbars-compiler.

Things like `isTop` and `isMethod` being set for example. These are obviously, Ember concerns (neither thing really makes sense in HTMLBars).

The node-land precompiler should now return the following template:

``` javascript
export default Ember.HTMLBars.template(/* output from compileSpec */)
```
