### PR TITLE
Use HTMLBars from published NPM package.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,7 @@
     "router.js": "https://github.com/tildeio/router.js.git#f7b4b11543222c52d91df861544592a8c1dcea8a",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
-    "ember-dev": "https://github.com/emberjs/ember-dev.git#1c30a1666273ab2a9b134a42bad28c774f9ecdfc",
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#83952381ed525eaff9b81c79ccd2ae5af1c9ed9f"
+    "ember-dev": "https://github.com/emberjs/ember-dev.git#1c30a1666273ab2a9b134a42bad28c774f9ecdfc"
   },
   "resolutions": {
     "handlebars": "~2.0.0"

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -9,7 +9,7 @@ module.exports = {
   'ember-testing':              {trees: null,  requirements: ['ember-application', 'ember-routing'], developmentOnly: true},
   'ember-handlebars-compiler':  {trees: null,  requirements: ['ember-views']},
   'ember-handlebars':           {trees: null,  requirements: ['ember-views', 'ember-handlebars-compiler']},
-  'ember-htmlbars':             {trees: null,  vendorRequirements: ['htmlbars', 'handlebars', 'simple-html-tokenizer', 'htmlbars-compiler'], requirements: ['ember-metal-views']},
+  'ember-htmlbars':             {trees: null,  vendorRequirements: ['handlebars', 'simple-html-tokenizer', 'htmlbars-compiler', 'htmlbars-test-helpers'], requirements: ['ember-metal-views']},
   'ember-routing':              {trees: null,  vendorRequirements: ['router', 'route-recognizer'],
                                                requirements: ['ember-runtime', 'ember-views']},
   'ember-routing-handlebars':   {trees: null,  requirements: ['ember-routing', 'ember-handlebars']},

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "git-repo-version": "0.0.1",
     "glob": "~3.2.8",
     "handlebars": "^2.0",
-    "htmlbars": "tildeio/htmlbars#e6cfd7517b279de437b93fc2f66775b37c029c5d",
+    "htmlbars": "0.1.3",
     "ncp": "~0.5.1",
     "rimraf": "~2.2.8",
     "rsvp": "~3.0.6"

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -2,7 +2,7 @@ import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import { compile } from "htmlbars-compiler/compiler";
-import { equalInnerHTML } from "../helpers";
+import { equalInnerHTML } from "htmlbars-test-helpers";
 
 var view;
 

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -1,6 +1,6 @@
 import { compile } from "htmlbars-compiler/compiler";
 import { defaultEnv } from "ember-htmlbars";
-import { equalHTML } from "./helpers";
+import { equalHTML } from "htmlbars-test-helpers";
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -25,7 +25,7 @@ import jQuery from "ember-views/system/jquery";
 import { outletHelper as handlebarsOutletHelper } from "ember-routing-handlebars/helpers/outlet";
 import { outletHelper as htmlbarsOutletHelper } from "ember-routing-htmlbars/helpers/outlet";
 
-import { compile as htmlbarsCompile } from "htmlbars-compiler/compiler";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
 import { registerHelper as htmlbarsRegisterHelper } from "ember-htmlbars/helpers";
 import htmlbarsHelpers from "ember-htmlbars/helpers";
 


### PR DESCRIPTION
- Now actually publishing HTMLBars to NPM. We can let the HTMLBars build do all the work for getting ES6 output in the right place and ready to consume.
- Removes need to do crazy monkey patching/nesting inside HTMLBars.
- Enables us to use the specific version of simple-html-tokenizer for the version of HTMLBars we are using.
- Do not use `htmlbars-runtime` (ember-htmlbars is our runtime).
