### PR TITLE
[DOC] Include `Ember.isEmpty({})` example

### DIFF
--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -14,6 +14,7 @@ import isNone from 'ember-metal/is_none';
   Ember.isEmpty(undefined);       // true
   Ember.isEmpty('');              // true
   Ember.isEmpty([]);              // true
+  Ember.isEmpty({});              // false
   Ember.isEmpty('Adam Hawkins');  // false
   Ember.isEmpty([0,1,2]);         // false
   ```

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -21,7 +21,7 @@ test("Ember.isEmpty", function() {
   equal(false, isEmpty(0),         "for 0");
   equal(true,  isEmpty([]),        "for an empty Array");
   equal(false, isEmpty({}),        "for an empty Object");
-  equal(true,  isEmpty(object),     "for an Object that has zero 'length'");
+  equal(true,  isEmpty(object),    "for an Object that has zero 'length'");
 });
 
 test("Ember.isEmpty Ember.Map", function() {


### PR DESCRIPTION
Coming from rails, I expected `Ember.isEmpty({})` to return `true`. Since this
isn't the case, it might be a good idea to illustrate this in the docs, since
there is already a unit test covering this case.
