### PR TITLE
Cleanup Gemfile to remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,5 @@
 source "https://rubygems.org"
 
-if ENV['HANDLEBARS_PATH']
-  gem "handlebars-source", :path => File.join(ENV['HANDLEBARS_PATH'], "dist", "components")
-end
-
-gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
-gem "ember-dev", :git => "https://github.com/emberjs/ember-dev.git", :branch => "master"
-
 # Require the specific version of handlebars-source that
 # we'll be precompiling and performing tests with.
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,3 @@
-GIT
-  remote: https://github.com/emberjs/ember-dev.git
-  revision: 662016f838fffec5520ad1cfb80a78bf40b9aa30
-  branch: master
-  specs:
-    ember-dev (0.1)
-      aws-sdk
-      colored
-      execjs
-      grit
-      kicker
-      puma
-      rack
-      rake-pipeline (~> 0.8.0)
-      rake-pipeline-web-filters (~> 0.7.0)
-      uglifier
-
-GIT
-  remote: https://github.com/livingsocial/rake-pipeline.git
-  revision: a75d96fbadcc659a35a0ae59212e0bc60b58cc54
-  specs:
-    rake-pipeline (0.8.0)
-      json
-      rake (~> 10.1.0)
-      thor
-
 PATH
   remote: .
   specs:
@@ -33,55 +7,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.35.0)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
-    colored (1.2)
-    diff-lcs (1.2.5)
-    execjs (2.0.2)
-    ffi (1.9.3)
-    grit (2.5.0)
-      diff-lcs (~> 1.1)
-      mime-types (~> 1.15)
-      posix-spawn (~> 0.3.6)
     handlebars-source (2.0.0)
-    json (1.8.1)
-    kicker (3.0.0)
-      listen (~> 1.3.0)
-      notify (~> 0.5.2)
-    listen (1.3.1)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-      rb-kqueue (>= 0.2)
-    mime-types (1.25.1)
-    mini_portile (0.5.2)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
-    notify (0.5.2)
-    posix-spawn (0.3.8)
-    puma (2.8.0)
-      rack (>= 1.1, < 2.0)
-    rack (1.5.2)
-    rake (10.1.1)
-    rake-pipeline-web-filters (0.7.0)
-      rack
-      rake-pipeline (~> 0.6)
-    rb-fsevent (0.9.4)
-    rb-inotify (0.9.3)
-      ffi (>= 0.5.0)
-    rb-kqueue (0.2.2)
-      ffi (>= 0.5.0)
-    thor (0.18.1)
-    uglifier (2.4.0)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
-    uuidtools (2.1.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  ember-dev!
   ember-source!
-  rake-pipeline!


### PR DESCRIPTION
Currently, Ember.js is built by Broccoli.
