### PR TITLE
[BUGFIX beta] Update HTMLBars to v0.8.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "ember-cli": "0.0.46",
     "ember-cli-yuidoc": "^0.3.1",
     "ember-publisher": "0.0.6",
-    "emberjs-build": "0.0.10",
+    "emberjs-build": "0.0.13",
     "express": "^4.5.0",
     "glob": "~3.2.8",
-    "htmlbars": "0.7.2",
+    "htmlbars": "0.8.0",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "rsvp": "~3.0.6"


### PR DESCRIPTION
Changes: https://github.com/tildeio/htmlbars/compare/v0.7.2...v0.8.0
- Support namespaced attributes.
- Remove ES5 only `Array.prototype.map`.
- Use correct namespace in `parseHTML()`.
- Introduces `childAtIndex` hook to use `.item()` API.
