### PR TITLE
Update HTMLBars to 0.7.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "emberjs-build": "0.0.10",
     "express": "^4.5.0",
     "glob": "~3.2.8",
-    "htmlbars": "0.7.0",
+    "htmlbars": "0.7.1",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "rsvp": "~3.0.6"


### PR DESCRIPTION
Fixes an extra trailing comma (that causes JScript to blow up).
