### PR TITLE
Update HTMLBars helpers to use their prototype better.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -2,6 +2,8 @@ import merge from "ember-metal/merge";
 import helpers from "ember-htmlbars/helpers";
 
 function HandlebarsCompatibleHelper(fn) {
+  this.handlebarsHelperFunction = fn;
+
   this.helperFunction = function helperFunc(params, hash, options, env) {
     var handlebarsOptions = {};
     merge(handlebarsOptions, options);
@@ -11,18 +13,21 @@ function HandlebarsCompatibleHelper(fn) {
     args.push(handlebarsOptions);
 
     var result = fn.apply(this, args);
+
     options.morph.update(result);
   };
+}
 
-  this.preprocessArguments = function(view, params, hash, options, env) {
+HandlebarsCompatibleHelper.prototype = {
+  preprocessArguments: function(view, params, hash, options, env) {
     options._raw = {
       params: params.slice(),
       hash: merge({}, hash)
     };
-  };
+  },
 
-  this.isHTMLBars = true;
-}
+  isHTMLBars: true
+};
 
 export function registerHandlebarsCompatibleHelper(name, value) {
   helpers[name] = new HandlebarsCompatibleHelper(value);

--- a/packages/ember-htmlbars/lib/system/helper.js
+++ b/packages/ember-htmlbars/lib/system/helper.js
@@ -8,10 +8,16 @@
   @namespace Ember.HTMLBars
 */
 function Helper(helper, preprocessArguments) {
-  this.isHTMLBars = true;
   this.helperFunction = helper;
-  this.preprocessArguments = preprocessArguments || function() { };
+
+  if (preprocessArguments) {
+    this.preprocessArguments = preprocessArguments;
+  }
 }
 
+Helper.prototype = {
+  preprocessArguments: function() { },
+  isHTMLBars: true
+};
 
 export default Helper;


### PR DESCRIPTION
As requested by @stefanpenner in https://github.com/emberjs/ember.js/pull/9638.

Please note, I could not make the `HandlebarsCompatibleHelper` share the `helperFunction` on the prototype because it is specifically invoked bound to the view context.

I'm open to discussing refactoring away from the view being the context of helpers, but it was specifically requested to be this way by Kris, Mat, and Martin so I'd want to confirm with them before changing away from it.
