### PR TITLE
Unify DOM helper across HTMLbars and Ember views

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -20,6 +20,7 @@ import EnumerableUtils from "ember-metal/enumerable_utils";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import Renderer from "ember-views/system/renderer";
+import { DOMHelper } from "morph";
 import SelectView from "ember-views/views/select";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import jQuery from "ember-views/system/jquery";
@@ -1002,7 +1003,7 @@ Application.reopenClass({
     registry.register('controller:object', ObjectController, { instantiate: false });
     registry.register('controller:array', ArrayController, { instantiate: false });
 
-    registry.register('renderer:-dom', { create: function(opts) { return new Renderer(opts); } });
+    registry.register('renderer:-dom', { create: function() { return new Renderer(new DOMHelper()); } });
 
     registry.injection('view', 'renderer', 'renderer:-dom');
     registry.register('view:select', SelectView);

--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -15,11 +15,7 @@ import set from "ember-htmlbars/hooks/set";
 
 import helpers from "ember-htmlbars/helpers";
 
-var domHelper = environment.hasDOM ? new DOMHelper() : null;
-
 export default {
-  dom: domHelper,
-
   hooks: {
     get: get,
     set: set,
@@ -35,3 +31,7 @@ export default {
 
   helpers: helpers
 };
+
+var domHelper = environment.hasDOM ? new DOMHelper() : null;
+
+export { domHelper };

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -27,7 +27,7 @@ function renderHTMLBarsTemplate(view, buffer, template) {
   var args = view._blockArguments;
   var env = {
     view: this,
-    dom: defaultEnv.dom,
+    dom: view.renderer._dom,
     hooks: defaultEnv.hooks,
     helpers: defaultEnv.helpers,
     data: {

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -2,12 +2,12 @@ import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import compile from "ember-template-compiler/system/compile";
+import Renderer from "ember-views/system/renderer";
 import { equalInnerHTML } from "htmlbars-test-helpers";
-import defaultEnv from "ember-htmlbars/env";
+import { domHelper as dom } from "ember-htmlbars/env";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 
-var view, originalSetAttribute, setAttributeCalls;
-var dom = defaultEnv.dom;
+var view, originalSetAttribute, setAttributeCalls, renderer;
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
@@ -199,9 +199,13 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
 
   QUnit.module('ember-htmlbars: {{attribute}} helper -- setAttribute', {
     setup: function() {
+      renderer = new Renderer(dom);
+
       originalSetAttribute = dom.setAttribute;
       dom.setAttribute = function(element, name, value) {
-        setAttributeCalls.push([name, value]);
+        if (name.substr(0, 5) === 'data-') {
+          setAttributeCalls.push([name, value]);
+        }
 
         originalSetAttribute.call(dom, element, name, value);
       };
@@ -219,6 +223,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
   test('calls setAttribute for new values', function() {
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
+      renderer: renderer,
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")
     });
@@ -237,6 +242,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
   test('does not call setAttribute if the same value is set', function() {
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
+      renderer: renderer,
       context: context,
       template: compile("<div data-name={{name}}>Hi!</div>")
     });

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -1,6 +1,8 @@
 import compile from "ember-template-compiler/system/compile";
 import defaultEnv from "ember-htmlbars/env";
+import { domHelper } from "ember-htmlbars/env";
 import { equalHTML } from "htmlbars-test-helpers";
+import merge from "ember-metal/merge";
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
@@ -8,7 +10,10 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
   test("HTMLBars is present and can be executed", function() {
     var template = compile("ohai");
-    var output = template.render({}, defaultEnv, document.body);
+
+    var env = merge({ dom: domHelper }, defaultEnv);
+
+    var output = template.render({}, env, document.body);
     equalHTML(output, "ohai");
   });
 }

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -3,7 +3,7 @@ import environment from "ember-metal/environment";
 
 var domHelper = environment.hasDOM ? new DOMHelper() : null;
 
-function Renderer() {
+function Renderer(_helper) {
   this._uuid = 0;
 
   // These sizes and values are somewhat arbitrary (but sensible)
@@ -13,7 +13,7 @@ function Renderer() {
   this._parents = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
   this._elements = new Array(17);
   this._inserts = {};
-  this._dom = domHelper;
+  this._dom = _helper || domHelper;
 }
 
 function Renderer_renderTree(_view, _parentView, _insertAt) {

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -4,7 +4,6 @@
 */
 
 import jQuery from "ember-views/system/jquery";
-import { DOMHelper } from "morph";
 import Ember from "ember-metal/core";
 import { create } from "ember-metal/platform";
 import environment from "ember-metal/environment";
@@ -39,10 +38,10 @@ import environment from "ember-metal/environment";
 var omittedStartTagChildren;
 var omittedStartTagChildTest = /(?:<script)*.*?<([\w:]+)/i;
 
-function detectOmittedStartTag(string, contextualElement) {
+function detectOmittedStartTag(dom, string, contextualElement) {
   omittedStartTagChildren = omittedStartTagChildren || {
-    tr: document.createElement('tbody'),
-    col: document.createElement('colgroup')
+    tr: dom.createElement('tbody'),
+    col: dom.createElement('colgroup')
   };
 
   // Omitted start tags are only inside table tags.
@@ -125,31 +124,29 @@ var canSetNameOnInputs = (function() {
 })();
 
 /**
-  `Ember.renderBuffer` gathers information regarding the view and generates the
-  final representation. `Ember.renderBuffer` will generate HTML which can be pushed
+  `Ember.RenderBuffer` gathers information regarding the view and generates the
+  final representation. `Ember.RenderBuffer` will generate HTML which can be pushed
   to the DOM.
 
    ```javascript
-   var buffer = Ember.renderBuffer('div', contextualElement);
+   var buffer = new Ember.RenderBuffer('div', contextualElement);
   ```
 
   @method renderBuffer
   @namespace Ember
   @param {String} tagName tag name (such as 'div' or 'p') used for the buffer
 */
-export default function renderBuffer(tagName, contextualElement) {
-  return new _RenderBuffer(tagName, contextualElement); // jshint ignore:line
-}
 
-function _RenderBuffer(tagName, contextualElement) {
-  this.tagName = tagName;
-  this._outerContextualElement = contextualElement;
+var RenderBuffer = function(domHelper) {
   this.buffer = null;
   this.childViews = [];
-  this.dom = environment.hasDOM ? new DOMHelper() : null;
-}
 
-_RenderBuffer.prototype = {
+  Ember.assert("RenderBuffer requires a DOM helper to be passed to its constructor.", !!domHelper);
+
+  this.dom = domHelper;
+};
+
+RenderBuffer.prototype = {
 
   reset: function(tagName, contextualElement) {
     this.tagName = tagName;
@@ -580,7 +577,7 @@ _RenderBuffer.prototype = {
 
     var omittedStartTag;
     if (html) {
-      omittedStartTag = detectOmittedStartTag(html, innerContextualElement);
+      omittedStartTag = detectOmittedStartTag(this.dom, html, innerContextualElement);
     }
     return omittedStartTag || innerContextualElement;
   },
@@ -596,3 +593,5 @@ _RenderBuffer.prototype = {
     return this.buffer;
   }
 };
+
+export default RenderBuffer;

--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core";
 import Renderer from 'ember-metal-views/renderer';
 import { create } from 'ember-metal/platform';
-import renderBuffer from "ember-views/system/render_buffer";
+import RenderBuffer from "ember-views/system/render_buffer";
 import run from "ember-metal/run_loop";
 import { set } from "ember-metal/property_set";
 import { get } from "ember-metal/property_get";
@@ -10,9 +10,9 @@ import {
   subscribers
 } from "ember-metal/instrumentation";
 
-function EmberRenderer() {
-  this.buffer = renderBuffer();
-  this._super$constructor();
+function EmberRenderer(domHelper) {
+  this._super$constructor(domHelper);
+  this.buffer = new RenderBuffer(domHelper);
 }
 
 EmberRenderer.prototype = create(Renderer.prototype);

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -1,4 +1,5 @@
 import Renderer from "ember-views/system/renderer";
+import { DOMHelper } from "morph";
 
 import {
   cloneStates,
@@ -48,8 +49,10 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     this.currentState = this._states.preRender;
     this._isVisible = get(this, 'isVisible');
 
+    // Fallback for legacy cases where the view was created directly
+    // via `create()` instead of going through the container.
     if (!this.renderer) {
-      renderer = renderer || new Renderer();
+      renderer = renderer || new Renderer(new DOMHelper());
       this.renderer = renderer;
     }
   },

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -1,5 +1,6 @@
 import jQuery from "ember-views/system/jquery";
 import RenderBuffer from "ember-views/system/render_buffer";
+import { DOMHelper } from "morph";
 
 var svgNamespace = "http://www.w3.org/2000/svg";
 var xhtmlNamespace = "http://www.w3.org/1999/xhtml";
@@ -10,8 +11,17 @@ var trim = jQuery.trim;
 //
 QUnit.module("RenderBuffer");
 
+var domHelper = new DOMHelper();
+
+function createRenderBuffer(tagName, contextualElement) {
+  var buffer = new RenderBuffer(domHelper);
+  buffer.reset(tagName, contextualElement);
+
+  return buffer;
+}
+
 test("RenderBuffers raise a deprecation warning without a contextualElement", function() {
-  var buffer = new RenderBuffer('div');
+  var buffer = createRenderBuffer('div');
   expectDeprecation(function() {
     buffer.generateElement();
     var el = buffer.element();
@@ -20,7 +30,7 @@ test("RenderBuffers raise a deprecation warning without a contextualElement", fu
 });
 
 test("reset RenderBuffers raise a deprecation warning without a contextualElement", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   buffer.reset('span');
   expectDeprecation(function() {
     buffer.generateElement();
@@ -30,7 +40,7 @@ test("reset RenderBuffers raise a deprecation warning without a contextualElemen
 });
 
 test("RenderBuffers combine strings", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   buffer.generateElement();
 
   buffer.push('a');
@@ -42,7 +52,7 @@ test("RenderBuffers combine strings", function() {
 });
 
 test("RenderBuffers push fragments", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   var fragment = document.createElement('span');
   buffer.generateElement();
 
@@ -54,7 +64,7 @@ test("RenderBuffers push fragments", function() {
 });
 
 test("RenderBuffers cannot push fragments when something else is in the buffer", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   var fragment = document.createElement('span');
   buffer.generateElement();
 
@@ -65,7 +75,7 @@ test("RenderBuffers cannot push fragments when something else is in the buffer",
 });
 
 test("RenderBuffers cannot push strings after fragments", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   var fragment = document.createElement('span');
   buffer.generateElement();
 
@@ -77,7 +87,7 @@ test("RenderBuffers cannot push strings after fragments", function() {
 
 test("value of 0 is included in output", function() {
   var buffer, el;
-  buffer = new RenderBuffer('input', document.body);
+  buffer = createRenderBuffer('input', document.body);
   buffer.prop('value', 0);
   buffer.generateElement();
   el = buffer.element();
@@ -85,7 +95,7 @@ test("value of 0 is included in output", function() {
 });
 
 test("sets attributes with camelCase", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   var content = "javascript:someCode()"; //jshint ignore:line
 
   buffer.attr('onClick', content);
@@ -95,7 +105,7 @@ test("sets attributes with camelCase", function() {
 });
 
 test("prevents XSS injection via `id`", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
 
   buffer.id('hacked" megahax="yes');
   buffer.generateElement();
@@ -105,7 +115,7 @@ test("prevents XSS injection via `id`", function() {
 });
 
 test("prevents XSS injection via `attr`", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
 
   buffer.attr('id', 'trololol" onmouseover="pwn()');
   buffer.attr('class', "hax><img src=\"trollface.png\"");
@@ -119,7 +129,7 @@ test("prevents XSS injection via `attr`", function() {
 });
 
 test("prevents XSS injection via `addClass`", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
 
   buffer.addClass('megahax" xss="true');
   buffer.generateElement();
@@ -129,7 +139,7 @@ test("prevents XSS injection via `addClass`", function() {
 });
 
 test("prevents XSS injection via `style`", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
 
   buffer.style('color', 'blue;" xss="true" style="color:red');
   buffer.generateElement();
@@ -148,7 +158,7 @@ test("prevents XSS injection via `style`", function() {
 });
 
 test("prevents XSS injection via `tagName`", function() {
-  var buffer = new RenderBuffer('cool-div><div xss="true"', document.body);
+  var buffer = createRenderBuffer('cool-div><div xss="true"', document.body);
   try {
     buffer.generateElement();
     equal(buffer.element().childNodes.length, 0, 'no extra nodes created');
@@ -158,7 +168,7 @@ test("prevents XSS injection via `tagName`", function() {
 });
 
 test("handles null props - Issue #2019", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
 
   buffer.prop('value', null);
   buffer.generateElement();
@@ -166,7 +176,7 @@ test("handles null props - Issue #2019", function() {
 });
 
 test("handles browsers like Firefox < 11 that don't support outerHTML Issue #1952", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   buffer.generateElement();
   // Make sure element.outerHTML is falsy to trigger the fallback.
   var elementStub = '<div></div>';
@@ -176,7 +186,7 @@ test("handles browsers like Firefox < 11 that don't support outerHTML Issue #195
 });
 
 test("lets `setClasses` and `addClass` work together", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   buffer.setClasses(['foo', 'bar']);
   buffer.addClass('baz');
   buffer.generateElement();
@@ -188,7 +198,7 @@ test("lets `setClasses` and `addClass` work together", function() {
 
 test("generates text and a div and text", function() {
   var div = document.createElement('div');
-  var buffer = new RenderBuffer(undefined, div);
+  var buffer = createRenderBuffer(undefined, div);
   buffer.buffer = 'Howdy<div>Nick</div>Cage';
 
   var el = buffer.element();
@@ -201,7 +211,7 @@ test("generates text and a div and text", function() {
 
 test("generates a tr from a tr innerString", function() {
   var table = document.createElement('table');
-  var buffer = new RenderBuffer(undefined, table);
+  var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<tr></tr>';
 
   var el = buffer.element();
@@ -210,7 +220,7 @@ test("generates a tr from a tr innerString", function() {
 
 test("generates a tr from a tr innerString with leading <script", function() {
   var table = document.createElement('table');
-  var buffer = new RenderBuffer(undefined, table);
+  var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<script></script><tr></tr>';
 
   var el = buffer.element();
@@ -219,7 +229,7 @@ test("generates a tr from a tr innerString with leading <script", function() {
 
 test("generates a tr from a tr innerString with leading comment", function() {
   var table = document.createElement('table');
-  var buffer = new RenderBuffer(undefined, table);
+  var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<!-- blargh! --><tr></tr>';
 
   var el = buffer.element();
@@ -227,7 +237,7 @@ test("generates a tr from a tr innerString with leading comment", function() {
 });
 
 test("generates a tr from a tr innerString on rerender", function() {
-  var buffer = new RenderBuffer('table', document.body);
+  var buffer = createRenderBuffer('table', document.body);
   buffer.generateElement();
   buffer.buffer = '<tr></tr>';
 
@@ -237,7 +247,7 @@ test("generates a tr from a tr innerString on rerender", function() {
 
 test("generates a tbody from a tbody innerString", function() {
   var table = document.createElement('table');
-  var buffer = new RenderBuffer(undefined, table);
+  var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<tbody><tr></tr></tbody>';
 
   var el = buffer.element();
@@ -246,7 +256,7 @@ test("generates a tbody from a tbody innerString", function() {
 
 test("generates a col from a col innerString", function() {
   var table = document.createElement('table');
-  var buffer = new RenderBuffer(undefined, table);
+  var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<col></col>';
 
   var el = buffer.element();
@@ -256,7 +266,7 @@ test("generates a col from a col innerString", function() {
 QUnit.module("RenderBuffer - without tagName");
 
 test("It is possible to create a RenderBuffer without a tagName", function() {
-  var buffer = new RenderBuffer(undefined, document.body);
+  var buffer = createRenderBuffer(undefined, document.body);
   buffer.push('a');
   buffer.push('b');
   buffer.push('c');
@@ -271,7 +281,7 @@ test("It is possible to create a RenderBuffer without a tagName", function() {
 QUnit.module("RenderBuffer#element");
 
 test("properly handles old IE's zero-scope bug", function() {
-  var buffer = new RenderBuffer('div', document.body);
+  var buffer = createRenderBuffer('div', document.body);
   buffer.generateElement();
   buffer.push('<script></script>foo');
 
@@ -285,7 +295,7 @@ if ('namespaceURI' in document.createElement('div')) {
   QUnit.module("RenderBuffer namespaces");
 
   test("properly makes a content string SVG namespace inside an SVG tag", function() {
-    var buffer = new RenderBuffer('svg', document.body);
+    var buffer = createRenderBuffer('svg', document.body);
     buffer.generateElement();
     buffer.push('<path></path>foo');
 
@@ -298,7 +308,7 @@ if ('namespaceURI' in document.createElement('div')) {
   });
 
   test("properly makes a path element svg namespace inside SVG context", function() {
-    var buffer = new RenderBuffer('path', document.createElementNS(svgNamespace, 'svg'));
+    var buffer = createRenderBuffer('path', document.createElementNS(svgNamespace, 'svg'));
     buffer.generateElement();
     buffer.push('<g></g>');
 
@@ -311,7 +321,7 @@ if ('namespaceURI' in document.createElement('div')) {
   });
 
   test("properly makes a foreignObject svg namespace inside SVG context", function() {
-    var buffer = new RenderBuffer('foreignObject', document.createElementNS(svgNamespace, 'svg'));
+    var buffer = createRenderBuffer('foreignObject', document.createElementNS(svgNamespace, 'svg'));
     buffer.generateElement();
     buffer.push('<div></div>');
 
@@ -324,7 +334,7 @@ if ('namespaceURI' in document.createElement('div')) {
   });
 
   test("properly makes a div xhtml namespace inside foreignObject context", function() {
-    var buffer = new RenderBuffer('div', document.createElementNS(svgNamespace, 'foreignObject'));
+    var buffer = createRenderBuffer('div', document.createElementNS(svgNamespace, 'foreignObject'));
     buffer.generateElement();
     buffer.push('<div></div>');
 


### PR DESCRIPTION
Previously, both HTMLbars and the Ember view layer had their own
instance of the DOM helper, which was hardcoded to a global singleton.
This made it difficult to swap out for a “virtual DOM” when running in
Node.js.

This change refactors internals so that a single DOM helper can be
created and passed from the view layer to HTMLbars, ensuring that the
two rendering paths are unified.

This PR just refactors some internals to accept a DOM helper where
previously it was hardcoded. However, we did need to update some tests
that were making assumptions about internals that no longer hold.
