### PR TITLE
[BUGIFX] Fix camelizing strings that begin with an initialism

### DIFF
--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -19,7 +19,7 @@ var STRING_DASHERIZE_CACHE = new Cache(1000, function(key) {
 var CAMELIZE_CACHE = new Cache(1000, function(key) {
   return key.replace(STRING_CAMELIZE_REGEXP, function(match, separator, chr) {
     return chr ? chr.toUpperCase() : '';
-  }).replace(/^([A-Z])/, function(match, separator, chr) {
+  }).replace(/^([A-Z](?![a-z]))+/, function(match, separator, chr) {
     return match.toLowerCase();
   });
 });

--- a/packages/ember-runtime/tests/system/string/camelize_test.js
+++ b/packages/ember-runtime/tests/system/string/camelize_test.js
@@ -44,6 +44,13 @@ test("camelize dot notation string", function() {
   }
 });
 
+test("camelize string with initialism as first word", function() {
+  deepEqual(camelize('HTMLElement'), 'htmlElement');
+  if (Ember.EXTEND_PROTOTYPES) {
+    deepEqual('HTMLElement'.camelize(), 'htmlElement');
+  }
+});
+
 test("does nothing with camelcased string", function() {
   deepEqual(camelize('innerHTML'), 'innerHTML');
   if (Ember.EXTEND_PROTOTYPES) {


### PR DESCRIPTION
This changes `Ember.String.camelize` to property lowercase an initialism when it's the first word in a string.

For example:
- `HTMLElement`-> `htmlElement` (previously: `hTMLElement`)
- `UUID` -> `uuid` (previously: `uUID`)
