### PR TITLE
Adding npm-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ bundle/
 *~
 publish_to_bower/
 bower_components/
+npm-debug.log


### PR DESCRIPTION
Ran into this a couple times. Removing the announce for everyone else. :smile:.
