### PR TITLE
Add query-params helper for HTMLBars.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/helpers/query-params.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/query-params.js
@@ -1,0 +1,29 @@
+/**
+@module ember
+@submodule ember-routing-htmlbars
+*/
+
+import Ember from "ember-metal/core"; // assert
+import QueryParams from "ember-routing/system/query_params";
+
+/**
+  This is a sub-expression to be used in conjunction with the link-to helper.
+  It will supply url query parameters to the target route.
+
+  Example
+
+  {#link-to 'posts' (query-params direction="asc")}}Sort{{/link-to}}
+
+  @method query-params
+  @for Ember.Handlebars.helpers
+  @param {Object} hash takes a hash of query parameters
+  @return {String} HTML string
+*/
+export function queryParamsHelper(params, hash) {
+  Ember.assert("The `query-params` helper only accepts hash parameters, e.g. (query-params queryParamPropertyName='foo') as opposed to just (query-params 'foo')", params.length === 0);
+
+  return QueryParams.create({
+    values: hash
+  });
+}
+

--- a/packages/ember-routing-htmlbars/lib/main.js
+++ b/packages/ember-routing-htmlbars/lib/main.js
@@ -16,10 +16,12 @@ import {
   deprecatedLinkToHelper
 } from "ember-routing-htmlbars/helpers/link-to";
 import { actionHelper } from "ember-routing-htmlbars/helpers/action";
+import { queryParamsHelper } from "ember-routing-htmlbars/helpers/query-params";
 
 registerHelper('outlet', outletHelper);
 registerHelper('link-to', linkToHelper);
 registerHelper('linkTo', deprecatedLinkToHelper);
 registerHelper('action', actionHelper);
+registerHelper('query-params', queryParamsHelper);
 
 export default Ember;


### PR DESCRIPTION
Tested against `ember` package `link-to` tests, but they cannot be added here due to other issues in that package that I am working on.
