### PR TITLE
[FEATURE ember-metal-warn-on-undefined-get]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,32 @@ for a detailed explanation.
 
 ## Feature Flags
 
+* `ember-metal-warn-on-undefined-get`
+
+  When `Ember.ENV.WARN_ON_UNDEFINED_GET` is true:
+
+  Warn when an undefined property is accessed via `Ember.get`. This
+  feature is meant to expose typos in variable names sooner rather than
+  later.
+
+  Access to properties that are defined with an inital `null` value won't
+  raise.
+
+  For example:
+
+  ```js
+  Ember.ENV.WARN_ON_UNDEFINED_GET = true;
+
+  var obj = Ember.Object.create({
+    foo: null
+  });
+
+  obj.get("foo"); // => null
+  obj.get("bar"); // => raises
+  obj.get("foo.bar"); // => raises
+  ```
+  Added in [#9950](https://github.com/emberjs/ember.js/issues/9950).
+
 * `ember-routing-named-substates`
 
   Add named substates; e.g. when resolving a `loading` or `error`
@@ -89,7 +115,7 @@ for a detailed explanation.
 
 * `ember-htmlbars-inline-if-helper`
 
-  Enables the use of the if helper in inline form. The truthy 
+  Enables the use of the if helper in inline form. The truthy
   and falsy values are passed as params, instead of using the block form.
 
   Added in [#9718](https://github.com/emberjs/ember.js/pull/9718).

--- a/features.json
+++ b/features.json
@@ -20,7 +20,8 @@
     "ember-htmlbars-block-params": true,
     "ember-htmlbars-component-generation": null,
     "ember-htmlbars-inline-if-helper": null,
-    "ember-htmlbars-attribute-syntax": null
+    "ember-htmlbars-attribute-syntax": null,
+    "ember-metal-warn-on-undefined-get": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -93,9 +93,18 @@ var get = function get(obj, keyName) {
       return obj.unknownProperty(keyName);
     }
 
+    if (warnOnUndefined()) {
+      Ember.assert("Called get for undefined property '" + keyName + "'", ret !== undefined);
+    }
+
     return ret;
   }
 };
+
+function warnOnUndefined() {
+  return Ember.FEATURES.isEnabled("ember-metal-warn-on-undefined-get") &&
+         Ember.ENV.WARN_ON_UNDEFINED_GET;
+}
 
 /**
   Normalizes a target/path pair to reflect that actual target/path that should
@@ -159,6 +168,9 @@ function _getPath(root, path) {
   len = parts.length;
   for (idx = 0; root != null && idx < len; idx++) {
     root = get(root, parts[idx], true);
+    if (warnOnUndefined()) {
+      Ember.assert("Called get for undefined property '" + path + "'", root !== null && parts.length > 1);
+    }
     if (root && root.isDestroyed) { return undefined; }
   }
   return root;

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -172,3 +172,28 @@ test('(regression) watched properties on unmodified inherited objects should sti
   equal(getWithDefault(theRealObject, 'someProperty', "fail"), 'foo', 'should return the set value, not false');
 });
 
+if (Ember.FEATURES.isEnabled("ember-metal-warn-on-undefined-get")) {
+  var warn;
+  QUnit.module("Ember.get: Ember.ENV.WARN_ON_UNDEFINED_GET", {
+    setup: function() {
+      warn = Ember.ENV.WARN_ON_UNDEFINED_GET;
+    }, teardown: function() {
+      Ember.ENV.WARN_ON_UNDEFINED_GET = warn;
+    }
+  });
+
+  test("warn on attempts to get an undefined property", function() {
+    Ember.ENV.WARN_ON_UNDEFINED_GET = true;
+
+    var nullProperty = get({ foo: null }, "foo");
+    equal(nullProperty, null, "retrieving a null property returns null");
+
+    expectAssertion(function() {
+      get({}, "bar");
+    }, /Called get for undefined property 'bar'/);
+
+    expectAssertion(function() {
+      get({ foo: null }, "foo.bar");
+    }, /Called get for undefined property 'foo.bar'/);
+  });
+}


### PR DESCRIPTION
Turn on `Ember.ENV.WARN_ON_UNDEFINED_GET` to expose typos in `Ember.get` calls
to `undefined` variables.
