### PR TITLE
[DOC] Fix return value of `Ember.run.bind`

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -153,8 +153,7 @@ run.join = function() {
     May be a function or a string. If you pass a string
     then it will be looked up on the passed target.
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
-  @return {Object} return value from invoking the passed function. Please note,
-  when called within an existing loop, no return value is possible.
+  @return {Function} returns a new function that will always have a particular context
   @since 1.4.0
 */
 run.bind = function(target, method /* args */) {


### PR DESCRIPTION
I think there's a mistake in the documentation for the function `Ember.run.bind`.

This function doesn't return the value from invoking the passed function, instead it returns a new function that will have the `target` object as it's context.
