### PR TITLE
[BUGFIX beta] Refactor route.render for increased sanity

### DIFF
--- a/packages/ember-htmlbars/lib/helpers.js
+++ b/packages/ember-htmlbars/lib/helpers.js
@@ -3,11 +3,13 @@
 @submodule ember-htmlbars
 */
 
+import { create as o_create } from "ember-metal/platform";
+
 /**
  @private
  @property helpers
 */
-var helpers = { };
+var helpers = o_create(null);
 
 /**
 @module ember

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -28,8 +28,9 @@ export var ISNT_HELPER_CACHE = new Cache(1000, function(key) {
   @return {Handlebars Helper}
 */
 export default function lookupHelper(name, view, env) {
-  if (env.helpers[name]) {
-    return env.helpers[name];
+  var helper = env.helpers[name];
+  if (helper) {
+    return helper;
   }
 
   var container = view.container;
@@ -39,7 +40,7 @@ export default function lookupHelper(name, view, env) {
   }
 
   var helperName = 'helper:' + name;
-  var helper = container.lookup(helperName);
+  helper = container.lookup(helperName);
   if (!helper) {
     var componentLookup = container.lookup('component-lookup:main');
     Ember.assert("Could not find 'component-lookup:main' on the provided container," +


### PR DESCRIPTION
The code for `route.render` has sprawled pretty bad. This refactors it to get back in line.

Biggest change besides the restructuring is that views use `lookupFactory` instead of `lookup`, allowing them to be created with initial values (and be consistent with how views are instantiated elsewhere).
