### PR TITLE
[BUGFIX canary] Initialize location in Ember.AutoLocation.

### DIFF
--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -42,6 +42,17 @@ export default {
   /**
     @private
 
+    Attached for mocking in tests
+
+    @since 1.5.1
+    @property _history
+    @default environment.history
+  */
+  _history: environment.history,
+
+  /**
+    @private
+
     This property is used by router:main to know whether to cancel the routing
     setup process, which is needed while we redirect the browser.
 

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -29,6 +29,15 @@ import { supportsHashChange, supportsHistory } from "ember-routing/location/feat
   @static
 */
 export default {
+  /**
+    @private
+
+    Attached for mocking in tests
+
+    @property location
+    @default environment.location
+  */
+  _location: environment.location,
 
   /**
     @private


### PR DESCRIPTION
In #9941 Ember.AutoLocation lost its `_location` and `_history` properties, that used to be an alias to `window.location` and `window._history`.

This commits brings it back, initializing it to the equivalent properties in the `environment` abstraction.
