### PR TITLE
[DOC] Fixed typo in concatenatedProperties docs

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -310,8 +310,8 @@ CoreObject.PrototypeMixin = Mixin.create({
     view.get('classNames'); // ['ember-view', 'bar', 'foo', 'baz']
     ```
 
-    Using the `concatenatedProperties` property, we can tell to Ember that mix
-    the content of the properties.
+    Using the `concatenatedProperties` property, we can tell Ember to mix the
+    content of the properties.
 
     In `Ember.View` the `classNameBindings` and `attributeBindings` properties
     are also concatenated, in addition to `classNames`.


### PR DESCRIPTION
Sentence previously read: "Using the `concatenatedProperties` property, we can tell to Ember that mix the content of the properties."

Now it reads: "Using the `concatenatedProperties` property, we can tell Ember to mix the content of the properties."
