### PR TITLE
[BUGFIX beta] Fix `unboundIf` when its inverse is not present

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -80,7 +80,7 @@ function unboundIfHelper(params, hash, options, env) {
   }
 
   if (!shouldDisplayIfHelperContent(value)) {
-    template = options.inverse;
+    template = options.inverse || EMPTY_TEMPLATE;
   }
 
   return template.render(this, env, options.morph.contextualElement);

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -199,6 +199,15 @@ test("The `unbound if` helper does not update when the value changes", function(
   equal(view.$().text(), 'Nope');
 });
 
+test("The `unboundIf` helper should work when its inverse is not present", function() {
+  view = EmberView.create({
+    conditional: false,
+    template: compile('{{#unboundIf view.conditional}}Yep{{/unboundIf}}')
+  });
+  runAppend(view);
+  equal(view.$().text(), '');
+});
+
 test("The `if` helper ignores a controller option", function() {
   var lookupCalled = false;
 


### PR DESCRIPTION
`unboundIf` helper did not work when its inverse was not present.

The tests for this feature runs with `unbound if` instead of `unboundIf`, so I wonder if there is any plan to deprecate `unboundIf` in favor of the `unbound if` syntax.
