### PR TITLE
[BUGFIX] Allow Ember.Select to have selection from a Promise

### DIFF
--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -190,6 +190,73 @@ test("selection can be set when multiple=false", function() {
   equal(select.$()[0].selectedIndex, 0, "After changing it, selection should be correct");
 });
 
+test("selection can be set from a Promise when multiple=false", function() {
+  expect(1);
+
+  var yehuda = { id: 1, firstName: 'Yehuda' };
+  var tom = { id: 2, firstName: 'Tom' };
+
+  run(function() {
+    select.set('content', Ember.A([yehuda, tom]));
+    select.set('multiple', false);
+    select.set('selection', Ember.RSVP.Promise.resolve(tom));
+  });
+
+  append();
+
+  equal(select.$()[0].selectedIndex, 1, "Should select from Promise content");
+});
+
+test("selection from a Promise don't overwrite newer selection once resolved, when multiple=false", function() {
+  expect(1);
+
+  var yehuda = { id: 1, firstName: 'Yehuda' };
+  var tom = { id: 2, firstName: 'Tom' };
+  var seb = { id: 3, firstName: 'Seb' };
+
+  QUnit.stop();
+
+  run(function() {
+    select.set('content', Ember.A([yehuda, tom, seb]));
+    select.set('multiple', false);
+    select.set('selection', new Ember.RSVP.Promise(function(resolve, reject) {
+      Ember.run.later(function() {
+        run(function(){
+          resolve(tom);
+        });
+        QUnit.start();
+        equal(select.$()[0].selectedIndex, 2, "Should not select from Promise if newer selection");
+      }, 40);
+    }));
+    select.set('selection', new Ember.RSVP.Promise(function(resolve, reject) {
+      Ember.run.later(function() {
+        run(function() {
+          resolve(seb);
+        });
+      }, 30);
+    }));
+  });
+
+  append();
+});
+
+test("selection from a Promise resolving to null should not select when multiple=false", function() {
+  expect(1);
+
+  var yehuda = { id: 1, firstName: 'Yehuda' };
+  var tom = { id: 2, firstName: 'Tom' };
+
+  run(function() {
+    select.set('content', Ember.A([yehuda, tom]));
+    select.set('multiple', false);
+    select.set('selection', Ember.RSVP.Promise.resolve(null));
+  });
+
+  append();
+
+  equal(select.$()[0].selectedIndex, -1, "Should not select any object when the Promise resolve to null");
+});
+
 test("selection can be set when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };


### PR DESCRIPTION
A fix to address https://github.com/emberjs/data/issues/2471

Currently working for single selection only (when `multiple=false`).
For `multiple=true`, what would you support? Array of Promises? a Promise returning an Array? Promise returning an Array of Promises? something more?

Any reason why a low wait (1 and 2) at https://github.com/BookingSync/ember.js/compare/select-promises?expand=1#diff-9383c698ce8f7f75cc2f5a6790a41b47R236 and https://github.com/BookingSync/ember.js/compare/select-promises?expand=1#diff-9383c698ce8f7f75cc2f5a6790a41b47R243 works when testing in isolation but not when running all tests?
This currently works fine but might become a random failing test then :/

Thanks @igort for the help.
