### PR TITLE
Requires commas as last token on a line in lists.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -5,6 +5,7 @@
   "disallowSpacesInsideArrayBrackets": "all",
   "disallowMultipleVarDeclWithAssignment": true,
   "requireSpaceBeforeObjectValues": true,
+  "requireCommaBeforeLineBreak": true,
   "requireBlocksOnNewline": 1,
   "disallowKeywordsOnNewLine": ["else"],
   "disallowSpacesBeforeSemicolons": true,


### PR DESCRIPTION
i.e:

``` javascript
// bad
var x = {
  one: 1
  , two: 2
};

// good
var x = {
  one: 1,
  two: 2
};
```
