### PR TITLE
[BUGFIX beta] Avoid extending a view for every {{each}}.

### DIFF
--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -247,9 +247,9 @@ function collectionHelper(path, options) {
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }
 
   if (hash.keyword) {
-    itemHash._context = this;
+    itemHash._contextBinding = '_parentView.context';
   } else {
-    itemHash._context = alias('content');
+    itemHash._contextBinding = 'content';
   }
 
   var viewOptions = ViewHelper.propertiesFromHTMLOptions({ data: data, hash: itemHash }, this);
@@ -270,7 +270,8 @@ function collectionHelper(path, options) {
     viewOptions.classNameBindings = itemClassBindings;
   }
 
-  hash.itemViewClass = itemViewClass.extend(viewOptions);
+  hash.itemViewClass = itemViewClass;
+  hash._itemViewProps = viewOptions;
 
   options.helperName = options.helperName || 'collection';
 

--- a/packages/ember-handlebars/lib/helpers/collection.js
+++ b/packages/ember-handlebars/lib/helpers/collection.js
@@ -12,7 +12,6 @@ import { get } from "ember-metal/property_get";
 import SimpleStream from "ember-metal/streams/simple";
 import { handlebarsGetView } from "ember-handlebars/ext";
 import { ViewHelper } from "ember-handlebars/helpers/view";
-import alias from "ember-metal/alias";
 import View from "ember-views/views/view";
 import CollectionView from "ember-views/views/collection_view";
 

--- a/packages/ember-htmlbars/lib/helpers/collection.js
+++ b/packages/ember-htmlbars/lib/helpers/collection.js
@@ -11,7 +11,6 @@ import { fmt } from "ember-runtime/system/string";
 import { get } from "ember-metal/property_get";
 import SimpleStream from "ember-metal/streams/simple";
 import { ViewHelper } from "ember-htmlbars/helpers/view";
-import alias from "ember-metal/alias";
 import View from "ember-views/views/view";
 import CollectionView from "ember-views/views/collection_view";
 import { readViewFactory } from "ember-views/streams/read";
@@ -235,9 +234,9 @@ export function collectionHelper(params, hash, options, env) {
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }
 
   if (hash.keyword) {
-    itemHash._context = alias('_parentView.context');
+    itemHash._contextBinding = '_parentView.context';
   } else {
-    itemHash._context = alias('content');
+    itemHash._contextBinding = 'content';
   }
 
   var viewOptions = ViewHelper.propertiesFromHTMLOptions(itemHash, {}, { data: data });
@@ -258,7 +257,8 @@ export function collectionHelper(params, hash, options, env) {
     viewOptions.classNameBindings = itemClassBindings;
   }
 
-  hash.itemViewClass = itemViewClass.extend(viewOptions);
+  hash.itemViewClass = itemViewClass;
+  hash._itemViewProps = viewOptions;
 
   options.helperName = options.helperName || 'collection';
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -343,22 +343,24 @@ var CollectionView = ContainerView.extend({
   */
   arrayDidChange: function(content, start, removed, added) {
     var addedViews = [];
-    var view, item, idx, len, itemViewClass, emptyView;
+    var view, item, idx, len, itemViewClass, emptyView, itemViewProps;
 
     len = content ? get(content, 'length') : 0;
 
     if (len) {
+      itemViewProps = this._itemViewProps || {};
       itemViewClass = get(this, 'itemViewClass');
+
       itemViewClass = readViewFactory(itemViewClass, this.container);
 
       for (idx = start; idx < start+added; idx++) {
         item = content.objectAt(idx);
 
-        view = this.createChildView(itemViewClass, {
-          content: item,
-          contentIndex: idx,
-          _blockArguments: [item]
-        });
+        itemViewProps.content = item;
+        itemViewProps._blockArguments = [item];
+        itemViewProps.contentIndex = idx;
+
+        view = this.createChildView(itemViewClass, itemViewProps);
 
         addedViews.push(view);
       }
@@ -372,6 +374,7 @@ var CollectionView = ContainerView.extend({
       }
 
       emptyView = this.createChildView(emptyView);
+
       addedViews.push(emptyView);
       set(this, 'emptyView', emptyView);
 


### PR DESCRIPTION
Credit goes to @ebryn. This was extracted from his work in #9670.

I believe that in general #9670 is absolutely the right way forward for things like `MODEL_FACTORY_INJECTIONS`, but it is not needed for this localized use case.  I'd rather get this into beta without adding new API surface, and then we can figure out the long term fix for factory injections.

Closes #9670 

/cc @stefanpenner @ebryn @mixonic
