### PR TITLE
[BUGFIX beta] Check for undefined outlet name

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -2010,6 +2010,10 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     } else {
       outletName = options.outlet;
       parentView = options.parentView;
+
+      if (options && Object.keys(options).indexOf('outlet') !== -1 && typeof options.outlet === 'undefined') {
+        throw new EmberError('You passed undefined as the outlet name.');
+      }
     }
     parentView = parentView && parentView.replace(/\//g, '.');
     outletName = outletName || 'main';
@@ -2118,6 +2122,10 @@ function buildRenderOptions(route, namePassed, isDefaultRender, name, options) {
     if (!controller) {
       throw new EmberError(`You passed \`controller: '${controllerName}'\` into the \`render\` method, but no such controller could be found.`);
     }
+  }
+
+  if (options && Object.keys(options).indexOf('outlet') !== -1 && typeof options.outlet === 'undefined') {
+    throw new EmberError('You passed undefined as the outlet name.');
   }
 
   if (options && options.model) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -5,8 +5,6 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import ActionManager from 'ember-views/system/action_manager';
 import EmberView from 'ember-views/views/view';
-import { arrayControllerDeprecation } from 'ember-runtime/controllers/array_controller';
-
 import EmberHandlebars from 'ember-htmlbars/compat';
 
 var compile = EmberHandlebars.compile;

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -5,6 +5,8 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import ActionManager from 'ember-views/system/action_manager';
 import EmberView from 'ember-views/views/view';
+import { arrayControllerDeprecation } from 'ember-runtime/controllers/array_controller';
+
 import EmberHandlebars from 'ember-htmlbars/compat';
 
 var compile = EmberHandlebars.compile;
@@ -3995,4 +3997,33 @@ QUnit.test('Doesnt swallow exception thrown from willTransition', function() {
       router.handleURL('/other');
     });
   }, /boom/, 'expected an exception that didnt happen');
+});
+
+QUnit.test('Exception if outlet name is undefined in render and disconnectOutlet', function(assert) {
+  App.ApplicationRoute = Ember.Route.extend({
+    actions: {
+      showModal: function() {
+        this.render({
+          outlet: undefined,
+          parentView: 'application'
+        });
+      },
+      hideModal: function() {
+        this.disconnectOutlet({
+          outlet: undefined,
+          parentView: 'application'
+        });
+      }
+    }
+  });
+
+  bootApplication();
+
+  throws(function() {
+    Ember.run(function() { router.send('showModal'); });
+  }, /You passed undefined as the outlet name/);
+
+  throws(function() {
+    Ember.run(function() { router.send('hideModal'); });
+  }, /You passed undefined as the outlet name/);
 });


### PR DESCRIPTION
Fixes #4838

Sending undefined as the outlet name will cause the main outlet to be
blown away which should be guarded against.

```
var options = { outlet: 'modal' };

this.render('modal', {
    into:'application',
    outlet: options.outlext
});
```

 Above shows how a typo causes the main outlet to be removed.
