### PR TITLE
[BUGFIX beta] Fixes issues with unescaped strings `{{{x}}}`

### DIFF
--- a/packages/ember-handlebars/lib/string.js
+++ b/packages/ember-handlebars/lib/string.js
@@ -16,6 +16,10 @@ import EmberStringUtils from "ember-runtime/system/string";
   @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
 */
 function htmlSafe(str) {
+  if (str === null || str === undefined) {
+    return "";
+  }
+
   if (typeof str !== 'string') {
     str = ''+str;
   }

--- a/packages/ember-handlebars/tests/handlebars_test.js
+++ b/packages/ember-handlebars/tests/handlebars_test.js
@@ -316,6 +316,14 @@ test("htmlSafe should return an instance of Handlebars.SafeString", function() {
   ok(safeString instanceof Handlebars.SafeString, "should return SafeString");
 });
 
+test("htmlSafe should return an empty string for null", function() {
+  equal(htmlSafe(null).toString(), "", "should return an empty string");
+});
+
+test("htmlSafe should return an empty string for undefined", function() {
+  equal(htmlSafe().toString(), "", "should return an empty string");
+});
+
 test("should escape HTML in normal mustaches", function() {
   view = EmberView.create({
     template: EmberHandlebars.compile('{{view.output}}'),


### PR DESCRIPTION
This Fixes #9805 in stable and should work in beta as well.
There is a separate fix for canary that has also been submitted
where the structure has changed for HTMLBars.
