### PR TITLE
Ensure an undefined inverse of {{unboundIf}} does not error.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -79,7 +79,7 @@ function unboundIfHelper(params, hash, options, env) {
   }
 
   if (!shouldDisplayIfHelperContent(value)) {
-    template = options.inverse;
+    template = options.inverse || EMPTY_TEMPLATE;
   }
 
   return template.render(this, env, options.morph.contextualElement);

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -165,6 +165,24 @@ test("The `unbound if` helper does not update when the value changes", function(
   equal(view.$().text(), 'Yep');
 });
 
+test("The `unboundIf` helper does not update when the value changes", function() {
+  view = EmberView.create({
+    truthy: true,
+    falsey: false,
+    template: compile('{{#unboundIf view.truthy}}Yep{{/unboundIf}}{{#unboundIf view.falsey}}Nope{{/unboundIf}}')
+  });
+
+  appendView(view);
+
+  equal(view.$().text(), 'Yep');
+
+  run(view, 'set', 'truthy', false);
+  equal(view.$().text(), 'Yep');
+
+  run(view, 'set', 'falsey', true);
+  equal(view.$().text(), 'Yep');
+});
+
 test("The `unless` helper updates when the value changes", function() {
   view = EmberView.create({
     conditional: false,


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/9774.
