### PR TITLE
[BUGFIX beta] Remove handlebars from dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,10 @@ PATH
   remote: .
   specs:
     ember-source (1.11.0.beta.1.canary)
-      handlebars-source (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    handlebars-source (2.0.0)
 
 PLATFORMS
   ruby

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "ember",
   "dependencies": {
-    "handlebars": "~2.0.0",
     "jquery": "~1.11.1",
     "qunit": "~1.12.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"

--- a/config/package_manager_files/bower.json
+++ b/config/package_manager_files/bower.json
@@ -5,7 +5,6 @@
     "./ember.debug.js"
   ],
   "dependencies": {
-    "jquery": ">= 1.7.0 <= 2.1.0",
-    "handlebars": ">= 2.0.0 < 3.0.0"
+    "jquery": ">= 1.7.0 <= 2.1.0"
   }
 }

--- a/config/package_manager_files/component.json
+++ b/config/package_manager_files/component.json
@@ -7,7 +7,6 @@
     "ember.debug.js"
   ],
   "dependencies": {
-    "components/jquery": ">= 1.7.0 <= 2.1.0",
-    "components/handlebars.js": ">= 2.0.0 < 3.0.0"
+    "components/jquery": ">= 1.7.0 <= 2.1.0"
   }
 }

--- a/config/package_manager_files/composer.json
+++ b/config/package_manager_files/composer.json
@@ -4,8 +4,7 @@
   "type": "component",
   "license": "MIT",
   "require": {
-    "components/jquery": ">=1.7.0, <= 2.1.0",
-    "components/handlebars.js": "2.*"
+    "components/jquery": ">=1.7.0, <= 2.1.0"
   },
   "extra": {
     "component": {
@@ -20,8 +19,7 @@
       "shim": {
         "exports": "Ember",
         "deps": [
-          "jquery",
-          "handlebars"
+          "jquery"
         ]
       }
     }

--- a/config/package_manager_files/package.json
+++ b/config/package_manager_files/package.json
@@ -7,7 +7,6 @@
   ],
   "main": "./ember.debug.js",
   "dependencies": {
-    "jquery": ">=1.7.0 <= 2.1.0",
-    "handlebars": ">= 2.0.0 < 3.0.0"
+    "jquery": ">=1.7.0 <= 2.1.0"
   }
 }

--- a/ember-source.gemspec
+++ b/ember-source.gemspec
@@ -13,7 +13,5 @@ Gem::Specification.new do |gem|
 
   gem.version       = Ember.rubygems_version_string
 
-  gem.add_dependency "handlebars-source", ["~> 2.0"]
-
   gem.files = %w(VERSION) + Dir['dist/*.js', 'lib/ember/*.rb']
 end


### PR DESCRIPTION
It seems that Handlebars is no longer required from Ember.js.
