### PR TITLE
Add options argument to pass url to Ember.deprecate

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -808,7 +808,7 @@ var Application = Namespace.extend(DeferredMixin, {
     @deprecated
   */
   then: function() {
-    Ember.deprecate('Do not use `.then` on an instance of Ember.Application.  Please use the `.ready` hook instead.');
+    Ember.deprecate('Do not use `.then` on an instance of Ember.Application.  Please use the `.ready` hook instead.', false, { url: 'http://emberjs.com/guides/deprecations/#toc_deprecate-code-then-code-on-ember-application' });
 
     this._super.apply(this, arguments);
   }

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -93,8 +93,10 @@ Ember.debug = function(message) {
   @param {String} message A description of the deprecation.
   @param {Boolean} test An optional boolean. If falsy, the deprecation
     will be displayed.
+  @param {Object} options An optional object that can be used to pass
+    in a `url` to the transition guide on the emberjs.com website.
 */
-Ember.deprecate = function(message, test) {
+Ember.deprecate = function(message, test, options) {
   var noDeprecation;
 
   if (typeof test === 'function') {
@@ -111,6 +113,13 @@ Ember.deprecate = function(message, test) {
 
   // When using new Error, we can't do the arguments check for Chrome. Alternatives are welcome
   try { __fail__.fail(); } catch (e) { error = e; }
+
+  if (arguments.length === 3) {
+    Ember.assert('options argument to Ember.deprecate should be an object', options && typeof options === 'object');
+    if (options.url) {
+      message += ' See ' + options.url + ' for more details.';
+    }
+  }
 
   if (Ember.LOG_STACKTRACE_ON_DEPRECATION && error.stack) {
     var stack;

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -175,10 +175,9 @@ function eachHelper(params, hash, options, env) {
 
   Ember.deprecate(
     "Using the context switching form of {{each}} is deprecated. " +
-    "Please use the keyword form (`{{#each foo in bar}}`) instead. " +
-    "See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope " +
-    "for more details.",
-    hash.keyword === true || typeof hash.keyword === 'string'
+    "Please use the keyword form (`{{#each foo in bar}}`) instead.",
+    hash.keyword === true || typeof hash.keyword === 'string',
+    { url: 'http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope' }
   );
 
   hash.dataSource = path;

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -72,9 +72,9 @@ export function withHelper(params, hash, options, env) {
   } else {
     Ember.deprecate(
       "Using the context switching form of `{{with}}` is deprecated. " +
-      "Please use the keyword form (`{{with foo as bar}}`) instead. " +
-      "See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope " +
-      "for more details."
+      "Please use the keyword form (`{{with foo as bar}}`) instead.",
+      false,
+      { url: 'http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope' }
     );
     preserveContext = false;
   }

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -53,8 +53,8 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
 });
 
 test("primitives should work correctly [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
-  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   view = EmberView.create({
     prims: Ember.A(["string", 12]),
@@ -453,7 +453,7 @@ test("bound helpers can handle nulls in array (with primitives) [DEPRECATED]", f
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(view.$().text(), '|NOPE 0|NOPE |NOPE false|NOPE OMG|GMO |NOPE 0|NOPE |NOPE false|NOPE OMG|GMO ', "helper output is correct");
 
@@ -481,7 +481,7 @@ test("bound helpers can handle nulls in array (with objects)", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(view.$().text(), '|NOPE 5|5 |NOPE 5|5 ', "helper output is correct");
 

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -447,7 +447,7 @@ test("should be able to bind classes to globals with {{bind-attr class}} (DEPREC
 });
 
 test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   view = EmberView.create({
     template: compile('{{#each view.images}}<img {{bind-attr src=this}}>{{/each}}'),
@@ -463,7 +463,7 @@ test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]",
 });
 
 test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}} [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   view = EmberView.create({
     template: compile('{{#each view.items}}<li {{bind-attr class="this"}}>Item</li>{{/each}}'),

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -472,7 +472,7 @@ test("should pass content as context when using {{#each}} helper [DEPRECATED]", 
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(view.$().text(), "Mac OS X 10.7: Lion Mac OS X 10.6: Snow Leopard Mac OS X 10.5: Leopard ", "prints each item in sequence");
 });

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -106,7 +106,7 @@ QUnit.module("the #each helper [DEPRECATED]", {
 
     expectDeprecation(function() {
       runAppend(view);
-    },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+    },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
   },
 
   teardown: function() {
@@ -776,7 +776,7 @@ test("views inside #each preserve the new context [DEPRECATED]", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -791,7 +791,7 @@ test("single-arg each defaults to current context [DEPRECATED]", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -806,7 +806,7 @@ test("single-arg each will iterate over controller if present [DEPRECATED]", fun
 
   expectDeprecation(function() {
     runAppend(view);
-  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -896,7 +896,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       expectDeprecation(function() {
         runAppend(view);
-      },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+      },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
       equal(view.$().text(), "AdamSteve");
     });
@@ -1019,7 +1019,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       expectDeprecation(function() {
         runAppend(view);
-      },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+      },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
       equal(view.$().text(), "AdamSteve");
     });
@@ -1034,7 +1034,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       expectDeprecation(function() {
         runAppend(view);
-      },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+      },'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
       equal(view.$().text(), "AdamSteve");
     });
@@ -1072,4 +1072,3 @@ testEachWithItem("{{#each foo in bar}}", false);
 if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
   testEachWithItem("{{#each bar as |foo|}}", true);
 }
-

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -47,7 +47,7 @@ test("unless should keep the current context (#784) [DEPRECATED]", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal(view.$().text(), 'foo: 42');
 });

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -244,7 +244,7 @@ test("it should wrap context with object controller [DEPRECATED]", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblaw");
 
@@ -390,7 +390,7 @@ test("destroys the controller generated with {{with foo controller='blah'}} [DEP
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   runDestroy(view);
 

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -156,7 +156,7 @@ test("yield inside a conditional uses the outer context [DEPRECATED]", function(
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, "Yield points at the right context");
 });
@@ -232,7 +232,7 @@ test("yield uses the layout context for non component [DEPRECATED]", function() 
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal('outerinner', view.$('p').text(), "Yield points at the right context");
 });

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -43,7 +43,7 @@ test('View should update when the property used with the #with helper changes [D
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal(view.$('#first').text(), 'bam', 'precond - view renders Handlebars template');
 
@@ -74,7 +74,7 @@ test('should expose a view keyword [DEPRECATED]', function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal(view.$().text(), 'barbang', 'renders values from view and child view');
 });
@@ -97,7 +97,7 @@ test('bindings can be `this`, in which case they *are* the current context [DEPR
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -172,7 +172,7 @@ test("should target the current controller inside an {{each}} loop [DEPRECATED]"
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   equal(registeredTarget, itemController, "the item controller is the target of action");
 });
@@ -204,14 +204,14 @@ test("should target the with-controller inside an {{#with controller='person'}} 
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   ok(registeredTarget instanceof PersonController, "the with-controller is the target of action");
 });
 
 test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
-  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   var eventsCalled = [];
 
@@ -512,7 +512,7 @@ test("should work properly in a #with block [DEPRECATED]", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   view.$('a').trigger('click');
 
@@ -943,7 +943,7 @@ test("a quoteless parameter should lookup actionName in context [DEPRECATED]", f
       view.set('controller', controller);
       view.appendTo('#qunit-fixture');
     });
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   var testBoundAction = function(propertyValue) {
     run(function() {

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -269,7 +269,7 @@ test("Outlets bind to the current template's view, not inner contexts [DEPRECATE
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   run(function() {
     view.connectOutlet('main', bottomView);

--- a/packages/ember-runtime/lib/mixins/deferred.js
+++ b/packages/ember-runtime/lib/mixins/deferred.js
@@ -68,7 +68,7 @@ export default Mixin.create({
   },
 
   _deferred: computed(function() {
-    Ember.deprecate('Usage of Ember.DeferredMixin or Ember.Deferred is deprecated.', this._suppressDeferredDeprecation);
+    Ember.deprecate('Usage of Ember.DeferredMixin or Ember.Deferred is deprecated.', this._suppressDeferredDeprecation, { url: 'http://emberjs.com/guides/deprecations/#toc_deprecate-ember-deferredmixin-and-ember-deferred' });
 
     return RSVP.defer('Ember: DeferredMixin - ' + this);
   })

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -333,7 +333,7 @@ export default Mixin.create({
   },
 
   addBeforeObserver: function(key, target, method) {
-    Ember.deprecate('Before observers are deprecated and will be removed in a future release. If you want to keep track of previous values you have to implement it yourself. See http://emberjs.com/guides/deprecations#toc_deprecate-beforeobservers');
+    Ember.deprecate('Before observers are deprecated and will be removed in a future release. If you want to keep track of previous values you have to implement it yourself.', false, { url: 'http://emberjs.com/guides/deprecations/#toc_deprecate-beforeobservers' });
     addBeforeObserver(this, key, target, method);
   },
 

--- a/packages/ember-runtime/lib/system/deferred.js
+++ b/packages/ember-runtime/lib/system/deferred.js
@@ -4,7 +4,7 @@ import EmberObject from "ember-runtime/system/object";
 
 var Deferred = EmberObject.extend(DeferredMixin, {
   init: function() {
-    Ember.deprecate('Usage of Ember.Deferred is deprecated.');
+    Ember.deprecate('Usage of Ember.Deferred is deprecated.', false, { url: 'http://emberjs.com/guides/deprecations/#toc_deprecate-ember-deferredmixin-and-ember-deferred' });
     this._super();
   }
 });

--- a/packages/ember-views/lib/streams/utils.js
+++ b/packages/ember-views/lib/streams/utils.js
@@ -13,7 +13,7 @@ export function readViewFactory(object, container) {
   if (typeof value === 'string') {
     if (isGlobal(value)) {
       viewClass = get(null, value);
-      Ember.deprecate('Resolved the view "'+value+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}. http://emberjs.com/guides/deprecations#toc_global-lookup-of-views', !viewClass);
+      Ember.deprecate('Resolved the view "'+value+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}.', !viewClass, { url: 'http://emberjs.com/guides/deprecations/#toc_global-lookup-of-views' });
     } else {
       Ember.assert("View requires a container to resolve views not passed in through the context", !!container);
       viewClass = container.lookupFactory('view:'+value);

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -937,7 +937,7 @@ test("The {{link-to}} helper works in an #each'd array of string route names", f
 
   expectDeprecation(function() {
     bootApplication();
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead. See http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope for more details.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   function linksEqual($links, expected) {
     equal($links.length, expected.length, "Has correct number of links");


### PR DESCRIPTION
Allows us to pass an `options` argument `Ember.deprecate` which contains urls to the deprecation guide.  The Ember Inspector for example can use this to link to the deprecations guide in the deprecations tab.
