### PR TITLE
Only register `View#elementId` observer in debug builds

### DIFF
--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -25,8 +25,10 @@ merge(inDOM, {
       View.views[view.elementId] = view;
     }
 
-    addBeforeObserver(view, 'elementId', function() {
-      throw new EmberError("Changing a view's elementId after creation is not allowed");
+    Ember.runInDebug(function() {
+      addBeforeObserver(view, 'elementId', function() {
+        throw new EmberError("Changing a view's elementId after creation is not allowed");
+      });
     });
   },
 

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -45,18 +45,20 @@ test("returns element if you set the value", function() {
   equal(get(view, 'element'), dom, 'now has set element');
 });
 
-test("should not allow the elementId to be changed after inserted", function() {
-  view = EmberView.create({
-    elementId: 'one'
+Ember.runInDebug(function() {
+  test("should not allow the elementId to be changed after inserted", function() {
+    view = EmberView.create({
+      elementId: 'one'
+    });
+
+    run(function() {
+      view.appendTo('#qunit-fixture');
+    });
+
+    raises(function() {
+      view.set('elementId', 'two');
+    }, "raises elementId changed exception");
+
+    equal(view.get('elementId'), 'one', 'elementId is still "one"');
   });
-
-  run(function() {
-    view.appendTo('#qunit-fixture');
-  });
-
-  raises(function() {
-    view.set('elementId', 'two');
-  }, "raises elementId changed exception");
-
-  equal(view.get('elementId'), 'one', 'elementId is still "one"');
 });


### PR DESCRIPTION
A little perf boost for production builds...

@stefanpenner 
