### PR TITLE
Moves route-recognizer to a NPM dep, bumps emberjs-build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
     "backburner": "https://github.com/ebryn/backburner.js.git#f4bd6a2df221240ed36d140f0c53c036a7ecacad",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
     "router.js": "https://github.com/tildeio/router.js.git#a1ffd97dc66a6d9d4e8dd89a72c1c4e21a3328c5",
-    "route-recognizer": "https://github.com/tildeio/route-recognizer.git#404b8485948120330f4c262a5cc997ac782d5466",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#1c30a1666273ab2a9b134a42bad28c774f9ecdfc"
   }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "ember-cli": "0.1.6",
     "ember-cli-yuidoc": "^0.3.1",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.0.21",
+    "emberjs-build": "0.0.22",
     "express": "^4.5.0",
     "glob": "~4.3.2",
     "htmlbars": "0.8.3",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
+    "route-recognizer": "0.1.5",
     "rsvp": "~3.0.6",
     "simple-dom": "^0.1.1"
   }


### PR DESCRIPTION
- https://github.com/tildeio/route-recognizer/pull/41 adds es6 build to
  npm package, released as 0.1.5
- https://github.com/emberjs/emberjs-build/pull/63 updates emberjs-build
  to use npm vendored RR, released as 0.0.22

Closes https://github.com/emberjs/ember.js/issues/10269
