### PR TITLE
[BUGFIX beta] Bump HTMLBars to v0.8.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "emberjs-build": "0.0.13",
     "express": "^4.5.0",
     "glob": "~3.2.8",
-    "htmlbars": "0.8.0",
+    "htmlbars": "0.8.1",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "rsvp": "~3.0.6"


### PR DESCRIPTION
- Call `String` on value in `setAttributeNS`.
- Change setProperty and morph to remove an undefined attr value.

Compare view: https://github.com/tildeio/htmlbars/compare/v0.8.0...v0.8.1.
