### PR TITLE
remove ember-data hooks for making things sync

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -97,13 +97,6 @@ var get = function get(obj, keyName) {
   }
 };
 
-// Currently used only by Ember Data tests
-if (Ember.config.overrideAccessors) {
-  Ember.get = get;
-  Ember.config.overrideAccessors();
-  get = Ember.get;
-}
-
 /**
   Normalizes a target/path pair to reflect that actual target/path that should
   be observed, etc. This takes into account passing in global property

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -104,14 +104,6 @@ var set = function set(obj, keyName, value, tolerant) {
   return value;
 };
 
-// Currently used only by Ember Data tests
-// ES6TODO: Verify still true
-if (Ember.config.overrideAccessors) {
-  Ember.set = set;
-  Ember.config.overrideAccessors();
-  set = Ember.set;
-}
-
 function setPath(root, path, value, tolerant) {
   var keyName;
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -458,10 +458,6 @@ function makeToString(ret) {
   return function() { return ret; };
 }
 
-if (Ember.config.overridePrototypeMixin) {
-  Ember.config.overridePrototypeMixin(CoreObject.PrototypeMixin);
-}
-
 CoreObject.__super__ = null;
 
 var ClassMixinProps = {
@@ -879,10 +875,6 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
 var ClassMixin = Mixin.create(ClassMixinProps);
 
 ClassMixin.ownerConstructor = CoreObject;
-
-if (Ember.config.overrideClassMixin) {
-  Ember.config.overrideClassMixin(ClassMixin);
-}
 
 CoreObject.ClassMixin = ClassMixin;
 


### PR DESCRIPTION
When they should instead be scheduled within
the ember run loop

these can be removed after emberjs/data#2477 gets merged
