### PR TITLE
typo in documentation

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -24,7 +24,7 @@ import copy from "ember-runtime/copy";
 // because they are so common.
 
 /**
-  The NativeArray mixin contains the properties needed to to make the native
+  The NativeArray mixin contains the properties needed to make the native
   Array support Ember.MutableArray and all of its dependent APIs. Unless you
   have `Ember.EXTEND_PROTOTYPES` or `Ember.EXTEND_PROTOTYPES.Array` set to
   false, this will be applied automatically. Otherwise you can apply the mixin


### PR DESCRIPTION
"to to" => "to"
