### PR TITLE
Allow opting out of enumerable-safety

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -119,12 +119,49 @@ function intern(str) {
 */
 var GUID_KEY = intern('__ember' + (+ new Date()));
 
-var GUID_DESC = {
-  writable:    false,
-  configurable: false,
-  enumerable:  false,
+export var GUID_DESC = {
+  writable:     true,
+  configurable: true,
+  enumerable:   false,
   value: null
 };
+
+var undefinedDescriptor = {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+  value: undefined
+};
+
+var nullDescriptor = {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+  value: null
+};
+
+var META_DESC = {
+  writable: true,
+  configurable: true,
+  enumerable: false,
+  value: null
+};
+
+export var EMBER_META_PROPERTY = {
+  name: '__ember_meta__',
+  descriptor: META_DESC
+};
+
+export var GUID_KEY_PROPERTY = {
+  name: GUID_KEY,
+  descriptor: nullDescriptor
+};
+
+export var NEXT_SUPER_PROPERTY = {
+  name: '__nextSuper',
+  descriptor: undefinedDescriptor
+};
+
 
 /**
   Generates a new guid, optionally saving the guid to the object that you
@@ -151,7 +188,11 @@ export function generateGuid(obj, prefix) {
       obj[GUID_KEY] = ret;
     } else {
       GUID_DESC.value = ret;
-      o_defineProperty(obj, GUID_KEY, GUID_DESC);
+      if (obj.__defineNonEnumerable) {
+        obj.__defineNonEnumerable(GUID_KEY_PROPERTY);
+      } else {
+        o_defineProperty(obj, GUID_KEY, GUID_DESC);
+      }
     }
   }
   return ret;
@@ -205,7 +246,12 @@ export function guidFor(obj) {
         obj[GUID_KEY] = ret;
       } else {
         GUID_DESC.value = ret;
-        o_defineProperty(obj, GUID_KEY, GUID_DESC);
+
+        if (obj.__defineNonEnumerable) {
+          obj.__defineNonEnumerable(GUID_KEY_PROPERTY);
+        } else {
+          o_defineProperty(obj, GUID_KEY, GUID_DESC);
+        }
       }
       return ret;
   }
@@ -214,14 +260,6 @@ export function guidFor(obj) {
 // ..........................................................
 // META
 //
-
-var META_DESC = {
-  writable: true,
-  configurable: false,
-  enumerable: false,
-  value: null
-};
-
 function Meta(obj) {
   this.descs = {};
   this.watching = {};
@@ -290,7 +328,13 @@ function meta(obj, writable) {
   if (writable===false) return ret || EMPTY_META;
 
   if (!ret) {
-    if (canDefineNonEnumerableProperties) o_defineProperty(obj, '__ember_meta__', META_DESC);
+    if (canDefineNonEnumerableProperties) {
+      if (obj.__defineNonEnumerable) {
+        obj.__defineNonEnumerable(EMBER_META_PROPERTY);
+      } else {
+        o_defineProperty(obj, '__ember_meta__', META_DESC);
+      }
+    }
 
     ret = new Meta(obj);
 
@@ -306,7 +350,11 @@ function meta(obj, writable) {
     ret.descs.constructor = null;
 
   } else if (ret.source !== obj) {
-    if (canDefineNonEnumerableProperties) o_defineProperty(obj, '__ember_meta__', META_DESC);
+    if (obj.__defineNonEnumerable) {
+      obj.__defineNonEnumerable(EMBER_META_PROPERTY);
+    } else {
+      o_defineProperty(obj, '__ember_meta__', META_DESC);
+    }
 
     ret = o_create(ret);
     ret.descs     = o_create(ret.descs);

--- a/packages/ember-routing/lib/ext/view.js
+++ b/packages/ember-routing/lib/ext/view.js
@@ -16,7 +16,7 @@ EmberView.reopen({
     @method init
    */
   init: function() {
-    set(this, '_outlets', {});
+    this._outlets = {};
     this._super();
   },
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -21,7 +21,8 @@ import {
 import { create as o_create } from "ember-metal/platform";
 import {
   generateGuid,
-  GUID_KEY,
+  GUID_KEY_PROPERTY,
+  NEXT_SUPER_PROPERTY,
   meta,
   makeArray
 } from "ember-metal/utils";
@@ -54,20 +55,6 @@ var finishPartial = Mixin.finishPartial;
 var reopen = Mixin.prototype.reopen;
 var hasCachedComputedProperties = false;
 
-var undefinedDescriptor = {
-  configurable: true,
-  writable: true,
-  enumerable: false,
-  value: undefined
-};
-
-var nullDescriptor = {
-  configurable: true,
-  writable: true,
-  enumerable: false,
-  value: null
-};
-
 function makeCtor() {
 
   // Note: avoid accessing any properties on the object since it makes the
@@ -81,8 +68,8 @@ function makeCtor() {
     if (!wasApplied) {
       Class.proto(); // prepare prototype...
     }
-    o_defineProperty(this, GUID_KEY, nullDescriptor);
-    o_defineProperty(this, '__nextSuper', undefinedDescriptor);
+    this.__defineNonEnumerable(GUID_KEY_PROPERTY);
+    this.__defineNonEnumerable(NEXT_SUPER_PROPERTY);
     var m = meta(this);
     var proto = m.proto;
     m.proto = this;
@@ -267,6 +254,10 @@ CoreObject.PrototypeMixin = Mixin.create({
     @method init
   */
   init: function() {},
+  __defineNonEnumerable: function(property) {
+    o_defineProperty(this, property.name, property.descriptor);
+    //this[property.name] = property.descriptor.value;
+  },
 
   /**
     Defines the properties that will be concatenated from the superclass

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1762,6 +1762,10 @@ var View = CoreView.extend({
     this.classNames = emberA(this.classNames.slice());
   },
 
+  __defineNonEnumerable: function(property) {
+    this[property.name] = property.descriptor.value;
+  },
+
   appendChild: function(view, options) {
     return this.currentState.appendChild(this, view, options);
   },
@@ -1980,10 +1984,12 @@ var View = CoreView.extend({
 
     return false;
   },
+
   transitionTo: function(state, children) {
     Ember.deprecate("Ember.View#transitionTo has been deprecated, it is for internal use only");
     this._transitionTo(state, children);
   },
+
   _transitionTo: function(state, children) {
     var priorState = this.currentState;
     var currentState = this.currentState = this._states[state];


### PR DESCRIPTION
Introduce a `__defineNonEnumerable` hook. This allows parts of Ember to opt-out of enumerable safety (marking internal properties as non-enumerable).

Unfortunately at this time there is no way to create fast, non-enumerable properties. Historically Ember has this to allow people to `merge`, `extend` and `JSON.stringify` Ember objects, which requires being careful about enumerability.

Unfortunately, classes like `Ember.View` should do not be used in these contexts, but still suffer from the pretty hefty overhead.

This PR Reduces the cost of view allocation by 300% -> 400%.

Micro bench (creating 10,000 views):

```
before: 120ms
after:   35ms
```

the 25ms of the remaining is mostly funkyness we do in Ember.View and CoreView ourselves. We can be careful and clean lots of that up still.
- [x] make it work
- [ ] consider more objects
- [ ] only enabled in test mode?
- [ ] more refactorings
- [ ] add support for symbols if they are available
