### PR TITLE
[BUGFIX canary] This fixes the output for not escaping `{{{x}}}`

### DIFF
--- a/packages/ember-htmlbars/lib/utils/string.js
+++ b/packages/ember-htmlbars/lib/utils/string.js
@@ -22,6 +22,10 @@ import EmberStringUtils from "ember-runtime/system/string";
   @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
 */
 function htmlSafe(str) {
+  if (str === null || str === undefined) {
+    return "";
+  }
+
   if (typeof str !== 'string') {
     str = ''+str;
   }

--- a/packages/ember-htmlbars/tests/utils/string_test.js
+++ b/packages/ember-htmlbars/tests/utils/string_test.js
@@ -8,3 +8,11 @@ test("htmlSafe should return an instance of SafeString", function() {
 
   ok(safeString instanceof SafeString, "should return SafeString");
 });
+
+test("htmlSafe should return an empty string for null", function() {
+  equal(htmlSafe(null).toString(), "", "should return an empty string");
+});
+
+test("htmlSafe should return an empty string for undefined", function() {
+  equal(htmlSafe().toString(), "", "should return an empty string");
+});


### PR DESCRIPTION
This version of the fix is for canary, where things have been moved
around a bit. I'll submit a fix for Beta/Release too which is
essentially the same only in a different place.
