### PR TITLE
[BUGFIX beta] CollectionView keeps child views and content in sync. Closes #4306

### DIFF
--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -323,7 +323,9 @@ var CollectionView = ContainerView.extend({
 
     for (idx = start + removedCount - 1; idx >= start; idx--) {
       childView = childViews[idx];
-      childView.destroy();
+      if (childView) {
+        childView.destroy();
+      }
     }
   },
 
@@ -343,11 +345,17 @@ var CollectionView = ContainerView.extend({
   */
   arrayDidChange: function(content, start, removed, added) {
     var addedViews = [];
-    var view, item, idx, len, itemViewClass, emptyView;
+    var view, item, idx, len, itemViewClass, emptyView, viewsLen;
 
+    viewsLen = get(this, 'length');
     len = content ? get(content, 'length') : 0;
 
     if (len) {
+      if (len === viewsLen) {
+        start = 0;
+        added = len;
+        this.replace(0, len, []);
+      }
       itemViewClass = get(this, 'itemViewClass');
       itemViewClass = readViewFactory(itemViewClass, this.container);
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -564,6 +564,56 @@ test("a array_proxy that backs an sorted array_controller that backs a collectio
   });
 });
 
+test("a collection view backed by an array_proxy whose arrangedContent is a computedProperty relying on its own content should make the correct changes to its child views when the array_proxy's content is modified", function() {
+
+  var arrangedArray = ArrayProxy.extend({
+    arrangedContent: Ember.computed('content.[]', function() {
+      return this.get('content');
+    })
+  });
+  var array = Ember.A(['firstItem']);
+  var arrayProxy = arrangedArray.create({
+    content: array
+  });
+
+  var container = CollectionView.create({
+    content: arrayProxy
+  });
+
+  run(function() {
+    container.appendTo('#qunit-fixture');
+  });
+
+  equal(container.get('content.length'), 1, 'CollectionView.content should have 1 entries');
+  equal(container.get('childViews.length'), 1, 'CollectionView.childViews should have 1 entries');
+
+  run(function() {
+    arrayProxy.set('content', Ember.A(['newFirstItem']));
+  });
+
+  equal(container.get('content.length'), 1, 'CollectionView.content should still have 1 entries');
+  equal(container.get('childViews.length'), 1, 'CollectionView.childViews should still have 1 entries');
+  equal(container.get('childViews.firstObject.content'), 'newFirstItem', 'CollectionView.childView.firstObject.content should match the first object in the content array');
+
+  run(function() {
+    arrayProxy.get('content').pushObject('secondItem');
+  });
+
+  equal(container.get('content.length'), 2, 'CollectionView.content should have 2 entries');
+  equal(container.get('childViews.length'), 2, 'CollectionView.childViews should have 2 entries');
+
+  run(function() {
+    arrayProxy.get('content').removeObject('secondItem');
+  });
+
+  equal(container.get('content.length'), 1, 'CollectionView.content should have 1 entries');
+  equal(container.get('childViews.length'), 1, 'CollectionView.childViews should have 1 entries');
+
+  run(function() {
+    container.destroy();
+  });
+});
+
 test("when a collection view is emptied, deeply nested views elements are not removed from the DOM and then destroyed again", function() {
   var assertProperDestruction = Mixin.create({
     destroyElement: function() {


### PR DESCRIPTION
CollectionView.arrayWillChange and CollectionView.arrayDidChange were
getting called multiple times when content was an ArrayProxy with a
computed property ArrangedContent relying on its content.

This is probably not the best way to fix it and it breaks a
CollectionView test that counts the life cycle events fired when content
is modified.

It does get the job done, though, and doesn't seem to break
anything.
