### PR TITLE
Make computed.or and computed.and return truthy values

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -478,6 +478,7 @@ registerComputedWithProperties('or', function(properties) {
   @param {String} dependentKey*
   @return {Ember.ComputedProperty} computed property which returns
   the first truthy value of given list of properties.
+  @deprecated Use `Ember.computed.or` instead.
 */
 registerComputedWithProperties('any', function(properties) {
   for (var key in properties) {

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -399,6 +399,8 @@ registerComputed('lte', function(dependentKey, value) {
   hamster.get('readyForCamp'); // false
   hamster.set('hasBackpack', true);
   hamster.get('readyForCamp'); // true
+  hamster.set('hasBackpack', 'Yes');
+  hamster.get('readyForCamp'); // 'Yes'
   ```
 
   @method computed.and
@@ -408,12 +410,14 @@ registerComputed('lte', function(dependentKey, value) {
   a logical `and` on the values of all the original values for properties.
 */
 registerComputedWithProperties('and', function(properties) {
+  var value;
   for (var key in properties) {
-    if (properties.hasOwnProperty(key) && !properties[key]) {
+    value = properties[key];
+    if (properties.hasOwnProperty(key) && !value) {
       return false;
     }
   }
-  return true;
+  return value;
 });
 
 /**
@@ -430,8 +434,10 @@ registerComputedWithProperties('and', function(properties) {
   var hamster = Hamster.create();
 
   hamster.get('readyForRain'); // false
-  hamster.set('hasJacket', true);
+  hamster.set('hasUmbrella', true);
   hamster.get('readyForRain'); // true
+  hamster.set('hasJacket', 'Yes');
+  hamster.get('readyForRain'); // 'Yes'
   ```
 
   @method computed.or
@@ -443,7 +449,7 @@ registerComputedWithProperties('and', function(properties) {
 registerComputedWithProperties('or', function(properties) {
   for (var key in properties) {
     if (properties.hasOwnProperty(key) && properties[key]) {
-      return true;
+      return properties[key];
     }
   }
   return false;

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -1085,6 +1085,11 @@ testBoth('computed.and', function(get, set) {
   set(obj, 'one', false);
 
   equal(get(obj, 'oneAndTwo'), false, 'one and not two');
+
+  set(obj, 'one', true);
+  set(obj, 'two', 2);
+
+  equal(get(obj, 'oneAndTwo'), 2, 'returns truthy value as in &&');
 });
 
 testBoth('computed.or', function(get, set) {
@@ -1101,9 +1106,13 @@ testBoth('computed.or', function(get, set) {
 
   equal(get(obj, 'oneOrTwo'), false, 'nore one nore two');
 
-  set(obj, 'one', true);
+  set(obj, 'two', true);
 
   equal(get(obj, 'oneOrTwo'), true, 'one or two');
+
+  set(obj, 'one', 1);
+
+  equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
 });
 
 testBoth('computed.any', function(get, set) {


### PR DESCRIPTION
This behavior more-closely mimics `||` and `&&` semantics.

Discussion in #10251
