### PR TITLE
[FEATURE] ember-testing-checkbox-helpers

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,34 @@ for a detailed explanation.
 
 ## Feature Flags
 
+* `ember-testing-checkbox-helpers`
+
+  Add `check` and `uncheck` test helpers.
+
+  `check`:
+
+  Checks a checkbox. Ensures the presence of the `checked` attribute
+
+  Example:
+
+  ```javascript
+  check('#remember-me').then(function() {
+    // assert something
+  });
+  ```
+
+  `uncheck`:
+
+  Unchecks a checkbox. Ensures the absence of the `checked` attribute
+
+  Example:
+
+  ```javascript
+  uncheck('#remember-me').then(function() {
+    // assert something
+  });
+  ```
+
 * `ember-routing-named-substates`
 
   Add named substates; e.g. when resolving a `loading` or `error`

--- a/features.json
+++ b/features.json
@@ -11,7 +11,8 @@
     "ember-htmlbars-inline-if-helper": true,
     "ember-htmlbars-attribute-syntax": true,
     "ember-routing-transitioning-classes": true,
-    "new-computed-syntax": null
+    "new-computed-syntax": null,
+    "ember-testing-checkbox-helpers": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -1,3 +1,4 @@
+import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import EmberError from "ember-metal/error";
 import run from "ember-metal/run_loop";
@@ -77,6 +78,34 @@ function click(app, selector, context) {
 
   run($el, 'mouseup');
   run($el, 'click');
+
+  return app.testHelpers.wait();
+}
+
+function check(app, selector, context) {
+  var $el = app.testHelpers.findWithAssert(selector, context);
+  var type = $el.prop('type');
+
+  Ember.assert('To check \'' + selector +
+      '\', the input must be a checkbox', type === 'checkbox');
+
+  run(function() {
+    $el.prop('checked', true).change();
+  });
+
+  return app.testHelpers.wait();
+}
+
+function uncheck(app, selector, context) {
+  var $el = app.testHelpers.findWithAssert(selector, context);
+  var type = $el.prop('type');
+
+  Ember.assert('To uncheck \'' + selector +
+      '\', the input must be a checkbox', type === 'checkbox');
+
+  run(function() {
+    $el.prop('checked', false).change();
+  });
 
   return app.testHelpers.wait();
 }
@@ -247,6 +276,43 @@ asyncHelper('visit', visit);
 */
 asyncHelper('click', click);
 
+if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
+  /**
+  * Checks a checkbox. Ensures the presence of the `checked` attribute
+  *
+  * Example:
+  *
+  * ```javascript
+  * check('#remember-me').then(function() {
+  *   // assert something
+  * });
+  * ```
+  *
+  * @method check
+  * @param {String} selector jQuery selector finding an `input[type="checkbox"]`
+  * element on the DOM to check
+  * @return {RSVP.Promise}
+  */
+  asyncHelper('check', check);
+
+  /**
+  * Unchecks a checkbox. Ensures the absence of the `checked` attribute
+  *
+  * Example:
+  *
+  * ```javascript
+  * uncheck('#remember-me').then(function() {
+  *   // assert something
+  * });
+  * ```
+  *
+  * @method check
+  * @param {String} selector jQuery selector finding an `input[type="checkbox"]`
+  * element on the DOM to uncheck
+  * @return {RSVP.Promise}
+  */
+  asyncHelper('uncheck', uncheck);
+}
 /**
 * Simulates a key event, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode
 *

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -56,6 +56,11 @@ function assertHelpers(application, helperContainer, expected) {
   checkHelperPresent('fillIn', expected);
   checkHelperPresent('wait', expected);
   checkHelperPresent('triggerEvent', expected);
+
+  if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
+    checkHelperPresent('check', expected);
+    checkHelperPresent('uncheck', expected);
+  }
 }
 
 function assertNoHelpers(application, helperContainer) {
@@ -541,6 +546,94 @@ test("`fillIn` focuses on the element", function() {
     equal(find('#first').val(), 'current value');
   });
 });
+
+if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
+  test("`check` ensures checkboxes are `checked` state for checkboxes", function() {
+    expect(2);
+    var check, find, visit, andThen;
+
+    App.IndexView = EmberView.extend({
+      template: compile('<input type="checkbox" id="unchecked"><input type="checkbox" id="checked" checked>')
+    });
+
+    run(App, App.advanceReadiness);
+
+    check = App.testHelpers.check;
+    find = App.testHelpers.find;
+    visit = App.testHelpers.visit;
+    andThen = App.testHelpers.andThen;
+
+    visit('/');
+    check('#unchecked');
+    check('#checked');
+    andThen(function() {
+      equal(find('#unchecked').is(":checked"), true, "can check an unchecked checkbox");
+      equal(find('#checked').is(":checked"), true, "can check a checked checkbox");
+    });
+  });
+
+  test("`uncheck` ensures checkboxes are not `checked`", function() {
+    expect(2);
+    var uncheck, find, visit, andThen;
+
+    App.IndexView = EmberView.extend({
+      template: compile('<input type="checkbox" id="unchecked"><input type="checkbox" id="checked" checked>')
+    });
+
+    run(App, App.advanceReadiness);
+
+    uncheck = App.testHelpers.uncheck;
+    find = App.testHelpers.find;
+    visit = App.testHelpers.visit;
+    andThen = App.testHelpers.andThen;
+
+    visit('/');
+    uncheck('#unchecked');
+    uncheck('#checked');
+    andThen(function() {
+      equal(find('#unchecked').is(":checked"), false, "can uncheck an unchecked checkbox");
+      equal(find('#checked').is(":checked"), false, "can uncheck a checked checkbox");
+    });
+  });
+
+  test("`check` asserts the selected inputs are checkboxes", function() {
+    var check, visit;
+
+    App.IndexView = EmberView.extend({
+      template: compile('<input type="text" id="text">')
+    });
+
+    run(App, App.advanceReadiness);
+
+    check = App.testHelpers.check;
+    visit = App.testHelpers.visit;
+
+    visit('/').then(function() {
+      expectAssertion(function() {
+        check('#text');
+      }, /must be a checkbox/);
+    });
+  });
+
+  test("`uncheck` asserts the selected inputs are checkboxes", function() {
+    var visit, uncheck;
+
+    App.IndexView = EmberView.extend({
+      template: compile('<input type="text" id="text">')
+    });
+
+    run(App, App.advanceReadiness);
+
+    visit = App.testHelpers.visit;
+    uncheck = App.testHelpers.uncheck;
+
+    visit('/').then(function() {
+      expectAssertion(function() {
+        uncheck('#text');
+      }, /must be a checkbox/);
+    });
+  });
+}
 
 test("`triggerEvent accepts an optional options hash and context", function() {
   expect(3);


### PR DESCRIPTION
The `fillIn` test helper should be able to handle checking and unchecking an
`<input type="checkbox">`. The helper can infer the input type based on the
provided value. If the value is a boolean, the input is assumed to be a
checkbox. If not, the input is assumed to support text.
