### PR TITLE
JSCS: Require spaces around operators

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -54,6 +54,29 @@
     "with",
     "return"
   ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!=="
+  ],
+  "requireSpaceAfterBinaryOperators": [
+    "=",
+    ",",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!=="
+  ],
   "requireSpaceBetweenArguments": true,
   "requireSpacesAfterClosingParenthesisInFunctionDeclaration": {
     "beforeOpeningRoundBrace": false,

--- a/.jscsrc
+++ b/.jscsrc
@@ -55,6 +55,8 @@
     "return"
   ],
   "requireSpaceBeforeBinaryOperators": [
+    "<",
+    ">",
     "=",
     "+",
     "-",
@@ -66,6 +68,8 @@
     "!=="
   ],
   "requireSpaceAfterBinaryOperators": [
+    "<",
+    ">",
     "=",
     ",",
     "+",

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -127,7 +127,7 @@ if (foo === 'bara') {
 }
 
 // parameters
-function (test, foo) {
+function(test, foo) {
 }
 ```
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -116,6 +116,21 @@ function foo() {
 foo();
 ```
 
++ Spaces are required around binary operators.
+
+```javascript
+// assignments
+var foo = bar + 'a';
+
+// conditionals
+if (foo === 'bara') {
+}
+
+// parameters
+function (test, foo) {
+}
+```
+
 ## Commas
 
 + Skip trailing commas.

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -231,7 +231,7 @@ Registry.prototype = {
     var normalizedName = this.normalize(fullName);
 
     if (this._resolveCache[normalizedName]) {
-      throw new Error('Cannot re-register: `' + fullName +'`, as it has already been resolved.');
+      throw new Error('Cannot re-register: `' + fullName + '`, as it has already been resolved.');
     }
 
     delete this._failCache[normalizedName];

--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -16,7 +16,7 @@ function verifyNeedsDependencies(controller, container, needs) {
   var dependency, i, l;
   var missing = [];
 
-  for (i=0, l=needs.length; i<l; i++) {
+  for (i = 0, l = needs.length; i < l; i++) {
     dependency = needs[i];
 
     Ember.assert(inspect(controller) + '#needs must not specify dependencies with periods in their names (' +
@@ -47,7 +47,7 @@ var defaultControllersComputedProperty = computed(function() {
       var needs = this.needs;
       var dependency, i, l;
 
-      for (i=0, l=needs.length; i<l; i++) {
+      for (i = 0, l = needs.length; i < l; i++) {
         dependency = needs[i];
         if (dependency === controllerName) {
           return this.container.lookup('controller:' + controllerName);

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -74,10 +74,10 @@ QUnit.test('Mixin sets up controllers if there is needs before calling super', f
 
   registry.register('controller:posts', ArrayController.extend());
 
-  container.lookup('controller:posts').set('model', A(['a','b','c']));
+  container.lookup('controller:posts').set('model', A(['a', 'b', 'c']));
 
-  deepEqual(['a','b','c'], container.lookup('controller:other').toArray());
-  deepEqual(['a','b','c'], container.lookup('controller:another').toArray());
+  deepEqual(['a', 'b', 'c'], container.lookup('controller:other').toArray());
+  deepEqual(['a', 'b', 'c'], container.lookup('controller:another').toArray());
 });
 
 QUnit.test('raises if trying to get a controller that was not pre-defined in `needs`', function() {

--- a/packages/ember-application/tests/system/readiness_test.js
+++ b/packages/ember-application/tests/system/readiness_test.js
@@ -33,7 +33,7 @@ QUnit.module('Application readiness', {
       if (domReadyCalled !== 0) { return; }
       domReadyCalled++;
       var i;
-      for (i=0; i<readyCallbacks.length; i++) {
+      for (i = 0; i < readyCallbacks.length; i++) {
         readyCallbacks[i]();
       }
     };

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -70,7 +70,7 @@ Ember.assert = function(desc, test) {
 */
 Ember.warn = function(message, test) {
   if (!test) {
-    Logger.warn('WARNING: '+message);
+    Logger.warn('WARNING: ' + message);
     if ('trace' in Logger) {
       Logger.trace();
     }
@@ -90,7 +90,7 @@ Ember.warn = function(message, test) {
   @public
 */
 Ember.debug = function(message) {
-  Logger.debug('DEBUG: '+message);
+  Logger.debug('DEBUG: ' + message);
 };
 
 /**
@@ -168,7 +168,7 @@ Ember.deprecate = function(message, test, options) {
     message = message + stackStr;
   }
 
-  Logger.warn('DEPRECATION: '+message);
+  Logger.warn('DEPRECATION: ' + message);
 };
 
 

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -43,7 +43,7 @@ QUnit.test('Model types added with DefaultResolver', function() {
   adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords() {
-      return Ember.A([1,2,3]);
+      return Ember.A([1, 2, 3]);
     },
     columnsForType() {
       return [{ name: 'title', desc: 'Title' }];
@@ -93,7 +93,7 @@ QUnit.test('Model types added with custom container-debug-adapter', function() {
   adapter = App.__container__.lookup('data-adapter:main');
   adapter.reopen({
     getRecords() {
-      return Ember.A([1,2,3]);
+      return Ember.A([1, 2, 3]);
     },
     columnsForType() {
       return [{ name: 'title', desc: 'Title' }];
@@ -119,7 +119,7 @@ QUnit.test('Model Types Updated', function() {
   App.Post = Model.extend();
 
   adapter = App.__container__.lookup('data-adapter:main');
-  var records = Ember.A([1,2,3]);
+  var records = Ember.A([1, 2, 3]);
   adapter.reopen({
     getRecords() {
       return records;

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -135,8 +135,8 @@ export function registerHandlebarsCompatibleHelper(name, value) {
 }
 
 export function handlebarsHelper(name, value) {
-  Ember.assert('You tried to register a component named \'' + name +
-               '\', but component names must include a \'-\'', !Component.detect(value) || name.match(/-/));
+  Ember.assert(`You tried to register a component named '${name}', but component names must include a '-'`,
+    !Component.detect(value) || name.match(/-/));
 
   if (View.detect(value)) {
     helpers[name] = makeViewHelper(value);
@@ -149,12 +149,12 @@ export function handlebarsHelper(name, value) {
 }
 
 function applyAttributes(dom, element, innerString) {
-  var string = '<' + element.tagName + ' ' + innerString + '></div>';
+  var string = `<${element.tagName} ${innerString}></div>`;
   var fragment = dom.parseHTML(string, dom.createElement(element.tagName));
 
   var attrs = fragment.firstChild.attributes;
 
-  for (var i=0, l=attrs.length; i<l; i++) {
+  for (let i = 0, l = attrs.length; i < l; i++) {
     element.setAttributeNode(attrs[i].cloneNode());
   }
 }

--- a/packages/ember-htmlbars/lib/helpers/-join-classes.js
+++ b/packages/ember-htmlbars/lib/helpers/-join-classes.js
@@ -7,8 +7,9 @@
 export default function joinClasses(classNames) {
   var result = [];
 
-  for (var i=0, l=classNames.length; i<l; i++) {
-    var className = classNames[i];
+  for (let i = 0, l = classNames.length; i < l; i++) {
+    let className = classNames[i];
+
     if (className) {
       result.push(className);
     }

--- a/packages/ember-htmlbars/lib/hooks/attributes.js
+++ b/packages/ember-htmlbars/lib/hooks/attributes.js
@@ -21,7 +21,7 @@ function normalizeClassStatement(statements, element) {
   let className = element.getAttribute('class');
   if (!className) { return; }
 
-  for (let i=0, l=statements.length; i<l; i++) {
+  for (let i = 0, l = statements.length; i < l; i++) {
     let statement = statements[i];
 
     if (statement[1] === 'class') {

--- a/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
@@ -10,7 +10,7 @@ export default function destroyRenderNode(renderNode) {
 
   var streamUnsubscribers = renderNode.streamUnsubscribers;
   if (streamUnsubscribers) {
-    for (let i=0, l=streamUnsubscribers.length; i<l; i++) {
+    for (let i = 0, l = streamUnsubscribers.length; i < l; i++) {
       streamUnsubscribers[i]();
     }
   }

--- a/packages/ember-htmlbars/lib/keywords/get.js
+++ b/packages/ember-htmlbars/lib/keywords/get.js
@@ -25,7 +25,7 @@ if (isEnabled('ember-htmlbars-get-helper')) {
   };
 
   var GetStream = function GetStream(obj, path) {
-    this.init('(get '+labelFor(obj)+' '+labelFor(path)+')');
+    this.init(`(get ${labelFor(obj)} ${labelFor(path)})`);
 
     this.objectParam = obj;
     this.pathParam = path;

--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -41,9 +41,10 @@ proto.cleanup = function() {
     }
   }
 
-  var toDestroy = this.emberToDestroy;
+  let toDestroy = this.emberToDestroy;
+
   if (toDestroy) {
-    for (var i=0, l=toDestroy.length; i<l; i++) {
+    for (var i = 0, l = toDestroy.length; i < l; i++) {
       toDestroy[i].destroy();
     }
 

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -112,7 +112,7 @@ function extractPositionalParams(renderNode, component, params, attrs) {
       attrs[positionalParams] = paramsStream;
     }
 
-    for (let i=0; i < positionalParams.length; i++) {
+    for (let i = 0; i < positionalParams.length; i++) {
       let param = params[paramsStartIndex + i];
       if (isNamed) {
         paramsStream.addDependency(param);

--- a/packages/ember-htmlbars/lib/streams/utils.js
+++ b/packages/ember-htmlbars/lib/streams/utils.js
@@ -5,7 +5,8 @@ import getValue from 'ember-htmlbars/hooks/get-value';
 export function getArrayValues(params) {
   let l = params.length;
   let out = new Array(l);
-  for (let i=0; i<l; i++) {
+
+  for (let i = 0; i < l; i++) {
     out[i] = getValue(params[i]);
   }
 
@@ -14,6 +15,7 @@ export function getArrayValues(params) {
 
 export function getHashValues(hash) {
   let out = {};
+
   for (let prop in hash) {
     out[prop] = getValue(hash[prop]);
   }

--- a/packages/ember-htmlbars/lib/utils/string.js
+++ b/packages/ember-htmlbars/lib/utils/string.js
@@ -28,7 +28,7 @@ function htmlSafe(str) {
   }
 
   if (typeof str !== 'string') {
-    str = ''+str;
+    str = '' + str;
   }
   return new SafeString(str);
 }

--- a/packages/ember-htmlbars/tests/attr_nodes/property_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/property_test.js
@@ -66,7 +66,7 @@ QUnit.test('array value can be set as property', function() {
 
   appendView(view);
 
-  Ember.run(view, view.set, 'context.items', [4,5]);
+  Ember.run(view, view.set, 'context.items', [4, 5]);
   ok(true, 'no legacy assertion prohibited setting an array');
 });
 }

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -58,7 +58,7 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
       multipartTemplate: compile('<iframe src=\'{{protocol}}{{path}}\'></iframe>') }
   ];
 
-  for (var i=0, l=badTags.length; i<l; i++) {
+  for (var i = 0, l = badTags.length; i < l; i++) {
     (function() {
     var subject = badTags[i];
 
@@ -66,7 +66,7 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
       return;
     }
 
-    QUnit.test(subject.tag +' '+subject.attr+' is sanitized when using blacklisted protocol', function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is sanitized when using blacklisted protocol`, function() {
       view = EmberView.create({
         context: { url: 'javascript://example.com' },
         template: subject.unquotedTemplate
@@ -79,7 +79,7 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
              'attribute is output');
     });
 
-    QUnit.test(subject.tag +' '+subject.attr+' is sanitized when using quoted non-whitelisted protocol', function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is sanitized when using quoted non-whitelisted protocol`, function() {
       view = EmberView.create({
         context: { url: 'javascript://example.com' },
         template: subject.quotedTemplate
@@ -92,7 +92,7 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
              'attribute is output');
     });
 
-    QUnit.test(subject.tag +' '+subject.attr+' is not sanitized when using non-whitelisted protocol with a SafeString', function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is not sanitized when using non-whitelisted protocol with a SafeString`, function() {
       view = EmberView.create({
         context: { url: new SafeString('javascript://example.com') },
         template: subject.unquotedTemplate
@@ -106,11 +106,11 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
                'attribute is output');
       } catch(e) {
         // IE does not allow javascript: to be set on img src
-        ok(true, 'caught exception '+e);
+        ok(true, 'caught exception ' + e);
       }
     });
 
-    QUnit.test(subject.tag+' '+subject.attr+' is sanitized when using quoted+concat non-whitelisted protocol', function() {
+    QUnit.test(`${subject.tag} ${subject.attr} is sanitized when using quoted+concat non-whitelisted protocol`, function() {
       view = EmberView.create({
         context: { protocol: 'javascript:', path: '//example.com' },
         template: subject.multipartTemplate

--- a/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
@@ -29,7 +29,7 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
   });
   appendView(view);
 
-  equalInnerHTML(view.element, '<svg viewBox="'+viewBoxString+'"></svg>', 'attribute is output');
+  equalInnerHTML(view.element, `<svg viewBox="${viewBoxString}"></svg>`, 'attribute is output');
 
   Ember.run(view, view.set, 'context.viewBoxString', null);
   equal(view.element.getAttribute('svg'), null, 'attribute is removed');
@@ -43,7 +43,7 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
   });
   appendView(view);
 
-  equalInnerHTML(view.element, '<svg viewBox="'+viewBoxString+'"></svg>', 'attribute is output');
+  equalInnerHTML(view.element, `<svg viewBox="${viewBoxString}"></svg>`, 'attribute is output');
 });
 
   QUnit.test('quoted viewBox property is concat', function() {
@@ -54,12 +54,12 @@ if (isEnabled('ember-htmlbars-attribute-syntax')) {
   });
   appendView(view);
 
-  equalInnerHTML(view.element, '<svg viewBox="0 0 '+viewBoxString+'"></svg>', 'attribute is output');
+  equalInnerHTML(view.element, `<svg viewBox="0 0 ${viewBoxString}"></svg>`, 'attribute is output');
 
   var newViewBoxString = '200 200';
   Ember.run(view, view.set, 'context.viewBoxString', newViewBoxString);
 
-  equalInnerHTML(view.element, '<svg viewBox="0 0 '+newViewBoxString+'"></svg>', 'attribute is output');
+  equalInnerHTML(view.element, `<svg viewBox="0 0 ${newViewBoxString}"></svg>`, 'attribute is output');
 });
 
   QUnit.test('class is output', function() {

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -531,7 +531,7 @@ QUnit.test('should render nested collections', function() {
   var container = registry.container();
   registry.register('view:inner-list', CollectionView.extend({
     tagName: 'ul',
-    content: A(['one','two','three'])
+    content: A(['one', 'two', 'three'])
   }));
 
   registry.register('view:outer-list', CollectionView.extend({
@@ -556,7 +556,7 @@ QUnit.test('should render multiple, bound nested collections (#68)', function() 
 
   run(function() {
     TemplateTests.contentController = ArrayProxy.create({
-      content: A(['foo','bar'])
+      content: A(['foo', 'bar'])
     });
 
     var InnerList = CollectionView.extend({
@@ -568,7 +568,7 @@ QUnit.test('should render multiple, bound nested collections (#68)', function() 
       innerListView: InnerList,
       template: compile('{{#collection view.innerListView class="inner"}}{{content}}{{/collection}}{{content}}'),
       innerListContent: computed(function() {
-        return A([1,2,3]);
+        return A([1, 2, 3]);
       })
     });
 
@@ -624,7 +624,7 @@ QUnit.test('should allow view objects to be swapped out without throwing an erro
   run(function() {
     dataset = EmberObject.create({
       ready: true,
-      items: A([1,2,3])
+      items: A([1, 2, 3])
     });
     TemplateTests.datasetController.set('dataset', dataset);
   });

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -335,7 +335,7 @@ QUnit.test('it works inside a table element', function() {
 QUnit.test('it supports itemController', function() {
   var Controller = EmberController.extend({
     controllerName: computed(function() {
-      return 'controller:'+this.get('model.name');
+      return `controller:${this.get('model.name')}`;
     })
   });
 
@@ -998,7 +998,7 @@ function testEachWithItem(moduleName, useBlockParams) {
   QUnit.test('itemController specified in template with name binding does not change context [DEPRECATED]', function() {
     var Controller = EmberController.extend({
       controllerName: computed(function() {
-        return 'controller:'+this.get('model.name');
+        return `controller:${this.get('model.name')}`;
       })
     });
 

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -87,7 +87,7 @@ QUnit.test('should not enter an infinite loop when binding an attribute in Handl
   // Use match, since old IE appends the whole URL
   var href = parentView.$('a').attr('href');
   var classNames = parentView.$('a').attr('class');
-  ok(href.match(/(^|\/)test$/), 'Expected href to be \'test\' but got "'+href+'"');
+  ok(href.match(/(^|\/)test$/), `Expected href to be 'test' but got "${href}"`);
   equal(classNames, 'ember-view app-link');
 
   runDestroy(parentView);

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -237,7 +237,7 @@ QUnit.test('it should wrap context with object controller [DEPRECATED]', functio
       this._super();
     },
     controllerName: computed(function() {
-      return 'controller:'+this.get('model.name') + ' and ' + this.get('parentController.name');
+      return `controller:${this.get('model.name')} and ${this.get('parentController.name')}`;
     }).property('model.name', 'parentController.name')
   });
 

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -75,7 +75,7 @@ QUnit.test('templates should yield to block, when the yield is embedded in a hie
     index: computed(function() {
       var n = this.attrs.n;
       var indexArray = A();
-      for (var i=0; i < n; i++) {
+      for (var i = 0; i < n; i++) {
         indexArray[i] = i;
       }
       return indexArray;

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -63,7 +63,7 @@ Renderer.prototype.dispatchLifecycleHooks =
     var lifecycleHooks = env.lifecycleHooks;
     var i, hook;
 
-    for (i = 0; i<lifecycleHooks.length; i++) {
+    for (i = 0; i < lifecycleHooks.length; i++) {
       hook = lifecycleHooks[i];
       ownerView._dispatching = hook.type;
 

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -63,7 +63,7 @@ Renderer.prototype.dispatchLifecycleHooks =
     var lifecycleHooks = env.lifecycleHooks;
     var i, hook;
 
-    for (i=0; i<lifecycleHooks.length; i++) {
+    for (i = 0; i<lifecycleHooks.length; i++) {
       hook = lifecycleHooks[i];
       ownerView._dispatching = hook.type;
 

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -275,7 +275,7 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
 };
 
 function finishChains(chainNodes) {
-  for (var i = 0, l = chainNodes.length; i<l; i++) {
+  for (var i = 0, l = chainNodes.length; i < l; i++) {
     chainNodes[i].didChange(null);
   }
 }

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -275,7 +275,7 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
 };
 
 function finishChains(chainNodes) {
-  for (var i=0, l=chainNodes.length; i<l; i++) {
+  for (var i = 0, l = chainNodes.length; i<l; i++) {
     chainNodes[i].didChange(null);
   }
 }

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -89,8 +89,8 @@ export function accumulateListeners(obj, eventName, otherActions) {
 
   for (var i = actions.length - 3; i >= 0; i -= 3) {
     var target = actions[i];
-    var method = actions[i+1];
-    var flags = actions[i+2];
+    var method = actions[i + 1];
+    var flags = actions[i + 2];
     var actionIndex = indexOf(otherActions, target, method);
 
     if (actionIndex === -1) {
@@ -184,7 +184,7 @@ function removeListener(obj, eventName, target, method) {
 
     if (!actions) { return; }
     for (var i = actions.length - 3; i >= 0; i -= 3) {
-      _removeListener(actions[i], actions[i+1]);
+      _removeListener(actions[i], actions[i + 1]);
     }
   }
 }
@@ -217,14 +217,14 @@ export function suspendListener(obj, eventName, target, method, callback) {
   var actionIndex = indexOf(actions, target, method);
 
   if (actionIndex !== -1) {
-    actions[actionIndex+2] |= SUSPENDED; // mark the action as suspended
+    actions[actionIndex + 2] |= SUSPENDED; // mark the action as suspended
   }
 
   try {
     return callback.call(target);
   } finally {
     if (actionIndex !== -1) {
-      actions[actionIndex+2] &= ~SUSPENDED;
+      actions[actionIndex + 2] &= ~SUSPENDED;
     }
   }
 }
@@ -251,13 +251,13 @@ export function suspendListeners(obj, eventNames, target, method, callback) {
   var suspendedActions = [];
   var actionsList = [];
 
-  for (let i=0, l=eventNames.length; i<l; i++) {
+  for (let i = 0, l = eventNames.length; i<l; i++) {
     let eventName = eventNames[i];
     let actions = actionsFor(obj, eventName);
     let actionIndex = indexOf(actions, target, method);
 
     if (actionIndex !== -1) {
-      actions[actionIndex+2] |= SUSPENDED;
+      actions[actionIndex + 2] |= SUSPENDED;
       suspendedActions.push(actionIndex);
       actionsList.push(actions);
     }
@@ -268,7 +268,7 @@ export function suspendListeners(obj, eventNames, target, method, callback) {
   } finally {
     for (let i = 0, l = suspendedActions.length; i < l; i++) {
       let actionIndex = suspendedActions[i];
-      actionsList[i][actionIndex+2] &= ~SUSPENDED;
+      actionsList[i][actionIndex + 2] &= ~SUSPENDED;
     }
   }
 }
@@ -326,8 +326,8 @@ export function sendEvent(obj, eventName, params, actions) {
 
   for (var i = actions.length - 3; i >= 0; i -= 3) { // looping in reverse for once listeners
     var target = actions[i];
-    var method = actions[i+1];
-    var flags = actions[i+2];
+    var method = actions[i + 1];
+    var flags = actions[i + 2];
 
     if (!method) { continue; }
     if (flags & SUSPENDED) { continue; }
@@ -380,7 +380,7 @@ export function listenersFor(obj, eventName) {
 
   for (var i = 0, l = actions.length; i < l; i += 3) {
     var target = actions[i];
-    var method = actions[i+1];
+    var method = actions[i + 1];
     ret.push([target, method]);
   }
 

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -251,7 +251,7 @@ export function suspendListeners(obj, eventNames, target, method, callback) {
   var suspendedActions = [];
   var actionsList = [];
 
-  for (let i = 0, l = eventNames.length; i<l; i++) {
+  for (let i = 0, l = eventNames.length; i < l; i++) {
     let eventName = eventNames[i];
     let actions = actionsFor(obj, eventName);
     let actionIndex = indexOf(actions, target, method);

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -54,7 +54,7 @@ var populateListeners = function(name) {
   var listeners = [];
   var subscriber;
 
-  for (var i = 0, l = subscribers.length; i<l; i++) {
+  for (var i = 0, l = subscribers.length; i < l; i++) {
     subscriber = subscribers[i];
     if (subscriber.regex.test(name)) {
       listeners.push(subscriber.object);
@@ -141,7 +141,7 @@ export function _instrumentStart(name, _payload) {
   var beforeValues = new Array(l);
   var i, listener;
   var timestamp = time();
-  for (i = 0; i<l; i++) {
+  for (i = 0; i < l; i++) {
     listener = listeners[i];
     beforeValues[i] = listener.before(name, timestamp, payload);
   }
@@ -149,7 +149,7 @@ export function _instrumentStart(name, _payload) {
   return function _instrumentEnd() {
     var i, l, listener;
     var timestamp = time();
-    for (i = 0, l = listeners.length; i<l; i++) {
+    for (i = 0, l = listeners.length; i < l; i++) {
       listener = listeners[i];
       listener.after(name, timestamp, payload, beforeValues[i]);
     }
@@ -177,7 +177,7 @@ export function subscribe(pattern, object) {
   var path;
   var regex = [];
 
-  for (var i = 0, l = paths.length; i<l; i++) {
+  for (var i = 0, l = paths.length; i < l; i++) {
     path = paths[i];
     if (path === '*') {
       regex.push('[^\\.]*');
@@ -213,7 +213,7 @@ export function subscribe(pattern, object) {
 export function unsubscribe(subscriber) {
   var index;
 
-  for (var i = 0, l = subscribers.length; i<l; i++) {
+  for (var i = 0, l = subscribers.length; i < l; i++) {
     if (subscribers[i] === subscriber) {
       index = i;
     }

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -54,7 +54,7 @@ var populateListeners = function(name) {
   var listeners = [];
   var subscriber;
 
-  for (var i=0, l=subscribers.length; i<l; i++) {
+  for (var i = 0, l = subscribers.length; i<l; i++) {
     subscriber = subscribers[i];
     if (subscriber.regex.test(name)) {
       listeners.push(subscriber.object);
@@ -141,7 +141,7 @@ export function _instrumentStart(name, _payload) {
   var beforeValues = new Array(l);
   var i, listener;
   var timestamp = time();
-  for (i=0; i<l; i++) {
+  for (i = 0; i<l; i++) {
     listener = listeners[i];
     beforeValues[i] = listener.before(name, timestamp, payload);
   }
@@ -149,7 +149,7 @@ export function _instrumentStart(name, _payload) {
   return function _instrumentEnd() {
     var i, l, listener;
     var timestamp = time();
-    for (i=0, l=listeners.length; i<l; i++) {
+    for (i = 0, l = listeners.length; i<l; i++) {
       listener = listeners[i];
       listener.after(name, timestamp, payload, beforeValues[i]);
     }
@@ -177,7 +177,7 @@ export function subscribe(pattern, object) {
   var path;
   var regex = [];
 
-  for (var i=0, l=paths.length; i<l; i++) {
+  for (var i = 0, l = paths.length; i<l; i++) {
     path = paths[i];
     if (path === '*') {
       regex.push('[^\\.]*');
@@ -213,7 +213,7 @@ export function subscribe(pattern, object) {
 export function unsubscribe(subscriber) {
   var index;
 
-  for (var i=0, l=subscribers.length; i<l; i++) {
+  for (var i = 0, l = subscribers.length; i<l; i++) {
     if (subscribers[i] === subscriber) {
       index = i;
     }

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -33,13 +33,13 @@ export default function merge(original, updates) {
 }
 
 export function assign(original, ...args) {
-  for (let i=0, l=args.length; i<l; i++) {
+  for (let i = 0, l = args.length; i<l; i++) {
     let arg = args[i];
     if (!arg) { continue; }
 
     let updates = Object.keys(arg);
 
-    for (let i=0, l=updates.length; i<l; i++) {
+    for (let i = 0, l = updates.length; i<l; i++) {
       let prop = updates[i];
       original[prop] = arg[prop];
     }

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -33,13 +33,13 @@ export default function merge(original, updates) {
 }
 
 export function assign(original, ...args) {
-  for (let i = 0, l = args.length; i<l; i++) {
+  for (let i = 0, l = args.length; i < l; i++) {
     let arg = args[i];
     if (!arg) { continue; }
 
     let updates = Object.keys(arg);
 
-    for (let i = 0, l = updates.length; i<l; i++) {
+    for (let i = 0, l = updates.length; i < l; i++) {
       let prop = updates[i];
       original[prop] = arg[prop];
     }

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -283,7 +283,7 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
     delete values[keyName];
   }
 
-  for (var i = 0, l = mixins.length; i<l; i++) {
+  for (var i = 0, l = mixins.length; i < l; i++) {
     currentMixin = mixins[i];
     Ember.assert(`Expected hash or Mixin instance, got ${Object.prototype.toString.call(currentMixin)}`,
                  typeof currentMixin === 'object' && currentMixin !== null && Object.prototype.toString.call(currentMixin) !== '[object Array]');
@@ -405,7 +405,7 @@ function updateObserversAndListeners(obj, key, observerOrListener, pathsKey, upd
   var paths = observerOrListener[pathsKey];
 
   if (paths) {
-    for (var i = 0, l = paths.length; i<l; i++) {
+    for (var i = 0, l = paths.length; i < l; i++) {
       updateMethod(obj, paths[i], null, key);
     }
   }
@@ -816,7 +816,7 @@ export function observer(...args) {
 
   paths = [];
 
-  for (var i = 0; i<_paths.length; ++i) {
+  for (var i = 0; i < _paths.length; ++i) {
     expandProperties(_paths[i], addWatchedProperty);
   }
 
@@ -856,7 +856,7 @@ export function observer(...args) {
 export function _immediateObserver() {
   Ember.deprecate('Usage of `Ember.immediateObserver` is deprecated, use `Ember.observer` instead.');
 
-  for (var i = 0, l = arguments.length; i<l; i++) {
+  for (var i = 0, l = arguments.length; i < l; i++) {
     var arg = arguments[i];
     Ember.assert('Immediate observers must observe internal properties only, not properties on other objects.',
                  typeof arg !== 'string' || arg.indexOf('.') === -1);
@@ -926,7 +926,7 @@ export function _beforeObserver(...args) {
 
   paths = [];
 
-  for (var i = 0; i<_paths.length; ++i) {
+  for (var i = 0; i < _paths.length; ++i) {
     expandProperties(_paths[i], addWatchedProperty);
   }
 

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -283,7 +283,7 @@ function mergeMixins(mixins, m, descs, values, base, keys) {
     delete values[keyName];
   }
 
-  for (var i=0, l=mixins.length; i<l; i++) {
+  for (var i = 0, l = mixins.length; i<l; i++) {
     currentMixin = mixins[i];
     Ember.assert(`Expected hash or Mixin instance, got ${Object.prototype.toString.call(currentMixin)}`,
                  typeof currentMixin === 'object' && currentMixin !== null && Object.prototype.toString.call(currentMixin) !== '[object Array]');
@@ -405,7 +405,7 @@ function updateObserversAndListeners(obj, key, observerOrListener, pathsKey, upd
   var paths = observerOrListener[pathsKey];
 
   if (paths) {
-    for (var i=0, l=paths.length; i<l; i++) {
+    for (var i = 0, l = paths.length; i<l; i++) {
       updateMethod(obj, paths[i], null, key);
     }
   }
@@ -613,7 +613,7 @@ MixinPrototype.reopen = function() {
   var mixins = this.mixins;
   var idx;
 
-  for (idx=0; idx < len; idx++) {
+  for (idx = 0; idx < len; idx++) {
     currentMixin = arguments[idx];
     Ember.assert(`Expected hash or Mixin instance, got ${Object.prototype.toString.call(currentMixin)}`,
                  typeof currentMixin === 'object' && currentMixin !== null &&
@@ -816,7 +816,7 @@ export function observer(...args) {
 
   paths = [];
 
-  for (var i=0; i<_paths.length; ++i) {
+  for (var i = 0; i<_paths.length; ++i) {
     expandProperties(_paths[i], addWatchedProperty);
   }
 
@@ -856,7 +856,7 @@ export function observer(...args) {
 export function _immediateObserver() {
   Ember.deprecate('Usage of `Ember.immediateObserver` is deprecated, use `Ember.observer` instead.');
 
-  for (var i=0, l=arguments.length; i<l; i++) {
+  for (var i = 0, l = arguments.length; i<l; i++) {
     var arg = arguments[i];
     Ember.assert('Immediate observers must observe internal properties only, not properties on other objects.',
                  typeof arg !== 'string' || arg.indexOf('.') === -1);
@@ -926,7 +926,7 @@ export function _beforeObserver(...args) {
 
   paths = [];
 
-  for (var i=0; i<_paths.length; ++i) {
+  for (var i = 0; i<_paths.length; ++i) {
     expandProperties(_paths[i], addWatchedProperty);
   }
 

--- a/packages/ember-metal/lib/observer_set.js
+++ b/packages/ember-metal/lib/observer_set.js
@@ -52,7 +52,7 @@ ObserverSet.prototype.flush = function() {
   var observers = this.observers;
   var i, len, observer, sender;
   this.clear();
-  for (i=0, len=observers.length; i < len; ++i) {
+  for (i = 0, len = observers.length; i < len; ++i) {
     observer = observers[i];
     sender = observer.sender;
     if (sender.isDestroying || sender.isDestroyed) { continue; }

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -176,7 +176,7 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
 
   if (deps) {
     keys = keysOf(deps);
-    for (i = 0; i<keys.length; i++) {
+    for (i = 0; i < keys.length; i++) {
       key = keys[i];
       possibleDesc = obj[key];
       desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -176,7 +176,7 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
 
   if (deps) {
     keys = keysOf(deps);
-    for (i=0; i<keys.length; i++) {
+    for (i = 0; i<keys.length; i++) {
       key = keys[i];
       possibleDesc = obj[key];
       desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
@@ -205,7 +205,7 @@ function chainsWillChange(obj, keyName, m) {
   }
 
   for (i = 0, l = events.length; i < l; i += 2) {
-    propertyWillChange(events[i], events[i+1]);
+    propertyWillChange(events[i], events[i + 1]);
   }
 }
 
@@ -228,7 +228,7 @@ function chainsDidChange(obj, keyName, m, suppressEvents) {
   }
 
   for (i = 0, l = events.length; i < l; i += 2) {
-    propertyDidChange(events[i], events[i+1]);
+    propertyDidChange(events[i], events[i + 1]);
   }
 }
 

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -137,7 +137,7 @@ export function normalizeTuple(target, path) {
   if (isGlobal && isPath(path)) {
     key = path.match(FIRST_KEY)[0];
     target = get(target, key);
-    path   = path.slice(key.length+1);
+    path   = path.slice(key.length + 1);
   }
 
   // must return some kind of path to be valid else other things will break.
@@ -148,7 +148,7 @@ export function normalizeTuple(target, path) {
 
 
 function validateIsPath(path) {
-  if (!path || path.length===0) {
+  if (!path || path.length === 0) {
     throw new EmberError(`Object in path ${path} could not be found or was destroyed.`);
   }
 }

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -124,7 +124,7 @@ function setPath(root, path, value, tolerant) {
   keyName = path.slice(path.lastIndexOf('.') + 1);
 
   // get the first part of the part
-  path    = (path === keyName) ? keyName : path.slice(0, path.length-(keyName.length+1));
+  path    = (path === keyName) ? keyName : path.slice(0, path.length - (keyName.length + 1));
 
   // unless the path is this, look up the first part to
   // get the root
@@ -140,7 +140,7 @@ function setPath(root, path, value, tolerant) {
     if (tolerant) {
       return;
     } else {
-      throw new EmberError('Property set failed: object in path "'+path+'" could not be found or was destroyed.');
+      throw new EmberError('Property set failed: object in path "' + path + '" could not be found or was destroyed.');
     }
   }
 

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -653,6 +653,6 @@ function checkAutoRun() {
 */
 run._addQueue = function(name, after) {
   if (run.queues.indexOf(name) === -1) {
-    run.queues.splice(run.queues.indexOf(after)+1, 0, name);
+    run.queues.splice(run.queues.indexOf(after) + 1, 0, name);
   }
 };

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -291,7 +291,7 @@ Stream.prototype = {
       var dependencies = this.dependencies;
 
       if (dependencies) {
-        for (var i = 0, l = dependencies.length; i<l; i++) {
+        for (var i = 0, l = dependencies.length; i < l; i++) {
           dependencies[i](prune);
         }
       }

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -291,7 +291,7 @@ Stream.prototype = {
       var dependencies = this.dependencies;
 
       if (dependencies) {
-        for (var i=0, l=dependencies.length; i<l; i++) {
+        for (var i = 0, l = dependencies.length; i<l; i++) {
           dependencies[i](prune);
         }
       }

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -198,7 +198,7 @@ export function concat(array, separator) {
 export function labelsFor(streams) {
   var labels =  [];
 
-  for (var i = 0, l = streams.length; i<l; i++) {
+  for (var i = 0, l = streams.length; i < l; i++) {
     var stream = streams[i];
     labels.push(labelFor(stream));
   }
@@ -264,7 +264,7 @@ export function zip(streams, callback, label) {
     return `${label}(${labelsFor(streams)})`;
   });
 
-  for (var i = 0, l = streams.length; i<l; i++) {
+  for (var i = 0, l = streams.length; i < l; i++) {
     stream.addDependency(streams[i]);
   }
 

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -182,7 +182,7 @@ export function concat(array, separator) {
       return `concat([${labels.join(', ')}]; separator=${inspect(separator)})`;
     });
 
-    for (i = 0, l=array.length; i < l; i++) {
+    for (i = 0, l = array.length; i < l; i++) {
       subscribe(array[i], stream.notify, stream);
     }
 
@@ -198,7 +198,7 @@ export function concat(array, separator) {
 export function labelsFor(streams) {
   var labels =  [];
 
-  for (var i=0, l=streams.length; i<l; i++) {
+  for (var i = 0, l = streams.length; i<l; i++) {
     var stream = streams[i];
     labels.push(labelFor(stream));
   }
@@ -264,7 +264,7 @@ export function zip(streams, callback, label) {
     return `${label}(${labelsFor(streams)})`;
   });
 
-  for (var i=0, l=streams.length; i<l; i++) {
+  for (var i = 0, l = streams.length; i<l; i++) {
     stream.addDependency(streams[i]);
   }
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -418,7 +418,7 @@ export function metaPath(obj, path, writable) {
   var _meta = meta(obj, writable);
   var keyName, value;
 
-  for (var i = 0, l = path.length; i<l; i++) {
+  for (var i = 0, l = path.length; i < l; i++) {
     keyName = path[i];
     value = _meta[keyName];
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -234,7 +234,7 @@ export function guidFor(obj) {
       ret = numberCache[obj];
 
       if (!ret) {
-        ret = numberCache[obj] = 'nu'+obj;
+        ret = numberCache[obj] = 'nu' + obj;
       }
 
       return ret;
@@ -329,7 +329,7 @@ if (isEnabled('mandatory-setter')) {
 */
 function meta(obj, writable) {
   var ret = obj.__ember_meta__;
-  if (writable===false) {
+  if (writable === false) {
     return ret || EMPTY_META;
   }
 
@@ -418,7 +418,7 @@ export function metaPath(obj, path, writable) {
   var _meta = meta(obj, writable);
   var keyName, value;
 
-  for (var i=0, l=path.length; i<l; i++) {
+  for (var i = 0, l = path.length; i<l; i++) {
     keyName = path[i];
     value = _meta[keyName];
 
@@ -598,7 +598,7 @@ export function inspect(obj) {
   // for non objects
   var type = typeof obj;
   if (type !== 'object' && type !== 'symbol') {
-    return ''+obj;
+    return '' + obj;
   }
   // overridden toString
   if (typeof obj.toString === 'function' && obj.toString !== toString) {

--- a/packages/ember-metal/tests/binding/sync_test.js
+++ b/packages/ember-metal/tests/binding/sync_test.js
@@ -11,8 +11,8 @@ QUnit.module('system/binding/sync_test.js');
 
 testBoth('bindings should not sync twice in a single run loop', function(get, set) {
   var a, b, setValue;
-  var setCalled=0;
-  var getCalled=0;
+  var setCalled = 0;
+  var getCalled = 0;
 
   run(function() {
     a = {};
@@ -49,7 +49,7 @@ testBoth('bindings should not sync twice in a single run loop', function(get, se
 
 testBoth('bindings should not infinite loop if computed properties return objects', function(get, set) {
   var a, b;
-  var getCalled=0;
+  var getCalled = 0;
 
   run(function() {
     a = {};

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -32,7 +32,7 @@ QUnit.test('defining computed property should invoke property on get', function(
   var count = 0;
   defineProperty(obj, 'foo', computed(function(key) {
     count++;
-    return 'computed '+key;
+    return 'computed ' + key;
   }));
 
   equal(get(obj, 'foo'), 'computed foo', 'should return value');
@@ -43,11 +43,11 @@ QUnit.test('defining computed property should invoke property on set', function(
   var obj = {};
   var count = 0;
   defineProperty(obj, 'foo', computed({
-    get: function(key) { return this['__'+key]; },
+    get: function(key) { return this['__' + key]; },
     set: function(key, value) {
       count++;
-      this['__'+key] = 'computed '+value;
-      return this['__'+key];
+      this['__' + key] = 'computed ' + value;
+      return this['__' + key];
     }
   }));
 
@@ -62,11 +62,11 @@ QUnit.module('computed should inherit through prototype', {
     objA = { __foo: 'FOO' };
     defineProperty(objA, 'foo', computed({
       get: function(key) {
-        return this['__'+key];
+        return this['__' + key];
       },
       set: function(key, value) {
-        this['__'+key] = 'computed '+value;
-        return this['__'+key];
+        this['__' + key] = 'computed ' + value;
+        return this['__' + key];
       }
     }));
 
@@ -101,11 +101,11 @@ QUnit.module('redefining computed property to normal', {
     objA = { __foo: 'FOO' };
     defineProperty(objA, 'foo', computed({
       get: function(key) {
-        return this['__'+key];
+        return this['__' + key];
       },
       set: function(key, value) {
-        this['__'+key] = 'computed '+value;
-        return this['__'+key];
+        this['__' + key] = 'computed ' + value;
+        return this['__' + key];
       }
     }));
 
@@ -140,21 +140,21 @@ QUnit.module('redefining computed property to another property', {
     objA = { __foo: 'FOO' };
     defineProperty(objA, 'foo', computed({
       get: function(key) {
-        return this['__'+key];
+        return this['__' + key];
       },
       set: function(key, value) {
-        this['__'+key] = 'A '+value;
-        return this['__'+key];
+        this['__' + key] = 'A ' + value;
+        return this['__' + key];
       }
     }));
 
     objB = Object.create(objA);
     objB.__foo = 'FOO';
     defineProperty(objB, 'foo', computed({
-      get: function(key) { return this['__'+key]; },
+      get: function(key) { return this['__' + key]; },
       set: function(key, value) {
-        this['__'+key] = 'B '+value;
-        return this['__'+key];
+        this['__' + key] = 'B ' + value;
+        return this['__' + key];
       }
     }));
   },
@@ -205,7 +205,7 @@ QUnit.module('computed - cacheable', {
     count = 0;
     var func = function(key, value) {
       count++;
-      return 'bar '+count;
+      return 'bar ' + count;
     };
     defineProperty(obj, 'foo', computed({ get: func, set: func }));
   },
@@ -300,7 +300,7 @@ QUnit.module('computed - dependentkey', {
     var getterAndSetter = function(key, value) {
       count++;
       get(this, 'bar');
-      return 'bar '+count;
+      return 'bar ' + count;
     };
     defineProperty(obj, 'foo', computed({
       get: getterAndSetter,
@@ -342,7 +342,7 @@ testBoth('should invalidate multiple nested dependent keys', function(get, set) 
   defineProperty(obj, 'bar', computed(function() {
     count++;
     get(this, 'baz');
-    return 'baz '+count;
+    return 'baz ' + count;
   }).property('baz'));
 
   equal(isWatching(obj, 'bar'), false, 'precond not watching dependent key');
@@ -365,13 +365,13 @@ testBoth('should invalidate multiple nested dependent keys', function(get, set) 
 testBoth('circular keys should not blow up', function(get, set) {
   var func = function(key, value) {
     count++;
-    return 'bar '+count;
+    return 'bar ' + count;
   };
   defineProperty(obj, 'bar', computed({ get: func, set: func }).property('foo'));
 
   defineProperty(obj, 'foo', computed(function(key) {
     count++;
-    return 'foo '+count;
+    return 'foo ' + count;
   }).property('bar'));
 
   equal(get(obj, 'foo'), 'foo 1', 'get once');
@@ -390,7 +390,7 @@ testBoth('redefining a property should undo old dependent keys', function(get, s
 
   defineProperty(obj, 'foo', computed(function() {
     count++;
-    return 'baz '+count;
+    return 'baz ' + count;
   }).property('baz'));
 
   equal(isWatching(obj, 'bar'), false, 'after redefining should not be watching dependent key');
@@ -407,7 +407,7 @@ testBoth('redefining a property should undo old dependent keys', function(get, s
 testBoth('can watch multiple dependent keys specified declaratively via brace expansion', function (get, set) {
   defineProperty(obj, 'foo', computed(function(key) {
     count++;
-    return 'foo '+count;
+    return 'foo ' + count;
   }).property('qux.{bar,baz}'));
 
   equal(get(obj, 'foo'), 'foo 1', 'get once');
@@ -472,7 +472,7 @@ var moduleOpts = {
     count = 0;
     func = function() {
       count++;
-      return get(obj, 'foo.bar.baz.biff')+' '+count;
+      return get(obj, 'foo.bar.baz.biff') + ' ' + count;
     };
   },
 
@@ -532,7 +532,7 @@ testBoth('depending on Global chain', function(get, set) {
   // assign computed property
   defineProperty(obj, 'prop', computed(function() {
     count++;
-    return get('Global.foo.bar.baz.biff')+' '+count;
+    return get('Global.foo.bar.baz.biff') + ' ' + count;
   }).property('Global.foo.bar.baz.biff'));
 
   equal(get(obj, 'prop'), 'BIFF 1');
@@ -599,7 +599,7 @@ QUnit.test('setter and getters are passed using an object', function() {
         equal(keyName, 'aInt', 'setter receives the keyName');
         equal(value, 123, 'setter receives the new value');
         equal(oldValue, 1, 'setter receives the old value');
-        this.set('a', ''+value); // side effect
+        this.set('a', '' + value); // side effect
         return parseInt(this.get('a'));
       }
     })

--- a/packages/ember-metal/tests/core/inspect_test.js
+++ b/packages/ember-metal/tests/core/inspect_test.js
@@ -38,7 +38,7 @@ QUnit.test('objects without a prototype', function() {
 });
 
 QUnit.test('array', function() {
-  equal(inspect([1,2,3]), '[1,2,3]');
+  equal(inspect([1, 2, 3]), '[1,2,3]');
 });
 
 QUnit.test('regexp', function() {

--- a/packages/ember-metal/tests/is_present_test.js
+++ b/packages/ember-metal/tests/is_present_test.js
@@ -22,5 +22,5 @@ QUnit.test('Ember.isPresent', function() {
   equal(false, isPresent([]), 'for an empty Array');
   equal(true, isPresent({}), 'for an empty Object');
   equal(false, isPresent(object), 'for an Object that has zero \'length\'');
-  equal(true, isPresent([1,2,3]), 'for a non-empty array');
+  equal(true, isPresent([1, 2, 3]), 'for a non-empty array');
 });

--- a/packages/ember-metal/tests/keys_test.js
+++ b/packages/ember-metal/tests/keys_test.js
@@ -17,7 +17,7 @@ QUnit.test('should get a key array for a specified object', function() {
 
   var object2 = Object.keys(object1);
 
-  deepEqual(object2, ['names','age','place']);
+  deepEqual(object2, ['names', 'age', 'place']);
 });
 
 // This test is for IE8.

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -450,7 +450,7 @@ function testMap(nameAndFunc) {
     equal(map.get(-0), 'zero');
 
     map.forEach(function(value, key) {
-      equal(1/key, Infinity, 'spec says key should be positive zero');
+      equal(1 / key, Infinity, 'spec says key should be positive zero');
     });
   });
 

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -20,19 +20,19 @@ QUnit.test('overriding computed properties', function() {
 
   MixinB = Mixin.create(MixinA, {
     aProp: computed(function() {
-      return this._super.apply(this, arguments)+'B';
+      return this._super.apply(this, arguments) + 'B';
     })
   });
 
   MixinC = Mixin.create(MixinA, {
     aProp: computed(function() {
-      return this._super.apply(this, arguments)+'C';
+      return this._super.apply(this, arguments) + 'C';
     })
   });
 
   MixinD = Mixin.create({
     aProp: computed(function() {
-      return this._super.apply(this, arguments)+'D';
+      return this._super.apply(this, arguments) + 'D';
     })
   });
 

--- a/packages/ember-metal/tests/mixin/concatenated_properties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenated_properties_test.js
@@ -44,23 +44,23 @@ QUnit.test('concatenatedProperties should be concatenated', function() {
   var MixinB = Mixin.create({
     concatenatedProperties: 'bar',
     foo: ['d', 'e', 'f'],
-    bar: [1,2,3]
+    bar: [1, 2, 3]
   });
 
   var MixinC = Mixin.create({
-    bar: [4,5,6]
+    bar: [4, 5, 6]
   });
 
   var obj = mixin({}, MixinA, MixinB, MixinC);
   deepEqual(get(obj, 'concatenatedProperties'), ['foo', 'bar'], 'get concatenatedProperties');
   deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f'], 'get foo');
-  deepEqual(get(obj, 'bar'), [1,2,3,4,5,6], 'get bar');
+  deepEqual(get(obj, 'bar'), [1, 2, 3, 4, 5, 6], 'get bar');
 });
 
 QUnit.test('adding a prop that is not an array should make array', function() {
   var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
-    foo: [1,2,3]
+    foo: [1, 2, 3]
   });
 
   var MixinB = Mixin.create({
@@ -68,7 +68,7 @@ QUnit.test('adding a prop that is not an array should make array', function() {
   });
 
   var obj = mixin({}, MixinA, MixinB);
-  deepEqual(get(obj, 'foo'), [1,2,3,4]);
+  deepEqual(get(obj, 'foo'), [1, 2, 3, 4]);
 });
 
 QUnit.test('adding a prop that is not an array should make array', function() {

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -30,15 +30,15 @@ QUnit.test('overriding public methods', function() {
   });
 
   MixinB = Mixin.create(MixinA, {
-    publicMethod() { return this._super.apply(this, arguments)+'B'; }
+    publicMethod() { return this._super.apply(this, arguments) + 'B'; }
   });
 
   MixinD = Mixin.create(MixinA, {
-    publicMethod() { return this._super.apply(this, arguments)+'D'; }
+    publicMethod() { return this._super.apply(this, arguments) + 'D'; }
   });
 
   MixinF = Mixin.create({
-    publicMethod() { return this._super.apply(this, arguments)+'F'; }
+    publicMethod() { return this._super.apply(this, arguments) + 'F'; }
   });
 
   obj = {};

--- a/packages/ember-metal/tests/mixin/observer_test.js
+++ b/packages/ember-metal/tests/mixin/observer_test.js
@@ -14,7 +14,7 @@ testBoth('global observer helper', function(get, set) {
     count: 0,
 
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
 
   });
@@ -32,7 +32,7 @@ testBoth('global observer helper takes multiple params', function(get, set) {
     count: 0,
 
     foo: observer('bar', 'baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
 
   });
@@ -52,14 +52,14 @@ testBoth('replacing observer should remove old observer', function(get, set) {
     count: 0,
 
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
 
   });
 
   var Mixin2 = Mixin.create({
     foo: observer('baz', function() {
-      set(this, 'count', get(this, 'count')+10);
+      set(this, 'count', get(this, 'count') + 10);
     })
   });
 
@@ -80,7 +80,7 @@ testBoth('observing chain with property before', function(get, set) {
     count: 0,
     bar: obj2,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -97,7 +97,7 @@ testBoth('observing chain with property after', function(get, set) {
   var MyMixin = Mixin.create({
     count: 0,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     }),
     bar: obj2
   });
@@ -116,7 +116,7 @@ testBoth('observing chain with property in mixin applied later', function(get, s
 
     count: 0,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -138,7 +138,7 @@ testBoth('observing chain with existing property', function(get, set) {
   var MyMixin = Mixin.create({
     count: 0,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -156,7 +156,7 @@ testBoth('observing chain with property in mixin before', function(get, set) {
   var MyMixin = Mixin.create({
     count: 0,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -174,7 +174,7 @@ testBoth('observing chain with property in mixin after', function(get, set) {
   var MyMixin = Mixin.create({
     count: 0,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -194,7 +194,7 @@ testBoth('observing chain with overriden property', function(get, set) {
   var MyMixin = Mixin.create({
     count: 0,
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -206,10 +206,10 @@ testBoth('removing an chain observer on change should not fail', function(get, s
   var obj2 = { foo: foo };
   var obj3 = { foo: foo };
   var obj4 = { foo: foo };
-  var count1=0;
-  var count2=0;
-  var count3=0;
-  var count4=0;
+  var count1 = 0;
+  var count2 = 0;
+  var count3 = 0;
+  var count4 = 0;
 
   function observer1() { count1++; }
   function observer2() { count2++; }
@@ -240,10 +240,10 @@ testBoth('removing an chain before observer on change should not fail', function
   var obj2 = { foo: foo };
   var obj3 = { foo: foo };
   var obj4 = { foo: foo };
-  var count1=0;
-  var count2=0;
-  var count3=0;
-  var count4=0;
+  var count1 = 0;
+  var count2 = 0;
+  var count3 = 0;
+  var count4 = 0;
 
   function observer1() { count1++; }
   function observer2() { count2++; }

--- a/packages/ember-metal/tests/performance_test.js
+++ b/packages/ember-metal/tests/performance_test.js
@@ -25,7 +25,7 @@ QUnit.test('computed properties that depend on multiple properties should run on
 
   defineProperty(obj, 'abc', computed(function(key) {
     cpCount++;
-    return 'computed '+key;
+    return 'computed ' + key;
   }).property('a', 'b', 'c'));
 
   get(obj, 'abc');

--- a/packages/ember-metal/tests/props_helper.js
+++ b/packages/ember-metal/tests/props_helper.js
@@ -9,11 +9,11 @@ var testBoth = function(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(testname+' using getFromEmberMetal()/Ember.set()', function() {
+  QUnit.test(testname + ' using getFromEmberMetal()/Ember.set()', function() {
     callback(emberget, emberset);
   });
 
-  QUnit.test(testname+' using accessors', function() {
+  QUnit.test(testname + ' using accessors', function() {
     if (Ember.USES_ACCESSORS) {
       callback(aget, aset);
     } else {
@@ -30,23 +30,23 @@ var testWithDefault = function(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  QUnit.test(testname+' using obj.get()', function() {
+  QUnit.test(testname + ' using obj.get()', function() {
     callback(emberget, emberset);
   });
 
-  QUnit.test(testname+' using obj.getWithDefault()', function() {
+  QUnit.test(testname + ' using obj.getWithDefault()', function() {
     callback(getwithdefault, emberset);
   });
 
-  QUnit.test(testname+' using getFromEmberMetal()', function() {
+  QUnit.test(testname + ' using getFromEmberMetal()', function() {
     callback(emberget, emberset);
   });
 
-  QUnit.test(testname+' using Ember.getWithDefault()', function() {
+  QUnit.test(testname + ' using Ember.getWithDefault()', function() {
     callback(embergetwithdefault, emberset);
   });
 
-  QUnit.test(testname+' using accessors', function() {
+  QUnit.test(testname + ' using accessors', function() {
     if (Ember.USES_ACCESSORS) {
       callback(aget, aset);
     } else {

--- a/packages/ember-metal/tests/run_loop/sync_test.js
+++ b/packages/ember-metal/tests/run_loop/sync_test.js
@@ -9,7 +9,7 @@ QUnit.test('sync() will immediately flush the sync queue only', function() {
     function cntup() { cnt++; }
 
     function syncfunc() {
-      if (++cnt<5) {
+      if (++cnt < 5) {
         run.schedule('sync', syncfunc);
       }
       run.schedule('actions', cntup);

--- a/packages/ember-routing-htmlbars/lib/keywords/element-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/element-action.js
@@ -149,7 +149,7 @@ function isAllowedEvent(event, allowedKeys) {
     return true;
   }
 
-  for (var i=0, l=MODIFIERS.length;i<l;i++) {
+  for (var i = 0, l = MODIFIERS.length; i < l; i++) {
     if (event[MODIFIERS[i] + 'Key'] && allowedKeys.indexOf(MODIFIERS[i]) === -1) {
       return false;
     }

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -803,10 +803,10 @@ QUnit.test('it does not trigger action with special clicks', function() {
     event[prop] = value;
     view.$('a').trigger(event);
     if (expected) {
-      ok(showCalled, 'should call action with '+prop+':'+value);
+      ok(showCalled, 'should call action with ' + prop + ':' + value);
       ok(event.isDefaultPrevented(), 'should prevent default');
     } else {
-      ok(!showCalled, 'should not call action with '+prop+':'+value);
+      ok(!showCalled, 'should not call action with ' + prop + ':' + value);
       ok(!event.isDefaultPrevented(), 'should not prevent default');
     }
   }
@@ -911,9 +911,9 @@ QUnit.test('a quoteless parameter should lookup actionName in context [DEPRECATE
   });
 
   var controller = EmberController.extend({
-    allactions: Ember.A([{ title: 'Biggity Boom',name: 'biggityBoom' },
-                         { title: 'Whomp Whomp',name: 'whompWhomp' },
-                         { title: 'Sloopy Dookie',name: 'sloopyDookie' }]),
+    allactions: Ember.A([{ title: 'Biggity Boom', name: 'biggityBoom' },
+                         { title: 'Whomp Whomp', name: 'whompWhomp' },
+                         { title: 'Sloopy Dookie', name: 'sloopyDookie' }]),
     actions: {
       biggityBoom() {
         lastAction = 'biggityBoom';
@@ -939,7 +939,7 @@ QUnit.test('a quoteless parameter should lookup actionName in context [DEPRECATE
 
   var testBoundAction = function(propertyValue) {
     run(function() {
-      view.$('#'+propertyValue).click();
+      view.$('#' + propertyValue).click();
     });
 
     equal(lastAction, propertyValue, 'lastAction set to ' + propertyValue);
@@ -964,9 +964,9 @@ QUnit.test('a quoteless string parameter should resolve actionName, including pa
   });
 
   var controller = EmberController.extend({
-    allactions: Ember.A([{ title: 'Biggity Boom',name: 'biggityBoom' },
-                         { title: 'Whomp Whomp',name: 'whompWhomp' },
-                         { title: 'Sloopy Dookie',name: 'sloopyDookie' }]),
+    allactions: Ember.A([{ title: 'Biggity Boom', name: 'biggityBoom' },
+                         { title: 'Whomp Whomp', name: 'whompWhomp' },
+                         { title: 'Sloopy Dookie', name: 'sloopyDookie' }]),
     actions: {
       biggityBoom() {
         lastAction = 'biggityBoom';
@@ -990,7 +990,7 @@ QUnit.test('a quoteless string parameter should resolve actionName, including pa
 
   var testBoundAction = function(propertyValue) {
     run(function() {
-      view.$('#'+propertyValue).click();
+      view.$('#' + propertyValue).click();
     });
 
     equal(lastAction, propertyValue, 'lastAction set to ' + propertyValue);

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -488,7 +488,7 @@ function computeActive(view, routerState) {
 }
 
 function modelsAreLoaded(models) {
-  for (var i=0, l=models.length; i<l; i++) {
+  for (var i = 0, l = models.length; i < l; i++) {
     if (models[i] == null) { return false; }
   }
 

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -32,7 +32,7 @@ ControllerMixin.reopen({
     @private
   */
   _qpChanged(controller, _prop) {
-    var prop = _prop.substr(0, _prop.length-3);
+    var prop = _prop.substr(0, _prop.length - 3);
 
     var delegate = controller._qpDelegate;
     var value = get(controller, prop);

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -117,7 +117,7 @@ export default EmberObject.extend({
     var rootURL = this.rootURL;
 
     Ember.assert('rootURL must end with a trailing forward slash e.g. "/app/"',
-                 rootURL.charAt(rootURL.length-1) === '/');
+                 rootURL.charAt(rootURL.length - 1) === '/');
 
     var implementation = detectImplementation({
       location: this.location,

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -68,7 +68,7 @@ export default Service.extend({
     var router = get(this, 'router');
 
     var handlers = router.router.recognizer.handlersFor(routeName);
-    var leafName = handlers[handlers.length-1].handler;
+    var leafName = handlers[handlers.length - 1].handler;
     var maximumContexts = numberOfContextsAcceptedByHandler(routeName, handlers);
 
     // NOTE: any ugliness in the calculation of activeness is largely

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -60,7 +60,7 @@ DSL.prototype = {
 
   push(url, name, callback) {
     var parts = name.split('.');
-    if (url === '' || url === '/' || parts[parts.length-1] === 'index') { this.explicitIndex = true; }
+    if (url === '' || url === '/' || parts[parts.length - 1] === 'index') { this.explicitIndex = true; }
 
     this.matches.push([url, name, callback]);
   },
@@ -88,7 +88,7 @@ DSL.prototype = {
     }
 
     return function(match) {
-      for (var i=0, l=dslMatches.length; i<l; i++) {
+      for (var i = 0, l = dslMatches.length; i < l; i++) {
         var dslMatch = dslMatches[i];
         match(dslMatch[0]).to(dslMatch[1], dslMatch[2]);
       }

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -754,7 +754,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
       var handlerInfos = transition.state.handlerInfos;
       var router = this.router;
-      var qpMeta = router._queryParamsFor(handlerInfos[handlerInfos.length-1].name);
+      var qpMeta = router._queryParamsFor(handlerInfos[handlerInfos.length - 1].name);
       var changes = router._qpUpdates;
       var replaceUrl;
 
@@ -1473,7 +1473,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     } else if (!name) {
       if (transition.resolveIndex < 1) { return; }
 
-      var parentModel = transition.state.handlerInfos[transition.resolveIndex-1].context;
+      var parentModel = transition.state.handlerInfos[transition.resolveIndex - 1].context;
 
       return parentModel;
     }
@@ -2083,9 +2083,9 @@ function handlerInfoFor(route, handlerInfos, _offset) {
 
   var offset = _offset || 0;
   var current;
-  for (var i=0, l=handlerInfos.length; i<l; i++) {
+  for (var i = 0, l = handlerInfos.length; i < l; i++) {
     current = handlerInfos[i].handler;
-    if (current === route) { return handlerInfos[i+offset]; }
+    if (current === route) { return handlerInfos[i + offset]; }
   }
 }
 
@@ -2161,7 +2161,7 @@ function getFullQueryParams(router, state) {
   state.fullQueryParams = {};
   merge(state.fullQueryParams, state.queryParams);
 
-  var targetRouteName = state.handlerInfos[state.handlerInfos.length-1].name;
+  var targetRouteName = state.handlerInfos[state.handlerInfos.length - 1].name;
   router._deserializeQueryParams(targetRouteName, state.fullQueryParams);
   return state.fullQueryParams;
 }

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -85,7 +85,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     function generateDSL() {
       this.route('application', { path: '/', resetNamespace: true, overrideNameAssertion: true }, function() {
-        for (var i=0; i < dslCallbacks.length; i++) {
+        for (var i = 0; i < dslCallbacks.length; i++) {
           dslCallbacks[i].call(this);
         }
       });
@@ -271,7 +271,7 @@ var EmberRouter = EmberObject.extend(Evented, {
       return this._doURLTransition('transitionTo', args[0]);
     }
 
-    var possibleQueryParams = args[args.length-1];
+    var possibleQueryParams = args[args.length - 1];
     if (possibleQueryParams && possibleQueryParams.hasOwnProperty('queryParams')) {
       queryParams = args.pop().queryParams;
     } else {
@@ -985,7 +985,7 @@ EmberRouter.reopenClass({
     }
 
     var name, nameParts, oldNameParts;
-    for (var i=1, l=handlerInfos.length; i<l; i++) {
+    for (var i = 1, l = handlerInfos.length; i < l; i++) {
       name = handlerInfos[i].name;
       nameParts = name.split('.');
       oldNameParts = slice.call(path);

--- a/packages/ember-routing/lib/utils.js
+++ b/packages/ember-routing/lib/utils.js
@@ -25,7 +25,7 @@ export function stashParamNames(router, handlerInfos) {
   // keeps separate a handlerInfo's list of parameter names depending
   // on whether a URL transition or named transition is happening.
   // Hopefully we can remove this in the future.
-  var targetRouteName = handlerInfos[handlerInfos.length-1].name;
+  var targetRouteName = handlerInfos[handlerInfos.length - 1].name;
   var recogHandlers = router.router.recognizer.handlersFor(targetRouteName);
   var dynamicParent = null;
 
@@ -58,13 +58,15 @@ function _calculateCacheValuePrefix(prefix, part) {
 
   var prefixParts = prefix.split('.');
   var currPrefix = '';
+
   for (var i = 0, len = prefixParts.length; i < len; i++) {
-    var currPart = prefixParts.slice(0, i+1).join('.');
+    var currPart = prefixParts.slice(0, i + 1).join('.');
     if (part.indexOf(currPart) !== 0) {
       break;
     }
     currPrefix = currPart;
   }
+
   return currPrefix;
 }
 

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -313,7 +313,7 @@ export default Mixin.create(Enumerable, {
     var idx;
 
     if (startAt === undefined || startAt >= len) {
-      startAt = len-1;
+      startAt = len - 1;
     }
 
     if (startAt < 0) {
@@ -500,7 +500,7 @@ export default Mixin.create(Enumerable, {
       propertyDidChange(this, 'firstObject');
     }
 
-    if (this.objectAt(length-1) !== cachedLast) {
+    if (this.objectAt(length - 1) !== cachedLast) {
       propertyWillChange(this, 'lastObject');
       propertyDidChange(this, 'lastObject');
     }

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -221,8 +221,8 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
       return null;
     }
 
-    var ret = this.objectAt(len-1);
-    this.removeAt(len-1, 1);
+    var ret = this.objectAt(len - 1);
+    this.removeAt(len - 1, 1);
     return ret;
   },
 

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -413,7 +413,7 @@ export default Mixin.create({
     @private
   */
   hasObserverFor(key) {
-    return hasListeners(this, key+':change');
+    return hasListeners(this, key + ':change');
   },
 
   /**

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -227,7 +227,7 @@ export default Mixin.create(MutableEnumerable, {
 
     if (isSorted) {
       var arrangedContent = get(this, 'arrangedContent');
-      var removedObjects = array.slice(idx, idx+removedCount);
+      var removedObjects = array.slice(idx, idx + removedCount);
       var sortProperties = get(this, 'sortProperties');
 
       removedObjects.forEach((item) => {
@@ -247,7 +247,7 @@ export default Mixin.create(MutableEnumerable, {
     var sortProperties = get(this, 'sortProperties');
 
     if (isSorted) {
-      var addedObjects = array.slice(idx, idx+addedCount);
+      var addedObjects = array.slice(idx, idx + addedCount);
 
       addedObjects.forEach((item) => {
         this.insertItemSorted(item);
@@ -298,7 +298,7 @@ export default Mixin.create(MutableEnumerable, {
     res = this.orderBy(midItem, item);
 
     if (res < 0) {
-      return this._binarySearch(item, mid+1, high);
+      return this._binarySearch(item, mid + 1, high);
     } else if (res > 0) {
       return this._binarySearch(item, low, mid);
     }

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -314,7 +314,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
       }
 
       // Get a list of indices in original content to remove
-      for (i = start; i<start + len; i++) {
+      for (i = start; i < start + len; i++) {
         // Use arrangedContent here so we avoid confusion with objects transformed by objectAtContent
         indices.push(content.indexOf(arrangedContent.objectAt(i)));
       }
@@ -323,7 +323,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
       indices.sort(function(a, b) { return b - a; });
 
       beginPropertyChanges();
-      for (i = 0; i<indices.length; i++) {
+      for (i = 0; i < indices.length; i++) {
         this._replace(indices[i], 1, EMPTY);
       }
       endPropertyChanges();

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -265,7 +265,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
 
   _replace(idx, amt, objects) {
     var content = get(this, 'content');
-    Ember.assert('The content property of '+ this.constructor + ' should be set before modifying it', content);
+    Ember.assert('The content property of ' + this.constructor + ' should be set before modifying it', content);
     if (content) {
       this.replaceContent(idx, amt, objects);
     }
@@ -314,7 +314,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
       }
 
       // Get a list of indices in original content to remove
-      for (i=start; i<start+len; i++) {
+      for (i = start; i<start + len; i++) {
         // Use arrangedContent here so we avoid confusion with objects transformed by objectAtContent
         indices.push(content.indexOf(arrangedContent.objectAt(i)));
       }
@@ -323,7 +323,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
       indices.sort(function(a, b) { return b - a; });
 
       beginPropertyChanges();
-      for (i=0; i<indices.length; i++) {
+      for (i = 0; i<indices.length; i++) {
         this._replace(indices[i], 1, EMPTY);
       }
       endPropertyChanges();

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -443,7 +443,7 @@ CoreObject.PrototypeMixin = Mixin.create({
   toString() {
     var hasToStringExtension = typeof this.toStringExtension === 'function';
     var extension = hasToStringExtension ? ':' + this.toStringExtension() : '';
-    var ret = '<'+this.constructor.toString()+':'+guidFor(this)+extension+'>';
+    var ret = '<' + this.constructor.toString() + ':' + guidFor(this) + extension + '>';
 
     this.toString = makeToString(ret);
     return ret;
@@ -737,7 +737,7 @@ var ClassMixinProps = {
   detect(obj) {
     if ('function' !== typeof obj) { return false; }
     while (obj) {
-      if (obj===this) { return true; }
+      if (obj === this) { return true; }
       obj = obj.superclass;
     }
     return false;
@@ -781,7 +781,7 @@ var ClassMixinProps = {
     var possibleDesc = proto[key];
     var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
-    Ember.assert('metaForProperty() could not find a computed property with key \''+key+'\'.', !!desc && desc instanceof ComputedProperty);
+    Ember.assert('metaForProperty() could not find a computed property with key \'' + key + '\'.', !!desc && desc instanceof ComputedProperty);
     return desc._meta || {};
   },
 

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -142,13 +142,13 @@ var EachProxy = EmberObject.extend({
     var keys = this._keys;
     var key, lim;
 
-    lim = removedCnt>0 ? idx + removedCnt : -1;
+    lim = removedCnt > 0 ? idx + removedCnt : -1;
     beginPropertyChanges(this);
 
     for (key in keys) {
       if (!keys.hasOwnProperty(key)) { continue; }
 
-      if (lim>0) { removeObserverForContentKey(content, key, this, idx, lim); }
+      if (lim > 0) { removeObserverForContentKey(content, key, this, idx, lim); }
 
       propertyWillChange(this, key);
     }
@@ -161,12 +161,12 @@ var EachProxy = EmberObject.extend({
     var keys = this._keys;
     var lim;
 
-    lim = addedCnt>0 ? idx + addedCnt : -1;
+    lim = addedCnt > 0 ? idx + addedCnt : -1;
     changeProperties(function() {
       for (var key in keys) {
         if (!keys.hasOwnProperty(key)) { continue; }
 
-        if (lim>0) { addObserverForContentKey(content, key, this, idx, lim); }
+        if (lim > 0) { addObserverForContentKey(content, key, this, idx, lim); }
 
         propertyDidChange(this, key);
       }
@@ -214,7 +214,7 @@ var EachProxy = EmberObject.extend({
 
   stopObservingContentKey(keyName) {
     var keys = this._keys;
-    if (keys && (keys[keyName]>0) && (--keys[keyName]<=0)) {
+    if (keys && (keys[keyName] > 0) && (--keys[keyName]<=0)) {
       var content = this._content;
       var len     = get(content, 'length');
 

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -142,7 +142,7 @@ var EachProxy = EmberObject.extend({
     var keys = this._keys;
     var key, lim;
 
-    lim = removedCnt>0 ? idx+removedCnt : -1;
+    lim = removedCnt>0 ? idx + removedCnt : -1;
     beginPropertyChanges(this);
 
     for (key in keys) {
@@ -161,7 +161,7 @@ var EachProxy = EmberObject.extend({
     var keys = this._keys;
     var lim;
 
-    lim = addedCnt>0 ? idx+addedCnt : -1;
+    lim = addedCnt>0 ? idx + addedCnt : -1;
     changeProperties(function() {
       for (var key in keys) {
         if (!keys.hasOwnProperty(key)) { continue; }

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -206,7 +206,7 @@ function processAllNamespaces() {
     var namespaces = Namespace.NAMESPACES;
     var namespace;
 
-    for (var i = 0, l = namespaces.length; i<l; i++) {
+    for (var i = 0, l = namespaces.length; i < l; i++) {
       namespace = namespaces[i];
       processNamespace([namespace.toString()], namespace, {});
     }

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -206,7 +206,7 @@ function processAllNamespaces() {
     var namespaces = Namespace.NAMESPACES;
     var namespace;
 
-    for (var i=0, l=namespaces.length; i<l; i++) {
+    for (var i = 0, l = namespaces.length; i<l; i++) {
       namespace = namespaces[i];
       processNamespace([namespace.toString()], namespace, {});
     }

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -37,7 +37,7 @@ var NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
   // because length is a built-in property we need to know to just get the
   // original property.
   get(key) {
-    if (key==='length') {
+    if (key === 'length') {
       return this.length;
     } else if ('number' === typeof key) {
       return this[key];

--- a/packages/ember-runtime/lib/system/subarray.js
+++ b/packages/ember-runtime/lib/system/subarray.js
@@ -79,7 +79,7 @@ SubArray.prototype = {
         returnValue = seenInSubArray;
       }
 
-      self._composeAt(self._operations.length-1);
+      self._composeAt(self._operations.length - 1);
     });
 
     return returnValue;
@@ -151,19 +151,19 @@ SubArray.prototype = {
     }
 
     if (index > 0) {
-      otherOp = this._operations[index-1];
+      otherOp = this._operations[index - 1];
       if (otherOp.type === op.type) {
         op.count += otherOp.count;
-        this._operations.splice(index-1, 1);
+        this._operations.splice(index - 1, 1);
         --index;
       }
     }
 
-    if (index < this._operations.length-1) {
-      otherOp = this._operations[index+1];
+    if (index < this._operations.length - 1) {
+      otherOp = this._operations[index + 1];
       if (otherOp.type === op.type) {
         op.count += otherOp.count;
-        this._operations.splice(index+1, 1);
+        this._operations.splice(index + 1, 1);
       }
     }
   },

--- a/packages/ember-runtime/lib/system/tracked_array.js
+++ b/packages/ember-runtime/lib/system/tracked_array.js
@@ -186,8 +186,8 @@ TrackedArray.prototype = {
   // see SubArray for a better implementation.
   _composeInsert(index) {
     var newArrayOperation = this._operations[index];
-    var leftArrayOperation = this._operations[index-1]; // may be undefined
-    var rightArrayOperation = this._operations[index+1]; // may be undefined
+    var leftArrayOperation = this._operations[index - 1]; // may be undefined
+    var rightArrayOperation = this._operations[index + 1]; // may be undefined
     var leftOp = leftArrayOperation && leftArrayOperation.type;
     var rightOp = rightArrayOperation && rightArrayOperation.type;
 
@@ -216,7 +216,7 @@ TrackedArray.prototype = {
   _composeDelete(index) {
     var arrayOperation = this._operations[index];
     var deletesToGo = arrayOperation.count;
-    var leftArrayOperation = this._operations[index-1]; // may be undefined
+    var leftArrayOperation = this._operations[index - 1]; // may be undefined
     var leftOp = leftArrayOperation && leftArrayOperation.type;
     var nextArrayOperation;
     var nextOp;
@@ -270,7 +270,7 @@ TrackedArray.prototype = {
     if (arrayOperation.count > 0) {
       // compose our new delete with possibly several operations to the right of
       // disparate types
-      this._operations.splice(index+1, i-1-index);
+      this._operations.splice(index + 1, i - 1 - index);
     } else {
       // The delete operation can go away; it has merely reduced some other
       // operation, as in d:3 i:4; it may also have eliminated that operation,

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -214,7 +214,7 @@ QUnit.test('filter is readOnly', function() {
 });
 
 QUnit.test('it filters according to the specified filter function', function() {
-  deepEqual(obj.get('filtered'), [2,4,6,8], 'filter filters by the specified function');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'filter filters by the specified function');
 });
 
 QUnit.test('it passes the index to the callback', function() {
@@ -254,24 +254,24 @@ QUnit.test('it caches properly', function() {
 QUnit.test('it updates as the array is modified', function() {
   var array = obj.get('array');
 
-  deepEqual(obj.get('filtered'), [2,4,6,8], 'precond - filtered array is initially correct');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   array.addObject(11);
-  deepEqual(obj.get('filtered'), [2,4,6,8], 'objects not passing the filter are not added');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'objects not passing the filter are not added');
 
   array.addObject(12);
-  deepEqual(obj.get('filtered'), [2,4,6,8,12], 'objects passing the filter are added');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8, 12], 'objects passing the filter are added');
 
   array.removeObject(3);
   array.removeObject(4);
 
-  deepEqual(obj.get('filtered'), [2,6,8,12], 'objects removed from the dependent array are removed from the computed array');
+  deepEqual(obj.get('filtered'), [2, 6, 8, 12], 'objects removed from the dependent array are removed from the computed array');
 });
 
 QUnit.test('the dependent array can be cleared one at a time', function() {
   var array = get(obj, 'array');
 
-  deepEqual(obj.get('filtered'), [2,4,6,8], 'precond - filtered array is initially correct');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   // clear 1-8 but in a random order
   array.removeObject(3);
@@ -287,7 +287,7 @@ QUnit.test('the dependent array can be cleared one at a time', function() {
 });
 
 QUnit.test('the dependent array can be `clear`ed directly (#3272)', function() {
-  deepEqual(obj.get('filtered'), [2,4,6,8], 'precond - filtered array is initially correct');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
   obj.get('array').clear();
 
@@ -295,11 +295,11 @@ QUnit.test('the dependent array can be `clear`ed directly (#3272)', function() {
 });
 
 QUnit.test('it updates as the array is replaced', function() {
-  deepEqual(obj.get('filtered'), [2,4,6,8], 'precond - filtered array is initially correct');
+  deepEqual(obj.get('filtered'), [2, 4, 6, 8], 'precond - filtered array is initially correct');
 
-  obj.set('array', [20,21,22,23,24]);
+  obj.set('array', [20, 21, 22, 23, 24]);
 
-  deepEqual(obj.get('filtered'), [20,22,24], 'computed array is updated when array is changed');
+  deepEqual(obj.get('filtered'), [20, 22, 24], 'computed array is updated when array is changed');
 });
 
 QUnit.module('filterBy', {
@@ -424,37 +424,37 @@ QUnit.test('properties values can be replaced', function() {
     var array = obj.get('array');
     var array2 = obj.get('array2');
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,7,8,9,10], name + ' does not include duplicates');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' does not include duplicates');
 
     array.pushObject(8);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,7,8,9,10], name + ' does not add existing items');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' does not add existing items');
 
     array.pushObject(11);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,7,8,9,10,11], name + ' adds new items');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' adds new items');
 
     array2.removeAt(6); // remove 7
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,7,8,9,10,11], name + ' does not remove items that are still in the dependent array');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], name + ' does not remove items that are still in the dependent array');
 
     array2.removeObject(7);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,8,9,10,11], name + ' removes items when their last instance is gone');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 8, 9, 10, 11], name + ' removes items when their last instance is gone');
   });
 
   QUnit.test('has set-union semantics', function() {
     var array = obj.get('array');
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,7,8,9,10], name + ' is initially correct');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], name + ' is initially correct');
 
     array.removeObject(6);
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,2,3,4,5,6,7,8,9,10], 'objects are not removed if they exist in other dependent arrays');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 'objects are not removed if they exist in other dependent arrays');
 
     array.clear();
 
-    deepEqual(obj.get('union').sort((x, y) => x - y), [1,4,5,6,7,8,9,10], 'objects are removed when they are no longer in any dependent array');
+    deepEqual(obj.get('union').sort((x, y) => x - y), [1, 4, 5, 6, 7, 8, 9, 10], 'objects are removed when they are no longer in any dependent array');
   });
 });
 
@@ -463,9 +463,9 @@ QUnit.module('computed.intersect', {
     obj = EmberObject.extend({
       intersection: intersect('array', 'array2', 'array3')
     }).create({
-      array: Ember.A([1,2,3,4,5,6]),
-      array2: Ember.A([3,3,3,4,5]),
-      array3: Ember.A([3,5,6,7,8])
+      array: Ember.A([1, 2, 3, 4, 5, 6]),
+      array2: Ember.A([3, 3, 3, 4, 5]),
+      array3: Ember.A([3, 5, 6, 7, 8])
     });
   },
   teardown() {
@@ -483,15 +483,15 @@ QUnit.test('it has set-intersection semantics', function() {
   var array2 = obj.get('array2');
   var array3 = obj.get('array3');
 
-  deepEqual(obj.get('intersection').sort((x,y) => x - y), [3,5], 'intersection is initially correct');
+  deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'intersection is initially correct');
 
   array2.shiftObject();
 
-  deepEqual(obj.get('intersection').sort((x,y) => x - y), [3,5], 'objects are not removed when they are still in all dependent arrays');
+  deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'objects are not removed when they are still in all dependent arrays');
 
   array2.shiftObject();
 
-  deepEqual(obj.get('intersection').sort((x,y) => x - y), [3,5], 'objects are not removed when they are still in all dependent arrays');
+  deepEqual(obj.get('intersection').sort((x, y) => x - y), [3, 5], 'objects are not removed when they are still in all dependent arrays');
 
   array2.shiftObject();
 
@@ -503,7 +503,7 @@ QUnit.test('it has set-intersection semantics', function() {
 
   array3.pushObject(1);
 
-  deepEqual(obj.get('intersection').sort((x,y) => x - y), [1,5], 'objects added once they belong to all dependent arrays');
+  deepEqual(obj.get('intersection').sort((x, y) => x - y), [1, 5], 'objects added once they belong to all dependent arrays');
 });
 
 QUnit.module('setDiff', {
@@ -511,8 +511,8 @@ QUnit.module('setDiff', {
     obj = EmberObject.extend({
       diff: setDiff('array', 'array2')
     }).create({
-      array: Ember.A([1,2,3,4,5,6,7]),
-      array2: Ember.A([3,4,5,10])
+      array: Ember.A([1, 2, 3, 4, 5, 6, 7]),
+      array2: Ember.A([3, 4, 5, 10])
     });
   },
   teardown() {
@@ -531,8 +531,8 @@ QUnit.test('it throws an error if given fewer or more than two dependent propert
     EmberObject.extend({
       diff: setDiff('array')
     }).create({
-      array: Ember.A([1,2,3,4,5,6,7]),
-      array2: Ember.A([3,4,5])
+      array: Ember.A([1, 2, 3, 4, 5, 6, 7]),
+      array2: Ember.A([3, 4, 5])
     });
   }, /requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 
@@ -540,8 +540,8 @@ QUnit.test('it throws an error if given fewer or more than two dependent propert
     EmberObject.extend({
       diff: setDiff('array', 'array2', 'array3')
     }).create({
-      array: Ember.A([1,2,3,4,5,6,7]),
-      array2: Ember.A([3,4,5]),
+      array: Ember.A([1, 2, 3, 4, 5, 6, 7]),
+      array2: Ember.A([3, 4, 5]),
       array3: Ember.A([7])
     });
   }, /requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
@@ -556,7 +556,7 @@ QUnit.test('it has set-diff semantics', function() {
 
   array2.popObject();
 
-  deepEqual(obj.get('diff').sort((x, y) => x - y), [1,2,6,7], 'removing objects from the remove set has no effect if the object is not in the keep set');
+  deepEqual(obj.get('diff').sort((x, y) => x - y), [1, 2, 6, 7], 'removing objects from the remove set has no effect if the object is not in the keep set');
 
   array2.shiftObject();
 
@@ -1204,7 +1204,7 @@ QUnit.module('max', {
     obj = EmberObject.extend({
       max: max('items')
     }).create({
-      items: Ember.A([1,2,3])
+      items: Ember.A([1, 2, 3])
     });
   },
   teardown() {
@@ -1249,7 +1249,7 @@ QUnit.module('min', {
     obj = EmberObject.extend({
       min: min('items')
     }).create({
-      items: Ember.A([1,2,3])
+      items: Ember.A([1, 2, 3])
     });
   },
   teardown() {

--- a/packages/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/array_controller_test.js
@@ -18,7 +18,7 @@ MutableArrayTests.extend({
   },
 
   mutate(obj) {
-    obj.pushObject(Ember.get(obj, 'length')+1);
+    obj.pushObject(Ember.get(obj, 'length') + 1);
   },
 
   toArray(obj) {

--- a/packages/ember-runtime/tests/core/isEqual_test.js
+++ b/packages/ember-runtime/tests/core/isEqual_test.js
@@ -26,8 +26,8 @@ QUnit.test('dates should be equal', function() {
 
 QUnit.test('array should be equal', function() {
   // NOTE: We don't test for array contents -- that would be too expensive.
-  ok(!isEqual([1,2], [1,2]), 'two array instances with the same values should not be equal');
-  ok(!isEqual([1,2], [1]), 'two array instances with different values should not be equal');
+  ok(!isEqual([1, 2], [1, 2]), 'two array instances with the same values should not be equal');
+  ok(!isEqual([1, 2], [1]), 'two array instances with different values should not be equal');
 });
 
 QUnit.test('first object implements isEqual should use it', function() {

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -7,7 +7,7 @@ QUnit.module('Ember Type Checking');
 var global = this;
 
 QUnit.test('Ember.isArray', function() {
-  var numarray      = [1,2,3];
+  var numarray      = [1, 2, 3];
   var number        = 23;
   var strarray      = ['Hello', 'Hi'];
   var string        = 'Hello';

--- a/packages/ember-runtime/tests/core/type_of_test.js
+++ b/packages/ember-runtime/tests/core/type_of_test.js
@@ -12,7 +12,7 @@ QUnit.test('Ember.typeOf', function() {
   var error       = new Error('boum');
   var object      = { a: 'b' };
   var a = null;
-  var arr = [1,2,3];
+  var arr = [1, 2, 3];
   var obj = {};
   var instance = EmberObject.create({ method() {} });
 
@@ -21,7 +21,7 @@ QUnit.test('Ember.typeOf', function() {
   equal(typeOf('Cyril'), 'string', 'Cyril');
   equal(typeOf(101), 'number', '101');
   equal(typeOf(true), 'boolean', 'true');
-  equal(typeOf([1,2,90]), 'array', '[1,2,90]');
+  equal(typeOf([1, 2, 90]), 'array', '[1,2,90]');
   equal(typeOf(/abc/), 'regexp', '/abc/');
   equal(typeOf(date), 'date', 'new Date()');
   equal(typeOf(mockedDate), 'date', 'mocked date');

--- a/packages/ember-runtime/tests/ext/function_test.js
+++ b/packages/ember-runtime/tests/ext/function_test.js
@@ -14,7 +14,7 @@ testBoth('global observer helper takes multiple params', function(get, set) {
     count: 0,
 
     foo: function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     }.observes('bar', 'baz')
 
   });
@@ -40,7 +40,7 @@ testBoth('sets up an event listener, and can trigger the function on multiple ev
     count: 0,
 
     foo: function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     }.on('bar', 'baz')
 
   });
@@ -64,7 +64,7 @@ testBoth('can be chained with observes', function(get, set) {
     count: 0,
     bay: 'bay',
     foo: function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     }.observes('bay').on('bar')
   });
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -441,7 +441,7 @@ QUnit.test('setting values should call function return value', function() {
     // property. Other properties blindly call set.
     expectedLength = 3;
     equal(calls.length, expectedLength, fmt('set(%@) should be called the right amount of times', [key]));
-    for (idx = 0;idx<2;idx++) {
+    for (idx = 0;idx < 2;idx++) {
       equal(calls[idx], values[idx], fmt('call #%@ to set(%@) should have passed value %@', [idx + 1, key, values[idx]]));
     }
   });
@@ -644,7 +644,7 @@ QUnit.module('Observable objects & object properties ', {
       getEach() {
         var keys = ['normal', 'abnormal'];
         var ret = [];
-        for (var idx = 0; idx<keys.length;idx++) {
+        for (var idx = 0; idx < keys.length;idx++) {
           ret[ret.length] = this.get(keys[idx]);
         }
         return ret;

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -441,8 +441,8 @@ QUnit.test('setting values should call function return value', function() {
     // property. Other properties blindly call set.
     expectedLength = 3;
     equal(calls.length, expectedLength, fmt('set(%@) should be called the right amount of times', [key]));
-    for (idx=0;idx<2;idx++) {
-      equal(calls[idx], values[idx], fmt('call #%@ to set(%@) should have passed value %@', [idx+1, key, values[idx]]));
+    for (idx = 0;idx<2;idx++) {
+      equal(calls[idx], values[idx], fmt('call #%@ to set(%@) should have passed value %@', [idx + 1, key, values[idx]]));
     }
   });
 });
@@ -466,7 +466,7 @@ QUnit.test('change dependent should clear cache', function() {
 
   object.set('changer', 'bar');
 
-  equal(object.get('inc'), ret1+1, 'should increment after dependent key changes'); // should run again
+  equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
 QUnit.test('just notifying change of dependent should clear cache', function() {
@@ -476,7 +476,7 @@ QUnit.test('just notifying change of dependent should clear cache', function() {
 
   object.notifyPropertyChange('changer');
 
-  equal(object.get('inc'), ret1+1, 'should increment after dependent key changes'); // should run again
+  equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
 QUnit.test('changing dependent should clear nested cache', function() {
@@ -486,7 +486,7 @@ QUnit.test('changing dependent should clear nested cache', function() {
 
   object.set('changer', 'bar');
 
-  equal(object.get('nestedInc'), ret1+1, 'should increment after dependent key changes'); // should run again
+  equal(object.get('nestedInc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
 QUnit.test('just notifying change of dependent should clear nested cache', function() {
@@ -496,7 +496,7 @@ QUnit.test('just notifying change of dependent should clear nested cache', funct
 
   object.notifyPropertyChange('changer');
 
-  equal(object.get('nestedInc'), ret1+1, 'should increment after dependent key changes'); // should run again
+  equal(object.get('nestedInc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
 });
 
 
@@ -509,7 +509,7 @@ QUnit.test('change dependent should clear cache when observers of dependent are 
 
   // add observer to verify change...
   object.addObserver('inc', this, function() {
-    equal(object.get('inc'), ret1+1, 'should increment after dependent key changes'); // should run again
+    equal(object.get('inc'), ret1 + 1, 'should increment after dependent key changes'); // should run again
   });
 
   // now run
@@ -642,9 +642,9 @@ QUnit.module('Observable objects & object properties ', {
   setup() {
     object = ObservableObject.extend({
       getEach() {
-        var keys = ['normal','abnormal'];
+        var keys = ['normal', 'abnormal'];
         var ret = [];
-        for (var idx=0; idx<keys.length;idx++) {
+        for (var idx = 0; idx<keys.length;idx++) {
           ret[ret.length] = this.get(keys[idx]);
         }
         return ret;
@@ -668,7 +668,7 @@ QUnit.module('Observable objects & object properties ', {
       toggleVal: true,
       observedProperty: 'beingWatched',
       testRemove: 'observerToBeRemoved',
-      normalArray: Ember.A([1,2,3,4,5])
+      normalArray: Ember.A([1, 2, 3, 4, 5])
     });
   }
 });
@@ -699,7 +699,7 @@ QUnit.test('incrementProperty and decrementProperty', function() {
   }, /Must pass a numeric value to incrementProperty/i);
 
   expectAssertion(function() {
-    newValue = object.incrementProperty('numberVal', 1/0); // Increment by Infinity
+    newValue = object.incrementProperty('numberVal', 1 / 0); // Increment by Infinity
   }, /Must pass a numeric value to incrementProperty/i);
 
   equal(25, newValue, 'Attempting to increment by non-numeric values should not increment value');
@@ -723,7 +723,7 @@ QUnit.test('incrementProperty and decrementProperty', function() {
   }, /Must pass a numeric value to decrementProperty/i);
 
   expectAssertion(function() {
-    newValue = object.decrementProperty('numberVal', 1/0); // Decrement by Infinity
+    newValue = object.decrementProperty('numberVal', 1 / 0); // Decrement by Infinity
   }, /Must pass a numeric value to decrementProperty/i);
 
   equal(25, newValue, 'Attempting to decrement by non-numeric values should not decrement value');
@@ -753,11 +753,11 @@ QUnit.module('object.addObserver()', {
       incrementor: 10,
 
       action() {
-        this.normal1= 'newZeroValue';
+        this.normal1 = 'newZeroValue';
       },
 
       observeOnceAction() {
-        this.incrementor= this.incrementor+1;
+        this.incrementor = this.incrementor + 1;
       },
 
       chainedObserver() {
@@ -792,7 +792,7 @@ QUnit.module('object.removeObserver()', {
       normal: 'value',
       normal1: 'zeroValue',
       normal2: 'dependentValue',
-      ArrayKeys: ['normal','normal1'],
+      ArrayKeys: ['normal', 'normal1'],
 
       addAction() {
         this.normal1 = 'newZeroValue';

--- a/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -219,7 +219,7 @@ QUnit.module('Custom Binding', {
     bon2 = EmberObject.create({
       val1: 'hello',
       val2: 25,
-      arr: [1,2,3,4]
+      arr: [1, 2, 3, 4]
     });
 
     Ember.lookup['TestNamespace'] = TestNamespace = {

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -76,7 +76,7 @@ QUnit.test('the return value of slice has Ember.Array applied', function() {
 });
 
 QUnit.test('slice supports negative index arguments', function() {
-  var testArray = new TestArray([1,2,3,4]);
+  var testArray = new TestArray([1, 2, 3, 4]);
 
   deepEqual(testArray.slice(-2), [3, 4], 'slice(-2)');
   deepEqual(testArray.slice(-2, -1), [3], 'slice(-2, -1');
@@ -84,10 +84,10 @@ QUnit.test('slice supports negative index arguments', function() {
   deepEqual(testArray.slice(-1, -2), [], 'slice(-1, -2)');
 
   deepEqual(testArray.slice(-4, 1), [1], 'slice(-4, 1)');
-  deepEqual(testArray.slice(-4, 5), [1,2,3,4], 'slice(-4, 5)');
-  deepEqual(testArray.slice(-4), [1,2,3,4], 'slice(-4)');
+  deepEqual(testArray.slice(-4, 5), [1, 2, 3, 4], 'slice(-4, 5)');
+  deepEqual(testArray.slice(-4), [1, 2, 3, 4], 'slice(-4)');
 
-  deepEqual(testArray.slice(0, -1), [1,2,3], 'slice(0, -1)');
+  deepEqual(testArray.slice(0, -1), [1, 2, 3], 'slice(0, -1)');
   deepEqual(testArray.slice(0, -4), [], 'slice(0, -4)');
   deepEqual(testArray.slice(0, -3), [1], 'slice(0, -3)');
 });
@@ -99,7 +99,7 @@ QUnit.test('slice supports negative index arguments', function() {
 var DummyArray = EmberObject.extend(EmberArray, {
   nextObject() {},
   length: 0,
-  objectAt(idx) { return 'ITEM-'+idx; }
+  objectAt(idx) { return 'ITEM-' + idx; }
 });
 
 var obj, observer;

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -58,7 +58,7 @@ EnumerableTests.extend({
 
   // allows for testing of the basic enumerable after an internal mutation
   mutate(obj) {
-    obj.addObject(obj._content.length+1);
+    obj.addObject(obj._content.length + 1);
   },
 
   toArray(obj) {
@@ -125,7 +125,7 @@ QUnit.test('any', function() {
 });
 
 QUnit.test('any with NaN', function() {
-  var numbers = Ember.A([1,2,NaN,4]);
+  var numbers = Ember.A([1, 2, NaN, 4]);
 
   var hasNaN = numbers.any(function(n) {
     return isNaN(n);

--- a/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/mutable_enumerable_test.js
@@ -24,7 +24,7 @@ var TestMutableEnumerable = EmberObject.extend(MutableEnumerable, {
 
   removeObject(obj) {
     var idx = this._content.indexOf(obj);
-    if (idx<0) {
+    if (idx < 0) {
       return this;
     }
 

--- a/packages/ember-runtime/tests/suites/array/indexOf.js
+++ b/packages/ember-runtime/tests/suites/array/indexOf.js
@@ -11,7 +11,7 @@ suite.test('should return index of object', function() {
   var len      = 3;
   var idx;
 
-  for (idx=0;idx<len;idx++) {
+  for (idx = 0;idx<len;idx++) {
     equal(obj.indexOf(expected[idx]), idx, fmt('obj.indexOf(%@) should match idx', [expected[idx]]));
   }
 });

--- a/packages/ember-runtime/tests/suites/array/indexOf.js
+++ b/packages/ember-runtime/tests/suites/array/indexOf.js
@@ -11,7 +11,7 @@ suite.test('should return index of object', function() {
   var len      = 3;
   var idx;
 
-  for (idx = 0;idx<len;idx++) {
+  for (idx = 0;idx < len;idx++) {
     equal(obj.indexOf(expected[idx]), idx, fmt('obj.indexOf(%@) should match idx', [expected[idx]]));
   }
 });

--- a/packages/ember-runtime/tests/suites/array/lastIndexOf.js
+++ b/packages/ember-runtime/tests/suites/array/lastIndexOf.js
@@ -11,7 +11,7 @@ suite.test('should return index of object\'s last occurrence', function() {
   var len      = 3;
   var idx;
 
-  for (idx = 0;idx<len;idx++) {
+  for (idx = 0;idx < len;idx++) {
     equal(obj.lastIndexOf(expected[idx]), idx,
       fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
   }
@@ -23,7 +23,7 @@ suite.test('should return index of object\'s last occurrence even startAt search
   var len      = 3;
   var idx;
 
-  for (idx = 0;idx<len;idx++) {
+  for (idx = 0;idx < len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len), idx,
       fmt('obj.lastIndexOfs(%@) should match idx', [expected[idx]]));
   }
@@ -35,7 +35,7 @@ suite.test('should return index of object\'s last occurrence even startAt search
   var len      = 3;
   var idx;
 
-  for (idx = 0;idx<len;idx++) {
+  for (idx = 0;idx < len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len + 1), idx,
       fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
   }

--- a/packages/ember-runtime/tests/suites/array/lastIndexOf.js
+++ b/packages/ember-runtime/tests/suites/array/lastIndexOf.js
@@ -11,7 +11,7 @@ suite.test('should return index of object\'s last occurrence', function() {
   var len      = 3;
   var idx;
 
-  for (idx=0;idx<len;idx++) {
+  for (idx = 0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx]), idx,
       fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
   }
@@ -23,7 +23,7 @@ suite.test('should return index of object\'s last occurrence even startAt search
   var len      = 3;
   var idx;
 
-  for (idx=0;idx<len;idx++) {
+  for (idx = 0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len), idx,
       fmt('obj.lastIndexOfs(%@) should match idx', [expected[idx]]));
   }
@@ -35,7 +35,7 @@ suite.test('should return index of object\'s last occurrence even startAt search
   var len      = 3;
   var idx;
 
-  for (idx=0;idx<len;idx++) {
+  for (idx = 0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len + 1), idx,
       fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
   }

--- a/packages/ember-runtime/tests/suites/array/objectAt.js
+++ b/packages/ember-runtime/tests/suites/array/objectAt.js
@@ -11,7 +11,7 @@ suite.test('should return object at specified index', function() {
   var len      = expected.length;
   var idx;
 
-  for (idx = 0;idx<len;idx++) {
+  for (idx = 0;idx < len;idx++) {
     equal(obj.objectAt(idx), expected[idx], fmt('obj.objectAt(%@) should match', [idx]));
   }
 });

--- a/packages/ember-runtime/tests/suites/array/objectAt.js
+++ b/packages/ember-runtime/tests/suites/array/objectAt.js
@@ -11,7 +11,7 @@ suite.test('should return object at specified index', function() {
   var len      = expected.length;
   var idx;
 
-  for (idx=0;idx<len;idx++) {
+  for (idx = 0;idx<len;idx++) {
     equal(obj.objectAt(idx), expected[idx], fmt('obj.objectAt(%@) should match', [idx]));
   }
 });

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -105,7 +105,7 @@ var ObserverClass = EmberObject.extend({
       return false;
     }
 
-    if (arguments.length>1) {
+    if (arguments.length > 1) {
       return this._values[key] === value;
     } else {
       return true;
@@ -266,11 +266,11 @@ var EnumerableTests = Suite.extend({
   */
   newObserver(obj) {
     var ret = get(this, 'observerClass').create();
-    if (arguments.length>0) {
+    if (arguments.length > 0) {
       ret.observeBefore.apply(ret, arguments);
     }
 
-    if (arguments.length>0) {
+    if (arguments.length > 0) {
       ret.observe.apply(ret, arguments);
     }
 

--- a/packages/ember-runtime/tests/suites/enumerable/every.js
+++ b/packages/ember-runtime/tests/suites/enumerable/every.js
@@ -33,7 +33,7 @@ suite.test('every should stop invoking when you return false', function() {
 
   result = obj.every(function(i) {
     found.push(i);
-    return --cnt>0;
+    return --cnt > 0;
   });
   equal(result, false, 'return value of obj.every');
   equal(found.length, exp, 'should invoke proper number of times');

--- a/packages/ember-runtime/tests/suites/enumerable/find.js
+++ b/packages/ember-runtime/tests/suites/enumerable/find.js
@@ -34,7 +34,7 @@ suite.test('every should stop invoking when you return true', function() {
     found.push(i);
     return --cnt >= 0;
   });
-  equal(result, ary[exp-1], 'return value of obj.find');
+  equal(result, ary[exp - 1], 'return value of obj.find');
   equal(found.length, exp, 'should invoke proper number of times');
   deepEqual(found, ary.slice(0, -2), 'items passed during find() should match');
 });

--- a/packages/ember-runtime/tests/suites/enumerable/invoke.js
+++ b/packages/ember-runtime/tests/suites/enumerable/invoke.js
@@ -9,7 +9,7 @@ suite.test('invoke should call on each object that implements', function() {
   var cnt, ary, obj;
 
   function F(amt) {
-    cnt += amt===undefined ? 1 : amt;
+    cnt += amt === undefined ? 1 : amt;
   }
   cnt = 0;
   ary = [

--- a/packages/ember-runtime/tests/suites/enumerable/lastObject.js
+++ b/packages/ember-runtime/tests/suites/enumerable/lastObject.js
@@ -9,7 +9,7 @@ suite.test('returns last item in enumerable', function() {
   var obj = this.newObject();
   var ary = this.toArray(obj);
 
-  equal(get(obj, 'lastObject'), ary[ary.length-1]);
+  equal(get(obj, 'lastObject'), ary[ary.length - 1]);
 });
 
 suite.test('returns undefined if enumerable is empty', function() {

--- a/packages/ember-runtime/tests/suites/enumerable/mapBy.js
+++ b/packages/ember-runtime/tests/suites/enumerable/mapBy.js
@@ -5,12 +5,12 @@ var suite = SuiteModuleBuilder.create();
 suite.module('mapBy');
 
 suite.test('get value of each property', function() {
-  var obj = this.newObject([{ a: 1 },{ a: 2 }]);
+  var obj = this.newObject([{ a: 1 }, { a: 2 }]);
   equal(obj.mapBy('a').join(''), '12');
 });
 
 suite.test('should work also through getEach alias', function() {
-  var obj = this.newObject([{ a: 1 },{ a: 2 }]);
+  var obj = this.newObject([{ a: 1 }, { a: 2 }]);
   equal(obj.getEach('a').join(''), '12');
 });
 

--- a/packages/ember-runtime/tests/suites/enumerable/reject.js
+++ b/packages/ember-runtime/tests/suites/enumerable/reject.js
@@ -10,23 +10,23 @@ var suite = SuiteModuleBuilder.create();
 suite.module('reject');
 
 suite.test('should reject any item that does not meet the condition', function() {
-  var obj = this.newObject([1,2,3,4]);
+  var obj = this.newObject([1, 2, 3, 4]);
   var result;
 
   result = obj.reject(function(i) { return i < 3; });
-  deepEqual(result, [3,4], 'reject the correct items');
+  deepEqual(result, [3, 4], 'reject the correct items');
 });
 
 suite.test('should be the inverse of filter', function() {
-  var obj = this.newObject([1,2,3,4]);
+  var obj = this.newObject([1, 2, 3, 4]);
   var isEven = function(i) { return i % 2 === 0; };
   var filtered, rejected;
 
   filtered = obj.filter(isEven);
   rejected = obj.reject(isEven);
 
-  deepEqual(filtered, [2,4], 'filtered evens');
-  deepEqual(rejected, [1,3], 'rejected evens');
+  deepEqual(filtered, [2, 4], 'filtered evens');
+  deepEqual(rejected, [1, 3], 'rejected evens');
 });
 
 // ..........................................................

--- a/packages/ember-runtime/tests/suites/enumerable/sortBy.js
+++ b/packages/ember-runtime/tests/suites/enumerable/sortBy.js
@@ -6,7 +6,7 @@ var suite = SuiteModuleBuilder.create();
 suite.module('sortBy');
 
 suite.test('sort by value of property', function() {
-  var obj = this.newObject([{ a: 2 },{ a: 1 }]);
+  var obj = this.newObject([{ a: 2 }, { a: 1 }]);
   var sorted = obj.sortBy('a');
 
   equal(get(sorted[0], 'a'), 1);

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -72,7 +72,7 @@ Suite.reopenClass({
     this.reopen({
       run() {
         this._super.apply(this, arguments);
-        var title = get(this, 'name')+': '+desc;
+        var title = get(this, 'name') + ': ' + desc;
         var ctx = this;
         QUnit.module(title, {
           setup() {

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -18,7 +18,7 @@ QUnit.module('ArrayProxy - arrangedContent', {
           }));
         })
       }).create({
-        content: Ember.A([1,2,4,5])
+        content: Ember.A([1, 2, 4, 5])
       });
     });
   },
@@ -31,22 +31,22 @@ QUnit.module('ArrayProxy - arrangedContent', {
 
 QUnit.test('addObject - adds to end of \'content\' if not present', function() {
   run(function() { array.addObject(3); });
-  deepEqual(array.get('content'), [1,2,4,5,3], 'adds to end of content');
-  deepEqual(array.get('arrangedContent'), [5,4,3,2,1], 'arrangedContent stays sorted');
+  deepEqual(array.get('content'), [1, 2, 4, 5, 3], 'adds to end of content');
+  deepEqual(array.get('arrangedContent'), [5, 4, 3, 2, 1], 'arrangedContent stays sorted');
 
   run(function() { array.addObject(1); });
-  deepEqual(array.get('content'), [1,2,4,5,3], 'does not add existing number to content');
+  deepEqual(array.get('content'), [1, 2, 4, 5, 3], 'does not add existing number to content');
 });
 
 QUnit.test('addObjects - adds to end of \'content\' if not present', function() {
-  run(function() { array.addObjects([1,3,6]); });
-  deepEqual(array.get('content'), [1,2,4,5,3,6], 'adds to end of content');
-  deepEqual(array.get('arrangedContent'), [6,5,4,3,2,1], 'arrangedContent stays sorted');
+  run(function() { array.addObjects([1, 3, 6]); });
+  deepEqual(array.get('content'), [1, 2, 4, 5, 3, 6], 'adds to end of content');
+  deepEqual(array.get('arrangedContent'), [6, 5, 4, 3, 2, 1], 'arrangedContent stays sorted');
 });
 
 QUnit.test('compact - returns arrangedContent without nulls and undefined', function() {
-  run(function() { array.set('content', Ember.A([1,3,null,2,undefined])); });
-  deepEqual(array.compact(), [3,2,1]);
+  run(function() { array.set('content', Ember.A([1, 3, null, 2, undefined])); });
+  deepEqual(array.compact(), [3, 2, 1]);
 });
 
 QUnit.test('indexOf - returns index of object in arrangedContent', function() {
@@ -78,39 +78,39 @@ QUnit.test('objectAtContent - returns object at index in arrangedContent', funct
 });
 
 QUnit.test('objectsAt - returns objects at indices in arrangedContent', function() {
-  deepEqual(array.objectsAt([0,2,4]), [5,2,undefined], 'returns objects at indices');
+  deepEqual(array.objectsAt([0, 2, 4]), [5, 2, undefined], 'returns objects at indices');
 });
 
 QUnit.test('popObject - removes last object in arrangedContent', function() {
   var popped;
   run(function() { popped = array.popObject(); });
   equal(popped, 1, 'returns last object');
-  deepEqual(array.get('content'), [2,4,5], 'removes from content');
+  deepEqual(array.get('content'), [2, 4, 5], 'removes from content');
 });
 
 QUnit.test('pushObject - adds to end of content even if it already exists', function() {
   run(function() { array.pushObject(1); });
-  deepEqual(array.get('content'), [1,2,4,5,1], 'adds to end of content');
+  deepEqual(array.get('content'), [1, 2, 4, 5, 1], 'adds to end of content');
 });
 
 QUnit.test('pushObjects - adds multiple to end of content even if it already exists', function() {
-  run(function() { array.pushObjects([1,2,4]); });
-  deepEqual(array.get('content'), [1,2,4,5,1,2,4], 'adds to end of content');
+  run(function() { array.pushObjects([1, 2, 4]); });
+  deepEqual(array.get('content'), [1, 2, 4, 5, 1, 2, 4], 'adds to end of content');
 });
 
 QUnit.test('removeAt - removes from index in arrangedContent', function() {
   run(function() { array.removeAt(1, 2); });
-  deepEqual(array.get('content'), [1,5]);
+  deepEqual(array.get('content'), [1, 5]);
 });
 
 QUnit.test('removeObject - removes object from content', function() {
   run(function() { array.removeObject(2); });
-  deepEqual(array.get('content'), [1,4,5]);
+  deepEqual(array.get('content'), [1, 4, 5]);
 });
 
 QUnit.test('removeObjects - removes objects from content', function() {
-  run(function() { array.removeObjects([2,4,6]); });
-  deepEqual(array.get('content'), [1,5]);
+  run(function() { array.removeObjects([2, 4, 6]); });
+  deepEqual(array.get('content'), [1, 5]);
 });
 
 QUnit.test('replace - raises, indeterminate behavior', function() {
@@ -121,7 +121,7 @@ QUnit.test('replace - raises, indeterminate behavior', function() {
 
 QUnit.test('replaceContent - does a standard array replace on content', function() {
   run(function() { array.replaceContent(1, 2, [3]); });
-  deepEqual(array.get('content'), [1,3,5]);
+  deepEqual(array.get('content'), [1, 3, 5]);
 });
 
 QUnit.test('reverseObjects - raises, use Sortable#sortAscending', function() {
@@ -131,37 +131,37 @@ QUnit.test('reverseObjects - raises, use Sortable#sortAscending', function() {
 });
 
 QUnit.test('setObjects - replaces entire content', function() {
-  run(function() { array.setObjects([6,7,8]); });
-  deepEqual(array.get('content'), [6,7,8], 'replaces content');
+  run(function() { array.setObjects([6, 7, 8]); });
+  deepEqual(array.get('content'), [6, 7, 8], 'replaces content');
 });
 
 QUnit.test('shiftObject - removes from start of arrangedContent', function() {
   var shifted;
   run(function() { shifted = array.shiftObject(); });
   equal(shifted, 5, 'returns first object');
-  deepEqual(array.get('content'), [1,2,4], 'removes object from content');
+  deepEqual(array.get('content'), [1, 2, 4], 'removes object from content');
 });
 
 QUnit.test('slice - returns a slice of the arrangedContent', function() {
-  deepEqual(array.slice(1, 3), [4,2], 'returns sliced arrangedContent');
+  deepEqual(array.slice(1, 3), [4, 2], 'returns sliced arrangedContent');
 });
 
 QUnit.test('toArray - returns copy of arrangedContent', function() {
-  deepEqual(array.toArray(), [5,4,2,1]);
+  deepEqual(array.toArray(), [5, 4, 2, 1]);
 });
 
 QUnit.test('unshiftObject - adds to start of content', function() {
   run(function() { array.unshiftObject(6); });
-  deepEqual(array.get('content'), [6,1,2,4,5], 'adds to start of content');
+  deepEqual(array.get('content'), [6, 1, 2, 4, 5], 'adds to start of content');
 });
 
 QUnit.test('unshiftObjects - adds to start of content', function() {
-  run(function() { array.unshiftObjects([6,7]); });
-  deepEqual(array.get('content'), [6,7,1,2,4,5], 'adds to start of content');
+  run(function() { array.unshiftObjects([6, 7]); });
+  deepEqual(array.get('content'), [6, 7, 1, 2, 4, 5], 'adds to start of content');
 });
 
 QUnit.test('without - returns arrangedContent without object', function() {
-  deepEqual(array.without(2), [5,4,1], 'returns arranged without object');
+  deepEqual(array.without(2), [5, 4, 1], 'returns arranged without object');
 });
 
 QUnit.test('lastObject - returns last arranged object', function() {
@@ -177,7 +177,7 @@ QUnit.module('ArrayProxy - arrangedContent matching content', {
   setup() {
     run(function() {
       array = ArrayProxy.create({
-        content: Ember.A([1,2,4,5])
+        content: Ember.A([1, 2, 4, 5])
       });
     });
   },
@@ -190,17 +190,17 @@ QUnit.module('ArrayProxy - arrangedContent matching content', {
 
 QUnit.test('insertAt - inserts object at specified index', function() {
   run(function() { array.insertAt(2, 3); });
-  deepEqual(array.get('content'), [1,2,3,4,5]);
+  deepEqual(array.get('content'), [1, 2, 3, 4, 5]);
 });
 
 QUnit.test('replace - does a standard array replace', function() {
   run(function() { array.replace(1, 2, [3]); });
-  deepEqual(array.get('content'), [1,3,5]);
+  deepEqual(array.get('content'), [1, 3, 5]);
 });
 
 QUnit.test('reverseObjects - reverses content', function() {
   run(function() { array.reverseObjects(); });
-  deepEqual(array.get('content'), [5,4,2,1]);
+  deepEqual(array.get('content'), [5, 4, 2, 1]);
 });
 
 QUnit.module('ArrayProxy - arrangedContent with transforms', {
@@ -221,7 +221,7 @@ QUnit.module('ArrayProxy - arrangedContent with transforms', {
           return obj && obj.toString();
         }
       }).create({
-        content: Ember.A([1,2,4,5])
+        content: Ember.A([1, 2, 4, 5])
       });
     });
   },
@@ -255,43 +255,43 @@ QUnit.test('objectAtContent - returns object at index in arrangedContent', funct
 });
 
 QUnit.test('objectsAt - returns objects at indices in arrangedContent', function() {
-  deepEqual(array.objectsAt([0,2,4]), ['5','2',undefined], 'returns objects at indices');
+  deepEqual(array.objectsAt([0, 2, 4]), ['5', '2', undefined], 'returns objects at indices');
 });
 
 QUnit.test('popObject - removes last object in arrangedContent', function() {
   var popped;
   run(function() { popped = array.popObject(); });
   equal(popped, '1', 'returns last object');
-  deepEqual(array.get('content'), [2,4,5], 'removes from content');
+  deepEqual(array.get('content'), [2, 4, 5], 'removes from content');
 });
 
 QUnit.test('removeObject - removes object from content', function() {
   run(function() { array.removeObject('2'); });
-  deepEqual(array.get('content'), [1,4,5]);
+  deepEqual(array.get('content'), [1, 4, 5]);
 });
 
 QUnit.test('removeObjects - removes objects from content', function() {
-  run(function() { array.removeObjects(['2','4','6']); });
-  deepEqual(array.get('content'), [1,5]);
+  run(function() { array.removeObjects(['2', '4', '6']); });
+  deepEqual(array.get('content'), [1, 5]);
 });
 
 QUnit.test('shiftObject - removes from start of arrangedContent', function() {
   var shifted;
   run(function() { shifted = array.shiftObject(); });
   equal(shifted, '5', 'returns first object');
-  deepEqual(array.get('content'), [1,2,4], 'removes object from content');
+  deepEqual(array.get('content'), [1, 2, 4], 'removes object from content');
 });
 
 QUnit.test('slice - returns a slice of the arrangedContent', function() {
-  deepEqual(array.slice(1, 3), ['4','2'], 'returns sliced arrangedContent');
+  deepEqual(array.slice(1, 3), ['4', '2'], 'returns sliced arrangedContent');
 });
 
 QUnit.test('toArray - returns copy of arrangedContent', function() {
-  deepEqual(array.toArray(), ['5','4','2','1']);
+  deepEqual(array.toArray(), ['5', '4', '2', '1']);
 });
 
 QUnit.test('without - returns arrangedContent without object', function() {
-  deepEqual(array.without('2'), ['5','4','1'], 'returns arranged without object');
+  deepEqual(array.without('2'), ['5', '4', '1'], 'returns arranged without object');
 });
 
 QUnit.test('lastObject - returns last arranged object', function() {

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -8,7 +8,7 @@ QUnit.module('ArrayProxy - content change');
 
 QUnit.test('should update length for null content', function() {
   var proxy = ArrayProxy.create({
-        content: Ember.A([1,2,3])
+        content: Ember.A([1, 2, 3])
       });
 
   equal(proxy.get('length'), 3, 'precond - length is 3');

--- a/packages/ember-runtime/tests/system/array_proxy/suite_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/suite_test.js
@@ -13,7 +13,7 @@ MutableArrayTests.extend({
   },
 
   mutate(obj) {
-    obj.pushObject(get(obj, 'length')+1);
+    obj.pushObject(get(obj, 'length') + 1);
   },
 
   toArray(obj) {

--- a/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -22,7 +22,7 @@ CopyableTests.extend({
       return false;
     }
 
-    return a[0]===b[0];
+    return a[0] === b[0];
   },
 
   shouldBeFreezable: false

--- a/packages/ember-runtime/tests/system/native_array/suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/suite_test.js
@@ -10,7 +10,7 @@ MutableArrayTests.extend({
   },
 
   mutate(obj) {
-    obj.pushObject(obj.length+1);
+    obj.pushObject(obj.length + 1);
   },
 
   toArray(obj) {

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -53,7 +53,7 @@ testWithDefault('complex depndent keys', function(get, set) {
     count: 0,
 
     foo: computed(function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
       return emberGet(get(this, 'bar'), 'baz') + ' ' + get(this, 'count');
     }).property('bar.baz')
 
@@ -90,7 +90,7 @@ testWithDefault('complex dependent keys changing complex dependent keys', functi
     count: 0,
 
     foo: computed(function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
       return emberGet(get(this, 'bar'), 'baz') + ' ' + get(this, 'count');
     }).property('bar.baz')
   });
@@ -104,7 +104,7 @@ testWithDefault('complex dependent keys changing complex dependent keys', functi
     count: 0,
 
     foo: computed(function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
       return emberGet(get(this, 'bar2'), 'baz') + ' ' + get(this, 'count');
     }).property('bar2.baz')
   });

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -159,7 +159,7 @@ QUnit.module('EmberObject.createWithMixins', moduleOptions);
 QUnit.test('Creates a new object that contains passed properties', function() {
   var called = false;
   var obj = EmberObject.extend({
-    method() { called=true; }
+    method() { called = true; }
   }).create({
     prop: 'FOO'
   });

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -12,7 +12,7 @@ testBoth('observer on class', function(get, set) {
     count: 0,
 
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
 
   });
@@ -30,14 +30,14 @@ testBoth('observer on subclass', function(get, set) {
     count: 0,
 
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
 
   });
 
   var Subclass = MyClass.extend({
     foo: observer('baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -54,7 +54,7 @@ testBoth('observer on subclass', function(get, set) {
 testBoth('observer on instance', function(get, set) {
   var obj = EmberObject.extend({
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   }).create({
     count: 0
@@ -71,13 +71,13 @@ testBoth('observer on instance overriding class', function(get, set) {
     count: 0,
 
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
   var obj = MyClass.extend({
     foo: observer('baz', function() { // <-- change property we observe
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   }).create();
 
@@ -94,7 +94,7 @@ testBoth('observer should not fire after being destroyed', function(get, set) {
   var obj = EmberObject.extend({
     count: 0,
     foo: observer('bar', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   }).create();
 
@@ -122,7 +122,7 @@ testBoth('chain observer on class', function(get, set) {
     count: 0,
 
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -152,7 +152,7 @@ testBoth('chain observer on class', function(get, set) {
     count: 0,
 
     foo: observer('bar.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   });
 
@@ -162,7 +162,7 @@ testBoth('chain observer on class', function(get, set) {
 
   var obj2 = MyClass.extend({
     foo: observer('bar2.baz', function() {
-      set(this, 'count', get(this, 'count')+1);
+      set(this, 'count', get(this, 'count') + 1);
     })
   }).create({
     bar: { baz: 'biff2' },

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -89,9 +89,9 @@ QUnit.test('toString includes toStringExtension if defined', function() {
   var bar = Bar.create();
 
   // simulate these classes being defined on a Namespace
-  Foo[GUID_KEY+'_name'] = 'Foo';
-  Bar[GUID_KEY+'_name'] = 'Bar';
+  Foo[GUID_KEY + '_name'] = 'Foo';
+  Bar[GUID_KEY + '_name'] = 'Bar';
 
-  equal(bar.toString(), '<Bar:'+guidFor(bar)+'>', 'does not include toStringExtension part');
-  equal(foo.toString(), '<Foo:'+guidFor(foo)+':fooey>', 'Includes toStringExtension result');
+  equal(bar.toString(), '<Bar:' + guidFor(bar) + '>', 'does not include toStringExtension part');
+  equal(foo.toString(), '<Foo:' + guidFor(foo) + ':fooey>', 'Includes toStringExtension result');
 });

--- a/packages/ember-runtime/tests/system/string/w_test.js
+++ b/packages/ember-runtime/tests/system/string/w_test.js
@@ -10,23 +10,23 @@ if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
 }
 
 QUnit.test('\'one two three\'.w() => [\'one\',\'two\',\'three\']', function() {
-  deepEqual(w('one two three'), ['one','two','three']);
+  deepEqual(w('one two three'), ['one', 'two', 'three']);
   if (Ember.EXTEND_PROTOTYPES) {
-    deepEqual('one two three'.w(), ['one','two','three']);
+    deepEqual('one two three'.w(), ['one', 'two', 'three']);
   }
 });
 
 QUnit.test('\'one    two    three\'.w() with extra spaces between words => [\'one\',\'two\',\'three\']', function() {
-  deepEqual(w('one   two  three'), ['one','two','three']);
+  deepEqual(w('one   two  three'), ['one', 'two', 'three']);
   if (Ember.EXTEND_PROTOTYPES) {
-    deepEqual('one   two  three'.w(), ['one','two','three']);
+    deepEqual('one   two  three'.w(), ['one', 'two', 'three']);
   }
 });
 
 QUnit.test('\'one two three\'.w() with tabs', function() {
-  deepEqual(w('one\ttwo  three'), ['one','two','three']);
+  deepEqual(w('one\ttwo  three'), ['one', 'two', 'three']);
   if (Ember.EXTEND_PROTOTYPES) {
-    deepEqual('one\ttwo  three'.w(), ['one','two','three']);
+    deepEqual('one\ttwo  three'.w(), ['one', 'two', 'three']);
   }
 });
 

--- a/packages/ember-runtime/tests/system/tracked_array_test.js
+++ b/packages/ember-runtime/tests/system/tracked_array_test.js
@@ -8,82 +8,82 @@ var DELETE = TrackedArray.DELETE;
 QUnit.module('Ember.TrackedArray');
 
 QUnit.test('operations for a tracked array of length n are initially retain:n', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   equal('r:4', trackedArray.toString(), 'initial mutation is retain n');
 });
 
 QUnit.test('insert zero items is a no-op', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(2, []);
 
   equal(trackedArray.toString(), 'r:4', 'insert:0 is a no-op');
 
-  deepEqual(trackedArray._operations[0].items, [1,2,3,4], 'after a no-op, existing operation has right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2, 3, 4], 'after a no-op, existing operation has right items');
 });
 
 QUnit.test('inserts can split retains', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(2, ['a']);
 
   equal(trackedArray.toString(), 'r:2 i:1 r:2', 'inserts can split retains');
 
-  deepEqual(trackedArray._operations[0].items, [1,2], 'split retains have the right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2], 'split retains have the right items');
   deepEqual(trackedArray._operations[1].items, ['a'], 'inserts have the right items');
-  deepEqual(trackedArray._operations[2].items, [3,4], 'split retains have the right items');
+  deepEqual(trackedArray._operations[2].items, [3, 4], 'split retains have the right items');
 });
 
 QUnit.test('inserts can expand (split/compose) inserts', function() {
   trackedArray = new TrackedArray([]);
 
-  trackedArray.addItems(0, [1,2,3,4]);
+  trackedArray.addItems(0, [1, 2, 3, 4]);
   trackedArray.addItems(2, ['a']);
 
   equal(trackedArray.toString(), 'i:5', 'inserts can expand inserts');
 
-  deepEqual(trackedArray._operations[0].items, [1,2,'a',3,4], 'expanded inserts have the right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2, 'a', 3, 4], 'expanded inserts have the right items');
 });
 
 QUnit.test('inserts left of inserts compose', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(2, ['b']);
   trackedArray.addItems(2, ['a']);
 
   equal(trackedArray.toString(), 'r:2 i:2 r:2', 'inserts left of inserts compose');
 
-  deepEqual(trackedArray._operations[0].items, [1,2], 'split retains have the right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2], 'split retains have the right items');
   deepEqual(trackedArray._operations[1].items, ['a', 'b'], 'composed inserts have the right items');
-  deepEqual(trackedArray._operations[2].items, [3,4], 'split retains have the right items');
+  deepEqual(trackedArray._operations[2].items, [3, 4], 'split retains have the right items');
 });
 
 QUnit.test('inserts right of inserts compose', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(2, ['a']);
   trackedArray.addItems(3, ['b']);
 
   equal(trackedArray.toString(), 'r:2 i:2 r:2', 'inserts right of inserts compose');
 
-  deepEqual(trackedArray._operations[0].items, [1,2], 'split retains have the right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2], 'split retains have the right items');
   deepEqual(trackedArray._operations[1].items, ['a', 'b'], 'composed inserts have the right items');
-  deepEqual(trackedArray._operations[2].items, [3,4], 'split retains have the right items');
+  deepEqual(trackedArray._operations[2].items, [3, 4], 'split retains have the right items');
 });
 
 QUnit.test('delete zero items is a no-op', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(2, []);
 
   equal(trackedArray.toString(), 'r:4', 'insert:0 is a no-op');
 
-  deepEqual(trackedArray._operations[0].items, [1,2,3,4], 'after a no-op, existing operation has right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2, 3, 4], 'after a no-op, existing operation has right items');
 });
 
 QUnit.test('deletes compose with several inserts and retains', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(4, ['e']);
   trackedArray.addItems(3, ['d']);
@@ -96,7 +96,7 @@ QUnit.test('deletes compose with several inserts and retains', function() {
 });
 
 QUnit.test('deletes compose with several inserts and retains and an adjacent delete', function() {
-  trackedArray = new TrackedArray([1,2,3,4,5]);
+  trackedArray = new TrackedArray([1, 2, 3, 4, 5]);
 
   trackedArray.removeItems(0, 1);
   trackedArray.addItems(4, ['e']);
@@ -110,7 +110,7 @@ QUnit.test('deletes compose with several inserts and retains and an adjacent del
 });
 
 QUnit.test('deletes compose with several inserts and retains and can reduce the last one', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(4, ['e', 'f']);
   trackedArray.addItems(3, ['d']);
@@ -124,32 +124,32 @@ QUnit.test('deletes compose with several inserts and retains and can reduce the 
 });
 
 QUnit.test('deletes can split retains', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
   trackedArray.removeItems(0, 2);
 
   equal(trackedArray.toString(), 'd:2 r:2', 'deletes can split retains');
-  deepEqual(trackedArray._operations[1].items, [3,4], 'retains reduced by delete have the right items');
+  deepEqual(trackedArray._operations[1].items, [3, 4], 'retains reduced by delete have the right items');
 });
 
 QUnit.test('deletes can trim retains on the right', function() {
-  trackedArray = new TrackedArray([1,2,3]);
+  trackedArray = new TrackedArray([1, 2, 3]);
   trackedArray.removeItems(2, 1);
 
   equal(trackedArray.toString(), 'r:2 d:1', 'deletes can trim retains on the right');
-  deepEqual(trackedArray._operations[0].items, [1,2], 'retains reduced by delete have the right items');
+  deepEqual(trackedArray._operations[0].items, [1, 2], 'retains reduced by delete have the right items');
 });
 
 QUnit.test('deletes can trim retains on the left', function() {
-  trackedArray = new TrackedArray([1,2,3]);
+  trackedArray = new TrackedArray([1, 2, 3]);
   trackedArray.removeItems(0, 1);
 
   equal(trackedArray.toString(), 'd:1 r:2', 'deletes can trim retains on the left');
-  deepEqual(trackedArray._operations[1].items, [2,3], 'retains reduced by delete have the right items');
+  deepEqual(trackedArray._operations[1].items, [2, 3], 'retains reduced by delete have the right items');
 });
 
 QUnit.test('deletes can split inserts', function() {
   trackedArray = new TrackedArray([]);
-  trackedArray.addItems(0, ['a','b','c']);
+  trackedArray.addItems(0, ['a', 'b', 'c']);
   trackedArray.removeItems(0, 1);
 
   equal(trackedArray.toString(), 'i:2', 'deletes can split inserts');
@@ -158,7 +158,7 @@ QUnit.test('deletes can split inserts', function() {
 
 QUnit.test('deletes can trim inserts on the right', function() {
   trackedArray = new TrackedArray([]);
-  trackedArray.addItems(0, ['a','b','c']);
+  trackedArray.addItems(0, ['a', 'b', 'c']);
   trackedArray.removeItems(2, 1);
 
   equal(trackedArray.toString(), 'i:2', 'deletes can trim inserts on the right');
@@ -167,7 +167,7 @@ QUnit.test('deletes can trim inserts on the right', function() {
 
 QUnit.test('deletes can trim inserts on the left', function() {
   trackedArray = new TrackedArray([]);
-  trackedArray.addItems(0, ['a','b','c']);
+  trackedArray.addItems(0, ['a', 'b', 'c']);
   trackedArray.removeItems(0, 1);
 
   equal(trackedArray.toString(), 'i:2', 'deletes can trim inserts on the right');
@@ -185,13 +185,13 @@ QUnit.test('deletes can trim inserts on the left while composing with a delete o
 });
 
 QUnit.test('deletes can reduce an insert or retain, compose with several mutations of different types and reduce the last mutation if it is non-delete', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
   trackedArray.addItems(4, ['e', 'f']);    // 1234ef
   trackedArray.addItems(3, ['d']);         // 123d4ef
   trackedArray.addItems(2, ['c']);         // 12c3d4ef
   trackedArray.addItems(1, ['b']);         // 1b2c3d4ef
-  trackedArray.addItems(0, ['a','a','a']); // aaa1b2c3d4ef i3r1i1r1i1r1i1r1i2
+  trackedArray.addItems(0, ['a', 'a', 'a']); // aaa1b2c3d4ef i3r1i1r1i1r1i1r1i2
 
   trackedArray.removeItems(1, 10);
   equal(trackedArray.toString(), 'i:1 d:4 i:1', 'deletes reduce an insert, compose with several inserts and retains, reducing the last one');
@@ -200,15 +200,15 @@ QUnit.test('deletes can reduce an insert or retain, compose with several mutatio
 });
 
 QUnit.test('removeItems returns the removed items', function() {
-  trackedArray = new TrackedArray([1,2,3,4]);
-  deepEqual(trackedArray.removeItems(1, 2), [2,3], '`removeItems` returns the removed items');
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
+  deepEqual(trackedArray.removeItems(1, 2), [2, 3], '`removeItems` returns the removed items');
 });
 
 QUnit.test('apply invokes the callback with each group of items and the mutation\'s calculated offset', function() {
   var i = 0;
-  trackedArray = new TrackedArray([1,2,3,4]);
+  trackedArray = new TrackedArray([1, 2, 3, 4]);
 
-  trackedArray.addItems(2, ['a','b','c']); // 12abc34
+  trackedArray.addItems(2, ['a', 'b', 'c']); // 12abc34
   trackedArray.removeItems(4, 2);          // 12ab4
   trackedArray.addItems(1, ['d']);         // 1d2ab4 r1 i1 r1 i2 d1 r1
 
@@ -232,7 +232,7 @@ QUnit.test('apply invokes the callback with each group of items and the mutation
         equal(operation, RETAIN, 'callback passed right operation');
         break;
       case 3:
-        deepEqual(items, ['a','b'], 'callback passed right items');
+        deepEqual(items, ['a', 'b'], 'callback passed right items');
         equal(offset, 3, 'callback passed right offset');
         equal(operation, INSERT, 'callback passed right operation');
         break;

--- a/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
@@ -32,7 +32,7 @@ function deprecateHash(moduleName, node, hash) {
     return;
   }
   var i, l, pair, paths;
-  for (i=0, l=hash.pairs.length;i<l;i++) {
+  for (i = 0, l = hash.pairs.length;i<l;i++) {
     pair = hash.pairs[i];
     paths = pair.value.params;
     deprecatePaths(moduleName, pair, paths);
@@ -44,7 +44,7 @@ function deprecatePaths(moduleName, node, paths) {
     return;
   }
   var i, l, path;
-  for (i=0, l=paths.length;i<l;i++) {
+  for (i = 0, l = paths.length;i<l;i++) {
     path = paths[i];
     deprecatePath(moduleName, node, path);
   }

--- a/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
@@ -32,7 +32,7 @@ function deprecateHash(moduleName, node, hash) {
     return;
   }
   var i, l, pair, paths;
-  for (i = 0, l = hash.pairs.length;i<l;i++) {
+  for (i = 0, l = hash.pairs.length;i < l;i++) {
     pair = hash.pairs[i];
     paths = pair.value.params;
     deprecatePaths(moduleName, pair, paths);
@@ -44,7 +44,7 @@ function deprecatePaths(moduleName, node, paths) {
     return;
   }
   var i, l, path;
-  for (i = 0, l = paths.length;i<l;i++) {
+  for (i = 0, l = paths.length;i < l;i++) {
     path = paths[i];
     deprecatePath(moduleName, node, path);
   }

--- a/packages/ember-template-compiler/lib/plugins/transform-component-attrs-into-mut.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-component-attrs-into-mut.js
@@ -32,7 +32,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i=0, l=list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i<l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-component-attrs-into-mut.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-component-attrs-into-mut.js
@@ -32,7 +32,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i = 0, l = list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i < l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-component-curly-to-readonly.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-component-curly-to-readonly.js
@@ -31,7 +31,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i=0, l=list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i<l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-component-curly-to-readonly.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-component-curly-to-readonly.js
@@ -31,7 +31,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i = 0, l = list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i < l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-each-into-collection.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-into-collection.js
@@ -55,7 +55,7 @@ function validate(node) {
 }
 
 function any(list, predicate) {
-  for (var i = 0, l = list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i < l; i++) {
     if (predicate(list[i])) { return list[i]; }
   }
 

--- a/packages/ember-template-compiler/lib/plugins/transform-each-into-collection.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-into-collection.js
@@ -55,7 +55,7 @@ function validate(node) {
 }
 
 function any(list, predicate) {
-  for (var i=0, l=list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i<l; i++) {
     if (predicate(list[i])) { return list[i]; }
   }
 

--- a/packages/ember-template-compiler/lib/plugins/transform-item-class.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-item-class.js
@@ -35,7 +35,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i = 0, l = list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i < l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-item-class.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-item-class.js
@@ -35,7 +35,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i=0, l=list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i<l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-old-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-binding-syntax.js
@@ -44,7 +44,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i = 0, l = list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i < l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-old-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-binding-syntax.js
@@ -44,7 +44,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i=0, l=list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i<l; i++) {
     callback(list[i]);
   }
 }

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
@@ -63,7 +63,7 @@ TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassB
 };
 
 function buildSexprs(microsyntax, sexprs, b) {
-  for (var i=0, l=microsyntax.length; i<l; i++) {
+  for (var i = 0, l = microsyntax.length; i<l; i++) {
     let [propName, activeClass, inactiveClass] = microsyntax[i];
     let sexpr;
 
@@ -107,7 +107,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i=0, l=list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i<l; i++) {
     callback(list[i], i);
   }
 }
@@ -115,7 +115,7 @@ function each(list, callback) {
 function parseMicrosyntax(string) {
   var segments = string.split(' ');
 
-  for (var i=0, l=segments.length; i<l; i++) {
+  for (var i = 0, l = segments.length; i<l; i++) {
     segments[i] = segments[i].split(':');
   }
 

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
@@ -63,7 +63,7 @@ TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassB
 };
 
 function buildSexprs(microsyntax, sexprs, b) {
-  for (var i = 0, l = microsyntax.length; i<l; i++) {
+  for (var i = 0, l = microsyntax.length; i < l; i++) {
     let [propName, activeClass, inactiveClass] = microsyntax[i];
     let sexpr;
 
@@ -107,7 +107,7 @@ function validate(node) {
 }
 
 function each(list, callback) {
-  for (var i = 0, l = list.length; i<l; i++) {
+  for (var i = 0, l = list.length; i < l; i++) {
     callback(list[i], i);
   }
 }
@@ -115,7 +115,7 @@ function each(list, callback) {
 function parseMicrosyntax(string) {
   var segments = string.split(' ');
 
-  for (var i = 0, l = segments.length; i<l; i++) {
+  for (var i = 0, l = segments.length; i < l; i++) {
     segments[i] = segments[i].split(':');
   }
 

--- a/packages/ember-template-compiler/lib/plugins/transform-top-level-components.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-top-level-components.js
@@ -21,7 +21,7 @@ function hasSingleComponentNode(body, callback) {
   let lastIndex;
   let nodeCount = 0;
 
-  for (let i=0, l=body.length; i<l; i++) {
+  for (let i = 0, l = body.length; i < l; i++) {
     let curr = body[i];
 
     // text node with whitespace only

--- a/packages/ember-template-compiler/lib/system/compile_options.js
+++ b/packages/ember-template-compiler/lib/system/compile_options.js
@@ -58,7 +58,7 @@ function detectTopLevel(program) {
   let lastIndex;
   let nodeCount = 0;
 
-  for (let i=0, l=body.length; i<l; i++) {
+  for (let i = 0, l = body.length; i < l; i++) {
     let curr = body[i];
 
     // text node with whitespace only

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -11,7 +11,7 @@ function incrementAjaxPendingRequests(_, xhr) {
 }
 
 function decrementAjaxPendingRequests(_, xhr) {
-  for (var i = 0;i<requests.length;i++) {
+  for (var i = 0;i < requests.length;i++) {
     if (xhr === requests[i]) {
       requests.splice(i, 1);
     }

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -11,7 +11,7 @@ function incrementAjaxPendingRequests(_, xhr) {
 }
 
 function decrementAjaxPendingRequests(_, xhr) {
-  for (var i=0;i<requests.length;i++) {
+  for (var i = 0;i<requests.length;i++) {
     if (xhr === requests[i]) {
       requests.splice(i, 1);
     }

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -254,12 +254,12 @@ QUnit.module('ember-testing: Helper methods', {
 QUnit.test('`wait` respects registerWaiters', function() {
   expect(3);
 
-  var counter=0;
+  var counter = 0;
   function waiter() {
     return ++counter > 2;
   }
 
-  var other=0;
+  var other = 0;
   function otherWaiter() {
     return ++other > 2;
   }
@@ -416,7 +416,7 @@ QUnit.test('`wait` respects registerWaiters with optional context', function() {
     }
   };
 
-  var other=0;
+  var other = 0;
   function otherWaiter() {
     return ++other > 2;
   }

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -77,7 +77,7 @@ let AttrsProxyMixin = {
 
     var keys = Object.keys(this.attrs);
 
-    for (var i = 0, l = keys.length; i<l; i++) {
+    for (var i = 0, l = keys.length; i < l; i++) {
       // Only issue the deprecation if it wasn't already issued when
       // setting attributes initially.
       if (!(keys[i] in this)) {

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -77,7 +77,7 @@ let AttrsProxyMixin = {
 
     var keys = Object.keys(this.attrs);
 
-    for (var i=0, l=keys.length; i<l; i++) {
+    for (var i = 0, l = keys.length; i<l; i++) {
       // Only issue the deprecation if it wasn't already issued when
       // setting attributes initially.
       if (!(keys[i] in this)) {

--- a/packages/ember-views/lib/compat/render_buffer.js
+++ b/packages/ember-views/lib/compat/render_buffer.js
@@ -281,7 +281,7 @@ RenderBuffer.prototype = {
   pushChildView(view) {
     var index = this.childViews.length;
     this.childViews[index] = view;
-    this.push('<script id=\'morph-'+index+'\' type=\'text/x-placeholder\'>\x3C/script>');
+    this.push('<script id=\'morph-' + index + '\' type=\'text/x-placeholder\'>\x3C/script>');
   },
 
   pushAttrNode(node) {
@@ -292,9 +292,9 @@ RenderBuffer.prototype = {
   hydrateMorphs(contextualElement) {
     var childViews = this.childViews;
     var el = this._element;
-    for (var i=0,l=childViews.length; i<l; i++) {
+    for (var i = 0, l = childViews.length; i<l; i++) {
       var childView = childViews[i];
-      var ref = el.querySelector('#morph-'+i);
+      var ref = el.querySelector('#morph-' + i);
 
       Ember.assert('An error occurred while setting up template bindings. Please check ' +
                    (((childView && childView.parentView && childView._parentView._debugTemplateName ? '"' + childView._parentView._debugTemplateName + '" template ' : ''))
@@ -535,7 +535,7 @@ RenderBuffer.prototype = {
   element() {
     if (this._element && this.attrNodes.length > 0) {
       var i, l, attrMorph, attrNode;
-      for (i=0, l=this.attrNodes.length; i<l; i++) {
+      for (i = 0, l = this.attrNodes.length; i<l; i++) {
         attrNode = this.attrNodes[i];
         attrMorph = this.dom.createAttrMorph(this._element, attrNode.attrName);
         attrNode._morph = attrMorph;

--- a/packages/ember-views/lib/compat/render_buffer.js
+++ b/packages/ember-views/lib/compat/render_buffer.js
@@ -292,7 +292,7 @@ RenderBuffer.prototype = {
   hydrateMorphs(contextualElement) {
     var childViews = this.childViews;
     var el = this._element;
-    for (var i = 0, l = childViews.length; i<l; i++) {
+    for (var i = 0, l = childViews.length; i < l; i++) {
       var childView = childViews[i];
       var ref = el.querySelector('#morph-' + i);
 
@@ -535,7 +535,7 @@ RenderBuffer.prototype = {
   element() {
     if (this._element && this.attrNodes.length > 0) {
       var i, l, attrMorph, attrNode;
-      for (i = 0, l = this.attrNodes.length; i<l; i++) {
+      for (i = 0, l = this.attrNodes.length; i < l; i++) {
         attrNode = this.attrNodes[i];
         attrMorph = this.dom.createAttrMorph(this._element, attrNode.attrName);
         attrNode._morph = attrMorph;

--- a/packages/ember-views/lib/streams/class_name_binding.js
+++ b/packages/ember-views/lib/streams/class_name_binding.js
@@ -97,7 +97,7 @@ export function classStringForValue(path, val, className, falsyClassName) {
     // as a class name. For exaple, content.foo.barBaz
     // becomes bar-baz.
     var parts = path.split('.');
-    return dasherize(parts[parts.length-1]);
+    return dasherize(parts[parts.length - 1]);
 
   // If the value is not false, undefined, or null, return the current
   // value of the property.
@@ -123,7 +123,7 @@ export function streamifyClassNameBinding(view, classNameBinding, prefix) {
       parsedPath.falsyClassName
     );
   } else {
-    var pathValue = view.getStream(prefix+parsedPath.path);
+    var pathValue = view.getStream(prefix + parsedPath.path);
     return chain(pathValue, function() {
       return classStringForValue(
         parsedPath.path,

--- a/packages/ember-views/lib/streams/utils.js
+++ b/packages/ember-views/lib/streams/utils.js
@@ -12,16 +12,16 @@ export function readViewFactory(object, container) {
   if (typeof value === 'string') {
     if (isGlobal(value)) {
       viewClass = get(null, value);
-      Ember.deprecate('Resolved the view "'+value+'" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}.', !viewClass, { url: 'http://emberjs.com/guides/deprecations/#toc_global-lookup-of-views' });
+      Ember.deprecate('Resolved the view "' + value + '" on the global context. Pass a view name to be looked up on the container instead, such as {{view "select"}}.', !viewClass, { url: 'http://emberjs.com/guides/deprecations/#toc_global-lookup-of-views' });
     } else {
       Ember.assert('View requires a container to resolve views not passed in through the context', !!container);
-      viewClass = container.lookupFactory('view:'+value);
+      viewClass = container.lookupFactory('view:' + value);
     }
   } else {
     viewClass = value;
   }
 
-  Ember.assert(fmt(value+' must be a subclass or an instance of Ember.View, not %@', [viewClass]), (function(viewClass) {
+  Ember.assert(fmt(value + ' must be a subclass or an instance of Ember.View, not %@', [viewClass]), (function(viewClass) {
     return viewClass && (viewClass.isViewFactory || viewClass.isView || viewClass.isComponentFactory || viewClass.isComponent);
   })(viewClass));
 

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -138,7 +138,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   var i, l;
 
   if (attributeBindings) {
-    for (i=0, l=attributeBindings.length; i<l; i++) {
+    for (i = 0, l = attributeBindings.length; i<l; i++) {
       var attr = attributeBindings[i];
       var colonIndex = attr.indexOf(':');
 
@@ -231,7 +231,7 @@ function normalizeClass(component, attrs) {
   }
 
   if (classNames) {
-    for (i=0, l=classNames.length; i<l; i++) {
+    for (i = 0, l = classNames.length; i<l; i++) {
       normalizedClass.push(classNames[i]);
     }
   }
@@ -248,7 +248,7 @@ function normalizeClass(component, attrs) {
 function normalizeClasses(classes, output) {
   var i, l;
 
-  for (i=0, l=classes.length; i<l; i++) {
+  for (i = 0, l = classes.length; i<l; i++) {
     var className = classes[i];
     Ember.assert('classNameBindings must not have spaces in them. Multiple class name bindings can be provided as elements of an array, e.g. [\'foo\', \':bar\']', className.indexOf(' ') === -1);
 

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -138,7 +138,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   var i, l;
 
   if (attributeBindings) {
-    for (i = 0, l = attributeBindings.length; i<l; i++) {
+    for (i = 0, l = attributeBindings.length; i < l; i++) {
       var attr = attributeBindings[i];
       var colonIndex = attr.indexOf(':');
 
@@ -231,7 +231,7 @@ function normalizeClass(component, attrs) {
   }
 
   if (classNames) {
-    for (i = 0, l = classNames.length; i<l; i++) {
+    for (i = 0, l = classNames.length; i < l; i++) {
       normalizedClass.push(classNames[i]);
     }
   }
@@ -248,7 +248,7 @@ function normalizeClass(component, attrs) {
 function normalizeClasses(classes, output) {
   var i, l;
 
-  for (i = 0, l = classes.length; i<l; i++) {
+  for (i = 0, l = classes.length; i < l; i++) {
     var className = classes[i];
     Ember.assert('classNameBindings must not have spaces in them. Multiple class name bindings can be provided as elements of an array, e.g. [\'foo\', \':bar\']', className.indexOf(' ') === -1);
 

--- a/packages/ember-views/lib/system/lookup_partial.js
+++ b/packages/ember-views/lib/system/lookup_partial.js
@@ -22,7 +22,7 @@ export default function lookupPartial(env, templateName) {
 
 function templateFor(env, underscored, name) {
   if (!name) { return; }
-  Ember.assert('templateNames are not allowed to contain periods: '+name, name.indexOf('.') === -1);
+  Ember.assert('templateNames are not allowed to contain periods: ' + name, name.indexOf('.') === -1);
 
   if (!env.container) {
     throw new EmberError('Container was not found when looking up a views template. ' +

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -375,7 +375,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     this._itemViewProps = itemProps;
     var childViews = get(this, 'childViews');
 
-    for (var i = 0, l = childViews.length; i<l; i++) {
+    for (var i = 0, l = childViews.length; i < l; i++) {
       childViews[i].setProperties(itemProps);
     }
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -325,7 +325,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
 
       itemViewClass = readViewFactory(itemViewClass, this.container);
 
-      for (idx = start; idx < start+added; idx++) {
+      for (idx = start; idx < start + added; idx++) {
         item = content.objectAt(idx);
         itemViewProps._context = this.keyword ? this.get('context') : item;
         itemViewProps.content = item;
@@ -375,7 +375,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     this._itemViewProps = itemProps;
     var childViews = get(this, 'childViews');
 
-    for (var i=0, l=childViews.length; i<l; i++) {
+    for (var i = 0, l = childViews.length; i<l; i++) {
       childViews[i].setProperties(itemProps);
     }
 

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -246,7 +246,7 @@ var ContainerView = View.extend(MutableArray, {
     var childViews = get(this, 'childViews');
 
     Ember.assert('You can\'t add a child to a container - the child is already a child of another view', () => {
-      for (var i=0, l=addedViews.length; i<l; i++) {
+      for (var i = 0, l = addedViews.length; i<l; i++) {
         var item = addedViews[i];
         if (item.parentView && item.parentView !== this) { return false; }
       }
@@ -263,7 +263,7 @@ var ContainerView = View.extend(MutableArray, {
     // Because of this, we synchronously fix up the parentView/childViews tree
     // as soon as views are added or removed, despite the fact that this will
     // happen automatically when we render.
-    var removedViews = childViews.slice(idx, idx+removedCount);
+    var removedViews = childViews.slice(idx, idx + removedCount);
     removedViews.forEach(view => this.unlinkChild(view));
     addedViews.forEach(view => this.linkChild(view));
 

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -246,7 +246,7 @@ var ContainerView = View.extend(MutableArray, {
     var childViews = get(this, 'childViews');
 
     Ember.assert('You can\'t add a child to a container - the child is already a child of another view', () => {
-      for (var i = 0, l = addedViews.length; i<l; i++) {
+      for (var i = 0, l = addedViews.length; i < l; i++) {
         var item = addedViews[i];
         if (item.parentView && item.parentView !== this) { return false; }
       }

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -778,7 +778,7 @@ var View = CoreView.extend(
 
   templateForName(name, type) {
     if (!name) { return; }
-    Ember.assert('templateNames are not allowed to contain periods: '+name, name.indexOf('.') === -1);
+    Ember.assert('templateNames are not allowed to contain periods: ' + name, name.indexOf('.') === -1);
 
     if (!this.container) {
       throw new EmberError('Container was not found when looking up a views template. ' +
@@ -1432,7 +1432,7 @@ var View = CoreView.extend(
     @private
   */
   _register() {
-    Ember.assert('Attempted to register a view with an id already in use: '+this.elementId, !this._viewRegistry[this.elementId]);
+    Ember.assert('Attempted to register a view with an id already in use: ' + this.elementId, !this._viewRegistry[this.elementId]);
     this._viewRegistry[this.elementId] = this;
   },
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -171,7 +171,7 @@ QUnit.test('events should stop propagating if the view is destroyed', function()
 });
 
 QUnit.test('should dispatch events to nearest event manager', function() {
-  var receivedEvent=0;
+  var receivedEvent = 0;
   view = View.create({
     template: compile('<input id="is-done" type="checkbox">'),
 
@@ -195,7 +195,7 @@ QUnit.test('should dispatch events to nearest event manager', function() {
 QUnit.test('event manager should be able to re-dispatch events to view', function() {
   expectDeprecation('Setting `childViews` on a Container is deprecated.');
 
-  var receivedEvent=0;
+  var receivedEvent = 0;
   view = ContainerView.extend({
 
     eventManager: EmberObject.extend({

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -129,7 +129,7 @@ QUnit.test('should allow custom item views by setting itemViewClass', function()
     view.append();
   });
 
-  content.forEach((item) => equal(view.$(':contains("'+item+'")').length, 1));
+  content.forEach((item) => equal(view.$(':contains("' + item + '")').length, 1));
 });
 
 QUnit.test('should insert a new item in DOM when an item is added to the content array', function() {
@@ -148,7 +148,7 @@ QUnit.test('should insert a new item in DOM when an item is added to the content
   });
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(function() {
@@ -172,13 +172,13 @@ QUnit.test('should remove an item from DOM when an item is removed from the cont
   run(() => view.append());
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(() => content.removeAt(1));
 
   content.forEach((item, idx) => {
-    equal(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text(), item);
+    equal(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text(), item);
   });
 });
 
@@ -197,7 +197,7 @@ QUnit.test('it updates the view if an item is replaced', function() {
   });
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(function() {
@@ -206,7 +206,7 @@ QUnit.test('it updates the view if an item is replaced', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -223,7 +223,7 @@ QUnit.test('can add and replace in the same runloop', function() {
   run(() => view.append());
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(() => {
@@ -233,7 +233,7 @@ QUnit.test('can add and replace in the same runloop', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -250,7 +250,7 @@ QUnit.test('can add and replace the object before the add in the same runloop', 
   run(() => view.append());
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(() => {
@@ -260,7 +260,7 @@ QUnit.test('can add and replace the object before the add in the same runloop', 
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -277,7 +277,7 @@ QUnit.test('can add and replace complicatedly', function() {
   run(() => view.append());
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(() => {
@@ -289,7 +289,7 @@ QUnit.test('can add and replace complicatedly', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, 'postcond - correct array update: '+item.name+'!='+view.$(fmt(':nth-child(%@)', [String(idx+1)])).text());
+    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update: ' + item.name + '!=' + view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text());
   });
 });
 
@@ -308,7 +308,7 @@ QUnit.test('can add and replace complicatedly harder', function() {
   });
 
   content.forEach((item) => {
-    equal(view.$(':contains("'+item+'")').length, 1, 'precond - generates pre-existing items');
+    equal(view.$(':contains("' + item + '")').length, 1, 'precond - generates pre-existing items');
   });
 
   run(function() {
@@ -321,7 +321,7 @@ QUnit.test('can add and replace complicatedly harder', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -404,7 +404,7 @@ QUnit.test('should fire life cycle events when elements are added and removed', 
   equal(trim(view.$().text()), '123');
 
   run(function () {
-    view.set('content', Ember.A([7,8,9]));
+    view.set('content', Ember.A([7, 8, 9]));
   });
 
   equal(didInsertElement, 8);

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -215,7 +215,7 @@ QUnit.test('should be able to push initial views onto the ContainerView and have
 
   equal(container.lengthSquared(), 4);
 
-  deepEqual(container.mapViewNames(), ['A','B']);
+  deepEqual(container.mapViewNames(), ['A', 'B']);
 
   run(container, 'appendTo', '#qunit-fixture');
 
@@ -230,7 +230,7 @@ QUnit.test('should be able to push initial views onto the ContainerView and have
 
   equal(container.lengthSquared(), 9);
 
-  deepEqual(container.mapViewNames(), ['A','B','C']);
+  deepEqual(container.mapViewNames(), ['A', 'B', 'C']);
 
   equal(container.$().text(), 'ABC');
 

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -607,8 +607,8 @@ QUnit.test('selection uses the same array when multiple=true', function() {
 
   select.$().trigger('change');
 
-  deepEqual(select.get('selection'), [tom,david], 'On change the selection is updated');
-  deepEqual(selection, [tom,david], 'On change the original selection array is updated');
+  deepEqual(select.get('selection'), [tom, david], 'On change the selection is updated');
+  deepEqual(selection, [tom, david], 'On change the original selection array is updated');
 });
 
 QUnit.test('Ember.SelectedOption knows when it is selected when multiple=false', function() {
@@ -735,7 +735,7 @@ QUnit.test('valueBinding handles 0 as initiated value (issue #2763)', function()
     select.destroy(); // Destroy the existing select
 
     select = EmberSelect.extend({
-      content: Ember.A([1,0]),
+      content: Ember.A([1, 0]),
       indirectData: indirectData,
       valueBinding: 'indirectData.value'
     }).create();

--- a/packages/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages/ember-views/tests/views/view/destroy_element_test.js
@@ -88,5 +88,5 @@ QUnit.test('removes element from parentNode if in DOM', function() {
   });
 
   equal(view.$(), undefined, 'view has no selector');
-  ok(!parent.find('#'+view.get('elementId')).length, 'element no longer in parent node');
+  ok(!parent.find('#' + view.get('elementId')).length, 'element no longer in parent node');
 });

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -130,12 +130,12 @@ QUnit.module('EmberView#isVisible with Container', {
   setup() {
     expectDeprecation('Setting `childViews` on a Container is deprecated.');
 
-    parentBecameVisible=0;
-    childBecameVisible=0;
-    grandchildBecameVisible=0;
-    parentBecameHidden=0;
-    childBecameHidden=0;
-    grandchildBecameHidden=0;
+    parentBecameVisible = 0;
+    childBecameVisible = 0;
+    grandchildBecameVisible = 0;
+    parentBecameHidden = 0;
+    childBecameHidden = 0;
+    grandchildBecameHidden = 0;
 
     View = ContainerView.extend({
       childViews: ['child'],

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -31,7 +31,7 @@ QUnit.test('returns receiver', function() {
 QUnit.test('removes child from parent.childViews array', function() {
   ok(get(parentView, 'childViews').indexOf(child)>=0, 'precond - has child in childViews array before remove');
   parentView.removeChild(child);
-  ok(get(parentView, 'childViews').indexOf(child)<0, 'removed child');
+  ok(get(parentView, 'childViews').indexOf(child) < 0, 'removed child');
 });
 
 QUnit.test('sets parentView property to null', function() {
@@ -103,7 +103,7 @@ QUnit.test('removes view from parent view', function() {
   });
 
   ok(!get(child, 'parentView'), 'no longer has parentView');
-  ok(get(parentView, 'childViews').indexOf(child)<0, 'no longer in parent childViews');
+  ok(get(parentView, 'childViews').indexOf(child) < 0, 'no longer in parent childViews');
   equal(parentView.$('div').length, 0, 'removes DOM element from parent');
 });
 

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -142,7 +142,7 @@ QUnit.test('the DOM element is gone after doing append and remove in two separat
     view.remove();
   });
 
-  var viewElem = jQuery('#'+get(view, 'elementId'));
+  var viewElem = jQuery('#' + get(view, 'elementId'));
   ok(viewElem.length === 0, 'view\'s element doesn\'t exist in DOM');
 });
 
@@ -153,7 +153,7 @@ QUnit.test('the DOM element is gone after doing append and remove in a single ru
     view.remove();
   });
 
-  var viewElem = jQuery('#'+get(view, 'elementId'));
+  var viewElem = jQuery('#' + get(view, 'elementId'));
   ok(viewElem.length === 0, 'view\'s element doesn\'t exist in DOM');
 });
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -954,7 +954,7 @@ QUnit.test('The {{link-to}} helper works in an #each\'d array of string route na
     for (idx = 0; idx < $links.length; idx++) {
       var href = Ember.$($links[idx]).attr('href');
       // Old IE includes the whole hostname as well
-      equal(href.slice(-expected[idx].length), expected[idx], 'Expected link to be \''+expected[idx]+'\', but was \''+href+'\'');
+      equal(href.slice(-expected[idx].length), expected[idx], 'Expected link to be \'' + expected[idx] + '\', but was \'' + href + '\'');
     }
   }
 

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -121,9 +121,9 @@ if (isEnabled('ember-routing-transitioning-classes')) {
       var i = 1;
       while (i < arguments.length) {
         var $a = arguments[i];
-        var shouldHaveClass = arguments[i+1];
+        var shouldHaveClass = arguments[i + 1];
         equal($a.hasClass(className), shouldHaveClass, $a.attr('id') + ' should ' + (shouldHaveClass ? '' : 'not ') + 'have class ' + className);
-        i +=2;
+        i += 2;
       }
     }
 
@@ -187,9 +187,9 @@ if (isEnabled('ember-routing-transitioning-classes')) {
       var i = 1;
       while (i < arguments.length) {
         var $a = arguments[i];
-        var shouldHaveClass = arguments[i+1];
+        var shouldHaveClass = arguments[i + 1];
         equal($a.hasClass(className), shouldHaveClass, $a.attr('id') + ' should ' + (shouldHaveClass ? '' : 'not ') + 'have class ' + className);
-        i +=2;
+        i += 2;
       }
     }
 

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -353,8 +353,8 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     });
 
     App.IndexController = Ember.Controller.extend({
-      pagesArray: [1,2],
-      biggerArray: [1,2,3],
+      pagesArray: [1, 2],
+      biggerArray: [1, 2, 3],
       emptyArray: []
     });
 
@@ -698,8 +698,8 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexController = Ember.Controller.extend({
       queryParams: ['pages'],
       pages: [],
-      pagesArray: [1,2],
-      biggerArray: [1,2,3],
+      pagesArray: [1, 2],
+      biggerArray: [1, 2, 3],
       emptyArray: []
     });
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -667,11 +667,11 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     var controller = container.lookup('controller:home');
 
-    setAndFlush(controller, 'foo', [1,2]);
+    setAndFlush(controller, 'foo', [1, 2]);
 
     equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
 
-    setAndFlush(controller, 'foo', [3,4]);
+    setAndFlush(controller, 'foo', [3, 4]);
     equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
   });
 
@@ -688,9 +688,9 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     equal(router.get('location.path'), '');
 
-    Ember.run(router, 'transitionTo', { queryParams: { foo: [2,3] } });
+    Ember.run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
     equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4,5] } });
+    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
     equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
     Ember.run(router, 'transitionTo', { queryParams: { foo: [] } });
     equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
@@ -709,7 +709,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
 
     var controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1','2','3']);
+    deepEqual(controller.get('foo'), ['1', '2', '3']);
   });
 
   QUnit.test('Url with array query param sets controller property to array when configuration occurs on the route and there is still a controller', function() {
@@ -727,7 +727,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
 
     var controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1','2','3']);
+    deepEqual(controller.get('foo'), ['1', '2', '3']);
   });
 
   QUnit.test('Array query params can be pushed/popped when configuration occurs on the route but there is still a controller', function() {
@@ -1672,11 +1672,11 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     var controller = container.lookup('controller:home');
 
-    setAndFlush(controller, 'foo', [1,2]);
+    setAndFlush(controller, 'foo', [1, 2]);
 
     equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
 
-    setAndFlush(controller, 'foo', [3,4]);
+    setAndFlush(controller, 'foo', [3, 4]);
     equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
   });
 
@@ -1693,9 +1693,9 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     equal(router.get('location.path'), '');
 
-    Ember.run(router, 'transitionTo', { queryParams: { foo: [2,3] } });
+    Ember.run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
     equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4,5] } });
+    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
     equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
     Ember.run(router, 'transitionTo', { queryParams: { foo: [] } });
     equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
@@ -1714,7 +1714,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
 
     var controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1','2','3']);
+    deepEqual(controller.get('foo'), ['1', '2', '3']);
   });
 
   QUnit.test('Array query params can be pushed/popped when configured on the route', function() {
@@ -2857,11 +2857,11 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     var controller = container.lookup('controller:home');
 
-    setAndFlush(controller, 'foo', [1,2]);
+    setAndFlush(controller, 'foo', [1, 2]);
 
     equal(router.get('location.path'), '/?foo=%5B1%2C2%5D');
 
-    setAndFlush(controller, 'foo', [3,4]);
+    setAndFlush(controller, 'foo', [3, 4]);
     equal(router.get('location.path'), '/?foo=%5B3%2C4%5D');
   });
 
@@ -2875,9 +2875,9 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
     equal(router.get('location.path'), '');
 
-    Ember.run(router, 'transitionTo', { queryParams: { foo: [2,3] } });
+    Ember.run(router, 'transitionTo', { queryParams: { foo: [2, 3] } });
     equal(router.get('location.path'), '/?foo=%5B2%2C3%5D', 'shorthand supported');
-    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4,5] } });
+    Ember.run(router, 'transitionTo', { queryParams: { 'index:foo': [4, 5] } });
     equal(router.get('location.path'), '/?foo=%5B4%2C5%5D', 'longform supported');
     Ember.run(router, 'transitionTo', { queryParams: { foo: [] } });
     equal(router.get('location.path'), '/?foo=%5B%5D', 'longform supported');
@@ -2893,7 +2893,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     bootApplication();
 
     var controller = container.lookup('controller:index');
-    deepEqual(controller.get('foo'), ['1','2','3']);
+    deepEqual(controller.get('foo'), ['1', '2', '3']);
   });
 
   QUnit.test('Array query params can be pushed/popped', function() {

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -171,7 +171,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       }
     });
 
-    App.ParentChildRoute= Ember.Route.extend({
+    App.ParentChildRoute = Ember.Route.extend({
       queryParams: {
         bar: {
           as: 'shared',

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -55,7 +55,7 @@ var mainContext = this;
       var reified = [];
       var length = deps.length;
 
-      for (var i=0; i<length; i++) {
+      for (var i = 0; i<length; i++) {
         if (deps[i] === 'exports') {
           reified.push(exports);
         } else {
@@ -75,7 +75,7 @@ var mainContext = this;
       var parts = child.split('/');
       var parentBase = name.split('/').slice(0, -1);
 
-      for (var i=0, l=parts.length; i<l; i++) {
+      for (var i = 0, l = parts.length; i<l; i++) {
         var part = parts[i];
 
         if (part === '..') {

--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -55,7 +55,7 @@ var mainContext = this;
       var reified = [];
       var length = deps.length;
 
-      for (var i = 0; i<length; i++) {
+      for (var i = 0; i < length; i++) {
         if (deps[i] === 'exports') {
           reified.push(exports);
         } else {
@@ -75,7 +75,7 @@ var mainContext = this;
       var parts = child.split('/');
       var parentBase = name.split('/').slice(0, -1);
 
-      for (var i = 0, l = parts.length; i<l; i++) {
+      for (var i = 0, l = parts.length; i < l; i++) {
         var part = parts[i];
 
         if (part === '..') {


### PR DESCRIPTION
Except for before a `,`.

_Note: The build will probably break, because there are violations of the new rules._

``` js
// bad
var a = b+c;
a = b+ b;
if (test> 0) {
}
function (abc ,def) {
}

// good
var a = b + c;
a = b + b;
if (test > 0) {
}
function (abc, def) {
}
```
