### PR TITLE
Address concerns with injected properties feature

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -733,8 +733,8 @@ function factoryFor(container, fullName) {
 
   var type = fullName.split(':')[0];
   if (!factory || typeof factory.extend !== 'function' || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
-    if (factory && typeof factory.onLookup === 'function') {
-      factory.onLookup(fullName);
+    if (factory && typeof factory._onLookup === 'function') {
+      factory._onLookup(fullName);
     }
 
     // TODO: think about a 'safe' merge style extension
@@ -750,8 +750,8 @@ function factoryFor(container, fullName) {
     var injectedFactory = factory.extend(injections);
     injectedFactory.reopenClass(factoryInjections);
 
-    if (factory && typeof factory.onLookup === 'function') {
-      factory.onLookup(fullName);
+    if (factory && typeof factory._onLookup === 'function') {
+      factory._onLookup(fullName);
     }
 
     cache[fullName] = injectedFactory;
@@ -821,8 +821,8 @@ function instantiate(container, fullName) {
       validationCache = container.validationCache;
 
       // Ensure that all lazy injections are valid at instantiation time
-      if (!validationCache[fullName] && typeof factory.lazyInjections === 'function') {
-        lazyInjections = factory.lazyInjections();
+      if (!validationCache[fullName] && typeof factory._lazyInjections === 'function') {
+        lazyInjections = factory._lazyInjections();
 
         validateInjections(container, normalizeInjectionsHash(lazyInjections));
       }

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -733,6 +733,10 @@ function factoryFor(container, fullName) {
 
   var type = fullName.split(':')[0];
   if (!factory || typeof factory.extend !== 'function' || (!Ember.MODEL_FACTORY_INJECTIONS && type === 'model')) {
+    if (factory && typeof factory.onLookup === 'function') {
+      factory.onLookup(fullName);
+    }
+
     // TODO: think about a 'safe' merge style extension
     // for now just fallback to create time injection
     cache[fullName] = factory;
@@ -745,6 +749,10 @@ function factoryFor(container, fullName) {
 
     var injectedFactory = factory.extend(injections);
     injectedFactory.reopenClass(factoryInjections);
+
+    if (factory && typeof factory.onLookup === 'function') {
+      factory.onLookup(fullName);
+    }
 
     cache[fullName] = injectedFactory;
 

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -670,6 +670,25 @@ test("factory for non extendables resolves are cached", function() {
 });
 
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  test("The `onLookup` hook is called on factories when looked up the first time", function() {
+    expect(2);
+
+    var container = new Container();
+    var Apple = factory();
+
+    Apple.reopenClass({
+      onLookup: function(fullName) {
+        equal(fullName, 'apple:main', 'calls lazy injection method with the lookup full name');
+        equal(this, Apple, 'calls lazy injection method in the factory context');
+      }
+    });
+
+    container.register('apple:main', Apple);
+
+    container.lookupFactory('apple:main');
+    container.lookupFactory('apple:main');
+  });
+
   test("A factory's lazy injections are validated when first instantiated", function() {
     var container = new Container();
     var Apple = factory();

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -670,14 +670,14 @@ test("factory for non extendables resolves are cached", function() {
 });
 
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
-  test("The `onLookup` hook is called on factories when looked up the first time", function() {
+  test("The `_onLookup` hook is called on factories when looked up the first time", function() {
     expect(2);
 
     var container = new Container();
     var Apple = factory();
 
     Apple.reopenClass({
-      onLookup: function(fullName) {
+      _onLookup: function(fullName) {
         equal(fullName, 'apple:main', 'calls lazy injection method with the lookup full name');
         equal(this, Apple, 'calls lazy injection method in the factory context');
       }
@@ -695,7 +695,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     var Orange = factory();
 
     Apple.reopenClass({
-      lazyInjections: function() {
+      _lazyInjections: function() {
         return [ 'orange:main', 'banana:main' ];
       }
     });
@@ -716,7 +716,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     var Orange = factory();
 
     Apple.reopenClass({
-      lazyInjections: function() {
+      _lazyInjections: function() {
         ok(true, 'should call lazy injection method');
         return [ 'orange:main' ];
       }

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -688,4 +688,25 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
       container.lookup('apple:main');
     }, /Attempting to inject an unknown injection: `banana:main`/);
   });
+
+  test("Lazy injection validations are cached", function() {
+    expect(1);
+
+    var container = new Container();
+    var Apple = factory();
+    var Orange = factory();
+
+    Apple.reopenClass({
+      lazyInjections: function() {
+        ok(true, 'should call lazy injection method');
+        return [ 'orange:main' ];
+      }
+    });
+
+    container.register('apple:main', Apple);
+    container.register('orange:main', Orange);
+
+    container.lookup('apple:main');
+    container.lookup('apple:main');
+  });
 }

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -2,7 +2,10 @@ import Ember from "ember-metal/core"; // Ember.assert
 import { ComputedProperty } from "ember-metal/computed";
 import { Descriptor } from "ember-metal/properties";
 import { create } from "ember-metal/platform";
-import { inspect } from "ember-metal/utils";
+import {
+  meta,
+  inspect
+} from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 
 /**
@@ -20,14 +23,22 @@ function InjectedProperty(type, name) {
   this.type = type;
   this.name = name;
 
-  this._super$Constructor(function(keyName) {
-    Ember.assert("Attempting to lookup an injected property on an object " +
-                 "without a container, ensure that the object was " +
-                 "instantiated via a container.", this.container);
-
-    return this.container.lookup(type + ':' + (name || keyName));
-  });
+  this._super$Constructor(injectedPropertyGet);
   this.readOnly();
+}
+
+function injectedPropertyGet(keyName) {
+  var desc = meta(this).descs[keyName];
+
+  Ember.assert("Attempting to lookup an injected property on an object " +
+               "without a container, ensure that the object was " +
+               "instantiated via a container.", this.container);
+
+  return this.container.lookup(desc.type + ':' + (desc.name || keyName));
+}
+
+function injectedPropertySet(obj, keyName) {
+  throw new EmberError("Cannot set injected property '" + keyName + "' on object: " + inspect(obj));
 }
 
 InjectedProperty.prototype = create(Descriptor.prototype);
@@ -40,9 +51,7 @@ InjectedPropertyPrototype._super$Constructor = ComputedProperty;
 InjectedPropertyPrototype.get = ComputedPropertyPrototype.get;
 InjectedPropertyPrototype.readOnly = ComputedPropertyPrototype.readOnly;
 
-InjectedPropertyPrototype.set = function(obj, keyName) {
-  throw new EmberError("Cannot set injected property '" + keyName + "' on object: " + inspect(obj));
-};
+InjectedPropertyPrototype.set = injectedPropertySet;
 
 InjectedPropertyPrototype.teardown = ComputedPropertyPrototype.teardown;
 

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,5 +1,6 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import { indexOf } from "ember-metal/enumerable_utils";
+import { meta } from "ember-metal/utils";
 import InjectedProperty from "ember-metal/injected_property";
 import keys from "ember-metal/keys";
 
@@ -37,26 +38,22 @@ export function createInjectionHelper(type, validator) {
 }
 
 /**
-  Validation function intended to be invoked at when extending a factory with
-  injected properties. Runs per-type validation functions once for each injected
-  type encountered.
-
-  Note that this currently modifies the mixin themselves, which is technically
-  dubious but is practically of little consequence. This may change in the
-  future.
+  Validation function that runs per-type validation functions once for each
+  injected type encountered.
 
   @private
   @method validatePropertyInjections
   @namespace Ember
-  @param {Object} factory The factory object being extended
-  @param {Object} props A hash of properties to be added to the factory
+  @param {Object} factory The factory object
 */
-export function validatePropertyInjections(factory, props) {
+export function validatePropertyInjections(factory) {
+  var proto = factory.proto();
+  var descs = meta(proto).descs;
   var types = [];
   var key, desc, validator, i, l;
 
-  for (key in props) {
-    desc = props[key];
+  for (key in descs) {
+    desc = descs[key];
     if (desc instanceof InjectedProperty && indexOf(types, desc.type) === -1) {
       types.push(desc.type);
     }

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -154,12 +154,6 @@ var ActionHandler = Mixin.create({
     @method willMergeMixin
   */
   willMergeMixin: function(props) {
-    if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
-      // Calling super is only OK here since we KNOW that there is another
-      // Mixin loaded first (injection dependency verification)
-      this._super.apply(this, arguments);
-    }
-
     var hashName;
 
     if (!props._actions) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -858,9 +858,9 @@ function addOnLookupHandler() {
       Provides lookup-time type validation for injected properties.
 
       @private
-      @method onLookup
+      @method _onLookup
       */
-    ClassMixinProps.onLookup = injectedPropertyAssertion;
+    ClassMixinProps._onLookup = injectedPropertyAssertion;
   });
 }
 
@@ -871,10 +871,10 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     Returns a hash of property names and container names that injected
     properties will lookup on the container lazily.
 
-    @method lazyInjections
+    @method _lazyInjections
     @return {Object} Hash of all lazy injected property keys to container names
   */
-  ClassMixinProps.lazyInjections = function() {
+  ClassMixinProps._lazyInjections = function() {
     var injections = {};
     var proto = this.proto();
     var descs = meta(proto).descs;

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -47,6 +47,7 @@ import {
   K
 } from 'ember-metal/core';
 import { hasPropertyAccessors } from "ember-metal/platform";
+import { validatePropertyInjections } from "ember-runtime/inject";
 
 var schedule = run.schedule;
 var applyMixin = Mixin._apply;
@@ -847,7 +848,25 @@ var ClassMixinProps = {
   }
 };
 
+function injectedPropertyAssertion() {
+  Ember.assert("Injected properties are invalid", validatePropertyInjections(this));
+}
+
+function addOnLookupHandler() {
+  Ember.runInDebug(function() {
+    /**
+      Provides lookup-time type validation for injected properties.
+
+      @private
+      @method onLookup
+      */
+    ClassMixinProps.onLookup = injectedPropertyAssertion;
+  });
+}
+
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
+  addOnLookupHandler();
+
   /**
     Returns a hash of property names and container names that injected
     properties will lookup on the container lazily.

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -3,10 +3,8 @@
 @submodule ember-runtime
 */
 
-import Ember from "ember-metal/core"; // Ember.assert
 import CoreObject from "ember-runtime/system/core_object";
 import Observable from "ember-runtime/mixins/observable";
-import { validatePropertyInjections } from "ember-runtime/inject";
 
 /**
   `Ember.Object` is the main base class for all Ember objects. It is a subclass
@@ -22,23 +20,5 @@ var EmberObject = CoreObject.extend(Observable);
 EmberObject.toString = function() {
   return "Ember.Object";
 };
-
-function injectedPropertyAssertion(props) {
-  // Injection validations are a debugging aid only, so ensure that they are
-  // not performed in production builds by invoking from an assertion
-  Ember.assert("Injected properties are invalid", validatePropertyInjections(this.constructor, props));
-}
-
-if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
-  EmberObject.reopen({
-    /**
-      Provides mixin-time validation for injected properties.
-
-      @private
-      @method willMergeMixin
-    */
-    willMergeMixin: injectedPropertyAssertion
-  });
-}
 
 export default EmberObject;

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -1,3 +1,5 @@
+/* global EmberDev */
+
 import Controller from "ember-runtime/controllers/controller";
 import Service from "ember-runtime/system/service";
 import ObjectController from "ember-runtime/controllers/object_controller";
@@ -181,16 +183,21 @@ test("specifying `content` (with `model` specified) does not result in deprecati
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('Controller injected properties');
 
-  test("defining a controller on a non-controller should fail assertion", function(){
-    expectAssertion(function() {
-      var AnObject = Object.extend({
-        foo: inject.controller('bar')
-      });
+  if (!EmberDev.runningProdBuild) {
+    test("defining a controller on a non-controller should fail assertion", function(){
+      expectAssertion(function() {
+        var container = new Container();
+        var AnObject = Object.extend({
+          container: container,
+          foo: inject.controller('bar')
+        });
 
-      // Prototype chains are lazy, make sure it's evaluated
-      AnObject.proto();
-    }, /Defining an injected controller property on a non-controller is not allowed./);
-  });
+        container.register('foo:main', AnObject);
+
+        container.lookupFactory('foo:main');
+      }, /Defining an injected controller property on a non-controller is not allowed./);
+    });
+  }
 
   test("controllers can be injected into controllers", function() {
     var container = new Container();

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -20,20 +20,23 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   if (!EmberDev.runningProdBuild) {
     // this check is done via an assertion which is stripped from
     // production builds
-    test("injection type validation function is run once at mixin time", function() {
+    test("injection type validation is run when first looked up", function() {
       expect(1);
 
       createInjectionHelper('foo', function() {
-        ok(true, 'should call validation function');
+        ok(true, 'should call validation method');
       });
 
+      var container = new Container();
       var AnObject = Object.extend({
+        container: container,
         bar: inject.foo(),
         baz: inject.foo()
       });
 
-      // Prototype chains are lazy, make sure it's evaluated
-      AnObject.proto();
+      container.register('foo:main', AnObject);
+
+      container.lookupFactory('foo:main');
     });
   }
 

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -60,6 +60,6 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
       bar: new InjectedProperty('quux')
     });
 
-    deepEqual(AnObject.lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, "should return injected container keys");
+    deepEqual(AnObject._lazyInjections(), { 'foo': 'foo:bar', 'bar': 'quux:bar' }, "should return injected container keys");
   });
 }


### PR DESCRIPTION
This addresses issues raised in the comments of #5162.
- [ ] [remove unnecessary `hasOwnProperty` check](https://github.com/emberjs/ember.js/pull/5162#discussion_r20398478)
- [x] [make `lazyInjections` private](https://github.com/emberjs/ember.js/pull/5162#discussion_r20398493)
- [x] [remove unnecessary closure in `InjectedProperty` func](https://github.com/emberjs/ember.js/pull/5162#discussion_r20398539)
- [x] [name anonymous functions for better debugging](https://github.com/emberjs/ember.js/pull/5162#discussion_r20398547)
- [x] [remove injection type validation from production builds entirely](https://github.com/emberjs/ember.js/pull/5162#discussion_r20398647)
- [x] [added `onLookup` factory hook](https://github.com/emberjs/ember.js/pull/5162#issuecomment-63155654)
- [x] [cache lazy lookup validation](https://github.com/emberjs/ember.js/pull/5162#issuecomment-64290852)

I haven't addressed the top two concerns yet because I'm still uncertain of how the container should be treated within Ember. I'm also not 100% sure about the `onLookup` API, e.g. whether it should be a hook or a callback mechanism.
