### PR TITLE
Use new cps (get/set) internally

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -117,6 +117,7 @@ function ComputedProperty(config, opts) {
       config.__ember_arity = config.length;
       this._getter = config;
       if (config.__ember_arity > 1) {
+        Ember.deprecate("Using the same function as getter and setter is deprecated");
         this._setter = config;
       }
     } else {

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -674,13 +674,16 @@ export function readOnly(dependentKey) {
   @deprecated Use `Ember.computed.oneWay` or custom CP with default instead.
 */
 export function defaultTo(defaultPath) {
-  return computed(function(key, newValue, cachedValue) {
-    Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
-
-    if (arguments.length === 1) {
+  return computed({
+    get: function(key) {
+      Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
       return get(this, defaultPath);
+    },
+
+    set: function(key, newValue, cachedValue) {
+      Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
+      return newValue != null ? newValue : get(this, defaultPath);
     }
-    return newValue != null ? newValue : get(this, defaultPath);
   });
 }
 
@@ -698,14 +701,15 @@ export function defaultTo(defaultPath) {
   @since 1.7.0
 */
 export function deprecatingAlias(dependentKey) {
-  return computed(dependentKey, function(key, value) {
-    Ember.deprecate(`Usage of \`${key}\` is deprecated, use \`${dependentKey}\` instead.`);
-
-    if (arguments.length > 1) {
+  return computed(dependentKey, {
+    get: function(key) {
+      Ember.deprecate(`Usage of \`${key}\` is deprecated, use \`${dependentKey}\` instead.`);
+      return get(this, dependentKey);
+    },
+    set: function(key, value) {
+      Ember.deprecate(`Usage of \`${key}\` is deprecated, use \`${dependentKey}\` instead.`);
       set(this, dependentKey, value);
       return value;
-    } else {
-      return get(this, dependentKey);
     }
   });
 }

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -17,14 +17,15 @@ testBoth("bindings should not sync twice in a single run loop", function(get, se
   run(function() {
     a = {};
 
-    defineProperty(a, 'foo', computed(function(key, value) {
-      if (arguments.length === 2) {
+    defineProperty(a, 'foo', computed({
+      get: function(key) {
+        getCalled++;
+        return setValue;
+      },
+      set: function(key, value) {
         setCalled++;
         setValue = value;
         return value;
-      } else {
-        getCalled++;
-        return setValue;
       }
     }).volatile());
 

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -51,7 +51,7 @@ QUnit.test('overriding computed properties', function() {
   equal(get(obj, 'aProp'), 'AD', "should define super for D");
 
   obj = { };
-  defineProperty(obj, 'aProp', computed(function(key, value) {
+  defineProperty(obj, 'aProp', computed(function(key) {
     return 'obj';
   }));
   MixinD.apply(obj);
@@ -66,19 +66,16 @@ QUnit.test('calling set on overridden computed properties', function() {
   var superSetOccurred = false;
 
   SuperMixin = Mixin.create({
-    aProp: computed(function(key, val) {
-      if (arguments.length === 1) {
-        superGetOccurred = true;
-      } else {
-        superSetOccurred = true;
-      }
-      return true;
+    aProp: computed({
+      get: function(key) { superGetOccurred = true; },
+      set: function(key, value) { superSetOccurred = true; }
     })
   });
 
   SubMixin = Mixin.create(SuperMixin, {
-    aProp: computed(function(key, val) {
-      return this._super.apply(this, arguments);
+    aProp: computed({
+      get: function(key) { return this._super.apply(this, arguments); },
+      set: function(key, value) { return this._super.apply(this, arguments); }
     })
   });
 
@@ -112,12 +109,14 @@ QUnit.test('setter behavior works properly when overriding computed properties',
   var cpWasCalled = false;
 
   var MixinB = Mixin.create({
-    cpWithSetter2: computed(function(k, v) {
-      cpWasCalled = true;
+    cpWithSetter2: computed({
+      get: K,
+      set: function(k, v) { cpWasCalled = true; }
     }),
 
-    cpWithSetter3: computed(function(k, v) {
-      cpWasCalled = true;
+    cpWithSetter3: computed({
+      get: K,
+      set: function(k, v) { cpWasCalled = true; }
     }),
 
     cpWithoutSetter: computed(function(k) {

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -1028,9 +1028,9 @@ testBoth('setting simple prop should not trigger', function(get, set) {
 testBoth('setting a cached computed property whose value has changed should trigger', function(get, set) {
   var obj = {};
 
-  defineProperty(obj, 'foo', computed(function(key, value) {
-    if (arguments.length === 2) { return value; }
-    return get(this, 'baz');
+  defineProperty(obj, 'foo', computed({
+    get: function() { return get(this, 'baz'); },
+    set: function(key, value) { return value; }
   }).property('baz'));
 
   var count = 0;
@@ -1070,11 +1070,9 @@ testBoth("immediate observers should fire synchronously", function(get, set) {
 
     mixin.apply(obj);
 
-    defineProperty(obj, 'foo', computed(function(key, value) {
-      if (arguments.length > 1) {
-        return value;
-      }
-      return "yes hello this is foo";
+    defineProperty(obj, 'foo', computed({
+      get: function() { return "yes hello this is foo"; },
+      set: function(key, value) { return value; }
     }));
 
     equal(get(obj, 'foo'), "yes hello this is foo", "precond - computed property returns a value");
@@ -1105,11 +1103,9 @@ if (Ember.EXTEND_PROTOTYPES) {
 
       mixin.apply(obj);
 
-      defineProperty(obj, 'foo', computed(function(key, value) {
-        if (arguments.length > 1) {
-          return value;
-        }
-        return "yes hello this is foo";
+      defineProperty(obj, 'foo', computed({
+        get: function(key) { return "yes hello this is foo"; },
+        set: function(key, value) { return value; }
       }));
 
       equal(get(obj, 'foo'), "yes hello this is foo", "precond - computed property returns a value");
@@ -1139,11 +1135,9 @@ testBoth('immediate observers watching multiple properties via brace expansion f
 
     mixin.apply(obj);
 
-    defineProperty(obj, 'foo', computed(function(key, value) {
-      if (arguments.length > 1) {
-        return value;
-      }
-      return "yes hello this is foo";
+    defineProperty(obj, 'foo', computed({
+      get: function() { return "yes hello this is foo"; },
+      set: function(key, value) { return value; }
     }));
 
     equal(get(obj, 'foo'), "yes hello this is foo", "precond - computed property returns a value");

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -28,12 +28,14 @@ function addListeners(obj, keyPath) {
 testBoth('unwatching a computed property - regular get/set', function(get, set) {
 
   var obj = {};
-  defineProperty(obj, 'foo', computed(function(keyName, value) {
-    if (value !== undefined) {
+  defineProperty(obj, 'foo', computed({
+    get: function() {
+      return this.__foo;
+    },
+    set: function(keyName, value) {
       this.__foo = value;
+      return this.__foo;
     }
-
-    return this.__foo;
   }));
   addListeners(obj, 'foo');
 

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -40,12 +40,16 @@ function addListeners(obj, keyPath) {
 
 testBoth('watching a computed property', function(get, set) {
   var obj = {};
-  Ember.defineProperty(obj, 'foo', Ember.computed(function(keyName, value) {
-    if (value !== undefined) {
-      this.__foo = value;
+  Ember.defineProperty(obj, 'foo', Ember.computed({
+    get: function() {
+      return this.__foo;
+    },
+    set: function(keyName, value) {
+      if (value !== undefined) {
+        this.__foo = value;
+      }
+      return this.__foo;
     }
-
-    return this.__foo;
   }));
   addListeners(obj, 'foo');
 

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -270,10 +270,15 @@ var LinkView = EmberComponent.extend({
     When `true` interactions with the element will not trigger route changes.
     @property disabled
   */
-  disabled: computed(function computeLinkViewDisabled(key, value) {
-    if (value !== undefined) { this.set('_isDisabled', value); }
+  disabled: computed({
+    get: function(key, value) {
+      return false;
+    },
+    set: function(key, value) {
+      if (value !== undefined) { this.set('_isDisabled', value); }
 
-    return value ? get(this, 'disabledClass') : false;
+      return value ? get(this, 'disabledClass') : false;
+    }
   }),
 
   /**

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -204,8 +204,11 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
     this._subControllers = [];
   },
 
-  model: computed(function (key, value) {
-    if (arguments.length > 1) {
+  model: computed({
+    get: function(key) {
+      return Ember.A();
+    },
+    set: function(key, value) {
       Ember.assert(
         'ArrayController expects `model` to implement the Ember.Array mixin. ' +
         'This can often be fixed by wrapping your model with `Ember.A()`.',
@@ -214,8 +217,6 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
 
       return value;
     }
-
-    return Ember.A();
   }),
 
   /**

--- a/packages/ember-runtime/lib/ext/rsvp.js
+++ b/packages/ember-runtime/lib/ext/rsvp.js
@@ -25,7 +25,7 @@ RSVP.configure('async', function(callback, promise) {
 
   if (Ember.testing && async) { asyncStart(); }
 
-  run.backburner.schedule('actions', function(){
+  run.backburner.schedule('actions', function() {
     if (Ember.testing && async) { asyncEnd(); }
     callback(promise);
   });

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -167,12 +167,14 @@ export default Mixin.create(Enumerable, {
     @property []
     @return this
   */
-  '[]': computed(function(key, value) {
-    if (value !== undefined) {
+  '[]': computed({
+    get: function(key) {
+      return this;
+    },
+    set: function(key, value) {
       this.replace(0, get(this, 'length'), value);
+      return this;
     }
-
-    return this;
   }),
 
   firstObject: computed(function() {

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -956,8 +956,8 @@ export default Mixin.create({
     @type Array
     @return this
   */
-  '[]': computed(function(key, value) {
-    return this;
+  '[]': computed({
+    get: function(key) { return this; }
   }),
 
   // ..........................................................

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -156,11 +156,12 @@ export default Mixin.create({
 
     @property promise
   */
-  promise: computed(function(key, promise) {
-    if (arguments.length === 2) {
-      return tap(this, promise);
-    } else {
+  promise: computed({
+    get: function() {
       throw new EmberError("PromiseProxy's promise must be set");
+    },
+    set: function(key, promise) {
+      return tap(this, promise);
     }
   }),
 

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -161,26 +161,28 @@ export default Mixin.create(MutableEnumerable, {
 
     @property arrangedContent
   */
-  arrangedContent: computed('content', 'sortProperties.@each', function(key, value) {
-    var content = get(this, 'content');
-    var isSorted = get(this, 'isSorted');
-    var sortProperties = get(this, 'sortProperties');
-    var self = this;
+  arrangedContent: computed('content', 'sortProperties.@each', {
+    get: function(key) {
+      var content = get(this, 'content');
+      var isSorted = get(this, 'isSorted');
+      var sortProperties = get(this, 'sortProperties');
+      var self = this;
 
-    if (content && isSorted) {
-      content = content.slice();
-      content.sort(function(item1, item2) {
-        return self.orderBy(item1, item2);
-      });
-      forEach(content, function(item) {
-        forEach(sortProperties, function(sortProperty) {
-          addObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+      if (content && isSorted) {
+        content = content.slice();
+        content.sort(function(item1, item2) {
+          return self.orderBy(item1, item2);
+        });
+        forEach(content, function(item) {
+          forEach(sortProperties, function(sortProperty) {
+            addObserver(item, sortProperty, this, 'contentItemSortPropertyDidChange');
+          }, this);
         }, this);
-      }, this);
-      return Ember.A(content);
-    }
+        return Ember.A(content);
+      }
 
-    return content;
+      return content;
+    }
   }),
 
   _contentWillChange: beforeObserver('content', function() {

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -238,11 +238,14 @@ QUnit.module("object.set()", {
 
       // computed property
       _computed: "computed",
-      computed: computed(function(key, value) {
-        if (value !== undefined) {
+      computed: computed({
+        get: function(key) {
+          return this._computed;
+        },
+        set: function(key, value) {
           this._computed = value;
+          return this._computed;
         }
-        return this._computed;
       }).volatile(),
 
       // method, but not a property
@@ -322,38 +325,62 @@ QUnit.module("Computed properties", {
       // REGULAR
 
       computedCalls: [],
-      computed: computed(function(key, value) {
-        this.computedCalls.push(value);
-        return 'computed';
+      computed: computed({
+        get: function() {
+          this.computedCalls.push('getter-called');
+          return 'computed';
+        },
+        set: function(key, value) {
+          this.computedCalls.push(value);
+        }
       }).volatile(),
 
       computedCachedCalls: [],
-      computedCached: computed(function(key, value) {
-        this.computedCachedCalls.push(value);
-        return 'computedCached';
+      computedCached: computed({
+        get: function() {
+          this.computedCachedCalls.push('getter-called');
+          return 'computedCached';
+        },
+        set: function(key, value) {
+          this.computedCachedCalls.push(value);
+        }
       }),
-
 
       // DEPENDENT KEYS
 
       changer: 'foo',
 
       dependentCalls: [],
-      dependent: computed(function(key, value) {
-        this.dependentCalls.push(value);
-        return 'dependent';
+      dependent: computed({
+        get: function() {
+          this.dependentCalls.push('getter-called');
+          return 'dependent';
+        },
+        set: function(key, value) {
+          this.dependentCalls.push(value);
+        }
       }).property('changer').volatile(),
 
       dependentFrontCalls: [],
-      dependentFront: computed('changer', function(key, value) {
-        this.dependentFrontCalls.push(value);
-        return 'dependentFront';
+      dependentFront: computed('changer', {
+        get: function() {
+          this.dependentFrontCalls.push('getter-called');
+          return 'dependentFront';
+        },
+        set: function(key, value) {
+          this.dependentFrontCalls.push(value);
+        }
       }).volatile(),
 
       dependentCachedCalls: [],
-      dependentCached: computed(function(key, value) {
-        this.dependentCachedCalls.push(value);
-        return 'dependentCached';
+      dependentCached: computed({
+        get: function() {
+          this.dependentCachedCalls.push('getter-called!');
+          return 'dependentCached';
+        },
+        set: function(key, value) {
+          this.dependentCachedCalls.push(value);
+        }
       }).property('changer'),
 
       // every time it is recomputed, increments call
@@ -364,26 +391,31 @@ QUnit.module("Computed properties", {
 
       // depends on cached property which depends on another property...
       nestedIncCallCount: 0,
-      nestedInc: computed(function(key, value) {
+      nestedInc: computed(function(key) {
         get(this, 'inc');
         return this.nestedIncCallCount++;
       }).property('inc'),
 
       // two computed properties that depend on a third property
       state: 'on',
-      isOn: computed(function(key, value) {
-        if (value !== undefined) {
+      isOn: computed({
+        get: function() {
+          return this.get('state') === 'on';
+        },
+        set: function(key, value) {
           this.set('state', 'on');
+          return this.get('state') === 'on';
         }
-
-        return this.get('state') === 'on';
       }).property('state').volatile(),
 
-      isOff: computed(function(key, value) {
-        if (value !== undefined) {
+      isOff: computed({
+        get: function() {
+          return this.get('state') === 'off';
+        },
+        set: function(key, value) {
           this.set('state', 'off');
+          return this.get('state') === 'off';
         }
-        return this.get('state') === 'off';
       }).property('state').volatile()
 
     });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -123,12 +123,12 @@ QUnit.test("should invalidate function property cache when notifyPropertyChange 
 
   var a = ObservableObject.createWithMixins({
     _b: null,
-    b: computed(function(key, value) {
-      if (value !== undefined) {
+    b: computed({
+      get: function() { return this._b; },
+      set: function(key, value) {
         this._b = value;
         return this;
       }
-      return this._b;
     }).volatile()
   });
 

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -46,11 +46,9 @@ testBoth('calling setProperties completes safely despite exceptions', function(g
   var obj = EmberObject.createWithMixins({
     firstName: "Steve",
     lastName: "Jobs",
-    companyName: computed(function(key, value) {
-      if (value !== undefined) {
-        throw exc;
-      }
-      return "Apple, Inc.";
+    companyName: computed({
+      get: function() { return "Apple, Inc."; },
+      set: function(key, value) { throw exc; }
     })
   });
 

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -31,9 +31,13 @@ QUnit.test("simple properties are set", function() {
 
 QUnit.test("calls computed property setters", function() {
   var MyClass = EmberObject.extend({
-    foo: computed(function(key, val) {
-      if (arguments.length === 2) { return val; }
-      return "this is not the value you're looking for";
+    foo: computed({
+      get: function() {
+        return "this is not the value you're looking for";
+      },
+      set: function(key, value) {
+        return value;
+      }
     })
   });
 

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -8,11 +8,12 @@ QUnit.module("ObjectProxy");
 
 testBoth("should not proxy properties passed to create", function (get, set) {
   var Proxy = ObjectProxy.extend({
-    cp: computed(function (key, value) {
-      if (value) {
+    cp: computed({
+      get: function(key) { return this._cp; },
+      set: function(key, value) {
         this._cp = value;
+        return this._cp;
       }
-      return this._cp;
     })
   });
   var proxy = Proxy.create({

--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -16,12 +16,13 @@ var ViewContextSupport = Mixin.create({
     @property context
     @type Object
   */
-  context: computed(function(key, value) {
-    if (arguments.length === 2) {
+  context: computed({
+    get: function() {
+      return get(this, '_context');
+    },
+    set: function(key, value) {
       set(this, '_context', value);
       return value;
-    } else {
-      return get(this, '_context');
     }
   }).volatile(),
 
@@ -43,23 +44,23 @@ var ViewContextSupport = Mixin.create({
     @property _context
     @private
   */
-  _context: computed(function(key, value) {
-    if (arguments.length === 2) {
+  _context: computed({
+    get: function() {
+      var parentView, controller;
+
+      if (controller = get(this, 'controller')) {
+        return controller;
+      }
+
+      parentView = this._parentView;
+      if (parentView) {
+        return get(parentView, '_context');
+      }
+      return null;
+    },
+    set: function(key, value) {
       return value;
     }
-
-    var parentView, controller;
-
-    if (controller = get(this, 'controller')) {
-      return controller;
-    }
-
-    parentView = this._parentView;
-    if (parentView) {
-      return get(parentView, '_context');
-    }
-
-    return null;
   }),
 
   _controller: null,
@@ -71,18 +72,18 @@ var ViewContextSupport = Mixin.create({
     @property controller
     @type Object
   */
-  controller: computed(function(key, value) {
-    if (arguments.length === 2) {
+  controller: computed({
+    get: function() {
+      if (this._controller) {
+        return this._controller;
+      }
+
+      return this._parentView ? get(this._parentView, 'controller') : null;
+    },
+    set: function(_, value) {
       this._controller = value;
       return value;
     }
-
-    if (this._controller) {
-      return this._controller;
-    }
-
-    var parentView = this._parentView;
-    return parentView ? get(parentView, 'controller') : null;
   })
 });
 

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -145,15 +145,18 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
   @deprecated
   @property template
   */
-  template: computed(function(key, value) {
-    if (value !== undefined) { return value; }
+  template: computed({
+    get: function() {
+      var templateName = get(this, 'templateName');
+      var template = this.templateForName(templateName, 'template');
 
-    var templateName = get(this, 'templateName');
-    var template = this.templateForName(templateName, 'template');
+      Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
 
-    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
-
-    return template || get(this, 'defaultTemplate');
+      return template || get(this, 'defaultTemplate');
+    },
+    set: function(key, value) {
+      return value;
+    }
   }).property('templateName'),
 
   /**

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -430,11 +430,15 @@ var Select = View.extend({
     @type String
     @default null
   */
-  value: computed('_valuePath', 'selection', function(key, value) {
-    if (arguments.length === 2) { return value; }
-    var valuePath = get(this, '_valuePath');
-    return valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection');
-  }),
+  value: computed({
+    get: function(key) {
+      var valuePath = get(this, '_valuePath');
+      return valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection');
+    },
+    set: function(key, value) {
+      return value;
+    }
+  }).property('_valuePath', 'selection'),
 
   /**
     If given, a top-most dummy option will be rendered to serve as a user

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -727,15 +727,18 @@ var View = CoreView.extend(
     @property template
     @type Function
   */
-  template: computed('templateName', function(key, value) {
-    if (value !== undefined) { return value; }
 
-    var templateName = get(this, 'templateName');
-    var template = this.templateForName(templateName, 'template');
-
-    Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
-
-    return template || get(this, 'defaultTemplate');
+  template: computed('templateName', {
+    get: function() {
+      var templateName = get(this, 'templateName');
+      var template = this.templateForName(templateName, 'template');
+      Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
+      return template || get(this, 'defaultTemplate');
+    },
+    set: function(key, value) {
+      if (value !== undefined) { return value; }
+      return get(this, key);
+    }
   }),
 
   /**


### PR DESCRIPTION
This is just a PR had prepared for when the new CP syntax in enabled by default, whenever it happens.

It deprecates using the same function as getter and setter, and changes all places in Ember where it is used that way, so ember itself does not raise any deprecation.

I'll just rebase this over master with regularity to avoid the nightmare I've just experienced now rebasing a 2 months old branch :sob: 
