### PR TITLE
[FEATURE] override attribute bindings

### DIFF
--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -410,3 +410,21 @@ QUnit.test("blacklists href bindings based on protocol", function() {
 
   equal(view.$().attr('href'), "javascript:alert('foo')", "value is not defined");
 });
+
+QUnit.test("attributeBindings should be overridable", function() {
+  var ParentView = EmberView.extend({
+    attributeBindings: ['href'],
+    href: "an href"
+  });
+
+  var ChildView = ParentView.extend({
+    attributeBindings: ['newHref:href'],
+    newHref: "a new href"
+  });
+
+  view = ChildView.create();
+
+  appendView();
+
+  equal(view.$().attr('href'), "a new href", "expect value from subclass attribute binding");
+});


### PR DESCRIPTION
Adds attribute binding override support.
Related with #10176.

Is there something missing? This is my first contribution attempt. :)

Maybe we should do something similar for classNameBindings.
I could make this override behaviour more abstract, but that would require to loop the attribute array again.
This way we only loop it once.

Should I wrap this behing a feature flag?
