### PR TITLE
Make HTMLBars helpers View local.

### DIFF
--- a/packages/ember-htmlbars/lib/ext/view.js
+++ b/packages/ember-htmlbars/lib/ext/view.js
@@ -1,0 +1,7 @@
+import EmberView from "ember-views/views/view";
+import helpers from "ember-htmlbars/helpers";
+
+EmberView.reopen({
+  mergedProperties: ['helpers'],
+  helpers: helpers
+});

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -51,6 +51,9 @@ import "ember-htmlbars/system/bootstrap";
 // Ember.Handlebars global if htmlbars is enabled
 import "ember-htmlbars/compat";
 
+// add Ember.View.prototype.helpers
+import "ember-htmlbars/ext/view";
+
 registerHelper('bindHelper', bindHelper);
 registerHelper('bind', bindHelper);
 registerHelper('view', viewHelper);

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -27,9 +27,13 @@ export var ISNT_HELPER_CACHE = new Cache(1000, function(key) {
   @param {String} name the name of the helper to lookup
   @return {Handlebars Helper}
 */
-export default function lookupHelper(name, view, env) {
-  if (env.helpers[name]) {
-    return env.helpers[name];
+export default function lookupHelper(name, view) {
+  var helper;
+  if (view.helpers) {
+    helper = view.helpers[name];
+    if (helper) {
+      return helper;
+    }
   }
 
   var container = view.container;
@@ -39,7 +43,7 @@ export default function lookupHelper(name, view, env) {
   }
 
   var helperName = 'helper:' + name;
-  var helper = container.lookup(helperName);
+  helper = container.lookup(helperName);
   if (!helper) {
     var componentLookup = container.lookup('component-lookup:main');
     Ember.assert("Could not find 'component-lookup:main' on the provided container," +

--- a/packages/ember-htmlbars/tests/integration/view_local_helpers_test.js
+++ b/packages/ember-htmlbars/tests/integration/view_local_helpers_test.js
@@ -1,0 +1,75 @@
+import Ember from 'ember-metal/core';
+import EmberView from 'ember-views/views/view';
+import EmberHandlebars from 'ember-handlebars';
+import htmlbarsCompile from 'ember-htmlbars/system/compile';
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var view, view1, view2;
+var compile;
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  compile = htmlbarsCompile;
+} else {
+  compile = EmberHandlebars.compile;
+}
+
+QUnit.module('ember-htmlbars: view local helper integration', {
+  teardown: function() {
+    runDestroy(view);
+    runDestroy(view1);
+    runDestroy(view2);
+    view = view1 = view2 = null;
+  }
+});
+
+test('are invoked', function() {
+  expect(2);
+
+  view = EmberView.create({
+    helpers: {
+      blah: {
+        helperFunction: function(params, hash, options, env) {
+          ok(true, 'blah helper was looked up');
+
+          return 'derp! ' + params[0];
+        },
+        isHTMLBars: true
+      }
+    },
+
+    template: compile('{{blah "hi"}}')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), 'derp! hi', 'local helper is used!');
+});
+
+test('are not shared', function() {
+  expect(3);
+
+  view1 = EmberView.create({
+    helpers: {
+      blah: {
+        helperFunction: function(params, hash, options, env) {
+          ok(true, 'blah helper was looked up');
+
+          return 'derp! ' + params[0];
+        },
+        isHTMLBars: true
+      }
+    },
+
+    template: compile('{{blah "hi"}}')
+  });
+
+  view2 = EmberView.create({
+    template: compile('{{blah}}')
+  });
+
+  runAppend(view1);
+  equal(view1.$().text(), 'derp! hi', 'local helper is used!');
+
+  runAppend(view2);
+  equal(view2.$().text(), '', 'local helper is used!');
+});

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -3,7 +3,7 @@ import ComponentLookup from "ember-views/component_lookup";
 import Container from "container";
 import Component from "ember-views/views/component";
 
-function generateEnv(helpers) {
+function generateView(helpers) {
   return {
     helpers: (helpers ? helpers : {})
   };
@@ -20,28 +20,27 @@ function generateContainer() {
 
 QUnit.module('ember-htmlbars: lookupHelper hook');
 
-test('looks for helpers in the provided `env.helpers`', function() {
-  var env = generateEnv({
+test('looks for helpers in the provided `view.helpers`', function() {
+  var view = generateView({
     'flubarb': function() { }
   });
 
-  var actual = lookupHelper('flubarb', null, env);
+  var actual = lookupHelper('flubarb', view);
 
-  equal(actual, env.helpers.flubarb, 'helpers are looked up on env');
+  equal(actual, view.helpers.flubarb, 'helpers are looked up on env');
 });
 
-test('returns undefined if no container exists (and helper is not found in env)', function() {
-  var env = generateEnv();
-  var view = {};
+test('returns undefined if no container exists (and helper is not found in view)', function() {
+  var view = generateView();
 
-  var actual = lookupHelper('flubarb', view, env);
+  var actual = lookupHelper('flubarb', view);
 
   equal(actual, undefined, 'does not blow up if view does not have a container');
 });
 
-test('does not lookup in the container if the name does not contain a dash (and helper is not found in env)', function() {
-  var env = generateEnv();
+test('does not lookup in the container if the name does not contain a dash (and helper is not found in view)', function() {
   var view = {
+    helpers: {},
     container: {
       lookup: function() {
         ok(false, 'should not lookup in the container');
@@ -49,31 +48,31 @@ test('does not lookup in the container if the name does not contain a dash (and 
     }
   };
 
-  var actual = lookupHelper('flubarb', view, env);
+  var actual = lookupHelper('flubarb', view);
 
   equal(actual, undefined, 'does not blow up if view does not have a container');
 });
 
-test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
-  var env = generateEnv();
+test('does a lookup in the container if the name contains a dash (and helper is not found in view)', function() {
   var view = {
-    container: generateContainer()
+    container: generateContainer(),
+    helpers: {}
   };
 
   function someName() {}
   someName.isHTMLBars = true;
   view.container.register('helper:some-name', someName);
 
-  var actual = lookupHelper('some-name', view, env);
+  var actual = lookupHelper('some-name', view);
 
   equal(actual, someName, 'does not wrap provided function if `isHTMLBars` is truthy');
 });
 
 test('wraps helper from container in a Handlebars compat helper', function() {
   expect(2);
-  var env = generateEnv();
   var view = {
-    container: generateContainer()
+    container: generateContainer(),
+    helpers: {}
   };
   var called;
 
@@ -82,7 +81,7 @@ test('wraps helper from container in a Handlebars compat helper', function() {
   }
   view.container.register('helper:some-name', someName);
 
-  var actual = lookupHelper('some-name', view, env);
+  var actual = lookupHelper('some-name', view);
 
   ok(actual.isHTMLBars, 'wraps provided helper in an HTMLBars compatible helper');
 
@@ -98,27 +97,37 @@ test('wraps helper from container in a Handlebars compat helper', function() {
 });
 
 test('asserts if component-lookup:main cannot be found', function() {
-  var env = generateEnv();
   var view = {
-    container: generateContainer()
+    container: generateContainer(),
+    helpers: { }
   };
 
   view.container.unregister('component-lookup:main');
 
   expectAssertion(function() {
-    lookupHelper('some-name', view, env);
+    lookupHelper('some-name', view);
   }, 'Could not find \'component-lookup:main\' on the provided container, which is necessary for performing component lookups');
 });
 
 test('registers a helper in the container if component is found', function() {
-  var env = generateEnv();
   var view = {
-    container: generateContainer()
+    container: generateContainer(),
+    helpers: {}
   };
 
   view.container.register('component:some-name', Component);
 
-  lookupHelper('some-name', view, env);
+  lookupHelper('some-name', view);
 
   ok(view.container.lookup('helper:some-name'), 'new helper was registered');
+});
+
+test('does not error if view.helpers is not present', function() {
+  var view = {
+    container: generateContainer()
+  };
+
+  var actual = lookupHelper('some-name', view);
+
+  equal(actual, undefined, 'no helper was found');
 });


### PR DESCRIPTION
Allows having specific helpers per View, and avoids poluting global space with local helpers.
