### PR TITLE
Avoid calling extend in the collection helper

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/collection.js
+++ b/packages/ember-htmlbars/lib/helpers/collection.js
@@ -11,10 +11,10 @@ import { fmt } from "ember-runtime/system/string";
 import { get } from "ember-metal/property_get";
 import SimpleStream from "ember-metal/streams/simple";
 import { ViewHelper } from "ember-htmlbars/helpers/view";
-import alias from "ember-metal/alias";
 import View from "ember-views/views/view";
 import CollectionView from "ember-views/views/collection_view";
 import { readViewFactory } from "ember-views/streams/read";
+import Factory from "ember-runtime/system/factory";
 
 /**
   `{{collection}}` is a `Ember.Handlebars` helper for adding instances of
@@ -235,9 +235,9 @@ export function collectionHelper(params, hash, options, env) {
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }
 
   if (hash.keyword) {
-    itemHash._context = alias('_parentView.context');
+    itemHash._contextBinding = '_parentView.context';
   } else {
-    itemHash._context = alias('content');
+    itemHash._contextBinding ='content';
   }
 
   var viewOptions = ViewHelper.propertiesFromHTMLOptions(itemHash, {}, { data: data });
@@ -258,7 +258,7 @@ export function collectionHelper(params, hash, options, env) {
     viewOptions.classNameBindings = itemClassBindings;
   }
 
-  hash.itemViewClass = itemViewClass.extend(viewOptions);
+  hash.itemViewClass = new Factory(itemViewClass, viewOptions);
 
   options.helperName = options.helperName || 'collection';
 

--- a/packages/ember-runtime/lib/system/factory.js
+++ b/packages/ember-runtime/lib/system/factory.js
@@ -1,0 +1,7 @@
+function Factory(klass, attrs) {
+  this.isFactory = true;
+  this.class = klass;
+  this.attrs = attrs;
+}
+
+export default Factory;

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -18,6 +18,7 @@ import {
 } from "ember-metal/mixin";
 import { readViewFactory } from "ember-views/streams/read";
 import EmberArray from "ember-runtime/mixins/array";
+import merge from "ember-metal/merge";
 
 /**
   `Ember.CollectionView` is an `Ember.View` descendent responsible for managing
@@ -343,21 +344,25 @@ var CollectionView = ContainerView.extend({
   */
   arrayDidChange: function(content, start, removed, added) {
     var addedViews = [];
-    var view, item, idx, len, itemViewClass, emptyView;
+    var view, item, idx, len, itemViewClass, emptyView, itemViewFactory, childAttrs;
 
     len = content ? get(content, 'length') : 0;
 
     if (len) {
+      childAttrs = {};
       itemViewClass = get(this, 'itemViewClass');
+      if (itemViewClass.isFactory) {
+        itemViewFactory = itemViewClass;
+        itemViewClass = itemViewFactory.class;
+        merge(childAttrs, itemViewFactory.attrs);
+      }
       itemViewClass = readViewFactory(itemViewClass, this.container);
 
       for (idx = start; idx < start+added; idx++) {
         item = content.objectAt(idx);
-
-        view = this.createChildView(itemViewClass, {
-          content: item,
-          contentIndex: idx
-        });
+        childAttrs.content = item;
+        childAttrs.contentIndex = idx;
+        view = this.createChildView(itemViewClass, childAttrs);
 
         addedViews.push(view);
       }


### PR DESCRIPTION
Punted on getting any fancier for now. Ultimately we'd ideally be able to pass the factory into `View#createChildView` and the `Factory#create` method would handle merging all the attributes in.

@rwjblue @stefanpenner 
