### PR TITLE
[BUGFIX beta] Allow tagName to be a CP with deprecation

### DIFF
--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -4,6 +4,7 @@ import { create } from 'ember-metal/platform';
 import renderBuffer from "ember-views/system/render_buffer";
 import run from "ember-metal/run_loop";
 import { set } from "ember-metal/property_set";
+import { get } from "ember-metal/property_get";
 import {
   _instrumentStart,
   subscribers
@@ -35,6 +36,10 @@ EmberRenderer.prototype.createElement =
     // provided buffer operation (for example, `insertAfter` will
     // insert a new buffer after the "parent buffer").
     var tagName = view.tagName;
+    if (!tagName) {
+      tagName = get(view, 'tagName');
+      Ember.deprecate('In the future using a computed property to define tagName will not be permitted. That value will be respected, but changing it will not update the element.', !tagName);
+    }
     var classNameBindings = view.classNameBindings;
     var taglessViewWithClassBindings = tagName === '' && classNameBindings.length > 0;
 

--- a/packages/ember-views/tests/views/view/render_test.js
+++ b/packages/ember-views/tests/views/view/render_test.js
@@ -3,6 +3,7 @@ import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 import EmberView from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
+import { computed } from "ember-metal/computed";
 
 import compile from "ember-htmlbars/system/compile";
 
@@ -119,6 +120,28 @@ test("should add ember-view to views", function() {
   });
 
   ok(view.$().hasClass('ember-view'), "the view has ember-view");
+});
+
+test("should allow tagName to be a computed property [DEPRECATED]", function() {
+  view = EmberView.extend({
+    tagName: computed(function() {
+      return 'span';
+    })
+  }).create();
+
+  expectDeprecation(function(){
+    run(function() {
+      view.createElement();
+    });
+  }, /using a computed property to define tagName will not be permitted/);
+
+  equal(view.element.tagName, 'SPAN', "the view has was created with the correct element");
+
+  run(function() {
+    view.set('tagName', 'div');
+  });
+
+  equal(view.element.tagName, 'SPAN', "the tagName cannot be changed after initial render");
 });
 
 test("should allow hX tags as tagName", function() {


### PR DESCRIPTION
Fixes #9743, which fixed a regression noted in #9742. Perhaps should also go into stable, certainly into beta.

In the future `tagName` CPs should throw an assertion, in 1.x they should raise a deprecation warning.
