### PR TITLE
Require space after opening object curly brace and before closing.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -17,6 +17,7 @@
   },
   "disallowSpacesInCallExpression": true,
   "disallowEmptyBlocks": true,
+  "requireSpacesInsideObjectBrackets": "all",
   "requireCurlyBraces": [
     "if",
     "else",

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -372,7 +372,7 @@ test("The container can get options that should be applied to a given factory", 
     }
   };
 
-  registry.options('view:post', {instantiate: true, singleton: false});
+  registry.options('view:post', { instantiate: true, singleton: false });
 
   var postView1 = container.lookup('view:post');
   var postView2 = container.lookup('view:post');

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -20,11 +20,11 @@ QUnit.module("Ember.Application Dependency Injection", {
     application.User                = EmberObject.extend({});
     application.PostIndexController = EmberObject.extend({});
 
-    application.register('model:person', application.Person, {singleton: false });
-    application.register('model:user', application.User, {singleton: false });
+    application.register('model:person', application.Person, { singleton: false });
+    application.register('model:user', application.User, { singleton: false });
     application.register('fruit:favorite', application.Orange);
-    application.register('communication:main', application.Email, {singleton: false});
-    application.register('controller:postIndex', application.PostIndexController, {singleton: true});
+    application.register('communication:main', application.Email, { singleton: false });
+    application.register('controller:postIndex', application.PostIndexController, { singleton: true });
 
     registry = application.__registry__;
     locator = application.__container__;

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -21,13 +21,13 @@ test("initializers require proper 'name' and 'initialize' properties", function(
 
   expectAssertion(function() {
     run(function() {
-      MyApplication.initializer({name: 'initializer'});
+      MyApplication.initializer({ name: 'initializer' });
     });
   });
 
   expectAssertion(function() {
     run(function() {
-      MyApplication.initializer({initialize: Ember.K});
+      MyApplication.initializer({ initialize: Ember.K });
     });
   });
 

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -212,7 +212,7 @@ test("log which view is used with a template", function() {
 
   App.register('template:application', function() { return 'Template with default view'; });
   App.register('template:foo', function() { return 'Template with custom view'; });
-  App.register('view:posts', View.extend({templateName: 'foo'}));
+  App.register('view:posts', View.extend({ templateName: 'foo' }));
   run(App, 'advanceReadiness');
 
   visit('/posts').then(function() {

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -46,7 +46,7 @@ test("Model types added with DefaultResolver", function() {
       return Ember.A([1,2,3]);
     },
     columnsForType: function() {
-      return [{ name: 'title', desc: 'Title'}];
+      return [{ name: 'title', desc: 'Title' }];
     }
   });
 
@@ -59,7 +59,7 @@ test("Model types added with DefaultResolver", function() {
     equal(postType.name, 'post', 'Correctly sets the name');
     equal(postType.count, 3, 'Correctly sets the record count');
     strictEqual(postType.object, App.Post, 'Correctly sets the object');
-    deepEqual(postType.columns, [{name: 'title', desc: 'Title'}], 'Correctly sets the columns');
+    deepEqual(postType.columns, [{ name: 'title', desc: 'Title' }], 'Correctly sets the columns');
   };
 
   adapter.watchModelTypes(modelTypesAdded);
@@ -83,7 +83,7 @@ test("Model types added with custom container-debug-adapter", function() {
       return Ember.A([1,2,3]);
     },
     columnsForType: function() {
-      return [{ name: 'title', desc: 'Title'}];
+      return [{ name: 'title', desc: 'Title' }];
     }
   });
 
@@ -97,7 +97,7 @@ test("Model types added with custom container-debug-adapter", function() {
     equal(postType.name, PostClass.toString(), 'Correctly sets the name');
     equal(postType.count, 3, 'Correctly sets the record count');
     strictEqual(postType.object, PostClass, 'Correctly sets the object');
-    deepEqual(postType.columns, [{name: 'title', desc: 'Title'}], 'Correctly sets the columns');
+    deepEqual(postType.columns, [{ name: 'title', desc: 'Title' }], 'Correctly sets the columns');
   };
 
   adapter.watchModelTypes(modelTypesAdded);

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -11,6 +11,6 @@ export default function component(env, morph, view, tagName, attrs, template) {
 
   Ember.assert('You specified `' + tagName + '` in your template, but a component for `' + tagName + '` could not be found.', !!helper);
 
-  return helper.helperFunction.call(view, [], attrs, {morph: morph, template: template}, env);
+  return helper.helperFunction.call(view, [], attrs, { morph: morph, template: template }, env);
 }
 

--- a/packages/ember-htmlbars/lib/hooks/inline.js
+++ b/packages/ember-htmlbars/lib/hooks/inline.js
@@ -12,7 +12,7 @@ export default function inline(env, morph, view, path, params, hash) {
 
   Ember.assert("A helper named '"+path+"' could not be found", helper);
 
-  var result = helper.helperFunction.call(view, params, hash, {morph: morph}, env);
+  var result = helper.helperFunction.call(view, params, hash, { morph: morph }, env);
 
   if (isStream(result)) {
     appendSimpleBoundView(view, morph, result);

--- a/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
@@ -22,7 +22,7 @@ QUnit.module("ember-htmlbars: boolean attribute", {
 
 test("disabled property can be set true", function() {
   view = EmberView.create({
-    context: {isDisabled: true},
+    context: { isDisabled: true },
     template: compile("<input disabled={{isDisabled}}>")
   });
   appendView(view);
@@ -35,7 +35,7 @@ test("disabled property can be set true", function() {
 
 test("disabled property can be set false with a blank string", function() {
   view = EmberView.create({
-    context: {isDisabled: ''},
+    context: { isDisabled: '' },
     template: compile("<input disabled={{isDisabled}}>")
   });
   appendView(view);
@@ -48,7 +48,7 @@ test("disabled property can be set false with a blank string", function() {
 
 test("disabled property can be set false", function() {
   view = EmberView.create({
-    context: {isDisabled: false},
+    context: { isDisabled: false },
     template: compile("<input disabled={{isDisabled}}>")
   });
   appendView(view);
@@ -61,7 +61,7 @@ test("disabled property can be set false", function() {
 
 test("disabled property can be set true with a string", function() {
   view = EmberView.create({
-    context: {isDisabled: "oh, no a string"},
+    context: { isDisabled: "oh, no a string" },
     template: compile("<input disabled={{isDisabled}}>")
   });
   appendView(view);
@@ -74,7 +74,7 @@ test("disabled property can be set true with a string", function() {
 
 test("disabled attribute turns a value to a string", function() {
   view = EmberView.create({
-    context: {isDisabled: false},
+    context: { isDisabled: false },
     template: compile("<input disabled='{{isDisabled}}'>")
   });
   appendView(view);
@@ -87,7 +87,7 @@ test("disabled attribute turns a value to a string", function() {
 
 test("disabled attribute preserves a blank string value", function() {
   view = EmberView.create({
-    context: {isDisabled: ''},
+    context: { isDisabled: '' },
     template: compile("<input disabled='{{isDisabled}}'>")
   });
   appendView(view);

--- a/packages/ember-htmlbars/tests/attr_nodes/class_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/class_test.js
@@ -31,7 +31,7 @@ test("class renders before didInsertElement", function() {
     didInsertElement: function() {
       matchingElement = this.$('div.blue');
     },
-    context: {color: 'blue'},
+    context: { color: 'blue' },
     template: compile("<div class={{color}}>Hi!</div>")
   });
   appendView(view);
@@ -42,7 +42,7 @@ test("class renders before didInsertElement", function() {
 
 test("class property can contain multiple classes", function() {
   view = EmberView.create({
-    context: {classes: 'large blue'},
+    context: { classes: 'large blue' },
     template: compile("<div class={{classes}}></div>")
   });
   appendView(view);
@@ -55,7 +55,7 @@ test("class property can contain multiple classes", function() {
 
 test("class property is removed when updated with a null value", function() {
   view = EmberView.create({
-    context: {class: 'large'},
+    context: { class: 'large' },
     template: compile("<div class={{class}}></div>")
   });
   appendView(view);
@@ -71,7 +71,7 @@ test("class property is removed when updated with a null value", function() {
 
 test("class attribute concats bound values", function() {
   view = EmberView.create({
-    context: {size: 'large', color: 'blue'},
+    context: { size: 'large', color: 'blue' },
     template: compile("<div class='{{size}} {{color}} round'></div>")
   });
   appendView(view);

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -19,7 +19,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("property is output", function() {
     view = EmberView.create({
-      context: {name: 'erik'},
+      context: { name: 'erik' },
       template: compile("<div data-name={{name}}>Hi!</div>")
     });
     runAppend(view);
@@ -33,7 +33,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
       didInsertElement: function() {
         matchingElement = this.$('div[data-name=erik]');
       },
-      context: {name: 'erik'},
+      context: { name: 'erik' },
       template: compile("<div data-name={{name}}>Hi!</div>")
     });
     runAppend(view);
@@ -44,7 +44,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("quoted attributes are concatenated", function() {
     view = EmberView.create({
-      context: {firstName: 'max', lastName: 'jackson'},
+      context: { firstName: 'max', lastName: 'jackson' },
       template: compile("<div data-name='{{firstName}} {{lastName}}'>Hi!</div>")
     });
     runAppend(view);
@@ -54,7 +54,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("quoted attributes are updated when changed", function() {
     view = EmberView.create({
-      context: {firstName: 'max', lastName: 'jackson'},
+      context: { firstName: 'max', lastName: 'jackson' },
       template: compile("<div data-name='{{firstName}} {{lastName}}'>Hi!</div>")
     });
     runAppend(view);
@@ -68,7 +68,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("quoted attributes are not removed when value is null", function() {
     view = EmberView.create({
-      context: {firstName: 'max', lastName: 'jackson'},
+      context: { firstName: 'max', lastName: 'jackson' },
       template: compile("<div data-name='{{firstName}}'>Hi!</div>")
     });
     runAppend(view);
@@ -82,7 +82,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("unquoted attributes are removed when value is null", function() {
     view = EmberView.create({
-      context: {firstName: 'max'},
+      context: { firstName: 'max' },
       template: compile("<div data-name={{firstName}}>Hi!</div>")
     });
     runAppend(view);
@@ -96,7 +96,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("unquoted attributes that are null are not added", function() {
     view = EmberView.create({
-      context: {firstName: null},
+      context: { firstName: null },
       template: compile("<div data-name={{firstName}}>Hi!</div>")
     });
     runAppend(view);
@@ -106,7 +106,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("unquoted attributes are added when changing from null", function() {
     view = EmberView.create({
-      context: {firstName: null},
+      context: { firstName: null },
       template: compile("<div data-name={{firstName}}>Hi!</div>")
     });
     runAppend(view);
@@ -120,7 +120,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("property value is directly added to attribute", function() {
     view = EmberView.create({
-      context: {name: '"" data-foo="blah"'},
+      context: { name: '"" data-foo="blah"' },
       template: compile("<div data-name={{name}}>Hi!</div>")
     });
     runAppend(view);
@@ -130,7 +130,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("path is output", function() {
     view = EmberView.create({
-      context: {name: {firstName: 'erik'}},
+      context: { name: { firstName: 'erik' } },
       template: compile("<div data-name={{name.firstName}}>Hi!</div>")
     });
     runAppend(view);
@@ -139,7 +139,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
   });
 
   test("changed property updates", function() {
-    var context = EmberObject.create({name: 'erik'});
+    var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")
@@ -156,7 +156,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
   test("updates are scheduled in the render queue", function() {
     expect(4);
 
-    var context = EmberObject.create({name: 'erik'});
+    var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")
@@ -182,7 +182,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   test("updates fail silently after an element is destroyed", function() {
 
-    var context = EmberObject.create({name: 'erik'});
+    var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")
@@ -217,7 +217,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
   });
 
   test('calls setAttribute for new values', function() {
-    var context = EmberObject.create({name: 'erik'});
+    var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")
@@ -235,7 +235,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
   });
 
   test('does not call setAttribute if the same value is set', function() {
-    var context = EmberObject.create({name: 'erik'});
+    var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")

--- a/packages/ember-htmlbars/tests/attr_nodes/href_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/href_test.js
@@ -22,7 +22,7 @@ QUnit.module("ember-htmlbars: href attribute", {
 
 test("href is set", function() {
   view = EmberView.create({
-    context: {url: 'http://example.com'},
+    context: { url: 'http://example.com' },
     template: compile("<a href={{url}}></a>")
   });
   appendView(view);

--- a/packages/ember-htmlbars/tests/attr_nodes/nonmatching_reflection_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/nonmatching_reflection_test.js
@@ -29,7 +29,7 @@ QUnit.module("ember-htmlbars: nonmatching reflection", {
 
 test("maxlength sets the property and attribute", function() {
   view = EmberView.create({
-    context: {length: 5},
+    context: { length: 5 },
     template: compile("<input maxlength={{length}}>")
   });
   appendView(view);
@@ -44,7 +44,7 @@ test("maxlength sets the property and attribute", function() {
 
 test("quoted maxlength sets the property and attribute", function() {
   view = EmberView.create({
-    context: {length: 5},
+    context: { length: 5 },
     template: compile("<input maxlength='{{length}}'>")
   });
   appendView(view);

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -45,7 +45,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
 
     test(subject.tag +" "+subject.attr+" is sanitized when using blacklisted protocol", function() {
       view = EmberView.create({
-        context: {url: 'javascript://example.com'},
+        context: { url: 'javascript://example.com' },
         template: subject.unquotedTemplate
       });
       runAppend(view);
@@ -57,7 +57,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
 
     test(subject.tag +" "+subject.attr+" is sanitized when using quoted non-whitelisted protocol", function() {
       view = EmberView.create({
-        context: {url: 'javascript://example.com'},
+        context: { url: 'javascript://example.com' },
         template: subject.quotedTemplate
       });
       runAppend(view);
@@ -69,7 +69,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
 
     test(subject.tag +" "+subject.attr+" is not sanitized when using non-whitelisted protocol with a SafeString", function() {
       view = EmberView.create({
-        context: {url: new SafeString('javascript://example.com')},
+        context: { url: new SafeString('javascript://example.com') },
         template: subject.unquotedTemplate
       });
 
@@ -87,7 +87,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
 
     test(subject.tag+" "+subject.attr+" is sanitized when using quoted+concat non-whitelisted protocol", function() {
       view = EmberView.create({
-        context: {protocol: 'javascript:', path: '//example.com'},
+        context: { protocol: 'javascript:', path: '//example.com' },
         template: subject.multipartTemplate
       });
       runAppend(view);

--- a/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
@@ -23,7 +23,7 @@ QUnit.module("ember-htmlbars: svg attribute", {
 test("unquoted viewBox property is output", function() {
   var viewBoxString = '0 0 100 100';
   view = EmberView.create({
-    context: {viewBoxString: viewBoxString},
+    context: { viewBoxString: viewBoxString },
     template: compile("<svg viewBox={{viewBoxString}}></svg>")
   });
   appendView(view);
@@ -37,7 +37,7 @@ test("unquoted viewBox property is output", function() {
 test("quoted viewBox property is output", function() {
   var viewBoxString = '0 0 100 100';
   view = EmberView.create({
-    context: {viewBoxString: viewBoxString},
+    context: { viewBoxString: viewBoxString },
     template: compile("<svg viewBox='{{viewBoxString}}'></svg>")
   });
   appendView(view);
@@ -48,7 +48,7 @@ test("quoted viewBox property is output", function() {
 test("quoted viewBox property is concat", function() {
   var viewBoxString = '100 100';
   view = EmberView.create({
-    context: {viewBoxString: viewBoxString},
+    context: { viewBoxString: viewBoxString },
     template: compile("<svg viewBox='0 0 {{viewBoxString}}'></svg>")
   });
   appendView(view);
@@ -63,7 +63,7 @@ test("quoted viewBox property is concat", function() {
 
 test("class is output", function() {
   view = EmberView.create({
-    context: {color: 'blue'},
+    context: { color: 'blue' },
     template: compile("<svg class='{{color}} tall'></svg>")
   });
   appendView(view);

--- a/packages/ember-htmlbars/tests/attr_nodes/value_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/value_test.js
@@ -22,7 +22,7 @@ QUnit.module("ember-htmlbars: value attribute", {
 
 test("property is output", function() {
   view = EmberView.create({
-    context: {name: 'rick'},
+    context: { name: 'rick' },
     template: compile("<input value={{name}}>")
   });
   appendView(view);
@@ -35,7 +35,7 @@ test("property is output", function() {
 
 test("string property is output", function() {
   view = EmberView.create({
-    context: {name: 'rick'},
+    context: { name: 'rick' },
     template: compile("<input value='{{name}}'>")
   });
   appendView(view);

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -80,7 +80,7 @@ test('it can lookup a path from the current keywords', function() {
 test('it can lookup a path from globals', function() {
   expect(1);
 
-  lookup.Blammo = { foo: 'blah'};
+  lookup.Blammo = { foo: 'blah' };
 
   registry.register('helper:handlebars-get', function(path, options) {
     var context = options.contexts && options.contexts[0] || this;

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -75,7 +75,7 @@ test("should update bound helpers when properties change", function() {
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({name: "Brogrammer"}),
+    controller: EmberObject.create({ name: "Brogrammer" }),
     template: compile("{{capitalize name}}")
   });
 
@@ -98,7 +98,7 @@ test("should update bound helpers in a subexpression when properties change", fu
   });
 
   view = EmberView.create({
-    controller: {prop: "isThing"},
+    controller: { prop: "isThing" },
     template: compile("<div {{bind-attr data-foo=(dasherize prop)}}>{{prop}}</div>")
   });
 
@@ -142,7 +142,7 @@ test("bound helpers should support options", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
-    controller: EmberObject.create({text: 'ab'}),
+    controller: EmberObject.create({ text: 'ab' }),
     template: compile("{{repeat text count=3}}")
   });
 
@@ -175,7 +175,7 @@ test("bound helpers should support global paths [DEPRECATED]", function() {
     return value.toUpperCase();
   });
 
-  Ember.lookup = {Text: 'ab'};
+  Ember.lookup = { Text: 'ab' };
 
   view = EmberView.create({
     template: compile("{{capitalize Text}}")
@@ -196,7 +196,7 @@ test("bound helper should support this keyword", function() {
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({text: 'ab'}),
+    controller: EmberObject.create({ text: 'ab' }),
     template: compile("{{capitalize this}}")
   });
 
@@ -209,7 +209,7 @@ test("bound helpers should support bound options", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
-    controller: EmberObject.create({text: 'ab', numRepeats: 3}),
+    controller: EmberObject.create({ text: 'ab', numRepeats: 3 }),
     template: compile('{{repeat text countBinding="numRepeats"}}')
   });
 
@@ -235,7 +235,7 @@ test("bound helpers should support unquoted values as bound options", function()
   registerRepeatHelper();
 
   view = EmberView.create({
-    controller: EmberObject.create({text: 'ab', numRepeats: 3}),
+    controller: EmberObject.create({ text: 'ab', numRepeats: 3 }),
     template: compile('{{repeat text count=numRepeats}}')
   });
 
@@ -266,7 +266,7 @@ test("bound helpers should support multiple bound properties", function() {
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({thing1: 'ZOID', thing2: 'BERG'}),
+    controller: EmberObject.create({ thing1: 'ZOID', thing2: 'BERG' }),
     template: compile('{{combine thing1 thing2}}')
   });
 
@@ -328,7 +328,7 @@ test("bound helpers can be invoked with zero args", function() {
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({trollText: "yumad"}),
+    controller: EmberObject.create({ trollText: "yumad" }),
     template: compile('{{troll}} and {{troll text="bork"}}')
   });
 
@@ -398,7 +398,7 @@ test("shouldn't treat raw numbers as bound paths", function() {
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({aNumber: 1}),
+    controller: EmberObject.create({ aNumber: 1 }),
     template: compile("{{sum aNumber 1}} {{sum 0 aNumber}} {{sum 5 6}}")
   });
 
@@ -421,7 +421,7 @@ test("shouldn't treat quoted strings as bound paths", function() {
   });
 
   view = EmberView.create({
-    controller: EmberObject.create({word: "jerkwater", loo: "unused"}),
+    controller: EmberObject.create({ word: "jerkwater", loo: "unused" }),
     template: compile("{{combine word 'loo'}} {{combine '' word}} {{combine 'will' \"didi\"}}")
   });
 

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -165,7 +165,7 @@ test("collection helper should try to use container to resolve view", function()
 
   registry.register('view:collectionTest', ACollectionView);
 
-  var controller = {container: container};
+  var controller = { container: container };
   view = EmberView.create({
     controller: controller,
     template: compile('{{#collection "collectionTest"}} <label></label> {{/collection}}')
@@ -214,7 +214,7 @@ test("empty views should be removed when content is added to the collection (reg
   equal(view.$('tr').length, 1, 'Make sure the empty view is there (regression)');
 
   run(function() {
-    listController.pushObject({title : "Go Away, Placeholder Row!"});
+    listController.pushObject({ title : "Go Away, Placeholder Row!" });
   });
 
   equal(view.$('tr').length, 1, 'has one row');
@@ -647,7 +647,7 @@ test("should allow view objects to be swapped out without throwing an error (#78
   equal(view.$('ul > li').length, 3, "renders the collection with the correct number of items when the dataset is ready");
 
   run(function() {
-    secondDataset = EmberObject.create({ready: false});
+    secondDataset = EmberObject.create({ ready: false });
     TemplateTests.datasetController.set('dataset', secondDataset);
   });
 
@@ -663,9 +663,9 @@ test("context should be content", function() {
   container = registry.container();
 
   var items = A([
-    EmberObject.create({name: 'Dave'}),
-    EmberObject.create({name: 'Mary'}),
-    EmberObject.create({name: 'Sara'})
+    EmberObject.create({ name: 'Dave' }),
+    EmberObject.create({ name: 'Mary' }),
+    EmberObject.create({ name: 'Sara' })
   ]);
 
   registry.register('view:an-item', EmberView.extend({

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -242,7 +242,7 @@ test("it does not mark each option tag as selected", function() {
   equal(selectView.$().find(':selected').text(), 'Please select a name', 'first option is selected');
 
   run(function() {
-    people.pushObject({name: "Black Francis"});
+    people.pushObject({ name: "Black Francis" });
   });
 
   equal(selectView.$().find(':selected').text(), 'Please select a name', 'first option is selected');
@@ -282,7 +282,7 @@ test("it works inside a ul element", function() {
   equal(ulView.$('li').length, 2, "renders two <li> elements");
 
   run(function() {
-    people.pushObject({name: "Black Francis"});
+    people.pushObject({ name: "Black Francis" });
   });
 
   equal(ulView.$('li').length, 3, "renders an additional <li> element when an object is added");
@@ -301,13 +301,13 @@ test("it works inside a table element", function() {
   equal(tableView.$('td').length, 2, "renders two <td> elements");
 
   run(function() {
-    people.pushObject({name: "Black Francis"});
+    people.pushObject({ name: "Black Francis" });
   });
 
   equal(tableView.$('td').length, 3, "renders an additional <td> element when an object is added");
 
   run(function() {
-    people.insertAt(0, {name: "Kim Deal"});
+    people.insertAt(0, { name: "Kim Deal" });
   });
 
   equal(tableView.$('td').length, 4, "renders an additional <td> when an object is inserted at the beginning of the array");

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -40,7 +40,7 @@ QUnit.module("ember-htmlbars: {{#if}} and {{#unless}} helpers", {
 
 test("unless should keep the current context (#784) [DEPRECATED]", function() {
   view = EmberView.create({
-    o: EmberObject.create({foo: '42'}),
+    o: EmberObject.create({ foo: '42' }),
 
     template: compile('{{#with view.o}}{{#view}}{{#unless view.doesNotExist}}foo: {{foo}}{{/unless}}{{/view}}{{/with}}')
   });
@@ -784,7 +784,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
 
   test("`if` helper with inline form: respects isTruthy when object changes", function() {
     view = EmberView.create({
-      conditional: Ember.Object.create({isTruthy: false}),
+      conditional: Ember.Object.create({ isTruthy: false }),
       template: compile('{{if view.conditional "truthy" "falsy"}}')
     });
 
@@ -793,13 +793,13 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'falsy');
 
     run(function() {
-      view.set('conditional', Ember.Object.create({isTruthy: true}));
+      view.set('conditional', Ember.Object.create({ isTruthy: true }));
     });
 
     equal(view.$().text(), 'truthy');
 
     run(function() {
-      view.set('conditional', Ember.Object.create({isTruthy: false}));
+      view.set('conditional', Ember.Object.create({ isTruthy: false }));
     });
 
     equal(view.$().text(), 'falsy');
@@ -807,7 +807,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
   });
 
   test("`if` helper with inline form: respects isTruthy when property changes", function() {
-    var candidate = Ember.Object.create({isTruthy: false});
+    var candidate = Ember.Object.create({ isTruthy: false });
 
     view = EmberView.create({
       conditional: candidate,

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -247,7 +247,8 @@ test("should be able to render an unbound helper invocation in #each helper", fu
           firstName: 'cindy',
           lastName:  'taylor'
         }
-    ])}
+      ])
+    }
   });
   runAppend(view);
 
@@ -385,7 +386,7 @@ test("should be able to use unbound helper in #each helper", function() {
 
 test("should be able to use unbound helper in #each helper (with objects)", function() {
   view = EmberView.create({
-    items: A([{wham: 'bam'}, {wham: 1}]),
+    items: A([{ wham: 'bam' }, { wham: 1 }]),
     template: compile('<ul>{{#each item in view.items}}<li>{{unbound item.wham}}</li>{{/each}}</ul>')
   });
 

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -190,7 +190,7 @@ test("View lookup - 'fu' when fu is a property and a view name", function() {
 
   view = EmberView.extend({
     template: compile("{{view 'fu'}}"),
-    context: {fu: 'boom!'},
+    context: { fu: 'boom!' },
     container: container
   }).create();
 

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -78,7 +78,7 @@ QUnit.module("Multiple Handlebars {{with foo as bar}} helpers", {
       template: compile("Admin: {{#with admin as person}}{{person.name}}{{/with}} User: {{#with user as person}}{{person.name}}{{/with}}"),
       context: {
         admin: { name: "Tom Dale" },
-        user: { name: "Yehuda Katz"}
+        user: { name: "Yehuda Katz" }
       }
     });
 
@@ -218,7 +218,7 @@ test("it should wrap context with object controller [DEPRECATED]", function() {
     })
   });
 
-  var person = EmberObject.create({name: 'Steve Holt'});
+  var person = EmberObject.create({ name: 'Steve Holt' });
   var registry = new Registry();
   var container = registry.container();
 
@@ -308,7 +308,7 @@ test("it should wrap keyword with object controller", function() {
     })
   });
 
-  var person = EmberObject.create({name: 'Steve Holt'});
+  var person = EmberObject.create({ name: 'Steve Holt' });
   var registry = new Registry();
   var container = registry.container();
 
@@ -362,7 +362,7 @@ test("destroys the controller generated with {{with foo controller='blah'}} [DEP
     }
   });
 
-  var person = EmberObject.create({name: 'Steve Holt'});
+  var person = EmberObject.create({ name: 'Steve Holt' });
   var registry = new Registry();
   var container = registry.container();
 
@@ -398,7 +398,7 @@ test("destroys the controller generated with {{with foo as bar controller='blah'
     }
   });
 
-  var person = EmberObject.create({name: 'Steve Holt'});
+  var person = EmberObject.create({ name: 'Steve Holt' });
   var registry = new Registry();
   var container = registry.container();
 
@@ -461,7 +461,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
         template: compile("Admin: {{#with admin as |person|}}{{person.name}}{{/with}} User: {{#with user as |person|}}{{person.name}}{{/with}}"),
         context: {
           admin: { name: "Tom Dale" },
-          user: { name: "Yehuda Katz"}
+          user: { name: "Yehuda Katz" }
         }
       });
 

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -16,7 +16,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
   test("property is output", function() {
     view = EmberView.create({
-      context: {name: 'erik'},
+      context: { name: 'erik' },
       template: compile("ohai {{name}}")
     });
     runAppend(view);
@@ -26,7 +26,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
   test("path is output", function() {
     view = EmberView.create({
-      context: {name: {firstName: 'erik'}},
+      context: { name: { firstName: 'erik' } },
       template: compile("ohai {{name.firstName}}")
     });
     runAppend(view);
@@ -35,7 +35,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   });
 
   test("changed property updates", function() {
-    var context = EmberObject.create({name: 'erik'});
+    var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
       template: compile("ohai {{name}}")

--- a/packages/ember-htmlbars/tests/integration/binding_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/binding_integration_test.js
@@ -61,7 +61,7 @@ test('should bind to the property if no registered helper found for a mustache w
 });
 
 test("should be able to update when bound property updates", function() {
-  MyApp.set('controller', EmberObject.create({name: 'first'}));
+  MyApp.set('controller', EmberObject.create({ name: 'first' }));
 
   var View = EmberView.extend({
     template: compile('<i>{{view.value.name}}, {{view.computed}}</i>'),
@@ -89,7 +89,7 @@ test("should be able to update when bound property updates", function() {
 
 test('should cleanup bound properties on rerender', function() {
   view = EmberView.create({
-    controller: EmberObject.create({name: 'wycats'}),
+    controller: EmberObject.create({ name: 'wycats' }),
     template: compile('{{name}}')
   });
 

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -36,15 +36,15 @@ test("works from a template with bindings", function() {
     }).property('firstName', 'lastName')
   });
 
-  var erik = Person.create({id: 4, firstName: 'Erik', lastName: 'Bryn'});
+  var erik = Person.create({ id: 4, firstName: 'Erik', lastName: 'Bryn' });
 
   var application = Namespace.create();
 
   application.peopleController = ArrayController.create({
     content: Ember.A([
-      Person.create({id: 1, firstName: 'Yehuda', lastName: 'Katz'}),
-      Person.create({id: 2, firstName: 'Tom', lastName: 'Dale'}),
-      Person.create({id: 3, firstName: 'Peter', lastName: 'Wagenet'}),
+      Person.create({ id: 1, firstName: 'Yehuda', lastName: 'Katz' }),
+      Person.create({ id: 2, firstName: 'Tom', lastName: 'Dale' }),
+      Person.create({ id: 3, firstName: 'Peter', lastName: 'Wagenet' }),
       erik
     ])
   });
@@ -80,7 +80,7 @@ test("works from a template with bindings", function() {
 
   equal(select.get('selection'), erik, "Selection was updated through binding");
   run(function() {
-    application.peopleController.pushObject(Person.create({id: 5, firstName: "James", lastName: "Rosen"}));
+    application.peopleController.pushObject(Person.create({ id: 5, firstName: "James", lastName: "Rosen" }));
   });
 
   equal(select.$('option').length, 6, "New option was added");
@@ -88,8 +88,8 @@ test("works from a template with bindings", function() {
 });
 
 test("upon content change, the DOM should reflect the selection (#481)", function() {
-  var userOne = {name: 'Mike', options: Ember.A(['a', 'b']), selectedOption: 'a'};
-  var userTwo = {name: 'John', options: Ember.A(['c', 'd']), selectedOption: 'd'};
+  var userOne = { name: 'Mike', options: Ember.A(['a', 'b']), selectedOption: 'a' };
+  var userTwo = { name: 'John', options: Ember.A(['c', 'd']), selectedOption: 'd' };
 
   view = EmberView.create({
     user: userOne,
@@ -118,8 +118,8 @@ test("upon content change, the DOM should reflect the selection (#481)", functio
 });
 
 test("upon content change with Array-like content, the DOM should reflect the selection", function() {
-  var tom = {id: 4, name: 'Tom'};
-  var sylvain = {id: 5, name: 'Sylvain'};
+  var tom = { id: 4, name: 'Tom' };
+  var sylvain = { id: 5, name: 'Sylvain' };
 
   var proxy = ArrayProxy.create({
     content: Ember.A(),
@@ -153,7 +153,7 @@ test("upon content change with Array-like content, the DOM should reflect the se
 
 function testValueBinding(templateString) {
   view = EmberView.create({
-    collection: Ember.A([{name: 'Wes', value: 'w'}, {name: 'Gordon', value: 'g'}]),
+    collection: Ember.A([{ name: 'Wes', value: 'w' }, { name: 'Gordon', value: 'g' }]),
     val: 'g',
     selectView: SelectView,
     template: compile(templateString)
@@ -201,8 +201,8 @@ test("select element should correctly initialize and update selectedIndex and bo
 
 function testSelectionBinding(templateString) {
   view = EmberView.create({
-    collection: Ember.A([{name: 'Wes', value: 'w'}, {name: 'Gordon', value: 'g'}]),
-    selection: {name: 'Gordon', value: 'g'},
+    collection: Ember.A([{ name: 'Wes', value: 'w' }, { name: 'Gordon', value: 'g' }]),
+    selection: { name: 'Gordon', value: 'g' },
     selectView: SelectView,
     template: compile(templateString)
   });
@@ -258,8 +258,8 @@ test("select element should correctly initialize and update selectedIndex and bo
     '    selection=view.selection}}';
 
   view = EmberView.create({
-    collection: Ember.A([{name: 'Wes', val: 'w'}, {name: 'Gordon', val: 'g'}]),
-    selection: {name: 'Gordon', val: 'g'},
+    collection: Ember.A([{ name: 'Wes', val: 'w' }, { name: 'Gordon', val: 'g' }]),
+    selection: { name: 'Gordon', val: 'g' },
     selectView: SelectView,
     template: Ember.Handlebars.compile(templateString)
   });

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -43,7 +43,7 @@ test("should update bound helpers in a subexpression when properties change", fu
 
   view = EmberView.create({
     container: container,
-    controller: {prop: "isThing"},
+    controller: { prop: "isThing" },
     template: compile("<div {{bind-attr data-foo=(x-dasherize prop)}}>{{prop}}</div>")
   });
 
@@ -63,7 +63,7 @@ test("should update bound helpers when properties change", function() {
 
   view = EmberView.create({
     container: container,
-    controller: {name: "Brogrammer"},
+    controller: { name: "Brogrammer" },
     template: compile("{{x-capitalize name}}")
   });
 
@@ -199,7 +199,7 @@ test("shouldn't treat raw numbers as bound paths", function() {
 
   view = EmberView.create({
     container: container,
-    controller: {aNumber: 1},
+    controller: { aNumber: 1 },
     template: compile("{{x-sum aNumber 1}} {{x-sum 0 aNumber}} {{x-sum 5 6}}")
   });
 

--- a/packages/ember-htmlbars/tests/system/make_view_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_view_helper_test.js
@@ -3,7 +3,7 @@ import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 QUnit.module("ember-htmlbars: makeViewHelper");
 
 test("makes helpful assertion when called with invalid arguments", function() {
-  var viewClass = {toString: function() { return 'Some Random Class'; }};
+  var viewClass = { toString: function() { return 'Some Random Class'; } };
 
   var helper = makeViewHelper(viewClass);
 

--- a/packages/ember-metal-views/tests/children_test.js
+++ b/packages/ember-metal-views/tests/children_test.js
@@ -12,7 +12,7 @@ test("a view can have child views", function() {
     isView: true,
     tagName: 'ul',
     childViews: [
-      {isView: true, tagName: 'li', textContent: 'ohai'}
+      { isView: true, tagName: 'li', textContent: 'ohai' }
     ]
   };
 
@@ -27,7 +27,7 @@ test("didInsertElement fires after children are rendered", function() {
     isView: true,
     tagName: 'ul',
     childViews: [
-      {isView: true, tagName: 'li', textContent: 'ohai'}
+      { isView: true, tagName: 'li', textContent: 'ohai' }
     ],
 
     didInsertElement: function() {

--- a/packages/ember-metal-views/tests/main_test.js
+++ b/packages/ember-metal-views/tests/main_test.js
@@ -16,7 +16,7 @@ testsFor("ember-metal-views", {
 
 // Test the behavior of the helper createElement stub
 test("by default, view renders as a div", function() {
-  view = {isView: true};
+  view = { isView: true };
 
   appendTo(view);
   equalHTML('qunit-fixture', "<div></div>");

--- a/packages/ember-metal/lib/keys.js
+++ b/packages/ember-metal/lib/keys.js
@@ -17,7 +17,7 @@ if (!keys || !canDefineNonEnumerableProperties) {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
   keys = (function () {
     var hasOwnProperty = Object.prototype.hasOwnProperty;
-    var hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString');
+    var hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString');
     var dontEnums = [
           'toString',
           'toLocaleString',

--- a/packages/ember-metal/lib/platform/create.js
+++ b/packages/ember-metal/lib/platform/create.js
@@ -22,7 +22,7 @@ if (!(Object.create && !Object.create(null).hasOwnProperty)) {
   /* jshint scripturl:true, proto:true */
   // Contributed by Brandon Benvie, October, 2012
   var createEmpty;
-  var supportsProto = !({'__proto__': null} instanceof Object);
+  var supportsProto = !({ '__proto__': null } instanceof Object);
   // the following produces false positives
   // in Opera Mini => not a reliable check
   // Object.prototype.__proto__ === null

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -38,9 +38,9 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       defineProperty(obj, 'a', { value: true });
       defineProperty(obj, 'b', { value: false });
       defineProperty(obj, 'c', { value: undefined });
-      defineProperty(obj, 'd', { value: undefined, writable: false});
-      defineProperty(obj, 'e', { value: undefined, configurable: false});
-      defineProperty(obj, 'f', { value: undefined, configurable: true});
+      defineProperty(obj, 'd', { value: undefined, writable: false });
+      defineProperty(obj, 'e', { value: undefined, configurable: false });
+      defineProperty(obj, 'f', { value: undefined, configurable: true });
 
       watch(obj, 'a');
       watch(obj, 'b');

--- a/packages/ember-metal/tests/accessors/setPath_test.js
+++ b/packages/ember-metal/tests/accessors/setPath_test.js
@@ -41,7 +41,7 @@ var moduleOpts = {
 QUnit.module('set with path', moduleOpts);
 
 test('[Foo, bar] -> Foo.bar', function() {
-  Ember.lookup.Foo = {toString: function() { return 'Foo'; }}; // Behave like an Ember.Namespace
+  Ember.lookup.Foo = { toString: function() { return 'Foo'; } }; // Behave like an Ember.Namespace
 
   set(Ember.lookup.Foo, 'bar', 'baz');
   equal(get(Ember.lookup.Foo, 'bar'), 'baz');

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -802,17 +802,17 @@ testBoth('protects against setting', function(get, set) {
 QUnit.module('CP macros');
 
 testBoth('computed.not', function(get, set) {
-  var obj = {foo: true};
+  var obj = { foo: true };
   defineProperty(obj, 'notFoo', computed.not('foo'));
   equal(get(obj, 'notFoo'), false);
 
-  obj = {foo: {bar: true}};
+  obj = { foo: { bar: true } };
   defineProperty(obj, 'notFoo', computed.not('foo.bar'));
   equal(get(obj, 'notFoo'), false);
 });
 
 testBoth('computed.empty', function(get, set) {
-  var obj = {foo: [], bar: undefined, baz: null, quz: ''};
+  var obj = { foo: [], bar: undefined, baz: null, quz: '' };
   defineProperty(obj, 'fooEmpty', computed.empty('foo'));
   defineProperty(obj, 'barEmpty', computed.empty('bar'));
   defineProperty(obj, 'bazEmpty', computed.empty('baz'));
@@ -829,7 +829,7 @@ testBoth('computed.empty', function(get, set) {
 });
 
 testBoth('computed.bool', function(get, set) {
-  var obj = {foo: function() {}, bar: 'asdf', baz: null, quz: false};
+  var obj = { foo: function() {}, bar: 'asdf', baz: null, quz: false };
   defineProperty(obj, 'fooBool', computed.bool('foo'));
   defineProperty(obj, 'barBool', computed.bool('bar'));
   defineProperty(obj, 'bazBool', computed.bool('baz'));
@@ -841,7 +841,7 @@ testBoth('computed.bool', function(get, set) {
 });
 
 testBoth('computed.alias', function(get, set) {
-  var obj = { bar: 'asdf', baz: null, quz: false};
+  var obj = { bar: 'asdf', baz: null, quz: false };
   defineProperty(obj, 'bay', computed(function(key) {
     return 'apple';
   }));
@@ -1122,7 +1122,7 @@ testBoth('computed.readOnly', function(get, set) {
 });
 
 testBoth('computed.deprecatingAlias', function(get, set) {
-  var obj = { bar: 'asdf', baz: null, quz: false};
+  var obj = { bar: 'asdf', baz: null, quz: false };
   defineProperty(obj, 'bay', computed(function(key) {
     return 'apple';
   }));

--- a/packages/ember-metal/tests/instrumentation_test.js
+++ b/packages/ember-metal/tests/instrumentation_test.js
@@ -122,7 +122,7 @@ test("instrument with 3 args (name, callback, binding) no payload", function() {
 test("instrument with 3 args (name, payload, callback) with payload", function() {
   expect(1);
 
-  var expectedPayload = { hi: 1};
+  var expectedPayload = { hi: 1 };
   subscribe("render", {
     before: function(name, timestamp, payload) {
       deepEqual(payload, expectedPayload);

--- a/packages/ember-metal/tests/is_blank_test.js
+++ b/packages/ember-metal/tests/is_blank_test.js
@@ -5,7 +5,7 @@ QUnit.module("Ember.isBlank");
 test("Ember.isBlank", function() {
   var string = "string";
   var fn = function() {};
-  var object = {length: 0};
+  var object = { length: 0 };
 
   equal(true,  isBlank(null),      "for null");
   equal(true,  isBlank(undefined), "for undefined");

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -9,7 +9,7 @@ QUnit.module("Ember.isEmpty");
 test("Ember.isEmpty", function() {
   var string = "string";
   var fn = function() {};
-  var object = {length: 0};
+  var object = { length: 0 };
 
   equal(true,  isEmpty(null),      "for null");
   equal(true,  isEmpty(undefined), "for undefined");

--- a/packages/ember-metal/tests/is_present_test.js
+++ b/packages/ember-metal/tests/is_present_test.js
@@ -5,7 +5,7 @@ QUnit.module("Ember.isPresent");
 test("Ember.isPresent", function() {
   var string = "string";
   var fn = function() {};
-  var object = {length: 0};
+  var object = { length: 0 };
 
   equal(false, isPresent(),          "for no params");
   equal(false, isPresent(null),      "for null");

--- a/packages/ember-metal/tests/mixin/observer_test.js
+++ b/packages/ember-metal/tests/mixin/observer_test.js
@@ -78,7 +78,7 @@ testBoth('replacing observer should remove old observer', function(get, set) {
 });
 
 testBoth('observing chain with property before', function(get, set) {
-  var obj2 = {baz: 'baz'};
+  var obj2 = { baz: 'baz' };
 
   var MyMixin = Mixin.create({
     count: 0,
@@ -96,7 +96,7 @@ testBoth('observing chain with property before', function(get, set) {
 });
 
 testBoth('observing chain with property after', function(get, set) {
-  var obj2 = {baz: 'baz'};
+  var obj2 = { baz: 'baz' };
 
   var MyMixin = Mixin.create({
     count: 0,
@@ -114,7 +114,7 @@ testBoth('observing chain with property after', function(get, set) {
 });
 
 testBoth('observing chain with property in mixin applied later', function(get, set) {
-  var obj2 = {baz: 'baz'};
+  var obj2 = { baz: 'baz' };
 
   var MyMixin = Mixin.create({
 
@@ -124,7 +124,7 @@ testBoth('observing chain with property in mixin applied later', function(get, s
     })
   });
 
-  var MyMixin2 = Mixin.create({bar: obj2});
+  var MyMixin2 = Mixin.create({ bar: obj2 });
 
   var obj = mixin({}, MyMixin);
   equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
@@ -137,7 +137,7 @@ testBoth('observing chain with property in mixin applied later', function(get, s
 });
 
 testBoth('observing chain with existing property', function(get, set) {
-  var obj2 = {baz: 'baz'};
+  var obj2 = { baz: 'baz' };
 
   var MyMixin = Mixin.create({
     count: 0,
@@ -146,7 +146,7 @@ testBoth('observing chain with existing property', function(get, set) {
     })
   });
 
-  var obj = mixin({bar: obj2}, MyMixin);
+  var obj = mixin({ bar: obj2 }, MyMixin);
   equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   set(obj2, 'baz', "BAZ");
@@ -154,8 +154,8 @@ testBoth('observing chain with existing property', function(get, set) {
 });
 
 testBoth('observing chain with property in mixin before', function(get, set) {
-  var obj2 = {baz: 'baz'};
-  var MyMixin2 = Mixin.create({bar: obj2});
+  var obj2 = { baz: 'baz' };
+  var MyMixin2 = Mixin.create({ bar: obj2 });
 
   var MyMixin = Mixin.create({
     count: 0,
@@ -172,8 +172,8 @@ testBoth('observing chain with property in mixin before', function(get, set) {
 });
 
 testBoth('observing chain with property in mixin after', function(get, set) {
-  var obj2 = {baz: 'baz'};
-  var MyMixin2 = Mixin.create({bar: obj2});
+  var obj2 = { baz: 'baz' };
+  var MyMixin2 = Mixin.create({ bar: obj2 });
 
   var MyMixin = Mixin.create({
     count: 0,
@@ -190,10 +190,10 @@ testBoth('observing chain with property in mixin after', function(get, set) {
 });
 
 testBoth('observing chain with overriden property', function(get, set) {
-  var obj2 = {baz: 'baz'};
-  var obj3 = {baz: 'foo'};
+  var obj2 = { baz: 'baz' };
+  var obj3 = { baz: 'foo' };
 
-  var MyMixin2 = Mixin.create({bar: obj3});
+  var MyMixin2 = Mixin.create({ bar: obj3 });
 
   var MyMixin = Mixin.create({
     count: 0,
@@ -202,7 +202,7 @@ testBoth('observing chain with overriden property', function(get, set) {
     })
   });
 
-  var obj = mixin({bar: obj2}, MyMixin, MyMixin2);
+  var obj = mixin({ bar: obj2 }, MyMixin, MyMixin2);
   equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
   equal(isWatching(obj2, 'baz'), false, 'should not be watching baz');

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -905,7 +905,7 @@ QUnit.module('addObserver - dependentkey with chained properties', {
 
 testBoth('depending on a chain with a computed property', function (get, set) {
   defineProperty(obj, 'computed', computed(function () {
-    return {foo: 'bar'};
+    return { foo: 'bar' };
   }));
 
   var changed = 0;

--- a/packages/ember-metal/tests/performance_test.js
+++ b/packages/ember-metal/tests/performance_test.js
@@ -19,7 +19,7 @@ import { addObserver } from "ember-metal/observer";
 QUnit.module("Computed Properties - Number of times evaluated");
 
 test("computed properties that depend on multiple properties should run only once per run loop", function() {
-  var obj = {a: 'a', b: 'b', c: 'c'};
+  var obj = { a: 'a', b: 'b', c: 'c' };
   var cpCount = 0;
   var obsCount = 0;
 

--- a/packages/ember-metal/tests/properties_test.js
+++ b/packages/ember-metal/tests/properties_test.js
@@ -46,7 +46,7 @@ if (hasPropertyAccessors) {
 
   test("enables access to deprecated property and returns the value of the new property", function() {
     expect(3);
-    var obj = {foo: 'bar'};
+    var obj = { foo: 'bar' };
 
     deprecateProperty(obj, 'baz', 'foo');
 
@@ -59,7 +59,7 @@ if (hasPropertyAccessors) {
 
   test("deprecatedKey is not enumerable", function() {
     expect(2);
-    var obj = {foo: 'bar', blammo: 'whammy'};
+    var obj = { foo: 'bar', blammo: 'whammy' };
 
     deprecateProperty(obj, 'baz', 'foo');
 
@@ -72,7 +72,7 @@ if (hasPropertyAccessors) {
 
   test("enables setter to deprecated property and updates the value of the new property", function() {
     expect(3);
-    var obj = {foo: 'bar'};
+    var obj = { foo: 'bar' };
 
     deprecateProperty(obj, 'baz', 'foo');
 

--- a/packages/ember-metal/tests/set_properties_test.js
+++ b/packages/ember-metal/tests/set_properties_test.js
@@ -12,13 +12,13 @@ test("supports setting multiple attributes at once", function() {
   deepEqual(setProperties({}, NaN),       {}, 'noop for NaN');
   deepEqual(setProperties({}, {}),        {}, 'meh');
 
-  deepEqual(setProperties({}, {foo: 1}),  {foo: 1}, 'Set a single property');
+  deepEqual(setProperties({}, { foo: 1 }),  { foo: 1 }, 'Set a single property');
 
-  deepEqual(setProperties({}, {foo: 1, bar: 1}), {foo: 1, bar: 1}, 'Set multiple properties');
+  deepEqual(setProperties({}, { foo: 1, bar: 1 }), { foo: 1, bar: 1 }, 'Set multiple properties');
 
-  deepEqual(setProperties({foo: 2, baz: 2}, {foo: 1}), {foo: 1, baz: 2}, 'Set one of multiple properties');
+  deepEqual(setProperties({ foo: 2, baz: 2 }, { foo: 1 }), { foo: 1, baz: 2 }, 'Set one of multiple properties');
 
-  deepEqual(setProperties({foo: 2, baz: 2}, {bar: 2}), {
+  deepEqual(setProperties({ foo: 2, baz: 2 }, { bar: 2 }), {
     bar: 2,
     foo: 2,
     baz: 2

--- a/packages/ember-metal/tests/utils/is_array_test.js
+++ b/packages/ember-metal/tests/utils/is_array_test.js
@@ -9,7 +9,7 @@ test("Ember.isArray", function() {
   var strarray      = ["Hello", "Hi"];
   var string        = "Hello";
   var object        = {};
-  var length        = {length: 12};
+  var length        = { length: 12 };
   var fn            = function() {};
 
   equal( isArray(numarray), true,  "[1,2,3]" );
@@ -17,7 +17,7 @@ test("Ember.isArray", function() {
   equal( isArray(strarray), true,  '["Hello", "Hi"]' );
   equal( isArray(string),   false, '"Hello"' );
   equal( isArray(object),   false, "{}" );
-  equal( isArray(length),   true,  "{length: 12}" );
+  equal( isArray(length),   true,  "{ length: 12 }" );
   equal( isArray(global),   false, "global" );
   equal( isArray(fn),       false, "function() {}" );
 });

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -57,7 +57,7 @@ QUnit.module("Ember.meta enumerable");
 if (canDefineNonEnumerableProperties) {
   test("meta is not enumerable", function () {
     var proto, obj, props, prop;
-    proto = {foo: 'bar'};
+    proto = { foo: 'bar' };
     meta(proto);
     obj = create(proto);
     meta(obj);
@@ -81,7 +81,7 @@ if (canDefineNonEnumerableProperties) {
   if (Ember.imports.jQuery) {
     test("meta is not jQuery.isPlainObject", function () {
       var proto, obj;
-      proto = {foo: 'bar'};
+      proto = { foo: 'bar' };
       equal(jQuery.isPlainObject(meta(proto)), false, 'meta should not be isPlainObject when meta property cannot be marked as enumerable: false');
       obj = create(proto);
       equal(jQuery.isPlainObject(meta(obj)), false, 'meta should not be isPlainObject when meta property cannot be marked as enumerable: false');

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -9,7 +9,7 @@ test("Ember.typeOf", function() {
   var mockedDate  = new MockedDate();
   var date        = new Date();
   var error       = new Error('boum');
-  var object      = {a: 'b'};
+  var object      = { a: 'b' };
 
   equal( typeOf(),            'undefined',  "undefined");
   equal( typeOf(null),        'null',       "null");

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -118,7 +118,7 @@ test("watching an object THEN defining it should work also", function() {
 
 test("watching a chain then defining the property", function () {
   var obj = {};
-  var foo = {bar: 'bar'};
+  var foo = { bar: 'bar' };
   addListeners(obj, 'foo.bar');
   addListeners(foo, 'bar');
 
@@ -135,8 +135,8 @@ test("watching a chain then defining the property", function () {
 
 test("watching a chain then defining the nested property", function () {
   var bar = {};
-  var obj = {foo: bar};
-  var baz = {baz: 'baz'};
+  var obj = { foo: bar };
+  var baz = { baz: 'baz' };
   addListeners(obj, 'foo.bar.baz');
   addListeners(baz, 'baz');
 
@@ -218,7 +218,7 @@ test('when watching a global object, destroy should remove chain watchers from t
 
 test('when watching another object, destroy should remove chain watchers from the other object', function() {
   var objA = {};
-  var objB = {foo: 'bar'};
+  var objB = { foo: 'bar' };
   objA.b = objB;
   addListeners(objA, 'b.foo');
 

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -228,8 +228,8 @@ test("should target the with-controller inside an {{each}} in a {{#with controll
   var parentController = EmberObject.create({
     container: container,
     people: Ember.A([
-      {name: 'robert'},
-      {name: 'brian'}
+      { name: 'robert' },
+      { name: 'brian' }
     ])
   });
 
@@ -487,7 +487,7 @@ test("should work properly in a {{#with foo as bar}} block", function() {
 
   view = EmberView.create({
     controller: controller,
-    something: {ohai: 'there'},
+    something: { ohai: 'there' },
     template: compile('{{#with view.something as somethingElse}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
   });
 
@@ -507,7 +507,7 @@ test("should work properly in a #with block [DEPRECATED]", function() {
 
   view = EmberView.create({
     controller: controller,
-    something: {ohai: 'there'},
+    something: { ohai: 'there' },
     template: compile('{{#with view.something}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
   });
 
@@ -920,9 +920,9 @@ test("a quoteless parameter should lookup actionName in context [DEPRECATED]", f
   });
 
   var controller = EmberController.extend({
-    allactions: Ember.A([{title: 'Biggity Boom',name: 'biggityBoom'},
-                         {title: 'Whomp Whomp',name: 'whompWhomp'},
-                         {title: 'Sloopy Dookie',name: 'sloopyDookie'}]),
+    allactions: Ember.A([{ title: 'Biggity Boom',name: 'biggityBoom' },
+                         { title: 'Whomp Whomp',name: 'whompWhomp' },
+                         { title: 'Sloopy Dookie',name: 'sloopyDookie' }]),
     actions: {
       biggityBoom: function() {
         lastAction = 'biggityBoom';
@@ -971,9 +971,9 @@ test("a quoteless parameter should resolve actionName, including path", function
   });
 
   var controller = EmberController.extend({
-    allactions: Ember.A([{title: 'Biggity Boom',name: 'biggityBoom'},
-                         {title: 'Whomp Whomp',name: 'whompWhomp'},
-                         {title: 'Sloopy Dookie',name: 'sloopyDookie'}]),
+    allactions: Ember.A([{ title: 'Biggity Boom',name: 'biggityBoom' },
+                         { title: 'Whomp Whomp',name: 'whompWhomp' },
+                         { title: 'Sloopy Dookie',name: 'sloopyDookie' }]),
     actions: {
       biggityBoom: function() {
         lastAction = 'biggityBoom';

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -127,7 +127,7 @@ QUnit.module("ember-routing-htmlbars: {{render}} helper", {
 
 test("{{render}} helper should render given template", function() {
   var template = "<h1>HI</h1>{{render 'home'}}";
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -143,7 +143,7 @@ test("{{render}} helper should render given template", function() {
 
 test("{{render}} helper should have assertion if neither template nor view exists", function() {
   var template = "<h1>HI</h1>{{render 'oops'}}";
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -156,8 +156,8 @@ test("{{render}} helper should have assertion if neither template nor view exist
 
 test("{{render}} helper should not have assertion if template is supplied in block-form", function() {
   var template = "<h1>HI</h1>{{#render 'good'}} {{name}}{{/render}}";
-  var controller = EmberController.extend({container: container});
-  container._registry.register('controller:good', EmberController.extend({ name: 'Rob'}));
+  var controller = EmberController.extend({ container: container });
+  container._registry.register('controller:good', EmberController.extend({ name: 'Rob' }));
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -170,7 +170,7 @@ test("{{render}} helper should not have assertion if template is supplied in blo
 
 test("{{render}} helper should not have assertion if view exists without a template", function() {
   var template = "<h1>HI</h1>{{render 'oops'}}";
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -256,7 +256,7 @@ test("{{render}} helper with a supplied model should not fire observers on the c
 
 test("{{render}} helper should raise an error when a given controller name does not resolve to a controller", function() {
   var template = '<h1>HI</h1>{{render "home" controller="postss"}}';
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   container._registry.register('controller:posts', EmberArrayController.extend());
   view = EmberView.create({
     controller: controller.create(),
@@ -272,7 +272,7 @@ test("{{render}} helper should raise an error when a given controller name does 
 
 test("{{render}} helper should render with given controller", function() {
   var template = '<h1>HI</h1>{{render "home" controller="posts"}}';
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   container._registry.register('controller:posts', EmberArrayController.extend());
   view = EmberView.create({
     controller: controller.create(),
@@ -289,7 +289,7 @@ test("{{render}} helper should render with given controller", function() {
 
 test("{{render}} helper should render a template without a model only once", function() {
   var template = "<h1>HI</h1>{{render 'home'}}<hr/>{{render 'home'}}";
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -325,7 +325,7 @@ test("{{render}} helper should render templates with models multiple times", fun
   });
 
   var PostController = EmberObjectController.extend();
-  container._registry.register('controller:post', PostController, {singleton: false});
+  container._registry.register('controller:post', PostController, { singleton: false });
 
   Ember.TEMPLATES['post'] = compile("<p>{{title}}</p>");
 
@@ -392,7 +392,7 @@ test("{{render}} helper should not treat invocations with falsy contexts as cont
   });
 
   var PostController = EmberObjectController.extend();
-  container._registry.register('controller:post', PostController, {singleton: false});
+  container._registry.register('controller:post', PostController, { singleton: false });
 
   Ember.TEMPLATES['post'] = compile("<p>{{#unless model}}NOTHING{{/unless}}</p>");
 
@@ -425,7 +425,7 @@ test("{{render}} helper should render templates both with and without models", f
   });
 
   var PostController = EmberObjectController.extend();
-  container._registry.register('controller:post', PostController, {singleton: false});
+  container._registry.register('controller:post', PostController, { singleton: false });
 
   Ember.TEMPLATES['post'] = compile("<p>Title:{{title}}</p>");
 
@@ -487,7 +487,7 @@ test("{{render}} helper should link child controllers to the parent controller",
 
 test("{{render}} helper should be able to render a template again when it was removed", function() {
   var template = "<h1>HI</h1>{{outlet}}";
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     template: compile(template)
   });
@@ -518,7 +518,7 @@ test("{{render}} helper should be able to render a template again when it was re
 test("{{render}} works with dot notation", function() {
   var template = '<h1>BLOG</h1>{{render "blog.post"}}';
 
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   container._registry.register('controller:blog.post', EmberObjectController.extend());
 
   view = EmberView.create({
@@ -538,7 +538,7 @@ test("{{render}} works with dot notation", function() {
 test("{{render}} works with slash notation", function() {
   var template = '<h1>BLOG</h1>{{render "blog/post"}}';
 
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   container._registry.register('controller:blog.post', EmberObjectController.extend());
 
   view = EmberView.create({
@@ -560,7 +560,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 test("throws an assertion if {{render}} is called with an unquoted template name", function() {
   var template = '<h1>HI</h1>{{render home}}';
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -575,7 +575,7 @@ test("throws an assertion if {{render}} is called with an unquoted template name
 
 test("throws an assertion if {{render}} is called with a literal for a model", function() {
   var template = '<h1>HI</h1>{{render "home" "model"}}';
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)
@@ -594,7 +594,7 @@ test("throws an assertion if {{render}} is called with a literal for a model", f
 
 test("Using quoteless templateName works properly (DEPRECATED)", function() {
   var template = '<h1>HI</h1>{{render home}}';
-  var controller = EmberController.extend({container: container});
+  var controller = EmberController.extend({ container: container });
   view = EmberView.create({
     controller: controller.create(),
     template: compile(template)

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -28,8 +28,8 @@ DSL.prototype = {
 
     if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
       if (this.enableLoadingSubtates) {
-        createRoute(this, name + '_loading', {resetNamespace: options.resetNamespace});
-        createRoute(this, name + '_error', { path: "/_unused_dummy_error_path_route_" + name + "/:error"});
+        createRoute(this, name + '_loading', { resetNamespace: options.resetNamespace });
+        createRoute(this, name + '_error', { path: "/_unused_dummy_error_path_route_" + name + "/:error" });
       }
     }
 

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -42,7 +42,7 @@ test("default store utilizes the container to acquire the model factory", functi
   route.container = container;
   route.set('_qp', null);
 
-  equal(route.model({ post_id: 1}), post);
+  equal(route.model({ post_id: 1 }), post);
   equal(route.findModel('post', 1), post, '#findModel returns the correct post');
 
   function lookupFactory(fullName) {
@@ -79,7 +79,7 @@ test("'store' can be injected by data persistence frameworks", function() {
 
   route = container.lookup('route:index');
 
-  equal(route.model({ post_id: 1}), post, '#model returns the correct post');
+  equal(route.model({ post_id: 1 }), post, '#model returns the correct post');
   equal(route.findModel('post', 1), post, '#findModel returns the correct post');
 });
 
@@ -112,7 +112,7 @@ test("asserts if model class is not found", function() {
   route = container.lookup('route:index');
 
   expectAssertion(function() {
-    route.model({ post_id: 1});
+    route.model({ post_id: 1 });
   }, "You used the dynamic segment post_id in your route undefined, but undefined.Post did not exist and you did not override your route's `model` hook.");
 });
 
@@ -129,7 +129,7 @@ test("'store' does not need to be injected", function() {
   route = container.lookup('route:index');
 
   ignoreAssertion(function() {
-    route.model({ post_id: 1});
+    route.model({ post_id: 1 });
   });
 
   ok(true, 'no error was raised');
@@ -183,15 +183,15 @@ QUnit.module("Ember.Route serialize", {
 });
 
 test("returns the models properties if params does not include *_id", function() {
-  var model = {id: 2, firstName: 'Ned', lastName: 'Ryerson'};
+  var model = { id: 2, firstName: 'Ned', lastName: 'Ryerson' };
 
-  deepEqual(route.serialize(model, ['firstName', 'lastName']), {firstName: 'Ned', lastName: 'Ryerson'}, "serialized correctly");
+  deepEqual(route.serialize(model, ['firstName', 'lastName']), { firstName: 'Ned', lastName: 'Ryerson' }, "serialized correctly");
 });
 
 test("returns model.id if params include *_id", function() {
-  var model = {id: 2};
+  var model = { id: 2 };
 
-  deepEqual(route.serialize(model, ['post_id']), {post_id: 2}, "serialized correctly");
+  deepEqual(route.serialize(model, ['post_id']), { post_id: 2 }, "serialized correctly");
 });
 
 test("returns undefined if model is not set", function() {

--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -54,7 +54,7 @@ export function runLoadHooks(name, object) {
   loaded[name] = object;
 
   if (typeof window === 'object' && typeof window.dispatchEvent === 'function' && typeof CustomEvent === "function") {
-    var event = new CustomEvent(name, {detail: object, name: name});
+    var event = new CustomEvent(name, { detail: object, name: name });
     window.dispatchEvent(event);
   }
 

--- a/packages/ember-runtime/tests/computed/compose_computed_test.js
+++ b/packages/ember-runtime/tests/computed/compose_computed_test.js
@@ -117,7 +117,7 @@ if (Ember.FEATURES.isEnabled('composable-computed-properties')) {
         state: null,
         napTime: notSleepy
       });
-    var obj0 = Type0.create({ state: 'sleepy'});
+    var obj0 = Type0.create({ state: 'sleepy' });
     var obj1 = Type1.create({ state: 'sleepy' });
 
     equal(get(obj0, 'state'), 'sleepy');

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -34,7 +34,7 @@ QUnit.module('computedMap', {
     run(function() {
       userFnCalls = 0;
       obj = EmberObject.createWithMixins({
-        array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
+        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }]),
 
         mapped: computedMap('array.@each.v', function(item) {
           ++userFnCalls;
@@ -42,8 +42,8 @@ QUnit.module('computedMap', {
         }),
 
         arrayObjects: Ember.A([
-          EmberObject.create({ v: { name: 'Robert' }}),
-          EmberObject.create({ v: { name: 'Leanna' }})]),
+          EmberObject.create({ v: { name: 'Robert' } }),
+          EmberObject.create({ v: { name: 'Leanna' } })]),
         mappedObjects: computedMap('arrayObjects.@each.v', function (item) {
           return {
             name: item.v.name
@@ -82,7 +82,7 @@ test("it caches properly", function() {
   equal(userFnCalls, 4, "precond - mapper called expected number of times");
 
   run(function() {
-    array.addObject({v: 7});
+    array.addObject({ v: 7 });
   });
 
   equal(userFnCalls, 5, "precond - mapper called expected number of times");
@@ -129,10 +129,10 @@ test("it passes the index to the callback", function() {
 });
 
 test("it maps objects", function() {
-  deepEqual(get(obj, 'mappedObjects'), [{ name: 'Robert'}, { name: 'Leanna' }]);
+  deepEqual(get(obj, 'mappedObjects'), [{ name: 'Robert' }, { name: 'Leanna' }]);
 
   run(function() {
-    obj.get('arrayObjects').pushObject({ v: { name: 'Eddard' }});
+    obj.get('arrayObjects').pushObject({ v: { name: 'Eddard' } });
   });
 
   deepEqual(get(obj, 'mappedObjects'), [{ name: 'Robert' }, { name: 'Leanna' }, { name: 'Eddard' }]);
@@ -180,7 +180,7 @@ QUnit.module('computedMapBy', {
   setup: function() {
     run(function() {
       obj = EmberObject.createWithMixins({
-        array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
+        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }]),
         mapped: computedMapBy('array', 'v')
       });
     });
@@ -372,10 +372,10 @@ QUnit.module('computedFilterBy', {
   setup: function() {
     obj = EmberObject.createWithMixins({
       array: Ember.A([
-        {name: "one", a: 1, b: false},
-        {name: "two", a: 2, b: false},
-        {name: "three", a: 1, b: true},
-        {name: "four", b: true}
+        { name: "one", a: 1, b: false },
+        { name: "two", a: 2, b: false },
+        { name: "three", a: 1, b: true },
+        { name: "four", b: true }
       ]),
       a1s: computedFilterBy('array', 'a', 1),
       as: computedFilterBy('array', 'a'),
@@ -408,7 +408,7 @@ test("properties can be filtered by truthiness", function() {
   deepEqual(bs.mapBy('name'), ['one', 'three'], "arrays computed by filtered property respond to property changes");
 
   run(function() {
-    array.pushObject({name: "five", a: 6, b: true});
+    array.pushObject({ name: "five", a: 6, b: true });
   });
   deepEqual(as.mapBy('name'), ['two', 'three', 'four', 'five'], "arrays computed by filter property respond to added objects");
   deepEqual(bs.mapBy('name'), ['one', 'three', 'five'], "arrays computed by filtered property respond to added objects");
@@ -420,7 +420,7 @@ test("properties can be filtered by truthiness", function() {
   deepEqual(bs.mapBy('name'), ['one', 'three'], "arrays computed by filtered property respond to removed objects");
 
   run(function() {
-    set(obj, 'array', Ember.A([{name: "six", a: 12, b: true}]));
+    set(obj, 'array', Ember.A([{ name: "six", a: 12, b: true }]));
   });
   deepEqual(as.mapBy('name'), ['six'], "arrays computed by filter property respond to array changes");
   deepEqual(bs.mapBy('name'), ['six'], "arrays computed by filtered property respond to array changes");
@@ -460,7 +460,7 @@ test("properties values can be replaced", function() {
   deepEqual(a1bs.mapBy('name'), [], "properties can be filtered by matching value");
 
   run(function() {
-    set(obj, 'array', Ember.A([{name: 'item1', a: 1, b: true}]));
+    set(obj, 'array', Ember.A([{ name: 'item1', a: 1, b: true }]));
   });
 
   a1bs = get(obj, 'a1bs');
@@ -1371,9 +1371,9 @@ test("filtering and sorting can be combined", function() {
   deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime'], "precond - array is initially filtered and sorted");
 
   run(function() {
-    items.pushObject({fname: 'Tywin',   lname: 'Lannister'});
-    items.pushObject({fname: 'Lyanna',  lname: 'Stark'});
-    items.pushObject({fname: 'Gerion',  lname: 'Lannister'});
+    items.pushObject({ fname: 'Tywin',   lname: 'Lannister' });
+    items.pushObject({ fname: 'Lyanna',  lname: 'Stark' });
+    items.pushObject({ fname: 'Gerion',  lname: 'Lannister' });
   });
 
   deepEqual(sorted.mapBy('fname'), ['Cersei', 'Gerion', 'Jaime', 'Tywin'], "updates propagate to array");
@@ -1387,20 +1387,20 @@ test("filtering, sorting and reduce (max) can be combined", function() {
   equal(16, get(obj, 'oldestStarkAge'), "precond - end of chain is initially correct");
 
   run(function() {
-    items.pushObject({fname: 'Rickon', lname: 'Stark', age: 5});
+    items.pushObject({ fname: 'Rickon', lname: 'Stark', age: 5 });
   });
 
   equal(16, get(obj, 'oldestStarkAge'), "chain is updated correctly");
 
   run(function() {
-    items.pushObject({fname: 'Eddard', lname: 'Stark', age: 35});
+    items.pushObject({ fname: 'Eddard', lname: 'Stark', age: 35 });
   });
 
   equal(35, get(obj, 'oldestStarkAge'), "chain is updated correctly");
 });
 
 function todo(name, priority) {
-  return EmberObject.create({name: name, priority: priority});
+  return EmberObject.create({ name: name, priority: priority });
 }
 
 function priorityComparator(todoA, todoB) {
@@ -1466,7 +1466,7 @@ QUnit.module('Chaining array and reduced CPs', {
     run(function() {
       userFnCalls = 0;
       obj = EmberObject.createWithMixins({
-        array: Ember.A([{ v: 1 }, { v: 3}, { v: 2 }, { v: 1 }]),
+        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }]),
         mapped: computedMapBy('array', 'v'),
         max: computedMax('mapped'),
         maxDidChange: observer('max', function() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -249,7 +249,7 @@ test("multiple item property keys can be specified via brace expansion", functio
 test("doubly nested item property keys (@each.foo.@each) are not supported", function() {
   run(function() {
     obj = EmberObject.createWithMixins({
-      peopleByOrdinalPosition: Ember.A([{ first: Ember.A([EmberObject.create({ name: "Jaime Lannister" })])}]),
+      peopleByOrdinalPosition: Ember.A([{ first: Ember.A([EmberObject.create({ name: "Jaime Lannister" })]) }]),
       people: arrayComputed({
         addedItem: function (array, item) {
           array.pushObject(get(item, 'first.firstObject'));
@@ -270,7 +270,7 @@ test("doubly nested item property keys (@each.foo.@each) are not supported", fun
 
   throws(function() {
     obj = EmberObject.createWithMixins({
-      people: [{ first: Ember.A([EmberObject.create({ name: "Jaime Lannister" })])}],
+      people: [{ first: Ember.A([EmberObject.create({ name: "Jaime Lannister" })]) }],
       names: arrayComputed({
         addedItem: function (array, item) {
           array.pushObject(item);

--- a/packages/ember-runtime/tests/core/compare_test.js
+++ b/packages/ember-runtime/tests/core/compare_test.js
@@ -25,7 +25,7 @@ QUnit.module('Ember.compare()', {
     data[8]  = [1, 2];
     data[9]  = [1, 2, 3];
     data[10] = [1, 3];
-    data[11] = {a: 'hash'};
+    data[11] = { a: 'hash' };
     data[12] = EmberObject.create();
     data[13] = function (a) {return a;};
     data[14] = new Date('2012/01/01');

--- a/packages/ember-runtime/tests/core/copy_test.js
+++ b/packages/ember-runtime/tests/core/copy_test.js
@@ -4,7 +4,7 @@ import copy from "ember-runtime/copy";
 QUnit.module("Ember Copy Method");
 
 test("Ember.copy null", function() {
-  var obj = {field: null};
+  var obj = { field: null };
 
   equal(copy(obj, true).field, null, "null should still be null");
 });

--- a/packages/ember-runtime/tests/ext/function_test.js
+++ b/packages/ember-runtime/tests/ext/function_test.js
@@ -95,7 +95,7 @@ testBoth('sets up a ComputedProperty', function(get, set) {
     }.property('firstName', 'lastName')
   });
 
-  var obj = MyClass.create({firstName: 'Fred', lastName: 'Flinstone'});
+  var obj = MyClass.create({ firstName: 'Fred', lastName: 'Flinstone' });
   equal(get(obj, 'fullName'), 'Fred Flinstone', 'should return the computed value');
 
   set(obj, 'firstName', "Wilma");

--- a/packages/ember-runtime/tests/mixins/comparable_test.js
+++ b/packages/ember-runtime/tests/mixins/comparable_test.js
@@ -22,8 +22,8 @@ var r1, r2;
 QUnit.module("Comparable", {
 
   setup: function() {
-    r1 = Rectangle.create({length: 6, width: 12});
-    r2 = Rectangle.create({length: 6, width: 13});
+    r1 = Rectangle.create({ length: 6, width: 12 });
+    r2 = Rectangle.create({ length: 6, width: 13 });
   },
 
   teardown: function() {

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -36,7 +36,7 @@ test('should be able to use setProperties to set multiple properties at once', f
     companyName: "Apple, Inc."
   });
 
-  obj.setProperties({firstName: "Tim", lastName: "Cook"});
+  obj.setProperties({ firstName: "Tim", lastName: "Cook" });
   equal("Tim", obj.get("firstName"));
   equal("Cook", obj.get("lastName"));
 });

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -37,13 +37,13 @@ test("if you do not specify `sortProperties` sortable have no effect", function(
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Dale', 'array is in it natural order');
 
-  unsortedArray.pushObject({id: 4, name: 'Scumbag Chavard'});
+  unsortedArray.pushObject({ id: 4, name: 'Scumbag Chavard' });
 
   equal(sortedArrayController.get('length'), 4, 'array has 4 items');
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Chavard', 'a new object was inserted in the natural order');
 
   sortedArrayController.set('sortProperties', []);
-  unsortedArray.pushObject({id: 5, name: 'Scumbag Jackson'});
+  unsortedArray.pushObject({ id: 5, name: 'Scumbag Jackson' });
 
   equal(sortedArrayController.get('length'), 5, 'array has 5 items');
   equal(sortedArrayController.objectAt(4).name, 'Scumbag Jackson', 'a new object was inserted in the natural order with empty array as sortProperties');
@@ -181,12 +181,12 @@ test("sortable object will expose associated content in the right order", functi
 test("you can add objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
-  unsortedArray.pushObject({id: 4, name: 'Scumbag Chavard'});
+  unsortedArray.pushObject({ id: 4, name: 'Scumbag Chavard' });
 
   equal(sortedArrayController.get('length'), 4, 'array has 4 items');
   equal(sortedArrayController.objectAt(1).name, 'Scumbag Chavard', 'a new object added to content was inserted according to given constraint');
 
-  sortedArrayController.addObject({id: 5, name: 'Scumbag Fucs'});
+  sortedArrayController.addObject({ id: 5, name: 'Scumbag Fucs' });
 
   equal(sortedArrayController.get('length'), 5, 'array has 5 items');
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
@@ -195,12 +195,12 @@ test("you can add objects in sorted order", function() {
 test("you can push objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
-  unsortedArray.pushObject({id: 4, name: 'Scumbag Chavard'});
+  unsortedArray.pushObject({ id: 4, name: 'Scumbag Chavard' });
 
   equal(sortedArrayController.get('length'), 4, 'array has 4 items');
   equal(sortedArrayController.objectAt(1).name, 'Scumbag Chavard', 'a new object added to content was inserted according to given constraint');
 
-  sortedArrayController.pushObject({id: 5, name: 'Scumbag Fucs'});
+  sortedArrayController.pushObject({ id: 5, name: 'Scumbag Fucs' });
 
   equal(sortedArrayController.get('length'), 5, 'array has 5 items');
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
@@ -209,12 +209,12 @@ test("you can push objects in sorted order", function() {
 test("you can unshift objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
-  unsortedArray.unshiftObject({id: 4, name: 'Scumbag Chavard'});
+  unsortedArray.unshiftObject({ id: 4, name: 'Scumbag Chavard' });
 
   equal(sortedArrayController.get('length'), 4, 'array has 4 items');
   equal(sortedArrayController.objectAt(1).name, 'Scumbag Chavard', 'a new object added to content was inserted according to given constraint');
 
-  sortedArrayController.addObject({id: 5, name: 'Scumbag Fucs'});
+  sortedArrayController.addObject({ id: 5, name: 'Scumbag Fucs' });
 
   equal(sortedArrayController.get('length'), 5, 'array has 5 items');
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -118,7 +118,7 @@ test("it should use the target specified in the argument", function() {
         action: 'anEvent'
       });
 
-  ok(true === obj.triggerAction({target: targetObj}), "a valid target and action were specified");
+  ok(true === obj.triggerAction({ target: targetObj }), "a valid target and action were specified");
 });
 
 test("it should use the action specified in the argument", function() {
@@ -131,7 +131,7 @@ test("it should use the action specified in the argument", function() {
       }
     })
   });
-  ok(true === obj.triggerAction({action: 'anEvent'}), "a valid target and action were specified");
+  ok(true === obj.triggerAction({ action: 'anEvent' }), "a valid target and action were specified");
 });
 
 test("it should use the actionContext specified in the argument", function() {
@@ -146,7 +146,7 @@ test("it should use the actionContext specified in the argument", function() {
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction({actionContext: context}), "a valid target and action were specified");
+  ok(true === obj.triggerAction({ actionContext: context }), "a valid target and action were specified");
 });
 
 test("it should allow multiple arguments from actionContext", function() {
@@ -163,7 +163,7 @@ test("it should allow multiple arguments from actionContext", function() {
     action: 'anEvent'
   });
 
-  ok(true === obj.triggerAction({actionContext: [param1, param2]}), "a valid target and action were specified");
+  ok(true === obj.triggerAction({ actionContext: [param1, param2] }), "a valid target and action were specified");
 });
 
 test("it should use a null value specified in the actionContext argument", function() {
@@ -176,5 +176,5 @@ test("it should use a null value specified in the actionContext argument", funct
     }),
     action: 'anEvent'
   });
-  ok(true === obj.triggerAction({actionContext: null}), "a valid target and action were specified");
+  ok(true === obj.triggerAction({ actionContext: null }), "a valid target and action were specified");
 });

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -64,10 +64,10 @@ suite.test('should filter on second argument if provided', function() {
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 2}),
-    { name: 'obj3', foo: 2},
-    EmberObject.create({ name: 'obj4', foo: 3})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 2 }),
+    { name: 'obj3', foo: 2 },
+    EmberObject.create({ name: 'obj4', foo: 3 })
   ];
 
   obj = this.newObject(ary);
@@ -79,10 +79,10 @@ suite.test('should correctly filter null second argument', function() {
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: null}),
-    { name: 'obj3', foo: null},
-    EmberObject.create({ name: 'obj4', foo: 3})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: null }),
+    { name: 'obj3', foo: null },
+    EmberObject.create({ name: 'obj4', foo: 3 })
   ];
 
   obj = this.newObject(ary);
@@ -94,8 +94,8 @@ suite.test('should not return all objects on undefined second argument', functio
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 2})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 2 })
   ];
 
   obj = this.newObject(ary);
@@ -107,12 +107,12 @@ suite.test('should correctly filter explicit undefined second argument', functio
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 3}),
-    { name: 'obj3', foo: undefined},
-    EmberObject.create({ name: 'obj4', foo: undefined}),
-    { name: 'obj5'},
-    EmberObject.create({ name: 'obj6'})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 3 }),
+    { name: 'obj3', foo: undefined },
+    EmberObject.create({ name: 'obj4', foo: undefined }),
+    { name: 'obj5' },
+    EmberObject.create({ name: 'obj6' })
   ];
 
   obj = this.newObject(ary);
@@ -124,12 +124,12 @@ suite.test('should not match undefined properties without second argument', func
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 3}),
-    { name: 'obj3', foo: undefined},
-    EmberObject.create({ name: 'obj4', foo: undefined}),
-    { name: 'obj5'},
-    EmberObject.create({ name: 'obj6'})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 3 }),
+    { name: 'obj3', foo: undefined },
+    EmberObject.create({ name: 'obj4', foo: undefined }),
+    { name: 'obj5' },
+    EmberObject.create({ name: 'obj6' })
   ];
 
   obj = this.newObject(ary);

--- a/packages/ember-runtime/tests/suites/enumerable/mapBy.js
+++ b/packages/ember-runtime/tests/suites/enumerable/mapBy.js
@@ -5,12 +5,12 @@ var suite = SuiteModuleBuilder.create();
 suite.module('mapBy');
 
 suite.test('get value of each property', function() {
-  var obj = this.newObject([{a: 1},{a: 2}]);
+  var obj = this.newObject([{ a: 1 },{ a: 2 }]);
   equal(obj.mapBy('a').join(''), '12');
 });
 
 suite.test('should work also through getEach alias', function() {
-  var obj = this.newObject([{a: 1},{a: 2}]);
+  var obj = this.newObject([{ a: 1 },{ a: 2 }]);
   equal(obj.getEach('a').join(''), '12');
 });
 

--- a/packages/ember-runtime/tests/suites/enumerable/reject.js
+++ b/packages/ember-runtime/tests/suites/enumerable/reject.js
@@ -67,10 +67,10 @@ suite.test('should reject on second argument if provided', function() {
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 2}),
-    { name: 'obj3', foo: 2},
-    EmberObject.create({ name: 'obj4', foo: 3})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 2 }),
+    { name: 'obj3', foo: 2 },
+    EmberObject.create({ name: 'obj4', foo: 3 })
   ];
 
   obj = this.newObject(ary);
@@ -82,10 +82,10 @@ suite.test('should correctly reject null second argument', function() {
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: null}),
-    { name: 'obj3', foo: null},
-    EmberObject.create({ name: 'obj4', foo: 3})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: null }),
+    { name: 'obj3', foo: null },
+    EmberObject.create({ name: 'obj4', foo: 3 })
   ];
 
   obj = this.newObject(ary);
@@ -97,8 +97,8 @@ suite.test('should correctly reject undefined second argument', function() {
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 2})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 2 })
   ];
 
   obj = this.newObject(ary);
@@ -110,12 +110,12 @@ suite.test('should correctly reject explicit undefined second argument', functio
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 3}),
-    { name: 'obj3', foo: undefined},
-    EmberObject.create({ name: 'obj4', foo: undefined}),
-    { name: 'obj5'},
-    EmberObject.create({ name: 'obj6'})
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 3 }),
+    { name: 'obj3', foo: undefined },
+    EmberObject.create({ name: 'obj4', foo: undefined }),
+    { name: 'obj5' },
+    EmberObject.create({ name: 'obj6' })
   ];
 
   obj = this.newObject(ary);
@@ -127,12 +127,12 @@ suite.test('should match undefined, null, or false properties without second arg
   var obj, ary;
 
   ary = [
-    { name: 'obj1', foo: 3},
-    EmberObject.create({ name: 'obj2', foo: 3}),
-    { name: 'obj3', foo: undefined},
-    EmberObject.create({ name: 'obj4', foo: undefined}),
-    { name: 'obj5'},
-    EmberObject.create({ name: 'obj6'}),
+    { name: 'obj1', foo: 3 },
+    EmberObject.create({ name: 'obj2', foo: 3 }),
+    { name: 'obj3', foo: undefined },
+    EmberObject.create({ name: 'obj4', foo: undefined }),
+    { name: 'obj5' },
+    EmberObject.create({ name: 'obj6' }),
     { name: 'obj7', foo: null },
     EmberObject.create({ name: 'obj8', foo: null }),
     { name: 'obj9', foo: false },

--- a/packages/ember-runtime/tests/suites/enumerable/sortBy.js
+++ b/packages/ember-runtime/tests/suites/enumerable/sortBy.js
@@ -6,7 +6,7 @@ var suite = SuiteModuleBuilder.create();
 suite.module('sortBy');
 
 suite.test('sort by value of property', function() {
-  var obj = this.newObject([{a: 2},{a: 1}]);
+  var obj = this.newObject([{ a: 2 },{ a: 1 }]);
   var sorted = obj.sortBy('a');
 
   equal(get(sorted[0], 'a'), 1);
@@ -14,7 +14,7 @@ suite.test('sort by value of property', function() {
 });
 
 suite.test('supports multiple propertyNames', function() {
-  var obj = this.newObject([{a: 1, b: 2},{a: 1, b: 1}]);
+  var obj = this.newObject([{ a: 1, b: 2 }, { a: 1, b: 1 }]);
   var sorted = obj.sortBy('a', 'b');
 
   equal(get(sorted[0], 'b'), 1);

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -25,7 +25,7 @@ moduleOptions = {
 QUnit.module('EmberObject.create', moduleOptions);
 
 test("simple properties are set", function() {
-  var o = EmberObject.create({ohai: 'there'});
+  var o = EmberObject.create({ ohai: 'there' });
   equal(o.get('ohai'), 'there');
 });
 
@@ -37,7 +37,7 @@ test("calls computed property setters", function() {
     })
   });
 
-  var o = MyClass.create({foo: 'bar'});
+  var o = MyClass.create({ foo: 'bar' });
   equal(o.get('foo'), 'bar');
 });
 
@@ -50,7 +50,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       fooDidChange: observer('foo', function() {})
     });
 
-    var o = MyClass.create({foo: 'bar', bar: 'baz'});
+    var o = MyClass.create({ foo: 'bar', bar: 'baz' });
     equal(o.get('foo'), 'bar');
 
     // Catch IE8 where Object.getOwnPropertyDescriptor exists but only works on DOM elements
@@ -86,7 +86,7 @@ test("calls setUnknownProperty if defined", function() {
     }
   });
 
-  MyClass.create({foo: 'bar'});
+  MyClass.create({ foo: 'bar' });
   ok(setUnknownPropertyCalled, 'setUnknownProperty was called');
 });
 

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -48,15 +48,15 @@ testBoth("should proxy properties to content", function(get, set) {
   equal(get(content, 'lastName'), 'Huda', 'content should have new value from set on proxy');
   equal(get(proxy, 'lastName'), 'Huda', 'proxy should have new value from set on proxy');
 
-  set(proxy, 'content', {firstName: 'Yehuda', lastName: 'Katz'});
+  set(proxy, 'content', { firstName: 'Yehuda', lastName: 'Katz' });
 
   equal(get(proxy, 'firstName'), 'Yehuda', 'proxy should reflect updated content');
   equal(get(proxy, 'lastName'), 'Katz', 'proxy should reflect updated content');
 });
 
 testBoth("should work with watched properties", function(get, set) {
-  var content1 = {firstName: 'Tom', lastName: 'Dale'};
-  var content2 = {firstName: 'Yehuda', lastName: 'Katz'};
+  var content1 = { firstName: 'Tom', lastName: 'Dale' };
+  var content2 = { firstName: 'Yehuda', lastName: 'Katz' };
   var count = 0;
   var Proxy, proxy, last;
 
@@ -116,8 +116,8 @@ testBoth("should work with watched properties", function(get, set) {
 });
 
 test("set and get should work with paths", function () {
-  var content = {foo: {bar: 'baz'}};
-  var proxy = ObjectProxy.create({content: content});
+  var content = { foo: { bar: 'baz' } };
+  var proxy = ObjectProxy.create({ content: content });
   var count = 0;
 
   proxy.set('foo.bar', 'hello');
@@ -136,8 +136,8 @@ test("set and get should work with paths", function () {
 });
 
 testBoth("should transition between watched and unwatched strategies", function(get, set) {
-  var content = {foo: 'foo'};
-  var proxy = ObjectProxy.create({content: content});
+  var content = { foo: 'foo' };
+  var proxy = ObjectProxy.create({ content: content });
   var count = 0;
 
   function observer() {

--- a/packages/ember-runtime/tests/system/string/fmt_string_test.js
+++ b/packages/ember-runtime/tests/system/string/fmt_string_test.js
@@ -31,10 +31,10 @@ test("'%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four
   }
 });
 
-test("'data: %@'.fmt({id: 3}) => 'data: {id: 3}'", function() {
-  equal(fmt('data: %@', [{id: 3}]), 'data: {id: 3}');
+test("'data: %@'.fmt({ id: 3 }) => 'data: {id: 3}'", function() {
+  equal(fmt('data: %@', [{ id: 3 }]), 'data: {id: 3}');
   if (Ember.EXTEND_PROTOTYPES) {
-    equal('data: %@'.fmt({id: 3}), 'data: {id: 3}');
+    equal('data: %@'.fmt({ id: 3 }), 'data: {id: 3}');
   }
 });
 

--- a/packages/ember-testing/tests/adapters/qunit_test.js
+++ b/packages/ember-testing/tests/adapters/qunit_test.js
@@ -37,7 +37,7 @@ test("asyncEnd calls start", function() {
 });
 
 test("exception causes a failing assertion", function() {
-  var error = {err: 'hai'};
+  var error = { err: 'hai' };
   var originalOk = window.ok;
   try {
     window.ok = function(val, msg) {

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -220,7 +220,7 @@ test("Ember.Application#injectTestHelpers adds helpers to provided object.", fun
 });
 
 test("Ember.Application#removeTestHelpers resets the helperContainer's original values", function() {
-  var helpers = {visit: 'snazzleflabber'};
+  var helpers = { visit: 'snazzleflabber' };
 
   run(function() {
     App = EmberApplication.create();
@@ -640,7 +640,7 @@ QUnit.module("ember-testing pendingAjaxRequests", {
 
 test("pendingAjaxRequests is maintained for ajaxSend and ajaxComplete events", function() {
   equal(Test.pendingAjaxRequests, 0);
-  var xhr = {some: 'xhr'};
+  var xhr = { some: 'xhr' };
   jQuery(document).trigger('ajaxSend', xhr);
   equal(Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests was incremented');
   jQuery(document).trigger('ajaxComplete', xhr);
@@ -649,7 +649,7 @@ test("pendingAjaxRequests is maintained for ajaxSend and ajaxComplete events", f
 
 test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesting calls", function() {
   equal(Test.pendingAjaxRequests, 0);
-  var xhr = {some: 'xhr'};
+  var xhr = { some: 'xhr' };
   jQuery(document).trigger('ajaxSend', xhr);
   equal(Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests was incremented');
 
@@ -658,7 +658,7 @@ test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesti
   });
   equal(Test.pendingAjaxRequests, 0, 'Ember.Test.pendingAjaxRequests was reset');
 
-  var altXhr = {some: 'more xhr'};
+  var altXhr = { some: 'more xhr' };
   jQuery(document).trigger('ajaxSend', altXhr);
   equal(Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests was incremented');
   jQuery(document).trigger('ajaxComplete', xhr);
@@ -716,7 +716,7 @@ QUnit.module("ember-testing async router", {
             // should be enough.
             setTimeout(function() {
               run(function() {
-                resolve(EmberObject.create({firstName: 'Tom'}));
+                resolve(EmberObject.create({ firstName: 'Tom' }));
               });
             }, 20);
           });

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -88,8 +88,8 @@ test("template is bound to empty array of people", function() {
 test("template is bound to array of 2 people", function() {
   App.Person.find = function() {
     var people = Ember.A();
-    var first = App.Person.create({firstName: "x"});
-    var last = App.Person.create({firstName: "y"});
+    var first = App.Person.create({ firstName: "x" });
+    var last = App.Person.create({ firstName: "y" });
     run(people, people.pushObject, first);
     run(people, people.pushObject, last);
     return people;

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -536,7 +536,7 @@ test("should not render the emptyView if content is emptied and refilled in the 
 test("a array_proxy that backs an sorted array_controller that backs a collection view functions properly", function() {
 
   var array = Ember.A([{ name: "Other Katz" }]);
-  var arrayProxy = ArrayProxy.create({content: array});
+  var arrayProxy = ArrayProxy.create({ content: array });
 
   var sortedController = ArrayController.create({
     content: arrayProxy,

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -172,7 +172,7 @@ test("Calling sendAction when the action name is not a string raises an exceptio
 test("Calling sendAction on a component with a context", function() {
   set(component, 'playing', "didStartPlaying");
 
-  var testContext = {song: 'She Broke My Ember'};
+  var testContext = { song: 'She Broke My Ember' };
 
   component.sendAction('playing', testContext);
 
@@ -182,8 +182,8 @@ test("Calling sendAction on a component with a context", function() {
 test("Calling sendAction on a component with multiple parameters", function() {
   set(component, 'playing', "didStartPlaying");
 
-  var firstContext  = {song: 'She Broke My Ember'};
-  var secondContext = {song: 'My Achey Breaky Ember'};
+  var firstContext  = { song: 'She Broke My Ember' };
+  var secondContext = { song: 'My Achey Breaky Ember' };
 
   component.sendAction('playing', firstContext, secondContext);
 

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -621,8 +621,8 @@ test("should be able to modify childViews then rerender then modify again the Co
       buffer.push(this.label);
     }
   });
-  var one = Child.create({label: 'one'});
-  var two = Child.create({label: 'two'});
+  var one = Child.create({ label: 'one' });
+  var two = Child.create({ label: 'two' });
 
   run(function() {
     container.pushObject(one);
@@ -649,8 +649,8 @@ test("should be able to modify childViews then rerender again the ContainerView 
       buffer.push(this.label);
     }
   });
-  var one = Child.create({label: 'one'});
-  var two = Child.create({label: 'two'});
+  var one = Child.create({ label: 'one' });
+  var two = Child.create({ label: 'two' });
 
   run(function() {
     container.pushObject(one);

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -686,10 +686,10 @@ test("should be able to select an option and then reselect the prompt", function
 test("should be able to get the current selection's value", function() {
   run(function() {
     select.set('content', Ember.A([
-      {label: 'Yehuda Katz', value: 'wycats'},
-      {label: 'Tom Dale', value: 'tomdale'},
-      {label: 'Peter Wagenet', value: 'wagenet'},
-      {label: 'Erik Bryn', value: 'ebryn'}
+      { label: 'Yehuda Katz', value: 'wycats' },
+      { label: 'Tom Dale', value: 'tomdale' },
+      { label: 'Peter Wagenet', value: 'wagenet' },
+      { label: 'Erik Bryn', value: 'ebryn' }
     ]));
     select.set('optionLabelPath', 'content.label');
     select.set('optionValuePath', 'content.value');
@@ -701,13 +701,13 @@ test("should be able to get the current selection's value", function() {
 });
 
 test("should be able to set the current selection by value", function() {
-  var ebryn = {label: 'Erik Bryn', value: 'ebryn'};
+  var ebryn = { label: 'Erik Bryn', value: 'ebryn' };
 
   run(function() {
     select.set('content', Ember.A([
-      {label: 'Yehuda Katz', value: 'wycats'},
-      {label: 'Tom Dale', value: 'tomdale'},
-      {label: 'Peter Wagenet', value: 'wagenet'},
+      { label: 'Yehuda Katz', value: 'wycats' },
+      { label: 'Tom Dale', value: 'tomdale' },
+      { label: 'Peter Wagenet', value: 'wagenet' },
       ebryn
     ]));
     select.set('optionLabelPath', 'content.label');

--- a/packages/ember-views/tests/views/view/destroy_test.js
+++ b/packages/ember-views/tests/views/view/destroy_test.js
@@ -7,7 +7,7 @@ QUnit.module("Ember.View#destroy");
 test("should teardown viewName on parentView when childView is destroyed", function() {
   var viewName = "someChildView";
   var parentView = EmberView.create();
-  var childView = parentView.createChildView(EmberView, {viewName: viewName});
+  var childView = parentView.createChildView(EmberView, { viewName: viewName });
 
   equal(get(parentView, viewName), childView, "Precond - child view was registered on parent");
 

--- a/packages/ember-views/tests/views/view/layout_test.js
+++ b/packages/ember-views/tests/views/view/layout_test.js
@@ -24,7 +24,7 @@ QUnit.module("EmberView - Layout Functionality", {
 test("Layout views return throw if their layout cannot be found", function() {
   view = EmberView.create({
     layoutName: 'cantBeFound',
-    container: { lookup: function() { }}
+    container: { lookup: function() { } }
   });
 
   expectAssertion(function() {

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -24,7 +24,7 @@ QUnit.module("EmberView - Template Functionality", {
 test("Template views return throw if their template cannot be found", function() {
   view = EmberView.create({
     templateName: 'cantBeFound',
-    container: { lookup: function() { }}
+    container: { lookup: function() { } }
   });
 
   expectAssertion(function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -580,7 +580,7 @@ test("The {{link-to}} helper accepts string/numeric arguments", function() {
 
   App.FilterController = Ember.Controller.extend({
     filter: "unpopular",
-    repo: Ember.Object.create({owner: 'ember', name: 'ember.js'}),
+    repo: Ember.Object.create({ owner: 'ember', name: 'ember.js' }),
     post_id: 123
   });
   Ember.TEMPLATES.filter = compile('<p>{{filter}}</p>{{#link-to "filter" "unpopular" id="link"}}Unpopular{{/link-to}}{{#link-to "filter" filter id="path-link"}}Unpopular{{/link-to}}{{#link-to "post" post_id id="post-path-link"}}Post{{/link-to}}{{#link-to "post" 123 id="post-number-link"}}Post{{/link-to}}{{#link-to "repo" repo id="repo-object-link"}}Repo{{/link-to}}');
@@ -815,8 +815,8 @@ test("The {{link-to}} helper refreshes href element when one of params changes",
     this.route('post', { path: '/posts/:post_id' });
   });
 
-  var post = Ember.Object.create({id: '1'});
-  var secondPost = Ember.Object.create({id: '2'});
+  var post = Ember.Object.create({ id: '1' });
+  var secondPost = Ember.Object.create({ id: '2' });
 
   Ember.TEMPLATES.index = compile('{{#link-to "post" post id="post"}}post{{/link-to}}');
 
@@ -845,8 +845,8 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
     this.route('post', { path: '/posts/:post_id' });
   });
 
-  var post = Ember.Object.create({id: '1'});
-  var secondPost = Ember.Object.create({id: '2'});
+  var post = Ember.Object.create({ id: '1' });
+  var secondPost = Ember.Object.create({ id: '2' });
 
   Ember.TEMPLATES = {
     index: compile(' '),
@@ -1172,11 +1172,11 @@ test("the {{link-to}} helper does not throw an error if its route has exited", f
   });
 
   App.PostController = Ember.Controller.extend({
-    model: {id: 1}
+    model: { id: 1 }
   });
 
   Router.map(function() {
-    this.route("post", {path: 'post/:post_id'});
+    this.route("post", { path: 'post/:post_id' });
   });
 
   bootApplication();

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -132,7 +132,7 @@ test("The Home page and the Camelot page with multiple Router.map calls", functi
   });
 
   Router.map(function() {
-    this.route("camelot", {path: "/camelot"});
+    this.route("camelot", { path: "/camelot" });
   });
 
   App.HomeRoute = Ember.Route.extend({
@@ -258,7 +258,7 @@ test("The template will pull in an alternate controller via key/value", function
 
   App.HomepageRoute = Ember.Route.extend({
     renderTemplate: function() {
-      this.render({controller: 'home'});
+      this.render({ controller: 'home' });
     }
   });
 
@@ -297,13 +297,13 @@ test("Model passed via renderTemplate model is set as controller's model", funct
   App.BioController = Ember.ObjectController.extend();
 
   Router.map(function() {
-    this.route('home', { path: '/'});
+    this.route('home', { path: '/' });
   });
 
   App.HomeRoute = Ember.Route.extend({
     renderTemplate: function() {
       this.render('bio', {
-        model: {name: 'emberjs'}
+        model: { name: 'emberjs' }
       });
     }
   });
@@ -344,7 +344,7 @@ test("Renders the view given in the view option", function() {
 
   App.HomeRoute = Ember.Route.extend({
     renderTemplate: function() {
-      this.render({view: 'homePage'});
+      this.render({ view: 'homePage' });
     }
   });
 
@@ -1570,7 +1570,7 @@ test("Route inherits model from parent route", function() {
     this.resource("the_post", { path: "/posts/:post_id" }, function() {
       this.route("comments");
 
-      this.resource("shares", { path: "/shares/:share_id"}, function() {
+      this.resource("shares", { path: "/shares/:share_id" }, function() {
         this.route("share");
       });
     });
@@ -2059,7 +2059,7 @@ test("Parent route context change", function() {
 
   App.PostRoute = Ember.Route.extend({
     model: function(params) {
-      return {id: params.postId};
+      return { id: params.postId };
     },
 
     actions: {
@@ -2090,7 +2090,7 @@ test("Parent route context change", function() {
   });
 
   Ember.run(function() {
-    router.send('showPost', {id: '2'});
+    router.send('showPost', { id: '2' });
   });
 
   Ember.run(function() {
@@ -2340,7 +2340,7 @@ test("The template is not re-rendered when the route's context changes", functio
 
   App.PageRoute = Ember.Route.extend({
     model: function(params) {
-      return Ember.Object.create({name: params.name});
+      return Ember.Object.create({ name: params.name });
     }
   });
 
@@ -2368,7 +2368,7 @@ test("The template is not re-rendered when the route's context changes", functio
   equal(insertionCount, 1, "view should have inserted only once");
 
   Ember.run(function() {
-    router.transitionTo('page', Ember.Object.create({name: 'third'}));
+    router.transitionTo('page', Ember.Object.create({ name: 'third' }));
   });
 
   equal(Ember.$('p', '#qunit-fixture').text(), "third");
@@ -2592,7 +2592,7 @@ test("Route supports clearing outlet explicitly", function() {
         });
       },
       hideModal: function() {
-        this.disconnectOutlet({outlet: 'modal', parentView: 'application'});
+        this.disconnectOutlet({ outlet: 'modal', parentView: 'application' });
       }
     }
   });
@@ -2605,7 +2605,7 @@ test("Route supports clearing outlet explicitly", function() {
         });
       },
       hideExtra: function() {
-        this.disconnectOutlet({parentView: 'posts/index'});
+        this.disconnectOutlet({ parentView: 'posts/index' });
       }
     }
   });
@@ -2708,13 +2708,13 @@ test("Route silently fails when cleaning an outlet from an inactive view", funct
   App.PostsRoute = Ember.Route.extend({
     actions: {
       hideSelf: function() {
-        this.disconnectOutlet({outlet: 'main', parentView: 'application'});
+        this.disconnectOutlet({ outlet: 'main', parentView: 'application' });
       },
       showModal: function() {
-        this.render('modal', {into: 'posts', outlet: 'modal'});
+        this.render('modal', { into: 'posts', outlet: 'modal' });
       },
       hideModal: function() {
-        this.disconnectOutlet({outlet: 'modal', parentView: 'posts'});
+        this.disconnectOutlet({ outlet: 'modal', parentView: 'posts' });
       }
     }
   });
@@ -3137,7 +3137,7 @@ test("rejecting the model hooks promise with a non-error prints the `message` pr
 
   App.YippieRoute = Ember.Route.extend({
     model: function() {
-      return Ember.RSVP.reject({message: rejectedMessage, stack: rejectedStack});
+      return Ember.RSVP.reject({ message: rejectedMessage, stack: rejectedStack });
     }
   });
 
@@ -3226,7 +3226,7 @@ test("Errors in transitionTo within redirect hook are logged", function() {
 
   App.YondoRoute = Ember.Route.extend({
     redirect: function() {
-      this.transitionTo('stink-bomb', {something: 'goes boom'});
+      this.transitionTo('stink-bomb', { something: 'goes boom' });
     }
   });
 
@@ -3252,7 +3252,7 @@ test("Errors in transition show error template if available", function() {
 
   App.YondoRoute = Ember.Route.extend({
     redirect: function() {
-      this.transitionTo('stink-bomb', {something: 'goes boom'});
+      this.transitionTo('stink-bomb', { something: 'goes boom' });
     }
   });
 
@@ -3344,7 +3344,7 @@ test("Exception during load of non-initial route is not swallowed", function() {
 
 test("Exception during initialization of initial route is not swallowed", function() {
   Router.map(function() {
-    this.route('boom', {path: '/'});
+    this.route('boom', { path: '/' });
   });
   App.BoomRoute = Ember.Route.extend({
     init: function() {
@@ -3358,7 +3358,7 @@ test("Exception during initialization of initial route is not swallowed", functi
 
 test("Exception during load of initial route is not swallowed", function() {
   Router.map(function() {
-    this.route('boom', {path: '/'});
+    this.route('boom', { path: '/' });
   });
   var lookup = container.lookup;
   container.lookup = function() {

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -518,7 +518,7 @@ test("Use Ember.get to retrieve query params 'refreshModel' configuration", func
   App.IndexRoute = Ember.Route.extend({
     queryParams: Ember.Object.create({
       unknownProperty: function(keyName) {
-        return {refreshModel: true};
+        return { refreshModel: true };
       }
     }),
     model: function(params) {


### PR DESCRIPTION
Related to #9849, #10072

Do you want all or nested mode?

Valid for mode "all"
`var x = {a: {b: 1}};`

Valid for mode "nested"
`var x = { a: {b: 1} };`

Invalid
`var x = { a: { b: 1 } };`
