### PR TITLE
Remove outdated documentation of itemController [ci skip]

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -105,22 +105,18 @@ import EmberError from 'ember-metal/error';
 export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
 
   /**
-    The controller used to wrap items, if any. If the value is a string, it will
-    be used to lookup the container for the controller. As an alternative, you
-    can also provide a controller class as the value.
+    A string containing the controller name used to wrap items.
 
     For example:
 
     ```javascript
     App.MyArrayController = Ember.ArrayController.extend({
-      itemController: Ember.ObjectController.extend({
-        //Item Controller Implementation
-      })
+      itemController: 'myItem' // use App.MyItemController
     });
     ```
 
     @property itemController
-    @type String | Ember.Controller
+    @type String
     @default null
   */
   itemController: null,


### PR DESCRIPTION
Looks likes #5301 feature got reverted based on [tomdale comment](https://github.com/emberjs/ember.js/pull/5301#issuecomment-65857454). But the documentation still points to it. This commit update the documentation just exposing the controller name implementation.
