### PR TITLE
Register default container on fallback registry.

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -143,14 +143,29 @@ Registry.prototype = {
   container: function(options) {
     var container = new Container(this, options);
 
-    // Allow deprecated access to the first child container's `lookup` and
-    // `lookupFactory` methods to avoid breaking compatibility for Ember 1.x
-    // initializers.
+    // 2.0TODO - remove `registerContainer`
+    this.registerContainer(container);
+
+    return container;
+  },
+
+  /**
+   Register the first container created for a registery to allow deprecated
+   access to its `lookup` and `lookupFactory` methods to avoid breaking
+   compatibility for Ember 1.x initializers.
+
+   2.0TODO: Remove this method. The bookkeeping is only needed to support
+            deprecated behavior.
+
+   @param {Container} newly created container
+   */
+  registerContainer: function(container) {
     if (!this._defaultContainer) {
       this._defaultContainer = container;
     }
-
-    return container;
+    if (this.fallback) {
+      this.fallback.registerContainer(container);
+    }
   },
 
   lookup: function(fullName, options) {


### PR DESCRIPTION
This ensures that all registries will have a reference to the first
container created that references them.

This ensures that deprecated access to `lookup` and `lookupFactory`
on the registry will be proxied to the first container created for a
registry. This avoids breaking compatibility with Ember 1.x
initializers.

[Fixes #10313]
