### PR TITLE
Replace listenersDiff and listenersUnion with accumulateListeners

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -81,11 +81,14 @@ function actionsFor(obj, eventName) {
   return actions;
 }
 
-export function listenersUnion(obj, eventName, otherActions) {
+export function accumulateListeners(obj, eventName, otherActions) {
   var meta = obj['__ember_meta__'];
   var actions = meta && meta.listeners && meta.listeners[eventName];
 
   if (!actions) { return; }
+
+  var newActions = [];
+
   for (var i = actions.length - 3; i >= 0; i -= 3) {
     var target = actions[i];
     var method = actions[i+1];
@@ -94,29 +97,11 @@ export function listenersUnion(obj, eventName, otherActions) {
 
     if (actionIndex === -1) {
       otherActions.push(target, method, flags);
+      newActions.push(target, method, flags);
     }
   }
-}
 
-export function listenersDiff(obj, eventName, otherActions) {
-  var meta = obj['__ember_meta__'];
-  var actions = meta && meta.listeners && meta.listeners[eventName];
-  var diffActions = [];
-
-  if (!actions) { return; }
-  for (var i = actions.length - 3; i >= 0; i -= 3) {
-    var target = actions[i];
-    var method = actions[i+1];
-    var flags = actions[i+2];
-    var actionIndex = indexOf(otherActions, target, method);
-
-    if (actionIndex !== -1) { continue; }
-
-    otherActions.push(target, method, flags);
-    diffActions.push(target, method, flags);
-  }
-
-  return diffActions;
+  return newActions;
 }
 
 /**

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -60,11 +60,10 @@ import {
 } from "ember-metal/property_get";
 
 import {
+  accumulateListeners,
   addListener,
   hasListeners,
-  listenersDiff,
   listenersFor,
-  listenersUnion,
   on,
   removeListener,
   sendEvent,
@@ -227,17 +226,16 @@ Ember._getPath       = _getPath;
 
 Ember.EnumerableUtils = EnumerableUtils;
 
-Ember.on                = on;
-Ember.addListener       = addListener;
-Ember.removeListener    = removeListener;
-Ember._suspendListener  = suspendListener;
-Ember._suspendListeners = suspendListeners;
-Ember.sendEvent         = sendEvent;
-Ember.hasListeners      = hasListeners;
-Ember.watchedEvents     = watchedEvents;
-Ember.listenersFor      = listenersFor;
-Ember.listenersDiff     = listenersDiff;
-Ember.listenersUnion    = listenersUnion;
+Ember.on                  = on;
+Ember.addListener         = addListener;
+Ember.removeListener      = removeListener;
+Ember._suspendListener    = suspendListener;
+Ember._suspendListeners   = suspendListeners;
+Ember.sendEvent           = sendEvent;
+Ember.hasListeners        = hasListeners;
+Ember.watchedEvents       = watchedEvents;
+Ember.listenersFor        = listenersFor;
+Ember.accumulateListeners = accumulateListeners;
 
 Ember._ObserverSet = ObserverSet;
 


### PR DESCRIPTION
I noticed that `listenersDiff` and `listenersUnion` are doing the same thing, except that the latter wasn't returning a value.  So I replaced them with a single function `accumulateListeners` and updated their usages.  I also think the name more accurately reflects what they do (listenersDiff was really doing a union and then returning the diff).  I realize 'accumulateListeners' is a mouthful, so I'd welcome better names for it.  I considered `mergeListeners`, but it seems less accurate.

Another, trivial, change was changing a parameter `cb` to `callback`, matching the JSDoc.
