### PR TITLE
Support basic Node.js rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "htmlbars": "0.8.1",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
-    "rsvp": "~3.0.6"
+    "rsvp": "~3.0.6",
+    "simple-dom": "^0.1.1"
   }
 }

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -16,6 +16,8 @@ import {
   getViewBoundingClientRect
 } from "ember-views/system/utils";
 import RenderBuffer from "ember-views/system/render_buffer";
+import Renderer from "ember-views/system/renderer";
+import { DOMHelper } from "morph";
 import "ember-views/system/ext";  // for the side effect of extending Ember.run.queues
 import {
   cloneStates,
@@ -68,6 +70,8 @@ Ember.CoreView = CoreView;
 Ember.View = View;
 Ember.View.states = states;
 Ember.View.cloneStates = cloneStates;
+Ember.View.DOMHelper = DOMHelper;
+Ember.View._Renderer = Renderer;
 Ember.Checkbox = Checkbox;
 Ember.TextField = TextField;
 Ember.TextArea = TextArea;

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -520,7 +520,7 @@ RenderBuffer.prototype = {
     this.dom.detectNamespace(contextualElement);
 
     if (!this._element) {
-      this._element = document.createDocumentFragment();
+      this._element = this.dom.createDocumentFragment();
     }
 
     if (content.nodeType) {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1878,9 +1878,11 @@ var View = CoreView.extend({
     var attrs = _attrs || {};
     var view;
     attrs._parentView = this;
+    attrs.renderer = this.renderer;
 
     if (CoreView.detect(maybeViewClass)) {
       attrs.container = this.container;
+
       view = maybeViewClass.create(attrs);
 
       // don't set the property on a virtual view, as they are invisible to

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -3,19 +3,116 @@
 var path = require('path');
 var distPath = path.join(__dirname, '../../dist');
 
+/*jshint -W079 */
+var Ember = require(path.join(distPath, 'ember.debug.cjs'));
+Ember.testing = true;
+var DOMHelper = Ember.View.DOMHelper;
+var SimpleDOM = require('simple-dom');
+
 QUnit.module("App boot");
 
 QUnit.test("App is created without throwing an exception", function() {
-  var Ember = require(path.join(distPath, 'ember.debug.cjs'));
+  var App;
 
-  var App = Ember.Application.create({
+  Ember.run(function() {
+    App = Ember.Application.create();
+
+    App.Router = Ember.Router.extend({
+      location: 'none'
+    });
+
+    App.advanceReadiness();
   });
-
-  App.Router = Ember.Router.extend({
-    location: 'none'
-  });
-
-  App.advanceReadiness();
 
   QUnit.ok(App);
+});
+
+QUnit.test("It is possible to render a view in Node", function() {
+  var View = Ember.View.extend({
+    renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
+    template: Ember.Handlebars.compile("<h1>Hello</h1>")
+  });
+
+  var morph = {
+    contextualElement: {},
+    setContent: function(element) {
+      this.element = element;
+    }
+  };
+
+  var view = View.create({
+    _domHelper: new DOMHelper(new SimpleDOM.Document()),
+    _morph: morph
+  });
+
+  var renderer = view.renderer;
+
+  Ember.run(function() {
+    renderer.renderTree(view);
+  });
+
+  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+  ok(serializer.serialize(morph.element).match(/<h1>Hello<\/h1>/));
+});
+
+QUnit.test("It is possible to render a view with curlies in Node", function() {
+  var View = Ember.Component.extend({
+    renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
+    layout: Ember.Handlebars.compile("<h1>Hello {{location}}</h1>"),
+    location: "World"
+  });
+
+  var morph = {
+    contextualElement: {},
+    setContent: function(element) {
+      this.element = element;
+    }
+  };
+
+  var view = View.create({
+    _domHelper: new DOMHelper(new SimpleDOM.Document()),
+    _morph: morph
+  });
+
+  var renderer = view.renderer;
+
+  Ember.run(function() {
+    renderer.renderTree(view);
+  });
+
+  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+  ok(serializer.serialize(morph.element).match(/<h1>Hello World<\/h1>/));
+});
+
+QUnit.test("It is possible to render a view with a nested {{view}} helper in Node", function() {
+  var View = Ember.Component.extend({
+    renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
+    layout: Ember.Handlebars.compile("<h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1> <div>{{view bar}}</div>"),
+    location: "World",
+    hasExistence: true,
+    bar: Ember.View.extend({
+      template: Ember.Handlebars.compile("<p>The files are *inside* the computer?!</p>")
+    })
+  });
+
+  var morph = {
+    contextualElement: {},
+    setContent: function(element) {
+      this.element = element;
+    }
+  };
+
+  var view = View.create({
+    _domHelper: new DOMHelper(new SimpleDOM.Document()),
+    _morph: morph
+  });
+
+  var renderer = view.renderer;
+
+  Ember.run(function() {
+    renderer.renderTree(view);
+  });
+
+  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+  ok(serializer.serialize(morph.element).match(/<h1>Hello World<\/h1> <div><div id="(.*)" class="ember-view"><p>The files are \*inside\* the computer\?\!<\/p><\/div><\/div>/));
 });


### PR DESCRIPTION
This commit makes some small cleanup changes across the framework that
ensure that views’ renderers are consistently inherited from their
parents (so that, e.g., if you render a view using a Node renderer, all
subviews will use that same renderer).

It also changes one instance where DOM was being relied upon rather than
using the DOMHelper abstraction.

It also includes a small suite of tests that manually patch views to use
the Node SSR renderer, verifying that compiled HTMLbars templates render
correctly.
