### PR TITLE
[BUGFIX] Ensure view bindings flush via runloop

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -42,7 +42,7 @@ function makeBindings(hash, options, view) {
       }
     } else {
       if (isStream(value) && prop !== 'id') {
-        hash[prop + 'Binding'] = value;
+        hash[prop + 'Binding'] = view._getBindingForStream(value);
         delete hash[prop];
       }
     }

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -289,6 +289,88 @@ test("mixing old and new styles of property binding fires a warning, treats valu
   Ember.warn = oldWarn;
 });
 
+test('"Binding"-suffixed bindings are runloop-synchronized', function() {
+  expect(5);
+
+  var subview;
+
+  var Subview = EmberView.extend({
+    init: function() {
+      subview = this;
+      return this._super();
+    },
+    template: compile('<div class="color">{{view.color}}</div>')
+  });
+
+  var View = EmberView.extend({
+    color: "mauve",
+    Subview: Subview,
+    template: compile('<h1>{{view view.Subview colorBinding="view.color"}}</h1>')
+  });
+
+  view = View.create();
+  runAppend(view);
+
+  equal(view.$('h1 .color').text(), 'mauve', 'renders bound value');
+
+  run(function() {
+    run.schedule('sync', function() {
+      equal(get(subview, 'color'), 'mauve', 'bound property is correctly scheduled into the sync queue');
+    });
+
+    view.set('color', 'persian rose');
+
+    run.schedule('sync', function() {
+      equal(get(subview, 'color'), 'persian rose', 'bound property is correctly scheduled into the sync queue');
+    });
+
+    equal(get(subview, 'color'), 'mauve', 'bound property does not update immediately');
+  });
+
+  equal(get(subview, 'color'), 'persian rose', 'bound property is updated after runloop flush');
+});
+
+test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
+  expect(5);
+
+  var subview;
+
+  var Subview = EmberView.extend({
+    init: function() {
+      subview = this;
+      return this._super();
+    },
+    template: compile('<div class="color">{{view.color}}</div>')
+  });
+
+  var View = EmberView.extend({
+    color: "mauve",
+    Subview: Subview,
+    template: compile('<h1>{{view view.Subview color=view.color}}</h1>')
+  });
+
+  view = View.create();
+  runAppend(view);
+
+  equal(view.$('h1 .color').text(), 'mauve', 'renders bound value');
+
+  run(function() {
+    run.schedule('sync', function() {
+      equal(get(subview, 'color'), 'mauve', 'bound property is correctly scheduled into the sync queue');
+    });
+
+    view.set('color', 'persian rose');
+
+    run.schedule('sync', function() {
+      equal(get(subview, 'color'), 'persian rose', 'bound property is correctly scheduled into the sync queue');
+    });
+
+    equal(get(subview, 'color'), 'mauve', 'bound property does not update immediately');
+  });
+
+  equal(get(subview, 'color'), 'persian rose', 'bound property is updated after runloop flush');
+});
+
 test("allows you to pass attributes that will be assigned to the class instance, like class=\"foo\"", function() {
   expect(4);
 


### PR DESCRIPTION
View and component bindings that didn't use the "Binding"-suffix were synching immediately, which caused some regressions in Skylight. This change causes all bindings to be flushed during the runloop, and also adds a test to verify the same behavior for "Binding"-suffixed bindings to prevent regressions.
