### PR TITLE
[FEATURE] ember-testing-checkbox-helpers

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -89,9 +89,9 @@ function check(app, selector, context) {
   Ember.assert('To check \'' + selector +
       '\', the input must be a checkbox', type === 'checkbox');
 
-  run(function() {
-    $el.prop('checked', true).change();
-  });
+  if (!$el.prop('checked')) {
+    app.testHelpers.click(selector, context);
+  }
 
   return app.testHelpers.wait();
 }
@@ -103,9 +103,9 @@ function uncheck(app, selector, context) {
   Ember.assert('To uncheck \'' + selector +
       '\', the input must be a checkbox', type === 'checkbox');
 
-  run(function() {
-    $el.prop('checked', false).change();
-  });
+  if ($el.prop('checked')) {
+    app.testHelpers.click(selector, context);
+  }
 
   return app.testHelpers.wait();
 }


### PR DESCRIPTION
Address concerns that helpers could behave differently than real users.

fixes #9798 (https://github.com/emberjs/ember.js/pull/9798#issuecomment-69384792)

When test driving, `click` and `unclick` are useful for ensuring the
state of a form.

``` javascript
export default DS.Model.extend({
  title: DS.attr(),
  body: DS.attr(),
  isDraft: DS.attr("boolean", defaultValue: false)
});

test("doesn't publish posts in draft mode", function() {
  fillIn("#title", "this post is hidden");
  fillIn("#body", "this won't be displayed");
  check("#is-draft");
  click("#submit");

  andThen(function() {
    equal(find(".post:contains('this post is hidden')").length, 0);
  });
});
```

`check` and `uncheck` allow the test to remain unchanged if the
`defaultValue` of `isDraft` changes from `false` to `true`.

The test only cares that:
- when `click("#submit")` executes, the `#is-draft` checkbox is `checked`
- `isDraft` is true
