### PR TITLE
[BUGFIX master] defeatureify doesn’t currently support !isEnabled.

### DIFF
--- a/packages/ember-handlebars/lib/loader.js
+++ b/packages/ember-handlebars/lib/loader.js
@@ -78,7 +78,8 @@ function registerComponentLookup(container) {
 */
 
 onLoad('Ember.Application', function(Application) {
-  if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+  } else {
 
   Application.initializer({
     name: 'domTemplates',


### PR DESCRIPTION
The current canary build is broken because the domTemplates initializer is defined twice when not enabling HTMLBars because it is not being stripped from the build properly.

This changes the logic to be removed by defeatureify properly
