### PR TITLE
[BUGFIX beta] mergedProperties fix for #5182

### DIFF
--- a/packages/ember-metal/tests/mixin/merged_properties_test.js
+++ b/packages/ember-metal/tests/mixin/merged_properties_test.js
@@ -91,6 +91,28 @@ test('mergedProperties should be concatenated', function() {
   deepEqual(get(obj, 'bar'), { a: true, l: true, e: true, x: true }, "get bar");
 });
 
+test("mergedProperties should exist even if not explicitly set on create", function() {
+
+  var AnObj = Ember.Object.extend({
+    mergedProperties: ['options'],
+    options: {
+      a: 'a',
+      b: {
+        c: 'ccc'
+      }
+    }
+  });
+
+  var obj = AnObj.create({
+    options: {
+      a: 'A'
+    }
+  });
+
+  equal(get(obj, "options").a, 'A');
+  equal(get(obj, "options").b.c, 'ccc');
+});
+
 test("mergedProperties' overwriting methods can call _super", function() {
 
   expect(4);

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -9,6 +9,7 @@
 */
 
 import Ember from "ember-metal/core";
+import merge from "ember-metal/merge";
 // Ember.assert, Ember.config
 
 // NOTE: this object should never be included directly. Instead use `Ember.Object`.
@@ -86,6 +87,7 @@ function makeCtor() {
       initProperties = null;
 
       var concatenatedProperties = this.concatenatedProperties;
+      var mergedProperties = this.mergedProperties;
 
       for (var i = 0, l = props.length; i < l; i++) {
         var properties = props[i];
@@ -136,6 +138,14 @@ function makeCtor() {
             } else {
               value = makeArray(value);
             }
+          }
+
+          if (mergedProperties &&
+              mergedProperties.length &&
+              indexOf(mergedProperties, keyName) >= 0) {
+            var originalValue = this[keyName];
+
+            value = merge(originalValue, value);
           }
 
           if (desc) {


### PR DESCRIPTION
Replaces #5673

Allows properties flagged as `mergedProperties` to be passed values at creation time. This is how `concatenatedProperties` already behave.

Closes #5182
