### PR TITLE
[bugfix canary] failing test showing infinite recursion w/_super

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -50,19 +50,22 @@ var a_slice = [].slice;
 
 function superFunction(){
   var func = this.__nextSuper;
+  var ret;
 
   if (func) {
     var length = arguments.length;
-
-    if (length === 0){
-      return this.__nextSuper();
+    this.__nextSuper = null;
+    if (length === 0) {
+      ret = func.call(this);
     } else if (length === 1) {
-      return this.__nextSuper(arguments[0]);
+      ret = func.call(this, arguments[0]);
     } else if (length === 2) {
-      return this.__nextSuper(arguments[0], arguments[1]);
+      ret = func.call(this, arguments[0], arguments[1]);
     } else {
-      return this.__nextSuper.apply(this, arguments);
+      ret = func.apply(this, arguments);
     }
+    this.__nextSuper = func;
+    return ret;
   }
 }
 

--- a/packages/ember-metal/tests/mixin/reopen_test.js
+++ b/packages/ember-metal/tests/mixin/reopen_test.js
@@ -13,15 +13,17 @@ test('using reopen() to add more properties to a simple', function() {
   equal(Ember.get(obj, 'bar'), 'BAR', 'include MixinB props');
 });
 
-test('using reopen() and calling _super does not cause infinite recursion', function(){
+test('using reopen() and calling _super where there is not a super function does not cause infinite recursion', function(){
 
   var Taco = Ember.Object.extend({
     createBreakfast: function(){
+      // There is no original createBreakfast function.
+      // Calling the wrapped _super function here
+      // used to end in an infinite call loop
       this._super.apply(this, arguments);
-      return "Breakfast";
+      return "Breakfast!";
     }
   });
-
 
   Taco.reopen({
     createBreakfast: function(){
@@ -34,9 +36,9 @@ test('using reopen() and calling _super does not cause infinite recursion', func
   var result;
   Ember.run(function(){
     try {
-    result = taco.createBreakfast();
+      result = taco.createBreakfast();
     } catch (e) {
-      result = "Oatmeal :( This should not error.";
+      result = "Your breakfast was interrupted by an infinite stack error.";
     }
   });
 

--- a/packages/ember-metal/tests/mixin/reopen_test.js
+++ b/packages/ember-metal/tests/mixin/reopen_test.js
@@ -13,3 +13,33 @@ test('using reopen() to add more properties to a simple', function() {
   equal(Ember.get(obj, 'bar'), 'BAR', 'include MixinB props');
 });
 
+test('using reopen() and calling _super does not cause infinite recursion', function(){
+
+  var Taco = Ember.Object.extend({
+    createBreakfast: function(){
+      this._super.apply(this, arguments);
+      return "Breakfast";
+    }
+  });
+
+
+  Taco.reopen({
+    createBreakfast: function(){
+      return this._super.apply(this, arguments);
+    }
+  });
+
+  var taco = Taco.create();
+
+  var result;
+  Ember.run(function(){
+    try {
+    result = taco.createBreakfast();
+    } catch (e) {
+      result = "Oatmeal :( This should not error.";
+    }
+  });
+
+  equal(result, "Breakfast!");
+});
+


### PR DESCRIPTION
restores a bit of code removed in #9651 that would set the `__nextSuper` to null. It's not there on master currently, causing an infinite loop to occur.

cc @stefanpenner @mixonic 

refs emberjs/ember.js PR #9651
