### PR TITLE
[DOC] Clear up description for isAny/isEvery

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -646,7 +646,7 @@ export default Mixin.create({
 
   /**
     Returns `true` if the passed property resolves to the value of the second
-    argument for all items in the enumerable. This method is often simpler/faster 
+    argument for all items in the enumerable. This method is often simpler/faster
     than using a callback.
 
     @method isEvery
@@ -756,7 +756,7 @@ export default Mixin.create({
 
   /**
     Returns `true` if the passed property resolves to the value of the second
-    argument for any item in the enumerable. This method is often simpler/faster 
+    argument for any item in the enumerable. This method is often simpler/faster
     than using a callback.
 
     @method isAny

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -645,12 +645,13 @@ export default Mixin.create({
   everyProperty: aliasMethod('isEvery'),
 
   /**
-    Returns `true` if the passed property resolves to `true` for all items in
-    the enumerable. This method is often simpler/faster than using a callback.
+    Returns `true` if the passed property resolves to the value of the second
+    argument for all items in the enumerable. This method is often simpler/faster 
+    than using a callback.
 
     @method isEvery
     @param {String} key the property to test
-    @param {String} [value] optional value to test against.
+    @param {String} [value] optional value to test against. Defaults to `true`
     @return {Boolean}
     @since 1.3.0
   */
@@ -754,12 +755,13 @@ export default Mixin.create({
   some: aliasMethod('any'),
 
   /**
-    Returns `true` if the passed property resolves to `true` for any item in
-    the enumerable. This method is often simpler/faster than using a callback.
+    Returns `true` if the passed property resolves to the value of the second
+    argument for any item in the enumerable. This method is often simpler/faster 
+    than using a callback.
 
     @method isAny
     @param {String} key the property to test
-    @param {String} [value] optional value to test against.
+    @param {String} [value] optional value to test against. Defaults to `true`
     @return {Boolean}
     @since 1.3.0
   */


### PR DESCRIPTION
The description of these methods wasn't quite correct given their behaviour.

I wasn't sure of the correct way to talk about default values for arguments though and couldn't find a consistent answer in the files I looked in. If there is another approach that is preferred let me know and I'm happy to update the PR...
