### PR TITLE
Use Ember.set to set controller in Route.setup

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1009,7 +1009,7 @@ var Route = EmberObject.extend(ActionHandler, {
 
     // Assign the route's controller so that it can more easily be
     // referenced in action handlers
-    this.controller = controller;
+    set(this, 'controller', controller);
 
     if (this.setupControllers) {
       Ember.deprecate("Ember.Route.setupControllers is deprecated. Please use Ember.Route.setupController(controller, model) instead.");


### PR DESCRIPTION
Under specific circumstances that I could not identify, the following error is raised after clicking on a link to a route:

```
Error while processing route: [route-name] Assertion Failed: You must use Ember.set() to set the `controller` property (of [route]) to `[controller]`.
```

This change fixes the error.

In my case, the `link-to` points to the same route with a different model, but I'm not sure this has any influence.
