### PR TITLE
Add tests for HTMLBars attribute hook/helper.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/attribute.js
+++ b/packages/ember-htmlbars/lib/helpers/attribute.js
@@ -1,0 +1,29 @@
+import run from "ember-metal/run_loop";
+
+export function attributeHelper(params, hash, options, env) {
+  var dom = env.dom;
+  var name = params[0];
+  var value = params[1];
+
+  var isDirty, lastRenderedValue;
+
+  value.subscribe(function(lazyValue) {
+    isDirty = true;
+
+    run.schedule('render', this, function() {
+      var value = lazyValue.value();
+
+      if (isDirty) {
+        isDirty = false;
+        if (value !== lastRenderedValue) {
+          lastRenderedValue = value;
+          dom.setAttribute(options.element, name, value);
+        }
+      }
+    });
+  });
+
+  lastRenderedValue = value.value();
+
+  dom.setAttribute(options.element, name, lastRenderedValue);
+}

--- a/packages/ember-htmlbars/lib/helpers/concat.js
+++ b/packages/ember-htmlbars/lib/helpers/concat.js
@@ -1,0 +1,19 @@
+import Stream from "ember-metal/streams/stream";
+import {readArray} from "ember-metal/streams/read";
+
+export function concatHelper(params, hash, options, env) {
+  var stream = new Stream(function() {
+    return readArray(params).join('');
+  });
+
+  for (var i = 0, l = params.length; i < l; i++) {
+    var param = params[i];
+
+    if (param && param.isStream) {
+      param.subscribe(stream.notifyAll, stream);
+    }
+  }
+
+  return stream;
+}
+

--- a/packages/ember-htmlbars/lib/helpers/unbound.js
+++ b/packages/ember-htmlbars/lib/helpers/unbound.js
@@ -1,4 +1,4 @@
-import { lookupHelper } from 'ember-htmlbars/system/lookup-helper';
+import lookupHelper from 'ember-htmlbars/system/lookup-helper';
 import { read } from 'ember-metal/streams/read';
 import EmberError from "ember-metal/error";
 import merge from "ember-metal/merge";

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -1,5 +1,5 @@
 import Ember from "ember-metal/core";
-import { lookupHelper } from "ember-htmlbars/system/lookup-helper";
+import lookupHelper from "ember-htmlbars/system/lookup-helper";
 import { sanitizeOptionsForHelper } from "ember-htmlbars/system/sanitize-for-helper";
 
 function streamifyArgs(view, params, hash, options, env, helper) {

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -14,6 +14,8 @@ import {
   helper,
   default as helpers
 } from "ember-htmlbars/helpers";
+import { attributeHelper} from "ember-htmlbars/helpers/attribute";
+import { concatHelper } from "ember-htmlbars/helpers/concat";
 import { bindHelper } from "ember-htmlbars/helpers/binding";
 import { viewHelper } from "ember-htmlbars/helpers/view";
 import { yieldHelper } from "ember-htmlbars/helpers/yield";
@@ -56,6 +58,8 @@ import "ember-htmlbars/system/bootstrap";
 // Ember.Handlebars global if htmlbars is enabled
 import "ember-htmlbars/compat";
 
+registerHelper('attribute', attributeHelper);
+registerHelper('concat', concatHelper);
 registerHelper('bindHelper', bindHelper);
 registerHelper('bind', bindHelper);
 registerHelper('view', viewHelper);

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -2,45 +2,10 @@ import Ember from "ember-metal/core";
 import Cache from "ember-metal/cache";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
-import Stream from "ember-metal/streams/stream";
-import {readArray} from "ember-metal/streams/read";
-import Helper from "ember-htmlbars/system/helper";
 
 export var ISNT_HELPER_CACHE = new Cache(1000, function(key) {
   return key.indexOf('-') === -1;
 });
-
-export function attribute(params, hash, options, env) {
-  var dom = env.dom;
-  var name = params[0];
-  var value = params[1];
-
-  value.subscribe(function(lazyValue) {
-    dom.setAttribute(options.element, name, lazyValue.value());
-  });
-
-  dom.setAttribute(options.element, name, value.value());
-}
-
-var attributeHelper = new Helper(attribute);
-
-export function concat(params, hash, options, env) {
-  var stream = new Stream(function() {
-    return readArray(params).join('');
-  });
-
-  for (var i = 0, l = params.length; i < l; i++) {
-    var param = params[i];
-
-    if (param && param.isStream) {
-      param.subscribe(stream.notifyAll, stream);
-    }
-  }
-
-  return stream;
-}
-
-var concatHelper = new Helper(concat);
 
 /**
   Used to lookup/resolve handlebars helpers. The lookup order is:
@@ -57,15 +22,7 @@ var concatHelper = new Helper(concat);
   @param {String} name the name of the helper to lookup
   @return {Handlebars Helper}
 */
-export function lookupHelper(name, view, env) {
-  if (name === 'concat') {
-    return concatHelper;
-  }
-
-  if (name === 'attribute') {
-    return attributeHelper;
-  }
-
+export default function lookupHelper(name, view, env) {
   if (env.helpers[name]) {
     return env.helpers[name];
   }

--- a/packages/ember-htmlbars/tests/helpers/attribute_test.js
+++ b/packages/ember-htmlbars/tests/helpers/attribute_test.js
@@ -1,0 +1,154 @@
+import EmberView from "ember-views/views/view";
+import run from "ember-metal/run_loop";
+import EmberObject from "ember-runtime/system/object";
+import { compile } from "htmlbars-compiler/compiler";
+import { equalInnerHTML } from "htmlbars-test-helpers";
+import { defaultEnv } from "ember-htmlbars";
+
+var view, originalSetAttribute, setAttributeCalls;
+var dom = defaultEnv.dom;
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  QUnit.module("ember-htmlbars: attribute", {
+    teardown: function(){
+      if (view) {
+        run(view, view.destroy);
+      }
+    }
+  });
+
+  test("property is output", function() {
+    view = EmberView.create({
+      context: {name: 'erik'},
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "attribute is output");
+  });
+
+  test("property value is directly added to attribute", function() {
+    view = EmberView.create({
+      context: {name: '"" data-foo="blah"'},
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, '<div data-name="&quot;&quot; data-foo=&quot;blah&quot;">Hi!</div>', "attribute is output");
+  });
+
+  test("path is output", function() {
+    view = EmberView.create({
+      context: {name: {firstName: 'erik'}},
+      template: compile("<div data-name={{name.firstName}}>Hi!</div>")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "attribute is output");
+  });
+
+  test("changed property updates", function() {
+    var context = EmberObject.create({name: 'erik'});
+    view = EmberView.create({
+      context: context,
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "precond - attribute is output");
+
+    run(context, context.set, 'name', 'mmun');
+
+    equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', "attribute is updated output");
+  });
+
+  test("updates are scheduled in the render queue", function() {
+    expect(4);
+
+    var context = EmberObject.create({name: 'erik'});
+    view = EmberView.create({
+      context: context,
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    appendView(view);
+
+    equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "precond - attribute is output");
+
+    run(function() {
+      run.schedule('render', function() { 
+        equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "precond - attribute is not updated sync");
+      });
+
+      context.set('name', 'mmun');
+
+      run.schedule('render', function() {
+        equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', "attribute is updated output");
+      });
+    });
+
+    equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', "attribute is updated output");
+  });
+
+  QUnit.module('ember-htmlbars: {{attribute}} helper -- setAttribute', {
+    setup: function() {
+      originalSetAttribute = dom.setAttribute;
+      dom.setAttribute = function(element, name, value) {
+        setAttributeCalls.push([name, value]);
+
+        originalSetAttribute.call(dom, element, name, value);
+      };
+
+      setAttributeCalls = [];
+    },
+
+    teardown: function() {
+      dom.setAttribute = originalSetAttribute;
+
+      if (view) {
+        run(view, view.destroy);
+      }
+    }
+  });
+
+  test('calls setAttribute for new values', function() {
+    var context = EmberObject.create({name: 'erik'});
+    view = EmberView.create({
+      context: context,
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    appendView(view);
+
+    run(context, context.set, 'name', 'mmun');
+
+    var expected = [
+      ['data-name', 'erik'],
+      ['data-name', 'mmun']
+    ];
+
+    deepEqual(setAttributeCalls, expected);
+  });
+
+  test('does not call setAttribute if the same value is set', function() {
+    var context = EmberObject.create({name: 'erik'});
+    view = EmberView.create({
+      context: context,
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    appendView(view);
+
+    run(function() {
+      context.set('name', 'mmun');
+      context.set('name', 'erik');
+    });
+
+    var expected = [
+      ['data-name', 'erik']
+    ];
+
+    deepEqual(setAttributeCalls, expected);
+  });
+}

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -1,8 +1,4 @@
-import {
-  concat,
-  attribute,
-  lookupHelper
-} from "ember-htmlbars/system/lookup-helper";
+import lookupHelper from "ember-htmlbars/system/lookup-helper";
 import ComponentLookup from "ember-views/component_lookup";
 import Container from "container";
 import Component from "ember-views/views/component";
@@ -23,18 +19,6 @@ function generateContainer() {
 }
 
 QUnit.module('ember-htmlbars: lookupHelper hook');
-
-test('returns concat when helper is `concat`', function() {
-  var actual = lookupHelper('concat');
-
-  equal(actual.helperFunction, concat, 'concat is a hard-coded helper');
-});
-
-test('returns attribute when helper is `attribute`', function() {
-  var actual = lookupHelper('attribute');
-
-  equal(actual.helperFunction, attribute, 'attribute is a hard-coded helper');
-});
 
 test('looks for helpers in the provided `env.helpers`', function() {
   var env = generateEnv({


### PR DESCRIPTION
- Add tests to confirm we are using `setAttribute` for some level of
  escaping (equivalent to what we have today with `{{bind-attr}}`).
- Updated to ensure that rerenders happen in the `render` queue.
- Added dirty tracking to not needlessly update attributes.
- Move `attribute` and `concat` to separate `helpers/` files.
- Changed `lookupHelper` to be a default export.
