### PR TITLE
use non es5 compliant defineProperty for android 2.3

### DIFF
--- a/packages/ember-metal/lib/platform/define_property.js
+++ b/packages/ember-metal/lib/platform/define_property.js
@@ -57,6 +57,13 @@ var defineProperty = (function checkCompliance(defineProperty) {
     // Object.defineProperty once accessors have already been set.
     if (obj.a !== true) return;
 
+    // Detects a bug in Android <3 where redefining a property without a value changes the value
+    // Object.defineProperty once accessors have already been set.
+    defineProperty(obj, 'a', {
+      enumerable: false
+    });
+    if (obj.a !== true) return;
+
     // defineProperty is compliant
     return defineProperty;
   } catch (e) {


### PR DESCRIPTION
Here's another android 2.3 issue.  It seems like the development version of ember on android 2.3 isn't working because defineProperty passes the es5 compliance tests currently in ember so we don't use the simple property setter.  In fact, it appears that android 2.3 defineProperty has some compliance issues.  @gabrielmaldi and @psithief did a good job of tracking this down at https://github.com/axemclion/IndexedDBShim/issues/73.

The gist of it appears to be that after you've define an object such as `{a: true}`, you should be able to redefine that property without changing the value, provided no new value is provided.

```
    defineProperty(obj, 'a', {
      enumerable: false
    });
    if (obj.a !== true) return;
```

The test above passes on chrome, firefox, safari, android 4.3 but fails on my android 2.3 phone.  I can't say for certain that the behavior I'm testing above is exactly why the test is failing, but I can run my app with the fallback property setter.

Note that this branch subsumes my other android2.3 pull request at https://github.com/emberjs/ember.js/pull/9951. I'd love to add both changes to whatever versions I can so that I can run my app on android2.3.  Thanks, Andrew
