### PR TITLE
[BUGFIX beta] Return streams from helpers.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -5,7 +5,6 @@
 
 import Ember from "ember-metal/core"; // Ember.FEATURES, Ember.assert, Ember.Handlebars, Ember.lookup
 import { IS_BINDING } from "ember-metal/mixin";
-import { appendSimpleBoundView } from "ember-views/views/simple_bound_view";
 import Helper from "ember-htmlbars/system/helper";
 
 import Stream from "ember-metal/streams/stream";
@@ -84,8 +83,6 @@ export default function makeBoundHelper(fn, compatMode) {
     } else {
       var lazyValue = new Stream(valueFn);
 
-      appendSimpleBoundView(this, options.morph, lazyValue);
-
       var param;
 
       for (i = 0; i < numParams; i++) {
@@ -118,6 +115,8 @@ export default function makeBoundHelper(fn, compatMode) {
           }
         }
       }
+
+      return lazyValue;
     }
   }
 

--- a/packages/ember-htmlbars/lib/helpers/binding.js
+++ b/packages/ember-htmlbars/lib/helpers/binding.js
@@ -8,7 +8,6 @@ import run from "ember-metal/run_loop";
 import { get } from "ember-metal/property_get";
 import SimpleStream from "ember-metal/streams/simple";
 import BoundView from "ember-views/views/bound_view";
-import { appendSimpleBoundView } from "ember-views/views/simple_bound_view";
 
 function exists(value) {
   return !isNone(value);
@@ -106,7 +105,7 @@ function bindHelper(params, hash, options, env) {
     Ember.deprecate("The block form of bind, {{#bind foo}}{{/bind}}, has been deprecated and will be removed.");
     bind.call(this, property, hash, options, env, false, exists);
   } else {
-    appendSimpleBoundView(this, options.morph, property);
+    return property;
   }
 }
 

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -9,6 +9,9 @@ import { A } from "ember-runtime/system/native_array";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import {
+  dasherize
+} from 'ember-runtime/system/string';
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -84,6 +87,27 @@ test("should update bound helpers when properties change", function() {
   });
 
   equal(view.$().text(), 'WES', "helper output updated");
+});
+
+test("should update bound helpers in a subexpression when properties change", function() {
+  expectDeprecationInHTMLBars();
+
+  helper('dasherize', function(value) {
+    return dasherize(value);
+  });
+
+  view = EmberView.create({
+    controller: {prop: "isThing"},
+    template: compile("<div {{bind-attr data-foo=(dasherize prop)}}>{{prop}}</div>")
+  });
+
+  runAppend(view);
+
+  equal(view.$('div[data-foo="is-thing"]').text(), 'isThing', "helper output is correct");
+
+  run(view, 'set', 'controller.prop', 'notThing');
+
+  equal(view.$('div[data-foo="not-thing"]').text(), 'notThing', "helper output is correct");
 });
 
 test("should allow for computed properties with dependencies", function() {


### PR DESCRIPTION
The hook calls appendSimpleBoundView automatically if a stream is returned (and `appendSimpleBoundView` is needed).
