### PR TITLE
[FEATURE ember-routing-named-substates]

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -753,7 +753,9 @@ var Application = Namespace.extend(DeferredMixin, {
     var router = this.__container__.lookup('router:main');
     if (!router) { return; }
 
-    router.startRouting();
+    var moduleBasedResolver = this.Resolver && this.Resolver.moduleBasedResolver;
+
+    router.startRouting(moduleBasedResolver);
   },
 
   handleURL: function(url) {

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -5,8 +5,9 @@ import Ember from "ember-metal/core"; // FEATURES, assert
 @submodule ember-routing
 */
 
-function DSL(name) {
+function DSL(name, options) {
   this.parent = name;
+  this.enableLoadingSubtates = options && options.enableLoadingSubtates;
   this.matches = [];
 }
 export default DSL;
@@ -26,13 +27,18 @@ DSL.prototype = {
     Ember.assert("'" + name + "' cannot be used as a " + type + " name.", name !== 'array' && name !== 'basic' && name !== 'object');
 
     if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
-      createRoute(this, name + '_loading', {resetNamespace: options.resetNamespace});
-      createRoute(this, name + '_error', { path: "/_unused_dummy_error_path_route_" + name + "/:error"});
+      if (this.enableLoadingSubtates) {
+        createRoute(this, name + '_loading', {resetNamespace: options.resetNamespace});
+        createRoute(this, name + '_error', { path: "/_unused_dummy_error_path_route_" + name + "/:error"});
+      }
     }
 
     if (callback) {
       var fullName = getFullName(this, name, options.resetNamespace);
-      var dsl = new DSL(fullName);
+      var dsl = new DSL(fullName, {
+        enableLoadingSubtates: this.enableLoadingSubtates
+      });
+
       createRoute(dsl, 'loading');
       createRoute(dsl, 'error', { path: "/_unused_dummy_error_path_route_" + name + "/:error" });
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -70,7 +70,7 @@ var EmberRouter = EmberObject.extend(Evented, {
   */
   rootURL: '/',
 
-  _initRouterJs: function() {
+  _initRouterJs: function(moduleBasedResolver) {
     var router = this.router = new Router();
     router.triggerEvent = triggerEvent;
 
@@ -78,13 +78,19 @@ var EmberRouter = EmberObject.extend(Evented, {
     router._triggerWillLeave = K;
 
     var dslCallbacks = this.constructor.dslCallbacks || [K];
-    var dsl = EmberRouterDSL.map(function() {
+    var dsl = new EmberRouterDSL(null, {
+      enableLoadingSubtates: !!moduleBasedResolver
+    });
+
+    function generateDSL() {
       this.resource('application', { path: "/" }, function() {
         for (var i=0; i < dslCallbacks.length; i++) {
           dslCallbacks[i].call(this);
         }
       });
-    });
+    }
+
+    generateDSL.call(dsl);
 
     if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {
       router.log = Ember.Logger.debug;
@@ -120,9 +126,9 @@ var EmberRouter = EmberObject.extend(Evented, {
     @method startRouting
     @private
   */
-  startRouting: function() {
+  startRouting: function(moduleBasedResolver) {
 
-    this._initRouterJs();
+    this._initRouterJs(moduleBasedResolver);
 
     var router = this.router;
     var location = get(this, 'location');
@@ -836,9 +842,7 @@ EmberRouter.reopenClass({
 
     this.dslCallbacks.push(callback);
 
-    return this.extend({
-      _isRouterMapResult: true
-    });
+    return this;
   },
 
   _routePath: function(handlerInfos) {

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -77,3 +77,35 @@ test("should retain resource namespace if nested with routes", function(){
   ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
   ok(router.router.recognizer.names['bleep.bloop.blork'], 'parent name was used as base of nested routes');
 });
+
+if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
+// jscs:disable validateIndentation
+
+test("should add loading and error routes if _isRouterMapResult is true", function(){
+  Router.map(function(){
+    this.route('blork');
+  });
+
+  var router = Router.create();
+  router._initRouterJs(true);
+
+  ok(router.router.recognizer.names['blork'], 'main route was created');
+  ok(router.router.recognizer.names['blork_loading'], 'loading route was added');
+  ok(router.router.recognizer.names['blork_error'], 'error route was added');
+});
+
+test("should not add loading and error routes if _isRouterMapResult is false", function(){
+  Router.map(function(){
+    this.route('blork');
+  });
+
+  var router = Router.create();
+  router._initRouterJs(false);
+
+  ok(router.router.recognizer.names['blork'], 'main route was created');
+  ok(!router.router.recognizer.names['blork_loading'], 'loading route was not added');
+  ok(!router.router.recognizer.names['blork_error'], 'error route was not added');
+});
+
+// jscs:enable validateIndentation
+}

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -20,22 +20,32 @@ test("should fail when using a reserved route name", function() {
   forEach(reservedNames, function(reservedName) {
 
     expectAssertion(function() {
+      Router = EmberRouter.extend();
+
       Router.map(function() {
         this.route(reservedName);
       });
+
+      var router = Router.create();
+      router._initRouterJs();
     }, "'" + reservedName + "' cannot be used as a route name.");
 
     expectAssertion(function() {
+      Router = EmberRouter.extend();
+
       Router.map(function() {
         this.resource(reservedName);
       });
+
+      var router = Router.create();
+      router._initRouterJs();
     }, "'" + reservedName + "' cannot be used as a resource name.");
 
   });
 });
 
 test("should reset namespace if nested with resource", function(){
-  var router = Router.map(function(){
+  Router = Router.map(function(){
     this.resource('bleep', function(){
       this.resource('bloop', function() {
         this.resource('blork');
@@ -43,13 +53,16 @@ test("should reset namespace if nested with resource", function(){
     });
   });
 
-  ok(router.recognizer.names['bleep'], 'nested resources do not contain parent name');
-  ok(router.recognizer.names['bloop'], 'nested resources do not contain parent name');
-  ok(router.recognizer.names['blork'], 'nested resources do not contain parent name');
+  var router = Router.create();
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['bleep'], 'nested resources do not contain parent name');
+  ok(router.router.recognizer.names['bloop'], 'nested resources do not contain parent name');
+  ok(router.router.recognizer.names['blork'], 'nested resources do not contain parent name');
 });
 
 test("should retain resource namespace if nested with routes", function(){
-  var router = Router.map(function(){
+  Router = Router.map(function(){
     this.route('bleep', function(){
       this.route('bloop', function() {
         this.route('blork');
@@ -57,7 +70,10 @@ test("should retain resource namespace if nested with routes", function(){
     });
   });
 
-  ok(router.recognizer.names['bleep'], 'parent name was used as base of nested routes');
-  ok(router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
-  ok(router.recognizer.names['bleep.bloop.blork'], 'parent name was used as base of nested routes');
+  var router = Router.create();
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['bleep'], 'parent name was used as base of nested routes');
+  ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+  ok(router.router.recognizer.names['bleep.bloop.blork'], 'parent name was used as base of nested routes');
 });

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -35,15 +35,15 @@ QUnit.module("Ember Router", {
 });
 
 test("can create a router without a container", function() {
-  var router = Router.create();
+  Router.create();
 
-  ok(router.router);
+  ok(true, 'no errors were thrown when creating without a container');
 });
 
-test("should create a router if one does not exist on the constructor", function() {
+test("should not create a router.js instance upon init", function() {
   createRouter();
 
-  ok(router.router);
+  ok(!router.router);
 });
 
 test("should destroy its location upon destroying the routers container.", function() {

--- a/packages/ember/tests/routing/router_map_test.js
+++ b/packages/ember/tests/routing/router_map_test.js
@@ -1,0 +1,49 @@
+import "ember";
+
+var Router, App, container;
+
+QUnit.module("Router.map", {
+  setup: function() {
+    Ember.run(function() {
+      App = Ember.Application.create({
+        name: "App",
+        rootElement: '#qunit-fixture'
+      });
+
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+
+      Router = App.Router;
+
+      container = App.__container__;
+
+      //Ember.TEMPLATES.application = compile("{{outlet}}");
+      //Ember.TEMPLATES.home = compile("<h3>Hours</h3>");
+      //Ember.TEMPLATES.homepage = compile("<h3>Megatroll</h3><p>{{home}}</p>");
+      //Ember.TEMPLATES.camelot = compile('<section><h3>Is a silly place</h3></section>');
+
+      //originalLoggerError = Ember.Logger.error;
+    });
+  },
+
+  teardown: function() {
+    Ember.run(function() {
+      App.destroy();
+      App = null;
+
+      Ember.TEMPLATES = {};
+      //Ember.Logger.error = originalLoggerError;
+    });
+  }
+});
+
+test("Router.map returns an Ember Router class", function () {
+  var ret = App.Router.map(function() {
+    this.route('hello');
+  });
+
+  ok(Ember.Router.detect(ret));
+});

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -422,6 +422,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     expect(2);
 
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
     var appDeferred = Ember.RSVP.defer();
 
     App.ApplicationRoute = Ember.Route.extend({
@@ -449,10 +452,12 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     expect(3);
 
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
     templates['application_loading'] = 'TOPLEVEL LOADING';
 
     var appDeferred = Ember.RSVP.defer();
-
     App.ApplicationRoute = Ember.Route.extend({
       model: function() {
         return appDeferred.promise;
@@ -483,6 +488,10 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
   test("Default error event moves into nested route, prioritizing more specifically named error route", function() {
 
     expect(5);
+
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
 
     templates['grandma'] = "GRANDMA {{outlet}}";
     templates['grandma/error'] = "ERROR: {{msg}}";
@@ -528,6 +537,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     expect(2);
 
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
     templates['foo/bar_loading'] = "FOOBAR LOADING";
     templates['foo/bar/index'] = "YAY";
 
@@ -560,6 +572,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     expect(2);
 
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
     templates['foo/bar_loading'] = "FOOBAR LOADING";
     templates['foo/bar'] = "YAY";
 
@@ -591,6 +606,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     expect(1);
 
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
     templates['foo/bar_error'] = "FOOBAR ERROR: {{msg}}";
     templates['foo/bar'] = "YAY";
 
@@ -618,6 +636,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
   test("Prioritized loading substate entry works with auto-generated index routes", function() {
 
     expect(2);
+
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
 
     templates['foo/index_loading'] = "FOO LOADING";
     templates['foo/index'] = "YAY";
@@ -656,6 +677,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
     expect(1);
 
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
+
     templates['foo/index_error'] = "FOO ERROR: {{msg}}";
     templates['foo/index'] = "YAY";
     templates['foo'] = "{{outlet}}";
@@ -689,6 +713,9 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
   test("Rejected promises returned from ApplicationRoute transition into top-level application_error", function() {
 
     expect(2);
+
+    // fake a modules resolver
+    App.Resolver = { moduleBasedResolver: true };
 
     templates['application_error'] = '<p id="toplevel-error">TOPLEVEL ERROR: {{msg}}</p>';
 


### PR DESCRIPTION
Only add loading and error substates if the resolver being used is a modules based resolver.

Also, return the Ember.Router from `Ember.Router.map` instead of the `router.js` router.

Related to https://github.com/stefanpenner/ember-resolver/pull/75.
