### PR TITLE
[DOC] Add example of new CP syntax in features.md

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -142,6 +142,20 @@ for a detailed explanation.
   Enables the new computed property syntax. In this new syntax, instead of passing
   a function that acts both as getter and setter for the property, `Ember.computed`
   receives an object with `get` and `set` keys, each one containing a function.
+
+  For example,
+
+  ```js
+  visible: Ember.computed('visibility', {
+    get: function(key) {
+      return this.get('visibility') !== 'hidden';
+    },
+    set: function(key, boolValue) {
+      this.set('visibility', boolValue ? 'visible' : 'hidden');
+    }
+  })
+  ```
+
   If the object does not contain a `set` key, the property will simply be overridden.
   Passing just function is still supported, and is equivalent to passing only a getter.
 


### PR DESCRIPTION
I've just wanted to enable the new CP syntax and when I looked the exact feature flag name, I realized that a small code example would make the feature much easier to understand.
