### PR TITLE
fix false missing template assertion on android 2.3

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1781,7 +1781,7 @@ var Route = EmberObject.extend(ActionHandler, {
     }
 
     if (!view && !template) {
-      Ember.assert("Could not find \"" + name + "\" template or view.", Ember.isEmpty(arguments[0]));
+      Ember.assert("Could not find \"" + name + "\" template or view.", Ember.isEmpty(arguments.length > 0 ? arguments[0] : undefined));
       if (get(this.router, 'namespace.LOG_VIEW_LOOKUPS')) {
         Ember.Logger.info("Could not find \"" + name + "\" template or view. Nothing will be rendered", { fullName: 'template:' + name });
       }


### PR DESCRIPTION
This pull request fixes a breakage on android 2.3 stock browser that was introduced in ember 1.6.  The assertion in question, is actually getting triggered on android 2.3 by the call `this.render()` in `renderTemplate`.  As far as I can tell (short of reading the entire 3 page ecmascript definition of `arguments`), you should be able dereference `arguments` with an non-existent key and expect `undefined` (just like any array or object), so that isn't actually the problem.  It seems that assigning to a named argument in the android stock browser will actually put the value into the arguments array.  So on android 2.3, the following will display "duck":

```
    (function duck(name) {
      name = 'duck';
      alert(arguments[0]);
    })();
```

whereas on everything else it seems to display "undefined".  Overwriting a named argument does not change `arguments.length` however, which is why this fix works.  I couldn't find a reported android bug but I'm not sure exactly where to look, so if anyone has any tips please let me know.  Also, please let me know if this could be added as a patch on ember 1.8.1 or 1.9, because I'm trying to deliver code that works on android 2.3 and iOS8 (you don't want my job... ;).  Thanks, Andrew
