### PR TITLE
Fix typos

### DIFF
--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -5,7 +5,7 @@ import DefaultResolver from "ember-application/system/resolver";
 
 var application;
 
-QUnit.module("Ember.Application Depedency Injection – customResolver", {
+QUnit.module("Ember.Application Dependency Injection – customResolver", {
   setup: function() {
     function fallbackTemplate() { return "<h1>Fallback</h1>"; }
 

--- a/packages/ember-application/tests/system/dependency_injection/normalization_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/normalization_test.js
@@ -4,7 +4,7 @@ import Application from "ember-application/system/application";
 
 var application, registry;
 
-QUnit.module("Ember.Application Depedency Injection – normalization", {
+QUnit.module("Ember.Application Dependency Injection – normalization", {
   setup: function() {
     application = run(Application, 'create');
     registry = application.__registry__;

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -215,7 +215,7 @@ function testSelectionBinding(templateString) {
   equal(view.get('selection.value'), 'g', "Precond: Initial bound property is correct");
   equal(select.get('selection.value'), 'g', "Precond: Initial selection is correct");
   equal(selectEl.selectedIndex, 2, "Precond: The DOM reflects the correct selection");
-  equal(select.$('option:eq(2)').prop('selected'), true, "Precond: selected proprty is set to proper option");
+  equal(select.$('option:eq(2)').prop('selected'), true, "Precond: selected property is set to proper option");
 
   select.$('option:eq(2)').removeAttr('selected');
   select.$('option:eq(1)').prop('selected', true);
@@ -224,7 +224,7 @@ function testSelectionBinding(templateString) {
   equal(view.get('selection.value'), 'w', "Updated bound property is correct");
   equal(select.get('selection.value'), 'w', "Updated selection is correct");
   equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
-  equal(select.$('option:eq(1)').prop('selected'), true, "Selected proprty is set to proper option");
+  equal(select.$('option:eq(1)').prop('selected'), true, "Selected property is set to proper option");
 }
 
 test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (old xBinding='' syntax)", function() {
@@ -274,7 +274,7 @@ test("select element should correctly initialize and update selectedIndex and bo
   equal(view.get('selection.val'), 'g', "Precond: Initial bound property is correct");
   equal(select.get('selection.val'), 'g', "Precond: Initial selection is correct");
   equal(selectEl.selectedIndex, 2, "Precond: The DOM reflects the correct selection");
-  equal(select.$('option:eq(1)').prop('selected'), false, "Precond: selected proprty is set to proper option");
+  equal(select.$('option:eq(1)').prop('selected'), false, "Precond: selected property is set to proper option");
 
   select.$('option:eq(2)').removeAttr('selected');
   select.$('option:eq(1)').prop('selected', true);
@@ -283,5 +283,5 @@ test("select element should correctly initialize and update selectedIndex and bo
   equal(view.get('selection.val'), 'w', "Updated bound property is correct");
   equal(select.get('selection.val'), 'w', "Updated selection is correct");
   equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
-  equal(select.$('option:eq(1)').prop('selected'), true, "selected proprty is set to proper option");
+  equal(select.$('option:eq(1)').prop('selected'), true, "selected property is set to proper option");
 });

--- a/packages/ember-htmlbars/tests/system/bootstrap_test.js
+++ b/packages/ember-htmlbars/tests/system/bootstrap_test.js
@@ -143,7 +143,7 @@ if (Ember.component) {
     equal(view.get('layoutName'), 'components/x-apple', 'has correct layout name');
   });
 
-  test('registerComponents and non-geneated components', function(){
+  test('registerComponents and non-generated components', function(){
     Ember.TEMPLATES['components/x-apple'] = 'asdf';
 
     run(function(){

--- a/packages/ember-metal/lib/dictionary.js
+++ b/packages/ember-metal/lib/dictionary.js
@@ -2,7 +2,7 @@ import { create } from "ember-metal/platform";
 
 // the delete is meant to hint at runtimes that this object should remain in
 // dictionary mode. This is clearly a runtime specific hack, but currently it
-// appears worthwile in some usecases. Please note, these deletes do increase
+// appears worthwhile in some usecases. Please note, these deletes do increase
 // the cost of creation dramatically over a plain Object.create. And as this
 // only makes sense for long-lived dictionaries that aren't instantiated often.
 export default function makeDictionary(parent) {

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -113,7 +113,7 @@ run.join = function() {
 /**
   Allows you to specify which context to call the specified function in while
   adding the execution of that function to the Ember run loop. This ability
-  makes this method a great way to asynchronusly integrate third-party libraries
+  makes this method a great way to asynchronously integrate third-party libraries
   into your Ember application.
 
   `run.bind` takes two main arguments, the desired context and the function to
@@ -144,7 +144,7 @@ run.join = function() {
 
   In this example, we use Ember.run.bind to bind the setupEditor message to the
   context of the App.RichTextEditorComponent and to have the invocation of that
-  method be safely handled and excuted by the Ember run loop.
+  method be safely handled and executed by the Ember run loop.
 
   @method bind
   @namespace Ember

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -72,8 +72,8 @@ var stringCache  = {};
   manipulation like splitting.
 
   Unfortunately checking equality of different ropes can be quite costly as
-  runtimes must resort to clever string comparison algorithims. These
-  algorithims typically cost in proportion to the length of the string.
+  runtimes must resort to clever string comparison algorithms. These
+  algorithms typically cost in proportion to the length of the string.
   Luckily, this is where the Symbols (interned strings) shine. As Symbols are
   unique by their string content, equality checks can be done by pointer
   comparison.

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -759,7 +759,7 @@ if (Ember.EXTEND_PROTOTYPES) {
   });
 }
 
-testBoth('before observer watching multiple properties via brce expansion should fire when properties change', function (get, set) {
+testBoth('before observer watching multiple properties via brace expansion should fire when properties change', function (get, set) {
   var obj = {};
   var count = 0;
 
@@ -819,7 +819,7 @@ testBoth('addBeforeObserver should propagate through prototype', function(get, s
 
   obj2.count = 0;
   set(obj, 'foo', 'baz');
-  equal(obj.count, 1, 'should have invoked oberver on parent');
+  equal(obj.count, 1, 'should have invoked observer on parent');
   equal(obj2.count, 0, 'should not have invoked observer on inherited');
 });
 

--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -102,7 +102,7 @@ import 'ember-htmlbars';
   `{{link-to}}` will use your application's Router to
   fill the element's `href` property with a url that
   matches the path to the supplied `routeName` for your
-  routers's configured `Location` scheme, which defaults
+  router's configured `Location` scheme, which defaults
   to Ember.HashLocation.
 
   ### Handling current route

--- a/packages/ember-routing/lib/ext/view.js
+++ b/packages/ember-routing/lib/ext/view.js
@@ -132,7 +132,7 @@ EmberView.reopen({
 
   /**
     Gets an outlet that is pending disconnection and then
-    nullifys the object on the `_outlet` object.
+    nullifies the object on the `_outlet` object.
 
     @private
     @method _finishDisconnections

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -152,7 +152,7 @@ export default {
   /**
     @private
 
-    Redirects the browser using location.replace, prepending the locatin.origin
+    Redirects the browser using location.replace, prepending the location.origin
     to prevent phishing attempts
 
     @method _replacePath

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -955,7 +955,7 @@ export default Mixin.create({
 
   /**
     This property will trigger anytime the enumerable's content changes.
-    You can observe this property to be notified of changes to the enumerables
+    You can observe this property to be notified of changes to the enumerable's
     content.
 
     For plain enumerables, this property is read only. `Array` overrides

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -84,7 +84,7 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
     objects = proxy._objects = {};
   }
 
-  var indicies, guid;
+  var indices, guid;
 
   while (--loc >= idx) {
     var item = content.objectAt(loc);
@@ -93,8 +93,8 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
       removeObserver(item, keyName, proxy, 'contentKeyDidChange');
 
       guid = guidFor(item);
-      indicies = objects[guid];
-      indicies[indexOf.call(indicies, loc)] = null;
+      indices = objects[guid];
+      indices[indexOf.call(indices, loc)] = null;
     }
   }
 }

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -210,7 +210,7 @@ test("it maps properties", function() {
   deepEqual(get(obj, 'mapped'), [1, 3, 2, 5]);
 });
 
-test("it is observerable", function() {
+test("it is observable", function() {
   get(obj, 'mapped');
   var calls = 0;
 
@@ -224,7 +224,7 @@ test("it is observerable", function() {
     obj.get('array').pushObject({ v: 5 });
   });
 
-  equal(calls, 1, 'computedMapBy is observerable');
+  equal(calls, 1, 'computedMapBy is observable');
 });
 
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -926,7 +926,7 @@ test("should bind property with method parameter as undefined", function() {
   });
 
   // support new-style bindings if available
-  equal("changedValue", objectA.get("name"), "objectA.name is binded");
+  equal("changedValue", objectA.get("name"), "objectA.name is bound");
 });
 
 // ..........................................................

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -93,7 +93,7 @@ test("should observe the changes within the begin and end property changes", fun
 });
 
 test("should indicate that the property of an object has just changed", function() {
-  // inidicate that proprty of foo will change to its subscribers
+  // indicate that property of foo will change to its subscribers
   ObjectA.propertyWillChange('foo');
 
   //Value of the prop is unchanged yet as this will be changed when foo changes

--- a/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -189,7 +189,7 @@ QUnit.module("chained binding", {
   }
 });
 
-test("changing first output should propograte to third after flush", function() {
+test("changing first output should propagate to third after flush", function() {
   run(function() {
     set(first, "output", "change");
     equal("change", get(first, "output"), "first.output");

--- a/packages/ember-runtime/tests/suites/enumerable/reduce.js
+++ b/packages/ember-runtime/tests/suites/enumerable/reduce.js
@@ -4,7 +4,7 @@ var suite = SuiteModuleBuilder.create();
 
 suite.module('reduce');
 
-suite.test('collectes a summary value from an enumeration', function() {
+suite.test('collects a summary value from an enumeration', function() {
   var obj = this.newObject([1, 2, 3]);
   var res = obj.reduce(function(previousValue, item, index, enumerable) { return previousValue + item; }, 0);
   equal(res, 6);

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -15,13 +15,13 @@ import { forEach } from "ember-metal/enumerable_utils";
   own code to verify compliance.
 
   To define a suite, you need to define the tests themselves as well as a
-  callback API implementors can use to tie your tests to their specific class.
+  callback API implementers can use to tie your tests to their specific class.
 
   ## Defining a Callback API
 
   To define the callback API, just extend this class and add your properties
   or methods that must be provided.  Use Ember.required() placeholders for
-  any properties that implementors must define themselves.
+  any properties that implementers must define themselves.
 
   ## Defining Unit Tests
 

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -87,7 +87,7 @@ testWithDefault('complex depndent keys', function(get, set) {
   equal(get(obj2, 'foo'), 'BOOM 22');
 });
 
-testWithDefault('complex depndent keys changing complex dependent keys', function(get, set) {
+testWithDefault('complex dependent keys changing complex dependent keys', function(get, set) {
 
   var MyClass = EmberObject.extend({
 

--- a/packages/ember-template-compiler/lib/system/template.js
+++ b/packages/ember-template-compiler/lib/system/template.js
@@ -4,7 +4,7 @@
 */
 
 /**
-  Augments the detault precompiled output of an HTMLBars template with
+  Augments the default precompiled output of an HTMLBars template with
   additional information needed by Ember.
 
   @private

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -169,8 +169,8 @@ test("Ember.Application#setupForTesting attaches ajax listeners only once", func
     documentEvents = {};
   }
 
-  ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listers setup prior to calling injectTestHelpers');
-  ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listers setup prior to calling injectTestHelpers');
+  ok(documentEvents['ajaxSend'] === undefined, 'there are no ajaxSend listeners setup prior to calling injectTestHelpers');
+  ok(documentEvents['ajaxComplete'] === undefined, 'there are no ajaxComplete listeners setup prior to calling injectTestHelpers');
 
   run(function() {
     setupForTesting();

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -26,7 +26,7 @@ function getViewRange(view) {
   `getViewClientRects` provides information about the position of the border
   box edges of a view relative to the viewport.
 
-  It is only intended to be used by development tools like the Ember Inpsector
+  It is only intended to be used by development tools like the Ember Inspector
   and may not work on older browsers.
 
   @private

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -121,7 +121,7 @@ import EmberArray from "ember-runtime/mixins/array";
 
   For cases where additional customization beyond the use of a single
   `itemViewClass` or `tagName` matching is required CollectionView's
-  `createChildView` method can be overidden:
+  `createChildView` method can be overridden:
 
   ```javascript
   App.CustomCollectionView = Ember.CollectionView.extend({

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -256,7 +256,7 @@ var EMPTY_ARRAY = [];
   <div id="ember1" class="ember-view enabled"></div>
   ```
 
-  When isEnabled is `false`, the resulting HTML reprensentation looks like
+  When isEnabled is `false`, the resulting HTML representation looks like
   this:
 
   ```html
@@ -567,7 +567,7 @@ var EMPTY_ARRAY = [];
   as the first argument to the method and an  `Ember.View` object as the
   second. The `Ember.View` will be the view whose rendered HTML was interacted
   with. This may be the view with the `eventManager` property or one of its
-  descendent views.
+  descendant views.
 
   ```javascript
   AView = Ember.View.extend({
@@ -575,7 +575,7 @@ var EMPTY_ARRAY = [];
       doubleClick: function(event, view) {
         // will be called when when an instance's
         // rendered element or any rendering
-        // of this views's descendent
+        // of this view's descendant
         // elements is clicked
       }
     })
@@ -599,11 +599,11 @@ var EMPTY_ARRAY = [];
   ```
 
   Similarly a view's event manager will take precedence for events of any views
-  rendered as a descendent. A method name that matches an event name will not
+  rendered as a descendant. A method name that matches an event name will not
   be called if the view instance was rendered inside the HTML representation of
   a view that has an `eventManager` property defined that handles events of the
   name. Events not handled by the event manager will still trigger method calls
-  on the descendent.
+  on the descendant.
 
   ```javascript
   var App = Ember.Application.create();

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -137,7 +137,7 @@ test("prevents XSS injection via `style`", function() {
   var el = buffer.element();
   var div = document.createElement('div');
 
-  // some browsers have different escaping strageties
+  // some browsers have different escaping strategies
   // we should ensure the outcome is consistent. Ultimately we now use
   // setAttribute under the hood, so we should always do the right thing.  But
   // this test should be kept to ensure we do. Also, I believe/hope it is

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -409,7 +409,7 @@ test("should fire life cycle events when elements are added and removed", functi
   equal(willDestroyElement, 0);
   equal(willDestroy, 0);
   equal(destroy, 0);
-  // Remove whitspace added by IE 8
+  // Remove whitespace added by IE 8
   equal(trim(view.$().text()), '01234');
 
   run(function () {
@@ -432,7 +432,7 @@ test("should fire life cycle events when elements are added and removed", functi
   equal(willDestroyElement, 5);
   equal(willDestroy, 5);
   equal(destroy, 5);
-  // Remove whitspace added by IE 8
+  // Remove whitespace added by IE 8
   equal(trim(view.$().text()), '789');
 
   run(function () {

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -26,11 +26,11 @@ QUnit.module("Ember.Component", {
 });
 
 test("The context of an Ember.Component is itself", function() {
-  strictEqual(component, component.get('context'), "A components's context is itself");
+  strictEqual(component, component.get('context'), "A component's context is itself");
 });
 
 test("The controller (target of `action`) of an Ember.Component is itself", function() {
-  strictEqual(component, component.get('controller'), "A components's controller is itself");
+  strictEqual(component, component.get('controller'), "A component's controller is itself");
 });
 
 test("A templateName specified to a component is moved to the layoutName", function(){

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -265,7 +265,7 @@ test("views that are removed from a ContainerView should have their child views 
   equal(container.$().html(),'', "the child view is removed from the DOM");
 });
 
-test("if a ContainerView starts with an empy currentView, nothing is displayed", function() {
+test("if a ContainerView starts with an empty currentView, nothing is displayed", function() {
   container = ContainerView.create();
 
   run(function() {

--- a/packages/ember-views/tests/views/metamorph_view_test.js
+++ b/packages/ember-views/tests/views/metamorph_view_test.js
@@ -120,7 +120,7 @@ test("a metamorph view can be rerendered", function() {
 // Redefining without setup/teardown
 QUnit.module("Metamorph views correctly handle DOM");
 
-test("a metamorph view calls its childrens' willInsertElement and didInsertElement", function() {
+test("a metamorph view calls its children's willInsertElement and didInsertElement", function() {
   var parentView;
   var willInsertElementCalled = false;
   var didInsertElementCalled = false;

--- a/packages/ember-views/tests/views/simple_bound_view_test.js
+++ b/packages/ember-views/tests/views/simple_bound_view_test.js
@@ -3,7 +3,7 @@ import SimpleBoundView from "ember-views/views/simple_bound_view";
 
 QUnit.module('SimpleBoundView');
 
-test('does not render if update is triggured by normalizedValue is the same as the previous normalizedValue', function(){
+test('does not render if update is triggered by normalizedValue is the same as the previous normalizedValue', function(){
   var value = null;
   var obj = { 'foo': 'bar' };
   var lazyValue = new Stream(function() {

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -725,7 +725,7 @@ test("Use Ember.get to retrieve query params 'replace' configuration", function(
   App.ApplicationRoute = Ember.Route.extend({
     queryParams: Ember.Object.create({
       unknownProperty: function(keyName) {
-        // We are simulating all qps requiring refress
+        // We are simulating all qps requiring refresh
         return { replace: true };
       }
     })


### PR DESCRIPTION
I ran into a typo and figured "what the hell".  All straightforward, except for descendents vs descendants, which are both correct but the usage wasn't consistent, so I switched to using descendants everywhere.
