### PR TITLE
Bump ember-cli-yuidoc version to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bower": "~1.3.2",
     "chalk": "^0.5.1",
     "ember-cli": "0.1.6",
-    "ember-cli-yuidoc": "^0.3.1",
+    "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
     "emberjs-build": "0.0.22",
     "express": "^4.5.0",


### PR DESCRIPTION
We have been released YUIDoc v0.4.0, v0.5.0 recently. `ember-cli-yuidoc@0.4.0` also published now. It has some new features and bug fixes as follows. I have confirmed that it works for me in my locally, but please let me know if there are any problems.
- https://github.com/cibernox/ember-cli-yuidoc/pull/9
- https://github.com/yui/yuidoc/releases/tag/v0.5.0
- https://github.com/yui/yuidoc/releases/tag/v0.4.0
