### PR TITLE
[REFACTOR] Use `aliasMethod` to alias `getEach`

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -282,9 +282,7 @@ export default Mixin.create({
     @param {String} key name of the property
     @return {Array} The mapped array.
   */
-  getEach: function(key) {
-    return this.mapBy(key);
-  },
+  getEach: aliasMethod('mapBy'),
 
   /**
     Sets the value on the named property for each member. This is more


### PR DESCRIPTION
As with the other aliases in this file use the `aliasMethod` method to alias `getEach` to `mapBy`.

I ran the tests in my browser locally before and after this change and all was good. Messing with the implementation of getEach showed that it is covered by tests so this change seems safe to me (although I'm not yet familiar with the internals of Ember)
