### PR TITLE
[BUGFIX beta] Remove vestigial `helper` import in ember-htmlbars

### DIFF
--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -12,7 +12,6 @@ import makeBoundHelper from "ember-htmlbars/system/make_bound_helper";
 
 import {
   registerHelper,
-  helper,
   default as helpers
 } from "ember-htmlbars/helpers";
 import { viewHelper } from "ember-htmlbars/helpers/view";


### PR DESCRIPTION
I noticed an error in JSHint the other day:

![JSHint Error](https://s3.amazonaws.com/f.cl.ly/items/0e0n040v0T3J2D160B39/Screen%20Shot%202015-01-12%20at%208.41.51%20PM.png)

It seems that references to `helper` had been removed when the HTMLBars public API was cleaned up on Jan 5 with 662a3ddde2ca7502d1d778aa758cdec3909df89f but the import remained. This cleans that up and gets JSHint to calm down.
