### PR TITLE
Port attributeBindings to AttrNode views

### DIFF
--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -163,6 +163,12 @@ Renderer.prototype.appendTo =
     this.scheduleInsert(view, morph);
   };
 
+Renderer.prototype.appendAttrTo =
+  function Renderer_appendAttrTo(view, target, attrName) {
+    var morph = this._dom.createAttrMorph(target, attrName);
+    this.scheduleInsert(view, morph);
+  };
+
 Renderer.prototype.replaceIn =
   function Renderer_replaceIn(view, target) {
     var morph = this._dom.createMorph(target, null, null);

--- a/packages/ember-views/lib/attr_nodes/attr_node.js
+++ b/packages/ember-views/lib/attr_nodes/attr_node.js
@@ -17,20 +17,20 @@ function AttrNode(attrName, attrValue) {
 AttrNode.prototype.init = function init(attrName, simpleAttrValue) {
   this.isView = true;
 
-  // That these semantics are used is very unfortunate.
   this.tagName = '';
-  this.classNameBindings = [];
+  this.isVirtual = true;
 
   this.attrName = attrName;
   this.attrValue = simpleAttrValue;
   this.isDirty = true;
+  this.isDestroying = false;
   this.lastValue = null;
 
   subscribe(this.attrValue, this.rerender, this);
 };
 
 AttrNode.prototype.renderIfDirty = function renderIfDirty() {
-  if (this.isDirty) {
+  if (this.isDirty && !this.isDestroying) {
     var value = read(this.attrValue);
     if (value !== this.lastValue) {
       this._renderer.renderTree(this, this._parentView);
@@ -42,11 +42,19 @@ AttrNode.prototype.renderIfDirty = function renderIfDirty() {
 
 AttrNode.prototype.render = function render(buffer) {
   this.isDirty = false;
+  if (this.isDestroying) {
+    return;
+  }
   var value = read(this.attrValue);
 
-  this._morph.setContent(value);
+  if (this.attrName === 'value' && (value === null || value === undefined)) {
+    value = '';
+  }
 
-  this.lastValue = value;
+  if (this.lastValue !== null || value !== null) {
+    this._morph.setContent(value);
+    this.lastValue = value;
+  }
 };
 
 AttrNode.prototype.rerender = function render() {
@@ -55,11 +63,14 @@ AttrNode.prototype.rerender = function render() {
 };
 
 AttrNode.prototype.destroy = function render() {
+  this.isDestroying = true;
   this.isDirty = false;
+
   unsubscribe(this.attrValue, this.rerender, this);
 
-  var parent = this._parentView;
-  if (parent) { parent.removeChild(this); }
+  if (!this.removedFromDOM && this._renderer) {
+    this._renderer.remove(this, true);
+  }
 };
 
 export default AttrNode;

--- a/packages/ember-views/lib/attr_nodes/legacy_bind.js
+++ b/packages/ember-views/lib/attr_nodes/legacy_bind.js
@@ -7,25 +7,32 @@ import AttrNode from "./attr_node";
 import { fmt } from "ember-runtime/system/string";
 import { typeOf } from "ember-metal/utils";
 import { read } from "ember-metal/streams/utils";
-import create from 'ember-metal/platform/create';
+import o_create from "ember-metal/platform/create";
 
 function LegacyBindAttrNode(attrName, attrValue) {
   this.init(attrName, attrValue);
 }
 
-LegacyBindAttrNode.prototype = create(AttrNode.prototype);
+LegacyBindAttrNode.prototype = o_create(AttrNode.prototype);
 
 LegacyBindAttrNode.prototype.render = function render(buffer) {
   this.isDirty = false;
+  if (this.isDestroying) {
+    return;
+  }
   var value = read(this.attrValue);
-  var type = typeOf(value);
+
+  if (this.attrName === 'value' && (value === null || value === undefined)) {
+    value = '';
+  }
 
   Ember.assert(fmt("Attributes must be numbers, strings or booleans, not %@", [value]),
-               value === null || value === undefined || type === 'number' || type === 'string' || type === 'boolean');
+               value === null || value === undefined || typeOf(value) === 'number' || typeOf(value) === 'string' || typeOf(value) === 'boolean');
 
-  this._morph.setContent(value);
-
-  this.lastValue = value;
+  if (this.lastValue !== null || value !== null) {
+    this._morph.setContent(value);
+    this.lastValue = value;
+  }
 };
 
 export default LegacyBindAttrNode;

--- a/packages/ember-views/lib/system/platform.js
+++ b/packages/ember-views/lib/system/platform.js
@@ -1,0 +1,14 @@
+import environment from "ember-metal/environment";
+
+// IE 6/7 have bugs around setting names on inputs during creation.
+// From http://msdn.microsoft.com/en-us/library/ie/ms536389(v=vs.85).aspx:
+// "To include the NAME attribute at run time on objects created with the createElement method, use the eTag."
+export var canSetNameOnInputs = environment.hasDOM && (function() {
+  var div = document.createElement('div');
+  var el = document.createElement('input');
+
+  el.setAttribute('name', 'foo');
+  div.appendChild(el);
+
+  return !!div.innerHTML.match('foo');
+})();

--- a/packages/ember-views/lib/views/states/in_buffer.js
+++ b/packages/ember-views/lib/views/states/in_buffer.js
@@ -48,6 +48,23 @@ merge(inBuffer, {
     return childView;
   },
 
+  appendAttr: function(view, attrNode) {
+    var buffer = view.buffer;
+    var _childViews = view._childViews;
+
+    if (!_childViews.length) { _childViews = view._childViews = _childViews.slice(); }
+    _childViews.push(attrNode);
+
+    if (!attrNode._morph) {
+      Ember.assert("bound attributes that do not have a morph must have a buffer", !!buffer);
+      buffer.pushAttrNode(attrNode);
+    }
+
+    view.propertyDidChange('childViews');
+
+    return attrNode;
+  },
+
   invokeObserver: function(target, observer) {
     observer.call(target);
   }

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -38,7 +38,22 @@ merge(inDOM, {
     if (!this.isVirtual) {
       delete View.views[view.elementId];
     }
+  },
+
+  appendAttr: function(view, attrNode) {
+    var _childViews = view._childViews;
+
+    if (!_childViews.length) { _childViews = view._childViews = _childViews.slice(); }
+    _childViews.push(attrNode);
+
+    attrNode._parentView = view;
+    view.renderer.appendAttrTo(attrNode, view.element, attrNode.attrName);
+
+    view.propertyDidChange('childViews');
+
+    return attrNode;
   }
+
 });
 
 export default inDOM;

--- a/packages/ember-views/tests/views/text_field_test.js
+++ b/packages/ember-views/tests/views/text_field_test.js
@@ -553,7 +553,6 @@ QUnit.test('should not reset cursor position when text field receives keyUp even
 
   appendView(view);
 
-  view.$().val('Brosiedoon, King of the Brocean');
   setCaretPosition(view.$(), 5);
 
   run(function() {

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -30,17 +30,12 @@ QUnit.module("EmberView - Attribute Bindings", {
 
 QUnit.test("should render attribute bindings", function() {
   view = EmberView.create({
-    classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
-    attributeBindings: ['type', 'isDisabled:disabled', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
+    attributeBindings: ['type', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
 
     type: 'submit',
-    isDisabled: true,
-    exploded: false,
-    destroyed: false,
     exists: true,
     nothing: null,
-    notDefined: undefined,
-    notNumber: NaN
+    notDefined: undefined
   });
 
   run(function() {
@@ -48,20 +43,15 @@ QUnit.test("should render attribute bindings", function() {
   });
 
   equal(view.$().attr('type'), 'submit', "updates type attribute");
-  ok(view.$().prop('disabled'), "supports customizing attribute name for Boolean values");
-  ok(!view.$().prop('exploded'), "removes exploded attribute when false");
-  ok(!view.$().prop('destroyed'), "removes destroyed attribute when false");
-  ok(view.$().prop('exists'), "adds exists attribute when true");
+  ok(view.$().attr('exists'), "adds exists attribute when true");
   ok(!view.$().attr('nothing'), "removes nothing attribute when null");
-  ok(!view.$().attr('notDefined'), "removes notDefined attribute when undefined");
-  ok(!view.$().attr('notNumber'), "removes notNumber attribute when NaN");
+  equal(view.$().attr('notDefined'), undefined, "removes notDefined attribute when undefined");
 });
 
 QUnit.test("should normalize case for attribute bindings", function() {
   view = EmberView.create({
     tagName: 'input',
     attributeBindings: ['disAbled'],
-
     disAbled: true
   });
 
@@ -72,20 +62,31 @@ QUnit.test("should normalize case for attribute bindings", function() {
   ok(view.$().prop('disabled'), "sets property with correct case");
 });
 
+QUnit.test("should render attribute bindings on input", function() {
+  view = EmberView.create({
+    tagName: 'input',
+    attributeBindings: ['type', 'isDisabled:disabled'],
+
+    type: 'submit',
+    isDisabled: true
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().attr('type'), 'submit', "updates type attribute");
+  ok(view.$().prop('disabled'), "supports customizing attribute name for Boolean values");
+});
+
 QUnit.test("should update attribute bindings", function() {
   view = EmberView.create({
-    classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
-    attributeBindings: ['type', 'isDisabled:disabled', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
-
+    attributeBindings: ['type', 'color:data-color', 'exploded', 'collapsed', 'times'],
     type: 'reset',
-    isDisabled: true,
-    exploded: true,
-    destroyed: true,
-    exists: false,
-    nothing: true,
-    notDefined: true,
-    notNumber: true,
-    explosions: 15
+    color: 'red',
+    exploded: 'bang',
+    collapsed: null,
+    times: 15
   });
 
   run(function() {
@@ -93,35 +94,105 @@ QUnit.test("should update attribute bindings", function() {
   });
 
   equal(view.$().attr('type'), 'reset', "adds type attribute");
-  ok(view.$().prop('disabled'), "adds disabled attribute when true");
-  ok(view.$().prop('exploded'), "adds exploded attribute when true");
-  ok(view.$().prop('destroyed'), "adds destroyed attribute when true");
-  ok(!view.$().prop('exists'), "does not add exists attribute when false");
-  ok(view.$().prop('nothing'), "adds nothing attribute when true");
-  ok(view.$().prop('notDefined'), "adds notDefined attribute when true");
-  ok(view.$().prop('notNumber'), "adds notNumber attribute when true");
-  equal(view.$().attr('explosions'), "15", "adds integer attributes");
+  equal(view.$().attr('data-color'), 'red', "attr value set with ternary");
+  equal(view.$().attr('exploded'), 'bang', "adds exploded attribute when it has a value");
+  ok(!view.$().attr('collapsed'), "does not add null attribute");
+  equal(view.$().attr('times'), '15', 'sets an integer to an attribute');
 
   run(function() {
     view.set('type', 'submit');
-    view.set('isDisabled', false);
-    view.set('exploded', false);
-    view.set('destroyed', false);
-    view.set('exists', true);
-    view.set('nothing', null);
-    view.set('notDefined', undefined);
-    view.set('notNumber', NaN);
+    view.set('color', 'blue');
+    view.set('exploded', null);
+    view.set('collapsed', 'swish');
+    view.set('times', 16);
   });
 
-  equal(view.$().attr('type'), 'submit', "updates type attribute");
-  ok(!view.$().prop('disabled'), "removes disabled attribute when false");
-  ok(!view.$().prop('exploded'), "removes exploded attribute when false");
-  ok(!view.$().prop('destroyed'), "removes destroyed attribute when false");
-  ok(view.$().prop('exists'), "adds exists attribute when true");
-  ok(!view.$().attr('nothing'), "removes nothing attribute when null");
-  ok(!view.$().attr('notDefined'), "removes notDefined attribute when undefined");
-  ok(!view.$().attr('notNumber'), "removes notNumber attribute when NaN");
+  equal(view.$().attr('type'), 'submit', "adds type attribute");
+  equal(view.$().attr('data-color'), 'blue', "attr value set with ternary");
+  ok(!view.$().attr('exploded'), "removed exploded attribute when it is null");
+  ok(view.$().attr('collapsed'), "swish", "adds an attribute when it has a value");
+  equal(view.$().attr('times'), '16', 'updates an integer attribute');
 });
+
+QUnit.test("should update attribute bindings on input (boolean)", function() {
+  view = EmberView.create({
+    tagName: 'input',
+    attributeBindings: ['disabled'],
+    disabled: true
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  ok(view.$().prop('disabled'), "adds disabled property when true");
+
+  run(function() {
+    view.set('disabled', false);
+  });
+
+  ok(!view.$().prop('disabled'), "updates disabled property when false");
+});
+
+QUnit.test("should update attribute bindings on input (raw number prop)", function() {
+  view = EmberView.create({
+    tagName: 'input',
+    attributeBindings: ['size'],
+    size: 20
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().prop('size'), 20, "adds size property");
+
+  run(function() {
+    view.set('size', 10);
+  });
+
+  equal(view.$().prop('size'), 10, "updates size property");
+});
+
+QUnit.test("should update attribute bindings on input (name)", function() {
+  view = EmberView.create({
+    tagName: 'input',
+    attributeBindings: ['name'],
+    name: 'bloody-awful'
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().prop('name'), 'bloody-awful', "adds name property");
+
+  run(function() {
+    view.set('name', 'simply-grand');
+  });
+
+  equal(view.$().prop('name'), 'simply-grand', "updates name property");
+});
+
+QUnit.test("should update attribute bindings with micro syntax", function() {
+  view = EmberView.create({
+    tagName: 'input',
+    attributeBindings: ['isDisabled:disabled'],
+    type: 'reset',
+    isDisabled: true
+  });
+
+  run(function() {
+    view.createElement();
+  });
+  ok(view.$().prop('disabled'), "adds disabled property when true");
+
+  run(function() {
+    view.set('isDisabled', false);
+  });
+  ok(!view.$().prop('disabled'), "updates disabled property when false");
+});
+
 
 QUnit.test("should update attribute bindings on svg", function() {
   view = EmberView.create({
@@ -160,10 +231,10 @@ QUnit.test("should allow binding to String objects", function() {
   equal(view.$().attr('foo'), 'bar', "should convert String object to bare string");
 
   run(function() {
-    view.set('foo', false);
+    view.set('foo', null);
   });
 
-  ok(!view.$().attr('foo'), "removes foo attribute when false");
+  ok(!view.$().attr('foo'), "removes foo attribute when null");
 });
 
 QUnit.test("should teardown observers on rerender", function() {
@@ -175,17 +246,18 @@ QUnit.test("should teardown observers on rerender", function() {
 
   appendView();
 
-  equal(observersFor(view, 'foo').length, 2);
+  equal(observersFor(view, 'foo').length, 2, 'observer count after render is two');
 
   run(function() {
     view.rerender();
   });
 
-  equal(observersFor(view, 'foo').length, 2);
+  equal(observersFor(view, 'foo').length, 2, 'observer count after rerender remains two');
 });
 
 QUnit.test("handles attribute bindings for properties", function() {
   view = EmberView.create({
+    tagName: 'input',
     attributeBindings: ['checked'],
     checked: null
   });
@@ -209,6 +281,7 @@ QUnit.test("handles attribute bindings for properties", function() {
 
 QUnit.test("handles `undefined` value for properties", function() {
   view = EmberView.create({
+    tagName: 'input',
     attributeBindings: ['value'],
     value: "test"
   });
@@ -221,7 +294,7 @@ QUnit.test("handles `undefined` value for properties", function() {
     view.set('value', undefined);
   });
 
-  equal(!!view.$().prop('value'), false, "value is not defined");
+  equal(view.$().prop('value'), '', "value is blank");
 });
 
 QUnit.test("handles null value for attributes on text fields", function() {
@@ -322,6 +395,7 @@ QUnit.test("blacklists href bindings based on protocol", function() {
   /* jshint scripturl:true */
 
   view = EmberView.create({
+    tagName: 'a',
     attributeBindings: ['href'],
     href: "javascript:alert('foo')"
   });


### PR DESCRIPTION
Ember's attribute bindings were a custom system based on the buffer and a view. The buffer would be updated with initial values, and the element have those attributes applied during it's own render pass. Observers were attached to watch changing values.

This refactors attribute bindings to use AttrNode objects, which in turn are rendered like a normal view on the renderer. They have access to morphs and the `domHelper` in a standard view-ish way.

TODO
- [x] There is a failing test that tries to assert a cursor position in a text field not changing. Needs a deep dive.
- [x] IE8 check. Should end up meaning `type` needs to be added to the buffer in a legacy string style. I've kept this in mind an not gutted the legacy system, so it should go fairly smoothly.
- [x] Upstream HTMLBars PR: https://github.com/tildeio/htmlbars/pull/248
- [x] Upstream PR to address attribute removal in IE https://github.com/tildeio/htmlbars/issues/251
- [x] Upstream PR to fix passing numbers to `parseHTML` https://github.com/tildeio/htmlbars/pull/253
- [x] Check for any obvious performance regression

/cc @mmun @krisselden and view-layer crew.

Closes #9921
