### PR TITLE
Partially revert 4826bd7aa6.

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -1,7 +1,10 @@
 import Ember from 'ember-metal/core'; // Ember.assert
 import emberKeys from "ember-metal/keys";
 import dictionary from 'ember-metal/dictionary';
-import Registry from './registry';
+
+// TODO - Temporary workaround for v0.4.0 of the ES6 transpiler, which lacks support for circular dependencies.
+// See the below usage of requireModule. Instead, it should be possible to simply `import Registry from './registry';`
+var Registry;
 
 /**
  A lightweight container used to instantiate and cache objects.
@@ -19,6 +22,9 @@ import Registry from './registry';
 function Container(registry, options) {
   this._registry = registry || (function() {
     Ember.deprecate("A container should only be created for an already instantiated registry. For backward compatibility, an isolated registry will be instantiated just for this container.");
+
+    // TODO - See note above about transpiler import workaround.
+    if (!Registry) { Registry = requireModule('container/registry')['default']; }
 
     return new Registry();
   }());


### PR DESCRIPTION
Due to our required usage of _evilES3SafeReExport we do not get the
cycle / late binding support that would support removing this.
