### PR TITLE
Prevents inserting element into documentFragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "git-repo-version": "0.0.1",
     "glob": "~3.2.8",
     "handlebars": "^2.0",
-    "htmlbars": "0.1.8",
+    "htmlbars": "0.1.9",
     "ncp": "~0.5.1",
     "rimraf": "~2.2.8",
     "rsvp": "~3.0.6"

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -399,41 +399,6 @@ test('should update the block when object passed to #if helper changes and an in
   });
 });
 
-if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
-test('edge case: child conditional should not render children if parent conditional becomes false', function() {
-  var childCreated = false;
-  var child = null;
-
-  view = EmberView.create({
-    cond1: true,
-    cond2: false,
-    viewClass: EmberView.extend({
-      init: function() {
-        this._super();
-        childCreated = true;
-        child = this;
-      }
-    }),
-    template: compile('{{#if view.cond1}}{{#if view.cond2}}{{#view view.viewClass}}test{{/view}}{{/if}}{{/if}}')
-  });
-
-  appendView(view);
-
-  ok(!childCreated, 'precondition');
-
-  run(function() {
-    // The order of these sets is important for the test
-    view.set('cond2', true);
-    view.set('cond1', false);
-  });
-
-  // TODO: Priority Queue, for now ensure correct result.
-  //ok(!childCreated, 'child should not be created');
-  ok(child.isDestroyed, 'child should be gone');
-  equal(view.$().text(), '');
-});
-}
-
 test('views within an if statement should be sane on re-render', function() {
   view = EmberView.create({
     template: compile('{{#if view.display}}{{input}}{{/if}}'),
@@ -659,4 +624,54 @@ test('the {{this}} helper should not fail on removal', function() {
   });
 
   equal(view.$().text(), '');
+});
+
+test('edge case: child conditional should not render children if parent conditional becomes false', function() {
+  var childCreated = false;
+  var child = null;
+
+  view = EmberView.create({
+    cond1: true,
+    cond2: false,
+    viewClass: EmberView.extend({
+      init: function() {
+        this._super();
+        childCreated = true;
+        child = this;
+      }
+    }),
+    template: compile('{{#if view.cond1}}{{#if view.cond2}}{{#view view.viewClass}}test{{/view}}{{/if}}{{/if}}')
+  });
+
+  appendView(view);
+
+  ok(!childCreated, 'precondition');
+
+  run(function() {
+    // The order of these sets is important for the test
+    view.set('cond2', true);
+    view.set('cond1', false);
+  });
+
+  // TODO: Priority Queue, for now ensure correct result.
+  //ok(!childCreated, 'child should not be created');
+  ok(child.isDestroyed, 'child should be gone');
+  equal(view.$().text(), '');
+});
+
+test('edge case: rerender appearance of inner virtual view', function() {
+  view = EmberView.create({
+    tagName: '',
+    cond2: false,
+    template: compile('{{#if view.cond2}}test{{/if}}')
+  });
+
+  appendView(view);
+  equal(Ember.$('#qunit-fixture').text(), '');
+
+  run(function() {
+    view.set('cond2', true);
+  });
+
+  equal(Ember.$('#qunit-fixture').text(), 'test');
 });

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -225,7 +225,10 @@ function Renderer_remove(_view, shouldDestroy, reset) {
 }
 
 function Renderer_insertElement(view, parentView, element, index) {
-  if (element === null || element === undefined) return;
+  if (element === null || element === undefined) {
+    return;
+  }
+
   if (view._morph) {
     view._morph.update(element);
   } else if (parentView) {


### PR DESCRIPTION
I was moving `if` and `unless` tests from `handlebars_test.js`
to be a part of `htmlbars` tests suite in this [PR](https://github.com/emberjs/ember.js/pull/9657)
and discovered a failing test.

This test failed with:

```
Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

I **think** what ends up happening in this test is that inner most `{{view}}`
is being inserted in outer most `{{if}}` (well, not `{{if}}` itself but the document fragment).

I added a fix but I'm unsure if it's correct. @krisselden or @mixonic mind providing some feedback?
