### PR TITLE
[BUGFIX beta] Ember.HTMLBars.makeBoundHelper does not support fooBinding syntax.

### DIFF
--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -4,7 +4,6 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.FEATURES, Ember.assert, Ember.Handlebars, Ember.lookup
-import { IS_BINDING } from "ember-metal/mixin";
 import Helper from "ember-htmlbars/system/helper";
 
 import Stream from "ember-metal/streams/stream";
@@ -63,14 +62,6 @@ export default function makeBoundHelper(fn) {
 
     Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !options.template);
 
-    for (var prop in hash) {
-      if (IS_BINDING.test(prop)) {
-        hash[prop.slice(0, -7)] = view._getBindingForStream(hash[prop]);
-
-        delete hash[prop];
-      }
-    }
-
     function valueFn() {
       return fn.call(view, readArray(params), readHash(hash), options, env);
     }
@@ -86,7 +77,7 @@ export default function makeBoundHelper(fn) {
         subscribe(param, lazyValue.notify, lazyValue);
       }
 
-      for (prop in hash) {
+      for (var prop in hash) {
         param = hash[prop];
         subscribe(param, lazyValue.notify, lazyValue);
       }

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -107,8 +107,10 @@ test("bound helpers should support keywords", function() {
   equal(view.$().text(), 'AB', "helper output is correct");
 });
 
-test("bound helpers should support bound options", function() {
-  registerRepeatHelper();
+test("bound helpers should not process `fooBinding` style hash properties", function() {
+  container.register('helper:x-repeat', makeBoundHelper(function(params, hash, options, env) {
+    equal(hash.timesBinding, "numRepeats");
+  }));
 
   view = EmberView.create({
     container: container,
@@ -120,19 +122,6 @@ test("bound helpers should support bound options", function() {
   });
 
   runAppend(view);
-
-  equal(view.$().text(), 'ababab', "helper output is correct");
-
-  run(view, 'set', 'controller.numRepeats', 4);
-
-  equal(view.$().text(), 'abababab', "helper correctly re-rendered after bound option was changed");
-
-  run(function() {
-    view.set('controller.numRepeats', 2);
-    view.set('controller.text', "YES");
-  });
-
-  equal(view.$().text(), 'YESYES', "helper correctly re-rendered after both bound option and property changed");
 });
 
 test("bound helpers should support multiple bound properties", function() {


### PR DESCRIPTION
We do not want to perpetuate the `fooBinding` style stuff into HTMLBars land.
