### PR TITLE
Extract `appendView`, `destroyView` for testing

### DIFF
--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -1,19 +1,15 @@
 /*jshint newcap:false*/
 import Ember from "ember-metal/core";
-import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars";
 import { A } from "ember-runtime/system/native_array";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view;
 
-var appendView = function(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-};
-
 QUnit.module("Templates redrawing and bindings", {
   teardown: function() {
-    run(view, 'destroy');
+    destroyView(view);
   }
 });
 

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -4,6 +4,7 @@ import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import handlebarsGet from "ember-htmlbars/compat/handlebars-get";
 import Container from "ember-runtime/system/container";
+import { appendView } from "ember-views/tests/view_helpers";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -11,10 +12,6 @@ var compile = EmberHandlebars.compile;
 
 var originalLookup = Ember.lookup;
 var TemplateTests, container, lookup, view;
-
-function appendView() {
-  run(view, 'appendTo', '#qunit-fixture');
-}
 
 QUnit.module("ember-htmlbars: Ember.Handlebars.get", {
   setup: function() {
@@ -60,7 +57,7 @@ test('it can lookup a path from the current context', function() {
     template: compile('{{handlebars-get "foo"}}')
   });
 
-  appendView();
+  appendView(view);
 });
 
 test('it can lookup a path from the current keywords', function() {
@@ -82,7 +79,7 @@ test('it can lookup a path from the current keywords', function() {
     template: compile('{{#with foo as bar}}{{handlebars-get "bar"}}{{/with}}')
   });
 
-  appendView();
+  appendView(view);
 });
 
 test('it can lookup a path from globals', function() {
@@ -104,7 +101,7 @@ test('it can lookup a path from globals', function() {
     template: compile('{{handlebars-get "Blammo.foo"}}')
   });
 
-  appendView();
+  appendView(view);
 });
 
 test('it raises a deprecation warning on use', function() {
@@ -126,5 +123,5 @@ test('it raises a deprecation warning on use', function() {
     template: compile('{{handlebars-get "foo"}}')
   });
 
-  appendView();
+  appendView(view);
 });

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -3,14 +3,10 @@ import {
 } from "ember-htmlbars/compat/helper";
 
 import EmberView from "ember-views/views/view";
-import run from "ember-metal/run_loop";
 
 import helpers from "ember-htmlbars/helpers";
 import compile from "ember-htmlbars/system/compile";
-
-function appendView(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-}
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view;
 
@@ -18,9 +14,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 QUnit.module('ember-htmlbars: Handlebars compatible helpers', {
   teardown: function() {
-    if (view) {
-      run(view, 'destroy');
-    }
+    destroyView(view);
 
     delete helpers.test;
   }

--- a/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
@@ -1,9 +1,9 @@
 import EmberView from "ember-views/views/view";
 import Container from 'container/container';
-import run from "ember-metal/run_loop";
 import EmberHandlebars from 'ember-handlebars-compiler';
 import htmlbarsCompile from "ember-htmlbars/system/compile";
 import Component from "ember-views/views/component";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
@@ -21,11 +21,8 @@ QUnit.module('ember-htmlbars: Ember.Handlebars.makeViewHelper compat', {
   },
 
   teardown: function() {
-    run(container, 'destroy');
-
-    if (view) {
-      run(view, 'destroy');
-    }
+    destroyView(container);
+    destroyView(view);
   }
 });
 
@@ -43,7 +40,7 @@ test('EmberHandlebars.makeViewHelper', function() {
     container: container
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  appendView(view);
 
   equal(view.$().text(), 'woot!');
 });

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -8,6 +8,7 @@ import { A } from "ember-runtime/system/native_array";
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -19,10 +20,6 @@ helper = EmberHandlebars.helper;
 var view;
 
 var originalLookup = Ember.lookup;
-
-function appendView() {
-  run(function() { view.appendTo('#qunit-fixture'); });
-}
 
 function registerRepeatHelper() {
   expectDeprecationInHTMLBars();
@@ -47,11 +44,7 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
   setup: function() {
   },
   teardown: function() {
-    run(function() {
-      if (view) {
-        view.destroy();
-      }
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -83,7 +76,7 @@ test("should update bound helpers when properties change", function() {
     template: compile("{{capitalize name}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'BROGRAMMER', "helper output is correct");
 
@@ -110,7 +103,7 @@ test("should allow for computed properties with dependencies", function() {
     template: compile("{{capitalizeName person}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'BROGRAMMER', "helper output is correct");
 
@@ -129,7 +122,7 @@ test("bound helpers should support options", function() {
     template: compile("{{repeat text count=3}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'ababab', "helper output is correct");
 });
@@ -146,7 +139,7 @@ test("bound helpers should support keywords", function() {
     template: compile("{{capitalize view.text}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'AB', "helper output is correct");
 });
@@ -165,7 +158,7 @@ test("bound helpers should support global paths [DEPRECATED]", function() {
   });
 
   expectDeprecation(function() {
-    appendView();
+    appendView(view);
   }, /Global lookup of Text from a Handlebars template is deprecated/);
 
   equal(view.$().text(), 'AB', "helper output is correct");
@@ -183,7 +176,7 @@ test("bound helper should support this keyword", function() {
     template: compile("{{capitalize this}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'AB', "helper output is correct");
 });
@@ -196,7 +189,7 @@ test("bound helpers should support bound options", function() {
     template: compile('{{repeat text countBinding="numRepeats"}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'ababab', "helper output is correct");
 
@@ -222,7 +215,7 @@ test("bound helpers should support unquoted values as bound options", function()
     template: compile('{{repeat text count=numRepeats}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'ababab', "helper output is correct");
 
@@ -253,7 +246,7 @@ test("bound helpers should support multiple bound properties", function() {
     template: compile('{{combine thing1 thing2}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'ZOIDBERG', "helper output is correct");
 
@@ -298,7 +291,7 @@ test("bound helpers should expose property names in options.data.properties", fu
     template: compile('{{echo thing1 thing2 thing3.foo}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'thing1 thing2 thing3.foo', "helper output is correct");
 });
@@ -315,7 +308,7 @@ test("bound helpers can be invoked with zero args", function() {
     template: compile('{{troll}} and {{troll text="bork"}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'TROLOLOL and bork', "helper output is correct");
 });
@@ -329,7 +322,7 @@ test("bound helpers should not be invoked with blocks", function() {
   });
 
   expectAssertion(function() {
-    appendView();
+    appendView(view);
   }, /registerBoundHelper-generated helpers do not support use with Handlebars blocks/i);
 });
 
@@ -384,7 +377,7 @@ test("shouldn't treat raw numbers as bound paths", function() {
     template: compile("{{sum aNumber 1}} {{sum 0 aNumber}} {{sum 5 6}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), '2 1 11', "helper output is correct");
 
@@ -407,7 +400,7 @@ test("shouldn't treat quoted strings as bound paths", function() {
     template: compile("{{combine word 'loo'}} {{combine '' word}} {{combine 'will' \"didi\"}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'jerkwaterloo jerkwater willdidi', "helper output is correct");
 
@@ -434,7 +427,7 @@ test("bound helpers can handle nulls in array (with primitives) [DEPRECATED]", f
   });
 
   expectDeprecation(function() {
-    appendView();
+    appendView(view);
   }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), '|NOPE 0|NOPE |NOPE false|NOPE OMG|GMO |NOPE 0|NOPE |NOPE false|NOPE OMG|GMO ', "helper output is correct");
@@ -462,7 +455,7 @@ test("bound helpers can handle nulls in array (with objects)", function() {
   });
 
   expectDeprecation(function() {
-    appendView();
+    appendView(view);
   }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), '|NOPE 5|5 |NOPE 5|5 ', "helper output is correct");
@@ -484,7 +477,7 @@ test("bound helpers can handle `this` keyword when it's a non-object", function(
     template: compile("{{shout this}}")
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'alex!', "helper output is correct");
 
@@ -513,7 +506,7 @@ test("should have correct argument types", function() {
     template: compile('{{getType null}}, {{getType undefProp}}, {{getType "string"}}, {{getType 1}}, {{getType}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), 'undefined, undefined, string, number, object', "helper output is correct");
 });

--- a/packages/ember-htmlbars/tests/helper_test.js
+++ b/packages/ember-htmlbars/tests/helper_test.js
@@ -3,6 +3,7 @@ import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import EmberHandlebars from "ember-handlebars-compiler";
 import { set } from "ember-metal/property_set";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 import {
   default as htmlbarsHelpers,
@@ -21,17 +22,11 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   helpers = EmberHandlebars.helpers;
 }
 
-function appendView(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-}
-
 var view;
 
 QUnit.module("ember-htmlbars: Ember.HTMLBars.helper", {
   teardown: function() {
-    if (view) {
-      run(view, 'destroy');
-    }
+    destroyView(view);
 
     delete helpers.oceanView;
     delete helpers.something;

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -11,6 +11,7 @@ import { computed } from "ember-metal/computed";
 import { observersFor } from "ember-metal/observer";
 import Container from "ember-runtime/system/container";
 import { set } from "ember-metal/property_set";
+import { appendView } from "ember-views/tests/view_helpers";
 
 import {
   default as htmlbarsHelpers
@@ -27,10 +28,6 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 }
 
 var view;
-
-var appendView = function() {
-  run(function() { view.appendTo('#qunit-fixture'); });
-};
 
 var originalLookup = Ember.lookup;
 var TemplateTests, container, lookup;
@@ -78,7 +75,7 @@ test("should be able to bind element attributes using {{bind-attr}}", function()
     })
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('src'), "http://www.emberjs.com/assets/images/logo.png", "sets src attribute");
   equal(view.$('img').attr('alt'), "The SproutCore Logo", "sets alt attribute");
@@ -125,7 +122,7 @@ test("should be able to bind to view attributes with {{bind-attr}}", function() 
     template: compile('<img src="test.jpg" {{bind-attr alt=view.value}}>')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('alt'), "Test", "renders initial value");
 
@@ -144,7 +141,7 @@ test("should be able to bind to globals with {{bind-attr}} (DEPRECATED)", functi
   });
 
   expectDeprecation(function(){
-    appendView();
+    appendView(view);
   }, /Global lookup of TemplateTests.value from a Handlebars template is deprecated/);
 
   equal(view.$('img').attr('alt'), "Test", "renders initial value");
@@ -158,7 +155,7 @@ test("should not allow XSS injection via {{bind-attr}}", function() {
     }
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('onmouseover'), undefined);
   // If the whole string is here, then it means we got properly escaped
@@ -176,7 +173,7 @@ test("should be able to bind use {{bind-attr}} more than once on an element", fu
     })
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('src'), "http://www.emberjs.com/assets/images/logo.png", "sets src attribute");
   equal(view.$('img').attr('alt'), "The SproutCore Logo", "sets alt attribute");
@@ -257,7 +254,7 @@ test("should be able to bind element attributes using {{bind-attr}} inside a blo
     })
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('src'), "http://www.emberjs.com/assets/images/logo.png", "sets src attribute");
   equal(view.$('img').attr('alt'), "The SproutCore Logo", "sets alt attribute");
@@ -277,7 +274,7 @@ test("should be able to bind class attribute with {{bind-attr}}", function() {
     foo: 'bar'
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('class'), 'bar', "renders class");
 
@@ -296,7 +293,7 @@ test("should be able to bind class attribute via a truthy property with {{bind-a
     isNumber: 5
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('.is-truthy').length, 1, "sets class name");
 
@@ -315,7 +312,7 @@ test("should be able to bind class to view attribute with {{bind-attr}}", functi
     foo: 'bar'
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('class'), 'bar', "renders class");
 
@@ -332,7 +329,7 @@ test("should not allow XSS injection via {{bind-attr}} with class", function() {
     foo: '" onmouseover="alert(\'I am in your classes hacking your app\');'
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('onmouseover'), undefined);
   // If the whole string is here, then it means we got properly escaped
@@ -350,7 +347,7 @@ test("should be able to bind class attribute using ternary operator in {{bind-at
     content: content
   });
 
-  appendView();
+  appendView(view);
 
   ok(view.$('img').hasClass('disabled'), 'disabled class is rendered');
   ok(!view.$('img').hasClass('enabled'), 'enabled class is not rendered');
@@ -377,7 +374,7 @@ test("should be able to add multiple classes using {{bind-attr class}}", functio
     content: content
   });
 
-  appendView();
+  appendView(view);
 
   ok(view.$('div').hasClass('is-awesome-sauce'), "dasherizes first property and sets classname");
   ok(view.$('div').hasClass('is-also-cool'), "dasherizes second property and sets classname");
@@ -407,7 +404,7 @@ test("should be able to bind classes to globals with {{bind-attr class}} (DEPREC
   });
 
   expectDeprecation(function(){
-    appendView();
+    appendView(view);
   }, /Global lookup of TemplateTests.isOpen from a Handlebars template is deprecated/);
 
   ok(view.$('img').hasClass('is-open'), "sets classname to the dasherized value of the global property");
@@ -421,7 +418,7 @@ test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]",
     images: A(['one.png', 'two.jpg', 'three.gif'])
   });
 
-  appendView();
+  appendView(view);
 
   var images = view.$('img');
   ok(/one\.png$/.test(images[0].src));
@@ -437,7 +434,7 @@ test("should be able to bind classes to 'this' in an {{#each}} block with {{bind
     items: A(['a', 'b', 'c'])
   });
 
-  appendView();
+  appendView(view);
 
   ok(view.$('li').eq(0).hasClass('a'), "sets classname to the value of the first item");
   ok(view.$('li').eq(1).hasClass('b'), "sets classname to the value of the second item");
@@ -450,7 +447,7 @@ test("should be able to bind-attr to var in {{#each var in list}} block", functi
     images: A(['one.png', 'two.jpg', 'three.gif'])
   });
 
-  appendView();
+  appendView(view);
 
   var images = view.$('img');
   ok(/one\.png$/.test(images[0].src));
@@ -474,7 +471,7 @@ test("should teardown observers from bind-attr on rerender", function() {
     foo: 'bar'
   });
 
-  appendView();
+  appendView(view);
 
   equal(observersFor(view, 'foo').length, 1);
 
@@ -492,7 +489,7 @@ test('should allow either quoted or unquoted values', function() {
     template: compile('<img {{bind-attr alt="view.value" src=view.source}}>')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$('img').attr('alt'), "Test", "renders initial value");
   equal(view.$('img').attr('src'), "test.jpg", "renders initial value");

--- a/packages/ember-htmlbars/tests/helpers/bind_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_test.js
@@ -9,10 +9,7 @@ import ObjectController from "ember-runtime/controllers/object_controller";
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-
-function appendView(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-}
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view, container;
 
@@ -105,7 +102,7 @@ QUnit.module("ember-htmlbars: {{bind}} with a container, block forms", {
     container.optionsForType('template', { instantiate: false });
   },
   teardown: function() {
-    Ember.run(function(){
+    run(function(){
       if (container) {
         container.destroy();
       }
@@ -214,9 +211,7 @@ test("Handlebars templates update properties if a content object changes", funct
 
   equal(view.$('#price').text(), "$5", "should update price field when price property is changed");
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 });
 
 test("Template updates correctly if a path is passed to the bind helper", function() {

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -12,6 +12,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import jQuery from "ember-views/system/jquery";
 import { computed } from "ember-metal/computed";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var trim = jQuery.trim;
 
@@ -78,9 +79,7 @@ test("Collection views that specify an example view class have their children be
     template: compile('{{#collection view.exampleViewCollection}}OHAI{{/collection}}')
   });
 
-  run(function() {
-    view.append();
-  });
+  appendView(view);
 
   ok(firstGrandchild(view).isCustom, "uses the example view class");
 });
@@ -124,9 +123,7 @@ test("itemViewClass works in the #collection helper with a property", function()
     template: compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass=view.possibleItemView}}beta{{/collection}}')
   });
 
-  run(function() {
-    view.append();
-  });
+  appendView(view);
 
   ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
@@ -145,9 +142,7 @@ test("itemViewClass works in the #collection via container", function() {
     template: compile('{{#collection view.exampleCollectionView content=view.exampleController itemViewClass="example-item"}}beta{{/collection}}')
   });
 
-  run(function() {
-    view.append();
-  });
+  appendView(view);
 
   ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
@@ -164,9 +159,7 @@ test("passing a block to the collection helper sets it as the template for examp
     template: compile('{{#collection view.collectionTestView}} <label></label> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('label').length, 3, 'one label element is created for each content item');
 });
@@ -187,9 +180,7 @@ test("collection helper should try to use container to resolve view", function()
     template: compile('{{#collection "collectionTest"}} <label></label> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('label').length, 3, 'one label element is created for each content item');
 });
@@ -203,9 +194,7 @@ test("collection helper should accept relative paths", function() {
     })
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('label').length, 3, 'one label element is created for each content item');
 });
@@ -229,9 +218,7 @@ test("empty views should be removed when content is added to the collection (reg
     template: compile('{{#collection view.listView content=view.listController tagName="table"}} <td>{{view.content.title}}</td> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('tr').length, 1, 'Make sure the empty view is there (regression)');
 
@@ -263,9 +250,7 @@ test("should be able to specify which class should be used for the empty view", 
     template: compile('{{collection emptyViewClass="empty-view"}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$().text(), 'This is an empty view', "Empty view should be rendered.");
 
@@ -285,9 +270,7 @@ test("if no content is passed, and no 'else' is specified, nothing is rendered",
     template: compile('{{#collection view.collectionTestView}} <aside></aside> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('li').length, 0, 'if no "else" is specified, nothing is rendered');
 });
@@ -303,9 +286,7 @@ test("if no content is passed, and 'else' is specified, the else block is render
     template: compile('{{#collection view.collectionTestView}} <aside></aside> {{ else }} <del></del> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('li:has(del)').length, 1, 'the else block is rendered');
 });
@@ -321,9 +302,7 @@ test("a block passed to a collection helper defaults to the content property of 
     template: compile('{{#collection view.collectionTestView}} <label>{{view.content}}</label> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('li:nth-child(1) label').length, 1);
   equal(view.$('li:nth-child(1) label').text(), 'foo');
@@ -344,9 +323,7 @@ test("a block passed to a collection helper defaults to the view", function() {
     template: compile('{{#collection view.collectionTestView}} <label>{{view.content}}</label> {{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   // Preconds
   equal(view.$('li:nth-child(1) label').length, 1);
@@ -373,9 +350,7 @@ test("should include an id attribute if id is set in the options hash", function
     template: compile('{{#collection view.collectionTestView id="baz"}}foo{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul#baz').length, 1, "adds an id attribute");
 });
@@ -390,9 +365,7 @@ test("should give its item views the class specified by itemClass", function() {
     template: compile('{{#collection view.itemClassTestCollectionView itemClass="baz"}}foo{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul li.baz').length, 3, "adds class attribute");
 });
@@ -409,9 +382,7 @@ test("should give its item views the classBinding specified by itemClassBinding"
     template: compile('{{#collection view.itemClassBindingTestCollectionView itemClassBinding="view.isBar"}}foo{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul li.is-bar').length, 3, "adds class on initial rendering");
 
@@ -437,9 +408,7 @@ test("should give its item views the property specified by itemPropertyBinding",
     template: compile('{{#collection contentBinding="view.content" tagName="ul" itemViewClass="item-property-binding-test-item-view" itemPropertyBinding="view.baz" preserveContext=false}}{{view.property}}{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul li').length, 3, "adds 3 itemView");
 
@@ -461,9 +430,7 @@ test("should unsubscribe stream bindings", function() {
     template: compile('{{#collection contentBinding="view.content" itemPropertyBinding="view.baz"}}{{view.property}}{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   var barStreamBinding = view._streamBindings['view.baz'];
 
@@ -489,9 +456,7 @@ test("should work inside a bound {{#if}}", function() {
     shouldDisplay: true
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul li').length, 3, "renders collection when conditional is true");
 
@@ -517,7 +482,7 @@ test("should pass content as context when using {{#each}} helper [DEPRECATED]", 
   });
 
   expectDeprecation(function() {
-    run(view, 'appendTo', '#qunit-fixture');
+    appendView(view);
   }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "Mac OS X 10.7: Lion Mac OS X 10.6: Snow Leopard Mac OS X 10.5: Leopard ", "prints each item in sequence");
@@ -534,9 +499,7 @@ test("should re-render when the content object changes", function() {
     template: compile('{{#collection view.rerenderTestView}}{{view.content}}{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   run(function() {
     set(firstChild(view), 'content', A(['bing', 'bat', 'bang']));
@@ -548,7 +511,6 @@ test("should re-render when the content object changes", function() {
 
   equal(view.$('li').length, 1, "rerenders with correct number of items");
   equal(trim(view.$('li:eq(0)').text()), "ramalamadingdong");
-
 });
 
 test("select tagName on collection helper automatically sets child tagName to option", function() {
@@ -561,12 +523,9 @@ test("select tagName on collection helper automatically sets child tagName to op
     template: compile('{{#collection view.rerenderTestView tagName="select"}}{{view.content}}{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('option').length, 1, "renders the correct child tag name");
-
 });
 
 test("tagName works in the #collection helper", function() {
@@ -579,9 +538,7 @@ test("tagName works in the #collection helper", function() {
     template: compile('{{#collection view.rerenderTestView tagName="ol"}}{{view.content}}{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ol').length, 1, "renders the correct tag name");
   equal(view.$('li').length, 2, "rerenders with correct number of items");
@@ -612,9 +569,7 @@ test("should render nested collections", function() {
     template: compile('{{#collection "outer-list" class="outer"}}{{content}}{{#collection "inner-list" class="inner"}}{{content}}{{/collection}}{{/collection}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul.outer > li').length, 1, "renders the outer list with correct number of items");
   equal(view.$('ul.inner').length, 1, "the inner list exsits");
@@ -655,18 +610,14 @@ test("should render multiple, bound nested collections (#68)", function() {
     });
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('ul.outer > li').length, 2, "renders the outer list with correct number of items");
   equal(view.$('ul.inner').length, 2, "renders the correct number of inner lists");
   equal(view.$('ul.inner:first > li').length, 3, "renders the first inner list with correct number of items");
   equal(view.$('ul.inner:last > li').length, 3, "renders the second list with correct number of items");
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 });
 
 test("should allow view objects to be swapped out without throwing an error (#78)", function() {
@@ -692,9 +643,7 @@ test("should allow view objects to be swapped out without throwing an error (#78
     view = ReportingView.create();
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$().text(), "Loading", "renders the loading text when the dataset is not ready");
 
@@ -715,9 +664,7 @@ test("should allow view objects to be swapped out without throwing an error (#78
 
   equal(view.$().text(), "Loading", "renders the loading text when the second dataset is not ready");
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 });
 
 test("context should be content", function() {
@@ -743,11 +690,9 @@ test("context should be content", function() {
     template: compile('{{collection contentBinding="items" itemViewClass="an-item"}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$().text(), "Greetings DaveGreetings MaryGreetings Sara");
 
-  run(view, 'destroy');
+  destroyView(view);
 });

--- a/packages/ember-htmlbars/tests/helpers/debug_test.js
+++ b/packages/ember-htmlbars/tests/helpers/debug_test.js
@@ -1,9 +1,10 @@
 import Ember from "ember-metal/core"; // Ember.lookup
 import EmberLogger from "ember-metal/logger";
-import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberHandlebars from "ember-handlebars-compiler";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
@@ -17,10 +18,6 @@ var lookup;
 var originalLog, logCalls;
 var view;
 
-function appendView() {
-  run(function() { view.appendTo('#qunit-fixture'); });
-}
-
 QUnit.module("Handlebars {{log}} helper", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };
@@ -31,12 +28,8 @@ QUnit.module("Handlebars {{log}} helper", {
   },
 
   teardown: function() {
-    if (view) {
-      run(function() {
-        view.destroy();
-      });
-      view = null;
-    }
+    destroyView(view);
+    view = null;
 
     EmberLogger.log = originalLog;
     Ember.lookup = originalLookup;
@@ -54,7 +47,7 @@ test("should be able to log multiple properties", function() {
     template: compile('{{log value valueTwo}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), "", "shouldn't render any text");
   equal(logCalls[0], 'one');
@@ -72,7 +65,7 @@ test("should be able to log primitives", function() {
     template: compile('{{log value "foo" 0 valueTwo true}}')
   });
 
-  appendView();
+  appendView(view);
 
   equal(view.$().text(), "", "shouldn't render any text");
   strictEqual(logCalls[0], 'one');

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -15,6 +15,7 @@ import Container from "ember-runtime/system/container";
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 import htmlbarsCompile from "ember-htmlbars/system/compile";
 var compile;
@@ -105,7 +106,7 @@ QUnit.module("the #each helper [DEPRECATED]", {
     });
 
     expectDeprecation(function() {
-      append(view);
+      appendView(view);
     },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
   },
 
@@ -122,13 +123,6 @@ QUnit.module("the #each helper [DEPRECATED]", {
     Ember.lookup = originalLookup;
   }
 });
-
-
-var append = function(view) {
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-};
 
 var assertHTML = function(view, expectedHTML) {
   var html = view.$().html();
@@ -156,26 +150,27 @@ test("it updates the view if an item is added", function() {
 });
 
 test("should be able to use standard Handlebars #each helper", function() {
-  run(view, 'destroy');
+  destroyView(view);
 
   view = EmberView.create({
     context: { items: ['a', 'b', 'c'] },
     template: Handlebars.compile("{{#each items}}{{this}}{{/each}}")
   });
 
-  append(view);
+  appendView(view);
 
   equal(view.$().html(), "abc");
 });
 
 test("it allows you to access the current context using {{this}}", function() {
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
+
   view = EmberView.create({
     template: templateFor("{{#each view.people}}{{this}}{{/each}}"),
     people: A(['Black Francis', 'Joey Santiago', 'Kim Deal', 'David Lovering'])
   });
 
-  append(view);
+  appendView(view);
 
   assertHTML(view, "Black FrancisJoey SantiagoKim DealDavid Lovering");
 });
@@ -249,7 +244,7 @@ test("it does not mark each option tag as selected", function() {
     people: people
   });
 
-  append(selectView);
+  appendView(selectView);
 
   equal(selectView.$('option').length, 3, "renders 3 <option> elements");
 
@@ -263,14 +258,11 @@ test("it does not mark each option tag as selected", function() {
 
   equal(selectView.$('option').length, 4, "renders an additional <option> element when an object is added");
 
-  run(function() {
-    selectView.destroy();
-  });
+  destroyView(selectView);
 });
 
 test("View should not use keyword incorrectly - Issue #1315", function() {
-  // destroy existing view
-  run(view, 'destroy');
+  destroyView(view);
 
   view = EmberView.create({
     container: container,
@@ -283,7 +275,7 @@ test("View should not use keyword incorrectly - Issue #1315", function() {
     ])
   });
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), 'X-1:One 2:Two Y-1:One 2:Two ');
 });
@@ -294,7 +286,7 @@ test("it works inside a ul element", function() {
     people: people
   });
 
-  append(ulView);
+  appendView(ulView);
 
   equal(ulView.$('li').length, 2, "renders two <li> elements");
 
@@ -304,9 +296,7 @@ test("it works inside a ul element", function() {
 
   equal(ulView.$('li').length, 3, "renders an additional <li> element when an object is added");
 
-  run(function() {
-    ulView.destroy();
-  });
+  destroyView(ulView);
 });
 
 test("it works inside a table element", function() {
@@ -315,7 +305,7 @@ test("it works inside a table element", function() {
     people: people
   });
 
-  append(tableView);
+  appendView(tableView);
 
   equal(tableView.$('td').length, 2, "renders two <td> elements");
 
@@ -331,9 +321,7 @@ test("it works inside a table element", function() {
 
   equal(tableView.$('td').length, 4, "renders an additional <td> when an object is inserted at the beginning of the array");
 
-  run(function() {
-    tableView.destroy();
-  });
+  destroyView(tableView);
 });
 
 test("it supports itemController", function() {
@@ -343,7 +331,7 @@ test("it supports itemController", function() {
     })
   });
 
-  run(function() { view.destroy(); }); // destroy existing view
+ destroyView(view);
 
   var parentController = {
     container: container
@@ -360,7 +348,7 @@ test("it supports itemController", function() {
 
   container.register('controller:person', Controller);
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), "controller:Steve Holtcontroller:Annabelle");
 
@@ -399,7 +387,7 @@ test("itemController specified in template gets a parentController property", fu
       };
 
   container.register('controller:array', ArrayController.extend());
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
 
   view = EmberView.create({
     container: container,
@@ -410,7 +398,7 @@ test("itemController specified in template gets a parentController property", fu
 
   container.register('controller:person', Controller);
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
@@ -429,7 +417,7 @@ test("itemController specified in ArrayController gets a parentController proper
 
   container.register('controller:people', PeopleController);
   container.register('controller:person', PersonController);
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
 
   view = EmberView.create({
     container: container,
@@ -438,7 +426,7 @@ test("itemController specified in ArrayController gets a parentController proper
   });
 
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
@@ -463,7 +451,7 @@ test("itemController's parentController property, when the ArrayController has a
   container.register('controller:people', PeopleController);
   container.register('controller:person', PersonController);
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     container: container,
     template: templateFor('{{#each}}{{controllerName}}{{/each}}'),
@@ -471,7 +459,7 @@ test("itemController's parentController property, when the ArrayController has a
   });
 
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
@@ -485,7 +473,7 @@ test("it supports itemController when using a custom keyword", function() {
 
   container.register('controller:array', ArrayController.extend());
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     container: container,
     template: templateFor('{{#each person in view.people itemController="person"}}{{person.controllerName}}{{/each}}'),
@@ -497,7 +485,7 @@ test("it supports itemController when using a custom keyword", function() {
 
   container.register('controller:person', Controller);
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), "controller:Steve Holtcontroller:Annabelle");
 
@@ -513,7 +501,7 @@ test("it supports {{itemView=}}", function() {
     template: templateFor('itemView:{{name}}')
   });
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     template: templateFor('{{each view.people itemView="anItemView"}}'),
     people: people,
@@ -524,7 +512,7 @@ test("it supports {{itemView=}}", function() {
 
   container.register('view:anItemView', itemView);
 
-  append(view);
+  appendView(view);
 
   assertText(view, "itemView:Steve HoltitemView:Annabelle");
 });
@@ -535,7 +523,7 @@ test("it defers all normalization of itemView names to the resolver", function()
     template: templateFor('itemView:{{name}}')
   });
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     template: templateFor('{{each view.people itemView="an-item-view"}}'),
     people: people,
@@ -549,12 +537,12 @@ test("it defers all normalization of itemView names to the resolver", function()
     equal(fullname, "view:an-item-view", "leaves fullname untouched");
     return Container.prototype.resolve.call(this, fullname);
   };
-  append(view);
+  appendView(view);
 
 });
 
 test("it supports {{itemViewClass=}} with global (DEPRECATED)", function() {
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     template: templateFor('{{each view.people itemViewClass=MyView}}'),
     people: people
@@ -566,14 +554,14 @@ test("it supports {{itemViewClass=}} with global (DEPRECATED)", function() {
   }
 
   expectDeprecation(function(){
-    append(view);
+    appendView(view);
   }, deprecation);
 
   assertText(view, "Steve HoltAnnabelle");
 });
 
 test("it supports {{itemViewClass=}} via container", function() {
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     container: {
       lookupFactory: function(name){
@@ -585,13 +573,13 @@ test("it supports {{itemViewClass=}} via container", function() {
     people: people
   });
 
-  append(view);
+  appendView(view);
 
   assertText(view, "Steve HoltAnnabelle");
 });
 
 test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function() {
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
       template: templateFor('{{each view.people itemViewClass=MyView tagName="ul"}}'),
       people: people
@@ -599,7 +587,7 @@ test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function() {
 
   expectDeprecation(/Supplying a tagName to Metamorph views is unreliable and is deprecated./);
 
-  append(view);
+  appendView(view);
   equal(view.$('ul').length, 1, 'rendered ul tag');
   equal(view.$('ul li').length, 2, 'rendered 2 li tags');
   equal(view.$('ul li').text(), 'Steve HoltAnnabelle');
@@ -611,7 +599,7 @@ test("it supports {{itemViewClass=}} with in format", function() {
     template: templateFor("{{person.name}}")
   });
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     container: {
       lookupFactory: function(name){
@@ -622,20 +610,20 @@ test("it supports {{itemViewClass=}} with in format", function() {
     people: people
   });
 
-  append(view);
+  appendView(view);
 
   assertText(view, "Steve HoltAnnabelle");
 
 });
 
 test("it supports {{else}}", function() {
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     template: templateFor("{{#each view.items}}{{this}}{{else}}Nothing{{/each}}"),
     items: A(['one', 'two'])
   });
 
-  append(view);
+  appendView(view);
 
   assertHTML(view, "onetwo");
 
@@ -647,26 +635,26 @@ test("it supports {{else}}", function() {
 });
 
 test("it works with the controller keyword", function() {
-  run(view, 'destroy'); // destroy existing view
+  destroyView(view);
 
   var controller = ArrayController.create({
     model: A(["foo", "bar", "baz"])
   });
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
   view = EmberView.create({
     container: container,
     controller: controller,
     template: templateFor("{{#view}}{{#each controller}}{{this}}{{/each}}{{/view}}")
   });
 
-  append(view);
+  appendView(view);
 
   equal(view.$().text(), "foobarbaz");
 });
 
 test("views inside #each preserve the new context [DEPRECATED]", function() {
-  run(view, 'destroy'); // destroy existing view
+  destroyView(view);
 
   var controller = A([ { name: "Adam" }, { name: "Steve" } ]);
 
@@ -678,14 +666,14 @@ test("views inside #each preserve the new context [DEPRECATED]", function() {
 
 
   expectDeprecation(function() {
-    append(view);
+    appendView(view);
   },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "AdamSteve");
 });
 
 test("single-arg each defaults to current context [DEPRECATED]", function() {
-  run(view, 'destroy'); // destroy existing view
+  destroyView(view);
 
   view = EmberView.create({
     context: A([ { name: "Adam" }, { name: "Steve" } ]),
@@ -693,14 +681,14 @@ test("single-arg each defaults to current context [DEPRECATED]", function() {
   });
 
   expectDeprecation(function() {
-    append(view);
+    appendView(view);
   },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "AdamSteve");
 });
 
 test("single-arg each will iterate over controller if present [DEPRECATED]", function() {
-  run(view, 'destroy'); // destroy existing view
+  destroyView(view);
 
   view = EmberView.create({
     controller: A([ { name: "Adam" }, { name: "Steve" } ]),
@@ -708,7 +696,7 @@ test("single-arg each will iterate over controller if present [DEPRECATED]", fun
   });
 
   expectDeprecation(function() {
-    append(view);
+    appendView(view);
   },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$().text(), "AdamSteve");
@@ -741,7 +729,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       items: A([1, 2])
     });
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "My Cool Each Test 1My Cool Each Test 2");
   });
@@ -761,7 +749,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       controller: controller
     });
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "bob the controller");
   });
@@ -774,7 +762,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       items: A([{ name: 1 }, { name: 2 }])
     });
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "My Cool Each Test 1My Cool Each Test 2");
   });
@@ -786,7 +774,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       controller: A([{ name: 1 }, { name: 2 }])
     });
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "My Cool Each Test 1My Cool Each Test 2");
   });
@@ -802,7 +790,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       });
 
       expectDeprecation(function() {
-        append(view);
+        appendView(view);
       },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
       equal(view.$().text(), "AdamSteve");
@@ -820,7 +808,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       template: templateFor('{{#EACH|this|personController}}{{#view controllerBinding="personController"}}{{name}}{{/view}}{{/each}}', useBlockParams)
     });
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "AdamSteve");
   });
@@ -831,7 +819,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       template: templateFor('<table><tbody>{{#EACH|this|name}}<tr><td>{{name}}</td></tr>{{/each}}</tbody></table>', useBlockParams)
     });
 
-    append(view);
+    appendView(view);
 
     ok(true, "No assertion from valid template");
   });
@@ -863,7 +851,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
     container.register('controller:person', Controller);
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "controller:parentController - controller:Steve Holt - controller:parentController - controller:Annabelle - ");
 
@@ -908,7 +896,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     });
 
 
-    append(view);
+    appendView(view);
 
     equal(view.$().text(), "controller:people - controller:Steve Holt of Yapp - controller:people - controller:Annabelle of Yapp - ");
   });
@@ -923,7 +911,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       });
 
       expectDeprecation(function() {
-        append(view);
+        appendView(view);
       },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
       equal(view.$().text(), "AdamSteve");
@@ -938,7 +926,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       });
 
       expectDeprecation(function() {
-        append(view);
+        appendView(view);
       },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
       equal(view.$().text(), "AdamSteve");

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -12,16 +12,13 @@ import { set } from 'ember-metal/property_set';
 import { fmt } from 'ember-runtime/system/string';
 import { typeOf } from 'ember-metal/utils';
 import { forEach } from 'ember-metal/enumerable_utils';
+import { appendView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   compile = htmlbarsCompile;
 } else {
   compile = EmberHandlebars.compile;
-}
-
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
 }
 
 var originalLookup = Ember.lookup;

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -1,6 +1,7 @@
 import run from "ember-metal/run_loop";
 import { set } from "ember-metal/property_set";
 import View from "ember-views/views/view";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 import EmberHandlebars from "ember-handlebars";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
@@ -14,12 +15,6 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 var view;
 var controller;
-
-function appendView(view) {
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-}
 
 QUnit.module("{{input type='text'}}", {
   setup: function() {
@@ -41,9 +36,7 @@ QUnit.module("{{input type='text'}}", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -110,9 +103,7 @@ QUnit.module("{{input type='text'}} - static values", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -163,9 +154,7 @@ QUnit.module("{{input type='text'}} - dynamic type", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -186,9 +175,7 @@ QUnit.module("{{input}} - default type", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -213,9 +200,7 @@ QUnit.module("{{input type='checkbox'}}", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -256,9 +241,7 @@ QUnit.module("{{input type='checkbox'}} - prevent value= usage", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -284,9 +267,7 @@ QUnit.module("{{input type=boundType}}", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 
@@ -317,9 +298,7 @@ QUnit.module("{{input type='checkbox'}} - static values", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, view.destroy);
-    }
+    destroyView(view);
   }
 });
 

--- a/packages/ember-htmlbars/tests/helpers/loc_test.js
+++ b/packages/ember-htmlbars/tests/helpers/loc_test.js
@@ -1,7 +1,7 @@
-import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
 import EmberHandlebars from 'ember-handlebars-compiler';
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
@@ -14,18 +14,6 @@ function buildView(template, context) {
   return EmberView.create({
     template: compile(template),
     context: (context || {})
-  });
-}
-
-function appendView(view) {
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-}
-
-function destroyView(view) {
-  run(function() {
-    view.destroy();
   });
 }
 

--- a/packages/ember-htmlbars/tests/helpers/log_test.js
+++ b/packages/ember-htmlbars/tests/helpers/log_test.js
@@ -1,8 +1,8 @@
-import run from 'ember-metal/run_loop';
 import Ember from 'ember-metal/core';
 import EmberView from 'ember-views/views/view';
 import EmberHandlebars from 'ember-handlebars';
 import htmlbarsCompile from 'ember-htmlbars/system/compile';
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var originalLookup, originalLog, logCalls, lookup, view, compile;
 
@@ -11,10 +11,6 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 } else {
   compile = EmberHandlebars.compile;
 }
-
-var appendView = function(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-};
 
 QUnit.module('ember-htmlbars: {{#log}} helper', {
   setup: function() {
@@ -28,9 +24,7 @@ QUnit.module('ember-htmlbars: {{#log}} helper', {
   },
 
   teardown: function() {
-    run(function() {
-      view.destroy();
-    });
+    destroyView(view);
 
     view = null;
 

--- a/packages/ember-htmlbars/tests/helpers/partial_test.js
+++ b/packages/ember-htmlbars/tests/helpers/partial_test.js
@@ -6,6 +6,7 @@ var trim = jQuery.trim;
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var MyApp, lookup, view, container;
 var originalLookup = Ember.lookup;
@@ -25,11 +26,7 @@ QUnit.module("Support for {{partial}} helper", {
     container.optionsForType('template', { instantiate: false });
   },
   teardown: function() {
-    run(function() {
-      if (view) {
-        view.destroy();
-      }
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -42,9 +39,7 @@ test("should render other templates registered with the container", function() {
     template: compile('This {{partial "subTemplateFromContainer"}} is pretty great.')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 });
@@ -57,9 +52,7 @@ test("should render other slash-separated templates registered with the containe
     template: compile('This {{partial "child/subTemplateFromContainer"}} is pretty great.')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 });
@@ -76,9 +69,7 @@ test("should use the current view's context", function() {
     lastName: 'Selden'
   }));
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(trim(view.$().text()), "Who is Kris Selden?");
 });
@@ -93,9 +84,7 @@ test("Quoteless parameters passed to {{template}} perform a bound property looku
     partialName: 'subTemplate'
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 

--- a/packages/ember-htmlbars/tests/helpers/template_test.js
+++ b/packages/ember-htmlbars/tests/helpers/template_test.js
@@ -1,4 +1,3 @@
-import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
@@ -7,6 +6,7 @@ var trim = jQuery.trim;
 import Container from "ember-runtime/system/container";
 import EmberHandlebars from "ember-handlebars-compiler";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var MyApp, lookup, view, container;
 var originalLookup = Ember.lookup;
@@ -26,11 +26,7 @@ QUnit.module("Support for {{template}} helper", {
     container.optionsForType('template', { instantiate: false });
   },
   teardown: function() {
-    run(function() {
-      if (view) {
-        view.destroy();
-      }
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -45,9 +41,7 @@ test("should render other templates via the container (DEPRECATED)", function() 
 
   expectDeprecation(/The `template` helper has been deprecated in favor of the `partial` helper./);
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 });
@@ -66,9 +60,7 @@ test("should use the current view's context (DEPRECATED)", function() {
 
   expectDeprecation(/The `template` helper has been deprecated in favor of the `partial` helper./);
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(trim(view.$().text()), "Who is Kris Selden?");
 });

--- a/packages/ember-htmlbars/tests/helpers/text_area_test.js
+++ b/packages/ember-htmlbars/tests/helpers/text_area_test.js
@@ -3,6 +3,7 @@ import View from "ember-views/views/view";
 import EmberHandlebars from "ember-htmlbars/compat";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
 import { set as o_set } from "ember-metal/property_set";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
@@ -17,18 +18,6 @@ function set(object, key, value) {
   run(function() { o_set(object, key, value); });
 }
 
-function append() {
-  run(function() {
-    textArea.appendTo('#qunit-fixture');
-  });
-}
-
-function destroy(object) {
-  run(function() {
-    object.destroy();
-  });
-}
-
 QUnit.module("{{textarea}}", {
   setup: function() {
     controller = {
@@ -40,11 +29,11 @@ QUnit.module("{{textarea}}", {
       template: compile('{{textarea disabled=disabled value=val}}')
     }).create();
 
-    append();
+    appendView(textArea);
   },
 
   teardown: function() {
-    destroy(textArea);
+    destroyView(textArea);
   }
 });
 

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -17,6 +17,7 @@ import registerHTMLBarsHelper from "ember-htmlbars/compat/register-bound-helper"
 import htmlbarsMakeBoundHelper from "ember-htmlbars/compat/make-bound-helper";
 
 import Container from 'ember-runtime/system/container';
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 import {
   makeBoundHelper as handlebarsMakeBoundHelper
@@ -34,12 +35,6 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   registerBoundHelper = EmberHandlebars.registerBoundHelper;
   helpers = EmberHandlebars.helpers;
   makeBoundHelper = handlebarsMakeBoundHelper;
-}
-
-function appendView(view) {
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
 }
 
 function expectDeprecationInHTMLBars() {
@@ -68,9 +63,7 @@ QUnit.module('ember-htmlbars: {{#unbound}} helper', {
   },
 
   teardown: function() {
-    run(function() {
-      view.destroy();
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -131,9 +124,7 @@ QUnit.module("ember-htmlbars: {{#unbound boundHelper arg1 arg2... argN}} form: r
     delete helpers['fauxconcat'];
     delete helpers['concatNames'];
 
-    run(function() {
-      view.destroy();
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -293,9 +284,7 @@ QUnit.module("ember-htmlbars: {{#unbound}} helper -- Container Lookup", {
   },
 
   teardown: function() {
-    if (view) {
-      run(view, 'destroy');
-    }
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -17,6 +17,7 @@ import htmlbarsTemplate from 'ember-htmlbars/system/template';
 import { observersFor } from "ember-metal/observer";
 import ObjectController from 'ember-runtime/controllers/object_controller';
 
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 import { set } from 'ember-metal/property_set';
 import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
@@ -52,9 +53,6 @@ function viewClass(options) {
 }
 
 var firstChild = nthChild;
-var appendView = function(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-};
 
 QUnit.module("ember-htmlbars: {{#view}} helper", {
   setup: function() {
@@ -101,13 +99,13 @@ test("should not enter an infinite loop when binding an attribute in Handlebars"
     template: compile('{{#view view.linkView href=view.test.href}} Test {{/view}}')
   });
 
-  run(parentView, 'appendTo', '#qunit-fixture');
+  appendView(parentView);
 
   // Use match, since old IE appends the whole URL
   var href = parentView.$('a').attr('href');
   ok(href.match(/(^|\/)test$/), 'Expected href to be \'test\' but got "'+href+'"');
 
-  run(parentView, 'destroy');
+  destroyView(parentView);
 });
 
 test("By default view:toplevel is used", function() {
@@ -1017,9 +1015,7 @@ test('should expose a controller keyword when present on the view', function() {
 
   equal(view.$().text(), 'BARBLARGH', 'updates the DOM when a bound value is updated');
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 
   view = EmberView.create({
     controller: 'aString',

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -10,16 +10,13 @@ import Container from "ember-runtime/system/container";
 // import { A } from "ember-runtime/system/native_array";
 import EmberHandlebars from "ember-handlebars";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   compile = htmlbarsCompile;
 } else {
   compile = EmberHandlebars.compile;
-}
-
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
 }
 
 var view, lookup;
@@ -42,9 +39,7 @@ function testWithAs(moduleName, templateString) {
     },
 
     teardown: function() {
-      run(function() {
-        view.destroy();
-      });
+      destroyView(view);
       Ember.lookup = originalLookup;
     }
   });
@@ -100,9 +95,7 @@ QUnit.module("Multiple Handlebars {{with foo as bar}} helpers", {
   },
 
   teardown: function() {
-    run(function() {
-      view.destroy();
-    });
+    destroyView(view);
 
     Ember.lookup = originalLookup;
   }
@@ -148,9 +141,7 @@ QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
   },
 
   teardown: function() {
-    run(function() {
-      view.destroy();
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -186,9 +177,7 @@ test("it should support #with view as foo", function() {
 
   equal(view.$().text(), "Thunder", "should update");
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 });
 
 test("it should support #with name as food, then #with foo as bar", function() {
@@ -206,9 +195,7 @@ test("it should support #with name as food, then #with foo as bar", function() {
 
   equal(view.$().text(), "butterfly", "should update");
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 });
 
 QUnit.module("Handlebars {{#with this as foo}}");
@@ -228,9 +215,7 @@ test("it should support #with this as qux", function() {
 
   equal(view.$().text(), "l'Pivots", "should update");
 
-  run(function() {
-    view.destroy();
-  });
+  destroyView(view);
 });
 
 QUnit.module("Handlebars {{#with foo}} with defined controller");
@@ -287,7 +272,7 @@ test("it should wrap context with object controller [DEPRECATED]", function() {
 
   strictEqual(view.get('_childViews')[0].get('controller.target'), parentController, "the target property of the child controllers are set correctly");
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
 });
 
 /* requires each
@@ -319,7 +304,7 @@ test("it should still have access to original parentController within an {{#each
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblawcontroller:Carl Weathers and Bob Loblaw");
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
 });
 */
 
@@ -371,7 +356,7 @@ test("it should wrap keyword with object controller", function() {
 
   equal(view.$().text(), "Carl Weathers - GOB");
 
-  run(function() { view.destroy(); }); // destroy existing view
+  destroyView(view);
 });
 
 test("destroys the controller generated with {{with foo controller='blah'}} [DEPRECATED]", function() {
@@ -404,7 +389,7 @@ test("destroys the controller generated with {{with foo controller='blah'}} [DEP
     appendView(view);
   }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
-  run(view, 'destroy'); // destroy existing view
+  destroyView(view);
 
   ok(destroyed, 'controller was destroyed properly');
 });
@@ -437,7 +422,7 @@ test("destroys the controller generated with {{with foo as bar controller='blah'
 
   appendView(view);
 
-  run(view, 'destroy'); // destroy existing view
+  destroyView(view);
 
   ok(destroyed, 'controller was destroyed properly');
 });
@@ -458,9 +443,7 @@ QUnit.module("{{#with}} helper binding to view keyword", {
   },
 
   teardown: function() {
-    run(function() {
-      view.destroy();
-    });
+    destroyView(view);
     Ember.lookup = originalLookup;
   }
 });
@@ -490,9 +473,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
     },
 
     teardown: function() {
-      run(function() {
-        view.destroy();
-      });
+      destroyView(view);
       Ember.lookup = originalLookup;
     }
   });

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -15,6 +15,7 @@ import {
 
 import EmberHandlebars from "ember-handlebars";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+import { appendView } from "ember-views/tests/view_helpers";
 
 var compile, helper;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
@@ -52,9 +53,7 @@ test("a view with a layout set renders its template where the {{yield}} helper a
     template: compile('{{#view view.withLayout title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
 });
@@ -73,9 +72,7 @@ test("block should work properly even when templates are not hard-coded", functi
     templateName: 'nested'
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
 
@@ -100,9 +97,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
     template: compile('<div id="container"><div class="title">Counting to 5</div>{{#view view.timesView n=5}}<div class="times-item">Hello</div>{{/view}}</div>')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div#container div.times-item').length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
 });
@@ -117,9 +112,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
     template: compile('<div id="container">{{#view view.nestingView}}<div id="block">Hello</div>{{/view}}</div>')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div#container div.nesting div#block').length, 1, 'nesting view yields correctly even within a view hierarchy in the nesting view');
 });
@@ -134,9 +127,7 @@ test("block should not be required", function() {
     template: compile('<div id="container">{{view view.yieldingView}}</div>')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div#container div.yielding').length, 1, 'yielding view is rendered as expected');
 });
@@ -152,9 +143,7 @@ test("yield uses the outer context", function() {
     template: compile('{{#view component}}{{boundText}}{{/view}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "Yield points at the right context");
 });
@@ -174,7 +163,7 @@ test("yield inside a conditional uses the outer context [DEPRECATED]", function(
   });
 
   expectDeprecation(function() {
-    run(view, 'appendTo', '#qunit-fixture');
+    appendView(view);
   }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, "Yield points at the right context");
@@ -191,9 +180,7 @@ test("outer keyword doesn't mask inner component property", function () {
     template: compile('{{#with boundText as item}}{{#view component}}{{item}}{{/view}}{{/with}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "inner component property isn't masked by outer keyword");
 });
@@ -209,9 +196,7 @@ test("inner keyword doesn't mask yield property", function() {
     template: compile('{{#view component}}{{item}}{{/view}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "outer property isn't masked by inner keyword");
 });
@@ -227,9 +212,7 @@ test("can bind a keyword to a component and use it in yield", function() {
     template: compile('{{#with boundText as item}}{{#view component contentBinding="item"}}{{item}}{{/view}}{{/with}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div p:contains(outer) + p:contains(outer)').length, 1, "component and yield have keyword");
 
@@ -255,7 +238,7 @@ test("yield uses the layout context for non component [DEPRECATED]", function() 
   });
 
   expectDeprecation(function() {
-    run(view, 'appendTo', '#qunit-fixture');
+    appendView(view);
   }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal('outerinner', view.$('p').text(), "Yield points at the right context");
@@ -284,9 +267,7 @@ test("yield view should be a virtual view", function() {
     }
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 });
 
 
@@ -374,9 +355,7 @@ test("yield with nested components (#3220)", function(){
     )
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div > span').text(), "Hello world");
 });
@@ -392,9 +371,7 @@ test("yield works inside a conditional in a component that has Ember._Metamorph 
     template: compile('{{#view component}}{{item}}{{/view}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$().text(), 'innerouter', "{{yield}} renders yielded content inside metamorph component");
 });
@@ -410,9 +387,7 @@ test("view keyword works inside component yield", function () {
     template: compile('{{#view view.component}}{{view.dummyText}}{{/view}}')
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   equal(view.$('div > p').text(), "hello", "view keyword inside component yield block should refer to the correct view");
 });

--- a/packages/ember-htmlbars/tests/hooks/attribute_test.js
+++ b/packages/ember-htmlbars/tests/hooks/attribute_test.js
@@ -4,20 +4,15 @@ import EmberObject from "ember-runtime/system/object";
 import compile from "ember-htmlbars/system/compile";
 import { equalInnerHTML } from "htmlbars-test-helpers";
 import { defaultEnv } from "ember-htmlbars";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view, originalSetAttribute, setAttributeCalls;
 var dom = defaultEnv.dom;
 
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
-}
-
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   QUnit.module("ember-htmlbars: attribute", {
     teardown: function(){
-      if (view) {
-        run(view, view.destroy);
-      }
+      destroyView(view);
     }
   });
 
@@ -155,7 +150,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "precond - attribute is output");
 
     run(function() {
-      run.schedule('render', function() { 
+      run.schedule('render', function() {
         equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "precond - attribute is not updated sync");
       });
 
@@ -184,9 +179,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     teardown: function() {
       dom.setAttribute = originalSetAttribute;
 
-      if (view) {
-        run(view, view.destroy);
-      }
+      destroyView(view);
     }
   });
 

--- a/packages/ember-htmlbars/tests/hooks/component_test.js
+++ b/packages/ember-htmlbars/tests/hooks/component_test.js
@@ -1,8 +1,8 @@
 import ComponentLookup from "ember-views/component_lookup";
 import Container from "container";
 import EmberView from "ember-views/views/view";
-import run from "ember-metal/run_loop";
 import compile from "ember-htmlbars/system/compile";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view, container;
 
@@ -13,10 +13,6 @@ function generateContainer() {
   container.register('component-lookup:main', ComponentLookup);
 
   return container;
-}
-
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
 }
 
 // this is working around a bug in defeatureify that prevents nested flags
@@ -34,9 +30,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
       },
 
       teardown: function(){
-        if (view) {
-          run(view, view.destroy);
-        }
+        destroyView(view);
       }
     });
 

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -3,19 +3,14 @@ import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import compile from "ember-htmlbars/system/compile";
 import { equalInnerHTML } from "htmlbars-test-helpers";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view;
-
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
-}
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   QUnit.module("ember-htmlbars: basic/text_node_test", {
     teardown: function(){
-      if (view) {
-        run(view, view.destroy);
-      }
+      destroyView(view);
     }
   });
 

--- a/packages/ember-htmlbars/tests/integration/binding_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/binding_integration_test.js
@@ -9,6 +9,7 @@ import htmlbarsCompile from 'ember-htmlbars/system/compile';
 import EmberHandlebars from "ember-handlebars";
 import { ViewHelper as handlebarsViewHelper } from 'ember-handlebars/helpers/view';
 import { ViewHelper as htmlbarsViewHelper } from 'ember-htmlbars/helpers/view';
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 import { set } from 'ember-metal/property_set';
 
@@ -22,10 +23,6 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   compile = EmberHandlebars.compile;
 }
 
-var appendView = function(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-};
-
 QUnit.module('ember-htmlbars: binding integration', {
   setup: function() {
     originalLookup = Ember.lookup;
@@ -38,9 +35,7 @@ QUnit.module('ember-htmlbars: binding integration', {
     Ember.lookup = originalLookup;
 
     run(function() {
-      if (view) {
-        view.destroy();
-      }
+      destroyView(view);
       view = null;
     });
 
@@ -165,7 +160,7 @@ test("should update bound values after view's parent is removed and then re-appe
   });
   equal(trim(view.$().text()), "bar");
 
-  run(parentView, 'destroy');
+  destroyView(parentView);
 });
 
 test('should accept bindings as a string or an Ember.Binding', function() {

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -5,12 +5,9 @@ import View from "ember-views/views/view";
 import compile from "ember-htmlbars/system/compile";
 import helpers from "ember-htmlbars/helpers";
 import { registerHelper } from "ember-htmlbars/helpers";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var container, view;
-
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
-}
 
 function aliasHelper(params, hash, options, env) {
   this.appendChild(View, {
@@ -37,13 +34,9 @@ QUnit.module("ember-htmlbars: block params", {
   teardown: function() {
     delete helpers.alias;
 
-    run(container, 'destroy');
+    destroyView(container);
 
-    if (view) {
-      run(function() {
-        view.destroy();
-      });
-    }
+    destroyView(view);
   }
 });
 

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -1,10 +1,10 @@
 import EmberView from "ember-views/views/view";
 import Container from 'container/container';
-import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 import EmberHandlebars from 'ember-handlebars-compiler';
 import htmlbarsCompile from "ember-htmlbars/system/compile";
 import ComponentLookup from 'ember-views/component_lookup';
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
@@ -26,11 +26,8 @@ QUnit.module('component - invocation', {
   },
 
   teardown: function() {
-    run(container, 'destroy');
-
-    if (view) {
-      run(view, 'destroy');
-    }
+    destroyView(container);
+    destroyView(view);
   }
 });
 
@@ -44,7 +41,7 @@ test('non-block without properties', function() {
     container: container
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  appendView(view);
 
   equal(jQuery('#qunit-fixture').text(), 'In layout');
 });
@@ -59,7 +56,7 @@ test('block without properties', function() {
     container: container
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  appendView(view);
 
   equal(jQuery('#qunit-fixture').text(), 'In layout - In template');
 });
@@ -74,7 +71,7 @@ test('non-block with properties', function() {
     container: container
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  appendView(view);
 
   equal(jQuery('#qunit-fixture').text(), 'In layout - someProp: something here');
 });
@@ -89,7 +86,7 @@ test('block with properties', function() {
     container: container
   }).create();
 
-  run(view, 'appendTo', '#qunit-fixture');
+  appendView(view);
 
   equal(jQuery('#qunit-fixture').text(), 'In layout - someProp: something here - In template');
 });

--- a/packages/ember-htmlbars/tests/integration/escape_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/escape_integration_test.js
@@ -6,6 +6,7 @@ import htmlbarsCompile from 'ember-htmlbars/system/compile';
 
 import { set } from 'ember-metal/property_set';
 import { create as o_create } from 'ember-metal/platform';
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile, view;
 
@@ -17,19 +18,11 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 QUnit.module('ember-htmlbars: Integration with Globals', {
   teardown: function() {
-    run(function() {
-      if (view) {
-        view.destroy();
-      }
+    destroyView(view);
 
-      view = null;
-    });
+    view = null;
   }
 });
-
-function appendView(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-}
 
 test('should read from a global-ish simple local path without deprecation', function() {
   view = EmberView.create({

--- a/packages/ember-htmlbars/tests/integration/globals_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/globals_integration_test.js
@@ -1,8 +1,8 @@
-import run from 'ember-metal/run_loop';
 import Ember from 'ember-metal/core';
 import EmberView from 'ember-views/views/view';
 import EmberHandlebars from 'ember-handlebars-compiler';
 import htmlbarsCompile from 'ember-htmlbars/system/compile';
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var compile, view, originalLookup, lookup;
 
@@ -14,23 +14,15 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 var originalLookup = Ember.lookup;
 
-function appendView(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-}
-
 QUnit.module('ember-htmlbars: Integration with Globals', {
   setup: function() {
     Ember.lookup = lookup = {};
   },
 
   teardown: function() {
-    run(function() {
-      if (view) {
-        view.destroy();
-      }
+    destroyView(view);
 
-      view = null;
-    });
+    view = null;
 
     Ember.lookup = lookup = originalLookup;
   }

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -10,6 +10,7 @@ import ArrayProxy from "ember-runtime/system/array_proxy";
 import SelectView from "ember-views/views/select";
 import EmberHandlebars from 'ember-handlebars-compiler';
 import { default as htmlbarsCompile } from 'ember-htmlbars/system/compile';
+import { appendView } from "ember-views/tests/view_helpers";
 
 var dispatcher, view;
 
@@ -75,9 +76,7 @@ test("works from a template with bindings", function() {
     )
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   var select = view.get('select');
   ok(select.$().length, "Select was rendered");
@@ -112,9 +111,7 @@ test("upon content change, the DOM should reflect the selection (#481)", functio
     )
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   var select = view.get('select');
   var selectEl = select.$()[0];
@@ -149,9 +146,7 @@ test("upon content change with Array-like content, the DOM should reflect the se
     )
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   var select = view.get('select');
   var selectEl = select.$()[0];
@@ -174,9 +169,7 @@ function testValueBinding(templateString) {
     template: compile(templateString)
   });
 
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
+  appendView(view);
 
   var select = view.get('select');
   var selectEl = select.$()[0];

--- a/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
+++ b/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
@@ -1,22 +1,14 @@
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import EmberHandlebars from "ember-htmlbars/compat";
+import { appendView, destroyView } from "ember-views/tests/view_helpers";
 
 var view;
 var compile = EmberHandlebars.compile;
 
-
-function appendView(view) {
-  run(function() { view.appendTo('#qunit-fixture'); });
-}
-
 QUnit.module("ember-htmlbars: tagless views should be able to add/remove child views", {
   teardown: function() {
-    run(function() {
-      if (view) {
-        view.destroy();
-      }
-    });
+    destroyView(view);
   }
 });
 

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -7,16 +7,13 @@ import EmberObject from 'ember-runtime/system/object';
 import _MetamorphView from 'ember-views/views/metamorph_view';
 import EmberHandlebars from 'ember-handlebars';
 import htmlbarsCompile from 'ember-htmlbars/system/compile';
+import { appendView } from "ember-views/tests/view_helpers";
 
 import { set } from 'ember-metal/property_set';
 
 var view, container;
 
 var trim = jQuery.trim;
-
-var appendView = function(view) {
-  run(view, 'appendTo', '#qunit-fixture');
-};
 
 var compile;
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-views/tests/view_helpers.js
+++ b/packages/ember-views/tests/view_helpers.js
@@ -1,0 +1,16 @@
+import run from "ember-metal/run_loop";
+
+function appendView(view) {
+  run(view, "appendTo", "#qunit-fixture");
+}
+
+function destroyView(view) {
+  if (view) {
+    run(view, "destroy");
+  }
+}
+
+export {
+  appendView,
+  destroyView
+};


### PR DESCRIPTION
Defining `appendView` and `destroyView` in multiple tests is verbose, 
repetitious, and copy-paste-error prone.
