### PR TITLE
Inject Renderer instead of hardcoding constructor

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -19,6 +19,7 @@ import Controller from "ember-runtime/controllers/controller";
 import EnumerableUtils from "ember-metal/enumerable_utils";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
+import Renderer from "ember-views/system/renderer";
 import SelectView from "ember-views/views/select";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import jQuery from "ember-views/system/jquery";
@@ -999,6 +1000,9 @@ Application.reopenClass({
     registry.register('controller:object', ObjectController, { instantiate: false });
     registry.register('controller:array', ArrayController, { instantiate: false });
 
+    registry.register('renderer:dom', { create: function(opts) { return new Renderer(opts); } });
+
+    registry.injection('view', 'renderer', 'renderer:dom');
     registry.register('view:select', SelectView);
 
     registry.register('route:basic', Route, { instantiate: false });

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1000,9 +1000,9 @@ Application.reopenClass({
     registry.register('controller:object', ObjectController, { instantiate: false });
     registry.register('controller:array', ArrayController, { instantiate: false });
 
-    registry.register('renderer:dom', { create: function(opts) { return new Renderer(opts); } });
+    registry.register('renderer:-dom', { create: function(opts) { return new Renderer(opts); } });
 
-    registry.injection('view', 'renderer', 'renderer:dom');
+    registry.injection('view', 'renderer', 'renderer:-dom');
     registry.register('view:select', SelectView);
 
     registry.register('route:basic', Route, { instantiate: false });

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -266,7 +266,7 @@ function Renderer_afterRemove(view, shouldDestroy) {
 }
 
 Renderer.prototype.remove = Renderer_remove;
-Renderer.prototype.destroy = function (view) {
+Renderer.prototype.removeAndDestroy = function (view) {
   this.remove(view, true);
 };
 

--- a/packages/ember-metal-views/tests/attributes_test.js
+++ b/packages/ember-metal-views/tests/attributes_test.js
@@ -17,5 +17,5 @@ test('aliased attributeBindings', function() {
 
   equal(el.getAttribute('disabled'), 'disabled', "The attribute alias was set");
 
-  subject().destroy(view);
+  subject().removeAndDestroy(view);
 });

--- a/packages/ember-metal-views/tests/children_test.js
+++ b/packages/ember-metal-views/tests/children_test.js
@@ -38,5 +38,5 @@ test("didInsertElement fires after children are rendered", function() {
   appendTo(view);
   equalHTML('qunit-fixture', "<ul><li>ohai</li></ul>");
 
-  subject().destroy(view);
+  subject().removeAndDestroy(view);
 });

--- a/packages/ember-metal-views/tests/main_test.js
+++ b/packages/ember-metal-views/tests/main_test.js
@@ -9,7 +9,7 @@ var view;
 
 testsFor("ember-metal-views", {
   teardown: function(renderer) {
-    if (view) { renderer.destroy(view); }
+    if (view) { renderer.removeAndDestroy(view); }
     view = null;
   }
 });

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -1,4 +1,4 @@
-import Rerender from "ember-views/system/renderer";
+import Renderer from "ember-views/system/renderer";
 
 import {
   cloneStates,
@@ -40,6 +40,10 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     this._state = 'preRender';
     this.currentState = this._states.preRender;
     this._isVisible = get(this, 'isVisible');
+
+    if (!this.renderer) {
+      this.renderer = new Renderer();
+    }
   },
 
   /**
@@ -129,10 +133,6 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   clearRenderedChildren: K,
   _transitionTo: K,
   destroyElement: K
-});
-
-CoreView.reopenClass({
-  renderer: new Rerender()
 });
 
 export default CoreView;

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -15,6 +15,13 @@ import { typeOf } from "ember-metal/utils";
 
 function K() { return this; }
 
+// Normally, the renderer is injected by the container when the view is looked
+// up. However, if someone creates a view without looking it up via the
+// container (e.g. `Ember.View.create().append()`) then we create a fallback
+// DOM renderer that is shared. In general, this path should be avoided since
+// views created this way cannot run in a node environment.
+var renderer;
+
 /**
   `Ember.CoreView` is an abstract class that exists to give view-like behavior
   to both Ember's main view class `Ember.View` and other classes that don't need
@@ -42,7 +49,8 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     this._isVisible = get(this, 'isVisible');
 
     if (!this.renderer) {
-      this.renderer = new Renderer();
+      renderer = renderer || new Renderer();
+      this.renderer = renderer;
     }
   },
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1407,7 +1407,7 @@ var View = CoreView.extend({
     Ember.assert("You tried to append to (" + selector + ") but that isn't in the DOM", target.length > 0);
     Ember.assert("You cannot append to an existing Ember.View. Consider using Ember.ContainerView instead.", !target.is('.ember-view') && !target.parents().is('.ember-view'));
 
-    this.constructor.renderer.appendTo(this, target[0]);
+    this.renderer.appendTo(this, target[0]);
 
     return this;
   },
@@ -1431,7 +1431,7 @@ var View = CoreView.extend({
     Ember.assert("You tried to replace in (" + selector + ") but that isn't in the DOM", target.length > 0);
     Ember.assert("You cannot replace an existing Ember.View. Consider using Ember.ContainerView instead.", !target.is('.ember-view') && !target.parents().is('.ember-view'));
 
-    this.constructor.renderer.replaceIn(this, target[0]);
+    this.renderer.replaceIn(this, target[0]);
 
     return this;
   },
@@ -1519,7 +1519,7 @@ var View = CoreView.extend({
     if (this.element) { return this; }
 
     this._didCreateElementWithoutMorph = true;
-    this.constructor.renderer.renderTree(this);
+    this.renderer.renderTree(this);
 
     return this;
   },

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -51,3 +51,33 @@ test("should warn if a non-array is used for classNamesBindings", function() {
     });
   }, /Only arrays are allowed/i);
 });
+
+test("creates a renderer if one is not provided", function() {
+  var childView;
+
+  view = EmberView.create({
+    render: function(buffer) {
+      buffer.push('Em');
+      this.appendChild(childView);
+    }
+  });
+
+  childView = EmberView.create({
+    template: function() { return 'ber'; }
+  });
+
+  run(function() {
+    view.append();
+  });
+
+  run(function() {
+    ok(get(view, 'renderer'), "view created without container receives a renderer");
+    strictEqual(get(view, 'renderer'), get(childView, 'renderer'), "parent and child share a renderer");
+  });
+
+
+  run(function() {
+    view.destroy();
+    childView.destroy();
+  });
+});


### PR DESCRIPTION
Previously, an instance of `Renderer` was created and added to the
`CoreView` class. The top-level view to be rendered would look up this
`Renderer` via `this.constructor.renderer`, then pass it to the
child views as needed.

In anticipation of server-side rendering, this PR uses an injection to
provide the default DOM renderer to views directly via an injected
`renderer` property.

In light of the fact that historically many views were created without
going through the container, this implementation detects when a
renderer has not been provided (likely because someone called
`Ember.View.create()` manually) and hardcodes a fallback to the DOM
renderer.

Going forward, users (including Ember internally) should always
instantiate views via a looked up factory rather than calling it
directly. Non-containerized views will not work in a non-node
environment.

As a side-effect of putting the renderer into the container, we
discovered that it contained a `destroy()` utility method that was
being called by the container, thinking it was the standard Ember
method for destroying an object.

We have renamed this method to `removeAndDestroy()` and have updated
all of the tests that call the old method.
