### PR TITLE
Simplify and modularize app/router initialization

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,27 @@ for a detailed explanation.
 
 ## Feature Flags
 
+* `ember-application-instance-initializers`
+
+  Splits apart initializers into two phases:
+
+  * Boot-time Initializers that receive a registry, and use it to set up
+    code structures
+  * Instance Initializers that receive an application instance, and use
+    it to set up application state per run of the application.
+
+  In FastBoot, each request will have its own run of the application,
+  and will only need to run the instance initializers.
+
+  In the future, tests will also be able to use this differentiation to
+  run just the instance initializers per-test.
+
+  With this change, `App.initializer` becomes a "boot-time" initializer,
+  and issues a deprecation warning if instances are accessed.
+
+  Apps should migrate any initializers that require instances to the new
+  `App.instanceInitializer` API.
+
 * `ember-application-initializer-context`
 
   Sets the context of the initializer function to its object instead of the

--- a/features.json
+++ b/features.json
@@ -15,6 +15,7 @@
     "ember-testing-checkbox-helpers": null,
     "ember-metal-stream": null,
     "ember-htmlbars-each-with-index": true,
+    "ember-application-instance-initializers": null,
     "ember-application-initializer-context": null
   },
   "debugStatements": [

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -136,13 +136,21 @@ Registry.prototype = {
 
   lookup: function(fullName, options) {
     Ember.assert('Create a container on the registry (with `registry.container()`) before calling `lookup`.', this._defaultContainer);
-    Ember.deprecate('`lookup` should not be called on a Registry. Call `lookup` directly on an associated Container instead.');
+
+    if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
+      Ember.deprecate('`lookup` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', { url: "http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers" });
+    }
+
     return this._defaultContainer.lookup(fullName, options);
   },
 
   lookupFactory: function(fullName) {
     Ember.assert('Create a container on the registry (with `registry.container()`) before calling `lookupFactory`.', this._defaultContainer);
-    Ember.deprecate('`lookupFactory` should not be called on a Registry. Call `lookupFactory` directly on an associated Container instead.');
+
+    if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
+      Ember.deprecate('`lookupFactory` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', { url: "http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers" });
+    }
+
     return this._defaultContainer.lookupFactory(fullName);
   },
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -1,0 +1,38 @@
+/**
+@module ember
+@submodule ember-application
+*/
+
+import EmberObject from "ember-runtime/system/object";
+import run from "ember-metal/run_loop";
+
+export default EmberObject.extend({
+  container: null,
+  customEvents: null,
+  rootElement: null,
+
+  startRouting: function(isModuleBasedResolver) {
+    var router = this.container.lookup('router:main');
+    if (!router) { return; }
+
+    router.startRouting(isModuleBasedResolver);
+  },
+
+  handleURL: function(url) {
+    var router = this.container.lookup('router:main');
+
+    return router.handleURL(url);
+  },
+
+  setupEventDispatcher: function() {
+    var dispatcher = this.container.lookup('event_dispatcher:main');
+
+    dispatcher.setup(this.customEvents, this.rootElement);
+
+    return dispatcher;
+  },
+
+  willDestroy: function() {
+    run(this.container, 'destroy');
+  }
+});

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -69,7 +69,7 @@ export default EmberObject.extend({
   rootElement: null,
 
   init: function() {
-    this._super();
+    this._super.apply(this, arguments);
     this.container = this.registry.container();
   },
 

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -29,8 +29,43 @@ import run from "ember-metal/run_loop";
 */
 
 export default EmberObject.extend({
+  /**
+    The application instance's container. The container stores all of the
+    instance-specific state for this application run.
+
+    @property {Ember.Container} container
+  */
+  container: null,
+
+  /**
+    The application's registry. The registry contains the classes, templates,
+    and other code that makes up the application.
+
+    @property {Ember.Registry} registry
+  */
   registry: null,
+
+  /**
+    The DOM events for which the event dispatcher should listen.
+
+    By default, the application's `Ember.EventDispatcher` listens
+    for a set of standard DOM events, such as `mousedown` and
+    `keyup`, and delegates them to your application's `Ember.View`
+    instances.
+
+    @private
+    @property {Object} customEvents
+  */
   customEvents: null,
+
+  /**
+    The root DOM element of the Application as an element or a
+    [jQuery-compatible selector
+    string](http://api.jquery.com/category/selectors/).
+
+    @private
+    @property {String|DOMElement} rootElement
+  */
   rootElement: null,
 
   init: function() {
@@ -38,6 +73,9 @@ export default EmberObject.extend({
     this.container = this.registry.container();
   },
 
+  /**
+    @private
+  */
   startRouting: function(isModuleBasedResolver) {
     var router = this.container.lookup('router:main');
     if (!router) { return; }
@@ -45,12 +83,18 @@ export default EmberObject.extend({
     router.startRouting(isModuleBasedResolver);
   },
 
+  /**
+    @private
+  */
   handleURL: function(url) {
     var router = this.container.lookup('router:main');
 
     return router.handleURL(url);
   },
 
+  /**
+    @private
+  */
   setupEventDispatcher: function() {
     var dispatcher = this.container.lookup('event_dispatcher:main');
 
@@ -59,6 +103,9 @@ export default EmberObject.extend({
     return dispatcher;
   },
 
+  /**
+    @private
+  */
   willDestroy: function() {
     this._super.apply(this, arguments);
     run(this.container, 'destroy');

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -1,15 +1,42 @@
 /**
 @module ember
 @submodule ember-application
+@private
 */
 
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
 
+/**
+  The `ApplicationInstance` encapsulates all of the stateful aspects of a
+  running `Application`.
+
+  At a high-level, we break application boot into two distinct phases:
+
+  * Definition time, where all of the classes, templates, and other
+    dependencies are loaded (typically in the browser).
+  * Run time, where we begin executing the application once everything
+    has loaded.
+
+  Definition time can be expensive and only needs to happen once since it is
+  an idempotent operation. For example, between test runs and FastBoot
+  requests, the application stays the same. It is only the state that we want
+  to reset.
+
+  That state is what the `ApplicationInstance` manages: it is responsible for
+  creating the container that contains all application state, and disposing of
+  it once the particular test run or FastBoot request has finished.
+*/
+
 export default EmberObject.extend({
-  container: null,
+  registry: null,
   customEvents: null,
   rootElement: null,
+
+  init: function() {
+    this._super();
+    this.container = this.registry.container();
+  },
 
   startRouting: function(isModuleBasedResolver) {
     var router = this.container.lookup('router:main');
@@ -33,6 +60,7 @@ export default EmberObject.extend({
   },
 
   willDestroy: function() {
+    this._super.apply(this, arguments);
     run(this.container, 'destroy');
   }
 });

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -267,6 +267,7 @@ var Application = Namespace.extend(DeferredMixin, {
     // Create subclass of Ember.Router for this Application instance.
     // This is to ensure that someone reopening `App.Router` does not
     // tamper with the default `Ember.Router`.
+    // 2.0TODO: Can we move this into a globals-mode-only library?
     this.Router = Router.extend();
     this.buildRegistry();
 
@@ -300,13 +301,14 @@ var Application = Namespace.extend(DeferredMixin, {
     @return {Ember.Container} the configured container
   */
   buildInstance: function() {
-    var container = this.__container__ = this.__registry__.container();
-
     var instance = this.__instance__ = ApplicationInstance.create({
       customEvents: get(this, 'customEvents'),
       rootElement: get(this, 'rootElement'),
-      container: container
+      registry: this.__registry__
     });
+
+    // TODO2.0: Legacy support for App.__container__
+    this.__container__ = instance.container;
 
     return instance;
   },

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -31,6 +31,7 @@ import HistoryLocation from "ember-routing/location/history_location";
 import AutoLocation from "ember-routing/location/auto_location";
 import NoneLocation from "ember-routing/location/none_location";
 import BucketCache from "ember-routing/system/cache";
+import ApplicationInstance from "ember-application/system/application-instance";
 
 import ContainerDebugAdapter from "ember-extension-support/container_debug_adapter";
 
@@ -1042,36 +1043,5 @@ function logLibraryVersions() {
     Ember.debug('-------------------------------');
   }
 }
-
-var ApplicationInstance = Ember.Object.extend({
-  container: null,
-  customEvents: null,
-  rootElement: null,
-
-  startRouting: function(isModuleBasedResolver) {
-    var router = this.container.lookup('router:main');
-    if (!router) { return; }
-
-    router.startRouting(isModuleBasedResolver);
-  },
-
-  handleURL: function(url) {
-    var router = this.container.lookup('router:main');
-
-    return router.handleURL(url);
-  },
-
-  setupEventDispatcher: function() {
-    var dispatcher = this.container.lookup('event_dispatcher:main');
-
-    dispatcher.setup(this.customEvents, this.rootElement);
-
-    return dispatcher;
-  },
-
-  willDestroy: function() {
-    run(this.container, 'destroy');
-  }
-});
 
 export default Application;

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -169,9 +169,7 @@ export default EmberObject.extend({
       resolved = this[resolveMethodName](parsedName);
     }
 
-    if (!resolved) {
-      resolved = this.resolveOther(parsedName);
-    }
+    resolved = resolved || this.resolveOther(parsedName);
 
     if (parsedName.root && parsedName.root.LOG_RESOLVER) {
       this._logLookup(resolved, parsedName);
@@ -179,6 +177,7 @@ export default EmberObject.extend({
 
     return resolved;
   },
+
   /**
     Convert the string name of the form 'type:name' to
     a Javascript object with the parsed aspects of the name
@@ -214,13 +213,15 @@ export default EmberObject.extend({
                    ' namespace, but the namespace could not be found', root);
     }
 
+    var resolveMethodName = fullNameWithoutType === 'main' ? 'Main' : classify(type);
+
     return {
       fullName: fullName,
       type: type,
       fullNameWithoutType: fullNameWithoutType,
       name: name,
       root: root,
-      resolveMethodName: 'resolve' + classify(type)
+      resolveMethodName: 'resolve' + resolveMethodName
     };
   },
 
@@ -253,6 +254,7 @@ export default EmberObject.extend({
   makeToString: function(factory, fullName) {
     return factory.toString();
   },
+
   /**
     Given a parseName object (output from `parseName`), apply
     the conventions expected by `Ember.Router`
@@ -366,6 +368,11 @@ export default EmberObject.extend({
     var className = classify(parsedName.name) + classify(parsedName.type);
     var factory = get(parsedName.root, className);
     if (factory) { return factory; }
+  },
+
+  resolveMain: function(parsedName) {
+    var className = classify(parsedName.type);
+    return get(parsedName.root, className);
   },
 
   /**

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -263,7 +263,7 @@ test("can resolve custom router", function() {
   var CustomRouter = Router.extend();
 
   var CustomResolver = DefaultResolver.extend({
-    resolveOther: function(parsedName) {
+    resolveMain: function(parsedName) {
       if (parsedName.type === "router") {
         return CustomRouter;
       } else {

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -75,6 +75,12 @@ test("the default resolver resolves models on the namespace", function() {
   detectEqual(application.Post, locator.lookupFactory('model:post'), "looks up Post model on application");
 });
 
+test("the default resolver resolves *:main on the namespace", function() {
+  application.FooBar = EmberObject.extend({});
+
+  detectEqual(application.FooBar, locator.lookupFactory('foo-bar:main'), "looks up FooBar type without name on application");
+});
+
 test("the default resolver resolves helpers", function() {
   expect(2);
 

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -2,6 +2,7 @@ import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import { indexOf } from "ember-metal/array";
 import jQuery from "ember-views/system/jquery";
+import Registry from "container/registry";
 
 var app;
 
@@ -31,6 +32,25 @@ test("initializers require proper 'name' and 'initialize' properties", function(
     });
   });
 
+});
+
+test("initializers are passed a registry and App", function() {
+  var MyApplication = Application.extend();
+
+  MyApplication.initializer({
+    name: 'initializer',
+    initialize: function(registry, App) {
+      ok(registry instanceof Registry, "initialize is passed a registry");
+      ok(App instanceof Application, "initialize is passed an Application");
+    }
+  });
+
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
+    });
+  });
 });
 
 test("initializers can be registered in a specified order", function() {

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -114,6 +114,69 @@ test("initializers can be registered in a specified order", function() {
   deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
 });
 
+test("initializers can be registered in a specified order as an array", function() {
+  var order = [];
+  var MyApplication = Application.extend();
+
+
+  MyApplication.initializer({
+    name: 'third',
+    initialize: function(registry) {
+      order.push('third');
+    }
+  });
+
+  MyApplication.initializer({
+    name: 'second',
+    after: 'first',
+    before: ['third', 'fourth'],
+    initialize: function(registry) {
+      order.push('second');
+    }
+  });
+
+  MyApplication.initializer({
+    name: 'fourth',
+    after: ['second', 'third'],
+    initialize: function(registry) {
+      order.push('fourth');
+    }
+  });
+
+  MyApplication.initializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize: function(registry) {
+      order.push('fifth');
+    }
+  });
+
+  MyApplication.initializer({
+    name: 'first',
+    before: ['second'],
+    initialize: function(registry) {
+      order.push('first');
+    }
+  });
+
+  MyApplication.initializer({
+    name: 'sixth',
+    initialize: function(registry) {
+      order.push('sixth');
+    }
+  });
+
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
+    });
+  });
+
+  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+});
+
 test("initializers can have multiple dependencies", function () {
   var order = [];
   var a = {

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -114,6 +114,69 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
   });
 
+  test("initializers can be registered in a specified order as an array", function() {
+    var order = [];
+    var MyApplication = Application.extend();
+
+
+    MyApplication.instanceInitializer({
+      name: 'third',
+      initialize: function(registry) {
+        order.push('third');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'second',
+      after: 'first',
+      before: ['third', 'fourth'],
+      initialize: function(registry) {
+        order.push('second');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'fourth',
+      after: ['second', 'third'],
+      initialize: function(registry) {
+        order.push('fourth');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'fifth',
+      after: 'fourth',
+      before: 'sixth',
+      initialize: function(registry) {
+        order.push('fifth');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'first',
+      before: ['second'],
+      initialize: function(registry) {
+        order.push('first');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'sixth',
+      initialize: function(registry) {
+        order.push('sixth');
+      }
+    });
+
+    run(function() {
+      app = MyApplication.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+
+    deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+  });
+
   test("initializers can have multiple dependencies", function () {
     var order = [];
     var a = {

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -1,0 +1,284 @@
+import run from "ember-metal/run_loop";
+import Application from "ember-application/system/application";
+import ApplicationInstance from "ember-application/system/application-instance";
+import { indexOf } from "ember-metal/array";
+import jQuery from "ember-views/system/jquery";
+
+var app;
+
+if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
+  QUnit.module("Ember.Application instance initializers", {
+    setup: function() {
+    },
+
+    teardown: function() {
+      if (app) {
+        run(function() { app.destroy(); });
+      }
+    }
+  });
+
+  test("initializers require proper 'name' and 'initialize' properties", function() {
+    var MyApplication = Application.extend();
+
+    expectAssertion(function() {
+      run(function() {
+        MyApplication.instanceInitializer({ name: 'initializer' });
+      });
+    });
+
+    expectAssertion(function() {
+      run(function() {
+        MyApplication.instanceInitializer({ initialize: Ember.K });
+      });
+    });
+
+  });
+
+  test("initializers are passed an app instance", function() {
+    var MyApplication = Application.extend();
+
+    MyApplication.instanceInitializer({
+      name: 'initializer',
+      initialize: function(instance) {
+        ok(instance instanceof ApplicationInstance, "initialize is passed an application instance");
+      }
+    });
+
+    run(function() {
+      app = MyApplication.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+  });
+
+  test("initializers can be registered in a specified order", function() {
+    var order = [];
+    var MyApplication = Application.extend();
+    MyApplication.instanceInitializer({
+      name: 'fourth',
+      after: 'third',
+      initialize: function(registry) {
+        order.push('fourth');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'second',
+      after: 'first',
+      before: 'third',
+      initialize: function(registry) {
+        order.push('second');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'fifth',
+      after: 'fourth',
+      before: 'sixth',
+      initialize: function(registry) {
+        order.push('fifth');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'first',
+      before: 'second',
+      initialize: function(registry) {
+        order.push('first');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'third',
+      initialize: function(registry) {
+        order.push('third');
+      }
+    });
+
+    MyApplication.instanceInitializer({
+      name: 'sixth',
+      initialize: function(registry) {
+        order.push('sixth');
+      }
+    });
+
+    run(function() {
+      app = MyApplication.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+
+    deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+  });
+
+  test("initializers can have multiple dependencies", function () {
+    var order = [];
+    var a = {
+      name: "a",
+      before: "b",
+      initialize: function(registry) {
+        order.push('a');
+      }
+    };
+    var b = {
+      name: "b",
+      initialize: function(registry) {
+        order.push('b');
+      }
+    };
+    var c = {
+      name: "c",
+      after: "b",
+      initialize: function(registry) {
+        order.push('c');
+      }
+    };
+    var afterB = {
+      name: "after b",
+      after: "b",
+      initialize: function(registry) {
+        order.push("after b");
+      }
+    };
+    var afterC = {
+      name: "after c",
+      after: "c",
+      initialize: function(registry) {
+        order.push("after c");
+      }
+    };
+
+    Application.instanceInitializer(b);
+    Application.instanceInitializer(a);
+    Application.instanceInitializer(afterC);
+    Application.instanceInitializer(afterB);
+    Application.instanceInitializer(c);
+
+    run(function() {
+      app = Application.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+
+    ok(indexOf.call(order, a.name) < indexOf.call(order, b.name), 'a < b');
+    ok(indexOf.call(order, b.name) < indexOf.call(order, c.name), 'b < c');
+    ok(indexOf.call(order, b.name) < indexOf.call(order, afterB.name), 'b < afterB');
+    ok(indexOf.call(order, c.name) < indexOf.call(order, afterC.name), 'c < afterC');
+  });
+
+  test("initializers set on Application subclasses should not be shared between apps", function() {
+    var firstInitializerRunCount = 0;
+    var secondInitializerRunCount = 0;
+    var FirstApp = Application.extend();
+    FirstApp.instanceInitializer({
+      name: 'first',
+      initialize: function(registry) {
+        firstInitializerRunCount++;
+      }
+    });
+    var SecondApp = Application.extend();
+    SecondApp.instanceInitializer({
+      name: 'second',
+      initialize: function(registry) {
+        secondInitializerRunCount++;
+      }
+    });
+    jQuery('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
+    run(function() {
+      FirstApp.create({
+        router: false,
+        rootElement: '#qunit-fixture #first'
+      });
+    });
+    equal(firstInitializerRunCount, 1, 'first initializer only was run');
+    equal(secondInitializerRunCount, 0, 'first initializer only was run');
+    run(function() {
+      SecondApp.create({
+        router: false,
+        rootElement: '#qunit-fixture #second'
+      });
+    });
+    equal(firstInitializerRunCount, 1, 'second initializer only was run');
+    equal(secondInitializerRunCount, 1, 'second initializer only was run');
+  });
+
+  test("initializers are concatenated", function() {
+    var firstInitializerRunCount = 0;
+    var secondInitializerRunCount = 0;
+    var FirstApp = Application.extend();
+    FirstApp.instanceInitializer({
+      name: 'first',
+      initialize: function(registry) {
+        firstInitializerRunCount++;
+      }
+    });
+
+    var SecondApp = FirstApp.extend();
+    SecondApp.instanceInitializer({
+      name: 'second',
+      initialize: function(registry) {
+        secondInitializerRunCount++;
+      }
+    });
+
+    jQuery('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
+    run(function() {
+      FirstApp.create({
+        router: false,
+        rootElement: '#qunit-fixture #first'
+      });
+    });
+    equal(firstInitializerRunCount, 1, 'first initializer only was run when base class created');
+    equal(secondInitializerRunCount, 0, 'first initializer only was run when base class created');
+    firstInitializerRunCount = 0;
+    run(function() {
+      SecondApp.create({
+        router: false,
+        rootElement: '#qunit-fixture #second'
+      });
+    });
+    equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
+    equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
+  });
+
+  test("initializers are per-app", function() {
+    expect(0);
+    var FirstApp = Application.extend();
+    FirstApp.instanceInitializer({
+      name: 'shouldNotCollide',
+      initialize: function(registry) {}
+    });
+
+    var SecondApp = Application.extend();
+    SecondApp.instanceInitializer({
+      name: 'shouldNotCollide',
+      initialize: function(registry) {}
+    });
+  });
+
+  if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
+    test("initializers should be executed in their own context", function() {
+      expect(1);
+      var MyApplication = Application.extend();
+
+      MyApplication.instanceInitializer({
+        name: 'coolBabeInitializer',
+        myProperty: 'coolBabe',
+        initialize: function(registry, application) {
+          equal(this.myProperty, 'coolBabe', 'should have access to its own context');
+        }
+      });
+
+      run(function() {
+        app = MyApplication.create({
+          router: false,
+          rootElement: '#qunit-fixture'
+        });
+      });
+    });
+  }
+}

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -297,6 +297,10 @@ var EmberRouter = EmberObject.extend(Evented, {
     }
   },
 
+  willDestroy: function() {
+    this.reset();
+  },
+
   _lookupActiveView: function(templateName) {
     var active = this._activeViews[templateName];
     return active && active[0];

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -298,6 +298,7 @@ var EmberRouter = EmberObject.extend(Evented, {
   },
 
   willDestroy: function() {
+    this._super.apply(this, arguments);
     this.reset();
   },
 

--- a/packages/ember/tests/application_lifecycle.js
+++ b/packages/ember/tests/application_lifecycle.js
@@ -9,7 +9,7 @@ QUnit.module("Application Lifecycle", {
         rootElement: '#qunit-fixture'
       });
 
-      App.Router.extend({
+      App.Router = App.Router.extend({
         location: 'none'
       });
 


### PR DESCRIPTION
`Ember.Application`'s initialization has evolved organically a number of times to support the transition from no router, to a globals-based router, and now the Ember CLI/ES6 modules world. Over time, this initialization code has accumulated some cruft that makes it difficult to reason about its behavior.

This carefully constructed series of targeted refactors preserves the previous semantics as closely as possible (with one exception that we may want to roll back depending on real-world impact; see below). This refactoring is in anticipation of our work to support multiple sessions of a single `Ember.Application` instance for the FastBoot effort.

---

The one exception to semantics-preservation is a small tweak to the globals resolver to bring it more in line with the Ember CLI resolver.

In the Ember CLI resolver, full paths named `something:main` would resolve to `appname/something.js`–the `main` suffix is special-cased to become a top-level lookup. In order to achieve something similar in the globals resolver, there are hardcoded registrations (`registry.register('foo:main', Foo)`) for `router` and `store`.

We changed the globals strategy to be more like the Ember CLI strategy: any `something:main` lookup in globals mode gets resolved to `App.Something`.

This is a slight change in semantics because the process of going from a full name to a factory first tries to go through the resolver before using any explicitly registered full names.

In order for this to become a problem:
- An application would need to explicitly register a `foo:main` in an initializer with a hardcoded value that **did not** live at `App.Foo` (e.g. registering `web-socket:main` with a hardcoded class **other than** App.WebSocket).
- They would also need to have an `App.WebSocket` model in their application

Note that this problem does not exist for `App.Router` or `App.Store`, since they have always been special-cased by Ember and Ember Data respectively.

If necessary, we could restrict the new behavior to `router:main`, but if we can get away with this minor semantics change, we think this would more closely align with how people already expect this to work, and how it **does** work in Ember CLI.
