### PR TITLE
[Bugfix beta] Prevent Ember from erroring when the errorThrown property ...

### DIFF
--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -47,6 +47,9 @@ RSVP.onerrorDefault = function (e) {
   if (e && e.errorThrown) {
     // jqXHR provides this
     error = e.errorThrown;
+    if (typeof error === 'string') {
+      error = new Error(error);
+    }
     error.__reason_with_error_thrown__ = e;
   } else {
     error = e;

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -142,3 +142,30 @@ test('rejections like jqXHR which have errorThrown property work', function() {
     Ember.testing = wasEmberTesting;
   }
 });
+
+
+test('rejections where the errorThrown is a string should wrap the sting in an error object', function() {
+  expect(2);
+
+  var wasEmberTesting = Ember.testing;
+  var wasOnError      = Ember.onerror;
+
+  try {
+    Ember.testing = false;
+    Ember.onerror = function(error) {
+      console.log('error', error);
+      equal(error.message, actualError, 'expected the real error on the jqXHR');
+      equal(error.__reason_with_error_thrown__, jqXHR, 'also retains a helpful reference to the rejection reason');
+    };
+
+    var actualError = "OMG what really happened";
+    var jqXHR = {
+      errorThrown: actualError
+    };
+
+    run(RSVP, 'reject', jqXHR);
+  } finally {
+    Ember.onerror = wasOnError;
+    Ember.testing = wasEmberTesting;
+  }
+});


### PR DESCRIPTION
... is a sting literal

This can happen when Ember Data receives an ajax request with an error code and a response string such as `401` and "Unauthorized".  See https://github.com/emberjs/data/issues/2694

It appears on Chrome and Safari if you attempt to assign a property to a string literal in strict mode you will get a type error. According to this V8 issue this is per spec. https://code.google.com/p/v8/issues/detail?id=3725
