### PR TITLE
Checkbox: Indeterminate property should be updated after user interaction

### DIFF
--- a/packages/ember-views/lib/views/checkbox.js
+++ b/packages/ember-views/lib/views/checkbox.js
@@ -68,5 +68,9 @@ export default EmberComponent.extend({
 
   _updateElementValue() {
     set(this, 'checked', this.$().prop('checked'));
+    // some browsers don't update this automatically, but according to the HTML5
+    // spec, the "indeterminate" value should be set to false before a change
+    // event is fired: http://www.w3.org/TR/html5/forms.html#checkbox-state-(type=checkbox)
+    set(this, 'indeterminate', false);
   }
 });

--- a/packages/ember-views/tests/views/checkbox_test.js
+++ b/packages/ember-views/tests/views/checkbox_test.js
@@ -140,18 +140,35 @@ QUnit.test('checking the checkbox updates the value', function() {
   equal(get(checkboxComponent, 'checked'), false, 'changing the checkbox causes the view\'s value to get updated');
 });
 
-test("checking the checkbox updates indeterminate", function() {
-  checkboxView = Checkbox.create({ checked: false, indeterminate: true });
+QUnit.test('sanity check for indeterminate', function() {
+  /* global jQuery */
+  var checkbox = jQuery('<input type="checkbox">').appendTo('#qunit-fixture');
+
+  var changeEventFired = false;
+  checkbox.on('change', function(e) { changeEventFired = true; });
+
+  // The presence of indeterminite: true on the checkbox causes phantomjs to not dispatch the
+  // change event.  Comment this out and re-run this test.
+  checkbox.prop('indeterminate', true);
+
+  checkbox[0].focus();
+  checkbox[0].click();
+  checkbox[0].blur();
+  equal(changeEventFired, true, 'Change Event Fired');
+});
+
+QUnit.test('checking the checkbox updates indeterminate', function() {
+  checkboxComponent = Checkbox.create({ checked: true, indeterminate: true });
   append();
 
-  equal(get(checkboxView, 'indeterminate'), true, "precond - initially starts with a indeterminate value");
-  equal(!!checkboxView.$().prop('indeterminate'), true, "precond - the initial indeterminate property is true");
+  equal(get(checkboxComponent, 'indeterminate'), true, 'precond - initially starts with a indeterminate value');
+  equal(!!checkboxComponent.$().prop('indeterminate'), true, 'precond - the initial indeterminate property is true');
 
   // IE fires 'change' event on blur.
-  checkboxView.$()[0].focus();
-  checkboxView.$()[0].click();
-  checkboxView.$()[0].blur();
+  checkboxComponent.$()[0].focus();
+  checkboxComponent.$()[0].click();
+  checkboxComponent.$()[0].blur();
 
-  equal(!!checkboxView.$().prop('indeterminate'), false, "after clicking a checkbox, the indeterminate property changed");
-  equal(get(checkboxView, 'indeterminate'), false, "changing the checkbox causes the view's value to get updated");
+  equal(!!checkboxComponent.$().prop('indeterminate'), false, 'after clicking a checkbox, the indeterminate property changed');
+  equal(get(checkboxComponent, 'indeterminate'), false, 'changing the checkbox causes the view\'s indeterminate value to get updated');
 });

--- a/packages/ember-views/tests/views/checkbox_test.js
+++ b/packages/ember-views/tests/views/checkbox_test.js
@@ -139,3 +139,19 @@ QUnit.test('checking the checkbox updates the value', function() {
   equal(!!checkboxComponent.$().prop('checked'), false, 'after clicking a checkbox, the checked property changed');
   equal(get(checkboxComponent, 'checked'), false, 'changing the checkbox causes the view\'s value to get updated');
 });
+
+test("checking the checkbox updates indeterminate", function() {
+  checkboxView = Checkbox.create({ checked: false, indeterminate: true });
+  append();
+
+  equal(get(checkboxView, 'indeterminate'), true, "precond - initially starts with a indeterminate value");
+  equal(!!checkboxView.$().prop('indeterminate'), true, "precond - the initial indeterminate property is true");
+
+  // IE fires 'change' event on blur.
+  checkboxView.$()[0].focus();
+  checkboxView.$()[0].click();
+  checkboxView.$()[0].blur();
+
+  equal(!!checkboxView.$().prop('indeterminate'), false, "after clicking a checkbox, the indeterminate property changed");
+  equal(get(checkboxView, 'indeterminate'), false, "changing the checkbox causes the view's value to get updated");
+});


### PR DESCRIPTION
Messing around with the `indeterminate` property on a checkbox, the binding doesn't seem to update when the user clicks the checkbox itself.

http://jsfiddle.net/6Evrq/263/

I would expect after checking the checkbox that `indeterminate` would return to false.

I would also expect that setting `indeterminate` to true afterwards would properly reflect in the checkbox. (but since it already is true, it doesn't apply its setting)
