### PR TITLE
Do not rewrite StringLiteral class attributes.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/attribute.js
+++ b/packages/ember-htmlbars/lib/hooks/attribute.js
@@ -5,13 +5,14 @@
 
 import attrNodeTypeFor from "ember-htmlbars/attr_nodes";
 import EmberError from "ember-metal/error";
+import { isStream } from "ember-metal/streams/utils";
 
 export default function attribute(element, attrName, quoted, view, attrValue, options, env) {
   var isAllowed = true;
 
   if (!Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     for (var i=0, l=attrValue.length; i<l; i++) {
-      if (attrValue[i].isStream) {
+      if (isStream(attrValue[i])) {
         isAllowed = false;
         break;
       }

--- a/packages/ember-htmlbars/lib/plugins/transform-quoted-class.js
+++ b/packages/ember-htmlbars/lib/plugins/transform-quoted-class.js
@@ -50,7 +50,7 @@ export default function(ast) {
       var values = attribute.value;
 
       var eachIndex = 0;
-      var eachValue, currentValue, parts;
+      var eachValue, currentValue, parts, containsNonStringLiterals;
       var i, l;
       while (eachValue = values[eachIndex]) {
         if (eachValue.type === 'StringLiteral') {
@@ -69,6 +69,7 @@ export default function(ast) {
             }
           }
         } else {
+          containsNonStringLiterals = true;
           if (!currentValue) {
             currentValue = buildConcatASTNode();
             quotedValues.push(currentValue);
@@ -77,7 +78,10 @@ export default function(ast) {
         }
         eachIndex++;
       }
-      attribute.value = quotedValues;
+
+      if (containsNonStringLiterals) {
+        attribute.value = quotedValues;
+      }
     }
   });
 


### PR DESCRIPTION
No need to rewrite `<div class="foo bar">`.  We only need to rewrite if we come across any non-StringLiteral portions.

This fixes that.
