### PR TITLE
Container creates a Registry if none is supplied.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -20,23 +20,20 @@ var Registry;
  @class Container
  */
 function Container(registry, options) {
-  if (!registry) {
+  this._registry = registry || (function() {
     Ember.deprecate("A container should only be created for an already instantiated registry. For backward compatibility, an isolated registry will be instantiated just for this container.");
 
     // TODO - See note above about transpiler import workaround.
     if (!Registry) { Registry = requireModule('container/registry')['default']; }
+    
+    return new Registry();
+  }());
 
-    registry = new Registry();
-  }
-
-  options = options || {};
-
-  this._registry    = registry;
-  this.cache        = dictionary(options.cache || null);
-  this.factoryCache = dictionary(options.factoryCache || null);
+  this.cache        = dictionary(options && options.cache ? options.cache : null);
+  this.factoryCache = dictionary(options && options.factoryCache ? options.factoryCache : null);
 
   if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
-    this.validationCache = dictionary(options.validationCache || null);
+    this.validationCache = dictionary(options && options.validationCache ? options.validationCache : null);
   }
 }
 

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -2,6 +2,10 @@ import Ember from 'ember-metal/core'; // Ember.assert
 import emberKeys from "ember-metal/keys";
 import dictionary from 'ember-metal/dictionary';
 
+// TODO - Temporary workaround for v0.4.0 of the ES6 transpiler, which lacks support for circular dependencies.
+// See the below usage of requireModule. Instead, it should be possible to simply `import Registry from './registry';`
+var Registry;
+
 /**
  A lightweight container used to instantiate and cache objects.
 
@@ -16,7 +20,14 @@ import dictionary from 'ember-metal/dictionary';
  @class Container
  */
 function Container(registry, options) {
-  Ember.assert("A Registry instance must be passed as an option when constructing a Container.", typeof registry === 'object');
+  if (!registry) {
+    Ember.deprecate("A container should only be created for an already instantiated registry. For backward compatibility, an isolated registry will be instantiated just for this container.");
+
+    // TODO - See note above about transpiler import workaround.
+    if (!Registry) { Registry = requireModule('container/registry')['default']; }
+
+    registry = new Registry();
+  }
 
   options = options || {};
 

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -1,6 +1,6 @@
 import Ember from 'ember-metal/core'; // Ember.assert
 import dictionary from 'ember-metal/dictionary';
-import Container from 'container/container';
+import Container from './container';
 
 var VALID_FULL_NAME_REGEXP = /^[^:]+.+:[^:]+$/;
 

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -18,12 +18,10 @@ var VALID_FULL_NAME_REGEXP = /^[^:]+.+:[^:]+$/;
  @class Registry
 */
 function Registry(options) {
-  options = options || {};
+  this.resolver = options && options.resolver ? options.resolver : function() {};
 
-  this.resolver = options.resolver || function() {};
-
-  this.registrations  = dictionary(options.registrations || null);
-  this.typeInjections = dictionary(options.typeInjections || null);
+  this.registrations  = dictionary(options && options.registrations ? options.registrations : null);
+  this.typeInjections = dictionary(options && options.typeInjections ? options.typeInjections : null);
   this.injections     = dictionary(null);
   this.factoryTypeInjections = dictionary(null);
   this.factoryInjections     = dictionary(null);
@@ -31,8 +29,8 @@ function Registry(options) {
   this._normalizeCache = dictionary(null);
   this._resolveCache   = dictionary(null);
 
-  this._options     = dictionary(options.options || null);
-  this._typeOptions = dictionary(options.typeOptions || null);
+  this._options     = dictionary(options && options.options ? options.options : null);
+  this._typeOptions = dictionary(options && options.typeOptions ? options.typeOptions : null);
 }
 
 Registry.prototype = {


### PR DESCRIPTION
In order to avoid breaking existing usages of Container in the wild, an
isolated registry will be created if none is supplied to the
constructor. This behavior is deprecated.

Note: This commit includes a temporary workaround for the lack of 
support for circular module dependencies in v0.4.0 of the ES6 
transpiler.
