### PR TITLE
Ensure `env.useFragmentCache` is passed through.

### DIFF
--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -30,6 +30,7 @@ function renderHTMLBarsTemplate(view, buffer, template) {
     dom: view.renderer._dom,
     hooks: defaultEnv.hooks,
     helpers: defaultEnv.helpers,
+    useFragmentCache: defaultEnv.useFragmentCache,
     data: {
       view: view,
       buffer: buffer

--- a/packages/ember-htmlbars/tests/system/render_view_test.js
+++ b/packages/ember-htmlbars/tests/system/render_view_test.js
@@ -1,0 +1,31 @@
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import EmberView from 'ember-views/views/view';
+import defaultEnv from "ember-htmlbars/env";
+import keys from 'ember-metal/keys';
+
+var view;
+QUnit.module('ember-htmlbars: renderView', {
+  teardown: function() {
+    runDestroy(view);
+  }
+});
+
+test('default environment values are passed through', function() {
+  var keyNames = keys(defaultEnv);
+  expect(keyNames.length);
+
+  view = EmberView.create({
+    template: {
+      isHTMLBars: true,
+      render: function(view, env, contextualElement, blockArguments) {
+        for (var i = 0, l = keyNames.length; i < l; i++) {
+          var keyName = keyNames[i];
+
+          deepEqual(env[keyName], defaultEnv[keyName], 'passes ' + keyName + ' from the default env');
+        }
+      }
+    }
+  });
+
+  runAppend(view);
+});


### PR DESCRIPTION
Also added test to make sure any new items added to the default environment, are also passed through (to help prevent future changes from causing a similar regression).

@linstula / @rwjblue
