### PR TITLE
[BUGFIX beta] Ensure bound attrs flush immediately

### DIFF
--- a/packages/ember-htmlbars/lib/attr_nodes/quoted.js
+++ b/packages/ember-htmlbars/lib/attr_nodes/quoted.js
@@ -8,7 +8,7 @@ import { create as o_create } from "ember-metal/platform";
 
 function QuotedAttrNode(element, attrName, attrValue, dom) {
   this.init(element, attrName, attrValue, dom);
-} 
+}
 
 QuotedAttrNode.prototype = o_create(SimpleAttrNode.prototype);
 

--- a/packages/ember-htmlbars/lib/attr_nodes/quoted_class.js
+++ b/packages/ember-htmlbars/lib/attr_nodes/quoted_class.js
@@ -39,21 +39,21 @@ function QuotedClassAttrNode(element, attrName, attrValue, dom) {
   this.element = element;
   this.attrName = attrName;
   this.dom = dom;
-  this.isDirty = false;
+  this.isDirty = true;
 
   this.classes = attrValue;
   this.oldClasses = [];
 
-  subscribe(attrValue, this.renderIfNeeded, this);
-  this.renderIfNeeded();
+  subscribe(attrValue, this.markDirty, this);
+  this.renderIfDirty();
 }
 
-QuotedClassAttrNode.prototype.renderIfNeeded = function renderIfNeeded(){
+QuotedClassAttrNode.prototype.markDirty = function markDirty(){
   this.isDirty = true;
-  run.schedule('render', this, this.scheduledRenderIfNeeded);
+  run.schedule('render', this, this.renderIfDirty);
 };
 
-QuotedClassAttrNode.prototype.scheduledRenderIfNeeded = function scheduledRenderIfNeeded(){
+QuotedClassAttrNode.prototype.renderIfDirty = function renderIfDirty(){
   if (this.isDirty) {
     this.isDirty = false;
     this.render();

--- a/packages/ember-htmlbars/lib/attr_nodes/simple.js
+++ b/packages/ember-htmlbars/lib/attr_nodes/simple.js
@@ -7,32 +7,32 @@ import run from "ember-metal/run_loop";
 
 function SimpleAttrNode() {
   // abstract class
-} 
+}
 
 SimpleAttrNode.prototype.init = function init(element, attrName, simpleAttrValue, dom){
   this.element = element;
   this.attrName = attrName;
   this.attrValue = simpleAttrValue;
   this.dom = dom;
-  this.isDirty = false;
+  this.isDirty = true;
   this.lastValue = null;
   this.currentValue = null;
 
   if (this.attrValue.isStream) {
-    this.attrValue.subscribe(this.renderIfNeeded, this);
-    this.renderIfNeeded();
+    this.attrValue.subscribe(this.markDirty, this);
+    this.renderIfDirty();
   } else {
     this.currentValue = simpleAttrValue;
     this.render();
   }
 };
 
-SimpleAttrNode.prototype.renderIfNeeded = function renderIfNeeded(){
+SimpleAttrNode.prototype.markDirty = function markDirty(){
   this.isDirty = true;
-  run.schedule('render', this, this.scheduledRenderIfNeeded);
+  run.schedule('render', this, this.renderIfDirty);
 };
 
-SimpleAttrNode.prototype.scheduledRenderIfNeeded = function scheduledRenderIfNeeded(){
+SimpleAttrNode.prototype.renderIfDirty = function renderIfDirty(){
   if (this.isDirty) {
     this.isDirty = false;
     var value = this.attrValue.value();

--- a/packages/ember-htmlbars/lib/attr_nodes/unquoted.js
+++ b/packages/ember-htmlbars/lib/attr_nodes/unquoted.js
@@ -10,7 +10,7 @@ import { normalizeProperty } from "ember-htmlbars/attr_nodes/utils";
 function UnquotedAttrNode(element, attrName, attrValue, dom) {
   var normalizedAttrName = normalizeProperty(element, attrName) || attrName;
   this.init(element, normalizedAttrName, attrValue, dom);
-} 
+}
 
 UnquotedAttrNode.prototype = o_create(SimpleAttrNode.prototype);
 

--- a/packages/ember-htmlbars/lib/attr_nodes/unquoted_nonproperty.js
+++ b/packages/ember-htmlbars/lib/attr_nodes/unquoted_nonproperty.js
@@ -8,7 +8,7 @@ import { create as o_create } from "ember-metal/platform";
 
 function UnquotedNonpropertyAttrNode(element, attrName, attrValue, dom) {
   this.init(element, attrName, attrValue, dom);
-} 
+}
 
 UnquotedNonpropertyAttrNode.prototype = o_create(SimpleAttrNode.prototype);
 

--- a/packages/ember-htmlbars/tests/attr_nodes/class_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/class_test.js
@@ -24,6 +24,21 @@ QUnit.module("ember-htmlbars: class attribute", {
   }
 });
 
+test("class renders before didInsertElement", function() {
+  var matchingElement;
+  view = EmberView.create({
+    didInsertElement: function(){
+      matchingElement = this.$('div.blue');
+    },
+    context: {color: 'blue'},
+    template: compile("<div class={{color}}>Hi!</div>")
+  });
+  appendView(view);
+
+  equalInnerHTML(view.element, '<div class="blue">Hi!</div>', "attribute is output");
+  equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
+});
+
 test("class property can contain multiple classes", function() {
   view = EmberView.create({
     context: {classes: 'large blue'},

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -27,6 +27,21 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "attribute is output");
   });
 
+  test("property set before didInsertElement", function() {
+    var matchingElement;
+    view = EmberView.create({
+      didInsertElement: function(){
+        matchingElement = this.$('div[data-name=erik]');
+      },
+      context: {name: 'erik'},
+      template: compile("<div data-name={{name}}>Hi!</div>")
+    });
+    runAppend(view);
+
+    equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "attribute is output");
+    equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
+  });
+
   test("quoted attributes are concatenated", function() {
     view = EmberView.create({
       context: {firstName: 'max', lastName: 'jackson'},

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -486,3 +486,16 @@ test('should allow either quoted or unquoted values', function() {
   equal(view.$('img').attr('alt'), "Updated", "updates value");
   equal(view.$('img').attr('src'), "test2.jpg", "updates value");
 });
+
+test("property before didInsertElement", function() {
+  var matchingElement;
+  view = EmberView.create({
+    name: 'bob',
+    template: compile('<div {{bind-attr alt=view.name}}></div>'),
+    didInsertElement: function(){
+      matchingElement = this.$('div[alt=bob]');
+    }
+  });
+  runAppend(view);
+  equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
+});


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/9823 which also indicated a regression in beta.

attr node objects deferred their rendering until later in the runloop- however this has the side effect of making the DOM during `didInsertElement` be inconsistent with what the user expects.

This is a fix as well as some terminology updates.
