### PR TITLE
Requires spaces after keyword in block statements

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,5 +14,22 @@
   ],
   "disallowTrailingWhitespace": true,
   "disallowTrailingComma": true,
-  "validateIndentation": 2
+  "validateIndentation": 2,
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "while",
+    "with",
+    "return"
+  ]
 }

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -229,9 +229,9 @@ if (!Ember.testing) {
       if (document.documentElement && document.documentElement.dataset && !document.documentElement.dataset.emberExtension) {
         var downloadURL;
 
-        if(isChrome) {
+        if (isChrome) {
           downloadURL = 'https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi';
-        } else if(isFirefox) {
+        } else if (isFirefox) {
           downloadURL = 'https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/';
         }
 

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -31,7 +31,7 @@ function registerRepeatHelper() {
   helper('repeat', function(value, options) {
     var count = options.hash.count || 1;
     var a = [];
-    while(a.length < count) {
+    while (a.length < count) {
       a.push(value);
     }
     return a.join('');
@@ -297,7 +297,7 @@ test("bound helpers should expose property names in options.data.properties", fu
     var options = arguments[arguments.length - 1];
     var values = [].slice.call(arguments, 0, -1);
     var a = [];
-    for(var i = 0; i < values.length; ++i) {
+    for (var i = 0; i < values.length; ++i) {
       var propertyName = options.data.properties[i];
       a.push(propertyName);
     }

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -142,7 +142,7 @@ test("should be able to render an unbound helper invocation", function() {
     registerBoundHelper('repeat', function(value, options) {
       var count = options.hash.count;
       var a = [];
-      while(a.length < count) {
+      while (a.length < count) {
         a.push(value);
       }
       return a.join('');

--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -89,9 +89,9 @@ var lastIndexOf = defineNativeShim(ArrayPrototype.lastIndexOf, function(obj, fro
     fromIndex += len;
   }
 
-  for(idx = fromIndex;idx>=0;idx--) {
+  for (idx = fromIndex; idx >= 0; idx--) {
     if (this[idx] === obj) {
-      return idx ;
+      return idx;
     }
   }
   return -1;

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -272,7 +272,7 @@ ChainNodePrototype.unchain = function(key, path) {
 ChainNodePrototype.willChange = function(events) {
   var chains = this._chains;
   if (chains) {
-    for(var key in chains) {
+    for (var key in chains) {
       if (!chains.hasOwnProperty(key)) {
         continue;
       }
@@ -342,7 +342,7 @@ ChainNodePrototype.didChange = function(events) {
   // then notify chains...
   var chains = this._chains;
   if (chains) {
-    for(var key in chains) {
+    for (var key in chains) {
       if (!chains.hasOwnProperty(key)) { continue; }
       chains[key].didChange(events);
     }
@@ -368,7 +368,7 @@ export function finishChains(obj) {
     // finish any current chains node watchers that reference obj
     chainWatchers = m.chainWatchers;
     if (chainWatchers) {
-      for(var key in chainWatchers) {
+      for (var key in chainWatchers) {
         if (!chainWatchers.hasOwnProperty(key)) {
           continue;
         }

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -333,7 +333,7 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
 
     if (result === UNDEFINED) {
       return undefined;
-    }  else if (result !== undefined) {
+    } else if (result !== undefined) {
       return result;
     }
 
@@ -429,7 +429,7 @@ ComputedPropertyPrototype._set = function computedPropertySet(obj, keyName, valu
   }
 
   if (cacheable && cache[keyName] !== undefined) {
-    if(cache[keyName] !== UNDEFINED) {
+    if (cache[keyName] !== UNDEFINED) {
       cachedValue = cache[keyName];
     }
 

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -14,7 +14,7 @@ var a_slice = [].slice;
 
 function getProperties(self, propertyNames) {
   var ret = {};
-  for(var i = 0; i < propertyNames.length; i++) {
+  for (var i = 0; i < propertyNames.length; i++) {
     ret[propertyNames[i]] = get(self, propertyNames[i]);
   }
   return ret;

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -69,7 +69,7 @@ if (Ember.ENV) {
   // do nothing if Ember.ENV is already setup
 } else if ('undefined' !== typeof EmberENV) {
   Ember.ENV = EmberENV;
-} else if('undefined' !== typeof ENV) {
+} else if ('undefined' !== typeof ENV) {
   Ember.ENV = ENV;
 } else {
   Ember.ENV = {};

--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -59,7 +59,7 @@ export function addDependentKeys(desc, obj, keyName, meta) {
 
   depsMeta = metaForDeps(meta);
 
-  for(idx = 0, len = depKeys.length; idx < len; idx++) {
+  for (idx = 0, len = depKeys.length; idx < len; idx++) {
     depKey = depKeys[idx];
     // Lookup keys meta for depKey
     keys = keysForDep(depsMeta, depKey);
@@ -81,7 +81,7 @@ export function removeDependentKeys(desc, obj, keyName, meta) {
 
   depsMeta = metaForDeps(meta);
 
-  for(idx = 0, len = depKeys.length; idx < len; idx++) {
+  for (idx = 0, len = depKeys.length; idx < len; idx++) {
     depKey = depKeys[idx];
     // Lookup keys meta for depKey
     keys = keysForDep(depsMeta, depKey);

--- a/packages/ember-metal/lib/get_properties.js
+++ b/packages/ember-metal/lib/get_properties.js
@@ -31,7 +31,7 @@ export default function getProperties(obj) {
     i = 0;
     propertyNames = arguments[1];
   }
-  for(var len = propertyNames.length; i < len; i++) {
+  for (var len = propertyNames.length; i < len; i++) {
     ret[propertyNames[i]] = get(obj, propertyNames[i]);
   }
   return ret;

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -280,7 +280,7 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
     delete values[keyName];
   }
 
-  for(var i=0, l=mixins.length; i<l; i++) {
+  for (var i=0, l=mixins.length; i<l; i++) {
     mixin = mixins[i];
     Ember.assert('Expected hash or Mixin instance, got ' + Object.prototype.toString.call(mixin),
                  typeof mixin === 'object' && mixin !== null && Object.prototype.toString.call(mixin) !== '[object Array]');
@@ -441,7 +441,7 @@ function applyMixin(obj, mixins, partial) {
   // * Copying `toString` in broken browsers
   mergeMixins(mixins, mixinsMeta(obj), descs, values, obj, keys);
 
-  for(var i = 0, l = keys.length; i < l; i++) {
+  for (var i = 0, l = keys.length; i < l; i++) {
     key = keys[i];
     if (key === 'constructor' || !values.hasOwnProperty(key)) { continue; }
 
@@ -612,7 +612,7 @@ MixinPrototype.reopen = function() {
   var mixins = this.mixins;
   var idx;
 
-  for(idx=0; idx < len; idx++) {
+  for (idx=0; idx < len; idx++) {
     mixin = arguments[idx];
     Ember.assert('Expected hash or Mixin instance, got ' + Object.prototype.toString.call(mixin),
                  typeof mixin === 'object' && mixin !== null &&
@@ -697,7 +697,7 @@ MixinPrototype.keys = function() {
   var seen = {};
   var ret = [];
   _keys(keys, this, seen);
-  for(var key in keys) {
+  for (var key in keys) {
     if (keys.hasOwnProperty(key)) {
       ret.push(key);
     }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -190,7 +190,7 @@ function chainsWillChange(obj, keyName, m) {
   var events = [];
   var i, l;
 
-  for(i = 0, l = nodes.length; i < l; i++) {
+  for (i = 0, l = nodes.length; i < l; i++) {
     nodes[i].willChange(events);
   }
 
@@ -209,7 +209,7 @@ function chainsDidChange(obj, keyName, m, suppressEvents) {
   var events = suppressEvents ? null : [];
   var i, l;
 
-  for(i = 0, l = nodes.length; i < l; i++) {
+  for (i = 0, l = nodes.length; i < l; i++) {
     nodes[i].didChange(events);
   }
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -232,7 +232,7 @@ export function guidFor(obj) {
   var type = typeof obj;
 
   // Don't allow prototype changes to String etc. to change the guidFor
-  switch(type) {
+  switch (type) {
     case 'number':
       ret = numberCache[obj];
 
@@ -641,7 +641,7 @@ export function tryInvoke(obj, methodName, args) {
 // https://github.com/emberjs/ember.js/pull/1617
 var needsFinallyFix = (function() {
   var count = 0;
-  try{
+  try {
     try {
     } finally {
       count++;
@@ -916,7 +916,7 @@ export function inspect(obj) {
 
   var v;
   var ret = [];
-  for(var key in obj) {
+  for (var key in obj) {
     if (obj.hasOwnProperty(key)) {
       v = obj[key];
       if (v === 'toString') { continue; } // ignore useless items

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -21,7 +21,7 @@ test('should get arbitrary properties on an object', function() {
     nullValue: null
   };
 
-  for(var key in obj) {
+  for (var key in obj) {
     if (!obj.hasOwnProperty(key)) {
       continue;
     }
@@ -106,7 +106,7 @@ test('should get arbitrary properties on an object', function() {
     nullValue: null
   };
 
-  for(var key in obj) {
+  for (var key in obj) {
     if (!obj.hasOwnProperty(key)) {
       continue;
     }

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -17,7 +17,7 @@ test('should set arbitrary properties on an object', function() {
     undefinedValue: 'emberjs'
   };
 
-  for(var key in obj) {
+  for (var key in obj) {
     if (!obj.hasOwnProperty(key)) {
       continue;
     }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -629,7 +629,7 @@ test('adding a computed property should show up in key iteration',function() {
   defineProperty(obj, 'foo', computed(function() {}));
 
   var found = [];
-  for(var key in obj) {
+  for (var key in obj) {
     found.push(key);
   }
   ok(indexOf(found, 'foo')>=0, 'should find computed property in iteration found=' + found);
@@ -641,7 +641,7 @@ testBoth("when setting a value after it had been retrieved empty don't pass func
   var oldValueIsNoFunction = true;
 
   defineProperty(obj, 'foo', computed(function(key, value, oldValue) {
-    if(typeof oldValue === 'function') {
+    if (typeof oldValue === 'function') {
       oldValueIsNoFunction = false;
     }
 

--- a/packages/ember-metal/tests/platform/defineProperty_test.js
+++ b/packages/ember-metal/tests/platform/defineProperty_test.js
@@ -3,7 +3,7 @@ import EnumerableUtils from 'ember-metal/enumerable_utils';
 
 function isEnumerable(obj, keyName) {
   var keys = [];
-  for(var key in obj) {
+  for (var key in obj) {
     if (obj.hasOwnProperty(key)) {
       keys.push(key);
     }

--- a/packages/ember-metal/tests/run_loop/later_test.js
+++ b/packages/ember-metal/tests/run_loop/later_test.js
@@ -87,7 +87,7 @@ asyncTest('should always invoke within a separate runloop', function() {
     // run loop has to flush, it would have considered
     // the timer already expired.
     var pauseUntil = +new Date() + 100;
-    while(+new Date() < pauseUntil) { /* do nothing - sleeping */ }
+    while (+new Date() < pauseUntil) { /* do nothing - sleeping */ }
   });
 
   ok(firstRunLoop, "first run loop captured");
@@ -219,7 +219,7 @@ asyncTest('setTimeout should never run with a negative wait', function() {
       // make sure that invokeLaterTimers doesn't end up scheduling
       // a negative setTimeout.
       var pauseUntil = +new Date() + 60;
-      while(+new Date() < pauseUntil) { /* do nothing - sleeping */ }
+      while (+new Date() < pauseUntil) { /* do nothing - sleeping */ }
     }, 1);
 
     run.later(function() {

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -23,7 +23,7 @@ test("Ember.typeOf", function() {
   equal( typeOf(error),       'error',      "error");
   equal( typeOf(object),      'object',     "object");
 
-  if(Ember.Object) {
+  if (Ember.Object) {
     var klass       = Ember.Object.extend();
     var instance    = Ember.Object.create();
 

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -178,7 +178,7 @@ export default EmberObject.extend({
     if (url !== '') {
       rootURL = rootURL.replace(/\/$/, '');
       baseURL = baseURL.replace(/\/$/, '');
-    } else if(baseURL.match(/^\//) && rootURL.match(/^\//)) {
+    } else if (baseURL.match(/^\//) && rootURL.match(/^\//)) {
       baseURL = baseURL.replace(/\/$/, '');
     }
 

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -140,8 +140,8 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
   FunctionPrototype.observesImmediately = function () {
     Ember.assert('Immediate observers must observe internal properties only, ' +
                  'not properties on other objects.', function checkIsInternalProperty() {
-      for(var i = 0, l = arguments.length; i < l; i++) {
-        if(arguments[i].indexOf('.') !== -1) {
+      for (var i = 0, l = arguments.length; i < l; i++) {
+        if (arguments[i].indexOf('.') !== -1) {
           return false;
         }
       }

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -263,7 +263,7 @@ export default Mixin.create({
       target = null;
     }
 
-    for(var idx = 0; idx < len; idx++) {
+    for (var idx = 0; idx < len; idx++) {
       var next = this.nextObject(idx, last, context) ;
       callback.call(target, next, idx, this);
       last = next ;
@@ -541,7 +541,7 @@ export default Mixin.create({
     var last = null;
     var next, ret;
 
-    for(var idx = 0; idx < len && !found; idx++) {
+    for (var idx = 0; idx < len && !found; idx++) {
       next = this.nextObject(idx, last, context);
 
       if (found = callback.call(target, next, idx, this)) {
@@ -1161,7 +1161,7 @@ export default Mixin.create({
     var sortKeys = arguments;
 
     return this.toArray().sort(function(a, b) {
-      for(var i = 0; i < sortKeys.length; i++) {
+      for (var i = 0; i < sortKeys.length; i++) {
         var key = sortKeys[i];
         var propA = get(a, key);
         var propB = get(b, key);

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -340,7 +340,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
   */
   removeObject: function(obj) {
     var loc = get(this, 'length') || 0;
-    while(--loc >= 0) {
+    while (--loc >= 0) {
       var curObject = this.objectAt(loc);
 
       if (curObject === obj) {

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -751,7 +751,7 @@ var ClassMixinProps = {
 
   detect: function(obj) {
     if ('function' !== typeof obj) { return false; }
-    while(obj) {
+    while (obj) {
       if (obj===this) { return true; }
       obj = obj.superclass;
     }

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -59,7 +59,7 @@ function addObserverForContentKey(content, keyName, proxy, idx, loc) {
     objects = proxy._objects = {};
   }
 
-  while(--loc>=idx) {
+  while (--loc >= idx) {
     var item = content.objectAt(loc);
     if (item) {
       Ember.assert('When using @each to observe the array ' + content + ', the array must return an object', typeOf(item) === 'instance' || typeOf(item) === 'object');
@@ -86,7 +86,7 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
 
   var indicies, guid;
 
-  while(--loc>=idx) {
+  while (--loc >= idx) {
     var item = content.objectAt(loc);
     if (item) {
       removeBeforeObserver(item, keyName, proxy, 'contentKeyWillChange');
@@ -150,7 +150,7 @@ var EachProxy = EmberObject.extend({
     lim = removedCnt>0 ? idx+removedCnt : -1;
     beginPropertyChanges(this);
 
-    for(key in keys) {
+    for (key in keys) {
       if (!keys.hasOwnProperty(key)) { continue; }
 
       if (lim>0) { removeObserverForContentKey(content, key, this, idx, lim); }
@@ -168,7 +168,7 @@ var EachProxy = EmberObject.extend({
 
     lim = addedCnt>0 ? idx+addedCnt : -1;
     changeProperties(function() {
-      for(var key in keys) {
+      for (var key in keys) {
         if (!keys.hasOwnProperty(key)) { continue; }
 
         if (lim>0) { addObserverForContentKey(content, key, this, idx, lim); }

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -89,7 +89,7 @@ function processNamespace(paths, root, seen) {
   NAMESPACES_BY_ID[paths.join('.')] = root;
 
   // Loop over all of the keys in the namespace, looking for classes
-  for(var key in root) {
+  for (var key in root) {
     if (!hasOwnProp.call(root, key)) { continue; }
     var obj = root[key];
 

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -206,7 +206,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
       return false;
     }
 
-    while(--loc >= 0) {
+    while (--loc >= 0) {
       if (!obj.contains(this[loc])) {
         return false;
       }
@@ -481,7 +481,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     var loc = get(this, 'length');
 
     set(ret, 'length', loc);
-    while(--loc>=0) {
+    while (--loc >= 0) {
       ret[loc] = this[loc];
       ret[guidFor(this[loc])] = loc;
     }
@@ -493,7 +493,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     var array = [];
     var idx;
 
-    for(idx = 0; idx < len; idx++) {
+    for (idx = 0; idx < len; idx++) {
       array[idx] = this[idx];
     }
     return fmt("Ember.Set<%@>", [array.join(',')]);

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -440,7 +440,7 @@ test("setting values should call function return value", function() {
     // property. Other properties blindly call set.
     expectedLength = 3;
     equal(calls.length, expectedLength, fmt('set(%@) should be called the right amount of times', [key]));
-    for(idx=0;idx<2;idx++) {
+    for (idx=0;idx<2;idx++) {
       equal(calls[idx], values[idx], fmt('call #%@ to set(%@) should have passed value %@', [idx+1, key, values[idx]]));
     }
   });
@@ -663,7 +663,7 @@ QUnit.module("Observable objects & object properties ", {
       getEach: function() {
         var keys = ['normal','abnormal'];
         var ret = [];
-        for(var idx=0; idx<keys.length;idx++) {
+        for (var idx=0; idx<keys.length;idx++) {
           ret[ret.length] = this.get(keys[idx]);
         }
         return ret ;

--- a/packages/ember-runtime/tests/suites/array/indexOf.js
+++ b/packages/ember-runtime/tests/suites/array/indexOf.js
@@ -11,7 +11,7 @@ suite.test("should return index of object", function() {
   var len      = 3;
   var idx;
 
-  for(idx=0;idx<len;idx++) {
+  for (idx=0;idx<len;idx++) {
     equal(obj.indexOf(expected[idx]), idx, fmt('obj.indexOf(%@) should match idx', [expected[idx]]));
   }
 

--- a/packages/ember-runtime/tests/suites/array/lastIndexOf.js
+++ b/packages/ember-runtime/tests/suites/array/lastIndexOf.js
@@ -11,7 +11,7 @@ suite.test("should return index of object's last occurrence", function() {
   var len      = 3;
   var idx;
 
-  for(idx=0;idx<len;idx++) {
+  for (idx=0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx]), idx,
       fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
   }
@@ -24,7 +24,7 @@ suite.test("should return index of object's last occurrence even startAt search 
   var len      = 3;
   var idx;
 
-  for(idx=0;idx<len;idx++) {
+  for (idx=0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len), idx,
       fmt('obj.lastIndexOfs(%@) should match idx', [expected[idx]]));
   }
@@ -37,7 +37,7 @@ suite.test("should return index of object's last occurrence even startAt search 
   var len      = 3;
   var idx;
 
-  for(idx=0;idx<len;idx++) {
+  for (idx=0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len + 1), idx,
       fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
   }

--- a/packages/ember-runtime/tests/suites/array/objectAt.js
+++ b/packages/ember-runtime/tests/suites/array/objectAt.js
@@ -11,7 +11,7 @@ suite.test("should return object at specified index", function() {
   var len      = expected.length;
   var idx;
 
-  for(idx=0;idx<len;idx++) {
+  for (idx=0;idx<len;idx++) {
     equal(obj.objectAt(idx), expected[idx], fmt('obj.objectAt(%@) should match', [idx]));
   }
 

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -55,7 +55,7 @@ var ObserverClass = EmberObject.extend({
   observeBefore: function(obj) {
     var keys = Array.prototype.slice.call(arguments, 1);
     var loc  = keys.length;
-    while(--loc>=0) {
+    while (--loc>=0) {
       addBeforeObserver(obj, keys[loc], this, 'propertyWillChange');
     }
 
@@ -76,7 +76,7 @@ var ObserverClass = EmberObject.extend({
       var keys = Array.prototype.slice.call(arguments, 1);
       var loc  = keys.length;
 
-      while(--loc>=0) {
+      while (--loc >= 0) {
         obj.addObserver(keys[loc], this, 'propertyDidChange');
       }
     } else {
@@ -183,7 +183,7 @@ var EnumerableTests = Suite.extend({
   */
   newFixture: function(cnt) {
     var ret = [];
-    while(--cnt >= 0) {
+    while (--cnt >= 0) {
       ret.push(generateGuid());
     }
 
@@ -202,7 +202,7 @@ var EnumerableTests = Suite.extend({
   newObjectsFixture: function(cnt) {
     var ret = [];
     var item;
-    while(--cnt >= 0) {
+    while (--cnt >= 0) {
       item = {};
       guidFor(item);
       ret.push(item);

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -16,7 +16,7 @@ QUnit.module('Namespace', {
   teardown: function() {
     Ember.BOOTED = false;
 
-    for(var prop in lookup) {
+    for (var prop in lookup) {
       if (lookup[prop]) { run(lookup[prop], 'destroy'); }
     }
 

--- a/packages/ember-runtime/tests/system/set/extra_test.js
+++ b/packages/ember-runtime/tests/system/set/extra_test.js
@@ -64,7 +64,7 @@ test('calling pop should return an object and remove it', function() {
     aSet = new Set([1,2,3]);
   });
 
-  while(count<10 && (obj = aSet.pop())) {
+  while (count<10 && (obj = aSet.pop())) {
     equal(aSet.contains(obj), false, 'set should no longer contain object');
     count++;
     equal(get(aSet, 'length'), 3-count, 'length should be shorter');

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -428,7 +428,7 @@ EmberApplication.reopen({
       protoWrap(Test.Promise.prototype, name, helper(this, name), helpers[name].meta.wait);
     }
 
-    for(var i = 0, l = injectHelpersCallbacks.length; i < l; i++) {
+    for (var i = 0, l = injectHelpersCallbacks.length; i < l; i++) {
       injectHelpersCallbacks[i](this);
     }
   },

--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -332,7 +332,7 @@ function sendAction(eventName, view, event) {
   view.sendAction(eventName, value);
 
   if (action || on === eventName) {
-    if(!get(view, 'bubbles')) {
+    if (!get(view, 'bubbles')) {
       event.stopPropagation();
     }
   }

--- a/packages/ember-views/lib/streams/class_name_binding.js
+++ b/packages/ember-views/lib/streams/class_name_binding.js
@@ -79,7 +79,7 @@ export function parsePropertyPath(path) {
   @private
 */
 export function classStringForValue(path, val, className, falsyClassName) {
-  if(isArray(val)) {
+  if (isArray(val)) {
     val = get(val, 'length') !== 0;
   }
 

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -105,7 +105,7 @@ function escapeAttribute(value) {
 
   var string = value.toString();
 
-  if(!POSSIBLE_CHARS_REGEXP.test(string)) { return string; }
+  if (!POSSIBLE_CHARS_REGEXP.test(string)) { return string; }
   return string.replace(BAD_CHARS_REGEXP, escapeChar);
 }
 

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -588,10 +588,10 @@ var Select = View.extend({
   _selectionDidChangeSingle: function() {
     var value = get(this, 'value');
     var self = this;
-    if(value && value.then) {
+    if (value && value.then) {
       value.then(function (resolved) {
         // Ensure that we don't overwrite new value
-        if(get(self, 'value') === value) {
+        if (get(self, 'value') === value) {
           self._setSelectedIndex(resolved);
         }
       });

--- a/packages/ember-views/lib/views/simple_bound_view.js
+++ b/packages/ember-views/lib/views/simple_bound_view.js
@@ -61,7 +61,7 @@ SimpleBoundView.prototype = {
   },
 
   rerender: function() {
-    switch(this.state) {
+    switch (this.state) {
       case 'preRender':
       case 'destroyed':
         break;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1360,7 +1360,7 @@ var View = CoreView.extend({
     var idx = childViews.length;
     var view;
 
-    while(--idx >= 0) {
+    while (--idx >= 0) {
       view = childViews[idx];
       callback(this, view, idx);
     }

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -19,8 +19,8 @@ QUnit.module("Ember.Component", {
   },
   teardown: function() {
     run(function() {
-      if(component)  { component.destroy(); }
-      if(controller) { controller.destroy(); }
+      if (component)  { component.destroy(); }
+      if (controller) { controller.destroy(); }
     });
   }
 });

--- a/packages/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages/ember-views/tests/views/view/create_child_view_test.js
@@ -18,7 +18,7 @@ QUnit.module("EmberView#createChildView", {
   teardown: function() {
     run(function() {
       view.destroy();
-      if(newView) { newView.destroy(); }
+      if (newView) { newView.destroy(); }
     });
   }
 });


### PR DESCRIPTION
``` javascript
while () {
 // code
}

for (var key in keys) {
 // code
}

for (var i = 0) {
 // code
}

switch () {
 // code
}

if () {
 // code
} else {
 // code
}
```
