### PR TITLE
Use delegate pattern for AutoLocation

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1029,7 +1029,6 @@ Application.reopenClass({
     registry.injection('controller', '_bucketCache', '-bucket-cache:main');
 
     registry.injection('route', 'router', 'router:main');
-    registry.injection('location', 'rootURL', '-location-setting:root-url');
 
     // DEBUGGING
     registry.register('resolver-for-debugging:main', registry.resolver.__resolver__, { instantiate: false });

--- a/packages/ember-metal/lib/environment.js
+++ b/packages/ember-metal/lib/environment.js
@@ -27,7 +27,8 @@ if (hasDOM) {
     isChrome: !!window.chrome && !window.opera,
     location: window.location,
     history: window.history,
-    userAgent: window.navigator.userAgent
+    userAgent: window.navigator.userAgent,
+    global: window
   };
 } else {
   environment = {
@@ -35,7 +36,8 @@ if (hasDOM) {
     isChrome: false,
     location: null,
     history: null,
-    userAgent: "Lynx (textmode)"
+    userAgent: "Lynx (textmode)",
+    global: null
   };
 }
 

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -1,5 +1,6 @@
 import Ember from "ember-metal/core"; // deprecate, assert
 import environment from "ember-metal/environment";
+import { getHash } from "ember-routing/location/util";
 
 /**
 @module ember
@@ -192,15 +193,6 @@ export default {
     @since 1.4.0
   */
   _getHash: function () {
-    // AutoLocation has it at _location, HashLocation at .location.
-    // Being nice and not changing
-    var href = (this._location || this.location).href;
-    var hashIndex = href.indexOf('#');
-
-    if (hashIndex === -1) {
-      return '';
-    } else {
-      return href.substr(hashIndex);
-    }
+    return getHash(this._location || this.location);
   }
 };

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -197,6 +197,6 @@ export default {
     @since 1.4.0
   */
   _getHash: function () {
-    return getHash(this._location || this.location);
+    return getHash(this.location);
   }
 };

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -112,6 +112,10 @@ import { getHash } from "ember-routing/location/util";
   * replaceURL(path): replace the current URL (optional).
   * onUpdateURL(callback): triggers the callback when the URL changes.
   * formatURL(url): formats `url` to be placed into `href` attribute.
+  * detect() (optional): instructs the location to do any feature detection
+      necessary. If the location needs to redirect to a different URL, it
+      can cancel routing by setting the `cancelRouterSetup` property on itself
+      to `false`.
 
   Calling setURL or replaceURL will not trigger onUpdateURL callbacks.
 

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -5,8 +5,16 @@ import { computed } from "ember-metal/computed";
 
 import EmberObject from "ember-runtime/system/object";
 import environment from "ember-metal/environment";
-import { supportsHashChange, supportsHistory } from "ember-routing/location/util";
-import { getPath, getOrigin, getHash, getFullPath } from "ember-routing/location/util";
+
+import {
+  supportsHashChange,
+  supportsHistory,
+  getPath,
+  getHash,
+  getFullPath,
+  replacePath
+} from "ember-routing/location/util";
+
 
 /**
 @module ember
@@ -100,7 +108,7 @@ export default EmberObject.extend({
     }
 
     return this.container.lookup('location:' + implementation);
-  }),
+  }).readOnly(),
 
   initState: delegateToConcreteImplementation('initState'),
   getURL: delegateToConcreteImplementation('getURL'),
@@ -256,8 +264,4 @@ function getHashPath(rootURL, location) {
   }
 
   return path;
-}
-
-function replacePath(location, path) {
-  location.replace(getOrigin(location) + path);
 }

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -257,15 +257,13 @@ export function getHistoryPath(rootURL, location) {
     }
 
     // This is the "expected" final order
-    path += routeHash;
-    path += query;
+    path = path + routeHash + query;
 
     if (hashParts.length) {
       path += '#' + hashParts.join('#');
     }
   } else {
-    path += query;
-    path += hash;
+    path = path + query + hash;
   }
 
   return path;

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -175,12 +175,12 @@ function delegateToConcreteImplementation(methodName) {
 */
 
 function detectImplementation(options) {
-  var location = options.location,
-      userAgent = options.userAgent,
-      history = options.history,
-      documentMode = options.documentMode,
-      global = options.global,
-      rootURL = options.rootURL;
+  var location = options.location;
+  var userAgent = options.userAgent;
+  var history = options.history;
+  var documentMode = options.documentMode;
+  var global = options.global;
+  var rootURL = options.rootURL;
 
   var implementation = 'none';
   var cancelRouterSetup = false;

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -15,7 +15,6 @@ import {
   replacePath
 } from "ember-routing/location/util";
 
-
 /**
 @module ember
 @submodule ember-routing

--- a/packages/ember-routing/lib/location/util.js
+++ b/packages/ember-routing/lib/location/util.js
@@ -1,3 +1,67 @@
+/**
+  @private
+
+  Returns the current `location.pathname`, normalized for IE inconsistencies.
+*/
+export function getPath(location) {
+  var pathname = location.pathname;
+  // Various versions of IE/Opera don't always return a leading slash
+  if (pathname.charAt(0) !== '/') {
+    pathname = '/' + pathname;
+  }
+
+  return pathname;
+}
+
+/**
+  @private
+
+  Returns the current `location.search`.
+*/
+export function getQuery(location) {
+  return location.search;
+}
+
+/**
+  @private
+
+  Returns the current `location.hash` by parsing location.href since browsers
+  inconsistently URL-decode `location.hash`.
+
+  Should be passed the browser's `location` object as the first argument.
+
+  https://bugzilla.mozilla.org/show_bug.cgi?id=483304
+*/
+export function getHash(location) {
+  var href = location.href;
+  var hashIndex = href.indexOf('#');
+
+  if (hashIndex === -1) {
+    return '';
+  } else {
+    return href.substr(hashIndex);
+  }
+}
+
+export function getFullPath(location) {
+  return getPath(location) + getQuery(location) + getHash(location);
+}
+
+export function getOrigin(location) {
+  var origin = location.origin;
+
+  // Older browsers, especially IE, don't have origin
+  if (!origin) {
+    origin = location.protocol + '//' + location.hostname;
+
+    if (location.port) {
+      origin += ':' + location.port;
+    }
+  }
+
+  return origin;
+}
+
 /*
   `documentMode` only exist in Internet Explorer, and it's tested because IE8 running in
   IE7 compatibility mode claims to support `onhashchange` but actually does not.
@@ -20,7 +84,6 @@ export function supportsHashChange(documentMode, global) {
   @private
   @function supportsHistory
 */
-
 export function supportsHistory(userAgent, history) {
   // Boosted from Modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
   // The stock browser on Android 2.2 & 2.3 returns positive on history support

--- a/packages/ember-routing/lib/location/util.js
+++ b/packages/ember-routing/lib/location/util.js
@@ -100,3 +100,13 @@ export function supportsHistory(userAgent, history) {
 
   return !!(history && 'pushState' in history);
 }
+
+/**
+  Replaces the current location, making sure we explicitly include the origin
+  to prevent redirecting to a different origin.
+
+  @private
+*/
+export function replacePath(location, path) {
+  location.replace(getOrigin(location) + path);
+}

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -387,12 +387,6 @@ var EmberRouter = EmberObject.extend(Evented, {
     var location = get(this, 'location');
     var rootURL = get(this, 'rootURL');
 
-    if (rootURL && this.container && !this.container._registry.has('-location-setting:root-url')) {
-      this.container._registry.register('-location-setting:root-url', rootURL, {
-        instantiate: false
-      });
-    }
-
     if ('string' === typeof location && this.container) {
       var resolvedLocation = this.container.lookup('location:' + location);
 
@@ -409,8 +403,15 @@ var EmberRouter = EmberObject.extend(Evented, {
     }
 
     if (location !== null && typeof location === 'object') {
-      if (rootURL && typeof rootURL === 'string') {
-        location.rootURL = rootURL;
+      if (rootURL) {
+        set(location, 'rootURL', rootURL);
+      }
+
+      // Allow the location to do any feature detection, such as AutoLocation
+      // detecting history support. This gives it a chance to set its
+      // `cancelRouterSetup` property which aborts routing.
+      if (typeof location.detect === 'function') {
+        location.detect();
       }
 
       // ensure that initState is called AFTER the rootURL is set on

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -8,40 +8,10 @@ import AutoLocation from "ember-routing/location/auto_location";
 import EmberLocation from "ember-routing/location/api";
 import { supportsHistory, supportsHashChange } from "ember-routing/location/util";
 
-var AutoTestLocation, location;
-
-var FakeHistoryLocation = EmberObject.extend({
-  implementation: 'history'
-});
-
-var FakeHashLocation = EmberObject.extend({
-  implementation: 'hash'
-});
-
-var FakeNoneLocation = EmberObject.extend({
-  implementation: 'none'
-});
-
-function createLocation(options) {
-  if (!options) { options = {}; }
-
-  if ('history' in options) {
-    AutoTestLocation._getSupportsHistory = function() {
-      return options.history;
-    };
-  }
-
-  if ('hashChange' in options) {
-    AutoTestLocation._getSupportsHashChange = function() {
-      return options.hashChange;
-    };
-  }
-
-  location = AutoTestLocation.create(options);
-}
+var autoLocation;
 
 function mockBrowserLocation(overrides) {
-  AutoTestLocation._location = merge({
+  return merge({
     href: 'http://test.com/',
     pathname: '/',
     hash: '',
@@ -53,7 +23,7 @@ function mockBrowserLocation(overrides) {
 }
 
 function mockBrowserHistory(overrides) {
-  AutoTestLocation._history = merge({
+  return merge({
     pushState: function () {
       ok(false, 'history.pushState should not be called during testing');
     },
@@ -65,17 +35,12 @@ function mockBrowserHistory(overrides) {
 
 QUnit.module("Ember.AutoLocation", {
   setup: function() {
-    AutoTestLocation = copy(AutoLocation);
-
-    AutoTestLocation._HistoryLocation = FakeHistoryLocation;
-    AutoTestLocation._HashLocation = FakeHashLocation;
-    AutoTestLocation._NoneLocation = FakeNoneLocation;
+    autoLocation = AutoLocation.create();
   },
 
   teardown: function() {
     run(function() {
-      if (location && location.destroy) { location.destroy(); }
-      location = AutoTestLocation = null;
+      autoLocation.destroy();
     });
   }
 });

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -6,7 +6,7 @@ import copy from "ember-runtime/copy";
 import EmberObject from "ember-runtime/system/object";
 import AutoLocation from "ember-routing/location/auto_location";
 import EmberLocation from "ember-routing/location/api";
-import { supportsHistory, supportsHashChange } from "ember-routing/location/feature_detect";
+import { supportsHistory, supportsHashChange } from "ember-routing/location/util";
 
 var AutoTestLocation, location;
 

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -80,25 +80,6 @@ QUnit.module("Ember.AutoLocation", {
   }
 });
 
-QUnit.test("_replacePath cannot be used to redirect to a different origin (website)", function() {
-  expect(1);
-
-  var expectedURL;
-
-  mockBrowserLocation({
-    protocol: 'http:',
-    hostname: 'emberjs.com',
-    port: '1337',
-
-    replace: function (url) {
-      equal(url, expectedURL);
-    }
-  });
-
-  expectedURL = 'http://emberjs.com:1337//google.com';
-  AutoTestLocation._replacePath('//google.com');
-});
-
 QUnit.test("AutoLocation.create() should return a HistoryLocation instance when pushStates are supported", function() {
   expect(2);
 

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -1,14 +1,16 @@
 import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
-import environment from "ember-metal/environment";
 import merge from "ember-metal/merge";
-import copy from "ember-runtime/copy";
-import EmberObject from "ember-runtime/system/object";
 import AutoLocation from "ember-routing/location/auto_location";
-import EmberLocation from "ember-routing/location/api";
-import { supportsHistory, supportsHashChange } from "ember-routing/location/util";
+import {
+  getHistoryPath,
+  getHashPath
+} from "ember-routing/location/auto_location";
+import HistoryLocation from "ember-routing/location/history_location";
+import HashLocation from "ember-routing/location/hash_location";
+import NoneLocation from "ember-routing/location/none_location";
+import Registry from "container/registry";
 
-var autoLocation;
 
 function mockBrowserLocation(overrides) {
   return merge({
@@ -33,68 +35,72 @@ function mockBrowserHistory(overrides) {
   }, overrides);
 }
 
-QUnit.module("Ember.AutoLocation", {
-  setup: function() {
-    autoLocation = AutoLocation.create();
-  },
+function createLocation(location, history) {
+  var registry = new Registry();
 
+  registry.register('location:history', HistoryLocation);
+  registry.register('location:hash', HashLocation);
+  registry.register('location:none', NoneLocation);
+
+  return AutoLocation.create({
+    container: registry.container(),
+    location: location,
+    history: history,
+    global: {}
+  });
+}
+
+var location;
+
+QUnit.module("Ember.AutoLocation", {
   teardown: function() {
-    run(function() {
-      autoLocation.destroy();
-    });
+    if (location) {
+      run(location, 'destroy');
+    }
   }
 });
 
-QUnit.test("AutoLocation.create() should return a HistoryLocation instance when pushStates are supported", function() {
-  expect(2);
+QUnit.test("AutoLocation should use a HistoryLocation instance when pushStates is supported", function() {
+  expect(1);
 
-  mockBrowserLocation();
+  var browserLocation = mockBrowserLocation();
+  var browserHistory = mockBrowserHistory();
 
-  createLocation({
-    history: true,
-    hashChange: true
-  });
+  location = createLocation(browserLocation, browserHistory);
+  location.detect();
 
-  equal(get(location, 'implementation'), 'history');
-  equal(location instanceof FakeHistoryLocation, true);
+  ok(get(location, 'concreteImplementation') instanceof HistoryLocation);
 });
 
-QUnit.test("AutoLocation.create() should return a HashLocation instance when pushStates are not supported, but hashchange events are and the URL is already in the HashLocation format", function() {
-  expect(2);
+QUnit.test("AutoLocation should use a HashLocation instance when pushStates are not supported, but hashchange events are and the URL is already in the HashLocation format", function() {
+  expect(1);
 
-  mockBrowserLocation({
+  var browserLocation = mockBrowserLocation({
     hash: '#/testd'
   });
 
-  createLocation({
-    history: false,
-    hashChange: true
-  });
+  location = createLocation(browserLocation);
+  location.global = {
+    onhashchange: function() { }
+  };
 
-  equal(get(location, 'implementation'), 'hash');
-  equal(location instanceof FakeHashLocation, true);
+  location.detect();
+  ok(get(location, 'concreteImplementation') instanceof HashLocation);
 });
 
-QUnit.test("AutoLocation.create() should return a NoneLocation instance when neither history nor hashchange is supported.", function() {
-  expect(2);
+QUnit.test("AutoLocation should use a NoneLocation instance when neither history nor hashchange are supported.", function() {
+  expect(1);
 
-  mockBrowserLocation({
-    hash: '#/testd'
-  });
+  location = createLocation(mockBrowserLocation());
+  location.detect();
 
-  createLocation({
-    history: false,
-    hashChange: false
-  });
-
-  equal(get(location, 'implementation'), 'none');
-  equal(location instanceof FakeNoneLocation, true);
+  ok(get(location, 'concreteImplementation') instanceof NoneLocation);
 });
 
-QUnit.test("AutoLocation.create() should consider an index path (i.e. '/\') without any location.hash as OK for HashLocation", function() {
-  expect(2);
+QUnit.test("AutoLocation should use an index path (i.e. '/') without any location.hash as OK for HashLocation", function() {
+  expect(1);
 
-  mockBrowserLocation({
+  var browserLocation = mockBrowserLocation({
     href: 'http://test.com/',
     pathname: '/',
     hash: '',
@@ -104,27 +110,20 @@ QUnit.test("AutoLocation.create() should consider an index path (i.e. '/\') with
     }
   });
 
-  createLocation({
-    history: false,
-    hashChange: true
-  });
+  location = createLocation(browserLocation);
+  location.global = {
+    onhashchange: function() { }
+  };
 
-  equal(get(location, 'implementation'), 'hash');
-  equal(location instanceof FakeHashLocation, true);
+  location.detect();
+
+  ok(get(location, 'concreteImplementation') instanceof HashLocation, "uses a HashLocation");
 });
 
-QUnit.test("Feature-detecting the history API", function() {
-  equal(supportsHistory("", { pushState: true }), true, "returns true if not Android Gingerbread and history.pushState exists");
-  equal(supportsHistory("", {}), false, "returns false if history.pushState doesn't exist");
-  equal(supportsHistory("", undefined), false, "returns false if history doesn't exist");
-  equal(supportsHistory("Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1", { pushState: true }),
-                        false, "returns false if Android Gingerbread stock browser claiming to support pushState");
-});
+QUnit.test("AutoLocation should transform the URL for hashchange-only browsers viewing a HistoryLocation-formatted path", function() {
+  expect(3);
 
-QUnit.test("AutoLocation.create() should transform the URL for hashchange-only browsers viewing a HistoryLocation-formatted path", function() {
-  expect(4);
-
-  mockBrowserLocation({
+  var browserLocation = mockBrowserLocation({
     hash: '',
     hostname: 'test.com',
     href: 'http://test.com/test',
@@ -138,20 +137,21 @@ QUnit.test("AutoLocation.create() should transform the URL for hashchange-only b
     }
   });
 
-  createLocation({
-    history: false,
-    hashChange: true
-  });
+  var location = createLocation(browserLocation);
+  location.global = {
+    onhashchange: function() { }
+  };
 
-  equal(get(location, 'implementation'), 'none', 'NoneLocation should be returned while we attempt to location.replace()');
-  equal(location instanceof FakeNoneLocation, true, 'NoneLocation should be returned while we attempt to location.replace()');
+  location.detect();
+
+  ok(get(location, 'concreteImplementation') instanceof NoneLocation, 'NoneLocation should be used while we attempt to location.replace()');
   equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
 });
 
-QUnit.test("AutoLocation.create() should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
+QUnit.test("AutoLocation should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
   expect(2);
 
-  mockBrowserLocation({
+  var browserLocation = mockBrowserLocation({
     hash: '#/test',
     hostname: 'test.com',
     href: 'http://test.com/#/test',
@@ -161,155 +161,95 @@ QUnit.test("AutoLocation.create() should replace the URL for pushState-supported
     search: ''
   });
 
-  mockBrowserHistory({
+  var browserHistory = mockBrowserHistory({
     replaceState: function (state, title, path) {
       equal(path, '/test', 'history.replaceState should be called with normalized HistoryLocation url');
     }
   });
 
-  createLocation({
-    history: true,
-    hashChange: true
-  });
+  var location = createLocation(browserLocation, browserHistory);
+  location.detect();
 
-  equal(get(location, 'implementation'), 'history');
+  ok(get(location, 'concreteImplementation'), HistoryLocation);
 });
 
-QUnit.test("Feature-Detecting onhashchange", function() {
-  mockBrowserLocation();
-
-  equal(supportsHashChange(undefined, { onhashchange: function() {} }), true, "When not in IE, use onhashchange existence as evidence of the feature");
-  equal(supportsHashChange(undefined, { }), false, "When not in IE, use onhashchange absence as evidence of the feature absence");
-  equal(supportsHashChange(7, { onhashchange: function() {} }), false, "When in IE7 compatibility mode, never report existence of the feature");
-  equal(supportsHashChange(8, { onhashchange: function() {} }), true, "When in IE8+, use onhashchange existence as evidence of the feature");
-});
-
-QUnit.test("AutoLocation._getPath() should normalize location.pathname, making sure it always returns a leading slash", function() {
-  expect(2);
-
-  mockBrowserLocation({ pathname: 'test' });
-  equal(AutoTestLocation._getPath(), '/test', 'When there is no leading slash, one is added.');
-
-  mockBrowserLocation({ pathname: '/test' });
-  equal(AutoTestLocation._getPath(), '/test', 'When a leading slash is already there, it isn\'t added again');
-});
-
-QUnit.test("AutoLocation._getHash() should be an alias to Ember.Location._getHash, otherwise it needs its own test!", function() {
-  expect(1);
-
-  equal(AutoTestLocation._getHash, EmberLocation._getHash);
-});
-
-QUnit.test("AutoLocation._getQuery() should return location.search as-is", function() {
-  expect(1);
-
-  mockBrowserLocation({ search: '?foo=bar' });
-  equal(AutoTestLocation._getQuery(), '?foo=bar');
-});
-
-QUnit.test("AutoLocation._getFullPath() should return full pathname including query and hash", function() {
-  expect(1);
-
-  mockBrowserLocation({
-    href: 'http://test.com/about?foo=bar#foo',
-    pathname: '/about',
-    search: '?foo=bar',
-    hash: '#foo'
-  });
-
-  equal(AutoTestLocation._getFullPath(), '/about?foo=bar#foo');
-});
-
-QUnit.test("AutoLocation._getHistoryPath() should return a normalized, HistoryLocation-supported path", function() {
+QUnit.test("AutoLocation requires any rootURL given to end in a trailing forward slash", function() {
   expect(3);
-
-  AutoTestLocation.rootURL = '/app/';
-
-  mockBrowserLocation({
-    href: 'http://test.com/app/about?foo=bar#foo',
-    pathname: '/app/about',
-    search: '?foo=bar',
-    hash: '#foo'
-  });
-  equal(AutoTestLocation._getHistoryPath(), '/app/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
-
-  mockBrowserLocation({
-    href: 'http://test.com/app/#/about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#/about?foo=bar#foo'
-  });
-  equal(AutoTestLocation._getHistoryPath(), '/app/about?foo=bar#foo', 'HashLocation formed URLs should be normalized');
-
-  mockBrowserLocation({
-    href: 'http://test.com/app/#about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#about?foo=bar#foo'
-  });
-  equal(AutoTestLocation._getHistoryPath(), '/app/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
-});
-
-QUnit.test("AutoLocation._getHashPath() should return a normalized, HashLocation-supported path", function() {
-  expect(3);
-
-  AutoTestLocation.rootURL = '/app/';
-
-  mockBrowserLocation({
-    href: 'http://test.com/app/#/about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#/about?foo=bar#foo'
-  });
-  equal(AutoTestLocation._getHashPath(), '/app/#/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
-
-  mockBrowserLocation({
-    href: 'http://test.com/app/about?foo=bar#foo',
-    pathname: '/app/about',
-    search: '?foo=bar',
-    hash: '#foo'
-  });
-  equal(AutoTestLocation._getHashPath(), '/app/#/about?foo=bar#foo', 'HistoryLocation formed URLs should be normalized');
-
-  mockBrowserLocation({
-    href: 'http://test.com/app/#about?foo=bar#foo',
-    pathname: '/app/',
-    search: '',
-    hash: '#about?foo=bar#foo'
-  });
-
-  equal(AutoTestLocation._getHashPath(), '/app/#/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
-});
-
-QUnit.test("AutoLocation.create requires any rootURL given to end in a trailing forward slash", function() {
-  expect(3);
-  mockBrowserLocation();
-
+  var browserLocation = mockBrowserLocation();
   var expectedMsg = /rootURL must end with a trailing forward slash e.g. "\/app\/"/;
 
-  expectAssertion(function() {
-    createLocation({ rootURL: 'app' });
-  }, expectedMsg);
+  location = createLocation(browserLocation);
+  location.rootURL = 'app';
 
   expectAssertion(function() {
-    createLocation({ rootURL: '/app' });
+    location.detect();
   }, expectedMsg);
 
+  location.rootURL = '/app';
   expectAssertion(function() {
-    // Note the trailing whitespace
-    createLocation({ rootURL: '/app/ ' });
+    location.detect();
+  }, expectedMsg);
+
+  // Note the trailing whitespace
+  location.rootURL = '/app/ ';
+  expectAssertion(function() {
+    location.detect();
   }, expectedMsg);
 });
 
-/*
- These next two reference check tests are needed to ensure window.location/history
- are always kept, since we can't actually test them directly and we mock them
- both in all the tests above. Without these two, #9958 could happen again.
- */
-QUnit.test("AutoLocation has valid references to window.location and window.history via environment", function() {
-  expect(2);
+QUnit.test("getHistoryPath() should return a normalized, HistoryLocation-supported path", function() {
+  expect(3);
 
-  equal(AutoTestLocation._location, environment.location, 'AutoLocation._location === environment.location');
-  equal(AutoTestLocation._history, environment.history, 'AutoLocation._history === environment.history');
+  var browserLocation = mockBrowserLocation({
+    href: 'http://test.com/app/about?foo=bar#foo',
+    pathname: '/app/about',
+    search: '?foo=bar',
+    hash: '#foo'
+  });
+
+  equal(getHistoryPath('/app/', browserLocation), '/app/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
+
+  browserLocation = mockBrowserLocation({
+    href: 'http://test.com/app/#/about?foo=bar#foo',
+    pathname: '/app/',
+    search: '',
+    hash: '#/about?foo=bar#foo'
+  });
+  equal(getHistoryPath('/app/', browserLocation), '/app/about?foo=bar#foo', 'HashLocation formed URLs should be normalized');
+
+  browserLocation = mockBrowserLocation({
+    href: 'http://test.com/app/#about?foo=bar#foo',
+    pathname: '/app/',
+    search: '',
+    hash: '#about?foo=bar#foo'
+  });
+  equal(getHistoryPath('/app', browserLocation), '/app/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
 });
 
+QUnit.test("getHashPath() should return a normalized, HashLocation-supported path", function() { expect(3);
+
+  var browserLocation = mockBrowserLocation({
+    href: 'http://test.com/app/#/about?foo=bar#foo',
+    pathname: '/app/',
+    search: '',
+    hash: '#/about?foo=bar#foo'
+  });
+  equal(getHashPath('/app/', browserLocation), '/app/#/about?foo=bar#foo', 'URLs already in HistoryLocation form should come out the same');
+
+  browserLocation = mockBrowserLocation({
+    href: 'http://test.com/app/about?foo=bar#foo',
+    pathname: '/app/about',
+    search: '?foo=bar',
+    hash: '#foo'
+  });
+  equal(getHashPath('/app/', browserLocation), '/app/#/about?foo=bar#foo', 'HistoryLocation formed URLs should be normalized');
+
+  browserLocation = mockBrowserLocation({
+    href: 'http://test.com/app/#about?foo=bar#foo',
+    pathname: '/app/',
+    search: '',
+    hash: '#about?foo=bar#foo'
+  });
+
+  equal(getHashPath('/app/', browserLocation), '/app/#/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
+});

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -226,7 +226,8 @@ QUnit.test("getHistoryPath() should return a normalized, HistoryLocation-support
   equal(getHistoryPath('/app', browserLocation), '/app/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
 });
 
-QUnit.test("getHashPath() should return a normalized, HashLocation-supported path", function() { expect(3);
+QUnit.test("getHashPath() should return a normalized, HashLocation-supported path", function() {
+  expect(3);
 
   var browserLocation = mockBrowserLocation({
     href: 'http://test.com/app/#/about?foo=bar#foo',

--- a/packages/ember-routing/tests/location/util_test.js
+++ b/packages/ember-routing/tests/location/util_test.js
@@ -1,0 +1,22 @@
+import { replacePath } from "ember-routing/location/util";
+
+QUnit.module("Location Utilities");
+
+test("replacePath cannot be used to redirect to a different origin", function() {
+  expect(1);
+
+  var expectedURL;
+
+  var location = {
+    protocol: 'http:',
+    hostname: 'emberjs.com',
+    port: '1337',
+
+    replace: function (url) {
+      equal(url, expectedURL);
+    }
+  };
+
+  expectedURL = 'http://emberjs.com:1337//google.com';
+  replacePath(location, '//google.com');
+});

--- a/packages/ember-routing/tests/location/util_test.js
+++ b/packages/ember-routing/tests/location/util_test.js
@@ -1,4 +1,26 @@
-import { replacePath } from "ember-routing/location/util";
+import merge from "ember-metal/merge";
+import {
+  replacePath,
+  getPath,
+  getQuery,
+  getFullPath
+} from "ember-routing/location/util";
+import {
+  supportsHistory,
+  supportsHashChange
+} from "ember-routing/location/util";
+
+function mockBrowserLocation(overrides) {
+  return merge({
+    href: 'http://test.com/',
+    pathname: '/',
+    hash: '',
+    search: '',
+    replace: function () {
+      ok(false, 'location.replace should not be called during testing');
+    }
+  }, overrides);
+}
 
 QUnit.module("Location Utilities");
 
@@ -20,3 +42,49 @@ test("replacePath cannot be used to redirect to a different origin", function() 
   expectedURL = 'http://emberjs.com:1337//google.com';
   replacePath(location, '//google.com');
 });
+
+test("getPath() should normalize location.pathname, making sure it always returns a leading slash", function() {
+  expect(2);
+
+  var location = mockBrowserLocation({ pathname: 'test' });
+  equal(getPath(location), '/test', 'When there is no leading slash, one is added.');
+
+  location = mockBrowserLocation({ pathname: '/test' });
+  equal(getPath(location), '/test', 'When a leading slash is already there, it isn\'t added again');
+});
+
+test("getQuery() should return location.search as-is", function() {
+  expect(1);
+
+  var location = mockBrowserLocation({ search: '?foo=bar' });
+  equal(getQuery(location), '?foo=bar');
+});
+
+test("getFullPath() should return full pathname including query and hash", function() {
+  expect(1);
+
+  var location = mockBrowserLocation({
+    href: 'http://test.com/about?foo=bar#foo',
+    pathname: '/about',
+    search: '?foo=bar',
+    hash: '#foo'
+  });
+
+  equal(getFullPath(location), '/about?foo=bar#foo');
+});
+
+test("Feature-Detecting onhashchange", function() {
+  equal(supportsHashChange(undefined, { onhashchange: function() {} }), true, "When not in IE, use onhashchange existence as evidence of the feature");
+  equal(supportsHashChange(undefined, { }), false, "When not in IE, use onhashchange absence as evidence of the feature absence");
+  equal(supportsHashChange(7, { onhashchange: function() {} }), false, "When in IE7 compatibility mode, never report existence of the feature");
+  equal(supportsHashChange(8, { onhashchange: function() {} }), true, "When in IE8+, use onhashchange existence as evidence of the feature");
+});
+
+test("Feature-detecting the history API", function() {
+  equal(supportsHistory("", { pushState: true }), true, "returns true if not Android Gingerbread and history.pushState exists");
+  equal(supportsHistory("", {}), false, "returns false if history.pushState doesn't exist");
+  equal(supportsHistory("", undefined), false, "returns false if history doesn't exist");
+  equal(supportsHistory("Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1", { pushState: true }),
+                        false, "returns false if Android Gingerbread stock browser claiming to support pushState");
+});
+

--- a/packages/ember-routing/tests/location/util_test.js
+++ b/packages/ember-routing/tests/location/util_test.js
@@ -24,7 +24,7 @@ function mockBrowserLocation(overrides) {
 
 QUnit.module("Location Utilities");
 
-test("replacePath cannot be used to redirect to a different origin", function() {
+QUnit.test("replacePath cannot be used to redirect to a different origin", function() {
   expect(1);
 
   var expectedURL;
@@ -43,7 +43,7 @@ test("replacePath cannot be used to redirect to a different origin", function() 
   replacePath(location, '//google.com');
 });
 
-test("getPath() should normalize location.pathname, making sure it always returns a leading slash", function() {
+QUnit.test("getPath() should normalize location.pathname, making sure it always returns a leading slash", function() {
   expect(2);
 
   var location = mockBrowserLocation({ pathname: 'test' });
@@ -53,14 +53,14 @@ test("getPath() should normalize location.pathname, making sure it always return
   equal(getPath(location), '/test', 'When a leading slash is already there, it isn\'t added again');
 });
 
-test("getQuery() should return location.search as-is", function() {
+QUnit.test("getQuery() should return location.search as-is", function() {
   expect(1);
 
   var location = mockBrowserLocation({ search: '?foo=bar' });
   equal(getQuery(location), '?foo=bar');
 });
 
-test("getFullPath() should return full pathname including query and hash", function() {
+QUnit.test("getFullPath() should return full pathname including query and hash", function() {
   expect(1);
 
   var location = mockBrowserLocation({
@@ -73,14 +73,14 @@ test("getFullPath() should return full pathname including query and hash", funct
   equal(getFullPath(location), '/about?foo=bar#foo');
 });
 
-test("Feature-Detecting onhashchange", function() {
+QUnit.test("Feature-Detecting onhashchange", function() {
   equal(supportsHashChange(undefined, { onhashchange: function() {} }), true, "When not in IE, use onhashchange existence as evidence of the feature");
   equal(supportsHashChange(undefined, { }), false, "When not in IE, use onhashchange absence as evidence of the feature absence");
   equal(supportsHashChange(7, { onhashchange: function() {} }), false, "When in IE7 compatibility mode, never report existence of the feature");
   equal(supportsHashChange(8, { onhashchange: function() {} }), true, "When in IE8+, use onhashchange existence as evidence of the feature");
 });
 
-test("Feature-detecting the history API", function() {
+QUnit.test("Feature-detecting the history API", function() {
   equal(supportsHistory("", { pushState: true }), true, "returns true if not Android Gingerbread and history.pushState exists");
   equal(supportsHistory("", {}), false, "returns false if history.pushState doesn't exist");
   equal(supportsHistory("", undefined), false, "returns false if history doesn't exist");

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -153,7 +153,7 @@ QUnit.test("AutoLocation should replace the url when it's not in the preferred f
     search: '',
     replace: function(url) {
       equal(url, 'http://test.com/rootdir/#/welcome');
-    },
+    }
   };
   location.history = null;
   location.global = {


### PR DESCRIPTION
**TL;DR** use delegate pattern for autolocation instead of choosing a concrete implementation and returning it from a fake `create()`

Previously, AutoLocation worked by faking out a `create()` method and returning a concrete implementation of either HistoryLocation or AutoLocation.

This was bad for a few reasons. First, messing with `create()` or `extend()` semantics makes it hard for people to reason about behavior. The fact that `AutoLocation.create() instanceof AutoLocation` evaluates to `false` breaks a lot of assumed invariants people have.

Second, it meant that any state needed to pass to the concrete implementation needed to be available at create time, which has forced us to write less-than-elegant code during our app instance refactor for FastBoot.

For example, you cannot say:

``` js
var location = this.container.lookup('location:auto');
location.rootURL = '/foo/';
```

Any state that needs to be set _must_ be set at create time, leading to hard-to-reason-about hacks like setting simple properties via an injection to guarantee it's available at creation time (since `lookup` doesn't take arguments). See https://github.com/emberjs/ember.js/blob/48e115928bcb6b366a621370339354c44aad86b1/packages/ember-routing/lib/system/router.js#L347-L351 for a taste of the madness.

Lastly, concrete implementations are instantiated directly via calls to `create()` rather than going through the container, meaning that `container` does not get set, nor would any registered injections actually get injected.

This commit refactors the entire class, making it a standard Ember.Object, and uses a simple delegate pattern to delegate any calls from the router onto a concrete implementation chosen at runtime.

Because the concrete implementation is not determined until runtime, state can be set on the location at any time until the concrete implementation is accessed, which should allow us to remove some of the contortions we have to do in the current router code.

Note that this commit does not provide passing tests, as all of the current tests are hardcoded to assume the concrete-implementation-at-create-time semantics.

I wanted to submit the PR early to verify that this seems like a reasonable approach to people, and to get many eyes on it as soon as possible as this is a large refactor of a critical part of the system. However, I believe the cleanup here will have cascading cleanup effects throughout the system, and that's always a good thing.
