### PR TITLE
[BUGFIX beta] Re-throw synchronous errors during initial transition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#f4bd6a2df221240ed36d140f0c53c036a7ecacad",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
-    "router.js": "https://github.com/tildeio/router.js.git#f7b4b11543222c52d91df861544592a8c1dcea8a",
+    "router.js": "https://github.com/tildeio/router.js.git#9471aaaa28c11907d8fdf8969b70c6a93ad19fd1",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#1c30a1666273ab2a9b134a42bad28c774f9ecdfc"

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -107,6 +107,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     var container = this.container;
     var self = this;
     var initialURL = get(this, 'initialURL');
+    var initialTransition;
 
     // Allow the Location class to cancel the router setup while it refreshes
     // the page
@@ -126,8 +127,10 @@ var EmberRouter = EmberObject.extend(Evented, {
     if (typeof initialURL === "undefined") {
       initialURL = location.getURL();
     }
-
-    this.handleURL(initialURL);
+    initialTransition = this.handleURL(initialURL);
+    if (initialTransition && initialTransition.error) {
+      throw initialTransition.error;
+    }
   },
 
   /**

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3331,3 +3331,76 @@ test("Route#resetController gets fired when changing models and exiting routes",
   Ember.run(router, 'transitionTo', 'out');
   deepEqual(calls, [['reset', 'c'], ['reset', 'a'], ['setup', 'out']]);
 });
+
+test("Exception during initialization of non-initial route is not swallowed", function() {
+  Router.map(function() {
+    this.route('boom');
+  });
+  App.BoomRoute = Ember.Route.extend({
+    init: function() {
+      throw new Error("boom!");
+    }
+  });
+  bootApplication();
+  throws(function(){
+    Ember.run(router, 'transitionTo', 'boom');
+  }, /\bboom\b/);
+});
+
+
+test("Exception during load of non-initial route is not swallowed", function() {
+  Router.map(function() {
+    this.route('boom');
+  });
+  var lookup = container.lookup;
+  container.lookup = function() {
+    if (arguments[0] === 'route:boom') {
+      throw new Error("boom!");
+    }
+    return lookup.apply(this, arguments);
+  };
+  App.BoomRoute = Ember.Route.extend({
+    init: function() {
+      throw new Error("boom!");
+    }
+  });
+  bootApplication();
+  throws(function(){
+    Ember.run(router, 'transitionTo', 'boom');
+  });
+});
+
+test("Exception during initialization of initial route is not swallowed", function() {
+  Router.map(function() {
+    this.route('boom', {path: '/'});
+  });
+  App.BoomRoute = Ember.Route.extend({
+    init: function() {
+      throw new Error("boom!");
+    }
+  });
+  throws(function(){
+    bootApplication();
+  }, /\bboom\b/);
+});
+
+test("Exception during load of initial route is not swallowed", function() {
+  Router.map(function() {
+    this.route('boom', {path: '/'});
+  });
+  var lookup = container.lookup;
+  container.lookup = function() {
+    if (arguments[0] === 'route:boom') {
+      throw new Error("boom!");
+    }
+    return lookup.apply(this, arguments);
+  };
+  App.BoomRoute = Ember.Route.extend({
+    init: function() {
+      throw new Error("boom!");
+    }
+  });
+  throws(function(){
+    bootApplication();
+  }, /\bboom\b/);
+});


### PR DESCRIPTION
This fixes #9542. It depends on https://github.com/tildeio/router.js/pull/139.

I pointed bower at my router.js fork so that CI can run. I will update the PR after router.js merges.
