### PR TITLE
[master] Add test: `unbound if` helper when its inverse is not present

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -200,6 +200,15 @@ test("The `unbound if` helper does not update when the value changes", function(
   equal(view.$().text(), 'Nope');
 });
 
+test("The `unbound if` helper should work when its inverse is not present", function() {
+  view = EmberView.create({
+    conditional: false,
+    template: compile('{{#unbound if view.conditional}}Yep{{/unbound}}')
+  });
+  runAppend(view);
+  equal(view.$().text(), '');
+});
+
 test("The `if` helper ignores a controller option", function() {
   var lookupCalled = false;
 


### PR DESCRIPTION
Relates to emberjs/ember.js#10091
