### PR TITLE
[BUGFIX beta] Don’t assert uncaught RSVP rejections

### DIFF
--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -69,7 +69,6 @@ RSVP.onerrorDefault = function (e) {
       Ember.onerror(error);
     } else {
       Logger.error(error.stack);
-      Ember.assert(error, false);
     }
   }
 };


### PR DESCRIPTION
Fixes #9901.

We already loudly log a stack trace, and the assert ends up breaking everything else on the run loop
queue and given that it doesn’t even preserve a meaningful stack trace related to the source of error, it doesn’t add a lot of value (and causes real problems a la #9901).
