### PR TITLE
[BUGFIX beta] Update HTMLBars to v0.8.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "emberjs-build": "0.0.19",
     "express": "^4.5.0",
     "glob": "~4.3.2",
-    "htmlbars": "0.8.1",
+    "htmlbars": "0.8.3",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "rsvp": "~3.0.6",


### PR DESCRIPTION
Compare view: https://github.com/tildeio/htmlbars/compare/v0.8.1...v0.8.3.
- Allow numbers to be parsed as HTML in IE.
- Add namespace detection to `AttrMorph`.
- Include line number in error thrown for unclosed html element (https://github.com/tildeio/htmlbars/issues/254).
- Fix failing tests on IE8.
- removeAttribute fix for IE <11 and SVG.
- Use linked list walking for childAtIndex.
