### PR TITLE
[DOCS globals -> modules]

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -83,7 +83,11 @@ ControllerMixin.reopen({
     For example, when you define a controller:
 
     ```javascript
-    App.CommentsController = Ember.ArrayController.extend({
+    // app/controllers/comments.js
+
+    import Ember from "ember";
+
+    export default Ember.ArrayController.extend({
       needs: ['post']
     });
     ```
@@ -93,20 +97,28 @@ ControllerMixin.reopen({
     `controllers` property:
 
     ```javascript
-    this.get('controllers.post'); // instance of App.PostController
+    this.get('controllers.post'); // instance of PostController
     ```
 
     Given that you have a nested controller (nested resource):
 
     ```javascript
-    App.CommentsNewController = Ember.ObjectController.extend({
+    // app/controllers/comments/new.js
+
+    import Ember from 'ember';
+
+    export default Ember.ObjectController.extend({
     });
     ```
 
     When you define a controller that requires access to a nested one:
 
     ```javascript
-    App.IndexController = Ember.ObjectController.extend({
+    // app/controllers/index.js
+
+    import Ember from 'ember';
+
+    export default Ember.ObjectController.extend({
       needs: ['commentsNew']
     });
     ```
@@ -114,7 +126,7 @@ ControllerMixin.reopen({
     You will be able to get access to it:
 
     ```javascript
-    this.get('controllers.commentsNew'); // instance of App.CommentsNewController
+    this.get('controllers.commentsNew'); // instance of CommentsNewController
     ```
 
     This is only available for singleton controllers.
@@ -161,10 +173,14 @@ ControllerMixin.reopen({
     property will be accessible by name through this property.
 
     ```javascript
-    App.CommentsController = Ember.ArrayController.extend({
+    // app/controllers/comments.js
+
+    import Ember from 'ember';
+
+    export default Ember.ArrayController.extend({
       needs: ['post'],
       postTitle: function(){
-        var currentPost = this.get('controllers.post'); // instance of App.PostController
+        var currentPost = this.get('controllers.post'); // instance of PostController
         return currentPost.get('title');
       }.property('controllers.post.title')
     });

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -57,7 +57,11 @@ var librariesRegistered = false;
   very first thing you should do in your application is create the instance:
 
   ```javascript
-  window.App = Ember.Application.create();
+  // app/app.js
+
+  import Ember from 'ember';
+
+  export default Ember.Application.create({});
   ```
 
   Typically, the application object is the only global variable. All other
@@ -67,7 +71,11 @@ var librariesRegistered = false;
   For example, if you define a view class, it might look like this:
 
   ```javascript
-  App.MyView = Ember.View.extend();
+  // app/views/my.js
+
+  import Ember from 'ember';
+
+  export default Ember.View.extend({});
   ```
 
   By default, calling `Ember.Application.create()` will automatically initialize
@@ -109,7 +117,11 @@ var librariesRegistered = false;
   names by setting the application's `customEvents` property:
 
   ```javascript
-  var App = Ember.Application.create({
+  // app/app.js
+
+  import Ember from 'ember';
+
+  export default Ember.Application.create({
     customEvents: {
       // add support for the paste event
       paste: 'paste'
@@ -126,7 +138,11 @@ var librariesRegistered = false;
   should be delegated, set your application's `rootElement` property:
 
   ```javascript
-  var App = Ember.Application.create({
+  // app/app.js
+
+  import Ember from 'ember';
+
+  export default Ember.Application.create({
     rootElement: '#ember-app'
   });
   ```
@@ -145,6 +161,10 @@ var librariesRegistered = false;
   Libraries on top of Ember can add initializers, like so:
 
   ```javascript
+  // app/initializers/api-adapter.js
+
+  import Ember from 'ember';
+
   Ember.Application.initializer({
     name: 'api-adapter',
 
@@ -169,7 +189,11 @@ var librariesRegistered = false;
   the `LOG_TRANSITIONS_INTERNAL` flag:
 
   ```javascript
-  var App = Ember.Application.create({
+  // app/app.js
+
+  import Ember from 'ember';
+
+  export default Ember.Application.create({
     LOG_TRANSITIONS: true, // basic logging of successful transitions
     LOG_TRANSITIONS_INTERNAL: true // detailed logging of all routing steps
   });
@@ -238,7 +262,7 @@ var Application = Namespace.extend(DeferredMixin, {
     corresponding view method name as the value. For example:
 
     ```javascript
-    var App = Ember.Application.create({
+    export default Ember.Application.create({
       customEvents: {
         // add support for the paste event
         paste: 'paste'

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -62,7 +62,11 @@ export var Resolver = EmberObject.extend({
   is resolved like so:
 
   ```javascript
-  App = Ember.Application.create({
+  // app/app.js
+
+  import Ember from 'ember';
+
+  export default Ember.Application.create({
     Resolver: Ember.DefaultResolver.extend({
       resolveTemplate: function(parsedName) {
         var resolvedTemplate = this._super(parsedName);
@@ -82,20 +86,20 @@ export var Resolver = EmberObject.extend({
   'template:blogPost'       //=> Ember.TEMPLATES['blogPost']
                             //   OR
                             //   Ember.TEMPLATES['blog_post']
-  'controller:post'         //=> App.PostController
-  'controller:posts.index'  //=> App.PostsIndexController
+  'controller:post'         //=> PostController
+  'controller:posts.index'  //=> PostsIndexController
   'controller:blog/post'    //=> Blog.PostController
   'controller:basic'        //=> Ember.Controller
-  'route:post'              //=> App.PostRoute
-  'route:posts.index'       //=> App.PostsIndexRoute
+  'route:post'              //=> PostRoute
+  'route:posts.index'       //=> PostsIndexRoute
   'route:blog/post'         //=> Blog.PostRoute
   'route:basic'             //=> Ember.Route
-  'view:post'               //=> App.PostView
-  'view:posts.index'        //=> App.PostsIndexView
+  'view:post'               //=> PostView
+  'view:posts.index'        //=> PostsIndexView
   'view:blog/post'          //=> Blog.PostView
   'view:basic'              //=> Ember.View
-  'foo:post'                //=> App.PostFoo
-  'model:post'              //=> App.Post
+  'foo:post'                //=> PostFoo
+  'model:post'              //=> Post
   ```
 
   @class DefaultResolver


### PR DESCRIPTION
Replace Global `App.` style documentation with `ember-cli` style ES6 modules
in files that follow the proper naming conventions.
