### PR TITLE
[BUGFIX] Clarify usage of classNames vs. classNameBindings, and fix classNameBindings typo

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1791,7 +1791,7 @@ var View = CoreView.extend({
     Ember.assert("Only arrays are allowed for 'classNameBindings'", typeOf(this.classNameBindings) === 'array');
     this.classNameBindings = emberA(this.classNameBindings.slice());
 
-    Ember.assert("Only arrays are allowed for 'classNames'", typeOf(this.classNames) === 'array');
+    Ember.assert("Only arrays of static class strings are allowed for 'classNames'. For dynamic classes, use 'classNameBindings'.", typeOf(this.classNames) === 'array');
     this.classNames = emberA(this.classNames.slice());
   },
 

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -30,7 +30,7 @@ test("registers view in the global views hash using layerId for event targeted",
 
 QUnit.module("EmberView.createWithMixins");
 
-test("should warn if a non-array is used for classNames", function() {
+test("should warn if a computed property is used for classNames", function() {
   expectAssertion(function() {
     EmberView.createWithMixins({
       elementId: 'test',
@@ -38,10 +38,10 @@ test("should warn if a non-array is used for classNames", function() {
         return ['className'];
       }).volatile()
     });
-  }, /Only arrays are allowed/i);
+  }, /Only arrays of static class strings.*For dynamic classes/i);
 });
 
-test("should warn if a non-array is used for classNamesBindings", function() {
+test("should warn if a non-array is used for classNameBindings", function() {
   expectAssertion(function() {
     EmberView.createWithMixins({
       elementId: 'test',


### PR DESCRIPTION
The test "should warn if a non-array is used for classNames" was really only testing for a warning when a computed property is used. Most other non-array values do not trigger warnings. So I changed the description of the text, and also added a note in the assertion description to clarify that `classNameBindings` should be used for binding class names to computed properties.

Lastly, in the `classNameBindings` test, I fixed a typo. (It had previously appeared as `classNamesBindings`, with a plural `Names`.)
