### PR TITLE
Add HTMLBars `makeHandlebarsCompatibleHelper` function.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -1,0 +1,31 @@
+import merge from "ember-metal/merge";
+import helpers from "ember-htmlbars/helpers";
+
+export function makeHandlebarsCompatibleHelper(fn) {
+  function helperFunc(params, hash, options, env) {
+    var handlebarsOptions = {};
+    merge(handlebarsOptions, options);
+    merge(handlebarsOptions, env);
+
+    var args = options._raw.params;
+    args.push(handlebarsOptions);
+
+    var result = fn.apply(this, args);
+    options.morph.update(result);
+  }
+
+  helperFunc._preprocessArguments = function(view, params, hash, options, env) {
+    options._raw = {
+      params: params.slice(),
+      hash: merge({}, hash)
+    };
+  };
+
+  helperFunc._isHTMLBars = true;
+
+  return helperFunc;
+}
+
+export function registerHandlebarsCompatibleHelper(name, value) {
+  helpers[name] = makeHandlebarsCompatibleHelper(value);
+}

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -14,6 +14,9 @@ import {
   helper,
   default as helpers
 } from "ember-htmlbars/helpers";
+import {
+  registerHandlebarsCompatibleHelper
+} from "ember-htmlbars/compat/helper";
 import { bindHelper } from "ember-htmlbars/helpers/binding";
 import { viewHelper } from "ember-htmlbars/helpers/view";
 import { yieldHelper } from "ember-htmlbars/helpers/yield";

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -1,5 +1,4 @@
 import Ember from "ember-metal/core"; // Ember.assert
-import { viewHelper } from "ember-htmlbars/helpers/view";
 
 /**
   Returns a helper function that renders the provided ViewClass.
@@ -13,10 +12,14 @@ import { viewHelper } from "ember-htmlbars/helpers/view";
   @since 1.2.0
 */
 export default function makeViewHelper(ViewClass) {
-  return function(params, hash, options, env) {
+  function helperFunc(params, hash, options, env) {
     Ember.assert("You can only pass attributes (such as name=value) not bare " +
                  "values to a helper for a View found in '" + ViewClass.toString() + "'", params.length === 0);
 
-    return viewHelper.call(this, [ViewClass], hash, options, env);
-  };
+    return env.helpers.view.call(this, [ViewClass], hash, options, env);
+  }
+
+  helperFunc._isHTMLBars = true;
+
+  return helperFunc;
 }

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -1,0 +1,73 @@
+import {
+  makeHandlebarsCompatibleHelper
+} from "ember-htmlbars/compat/helper";
+
+var fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv;
+
+QUnit.module('ember-htmlbars: Handlebars compatible helpers', {
+  setup: function() {
+    fakeView = {};
+    fakeParams = [];
+    fakeHash = {};
+    fakeOptions = {
+      morph: {
+        update: function() { }
+      }
+    };
+    fakeEnv = {};
+  },
+
+  teardown: function() {
+
+  }
+});
+
+test('wraps provided function so that original path params are provided to the helper', function() {
+  expect(2);
+
+  function someHelper(param1, param2, options) {
+    equal(param1, 'blammo');
+    equal(param2, 'blazzico');
+  }
+
+  var compatHelper = makeHandlebarsCompatibleHelper(someHelper);
+
+  fakeParams = [ 'blammo', 'blazzico' ];
+  compatHelper._preprocessArguments(fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv);
+
+  compatHelper(fakeParams, fakeHash, fakeOptions, fakeEnv);
+});
+
+test('combines `env` and `options` for the wrapped helper', function() {
+  expect(2);
+
+  function someHelper(options) {
+    equal(options.first, 'Max');
+    equal(options.second, 'James');
+  }
+
+  var compatHelper = makeHandlebarsCompatibleHelper(someHelper);
+
+  fakeOptions.first = 'Max';
+  fakeEnv.second = 'James';
+
+  compatHelper._preprocessArguments(fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv);
+  compatHelper(fakeParams, fakeHash, fakeOptions, fakeEnv);
+});
+
+test('calls morph.update with the return value from the helper', function() {
+  expect(1);
+
+  function someHelper(options) {
+    return 'Lucy!';
+  }
+
+  var compatHelper = makeHandlebarsCompatibleHelper(someHelper);
+
+  fakeOptions.morph.update = function(value) {
+    equal(value, 'Lucy!');
+  };
+
+  compatHelper._preprocessArguments(fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv);
+  compatHelper(fakeParams, fakeHash, fakeOptions, fakeEnv);
+});

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -77,11 +77,41 @@ test('does a lookup in the container if the name contains a dash (and helper is 
   };
 
   function someName() {}
+  someName._isHTMLBars = true;
   view.container.register('helper:some-name', someName);
 
   var actual = lookupHelper('some-name', view, env);
 
-  equal(actual, someName, 'does not blow up if view does not have a container');
+  equal(actual, someName, 'does not wrap provided function if `_isHTMLBars` is truthy');
+});
+
+test('wraps helper from container in a Handlebars compat helper', function() {
+  expect(2);
+  var env = generateEnv();
+  var view = {
+    container: generateContainer()
+  };
+  var called;
+
+  function someName() {
+    called = true;
+  }
+  view.container.register('helper:some-name', someName);
+
+  var actual = lookupHelper('some-name', view, env);
+
+  ok(actual._isHTMLBars, 'wraps provided helper in an HTMLBars compatible helper');
+
+  var fakeParams = [];
+  var fakeHash = {};
+  var fakeOptions = {
+    _raw: { params: []},
+    morph: { update: function() { } }
+  };
+  var fakeEnv = {};
+  actual(fakeParams, fakeHash, fakeOptions, fakeEnv);
+
+  ok(called, 'HTMLBars compatible wrapper is wraping the provided function');
 });
 
 test('asserts if component-lookup:main cannot be found', function() {

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -56,9 +56,6 @@ var boot = function(callback) {
   });
 };
 
-if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  // need to make container lookup of helpers normalize the path to
-  // old format (currently using `params, hash, options, env`)
 test("Unbound dashed helpers registered on the container can be late-invoked", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf YES}}</div>");
@@ -73,6 +70,8 @@ test("Unbound dashed helpers registered on the container can be late-invoked", f
   ok(!helpers['x-borf'], "Container-registered helper doesn't wind up on global helpers hash");
 });
 
+if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  // need to make `makeBoundHelper` for HTMLBars
 test("Bound helpers registered on the container can be late-invoked", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-reverse}} {{x-reverse foo}}</div>");


### PR DESCRIPTION
- `makeHandlebarsCompatibleHelper` will be setup at `Ember.Handlebars.registerHelper` in the future.
- HTMLBars compatible helpers from the container need a `_isHTMLBars` flag so that we do not wrap them.
- Make `lookupHelper` wrap any `helpers:` lookups from the container that do not have `_isHTMLBars` set
  in a new `makeHandlebarsCompatibleHelper` wrapped helper.
