### PR TITLE
[BUGFIX beta] Allow unbound helpers to add attributes.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -3,18 +3,37 @@
 @submodule ember-htmlbars
 */
 
+import Ember from "ember-metal/core";
+import { read } from "ember-metal/streams/utils";
 import lookupHelper from "ember-htmlbars/system/lookup-helper";
 
 export default function element(env, domElement, view, path, params, hash) { //jshint ignore:line
   var helper = lookupHelper(path, view, env);
+  var valueOrLazyValue;
 
   if (helper) {
     var options = {
       element: domElement
     };
-    return helper.helperFunction.call(view, params, hash, options, env);
+    valueOrLazyValue = helper.helperFunction.call(view, params, hash, options, env);
   } else {
-    return view.getStream(path);
+    valueOrLazyValue = view.getStream(path);
+  }
+
+  var value = read(valueOrLazyValue);
+  if (value) {
+    Ember.deprecate('Returning a string of attributes from a helper inside an element is deprecated.');
+
+    var parts = value.toString().split(/\s+/);
+    for (var i = 0, l = parts.length; i < l; i++) {
+      var attrParts = parts[i].split('=');
+      var attrName = attrParts[0];
+      var attrValue = attrParts[1];
+
+      attrValue = attrValue.replace(/^['"]/, '').replace(/['"]$/, '');
+
+      env.dom.setAttribute(domElement, attrName, attrValue);
+    }
   }
 }
 

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -122,6 +122,32 @@ test('bound ordered params are provided with their original paths', function() {
   runAppend(view);
 });
 
+test('allows unbound usage within an element', function() {
+  expect(4);
+
+  function someHelper(param1, param2, options) {
+    equal(param1, 'blammo');
+    equal(param2, 'blazzico');
+
+    return "class='foo'";
+  }
+
+  registerHandlebarsCompatibleHelper('test', someHelper);
+
+  view = EmberView.create({
+    controller: {
+      value: 'foo'
+    },
+    template: compile('<div {{test "blammo" "blazzico"}}>Bar</div>')
+  });
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, 'Returning a string of attributes from a helper inside an element is deprecated.');
+
+  equal(view.$('.foo').length, 1, 'class attribute was added by helper');
+});
+
 test('registering a helper created from `Ember.Handlebars.makeViewHelper` does not double wrap the helper', function() {
   expect(1);
 

--- a/packages/ember-htmlbars/tests/hooks/element_test.js
+++ b/packages/ember-htmlbars/tests/hooks/element_test.js
@@ -1,0 +1,76 @@
+import EmberView from "ember-views/views/view";
+import {
+  default as helpers,
+  registerHelper
+} from "ember-htmlbars/helpers";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import compile from "ember-template-compiler/system/compile";
+
+var view;
+
+QUnit.module('ember-htmlbars: element hook', {
+  teardown: function() {
+    runDestroy(view);
+    delete helpers.test;
+  }
+});
+
+test('allows unbound usage within an element', function() {
+  expect(4);
+
+  function someHelper(params, hash, options, env) {
+    equal(params[0], 'blammo');
+    equal(params[1], 'blazzico');
+
+    return "class='foo'";
+  }
+
+  registerHelper('test', someHelper);
+
+  view = EmberView.create({
+    controller: {
+      value: 'foo'
+    },
+    template: compile('<div {{test "blammo" "blazzico"}}>Bar</div>')
+  });
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, 'Returning a string of attributes from a helper inside an element is deprecated.');
+
+  equal(view.$('.foo').length, 1, 'class attribute was added by helper');
+});
+
+test('allows unbound usage within an element from property', function() {
+  expect(2);
+
+  view = EmberView.create({
+    controller: {
+      someProp: 'class="foo"'
+    },
+    template: compile('<div {{someProp}}>Bar</div>')
+  });
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, 'Returning a string of attributes from a helper inside an element is deprecated.');
+
+  equal(view.$('.foo').length, 1, 'class attribute was added by helper');
+});
+
+test('allows unbound usage within an element creating multiple attributes', function() {
+  expect(2);
+
+  view = EmberView.create({
+    controller: {
+      someProp: 'class="foo" data-foo="bar"'
+    },
+    template: compile('<div {{someProp}}>Bar</div>')
+  });
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, 'Returning a string of attributes from a helper inside an element is deprecated.');
+
+  equal(view.$('.foo[data-foo="bar"]').length, 1, 'attributes added by helper');
+});


### PR DESCRIPTION
In prior versions of Ember you could render attributes via:

```
<div {{someHelper}}></div>
```

This brings that back.

---

@mixonic / @mmun - Definitely looking for feedback on this one.

Fixes https://github.com/emberjs/ember.js/issues/9961.
