### PR TITLE
[BUGFIX beta] Make computed.or return more like ||

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -467,12 +467,14 @@ export var and = generateComputedWithProperties(function(properties) {
   @public
 */
 export var or = generateComputedWithProperties(function(properties) {
+  var value;
   for (var key in properties) {
-    if (properties.hasOwnProperty(key) && properties[key]) {
-      return properties[key];
+    value = properties[key];
+    if (properties.hasOwnProperty(key) && value) {
+      return value;
     }
   }
-  return false;
+  return value;
 });
 
 /**

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -277,6 +277,10 @@ testBoth('computed.or', function(get, set) {
 
   equal(get(obj, 'oneOrTwo'), false, 'nore one nore two');
 
+  set(obj, 'two', null);
+
+  equal(get(obj, 'oneOrTwo'), null, 'returns last falsy value as in ||');
+
   set(obj, 'two', true);
 
   equal(get(obj, 'oneOrTwo'), true, 'one or two');


### PR DESCRIPTION
Given [the recent deprecation of computed.any in favor of computed.or](https://github.com/emberjs/ember.js/pull/10254) it
seems more-appropriate to return the last falsy value to enable
these computed properties to potentially be rendered directly in
templates without the need to be wrapped in {{#if}} blocks.

The behavior of computed.any was to return null, so this brings
computed.or more inline with replacing computed.any

The way javascript `||` works is that it returns the last value, so 

``` javascript
undefined || null // => null
null || undefined // => undefined
null || false // => false
```

Edit: update to fix merge conflict, the way computed properties are declared/exported changed slightly
