### PR TITLE
Disallows spaces inside round braces when calling a function

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -17,6 +17,7 @@
     "beforeAlternate": true
   },
   "disallowSpacesInCallExpression": true,
+  "disallowSpacesInsideRoundBracesInCallExpression": true,
   "disallowEmptyBlocks": true,
   "requireSpacesInsideObjectBrackets": "all",
   "requireCurlyBraces": [

--- a/lib/jscs-rules/disallow-space-inside-round-braces-in-call-expression.js
+++ b/lib/jscs-rules/disallow-space-inside-round-braces-in-call-expression.js
@@ -1,0 +1,76 @@
+var assert = require('assert');
+
+function spaceAfterBrace(arg, braceToken) {
+  if (arg) {
+    var supportedArgs = arg.type !== 'UnaryExpression' && arg.type !== 'BinaryExpression';
+
+    return supportedArgs && braceToken.value === '(' && braceToken.range[1] + 1 === arg.range[0];
+  }
+
+  return false;
+}
+
+function spaceBeforeBrace(arg, braceToken) {
+  if (arg) {
+    var supportedArgs = arg.type !== 'UnaryExpression' && arg.type !== 'BinaryExpression';
+
+    return supportedArgs && braceToken.value === ')' && braceToken.range[0] === arg.range[1] + 1;
+  }
+
+  return false;
+}
+
+module.exports = function() {};
+
+module.exports.prototype = {
+  configure: function(requireSpacesInsideRoundBracesInCallExpression) {
+    assert(
+      requireSpacesInsideRoundBracesInCallExpression === true,
+      'disallowSpacesInsideRoundBracesInCallExpression option requires true value or should be removed'
+    );
+  },
+
+  getOptionName: function() {
+    return 'disallowSpacesInsideRoundBracesInCallExpression';
+  },
+
+  check: function(file, errors) {
+    var tokens = file.getTokens();
+
+    file.iterateNodesByType('CallExpression', function(node) {
+      var nodeBeforeRoundBrace = node;
+
+      if (node.callee) {
+        nodeBeforeRoundBrace = node.callee;
+      }
+
+      var roundBraceTokenStart = file.getTokenByRangeStart(nodeBeforeRoundBrace.range[0]);
+      var roundBraceTokenEnd   = file.getTokenByRangeStart(nodeBeforeRoundBrace.range[0]);
+
+      do {
+        roundBraceTokenStart = file.findNextToken(roundBraceTokenStart, 'Punctuator', '(');
+        roundBraceTokenEnd   = file.findNextToken(roundBraceTokenEnd, 'Punctuator', ')');
+      } while (roundBraceTokenStart.range[0] < nodeBeforeRoundBrace.range[1]);
+
+      var firstArg = nodeBeforeRoundBrace.parentNode.arguments[0];
+      var lastArg  = nodeBeforeRoundBrace.parentNode.arguments[nodeBeforeRoundBrace.parentNode.arguments.length - 1];
+
+      var spaceAfterOpeningRoundBraceExists  = spaceAfterBrace(firstArg, roundBraceTokenStart);
+      var spaceBeforeClosingRoundBraceExists = spaceBeforeBrace(lastArg, roundBraceTokenEnd);
+
+      if (spaceAfterOpeningRoundBraceExists) {
+        errors.add(
+          'Illegal space after opening round brace',
+          roundBraceTokenStart.loc.start
+        );
+      }
+
+      if (spaceBeforeClosingRoundBraceExists) {
+        errors.add(
+          'Illegal space before closing round brace',
+          roundBraceTokenEnd.loc.start
+        );
+      }
+    });
+  }
+};

--- a/packages/ember-htmlbars/lib/system/bootstrap.js
+++ b/packages/ember-htmlbars/lib/system/bootstrap.js
@@ -65,7 +65,7 @@ function bootstrap(ctx) {
 }
 
 function _bootstrap() {
-  bootstrap( jQuery(document) );
+  bootstrap(jQuery(document));
 }
 
 function registerComponentLookup(registry) {

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -50,9 +50,9 @@ for (var i=0, l=badTags.length; i<l; i++) {
       });
       runAppend(view);
 
-      equal( view.element.firstChild.getAttribute(subject.attr),
+      equal(view.element.firstChild.getAttribute(subject.attr),
              "unsafe:javascript://example.com",
-             "attribute is output" );
+             "attribute is output");
     });
 
     test(subject.tag +" "+subject.attr+" is sanitized when using quoted non-whitelisted protocol", function() {
@@ -62,9 +62,9 @@ for (var i=0, l=badTags.length; i<l; i++) {
       });
       runAppend(view);
 
-      equal( view.element.firstChild.getAttribute(subject.attr),
+      equal(view.element.firstChild.getAttribute(subject.attr),
              "unsafe:javascript://example.com",
-             "attribute is output" );
+             "attribute is output");
     });
 
     test(subject.tag +" "+subject.attr+" is not sanitized when using non-whitelisted protocol with a SafeString", function() {
@@ -76,9 +76,9 @@ for (var i=0, l=badTags.length; i<l; i++) {
       try {
         runAppend(view);
 
-        equal( view.element.firstChild.getAttribute(subject.attr),
+        equal(view.element.firstChild.getAttribute(subject.attr),
                "javascript://example.com",
-               "attribute is output" );
+               "attribute is output");
       } catch(e) {
         // IE does not allow javascript: to be set on img src
         ok(true, 'caught exception '+e);
@@ -92,9 +92,9 @@ for (var i=0, l=badTags.length; i<l; i++) {
       });
       runAppend(view);
 
-      equal( view.element.firstChild.getAttribute(subject.attr),
+      equal(view.element.firstChild.getAttribute(subject.attr),
              "unsafe:javascript://example.com",
-             "attribute is output" );
+             "attribute is output");
     });
 
   })(); //jshint ignore:line

--- a/packages/ember-htmlbars/tests/helpers/sanitized_bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/sanitized_bind_attr_test.js
@@ -39,9 +39,9 @@ for (var i=0, l=badTags.length; i<l; i++) {
 
       runAppend(view);
 
-      equal( view.element.firstChild.getAttribute(attr),
+      equal(view.element.firstChild.getAttribute(attr),
              "unsafe:javascript:alert('XSS')",
-             "attribute is output" );
+             "attribute is output");
     });
 
     test("XSS - should not bind unsafe "+tagName+" "+attr+" values on rerender", function() {
@@ -52,15 +52,15 @@ for (var i=0, l=badTags.length; i<l; i++) {
 
       runAppend(view);
 
-      equal( view.element.firstChild.getAttribute(attr),
+      equal(view.element.firstChild.getAttribute(attr),
              "/sunshine/and/rainbows",
-             "attribute is output" );
+             "attribute is output");
 
       run(view, 'set', 'badValue', "javascript:alert('XSS')");
 
-      equal( view.element.firstChild.getAttribute(attr),
+      equal(view.element.firstChild.getAttribute(attr),
              "unsafe:javascript:alert('XSS')",
-             "attribute is output" );
+             "attribute is output");
     });
 
     test("should bind unsafe "+tagName+" "+attr+" values if they are SafeString", function() {
@@ -72,9 +72,9 @@ for (var i=0, l=badTags.length; i<l; i++) {
       try {
         runAppend(view);
 
-        equal( view.element.firstChild.getAttribute(attr),
+        equal(view.element.firstChild.getAttribute(attr),
                "javascript:alert('XSS')",
-               "attribute is output" );
+               "attribute is output");
       } catch(e) {
         // IE does not allow javascript: to be set on img src
         ok(true, 'caught exception '+e);

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -15,7 +15,7 @@ var view, registry, container;
 function registerRepeatHelper() {
   registry.register('helper:x-repeat', makeBoundHelper(function(params, hash, options, env) {
     var times = hash.times || 1;
-    return new Array(times + 1).join( params[0] );
+    return new Array(times + 1).join(params[0]);
   }));
 }
 

--- a/packages/ember-metal/tests/accessors/isGlobalPath_test.js
+++ b/packages/ember-metal/tests/accessors/isGlobalPath_test.js
@@ -3,16 +3,16 @@ import { isGlobalPath } from "ember-metal/binding";
 QUnit.module('Ember.isGlobalPath');
 
 test("global path's are recognized", function() {
-  ok( isGlobalPath('App.myProperty') );
-  ok( isGlobalPath('App.myProperty.subProperty') );
+  ok(isGlobalPath('App.myProperty'));
+  ok(isGlobalPath('App.myProperty.subProperty'));
 });
 
 test("if there is a 'this' in the path, it's not a global path", function() {
-  ok( !isGlobalPath('this.myProperty') );
-  ok( !isGlobalPath('this') );
+  ok(!isGlobalPath('this.myProperty'));
+  ok(!isGlobalPath('this'));
 });
 
 test("if the path starts with a lowercase character, it is not a global path", function() {
-  ok( !isGlobalPath('myObj') );
-  ok( !isGlobalPath('myObj.SecondProperty') );
+  ok(!isGlobalPath('myObj'));
+  ok(!isGlobalPath('myObj.SecondProperty'));
 });

--- a/packages/ember-metal/tests/error_test.js
+++ b/packages/ember-metal/tests/error_test.js
@@ -1,9 +1,9 @@
 QUnit.module("Ember Error Throwing");
 
 test("new Ember.Error displays provided message", function() {
-  raises( function() {
+  raises(function() {
     throw new Ember.Error('A Message');
   }, function(e) {
     return e.message === 'A Message';
-  }, 'the assigned message was displayed' );
+  }, 'the assigned message was displayed');
 });

--- a/packages/ember-metal/tests/utils/generate_guid_test.js
+++ b/packages/ember-metal/tests/utils/generate_guid_test.js
@@ -5,5 +5,5 @@ QUnit.module("Ember.generateGuid");
 test("Prefix", function() {
   var a = {};
 
-  ok( generateGuid(a, 'tyrell').indexOf('tyrell') > -1, "guid can be prefixed" );
+  ok(generateGuid(a, 'tyrell').indexOf('tyrell') > -1, "guid can be prefixed");
 });

--- a/packages/ember-metal/tests/utils/guidFor_test.js
+++ b/packages/ember-metal/tests/utils/guidFor_test.js
@@ -5,25 +5,25 @@ import {
 QUnit.module("guidFor");
 
 var sameGuid = function(a, b, message) {
-  equal( guidFor(a), guidFor(b), message );
+  equal(guidFor(a), guidFor(b), message);
 };
 
 var diffGuid = function(a, b, message) {
-  ok( guidFor(a) !== guidFor(b), message);
+  ok(guidFor(a) !== guidFor(b), message);
 };
 
 var nanGuid = function(obj) {
   var type = typeof obj;
-  ok( isNaN(parseInt(guidFor(obj), 0)), "guids for " + type + "don't parse to numbers");
+  ok(isNaN(parseInt(guidFor(obj), 0)), "guids for " + type + "don't parse to numbers");
 };
 
 test("Object", function() {
   var a = {};
   var b = {};
 
-  sameGuid( a, a, "same object always yields same guid" );
-  diffGuid( a, b, "different objects yield different guids" );
-  nanGuid( a );
+  sameGuid(a, a, "same object always yields same guid");
+  diffGuid(a, b, "different objects yield different guids");
+  nanGuid(a);
 });
 
 test("strings", function() {
@@ -31,10 +31,10 @@ test("strings", function() {
   var aprime = "string A";
   var b = "String B";
 
-  sameGuid( a, a,      "same string always yields same guid" );
-  sameGuid( a, aprime, "identical strings always yield the same guid" );
-  diffGuid( a, b,      "different strings yield different guids" );
-  nanGuid( a );
+  sameGuid(a, a,      "same string always yields same guid");
+  sameGuid(a, aprime, "identical strings always yield the same guid");
+  diffGuid(a, b,      "different strings yield different guids");
+  nanGuid(a);
 });
 
 test("numbers", function() {
@@ -42,10 +42,10 @@ test("numbers", function() {
   var aprime = 23;
   var b = 34;
 
-  sameGuid( a, a,      "same numbers always yields same guid" );
-  sameGuid( a, aprime, "identical numbers always yield the same guid" );
-  diffGuid( a, b,      "different numbers yield different guids" );
-  nanGuid( a );
+  sameGuid(a, a,      "same numbers always yields same guid");
+  sameGuid(a, aprime, "identical numbers always yield the same guid");
+  diffGuid(a, b,      "different numbers yield different guids");
+  nanGuid(a);
 });
 
 test("numbers", function() {
@@ -53,11 +53,11 @@ test("numbers", function() {
   var aprime = true;
   var b = false;
 
-  sameGuid( a, a,      "same booleans always yields same guid" );
-  sameGuid( a, aprime, "identical booleans always yield the same guid" );
-  diffGuid( a, b,      "different boolean yield different guids" );
-  nanGuid( a );
-  nanGuid( b );
+  sameGuid(a, a,      "same booleans always yields same guid");
+  sameGuid(a, aprime, "identical booleans always yield the same guid");
+  diffGuid(a, b,      "different boolean yield different guids");
+  nanGuid(a);
+  nanGuid(b);
 });
 
 test("null and undefined", function() {
@@ -65,12 +65,12 @@ test("null and undefined", function() {
   var aprime = null;
   var b;
 
-  sameGuid( a, a,      "null always returns the same guid" );
-  sameGuid( b, b,      "undefined always returns the same guid" );
-  sameGuid( a, aprime, "different nulls return the same guid" );
-  diffGuid( a, b,      "null and undefined return different guids" );
-  nanGuid( a );
-  nanGuid( b );
+  sameGuid(a, a,      "null always returns the same guid");
+  sameGuid(b, b,      "undefined always returns the same guid");
+  sameGuid(a, aprime, "different nulls return the same guid");
+  diffGuid(a, b,      "null and undefined return different guids");
+  nanGuid(a);
+  nanGuid(b);
 });
 
 test("arrays", function() {
@@ -78,9 +78,8 @@ test("arrays", function() {
   var aprime = ["a", "b", "c"];
   var b = ["1", "2", "3"];
 
-  sameGuid( a, a,      "same instance always yields same guid" );
-  diffGuid( a, aprime, "identical arrays always yield the same guid" );
-  diffGuid( a, b,      "different arrays yield different guids" );
-  nanGuid( a );
+  sameGuid(a, a,      "same instance always yields same guid");
+  diffGuid(a, aprime, "identical arrays always yield the same guid");
+  diffGuid(a, b,      "different arrays yield different guids");
+  nanGuid(a);
 });
-

--- a/packages/ember-metal/tests/utils/is_array_test.js
+++ b/packages/ember-metal/tests/utils/is_array_test.js
@@ -12,12 +12,12 @@ test("Ember.isArray", function() {
   var length        = { length: 12 };
   var fn            = function() {};
 
-  equal( isArray(numarray), true,  "[1,2,3]" );
-  equal( isArray(number),   false, "23" );
-  equal( isArray(strarray), true,  '["Hello", "Hi"]' );
-  equal( isArray(string),   false, '"Hello"' );
-  equal( isArray(object),   false, "{}" );
-  equal( isArray(length),   true,  "{ length: 12 }" );
-  equal( isArray(global),   false, "global" );
-  equal( isArray(fn),       false, "function() {}" );
+  equal(isArray(numarray), true,  "[1,2,3]");
+  equal(isArray(number),   false, "23");
+  equal(isArray(strarray), true,  '["Hello", "Hi"]');
+  equal(isArray(string),   false, '"Hello"');
+  equal(isArray(object),   false, "{}");
+  equal(isArray(length),   true,  "{ length: 12 }");
+  equal(isArray(global),   false, "global");
+  equal(isArray(fn),       false, "function() {}");
 });

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -11,23 +11,23 @@ test("Ember.typeOf", function() {
   var error       = new Error('boum');
   var object      = { a: 'b' };
 
-  equal( typeOf(),            'undefined',  "undefined");
-  equal( typeOf(null),        'null',       "null");
-  equal( typeOf('Cyril'),     'string',     "Cyril");
-  equal( typeOf(101),         'number',     "101");
-  equal( typeOf(true),        'boolean',    "true");
-  equal( typeOf([1,2,90]),    'array',      "[1,2,90]");
-  equal( typeOf(/abc/),       'regexp',     "/abc/");
-  equal( typeOf(date),        'date',       "new Date()");
-  equal( typeOf(mockedDate),  'date',       "mocked date");
-  equal( typeOf(error),       'error',      "error");
-  equal( typeOf(object),      'object',     "object");
+  equal(typeOf(),            'undefined',  "undefined");
+  equal(typeOf(null),        'null',       "null");
+  equal(typeOf('Cyril'),     'string',     "Cyril");
+  equal(typeOf(101),         'number',     "101");
+  equal(typeOf(true),        'boolean',    "true");
+  equal(typeOf([1,2,90]),    'array',      "[1,2,90]");
+  equal(typeOf(/abc/),       'regexp',     "/abc/");
+  equal(typeOf(date),        'date',       "new Date()");
+  equal(typeOf(mockedDate),  'date',       "mocked date");
+  equal(typeOf(error),       'error',      "error");
+  equal(typeOf(object),      'object',     "object");
 
   if (Ember.Object) {
     var klass       = Ember.Object.extend();
     var instance    = Ember.Object.create();
 
-    equal( typeOf(klass),     'class',      "class");
-    equal( typeOf(instance),  'instance',   "instance");
+    equal(typeOf(klass),     'class',      "class");
+    equal(typeOf(instance),  'instance',   "instance");
   }
 });

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -387,7 +387,7 @@ function ChangeMeta(dependentArray, item, index, propertyName, property, changed
 
 function addItems(dependentArray, callbacks, cp, propertyName, meta) {
   forEach(dependentArray, function (item, index) {
-    meta.setValue( callbacks.addedItem.call(
+    meta.setValue(callbacks.addedItem.call(
       this, meta.getValue(), item, new ChangeMeta(dependentArray, item, index, propertyName, cp, dependentArray.length), meta.sugarMeta));
   }, this);
   callbacks.flushedChanges.call(this, meta.getValue(), meta.sugarMeta);

--- a/packages/ember-runtime/tests/core/isEqual_test.js
+++ b/packages/ember-runtime/tests/core/isEqual_test.js
@@ -3,31 +3,31 @@ import {isEqual} from "ember-runtime/core";
 QUnit.module("isEqual");
 
 test("undefined and null", function() {
-  ok(  isEqual(undefined, undefined), "undefined is equal to undefined" );
-  ok( !isEqual(undefined, null),      "undefined is not equal to null" );
-  ok(  isEqual(null, null),           "null is equal to null" );
-  ok( !isEqual(null, undefined),      "null is not equal to undefined" );
+  ok(isEqual(undefined, undefined), "undefined is equal to undefined");
+  ok(!isEqual(undefined, null),      "undefined is not equal to null");
+  ok(isEqual(null, null),           "null is equal to null");
+  ok(!isEqual(null, undefined),      "null is not equal to undefined");
 });
 
 test("strings should be equal", function() {
-  ok( !isEqual("Hello", "Hi"),    "different Strings are unequal" );
-  ok(  isEqual("Hello", "Hello"), "same Strings are equal" );
+  ok(!isEqual("Hello", "Hi"),    "different Strings are unequal");
+  ok(isEqual("Hello", "Hello"), "same Strings are equal");
 });
 
 test("numericals should be equal", function() {
-  ok(  isEqual(24, 24), "same numbers are equal" );
-  ok( !isEqual(24, 21), "different numbers are inequal" );
+  ok(isEqual(24, 24), "same numbers are equal");
+  ok(!isEqual(24, 21), "different numbers are inequal");
 });
 
 test("dates should be equal", function() {
-  ok(  isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), "same dates are equal" );
-  ok( !isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), "different dates are not equal" );
+  ok(isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), "same dates are equal");
+  ok(!isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), "different dates are not equal");
 });
 
 test("array should be equal", function() {
   // NOTE: We don't test for array contents -- that would be too expensive.
-  ok( !isEqual( [1,2], [1,2] ), 'two array instances with the same values should not be equal' );
-  ok( !isEqual( [1,2], [1] ),   'two array instances with different values should not be equal' );
+  ok(!isEqual([1,2], [1,2]), 'two array instances with the same values should not be equal');
+  ok(!isEqual([1,2], [1]),   'two array instances with different values should not be equal');
 });
 
 test("first object implements isEqual should use it", function() {

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -97,7 +97,7 @@ test("should indicate that the property of an object has just changed", function
   ObjectA.propertyWillChange('foo');
 
   //Value of the prop is unchanged yet as this will be changed when foo changes
-  equal(ObjectA.prop, 'propValue' );
+  equal(ObjectA.prop, 'propValue');
 
   //change the value of foo.
   ObjectA.set('foo', 'changeFooValue');

--- a/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -57,13 +57,12 @@ test("Should allow changing of those properties by calling EmberObject#set", fun
   equal(get(obj, 'foo'), 'bar');
   equal(get(obj, 'total'), 12345);
 
-  set(obj,  'foo', 'Chunky Bacon' );
-  set(obj,  'total', 12 );
+  set(obj,  'foo', 'Chunky Bacon');
+  set(obj,  'total', 12);
 
   equal(get(obj, 'foo'), 'Chunky Bacon');
   equal(get(obj, 'total'), 12);
 });
-
 
 QUnit.module("EmberObject observers", {
   setup: function() {
@@ -119,8 +118,6 @@ test("Global+Local observer works", function() {
   set(obj, "prop1", false);
   equal(obj._both, true, "Both observer did change.");
 });
-
-
 
 QUnit.module("EmberObject superclass and subclasses", {
   setup: function() {

--- a/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
@@ -8,7 +8,7 @@ suite.test("should raise exception if not Ember.Enumerable is passed to pushObje
   var obj = this.newObject([]);
 
   raises(function() {
-    obj.pushObjects( "string" );
+    obj.pushObjects("string");
   });
 });
 

--- a/packages/ember-runtime/tests/system/object/detectInstance_test.js
+++ b/packages/ember-runtime/tests/system/object/detectInstance_test.js
@@ -13,24 +13,24 @@ test('detectInstance detects instances correctly', function() {
   var b = B.create();
   var c = C.create();
 
-  ok( EmberObject.detectInstance(o), 'o is an instance of EmberObject' );
-  ok( EmberObject.detectInstance(a), 'a is an instance of EmberObject' );
-  ok( EmberObject.detectInstance(b), 'b is an instance of EmberObject' );
-  ok( EmberObject.detectInstance(c), 'c is an instance of EmberObject' );
+  ok(EmberObject.detectInstance(o), 'o is an instance of EmberObject');
+  ok(EmberObject.detectInstance(a), 'a is an instance of EmberObject');
+  ok(EmberObject.detectInstance(b), 'b is an instance of EmberObject');
+  ok(EmberObject.detectInstance(c), 'c is an instance of EmberObject');
 
-  ok( !A.detectInstance(o), 'o is not an instance of A');
-  ok( A.detectInstance(a), 'a is an instance of A' );
-  ok( A.detectInstance(b), 'b is an instance of A' );
-  ok( A.detectInstance(c), 'c is an instance of A' );
+  ok(!A.detectInstance(o), 'o is not an instance of A');
+  ok(A.detectInstance(a), 'a is an instance of A');
+  ok(A.detectInstance(b), 'b is an instance of A');
+  ok(A.detectInstance(c), 'c is an instance of A');
 
-  ok( !B.detectInstance(o), 'o is not an instance of B' );
-  ok( !B.detectInstance(a), 'a is not an instance of B' );
-  ok( B.detectInstance(b), 'b is an instance of B' );
-  ok( !B.detectInstance(c), 'c is not an instance of B' );
+  ok(!B.detectInstance(o), 'o is not an instance of B');
+  ok(!B.detectInstance(a), 'a is not an instance of B');
+  ok(B.detectInstance(b), 'b is an instance of B');
+  ok(!B.detectInstance(c), 'c is not an instance of B');
 
-  ok( !C.detectInstance(o), 'o is not an instance of C' );
-  ok( !C.detectInstance(a), 'a is not an instance of C' );
-  ok( !C.detectInstance(b), 'b is not an instance of C' );
-  ok( C.detectInstance(c), 'c is an instance of C' );
+  ok(!C.detectInstance(o), 'o is not an instance of C');
+  ok(!C.detectInstance(a), 'a is not an instance of C');
+  ok(!C.detectInstance(b), 'b is not an instance of C');
+  ok(C.detectInstance(c), 'c is an instance of C');
 
 });

--- a/packages/ember-runtime/tests/system/object/detect_test.js
+++ b/packages/ember-runtime/tests/system/object/detect_test.js
@@ -8,24 +8,24 @@ test('detect detects classes correctly', function() {
   var B = A.extend();
   var C = A.extend();
 
-  ok( EmberObject.detect(EmberObject), 'EmberObject is an EmberObject class' );
-  ok( EmberObject.detect(A), 'A is an EmberObject class' );
-  ok( EmberObject.detect(B), 'B is an EmberObject class' );
-  ok( EmberObject.detect(C), 'C is an EmberObject class' );
+  ok(EmberObject.detect(EmberObject), 'EmberObject is an EmberObject class');
+  ok(EmberObject.detect(A), 'A is an EmberObject class');
+  ok(EmberObject.detect(B), 'B is an EmberObject class');
+  ok(EmberObject.detect(C), 'C is an EmberObject class');
 
-  ok( !A.detect(EmberObject), 'EmberObject is not an A class' );
-  ok( A.detect(A), 'A is an A class' );
-  ok( A.detect(B), 'B is an A class' );
-  ok( A.detect(C), 'C is an A class' );
+  ok(!A.detect(EmberObject), 'EmberObject is not an A class');
+  ok(A.detect(A), 'A is an A class');
+  ok(A.detect(B), 'B is an A class');
+  ok(A.detect(C), 'C is an A class');
 
-  ok( !B.detect(EmberObject), 'EmberObject is not a B class' );
-  ok( !B.detect(A), 'A is not a B class' );
-  ok( B.detect(B), 'B is a B class' );
-  ok( !B.detect(C), 'C is not a B class' );
+  ok(!B.detect(EmberObject), 'EmberObject is not a B class');
+  ok(!B.detect(A), 'A is not a B class');
+  ok(B.detect(B), 'B is a B class');
+  ok(!B.detect(C), 'C is not a B class');
 
-  ok( !C.detect(EmberObject), 'EmberObject is not a C class' );
-  ok( !C.detect(A), 'A is not a C class' );
-  ok( !C.detect(B), 'B is not a C class' );
-  ok( C.detect(C), 'C is a C class' );
+  ok(!C.detect(EmberObject), 'EmberObject is not a C class');
+  ok(!C.detect(A), 'A is not a C class');
+  ok(!C.detect(B), 'B is not a C class');
+  ok(C.detect(C), 'C is a C class');
 
 });

--- a/packages/ember-runtime/tests/system/object/reopen_test.js
+++ b/packages/ember-runtime/tests/system/object/reopen_test.js
@@ -11,7 +11,7 @@ test('adds new properties to subclass instance', function() {
     bar: 'BAR'
   });
 
-  equal( new Subclass().foo(), 'FOO', 'Adds method');
+  equal(new Subclass().foo(), 'FOO', 'Adds method');
   equal(get(new Subclass(), 'bar'), 'BAR', 'Adds property');
 });
 
@@ -26,7 +26,7 @@ test('reopened properties inherited by subclasses', function() {
   });
 
 
-  equal( new SubSub().foo(), 'FOO', 'Adds method');
+  equal(new SubSub().foo(), 'FOO', 'Adds method');
   equal(get(new SubSub(), 'bar'), 'BAR', 'Adds property');
 });
 

--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -42,7 +42,7 @@ if (environment.hasDOM) {
         $.event.special.click = {
           // For checkbox, fire native event so checked state will be right
           trigger: function() {
-            if ($.nodeName( this, "input" ) && this.type === "checkbox" && this.click) {
+            if ($.nodeName(this, "input") && this.type === "checkbox" && this.click) {
               this.click();
               return false;
             }

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -314,7 +314,7 @@ test("additional events which should be listened on can be passed", function () 
       myEvent: function() {
         ok(true, "custom event has been triggered");
       }
-    }).appendTo( dispatcher.get("rootElement") );
+    }).appendTo(dispatcher.get("rootElement"));
   });
 
   jQuery("#leView").trigger("myevent");
@@ -333,7 +333,7 @@ test("additional events and rootElement can be specified", function () {
       myEvent: function() {
         ok(true, "custom event has been triggered");
       }
-    }).appendTo( dispatcher.get("rootElement") );
+    }).appendTo(dispatcher.get("rootElement"));
   });
 
   ok(jQuery(".custom-root").hasClass("ember-application"), "the custom rootElement is used");

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -206,7 +206,7 @@ test("it updates the view if an item is replaced", function() {
 
   run(function() {
     content.removeAt(1);
-    content.insertAt(1, "Kazuki" );
+    content.insertAt(1, "Kazuki");
   });
 
   forEach(content, function(item, idx) {
@@ -235,9 +235,9 @@ test("can add and replace in the same runloop", function() {
   });
 
   run(function() {
-    content.pushObject("Tom Dale" );
+    content.pushObject("Tom Dale");
     content.removeAt(0);
-    content.insertAt(0, "Kazuki" );
+    content.insertAt(0, "Kazuki");
   });
 
   forEach(content, function(item, idx) {
@@ -267,9 +267,9 @@ test("can add and replace the object before the add in the same runloop", functi
   });
 
   run(function() {
-    content.pushObject("Tom Dale" );
+    content.pushObject("Tom Dale");
     content.removeAt(1);
-    content.insertAt(1, "Kazuki" );
+    content.insertAt(1, "Kazuki");
   });
 
   forEach(content, function(item, idx) {
@@ -298,11 +298,11 @@ test("can add and replace complicatedly", function() {
   });
 
   run(function() {
-    content.pushObject("Tom Dale" );
+    content.pushObject("Tom Dale");
     content.removeAt(1);
-    content.insertAt(1, "Kazuki" );
-    content.pushObject("Firestone" );
-    content.pushObject("McMunch" );
+    content.insertAt(1, "Kazuki");
+    content.pushObject("Firestone");
+    content.pushObject("McMunch");
   });
 
   forEach(content, function(item, idx) {
@@ -331,11 +331,11 @@ test("can add and replace complicatedly harder", function() {
   });
 
   run(function() {
-    content.pushObject("Tom Dale" );
+    content.pushObject("Tom Dale");
     content.removeAt(1);
-    content.insertAt(1, "Kazuki" );
-    content.pushObject("Firestone" );
-    content.pushObject("McMunch" );
+    content.insertAt(1, "Kazuki");
+    content.pushObject("Firestone");
+    content.pushObject("McMunch");
     content.removeAt(2);
   });
 

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -80,7 +80,7 @@ test("should add, remove, or change class names if changed after element is crea
     set(view, 'canIgnore', true);
     set(view, 'isEnabled', false);
     set(view, 'messages.count', 'six-messages');
-    set(view, 'messages.resent', true );
+    set(view, 'messages.resent', true);
   });
 
   ok(view.$().hasClass('orange'), "updates string values");

--- a/packages/ember-views/tests/views/view/nearest_of_type_test.js
+++ b/packages/ember-views/tests/views/view/nearest_of_type_test.js
@@ -17,7 +17,7 @@ QUnit.module("View#nearest*", {
   var Mixin = EmberMixin.create({});
   var Parent = View.extend(Mixin, {
     render: function(buffer) {
-      this.appendChild( View.create() );
+      this.appendChild(View.create());
     }
   });
 

--- a/packages/ember/tests/location_test.js
+++ b/packages/ember/tests/location_test.js
@@ -30,7 +30,7 @@ QUnit.module('AutoLocation', {
         location: 'none',
         rootURL: '/rootdir/'
       });
-      App.__registry__.register('location:auto', AutoTestLocation );
+      App.__registry__.register('location:auto', AutoTestLocation);
       App.deferReadiness();
     });
   },

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -2283,7 +2283,7 @@ test("Generated route should be an instance of App.Route if provided", function(
 test("Nested index route is not overriden by parent's implicit index route", function() {
   Router.map(function() {
     this.resource('posts', function() {
-      this.route('index', { path: ':category' } );
+      this.route('index', { path: ':category' });
     });
   });
 


### PR DESCRIPTION
i.e:

``` javascript
// bad
foo( 'test' );

// good
foo('test');
```
