### PR TITLE
Fix YUIDoc generation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 
 install:
   - "npm install"
-  - "npm run docs"
 
 after_success:
   - "./bin/publish_builds"

--- a/bin/publish_builds
+++ b/bin/publish_builds
@@ -9,6 +9,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     ember build --environment=production
   fi
 
+  npm run docs # generate documentation to be published
   ./bin/publish_to_s3.js
   ./bin/bower_ember_build
 fi

--- a/package.json
+++ b/package.json
@@ -15,13 +15,14 @@
     "bower": "~1.3.2",
     "chalk": "~0.4.0",
     "ember-cli": "0.0.46",
+    "ember-cli-yuidoc": "^0.3.1",
     "ember-publisher": "0.0.6",
+    "emberjs-build": "0.0.4",
     "express": "^4.5.0",
     "glob": "~3.2.8",
     "htmlbars": "0.5.0",
-    "rsvp": "~3.0.6",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
-    "emberjs-build": "0.0.4"
+    "rsvp": "~3.0.6"
   }
 }


### PR DESCRIPTION
The builds were not publishing to S3 because `ember yuidoc` command did not exist after refactoring the Brocfile into its own repo.  This brings back the addon (and therefore the command) so that we can properly generate the data.json output.
