### PR TITLE
[DOC beta] Fix the namespace of the Ember.getProperties method.

### DIFF
--- a/packages/ember-metal/lib/get_properties.js
+++ b/packages/ember-metal/lib/get_properties.js
@@ -18,9 +18,10 @@ import { typeOf } from "ember-metal/utils";
   ```
 
   @method getProperties
-  @param obj
+  @for Ember
+  @param {Object} obj
   @param {String...|Array} list of keys to get
-  @return {Hash}
+  @return {Object}
 */
 export default function getProperties(obj) {
   var ret = {};


### PR DESCRIPTION
Previously it was incorrectly being rendered on the Ember.InjectedProperty page.

![screen shot 2014-12-30 at 10 30 19 am](https://cloud.githubusercontent.com/assets/54056/5579912/cf517750-900f-11e4-8a90-ceece6c6cf94.png)
