### PR TITLE
Enable Handlebars compat mode when HTMLBars is enabled.

### DIFF
--- a/packages/ember-handlebars-compiler/tests/precompile_type_test.js
+++ b/packages/ember-handlebars-compiler/tests/precompile_type_test.js
@@ -6,6 +6,10 @@ var result;
 
 QUnit.module("Ember.Handlebars.precompileType");
 
+if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  // precompile does not accept the same args with ember-htmlbars/system/compile
+  // Do we need to support `asObject` param?
+
 test("precompile creates an object when asObject isn't defined", function(){
   result = precompile(template);
   equal(typeof(result), "object");
@@ -26,3 +30,5 @@ test("precompile creates an object when passed an AST", function(){
   result = precompile(ast);
   equal(typeof(result), "object");
 });
+
+}

--- a/packages/ember-handlebars/lib/helpers/view.js
+++ b/packages/ember-handlebars/lib/helpers/view.js
@@ -94,7 +94,7 @@ export var ViewHelper = EmberObject.create({
     }
 
     if (hash.attributeBindings) {
-      Ember.assert("Setting 'attributeBindings' via Handlebars is not allowed." +
+      Ember.assert("Setting 'attributeBindings' via template helpers is not allowed." +
                    " Please subclass Ember.View and set it there instead.");
       extensions.attributeBindings = null;
     }

--- a/packages/ember-htmlbars/lib/compat.js
+++ b/packages/ember-htmlbars/lib/compat.js
@@ -1,0 +1,26 @@
+import EmberHandlebars from "ember-handlebars";
+import helpers from "ember-htmlbars/helpers";
+import template from "ember-htmlbars/system/template";
+import compile from "ember-htmlbars/system/compile";
+import {
+  registerHandlebarsCompatibleHelper as compatRegisterHelper,
+  handlebarsHelper as compatHandlebarsHelper
+} from "ember-htmlbars/compat/helper";
+import compatHandlebarsGet from "ember-htmlbars/compat/handlebars-get";
+import compatMakeBoundHelper from "ember-htmlbars/compat/make-bound-helper";
+import compatRegisterBoundHelper from "ember-htmlbars/compat/register-bound-helper";
+import compatPrecompile from "ember-htmlbars/compat/precompile";
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  EmberHandlebars.helpers = helpers;
+  EmberHandlebars.helper = compatHandlebarsHelper;
+  EmberHandlebars.registerHelper = compatRegisterHelper;
+  EmberHandlebars.registerBoundHelper = compatRegisterBoundHelper;
+  EmberHandlebars.makeBoundHelper = compatMakeBoundHelper;
+  EmberHandlebars.get = compatHandlebarsGet;
+  EmberHandlebars.precompile = compatPrecompile;
+  EmberHandlebars.compile = compile;
+  EmberHandlebars.template = template;
+}
+
+export default EmberHandlebars;

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -1,11 +1,18 @@
 import merge from "ember-metal/merge";
 import helpers from "ember-htmlbars/helpers";
+import View from "ember-views/views/view";
+import Component from "ember-views/views/component";
+import makeViewHelper from "ember-htmlbars/system/make-view-helper";
+import makeBoundHelper from "ember-htmlbars/compat/make-bound-helper";
+
+var slice = [].slice;
 
 function HandlebarsCompatibleHelper(fn) {
   this.helperFunction = function helperFunc(params, hash, options, env) {
     var handlebarsOptions = {};
     merge(handlebarsOptions, options);
     merge(handlebarsOptions, env);
+    handlebarsOptions.hash = options._raw.hash;
 
     var args = options._raw.params;
     args.push(handlebarsOptions);
@@ -29,6 +36,20 @@ HandlebarsCompatibleHelper.prototype = {
 
 export function registerHandlebarsCompatibleHelper(name, value) {
   helpers[name] = new HandlebarsCompatibleHelper(value);
+}
+
+export function handlebarsHelper(name, value) {
+  Ember.assert("You tried to register a component named '" + name +
+               "', but component names must include a '-'", !Component.detect(value) || name.match(/-/));
+
+  if (View.detect(value)) {
+    helpers[name] = makeViewHelper(value);
+  } else {
+    var boundHelperArgs = slice.call(arguments, 1);
+    var boundFn = makeBoundHelper.apply(this, boundHelperArgs);
+
+    helpers[name] = boundFn;
+  }
 }
 
 export default HandlebarsCompatibleHelper;

--- a/packages/ember-htmlbars/lib/compat/precompile.js
+++ b/packages/ember-htmlbars/lib/compat/precompile.js
@@ -1,0 +1,3 @@
+import { compile } from "htmlbars-compiler/compiler";
+
+export default compile;

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -14,9 +14,6 @@ import {
   helper,
   default as helpers
 } from "ember-htmlbars/helpers";
-import {
-  registerHandlebarsCompatibleHelper
-} from "ember-htmlbars/compat/helper";
 import { bindHelper } from "ember-htmlbars/helpers/binding";
 import { viewHelper } from "ember-htmlbars/helpers/view";
 import { yieldHelper } from "ember-htmlbars/helpers/yield";
@@ -55,6 +52,10 @@ import {
 // initializer to enable embedded templates
 import "ember-htmlbars/system/bootstrap";
 
+// importing ember-htmlbars/compat updates the
+// Ember.Handlebars global if htmlbars is enabled
+import "ember-htmlbars/compat";
+
 registerHelper('bindHelper', bindHelper);
 registerHelper('bind', bindHelper);
 registerHelper('view', viewHelper);
@@ -85,6 +86,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     template: template,
     compile: compile
   };
+
 }
 
 export var defaultEnv = {

--- a/packages/ember-htmlbars/lib/system/compile.js
+++ b/packages/ember-htmlbars/lib/system/compile.js
@@ -10,7 +10,6 @@ import template from "ember-htmlbars/system/template";
   @method template
   @param {String} templateString This is the string to be compiled by HTMLBars.
 */
-
 export default function(templateString) {
   var templateSpec = compile(templateString);
 

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -2,19 +2,12 @@ import Ember from "ember-metal/core"; // Ember.lookup
 import _MetamorphView from "ember-views/views/metamorph_view";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
-import EmberHandlebars from "ember-handlebars";
 import handlebarsGet from "ember-htmlbars/compat/handlebars-get";
 import Container from "ember-runtime/system/container";
 
-import EmberHandlebars from "ember-handlebars";
-import htmlbarsCompile from "ember-htmlbars/system/compile";
+import EmberHandlebars from "ember-htmlbars/compat";
 
-var compile;
-if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  compile = htmlbarsCompile;
-} else {
-  compile = EmberHandlebars.compile;
-}
+var compile = EmberHandlebars.compile;
 
 var originalLookup = Ember.lookup;
 var TemplateTests, container, lookup, view;

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -53,6 +53,21 @@ test('combines `env` and `options` for the wrapped helper', function() {
   compatHelper.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv);
 });
 
+test('adds `hash` into options `options` for the wrapped helper', function() {
+  expect(1);
+
+  function someHelper(options) {
+    equal(options.hash.bestFriend, 'Jacquie');
+  }
+
+  var compatHelper = new HandlebarsCompatibleHelper(someHelper);
+
+  fakeHash.bestFriend = 'Jacquie';
+
+  compatHelper.preprocessArguments(fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv);
+  compatHelper.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv);
+});
+
 test('calls morph.update with the return value from the helper', function() {
   expect(1);
 

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -9,24 +9,12 @@ import { A } from "ember-runtime/system/native_array";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 
-import EmberHandlebars from "ember-handlebars-compiler";
-import htmlbarsHelpers from "ember-htmlbars/helpers";
-import htmlbarsRegisterBoundHelper from "ember-htmlbars/compat/register-bound-helper";
-
-import EmberHandlebars from "ember-handlebars";
-import htmlbarsCompile from "ember-htmlbars/system/compile";
+import EmberHandlebars from "ember-htmlbars/compat";
 
 var compile, helpers, helper;
-if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  compile = htmlbarsCompile;
-  helpers = htmlbarsHelpers;
-  helper = htmlbarsRegisterBoundHelper;
-} else {
-  compile = EmberHandlebars.compile;
-  helpers = EmberHandlebars.helpers;
-  helper = EmberHandlebars.helper;
-}
-
+compile = EmberHandlebars.compile;
+helpers = EmberHandlebars.helpers;
+helper = EmberHandlebars.helper;
 
 var view;
 

--- a/packages/ember-htmlbars/tests/helpers/debug_test.js
+++ b/packages/ember-htmlbars/tests/helpers/debug_test.js
@@ -3,7 +3,6 @@ import EmberLogger from "ember-metal/logger";
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
-import { logHelper } from "ember-handlebars/helpers/debug";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
 
 var compile;
@@ -16,7 +15,6 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 var originalLookup = Ember.lookup;
 var lookup;
 var originalLog, logCalls;
-var originalLogHelper;
 var view;
 
 function appendView() {
@@ -26,9 +24,6 @@ function appendView() {
 QUnit.module("Handlebars {{log}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
-
-    originalLogHelper = EmberHandlebars.helpers.log;
-    EmberHandlebars.registerHelper("log", logHelper);
 
     originalLog = EmberLogger.log;
     logCalls = [];
@@ -44,7 +39,6 @@ QUnit.module("Handlebars {{log}} helper", {
     }
 
     EmberLogger.log = originalLog;
-    EmberHandlebars.helpers.log = originalLogHelper;
     Ember.lookup = originalLookup;
   }
 });

--- a/packages/ember-htmlbars/tests/helpers/text_area_test.js
+++ b/packages/ember-htmlbars/tests/helpers/text_area_test.js
@@ -1,15 +1,9 @@
 import run from "ember-metal/run_loop";
 import View from "ember-views/views/view";
-import EmberHandlebars from "ember-handlebars";
+import EmberHandlebars from "ember-htmlbars/compat";
 import { set as o_set } from "ember-metal/property_set";
-import htmlbarsCompile from "ember-htmlbars/system/compile";
 
-var compile;
-if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  compile = htmlbarsCompile;
-} else {
-  compile = EmberHandlebars.compile;
-}
+var compile = EmberHandlebars.compile;
 
 var textArea, controller;
 

--- a/packages/ember-htmlbars/tests/integration/tagless-views-rerender_test.js
+++ b/packages/ember-htmlbars/tests/integration/tagless-views-rerender_test.js
@@ -1,15 +1,9 @@
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
-import EmberHandlebars from "ember-handlebars";
-import htmlbarsCompile from "ember-htmlbars/system/compile";
+import EmberHandlebars from "ember-htmlbars/compat";
 
 var view;
-var compile;
-if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  compile = htmlbarsCompile;
-} else {
-  compile = EmberHandlebars.compile;
-}
+var compile = EmberHandlebars.compile;
 
 
 function appendView(view) {


### PR DESCRIPTION
This is stage one in being fully backwards compat with the Ember.Handelbars API's.

Over the next few PR's I will remove all but the bare minimum required instances of the ember-htmlbars feature flag.
