### PR TITLE
Remove unnecessary check for `NativeArray`

### DIFF
--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -108,9 +108,7 @@ forEach(NativeArray.keys(), function(methodName) {
   }
 });
 
-if (ignore.length > 0) {
-  NativeArray = NativeArray.without.apply(NativeArray, ignore);
-}
+NativeArray = NativeArray.without.apply(NativeArray, ignore);
 
 /**
   Creates an `Ember.NativeArray` from an Array like object.


### PR DESCRIPTION
`ignore` has always [one or more items](https://github.com/emberjs/ember.js/blob/69f6bea2c26d60c4c15ac96a674fa0865632d8fc/packages/ember-runtime/lib/system/native_array.js#L104).
