### PR TITLE
Implement block params for HTMLBars

### DIFF
--- a/features.json
+++ b/features.json
@@ -17,6 +17,7 @@
     "ember-routing-fire-activate-deactivate-events": true,
     "ember-testing-pause-test": true,
     "ember-htmlbars": null,
+    "ember-htmlbars-block-params": null,
     "ember-htmlbars-component-generation": null
   },
   "debugStatements": [

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "git-repo-version": "0.0.1",
     "glob": "~3.2.8",
     "handlebars": "^2.0",
-    "htmlbars": "0.1.7",
+    "htmlbars": "0.1.8",
     "ncp": "~0.5.1",
     "rimraf": "~2.2.8",
     "rsvp": "~3.0.6"

--- a/packages/ember-htmlbars/lib/helpers/yield.js
+++ b/packages/ember-htmlbars/lib/helpers/yield.js
@@ -103,5 +103,5 @@ export function yieldHelper(params, hash, options, env) {
 
   Ember.assert("You called yield in a template that was not a layout", !!view);
 
-  view._yield(null, env, options.morph);
+  view._yield(null, env, options.morph, params);
 }

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import EmberError from "ember-metal/error";
 import run from "ember-metal/run_loop";
 import lookupHelper from "ember-htmlbars/system/lookup-helper";
 import concat from "ember-htmlbars/system/concat";
@@ -21,6 +22,17 @@ function streamifyArgs(view, params, hash, options, env, helper) {
     if (hashTypes[key] === 'id' && key !== 'classBinding' && key !== 'class') {
       hash[key] = view.getStream(hash[key]);
     }
+  }
+}
+
+export function set(view, name, value) {
+  if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
+    view._keywords[name] = value;
+  } else {
+    throw new EmberError(
+      "You must enable the ember-htmlbars-block-params feature " +
+      "flag to use the block params feature in Ember."
+    );
   }
 }
 

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,5 +1,6 @@
 import Ember from "ember-metal/core";
 import {
+  set,
   content,
   element,
   subexpr,
@@ -94,6 +95,7 @@ export var defaultEnv = {
   dom: new DOMHelper(),
 
   hooks: {
+    set: set,
     content: content,
     element: element,
     subexpr: subexpr,

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -1,0 +1,132 @@
+import Container from 'container/container';
+import run from "ember-metal/run_loop";
+import ComponentLookup from 'ember-views/component_lookup';
+import View from "ember-views/views/view";
+import compile from "ember-htmlbars/system/compile";
+import helpers from "ember-htmlbars/helpers";
+import { registerHelper } from "ember-htmlbars/helpers";
+
+var container, view;
+
+function appendView(view) {
+  run(function() { view.appendTo('#qunit-fixture'); });
+}
+
+function aliasHelper(params, hash, options, env) {
+  this.appendChild(View, {
+    isVirtual: true,
+    _morph: options.morph,
+    template: options.render,
+    _blockArguments: params
+  });
+}
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
+
+QUnit.module("ember-htmlbars: block params", {
+  setup: function() {
+    registerHelper('alias', aliasHelper);
+
+    container = new Container();
+    container.optionsForType('component', { singleton: false });
+    container.optionsForType('view', { singleton: false });
+    container.optionsForType('template', { instantiate: false });
+    container.optionsForType('helper', { instantiate: false });
+    container.register('component-lookup:main', ComponentLookup);
+  },
+  teardown: function() {
+    delete helpers.alias;
+
+    run(container, 'destroy');
+
+    if (view) {
+      run(function() {
+        view.destroy();
+      });
+    }
+  }
+});
+
+test("basic block params usage", function() {
+  view = View.create({
+    committer: { name: "rwjblue" },
+    template: compile('{{#alias view.committer.name as |name|}}name: {{name}}, length: {{name.length}}{{/alias}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "name: rwjblue, length: 7");
+
+  run(function() {
+    view.set('committer.name', "krisselden");
+  });
+
+  equal(view.$().text(), "name: krisselden, length: 10");
+});
+
+test("nested block params shadow correctly", function() {
+  view = View.create({
+    context: { name: "ebryn" },
+    committer1: { name: "trek" },
+    committer2: { name: "machty" },
+    template: compile(
+      '{{name}}' +
+      '{{#alias view.committer1.name as |name|}}' +
+        '[{{name}}' +
+        '{{#alias view.committer2.name as |name|}}' +
+          '[{{name}}]' +
+        '{{/alias}}' +
+        '{{name}}]' +
+      '{{/alias}}' +
+      '{{name}}' +
+      '{{#alias view.committer2.name as |name|}}' +
+        '[{{name}}' +
+        '{{#alias view.committer1.name as |name|}}' +
+          '[{{name}}]' +
+        '{{/alias}}' +
+        '{{name}}]' +
+      '{{/alias}}' +
+      '{{name}}'
+    )
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn");
+});
+
+test("components can yield values", function() {
+  container.register('template:components/x-alias', compile('{{yield param.name}}'));
+
+  view = View.create({
+    container: container,
+    context: { name: "ebryn" },
+    committer1: { name: "trek" },
+    committer2: { name: "machty" },
+    template: compile(
+      '{{name}}' +
+      '{{#x-alias param=view.committer1 as |name|}}' +
+        '[{{name}}' +
+        '{{#x-alias param=view.committer2 as |name|}}' +
+          '[{{name}}]' +
+        '{{/x-alias}}' +
+        '{{name}}]' +
+      '{{/x-alias}}' +
+      '{{name}}' +
+      '{{#x-alias param=view.committer2 as |name|}}' +
+        '[{{name}}' +
+        '{{#x-alias param=view.committer1 as |name|}}' +
+          '[{{name}}]' +
+        '{{/x-alias}}' +
+        '{{name}}]' +
+      '{{/x-alias}}' +
+      '{{name}}'
+    )
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), "ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn");
+});
+
+}

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -169,7 +169,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     this._keywords.view.setSource(this);
   },
 
-  _yield: function(context, options, morph) {
+  _yield: function(context, options, morph, blockArguments) {
     var view = options.data.view;
     var parentView = this._parentView;
     var template = get(this, 'template');
@@ -181,6 +181,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
         isVirtual: true,
         tagName: '',
         template: template,
+        _blockArguments: blockArguments,
         _contextView: parentView,
         _morph: morph,
         context: get(parentView, 'context'),

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -807,7 +807,7 @@ var View = CoreView.extend({
     if (template) {
       var useHTMLBars = false;
       if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-        useHTMLBars = template.length === 3;
+        useHTMLBars = template.length >= 3;
       }
 
       if (useHTMLBars) {
@@ -820,6 +820,8 @@ var View = CoreView.extend({
       morph.update(result);
     }
   },
+
+  _blockArguments: EMPTY_ARRAY,
 
   templateForName: function(name, type) {
     if (!name) { return; }
@@ -1096,12 +1098,12 @@ var View = CoreView.extend({
       var useHTMLBars = false;
 
       if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-        useHTMLBars = template.length === 3;
+        useHTMLBars = template.length >= 3;
       }
 
       if (useHTMLBars) {
         var env = Ember.merge(buildHTMLBarsDefaultEnv(), options);
-        output = template(this, env, buffer.innerContextualElement());
+        output = template(this, env, buffer.innerContextualElement(), this._blockArguments);
       } else {
         output = template(context, options);
       }


### PR DESCRIPTION
Adds block params support for htmlbars behind the feature flag `ember-htmlbars-block-params`.
- Updates to `htmlbars@0.1.8`
- Templates can be called with an array of values as their fourth argument.
- Components can yield values `{{yield foo bar baz}}`.
