### PR TITLE
[BUGFIX release] Re-enable runtime 'mandatory-setter' feature flag

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -70,7 +70,7 @@ function defeatureifyConfig(opts) {
 
   for (var flag in features) {
     if (features[flag] === 'development-only') {
-      features[flag] = options.environment !== 'production';
+      features[flag] = options.environment !== 'production' && null;
     }
   }
 

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -123,6 +123,9 @@ Ember.FEATURES.isEnabled = function(feature) {
 
   if (Ember.ENV.ENABLE_ALL_FEATURES) {
     return true;
+  } else if (feature === 'mandatory-setter') {
+    // mandatory-setter feature is unique in that it is *enabled* by default
+    return featureValue !== false;
   } else if (featureValue === true || featureValue === false || featureValue === undefined) {
     return featureValue;
   } else if (Ember.ENV.ENABLE_OPTIONAL_FEATURES) {

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -1,19 +1,21 @@
 import Ember from 'ember-metal/core';
 
 var isEnabled = Ember.FEATURES.isEnabled;
-var origFeatures, origEnableAll, origEnableOptional;
+var origFeatures, origEnableAll, origEnableOptional, origMandatorySetter;
 
 QUnit.module("Ember.FEATURES.isEnabled", {
   setup: function(){
-    origFeatures       = Ember.FEATURES;
-    origEnableAll      = Ember.ENV.ENABLE_ALL_FEATURES;
-    origEnableOptional = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
+    origFeatures        = Ember.FEATURES;
+    origEnableAll       = Ember.ENV.ENABLE_ALL_FEATURES;
+    origEnableOptional  = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
+    origMandatorySetter = Ember.FEATURES['mandatory-setter'];
   },
 
   teardown: function(){
     Ember.FEATURES                     = origFeatures;
     Ember.ENV.ENABLE_ALL_FEATURES      = origEnableAll;
     Ember.ENV.ENABLE_OPTIONAL_FEATURES = origEnableOptional;
+    Ember.FEATURES['mandatory-setter'] = origMandatorySetter;
   }
 });
 
@@ -51,4 +53,11 @@ test("isEnabled without ENV options", function(){
   equal(isEnabled('barney'), true,  "returns flag value if true");
   equal(isEnabled('wilma'),  false, "returns false if flag is not set");
   equal(isEnabled('betty'),  undefined, "returns flag value if undefined");
+});
+
+test("isEnabled with mandatory-setter feature", function() {
+  Ember.FEATURES['mandatory-setter'] = undefined;
+  equal(isEnabled('mandatory-setter'), true,  "returns true by default");
+  Ember.FEATURES['mandatory-setter'] = false;
+  equal(isEnabled('mandatory-setter'), false, "returns false if explicit");
 });


### PR DESCRIPTION
Fixes #9897. The one caveat here is that `mandatory-setter` feature is _enabled_ by default in development– this goes contrary to most features being _disabled_ by default. Alternatively, this feature could be renamed `skip-mandatory-setter`.
