### PR TITLE
Ignore TextNode's in quoted class AST transform.

### DIFF
--- a/packages/ember-htmlbars/lib/plugins/transform-quoted-class.js
+++ b/packages/ember-htmlbars/lib/plugins/transform-quoted-class.js
@@ -53,6 +53,10 @@ export default function(ast) {
       var eachValue, currentValue, parts, containsNonStringLiterals;
       var i, l;
       while (eachValue = values[eachIndex]) {
+        if (eachValue.type === 'TextNode') {
+          return; // TextNode means no dynamic parts
+        }
+
         if (eachValue.type === 'StringLiteral') {
           parts = eachValue.value.split(' ');
           for (i=0,l=parts.length;i<l;i++) {


### PR DESCRIPTION
`TextNode`'s only occur when the attribute has a single non-dynamic value.
