### PR TITLE
Allow to pass a custom view to an input helper

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/input.js
+++ b/packages/ember-htmlbars/lib/helpers/input.js
@@ -190,6 +190,8 @@ export function inputHelper(params, hash, options, env) {
 
   var onEvent = hash.on;
   var inputType;
+  var view = hash.view;
+  delete hash.view;
 
   inputType = read(hash.type);
 
@@ -199,11 +201,11 @@ export function inputHelper(params, hash, options, env) {
     Ember.assert("{{input type='checkbox'}} does not support setting `value=someBooleanValue`;" +
                  " you must use `checked=someBooleanValue` instead.", !hash.hasOwnProperty('value'));
 
-    env.helpers.view.helperFunction.call(this, [Checkbox], hash, options, env);
+    env.helpers.view.helperFunction.call(this, [view || Checkbox], hash, options, env);
   } else {
     delete hash.on;
 
     hash.onEvent = onEvent || 'enter';
-    env.helpers.view.helperFunction.call(this, [TextField], hash, options, env);
+    env.helpers.view.helperFunction.call(this, [view || TextField], hash, options, env);
   }
 }

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -3,9 +3,49 @@ import { set } from "ember-metal/property_set";
 import View from "ember-views/views/view";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import compile from "ember-template-compiler/system/compile";
+import TextField from "ember-views/views/text_field";
 
 var view;
 var controller;
+var CustomTextField;
+
+QUnit.module("{{input type='text'}}", {
+  setup: function() {
+    function lookupFactory(fullName) {
+      equal(fullName, 'view:custom-text-field');
+
+      return CustomTextField;
+    }
+
+    var container = {
+      lookupFactory: lookupFactory
+    };
+
+    CustomTextField = TextField.extend({
+      attributeBindings: ['foo']
+    });
+
+    controller = {
+      val: "hello"
+    };
+
+    view = View.extend({
+      controller: controller,
+      template: compile('{{input type="text" value=val foo="bar" view="custom-text-field"}}'),
+      container: container
+    }).create();
+
+    runAppend(view);
+  },
+
+  teardown: function() {
+    runDestroy(view);
+  }
+});
+
+test("custom view with extended attribute bindings is used", function() {
+  equal(view.$('input').attr('foo'), "bar", "sets foo attribute to 'bar'");
+});
 
 QUnit.module("{{input type='text'}}", {
   setup: function() {


### PR DESCRIPTION
Sometimes it's handy to use a custom view with an input helper, for example to
add additional attributes bindings. Instead of creating a custom helper from the
start it's easier to write:

``` handlebars
  {{input type="text" view="custom-text-field"}}
```

or even register own helper, but just reuse input helper:

``` javascript
registerHelper('custom-input', function(params, hash, options, env) {
  hash.view = 'custom-text-field';
  env.helpers['input'].helperFunction.call(this, params, hash, options, env)
});
```
