### PR TITLE
[BUGFIX beta] Rewrite with transform to use block params

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -69,7 +69,7 @@ export function withHelper(params, hash, options, env) {
 
   var preserveContext;
 
-  if (hash.keywordName || options.blockParams) {
+  if (options.blockParams) {
     preserveContext = true;
   } else {
     Ember.deprecate(

--- a/packages/ember-htmlbars/lib/plugins/transform-with-as-to-hash.js
+++ b/packages/ember-htmlbars/lib/plugins/transform-with-as-to-hash.js
@@ -14,7 +14,7 @@
   with
 
   ```handlebars
-  {{#with foo.bar keywordName="bar"}}
+  {{#with foo.bar as |bar|}}
   {{/with}}
   ```
 
@@ -34,22 +34,12 @@ function TransformWithAsToHash() {
 TransformWithAsToHash.prototype.transform = function TransformWithAsToHash_transform(ast) {
   var pluginContext = this;
   var walker = new pluginContext.syntax.Walker();
-  var b = pluginContext.syntax.builders;
 
   walker.visit(ast, function(node) {
     if (pluginContext.validate(node)) {
       var removedParams = node.sexpr.params.splice(1, 2);
       var keyword = removedParams[1].original;
-
-      // TODO: This may not be necessary.
-      if (!node.sexpr.hash) {
-        node.sexpr.hash = b.hash();
-      }
-
-      node.sexpr.hash.pairs.push(b.pair(
-        'keywordName',
-        b.string(keyword)
-      ));
+      node.program.blockParams = [ keyword ];
     }
   });
 

--- a/packages/ember-views/lib/views/with_view.js
+++ b/packages/ember-views/lib/views/with_view.js
@@ -12,10 +12,7 @@ export default BoundView.extend({
   init: function() {
     apply(this, this._super, arguments);
 
-    var keywordName     = this.templateHash.keywordName;
     var controllerName  = this.templateHash.controller;
-
-    this._blockArguments = [this.lazyValue];
 
     if (controllerName) {
       var previousContext = this.previousContext;
@@ -27,7 +24,7 @@ export default BoundView.extend({
       this._generatedController = controller;
 
       if (this.preserveContext) {
-        this._keywords[keywordName] = controller;
+        this._blockArguments = [ controller ];
         this.lazyValue.subscribe(function(modelStream) {
           set(controller, 'model', modelStream.value());
         });
@@ -42,7 +39,7 @@ export default BoundView.extend({
       set(controller, 'model', this.lazyValue.value());
     } else {
       if (this.preserveContext) {
-        this._keywords[keywordName] = this.lazyValue;
+        this._blockArguments = [ this.lazyValue ];
       }
     }
   },


### PR DESCRIPTION
- Rewrites `{{#with foo.bar as bar}}` to `{{#with foo.bar as |bar|}}` instead of `{{#with foo.bar keywordName="bar"}}`.
- Fixes a bug this exposed where `{{#with foo.bar controller="blah" as |bar|}}` was not yielding the object instead of the controller.
