### PR TITLE
Allow properly bound attributes for HTMLBars link-to helper.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -5,8 +5,8 @@
 
 import Ember from "ember-metal/core"; // assert
 import { LinkView } from "ember-routing-views/views/link";
-import { readUnwrappedModel } from "ember-views/streams/read";
 import { read } from "ember-metal/streams/read";
+import ControllerMixin from "ember-runtime/mixins/controller";
 
 // We need the HTMLBars view helper from ensure ember-htmlbars.
 // This ensures it is loaded first:
@@ -323,7 +323,13 @@ function linkToHelper(params, hash, options, env) {
 
   for (var i = 0; i < params.length; i++) {
     if (types[i] === 'id') {
-      var lazyValue = readUnwrappedModel(params[i]);
+      var lazyValue = params[i];
+
+      if (!lazyValue._isController) {
+        while (ControllerMixin.detect(lazyValue.value())) {
+          lazyValue = lazyValue.get('model');
+        }
+      }
 
       params[i] = lazyValue;
     }


### PR DESCRIPTION
Initially I used `readUnwrappedModel`, but that replaces the stream with a static string (clearly will not be bound at that point). This uses similar logic as the Handlebars link-to (and `readUnwrappedModel`) to find the lowest unwrapped model, but preserves things as a stream.

I came accross this while working through the `{{link-to}}` tests in the `ember` package (but they cannot yet be added due to other issues).
