### PR TITLE
[BUGFIX beta] Fix broken unregisterWaiter semantics

### DIFF
--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -1,7 +1,6 @@
 import Ember from "ember-metal/core";
 import emberRun from "ember-metal/run_loop";
 import { create } from "ember-metal/platform";
-import compare from "ember-runtime/compare";
 import RSVP from "ember-runtime/ext/rsvp";
 import setupForTesting from "ember-testing/setup_for_testing";
 import EmberApplication from "ember-application/system/application";
@@ -265,15 +264,13 @@ var Test = {
      @since 1.2.0
   */
   unregisterWaiter: function(context, callback) {
-    var pair;
     if (!this.waiters) { return; }
     if (arguments.length === 1) {
       callback = context;
       context = null;
     }
-    pair = [context, callback];
     this.waiters = Ember.A(this.waiters.filter(function(elt) {
-      return compare(elt, pair)!==0;
+      return !(elt[0] === context && elt[1] === callback);
     }));
   }
 };


### PR DESCRIPTION
Ember.Test.unregisterWaiter is supposed to unregister only the waiter that matches the arguments you pass it. Due to a bug it actually unregisters all waiters with the same context.
