### PR TITLE
[DOC] Document final argument for transitionTo/transitionToRoute

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -202,13 +202,28 @@ ControllerMixin.reopen({
     ```javascript
     aController.transitionToRoute('/');
     aController.transitionToRoute('/blog/post/1/comment/13');
+    aController.transitionToRoute('/blog/posts?sort=title');
+    ```
+
+    An options hash with a `queryParams` property may be provided as
+    the final argument to add query parameters to the destination URL.
+
+    ```javascript
+    aController.transitionToRoute('blogPost', 1, {
+      queryParams: {showComments: 'true'}
+    });
+
+    // if you just want to transition the query parameters without changing the route
+    aController.transitionToRoute({queryParams: {sort: 'date'}});
     ```
 
     See also [replaceRoute](/api/classes/Ember.ControllerMixin.html#method_replaceRoute).
 
     @param {String} name the name of the route or a URL
     @param {...Object} models the model(s) or identifier(s) to be used
-    while transitioning to the route.
+      while transitioning to the route.
+    @param {Object} [options] optional hash with a queryParams property
+      containing a mapping of query parameters
     @for Ember.ControllerMixin
     @method transitionToRoute
   */

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -794,6 +794,19 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     ```javascript
     this.transitionTo('/');
     this.transitionTo('/blog/post/1/comment/13');
+    this.transitionTo('/blog/posts?sort=title');
+    ```
+
+    An options hash with a `queryParams` property may be provided as
+    the final argument to add query parameters to the destination URL.
+
+    ```javascript
+    this.transitionTo('blogPost', 1, {
+      queryParams: {showComments: 'true'}
+    });
+
+    // if you just want to transition the query parameters without changing the route
+    this.transitionTo({queryParams: {sort: 'date'}});
     ```
 
     See also 'replaceWith'.
@@ -861,10 +874,30 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     });
     ```
 
+    Nested Route with Query String Example
+
+    ```javascript
+    App.Router.map(function() {
+      this.resource('fruits', function() {
+        this.route('apples');
+      });
+    });
+
+    App.IndexRoute = Ember.Route.extend({
+      actions: {
+        transitionToApples: function() {
+          this.transitionTo('fruits.apples', {queryParams: {color: 'red'}});
+        }
+      }
+    });
+    ```
+
     @method transitionTo
     @param {String} name the name of the route or a URL
     @param {...Object} models the model(s) or identifier(s) to be used while
       transitioning to the route.
+    @param {Object} [options] optional hash with a queryParams property
+      containing a mapping of query parameters
     @return {Transition} the transition object associated with this
       attempted transition
   */


### PR DESCRIPTION
Adds documentation for a final options argument for the `Controller#transitionToRoute` and `Route#transitionTo` methods.

Fixes #9973.
