### PR TITLE
[FEATURE] ember-htmlbars-component-generation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -81,3 +81,8 @@ for a detailed explanation.
   Helper to pause a test, for use in debugging and TDD.
 
   Added in [#9383](https://github.com/emberjs/ember.js/pull/9383)
+
+* `ember-htmlbars-component-generation`
+
+  Enables HTMLBars compiler to interpret `<x-foo></x-foo>` as a component
+  invocation (instead of a standard HTML5 style element).

--- a/features.json
+++ b/features.json
@@ -16,7 +16,8 @@
     "mandatory-setter": "development-only",
     "ember-routing-fire-activate-deactivate-events": true,
     "ember-testing-pause-test": true,
-    "ember-htmlbars": null
+    "ember-htmlbars": null,
+    "ember-htmlbars-component-generation": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-htmlbars/lib/system/compile.js
+++ b/packages/ember-htmlbars/lib/system/compile.js
@@ -1,5 +1,11 @@
+import Ember from "ember-metal/core";
 import { compile } from "htmlbars-compiler/compiler";
 import template from "ember-htmlbars/system/template";
+
+var disableComponentGeneration = true;
+if (Ember.FEATURES.isEnabled('ember-htmlbars-component-generation')) {
+  disableComponentGeneration = false;
+}
 
 /**
   Uses HTMLBars `compile` function to process a string into a compiled template.
@@ -11,7 +17,9 @@ import template from "ember-htmlbars/system/template";
   @param {String} templateString This is the string to be compiled by HTMLBars.
 */
 export default function(templateString) {
-  var templateSpec = compile(templateString);
+  var templateSpec = compile(templateString, {
+    disableComponentGeneration: disableComponentGeneration
+  });
 
   return template(templateSpec);
 }


### PR DESCRIPTION
Disable HTMLBars `component` hook unless this feature is enabled.  Implemented upstream in https://github.com/tildeio/htmlbars/pull/152.

---

This needs to be disabled until we are prepared to:
- Properly handled features/changes that the 2.0 RFC suggests are enabled by this syntax.
- Determine how to handle actual web components (for things like polymer interop).
