### PR TITLE
[BUGFIX beta] Deprecate passing non-Array enumerables to addObjects() and pushObjects()

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -19,7 +19,7 @@ var EMPTY = [];
 //
 
 import { get } from "ember-metal/property_get";
-import { isArray } from "ember-metal/utils";
+import { isArray, typeOf } from "ember-metal/utils";
 import EmberError from "ember-metal/error";
 import {
   Mixin,
@@ -163,7 +163,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
   },
 
   /**
-    Add the objects in the passed numerable to the end of the array. Defers
+    Add the objects in the passed array to the end of the array. Defers
     notifying observers of the change until all objects are added.
 
     ```javascript
@@ -172,13 +172,14 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     ```
 
     @method pushObjects
-    @param {Ember.Enumerable} objects the objects to add
+    @param {Array} objects the objects to add
     @return {Ember.Array} receiver
   */
   pushObjects: function(objects) {
     if (!(Enumerable.detect(objects) || isArray(objects))) {
       throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
     }
+    Ember.deprecate("Passing an array-like object that is not a native Array to pushObjects() is deprecated. Please convert to a native Array, e.g. by calling .toArray().", typeOf(objects) === 'array');
     this.replace(get(this, 'length'), 0, objects);
     return this;
   },
@@ -255,7 +256,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     ```
 
     @method unshiftObjects
-    @param {Ember.Enumerable} objects the objects to add
+    @param {Array} objects the objects to add
     @return {Ember.Array} receiver
   */
   unshiftObjects: function(objects) {
@@ -289,7 +290,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     ```
 
     @method setObjects
-    @param {Ember.Array} objects array whose content will be used for replacing
+    @param {Array} objects array whose content will be used for replacing
         the content of the receiver
     @return {Ember.Array} receiver with the new content
    */

--- a/packages/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -1,4 +1,5 @@
 import { forEach } from "ember-metal/enumerable_utils";
+import { isArray, typeOf } from "ember-metal/utils";
 import Enumerable from "ember-runtime/mixins/enumerable";
 import {Mixin, required} from "ember-metal/mixin";
 import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_events";
@@ -66,13 +67,17 @@ export default Mixin.create(Enumerable, {
   addObject: required(Function),
 
   /**
-    Adds each object in the passed enumerable to the receiver.
+    Adds each object in the passed array to the receiver.
 
     @method addObjects
-    @param {Ember.Enumerable} objects the objects to add.
+    @param {Array} objects the objects to add.
     @return {Object} receiver
   */
   addObjects: function(objects) {
+    if (!(Enumerable.detect(objects) || isArray(objects))) {
+      throw new TypeError("Must pass Ember.Enumerable to Ember.MutableEnumerable#addObjects");
+    }
+    Ember.deprecate("Passing an array-like object that is not a native Array to addObjects() is deprecated. Please convert to a native Array, e.g. by calling .toArray().", typeOf(objects) === 'array');
     beginPropertyChanges(this);
     forEach(objects, function(obj) { this.addObject(obj); }, this);
     endPropertyChanges(this);
@@ -97,10 +102,10 @@ export default Mixin.create(Enumerable, {
 
 
   /**
-    Removes each object in the passed enumerable from the receiver.
+    Removes each object in the passed array from the receiver.
 
     @method removeObjects
-    @param {Ember.Enumerable} objects the objects to remove
+    @param {Array} objects the objects to remove
     @return {Object} receiver
   */
   removeObjects: function(objects) {

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -2,7 +2,8 @@ import Ember from "ember-metal/core"; // Ember.assert
 import { get } from "ember-metal/property_get";
 import {
   isArray,
-  apply
+  apply,
+  typeOf
 } from "ember-metal/utils";
 import { computed } from "ember-metal/computed";
 import {
@@ -328,6 +329,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     if (!(Enumerable.detect(objects) || isArray(objects))) {
       throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
     }
+    Ember.deprecate("Passing an array-like object that is not a native Array to pushObjects() is deprecated. Please convert to a native Array, e.g. by calling .toArray().", typeOf(objects) === 'array');
     this._replace(get(this, 'length'), 0, objects);
     return this;
   },

--- a/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
@@ -1,4 +1,6 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+import EmberObject from 'ember-runtime/system/object';
+import Enumerable from 'ember-runtime/mixins/enumerable';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -10,6 +12,33 @@ suite.test("should raise exception if not Ember.Enumerable is passed to pushObje
   raises(function() {
     obj.pushObjects( "string" );
   });
+});
+
+suite.test('Pushing objects from an Array is not deprecated', function() {
+  expectNoDeprecation();
+  var obj = this.newObject(this.newFixture(3));
+  var items = Ember.A(this.newFixture(1));
+
+  obj.pushObjects(items);
+});
+
+suite.test('Pushing objects from non-Array Enumerable is deprecated', function() {
+  var obj = this.newObject(this.newFixture(3));
+  var items = EmberObject.extend(Enumerable, {
+    elt: this.newFixture(1)[0],
+
+    length: 1,
+    nextObject: function(idx) {
+      return idx === 0 ? this.elt : undefined;
+    },
+    slice: function() {
+      return [this.elt];
+    }
+  }).create();
+
+  expectDeprecation(function(){
+    obj.pushObjects(items);
+  }, 'Passing an array-like object that is not a native Array to pushObjects() is deprecated. Please convert to a native Array, e.g. by calling .toArray().');
 });
 
 export default suite;

--- a/packages/ember-runtime/tests/suites/mutable_enumerable.js
+++ b/packages/ember-runtime/tests/suites/mutable_enumerable.js
@@ -1,11 +1,13 @@
 import { EnumerableTests } from 'ember-runtime/tests/suites/enumerable';
 
 import addObjectTests from 'ember-runtime/tests/suites/mutable_enumerable/addObject';
+import addObjectsTests from 'ember-runtime/tests/suites/mutable_enumerable/addObjects';
 import removeObjectTests from 'ember-runtime/tests/suites/mutable_enumerable/removeObject';
 import removeObjectsTests from 'ember-runtime/tests/suites/mutable_enumerable/removeObjects';
 
 var MutableEnumerableTests = EnumerableTests.extend();
 MutableEnumerableTests.importModuleTests(addObjectTests);
+MutableEnumerableTests.importModuleTests(addObjectsTests);
 MutableEnumerableTests.importModuleTests(removeObjectTests);
 MutableEnumerableTests.importModuleTests(removeObjectsTests);
 

--- a/packages/ember-runtime/tests/suites/mutable_enumerable/addObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_enumerable/addObjects.js
@@ -1,0 +1,136 @@
+import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
+import EmberObject from 'ember-runtime/system/object';
+import Enumerable from 'ember-runtime/mixins/enumerable';
+import {get} from 'ember-metal/property_get';
+import Ember from "ember-metal/core";
+
+var suite = SuiteModuleBuilder.create();
+
+suite.module('addObjects');
+
+suite.test("should return receiver", function() {
+  var before, obj;
+  before = Ember.A(this.newFixture(3));
+  obj = before;
+  equal(obj.addObjects(this.newFixture(1)), obj, 'should return receiver');
+});
+
+suite.test("[A,B].addObjects([C]) => [A,B,C] + notify", function() {
+  var obj, before, after, observer, items;
+
+  before = Ember.A(this.newFixture(2));
+  items  = Ember.A(this.newFixture(1));
+  after  = [before[0], before[1], items[0]];
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
+  get(obj, 'firstObject');
+  get(obj, 'lastObject');
+
+  obj.addObjects(items);
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(get(obj, 'length'), after.length, 'length');
+
+  if (observer.isEnabled) {
+    equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+    // This gets called since MutableEnumerable is naive about changes
+    equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  }
+});
+
+suite.test("[A,B].addObjects([B,C]) => [A,B,C] + notify", function() {
+  var obj, before, after, observer, items;
+
+  before = Ember.A(this.newFixture(2));
+  items  = Ember.A([before[1], this.newFixture(1)[0]]);
+  after  = [before[0], before[1], items[1]];
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
+  get(obj, 'firstObject');
+  get(obj, 'lastObject');
+
+  obj.addObjects(items);
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(get(obj, 'length'), after.length, 'length');
+
+  if (observer.isEnabled) {
+    equal(observer.timesCalled('[]'), 1, 'should have notified [] once');
+    equal(observer.timesCalled('length'), 1, 'should have notified length once');
+    equal(observer.timesCalled('lastObject'), 1, 'should have notified lastObject once');
+    // This gets called since MutableEnumerable is naive about changes
+    equal(observer.timesCalled('firstObject'), 1, 'should have notified firstObject once');
+  }
+});
+
+suite.test("[A,B,C].addObjects([A]) => [A,B,C] + NO notify", function() {
+  var obj, before, after, observer, items;
+
+  before = this.newFixture(3);
+  after  = before;
+  items  = Ember.A([before[0]]);
+  obj = this.newObject(before);
+  observer = this.newObserver(obj, '[]', 'length', 'firstObject', 'lastObject');
+
+  obj.addObjects(items); // note: items in set
+
+  deepEqual(this.toArray(obj), after, 'post item results');
+  equal(get(obj, 'length'), after.length, 'length');
+
+  if (observer.isEnabled) {
+    equal(observer.validate('[]'), false, 'should NOT have notified []');
+    equal(observer.validate('length'), false, 'should NOT have notified length');
+    equal(observer.validate('firstObject'), false, 'should NOT have notified firstObject');
+    equal(observer.validate('lastObject'), false, 'should NOT have notified lastObject');
+  }
+});
+
+suite.test('Adding objects should notify enumerable observer', function() {
+  var obj = this.newObject(this.newFixture(3));
+  var observer = this.newObserver(obj).observeEnumerable(obj);
+  var item = this.newFixture(1)[0];
+
+  obj.addObjects(Ember.A([item]));
+
+  deepEqual(observer._before, [obj, null, [item]]);
+  deepEqual(observer._after, [obj, null, [item]]);
+});
+
+suite.test("should raise exception if not Ember.Enumerable is passed to addObjects", function() {
+  var obj = this.newObject([]);
+
+  raises(function() {
+    obj.addObjects( "string" );
+  });
+});
+
+suite.test('Adding objects from an Array is not deprecated', function() {
+  expectNoDeprecation();
+  var obj = this.newObject(this.newFixture(3));
+  var items = Ember.A(this.newFixture(1));
+
+  obj.addObjects(items);
+});
+
+suite.test('Adding objects from non-Array Enumerable is deprecated', function() {
+  var obj = this.newObject(this.newFixture(3));
+  var items = EmberObject.extend(Enumerable, {
+    elt: this.newFixture(1)[0],
+
+    length: 1,
+    nextObject: function(idx) {
+      return idx === 0 ? this.elt : undefined;
+    },
+    slice: function() {
+      return [this.elt];
+    }
+  }).create();
+
+  expectDeprecation(function(){
+    obj.addObjects(items);
+  }, 'Passing an array-like object that is not a native Array to addObjects() is deprecated. Please convert to a native Array, e.g. by calling .toArray().');
+});
+
+export default suite;


### PR DESCRIPTION
This is the result of the discussion in #9843 

pushObjects(), unshiftObjects(), removeObjects() and setObjects() were all documented to accept enumerables, but would only function properly when passed a native array, so update their documentation.

pushObjects() has an assert ensuring that the argument is an enumerable or array-like object. It should really be asserting that the argument is a native array, but changing it would cause calls passing in an enumerable that now produce incorrect behavior to start throwing an exception, so instead just add a deprecation warning in case the argument is not a native array.

addObjects() was documented to accept enumerables, and would behave correctly when passed an enumerable, which is not consistent with its sister methods and therefore not desired behavior. So update the documentation and add a deprecation warning in case the argument is not a native array.

Also take the opportunity to implement some addObjects() unit tests.
