### PR TITLE
Disallows space before `()` in call expressions

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -11,6 +11,7 @@
     "afterConsequent": true,
     "beforeAlternate": true
   },
+  "disallowSpacesInCallExpression": true,
   "requireCurlyBraces": [
     "if",
     "else",

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -264,7 +264,7 @@ test("factory for non extendables resolves are cached", function() {
   deepEqual(resolveWasCalled, ['foo:post']);
 });
 
-test ("registry.container creates an associated container", function() {
+test("registry.container creates an associated container", function() {
   var registry = new Registry();
   var PostController = factory();
   registry.register('controller:post', PostController);

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -104,7 +104,7 @@ test("raises if trying to get a controller that was not pre-defined in `needs`",
   'should throw if no such controller was needed');
 });
 
-test ("setting the value of a controller dependency should not be possible", function() {
+test("setting the value of a controller dependency should not be possible", function() {
   var registry = new Registry();
   var container = registry.container();
 

--- a/packages/ember-routing/tests/location/hash_location_test.js
+++ b/packages/ember-routing/tests/location/hash_location_test.js
@@ -14,7 +14,7 @@ function createLocation(options) {
 function mockBrowserLocation(path) {
   // This is a neat trick to auto-magically extract the hostname from any
   // url by letting the browser do the work ;)
-  var tmp = document.createElement ('a');
+  var tmp = document.createElement('a');
   tmp.href = path;
 
   var protocol = (!tmp.protocol || tmp.protocol === ':') ? 'http' : tmp.protocol;

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -12,7 +12,7 @@ function createLocation(options) {
 function mockBrowserLocation(path) {
   // This is a neat trick to auto-magically extract the hostname from any
   // url by letting the browser do the work ;)
-  var tmp = document.createElement ('a');
+  var tmp = document.createElement('a');
   tmp.href = path;
 
   var protocol = (!tmp.protocol || tmp.protocol === ':') ? 'http' : tmp.protocol;

--- a/packages/ember-runtime/tests/core/isEqual_test.js
+++ b/packages/ember-runtime/tests/core/isEqual_test.js
@@ -20,8 +20,8 @@ test("numericals should be equal", function() {
 });
 
 test("dates should be equal", function() {
-  ok (  isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), "same dates are equal" );
-  ok ( !isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), "different dates are not equal" );
+  ok(  isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), "same dates are equal" );
+  ok( !isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), "different dates are not equal" );
 });
 
 test("array should be equal", function() {

--- a/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -124,13 +124,13 @@ test("Global+Local observer works", function() {
 
 QUnit.module("EmberObject superclass and subclasses", {
   setup: function() {
-    obj = EmberObject.extend ({
+    obj = EmberObject.extend({
       method1: function() {
         return "hello";
       }
     });
     obj1 = obj.extend();
-    don = obj1.create ({
+    don = obj1.create({
       method2: function() {
         return this.superclass();
       }

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1163,7 +1163,7 @@ asyncTest("Events are triggered on the controller if a matching action name is i
   var controller = Ember.Controller.extend({
     actions: {
       showStuff: function(context) {
-        ok (stateIsNotCalled, "an event on the state is not triggered");
+        ok(stateIsNotCalled, "an event on the state is not triggered");
         deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
         QUnit.start();
       }
@@ -1380,7 +1380,7 @@ asyncTest("Actions are not triggered on the controller if a matching action name
 
     actions: {
       showStuff: function(context) {
-        ok (stateIsNotCalled, "an event on the state is not triggered");
+        ok(stateIsNotCalled, "an event on the state is not triggered");
         deepEqual(context, { name: "Tom Dale" }, "an event with context is passed");
         QUnit.start();
       }
@@ -1394,7 +1394,7 @@ asyncTest("Actions are not triggered on the controller if a matching action name
   var controller = Ember.Controller.extend({
     showStuff: function(context) {
       stateIsNotCalled = false;
-      ok (stateIsNotCalled, "an event on the state is not triggered");
+      ok(stateIsNotCalled, "an event on the state is not triggered");
     }
   });
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -267,7 +267,7 @@ test("controllers won't be eagerly instantiated by internal query params logic",
     foo: "123",
     init: function() {
       this._super();
-      ok (homeShouldBeCreated, "HomeController should be created at this time");
+      ok(homeShouldBeCreated, "HomeController should be created at this time");
     }
   });
 
@@ -283,7 +283,7 @@ test("controllers won't be eagerly instantiated by internal query params logic",
     lol: "haha",
     init: function() {
       this._super();
-      ok (aboutShouldBeCreated, "AboutController should be created at this time");
+      ok(aboutShouldBeCreated, "AboutController should be created at this time");
     }
   });
 
@@ -306,7 +306,7 @@ test("controllers won't be eagerly instantiated by internal query params logic",
     name: null,
     init: function() {
       this._super();
-      ok (catsIndexShouldBeCreated, "CatsIndexController should be created at this time");
+      ok(catsIndexShouldBeCreated, "CatsIndexController should be created at this time");
     }
   });
 


### PR DESCRIPTION
i.e:

``` javascript
// bad
foobar ();

// good
foobar();
```
