### PR TITLE
[FEATURE] ember-testing-checkbox-helpers

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -89,9 +89,13 @@ function check(app, selector, context) {
   Ember.assert('To check \'' + selector +
       '\', the input must be a checkbox', type === 'checkbox');
 
-  if (!$el.prop('checked')) {
-    app.testHelpers.click(selector, context);
-  }
+  Ember.assert('Expected \'' + selector +
+      '\'to be unchecked before click, but was checked', !$el.prop('checked'));
+
+  app.testHelpers.click(selector, context);
+
+  Ember.assert('Expected \'' + selector +
+      '\'to be checked after click, but was unchecked', $el.prop('checked'));
 
   return app.testHelpers.wait();
 }
@@ -102,10 +106,13 @@ function uncheck(app, selector, context) {
 
   Ember.assert('To uncheck \'' + selector +
       '\', the input must be a checkbox', type === 'checkbox');
+  Ember.assert('Expected \'' + selector +
+      '\'to be checked before click, but was unchecked', $el.prop('checked'));
 
-  if ($el.prop('checked')) {
-    app.testHelpers.click(selector, context);
-  }
+  app.testHelpers.click(selector, context);
+
+  Ember.assert('Expected \'' + selector +
+      '\'to be unchecked after click, but was checked', !$el.prop('checked'));
 
   return app.testHelpers.wait();
 }


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/10287#issuecomment-72258163

> We did reach consensus that we would like the check() and uncheck()
> helpers to be a combination of setting the value and asserting it
> becomes a specific value. In the case of check():
> 
> Before mutating the value, assert that the checkbox is unchecked.
> Simulate a click event on the checkbox.
> Assert that the checkbox has been checked (to catch, for example,
> the disabled case).
>  -- tomdale
