### PR TITLE
[DOC] API doc for `init` event on Ember.CoreObject

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -189,6 +189,30 @@ function makeCtor() {
 
     m.proto = proto;
     finishChains(this);
+
+    /**
+      This event is sent when objects are instantiated. This way, you can
+      execute functions when the object is created without having to override
+      `init` (the [method](#method_init)).
+
+      Example:
+
+      ```javascript
+      App.Person = Ember.Object.extend({
+        doSomethingAtCreation: function() {
+          alert('Name is ' + this.get('name'));
+        }.on('init')
+      });
+
+      var steve = App.Person.create({
+        name: "Steve"
+      });
+
+      // alerts 'Name is Steve'.
+      ```
+
+      @event init
+    */
     sendEvent(this, 'init');
   };
 
@@ -260,7 +284,8 @@ CoreObject.PrototypeMixin = Mixin.create({
     `Ember.ArrayController`, be sure to call `this._super()` in your
     `init` declaration! If you don't, Ember may not have an opportunity to
     do important setup work, and you'll see strange behavior in your
-    application.
+    application. This is why in most cases, you should consider using the
+    [event of the same name](#event_init) instead of overriding this method.
 
     @method init
   */


### PR DESCRIPTION
Hello,

I noticed that there was no documentation for the `init` event, which allows to hook into the object creation without having to override the method `init`, so I thought I'd just write it.

I hope I did this right, if not let me know how to correct this.

Thanks, and have a good day
