### PR TITLE
[FEATURE "ember-routing-transitioning-classes”]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -111,3 +111,14 @@ for a detailed explanation.
   to perform the lookup instead.  Replaces the need for `needs` in controllers.
 
   Added in [#5162](https://github.com/emberjs/ember.js/pull/5162).
+
+* `ember-routing-transitioning-classes`
+
+  Disables eager URL updates during slow transitions in favor of new CSS
+  classes added to `link-to`s (in addition to `active` class):
+
+  - `transitioning-in`: link-to is not currently active, but will be
+    when the current underway (slow) transition completes.
+  - `transitioning-out`: link-to is currently active, but will no longer
+    be active when the current underway (slow) transition completes.
+

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#f4bd6a2df221240ed36d140f0c53c036a7ecacad",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
-    "router.js": "https://github.com/tildeio/router.js.git#9471aaaa28c11907d8fdf8969b70c6a93ad19fd1",
+    "router.js": "https://github.com/tildeio/router.js.git#a1ffd97dc66a6d9d4e8dd89a72c1c4e21a3328c5",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#1c30a1666273ab2a9b134a42bad28c774f9ecdfc"

--- a/features.json
+++ b/features.json
@@ -12,7 +12,8 @@
     "ember-htmlbars-block-params": true,
     "ember-htmlbars-component-generation": null,
     "ember-htmlbars-inline-if-helper": null,
-    "ember-htmlbars-attribute-syntax": null
+    "ember-htmlbars-attribute-syntax": null,
+    "ember-routing-transitioning-classes": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing/lib/system/router_state.js
+++ b/packages/ember-routing/lib/system/router_state.js
@@ -1,0 +1,40 @@
+import Ember from "ember-metal/core";
+import EmberObject from "ember-runtime/system/object";
+import merge from "ember-metal/merge";
+
+var RouterState = EmberObject.extend({
+  emberRouter: null,
+  routerJs: null,
+  routerJsState: null,
+
+  isActiveIntent: function(routeName, models, queryParams, queryParamsMustMatch) {
+    var state = this.routerJsState;
+    if (!this.routerJs.isActiveIntent(routeName, models, null, state)) { return false; }
+
+    var emptyQueryParams = Ember.isEmpty(Ember.keys(queryParams));
+
+    if (queryParamsMustMatch && !emptyQueryParams) {
+      var visibleQueryParams = {};
+      merge(visibleQueryParams, queryParams);
+
+      this.emberRouter._prepareQueryParams(routeName, models, visibleQueryParams);
+      return shallowEqual(visibleQueryParams, state.queryParams);
+    }
+
+    return true;
+  }
+});
+
+function shallowEqual(a, b) {
+  var k;
+  for (k in a) {
+    if (a.hasOwnProperty(k) && a[k] !== b[k]) { return false; }
+  }
+  for (k in b) {
+    if (b.hasOwnProperty(k) && a[k] !== b[k]) { return false; }
+  }
+  return true;
+}
+
+export default RouterState;
+


### PR DESCRIPTION
Disables eager URL updates during slow transitions in favor of new CSS classes
added to `link-to`s (in addition to `active` class):
- `transitioning-in`: link-to is not currently active, but will be
  when the current underway (slow) transition completes.
- `transitioning-out`: link-to is currently active, but will no longer
  be active when the current underway (slow) transition completes.

This reverts the feature we added some months ago to eagerly update the URL even when a transition takes a while to complete; we realized that certain bugs (e.g. #5210 and #4908) didn't really otherwise have a clean solution since the original feature was at odds with the URL behavior people have come to expect from browsers. 
