### PR TITLE
Use run loop for updating component helper's component 

### DIFF
--- a/packages/ember-views/lib/views/bound_component_view.js
+++ b/packages/ember-views/lib/views/bound_component_view.js
@@ -9,6 +9,7 @@ import { readComponentFactory } from "ember-views/streams/utils";
 import mergeViewBindings from "ember-htmlbars/system/merge-view-bindings";
 import EmberError from "ember-metal/error";
 import ContainerView from "ember-views/views/container_view";
+import run from "ember-metal/run_loop";
 
 export default ContainerView.extend(_Metamorph, {
   init: function() {
@@ -19,12 +20,15 @@ export default ContainerView.extend(_Metamorph, {
       return readComponentFactory(componentNameStream, container);
     });
 
-    subscribe(this.componentClassStream, this._updateBoundChildComponent, this);
+    subscribe(this.componentClassStream, this._scheduleBoundChildComponentUpdate, this);
     this._updateBoundChildComponent();
   },
   willDestroy: function() {
-    unsubscribe(this.componentClassStream, this._updateBoundChildComponent, this);
+    unsubscribe(this.componentClassStream, this._scheduleBoundChildComponentUpdate, this);
     this._super.apply(this, arguments);
+  },
+  _scheduleBoundChildComponentUpdate: function() {
+    run.schedule('actions', this, '_updateBoundChildComponent');
   },
   _updateBoundChildComponent: function() {
     this.replace(0, 1, [this._createNewComponent()]);


### PR DESCRIPTION
This commit addresses a failing test prepared by @bagby. The test illustrates a race between streams where one stream triggers the component helper to create a new component instance, and the other stream updates a binding provided to that component helper.

The solution in this PR is to schedule the component helper's "swap" on the run loop, so that by the time it executes, other bound streams to catch up before rendering a new component.

Would love input from @mmun, @krisselden and/or @mixonic, and also confirmation from @bagby that this addresses your real-world scenario.
