### PR TITLE
[DOC] Fix typo: "an run" to "a run"

### DIFF
--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -611,7 +611,7 @@ run.throttle = function() {
 function checkAutoRun() {
   if (!run.currentRunLoop) {
     Ember.assert("You have turned on testing mode, which disabled the run-loop's autorun." +
-                 " You will need to wrap any code with asynchronous side-effects in an run", !Ember.testing);
+                 " You will need to wrap any code with asynchronous side-effects in a run", !Ember.testing);
   }
 }
 

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -70,10 +70,10 @@ test('prior queues should be flushed before moving on to next queue', function()
 test('makes sure it does not trigger an autorun during testing', function() {
   expectAssertion(function() {
     run.schedule('actions', function() {});
-  }, /wrap any code with asynchronous side-effects in an run/);
+  }, /wrap any code with asynchronous side-effects in a run/);
 
   // make sure not just the first violation is asserted.
   expectAssertion(function() {
     run.schedule('actions', function() {});
-  }, /wrap any code with asynchronous side-effects in an run/);
+  }, /wrap any code with asynchronous side-effects in a run/);
 });


### PR DESCRIPTION
The "n" was still hanging out from when it read "an Ember.run"
