### PR TITLE
Extact View's render method into a function

### DIFF
--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -1,0 +1,37 @@
+import environment from "ember-metal/environment";
+
+import { DOMHelper } from "morph";
+
+import inline from "ember-htmlbars/hooks/inline";
+import content from "ember-htmlbars/hooks/content";
+import component from "ember-htmlbars/hooks/component";
+import block from "ember-htmlbars/hooks/block";
+import element from "ember-htmlbars/hooks/element";
+import subexpr from "ember-htmlbars/hooks/subexpr";
+import attribute from "ember-htmlbars/hooks/attribute";
+import concat from "ember-htmlbars/hooks/concat";
+import get from "ember-htmlbars/hooks/get";
+import set from "ember-htmlbars/hooks/set";
+
+import helpers from "ember-htmlbars/helpers";
+
+var domHelper = environment.hasDOM ? new DOMHelper() : null;
+
+export default {
+  dom: domHelper,
+
+  hooks: {
+    get: get,
+    set: set,
+    inline: inline,
+    content: content,
+    block: block,
+    element: element,
+    subexpr: subexpr,
+    component: component,
+    attribute: attribute,
+    concat: concat
+  },
+
+  helpers: helpers
+};

--- a/packages/ember-htmlbars/lib/helpers/partial.js
+++ b/packages/ember-htmlbars/lib/helpers/partial.js
@@ -2,7 +2,6 @@ import { get } from "ember-metal/property_get";
 import { isStream } from "ember-metal/streams/utils";
 import BoundPartialView from "ember-views/views/bound_partial_view";
 import lookupPartial from "ember-views/system/lookup_partial";
-import emptyTemplate from "ember-htmlbars/templates/empty";
 
 /**
 @module ember
@@ -57,7 +56,6 @@ export function partialHelper(params, hash, options, env) {
       _morph: options.morph,
       _context: get(this, 'context'),
       templateNameStream: templateName,
-      emptyTemplate: emptyTemplate,
       helperName: options.helperName || 'partial'
     });
   } else {

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -7,17 +7,6 @@ import {
   registerPlugin
 } from "ember-template-compiler";
 
-import inline from "ember-htmlbars/hooks/inline";
-import content from "ember-htmlbars/hooks/content";
-import component from "ember-htmlbars/hooks/component";
-import block from "ember-htmlbars/hooks/block";
-import element from "ember-htmlbars/hooks/element";
-import subexpr from "ember-htmlbars/hooks/subexpr";
-import attribute from "ember-htmlbars/hooks/attribute";
-import concat from "ember-htmlbars/hooks/concat";
-import get from "ember-htmlbars/hooks/get";
-import set from "ember-htmlbars/hooks/set";
-import { DOMHelper } from "morph";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 import makeBoundHelper from "ember-htmlbars/system/make_bound_helper";
 
@@ -49,8 +38,6 @@ import { collectionHelper } from "ember-htmlbars/helpers/collection";
 import { eachHelper } from "ember-htmlbars/helpers/each";
 import { unboundHelper } from "ember-htmlbars/helpers/unbound";
 
-import environment from "ember-metal/environment";
-
 // importing adds template bootstrapping
 // initializer to enable embedded templates
 import "ember-htmlbars/system/bootstrap";
@@ -79,7 +66,6 @@ registerHelper('textarea', textareaHelper);
 registerHelper('collection', collectionHelper);
 registerHelper('each', eachHelper);
 registerHelper('unbound', unboundHelper);
-registerHelper('concat', concat);
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   Ember.HTMLBars = {
@@ -95,24 +81,3 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
   };
 
 }
-
-var domHelper = environment.hasDOM ? new DOMHelper() : null;
-
-export var defaultEnv = {
-  dom: domHelper,
-
-  hooks: {
-    get: get,
-    set: set,
-    inline: inline,
-    content: content,
-    block: block,
-    element: element,
-    subexpr: subexpr,
-    component: component,
-    attribute: attribute,
-    concat: concat
-  },
-
-  helpers: helpers
-};

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -1,0 +1,52 @@
+import Ember from "ember-metal/core";
+import { get } from "ember-metal/property_get";
+import defaultEnv from "ember-htmlbars/env";
+
+export default function renderView(view, buffer, template) {
+  if (!template) {
+    return;
+  }
+
+  var output;
+
+  if (template.isHTMLBars) {
+    Ember.assert('template must be an object. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'object');
+    output = renderHTMLBarsTemplate(view, buffer, template);
+  } else {
+    Ember.assert('template must be a function. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'function');
+    output = renderLegacyTemplate(view, buffer, template);
+  }
+
+  if (output !== undefined) {
+    buffer.push(output);
+  }
+}
+
+function renderHTMLBarsTemplate(view, buffer, template) {
+  var contextualElement = buffer.innerContextualElement();
+  var args = view._blockArguments;
+  var env = {
+    view: this,
+    dom: defaultEnv.dom,
+    hooks: defaultEnv.hooks,
+    helpers: defaultEnv.helpers,
+    data: {
+      view: view,
+      buffer: buffer
+    }
+  };
+
+  return template.render(view, env, contextualElement, args);
+}
+
+function renderLegacyTemplate(view, buffer, template) {
+  var context = get(view, 'context');
+  var options = {
+    data: {
+      view: view,
+      buffer: buffer
+    }
+  };
+
+  return template(context, options);
+}

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -3,7 +3,7 @@ import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import compile from "ember-template-compiler/system/compile";
 import { equalInnerHTML } from "htmlbars-test-helpers";
-import { defaultEnv } from "ember-htmlbars";
+import defaultEnv from "ember-htmlbars/env";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 
 var view, originalSetAttribute, setAttributeCalls;

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -1,5 +1,5 @@
 import compile from "ember-template-compiler/system/compile";
-import { defaultEnv } from "ember-htmlbars";
+import defaultEnv from "ember-htmlbars/env";
 import { equalHTML } from "htmlbars-test-helpers";
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {

--- a/packages/ember-views/lib/views/bound_if_view.js
+++ b/packages/ember-views/lib/views/bound_if_view.js
@@ -1,7 +1,7 @@
-import { set } from "ember-metal/property_set";
 import run from 'ember-metal/run_loop';
 import _MetamorphView from "ember-views/views/metamorph_view";
 import NormalizedRerenderIfNeededSupport from "ember-views/mixins/normalized_rerender_if_needed";
+import renderView from "ember-htmlbars/system/render-view";
 
 export default _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
   init: function() {
@@ -22,12 +22,7 @@ export default _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
     var result = this.conditionStream.value();
     this._lastNormalizedValue = result;
 
-    if (result) {
-      set(this, 'template', this.truthyTemplate);
-    } else {
-      set(this, 'template', this.falsyTemplate);
-    }
-
-    return this._super(buffer);
+    var template = result ? this.truthyTemplate : this.falsyTemplate;
+    renderView(this, buffer, template);
   }
 });

--- a/packages/ember-views/lib/views/bound_partial_view.js
+++ b/packages/ember-views/lib/views/bound_partial_view.js
@@ -3,12 +3,13 @@
 @submodule ember-views
 */
 
-import { set } from "ember-metal/property_set";
 import run from 'ember-metal/run_loop';
 import _MetamorphView from "ember-views/views/metamorph_view";
 import NormalizedRerenderIfNeededSupport from "ember-views/mixins/normalized_rerender_if_needed";
 import lookupPartial from "ember-views/system/lookup_partial";
 import run from 'ember-metal/run_loop';
+import renderView from "ember-htmlbars/system/render-view";
+import emptyTemplate from "ember-htmlbars/templates/empty";
 
 export default _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
   init: function() {
@@ -29,12 +30,11 @@ export default _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
     var templateName = this.normalizedValue();
     this._lastNormalizedValue = templateName;
 
+    var template;
     if (templateName) {
-      set(this, 'template', lookupPartial(this, templateName));
-    } else {
-      set(this, 'template', this.emptyTemplate);
+      template = lookupPartial(this, templateName);
     }
 
-    return this._super(buffer);
+    renderView(this, buffer, template || emptyTemplate);
   }
 });

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -60,12 +60,12 @@ import sanitizeAttributeValue from "ember-views/system/sanitize_attribute_value"
 function K() { return this; }
 
 // Circular dep
-var _htmlbarsDefaultEnv;
-function buildHTMLBarsDefaultEnv() {
-  if (!_htmlbarsDefaultEnv) {
-    _htmlbarsDefaultEnv = require('ember-htmlbars').defaultEnv;
+var _renderView;
+function renderView(view, buffer, template) {
+  if (_renderView === undefined) {
+    _renderView = require('ember-htmlbars/system/render-view')['default'];
   }
-  return create(_htmlbarsDefaultEnv);
+  _renderView(view, buffer, template);
 }
 
 /**
@@ -1095,43 +1095,7 @@ var View = CoreView.extend({
     // the layout to render the view's template. Otherwise, render the template
     // directly.
     var template = get(this, 'layout') || get(this, 'template');
-
-    if (template) {
-      var context = get(this, 'context');
-      var output;
-
-      var data = {
-        view: this,
-        buffer: buffer,
-        isRenderData: true
-      };
-
-      // Invoke the template with the provided template context, which
-      // is the view's controller by default. A hash of data is also passed that provides
-      // the template with access to the view and render buffer.
-
-      // The template should write directly to the render buffer instead
-      // of returning a string.
-      var options = { data: data };
-      var useHTMLBars = false;
-
-      if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-        useHTMLBars = template.isHTMLBars;
-      }
-
-      if (useHTMLBars) {
-        Ember.assert('template must be an object. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'object');
-        var env = Ember.merge(buildHTMLBarsDefaultEnv(), options);
-        output = template.render(this, env, buffer.innerContextualElement(), this._blockArguments);
-      } else {
-        Ember.assert('template must be a function. Did you mean to call Ember.Handlebars.compile("...") or specify templateName instead?', typeof template === 'function');
-        output = template(context, options);
-      }
-
-      // If the template returned a string instead of writing to the buffer,
-      // push the string onto the buffer.
-      if (output !== undefined) { buffer.push(output); }
-    }
+    renderView(this, buffer, template);
   },
 
   /**

--- a/packages/ember-views/lib/views/with_view.js
+++ b/packages/ember-views/lib/views/with_view.js
@@ -8,6 +8,7 @@ import run from 'ember-metal/run_loop';
 import _MetamorphView from "ember-views/views/metamorph_view";
 import NormalizedRerenderIfNeededSupport from "ember-views/mixins/normalized_rerender_if_needed";
 import run from 'ember-metal/run_loop';
+import renderView from "ember-htmlbars/system/render-view";
 
 export default _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
   init: function() {
@@ -58,13 +59,8 @@ export default _MetamorphView.extend(NormalizedRerenderIfNeededSupport, {
       set(this, '_context', withValue);
     }
 
-    if (withValue) {
-      set(this, 'template', this.mainTemplate);
-    } else {
-      set(this, 'template', this.inverseTemplate);
-    }
-
-    return this._super(buffer);
+    var template = withValue ? this.mainTemplate : this.inverseTemplate;
+    renderView(this, buffer, template);
   },
 
   willDestroy: function() {


### PR DESCRIPTION
- Extracts defaultEnv to its own module (to break a module cycle).
- Extracts the guts of View.prototype.render into an ember-htmlbars specific module.
- Now you render the template directly to the buffer instead of depending on the side-effect of `set(view, 'template', theTemplate)`.
