### PR TITLE
Cleanup some more escaping

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/binding.js
+++ b/packages/ember-htmlbars/lib/helpers/binding.js
@@ -48,7 +48,6 @@ function bind(property, hash, options, env, preserveContext, shouldDisplay, valu
     inverseTemplate: options.inverse,
     lazyValue: lazyValue,
     previousContext: get(this, 'context'),
-    isEscaped: !hash.unescaped,
     templateHash: hash,
     helperName: options.helperName
   };

--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -1,15 +1,12 @@
 /**
 @module ember
-@submodule ember-routing-handlebars
+@submodule ember-routing-htmlbars
 */
 
 import Ember from "ember-metal/core"; // assert
 import { LinkView } from "ember-routing-views/views/link";
 import { read, isStream } from "ember-metal/streams/utils";
 import ControllerMixin from "ember-runtime/mixins/controller";
-import {
-  escapeExpression
-} from "ember-htmlbars/utils/string";
 
 // We need the HTMLBars view helper from ensure ember-htmlbars.
 // This ensures it is loaded first:
@@ -278,7 +275,6 @@ import 'ember-htmlbars';
   @see {Ember.LinkView}
 */
 function linkToHelper(params, hash, options, env) {
-  var shouldEscape = !hash.unescaped;
   var queryParamsObject;
 
   Ember.assert("You must provide one or more parameters to the link-to helper.", params.length);
@@ -296,6 +292,7 @@ function linkToHelper(params, hash, options, env) {
 
   if (!options.template) {
     var linkTitle = params.shift();
+    var shouldEscape = options.morph.escaped;
 
     if (isStream(linkTitle)) {
       hash.linkTitle = { stream: linkTitle };
@@ -303,12 +300,12 @@ function linkToHelper(params, hash, options, env) {
 
     options.template = {
       isHTMLBars: true,
-      render: function() {
-        var value = read(linkTitle);
-        if (value) {
-          return shouldEscape ? escapeExpression(value) : value;
+      render: function(view, env) {
+        var value = read(linkTitle) || "";
+        if (shouldEscape) {
+          return env.dom.createTextNode(value);
         } else {
-          return "";
+          return value;
         }
       }
     };

--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -8,7 +8,7 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 
 var view;
 
-QUnit.module("Handlebars {{link-to}} helper", {
+QUnit.module("ember-routing-htmlbars: link-to helper", {
   teardown: function() {
     runDestroy(view);
   }
@@ -62,10 +62,9 @@ test("can read bound title", function() {
   equal(view.$().text(), 'foo');
 });
 
-test("escapes title in non-block form", function() {
+test("escaped inline form (double curlies) escapes link title", function() {
   view = EmberView.create({
     title: "<b>blah</b>",
-
     template: compile("{{link-to view.title}}")
   });
 
@@ -74,11 +73,10 @@ test("escapes title in non-block form", function() {
   equal(view.$('b').length, 0, 'no <b> were found');
 });
 
-test("does not escape title in non-block form when `unescaped` is true", function() {
+test("unescaped inline form (triple curlies) does not escape link title", function() {
   view = EmberView.create({
     title: "<b>blah</b>",
-
-    template: compile("{{link-to view.title unescaped=true}}")
+    template: compile("{{{link-to view.title}}}")
   });
 
   runAppend(view);

--- a/packages/ember-views/lib/views/bound_view.js
+++ b/packages/ember-views/lib/views/bound_view.js
@@ -7,10 +7,6 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import merge from "ember-metal/merge";
 import {
-  escapeExpression,
-  SafeString
-} from "ember-htmlbars/utils/string";
-import {
   cloneStates,
   states as viewStates
 } from "ember-views/views/states";
@@ -140,10 +136,6 @@ var BoundView = _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
     @param {Ember.RenderBuffer} buffer
   */
   render: function(buffer) {
-    // If not invoked via a triple-mustache ({{{foo}}}), escape
-    // the content of the template.
-    var escape = get(this, 'isEscaped');
-
     var shouldDisplay = get(this, 'shouldDisplayFunc');
     var preserveContext = get(this, 'preserveContext');
     var context = get(this, 'previousContext');
@@ -174,11 +166,8 @@ var BoundView = _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
         // expression to the render context and return.
           if (result === null || result === undefined) {
             result = "";
-          } else if (!(result instanceof SafeString)) {
-            result = String(result);
           }
 
-          if (escape) { result = escapeExpression(result); }
           buffer.push(result);
           return;
         }


### PR DESCRIPTION
- BoundView doesn't need to deal with escaping anymore because Morph handles it now.
- `{{{link-to "<b>home</b>"}}}` was not working correctly in HTMLBars. I modified the test so that it tests the right thing now (we no longer use hash.unescaped to pass the escaped-ness to the helper).
