### PR TITLE
Remove ember-template-compiler.js from S3 deployment.

### DIFF
--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -3,7 +3,6 @@ fileMap = function(revision,tag,date) {
     "ember.js":                   fileObject("ember",                   ".js",   "text/javascript",  revision, tag, date),
     "ember.debug.js":             fileObject("ember.debug",             ".js",   "text/javascript",  revision, tag, date),
     "ember-tests.js":             fileObject("ember-tests",             ".js",   "text/javascript",  revision, tag, date),
-    "ember-template-compiler.js": fileObject("ember-template-compiler", ".js",   "text/javascript",  revision, tag, date),
     "ember-runtime.js":           fileObject("ember-runtime",           ".js",   "text/javascript",  revision, tag, date),
     "ember.min.js":               fileObject("ember.min",               ".js",   "text/javascript",  revision, tag, date),
     "ember.prod.js":              fileObject("ember.prod",              ".js",   "text/javascript",  revision, tag, date),


### PR DESCRIPTION
This will come back in a future refactor, but for now we are no longer bundling ember-template-compiler (from ember-handlebars-compiler package).
