### PR TITLE
make “loc” helper bound

### DIFF
--- a/packages/ember-handlebars/lib/main.js
+++ b/packages/ember-handlebars/lib/main.js
@@ -102,7 +102,7 @@ EmberHandlebars.registerHelper('collection', collectionHelper);
 EmberHandlebars.registerHelper('log', logHelper);
 EmberHandlebars.registerHelper('debugger', debuggerHelper);
 EmberHandlebars.registerHelper('each', eachHelper);
-EmberHandlebars.registerHelper('loc', locHelper);
+EmberHandlebars.registerBoundHelper('loc', locHelper);
 EmberHandlebars.registerHelper('partial', partialHelper);
 EmberHandlebars.registerHelper('template', templateHelper);
 EmberHandlebars.registerHelper('yield', yieldHelper);

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -1,6 +1,4 @@
-import Ember from 'ember-metal/core';
 import { loc } from 'ember-runtime/system/string';
-import { isStream } from "ember-metal/streams/utils";
 
 /**
 @module ember
@@ -39,15 +37,10 @@ import { isStream } from "ember-metal/streams/utils";
   @param {String} str The string to format
   @see {Ember.String#loc}
 */
-export function locHelper(params, hash, options, env) {
-  Ember.assert('You cannot pass bindings to `loc` helper', (function ifParamsContainBindings() {
-    for (var i = 0, l = params.length; i < l; i++) {
-      if (isStream(params[i])) {
-        return false;
-      }
-    }
-    return true;
-  })());
 
-  return loc.apply(this, params);
+export function locHelper(params, hash, options, env) {
+  var formatString = params[0];
+  var formats = params.slice(1);
+  return loc.call(null, formatString, formats);
 }
+

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -16,7 +16,8 @@ import makeBoundHelper from "ember-htmlbars/system/make_bound_helper";
 import {
   registerHelper,
   helper,
-  default as helpers
+  default as helpers,
+  registerBoundHelper
 } from "ember-htmlbars/helpers";
 import { bindHelper } from "ember-htmlbars/helpers/binding";
 import { viewHelper } from "ember-htmlbars/helpers/view";
@@ -62,7 +63,7 @@ registerHelper('unboundIf', unboundIfHelper);
 registerHelper('boundIf', boundIfHelper);
 registerHelper('log', logHelper);
 registerHelper('debugger', debuggerHelper);
-registerHelper('loc', locHelper);
+registerBoundHelper('loc', locHelper);
 registerHelper('partial', partialHelper);
 registerHelper('template', templateHelper);
 registerHelper('bind-attr', bindAttrHelper);


### PR DESCRIPTION
loc helper can now accept bound values!

``` hbs
for example {{loc formatString value1 value2}}
```

closes emberjs/ember.js #9581
