### PR TITLE
Remove `meta.descs`

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -6,7 +6,7 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import { get } from "ember-metal/property_get";
 import EmberError from "ember-metal/error";
-import { inspect, meta } from "ember-metal/utils";
+import { inspect } from "ember-metal/utils";
 import { computed } from "ember-metal/computed";
 import ControllerMixin from "ember-runtime/mixins/controller";
 import controllerFor from "ember-routing/system/controller_for";
@@ -131,7 +131,7 @@ ControllerMixin.reopen({
       Ember.assert(' `' + inspect(this) + ' specifies `needs`, but does ' +
                    "not have a container. Please ensure this controller was " +
                    "instantiated with a container.",
-                   this.container || meta(this, false).descs.controllers !== defaultControllersComputedProperty);
+                   this.container || this.controllers !== defaultControllersComputedProperty);
 
       if (this.container) {
         verifyNeedsDependencies(this, this.container, needs);

--- a/packages/ember-htmlbars/lib/system/append-templated-view.js
+++ b/packages/ember-htmlbars/lib/system/append-templated-view.js
@@ -22,7 +22,10 @@ export default function appendTemplatedView(parentView, morph, viewClassOrInstan
 
   // We only want to override the `_context` computed property if there is
   // no specified controller. See View#_context for more information.
-  if (!viewProto.controller &&
+
+  var noControllerInProto = !viewProto.controller;
+  if (viewProto.controller.isDescriptor) { noControllerInProto = true; }
+  if (noControllerInProto &&
       !viewProto.controllerBinding &&
       !props.controller &&
       !props.controllerBinding) {

--- a/packages/ember-metal/lib/alias.js
+++ b/packages/ember-metal/lib/alias.js
@@ -22,6 +22,7 @@ export default function alias(altKey) {
 }
 
 export function AliasedProperty(altKey) {
+  this.isDescriptor = true;
   this.altKey = altKey;
   this._dependentKeys = [altKey];
 }

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -119,7 +119,8 @@ function lazyGet(obj, key) {
   }
 
   // if a CP only return cached value
-  var desc = meta && meta.descs[key];
+  var possibleDesc = obj[key];
+  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
   if (desc && desc._cacheable) {
     if (key in meta.cache) {
       return meta.cache[key];

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -113,6 +113,7 @@ function UNDEFINED() { }
   @constructor
 */
 function ComputedProperty(config, opts) {
+  this.isDescriptor = true;
   if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
     if (typeof config === "function") {
       config.__ember_arity = config.length;

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -3,7 +3,6 @@ import { ComputedProperty } from "ember-metal/computed";
 import { AliasedProperty } from "ember-metal/alias";
 import { Descriptor } from "ember-metal/properties";
 import create from "ember-metal/platform/create";
-import { meta } from "ember-metal/utils";
 
 /**
   Read-only property that returns the result of a container lookup.
@@ -25,7 +24,8 @@ function InjectedProperty(type, name) {
 }
 
 function injectedPropertyGet(keyName) {
-  var desc = meta(this).descs[keyName];
+  var possibleDesc = this[keyName];
+  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
   Ember.assert("Attempting to lookup an injected property on an object " +
                "without a container, ensure that the object was " +

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -35,7 +35,8 @@ function propertyWillChange(obj, keyName) {
   var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
-  var desc = m && m.descs[keyName];
+  var possibleDesc = obj[keyName];
+  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
   if (!watching) {
     return;
@@ -73,7 +74,8 @@ function propertyDidChange(obj, keyName) {
   var m = obj['__ember_meta__'];
   var watching = (m && m.watching[keyName] > 0) || keyName === 'length';
   var proto = m && m.proto;
-  var desc = m && m.descs[keyName];
+  var possibleDesc = obj[keyName];
+  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
   if (proto === obj) {
     return;
@@ -150,7 +152,7 @@ function keysOf(obj) {
 }
 
 function iterDeps(method, obj, deps, depKey, seen, meta) {
-  var keys, key, i, desc;
+  var keys, key, i, possibleDesc, desc;
   var guid = guidFor(obj);
   var current = seen[guid];
 
@@ -166,10 +168,10 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
 
   if (deps) {
     keys = keysOf(deps);
-    var descs = meta.descs;
     for (i=0; i<keys.length; i++) {
       key = keys[i];
-      desc = descs[key];
+      possibleDesc = obj[key];
+      desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
 
       if (desc && desc._suspended === obj) {
         continue;

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -68,7 +68,8 @@ export function get(obj, keyName) {
   }
 
   var meta = obj['__ember_meta__'];
-  var desc = meta && meta.descs[keyName];
+  var possibleDesc = obj[keyName];
+  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
   var ret;
 
   if (desc === undefined && isPath(keyName)) {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -41,7 +41,9 @@ export function set(obj, keyName, value, tolerant) {
   }
 
   var meta = obj['__ember_meta__'];
-  var desc = meta && meta.descs[keyName];
+  var possibleDesc = obj[keyName];
+  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
+
   var isUnknown, currentValue;
 
   if (desc === undefined && isPath(keyName)) {
@@ -51,7 +53,7 @@ export function set(obj, keyName, value, tolerant) {
   Ember.assert("You need to provide an object and key to `set`.", !!obj && keyName !== undefined);
   Ember.assert('calling set on destroyed object', !obj.isDestroyed);
 
-  if (desc !== undefined) {
+  if (desc) {
     desc.set(obj, keyName, value);
   } else {
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -288,7 +288,6 @@ export function guidFor(obj) {
 // META
 //
 function Meta(obj) {
-  this.descs = {};
   this.watching = {};
   this.cache = {};
   this.cacheMeta = {};
@@ -303,7 +302,7 @@ function Meta(obj) {
 }
 
 Meta.prototype = {
-  chainWatchers: null
+  chainWatchers: null // FIXME
 };
 
 if (!canDefineNonEnumerableProperties) {
@@ -346,7 +345,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   @return {Object} the meta hash for an object
 */
 function meta(obj, writable) {
-  var ret = obj['__ember_meta__'];
+  var ret = obj.__ember_meta__;
   if (writable===false) {
     return ret || EMPTY_META;
   }
@@ -368,11 +367,7 @@ function meta(obj, writable) {
       }
     }
 
-    obj['__ember_meta__'] = ret;
-
-    // make sure we don't accidentally try to create constructor like desc
-    ret.descs.constructor = null;
-
+    obj.__ember_meta__ = ret;
   } else if (ret.source !== obj) {
     if (obj.__defineNonEnumerable) {
       obj.__defineNonEnumerable(EMBER_META_PROPERTY);
@@ -381,7 +376,6 @@ function meta(obj, writable) {
     }
 
     ret = o_create(ret);
-    ret.descs     = o_create(ret.descs);
     ret.watching  = o_create(ret.watching);
     ret.cache     = {};
     ret.cacheMeta = {};

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -23,7 +23,8 @@ export function watchKey(obj, keyName, meta) {
   if (!watching[keyName]) {
     watching[keyName] = 1;
 
-    var desc = m.descs[keyName];
+    var possibleDesc = obj[keyName];
+    var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
     if (desc && desc.willWatch) { desc.willWatch(obj, keyName); }
 
     if ('function' === typeof obj.willWatchProperty) {
@@ -47,6 +48,10 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
     var configurable = descriptor ? descriptor.configurable : true;
     var isWritable = descriptor ? descriptor.writable : true;
     var hasValue = descriptor ? 'value' in descriptor : true;
+    var possibleDesc = descriptor && descriptor.value;
+    var isDescriptor = possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor;
+
+    if (isDescriptor) { return; }
 
     // this x in Y deopts, so keeping it in this function is better;
     if (configurable && isWritable && hasValue && keyName in obj) {
@@ -68,7 +73,8 @@ export function unwatchKey(obj, keyName, meta) {
   if (watching[keyName] === 1) {
     watching[keyName] = 0;
 
-    var desc = m.descs[keyName];
+    var possibleDesc = obj[keyName];
+    var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
     if (desc && desc.didUnwatch) { desc.didUnwatch(obj, keyName); }
 
     if ('function' === typeof obj.didUnwatchProperty) {
@@ -76,7 +82,7 @@ export function unwatchKey(obj, keyName, meta) {
     }
 
     if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-      if (hasPropertyAccessors && keyName in obj) {
+      if (!desc && hasPropertyAccessors && keyName in obj) {
         o_defineProperty(obj, keyName, {
           configurable: true,
           enumerable: Object.prototype.propertyIsEnumerable.call(obj, keyName),

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -35,7 +35,6 @@ import {
 } from "ember-metal/properties";
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import { meta } from 'ember-metal/utils';
 import { isWatching } from "ember-metal/watching";
 import {
   addObserver,
@@ -861,7 +860,7 @@ testBoth("when setting a value on a computed property that doesn't handle sets",
   set(obj, 'foo', 'bar');
 
   equal(get(obj, 'foo'), 'bar', 'The set value is properly returned');
-  ok(!meta(obj).descs.foo, 'The computed property was removed');
+  ok(typeof obj.foo === 'string', 'The computed property was removed');
   ok(observerFired, 'The observer was still notified');
 });
 

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -1,6 +1,5 @@
 import Ember from "ember-metal/core"; // Ember.assert
 import { indexOf } from "ember-metal/enumerable_utils";
-import { meta } from "ember-metal/utils";
 import InjectedProperty from "ember-metal/injected_property";
 import keys from "ember-metal/keys";
 
@@ -48,12 +47,11 @@ export function createInjectionHelper(type, validator) {
 */
 export function validatePropertyInjections(factory) {
   var proto = factory.proto();
-  var descs = meta(proto).descs;
   var types = [];
   var key, desc, validator, i, l;
 
-  for (key in descs) {
-    desc = descs[key];
+  for (key in proto) {
+    desc = proto[key];
     if (desc instanceof InjectedProperty && indexOf(types, desc.type) === -1) {
       types.push(desc.type);
     }

--- a/packages/ember-views/lib/system/renderer.js
+++ b/packages/ember-views/lib/system/renderer.js
@@ -35,7 +35,7 @@ EmberRenderer.prototype.createElement =
     // provided buffer operation (for example, `insertAfter` will
     // insert a new buffer after the "parent buffer").
     var tagName = view.tagName;
-    if (tagName === undefined) {
+    if (tagName !== null && typeof tagName === 'object' && tagName.isDescriptor) {
       tagName = get(view, 'tagName');
       Ember.deprecate('In the future using a computed property to define tagName will not be permitted. That value will be respected, but changing it will not update the element.', !tagName);
     }


### PR DESCRIPTION
@stefanpenner @krisselden @mmun One less allocation in meta. This also means we dont need to instantiate a meta object just to add a computed property to a POJO.
