### PR TITLE
Execute initializers in their respective context

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,13 @@ for a detailed explanation.
 
 ## Feature Flags
 
+* `ember-application-initializer-context`
+
+  Sets the context of the initializer function to its object instead of the
+  global object.
+
+  Added in [#10179](https://github.com/emberjs/ember.js/pull/10179).
+
 * `ember-testing-checkbox-helpers`
 
   Add `check` and `uncheck` test helpers.

--- a/features.json
+++ b/features.json
@@ -14,7 +14,8 @@
     "new-computed-syntax": null,
     "ember-testing-checkbox-helpers": null,
     "ember-metal-stream": null,
-    "ember-htmlbars-each-with-index": true
+    "ember-htmlbars-each-with-index": true,
+    "ember-application-initializer-context": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -695,13 +695,19 @@ var Application = Namespace.extend(DeferredMixin, {
 
     for (var i = 0; i < initializers.length; i++) {
       initializer = initializersByName[initializers[i]];
-      graph.addEdges(initializer.name, initializer.initialize, initializer.before, initializer.after);
+      graph.addEdges(initializer.name, initializer, initializer.before, initializer.after);
     }
 
     graph.topsort(function (vertex) {
       var initializer = vertex.value;
       Ember.assert("No application initializer named '" + vertex.name + "'", !!initializer);
-      initializer(registry, namespace);
+
+      if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
+        initializer.initialize(registry, namespace);
+      } else {
+        var ref = initializer.initialize;
+        ref(registry, namespace);
+      }
     });
   },
 

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -239,3 +239,25 @@ test("initializers are per-app", function() {
     initialize: function(registry) {}
   });
 });
+
+if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
+  test("initializers should be executed in their own context", function() {
+    expect(1);
+    var MyApplication = Application.extend();
+
+    MyApplication.initializer({
+      name: 'coolBabeInitializer',
+      myProperty: 'coolBabe',
+      initialize: function(registry, application) {
+        equal(this.myProperty, 'coolBabe', 'should have access to its own context');
+      }
+    });
+
+    run(function() {
+      app = MyApplication.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+  });
+}


### PR DESCRIPTION
Currently initializers are executed in the global context; this small but useful change will execute the `initialize` function in the context of its object. Below is an example of where something like this would come in handy. In the example sometimes it's useful (especially with testing) to be able to reset `app-state` or to switch out various app states at different times.

``` javascript
import Ember from 'ember';

export default {
  name: 'app-state',

  state() {
    return Ember.Object.create({
      components:  Ember.Object.create(),
      controllers: Ember.Object.create(),
      routes:      Ember.Object.create(),
      views:       Ember.Object.create()
    });
  },

  initialize(container, app) {
    app.register('state:main', this.state(), { instantiate: false });

    app.inject('component',  'app-state', 'state:main');
    app.inject('controller', 'app-state', 'state:main');
    app.inject('route',      'app-state', 'state:main');
    app.inject('view',       'app-state', 'state:main');
  }
};
```
