### PR TITLE
Add `.ember-cli` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ bundle/
 publish_to_bower/
 bower_components/
 npm-debug.log
+.ember-cli


### PR DESCRIPTION
I typically need to run `ember s --port 5200` (non-standard port) due to
having many other ember-cli apps running concurrently.  If we add
`.ember-cli` to the `.gitignore` we can all add our own custom port and
configuration options.
