### PR TITLE
Ensure streams have an appropriate type after streamifying.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/input.js
+++ b/packages/ember-htmlbars/lib/helpers/input.js
@@ -199,7 +199,7 @@ export function inputHelper(params, hash, options, env) {
     delete types.type;
 
     Ember.assert("{{input type='checkbox'}} does not support setting `value=someBooleanValue`;" +
-                 " you must use `checked=someBooleanValue` instead.", options.hashTypes.value !== 'id');
+                 " you must use `checked=someBooleanValue` instead.", options.hashTypes.value !== 'stream');
 
     return env.helpers.view.call(this, [Checkbox], hash, options, env);
   } else {

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -41,7 +41,7 @@ import { loc } from 'ember-runtime/system/string';
 export function locHelper(params, hash, options, env) {
   Ember.assert('You cannot pass bindings to `loc` helper', function ifParamsContainBindings() {
     for (var i = 0, l = params.length; i < l; i++) {
-      if (options.types[i] === 'id') {
+      if (options.types[i] === 'stream') {
         return false;
       }
     }

--- a/packages/ember-htmlbars/lib/helpers/log.js
+++ b/packages/ember-htmlbars/lib/helpers/log.js
@@ -21,7 +21,7 @@ export function logHelper(params, hash, options, env) {
   var values = [];
 
   for (var i = 0; i < params.length; i++) {
-    if (options.types[i] === 'id') {
+    if (options.types[i] === 'stream') {
       var stream = params[i];
       values.push(stream.value());
     } else {

--- a/packages/ember-htmlbars/lib/helpers/partial.js
+++ b/packages/ember-htmlbars/lib/helpers/partial.js
@@ -53,7 +53,7 @@ export function partialHelper(params, hash, options, env) {
 
   options.helperName = options.helperName || 'partial';
 
-  if (options.types[0] === "id") {
+  if (options.types[0] === "stream") {
     var partialNameStream = params[0];
     // Helper was passed a property path; we need to
     // create a binding that will re-render whenever

--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -22,12 +22,12 @@ function makeBindings(hash, options, view) {
     var valueOrStream = hash[prop];
 
     // classBinding is processed separately
-    if (prop === 'classBinding') {
+    if (prop === 'classBinding' || prop === 'id') {
       continue;
     }
 
     if (IS_BINDING.test(prop)) {
-      if (hashType === 'id') {
+      if (hashType === 'stream') {
         // valueOrStream is a stream, streamifyArgs took care of it
         Ember.warn("You're attempting to render a view by passing " +
                    prop + " " +
@@ -39,8 +39,9 @@ function makeBindings(hash, options, view) {
         hash[prop] = view._getBindingForStream(valueOrStream);
       }
     } else {
-      if (hashType === 'id' && prop !== 'id') {
+      if (hashType === 'stream' || hashType === 'id') {
         hash[prop + 'Binding'] = valueOrStream;
+        hashTypes[prop + 'Binding'] = hashType;
 
         delete hash[prop];
         delete hashTypes[prop];
@@ -67,8 +68,7 @@ export var ViewHelper = EmberObject.create({
     }
 
     if (classes) {
-      classes = classes.split(' ');
-      extensions.classNames = classes;
+      extensions.classNames = classes.split(' ');
     }
 
     if (hash.classBinding) {

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -69,7 +69,7 @@ export function withHelper(params, hash, options, env) {
 
   var source, keyword;
   var preserveContext, context;
-  if (options.types[0] === 'id') {
+  if (options.types[0] === 'stream') {
     Ember.deprecate('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
     source = params[0];

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -15,6 +15,7 @@ function streamifyArgs(view, params, hash, options, env) {
     for (var i = 0, l = params.length; i < l; i++) {
       if (options.types[i] === 'id') {
         params[i] = view.getStream(params[i]);
+        options.types[i] = 'stream';
       }
     }
   }
@@ -24,6 +25,7 @@ function streamifyArgs(view, params, hash, options, env) {
   for (var key in hash) {
     if (hashTypes[key] === 'id' && key !== 'classBinding' && key !== 'class') {
       hash[key] = view.getStream(hash[key]);
+      hashTypes[key] = 'stream';
     }
   }
 }


### PR DESCRIPTION
Previously, you would have to check to ensure you were working on a stream (everything should be a stream, but that isn't quite true):

```
types[0] === 'id' && params[0].isStream
```

Now the type will be `stream` when it is a stream. This makes me happier. :smile:
