### PR TITLE
[BUGFIX beta] Ember.Map#forEach callback should include map being ite...

### DIFF
--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -379,7 +379,8 @@ Map.prototype = {
 
   /**
     Iterate over all the keys and values. Calls the function once
-    for each key, passing in the value and key, in that order.
+    for each key, passing in value, key, and the map being iterated over,
+    in that order.
 
     The keys are guaranteed to be iterated over in insertion order.
 
@@ -402,11 +403,11 @@ Map.prototype = {
     if (length === 2) {
       thisArg = arguments[1];
       cb = function(key) {
-        callback.call(thisArg, map.get(key), key);
+        callback.call(thisArg, map.get(key), key, map);
       };
     } else {
       cb = function(key) {
-        callback(map.get(key), key);
+        callback(map.get(key), key, map);
       };
     }
 

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -316,12 +316,13 @@ function testMap(nameAndFunc) {
       { value: 3, key: "c", context: unboundThis },
     ];
 
-    map.forEach(function(value, key) {
+    map.forEach(function(value, key, theMap) {
       var expectation = expectations[iteration];
 
       equal(value, expectation.value, 'value should be correct');
       equal(key, expectation.key, 'key should be correct');
       equal(this, expectation.context, 'context should be as if it was unbound');
+      equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     });
@@ -343,12 +344,13 @@ function testMap(nameAndFunc) {
       { value: 3, key: "c", context: context },
     ];
 
-    map.forEach(function(value, key) {
+    map.forEach(function(value, key, theMap) {
       var expectation = expectations[iteration];
 
       equal(value, expectation.value, 'value should be correct');
       equal(key, expectation.key, 'key should be correct');
       equal(this, expectation.context, 'context should be as if it was unbound');
+      equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
 
@@ -369,7 +371,7 @@ function testMap(nameAndFunc) {
       { value: 2, key: "b", context: unboundThis }
     ];
 
-    map.forEach(function(value, key) {
+    map.forEach(function(value, key, theMap) {
       if (iteration === 0) {
         map.delete("c");
       }
@@ -379,6 +381,7 @@ function testMap(nameAndFunc) {
       equal(value, expectation.value, 'value should be correct');
       equal(key, expectation.key, 'key should be correct');
       equal(this, expectation.context, 'context should be as if it was unbound');
+      equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     });
@@ -400,7 +403,7 @@ function testMap(nameAndFunc) {
       { value: 4, key: "d", context: unboundThis },
     ];
 
-    map.forEach(function(value, key) {
+    map.forEach(function(value, key, theMap) {
       if (iteration === 0) {
         map.set('d', 4);
       }
@@ -410,6 +413,7 @@ function testMap(nameAndFunc) {
       equal(value, expectation.value, 'value should be correct');
       equal(key, expectation.key, 'key should be correct');
       equal(this, expectation.context, 'context should be as if it was unbound');
+      equal(map, theMap, 'map being iterated over should be passed in');
 
       iteration++;
     });


### PR DESCRIPTION
...rated over

According to the ES6-spec, the callback for `forEach` on `Map` should include the Map being iterated over as the third parameter.

Source: https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map.prototype.foreach
