### PR TITLE
[BUGFIX beta] Do not stringify null classes, allow unquoted bind-attr class

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/concat.js
+++ b/packages/ember-htmlbars/lib/hooks/concat.js
@@ -3,39 +3,11 @@
 @submodule ember-htmlbars
 */
 
-import Stream from "ember-metal/streams/stream";
 import {
-  isStream,
-  readArray,
-  subscribe
+  concat as streamConcat
 } from "ember-metal/streams/utils";
 
-// TODO: Create subclass ConcatStream < Stream. Defer
-// subscribing to streams until the value() is called.
 export default function concat(params) {
-  var i;
-  var isStatic = true;
-
-  for (i = 0; i < params.length; i++) {
-    if (isStream(params[i])) {
-      isStatic = false;
-      break;
-    }
-  }
-
-  if (isStatic) {
-    return params.join('');
-  } else {
-    var stream = new Stream(function() {
-      return readArray(params).join('');
-    });
-
-    for (i = 0; i < params.length; i++) {
-      subscribe(params[i], stream.notify, stream);
-    }
-
-    return stream;
-  }
-
+  return streamConcat(params, '');
 }
 

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -11,6 +11,7 @@ import { observersFor } from "ember-metal/observer";
 import Container from "ember-runtime/system/container";
 import { set } from "ember-metal/property_set";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import { equalInnerHTML } from "htmlbars-test-helpers";
 
 import helpers from "ember-htmlbars/helpers";
 import compile from "ember-htmlbars/system/compile";
@@ -259,6 +260,25 @@ test("should be able to bind class attribute with {{bind-attr}}", function() {
 
   runAppend(view);
 
+  equalInnerHTML(view.element, '<img class="bar">', 'renders class');
+
+  run(function() {
+    set(view, 'foo', 'baz');
+  });
+
+  equalInnerHTML(view.element, '<img class="baz">', 'updates rendered class');
+});
+
+test("should be able to bind unquoted class attribute with {{bind-attr}}", function() {
+  var template = compile('<img {{bind-attr class=view.foo}}>');
+
+  view = EmberView.create({
+    template: template,
+    foo: 'bar'
+  });
+
+  runAppend(view);
+
   equal(view.$('img').attr('class'), 'bar', "renders class");
 
   run(function() {
@@ -278,13 +298,13 @@ test("should be able to bind class attribute via a truthy property with {{bind-a
 
   runAppend(view);
 
-  equal(view.$('.is-truthy').length, 1, "sets class name");
+  equalInnerHTML(view.element, '<img class="is-truthy">', 'renders class');
 
   run(function() {
     set(view, 'isNumber', 0);
   });
 
-  equal(view.$('.is-truthy').length, 0, "removes class name if bound property is set to something non-truthy");
+  equalInnerHTML(view.element.firstChild.className, undefined, 'removes class');
 });
 
 test("should be able to bind class to view attribute with {{bind-attr}}", function() {

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -8,7 +8,7 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 var view;
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  QUnit.module("ember-htmlbars: basic/text_node_test", {
+  QUnit.module("ember-htmlbars: hooks/text_node_test", {
     teardown: function(){
       runDestroy(view);
     }

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -125,7 +125,7 @@ Stream.prototype = {
         children[key].destroy();
       }
 
-      return true;      
+      return true;
     }
   },
 

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -1,3 +1,5 @@
+import Stream from "./stream";
+
 export function isStream(object) {
   return object && object.isStream;
 }
@@ -74,4 +76,34 @@ export function scanHash(hash) {
   }
 
   return containsStream;
+}
+
+// TODO: Create subclass ConcatStream < Stream. Defer
+// subscribing to streams until the value() is called.
+export function concat(array, key) {
+  var hasStream = scanArray(array);
+  if (hasStream) {
+    var i, l;
+    var stream = new Stream(function() {
+      return readArray(array).join(key);
+    });
+
+    for (i = 0, l=array.length; i < l; i++) {
+      subscribe(array[i], stream.notify, stream);
+    }
+
+    return stream;
+  } else {
+    return array.join(key);
+  }
+}
+
+export function chainStream(value, fn) {
+  if (isStream(value)) {
+    var stream = new Stream(fn);
+    subscribe(value, stream.notify, stream);
+    return stream;
+  } else {
+    return fn();
+  }
 }

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -50,7 +50,6 @@ test("RenderBuffers push fragments", function() {
 
   var el = buffer.element();
   equal(el.tagName.toLowerCase(), 'div');
-  console.log('el.', el.childNodes);
   equal(el.childNodes[0].tagName, 'SPAN', "Fragment is pushed into the buffer");
 });
 


### PR DESCRIPTION
Fixes #9893 and #9890.

@mmun as discussed in #9908 I've added a concat helper to the stream utils that takes an argument for join value. Additionally I've added a `chainStream` helper that either processes immediately or chains a stream onto the passed value. This decreases the crazy in class name bindings.
