### PR TITLE
[BUGFIX beta] makeBoundHelper should act as if the helper is unbound when parameters aren't bound. [perf]

### DIFF
--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -3,6 +3,7 @@ import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import { A } from "ember-runtime/system/native_array";
+import SimpleBoundView from "ember-views/views/simple_bound_view";
 
 // import {expectAssertion} from "ember-metal/tests/debug_helpers";
 
@@ -28,7 +29,7 @@ function registerRepeatHelper() {
   expectDeprecationInHTMLBars();
 
   helper('repeat', function(value, options) {
-    var count = options.hash.count;
+    var count = options.hash.count || 1;
     var a = [];
     while(a.length < count) {
         a.push(value);
@@ -532,4 +533,51 @@ test("should have correct argument types", function() {
   runAppend(view);
 
   equal(view.$().text(), 'undefined, undefined, string, number, object', "helper output is correct");
+});
+
+test("when no parameters are bound, no new views are created", function(){
+  registerRepeatHelper();
+  var originalRender = SimpleBoundView.prototype.render;
+  var renderWasCalled = false;
+  SimpleBoundView.prototype.render = function(){
+    renderWasCalled = true;
+    return originalRender.apply(this, arguments);
+  };
+
+  try {
+    view = EmberView.create({
+      template: compile('{{repeat "a"}}'),
+      controller: EmberObject.create()
+    });
+    runAppend(view);
+  } finally {
+    SimpleBoundView.prototype.render = originalRender;
+  }
+
+  ok(!renderWasCalled, 'simple bound view should not have been created and rendered');
+  equal(view.$().text(), 'a');
+});
+
+
+test('when no hash parameters are bound, no new views are created', function(){
+  registerRepeatHelper();
+  var originalRender = SimpleBoundView.prototype.render;
+  var renderWasCalled = false;
+  SimpleBoundView.prototype.render = function(){
+    renderWasCalled = true;
+    return originalRender.apply(this, arguments);
+  };
+
+  try {
+    view = EmberView.create({
+      template: compile('{{repeat "a" count=3}}'),
+      controller: EmberObject.create()
+    });
+    runAppend(view);
+  } finally {
+    SimpleBoundView.prototype.render = originalRender;
+  }
+
+  ok(!renderWasCalled, 'simple bound view should not have been created and rendered');
+  equal(view.$().text(), 'aaa');
 });

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -14,7 +14,8 @@ var view, container;
 
 function registerRepeatHelper() {
   container.register('helper:x-repeat', makeBoundHelper(function(params, hash, options, env) {
-    return new Array(hash.times + 1).join( params[0] );
+    var times = hash.times || 1;
+    return new Array(times + 1).join( params[0] );
   }));
 }
 
@@ -235,8 +236,9 @@ test("when no parameters are bound, no new views are created", function(){
 
   try {
     view = EmberView.create({
-      template: compile('{{repeat "a"}}'),
-      controller: EmberObject.create()
+      template: compile('{{x-repeat "a"}}'),
+      controller: EmberObject.create(),
+      container: container
     });
     runAppend(view);
   } finally {
@@ -259,8 +261,9 @@ test('when no hash parameters are bound, no new views are created', function(){
 
   try {
     view = EmberView.create({
-      template: compile('{{repeat "a" count=3}}'),
-      controller: EmberObject.create()
+      template: compile('{{x-repeat "a" times=3}}'),
+      controller: EmberObject.create(),
+      container: container
     });
     runAppend(view);
   } finally {

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -7,6 +7,8 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import {
   dasherize
 } from 'ember-runtime/system/string';
+import SimpleBoundView from "ember-views/views/simple_bound_view";
+import EmberObject from "ember-runtime/system/object";
 
 var view, container;
 
@@ -220,6 +222,53 @@ test("should have correct argument types", function() {
   runAppend(view);
 
   equal(view.$().text(), 'undefined, undefined, string, number, object', "helper output is correct");
+});
+
+test("when no parameters are bound, no new views are created", function(){
+  registerRepeatHelper();
+  var originalRender = SimpleBoundView.prototype.render;
+  var renderWasCalled = false;
+  SimpleBoundView.prototype.render = function(){
+    renderWasCalled = true;
+    return originalRender.apply(this, arguments);
+  };
+
+  try {
+    view = EmberView.create({
+      template: compile('{{repeat "a"}}'),
+      controller: EmberObject.create()
+    });
+    runAppend(view);
+  } finally {
+    SimpleBoundView.prototype.render = originalRender;
+  }
+
+  ok(!renderWasCalled, 'simple bound view should not have been created and rendered');
+  equal(view.$().text(), 'a');
+});
+
+
+test('when no hash parameters are bound, no new views are created', function(){
+  registerRepeatHelper();
+  var originalRender = SimpleBoundView.prototype.render;
+  var renderWasCalled = false;
+  SimpleBoundView.prototype.render = function(){
+    renderWasCalled = true;
+    return originalRender.apply(this, arguments);
+  };
+
+  try {
+    view = EmberView.create({
+      template: compile('{{repeat "a" count=3}}'),
+      controller: EmberObject.create()
+    });
+    runAppend(view);
+  } finally {
+    SimpleBoundView.prototype.render = originalRender;
+  }
+
+  ok(!renderWasCalled, 'simple bound view should not have been created and rendered');
+  equal(view.$().text(), 'aaa');
 });
 
 }

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -38,3 +38,40 @@ export function readHash(object) {
   }
   return ret;
 }
+
+/**
+ * @function scanArray
+ * @param array Array array given to a handlebars helper
+ * @return Boolean whether the array contains a stream/bound value
+*/
+export function scanArray(array) {
+  var length = array.length;
+  var containsStream = false;
+
+  for (var i = 0; i < length; i++){
+    if (isStream(array[i])) {
+      containsStream = true;
+      break;
+    }
+  }
+
+  return containsStream;
+}
+
+/**
+ * @function scanHash
+ * @param Object hash "hash" argument given to a handlebars helper
+ * @return Boolean whether the object contains a stream/bound value
+*/
+export function scanHash(hash) {
+  var containsStream = false;
+
+  for (var prop in hash) {
+    if (isStream(hash[prop])) {
+      containsStream = true;
+      break;
+    }
+  }
+
+  return containsStream;
+}


### PR DESCRIPTION
attached is a failing test showing extra views w/makeBoundHelper. I have a working implementation I will  push up soon, but I wanted to show a failing test case first. I don't like this test case; we are essentially testing implementation. However, the SimpleBoundView does not end up in `Ember.View.views` hash, so I was unsure how else to test this doesn't get called.

refs #9902 
