### PR TITLE
[BUGFIX beta] Expose `Ember.inject.registerInjectionType`.

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -1,7 +1,7 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import EmberObject from 'ember-runtime/system/object';
 import Mixin from 'ember-runtime/mixins/controller';
-import { createInjectionHelper } from 'ember-runtime/inject';
+import { registerInjectionType } from 'ember-runtime/inject';
 
 /**
 @module ember
@@ -51,7 +51,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
            to the property's name
     @return {Ember.InjectedProperty} injection descriptor instance
     */
-  createInjectionHelper('controller', controllerInjectionHelper);
+  registerInjectionType('controller', controllerInjectionHelper);
 }
 
 export default Controller;

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -15,7 +15,7 @@ function inject() {
                keys(inject).join("`, `") + "`");
 }
 
-// Dictionary of injection validations by type, added to by `createInjectionHelper`
+// Dictionary of injection validations by type, added to by `registerInjectionType`
 var typeValidators = {};
 
 /**
@@ -24,12 +24,12 @@ var typeValidators = {};
   container type itself.
 
   @private
-  @method createInjectionHelper
-  @namespace Ember
+  @method registerInjectionType
+  @namespace Ember.inject
   @param {String} type The container type the helper will inject
   @param {Function} validator A validation callback that is executed at mixin-time
 */
-export function createInjectionHelper(type, validator) {
+export function registerInjectionType(type, validator) {
   typeValidators[type] = validator;
 
   inject[type] = function(name) {

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -11,7 +11,10 @@ import Ember from 'ember-metal';
 import { isEqual } from 'ember-runtime/core';
 import compare from 'ember-runtime/compare';
 import copy from 'ember-runtime/copy';
-import inject from 'ember-runtime/inject';
+import {
+  default as inject,
+  registerInjectionType
+} from 'ember-runtime/inject';
 
 import Namespace from 'ember-runtime/system/namespace';
 import EmberObject from 'ember-runtime/system/object';
@@ -100,6 +103,7 @@ Ember.isEqual = isEqual;
 
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   Ember.inject = inject;
+  Ember.inject.registerInjectionType = registerInjectionType;
 }
 
 Ember.Array = EmberArray;

--- a/packages/ember-runtime/lib/system/service.js
+++ b/packages/ember-runtime/lib/system/service.js
@@ -1,5 +1,5 @@
 import Object from "ember-runtime/system/object";
-import { createInjectionHelper } from 'ember-runtime/inject';
+import { registerInjectionType } from 'ember-runtime/inject';
 
 var Service;
 
@@ -37,7 +37,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
            the property's name
     @return {Ember.InjectedProperty} injection descriptor instance
   */
-  createInjectionHelper('service');
+  registerInjectionType('service');
 }
 
 export default Service;

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -2,7 +2,7 @@
 
 import InjectedProperty from "ember-metal/injected_property";
 import {
-  createInjectionHelper,
+  registerInjectionType,
   default as inject
 } from "ember-runtime/inject";
 import { Registry } from "ember-runtime/system/container";
@@ -23,7 +23,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     test("injection type validation is run when first looked up", function() {
       expect(1);
 
-      createInjectionHelper('foo', function() {
+      registerInjectionType('foo', function() {
         ok(true, 'should call validation method');
       });
 


### PR DESCRIPTION
Allow consumers to use the `Ember.inject` system for custom types.

This was previously missed during the initial exposure of the feature. Without this, it is only possible to use internally in Ember, and things like `Ember.inject.store()` can't be created by Ember Data or other 3rd party libraries.
