### PR TITLE
[BUGFIX beta] Prevent mandatory-setter when setter is already present.

### DIFF
--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -45,9 +45,11 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   var handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
     var descriptor = Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor(obj, keyName);
     var configurable = descriptor ? descriptor.configurable : true;
+    var isWritable = descriptor ? descriptor.writable : true;
+    var hasValue = descriptor ? 'value' in descriptor : true;
 
     // this x in Y deopts, so keeping it in this function is better;
-    if (configurable && keyName in obj) {
+    if (configurable && isWritable && hasValue && keyName in obj) {
       m.values[keyName] = obj[keyName];
       o_defineProperty(obj, keyName, {
         configurable: true,

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -10,6 +10,12 @@ import { meta as metaFor } from "ember-metal/utils";
 
 QUnit.module('mandatory-setters');
 
+function hasMandatorySetter(object, property) {
+  var meta = metaFor(object);
+
+  return property in meta.values;
+}
+
 if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   if (hasPropertyAccessors) {
     test('does not assert if property is not being watched', function() {
@@ -22,6 +28,50 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
 
       obj.someProp = 'blastix';
       equal(get(obj, 'someProp'), 'blastix');
+    });
+
+    test('should not setup mandatory-setter if property is not writable', function() {
+      expect(6);
+
+      var obj = { };
+
+      defineProperty(obj, 'a', { value: true });
+      defineProperty(obj, 'b', { value: false });
+      defineProperty(obj, 'c', { value: undefined });
+      defineProperty(obj, 'd', { value: undefined, writable: false});
+      defineProperty(obj, 'e', { value: undefined, configurable: false});
+      defineProperty(obj, 'f', { value: undefined, configurable: true});
+
+      watch(obj, 'a');
+      watch(obj, 'b');
+      watch(obj, 'c');
+      watch(obj, 'd');
+      watch(obj, 'e');
+      watch(obj, 'f');
+
+      ok(!hasMandatorySetter(obj, 'a'), 'mandatory-setter should not be installed');
+      ok(!hasMandatorySetter(obj, 'b'), 'mandatory-setter should not be installed');
+      ok(!hasMandatorySetter(obj, 'c'), 'mandatory-setter should not be installed');
+      ok(!hasMandatorySetter(obj, 'd'), 'mandatory-setter should not be installed');
+      ok(!hasMandatorySetter(obj, 'e'), 'mandatory-setter should not be installed');
+      ok(!hasMandatorySetter(obj, 'f'), 'mandatory-setter should not be installed');
+    });
+
+    test('should not setup mandatory-setter if setter is already setup on property', function() {
+      expect(2);
+
+      var obj = { someProp: null };
+
+      defineProperty(obj, 'someProp', {
+        set: function(value) {
+          equal(value, 'foo-bar', 'custom setter was called');
+        }
+      });
+
+      watch(obj, 'someProp');
+      ok(!hasMandatorySetter(obj, 'someProp'), 'mandatory-setter should not be installed');
+
+      obj.someProp = 'foo-bar';
     });
 
     test('should assert if set without Ember.set when property is being watched', function() {


### PR DESCRIPTION
Closes #9899.
Fixes #9897.
