### PR TITLE
Add deprecation for quoteless outlet names

### DIFF
--- a/packages/ember-routing-handlebars/lib/helpers/outlet.js
+++ b/packages/ember-routing-handlebars/lib/helpers/outlet.js
@@ -82,6 +82,12 @@ export function outletHelper(property, options) {
     property = 'main';
   }
 
+  Ember.deprecate(
+    "Using {{outlet}} with an unquoted name is not supported. " +
+    "Please update to quoted usage '{{outlet \"" + property + "\"}}'.",
+    arguments.length === 1 || options.types[0] === 'STRING'
+  );
+
   var view = options.data.view;
   var container = view.container;
 
@@ -96,9 +102,15 @@ export function outletHelper(property, options) {
 
   if (viewName) {
     viewFullName = 'view:' + viewName;
-    Ember.assert("Using a quoteless view parameter with {{outlet}} is not supported." +
-                 " Please update to quoted usage '{{outlet \"" + viewName + "\"}}.", options.hashTypes.view !== 'ID');
-    Ember.assert("The view name you supplied '" + viewName + "' did not resolve to a view.", container.has(viewFullName));
+    Ember.assert(
+      "Using a quoteless view parameter with {{outlet}} is not supported." +
+      " Please update to quoted usage '{{outlet ... view=\"" + viewName + "\"}}.",
+      options.hashTypes.view !== 'ID'
+    );
+    Ember.assert(
+      "The view name you supplied '" + viewName + "' did not resolve to a view.",
+      container.has(viewFullName)
+    );
   }
 
   viewClass = viewName ? container.lookupFactory(viewFullName) : options.hash.viewClass || OutletView;

--- a/packages/ember-routing-htmlbars/lib/helpers/outlet.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/outlet.js
@@ -77,8 +77,10 @@ export function outletHelper(params, hash, options, env) {
   var viewClass;
   var viewFullName;
 
-  Ember.assert("Outlet names must be a string literal, e.g. {{outlet \"header\"}}",
-    params.length === 0 || options.types[0] === 'string');
+  Ember.assert(
+    "Using {{outlet}} with an unquoted name is not supported.",
+    params.length === 0 || options.types[0] === 'string'
+  );
 
   var property = params[0] || 'main';
 
@@ -93,9 +95,15 @@ export function outletHelper(params, hash, options, env) {
 
   if (viewName) {
     viewFullName = 'view:' + viewName;
-    Ember.assert("Using a quoteless view parameter with {{outlet}} is not supported." +
-                 " Please update to quoted usage '{{outlet \"" + viewName + "\"}}.", options.hashTypes.view === 'string');
-    Ember.assert("The view name you supplied '" + viewName + "' did not resolve to a view.", this.container.has(viewFullName));
+    Ember.assert(
+      "Using a quoteless view parameter with {{outlet}} is not supported." +
+      " Please update to quoted usage '{{outlet ... view=\"" + viewName + "\"}}.",
+      options.hashTypes.view === 'string'
+    );
+    Ember.assert(
+      "The view name you supplied '" + viewName + "' did not resolve to a view.",
+      this.container.has(viewFullName)
+    );
   }
 
   viewClass = viewName ? this.container.lookupFactory(viewFullName) : hash.viewClass || OutletView;

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -380,3 +380,39 @@ test("should support layouts", function() {
   // Replace whitespace for older IE
   equal(trim(view.$().text()), 'HIBYE');
 });
+
+test("should not throw deprecations if {{outlet}} is used without a name", function() {
+  expectNoDeprecation();
+  view = EmberView.create({
+    template: compile("{{outlet}}")
+  });
+  appendView(view);
+});
+
+test("should not throw deprecations if {{outlet}} is used with a quoted name", function() {
+  expectNoDeprecation();
+  view = EmberView.create({
+    template: compile("{{outlet \"foo\"}}"),
+  });
+  appendView(view);
+});
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  test("should throw an assertion if {{outlet}} used with unquoted name", function() {
+    view = EmberView.create({
+      template: compile("{{outlet foo}}"),
+    });
+    expectAssertion(function() {
+      appendView(view);
+    }, "Using {{outlet}} with an unquoted name is not supported.");
+  });
+} else {
+  test("should throw a deprecation if {{outlet}} is used with an unquoted name", function() {
+    view = EmberView.create({
+      template: compile("{{outlet foo}}")
+    });
+    expectDeprecation(function() {
+      appendView(view);
+    }, 'Using {{outlet}} with an unquoted name is not supported. Please update to quoted usage \'{{outlet "foo"}}\'.');
+  });
+}


### PR DESCRIPTION
Handlebars: {{outlet foo}} is deprecated in favor of {{outlet 'foo'}}
HTMLBars: {{outlet foo}} will throw an assertion.
