### PR TITLE
Helpers return content instead of updating a morph

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -17,9 +17,7 @@ function HandlebarsCompatibleHelper(fn) {
     var args = options._raw.params;
     args.push(handlebarsOptions);
 
-    var result = fn.apply(this, args);
-
-    options.morph.update(result);
+    return fn.apply(this, args);
   };
 
   this.isHTMLBars = true;

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -48,5 +48,5 @@ export function locHelper(params, hash, options, env) {
     return true;
   });
 
-  options.morph.update(loc.apply(this, params));
+  return loc.apply(this, params);
 }

--- a/packages/ember-htmlbars/lib/helpers/template.js
+++ b/packages/ember-htmlbars/lib/helpers/template.js
@@ -17,5 +17,5 @@ export function templateHelper(params, hash, options, env) {
 
   options.helperName = options.helperName || 'template';
 
-  env.helpers.partial.helperFunction.call(this, params, hash, options, env);
+  return env.helpers.partial.helperFunction.call(this, params, hash, options, env);
 }

--- a/packages/ember-htmlbars/lib/helpers/unbound.js
+++ b/packages/ember-htmlbars/lib/helpers/unbound.js
@@ -59,11 +59,7 @@ export function unboundHelper(params, hash, options, env) {
     delete env.data.isUnbound;
   }
 
-  if (!options.morph) {
-    return result;
-  }
-
-  options.morph.update(result);
+  return result;
 }
 
 export function preprocessArgumentsForUnbound(view, params, hash, options, env) {

--- a/packages/ember-htmlbars/lib/helpers/yield.js
+++ b/packages/ember-htmlbars/lib/helpers/yield.js
@@ -103,5 +103,5 @@ export function yieldHelper(params, hash, options, env) {
 
   Ember.assert("You called yield in a template that was not a layout", !!view);
 
-  view._yield(null, env, options.morph, params);
+  return view._yield(null, env, options.morph, params);
 }

--- a/packages/ember-htmlbars/lib/hooks/content.js
+++ b/packages/ember-htmlbars/lib/hooks/content.js
@@ -1,16 +1,12 @@
-import streamifyArgs from "ember-htmlbars/system/streamify-arguments";
-import lookupHelper from "ember-htmlbars/system/lookup-helper";
+import subexpr from "ember-htmlbars/hooks/subexpr";
+import { appendSimpleBoundView } from "ember-views/views/simple_bound_view";
 
 export default function content(morph, path, view, params, hash, options, env) {
-  var helper = lookupHelper(path, view, env);
-  if (!helper) {
-    helper = lookupHelper('bindHelper', view, env);
-    // Modify params to include the first word
-    params.unshift(path);
-    options.paramTypes = ['id'];
+  var result = subexpr(path, view, params, hash, options, env);
+
+  if (result && result.isStream) {
+    appendSimpleBoundView(view, morph, result);
+  } else {
+    morph.update(result);
   }
-
-  streamifyArgs(view, params, hash, options, env, helper);
-  return helper.helperFunction.call(view, params, hash, options, env);
 }
-

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -67,20 +67,3 @@ test('adds `hash` into options `options` for the wrapped helper', function() {
   compatHelper.preprocessArguments(fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv);
   compatHelper.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv);
 });
-
-test('calls morph.update with the return value from the helper', function() {
-  expect(1);
-
-  function someHelper(options) {
-    return 'Lucy!';
-  }
-
-  var compatHelper = new HandlebarsCompatibleHelper(someHelper);
-
-  fakeOptions.morph.update = function(value) {
-    equal(value, 'Lucy!');
-  };
-
-  compatHelper.preprocessArguments(fakeView, fakeParams, fakeHash, fakeOptions, fakeEnv);
-  compatHelper.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv);
-});

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -802,7 +802,6 @@ var View = CoreView.extend({
 
   _yield: function(context, options, morph) {
     var template = get(this, 'template');
-    var result;
 
     if (template) {
       var useHTMLBars = false;
@@ -811,13 +810,10 @@ var View = CoreView.extend({
       }
 
       if (useHTMLBars) {
-        result = template(this, options, morph.contextualElement);
+        return template(this, options, morph.contextualElement);
       } else {
-        result = template(context, options);
+        return template(context, options);
       }
-    }
-    if (morph) {
-      morph.update(result);
     }
   },
 


### PR DESCRIPTION
This also lets helpers be transparently usable as both nested helpers (subexpressions) and unnested helpers.
