### PR TITLE
[BUGFIX beta] Do not stringify class values before they are passed to concat

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/bind-attr.js
+++ b/packages/ember-htmlbars/lib/helpers/bind-attr.js
@@ -218,14 +218,14 @@ function streamifyClassBindings(view, classBindingsString) {
     parsedPath = View._parsePropertyPath(classBindings[i]);
 
     if (parsedPath.path === '') {
-      streamified.push(classStringForParsedPath(parsedPath, true) + " ");
+      streamified.push(classStringForParsedPath(parsedPath, true));
     } else {
       (function(){
         var lazyValue = view.getStream(parsedPath.path);
         var _parsedPath = parsedPath;
         var classNameBound = new Stream(function(){
           var value = lazyValue.value();
-          return classStringForParsedPath(_parsedPath, value) + " ";
+          return classStringForParsedPath(_parsedPath, value);
         });
         lazyValue.subscribe(classNameBound.notify, classNameBound);
         streamified.push(classNameBound);
@@ -233,7 +233,7 @@ function streamifyClassBindings(view, classBindingsString) {
     }
   }
 
-  return concat(streamified);
+  return concat(streamified, {joinWith: ' '});
 }
 
 function classStringForParsedPath(parsedPath, value) {

--- a/packages/ember-htmlbars/lib/hooks/concat.js
+++ b/packages/ember-htmlbars/lib/hooks/concat.js
@@ -7,12 +7,14 @@ import Stream from "ember-metal/streams/stream";
 import {
   isStream,
   readArray,
+  read,
   subscribe
 } from "ember-metal/streams/utils";
 
 // TODO: Create subclass ConcatStream < Stream. Defer
 // subscribing to streams until the value() is called.
-export default function concat(params) {
+export default function concat(params, hash) {
+  var joinWith = read(hash.joinWith) || '';
   var i;
   var isStatic = true;
 
@@ -24,10 +26,10 @@ export default function concat(params) {
   }
 
   if (isStatic) {
-    return params.join('');
+    return params.join(joinWith);
   } else {
     var stream = new Stream(function() {
-      return readArray(params).join('');
+      return readArray(params).join(joinWith);
     });
 
     for (i = 0; i < params.length; i++) {

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -11,6 +11,7 @@ import { observersFor } from "ember-metal/observer";
 import Container from "ember-runtime/system/container";
 import { set } from "ember-metal/property_set";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import { equalInnerHTML } from "htmlbars-test-helpers";
 
 import helpers from "ember-htmlbars/helpers";
 import compile from "ember-htmlbars/system/compile";
@@ -259,13 +260,13 @@ test("should be able to bind class attribute with {{bind-attr}}", function() {
 
   runAppend(view);
 
-  equal(view.$('img').attr('class'), 'bar', "renders class");
+  equalInnerHTML(view.element, '<img class="bar">', 'renders class');
 
   run(function() {
     set(view, 'foo', 'baz');
   });
 
-  equal(view.$('img').attr('class'), 'baz', "updates class");
+  equalInnerHTML(view.element, '<img class="baz">', 'updates rendered class');
 });
 
 test("should be able to bind class attribute via a truthy property with {{bind-attr}}", function() {
@@ -278,13 +279,13 @@ test("should be able to bind class attribute via a truthy property with {{bind-a
 
   runAppend(view);
 
-  equal(view.$('.is-truthy').length, 1, "sets class name");
+  equalInnerHTML(view.element, '<img class="is-truthy">', 'renders class');
 
   run(function() {
     set(view, 'isNumber', 0);
   });
 
-  equal(view.$('.is-truthy').length, 0, "removes class name if bound property is set to something non-truthy");
+  equalInnerHTML(view.element.firstChild.className, undefined, 'removes class');
 });
 
 test("should be able to bind class to view attribute with {{bind-attr}}", function() {

--- a/packages/ember-htmlbars/tests/hooks/concat_test.js
+++ b/packages/ember-htmlbars/tests/hooks/concat_test.js
@@ -1,0 +1,34 @@
+import EmberView from "ember-views/views/view";
+import compile from "ember-htmlbars/system/compile";
+import { equalInnerHTML } from "htmlbars-test-helpers";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var view;
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+
+QUnit.module("ember-htmlbars: hooks/concat_test", {
+  teardown: function(){
+    runDestroy(view);
+  }
+});
+
+test("output is concatenated", function() {
+  view = EmberView.create({
+    context: {fname: 'erik', lname: 'smushname'},
+    template: compile("ohai {{concat fname lname}}")
+  });
+  runAppend(view);
+  equalInnerHTML(view.element, 'ohai eriksmushname', "output is concatenated");
+});
+
+test("output is concatenated with joinWith", function() {
+  view = EmberView.create({
+    context: {fname: 'erik', lname: 'bwap'},
+    template: compile("ohai {{concat fname lname 'name' joinWith=\"+\"}}")
+  });
+  runAppend(view);
+  equalInnerHTML(view.element, 'ohai erik+bwap+name', "output is concatented with joinWith");
+});
+
+}

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -8,7 +8,7 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 var view;
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  QUnit.module("ember-htmlbars: basic/text_node_test", {
+  QUnit.module("ember-htmlbars: hooks/text_node_test", {
     teardown: function(){
       runDestroy(view);
     }


### PR DESCRIPTION
Fixes #9893.

falsy values from class bindings were beings made into strings before going through the concat helper.

@mmun here I've added `joinWith` as a hash param to `concat`. As an alternative I could spin out the relevant parts of concat out into a utils method and not change the API of the hook.
