### PR TITLE
[BUGFIX beta] Clean up memory leaks for View and SimpleBoundView

### DIFF
--- a/packages/ember-views/lib/views/simple_bound_view.js
+++ b/packages/ember-views/lib/views/simple_bound_view.js
@@ -37,6 +37,7 @@ SimpleBoundView.prototype = {
       this._parentView.removeChild(this);
     }
     this.morph = null;
+    this.stream.destroy();
     this.state = 'destroyed';
   },
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1854,6 +1854,9 @@ var View = CoreView.extend({
       nonVirtualParentView.set(viewName, null);
     }
 
+    // teardown keywords stream
+    this._keywords.view.destroy();
+
     return this;
   },
 


### PR DESCRIPTION
Streams weren't being destroyed when views were destroyed. Because
the stream was still subscribed to, the garbage collector couldn't
collect it.

Refs #10267, you can see that issue for more backstory. I apologize for being brief, this has eaten a lot of my mental energy. :P

If you have ideas for testing around here, I'm game too. Just let me know.

Before:

![before code change results](https://camo.githubusercontent.com/3e118504cd4da4860f0165fbb9329369012a00b5/68747470733a2f2f646c2e64726f70626f7875736572636f6e74656e742e636f6d2f732f6e6c3064753331376471336e7268792f323031352d30312d3231253230617425323031312e3333253230504d25323032782e706e673f646c3d30)

After:

![after code change result](http://i.imgur.com/aMRkJeS.png)

This doesn't completely solve the memory performance mentioned in the original PR for the original JSBin, but I have some more places to look for some more leaks.

cc @stefanpenner @mmun @mixonic @ebryn @rwjblue
