### PR TITLE
[BUGFIX] Ensure that dynamic injections are not cacheable in a Container.

### DIFF
--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -404,7 +404,23 @@ QUnit.test('Options can be registered that should be applied to all factories fo
   ok(postView1 !== postView2, 'The two lookups are different');
 });
 
-QUnit.test('factory resolves are cached', function() {
+QUnit.test('An injected non-singleton instance is never cached', function() {
+  var registry = new Registry();
+  var container = registry.container();
+  var PostView = factory();
+  var PostViewHelper = factory();
+
+  registry.register('view:post', PostView, { singleton: false });
+  registry.register('view_helper:post', PostViewHelper, { singleton: false });
+  registry.injection('view:post', 'viewHelper', 'view_helper:post');
+
+  var postView1 = container.lookup('view:post');
+  var postView2 = container.lookup('view:post');
+
+  ok(postView1.viewHelper !== postView2.viewHelper, 'Injected non-singletons are not cached');
+});
+
+QUnit.test('Factory resolves are cached', function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -360,7 +360,7 @@ QUnit.test('The container normalizes names when looking factory up', function() 
   equal(fact.toString() === PostController.extend().toString(), true, 'Normalizes the name when looking factory up');
 });
 
-QUnit.test('The container can get options that should be applied to a given factory', function() {
+QUnit.test('Options can be registered that should be applied to a given factory', function() {
   var registry = new Registry();
   var container = registry.container();
   var PostView = factory();
@@ -382,7 +382,7 @@ QUnit.test('The container can get options that should be applied to a given fact
   ok(postView1 !== postView2, 'The two lookups are different');
 });
 
-QUnit.test('The container can get options that should be applied to all factories for a given type', function() {
+QUnit.test('Options can be registered that should be applied to all factories for a given type', function() {
   var registry = new Registry();
   var container = registry.container();
   var PostView = factory();


### PR DESCRIPTION
A non-singleton injection should prevent caching of an object or factory instance in a container.

Fixes #3310
