### PR TITLE
Add Support for ESNext

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -16,6 +16,7 @@ var replace = require('broccoli-replace');
 var es3recast = require('broccoli-es3-safe-recast');
 var useStrictRemover = require('broccoli-use-strict-remover');
 var derequire = require('broccoli-derequire');
+var compileEsnext = require('broccoli-esnext');
 
 var getVersion = require('git-repo-version');
 var yuidocPlugin = require('ember-cli-yuidoc');
@@ -456,6 +457,9 @@ function es6Package(packageName) {
     srcFile: packageName + '/main.js',
     destFile: packageName + '.js'
   });
+
+  // Compile from ES6 to ES5
+  libTree = compileEsnext(libTree);
 
   var libJSHintTree = jshintTree(libTree);
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "broccoli-derequire": "0.0.1",
     "broccoli-es3-safe-recast": "0.0.8",
     "broccoli-es6-module-transpiler": "~0.1.0",
+    "broccoli-esnext": "^0.5.0",
     "broccoli-file-creator": "~0.1.0",
     "broccoli-file-mover": "~0.2.0",
     "broccoli-file-remover": "~0.2.0",


### PR DESCRIPTION
Since `ember-cli` includes `esnext` by default, we could also use new ES6
language features.
