### PR TITLE
Fix issue rendering tagless container views.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/tagless-views-rerender_test.js
+++ b/packages/ember-htmlbars/tests/integration/tagless-views-rerender_test.js
@@ -1,0 +1,79 @@
+import run from "ember-metal/run_loop";
+import EmberView from "ember-views/views/view";
+import EmberHandlebars from "ember-handlebars";
+import htmlbarsCompile from "ember-htmlbars/system/compile";
+
+var view;
+var compile;
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  compile = htmlbarsCompile;
+} else {
+  compile = EmberHandlebars.compile;
+}
+
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+QUnit.module("ember-htmlbars: tagless views should be able to add/remove child views", {
+  teardown: function() {
+    run(function() {
+      if (view) {
+        view.destroy();
+      }
+    });
+  }
+});
+
+test("can insert new child views after initial tagless view rendering", function() {
+  view = EmberView.create({
+    shouldShow: false,
+    array: Ember.A([ 1 ]),
+
+    template: compile('{{#if view.shouldShow}}{{#each item in view.array}}{{item}}{{/each}}{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), '');
+
+  run(function() {
+    view.set('shouldShow', true);
+  });
+
+  equal(view.$().text(), '1');
+
+
+  run(function() {
+    view.get('array').pushObject(2);
+  });
+
+  equal(view.$().text(), '12');
+});
+
+test("can remove child views after initial tagless view rendering", function() {
+  view = EmberView.create({
+    shouldShow: false,
+    array: Ember.A([ ]),
+
+    template: compile('{{#if view.shouldShow}}{{#each item in view.array}}{{item}}{{/each}}{{/if}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), '');
+
+  run(function() {
+    view.set('shouldShow', true);
+    view.get('array').pushObject(1);
+  });
+
+  equal(view.$().text(), '1');
+
+  run(function() {
+    view.get('array').removeObject(1);
+  });
+
+  equal(view.$().text(), '');
+});

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -268,12 +268,9 @@ var ContainerView = View.extend(MutableArray, {
     var dom = buffer.dom;
 
     if (this.tagName === '') {
-      if (this._morph) {
-        this._childViewsMorph = this._morph;
-      } else {
-        element = dom.createDocumentFragment();
-        this._childViewsMorph = dom.appendMorph(element);
-      }
+      element = dom.createDocumentFragment();
+      buffer._element = element;
+      this._childViewsMorph = dom.appendMorph(element, this._morph.contextualElement);
     } else {
       this._childViewsMorph = dom.createMorph(element, element.lastChild, null);
     }


### PR DESCRIPTION
Need a bit of help tracking this down.  Hoping that @krisselden has some ideas here.

Recieving the following errors from these tests.
- Inserting:

```
Source:         
Error: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
    at Error (native)
    at Morph._updateNode (http://localhost:5200/ember.js:54972:14)
    at Morph._update (http://localhost:5200/ember.js:54953:14)
    at Morph.insert (http://localhost:5200/ember.js:55033:13)
    at EmberRenderer.Renderer_insertElement [as insertElement] (http://localhost:5200/ember.js:12458:53)
    at EmberRenderer.Renderer_renderTree [as renderTree] (http://localhost:5200/ember.js:12334:12)
    at Object.merge.ensureChildrenAreInDOM (http://localhost:5200/ember.js:45434:22)
    at View.extend._ensureChildrenAreInDOM (http://localhost:5200/ember.js:45397:27)
    at Queue.invoke (http://localhost:5200/ember.js:840:18)
    at Object.Queue.flush (http://localhost:5200/ember.js:905:13)
```
- Removing:

```
Error: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at Error (native)
    at clear (http://localhost:5200/ember.js:55130:16)
    at Morph.replace (http://localhost:5200/ember.js:55065:9)
    at Morph.removeMorph (http://localhost:5200/ember.js:54913:16)
    at Morph.destroy (http://localhost:5200/ember.js:54903:20)
    at EmberRenderer.Renderer_remove [as remove] (http://localhost:5200/ember.js:12434:15)
    at EmberObject.extend.destroy (http://localhost:5200/ember.js:45559:26)
    at apply (http://localhost:5200/ember.js:21879:32)
    at superWrapper (http://localhost:5200/ember.js:21453:15)
    at apply (http://localhost:5200/ember.js:21879:32)
```
