### PR TITLE
[FEATURE ember-htmlbars-scoped-helpers]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -182,3 +182,42 @@ for a detailed explanation.
   ```
 
   Added in [#10160](https://github.com/emberjs/ember.js/pull/10160)
+
+* `ember-htmlbars-scoped-helpers`
+
+  Adds the ability for helpers to be resolved from the local component.  Allowing components to
+  use local helpers (that do not get made available globally) AND/OR providing local helpers to
+  the provided block param.
+
+  Block Params Example:
+
+```javascript
+// app/components/form-for.js
+
+import Ember from "ember";
+import FormForInput from "./helpers/input";
+
+var makeViewHelper = Ember.HTMLBars.makeViewHelper;
+
+export default Ember.Component.extend({
+  formHelpers: {
+    input: makeViewHelper(FormForInput)
+  }
+});
+```
+
+```handlebars
+{{! app/templates/components/form-for.hbs }}
+
+{{yield formHelpers}}
+```
+
+```handlebars
+{{! app/templates/post/new.hbs }}
+
+{{#form-for as |f|}}
+  {{f.input label="Title" value=model.title}}
+{{/form-for}}
+```
+
+  Added in [#10244](https://github.com/emberjs/ember.js/pull/10244)

--- a/features.json
+++ b/features.json
@@ -15,7 +15,8 @@
     "ember-testing-checkbox-helpers": null,
     "ember-metal-stream": null,
     "ember-htmlbars-each-with-index": true,
-    "ember-application-initializer-context": null
+    "ember-application-initializer-context": null,
+    "ember-htmlbars-scoped-helpers": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -33,6 +33,13 @@ export default function lookupHelper(name, view, env) {
     return helper;
   }
 
+  if (Ember.FEATURES.isEnabled('ember-htmlbars-scoped-helpers')) {
+    helper = view.getStream(name).value();
+    if (helper && helper.isHTMLBars) {
+      return helper;
+    }
+  }
+
   var container = view.container;
 
   if (!container || ISNT_HELPER_CACHE.get(name)) {

--- a/packages/ember-htmlbars/tests/integration/helper_lookup_test.js
+++ b/packages/ember-htmlbars/tests/integration/helper_lookup_test.js
@@ -1,0 +1,97 @@
+import Registry from "container/registry";
+import run from "ember-metal/run_loop";
+import ComponentLookup from 'ember-views/component_lookup';
+import View from "ember-views/views/view";
+import Component from "ember-views/views/component";
+import compile from "ember-template-compiler/system/compile";
+import makeBoundHelper from "ember-htmlbars/system/make_bound_helper";
+import makeViewHelper from "ember-htmlbars/system/make-view-helper";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var registry, container, view;
+
+var blockParamsEnabled;
+if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
+  blockParamsEnabled = true;
+}
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars-scoped-helpers')) {
+// jscs:disable validateIndentation
+
+QUnit.module("ember-htmlbars: helper lookup -- scoped helpers", {
+  setup: function() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('component', { singleton: false });
+    registry.optionsForType('view', { singleton: false });
+    registry.optionsForType('template', { instantiate: false });
+    registry.optionsForType('helper', { instantiate: false });
+    registry.register('component-lookup:main', ComponentLookup);
+  },
+
+  teardown: function() {
+    runDestroy(container);
+    runDestroy(view);
+
+    registry = container = view = null;
+  }
+});
+
+test("basic scoped helper usage", function() {
+  view = View.create({
+    name: 'lucy',
+
+    capitalize: makeBoundHelper(function(params) {
+      return params[0].toUpperCase();
+    }),
+
+    template: compile('{{view.name}} - {{view.capitalize view.name}}')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), "lucy - LUCY");
+
+  run(function() {
+    view.set('name', "molly");
+  });
+
+  equal(view.$().text(), "molly - MOLLY");
+});
+
+if (blockParamsEnabled) {
+  test("scoped helper usage through block param", function() {
+    registry.register('template:components/form-for', compile('{{yield formHelpers}}'));
+
+    registry.register('component:form-for', Component.extend({
+      tagName: 'form',
+
+      formHelpers: {
+        input: makeViewHelper(Component.extend({
+          layout: compile('<label {{bind-attr for=inputId.elementId}}>{{label}}</label>{{input value=value viewName="inputId"}}')
+        }))
+      }
+    }));
+
+    view = View.create({
+      firstName: 'Robert',
+      container: container,
+      template: compile('{{#form-for as |f|}} {{f.input label="First Name" value=view.firstName}} {{/form-for}}')
+    });
+
+    runAppend(view);
+
+    equal(view.$('form').length, 1, 'form was created');
+    equal(view.$('label').text(), 'First Name', 'label was created');
+    equal(view.$('input').val(), 'Robert', 'input was created');
+
+    run(function() {
+      view.set('firstName', 'Jacquie');
+    });
+
+    equal(view.$('input').val(), 'Jacquie', 'input was updated');
+  });
+}
+
+// jscs:enable validateIndentation
+}


### PR DESCRIPTION
Allows locally scoped helpers to be used in a components layout (or in the template block if using block params).

---

Local Helpers Example:

``` javascript
// app/components/x-foo.js

import Ember from "ember";

var makeBoundHelper = Ember.HTMLBars.makeBoundHelper;

export default Ember.Component.extend({
  capitalize: makeBoundHelper(function(params) {
    return params[0].toUpperCase();
  })
});
```

``` handlebars
{{! app/templates/components/x-foo.hbs }}

{{capitalize 'blahzorz'}} === BLAHZORZ
```

---

Block Params Example:

``` javascript
// app/components/form-for.js

import Ember from "ember";
import FormForInput from "./helpers/input";

var makeViewHelper = Ember.HTMLBars.makeViewHelper;

export default Ember.Component.extend({
  formHelpers: {
    input: makeViewHelper(FormForInput)
  }
});
```

``` handlebars
{{! app/templates/components/form-for.hbs }}

{{yield formHelpers}}
```

``` handlebars
{{! app/templates/post/new.hbs }}

{{#form-for as |f|}}
  {{f.input label="Title" value=model.title}}
{{/form-for}}
```
