### PR TITLE
Update out-of-date JSDoc, rename parameter '_path'

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -126,7 +126,7 @@ export function listenersDiff(obj, eventName, otherActions) {
   @for Ember
   @param obj
   @param {String} eventName
-  @param {Object|Function} targetOrMethod A target object or a function
+  @param {Object|Function} target A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Boolean} once A flag whether a function should only be called once
 */
@@ -162,7 +162,7 @@ export function addListener(obj, eventName, target, method, once) {
   @for Ember
   @param obj
   @param {String} eventName
-  @param {Object|Function} targetOrMethod A target object or a function
+  @param {Object|Function} target A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
 */
 function removeListener(obj, eventName, target, method) {
@@ -214,7 +214,7 @@ function removeListener(obj, eventName, target, method) {
   @private
   @param obj
   @param {String} eventName
-  @param {Object|Function} targetOrMethod A target object or a function
+  @param {Object|Function} target A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Function} callback
 */
@@ -245,8 +245,8 @@ export function suspendListener(obj, eventName, target, method, callback) {
 
   @private
   @param obj
-  @param {Array} eventName Array of event names
-  @param {Object|Function} targetOrMethod A target object or a function
+  @param {Array} eventNames Array of event names
+  @param {Object|Function} target A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Function} callback
 */

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -49,12 +49,12 @@ export function observersFor(obj, path) {
   @for Ember
   @param obj
   @param {String} path
-  @param {Object|Function} targetOrMethod
+  @param {Object|Function} target
   @param {Function|String} [method]
 */
-export function removeObserver(obj, _path, target, method) {
-  unwatch(obj, _path);
-  removeListener(obj, changeEvent(_path), target, method);
+export function removeObserver(obj, path, target, method) {
+  unwatch(obj, path);
+  removeListener(obj, changeEvent(path), target, method);
 
   return this;
 }
@@ -64,12 +64,12 @@ export function removeObserver(obj, _path, target, method) {
   @for Ember
   @param obj
   @param {String} path
-  @param {Object|Function} targetOrMethod
+  @param {Object|Function} target
   @param {Function|String} [method]
 */
-export function addBeforeObserver(obj, _path, target, method) {
-  addListener(obj, beforeEvent(_path), target, method);
-  watch(obj, _path);
+export function addBeforeObserver(obj, path, target, method) {
+  addListener(obj, beforeEvent(path), target, method);
+  watch(obj, path);
 
   return this;
 }
@@ -105,12 +105,12 @@ export function beforeObserversFor(obj, path) {
   @for Ember
   @param obj
   @param {String} path
-  @param {Object|Function} targetOrMethod
+  @param {Object|Function} target
   @param {Function|String} [method]
 */
-export function removeBeforeObserver(obj, _path, target, method) {
-  unwatch(obj, _path);
-  removeListener(obj, beforeEvent(_path), target, method);
+export function removeBeforeObserver(obj, path, target, method) {
+  unwatch(obj, path);
+  removeListener(obj, beforeEvent(path), target, method);
 
   return this;
 }


### PR DESCRIPTION
A couple of trivial changes in ember-metal:

(a) Update out-of-date parameter names in JSDoc for some functions,
(b) Rename the parameter `_path` back to `path`.  At some point an anonymous function was used there with a parameter called `path`, so the outer function's parameter was renamed to `_path`.  The anonymous function has since been removed, so I changed it back.
