### PR TITLE
Draft of the JavaScript style guide for Ember

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,14 @@ require no new tests. If you are adding functionality or fixing a bug, we need
 a test! If your change is a new feature, please
 [wrap it in a feature flag](http://emberjs.com/guides/contributing/adding-new-features/).
 
-4. Make the test pass.
+4. Make sure to check out the
+   [JavaScript Style Guide](https://github.com/emberjs/ember.js/blob/master/STYLEGUIDE.md) and
+   ensure that your code complies with the rules. If you missed a rule or two, don't worry, our
+   tests will warn you.
 
-5. Commit your changes. Please use an appropriate commit prefix.
+5. Make the test pass.
+
+6. Commit your changes. Please use an appropriate commit prefix.
 If your pull request fixes an issue specify it in the commit message. Some examples:
 
   ```
@@ -101,7 +106,7 @@ If your pull request fixes an issue specify it in the commit message. Some examp
   [Robert Jacksons slides on contributing to Ember](https://speakerdeck.com/rwjblue/contributing-to-ember).
 
 
-6. Push to your fork and submit a pull request. Please provide us with some
+7. Push to your fork and submit a pull request. Please provide us with some
 explanation of why you made the changes you made. For new features make sure to
 explain a standard use case to us.
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,326 @@
+# Ember.js JavaScript Style Guide
+
+## Table Of Contents
+
++ [Objects](#objects)
++ [Array](#arrays)
++ [Variables](#variables)
++ [Whitespace](#whitespace)
++ [Commas](#commas)
++ [Semicolons](#semicolons)
++ [Block Statements](#block-statements)
++ [Conditional Statements](#conditional-statements)
++ [Properties](#properties)
++ [Functions](#functions)
++ [Function Arguments](#function-arguments)
++ [Comments](#comments)
+
+## Objects
+
++ Use literal form for object creation.
+
+```javascript
+var foo = {};
+```
+
+## Arrays
+
++ Use literal form for array creation (unless you know the exact length).
+
+```javascript
+var foo = [];
+```
+
++ If you know the exact length and know that array is not going to grow, use `Array`.
+
+```javascript
+var foo = new Array(16);
+```
+
++ Use `push` to add an item to an array.
+
+```javascript
+var foo = [];
+foo.push('bar');
+```
+
+## Variables
+
++ Put all non assigning declarations on one line.
+
+```javascript
+var a, b;
+```
+
++ Use a single `var` declaration for each assignment.
+
+```javascript
+var a = 1;
+var b = 2;
+```
+
++ Declare variables at the top of their scope.
+
+```javascript
+function foo() {
+  var bar;
+
+  console.log('foo bar!');
+
+  bar = getBar();
+}
+```
+
+## Whitespace
+
++ Use soft tabs set to 2 spaces.
+
+```javascript
+function() {
+∙∙var name;
+}
+```
+
++ Place 1 space before the leading brace.
+
+```javascript
+obj.set('foo', {
+  foo: 'bar'
+});
+
+test('foo-bar', function() {
+});
+```
+
++ No spaces before semicolons.
+
+```javascript
+var foo = {};
+```
+
++ No spaces after the function name when it's declared or called.
+
+```javascript
+function foo() {
+}
+
+foo();
+```
+
+## Commas
+
++ No trailing commas.
+
+```javascript
+var foo = [1, 2, 3];
+var bar = {a: 'a'};
+```
+
++ No leading commas.
+
+```javascript
+var foo = [
+  1,
+  2,
+  3
+];
+```
+
+## Semicolons
+
++ Use semicolons.
+
+## Block Statements
+
++ Use spaces.
+
+```javascript
+// conditional
+if (notFound) {
+  return 0;
+} else {
+  return 1;
+}
+
+switch (condition) {
+  case "yes":
+    // code
+    break;
+}
+
+// loops
+for (var key in keys) {
+  // code
+}
+
+for (var i = 0, l = keys.length; i < l; i++) {
+  // code
+}
+
+while (true) {
+  // code
+}
+
+try {
+  // code that throws an error
+} catch(e) {
+  // code that handles an error
+}
+```
+
++ Don't use new lines before opening curly brace.
+
+```javascript
+function foo() {
+  var obj = {
+    val: 'test'
+  };
+
+  return {
+    data: obj
+  };
+}
+
+if (foo === 1) {
+  foo();
+}
+
+for (var key in keys) {
+  bar(e);
+}
+
+while (true) {
+  foo();
+}
+```
+
++ Don't place `else` on a new line.
+
+```javascript
+if (foo === 1) {
+  bar = 2;
+} else {
+  bar = '2';
+}
+
+if (foo === 1) {
+  bar = 2;
+} else if (foo === 2) {
+  bar = 1;
+} else {
+  bar = 3;
+}
+```
+
+## Conditional Statements
+
++ Use `===` and `!==`.
++ Use curly braces.
+
+```javascript
+if (notFound) {
+  return;
+}
+```
+
++ Use explicit conditions.
+
+```javascript
+if (arr.length > 0) {
+  // code
+}
+
+if (foo !== '') {
+  // code
+}
+```
+
+## Properties
+
++ Use dot notation when accessing properties.
+
+```javascript
+var foo = {
+  bar: 'bar'
+};
+
+foo.bar;
+```
+
++ Use `[]` when accessing properties with a variable.
+
+```javascript
+var propertyName = 'bar';
+var foo = {
+  bar: 'bar'
+};
+
+foo[propertyName];
+```
+
+## Functions
+
++ Make sure to name the functions when you define them.
+
+```javascript
+function fooBar() {
+}
+```
+
+## Function Arguments
+
+`arguments` object must not be passed or leaked anywhere.
+See the [reference](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments).
+
++ Don't use `slice` with `arguments`, use `for` loop.
+
+```javascript
+function fooBar() {
+  var args = new Array(arguments.length);
+
+  for (var i = 0; i < args.length; ++i) {
+    args[i] = arguments[i];
+  }
+
+  return args;
+}
+```
+
++ Don't re-assign the arguments.
+
+```javascript
+function fooBar() {
+  arguments = 3;
+}
+
+function fooBar(opt) {
+  opt = 3;
+}
+```
+
++ Use a new variable if you need to re-assign the argument.
+
+```javascript
+function fooBar(opt) {
+  var options = opt;
+
+  options = 3;
+}
+```
+
+## Comments
+
++ Use [Yuidoc](http://yui.github.io/yuidoc/syntax/index.html) comments for
+  documenting functions.
++ Use `//` for single line comments.
+
+```javascript
+function foo() {
+  var bar = 5;
+
+  // multiplies `bar` by 2.
+  fooBar(bar);
+
+  console.log(bar);
+}
+```


### PR DESCRIPTION
Related to #9849
- [x] use spaces after the keyword in block statements (#10073)
  - [x] `requireSpaceBeforeKeywords`
  - [x] `requireSpaceAfterKeywords`
- [x] use spaces before block statements (#10095)
  - [x] `requireSpaceBeforeBlockStatements`
- [x] use spaces in ternary conditional statements (#10097)
  - [x] `requireSpacesInConditionalExpression`
- [x] use spaces in functional declarations (#10098)
  - [x] `requireSpacesAfterClosingParenthesisInFunctionDeclaration`
- [x] disallow space before () in call expressions (#10099)
  - [x] `disallowSpacesInCallExpression`
- [x] disallow newline before opening curly brace of all block statements (#10109)
  - [x] `disallowNewlineBeforeBlockStatements`
- [x] disallows placing keywords on a new line (#10110)
  - [x] `disallowKeywordsOnNewLine`
- [ ] disallow block statements from beginning and ending with 2 newlines (#10111)
  - [ ] `disallowPaddingNewlinesInBlocks`
- [x] disallow spaces around round braces when calling a function (#10123)
  - [x] `disallowSpacesInsideRoundBracesInCallExpression`
- [x] disallow empty block statements (#10101)
  - [x] `disallowEmptyBlocks`
- [x] disallow space after opening array square bracket and before closing (#10102)
  - [x] `disallowSpacesInsideArrayBrackets: all`
- [x] disallow space after opening round bracket and before closing (#10103)
- [x] disallow spaces before semicolons (#10084)
  - [x] `disallowSpacesBeforeSemicolons`
- [x] requires blocks to begin and end with a newline (#10100)
  - [x] `requireBlocksOnNewline`
- [x] no leading commas (#10115)
  - [x] `requireCommaBeforeLineBreak`
- [x] no trailing commas
  - [x] `disableTrailingComma`

cc @rwjblue 
