### PR TITLE
[DOCS]Mark some Em.CoreObject's members as static

### DIFF
--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -795,7 +795,7 @@ var ClassMixinProps = {
     ```
 
     This will return the original hash that was passed to `meta()`.
-    
+
     @static
     @method metaForProperty
     @param key {String} property name
@@ -831,7 +831,7 @@ var ClassMixinProps = {
   /**
     Iterate over each computed property for the class, passing its name
     and any associated metadata (see `metaForProperty`) to the callback.
-    
+
     @static
     @method eachComputedProperty
     @param {Function} callback

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -795,7 +795,8 @@ var ClassMixinProps = {
     ```
 
     This will return the original hash that was passed to `meta()`.
-
+    
+    @static
     @method metaForProperty
     @param key {String} property name
   */
@@ -830,7 +831,8 @@ var ClassMixinProps = {
   /**
     Iterate over each computed property for the class, passing its name
     and any associated metadata (see `metaForProperty`) to the callback.
-
+    
+    @static
     @method eachComputedProperty
     @param {Function} callback
     @param {Object} binding


### PR DESCRIPTION
Seems like `eachComputedProperty` and `metaForProperty` are actually static members of Ember.CoreObject. I was confused when `console.log()` of `instanceOfEmObject.eachComputedProperty` returned `undefined`. However I could use it with `Foo.eachComputedProperty()` where `Foo = Em.Object.extend();`. [Demo here](http://emberjs.jsbin.com/powelibeve/4/edit). I hope it will save time and frustration of other developers.
