### PR TITLE
Introduce an ApplicationInstance-specific registry to Boot Cleanup WIP

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -270,8 +270,8 @@ function injectionsFor(container, fullName) {
   var type = splitName[0];
 
   var injections = buildInjections(container,
-                                   registry.typeInjections[type],
-                                   registry.injections[fullName]);
+                                   registry.getTypeInjections(type),
+                                   registry.getInjections(fullName));
   injections._debugContainerKey = fullName;
   injections.container = container;
 
@@ -284,8 +284,8 @@ function factoryInjectionsFor(container, fullName) {
   var type = splitName[0];
 
   var factoryInjections = buildInjections(container,
-                                          registry.factoryTypeInjections[type],
-                                          registry.factoryInjections[fullName]);
+                                          registry.getFactoryTypeInjections(type),
+                                          registry.getFactoryInjections(fullName));
   factoryInjections._debugContainerKey = fullName;
 
   return factoryInjections;

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -318,7 +318,7 @@ var Application = Namespace.extend(DeferredMixin, {
     return ApplicationInstance.create({
       customEvents: get(this, 'customEvents'),
       rootElement: get(this, 'rootElement'),
-      registry: this.registry
+      applicationRegistry: this.registry
     });
   },
 

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -161,10 +161,6 @@ export default EmberObject.extend({
     var resolveMethodName = parsedName.resolveMethodName;
     var resolved;
 
-    if (!(parsedName.name && parsedName.type)) {
-      throw new TypeError('Invalid fullName: `' + fullName + '`, must be of the form `type:name` ');
-    }
-
     if (this[resolveMethodName]) {
       resolved = this[resolveMethodName](parsedName);
     }
@@ -214,6 +210,10 @@ export default EmberObject.extend({
     }
 
     var resolveMethodName = fullNameWithoutType === 'main' ? 'Main' : classify(type);
+
+    if (!(name && type)) {
+      throw new TypeError('Invalid fullName: `' + fullName + '`, must be of the form `type:name` ');
+    }
 
     return {
       fullName: fullName,

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -11,7 +11,7 @@ import {
 
 var registry, locator, application, originalLookup, originalLoggerInfo;
 
-QUnit.module("Ember.Application Depedency Injection", {
+QUnit.module("Ember.Application Dependency Injection - default resolver", {
   setup: function() {
     originalLookup = Ember.lookup;
     application = run(Application, 'create');


### PR DESCRIPTION
The ApplicationInstance-specific registry uses its corresponding Application's registry as a failover to resolve registrations and injections.

Soon, this registry will be abstracted behind proxies such as `register` and `inject` on the instance itself.

cc @wycats @tomdale 
