### PR TITLE
Ensure {{unbound if}} works for undefined values.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -9,6 +9,7 @@ import { bind } from "ember-htmlbars/helpers/binding";
 import { get } from "ember-metal/property_get";
 import { isArray } from "ember-metal/utils";
 import ConditionalStream from "ember-views/streams/conditional_stream";
+import { isStream } from "ember-metal/streams/utils";
 
 function shouldDisplayIfHelperContent(result) {
   var truthy = result && get(result, 'isTruthy');
@@ -74,7 +75,7 @@ function unboundIfHelper(params, hash, options, env) {
   var template = options.template;
   var value = params[0];
 
-  if (params[0].isStream) {
+  if (isStream(params[0])) {
     value = params[0].value();
   }
 

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -72,6 +72,28 @@ test("The `if` helper tests for `isTruthy` if available", function() {
   equal(view.$().text(), 'Yep');
 });
 
+test("The `if` helper does not error on undefined", function() {
+  view = EmberView.create({
+    undefinedValue: undefined,
+    template: compile('{{#if view.undefinedValue}}Yep{{/if}}{{#unbound if view.undefinedValue}}Yep{{/unbound}}')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '');
+});
+
+test("The `unless` helper does not error on undefined", function() {
+  view = EmberView.create({
+    undefinedValue: undefined,
+    template: compile('{{#unless view.undefinedValue}}Yep{{/unless}}{{#unbound unless view.undefinedValue}}Yep{{/unbound}}')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), 'YepYep');
+});
+
 test("The `if` helper does not print the contents for an object proxy without content", function() {
   view = EmberView.create({
     truthy: ObjectProxy.create({ content: {} }),


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/9774.
