### PR TITLE
[FEATURE ember-metal-stream]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -137,3 +137,9 @@ for a detailed explanation.
   Passing just function is still supported, and is equivalent to passing only a getter.
 
   Added in [#9527](https://github.com/emberjs/ember.js/pull/9527).
+
+* `ember-metal-stream`
+
+  Exposes the basic internal stream implementation as `Ember.Stream`.
+
+  Added in [#9693](https://github.com/emberjs/ember.js/pull/9693)

--- a/features.json
+++ b/features.json
@@ -12,7 +12,8 @@
     "ember-htmlbars-attribute-syntax": true,
     "ember-routing-transitioning-classes": true,
     "new-computed-syntax": null,
-    "ember-testing-checkbox-helpers": null
+    "ember-testing-checkbox-helpers": null,
+    "ember-metal-stream": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -166,6 +166,20 @@ import isBlank from 'ember-metal/is_blank';
 import isPresent from 'ember-metal/is_present';
 import keys from 'ember-metal/keys';
 import Backburner from 'backburner';
+import {
+  isStream,
+  subscribe,
+  unsubscribe,
+  read,
+  readHash,
+  readArray,
+  scanArray,
+  scanHash,
+  concat,
+  chain
+} from "ember-metal/streams/utils";
+
+import Stream from "ember-metal/streams/stream";
 
 // END IMPORTS
 
@@ -326,6 +340,23 @@ Ember.isBlank = isBlank;
 Ember.isPresent = isPresent;
 
 Ember.merge = merge;
+
+if (Ember.FEATURES.isEnabled('ember-metal-stream')) {
+  Ember.stream = {
+    Stream: Stream,
+
+    isStream: isStream,
+    subscribe: subscribe,
+    unsubscribe: unsubscribe,
+    read: read,
+    readHash: readHash,
+    readArray: readArray,
+    scanArray: scanArray,
+    scanHash: scanHash,
+    concat: concat,
+    chain: chain
+  };
+}
 
 /**
   A function may be assigned to `Ember.onerror` to be called when Ember

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -4,6 +4,16 @@ import {
   getTailPath
 } from "ember-metal/path_cache";
 
+/**
+@module ember-metal
+*/
+
+/**
+  @public
+  @class Stream
+  @namespace Ember.stream
+  @constructor
+*/
 function Stream(fn) {
   this.init();
   this.valueFn = fn;

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -3,7 +3,8 @@ import Stream from "./stream";
 /**
  Check whether an object is a stream or not
 
- @private
+ @public
+ @for Ember.stream
  @function isStream
  @param {Object|Stream} object object to check whether it is a stream
  @return {Boolean} `true` if the object is a stream, `false` otherwise
@@ -16,7 +17,8 @@ export function isStream(object) {
  A method of subscribing to a stream which is safe for use with a non-stream
  object. If a non-stream object is passed, the function does nothing.
 
- @private
+ @public
+ @for Ember.stream
  @function subscribe
  @param {Object|Stream} object object or stream to potentially subscribe to
  @param {Function} callback function to run when stream value changes
@@ -33,7 +35,8 @@ export function subscribe(object, callback, context) {
  A method of unsubscribing from a stream which is safe for use with a non-stream
  object. If a non-stream object is passed, the function does nothing.
 
- @private
+ @public
+ @for Ember.stream
  @function unsubscribe
  @param {Object|Stream} object object or stream to potentially unsubscribe from
  @param {Function} callback function originally passed to `subscribe()`
@@ -49,7 +52,8 @@ export function unsubscribe(object, callback, context) {
  Retrieve the value of a stream, or in the case a non-stream object is passed,
  return the object itself.
 
- @private
+ @public
+ @for Ember.stream
  @function read
  @param {Object|Stream} object object to return the value of
  @return the stream's current value, or the non-stream object itself
@@ -65,7 +69,8 @@ export function read(object) {
 /**
  Map an array, replacing any streams with their values.
 
- @private
+ @public
+ @for Ember.stream
  @function readArray
  @param {Array} array The array to read values from
  @return {Array} a new array of the same length with the values of non-stream
@@ -86,7 +91,8 @@ export function readArray(array) {
  Map a hash, replacing any stream property values with the current value of that
  stream.
 
- @private
+ @public
+ @for Ember.stream
  @function readHash
  @param {Object} object The hash to read keys and values from
  @return {Object} a new object with the same keys as the passed object. The
@@ -105,7 +111,8 @@ export function readHash(object) {
 /**
  Check whether an array contains any stream values
 
- @private
+ @public
+ @for Ember.stream
  @function scanArray
  @param {Array} array array given to a handlebars helper
  @return {Boolean} `true` if the array contains a stream/bound value, `false`
@@ -128,7 +135,8 @@ export function scanArray(array) {
 /**
  Check whether a hash has any stream property values
 
- @private
+ @public
+ @for Ember.stream
  @function scanHash
  @param {Object} hash "hash" argument given to a handlebars helper
  @return {Boolean} `true` if the object contains a stream/bound value, `false`
@@ -150,7 +158,8 @@ export function scanHash(hash) {
 /**
  Join an array, with any streams replaced by their current values
 
- @private
+ @public
+ @for Ember.stream
  @function concat
  @param {Array} array An array containing zero or more stream objects and
                       zero or more non-stream objects
@@ -199,7 +208,8 @@ export function concat(array, separator) {
  In the example, result is a stream if source is a stream, or a number of
  source was numeric.
 
- @private
+ @public
+ @for Ember.stream
  @function chain
  @param {Object|Stream} value A stream or non-stream object
  @param {Function} fn function to be run when the stream value changes, or to


### PR DESCRIPTION
Expose the base internal stream implementation as `Ember.Stream`.
