### PR TITLE
[FEATURE ember-views-text-support-on-change]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,26 +5,29 @@ for a detailed explanation.
 
 ## Feature Flags
 
-* `ember-application-instance-initializers`
+* `ember-views-text-support-on-change`
 
-  Splits apart initializers into two phases:
+  Firing an `on-change` event indicates that `focusOut` has happened
+  and that the value has changed. Observers exist for detecting changes to
+  the underlying value, but `on-change` will only fire when the value changes
+  **and** `focusOut` fires.
 
-  * Boot-time Initializers that receive a registry, and use it to set up
-    code structures
-  * Instance Initializers that receive an application instance, and use
-    it to set up application state per run of the application.
+  Usage:
 
-  In FastBoot, each request will have its own run of the application,
-  and will only need to run the instance initializers.
+  ```hbs
+  {{input type="text" on-change="handleChange"}}
+  ```
 
-  In the future, tests will also be able to use this differentiation to
-  run just the instance initializers per-test.
+  Firing an `on-input` event indicates that the value has changed and focus
+  **has not been lost**.
 
-  With this change, `App.initializer` becomes a "boot-time" initializer,
-  and issues a deprecation warning if instances are accessed.
+  Usage:
 
-  Apps should migrate any initializers that require instances to the new
-  `App.instanceInitializer` API.
+  ```hbs
+  {{input type="text" on-input="handleChange"}}
+  ```
+
+  Added in [#9734](https://github.com/emberjs/ember.js/pull/9734)
 
 * `ember-application-initializer-context`
 

--- a/features.json
+++ b/features.json
@@ -16,7 +16,8 @@
     "ember-metal-stream": null,
     "ember-htmlbars-each-with-index": true,
     "ember-application-instance-initializers": null,
-    "ember-application-initializer-context": null
+    "ember-application-initializer-context": null,
+    "ember-views-text-support-on-change": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -3,6 +3,7 @@
 @submodule ember-views
 */
 
+import Ember from "ember-metal/core"; // FEATURES
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { Mixin } from "ember-metal/mixin";
@@ -187,8 +188,50 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     set(this, 'value', this.$().val());
   },
 
+
+  /**
+    This event is behind the `ember-views-text-support-on-change` feature flag.
+
+    Allows you to specify a controller action to invoke when a field changes
+    **and** loses focus. To use this method, set the `on-change` attribute.
+    The value of that attribute should be the name of the action in
+    your controller that you wish to invoke.
+
+    To handle a value change without losing focus, see: `input` event.
+
+    For an example on how to use the `on-change` attribute, please reference the
+    example near the top of this file.
+
+    @method change
+    @param {Event} event
+  */
   change: function(event) {
     this._elementValueDidChange(event);
+
+    if (Ember.FEATURES.isEnabled('ember-views-text-support-on-change')) {
+      sendAction('on-change', this, event);
+    }
+  },
+
+  /**
+    This event is behind the `ember-views-text-support-on-change` feature flag.
+
+    Allows you to specify a controller action to invoke when a text field changes.
+    To use this method, set the `on-input` attribute. The value of that attribute
+    should be the name of the action in your controller that you wish to invoke.
+
+    For an example on how to use the `on-input` attribute, please reference the
+    example near the top of this file.
+
+    @method change
+    @param {Event} event
+  */
+  input: function(event) {
+    this._elementValueDidChange(event);
+
+    if (Ember.FEATURES.isEnabled('ember-views-text-support-on-change')) {
+      sendAction('on-input', this, event);
+    }
   },
 
   /**

--- a/packages/ember-views/tests/mixins/text_support_test.js
+++ b/packages/ember-views/tests/mixins/text_support_test.js
@@ -1,0 +1,62 @@
+import Ember from "ember-metal/core"; // FEATURES
+import run from "ember-metal/run_loop";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import EmberObject from "ember-runtime/system/object";
+import Component from "ember-views/views/component";
+import TextSupport from "ember-views/mixins/text_support";
+import EventDispatcher from "ember-views/system/event_dispatcher";
+
+var component, dispatcher;
+var isEnabled = Ember.FEATURES.isEnabled;
+
+if (isEnabled("ember-views-text-support-on-change")) {
+  QUnit.module("Mixin: TextSupport", {
+    setup: function() {
+      dispatcher = EventDispatcher.create();
+      dispatcher.setup();
+    },
+
+    teardown: function() {
+      runDestroy(dispatcher);
+      runDestroy(component);
+    }
+  });
+
+  test("`change` event is sent to controller", function() {
+    expect(1);
+
+    var controller = EmberObject.extend({
+      send: function(actionName) {
+        equal(actionName, "changeFired", "component sent 'change' event");
+      }
+    });
+    component = Component.createWithMixins(TextSupport, {
+      "on-change": "changeFired",
+      targetObject: controller.create({})
+    });
+    runAppend(component);
+
+    run(function() {
+      component.$().trigger({ type: "change" });
+    });
+  });
+
+  test("`input` event is sent to controller", function() {
+    expect(1);
+
+    var controller = EmberObject.extend({
+      send: function(actionName) {
+        equal(actionName, "inputFired", "component sent 'input' event");
+      }
+    });
+    component = Component.createWithMixins(TextSupport, {
+      "on-input": "inputFired",
+      targetObject: controller.create({})
+    });
+    runAppend(component);
+
+    run(function() {
+      component.$().trigger({ type: "input" });
+    });
+  });
+}


### PR DESCRIPTION
Fixes #5492.

When an `<input type="text">` or `<textarea>` value changes, expose and emit a
`change` event.
