### PR TITLE
[BUGFIX beta] Deprecate `{{bind}}` helper.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/binding.js
+++ b/packages/ember-htmlbars/lib/helpers/binding.js
@@ -106,6 +106,8 @@ function bindHelper(params, hash, options, env) {
     Ember.deprecate("The block form of bind, {{#bind foo}}{{/bind}}, has been deprecated and will be removed.");
     bind.call(this, property, hash, options, env, false, exists);
   } else {
+    Ember.deprecate("The `{{bind}}` helper has been deprecated and will be removed.");
+
     return property;
   }
 }

--- a/packages/ember-htmlbars/tests/helpers/bind_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_test.js
@@ -18,6 +18,8 @@ QUnit.module("ember-htmlbars: {{bind}} helper", {
     container.optionsForType('template', { instantiate: false });
     container.register('view:default', _MetamorphView);
     container.register('view:toplevel', EmberView.extend());
+
+    expectDeprecation('The `{{bind}}` helper has been deprecated and will be removed.');
   },
   teardown: function() {
     runDestroy(container);
@@ -85,6 +87,8 @@ QUnit.module("ember-htmlbars: {{bind}} with a container, block forms", {
   setup: function() {
     container = new Container();
     container.optionsForType('template', { instantiate: false });
+
+    expectDeprecation('The `{{bind}}` helper has been deprecated and will be removed.');
   },
   teardown: function() {
     runDestroy(container);


### PR DESCRIPTION
Closes https://github.com/emberjs/ember.js/issues/10017.
