### PR TITLE
Ensure that bound properties work with {{view}} helper.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -21,12 +21,12 @@ function makeBindings(hash, options, view) {
     var hashType = hashTypes[prop];
     var valueOrStream = hash[prop];
 
-    if (IS_BINDING.test(prop)) {
-      // classBinding is processed separately
-      if (prop === 'classBinding') {
-        continue;
-      }
+    // classBinding is processed separately
+    if (prop === 'classBinding') {
+      continue;
+    }
 
+    if (IS_BINDING.test(prop)) {
       if (hashType === 'id') {
         // valueOrStream is a stream, streamifyArgs took care of it
         Ember.warn("You're attempting to render a view by passing " +
@@ -37,6 +37,13 @@ function makeBindings(hash, options, view) {
                    "from " + prop + ".");
       } else if (typeof valueOrStream === 'string') {
         hash[prop] = view._getBindingForStream(valueOrStream);
+      }
+    } else {
+      if (hashType === 'id' && prop !== 'id') {
+        hash[prop + 'Binding'] = valueOrStream;
+
+        delete hash[prop];
+        delete hashTypes[prop];
       }
     }
   }

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -22,7 +22,7 @@ function streamifyArgs(view, params, hash, options, env) {
   // Convert hash ID values to streams
   var hashTypes = options.hashTypes;
   for (var key in hash) {
-    if (hashTypes[key] === 'id' && key !== 'classBinding') {
+    if (hashTypes[key] === 'id' && key !== 'classBinding' && key !== 'class') {
       hash[key] = view.getStream(hash[key]);
     }
   }


### PR DESCRIPTION
Prior to this change, any bound properties specified for components or views would result in the property being set to the actual `Stream` object instead of the property value. Sadly, we had no tests that confirmed this worked so it seemed as if all was well.  We now have tests for this...
