### PR TITLE
Documentation to clarify renderTemplate

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1656,6 +1656,25 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     });
     ```
 
+    If the PostsRoute is a resource, it is important to keep in mind
+    that this would only work for the PostsRoute, and not for the
+    PostsIndexRoute. The posts/index.hbs has no children routes, and
+    thus there is no `{{outlet}}` for the posts/index template.
+    Here of an example that **would not** work:
+
+    ```javascript
+    App.PostsIndexRoute = Ember.Route.extend({
+      renderTemplate: function(controller, model) {
+        this.render('posts/index', { controller: 'posts/index' } );
+
+        this.render('favoritePost', {
+          into: 'posts/index',
+          outlet: 'favorite-post',
+        });
+      }
+    });
+    ```
+
     @method renderTemplate
     @param {Object} controller the route's controller
     @param {Object} model the route's model


### PR DESCRIPTION
Added documentation to clarify the `renderTemplate` hook on a route. 

Although it was probably stated elsewhere in the docs that PostsIndexRoute has no children routes, and thus there is no `{{outlet}}` for the posts/index.hbs, I believe this should be here to help clarify when people begin implementing `renderTemplate` so that they don't get stuck trying to figure out why it doesn't work. 
