### PR TITLE
Enable passage of null/undefined for array values in intersection; Add union to EnumerableUtils

### DIFF
--- a/packages/ember-metal/lib/enumerable_utils.js
+++ b/packages/ember-metal/lib/enumerable_utils.js
@@ -226,6 +226,46 @@ export function intersection(array1, array2) {
   return result;
 }
 
+/**
+ * Calculates the union of two arrays. This method returns a new array
+ * made up of the records in the first array combined with the records in the second array
+ * without duplicating the records which are found in both arrays.
+ *
+ * ```javascript
+ * var array1 = [1, 2, 3];
+ * var array2 = [3, 5, 6];
+ *
+ * Ember.EnumerableUtils.union(array1, array2); // [1, 2, 3, 5, 6]
+ *
+ * var array1 = [1, 2, 3];
+ * var array2 = [4, 5, 6];
+ *
+ * Ember.EnumerableUtils.union(array1, array2); // [1, 2, 3, 4, 5, 6]
+ * ```
+ *
+ * @method union
+ * @param {Array} array1 The first array
+ * @param {Array} array2 The second array
+ *
+ * @return {Array} The union of the two passed arrays.
+ */
+export function union(array1, array2) {
+  // Account for undefined/null array parameters
+  array1 = array1 || [];
+  array2 = array2 || [];
+
+  var result = array1;
+
+  forEach(array2, function(element) {
+    if (indexOf(result, element) === -1) {
+      result.push(element);
+    }
+  });
+
+  return result;
+}
+
+
 // TODO: this only exists to maintain the existing api, as we move forward it
 // should only be part of the "global build" via some shim
 export default {
@@ -236,6 +276,7 @@ export default {
   indexOf: indexOf,
   indexesOf: indexesOf,
   intersection: intersection,
+  union: union,
   map: map,
   removeObject: removeObject,
   replace: replace

--- a/packages/ember-metal/lib/enumerable_utils.js
+++ b/packages/ember-metal/lib/enumerable_utils.js
@@ -212,6 +212,11 @@ export function replace(array, idx, amt, objects) {
  */
 export function intersection(array1, array2) {
   var result = [];
+
+  // Account for undefined/null array parameters
+  array1 = array1 || [];
+  array2 = array2 || [];
+
   forEach(array1, function(element) {
     if (indexOf(array2, element) >= 0) {
       result.push(element);

--- a/packages/ember-metal/tests/enumerable_utils_test.js
+++ b/packages/ember-metal/tests/enumerable_utils_test.js
@@ -5,12 +5,27 @@ QUnit.module('Ember.EnumerableUtils.intersection');
 test('returns an array of objects that appear in both enumerables', function() {
   var a = [1,2,3];
   var b = [2,3,4];
-  var result;
-
-  result = EnumerableUtils.intersection(a, b);
+  var result = EnumerableUtils.intersection(a, b);
 
   deepEqual(result, [2,3]);
 });
+
+test('returns an empty array if one of the arrays is undefined', function() {
+  var a; //undefined
+  var b = [2,3,4];
+  var result = EnumerableUtils.intersection(a, b);
+
+  deepEqual(result, []);
+});
+
+test('returns an empty array if one of the arrays is null', function() {
+  var a = null;
+  var b = [2,3,4];
+  var result = EnumerableUtils.intersection(a, b);
+
+  deepEqual(result, []);
+});
+
 
 test("large replace", function() {
   expect(0);

--- a/packages/ember-metal/tests/enumerable_utils_test.js
+++ b/packages/ember-metal/tests/enumerable_utils_test.js
@@ -1,6 +1,6 @@
 import EnumerableUtils from 'ember-metal/enumerable_utils';
 
-QUnit.module('Ember.EnumerableUtils.intersection');
+QUnit.module('Ember.EnumerableUtils');
 
 test('returns an array of objects that appear in both enumerables', function() {
   var a = [1,2,3];
@@ -34,4 +34,19 @@ test("large replace", function() {
   EnumerableUtils.replace([], 0, undefined, new Array(62401));   // max + 1 in Chrome  28.0.1500.71
   EnumerableUtils.replace([], 0, undefined, new Array(65535));   // max + 1 in Safari  6.0.5 (8536.30.1)
   EnumerableUtils.replace([], 0, undefined, new Array(491519));  // max + 1 in FireFox 22.0
+});
+
+test('returns a union of objects that appear in both enumerables', function() {
+  var a = [1, 2, 3];
+  var b = [2, 3, 4];
+  var result = EnumerableUtils.union(a, b);
+
+  deepEqual(result, [1, 2, 3, 4]);
+
+  a = [1, 2, 3];
+  b = [4, 5, 6];
+  result = EnumerableUtils.union(a, b);
+
+  deepEqual(result, [1, 2, 3, 4, 5, 6]);
+
 });


### PR DESCRIPTION
If one of the arrays being passed into `intersection()` method is null or undefined, it should just return an empty array instead of erroring out. This is useful, I think, since a lot of times in Ember an array starts out undefined and then asynchronously gets populated.

See the following SO answer for example, with an accompanying jsbin demo:

http://stackoverflow.com/a/28158832/908842
http://emberjs.jsbin.com/qoturu/1/edit?html,js,output
