### PR TITLE
Update to htmlbars@0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "git-repo-version": "0.0.1",
     "glob": "~3.2.8",
     "handlebars": "^2.0",
-    "htmlbars": "0.1.13",
+    "htmlbars": "0.2.0",
     "ncp": "~0.5.1",
     "rimraf": "~2.2.8",
     "rsvp": "~3.0.6"

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -52,7 +52,7 @@ export default function makeBoundHelper(fn, compatMode) {
     var view = this;
     var numParams = params.length;
 
-    Ember.assert("registerBoundHelper-generated helpers do not support use with Handlebars blocks.", !options.render);
+    Ember.assert("registerBoundHelper-generated helpers do not support use with Handlebars blocks.", !options.template);
 
     for (var prop in hash) {
       if (IS_BINDING.test(prop)) {

--- a/packages/ember-htmlbars/lib/helpers/binding.js
+++ b/packages/ember-htmlbars/lib/helpers/binding.js
@@ -44,7 +44,7 @@ function bind(property, hash, options, env, preserveContext, shouldDisplay, valu
     preserveContext: preserveContext,
     shouldDisplayFunc: shouldDisplay,
     valueNormalizerFunc: valueNormalizer,
-    displayTemplate: options.render,
+    displayTemplate: options.template,
     inverseTemplate: options.inverse,
     lazyValue: lazyValue,
     previousContext: get(this, 'context'),
@@ -101,7 +101,7 @@ function bindHelper(params, hash, options, env) {
     property = this.getStream(property);
   }
 
-  if (options.render) {
+  if (options.template) {
     options.helperName = 'bind';
     Ember.deprecate("The block form of bind, {{#bind foo}}{{/bind}}, has been deprecated and will be removed.");
     bind.call(this, property, hash, options, env, false, exists);

--- a/packages/ember-htmlbars/lib/helpers/collection.js
+++ b/packages/ember-htmlbars/lib/helpers/collection.js
@@ -149,8 +149,8 @@ export function collectionHelper(params, hash, options, env) {
 
   Ember.assert("You cannot pass more than one argument to the collection helper", params.length <= 1);
 
-  var fn        = options.render,
-      data      = env.data,
+  var data      = env.data,
+      template  = options.template,
       inverse   = options.inverse,
       view      = data.view,
       // This should be deterministic, and should probably come from a
@@ -213,9 +213,9 @@ export function collectionHelper(params, hash, options, env) {
     }
   }
 
-  if (fn) {
-    itemHash.template = fn;
-    delete options.render;
+  if (template) {
+    itemHash.template = template;
+    delete options.template;
   }
 
   var emptyViewClass;

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -21,6 +21,12 @@ function shouldDisplayIfHelperContent(result) {
   }
 }
 
+var EMPTY_TEMPLATE = {
+  isHTMLBars: true,
+  render: function() {
+    return '';
+  }
+};
 /**
   Use the `boundIf` helper to create a conditional that re-evaluates
   whenever the truthiness of the bound value changes.
@@ -65,7 +71,7 @@ function boundIfHelper(params, hash, options, env) {
   @since 1.4.0
 */
 function unboundIfHelper(params, hash, options, env) {
-  var template = options.render;
+  var template = options.template;
   var value = params[0];
 
   if (params[0].isStream) {
@@ -76,7 +82,7 @@ function unboundIfHelper(params, hash, options, env) {
     template = options.inverse;
   }
 
-  return template(this, env, options.morph.contextualElement);
+  return template.render(this, env, options.morph.contextualElement);
 }
 
 /**
@@ -90,9 +96,9 @@ function unboundIfHelper(params, hash, options, env) {
   @return {String} HTML string
 */
 function ifHelper(params, hash, options, env) {
-  Ember.assert("If helper in block form expect exactly one argument", !options.render || params.length === 1);
+  Ember.assert("If helper in block form expect exactly one argument", !options.template || params.length === 1);
   if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
-    if (!options.render) {
+    if (!options.template) {
       Ember.assert("If helper in inline form expects between two and three arguments", params.length === 2 || params.length === 3);
       var condition = params[0];
       var truthy = params[1];
@@ -101,7 +107,7 @@ function ifHelper(params, hash, options, env) {
     }
   }
 
-  options.inverse = options.inverse || function(){ return ''; };
+  options.inverse = options.inverse || EMPTY_TEMPLATE;
 
   options.helperName = options.helperName || ('if ');
 
@@ -121,14 +127,14 @@ function ifHelper(params, hash, options, env) {
 */
 function unlessHelper(params, hash, options, env) {
   Ember.assert("You must pass exactly one argument to the unless helper", params.length === 1);
-  Ember.assert("You must pass a block to the unless helper", !!options.render);
+  Ember.assert("You must pass a block to the unless helper", !!options.template);
 
-  var fn = options.render;
-  var inverse = options.inverse || function(){ return ''; };
+  var template = options.template;
+  var inverse = options.inverse || EMPTY_TEMPLATE;
   var helperName = 'unless';
 
-  options.render = inverse;
-  options.inverse = fn;
+  options.template = inverse;
+  options.inverse = template;
 
   options.helperName = options.helperName || helperName;
 

--- a/packages/ember-htmlbars/lib/helpers/partial.js
+++ b/packages/ember-htmlbars/lib/helpers/partial.js
@@ -54,7 +54,7 @@ export function partialHelper(params, hash, options, env) {
   var name = params[0];
 
   if (name && name.isStream) {
-    options.render = createPartialTemplate(name);
+    options.template = createPartialTemplate(name);
     bind.call(this, name, hash, options, env, true, exists);
   } else {
     return renderPartial(name, this, env, options.morph.contextualElement);
@@ -84,11 +84,14 @@ function lookupPartial(view, templateName) {
 
 function renderPartial(name, view, env, contextualElement) {
   var template = lookupPartial(view, name);
-  return template(view, env, contextualElement);
+  return template.render(view, env, contextualElement);
 }
 
 function createPartialTemplate(nameStream) {
-  return function(view, env, contextualElement) {
-    return renderPartial(nameStream.value(), view, env, contextualElement);
+  return {
+    isHTMLBars: true,
+    render: function(view, env, contextualElement) {
+      return renderPartial(nameStream.value(), view, env, contextualElement);
+    }
   };
 }

--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -120,7 +120,7 @@ export var ViewHelper = EmberObject.create({
 
   helper: function(newView, hash, options, env) {
     var data = env.data;
-    var fn   = options.render;
+    var template = options.template;
 
     makeBindings(hash, options, env.data.view);
 
@@ -128,10 +128,12 @@ export var ViewHelper = EmberObject.create({
     var currentView = data.view;
     var newViewProto = newView.proto();
 
-    if (fn) {
-      Ember.assert("You cannot provide a template block if you also specified a templateName",
-                   !get(viewOptions, 'templateName') && !get(newViewProto, 'templateName'));
-      viewOptions.template = fn;
+    if (template) {
+      Ember.assert(
+        "You cannot provide a template block if you also specified a templateName",
+        !get(viewOptions, 'templateName') && !get(newViewProto, 'templateName')
+      );
+      viewOptions.template = template;
     }
 
     // We only want to override the `_context` computed property if there is
@@ -147,7 +149,7 @@ export var ViewHelper = EmberObject.create({
 
   instanceHelper: function(newView, hash, options, env) {
     var data = env.data;
-    var fn   = options.render;
+    var template = options.template;
 
     makeBindings(hash, options, env.data.view);
 
@@ -159,10 +161,12 @@ export var ViewHelper = EmberObject.create({
     var viewOptions = this.propertiesFromHTMLOptions(hash, options, env);
     var currentView = data.view;
 
-    if (fn) {
-      Ember.assert("You cannot provide a template block if you also specified a templateName",
-                   !get(viewOptions, 'templateName') && !get(newView, 'templateName'));
-      viewOptions.template = fn;
+    if (template) {
+      Ember.assert(
+        "You cannot provide a template block if you also specified a templateName",
+        !get(viewOptions, 'templateName') && !get(newView, 'templateName')
+      );
+      viewOptions.template = template;
     }
 
     // We only want to override the `_context` computed property if there is

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -64,7 +64,7 @@ export function withHelper(params, hash, options, env) {
 
   Ember.assert(
     "The {{#with}} helper must be called with a block",
-    !!options.render
+    !!options.template
   );
 
   var preserveContext;

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -61,7 +61,7 @@ export default function makeBoundHelper(fn) {
   function helperFunc(params, hash, options, env) {
     var view = this;
 
-    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !options.render);
+    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !options.template);
 
     for (var prop in hash) {
       if (IS_BINDING.test(prop)) {

--- a/packages/ember-htmlbars/tests/compat/precompile_test.js
+++ b/packages/ember-htmlbars/tests/compat/precompile_test.js
@@ -6,21 +6,14 @@ var result;
 
 QUnit.module("ember-htmlbars: Ember.Handlebars.precompile");
 
-var templateType;
-if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  templateType = 'function';
-} else {
-  templateType = 'object';
-}
-
 test("precompile creates an object when asObject isn't defined", function(){
   result = precompile(template);
-  equal(typeof(result), templateType);
+  equal(typeof(result), "object");
 });
 
 test("precompile creates an object when asObject is true", function(){
   result = precompile(template, true);
-  equal(typeof(result), templateType);
+  equal(typeof(result), "object");
 });
 
 test("precompile creates a string when asObject is false", function(){

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -8,7 +8,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
   test("HTMLBars is present and can be executed", function() {
     var template = compile("ohai");
-    var output = template({}, defaultEnv, document.body);
+    var output = template.render({}, defaultEnv, document.body);
     equalHTML(output, "ohai");
   });
 }

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -13,7 +13,7 @@ function aliasHelper(params, hash, options, env) {
   this.appendChild(View, {
     isVirtual: true,
     _morph: options.morph,
-    template: options.render,
+    template: options.template,
     _blockArguments: params
   });
 }

--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -291,21 +291,24 @@ function linkToHelper(params, hash, options, env) {
     delete hash.disabledWhen;
   }
 
-  if (!options.render) {
+  if (!options.template) {
     var linkTitle = params.shift();
 
     if (isStream(linkTitle)) {
       hash.linkTitle = { stream: linkTitle };
     }
 
-    options.render = function() {
-      // HTMLBars TODO: what do we use as a replacement to
-      // `Handlebars.Utils.escapeExpression` ?
-      var value = read(linkTitle);
-      if (value) {
-        return shouldEscape ? Handlebars.Utils.escapeExpression(value) : value;
-      } else {
-        return "";
+    options.template = {
+      isHTMLBars: true,
+      render: function() {
+        // HTMLBars TODO: what do we use as a replacement to
+        // `Handlebars.Utils.escapeExpression` ?
+        var value = read(linkTitle);
+        if (value) {
+          return shouldEscape ? Handlebars.Utils.escapeExpression(value) : value;
+        } else {
+          return "";
+        }
       }
     };
   }

--- a/packages/ember-routing-htmlbars/lib/helpers/render.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/render.js
@@ -158,7 +158,7 @@ export function renderHelper(params, hash, options, env) {
 
   var templateName = 'template:' + name;
   Ember.assert("You used `{{render '" + name + "'}}`, but '" + name + "' can not be found as either" +
-               " a template or a view.", container.has("view:" + name) || container.has(templateName) || !!options.render);
+               " a template or a view.", container.has("view:" + name) || container.has(templateName) || !!options.template);
   hash.template = container.lookup(templateName);
 
   hash.controller = controller;

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -34,15 +34,11 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   defaultTemplate = handlebarsTemplate;
 }
 
-var SelectOption = View.extend({
-  instrumentDisplay: 'Ember.SelectOption',
-
-  tagName: 'option',
-  attributeBindings: ['value', 'selected'],
-
-  defaultTemplate: function(context, env, contextualElement) {
-    var options;
-    if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+var selectOptionDefaultTemplate;
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  selectOptionDefaultTemplate = {
+    isHTMLBars: true,
+    render: function(context, env, contextualElement) {
       var lazyValue = context.getStream('view.label');
 
       lazyValue.subscribe(context._wrapAsScheduled(function() {
@@ -50,11 +46,22 @@ var SelectOption = View.extend({
       }));
 
       return lazyValue.value();
-    } else {
-      options = { data: env.data, hash: {} };
-      EmberHandlebars.helpers.bind.call(context, "view.label", options);
     }
-  },
+  };
+} else {
+  selectOptionDefaultTemplate = function(context, env) {
+    var options = { data: env.data, hash: {} };
+    EmberHandlebars.helpers.bind.call(context, "view.label", options);
+  };
+}
+
+var SelectOption = View.extend({
+  instrumentDisplay: 'Ember.SelectOption',
+
+  tagName: 'option',
+  attributeBindings: ['value', 'selected'],
+
+  defaultTemplate: selectOptionDefaultTemplate,
 
   init: function() {
     this.labelPathDidChange();

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -806,11 +806,11 @@ var View = CoreView.extend({
     if (template) {
       var useHTMLBars = false;
       if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-        useHTMLBars = template.length >= 3;
+        useHTMLBars = template.isHTMLBars;
       }
 
       if (useHTMLBars) {
-        return template(this, options, morph.contextualElement);
+        return template.render(this, options, morph.contextualElement);
       } else {
         return template(context, options);
       }
@@ -1087,20 +1087,21 @@ var View = CoreView.extend({
       // is the view's controller by default. A hash of data is also passed that provides
       // the template with access to the view and render buffer.
 
-      Ember.assert('template must be a function. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'function');
       // The template should write directly to the render buffer instead
       // of returning a string.
       var options = { data: data };
       var useHTMLBars = false;
 
       if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-        useHTMLBars = template.length >= 3;
+        useHTMLBars = template.isHTMLBars;
       }
 
       if (useHTMLBars) {
+        Ember.assert('template must be an object. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'object');
         var env = Ember.merge(buildHTMLBarsDefaultEnv(), options);
-        output = template(this, env, buffer.innerContextualElement(), this._blockArguments);
+        output = template.render(this, env, buffer.innerContextualElement(), this._blockArguments);
       } else {
+        Ember.assert('template must be a function. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'function');
         output = template(context, options);
       }
 


### PR DESCRIPTION
The primary difference is that templates are now compiled to objects with a `render` method instead of directly to functions.
