### PR TITLE
[BUGFIX beta] Consistently use isStream helper.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -9,6 +9,7 @@ import View from "ember-views/views/view";
 import Component from "ember-views/views/component";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 import makeBoundHelper from "ember-htmlbars/compat/make-bound-helper";
+import { isStream } from "ember-metal/streams/utils";
 
 var slice = [].slice;
 
@@ -30,7 +31,7 @@ function HandlebarsCompatibleHelper(fn) {
     for (var prop in hash) {
       param = hash[prop];
 
-      if (param.isStream) {
+      if (isStream(param)) {
         handlebarsOptions.hash[prop] = param._label;
       } else {
         handlebarsOptions.hash[prop] = param;
@@ -41,7 +42,7 @@ function HandlebarsCompatibleHelper(fn) {
     for (var i = 0, l = params.length; i < l; i++) {
       param = params[i];
 
-      if (param.isStream) {
+      if (isStream(param)) {
         args[i] = param._label;
       } else {
         args[i] = param;

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -12,7 +12,8 @@ import {
   readArray,
   scanArray,
   scanHash,
-  readHash
+  readHash,
+  isStream
 } from "ember-metal/streams/utils";
 
 /**
@@ -67,7 +68,7 @@ export default function makeBoundHelper(fn, compatMode) {
       for (var i = 0, l = params.length; i < l; i++) {
         param = params[i];
 
-        if (param.isStream) {
+        if (isStream(param)) {
           properties[i] = param._label;
         } else {
           properties[i] = param;
@@ -92,14 +93,14 @@ export default function makeBoundHelper(fn, compatMode) {
 
       for (i = 0; i < numParams; i++) {
         param = params[i];
-        if (param && param.isStream) {
+        if (isStream(param)) {
           param.subscribe(lazyValue.notify, lazyValue);
         }
       }
 
       for (prop in hash) {
         param = hash[prop];
-        if (param && param.isStream) {
+        if (isStream(param)) {
           param.subscribe(lazyValue.notify, lazyValue);
         }
       }
@@ -108,7 +109,7 @@ export default function makeBoundHelper(fn, compatMode) {
         var firstParam = params[0];
         // Only bother with subscriptions if the first argument
         // is a stream itself, and not a primitive.
-        if (firstParam && firstParam.isStream) {
+        if (isStream(firstParam)) {
           var onDependentKeyNotify = function onDependentKeyNotify(stream) {
             stream.value();
             lazyValue.notify();

--- a/packages/ember-htmlbars/lib/helpers/binding.js
+++ b/packages/ember-htmlbars/lib/helpers/binding.js
@@ -8,6 +8,7 @@ import run from "ember-metal/run_loop";
 import { get } from "ember-metal/property_get";
 import SimpleStream from "ember-metal/streams/simple";
 import BoundView from "ember-views/views/bound_view";
+import { isStream } from "ember-metal/streams/utils";
 
 function exists(value) {
   return !isNone(value);
@@ -16,7 +17,7 @@ function exists(value) {
 // Binds a property into the DOM. This will create a hook in DOM that the
 // KVO system will look for and update if the property changes.
 function bind(property, hash, options, env, preserveContext, shouldDisplay, valueNormalizer, childProperties, _viewClass) {
-  var valueStream = property.isStream ? property : this.getStream(property);
+  var valueStream = isStream(property) ? property : this.getStream(property);
   var lazyValue;
 
   if (childProperties) {

--- a/packages/ember-htmlbars/lib/helpers/partial.js
+++ b/packages/ember-htmlbars/lib/helpers/partial.js
@@ -2,6 +2,7 @@ import Ember from "ember-metal/core"; // Ember.assert
 
 import isNone from 'ember-metal/is_none';
 import { bind } from "./binding";
+import { isStream } from "ember-metal/streams/utils";
 
 /**
 @module ember
@@ -53,7 +54,7 @@ export function partialHelper(params, hash, options, env) {
 
   var name = params[0];
 
-  if (name && name.isStream) {
+  if (isStream(name)) {
     options.template = createPartialTemplate(name);
     bind.call(this, name, hash, options, env, true, exists);
   } else {

--- a/packages/ember-htmlbars/lib/hooks/content.js
+++ b/packages/ember-htmlbars/lib/hooks/content.js
@@ -5,11 +5,12 @@
 
 import subexpr from "ember-htmlbars/hooks/subexpr";
 import { appendSimpleBoundView } from "ember-views/views/simple_bound_view";
+import { isStream } from "ember-metal/streams/utils";
 
 export default function content(morph, path, view, params, hash, options, env) {
   var result = subexpr(path, view, params, hash, options, env);
 
-  if (result && result.isStream) {
+  if (isStream(result)) {
     appendSimpleBoundView(view, morph, result);
   } else {
     morph.update(result);

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -44,6 +44,7 @@ import {
   addListener,
   removeListener
 } from "ember-metal/events";
+import { isStream } from "ember-metal/streams/utils";
 
 var REQUIRED;
 var a_slice = [].slice;
@@ -356,7 +357,7 @@ function connectBindings(obj, m) {
       binding = bindings[key];
       if (binding) {
         to = key.slice(0, -7); // strip Binding off end
-        if (binding.isStream) {
+        if (isStream(binding)) {
           connectStreamBinding(obj, to, binding);
           continue;
         } else if (binding instanceof Binding) {

--- a/packages/ember-metal/lib/streams/simple.js
+++ b/packages/ember-metal/lib/streams/simple.js
@@ -1,13 +1,13 @@
 import merge from "ember-metal/merge";
 import Stream from "ember-metal/streams/stream";
 import { create } from "ember-metal/platform";
-import { read } from "ember-metal/streams/utils";
+import { read, isStream } from "ember-metal/streams/utils";
 
 function SimpleStream(source) {
   this.init();
   this.source = source;
 
-  if (source && source.isStream) {
+  if (isStream(source)) {
     source.subscribe(this._didChange, this);
   }
 }
@@ -22,7 +22,7 @@ merge(SimpleStream.prototype, {
   setValue: function(value) {
     var source = this.source;
 
-    if (source && source.isStream) {
+    if (isStream(source)) {
       source.setValue(value);
     }
   },
@@ -30,11 +30,11 @@ merge(SimpleStream.prototype, {
   setSource: function(nextSource) {
     var prevSource = this.source;
     if (nextSource !== prevSource) {
-      if (prevSource && prevSource.isStream) {
+      if (isStream(prevSource)) {
         prevSource.unsubscribe(this._didChange, this);
       }
 
-      if (nextSource && nextSource.isStream) {
+      if (isStream(nextSource)) {
         nextSource.subscribe(this._didChange, this);
       }
 
@@ -51,7 +51,7 @@ merge(SimpleStream.prototype, {
 
   destroy: function() {
     if (this._super$destroy()) {
-      if (this.source && this.source.isStream) {
+      if (isStream(this.source)) {
         this.source.unsubscribe(this._didChange, this);
       }
       this.source = undefined;

--- a/packages/ember-routing-handlebars/lib/helpers/action.js
+++ b/packages/ember-routing-handlebars/lib/helpers/action.js
@@ -11,6 +11,7 @@ import run from "ember-metal/run_loop";
 import { readUnwrappedModel } from "ember-views/streams/utils";
 import { isSimpleClick } from "ember-views/system/utils";
 import ActionManager from "ember-views/system/action_manager";
+import { isStream } from "ember-metal/streams/utils";
 
 function actionArgs(parameters, actionName) {
   var ret, i;
@@ -105,7 +106,7 @@ ActionHelper.registerAction = function(actionNameOrStream, options, allowedKeys)
 
       var actionName;
 
-      if (actionNameOrStream.isStream) {
+      if (isStream(actionNameOrStream)) {
         actionName = actionNameOrStream.value();
 
         Ember.assert("You specified a quoteless path to the {{action}} helper " +

--- a/packages/ember-routing-htmlbars/lib/helpers/action.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/action.js
@@ -10,6 +10,7 @@ import { readUnwrappedModel } from "ember-views/streams/utils";
 import { isSimpleClick } from "ember-views/system/utils";
 import ActionManager from "ember-views/system/action_manager";
 import { indexOf } from "ember-metal/array";
+import { isStream } from "ember-metal/streams/utils";
 
 function actionArgs(parameters, actionName) {
   var ret, i, l;
@@ -100,7 +101,7 @@ ActionHelper.registerAction = function(actionNameOrStream, options, allowedKeys)
 
       var actionName;
 
-      if (actionNameOrStream.isStream) {
+      if (isStream(actionNameOrStream)) {
         actionName = actionNameOrStream.value();
 
         Ember.assert("You specified a quoteless path to the {{action}} helper " +
@@ -297,7 +298,7 @@ export function actionHelper(params, hash, options, env) {
   var target;
   if (!hash.target) {
     target = this.getStream('controller');
-  } else if (hash.target.isStream) {
+  } else if (isStream(hash.target)) {
     target = hash.target;
   } else {
     target = this.getStream(hash.target);

--- a/packages/ember-views/lib/streams/key_stream.js
+++ b/packages/ember-views/lib/streams/key_stream.js
@@ -9,7 +9,7 @@ import {
   removeObserver
 } from "ember-metal/observer";
 import Stream from "ember-metal/streams/stream";
-import { read } from "ember-metal/streams/utils";
+import { read, isStream } from "ember-metal/streams/utils";
 
 function KeyStream(source, key) {
   Ember.assert("KeyStream error: key must be a non-empty string", typeof key === 'string' && key.length > 0);
@@ -20,7 +20,7 @@ function KeyStream(source, key) {
   this.obj = undefined;
   this.key = key;
 
-  if (source && source.isStream) {
+  if (isStream(source)) {
     source.subscribe(this._didChange, this);
   }
 }
@@ -61,11 +61,11 @@ merge(KeyStream.prototype, {
     var prevSource = this.source;
 
     if (nextSource !== prevSource) {
-      if (prevSource && prevSource.isStream) {
+      if (isStream(prevSource)) {
         prevSource.unsubscribe(this._didChange, this);
       }
 
-      if (nextSource && nextSource.isStream) {
+      if (isStream(nextSource)) {
         nextSource.subscribe(this._didChange, this);
       }
 
@@ -82,7 +82,7 @@ merge(KeyStream.prototype, {
 
   destroy: function() {
     if (this._super$destroy()) {
-      if (this.source && this.source.isStream) {
+      if (isStream(this.source)) {
         this.source.unsubscribe(this._didChange, this);
       }
 

--- a/packages/ember-views/lib/streams/utils.js
+++ b/packages/ember-views/lib/streams/utils.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import { isGlobal } from "ember-metal/path_cache";
 import { fmt } from "ember-runtime/system/string";
-import { read } from "ember-metal/streams/utils";
+import { read, isStream } from "ember-metal/streams/utils";
 import View from "ember-views/views/view";
 import ControllerMixin from "ember-runtime/mixins/controller";
 
@@ -28,7 +28,7 @@ export function readViewFactory(object, container) {
 }
 
 export function readUnwrappedModel(object) {
-  if (object && object.isStream) {
+  if (isStream(object)) {
     var result = object.value();
 
     // If the path is exactly `controller` then we don't unwrap it.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -51,6 +51,7 @@ import jQuery from "ember-views/system/jquery";
 import "ember-views/system/ext";  // for the side effect of extending Ember.run.queues
 
 import CoreView from "ember-views/views/core_view";
+import { isStream } from "ember-metal/streams/utils";
 
 function K() { return this; }
 
@@ -2063,7 +2064,7 @@ var View = CoreView.extend({
     }
 
     var path = pathOrStream;
-    if (pathOrStream.isStream) {
+    if (isStream(pathOrStream)) {
       path = pathOrStream._label;
 
       if (!path) {


### PR DESCRIPTION
There were a number of scenarios where we were not properly gaurding against `null` or `undefined` objects before checking for `isStream` on them.  This refactors all `someThing.isStream` checks to use the stream utility function which handles this properly.

Fixes #9910.
