### PR TITLE
Cleanup view helper

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/collection.js
+++ b/packages/ember-htmlbars/lib/helpers/collection.js
@@ -7,7 +7,6 @@ import Ember from "ember-metal/core"; // Ember.assert, Ember.deprecate
 import { IS_BINDING } from "ember-metal/mixin";
 import { fmt } from "ember-runtime/system/string";
 import { get } from "ember-metal/property_get";
-import { ViewHelper } from "ember-htmlbars/helpers/view";
 import CollectionView from "ember-views/views/collection_view";
 import { readViewFactory } from "ember-views/streams/utils";
 import { map } from 'ember-metal/enumerable_utils';
@@ -15,6 +14,7 @@ import {
   streamifyClassNameBinding
 } from "ember-views/streams/class_name_binding";
 import { Binding } from 'ember-metal/binding';
+import mergeViewBindings from "ember-htmlbars/system/merge-view-bindings";
 
 /**
   `{{collection}}` is a `Ember.Handlebars` helper for adding instances of
@@ -137,9 +137,6 @@ import { Binding } from 'ember-metal/binding';
 
   @method collection
   @for Ember.Handlebars.helpers
-  @param {String} path
-  @param {Hash} options
-  @return {String} HTML string
   @deprecated Use `{{each}}` helper instead.
 */
 export function collectionHelper(params, hash, options, env) {
@@ -239,7 +236,7 @@ export function collectionHelper(params, hash, options, env) {
     itemHash._contextBinding = Binding.oneWay('content');
   }
 
-  var viewOptions = ViewHelper.propertiesFromHTMLOptions(itemHash, {}, { data: data });
+  var viewOptions = mergeViewBindings(this, {}, itemHash);
 
   if (hash.itemClassBinding) {
     var itemClassBindings = hash.itemClassBinding.split(' ');

--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -4,159 +4,10 @@
 */
 
 import Ember from "ember-metal/core"; // Ember.warn, Ember.assert
-
-import EmberObject from "ember-runtime/system/object";
-import { get } from "ember-metal/property_get";
-import SimpleStream from "ember-metal/streams/simple";
-import keys from "ember-metal/keys";
-import { IS_BINDING } from "ember-metal/mixin";
-import { read, isStream } from "ember-metal/streams/utils";
 import { readViewFactory } from "ember-views/streams/utils";
 import View from "ember-views/views/view";
-
-import { map } from 'ember-metal/enumerable_utils';
-import {
-  streamifyClassNameBinding
-} from "ember-views/streams/class_name_binding";
-
-function makeBindings(hash, options, view) {
-  for (var prop in hash) {
-    var value = hash[prop];
-
-    // Classes are processed separately
-    if (prop === 'class' && isStream(value)) {
-      hash.classBinding = value._label;
-      delete hash['class'];
-      continue;
-    }
-
-    if (prop === 'classBinding') {
-      continue;
-    }
-
-    if (IS_BINDING.test(prop)) {
-      if (isStream(value)) {
-        Ember.warn("You're attempting to render a view by passing " +
-                   prop + " " +
-                   "to a view helper without a quoted value, " +
-                   "but this syntax is ambiguous. You should either surround " +
-                   prop + "'s value in quotes or remove `Binding` " +
-                   "from " + prop + ".");
-      } else if (typeof value === 'string') {
-        hash[prop] = view._getBindingForStream(value);
-      }
-    } else {
-      if (isStream(value) && prop !== 'id') {
-        hash[prop + 'Binding'] = view._getBindingForStream(value);
-        delete hash[prop];
-      }
-    }
-  }
-}
-
-export var ViewHelper = EmberObject.create({
-  propertiesFromHTMLOptions: function(hash, options, env) {
-    var view    = env.data.view;
-    var classes = read(hash['class']);
-
-    var extensions = {
-      helperName: options.helperName || ''
-    };
-
-    if (hash.id) {
-      extensions.elementId = read(hash.id);
-    }
-
-    if (hash.tag) {
-      extensions.tagName = hash.tag;
-    }
-
-    if (classes) {
-      classes = classes.split(' ');
-      extensions.classNames = classes;
-    }
-
-    if (hash.classBinding) {
-      extensions.classNameBindings = hash.classBinding.split(' ');
-    }
-
-    if (hash.classNameBindings) {
-      if (extensions.classNameBindings === undefined) {
-        extensions.classNameBindings = [];
-      }
-      extensions.classNameBindings = extensions.classNameBindings.concat(hash.classNameBindings.split(' '));
-    }
-
-    if (hash.attributeBindings) {
-      Ember.assert("Setting 'attributeBindings' via template helpers is not allowed." +
-                   " Please subclass Ember.View and set it there instead.");
-      extensions.attributeBindings = null;
-    }
-
-    // Set the proper context for all bindings passed to the helper. This applies to regular attribute bindings
-    // as well as class name bindings. If the bindings are local, make them relative to the current context
-    // instead of the view.
-
-    var hashKeys = keys(hash);
-
-    for (var i = 0, l = hashKeys.length; i < l; i++) {
-      var prop = hashKeys[i];
-
-      if (prop !== 'classNameBindings') {
-        extensions[prop] = hash[prop];
-      }
-    }
-
-    if (extensions.classNameBindings) {
-      extensions.classNameBindings = map(extensions.classNameBindings, function(classNameBinding){
-        var binding = streamifyClassNameBinding(view, classNameBinding);
-        if (isStream(binding)) {
-          return binding;
-        } else {
-          // returning a stream informs the classNameBindings logic
-          // in views/view that this value is already processed.
-          return new SimpleStream(binding);
-        }
-      });
-    }
-
-    return extensions;
-  },
-
-  helper: function(viewInstanceOrClass, hash, options, env) {
-    var currentView = env.data.view;
-    var viewProto;
-
-    makeBindings(hash, options, currentView);
-
-    var props = this.propertiesFromHTMLOptions(hash, options, env);
-
-    if (View.detectInstance(viewInstanceOrClass)) {
-      viewProto = viewInstanceOrClass;
-    } else {
-      viewProto = viewInstanceOrClass.proto();
-    }
-
-    var template = options.template;
-    if (template) {
-      Ember.assert(
-        "You cannot provide a template block if you also specified a templateName",
-        !get(props, 'templateName') && !get(viewProto, 'templateName')
-      );
-      props.template = template;
-    }
-
-    // We only want to override the `_context` computed property if there is
-    // no specified controller. See View#_context for more information.
-    if (!viewProto.controller && !viewProto.controllerBinding && !props.controller && !props.controllerBinding) {
-      props._context = get(currentView, 'context'); // TODO: is this right?!
-    }
-
-    props._morph = options.morph;
-
-    currentView.appendChild(viewInstanceOrClass, props);
-  }
-});
+import mergeViewBindings from "ember-htmlbars/system/merge-view-bindings";
+import appendTemplatedView from "ember-htmlbars/system/append-templated-view";
 
 /**
   `{{view}}` inserts a new instance of an `Ember.View` into a template passing its
@@ -332,30 +183,33 @@ export var ViewHelper = EmberObject.create({
 
   @method view
   @for Ember.Handlebars.helpers
-  @param {String} path
-  @param {Hash} options
-  @return {String} HTML string
 */
 export function viewHelper(params, hash, options, env) {
-  Ember.assert("The view helper only takes a single argument", params.length <= 2);
+  Ember.assert(
+    "The `view` helper expects zero or one arguments.",
+    params.length <= 2
+  );
 
   var container = this.container || this._keywords.view.value().container;
-  var viewClass;
-
-  // If no path is provided, treat path param as options
-  // and get an instance of the registered `view:toplevel`
+  var viewClassOrInstance;
   if (params.length === 0) {
     if (container) {
-      viewClass = container.lookupFactory('view:toplevel');
+      viewClassOrInstance = container.lookupFactory('view:toplevel');
     } else {
-      viewClass = View;
+      viewClassOrInstance = View;
     }
   } else {
-    var pathStream = params[0];
-    viewClass = readViewFactory(pathStream, container);
+    viewClassOrInstance = readViewFactory(params[0], container);
   }
 
-  options.helperName = options.helperName || 'view';
+  var props = {
+    helperName: options.helperName || 'view'
+  };
 
-  return ViewHelper.helper(viewClass, hash, options, env);
+  if (options.template) {
+    props.template = options.template;
+  }
+
+  mergeViewBindings(this, props, hash);
+  appendTemplatedView(this, options.morph, viewClassOrInstance, props);
 }

--- a/packages/ember-htmlbars/lib/system/append-templated-view.js
+++ b/packages/ember-htmlbars/lib/system/append-templated-view.js
@@ -1,0 +1,35 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import Ember from "ember-metal/core"; // Ember.assert
+import { get } from "ember-metal/property_get";
+import View from "ember-views/views/view";
+
+export default function appendTemplatedView(parentView, morph, viewClassOrInstance, props) {
+  var viewProto;
+  if (View.detectInstance(viewClassOrInstance)) {
+    viewProto = viewClassOrInstance;
+  } else {
+    viewProto = viewClassOrInstance.proto();
+  }
+
+  Ember.assert(
+    "You cannot provide a template block if you also specified a templateName",
+    !props.template || (!get(props, 'templateName') && !get(viewProto, 'templateName'))
+  );
+
+  // We only want to override the `_context` computed property if there is
+  // no specified controller. See View#_context for more information.
+  if (!viewProto.controller &&
+      !viewProto.controllerBinding &&
+      !props.controller &&
+      !props.controllerBinding) {
+    props._context = get(parentView, 'context'); // TODO: is this right?!
+  }
+
+  props._morph = morph;
+
+  return parentView.appendChild(viewClassOrInstance, props);
+}

--- a/packages/ember-htmlbars/lib/system/merge-view-bindings.js
+++ b/packages/ember-htmlbars/lib/system/merge-view-bindings.js
@@ -1,0 +1,100 @@
+import Ember from "ember-metal/core"; // Ember.warn, Ember.assert
+import { IS_BINDING } from "ember-metal/mixin";
+import SimpleStream from "ember-metal/streams/simple";
+import { read, isStream } from "ember-metal/streams/utils";
+import {
+  streamifyClassNameBinding
+} from "ember-views/streams/class_name_binding";
+
+var a_push = Array.prototype.push;
+
+export default function mergeViewBindings(view, props, hash) {
+  mergeGenericViewBindings(view, props, hash);
+  mergeDOMViewBindings(view, props, hash);
+  return props;
+}
+
+function mergeGenericViewBindings(view, props, hash) {
+  for (var key in hash) {
+    if (key === 'id' ||
+        key === 'tag' ||
+        key === 'class' ||
+        key === 'classBinding' ||
+        key === 'classNameBindings' ||
+        key === 'attributeBindings') {
+      continue;
+    }
+
+    var value = hash[key];
+
+    if (IS_BINDING.test(key)) {
+      if (typeof value === 'string') {
+        props[key] = view._getBindingForStream(value);
+      } else if (isStream(value)) {
+        Ember.warn(
+          "You're attempting to render a view by passing " + key + " " +
+          "to a view helper without a quoted value, but this syntax is " +
+          "ambiguous. You should either surround " + key + "'s value in " +
+          "quotes or remove `Binding` from " + key + "."
+        );
+
+        props[key] = view._getBindingForStream(value);
+      } else {
+        props[key] = value;
+      }
+    } else {
+      if (isStream(value)) {
+        props[key + 'Binding'] = view._getBindingForStream(value);
+      } else {
+        props[key] = value;
+      }
+    }
+  }
+}
+
+function mergeDOMViewBindings(view, props, hash) {
+  Ember.assert(
+    "Setting 'attributeBindings' via template helpers is not allowed. " +
+    "Please subclass Ember.View and set it there instead.",
+    !hash.attributeBindings
+  );
+
+  if (hash.id) {
+    props.elementId = read(hash.id);
+  }
+
+  if (hash.tag) {
+    props.tagName = read(hash.tag);
+  }
+
+  var classBindings = [];
+
+  if (hash['class']) {
+    if (typeof hash['class'] === 'string') {
+      props.classNames = hash['class'].split(' ');
+    } else {
+      classBindings.push(hash['class']._label);
+    }
+  }
+
+  if (hash.classBinding) {
+    a_push.apply(classBindings, hash.classBinding.split(' '));
+  }
+
+  if (hash.classNameBindings) {
+    a_push.apply(classBindings, hash.classNameBindings.split(' '));
+  }
+
+  if (classBindings.length > 0) {
+    props.classNameBindings = classBindings;
+
+    for (var i = 0; i < classBindings.length; i++) {
+      var classBinding = streamifyClassNameBinding(view, classBindings[i]);
+      if (isStream(classBinding)) {
+        classBindings[i] = classBinding;
+      } else {
+        classBindings[i] = new SimpleStream(classBinding);
+      }
+    }
+  }
+}

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -618,7 +618,6 @@ test('views set the template of their children to a passed block', function() {
 test('{{view}} should not override class bindings defined on a child view', function() {
   var LabelView = EmberView.extend({
     container:         container,
-    templateName:      'nested',
     classNameBindings: ['something'],
     something:         'visible'
   });


### PR DESCRIPTION
Removes the `ViewHelper` object in favor of two auxiliary functions: `appendTemplatedView` and `mergeViewBindings`.

The next step is to rewrite the other helpers to use these functions instead of using `helpers.viewHelper.call`.
