### PR TITLE
[Bugfix beta] Ember.assert(message, Ember.Object) should not raise, and ...

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -37,7 +37,7 @@ Ember Debug
 Ember.assert = function(desc, test) {
   var throwAssertion;
 
-  if (typeof test === 'function') {
+  if (Ember.typeOf(test) === 'function') {
     throwAssertion = !test();
   } else {
     throwAssertion = !test;

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -93,3 +93,13 @@ test('Ember.assert does not throw if second argument is truthy', function() {
 
   ok(true, 'assertions were not thrown');
 });
+
+test('Ember.assert does not throw if second argument is an object', function() {
+  expect(1);
+  var Igor = Ember.Object.extend();
+
+  Ember.assert('is truthy', Igor);
+  Ember.assert('is truthy', Igor.create());
+
+  ok(true, 'assertions were not thrown');
+});


### PR DESCRIPTION
...should not try to invoke Ember.Object as if it was a function.
