### PR TITLE
Unwatch chained property with capitalized name

### DIFF
--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -108,6 +108,24 @@ testBoth('unwatching "length" property on an object', function(get, set) {
 
 });
 
+test("unwatching capitalized property name", function() {
+  var obj = { Foo: "bar" };
+  addListeners(obj, 'Foo');
+
+  watch(obj, 'Foo');
+
+  set(obj, 'Foo', 'FOO');
+  equal(willCount, 1, 'should have invoked willCount');
+  equal(didCount, 1, 'should have invoked didCount');
+
+  unwatch(obj, 'Foo');
+  willCount = didCount = 0;
+  set(obj, 'Foo', 'BAR');
+  equal(willCount, 0, 'should NOT have invoked willCount');
+  equal(didCount, 0, 'should NOT have invoked didCount');
+
+});
+
 test("unwatching a chain", function() {
   var Bar = {};
   var obj = { foo: Bar };

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -107,3 +107,41 @@ testBoth('unwatching "length" property on an object', function(get, set) {
   equal(didCount, 0, 'should NOT have invoked didCount');
 
 });
+
+test("unwatching a chain", function() {
+  var Bar = {};
+  var obj = { foo: Bar };
+  addListeners(obj, 'foo.Bar');
+
+  watch(obj, 'foo.Bar');
+
+  set(obj, 'foo.Bar', 'FOOBAR');
+  equal(willCount, 1, 'should have invoked willCount');
+  equal(didCount, 1, 'should have invoked didCount');
+
+  unwatch(obj, 'foo.Bar');
+  willCount = didCount = 0;
+  set(obj, 'foo.Bar', 'BARFOO');
+  equal(willCount, 0, 'should NOT have invoked willCount');
+  equal(didCount, 0, 'should NOT have invoked didCount');
+
+});
+
+test("unwatching a chain with capitalize property names", function() {
+  var Bar = {};
+  var obj = { Foo: Bar };
+  addListeners(obj, 'Foo.Bar');
+
+  watch(obj, 'Foo.Bar');
+
+  set(obj, 'Foo.Bar', 'FOOBAR');
+  equal(willCount, 1, 'should have invoked willCount');
+  equal(didCount, 1, 'should have invoked didCount');
+
+  unwatch(obj, 'Foo.Bar');
+  willCount = didCount = 0;
+  set(obj, 'Foo.Bar', 'BARFOO');
+  equal(willCount, 0, 'should NOT have invoked willCount');
+  equal(didCount, 0, 'should NOT have invoked didCount');
+
+});


### PR DESCRIPTION
I began a simple application, which consumes a JSON payload and render the response. So my route sets the model to something like this:

```
{
  "Config": {
    "Image": "xxx"
  }
}
```

and my template bind to this value: `<span>{{Config.Image}}</span>`. But if I leave the route, Ember throws an exception: `Uncaught TypeError: Cannot read property 'unchain' of undefined`.
But if I rename "Config" to "config" it works. Do I misunderstood any ember magic or is this a bug?

So I wrote a failing test for chained properties. Can everybody help to get solve the problem, please?
