### PR TITLE
[BUGFIX release] Remove Unnecessary Override of emptyViewclass in Each Helper

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -178,7 +178,6 @@ function eachHelper(params, hash, options, env) {
     hash.keyword === true || typeof hash.keyword === 'string'
   );
 
-  hash.emptyViewClass = Ember._MetamorphView;
   hash.dataSource = path;
   options.helperName = options.helperName || helperName;
 

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -18,7 +18,7 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import compile from "ember-template-compiler/system/compile";
 
 var people, view, registry, container;
-var template, templateMyView, MyView;
+var template, templateMyView, MyView, MyEmptyView, templateMyEmptyView;
 
 // This function lets us write {{#EACH|people|p}} {{p}} {{/each}}
 // and generate:
@@ -97,6 +97,11 @@ QUnit.module("the #each helper [DEPRECATED]", {
     templateMyView = templateFor("{{name}}");
     lookup.MyView = MyView = EmberView.extend({
       template: templateMyView
+    });
+
+    templateMyEmptyView = templateFor("I'm empty");
+    lookup.MyEmptyView = MyEmptyView = EmberView.extend({
+      template: templateMyEmptyView
     });
 
     expectDeprecation(function() {
@@ -496,9 +501,7 @@ test("it supports {{itemView=}}", function() {
   view = EmberView.create({
     template: templateFor('{{each view.people itemView="anItemView"}}'),
     people: people,
-    controller: {
-      container: container
-    }
+    container: container
   });
 
   registry.register('view:anItemView', itemView);
@@ -518,9 +521,7 @@ test("it defers all normalization of itemView names to the resolver", function()
   view = EmberView.create({
     template: templateFor('{{each view.people itemView="an-item-view"}}'),
     people: people,
-    controller: {
-      container: container
-    }
+    container: container
   });
 
   registry.register('view:an-item-view', itemView);
@@ -605,6 +606,123 @@ test("it supports {{itemViewClass=}} with in format", function() {
 
   assertText(view, "Steve HoltAnnabelle");
 
+});
+
+test("it supports {{emptyView=}}", function() {
+  var emptyView = EmberView.extend({
+    template: templateFor('emptyView:sad panda')
+  });
+
+  runDestroy(view);
+
+  view = EmberView.create({
+    template: templateFor('{{each view.people emptyView="anEmptyView"}}'),
+    people: A(),
+    container: container
+  });
+
+  registry.register('view:anEmptyView', emptyView);
+
+  runAppend(view);
+
+  assertText(view, "emptyView:sad panda");
+});
+
+test("it defers all normalization of emptyView names to the resolver", function() {
+  var emptyView = EmberView.extend({
+    template: templateFor('emptyView:sad panda')
+  });
+
+  runDestroy(view);
+
+  view = EmberView.create({
+    template: templateFor('{{each view.people emptyView="an-empty-view"}}'),
+    people: A(),
+    container: container
+  });
+
+  registry.register('view:an-empty-view', emptyView);
+
+  registry.resolve = function(fullname) {
+    equal(fullname, "view:an-empty-view", "leaves fullname untouched");
+    return Registry.prototype.resolve.call(this, fullname);
+  };
+
+  runAppend(view);
+});
+
+test("it supports {{emptyViewClass=}} with global (DEPRECATED)", function() {
+  runDestroy(view);
+
+  view = EmberView.create({
+    template: templateFor('{{each view.people emptyViewClass=MyEmptyView}}'),
+    people: A()
+  });
+
+  var deprecation = /Resolved the view "MyEmptyView" on the global context/;
+
+  if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
+    deprecation = /Global lookup of MyEmptyView from a Handlebars template is deprecated/;
+  }
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, deprecation);
+
+  assertText(view, "I'm empty");
+});
+
+test("it supports {{emptyViewClass=}} via container", function() {
+  runDestroy(view);
+
+  view = EmberView.create({
+    container: {
+      lookupFactory: function(name) {
+        equal(name, 'view:my-empty-view');
+        return MyEmptyView;
+      }
+    },
+    template: templateFor('{{each view.people emptyViewClass="my-empty-view"}}'),
+    people: A()
+  });
+
+  runAppend(view);
+
+  assertText(view, "I'm empty");
+});
+
+test("it supports {{emptyViewClass=}} with tagName (DEPRECATED)", function() {
+  runDestroy(view);
+
+  view = EmberView.create({
+    template: templateFor('{{each view.people emptyViewClass=MyEmptyView tagName="b"}}'),
+    people: A()
+  });
+
+  expectDeprecation(/Supplying a tagName to Metamorph views is unreliable and is deprecated./);
+
+  runAppend(view);
+
+  equal(view.$('b').length, 1, 'rendered b tag');
+  equal(view.$('b').text(), "I'm empty");
+});
+
+test("it supports {{emptyViewClass=}} with in format", function() {
+  runDestroy(view);
+
+  view = EmberView.create({
+    container: {
+      lookupFactory: function(name) {
+        return MyEmptyView;
+      }
+    },
+    template: templateFor('{{each person in view.people emptyViewClass="myEmptyView"}}'),
+    people: A()
+  });
+
+  runAppend(view);
+
+  assertText(view, "I'm empty");
 });
 
 test("it supports {{else}}", function() {


### PR DESCRIPTION
Overriding the `emptyViewClass` in the each helper is breaking usage of
the {{#each}} helper when used as follows:

``` handlebars
{{each person in people emptyView='myEmptyView'}}
```

Fixes #10019

HT @mmun for all of the help!
