### PR TITLE
[FEATURE ember-routing-transitioning-classes] namespace classes

### DIFF
--- a/features.json
+++ b/features.json
@@ -13,7 +13,7 @@
     "ember-htmlbars-component-generation": null,
     "ember-htmlbars-inline-if-helper": null,
     "ember-htmlbars-attribute-syntax": null,
-    "ember-routing-transitioning-classes": null
+    "ember-routing-transitioning-classes": true
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -312,14 +312,14 @@ var LinkView = Ember.LinkView = EmberComponent.extend({
     var willBeActive = get(this, 'willBeActive');
     if (typeof willBeActive === 'undefined') { return false; }
 
-    return !get(this, 'active') && willBeActive;
+    return !get(this, 'active') && willBeActive && 'ember-transitioning-in';
   }),
 
   transitioningOut: computed('active', 'willBeActive', function() {
     var willBeActive = get(this, 'willBeActive');
     if (typeof willBeActive === 'undefined') { return false; }
 
-    return get(this, 'active') && !willBeActive;
+    return get(this, 'active') && !willBeActive && 'ember-transitioning-out';
   }),
 
   /**

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1812,14 +1812,14 @@ if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
     Ember.run($about, 'click');
 
     assertHasClass('active', $index, true, $about, false, $other, false);
-    assertHasClass('transitioning-in',  $index, false, $about, true, $other, false);
-    assertHasClass('transitioning-out', $index, true, $about, false, $other, false);
+    assertHasClass('ember-transitioning-in',  $index, false, $about, true, $other, false);
+    assertHasClass('ember-transitioning-out', $index, true, $about, false, $other, false);
 
     Ember.run(aboutDefer, 'resolve');
 
     assertHasClass('active', $index, false, $about, true, $other, false);
-    assertHasClass('transitioning-in',  $index, false, $about, false, $other, false);
-    assertHasClass('transitioning-out', $index, false, $about, false, $other, false);
+    assertHasClass('ember-transitioning-in',  $index, false, $about, false, $other, false);
+    assertHasClass('ember-transitioning-out', $index, false, $about, false, $other, false);
   });
 }
 


### PR DESCRIPTION
Use .ember-transitioning-in and .ember-transitioning-out instead of
non-ember-namespaced classes.
