### PR TITLE
[BUGFIX beta] Only register core libraries once.

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -53,6 +53,8 @@ function props(obj) {
   return properties;
 }
 
+var librariesRegistered = false;
+
 /**
   An instance of `Ember.Application` is the starting point for every Ember
   application. It helps to instantiate, initialize and coordinate the many
@@ -273,8 +275,11 @@ var Application = Namespace.extend(DeferredMixin, {
 
     this.scheduleInitialize();
 
-    Ember.libraries.registerCoreLibrary('Handlebars' + (EmberHandlebars.compile ? '' : '-runtime'), EmberHandlebars.VERSION);
-    Ember.libraries.registerCoreLibrary('jQuery', jQuery().jquery);
+    if (!librariesRegistered) {
+      librariesRegistered = true;
+      Ember.libraries.registerCoreLibrary('Handlebars' + (EmberHandlebars.compile ? '' : '-runtime'), EmberHandlebars.VERSION);
+      Ember.libraries.registerCoreLibrary('jQuery', jQuery().jquery);
+    }
 
     if (Ember.LOG_VERSION) {
       // we only need to see this once per Application#init


### PR DESCRIPTION
In Ember CLI (and in our own test suite) many Ember.Application instances are created.  This prevents each test from triggering a warning that the library has already been registered.

**tldr;** Prevents the following:

![image](https://cloud.githubusercontent.com/assets/12637/5193981/322d247e-74d5-11e4-9bbf-a9d4d3cc44f3.png)
