### PR TITLE
[BUGFIX beta] Fix compat mode registerHelper interop with makeViewHelper.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -61,7 +61,15 @@ HandlebarsCompatibleHelper.prototype = {
 };
 
 export function registerHandlebarsCompatibleHelper(name, value) {
-  helpers[name] = new HandlebarsCompatibleHelper(value);
+  var helper;
+
+  if (value && value.isHTMLBars) {
+    helper = value;
+  } else {
+    helper = new HandlebarsCompatibleHelper(value);
+  }
+
+  helpers[name] = helper;
 }
 
 export function handlebarsHelper(name, value) {

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -3,7 +3,9 @@ import {
 } from "ember-htmlbars/compat/helper";
 
 import EmberView from "ember-views/views/view";
+import Component from "ember-views/views/component";
 
+import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 import helpers from "ember-htmlbars/helpers";
 import compile from "ember-template-compiler/system/compile";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
@@ -18,6 +20,7 @@ QUnit.module('ember-htmlbars: Handlebars compatible helpers', {
     runDestroy(view);
 
     delete helpers.test;
+    delete helpers['view-helper'];
   }
 });
 
@@ -117,6 +120,25 @@ test('bound ordered params are provided with their original paths', function() {
   });
 
   runAppend(view);
+});
+
+test('registering a helper created from `Ember.Handlebars.makeViewHelper` does not double wrap the helper', function() {
+  expect(1);
+
+  var ViewHelperComponent = Component.extend({
+    layout: compile('woot!')
+  });
+
+  var helper = makeViewHelper(ViewHelperComponent);
+  registerHandlebarsCompatibleHelper('view-helper', helper);
+
+  view = EmberView.extend({
+    template: compile('{{view-helper}}')
+  }).create();
+
+  runAppend(view);
+
+  equal(view.$().text(), 'woot!');
 });
 
 // jscs:enable validateIndentation


### PR DESCRIPTION
Prior to this change the following code would result in a Helper that is "double wrapped":

``` javascript
var Component = Ember.Component.extend();
var helper = Ember.Handlebars.makeViewHelper(Component);

Ember.Handlebars.registerHelper('derp', helper);
```

In this case `helper` would have the following (incorrect) format:

``` javascript
{
  isHTMLBars: true,
  helperFunction: {
    isHTMLBars: true,
    helperFunction: function(p, h, o, e) { }
  }
}
```

Paired with @rwjblue and @maabernethy on this.
