### PR TITLE
Enable integration tests for HTMLBars.

### DIFF
--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2021,10 +2021,6 @@ test("Rendering into specified template with slash notation", function() {
   equal(Ember.$('#qunit-fixture:contains(profile details!)').length, 1, "The templates were rendered");
 });
 
-
-if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
-    // bizarre error in morph attempting to remove a child it does not have
-
 test("Parent route context change", function() {
   var editCount = 0;
   var editedPostIds = Ember.A();
@@ -2094,8 +2090,6 @@ test("Parent route context change", function() {
   equal(editCount, 2, 'set up the edit route twice without failure');
   deepEqual(editedPostIds, ['1', '2'], 'modelFor posts.post returns the right context');
 });
-
-}
 
 test("Router accounts for rootURL on page load when using history location", function() {
   var rootURL = window.location.pathname + '/app';

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -679,9 +679,6 @@ test("An explicit replace:false on a changed QP always wins and causes a pushSta
   Ember.run(appController, 'setProperties', { alex: 'sriracha' });
 });
 
-if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
-    // bizarre error in morph attempting to remove a child it does not have
-
 test("can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent", function() {
   Ember.TEMPLATES.parent = compile('{{outlet}}');
   Ember.TEMPLATES['parent/child'] = compile("{{link-to 'Parent' 'parent' (query-params foo='change') id='parent-link'}}");
@@ -720,8 +717,6 @@ test("can opt into full transition by setting refreshModel in route queryParams 
 
   equal(parentModelCount, 2);
 });
-
-}
 
 test("Use Ember.get to retrieve query params 'replace' configuration", function() {
   expect(2);

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -108,8 +108,6 @@ test("Slow promise from a child route of application enters nested loading state
   equal(Ember.$('#app', '#qunit-fixture').text(), "BRO", "bro template has loaded and replaced loading template");
 });
 
-if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
-
 test("Slow promises waterfall on startup", function() {
 
   expect(7);
@@ -198,8 +196,6 @@ test("ApplicationRoute#currentPath reflects loading state path", function() {
   equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA MOM");
   equal(appController.get('currentPath'), "grandma.mom", "currentPath reflects final state");
 });
-
-}
 
 test("Slow promises returned from ApplicationRoute#model don't enter LoadingRoute", function() {
 
@@ -624,9 +620,6 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "FOOBAR ERROR: did it broke?", "foo.bar_error was entered (as opposed to something like foo/foo/bar_error)");
   });
 
-  if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
-    // bizarre error in morph attempting to remove a child it does not have
-
   test("Prioritized loading substate entry works with auto-generated index routes", function() {
 
     expect(2);
@@ -663,8 +656,6 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     equal(Ember.$('#app', '#qunit-fixture').text(), "YAY");
   });
-
-  }
 
   test("Prioritized error substate entry works with auto-generated index routes", function() {
 


### PR DESCRIPTION
These were fixed by https://github.com/emberjs/ember.js/pull/9647.

This enables all tests in the Ember package for HTMLBars that are applicable.
