### PR TITLE
[BUGFIX beta] bound if/unless inside unbound if/unless (#9894)

### DIFF
--- a/packages/ember-handlebars/lib/helpers/if_unless.js
+++ b/packages/ember-handlebars/lib/helpers/if_unless.js
@@ -103,6 +103,7 @@ function ifHelper(context, options) {
   options.helperName = options.helperName || ('if ' + context);
 
   if (options.data.isUnbound) {
+    options.data.isUnbound = false;
     return helpers.unboundIf.call(options.contexts[0], context, options);
   } else {
     return helpers.boundIf.call(options.contexts[0], context, options);
@@ -134,6 +135,7 @@ function unlessHelper(context, options) {
   options.helperName = options.helperName || helperName;
 
   if (options.data.isUnbound) {
+    options.data.isUnbound = false;
     return helpers.unboundIf.call(options.contexts[0], context, options);
   } else {
     return helpers.boundIf.call(options.contexts[0], context, options);

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -117,6 +117,7 @@ function ifHelper(params, hash, options, env) {
   options.helperName = options.helperName || ('if ');
 
   if (env.data.isUnbound) {
+    env.data.isUnbound = false;
     return env.helpers.unboundIf.helperFunction.call(this, params, hash, options, env);
   } else {
     return env.helpers.boundIf.helperFunction.call(this, params, hash, options, env);
@@ -144,6 +145,7 @@ function unlessHelper(params, hash, options, env) {
   options.helperName = options.helperName || helperName;
 
   if (env.data.isUnbound) {
+    env.data.isUnbound = false;
     return env.helpers.unboundIf.helperFunction.call(this, params, hash, options, env);
   } else {
     return env.helpers.boundIf.helperFunction.call(this, params, hash, options, env);

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -254,6 +254,34 @@ test("should be able to render an unbound helper invocation with bound hash opti
   }
 });
 
+test("should be able to render bound form of a helper inside unbound form of same helper", function() {
+  view = EmberView.create({
+    template: compile(
+      ["{{#unbound if foo}}",
+        "{{#if bar}}true{{/if}}",
+        "{{#unless bar}}false{{/unless}}",
+        "{{/unbound}}",
+        "{{#unbound unless notfoo}}",
+        "{{#if bar}}true{{/if}}",
+        "{{#unless bar}}false{{/unless}}",
+        "{{/unbound}}"].join("")),
+    context: EmberObject.create({
+      foo: true,
+      notfoo: false,
+      bar: true
+    })
+  });
+  runAppend(view);
+
+  equal(view.$().text(), "truetrue", "first render is correct");
+
+  run(function() {
+    set(view, 'context.bar', false);
+  });
+
+  equal(view.$().text(), "falsefalse", "bound if and unless inside unbound if/unless are updated");
+});
+
 QUnit.module("ember-htmlbars: {{#unbound}} helper -- Container Lookup", {
   setup: function() {
     Ember.lookup = lookup = { Ember: Ember };


### PR DESCRIPTION
Addsa previously failing test and simple fix for https://github.com/emberjs/ember.js/issues/9894.  The problem was that `isUnbound` was not being unset until after the inner templates were rendered, so it was interpreting the inner if/unless as unbound too.  I made the same changes in both the handlebars and htmlbars packages, but the tests seems to only be for htmlbars.  Let me know if this isn't the right way to do it.

Also, I considered doing something more fancy/elegant, in order to avoid needing to delete `isUnbound` everywhere it's used that could cause problems.  (And, note that it has other usages than if/unless, but I believe those are ok).  Something like setting it to a function which returns true the first time and false afterwards, or something like that.  

I'd be happy to do it if it seems like added complexity is justified by its allowing us to keep the logic in one place (in the unbound helper rather than needing to set it there and unset it in the if/unless helpers, as currently), so just let me know what you think.
