### PR TITLE
Simplify input helper

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/input.js
+++ b/packages/ember-htmlbars/lib/helpers/input.js
@@ -193,11 +193,6 @@ export function inputHelper(params, hash, options, env) {
   inputType = read(hash.type);
 
   if (inputType === 'checkbox') {
-    delete hash.type;
-
-    Ember.assert("{{input type='checkbox'}} does not support setting `value=someBooleanValue`;" +
-                 " you must use `checked=someBooleanValue` instead.", !hash.hasOwnProperty('value'));
-
     env.helpers.view.helperFunction.call(this, [Checkbox], hash, options, env);
   } else {
     env.helpers.view.helperFunction.call(this, [TextField], hash, options, env);

--- a/packages/ember-htmlbars/lib/helpers/input.js
+++ b/packages/ember-htmlbars/lib/helpers/input.js
@@ -188,7 +188,6 @@ import Ember from "ember-metal/core"; // Ember.assert
 export function inputHelper(params, hash, options, env) {
   Ember.assert('You can only pass attributes to the `input` helper, not arguments', params.length === 0);
 
-  var onEvent = hash.on;
   var inputType;
 
   inputType = read(hash.type);
@@ -201,9 +200,6 @@ export function inputHelper(params, hash, options, env) {
 
     env.helpers.view.helperFunction.call(this, [Checkbox], hash, options, env);
   } else {
-    delete hash.on;
-
-    hash.onEvent = onEvent || 'enter';
     env.helpers.view.helperFunction.call(this, [TextField], hash, options, env);
   }
 }

--- a/packages/ember-htmlbars/lib/helpers/input.js
+++ b/packages/ember-htmlbars/lib/helpers/input.js
@@ -1,6 +1,8 @@
 import Checkbox from "ember-views/views/checkbox";
 import TextField from "ember-views/views/text_field";
 import { read } from "ember-metal/streams/utils";
+import mergeViewBindings from "ember-htmlbars/system/merge-view-bindings";
+import appendTemplatedView from "ember-htmlbars/system/append-templated-view";
 
 import Ember from "ember-metal/core"; // Ember.assert
 
@@ -188,13 +190,12 @@ import Ember from "ember-metal/core"; // Ember.assert
 export function inputHelper(params, hash, options, env) {
   Ember.assert('You can only pass attributes to the `input` helper, not arguments', params.length === 0);
 
-  var inputType;
+  var props = {
+    helperName: options.helperName || 'input'
+  };
 
-  inputType = read(hash.type);
+  var view = read(hash.type) === 'checkbox' ? Checkbox : TextField;
 
-  if (inputType === 'checkbox') {
-    env.helpers.view.helperFunction.call(this, [Checkbox], hash, options, env);
-  } else {
-    env.helpers.view.helperFunction.call(this, [TextField], hash, options, env);
-  }
+  mergeViewBindings(this, props, hash);
+  appendTemplatedView(this, options.morph, view, props);
 }

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -1,8 +1,10 @@
 import run from "ember-metal/run_loop";
+import EventDispatcher from "ember-views/system/event_dispatcher";
 import { set } from "ember-metal/property_set";
 import View from "ember-views/views/view";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import compile from "ember-template-compiler/system/compile";
+import jQuery from "ember-views/system/jquery";
 
 var view;
 var controller;
@@ -173,6 +175,43 @@ QUnit.module("{{input}} - default type", {
 test("should have the default type", function() {
   equal(view.$('input').attr('type'), 'text', "Has a default text type");
 });
+
+var dispatcher;
+QUnit.module("{{input action='doSomething' on='key-press'}}", {
+  setup: function() {
+    controller = {
+      send: function(actionName, value, sender) {
+        equal(actionName, 'doSomething', "the action was called");
+      }
+    };
+
+    dispatcher = EventDispatcher.create();
+    dispatcher.setup();
+
+    view = View.extend({
+      controller: controller,
+      template: compile('{{input action="doSomething" on="key-press"}}')
+    }).create();
+
+    runAppend(view);
+  },
+
+  teardown: function() {
+    run(function() {
+      dispatcher.destroy();
+    });
+
+    runDestroy(view);
+  }
+});
+
+test("should trigger an action on key-press event", function() {
+  expect(1);
+  var event = jQuery.Event("keypress");
+  event.keyCode = event.which = 13;
+  view.$('input').trigger(event);
+});
+
 
 QUnit.module("{{input type='checkbox'}}", {
   setup: function() {

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -278,7 +278,7 @@ QUnit.module("{{input type='checkbox'}} - prevent value= usage", {
 test("It asserts the presence of checked=", function() {
   expectAssertion(function() {
     runAppend(view);
-  }, /you must use `checked=/);
+  }, /you must use `checked/);
 });
 
 QUnit.module("{{input type=boundType}}", {

--- a/packages/ember-views/lib/views/checkbox.js
+++ b/packages/ember-views/lib/views/checkbox.js
@@ -56,6 +56,9 @@ export default View.extend({
   indeterminate: false,
 
   init: function() {
+    Ember.assert("{{input type='checkbox'}} (or Ember.Checkbox) does not support setting `value` property;" +
+                 " you must use `checked` property instead.", !(this.hasOwnProperty('value') || this.hasOwnProperty('valueBinding')));
+
     this._super.apply(this, arguments);
     this.on('change', this, this._updateElementValue);
   },

--- a/packages/ember-views/lib/views/text_field.js
+++ b/packages/ember-views/lib/views/text_field.js
@@ -23,7 +23,7 @@ import TextSupport from "ember-views/mixins/text_support";
   @extends Ember.Component
   @uses Ember.TextSupport
 */
-export default Component.extend(TextSupport, {
+var TextField = Component.extend(TextSupport, {
   instrumentDisplay: '{{input type="text"}}',
 
   classNames: ['ember-text-field'],
@@ -111,3 +111,20 @@ export default Component.extend(TextSupport, {
   */
   max: null
 });
+
+TextField.reopenClass({
+  create: function(attributes) {
+    attributes = attributes || {};
+
+    Ember.assert('You can either pass `on` or `onEvent` to TextField, not both', !(attributes.on && attributes.onEvent));
+
+    if (!attributes.onEvent) {
+      attributes.onEvent = attributes.on || 'enter';
+      delete attributes.on;
+    }
+
+    return this._super.apply(this, arguments);
+  }
+});
+
+export default TextField;

--- a/packages/ember-views/tests/views/text_field_test.js
+++ b/packages/ember-views/tests/views/text_field_test.js
@@ -359,6 +359,29 @@ test("bubbling of handled actions can be enabled via bubbles property", function
   equal(stopPropagationCount, 1, "propagation was prevented if bubbles is false");
 });
 
+test('when both on and onEvent are passed the error is thrown', function() {
+  expectAssertion(function() {
+    textField = TextField.create({
+      on: 'key-press',
+      onEvent: 'key-up'
+    });
+  }, /You can either pass `on` or `onEvent`/);
+});
+
+test('onEvent is set to "enter" by default', function() {
+  textField = TextField.create();
+
+  equal(textField.get('onEvent'), 'enter', 'onEvent should be set to "enter"');
+});
+
+test('value passed as `on` is set to `onEvent`', function() {
+  textField = TextField.create({
+    on: 'key-press'
+  });
+
+  equal(textField.get('onEvent'), 'key-press', '`onEvent` should be set to "key-press"');
+  ok(textField.get('on') !== 'key-press', '`on` should not be set to "key-press"');
+});
 
 var dispatcher, StubController;
 QUnit.module("Ember.TextField - Action events", {


### PR DESCRIPTION
The motivation behind this PR is to simplify the `input` helper, so that `TextField` and `Checkbox` subclasses can be rendered directly and work just like `input`. Having additional code in the `input` helper may make it confusing at the moment. For example with a component `CustomTextField = Ember.TextField.extend()` the following code will not work as expected (what's worse it will throw a non descriptive error):

``` handlebars
{{custom-text-field value=something action="doSomething" on="key-up"}}
```

@rwjblue mentioned that I shouldn't override the `create` method on `TextField`, but unfortunately I can't see any way to do that. If that's a no go, I'd like to propose deprecating `on` shortcut and either use `on-event` or come up with something new.
