### PR TITLE
Run Ember in node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,4 @@ env:
     - TEST_SUITE=built-tests
     - TEST_SUITE=old-jquery
     - TEST_SUITE=extend-prototypes
+    - TEST_SUITE=node

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -650,6 +650,7 @@ var deprecatedDebugFile = replace(compiledSource, {
     { match: /var runningNonEmberDebugJS = false;/, replacement: 'var runningNonEmberDebugJS = true;'}
   ]
 });
+
 deprecatedDebugFile = concat(deprecatedDebugFile, {
   inputFiles: [ 'ember.debug.js' ],
   outputFile: '/ember.js'
@@ -691,6 +692,26 @@ function buildRuntimeTree() {
     wrapInEval: false,
     inputFiles: ['ember-runtime.js', 'export-ember'],
     outputFile: '/ember-runtime.js'
+  });
+}
+
+function buildCJSTree() {
+  var compiledSource = concatES6(devSourceTrees, {
+    es3Safe: env !== 'development',
+    derequire: env !== 'development',
+    includeLoader: true,
+    bootstrapModule: 'ember',
+    vendorTrees: vendorTrees,
+    inputFiles: ['**/*.js'],
+    destFile: '/ember.debug.cjs.js'
+  });
+
+  var exportsTree = writeFile('export-ember', ';module.exports = Ember;\n');
+
+  return concat(mergeTrees([compiledSource, exportsTree]), {
+    wrapInEval: false,
+    inputFiles: ['ember.debug.cjs.js', 'export-ember'],
+    outputFile: '/ember.debug.cjs.js'
   });
 }
 
@@ -767,6 +788,7 @@ if (env !== 'development') {
     distTrees.push(minCompiledSource);
   }
   distTrees.push(buildRuntimeTree());
+  distTrees.push(buildCJSTree());
 }
 
 // merge distTrees and sub out version placeholders for distribution

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -696,21 +696,11 @@ function buildRuntimeTree() {
 }
 
 function buildCJSTree() {
-  var compiledSource = concatES6(devSourceTrees, {
-    es3Safe: env !== 'development',
-    derequire: env !== 'development',
-    includeLoader: true,
-    bootstrapModule: 'ember',
-    vendorTrees: vendorTrees,
-    inputFiles: ['**/*.js'],
-    destFile: '/ember.debug.cjs.js'
-  });
-
   var exportsTree = writeFile('export-ember', ';module.exports = Ember;\n');
 
   return concat(mergeTrees([compiledSource, exportsTree]), {
     wrapInEval: false,
-    inputFiles: ['ember.debug.cjs.js', 'export-ember'],
+    inputFiles: ['ember.debug.js', 'export-ember'],
     outputFile: '/ember.debug.cjs.js'
   });
 }

--- a/bin/run-node-tests.js
+++ b/bin/run-node-tests.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+require('qunitjs');
+
+// adds test reporting
+var qe = require('qunit-extras');
+qe.runInContext(global);
+
+var glob = require('glob');
+var root = 'tests/';
+
+function addFiles(files) {
+  glob.sync(root + files)
+    .map(function(name) {
+      return "../" + name.substring(0, name.length - 3);
+    })
+    .forEach(require);
+}
+
+addFiles('/**/*-test.js');
+
+QUnit.load();

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -135,6 +135,9 @@ switch (process.env.TEST_SUITE) {
     generateExtendPrototypeTests();
     generateEachPackageTests();
     break;
+  case 'node':
+    require('./run-node-tests');
+    return;
   default:
     generateEachPackageTests();
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "git-repo-version": "0.0.1",
     "glob": "~3.2.8",
     "htmlbars": "0.5.0",
-    "rsvp": "~3.0.6"
+    "rsvp": "~3.0.6",
+    "qunit-extras": "^1.3.0",
+    "qunitjs": "^1.16.0"
   }
 }

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -31,16 +31,10 @@ import AutoLocation from "ember-routing/location/auto_location";
 import NoneLocation from "ember-routing/location/none_location";
 import BucketCache from "ember-routing/system/cache";
 
-// this is technically incorrect (per @wycats)
-// it should work properly with:
-// `import ContainerDebugAdapter from 'ember-extension-support/container_debug_adapter';` but
-// es6-module-transpiler 0.4.0 eagerly grabs the module (which is undefined)
-
 import ContainerDebugAdapter from "ember-extension-support/container_debug_adapter";
 
-import {
-  K
-} from 'ember-metal/core';
+import { K } from 'ember-metal/core';
+import environment from 'ember-metal/environment';
 
 function props(obj) {
   var properties = [];
@@ -276,7 +270,10 @@ var Application = Namespace.extend(DeferredMixin, {
 
     if (!librariesRegistered) {
       librariesRegistered = true;
-      Ember.libraries.registerCoreLibrary('jQuery', jQuery().jquery);
+
+      if (environment.hasDOM) {
+        Ember.libraries.registerCoreLibrary('jQuery', jQuery().jquery);
+      }
     }
 
     if (Ember.LOG_VERSION) {
@@ -695,7 +692,10 @@ var Application = Namespace.extend(DeferredMixin, {
     @method didBecomeReady
   */
   didBecomeReady: function() {
-    this.setupEventDispatcher();
+    if (environment.hasDOM) {
+      this.setupEventDispatcher();
+    }
+
     this.ready(); // user hook
     this.startRouting();
 

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -4,6 +4,8 @@ import Ember from "ember-metal/core";
 import EmberError from "ember-metal/error";
 import Logger from "ember-metal/logger";
 
+import environment from "ember-metal/environment";
+
 /**
 Ember Debug
 
@@ -218,7 +220,7 @@ if (!Ember.testing) {
 
   // Inform the developer about the Ember Inspector if not installed.
   var isFirefox = typeof InstallTrigger !== 'undefined';
-  var isChrome = !!window.chrome && !window.opera;
+  var isChrome = environment.isChrome;
 
   if (typeof window !== 'undefined' && (isFirefox || isChrome) && window.addEventListener) {
     window.addEventListener("load", function() {

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -47,6 +47,8 @@ import { registerASTPlugin } from "ember-htmlbars/plugins";
 import TransformEachInToHash from "ember-htmlbars/plugins/transform-each-in-to-hash";
 import TransformWithAsToHash from "ember-htmlbars/plugins/transform-with-as-to-hash";
 
+import environment from "ember-metal/environment";
+
 // importing adds template bootstrapping
 // initializer to enable embedded templates
 import "ember-htmlbars/system/bootstrap";
@@ -95,8 +97,10 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 }
 
+var domHelper = environment.hasDOM ? new DOMHelper() : null;
+
 export var defaultEnv = {
-  dom: new DOMHelper(),
+  dom: domHelper,
 
   hooks: {
     get: get,

--- a/packages/ember-htmlbars/lib/system/bootstrap.js
+++ b/packages/ember-htmlbars/lib/system/bootstrap.js
@@ -11,6 +11,7 @@ import jQuery from "ember-views/system/jquery";
 import EmberError from "ember-metal/error";
 import { onLoad } from "ember-runtime/system/lazy_load";
 import htmlbarsCompile from "ember-htmlbars/system/compile";
+import environment from "ember-metal/environment";
 
 /**
 @module ember
@@ -87,7 +88,7 @@ onLoad('Ember.Application', function(Application) {
 
   Application.initializer({
     name: 'domTemplates',
-    initialize: _bootstrap
+    initialize: environment.hasDOM ? _bootstrap : function() { }
   });
 
   Application.initializer({

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -1,4 +1,7 @@
 import { DOMHelper } from "morph";
+import environment from "ember-metal/environment";
+
+var domHelper = environment.hasDOM ? new DOMHelper() : null;
 
 function Renderer() {
   this._uuid = 0;
@@ -7,7 +10,7 @@ function Renderer() {
   this._parents = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
   this._elements = new Array(17);
   this._inserts = {};
-  this._dom = new DOMHelper();
+  this._dom = domHelper;
 }
 
 function Renderer_renderTree(_view, _parentView, _insertAt) {

--- a/packages/ember-metal/lib/environment.js
+++ b/packages/ember-metal/lib/environment.js
@@ -1,0 +1,41 @@
+
+/*
+  Ember can run in many different environments, including environments like
+  Node.js where the DOM is unavailable. This object serves as an abstraction
+  over the browser features that Ember relies on, so that code does not
+  explode when trying to boot in an environment that doesn't have them.
+
+  This is a private abstraction. In the future, we hope that other
+  abstractions (like `Location`, `Renderer`, `dom-helper`) can fully abstract
+  over the differences in environment.
+*/
+var environment;
+
+// This code attempts to automatically detect an environment with DOM
+// by searching for window and document.createElement. An environment
+// with DOM may disable the DOM functionality of Ember explicitly by
+// defining a `disableBrowserEnvironment` ENV.
+var hasDOM = typeof window !== 'undefined' &&
+             typeof document !== 'undefined' &&
+             typeof document.createElement === 'function' &&
+             !Ember.ENV.disableBrowserEnvironment;
+
+if (hasDOM) {
+  environment = {
+    hasDOM: true,
+    isChrome: !!window.chrome && !window.opera,
+    location: window.location,
+    history: window.history,
+    userAgent: window.navigator.userAgent
+  };
+} else {
+  environment = {
+    hasDOM: false,
+    isChrome: false,
+    location: null,
+    history: null,
+    userAgent: "Lynx (textmode)"
+  };
+}
+
+export default environment;

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core"; // deprecate, assert
+import environment from "ember-metal/environment";
 
 /**
 @module ember
@@ -178,7 +179,7 @@ export default {
   },
 
   implementations: {},
-  _location: window.location,
+  _location: environment.location,
 
   /**
     Returns the current `location.hash` by parsing location.href since browsers

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -6,6 +6,9 @@ import HistoryLocation from "ember-routing/location/history_location";
 import HashLocation from "ember-routing/location/hash_location";
 import NoneLocation from "ember-routing/location/none_location";
 
+import environment from "ember-metal/environment";
+import { supportsHashChange, supportsHistory } from "ember-routing/location/feature_detect";
+
 /**
 @module ember
 @submodule ember-routing
@@ -49,38 +52,6 @@ export default {
     @default '/'
   */
   rootURL: '/',
-
-  /**
-    @private
-
-    Attached for mocking in tests
-
-    @since 1.5.1
-    @property _window
-    @default window
-  */
-  _window: window,
-
-  /**
-    @private
-
-    Attached for mocking in tests
-
-    @property location
-    @default window.location
-  */
-  _location: window.location,
-
-  /**
-    @private
-
-    Attached for mocking in tests
-
-    @since 1.5.1
-    @property _history
-    @default window.history
-  */
-  _history: window.history,
 
   /**
     @private
@@ -138,45 +109,24 @@ export default {
     return origin;
   },
 
+  _userAgent: environment.userAgent,
+
   /**
     @private
-
-    We assume that if the history object has a pushState method, the host should
-    support HistoryLocation.
 
     @method _getSupportsHistory
   */
   _getSupportsHistory: function () {
-    // Boosted from Modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
-    // The stock browser on Android 2.2 & 2.3 returns positive on history support
-    // Unfortunately support is really buggy and there is no clean way to detect
-    // these bugs, so we fall back to a user agent sniff :(
-    var userAgent = this._window.navigator.userAgent;
-
-    // We only want Android 2, stock browser, and not Chrome which identifies
-    // itself as 'Mobile Safari' as well
-    if (userAgent.indexOf('Android 2') !== -1 &&
-        userAgent.indexOf('Mobile Safari') !== -1 &&
-        userAgent.indexOf('Chrome') === -1) {
-      return false;
-    }
-
-    return !!(this._history && 'pushState' in this._history);
+    return supportsHistory(environment.userAgent, environment.history);
   },
 
   /**
     @private
 
-    IE8 running in IE7 compatibility mode gives false positive, so we must also
-    check documentMode.
-
     @method _getSupportsHashChange
   */
   _getSupportsHashChange: function () {
-    var _window = this._window;
-    var documentMode = _window.document.documentMode;
-
-    return ('onhashchange' in _window && (documentMode === undefined || documentMode > 7 ));
+    return supportsHashChange(document.documentMode, window);
   },
 
   /**

--- a/packages/ember-routing/lib/location/feature_detect.js
+++ b/packages/ember-routing/lib/location/feature_detect.js
@@ -1,4 +1,4 @@
-/**
+/*
   `documentMode` only exist in Internet Explorer, and it's tested because IE8 running in
   IE7 compatibility mode claims to support `onhashchange` but actually does not.
 
@@ -11,7 +11,7 @@ export function supportsHashChange(documentMode, global) {
   return ('onhashchange' in global) && (documentMode === undefined || documentMode > 7);
 }
 
-/**
+/*
   `userAgent` is a user agent string. We use user agent testing here, because
   the stock Android browser in Gingerbread has a buggy versions of this API,
   Before feature detecting, we blacklist a browser identifying as both Android 2
@@ -20,6 +20,7 @@ export function supportsHashChange(documentMode, global) {
   @private
   @function supportsHistory
 */
+
 export function supportsHistory(userAgent, history) {
   // Boosted from Modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
   // The stock browser on Android 2.2 & 2.3 returns positive on history support

--- a/packages/ember-routing/lib/location/feature_detect.js
+++ b/packages/ember-routing/lib/location/feature_detect.js
@@ -1,0 +1,38 @@
+/**
+  `documentMode` only exist in Internet Explorer, and it's tested because IE8 running in
+  IE7 compatibility mode claims to support `onhashchange` but actually does not.
+
+  `global` is an object that may have an `onhashchange` property.
+
+  @private
+  @function supportsHashChange
+*/
+export function supportsHashChange(documentMode, global) {
+  return ('onhashchange' in global) && (documentMode === undefined || documentMode > 7);
+}
+
+/**
+  `userAgent` is a user agent string. We use user agent testing here, because
+  the stock Android browser in Gingerbread has a buggy versions of this API,
+  Before feature detecting, we blacklist a browser identifying as both Android 2
+  and Mobile Safari, but not Chrome.
+
+  @private
+  @function supportsHistory
+*/
+export function supportsHistory(userAgent, history) {
+  // Boosted from Modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
+  // The stock browser on Android 2.2 & 2.3 returns positive on history support
+  // Unfortunately support is really buggy and there is no clean way to detect
+  // these bugs, so we fall back to a user agent sniff :(
+
+  // We only want Android 2, stock browser, and not Chrome which identifies
+  // itself as 'Mobile Safari' as well
+  if (userAgent.indexOf('Android 2') !== -1 &&
+      userAgent.indexOf('Mobile Safari') !== -1 &&
+      userAgent.indexOf('Chrome') === -1) {
+    return false;
+  }
+
+  return !!(history && 'pushState' in history);
+}

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -12,7 +12,6 @@ import jQuery from "ember-views/system/jquery";
 */
 
 var popstateFired = false;
-var supportsHistoryState = window.history && 'state' in window.history;
 
 /**
   Ember.HistoryLocation implements the location API using the browser's
@@ -82,7 +81,7 @@ export default EmberObject.extend({
     @param path {String}
   */
   setURL: function(path) {
-    var state = this.getState();
+    var state = this._historyState;
     path = this.formatURL(path);
 
     if (!state || state.path !== path) {
@@ -99,26 +98,12 @@ export default EmberObject.extend({
     @param path {String}
   */
   replaceURL: function(path) {
-    var state = this.getState();
+    var state = this._historyState;
     path = this.formatURL(path);
 
     if (!state || state.path !== path) {
       this.replaceState(path);
     }
-  },
-
-  /**
-   Get the current `history.state`. Checks for if a polyfill is
-   required and if so fetches this._historyState. The state returned
-   from getState may be null if an iframe has changed a window's
-   history.
-
-   @private
-   @method getState
-   @return state {Object}
-  */
-  getState: function() {
-    return supportsHistoryState ? get(this, 'history').state : this._historyState;
   },
 
   /**
@@ -131,12 +116,9 @@ export default EmberObject.extend({
   pushState: function(path) {
     var state = { path: path };
 
-    get(this, 'history').pushState(state, null, path);
+    get(this, 'history').pushState(null, null, path);
 
-    // store state if browser doesn't support `history.state`
-    if (!supportsHistoryState) {
-      this._historyState = state;
-    }
+    this._historyState = state;
 
     // used for webkit workaround
     this._previousURL = this.getURL();
@@ -151,12 +133,9 @@ export default EmberObject.extend({
   */
   replaceState: function(path) {
     var state = { path: path };
-    get(this, 'history').replaceState(state, null, path);
+    get(this, 'history').replaceState(null, null, path);
 
-    // store state if browser doesn't support `history.state`
-    if (!supportsHistoryState) {
-      this._historyState = state;
-    }
+    this._historyState = state;
 
     // used for webkit workaround
     this._previousURL = this.getURL();

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -127,7 +127,7 @@ test("base URL is preserved when moving around", function() {
     location.initState();
     location.setURL('/one/two');
 
-    equal(FakeHistory.state.path, '/base/one/two');
+    equal(location._historyState.path, '/base/one/two');
 });
 
 test("setURL continues to set even with a null state (iframes may set this)", function() {
@@ -139,7 +139,7 @@ test("setURL continues to set even with a null state (iframes may set this)", fu
     FakeHistory.pushState(null);
     location.setURL('/three/four');
 
-    equal(FakeHistory.state && FakeHistory.state.path, '/three/four');
+    equal(location._historyState.path, '/three/four');
 });
 
 test("replaceURL continues to set even with a null state (iframes may set this)", function() {
@@ -151,7 +151,7 @@ test("replaceURL continues to set even with a null state (iframes may set this)"
     FakeHistory.pushState(null);
     location.replaceURL('/three/four');
 
-    equal(FakeHistory.state && FakeHistory.state.path, '/three/four');
+    equal(location._historyState.path, '/three/four');
 });
 
 test("HistoryLocation.getURL() returns the current url, excluding both rootURL and baseURL", function() {

--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -1,6 +1,8 @@
 import Ember from "ember-metal/core";
 import jQuery from "ember-views/system/jquery";
 
+import environment from "ember-metal/environment";
+
 /**
   @module ember
   @submodule ember-testing
@@ -25,31 +27,33 @@ function testCheckboxClick(handler) {
     .remove();
 }
 
-$(function() {
-  /*
-    Determine whether a checkbox checked using jQuery's "click" method will have
-    the correct value for its checked property.
+if (environment.hasDOM) {
+  $(function() {
+    /*
+      Determine whether a checkbox checked using jQuery's "click" method will have
+      the correct value for its checked property.
 
-    If we determine that the current jQuery version exhibits this behavior,
-    patch it to work correctly as in the commit for the actual fix:
-    https://github.com/jquery/jquery/commit/1fb2f92.
-  */
-  testCheckboxClick(function() {
-    if (!this.checked && !$.event.special.click) {
-      $.event.special.click = {
-        // For checkbox, fire native event so checked state will be right
-        trigger: function() {
-          if ($.nodeName( this, "input" ) && this.type === "checkbox" && this.click) {
-            this.click();
-            return false;
+      If we determine that the current jQuery version exhibits this behavior,
+      patch it to work correctly as in the commit for the actual fix:
+      https://github.com/jquery/jquery/commit/1fb2f92.
+    */
+    testCheckboxClick(function() {
+      if (!this.checked && !$.event.special.click) {
+        $.event.special.click = {
+          // For checkbox, fire native event so checked state will be right
+          trigger: function() {
+            if ($.nodeName( this, "input" ) && this.type === "checkbox" && this.click) {
+              this.click();
+              return false;
+            }
           }
-        }
-      };
-    }
-  });
+        };
+      }
+    });
 
-  // Try again to verify that the patch took effect or blow up.
-  testCheckboxClick(function() {
-    Ember.warn("clicked checkboxes should be checked! the jQuery patch didn't work", this.checked);
+    // Try again to verify that the patch took effect or blow up.
+    testCheckboxClick(function() {
+      Ember.warn("clicked checkboxes should be checked! the jQuery patch didn't work", this.checked);
+    });
   });
-});
+}

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -395,7 +395,7 @@ EmberApplication.reopen({
     @default window
     @since 1.2.0
   */
-  helperContainer: window,
+  helperContainer: null,
 
   /**
     This injects the test helpers into the `helperContainer` object. If an object is provided
@@ -415,7 +415,11 @@ EmberApplication.reopen({
     @method injectTestHelpers
   */
   injectTestHelpers: function(helperContainer) {
-    if (helperContainer) { this.helperContainer = helperContainer; }
+    if (helperContainer) {
+      this.helperContainer = helperContainer;
+    } else {
+      this.helperContainer = window;
+    }
 
     this.testHelpers = {};
     for (var name in helpers) {
@@ -443,6 +447,8 @@ EmberApplication.reopen({
     @method removeTestHelpers
   */
   removeTestHelpers: function() {
+    if (!this.helperContainer) { return; }
+
     for (var name in helpers) {
       this.helperContainer[name] = this.originalMethods[name];
       delete this.testHelpers[name];

--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -2,6 +2,7 @@ import Ember from 'ember-metal/core'; // Ember.assert
 
 // ES6TODO: the functions on EnumerableUtils need their own exports
 import { forEach } from 'ember-metal/enumerable_utils';
+import environment from 'ember-metal/environment';
 
 /**
 Ember Views
@@ -12,38 +13,42 @@ Ember Views
 @main ember-views
 */
 
-var jQuery = (Ember.imports && Ember.imports.jQuery) || (this && this.jQuery);
-if (!jQuery && typeof require === 'function') {
-  jQuery = require('jquery');
-}
+var jQuery;
 
-Ember.assert("Ember Views require jQuery between 1.7 and 2.1", jQuery &&
-             (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) ||
-              Ember.ENV.FORCE_JQUERY));
+if (environment.hasDOM) {
+  jQuery = (Ember.imports && Ember.imports.jQuery) || (this && this.jQuery);
+  if (!jQuery && typeof require === 'function') {
+    jQuery = require('jquery');
+  }
 
-/**
-@module ember
-@submodule ember-views
-*/
-if (jQuery) {
-  // http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dndevents
-  var dragEvents = [
-    'dragstart',
-    'drag',
-    'dragenter',
-    'dragleave',
-    'dragover',
-    'drop',
-    'dragend'
-  ];
+  Ember.assert("Ember Views require jQuery between 1.7 and 2.1", jQuery &&
+               (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) ||
+                Ember.ENV.FORCE_JQUERY));
 
-  // Copies the `dataTransfer` property from a browser event object onto the
-  // jQuery event object for the specified events
-  forEach(dragEvents, function(eventName) {
-    jQuery.event.fixHooks[eventName] = {
-      props: ['dataTransfer']
-    };
-  });
+  /**
+  @module ember
+  @submodule ember-views
+  */
+  if (jQuery) {
+    // http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dndevents
+    var dragEvents = [
+      'dragstart',
+      'drag',
+      'dragenter',
+      'dragleave',
+      'dragover',
+      'drop',
+      'dragend'
+    ];
+
+    // Copies the `dataTransfer` property from a browser event object onto the
+    // jQuery event object for the specified events
+    forEach(dragEvents, function(eventName) {
+      jQuery.event.fixHooks[eventName] = {
+        props: ['dataTransfer']
+      };
+    });
+  }
 }
 
 export default jQuery;

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -7,6 +7,7 @@ import jQuery from "ember-views/system/jquery";
 import { DOMHelper } from "morph";
 import Ember from "ember-metal/core";
 import { create } from "ember-metal/platform";
+import environment from "ember-metal/environment";
 
 // The HTML spec allows for "omitted start tags". These tags are optional
 // when their intended child is the first thing in the parent tag. For
@@ -35,14 +36,15 @@ import { create } from "ember-metal/platform";
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/tables.html#the-tbody-element
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/tables.html#the-colgroup-element
 //
-var omittedStartTagChildren = {
-  tr: document.createElement('tbody'),
-  col: document.createElement('colgroup')
-};
-
+var omittedStartTagChildren;
 var omittedStartTagChildTest = /(?:<script)*.*?<([\w:]+)/i;
 
 function detectOmittedStartTag(string, contextualElement){
+  omittedStartTagChildren = omittedStartTagChildren || {
+    tr: document.createElement('tbody'),
+    col: document.createElement('colgroup')
+  };
+
   // Omitted start tags are only inside table tags.
   if (contextualElement.tagName === 'TABLE') {
     var omittedStartTagChildMatch = omittedStartTagChildTest.exec(string);
@@ -111,6 +113,8 @@ function escapeAttribute(value) {
 // From http://msdn.microsoft.com/en-us/library/ie/ms536389(v=vs.85).aspx:
 // "To include the NAME attribute at run time on objects created with the createElement method, use the eTag."
 var canSetNameOnInputs = (function() {
+  if (!environment.hasDOM) { return false; }
+
   var div = document.createElement('div');
   var el = document.createElement('input');
 
@@ -142,7 +146,7 @@ function _RenderBuffer(tagName, contextualElement) {
   this._outerContextualElement = contextualElement;
   this.buffer = null;
   this.childViews = [];
-  this.dom = new DOMHelper();
+  this.dom = environment.hasDOM ? new DOMHelper() : null;
 }
 
 _RenderBuffer.prototype = {

--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -1,4 +1,3 @@
-/* global navigator */
 // require the main entry points for each of these packages
 // this is so that the global exports occur properly
 import "ember-metal";
@@ -9,6 +8,8 @@ import "ember-application";
 import "ember-extension-support";
 import "ember-htmlbars";
 import "ember-routing-htmlbars";
+
+import environment from "ember-metal/environment";
 
 // do this to ensure that Ember.Test is defined properly on the global
 // if it is present.
@@ -22,4 +23,4 @@ Ember
 @module ember
 */
 
-Ember.deprecate('Usage of Ember is deprecated for Internet Explorer 6 and 7, support will be removed in the next major version.', !navigator.userAgent.match(/MSIE [67]/));
+Ember.deprecate('Usage of Ember is deprecated for Internet Explorer 6 and 7, support will be removed in the next major version.', !environment.userAgent.match(/MSIE [67]/));

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -1,0 +1,21 @@
+/*globals __dirname*/
+
+var path = require('path');
+var distPath = path.join(__dirname, '../../dist');
+
+QUnit.module("App boot");
+
+QUnit.test("App is created without throwing an exception", function() {
+  var Ember = require(path.join(distPath, 'ember.debug'));
+
+  var App = Ember.Application.create({
+  });
+
+  App.Router = Ember.Router.extend({
+    location: 'none'
+  });
+
+  App.advanceReadiness();
+
+  QUnit.ok(App);
+});

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -6,7 +6,7 @@ var distPath = path.join(__dirname, '../../dist');
 QUnit.module("App boot");
 
 QUnit.test("App is created without throwing an exception", function() {
-  var Ember = require(path.join(distPath, 'ember.debug'));
+  var Ember = require(path.join(distPath, 'ember.debug.cjs'));
 
   var App = Ember.Application.create({
   });

--- a/tests/node/runtime-test.js
+++ b/tests/node/runtime-test.js
@@ -1,0 +1,38 @@
+/*globals __dirname*/
+
+var path = require('path');
+
+var module = QUnit.module;
+var ok = QUnit.ok;
+var equal = QUnit.equal;
+
+var distPath = path.join(__dirname, '../../dist');
+
+module('ember-runtime.js');
+
+test('can be required', function() {
+  var Ember = require(path.join(distPath, 'ember-runtime'));
+
+  ok(Ember.Object, 'Ember.Object is present');
+});
+
+test('basic object system functions properly', function() {
+  var Ember = require(path.join(distPath, 'ember-runtime'));
+
+  var Person = Ember.Object.extend({
+    name: Ember.computed('firstName', 'lastName', function() {
+      return this.get('firstName') + ' ' + this.get('lastName');
+    })
+  });
+
+  var person = Person.create({
+    firstName: 'Max',
+    lastName: 'Jackson'
+  });
+
+  equal(person.get('name'), 'Max Jackson');
+
+  person.set('firstName', 'James');
+
+  equal(person.get('name'), 'James Jackson');
+});


### PR DESCRIPTION
This commit removes any strict dependencies on browser-only APIs.
Anything user agent specific (such as window, document, etc.) are
abstracted out into a new `environment` object.

Currently we feature detect whether a DOM implementation is available
and only enable certain behavior if so. The intent of the feature
detection is to determine if a DOM implementation is available, not
whether we’re running in the browser or in node. This makes it possible
to run Ember in a node environment with a “fake” DOM.

This commit also introduces some refactoring to the location APIs, such
that hardcoded document/history/navigator dependencies are reduced.

Note that some APIs are guarded with `environment.hasDOM` checks.
Code inside those guards can freely use DOM APIs, but some of those
APIs are needed for full server-side usage of Ember. This is a first
step that is designed to explicitly separate out code with DOM
dependencies from isomorphic code. Further PRs will implement the
Renderer and Location APIs for non-DOM environments.
