### PR TITLE
Cleanup if and unbound helper

### DIFF
--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -85,10 +85,7 @@ export default function makeBoundHelper(fn, compatMode) {
     // If none of the hash parameters are bound, act as an unbound helper.
     // This prevents views from being unnecessarily created
     var hasStream = scanArray(params) || scanHash(hash);
-
-    if (env.data.isUnbound || !hasStream){
-      return valueFn();
-    } else {
+    if (hasStream) {
       var lazyValue = new Stream(valueFn);
 
       for (i = 0; i < numParams; i++) {
@@ -123,6 +120,8 @@ export default function makeBoundHelper(fn, compatMode) {
       }
 
       return lazyValue;
+    } else {
+      return valueFn();
     }
   }
 

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -6,145 +6,93 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import conditional from "ember-metal/streams/conditional";
 import shouldDisplay from "ember-views/streams/should_display";
-import { read } from "ember-metal/streams/utils";
 import { get } from "ember-metal/property_get";
 import { isStream } from "ember-metal/streams/utils";
 import BoundIfView from "ember-views/views/bound_if_view";
 import emptyTemplate from "ember-htmlbars/templates/empty";
 
-
 /**
-  Use the `boundIf` helper to create a conditional that re-evaluates
-  whenever the truthiness of the bound value changes.
-
-  ```handlebars
-  {{#boundIf "content.shouldDisplayTitle"}}
-    {{content.title}}
-  {{/boundIf}}
-  ```
-
-  @private
-  @method boundIf
-  @for Ember.Handlebars.helpers
-  @param {String} property Property to bind
-  @param {Function} fn Context to provide for rendering
-  @return {String} HTML string
-*/
-function boundIfHelper(params, hash, options, env) {
-  options.helperName = options.helperName || 'boundIf';
-  var property = params[0];
-  var stream = isStream(property) ? property : this.getStream(property);
-
-  var viewOptions = {
-    _morph: options.morph,
-    _context: get(this, 'context'),
-    conditionStream: shouldDisplay(stream),
-    truthyTemplate: options.template,
-    falsyTemplate: options.inverse,
-    helperName: options.helperName
-  };
-
-  this.appendChild(BoundIfView, viewOptions);
-}
-
-/**
-  @private
-
-  Use the `unboundIf` helper to create a conditional that evaluates once.
-
-  ```handlebars
-  {{#unboundIf "content.shouldDisplayTitle"}}
-    {{content.title}}
-  {{/unboundIf}}
-  ```
-
-  @method unboundIf
-  @for Ember.Handlebars.helpers
-  @param {String} property Property to bind
-  @param {Function} fn Context to provide for rendering
-  @return {String} HTML string
-  @since 1.4.0
-*/
-function unboundIfHelper(params, hash, options, env) {
-  var template = options.template;
-  var value = params[0];
-
-  if (!read(shouldDisplay(value))) {
-    template = options.inverse;
-  }
-
-  return template.render(this, env, options.morph.contextualElement);
-}
-
-function _inlineIfAssertion(params) {
-  Ember.assert("If helper in inline form expects between two and three arguments", params.length === 2 || params.length === 3);
-}
-
-/**
-  See [boundIf](/api/classes/Ember.Handlebars.helpers.html#method_boundIf)
-  and [unboundIf](/api/classes/Ember.Handlebars.helpers.html#method_unboundIf)
-
   @method if
   @for Ember.Handlebars.helpers
-  @param {Function} context
-  @param {Hash} options
-  @return {String} HTML string
 */
 function ifHelper(params, hash, options, env) {
-  Ember.assert("If helper in block form expect exactly one argument", !options.template || params.length === 1);
-  if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
-    if (!options.template) {
-      _inlineIfAssertion(params);
-      var condition = params[0];
-      var truthy = params[1];
-      var falsy = params[2];
-      return conditional(shouldDisplay(condition), truthy, falsy);
-    }
-  }
-
-  options.inverse = options.inverse || emptyTemplate;
-
-  options.helperName = options.helperName || ('if ');
-
-  if (env.data.isUnbound) {
-    env.data.isUnbound = false;
-    return env.helpers.unboundIf.helperFunction.call(this, params, hash, options, env);
-  } else {
-    return env.helpers.boundIf.helperFunction.call(this, params, hash, options, env);
-  }
+  var helperName = options.helperName || 'if';
+  return appendConditional(this, false, helperName, params, hash, options, env);
 }
 
 /**
   @method unless
   @for Ember.Handlebars.helpers
-  @param {Function} context
-  @param {Hash} options
-  @return {String} HTML string
 */
 function unlessHelper(params, hash, options, env) {
-  Ember.assert("You must pass exactly one argument to the unless helper", params.length === 1);
-  Ember.assert("You must pass a block to the unless helper", !!options.template);
+  var helperName = options.helperName || 'unless';
+  return appendConditional(this, true, helperName, params, hash, options, env);
+}
 
-  var template = options.template;
-  var inverse = options.inverse || emptyTemplate;
-  var helperName = 'unless';
 
-  options.template = inverse;
-  options.inverse = template;
+function assertInlineIfNotEnabled() {
+  Ember.assert(
+    "To use the inline forms of the `if` and `unless` helpers you must " +
+    "enable the `ember-htmlbars-inline-if-helper` feature flag."
+  );
+}
 
-  options.helperName = options.helperName || helperName;
-
-  if (env.data.isUnbound) {
-    env.data.isUnbound = false;
-    return env.helpers.unboundIf.helperFunction.call(this, params, hash, options, env);
+function appendConditional(view, inverted, helperName, params, hash, options, env) {
+  if (options.template || options.inverse) {
+    return appendBlockConditional(view, inverted, helperName, params, hash, options, env);
   } else {
-    return env.helpers.boundIf.helperFunction.call(this, params, hash, options, env);
+    if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
+      return appendInlineConditional(view, inverted, helperName, params, hash, options, env);
+    } else {
+      assertInlineIfNotEnabled();
+    }
   }
+}
+
+function appendBlockConditional(view, inverted, helperName, params, hash, options, env) {
+  Ember.assert(
+    "The block form of the `if` and `unless` helpers expect exactly one " +
+    "argument, e.g. `{{#if newMessages}} You have new messages. {{/if}}.`",
+    params.length === 1
+  );
+
+  var condition = shouldDisplay(params[0]);
+  var truthyTemplate = (inverted ? options.inverse : options.template) || emptyTemplate;
+  var falsyTemplate = (inverted ? options.template : options.inverse) || emptyTemplate;
+
+  if (isStream(condition)) {
+    view.appendChild(BoundIfView, {
+      _morph: options.morph,
+      _context: get(view, 'context'),
+      conditionStream: condition,
+      truthyTemplate: truthyTemplate,
+      falsyTemplate: falsyTemplate,
+      helperName: helperName
+    });
+  } else {
+    var template = condition ? truthyTemplate : falsyTemplate;
+    if (template) {
+      return template.render(view, env, options.morph.contextualElement);
+    }
+  }
+}
+
+function appendInlineConditional(view, inverted, helperName, params) {
+  Ember.assert(
+    "The inline form of the `if` and `unless` helpers expect two or " +
+    "three arguments, e.g. `{{if trialExpired 'Expired' expiryDate}}` " +
+    "or `{{unless isFirstLogin 'Welcome back!'}}`.",
+    params.length === 2 || params.length === 3
+  );
+
+  return conditional(
+    shouldDisplay(params[0]),
+    inverted ? params[2] : params[1],
+    inverted ? params[1] : params[2]
+  );
 }
 
 export {
   ifHelper,
-  boundIfHelper,
-  unboundIfHelper,
   unlessHelper
 };

--- a/packages/ember-htmlbars/lib/helpers/unbound.js
+++ b/packages/ember-htmlbars/lib/helpers/unbound.js
@@ -1,6 +1,7 @@
-import lookupHelper from "ember-htmlbars/system/lookup-helper";
-import { read } from "ember-metal/streams/utils";
 import EmberError from "ember-metal/error";
+import { IS_BINDING } from "ember-metal/mixin";
+import { read } from "ember-metal/streams/utils";
+import lookupHelper from "ember-htmlbars/system/lookup-helper";
 
 /**
 @module ember
@@ -28,35 +29,54 @@ import EmberError from "ember-metal/error";
   @return {String} HTML string
 */
 export function unboundHelper(params, hash, options, env) {
-  var length = params.length;
-  var result;
+  Ember.assert(
+    "The `unbound` helper expects at least one argument, " +
+    "e.g. `{{unbound user.name}}`.",
+    params.length > 0
+  );
 
-  options.helperName = options.helperName || 'unbound';
-
-  if (length === 1) {
-    result = read(params[0]);
-  } else if (length >= 2) {
-    env.data.isUnbound = true;
+  if (params.length === 1) {
+    return read(params[0]);
+  } else {
+    options.helperName = options.helperName || 'unbound';
 
     var helperName = params[0]._label;
-    var args = [];
-
-    for (var i = 1, l = params.length; i < l; i++) {
-      var value = read(params[i]);
-
-      args.push(value);
-    }
-
     var helper = lookupHelper(helperName, this, env);
 
     if (!helper) {
       throw new EmberError('HTMLBars error: Could not find component or helper named ' + helperName + '.');
     }
 
-    result = helper.helperFunction.call(this, args, hash, options, env);
+    return helper.helperFunction.call(this, readParams(params), readHash(hash, this), options, env);
+  }
+}
 
-    delete env.data.isUnbound;
+function readParams(params) {
+  var l = params.length;
+  var unboundParams = new Array(l - 1);
+
+  for (var i = 1; i < l; i++) {
+    unboundParams[i-1] = read(params[i]);
   }
 
-  return result;
+  return unboundParams;
+}
+
+function readHash(hash, view) {
+  var unboundHash = {};
+
+  for (var prop in hash) {
+    if (IS_BINDING.test(prop)) {
+      var value = hash[prop];
+      if (typeof value === 'string') {
+        value = view.getStream(value);
+      }
+
+      unboundHash[prop.slice(0, -7)] = read(value);
+    } else {
+      unboundHash[prop] = read(hash[prop]);
+    }
+  }
+
+  return unboundHash;
 }

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -35,9 +35,7 @@ import {
 } from "ember-htmlbars/helpers/bind-attr";
 import {
   ifHelper,
-  unlessHelper,
-  unboundIfHelper,
-  boundIfHelper
+  unlessHelper
 } from "ember-htmlbars/helpers/if_unless";
 import { locHelper } from "ember-htmlbars/helpers/loc";
 import { partialHelper } from "ember-htmlbars/helpers/partial";
@@ -63,8 +61,6 @@ registerHelper('yield', yieldHelper);
 registerHelper('with', withHelper);
 registerHelper('if', ifHelper);
 registerHelper('unless', unlessHelper);
-registerHelper('unboundIf', unboundIfHelper);
-registerHelper('boundIf', boundIfHelper);
 registerHelper('log', logHelper);
 registerHelper('debugger', debuggerHelper);
 registerHelper('loc', locHelper);

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -73,10 +73,7 @@ export default function makeBoundHelper(fn) {
     // If none of the hash parameters are bound, act as an unbound helper.
     // This prevents views from being unnecessarily created
     var hasStream = scanArray(params) || scanHash(hash);
-
-    if (env.data.isUnbound || !hasStream) {
-      return valueFn();
-    } else {
+    if (hasStream) {
       var lazyValue = new Stream(valueFn);
 
       for (var i = 0; i < numParams; i++) {
@@ -90,6 +87,8 @@ export default function makeBoundHelper(fn) {
       }
 
       return lazyValue;
+    } else {
+      return valueFn();
     }
   }
 

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -219,11 +219,11 @@ test("The `if` helper ignores a controller option", function() {
   equal(lookupCalled, false, 'controller option should NOT be used');
 });
 
-test('should not update boundIf if truthiness does not change', function() {
+test('should not rerender if truthiness does not change', function() {
   var renderCount = 0;
 
   view = EmberView.create({
-    template: compile('<h1 id="first">{{#boundIf "view.shouldDisplay"}}{{view view.InnerViewClass}}{{/boundIf}}</h1>'),
+    template: compile('<h1 id="first">{{#if view.shouldDisplay}}{{view view.InnerViewClass}}{{/if}}</h1>'),
 
     shouldDisplay: true,
 
@@ -779,7 +779,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
 
     expectAssertion(function() {
       runAppend(view);
-    }, 'If helper in inline form expects between two and three arguments');
+    }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
   });
 
   test("`if` helper with inline form: raises when using less than two arguments", function() {
@@ -790,7 +790,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
 
     expectAssertion(function() {
       runAppend(view);
-    }, 'If helper in inline form expects between two and three arguments');
+    }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
   });
 
   test("`if` helper with inline form: works when used in a sub expression", function() {


### PR DESCRIPTION
- Removes private `unboundIf` and `boundIf` helpers in favor of a different implementation.
- Unifies `if` and `unless` code paths.
- Removes `data.isUnbound` in favor of pre-mapping params and hash by `read`
