### PR TITLE
Include number of expected assertions

### DIFF
--- a/packages/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages/ember-metal/tests/run_loop/run_bind_test.js
@@ -19,6 +19,7 @@ test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
 });
 
 test('Ember.run.bind keeps the async callback arguments', function() {
+  expect(4);
 
   var asyncCallback = function(increment, increment2, increment3) {
     ok(run.currentRunLoop, 'expected a run-loop');


### PR DESCRIPTION
Without specifying the number of expected assertions, the callback might never
be evaluated, and the test might pass, acting as a false positive.
