### PR TITLE
Fix hasThis lookup regression

### DIFF
--- a/packages/ember-metal/lib/path_cache.js
+++ b/packages/ember-metal/lib/path_cache.js
@@ -6,7 +6,7 @@ var HAS_THIS       = 'this.';
 
 var isGlobalCache       = new Cache(1000, function(key) { return IS_GLOBAL.test(key);          });
 var isGlobalPathCache   = new Cache(1000, function(key) { return IS_GLOBAL_PATH.test(key);     });
-var hasThisCache        = new Cache(1000, function(key) { return key.indexOf(HAS_THIS) !== -1; });
+var hasThisCache        = new Cache(1000, function(key) { return key.lastIndexOf(HAS_THIS, 0) === 0; });
 var firstDotIndexCache  = new Cache(1000, function(key) { return key.indexOf('.');             });
 
 var firstKeyCache = new Cache(1000, function(path) {

--- a/packages/ember-metal/tests/accessors/getPath_test.js
+++ b/packages/ember-metal/tests/accessors/getPath_test.js
@@ -11,6 +11,11 @@ var moduleOpts = {
           baz: { biff: 'BIFF' }
         }
       },
+      foothis: {
+        bar: {
+          baz: { biff: 'BIFF' }
+        }
+      },
       falseValue: false
     };
 
@@ -49,6 +54,10 @@ test('[obj, foo] -> obj.foo', function() {
 
 test('[obj, foo.bar] -> obj.foo.bar', function() {
   deepEqual(get(obj, 'foo.bar'), obj.foo.bar);
+});
+
+test('[obj, foothis.bar] -> obj.foothis.bar', function() {
+  deepEqual(get(obj, 'foothis.bar'), obj.foothis.bar);
 });
 
 test('[obj, this.foo] -> obj.foo', function() {


### PR DESCRIPTION
Path lookups on keys named `<something>this` results in invalid lookups, returning values for other properties or `undefined`.

This patch fixes the lookup, adds a test, and, as an added bonus, makes the lookup faster.

The faulty behavior was introduced in b9d2369f3d0e601f1d5ddc05e5008e931bac9003, and has been part of all stable releases since 1.8.0.

/cc @stefanpenner 
