### PR TITLE
Let `View#appendChild` instantiate `SimpleBoundView`s rather than doing it manually ourselves

### DIFF
--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -149,4 +149,8 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   destroyElement: K
 });
 
+CoreView.reopenClass({
+  isViewClass: true
+});
+
 export default CoreView;

--- a/packages/ember-views/lib/views/simple_bound_view.js
+++ b/packages/ember-views/lib/views/simple_bound_view.js
@@ -12,15 +12,16 @@ import {
 
 function K() { return this; }
 
-function SimpleBoundView(stream) {
+function SimpleBoundView(parentView, renderer, morph, stream) {
   this.stream = stream;
   this[GUID_KEY] = uuid();
   this._lastNormalizedValue = undefined;
   this.state = 'preRender';
   this.updateId = null;
-  this._parentView = null;
+  this._parentView = parentView;
   this.buffer = null;
-  this._morph = null;
+  this._morph = morph;
+  this.renderer = renderer;
 }
 
 SimpleBoundView.prototype = {
@@ -90,15 +91,18 @@ SimpleBoundView.prototype = {
   }
 };
 
+SimpleBoundView.create = function(attrs) {
+  return new SimpleBoundView(attrs._parentView, attrs.renderer, attrs._morph, attrs.stream);
+};
+
+SimpleBoundView.isViewClass = true;
+
 export function appendSimpleBoundView(parentView, morph, stream) {
-  var view = new SimpleBoundView(stream);
-  view._morph = morph;
+  var view = parentView.appendChild(SimpleBoundView, { _morph: morph, stream: stream });
 
   stream.subscribe(parentView._wrapAsScheduled(function() {
     run.scheduleOnce('render', view, 'rerender');
   }));
-
-  parentView.appendChild(view);
 }
 
 export default SimpleBoundView;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -387,7 +387,7 @@ var ViewChildViewsSupport = Mixin.create({
     attrs._parentView = this;
     attrs.renderer = this.renderer;
 
-    if (CoreView.detect(maybeViewClass)) {
+    if (maybeViewClass.isViewClass) {
       attrs.container = this.container;
 
       view = maybeViewClass.create(attrs);

--- a/packages/ember-views/tests/views/simple_bound_view_test.js
+++ b/packages/ember-views/tests/views/simple_bound_view_test.js
@@ -9,12 +9,12 @@ test('does not render if update is triggered by normalizedValue is the same as t
   var lazyValue = new Stream(function() {
     return obj.foo;
   });
-  var view = new SimpleBoundView(lazyValue);
-  view._morph = {
+  var morph = {
     setContent: function(newValue) {
       value = newValue;
     }
   };
+  var view = new SimpleBoundView(null, null, morph, lazyValue);
 
   equal(value, null);
 


### PR DESCRIPTION
This is a good idea because otherwise these SimpleBoundView instances go through the instance-based path in createChildViews and that ends up using `setProperties` to pass in the parentView and renderer.

@mmun 
