### PR TITLE
Deprecate View#nearestChildOf

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1022,6 +1022,8 @@ var View = CoreView.extend({
     @return Ember.View
   */
   nearestChildOf: function(klass) {
+    Ember.deprecate("nearestChildOf has been deprecated.\nFor existing behavior, use nearestOfType.");
+
     var view = get(this, 'parentView');
 
     while (view) {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1020,9 +1020,10 @@ var View = CoreView.extend({
     @method nearestChildOf
     @param {Class} klass Subclass of Ember.View (or Ember.View itself)
     @return Ember.View
+    @deprecated
   */
   nearestChildOf: function(klass) {
-    Ember.deprecate("nearestChildOf has been deprecated.\nFor existing behavior, use nearestOfType.");
+    Ember.deprecate("nearestChildOf has been deprecated.");
 
     var view = get(this, 'parentView');
 

--- a/packages/ember-views/tests/views/view/nearest_of_type_test.js
+++ b/packages/ember-views/tests/views/view/nearest_of_type_test.js
@@ -64,4 +64,18 @@ QUnit.module("View#nearest*", {
     equal(childView.nearestWithProperty('myProp'), view);
 
   });
+
+  test("nearestChildOf should be deprecated", function() {
+    var child;
+
+    run(function() {
+      parentView = Parent.create();
+      parentView.appendTo('#qunit-fixture');
+    });
+
+    child = parentView.get('childViews')[0];
+    expectDeprecation(function() {
+      child.nearestChildOf(Parent);
+    }, 'nearestChildOf has been deprecated.\nFor existing behavior, use nearestOfType.');
+  });
 }());

--- a/packages/ember-views/tests/views/view/nearest_of_type_test.js
+++ b/packages/ember-views/tests/views/view/nearest_of_type_test.js
@@ -76,6 +76,6 @@ QUnit.module("View#nearest*", {
     child = parentView.get('childViews')[0];
     expectDeprecation(function() {
       child.nearestChildOf(Parent);
-    }, 'nearestChildOf has been deprecated.\nFor existing behavior, use nearestOfType.');
+    }, 'nearestChildOf has been deprecated.');
   });
 }());


### PR DESCRIPTION
Judging from the code in nearestChildOf, it never worked. This formally deprecates this function to prevent confusion (fixes #9641).
