### PR TITLE
Correct new CP syntax example and add more tests

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -152,6 +152,7 @@ for a detailed explanation.
     },
     set: function(key, boolValue) {
       this.set('visibility', boolValue ? 'visible' : 'hidden');
+      return boolValue;
     }
   })
   ```

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -665,6 +665,24 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
     testObj.set('aInt', '123');
     ok(testObj.get('aInt') === '123', 'cp has been updated too');
   });
+
+  test('the return value of the setter gets cached', function() {
+    var testObj = Ember.Object.extend({
+      a: '1',
+      sampleCP: computed('a', {
+        get: function(keyName) {
+          ok(false, "The getter should not be invoked");
+          return 'get-value';
+        },
+        set: function(keyName, value, oldValue) {
+          return 'set-value';
+        }
+      })
+    }).create();
+
+    testObj.set('sampleCP', 'abcd');
+    ok(testObj.get('sampleCP') === 'set-value', 'The return value of the CP was cached');
+  });
 }
 
 // ..........................................................


### PR DESCRIPTION
The example I added in https://github.com/emberjs/ember.js/pull/10237 was misleading, because it would cache undefined. This fixes the example.

Also, I add a test for checking that in the new CP syntax the caching works as it used to work. I didn't covered that situation in the tests.
