### PR TITLE
[BUGFIX beta] Ensure that calling `wait` without routing works.

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -207,8 +207,10 @@ function wait(app, value) {
 
     // Every 10ms, poll for the async thing to have finished
     var watcher = setInterval(function() {
+      var router = app.__container__.lookup('router:main');
+
       // 1. If the router is loading, keep polling
-      var routerIsLoading = !!app.__container__.lookup('router:main').router.activeTransition;
+      var routerIsLoading = router.router && !!router.router.activeTransition;
       if (routerIsLoading) { return; }
 
       // 2. If there are pending Ajax requests, keep polling

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -416,6 +416,14 @@ test("`wait` respects registerWaiters with optional context", function() {
   });
 });
 
+test("`wait` does not error if routing has not begun", function() {
+  expect(1);
+
+  App.testHelpers.wait().then(function() {
+    ok(true, 'should not error without `visit`');
+  });
+});
+
 test("`triggerEvent accepts an optional options hash without context", function() {
   expect(3);
 


### PR DESCRIPTION
Fixes #10263.
