### PR TITLE
[BUGFIX beta] Stream subscription events only called once

### DIFF
--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -85,9 +85,15 @@ Stream.prototype = {
   },
 
   subscribe: function(callback, context) {
-    if (this.subscribers === undefined) {
+    var subscribers = this.subscribers;
+    if (subscribers === undefined) {
       this.subscribers = [callback, context];
     } else {
+      for (var i = 0, length = subscribers.length; i < length; i+=2) {
+        if (subscribers[i] === callback && subscribers[i+1] === context) {
+          return;
+        }
+      }
       this.subscribers.push(callback, context);
     }
   },


### PR DESCRIPTION
Stream subscription events are now only called once per
callback/context pair. Previously, "Stream.proto.subscribe"
you to subscribe as many times with a callback/context pair.
Stream.proto.unsubscribe returns early when it finds a
callback/context pair. This means that any other context/
callback pair won't get released, leading to memory leaks.

This patch fixes those memory leaks, and also makes it so
subscription events only happen once per callback/context
pair.

How I found this leak:

http://jsbin.com/hugiwa

This demo fakes out a database connection and just generates random data every second. If you leave it open for a while, it will eventually run out of memory and kill the tab. The memory usage also seemed quite high for 25 items rerendering.

I [cloned the jsbin](http://jsbin.com/visolu/1/edit?html,css,js,output) and broke the data rendering up via action buttons so i could simulate teardown of views manually to try and figure out the leak. I used the Heap Snapshot tool in the Chrome Devtools:

![before change](https://dl.dropboxusercontent.com/s/nl0du317dq3nrhy/2015-01-21%20at%2011.33%20PM%202x.png?dl=0)

I started out by looking at what was on the page during initial render. What's useful here is the comparison between snapshot 2 and snapshot 4. Snapshot 2 and 4 both represent when the list is empty. Using the comparison view, we can see that 6300 `SimpleStream` instances were there _after_ we render the list. I would expect that these would have been cleared up, not left around.

I followed the retainer tree down to the each view, but I noticed there were lots of subscribers subscribing to subscribers left around. So I started looking at the subscribe/unsubscribe code and here we are.

I'm typing this up so @mmun can take a look, but _this isn't actually the right fix_. Just thought I'd document the steps I went through. Using http://jsbin.com/visolu/2/edit?html,css,js,output with the compiled output, the diff is sadly still the same, I must have screwed up the compare view last night. There's always 6300 StreamObjects being leaked on teardown of items in the list (and if you leave the list rendered and dynamically updating as in the original jsbin, it will update in the same kind of way).

I'm closing until I have time to identify the source of the leak.
