### PR TITLE
[BUGFIX beta] Changed injected properties to behave like Ember.computed.reads

### DIFF
--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -1,12 +1,9 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import { ComputedProperty } from "ember-metal/computed";
+import { AliasedProperty } from "ember-metal/alias";
 import { Descriptor } from "ember-metal/properties";
 import { create } from "ember-metal/platform";
-import {
-  meta,
-  inspect
-} from "ember-metal/utils";
-import EmberError from "ember-metal/error";
+import { meta } from "ember-metal/utils";
 
 /**
   Read-only property that returns the result of a container lookup.
@@ -24,7 +21,7 @@ function InjectedProperty(type, name) {
   this.name = name;
 
   this._super$Constructor(injectedPropertyGet);
-  this.readOnly();
+  AliasedPropertyPrototype.oneWay.call(this);
 }
 
 function injectedPropertyGet(keyName) {
@@ -37,21 +34,16 @@ function injectedPropertyGet(keyName) {
   return this.container.lookup(desc.type + ':' + (desc.name || keyName));
 }
 
-function injectedPropertySet(obj, keyName) {
-  throw new EmberError("Cannot set injected property '" + keyName + "' on object: " + inspect(obj));
-}
-
 InjectedProperty.prototype = create(Descriptor.prototype);
 
 var InjectedPropertyPrototype = InjectedProperty.prototype;
 var ComputedPropertyPrototype = ComputedProperty.prototype;
+var AliasedPropertyPrototype = AliasedProperty.prototype;
 
 InjectedPropertyPrototype._super$Constructor = ComputedProperty;
 
 InjectedPropertyPrototype.get = ComputedPropertyPrototype.get;
 InjectedPropertyPrototype.readOnly = ComputedPropertyPrototype.readOnly;
-
-InjectedPropertyPrototype.set = injectedPropertySet;
 
 InjectedPropertyPrototype.teardown = ComputedPropertyPrototype.teardown;
 

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -13,13 +13,13 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     ok(new InjectedProperty() instanceof Descriptor);
   });
 
-  test('setting the injected property should error', function() {
+  test('injected properties should be overridable', function() {
     var obj = {};
     defineProperty(obj, 'foo', new InjectedProperty());
 
-    throws(function() {
-      set(obj, 'foo', 'bar');
-    }, /Cannot set injected property 'foo' on object/);
+    set(obj, 'foo', 'bar');
+
+    equal(get(obj, 'foo'), 'bar', 'should return the overriden value');
   });
 
   test("getting on an object without a container should fail assertion", function() {


### PR DESCRIPTION
Fixes #9884.

Removes assertion when attempting to set an injected property. Implemented by reusing alias properties' `set` method. I didn't understand the implementation of it fully, but I assume it was done that way for a good reason.
