### PR TITLE
Add Stream.prototype._label and remove HandlebarsCompatibleHelper.prototype.preprocessArguments.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -21,12 +21,32 @@ var slice = [].slice;
 */
 function HandlebarsCompatibleHelper(fn) {
   this.helperFunction = function helperFunc(params, hash, options, env) {
+    var param;
     var handlebarsOptions = {};
     merge(handlebarsOptions, options);
     merge(handlebarsOptions, env);
-    handlebarsOptions.hash = options._raw.hash;
 
-    var args = options._raw.params;
+    handlebarsOptions.hash = {};
+    for (var prop in hash) {
+      param = hash[prop];
+
+      if (param.isStream) {
+        handlebarsOptions.hash[prop] = param._label;
+      } else {
+        handlebarsOptions.hash[prop] = param;
+      }
+    }
+
+    var args = new Array(params.length);
+    for (var i = 0, l = params.length; i < l; i++) {
+      param = params[i];
+
+      if (param.isStream) {
+        args[i] = param._label;
+      } else {
+        args[i] = param;
+      }
+    }
     args.push(handlebarsOptions);
 
     return fn.apply(this, args);
@@ -36,12 +56,7 @@ function HandlebarsCompatibleHelper(fn) {
 }
 
 HandlebarsCompatibleHelper.prototype = {
-  preprocessArguments: function(view, params, hash, options, env) {
-    options._raw = {
-      params: params.slice(),
-      hash: merge({}, hash)
-    };
-  }
+  preprocessArguments: function() { }
 };
 
 export function registerHandlebarsCompatibleHelper(name, value) {

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -12,6 +12,8 @@ function Stream(fn) {
 Stream.prototype = {
   isStream: true,
 
+  _label: null,
+
   init: function() {
     this.state = 'dirty';
     this.cache = undefined;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -2032,20 +2032,40 @@ var View = CoreView.extend({
   },
 
   getStream: function(path) {
-    return this._getContextStream().get(path);
+    var stream = this._getContextStream().get(path);
+
+    stream._label = path;
+
+    return stream;
   },
 
-  _getBindingForStream: function(path) {
+  _getBindingForStream: function(pathOrStream) {
     if (this._streamBindings === undefined) {
       this._streamBindings = create(null);
       this.one('willDestroyElement', this, this._destroyStreamBindings);
+    }
+
+    var path = pathOrStream;
+    if (pathOrStream.isStream) {
+      path = pathOrStream._label;
+
+      if (!path) {
+        // if no _label is present on the provided stream
+        // it is likely a subexpr and cannot be set (so it
+        // does not need a StreamBinding)
+        return pathOrStream;
+      }
     }
 
     if (this._streamBindings[path] !== undefined) {
       return this._streamBindings[path];
     } else {
       var stream = this._getContextStream().get(path);
-      return this._streamBindings[path] = new StreamBinding(stream);
+      var streamBinding = new StreamBinding(stream);
+
+      streamBinding._label = path;
+
+      return this._streamBindings[path] = streamBinding;
     }
   },
 

--- a/packages/ember-views/tests/views/view/stream_test.js
+++ b/packages/ember-views/tests/views/view/stream_test.js
@@ -1,0 +1,75 @@
+import run from "ember-metal/run_loop";
+import EmberView from "ember-views/views/view";
+
+var view;
+
+QUnit.module("ember-views: streams", {
+  teardown: function() {
+    if (view) {
+      run(view, 'destroy');
+    }
+  }
+});
+
+test("can return a stream that is notified of changes", function() {
+  expect(2);
+
+  view = EmberView.create({
+    controller: {
+      name: 'Robert'
+    }
+  });
+
+  var stream = view.getStream('name');
+
+  equal(stream.value(), 'Robert', 'initial value is correct');
+
+  stream.subscribe(function() {
+    equal(stream.value(), 'Max', 'value is updated');
+  });
+
+  run(view, 'set', 'controller.name', 'Max');
+});
+
+test("a single stream is used for the same path", function() {
+  expect(2);
+
+  var stream1, stream2;
+
+  view = EmberView.create({
+    controller: {
+      name: 'Robert'
+    }
+  });
+
+  stream1 = view.getStream('name');
+  stream2 = view.getStream('name');
+
+  equal(stream1, stream2, 'streams for the same path should be the same object');
+
+  stream1 = view.getStream('');
+  stream2 = view.getStream('this');
+
+  equal(stream1, stream2, 'streams "" and "this"  should be the same object');
+});
+
+test("the stream returned is labeled with the requested path", function() {
+  expect(2);
+  var stream;
+
+  view = EmberView.create({
+    controller: {
+      name: 'Robert'
+    },
+    
+    foo: 'bar'
+  });
+
+  stream = view.getStream('name');
+
+  equal(stream._label, 'name', 'stream is labeled');
+
+  stream = view.getStream('view.foo');
+
+  equal(stream._label, 'view.foo', 'stream is labeled');
+});


### PR DESCRIPTION
- Add `Stream.prototype._label`.
- Refactor `HandlebarsCompatibleHelper` to avoid `preprocessArguments` (future refactorings are likely to remove this).
