### PR TITLE
Loader perf/fixes

### DIFF
--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -29,29 +29,30 @@ var define, requireModule, require, requirejs, Ember;
         if (deps[i] === 'exports') {
           reified.push(exports = {});
         } else {
-          reified.push(requireModule(resolve(deps[i])));
+          reified.push(requireModule(resolve(deps[i], name)));
         }
       }
 
       var value = callback.apply(this, reified);
       return seen[name] = exports || value;
-
-      function resolve(child) {
-        if (child.charAt(0) !== '.') { return child; }
-        var parts = child.split("/");
-        var parentBase = name.split("/").slice(0, -1);
-
-        for (var i=0, l=parts.length; i<l; i++) {
-          var part = parts[i];
-
-          if (part === '..') { parentBase.pop(); }
-          else if (part === '.') { continue; }
-          else { parentBase.push(part); }
-        }
-
-        return parentBase.join("/");
-      }
     };
+
+    function resolve(child, name) {
+      if (child.charAt(0) !== '.') { return child; }
+      var parts = child.split("/");
+      var parentBase = name.split("/").slice(0, -1);
+
+      for (var i=0, l=parts.length; i<l; i++) {
+        var part = parts[i];
+
+        if (part === '..') { parentBase.pop(); }
+        else if (part === '.') { continue; }
+        else { parentBase.push(part); }
+      }
+
+      return parentBase.join("/");
+    }
+
     requirejs._eak_seen = registry;
 
     Ember.__loader = {define: define, require: require, registry: registry};

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -21,7 +21,7 @@ var define, requireModule, require, requirejs, Ember;
       seen[name] = {};
 
       if (!registry[name]) {
-        throw new Error("Could not find module " + name);
+        throw new Error('Could not find module ' + name);
       }
 
       var mod = registry[name];
@@ -45,9 +45,11 @@ var define, requireModule, require, requirejs, Ember;
     };
 
     function resolve(child, name) {
-      if (child.charAt(0) !== '.') { return child; }
-      var parts = child.split("/");
-      var parentBase = name.split("/").slice(0, -1);
+      if (child.charAt(0) !== '.') {
+        return child;
+      }
+      var parts = child.split('/');
+      var parentBase = name.split('/').slice(0, -1);
 
       for (var i=0, l=parts.length; i<l; i++) {
         var part = parts[i];
@@ -57,12 +59,16 @@ var define, requireModule, require, requirejs, Ember;
         else { parentBase.push(part); }
       }
 
-      return parentBase.join("/");
+      return parentBase.join('/');
     }
 
     requirejs._eak_seen = registry;
 
-    Ember.__loader = {define: define, require: require, registry: registry};
+    Ember.__loader = {
+      define: define,
+      require: require,
+      registry: registry
+    };
   } else {
     define = Ember.__loader.define;
     requirejs = require = requireModule = Ember.__loader.require;

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -24,8 +24,9 @@ var define, requireModule, require, requirejs, Ember;
       var callback = mod.callback;
       var reified = [];
       var exports;
+      var length = deps.length;
 
-      for (var i=0, l=deps.length; i<l; i++) {
+      for (var i=0; i<length; i++) {
         if (deps[i] === 'exports') {
           reified.push(exports = {});
         } else {
@@ -33,7 +34,8 @@ var define, requireModule, require, requirejs, Ember;
         }
       }
 
-      var value = callback.apply(this, reified);
+      var value = length === 0 ? callback.call(this) : callback.apply(this, reified);
+
       return seen[name] = exports || value;
     };
 

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -3,6 +3,7 @@ var define, requireModule, require, requirejs, Ember;
 (function() {
   Ember = this.Ember = this.Ember || {};
   if (typeof Ember === 'undefined') { Ember = {}; };
+  function UNDEFINED() { }
 
   if (typeof Ember.__loader === 'undefined') {
     var registry = {}, seen = {};
@@ -12,7 +13,11 @@ var define, requireModule, require, requirejs, Ember;
     };
 
     requirejs = require = requireModule = function(name) {
-      if (seen.hasOwnProperty(name)) { return seen[name]; }
+      var s = seen[name];
+
+      if (s !== undefined) { return seen[name]; }
+      if (s === UNDEFINED) { return undefined;  }
+
       seen[name] = {};
 
       if (!registry[name]) {
@@ -36,7 +41,7 @@ var define, requireModule, require, requirejs, Ember;
 
       var value = length === 0 ? callback.call(this) : callback.apply(this, reified);
 
-      return seen[name] = exports || value;
+      return seen[name] = exports || (value === undefined ? UNDEFINED : value);
     };
 
     function resolve(child, name) {


### PR DESCRIPTION
- [x] fix some random global failure
- [x] don't re-allocate the resolve function for each requireModule
- [x] more accurate numbers

seems to be a smallish improvement on android 4.4.4 (maybe more on older)
So android is like 5->10x slower then everything else... include iOS 8, those other browser all seem to be about the same. But android is slightly better.

before:

```
685ms - 736ms cold, 510 - 680ms hot
```

after:

```
 585 - 700ms cold, 425 - 510ms hot
```
