### PR TITLE
Move argument special casing to the helpers.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -189,6 +189,17 @@ function eachHelper(params, hash, options, env) {
   return env.helpers.collection.call(this, [EachView], hash, options, env);
 }
 
+eachHelper._preprocessArguments = function(view, params, hash, options, env) {
+  if (params.length === 3 && params[1] === "in") {
+    params.splice(0, 3, {
+      from: params[2],
+      to: params[0],
+      stream: view.getStream(params[2])
+    });
+    options.types.splice(0, 3, 'keyword');
+  }
+};
+
 export {
   EachView,
   eachHelper

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -93,6 +93,18 @@ export function withHelper(params, hash, options, env) {
   bind.call(this, source, hash, options, env, preserveContext, exists, undefined, undefined, WithView);
 }
 
+withHelper._preprocessArguments = function(view, params, hash, options, env) {
+  if (params.length === 3 && params[1] === "as") {
+    params.splice(0, 3, {
+      from: params[0],
+      to: params[2],
+      stream: view.getStream(params[0])
+    });
+
+    options.types.splice(0, 3, 'keyword');
+  }
+};
+
 function exists(value) {
   return !isNone(value);
 }


### PR DESCRIPTION
Paves the way for Handlbars compat version of `registerHelper` and `makeBoundHelper`. Also, cleans up troubling bits of `streamifyArgs`.
