### PR TITLE
ember-routing-htmlbars Extract Test Utils

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -1,20 +1,7 @@
 import Ember from 'ember-metal/core'; // TEMPLATES
-import { get } from "ember-metal/property_get";
-import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 
-import Registry from "container/registry";
 import Namespace from "ember-runtime/system/namespace";
-import {
-  decamelize,
-  classify
-} from "ember-runtime/system/string";
-import Controller from "ember-runtime/controllers/controller";
-import ObjectController from "ember-runtime/controllers/object_controller";
-import ArrayController from "ember-runtime/controllers/array_controller";
-
-import EmberRouter from "ember-routing/system/router";
-import HashLocation from "ember-routing/location/hash_location";
 
 import _MetamorphView from "ember-views/views/metamorph_view";
 import EmberView from "ember-routing/ext/view";
@@ -27,68 +14,22 @@ import compile from "ember-template-compiler/system/compile";
 import { registerHelper } from "ember-htmlbars/helpers";
 import helpers from "ember-htmlbars/helpers";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
-
-var buildRegistry = function(namespace) {
-  var registry = new Registry();
-
-  registry.set = set;
-  registry.resolver = resolverFor(namespace);
-  registry.optionsForType('view', { singleton: false });
-  registry.optionsForType('template', { instantiate: false });
-  registry.register('application:main', namespace, { instantiate: false });
-  registry.injection('router:main', 'namespace', 'application:main');
-
-  registry.register('location:hash', HashLocation);
-
-  registry.register('controller:basic', Controller, { instantiate: false });
-  registry.register('controller:object', ObjectController, { instantiate: false });
-  registry.register('controller:array', ArrayController, { instantiate: false });
-
-  registry.typeInjection('route', 'router', 'router:main');
-
-  return registry;
-};
-
-var buildContainer = function(registry) {
-  return registry.container();
-};
-
-function resolverFor(namespace) {
-  return function(fullName) {
-    var nameParts = fullName.split(":");
-    var type = nameParts[0];
-    var name = nameParts[1];
-
-    if (type === 'template') {
-      var templateName = decamelize(name);
-      if (Ember.TEMPLATES[templateName]) {
-        return Ember.TEMPLATES[templateName];
-      }
-    }
-
-    var className = classify(name) + classify(type);
-    var factory = get(namespace, className);
-
-    if (factory) { return factory; }
-  };
-}
+import { buildRegistry } from "ember-routing-htmlbars/tests/utils";
 
 var trim = jQuery.trim;
 
 var view, registry, container, originalOutletHelper;
 
 QUnit.module("ember-routing-htmlbars: {{outlet}} helper", {
-
   setup: function() {
     originalOutletHelper = helpers['outlet'];
     registerHelper('outlet', outletHelper);
 
     var namespace = Namespace.create();
     registry = buildRegistry(namespace);
-    container = buildContainer(registry);
-    registry.register('view:default', _MetamorphView);
-    registry.register('router:main', EmberRouter.extend());
+    container = registry.container();
   },
+
   teardown: function() {
     delete helpers['outlet'];
     helpers['outlet'] = originalOutletHelper;

--- a/packages/ember-routing-htmlbars/tests/utils.js
+++ b/packages/ember-routing-htmlbars/tests/utils.js
@@ -1,0 +1,65 @@
+import { get } from "ember-metal/property_get";
+import { set } from "ember-metal/property_set";
+import {
+  classify,
+  decamelize
+} from "ember-runtime/system/string";
+
+import Registry from "container/registry";
+import Controller from "ember-runtime/controllers/controller";
+import ObjectController from "ember-runtime/controllers/object_controller";
+import ArrayController from "ember-runtime/controllers/array_controller";
+
+import _MetamorphView from "ember-views/views/metamorph_view";
+import EmberRouter from "ember-routing/system/router";
+
+import HashLocation from "ember-routing/location/hash_location";
+
+function resolverFor(namespace) {
+  return function(fullName) {
+    var nameParts = fullName.split(":");
+    var type = nameParts[0];
+    var name = nameParts[1];
+
+    if (type === "template") {
+      var templateName = decamelize(name);
+      if (Ember.TEMPLATES[templateName]) {
+        return Ember.TEMPLATES[templateName];
+      }
+    }
+
+    var className = classify(name) + classify(type);
+    var factory = get(namespace, className);
+
+    if (factory) { return factory; }
+  };
+}
+
+function buildRegistry(namespace) {
+  var registry = new Registry();
+
+  registry.set = set;
+  registry.resolver = resolverFor(namespace);
+  registry.optionsForType("view", { singleton: false });
+  registry.optionsForType("template", { instantiate: false });
+  registry.register("application:main", namespace, { instantiate: false });
+  registry.injection("router:main", "namespace", "application:main");
+
+  registry.register("location:hash", HashLocation);
+
+  registry.register("controller:basic", Controller, { instantiate: false });
+  registry.register("controller:object", ObjectController, { instantiate: false });
+  registry.register("controller:array", ArrayController, { instantiate: false });
+
+  registry.register("view:default", _MetamorphView);
+  registry.register("router:main", EmberRouter.extend());
+
+  registry.typeInjection("route", "router", "router:main");
+
+  return registry;
+}
+
+export {
+  resolverFor,
+  buildRegistry
+};


### PR DESCRIPTION
`buildRegistry` and `buildContainer` were very similar.

Added bonus: extracting a common `utils` file also reduced the number of
`import` statements.
