### PR TITLE
[BUGFIX] Tweak FEATURES.md to reflect namespaced transition classes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -123,10 +123,12 @@ for a detailed explanation.
   Disables eager URL updates during slow transitions in favor of new CSS
   classes added to `link-to`s (in addition to `active` class):
 
-  - `transitioning-in`: link-to is not currently active, but will be
+  - `ember-transitioning-in`: link-to is not currently active, but will be
     when the current underway (slow) transition completes.
-  - `transitioning-out`: link-to is currently active, but will no longer
+  - `ember-transitioning-out`: link-to is currently active, but will no longer
     be active when the current underway (slow) transition completes.
+
+  Added in [#9919](https://github.com/emberjs/ember.js/pull/9919)
 
 * `new-computed-syntax`
 


### PR DESCRIPTION
Not sure if this is something anyone will actually care about but I noticed that `FEATURES.md` had not been updated when the transitioning class names were namespaced in https://github.com/emberjs/ember.js/pull/9987.

I also added a link to the original PR for good measure.

As with my other PR the other day I'm not entirely confident that BUGFIX is the proper prefix for something like this. Will be happy to amend my commit if this presents an issue.
