### PR TITLE
[DOC beta] Mark Ember.Set as Deprecated

### DIFF
--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -121,6 +121,7 @@ import { computed } from "ember-metal/computed";
   @uses Ember.Copyable
   @uses Ember.Freezable
   @since Ember 0.9
+  @deprecated
 */
 export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 


### PR DESCRIPTION
We may as well mark Ember.Set as deprecated in the documentation too.
It's always good to be up front about this sort of thing.
