### PR TITLE
[DOC] Use `EmberENV` instead of `ENV`

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -87,7 +87,7 @@ if ('undefined' === typeof Ember.ENV.DISABLE_RANGE_API) {
 /**
   Hash of enabled Canary features. Add to this before creating your application.
 
-  You can also define `ENV.FEATURES` if you need to enable features flagged at runtime.
+  You can also define `EmberENV.FEATURES` if you need to enable features flagged at runtime.
 
   @class FEATURES
   @namespace Ember
@@ -107,8 +107,8 @@ if (!Ember.FEATURES) {
 
   You can define the following configuration options:
 
-  * `ENV.ENABLE_ALL_FEATURES` - force all features to be enabled.
-  * `ENV.ENABLE_OPTIONAL_FEATURES` - enable any features that have not been explicitly
+  * `EmberENV.ENABLE_ALL_FEATURES` - force all features to be enabled.
+  * `EmberENV.ENABLE_OPTIONAL_FEATURES` - enable any features that have not been explicitly
     enabled/disabled.
 
   @method isEnabled
@@ -144,7 +144,7 @@ Ember.FEATURES.isEnabled = function(feature) {
 
   In general we recommend leaving this option set to true since it rarely
   conflicts with other code. If you need to turn it off however, you can
-  define an `ENV.EXTEND_PROTOTYPES` config to disable it.
+  define an `EmberENV.EXTEND_PROTOTYPES` config to disable it.
 
   @property EXTEND_PROTOTYPES
   @type Boolean


### PR DESCRIPTION
Using `EmebrENV` is current Ember.js way.
see: https://github.com/emberjs/ember.js/blob/v1.9.1/packages/ember-metal/lib/core.js#L57-L66
