### PR TITLE
make isEqual() decide equality of property values.

### DIFF
--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -10,6 +10,7 @@ import {
   isPath
 } from "ember-metal/path_cache";
 import { hasPropertyAccessors } from "ember-metal/platform";
+import { isEqual } from "ember-runtime/core";
 
 var IS_GLOBAL = /^([A-Z$]|([0-9][A-Z$]))/;
 
@@ -79,7 +80,7 @@ var set = function set(obj, keyName, value, tolerant) {
         }
       }
       // only trigger a change if the value has changed
-      if (value !== currentValue) {
+      if (!isEqual(value, currentValue)) {
         propertyWillChange(obj, keyName);
         if (Ember.FEATURES.isEnabled('mandatory-setter')) {
           if (hasPropertyAccessors) {


### PR DESCRIPTION
For vanilla properties, calling `set` with the current value, will not
fire any property changes. Currently, this comparison of "sameness"
happens with the `===` operator which compares object identity.

This change uses the `isEqual` method to compare property values
instead. In most cases, this exactly the same as `===`, but does allow
for programmer-defined objects to decide whether they are equal to each
other and whether notifications should be fired when one replaces the
other.

To define a simple, immutable value object today that works seemlessly
with the Ember change notification system today, you have to make an
identity map coupled with a factory method (which could be an overridden
version of `create`) such that:

Car.for("ford", "mustang") === Car.for("ford", "mustang") //=> same object

Until such time as `WeakReference` is a thing in javascript, this
approach becomes unwieldy for types that have a large or perhaps infinite
number of values, since ensuring referential integrity means retaining
every instance ever created.

By allowing types to define their own notion of equality as pertains to
property access, you allow programmers to enrich the vocabulary of basic
property values without having to worry about over-chattiness, or worse
infinite-loopiness of observer notification.
