### PR TITLE
[BUGFIX beta] update RSVP to 3.0.16

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#f4bd6a2df221240ed36d140f0c53c036a7ecacad",
-    "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
+    "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.16",
     "router.js": "https://github.com/tildeio/router.js.git#a1ffd97dc66a6d9d4e8dd89a72c1c4e21a3328c5",
     "route-recognizer": "https://github.com/tildeio/route-recognizer.git#8e1058e29de741b8e05690c69da9ec402a167c69",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",


### PR DESCRIPTION
refs #9939 - upgraded for fixes for the old version of the transpiler ember is using.
