### PR TITLE
[ember-routing-htmlbars] Cleanup `ActionHelper`

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -72,6 +72,8 @@ QUnit.module("ember-routing-htmlbars: action helper", {
 
     delete helpers['action'];
     helpers['action'] = originalActionHelper;
+
+    ActionHelper.registerAction = originalRegisterAction;
   }
 });
 
@@ -99,8 +101,6 @@ test("should by default register a click event", function() {
   appendView();
 
   equal(registeredEventName, 'click', "The click event was properly registered");
-
-  ActionHelper.registerAction = originalRegisterAction;
 });
 
 test("should allow alternative events to be handled", function() {
@@ -117,8 +117,6 @@ test("should allow alternative events to be handled", function() {
   appendView();
 
   equal(registeredEventName, 'mouseUp', "The alternative mouseUp event was properly registered");
-
-  ActionHelper.registerAction = originalRegisterAction;
 });
 
 test("should by default target the view's controller", function() {
@@ -137,8 +135,6 @@ test("should by default target the view's controller", function() {
   appendView();
 
   equal(registeredTarget, controller, "The controller was registered as the target");
-
-  ActionHelper.registerAction = originalRegisterAction;
 });
 
 test("Inside a yield, the target points at the original target", function() {
@@ -203,8 +199,6 @@ test("should target the current controller inside an {{each}} loop [DEPRECATED]"
   }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   equal(registeredTarget, itemController, "the item controller is the target of action");
-
-  ActionHelper.registerAction = originalRegisterAction;
 });
 }
 
@@ -235,8 +229,6 @@ test("should target the with-controller inside an {{#with controller='person'}} 
   }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
 
   ok(registeredTarget instanceof PersonController, "the with-controller is the target of action");
-
-  ActionHelper.registerAction = originalRegisterAction;
 });
 
 test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
@@ -294,8 +286,6 @@ test("should allow a target to be specified", function() {
   appendView();
 
   equal(registeredTarget, anotherTarget, "The specified target was registered");
-
-  ActionHelper.registerAction = originalRegisterAction;
 
   run(function() {
     anotherTarget.destroy();


### PR DESCRIPTION
DRY up `ActionHelper` cleanup in tests by moving to `teardown` block.
