### PR TITLE
Enable HTMLBars & Block Params.

### DIFF
--- a/features.json
+++ b/features.json
@@ -16,8 +16,8 @@
     "mandatory-setter": "development-only",
     "ember-routing-fire-activate-deactivate-events": true,
     "ember-testing-pause-test": true,
-    "ember-htmlbars": null,
-    "ember-htmlbars-block-params": null,
+    "ember-htmlbars": true,
+    "ember-htmlbars-block-params": true,
     "ember-htmlbars-component-generation": null,
     "ember-htmlbars-inline-if-helper": null,
     "ember-htmlbars-attribute-syntax": null

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -67,8 +67,6 @@ export function handlebarsHelper(name, value) {
   Ember.assert("You tried to register a component named '" + name +
                "', but component names must include a '-'", !Component.detect(value) || name.match(/-/));
 
-  Ember.deprecate('Usage of `Ember.Handlebars.helper` is deprecated. Please use `Ember.HTMLBars.helper`.');
-
   if (View.detect(value)) {
     helpers[name] = makeViewHelper(value);
   } else {

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -41,8 +41,6 @@ import {
   @deprecated
 */
 export default function makeBoundHelper(fn, compatMode) {
-  Ember.deprecate('`Ember.Handlebars.makeBoundHelper` has been deprecated in favor of `Ember.HTMLBars.makeBoundHelper`.');
-
   var dependentKeys = [];
   for (var i = 1; i < arguments.length; i++) {
     dependentKeys.push(arguments[i]);

--- a/packages/ember-htmlbars/lib/helpers.js
+++ b/packages/ember-htmlbars/lib/helpers.js
@@ -3,6 +3,10 @@
 @submodule ember-htmlbars
 */
 
+/**
+ @private
+ @property helpers
+*/
 var helpers = { };
 
 /**
@@ -63,6 +67,7 @@ import makeBoundHelper from "ember-htmlbars/system/make_bound_helper";
   Options in the helper will be passed to the view in exactly the same
   manner as with the `view` helper.
 
+  @private
   @method helper
   @for Ember.HTMLBars
   @param {String} name

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -52,6 +52,7 @@ import {
     Assuming that `repeatCount` resolved to 2, the bound helper would receive `["foo"]` as its first argument,
     and { count: 2 } as its second.
 
+  @private
   @method makeBoundHelper
   @for Ember.HTMLBars
   @param {Function} function

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -35,9 +35,8 @@ function registerRepeatHelper() {
 }
 
 function expectDeprecationInHTMLBars() {
-  if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-    expectDeprecation('`Ember.Handlebars.makeBoundHelper` has been deprecated in favor of `Ember.HTMLBars.makeBoundHelper`.');
-  }
+  // leave this empty function as a place holder to
+  // enable a deprecation notice
 }
 
 QUnit.module("ember-htmlbars: makeBoundHelper", {

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -38,9 +38,8 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 }
 
 function expectDeprecationInHTMLBars() {
-  if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-    expectDeprecation('`Ember.Handlebars.makeBoundHelper` has been deprecated in favor of `Ember.HTMLBars.makeBoundHelper`.');
-  }
+  // leave this as an empty function until we are ready to use it
+  // to enforce deprecation notice for old Handlebars versions
 }
 
 

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -66,10 +66,6 @@ test("Unbound dashed helpers registered on the container can be late-invoked", f
 
   // need to make `makeBoundHelper` for HTMLBars
 test("Bound helpers registered on the container can be late-invoked", function() {
-  if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-    expectDeprecation('`Ember.Handlebars.makeBoundHelper` has been deprecated in favor of `Ember.HTMLBars.makeBoundHelper`.');
-  }
-
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-reverse}} {{x-reverse foo}}</div>");
 
   boot(function() {


### PR DESCRIPTION
All `Ember.HTMLBars` API surface is private for 1.10, they are still somewhat experimental.
