### PR TITLE
[BUGFIX beta] Allow tagName to be a computed property.

### DIFF
--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -4,6 +4,7 @@ import { create } from 'ember-metal/platform';
 import renderBuffer from "ember-views/system/render_buffer";
 import run from "ember-metal/run_loop";
 import { set } from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
 import {
   _instrumentStart,
   subscribers
@@ -34,7 +35,7 @@ EmberRenderer.prototype.createElement =
     // create a new buffer relative to the original using the
     // provided buffer operation (for example, `insertAfter` will
     // insert a new buffer after the "parent buffer").
-    var tagName = view.tagName;
+    var tagName = get(view, 'tagName');
     var classNameBindings = view.classNameBindings;
     var taglessViewWithClassBindings = tagName === '' && classNameBindings.length > 0;
 

--- a/packages/ember-views/tests/views/view/render_test.js
+++ b/packages/ember-views/tests/views/view/render_test.js
@@ -3,6 +3,7 @@ import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 import EmberView from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
+import { computed } from "ember-metal/computed";
 
 import EmberHandlebars from "ember-handlebars-compiler";
 
@@ -121,6 +122,26 @@ test("should add ember-view to views", function() {
   });
 
   ok(view.$().hasClass('ember-view'), "the view has ember-view");
+});
+
+test("should allow tagName to be a computed property", function() {
+  view = EmberView.extend({
+    tagName: computed(function() {
+      return 'span';
+    })
+  }).create();
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.element.tagName, 'SPAN', "the view has was created with the correct element");
+
+  run(function() {
+    view.set('tagName', 'div');
+  });
+
+  equal(view.element.tagName, 'SPAN', "the tagName cannot be changed after initial render");
 });
 
 test("should allow hX tags as tagName", function() {


### PR DESCRIPTION
It will only be used to determine the initial tagName to use, and will not cause a rerender if its value changes.

Closes #9742.
