### PR TITLE
[BUGFIX beta] Buffer cleanup and profiling catches

### DIFF
--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -303,15 +303,15 @@ _RenderBuffer.prototype = {
     @chainable
   */
   push: function(content) {
-    if (content.nodeType) {
-      Ember.assert("A fragment cannot be pushed into a buffer that contains content", !this.buffer);
-      this.buffer = content;
-    } else {
+    if (typeof content === 'string') {
       if (this.buffer === null) {
         this.buffer = '';
       }
       Ember.assert("A string cannot be pushed into the buffer after a fragment", !this.buffer.nodeType);
       this.buffer += content;
+    } else {
+      Ember.assert("A fragment cannot be pushed into a buffer that contains content", !this.buffer);
+      this.buffer = content;
     }
     return this;
   },

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -459,7 +459,6 @@ _RenderBuffer.prototype = {
     }
 
     var element = this.dom.createElement(tagString, this.outerContextualElement());
-    var $element = jQuery(element);
 
     if (id) {
       this.dom.setAttribute(element, 'id', id);
@@ -473,9 +472,7 @@ _RenderBuffer.prototype = {
 
     if (style) {
       for (prop in style) {
-        if (style.hasOwnProperty(prop)) {
-          styleBuffer += (prop + ':' + style[prop] + ';');
-        }
+        styleBuffer += (prop + ':' + style[prop] + ';');
       }
 
       this.dom.setAttribute(element, 'style', styleBuffer);
@@ -485,9 +482,7 @@ _RenderBuffer.prototype = {
 
     if (attrs) {
       for (attr in attrs) {
-        if (attrs.hasOwnProperty(attr)) {
-          this.dom.setAttribute(element, attr, attrs[attr]);
-        }
+        this.dom.setAttribute(element, attr, attrs[attr]);
       }
 
       this.elementAttributes = null;
@@ -495,9 +490,7 @@ _RenderBuffer.prototype = {
 
     if (props) {
       for (prop in props) {
-        if (props.hasOwnProperty(prop)) {
-          $element.prop(prop, props[prop]);
-        }
+        this.dom.setProperty(element, prop, props[prop]);
       }
 
       this.elementProperties = null;

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -528,7 +528,10 @@ _RenderBuffer.prototype = {
         this._element.appendChild(nodes[0]);
       }
     }
-    this.hydrateMorphs(contextualElement);
+    // This should only happen with legacy string buffers
+    if (this.childViews.length > 0) {
+      this.hydrateMorphs(contextualElement);
+    }
 
     return this._element;
   },


### PR DESCRIPTION
Some cleanup to the render buffer. Most controversial:
- Not checking `hasOwnProperty` on style, attr, and prop lists.
- Dropping jQuery `prop` in favor of `dom.setProperty`
