### PR TITLE
Deprecate Ember.ObjectController.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -861,7 +861,7 @@ function testEachWithItem(moduleName, useBlockParams) {
   test("itemController specified in ArrayController with name binding does not change context", function() {
     people = A([{ name: "Steve Holt" }, { name: "Annabelle" }]);
 
-    var PersonController = ObjectController.extend({
+    var PersonController = EmberController.extend({
           controllerName: computed(function() {
             return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
           })

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -14,7 +14,7 @@ import precompile from 'ember-htmlbars/compat/precompile';
 import compile from "ember-template-compiler/system/compile";
 import template from 'ember-template-compiler/system/template';
 import { observersFor } from "ember-metal/observer";
-import ObjectController from 'ember-runtime/controllers/object_controller';
+import Controller from 'ember-runtime/controllers/controller';
 
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import { set } from 'ember-metal/property_set';
@@ -622,7 +622,7 @@ test('{{view}} should not override class bindings defined on a child view', func
     something:         'visible'
   });
 
-  registry.register('controller:label', ObjectController, { instantiate: true });
+  registry.register('controller:label', Controller, { instantiate: true });
   registry.register('view:label',       LabelView);
   registry.register('template:label',   compile('<div id="child-view"></div>'));
   registry.register('template:nester',  compile('{{render "label"}}'));
@@ -630,7 +630,7 @@ test('{{view}} should not override class bindings defined on a child view', func
   view = EmberView.create({
     container:    container,
     templateName: 'nester',
-    controller:   ObjectController.create({
+    controller:   Controller.create({
       container: container
     })
   });

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -5,7 +5,11 @@ import EmberObject from "ember-runtime/system/object";
 import { computed } from "ember-metal/computed";
 import { set } from "ember-metal/property_set";
 import { get } from "ember-metal/property_get";
-import ObjectController from "ember-runtime/controllers/object_controller";
+import {
+  default as ObjectController,
+  objectControllerDeprecation
+} from "ember-runtime/controllers/object_controller";
+import EmberController from 'ember-runtime/controllers/controller';
 import { Registry } from "ember-runtime/system/container";
 import compile from "ember-template-compiler/system/compile";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
@@ -212,6 +216,8 @@ test("it should support #with this as qux", function() {
 QUnit.module("Handlebars {{#with foo}} with defined controller");
 
 test("it should wrap context with object controller [DEPRECATED]", function() {
+  expectDeprecation(objectControllerDeprecation);
+
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
@@ -301,7 +307,9 @@ test("it should still have access to original parentController within an {{#each
 });
 */
 
-test("it should wrap keyword with object controller", function() {
+test("it should wrap keyword with object controller [DEPRECATED]", function() {
+  expectDeprecation(objectControllerDeprecation);
+
   var PersonController = ObjectController.extend({
     name: computed('model.name', function() {
       return get(this, 'model.name').toUpperCase();
@@ -355,7 +363,7 @@ test("it should wrap keyword with object controller", function() {
 
 test("destroys the controller generated with {{with foo controller='blah'}} [DEPRECATED]", function() {
   var destroyed = false;
-  var Controller = ObjectController.extend({
+  var Controller = EmberController.extend({
     willDestroy: function() {
       this._super();
       destroyed = true;
@@ -391,7 +399,7 @@ test("destroys the controller generated with {{with foo controller='blah'}} [DEP
 
 test("destroys the controller generated with {{with foo as bar controller='blah'}}", function() {
   var destroyed = false;
-  var Controller = ObjectController.extend({
+  var Controller = EmberController.extend({
     willDestroy: function() {
       this._super();
       destroyed = true;

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -7,7 +7,6 @@ import ActionManager from "ember-views/system/action_manager";
 import { Registry } from "ember-runtime/system/container";
 import EmberObject from "ember-runtime/system/object";
 import { default as EmberController } from "ember-runtime/controllers/controller";
-import EmberObjectController from "ember-runtime/controllers/object_controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 
 import compile from "ember-template-compiler/system/compile";
@@ -153,7 +152,7 @@ test("should target the current controller inside an {{each}} loop [DEPRECATED]"
     registeredTarget = options.target.value();
   };
 
-  var itemController = EmberObjectController.create();
+  var itemController = EmberController.create();
 
   var ArrayController = EmberArrayController.extend({
     itemController: 'stub',
@@ -187,7 +186,7 @@ test("should target the with-controller inside an {{#with controller='person'}} 
     registeredTarget = options.target.value();
   };
 
-  var PersonController = EmberObjectController.extend();
+  var PersonController = EmberController.extend();
   var registry = new Registry();
   var container = registry.container();
   var parentController = EmberObject.create({
@@ -693,7 +692,7 @@ test("should only trigger actions for the event they were registered on", functi
 test("should unwrap controllers passed as a context", function() {
   var passedContext;
   var model = EmberObject.create();
-  var controller = EmberObjectController.extend({
+  var controller = EmberController.extend({
     model: model,
     actions: {
       edit: function(context) {
@@ -717,7 +716,7 @@ test("should unwrap controllers passed as a context", function() {
 test("should not unwrap controllers passed as `controller`", function() {
   var passedContext;
   var model = EmberObject.create();
-  var controller = EmberObjectController.extend({
+  var controller = EmberController.extend({
     model: model,
     actions: {
       edit: function(context) {

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -13,7 +13,6 @@ import {
 } from "ember-runtime/system/string";
 
 import { default as EmberController } from "ember-runtime/controllers/controller";
-import EmberObjectController from "ember-runtime/controllers/object_controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 
 import EmberRouter from "ember-routing/system/router";
@@ -54,7 +53,6 @@ function buildContainer(namespace) {
   registry.register('location:hash', HashLocation);
 
   registry.register('controller:basic', EmberController, { instantiate: false });
-  registry.register('controller:object', EmberObjectController, { instantiate: false });
   registry.register('controller:array', EmberArrayController, { instantiate: false });
 
   registry.typeInjection('route', 'router', 'router:main');
@@ -202,10 +200,10 @@ test("{{render}} helper should render given template with a supplied model", fun
     template: compile(template)
   });
 
-  var PostController = EmberObjectController.extend();
+  var PostController = EmberController.extend();
   container._registry.register('controller:post', PostController);
 
-  Ember.TEMPLATES['post'] = compile("<p>{{title}}</p>");
+  Ember.TEMPLATES['post'] = compile("<p>{{model.title}}</p>");
 
   appendView(view);
 
@@ -238,7 +236,7 @@ test("{{render}} helper with a supplied model should not fire observers on the c
     template: compile(template)
   });
 
-  var PostController = EmberObjectController.extend({
+  var PostController = EmberController.extend({
     modelDidChange: observer('model', function() {
       modelDidChange++;
     })
@@ -324,10 +322,10 @@ test("{{render}} helper should render templates with models multiple times", fun
     template: compile(template)
   });
 
-  var PostController = EmberObjectController.extend();
+  var PostController = EmberController.extend();
   container._registry.register('controller:post', PostController, { singleton: false });
 
-  Ember.TEMPLATES['post'] = compile("<p>{{title}}</p>");
+  Ember.TEMPLATES['post'] = compile("<p>{{model.title}}</p>");
 
   appendView(view);
 
@@ -366,7 +364,7 @@ test("{{render}} helper should not leak controllers", function() {
     template: compile(template)
   });
 
-  var PostController = EmberObjectController.extend();
+  var PostController = EmberController.extend();
   container._registry.register('controller:post', PostController);
 
   Ember.TEMPLATES['post'] = compile("<p>{{title}}</p>");
@@ -391,7 +389,7 @@ test("{{render}} helper should not treat invocations with falsy contexts as cont
     template: compile(template)
   });
 
-  var PostController = EmberObjectController.extend();
+  var PostController = EmberController.extend();
   container._registry.register('controller:post', PostController, { singleton: false });
 
   Ember.TEMPLATES['post'] = compile("<p>{{#unless model}}NOTHING{{/unless}}</p>");
@@ -424,10 +422,10 @@ test("{{render}} helper should render templates both with and without models", f
     template: compile(template)
   });
 
-  var PostController = EmberObjectController.extend();
+  var PostController = EmberController.extend();
   container._registry.register('controller:post', PostController, { singleton: false });
 
-  Ember.TEMPLATES['post'] = compile("<p>Title:{{title}}</p>");
+  Ember.TEMPLATES['post'] = compile("<p>Title:{{model.title}}</p>");
 
   appendView(view);
 
@@ -519,7 +517,7 @@ test("{{render}} works with dot notation", function() {
   var template = '<h1>BLOG</h1>{{render "blog.post"}}';
 
   var controller = EmberController.extend({ container: container });
-  container._registry.register('controller:blog.post', EmberObjectController.extend());
+  container._registry.register('controller:blog.post', EmberController.extend());
 
   view = EmberView.create({
     controller: controller.create(),
@@ -539,7 +537,7 @@ test("{{render}} works with slash notation", function() {
   var template = '<h1>BLOG</h1>{{render "blog/post"}}';
 
   var controller = EmberController.extend({ container: container });
-  container._registry.register('controller:blog.post', EmberObjectController.extend());
+  container._registry.register('controller:blog.post', EmberController.extend());
 
   view = EmberView.create({
     controller: controller.create(),

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -7,7 +7,9 @@ import Registry from 'container/registry';
 import Namespace from "ember-runtime/system/namespace";
 import { classify } from "ember-runtime/system/string";
 import Controller from "ember-runtime/controllers/controller";
-import ObjectController from "ember-runtime/controllers/object_controller";
+import {
+  default as ObjectController
+} from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import controllerFor from "ember-routing/system/controller_for";
 import {
@@ -95,7 +97,7 @@ test("generateController should create Ember.Controller", function() {
   ok(controller instanceof Controller, 'should create controller');
 });
 
-test("generateController should create Ember.ObjectController", function() {
+test("generateController should create Ember.ObjectController [DEPRECATED]", function() {
   var context = {};
   var controller = generateController(container, 'home', context);
 

--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -1,5 +1,9 @@
+import Ember from 'ember-metal/core';
 import ControllerMixin from 'ember-runtime/mixins/controller';
 import ObjectProxy from 'ember-runtime/system/object_proxy';
+
+export var objectControllerDeprecation = 'Ember.ObjectController is deprected, ' +
+  'please use Ember.Controller and use `model.propertyName`.';
 
 /**
 @module ember
@@ -18,5 +22,10 @@ import ObjectProxy from 'ember-runtime/system/object_proxy';
   @namespace Ember
   @extends Ember.ObjectProxy
   @uses Ember.ControllerMixin
+  @deprecated
 **/
-export default ObjectProxy.extend(ControllerMixin);
+export default ObjectProxy.extend(ControllerMixin, {
+  init: function() {
+    Ember.deprecate(objectControllerDeprecation, this.isGenerated);
+  }
+});

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -73,6 +73,11 @@ export default Mixin.create({
   unknownProperty: function (key) {
     var content = get(this, 'content');
     if (content) {
+      Ember.deprecate(
+        fmt('You attempted to access `%@` from `%@`, but object proxying is deprecated. ' +
+            'Please use `model.%@` instead.', [key, this, key]),
+        !this.isController
+      );
       return get(content, key);
     }
   },
@@ -89,6 +94,12 @@ export default Mixin.create({
     var content = get(this, 'content');
     Ember.assert(fmt("Cannot delegate set('%@', %@) to the 'content' property of" +
                      " object proxy %@: its 'content' is undefined.", [key, value, this]), content);
+
+    Ember.deprecate(
+      fmt('You attempted to set `%@` from `%@`, but object proxying is deprecated. ' +
+          'Please use `model.%@` instead.', [key, this, key]),
+      !this.isController
+    );
     return set(content, key, value);
   }
 

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -2,7 +2,10 @@
 
 import Controller from "ember-runtime/controllers/controller";
 import Service from "ember-runtime/system/service";
-import ObjectController from "ember-runtime/controllers/object_controller";
+import {
+  default as ObjectController,
+  objectControllerDeprecation
+} from "ember-runtime/controllers/object_controller";
 import Mixin from "ember-metal/mixin";
 import Object from "ember-runtime/system/object";
 import { Registry } from "ember-runtime/system/container";
@@ -55,6 +58,8 @@ test("When `_actions` is provided, `actions` is left alone", function() {
 });
 
 test("Actions object doesn't shadow a proxied object's 'actions' property", function() {
+  expectDeprecation(objectControllerDeprecation);
+
   var TestController = ObjectController.extend({
     model: {
       actions: 'foo'

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -6,7 +6,7 @@ import {computed} from "ember-metal/computed";
 import compare from "ember-runtime/compare";
 import EmberObject from "ember-runtime/system/object";
 import ArrayController from "ember-runtime/controllers/array_controller";
-import ObjectController from "ember-runtime/controllers/object_controller";
+import Controller from "ember-runtime/controllers/controller";
 import {sort} from "ember-runtime/computed/reduce_computed_macros";
 import Registry from "container/registry";
 
@@ -25,7 +25,7 @@ QUnit.module("Ember.ArrayController - itemController", {
     lannisters = Ember.A([tywin, jaime, cersei]);
 
     itemControllerCount = 0;
-    controllerClass = ObjectController.extend({
+    controllerClass = Controller.extend({
       init: function() {
         ++itemControllerCount;
         this._super();
@@ -36,7 +36,7 @@ QUnit.module("Ember.ArrayController - itemController", {
       }
     });
 
-    otherControllerClass = ObjectController.extend({
+    otherControllerClass = Controller.extend({
       toString: function() {
         return "otherItemController for " + this.get('name');
       }
@@ -305,7 +305,7 @@ test("array observers can invoke `objectAt` without overwriting existing item co
     lannistersWillChange: function() { return this; },
     lannistersDidChange: function(_, idx, removedAmt, addedAmt) {
       arrayObserverCalled = true;
-      equal(this.objectAt(idx).get('name'), "Tyrion", "Array observers get the right object via `objectAt`");
+      equal(this.objectAt(idx).get('model.name'), "Tyrion", "Array observers get the right object via `objectAt`");
     }
   });
   arrayController.addArrayObserver(arrayController, {
@@ -318,7 +318,7 @@ test("array observers can invoke `objectAt` without overwriting existing item co
   });
 
   equal(arrayObserverCalled, true, "Array observers are called normally");
-  equal(tywinController.get('name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' model");
+  equal(tywinController.get('model.name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' model");
 });
 
 test("`itemController`'s life cycle should be entangled with its parent controller", function() {
@@ -342,7 +342,7 @@ QUnit.module('Ember.ArrayController - itemController with arrayComputed', {
     jaime = EmberObject.create({ name: 'Jaime' });
     lannisters = Ember.A([jaime, cersei]);
 
-    controllerClass = ObjectController.extend({
+    controllerClass = Controller.extend({
       title: computed(function () {
         switch (get(this, 'name')) {
           case 'Jaime':   return 'Kingsguard';
@@ -374,5 +374,5 @@ test("item controllers can be used to provide properties for array computed macr
     sorted: sort('@this', 'sortProperties')
   });
 
-  deepEqual(arrayController.get('sorted').mapProperty('name'), ['Jaime', 'Cersei'], "ArrayController items can be sorted on itemController properties");
+  deepEqual(arrayController.get('sorted').mapProperty('model.name'), ['Jaime', 'Cersei'], "ArrayController items can be sorted on itemController properties");
 });

--- a/packages/ember-runtime/tests/controllers/object_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/object_controller_test.js
@@ -1,9 +1,14 @@
-import ObjectController from "ember-runtime/controllers/object_controller";
+import {
+  default as ObjectController,
+  objectControllerDeprecation
+} from "ember-runtime/controllers/object_controller";
 import { observer } from 'ember-metal/mixin';
 
 QUnit.module("Ember.ObjectController");
 
 test("should be able to set the target property of an ObjectController", function() {
+  expectDeprecation(objectControllerDeprecation);
+
   var controller = ObjectController.create();
   var target = {};
 
@@ -13,9 +18,53 @@ test("should be able to set the target property of an ObjectController", functio
 
 // See https://github.com/emberjs/ember.js/issues/5112
 test("can observe a path on an ObjectController", function() {
+  expectDeprecation(objectControllerDeprecation);
+
   var controller = ObjectController.extend({
     baz: observer('foo.bar', function() {})
   }).create();
   controller.set('model', {});
   ok(true, "should not fail");
+});
+
+test('accessing model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
+  var controller;
+
+  expectDeprecation(function() {
+    controller = ObjectController.extend({
+      model: {
+        foo: 'bar',
+        baz: 'qux'
+      }
+    }).create();
+  }, objectControllerDeprecation);
+
+  expectDeprecation(function() {
+    controller.get('bar');
+  }, /object proxying is deprecated\. Please use `model\.bar` instead\./);
+});
+
+test('setting model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
+  var controller;
+
+  expectDeprecation(function() {
+    controller = ObjectController.extend({
+      model: {
+        foo: 'bar',
+        baz: 'qux'
+      }
+    }).create();
+  }, objectControllerDeprecation);
+
+  expectDeprecation(function() {
+    controller.set('bar', 'derp');
+  }, /object proxying is deprecated\. Please use `model\.bar` instead\./);
+});
+
+test('auto-generated controllers are not deprecated', function() {
+  expectNoDeprecation(function() {
+    ObjectController.extend({
+      isGenerated: true
+    }).create();
+  });
 });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,5 +1,6 @@
 import "ember";
 
+import { objectControllerDeprecation } from "ember-runtime/controllers/object_controller";
 import EmberHandlebars from "ember-htmlbars/compat";
 
 var compile = EmberHandlebars.compile;
@@ -74,7 +75,7 @@ QUnit.module("The {{link-to}} helper", {
       Ember.TEMPLATES.app = compile("{{outlet}}");
       Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'about' id='about-link'}}About{{/link-to}}{{#link-to 'index' id='self-link'}}Self{{/link-to}}");
       Ember.TEMPLATES.about = compile("<h3>About</h3>{{#link-to 'index' id='home-link'}}Home{{/link-to}}{{#link-to 'about' id='self-link'}}Self{{/link-to}}");
-      Ember.TEMPLATES.item = compile("<h3>Item</h3><p>{{name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
+      Ember.TEMPLATES.item = compile("<h3>Item</h3><p>{{model.name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
       AppView = Ember.View.extend({
         templateName: 'app'
@@ -448,7 +449,7 @@ test("The {{link-to}} helper moves into the named route with context", function(
     this.resource("item", { path: "/item/:id" });
   });
 
-  Ember.TEMPLATES.about = compile("<h3>List</h3><ul>{{#each person in controller}}<li>{{#link-to 'item' person}}{{person.name}}{{/link-to}}</li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
+  Ember.TEMPLATES.about = compile("<h3>List</h3><ul>{{#each person in model}}<li>{{#link-to 'item' person}}{{person.name}}{{/link-to}}</li>{{/each}}</ul>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
   App.AboutRoute = Ember.Route.extend({
     model: function() {
@@ -655,7 +656,7 @@ test("The {{link-to}} helper unwraps controllers", function() {
     }
   });
 
-  Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>');
+  Ember.TEMPLATES.filter = compile('<p>{{model.filter}}</p>');
   Ember.TEMPLATES.index = compile('{{#link-to "filter" this id="link"}}Filter{{/link-to}}');
 
   bootApplication();
@@ -841,6 +842,8 @@ test("The {{link-to}} helper refreshes href element when one of params changes",
 });
 
 test("The {{link-to}} helper's bound parameter functionality works as expected in conjunction with an ObjectProxy/Controller", function() {
+  expectDeprecation(objectControllerDeprecation);
+
   Router.map(function() {
     this.route('post', { path: '/posts/:post_id' });
   });
@@ -1050,7 +1053,7 @@ test("The non-block form {{link-to}} helper moves into the named route with cont
   });
 
   Ember.TEMPLATES.index = compile("<h3>Home</h3><ul>{{#each person in controller}}<li>{{link-to person.name 'item' person}}</li>{{/each}}</ul>");
-  Ember.TEMPLATES.item = compile("<h3>Item</h3><p>{{name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
+  Ember.TEMPLATES.item = compile("<h3>Item</h3><p>{{model.name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
   bootApplication();
 
@@ -1572,7 +1575,7 @@ test("The {{link-to}} helper applies active class to parent route", function() {
     "{{outlet}}"
   );
 
-  App.ParentChildController = Ember.ObjectController.extend({
+  App.ParentChildController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: 'bar'
   });
@@ -1596,7 +1599,7 @@ test("The {{link-to}} helper disregards query-params in activeness computation w
   Ember.TEMPLATES.parent = compile(
     "{{#link-to 'parent' (query-params page=1) current-when='parent' id='parent-link'}}Parent{{/link-to}} {{outlet}}");
 
-  App.ParentController = Ember.ObjectController.extend({
+  App.ParentController = Ember.Controller.extend({
     queryParams: ['page'],
     page: 1
   });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -71,7 +71,7 @@ QUnit.module("Basic Routing", {
 
       Ember.TEMPLATES.application = compile("{{outlet}}");
       Ember.TEMPLATES.home = compile("<h3>Hours</h3>");
-      Ember.TEMPLATES.homepage = compile("<h3>Megatroll</h3><p>{{home}}</p>");
+      Ember.TEMPLATES.homepage = compile("<h3>Megatroll</h3><p>{{model.home}}</p>");
       Ember.TEMPLATES.camelot = compile('<section><h3>Is a silly place</h3></section>');
 
       originalLoggerError = Ember.Logger.error;
@@ -218,7 +218,9 @@ test("An alternate template will pull in an alternate controller", function() {
   });
 
   App.HomepageController = Ember.Controller.extend({
-    home: "Comes from homepage"
+    model: {
+      home: "Comes from homepage"
+    }
   });
 
   bootApplication();
@@ -239,11 +241,15 @@ test("An alternate template will pull in an alternate controller instead of cont
   });
 
   App.FooController = Ember.Controller.extend({
-    home: "Comes from Foo"
+    model: {
+      home: "Comes from Foo"
+    }
   });
 
   App.HomepageController = Ember.Controller.extend({
-    home: "Comes from homepage"
+    model: {
+      home: "Comes from homepage"
+    }
   });
 
   bootApplication();
@@ -263,7 +269,9 @@ test("The template will pull in an alternate controller via key/value", function
   });
 
   App.HomeController = Ember.Controller.extend({
-    home: "Comes from home."
+    model: {
+      home: "Comes from home."
+    }
   });
 
   bootApplication();
@@ -277,7 +285,9 @@ test("The Homepage with explicit template name in renderTemplate and controller"
   });
 
   App.HomeController = Ember.Controller.extend({
-    home: "YES I AM HOME"
+    model: {
+      home: "YES I AM HOME"
+    }
   });
 
   App.HomeRoute = Ember.Route.extend({
@@ -292,9 +302,9 @@ test("The Homepage with explicit template name in renderTemplate and controller"
 });
 
 test("Model passed via renderTemplate model is set as controller's model", function() {
-  Ember.TEMPLATES['bio'] = compile("<p>{{name}}</p>");
+  Ember.TEMPLATES['bio'] = compile("<p>{{model.name}}</p>");
 
-  App.BioController = Ember.ObjectController.extend();
+  App.BioController = Ember.Controller.extend();
 
   Router.map(function() {
     this.route('home', { path: '/' });
@@ -470,10 +480,10 @@ test('Specifying a name to render should have precedence over everything else', 
   });
 
   App.HomeView = Ember.View.extend({
-    template: compile("<h3>This should not be rendered</h3><p>{{home}}</p>")
+    template: compile("<h3>This should not be rendered</h3><p>{{model.home}}</p>")
   });
 
-  App.HomepageController = Ember.ObjectController.extend({
+  App.HomepageController = Ember.Controller.extend({
     model: {
       home: 'Tinytroll'
     }
@@ -1203,7 +1213,7 @@ asyncTest("Events are triggered on the current state when defined in `actions` o
   });
 
   Ember.TEMPLATES.home = compile(
-    "<a {{action 'showStuff' model}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{model.name}}</a>"
   );
 
   bootApplication();
@@ -1241,7 +1251,7 @@ asyncTest("Events defined in `actions` object are triggered on the current state
   });
 
   Ember.TEMPLATES['root/index'] = compile(
-    "<a {{action 'showStuff' model}}>{{name}}</a>"
+    "<a {{action 'showStuff' model}}>{{model.name}}</a>"
   );
 
   bootApplication();
@@ -2352,7 +2362,7 @@ test("The template is not re-rendered when the route's context changes", functio
   });
 
   Ember.TEMPLATES.page = compile(
-    "<p>{{name}}</p>"
+    "<p>{{model.name}}</p>"
   );
 
   bootApplication();
@@ -2459,7 +2469,7 @@ test("ApplicationRoute with model does not proxy the currentPath", function() {
     model: function () { return model; }
   });
 
-  App.ApplicationController = Ember.ObjectController.extend({
+  App.ApplicationController = Ember.Controller.extend({
     currentPathDidChange: Ember.observer('currentPath', function() {
       currentPath = get(this, 'currentPath');
     })

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1074,7 +1074,7 @@ test("Defaulting to params hash as the model should not result in that params ob
   // model if no other model could be resolved given the provided
   // params (and no custom model hook was defined), to be watched,
   // unless we return a copy of the params hash.
-  App.ApplicationController = Ember.ObjectController.extend({
+  App.ApplicationController = Ember.Controller.extend({
     queryParams: ['woot'],
     woot: 'wat'
   });
@@ -1254,7 +1254,7 @@ QUnit.module("Model Dep Query Params", {
       }
     });
 
-    App.ArticleController = Ember.ObjectController.extend({
+    App.ArticleController = Ember.Controller.extend({
       queryParams: ['q', 'z'],
       q: 'wat',
       z: 0

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -378,7 +378,7 @@ test("Default error event moves into nested route", function() {
   expect(5);
 
   templates['grandma'] = "GRANDMA {{outlet}}";
-  templates['grandma/error'] = "ERROR: {{msg}}";
+  templates['grandma/error'] = "ERROR: {{model.msg}}";
 
   Router.map(function() {
     this.resource('grandma', function() {
@@ -494,8 +494,8 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
 
     templates['grandma'] = "GRANDMA {{outlet}}";
-    templates['grandma/error'] = "ERROR: {{msg}}";
-    templates['grandma/mom_error'] = "MOM ERROR: {{msg}}";
+    templates['grandma/error'] = "ERROR: {{model.msg}}";
+    templates['grandma/mom_error'] = "MOM ERROR: {{model.msg}}";
 
     Router.map(function() {
       this.resource('grandma', function() {
@@ -609,7 +609,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     // fake a modules resolver
     App.Resolver = { moduleBasedResolver: true };
 
-    templates['foo/bar_error'] = "FOOBAR ERROR: {{msg}}";
+    templates['foo/bar_error'] = "FOOBAR ERROR: {{model.msg}}";
     templates['foo/bar'] = "YAY";
 
     Router.map(function() {
@@ -680,7 +680,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     // fake a modules resolver
     App.Resolver = { moduleBasedResolver: true };
 
-    templates['foo/index_error'] = "FOO ERROR: {{msg}}";
+    templates['foo/index_error'] = "FOO ERROR: {{model.msg}}";
     templates['foo/index'] = "YAY";
     templates['foo'] = "{{outlet}}";
 
@@ -717,7 +717,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     // fake a modules resolver
     App.Resolver = { moduleBasedResolver: true };
 
-    templates['application_error'] = '<p id="toplevel-error">TOPLEVEL ERROR: {{msg}}</p>';
+    templates['application_error'] = '<p id="toplevel-error">TOPLEVEL ERROR: {{model.msg}}</p>';
 
     var reject = true;
     App.ApplicationRoute = Ember.Route.extend({


### PR DESCRIPTION
- Deprecate on `init` of `Ember.ObjectController`'s when not auto-generated.
- Deprecate on `get` of a proxied property.
- Deprecate on `set` of a proxied property.
