### PR TITLE
[BUGFIX beta] Route.send is unit testable

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -26,6 +26,8 @@ import ActionHandler from "ember-runtime/mixins/action_handler";
 import generateController from "ember-routing/system/generate_controller";
 import { stashParamNames } from "ember-routing/utils";
 
+var slice = Array.prototype.slice;
+
 function K() { return this; }
 
 /**
@@ -990,7 +992,16 @@ var Route = EmberObject.extend(ActionHandler, {
     @param {...*} args
   */
   send: function() {
-    return this.router.send.apply(this.router, arguments);
+    if (this.router || !Ember.testing) {
+      this.router.send.apply(this.router, arguments);
+    } else {
+      var name = arguments[0];
+      var args = slice.call(arguments, 1);
+      var action = this._actions[name];
+      if (action) {
+        return this._actions[name].apply(this, args);
+      }
+    }
   },
 
   /**

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -146,6 +146,31 @@ test("modelFor doesn't require the router", function() {
   equal(route.modelFor('foo'), foo);
 });
 
+
+test(".send just calls an action if the router is absent", function() {
+  expect(7);
+  var route = Ember.Route.createWithMixins({
+    actions: {
+      returnsTrue: function(foo, bar) {
+        equal(foo, 1);
+        equal(bar, 2);
+        equal(this, route);
+        return true;
+      },
+
+      returnsFalse: function() {
+        ok(true, "returnsFalse was called");
+        return false;
+      }
+    }
+  });
+
+  equal(true, route.send('returnsTrue', 1, 2));
+  equal(false, route.send('returnsFalse'));
+  equal(undefined, route.send('nonexistent', 1, 2, 3));
+});
+
+
 QUnit.module("Ember.Route serialize", {
   setup: createRoute,
   teardown: cleanupRoute


### PR DESCRIPTION
this.router doesn’t exist when unit testing Ember.Route, and hence .send
breaks all the time; this change allows you to unit test routes and their
actions even when this.router is absent.

/cc @rwjblue
