### PR TITLE
[FEATURE] Ember.View's defaultTemplate to support precompiled templates

### DIFF
--- a/features.json
+++ b/features.json
@@ -1,5 +1,6 @@
 {
   "features": {
+    "default-template-name": null,
     "features-stripped-test": null,
     "ember-routing-named-substates": true,
     "ember-metal-injected-properties": true,

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -68,6 +68,8 @@ function buildHTMLBarsDefaultEnv() {
   return create(_htmlbarsDefaultEnv);
 }
 
+var defaultTemplateNameEnabled = Ember.FEATURES.isEnabled('default-template-name');
+
 /**
 @module ember
 @submodule ember-views
@@ -725,6 +727,15 @@ var View = CoreView.extend({
   templateName: null,
 
   /**
+    The name of the default template to lookup if no template is provided.
+
+    @property defaultTemplateName
+    @type String
+    @default null
+  */
+  defaultTemplateName: null,
+
+  /**
     The name of the layout to lookup if no layout is provided.
 
     By default `Ember.View` will lookup a template with this name in
@@ -749,6 +760,27 @@ var View = CoreView.extend({
   }),
 
   /**
+    The template used to render the view when a template is not specified.
+    This should be a function that accepts an optional context parameter and
+    returns a string of HTML that will be inserted into the DOM relative to
+    its parent view.
+
+    In general, you should set the `defaultTemplateName` property instead of
+    setting the template yourself.
+
+    @property defaultTemplate
+    @type Function
+  */
+  defaultTemplate: defaultTemplateNameEnabled ? computed('defaultTemplateName', function () {
+    var defaultTemplateName = get(this, 'defaultTemplateName');
+    var template = this.templateForName(defaultTemplateName, 'template');
+
+    Ember.assert("You specified the defaultTemplateName " + defaultTemplateName + " for " + this + ", but it did not exist.", !defaultTemplateName || !!template);
+
+    return template;
+  }) : null,
+
+  /**
     The template used to render the view. This should be a function that
     accepts an optional context parameter and returns a string of HTML that
     will be inserted into the DOM relative to its parent view.
@@ -759,7 +791,7 @@ var View = CoreView.extend({
     @property template
     @type Function
   */
-  template: computed('templateName', function(key, value) {
+  template: computed('templateName', 'defaultTemplate', function(key, value) {
     if (value !== undefined) { return value; }
 
     var templateName = get(this, 'templateName');
@@ -807,7 +839,7 @@ var View = CoreView.extend({
     @property layout
     @type Function
   */
-  layout: computed(function(key) {
+  layout: computed(function() {
     var layoutName = get(this, 'layoutName');
     var layout = this.templateForName(layoutName, 'layout');
 

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -105,6 +105,52 @@ test("should fall back to defaultTemplate if neither template nor templateName a
   equal("template was called for Tom DAAAALE", view.$('#twas-called').text(), "the named template was called with the view as the data source");
 });
 
+if (Ember.FEATURES.isEnabled("default-template-name")) {
+  test("should fall back to defaultTemplate if defaultTemplateName is provided when neither template nor templateName are provided", function() {
+    var View;
+
+    registry.register("template:testTemplate", function(dataSource) {
+      return "<h1 id='twas-called'>defaultTemplate was called for " + get(dataSource, 'personName') + "</h1>";
+    });
+
+    View = EmberView.extend({
+      container: container,
+      defaultTemplateName: "testTemplate"
+    });
+
+    view = View.create({
+      context: {
+        personName: "Tom DAAAALE"
+      }
+    });
+
+    run(function() {
+      view.createElement();
+    });
+
+    equal("defaultTemplate was called for Tom DAAAALE", view.$('#twas-called').text(), "the named template was called with the view as the data source");
+  });
+
+  test("should not use defaultTemplateName if template is provided", function() {
+    var View;
+
+    registry.register("template:bar", function() { return "bar"; });
+
+    View = EmberView.extend({
+      container: container,
+      defaultTemplateName: "bar",
+      template:  function() { return "foo"; }
+    });
+
+    view = View.create();
+    run(function() {
+      view.createElement();
+    });
+
+    equal("foo", view.$().text(), "default template was not printed");
+  });
+}
+
 test("should not use defaultTemplate if template is provided", function() {
   var View;
 


### PR DESCRIPTION
Right now, `defaultTemplate` forces us from being able to precompile all of our templates.  This PR optionally adds the ability to reference the template name by string and resolves using `templateForName`

I'm open to suggestions, such as keeping with convention and adding something like `defaultTemplateName`.  

I also will add tests if there is interest in this feature.
