### PR TITLE
Fix bug aborting popstate

### DIFF
--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -52,7 +52,7 @@ export default EmberObject.extend({
   getURL: function() {
     var originalPath = this.getHash().substr(1);
     var outPath = originalPath;
-    
+
     if (outPath.charAt(0) !== '/') {
       outPath = '/';
 
@@ -111,13 +111,22 @@ export default EmberObject.extend({
     Ember.$(window).on('hashchange.ember-location-'+guid, function() {
       run(function() {
         var path = self.getURL();
-        if (get(self, 'lastSetURL') === path) { return; }
-
-        set(self, 'lastSetURL', null);
-
-        callback(path);
+        if (get(self, 'lastSetURL') !== path) {
+          callback(path);
+        }
       });
     });
+  },
+
+  /**
+    Restores the previous url.
+    Used when aborting a history.back() to correct wrong eager url update.
+
+    @private
+    @method restorePreviousURL
+  */
+  restorePreviousURL: function(){
+    this.setURL(get(this, 'lastSetURL'));
   },
 
   /**

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -162,6 +162,18 @@ export default EmberObject.extend({
     this._previousURL = this.getURL();
   },
 
+
+  /**
+    Restores the previous url.
+    Used when aborting a history.back() to correct wrong eager url update.
+
+    @private
+    @method restorePreviousURL
+  */
+  restorePreviousURL: function(){
+    this.pushState(this._previousURL);
+  },
+
   /**
     Register a callback to be invoked whenever the browser
     history changes, including using forward and back buttons.

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -169,6 +169,9 @@ var EmberRouter = EmberObject.extend(Evented, {
   _doURLTransition: function(routerJsMethod, url) {
     var transition = this.router[routerJsMethod](url || '/');
     listenForTransitionErrors(transition);
+    if (transition.isAborted && this.location.restorePreviousURL) {
+      this.location.restorePreviousURL();
+    }
     return transition;
   },
 


### PR DESCRIPTION
I hit the bug reported in this issue #5210 a few days ago. 

tl;dr
When you hit the back button and the transition is aborted, the url has already been updated is not rollbacked.

I've managed to fix it, but I have no clue about how to test it, because I would involve set some routes and play with the history. Seems almost an acceptance test to me.
