### PR TITLE
[BUGFIX beta] remove dots from default resolver descriptions

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -237,12 +237,13 @@ export default EmberObject.extend({
   */
   lookupDescription: function(fullName) {
     var parsedName = this.parseName(fullName);
+    var description;
 
     if (parsedName.type === 'template') {
       return 'template at ' + parsedName.fullNameWithoutType.replace(/\./g, '/');
     }
 
-    var description = parsedName.root + '.' + classify(parsedName.name);
+    description = parsedName.root + '.' + classify(parsedName.name).replace(/\./g, '');
 
     if (parsedName.type !== 'model') {
       description += classify(parsedName.type);

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -171,3 +171,12 @@ test("doesn't log without LOG_RESOLVER", function() {
   registry.resolve('doo:scrappy');
   equal(infoCount, 0, 'Logger.info should not be called if LOG_RESOLVER is not set');
 });
+
+test("lookup description", function() {
+  application.toString = function() { return 'App'; };
+
+  equal(registry.describe('controller:foo'), 'App.FooController', 'Type gets appended at the end');
+  equal(registry.describe('controller:foo.bar'), 'App.FooBarController', 'dots are removed');
+  equal(registry.describe('model:foo'), 'App.Foo', "models don't get appended at the end");
+
+});


### PR DESCRIPTION
I don't think there should be dots in the object description unless it's for the namespace (example `controller:foo.bar` description should be `App.FooBar` instead of `App.Foo.Bar`.

Part of fixing https://github.com/emberjs/ember-inspector/issues/196
