### PR TITLE
Fix indentation.

### DIFF
--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -55,9 +55,13 @@ var define, requireModule, require, requirejs, Ember;
       for (var i=0, l=parts.length; i<l; i++) {
         var part = parts[i];
 
-        if (part === '..') { parentBase.pop(); }
-        else if (part === '.') { continue; }
-        else { parentBase.push(part); }
+        if (part === '..') {
+          parentBase.pop();
+        } else if (part === '.') {
+          continue;
+        } else {
+          parentBase.push(part);
+        }
       }
 
       return parentBase.join('/');


### PR DESCRIPTION
This change fixes the following 10 errors I saw when running jscs.

```
Expected indentation of 8 characters at packages/loader/lib/main.js :
    59 |        else if (part === '.') { continue; }
    60 |        else { parentBase.push(part); }
    61 |      }
----------------^
    62 |
    63 |      return parentBase.join('/');

Expected indentation of 8 characters at packages/loader/lib/main.js :
    61 |      }
    62 |
    63 |      return parentBase.join('/');
----------------^
    64 |    }
    65 |

Expected indentation of 6 characters at packages/loader/lib/main.js :
    62 |
    63 |      return parentBase.join('/');
    64 |    }
--------------^
    65 |
    66 |    requirejs._eak_seen = registry;

Expected indentation of 6 characters at packages/loader/lib/main.js :
    64 |    }
    65 |
    66 |    requirejs._eak_seen = registry;
--------------^
    67 |
    68 |    Ember.__loader = {

Expected indentation of 6 characters at packages/loader/lib/main.js :
    66 |    requirejs._eak_seen = registry;
    67 |
    68 |    Ember.__loader = {
--------------^
    69 |      define: define,
    70 |      require: require,

Expected indentation of 4 characters at packages/loader/lib/main.js :
    71 |      registry: registry
    72 |    };
    73 |  } else {
------------^
    74 |    define = Ember.__loader.define;
    75 |    requirejs = require = requireModule = Ember.__loader.require;

Expected indentation of 6 characters at packages/loader/lib/main.js :
    72 |    };
    73 |  } else {
    74 |    define = Ember.__loader.define;
--------------^
    75 |    requirejs = require = requireModule = Ember.__loader.require;
    76 |  }

Expected indentation of 6 characters at packages/loader/lib/main.js :
    73 |  } else {
    74 |    define = Ember.__loader.define;
    75 |    requirejs = require = requireModule = Ember.__loader.require;
--------------^
    76 |  }
    77 |})();

Expected indentation of 4 characters at packages/loader/lib/main.js :
    74 |    define = Ember.__loader.define;
    75 |    requirejs = require = requireModule = Ember.__loader.require;
    76 |  }
------------^
    77 |})();
    78 |

Expected indentation of 2 characters at packages/loader/lib/main.js :
    75 |    requirejs = require = requireModule = Ember.__loader.require;
    76 |  }
    77 |})();
----------^
    78 |

```
