### PR TITLE
Requires spaces in conditional statements

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -5,6 +5,12 @@
   "disallowMultipleVarDeclWithAssignment": true,
   "requireSpaceBeforeObjectValues": true,
   "disallowSpacesBeforeSemicolons": true,
+  "requireSpacesInConditionalExpression": {
+    "afterTest": true,
+    "beforeConsequent": true,
+    "afterConsequent": true,
+    "beforeAlternate": true
+  },
   "requireCurlyBraces": [
     "if",
     "else",


### PR DESCRIPTION
i.e:

``` javascript
var a = b ? c : d;
```
