### PR TITLE
Prefer `import` over global `Ember.FOO`

### DIFF
--- a/packages/ember-metal/tests/accessors/getPath_test.js
+++ b/packages/ember-metal/tests/accessors/getPath_test.js
@@ -73,13 +73,13 @@ test('[obj, falseValue.notDefined] -> (null)', function() {
 
 test('[null, length] returning data is deprecated', function() {
   expectDeprecation(function(){
-    equal(5, Ember.get(null, 'localPathGlobal'));
+    equal(5, get(null, 'localPathGlobal'));
   }, "Ember.get fetched 'localPathGlobal' from the global context. This behavior will change in the future (issue #3852)");
 });
 
 test('[length] returning data is deprecated', function() {
   expectDeprecation(function(){
-    equal(5, Ember.get('localPathGlobal'));
+    equal(5, get('localPathGlobal'));
   }, "Ember.get fetched 'localPathGlobal' from the global context. This behavior will change in the future (issue #3852)");
 });
 

--- a/packages/ember-metal/tests/mixin/alias_method_test.js
+++ b/packages/ember-metal/tests/mixin/alias_method_test.js
@@ -1,4 +1,11 @@
-QUnit.module('Ember.aliasMethod');
+import { get } from 'ember-metal/property_get';
+import {
+  Mixin,
+  mixin,
+  aliasMethod
+} from 'ember-metal/mixin';
+
+QUnit.module('aliasMethod');
 
 function validateAliasMethod(obj) {
   equal(obj.fooMethod(), 'FOO', 'obj.fooMethod()');
@@ -6,10 +13,9 @@ function validateAliasMethod(obj) {
 }
 
 test('methods of another name are aliased when the mixin is applied', function() {
-
-  var MyMixin = Ember.Mixin.create({
+  var MyMixin = Mixin.create({
     fooMethod: function() { return 'FOO'; },
-    barMethod: Ember.aliasMethod('fooMethod')
+    barMethod: aliasMethod('fooMethod')
   });
 
   var obj = MyMixin.apply({});
@@ -17,24 +23,23 @@ test('methods of another name are aliased when the mixin is applied', function()
 });
 
 test('should follow aliasMethods all the way down', function() {
-  var MyMixin = Ember.Mixin.create({
-    bar: Ember.aliasMethod('foo'), // put first to break ordered iteration
+  var MyMixin = Mixin.create({
+    bar: aliasMethod('foo'), // put first to break ordered iteration
     baz: function() { return 'baz'; },
-    foo: Ember.aliasMethod('baz')
+    foo: aliasMethod('baz')
   });
 
   var obj = MyMixin.apply({});
-  equal(Ember.get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
+  equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
 });
 
 test('should alias methods from other dependent mixins', function() {
-
-  var BaseMixin = Ember.Mixin.create({
+  var BaseMixin = Mixin.create({
     fooMethod: function() { return 'FOO'; }
   });
 
-  var MyMixin = Ember.Mixin.create(BaseMixin, {
-    barMethod: Ember.aliasMethod('fooMethod')
+  var MyMixin = Mixin.create(BaseMixin, {
+    barMethod: aliasMethod('fooMethod')
   });
 
   var obj = MyMixin.apply({});
@@ -42,28 +47,26 @@ test('should alias methods from other dependent mixins', function() {
 });
 
 test('should alias methods from other mixins applied at same time', function() {
-
-  var BaseMixin = Ember.Mixin.create({
+  var BaseMixin = Mixin.create({
     fooMethod: function() { return 'FOO'; }
   });
 
-  var MyMixin = Ember.Mixin.create({
-    barMethod: Ember.aliasMethod('fooMethod')
+  var MyMixin = Mixin.create({
+    barMethod: aliasMethod('fooMethod')
   });
 
-  var obj = Ember.mixin({}, BaseMixin, MyMixin);
+  var obj = mixin({}, BaseMixin, MyMixin);
   validateAliasMethod(obj);
 });
 
 test('should alias methods from mixins already applied on object', function() {
-
-  var BaseMixin = Ember.Mixin.create({
+  var BaseMixin = Mixin.create({
     quxMethod: function() { return 'qux'; }
   });
 
-  var MyMixin = Ember.Mixin.create({
-    bar: Ember.aliasMethod('foo'),
-    barMethod: Ember.aliasMethod('fooMethod')
+  var MyMixin = Mixin.create({
+    bar: aliasMethod('foo'),
+    barMethod: aliasMethod('fooMethod')
   });
 
   var obj = {

--- a/packages/ember-metal/tests/mixin/apply_test.js
+++ b/packages/ember-metal/tests/mixin/apply_test.js
@@ -1,36 +1,42 @@
+import get from 'ember-metal/property_get';
+import {
+  Mixin,
+  mixin
+} from 'ember-metal/mixin';
+
 QUnit.module('Ember.Mixin.apply');
 
 function K() {}
 
 test('using apply() should apply properties', function() {
-  var MixinA = Ember.Mixin.create({ foo: 'FOO', baz: K });
+  var MixinA = Mixin.create({ foo: 'FOO', baz: K });
   var obj = {};
-  Ember.mixin(obj, MixinA);
+  mixin(obj, MixinA);
 
-  equal(Ember.get(obj, 'foo'), "FOO", 'should apply foo');
-  equal(Ember.get(obj, 'baz'), K, 'should apply foo');
+  equal(get(obj, 'foo'), "FOO", 'should apply foo');
+  equal(get(obj, 'baz'), K, 'should apply foo');
 });
 
 test('applying anonymous properties', function() {
   var obj = {};
-  Ember.mixin(obj, {
+  mixin(obj, {
     foo: 'FOO',
     baz: K
   });
 
-  equal(Ember.get(obj, 'foo'), "FOO", 'should apply foo');
-  equal(Ember.get(obj, 'baz'), K, 'should apply foo');
+  equal(get(obj, 'foo'), "FOO", 'should apply foo');
+  equal(get(obj, 'baz'), K, 'should apply foo');
 });
 
 test('applying null values', function() {
   expectAssertion(function() {
-    Ember.mixin({}, null);
+    mixin({}, null);
   });
 });
 
 test('applying a property with an undefined value', function() {
   var obj = { tagName: '' };
-  Ember.mixin(obj, { tagName: undefined });
+  mixin(obj, { tagName: undefined });
 
-  strictEqual(Ember.get(obj, 'tagName'), '');
+  strictEqual(get(obj, 'tagName'), '');
 });

--- a/packages/ember-metal/tests/mixin/concatenatedProperties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenatedProperties_test.js
@@ -1,31 +1,37 @@
-QUnit.module('Ember.Mixin concatenatedProperties');
+import get from 'ember-metal/property_get';
+import {
+  Mixin,
+  mixin
+} from 'ember-metal/mixin';
+
+QUnit.module('Mixin concatenatedProperties');
 
 test('defining concatenated properties should concat future version', function() {
 
-  var MixinA = Ember.Mixin.create({
+  var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: ['a', 'b', 'c']
   });
 
-  var MixinB = Ember.Mixin.create({
+  var MixinB = Mixin.create({
     foo: ['d', 'e', 'f']
   });
 
-  var obj = Ember.mixin({}, MixinA, MixinB);
-  deepEqual(Ember.get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
+  var obj = mixin({}, MixinA, MixinB);
+  deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
 });
 
 test('defining concatenated properties should concat future version', function() {
 
-  var MixinA = Ember.Mixin.create({
+  var MixinA = Mixin.create({
     concatenatedProperties: null
   });
 
-  var MixinB = Ember.Mixin.create({
+  var MixinB = Mixin.create({
     concatenatedProperties: null
   });
 
-  var obj = Ember.mixin({}, MixinA, MixinB);
+  var obj = mixin({}, MixinA, MixinB);
 
   deepEqual(obj.concatenatedProperties, []);
 });
@@ -33,79 +39,79 @@ test('defining concatenated properties should concat future version', function()
 
 test('concatenatedProperties should be concatenated', function() {
 
-  var MixinA = Ember.Mixin.create({
+  var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: ['a', 'b', 'c']
   });
 
-  var MixinB = Ember.Mixin.create({
+  var MixinB = Mixin.create({
     concatenatedProperties: 'bar',
     foo: ['d', 'e', 'f'],
     bar: [1,2,3]
   });
 
-  var MixinC = Ember.Mixin.create({
+  var MixinC = Mixin.create({
     bar: [4,5,6]
   });
 
-  var obj = Ember.mixin({}, MixinA, MixinB, MixinC);
-  deepEqual(Ember.get(obj, 'concatenatedProperties'), ['foo', 'bar'], 'get concatenatedProperties');
-  deepEqual(Ember.get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f'], 'get foo');
-  deepEqual(Ember.get(obj, 'bar'), [1,2,3,4,5,6], 'get bar');
+  var obj = mixin({}, MixinA, MixinB, MixinC);
+  deepEqual(get(obj, 'concatenatedProperties'), ['foo', 'bar'], 'get concatenatedProperties');
+  deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f'], 'get foo');
+  deepEqual(get(obj, 'bar'), [1,2,3,4,5,6], 'get bar');
 });
 
 test('adding a prop that is not an array should make array', function() {
 
-  var MixinA = Ember.Mixin.create({
+  var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: [1,2,3]
   });
 
-  var MixinB = Ember.Mixin.create({
+  var MixinB = Mixin.create({
     foo: 4
   });
 
-  var obj = Ember.mixin({}, MixinA, MixinB);
-  deepEqual(Ember.get(obj, 'foo'), [1,2,3,4]);
+  var obj = mixin({}, MixinA, MixinB);
+  deepEqual(get(obj, 'foo'), [1,2,3,4]);
 });
 
 test('adding a prop that is not an array should make array', function() {
 
-  var MixinA = Ember.Mixin.create({
+  var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: 'bar'
   });
 
-  var obj = Ember.mixin({}, MixinA);
-  deepEqual(Ember.get(obj, 'foo'), ['bar']);
+  var obj = mixin({}, MixinA);
+  deepEqual(get(obj, 'foo'), ['bar']);
 });
 
 test('adding a non-concatenable property that already has a defined value should result in an array with both values', function() {
 
-  var mixinA = Ember.Mixin.create({
+  var mixinA = Mixin.create({
     foo: 1
   });
 
-  var mixinB = Ember.Mixin.create({
+  var mixinB = Mixin.create({
     concatenatedProperties: ['foo'],
     foo: 2
   });
 
-  var obj = Ember.mixin({}, mixinA, mixinB);
-  deepEqual(Ember.get(obj, 'foo'), [1, 2]);
+  var obj = mixin({}, mixinA, mixinB);
+  deepEqual(get(obj, 'foo'), [1, 2]);
 });
 
 test('adding a concatenable property that already has a defined value should result in a concatenated value', function() {
 
-  var mixinA = Ember.Mixin.create({
+  var mixinA = Mixin.create({
     foobar: 'foo'
   });
 
-  var mixinB = Ember.Mixin.create({
+  var mixinB = Mixin.create({
     concatenatedProperties: ['foobar'],
     foobar: 'bar'
   });
 
-  var obj = Ember.mixin({}, mixinA, mixinB);
-  equal(Ember.get(obj, 'foobar'), 'foobar');
+  var obj = mixin({}, mixinA, mixinB);
+  equal(get(obj, 'foobar'), 'foobar');
 });

--- a/packages/ember-metal/tests/mixin/reopen_test.js
+++ b/packages/ember-metal/tests/mixin/reopen_test.js
@@ -1,3 +1,6 @@
+import run from 'ember-metal/run_loop';
+import get from 'ember-metal/property_get';
+import EmberObject from 'ember-runtime/system/object';
 import Mixin from 'ember-metal/mixin';
 
 QUnit.module('Ember.Mixin#reopen');
@@ -8,14 +11,13 @@ test('using reopen() to add more properties to a simple', function() {
   var obj = {};
   MixinA.apply(obj);
 
-  equal(Ember.get(obj, 'foo'), 'FOO2', 'mixin() should override');
-  equal(Ember.get(obj, 'baz'), 'BAZ', 'preserve MixinA props');
-  equal(Ember.get(obj, 'bar'), 'BAR', 'include MixinB props');
+  equal(get(obj, 'foo'), 'FOO2', 'mixin() should override');
+  equal(get(obj, 'baz'), 'BAZ', 'preserve MixinA props');
+  equal(get(obj, 'bar'), 'BAR', 'include MixinB props');
 });
 
 test('using reopen() and calling _super where there is not a super function does not cause infinite recursion', function(){
-
-  var Taco = Ember.Object.extend({
+  var Taco = EmberObject.extend({
     createBreakfast: function(){
       // There is no original createBreakfast function.
       // Calling the wrapped _super function here
@@ -34,7 +36,7 @@ test('using reopen() and calling _super where there is not a super function does
   var taco = Taco.create();
 
   var result;
-  Ember.run(function(){
+  run(function(){
     try {
       result = taco.createBreakfast();
     } catch (e) {

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -74,8 +74,8 @@ testBoth('observer should continue to fire after dependent properties are access
   var observerCount = 0;
   var obj = {};
 
-  defineProperty(obj, 'prop', Ember.computed(function () { return Math.random(); }));
-  defineProperty(obj, 'anotherProp', Ember.computed('prop', function () { return get(this, 'prop') + Math.random(); }));
+  defineProperty(obj, 'prop', computed(function () { return Math.random(); }));
+  defineProperty(obj, 'anotherProp', computed('prop', function () { return get(this, 'prop') + Math.random(); }));
 
   addObserver(obj, 'prop', function () { observerCount++; });
 

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -27,7 +27,7 @@ test("Ember.typeOf", function() {
     var klass       = Ember.Object.extend();
     var instance    = Ember.Object.create();
 
-    equal( Ember.typeOf(klass),     'class',      "class");
-    equal( Ember.typeOf(instance),  'instance',   "instance");
+    equal( typeOf(klass),     'class',      "class");
+    equal( typeOf(instance),  'instance',   "instance");
   }
 });

--- a/packages/ember-metal/tests/watching/isWatching_test.js
+++ b/packages/ember-metal/tests/watching/isWatching_test.js
@@ -1,3 +1,4 @@
+import { computed } from 'ember-metal/computed';
 import { get } from 'ember-metal/property_get';
 import { defineProperty } from "ember-metal/properties";
 import {
@@ -52,7 +53,7 @@ test("isWatching is true for chained observers", function() {
 
 test("isWatching is true for computed properties", function() {
   testObserver(function(obj, key, fn) {
-    defineProperty(obj, 'computed', Ember.computed(fn).property(key));
+    defineProperty(obj, 'computed', computed(fn).property(key));
     get(obj, 'computed');
   }, function(obj, key, fn) {
     defineProperty(obj, 'computed', null);
@@ -61,7 +62,7 @@ test("isWatching is true for computed properties", function() {
 
 test("isWatching is true for chained computed properties", function() {
   testObserver(function(obj, key, fn) {
-    defineProperty(obj, 'computed', Ember.computed(fn).property(key + '.bar'));
+    defineProperty(obj, 'computed', computed(fn).property(key + '.bar'));
     get(obj, 'computed');
   }, function(obj, key, fn) {
     defineProperty(obj, 'computed', null);

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -555,7 +555,7 @@ test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesti
   jQuery(document).trigger('ajaxSend', xhr);
   equal(Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests was incremented');
 
-  Ember.run(function(){
+  run(function(){
     setupForTesting();
   });
   equal(Test.pendingAjaxRequests, 0, 'Ember.Test.pendingAjaxRequests was reset');
@@ -569,7 +569,7 @@ test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesti
 
 test("pendingAjaxRequests is reset by setupForTesting", function() {
   Test.pendingAjaxRequests = 1;
-  Ember.run(function(){
+  run(function(){
     setupForTesting();
   });
   equal(Test.pendingAjaxRequests, 0, 'pendingAjaxRequests is reset');

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -1,3 +1,4 @@
+import EmberSelect from "ember-views/views/select";
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
@@ -12,7 +13,7 @@ QUnit.module("Ember.Select", {
   setup: function() {
     dispatcher = EventDispatcher.create();
     dispatcher.setup();
-    select = Ember.Select.create();
+    select = EmberSelect.create();
   },
 
   teardown: function() {
@@ -369,7 +370,7 @@ test("multiple selections can be set indirectly via bindings and in-place when m
     select.destroy(); // Destroy the existing select
 
     run(function() {
-      select = Ember.Select.extend({
+      select = EmberSelect.extend({
         indirectContent: indirectContent,
         contentBinding: 'indirectContent.controller.content',
         selectionBinding: 'indirectContent.controller.selection',
@@ -649,7 +650,7 @@ test("valueBinding handles 0 as initiated value (issue #2763)", function() {
   run(function() {
     select.destroy(); // Destroy the existing select
 
-    select = Ember.Select.extend({
+    select = EmberSelect.extend({
       content: Ember.A([1,0]),
       indirectData: indirectData,
       valueBinding: 'indirectData.value'


### PR DESCRIPTION
Import dependencies in tests, instead of reaching into global `Ember` 
junk-drawer.
