### PR TITLE
Update to QUnit 1.17.1.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,6 @@
         "equal",
         "notEqual",
         "notStrictEqual",
-        "test",
         "asyncTest",
         "throws",
         "deepEqual",

--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,6 @@
         "notStrictEqual",
         "test",
         "asyncTest",
-        "raises",
         "throws",
         "deepEqual",
         "ok",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember",
   "dependencies": {
     "jquery": "~1.11.1",
-    "qunit": "~1.12.0",
+    "qunit": "~1.17.1",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#1.2.0"
   },
   "devDependencies": {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -15,7 +15,7 @@ QUnit.module("Container", {
   }
 });
 
-test("A registered factory returns the same instance each time", function() {
+QUnit.test("A registered factory returns the same instance each time", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -29,7 +29,7 @@ test("A registered factory returns the same instance each time", function() {
   equal(postController, container.lookup('controller:post'));
 });
 
-test("A registered factory is returned from lookupFactory", function() {
+QUnit.test("A registered factory is returned from lookupFactory", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -42,7 +42,7 @@ test("A registered factory is returned from lookupFactory", function() {
   ok(PostControllerFactory.create() instanceof  PostController, "The return of factory.create is an instance of PostController");
 });
 
-test("A registered factory is returned from lookupFactory is the same factory each time", function() {
+QUnit.test("A registered factory is returned from lookupFactory is the same factory each time", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -52,7 +52,7 @@ test("A registered factory is returned from lookupFactory is the same factory ea
   deepEqual(container.lookupFactory('controller:post'), container.lookupFactory('controller:post'), 'The return of lookupFactory is always the same');
 });
 
-test("A factory returned from lookupFactory has a debugkey", function() {
+QUnit.test("A factory returned from lookupFactory has a debugkey", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -64,7 +64,7 @@ test("A factory returned from lookupFactory has a debugkey", function() {
   equal(PostFactory._debugContainerKey, 'controller:post', 'factory instance receives _debugContainerKey');
 });
 
-test("fallback for to create time injections if factory has no extend", function() {
+QUnit.test("fallback for to create time injections if factory has no extend", function() {
   var registry = new Registry();
   var container = registry.container();
   var AppleController = factory();
@@ -84,7 +84,7 @@ test("fallback for to create time injections if factory has no extend", function
   ok(postController.apple instanceof AppleController, 'instance receives an apple of instance AppleController');
 });
 
-test("The descendants of a factory returned from lookupFactory have a container and debugkey", function() {
+QUnit.test("The descendants of a factory returned from lookupFactory have a container and debugkey", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -99,7 +99,7 @@ test("The descendants of a factory returned from lookupFactory have a container 
   ok(instance instanceof PostController, 'factory instance is instance of factory');
 });
 
-test("A registered factory returns a fresh instance if singleton: false is passed as an option", function() {
+QUnit.test("A registered factory returns a fresh instance if singleton: false is passed as an option", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -122,7 +122,7 @@ test("A registered factory returns a fresh instance if singleton: false is passe
   ok(postController4 instanceof PostController, "All instances are instances of the registered factory");
 });
 
-test("A container lookup has access to the container", function() {
+QUnit.test("A container lookup has access to the container", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -134,7 +134,7 @@ test("A container lookup has access to the container", function() {
   equal(postController.container, container);
 });
 
-test("A factory type with a registered injection's instances receive that injection", function() {
+QUnit.test("A factory type with a registered injection's instances receive that injection", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -151,7 +151,7 @@ test("A factory type with a registered injection's instances receive that inject
   equal(postController.store, store);
 });
 
-test("An individual factory with a registered injection receives the injection", function() {
+QUnit.test("An individual factory with a registered injection receives the injection", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -173,7 +173,7 @@ test("An individual factory with a registered injection receives the injection",
   equal(postController.store, store, 'has the correct store injected');
 });
 
-test("A factory with both type and individual injections", function() {
+QUnit.test("A factory with both type and individual injections", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -195,7 +195,7 @@ test("A factory with both type and individual injections", function() {
   equal(postController.router, router);
 });
 
-test("A factory with both type and individual factoryInjections", function() {
+QUnit.test("A factory with both type and individual factoryInjections", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -217,7 +217,7 @@ test("A factory with both type and individual factoryInjections", function() {
   equal(PostControllerFactory.router, router, 'PostControllerFactory has the route instance');
 });
 
-test("A non-singleton instance is never cached", function() {
+QUnit.test("A non-singleton instance is never cached", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostView = factory();
@@ -230,7 +230,7 @@ test("A non-singleton instance is never cached", function() {
   ok(postView1 !== postView2, "Non-singletons are not cached");
 });
 
-test("A non-instantiated property is not instantiated", function() {
+QUnit.test("A non-instantiated property is not instantiated", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -239,14 +239,14 @@ test("A non-instantiated property is not instantiated", function() {
   equal(container.lookup('template:foo'), template);
 });
 
-test("A failed lookup returns undefined", function() {
+QUnit.test("A failed lookup returns undefined", function() {
   var registry = new Registry();
   var container = registry.container();
 
   equal(container.lookup('doesnot:exist'), undefined);
 });
 
-test("An invalid factory throws an error", function() {
+QUnit.test("An invalid factory throws an error", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -257,7 +257,7 @@ test("An invalid factory throws an error", function() {
   }, /Failed to create an instance of \'controller:foo\'/);
 });
 
-test("Injecting a failed lookup raises an error", function() {
+QUnit.test("Injecting a failed lookup raises an error", function() {
   Ember.MODEL_FACTORY_INJECTIONS = true;
 
   var registry = new Registry();
@@ -279,7 +279,7 @@ test("Injecting a failed lookup raises an error", function() {
   });
 });
 
-test("Injecting a falsy value does not raise an error", function() {
+QUnit.test("Injecting a falsy value does not raise an error", function() {
   var registry = new Registry();
   var container = registry.container();
   var ApplicationController = factory();
@@ -291,7 +291,7 @@ test("Injecting a falsy value does not raise an error", function() {
   equal(container.lookup('controller:application').currentUser, null);
 });
 
-test("Destroying the container destroys any cached singletons", function() {
+QUnit.test("Destroying the container destroys any cached singletons", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -315,7 +315,7 @@ test("Destroying the container destroys any cached singletons", function() {
   ok(!postView.isDestroyed, "Non-singletons are not destroyed");
 });
 
-test("The container can use a registry hook to resolve factories lazily", function() {
+QUnit.test("The container can use a registry hook to resolve factories lazily", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -331,7 +331,7 @@ test("The container can use a registry hook to resolve factories lazily", functi
   ok(postController instanceof PostController, "The correct factory was provided");
 });
 
-test("The container normalizes names before resolving", function() {
+QUnit.test("The container normalizes names before resolving", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -346,7 +346,7 @@ test("The container normalizes names before resolving", function() {
   ok(postController instanceof PostController, "Normalizes the name before resolving");
 });
 
-test("The container normalizes names when looking factory up", function() {
+QUnit.test("The container normalizes names when looking factory up", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -361,7 +361,7 @@ test("The container normalizes names when looking factory up", function() {
   equal(fact.toString() === PostController.extend().toString(), true, "Normalizes the name when looking factory up");
 });
 
-test("The container can get options that should be applied to a given factory", function() {
+QUnit.test("The container can get options that should be applied to a given factory", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostView = factory();
@@ -383,7 +383,7 @@ test("The container can get options that should be applied to a given factory", 
   ok(postView1 !== postView2, "The two lookups are different");
 });
 
-test("The container can get options that should be applied to all factories for a given type", function() {
+QUnit.test("The container can get options that should be applied to all factories for a given type", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostView = factory();
@@ -405,7 +405,7 @@ test("The container can get options that should be applied to all factories for 
   ok(postView1 !== postView2, "The two lookups are different");
 });
 
-test("factory resolves are cached", function() {
+QUnit.test("factory resolves are cached", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -423,7 +423,7 @@ test("factory resolves are cached", function() {
   deepEqual(resolveWasCalled, ['controller:post']);
 });
 
-test("factory for non extendables (MODEL) resolves are cached", function() {
+QUnit.test("factory for non extendables (MODEL) resolves are cached", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = factory();
@@ -441,7 +441,7 @@ test("factory for non extendables (MODEL) resolves are cached", function() {
   deepEqual(resolveWasCalled, ['model:post']);
 });
 
-test("factory for non extendables resolves are cached", function() {
+QUnit.test("factory for non extendables resolves are cached", function() {
   var registry = new Registry();
   var container = registry.container();
   var PostController = {};
@@ -461,7 +461,7 @@ test("factory for non extendables resolves are cached", function() {
 });
 
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
-  test("The `_onLookup` hook is called on factories when looked up the first time", function() {
+  QUnit.test("The `_onLookup` hook is called on factories when looked up the first time", function() {
     expect(2);
 
     var registry = new Registry();
@@ -481,7 +481,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     container.lookupFactory('apple:main');
   });
 
-  test("A factory's lazy injections are validated when first instantiated", function() {
+  QUnit.test("A factory's lazy injections are validated when first instantiated", function() {
     var registry = new Registry();
     var container = registry.container();
     var Apple = factory();
@@ -501,7 +501,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     }, /Attempting to inject an unknown injection: `banana:main`/);
   });
 
-  test("Lazy injection validations are cached", function() {
+  QUnit.test("Lazy injection validations are cached", function() {
     expect(1);
 
     var registry = new Registry();

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -17,7 +17,7 @@ QUnit.module("Registry", {
   }
 });
 
-test("A registered factory is returned from resolve", function() {
+QUnit.test("A registered factory is returned from resolve", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -29,7 +29,7 @@ test("A registered factory is returned from resolve", function() {
   ok(PostControllerFactory.create() instanceof  PostController, "The return of factory.create is an instance of PostController");
 });
 
-test("The registered factory returned from resolve is the same factory each time", function() {
+QUnit.test("The registered factory returned from resolve is the same factory each time", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -38,7 +38,7 @@ test("The registered factory returned from resolve is the same factory each time
   deepEqual(registry.resolve('controller:post'), registry.resolve('controller:post'), 'The return of resolve is always the same');
 });
 
-test("A registered factory returns true for `has` if an item is registered", function() {
+QUnit.test("A registered factory returns true for `has` if an item is registered", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -48,7 +48,7 @@ test("A registered factory returns true for `has` if an item is registered", fun
   equal(registry.has('controller:posts'), false, "The `has` method returned false for unregistered factories");
 });
 
-test("Throw exception when trying to inject `type:thing` on all type(s)", function() {
+QUnit.test("Throw exception when trying to inject `type:thing` on all type(s)", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -59,7 +59,7 @@ test("Throw exception when trying to inject `type:thing` on all type(s)", functi
   }, 'Cannot inject a `controller:post` on other controller(s). Register the `controller:post` as a different type and perform the typeInjection.');
 });
 
-test("The registry can take a hook to resolve factories lazily", function() {
+QUnit.test("The registry can take a hook to resolve factories lazily", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -72,7 +72,7 @@ test("The registry can take a hook to resolve factories lazily", function() {
   strictEqual(registry.resolve('controller:post'), PostController, "The correct factory was provided");
 });
 
-test("The registry respects the resolver hook for `has`", function() {
+QUnit.test("The registry respects the resolver hook for `has`", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -85,7 +85,7 @@ test("The registry respects the resolver hook for `has`", function() {
   ok(registry.has('controller:post'), "the `has` method uses the resolver hook");
 });
 
-test("The registry normalizes names when resolving", function() {
+QUnit.test("The registry normalizes names when resolving", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -99,7 +99,7 @@ test("The registry normalizes names when resolving", function() {
   strictEqual(type, PostController, "Normalizes the name when resolving");
 });
 
-test("The registry normalizes names when checking if the factory is registered", function() {
+QUnit.test("The registry normalizes names when checking if the factory is registered", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -113,7 +113,7 @@ test("The registry normalizes names when checking if the factory is registered",
   equal(isPresent, true, "Normalizes the name when checking if the factory or instance is present");
 });
 
-test("validateFullName throws an error if name is incorrect", function() {
+QUnit.test("validateFullName throws an error if name is incorrect", function() {
   var registry = new Registry();
   var PostController = factory();
 
@@ -127,7 +127,7 @@ test("validateFullName throws an error if name is incorrect", function() {
   }, 'TypeError: Invalid Fullname, expected: `type:name` got: post');
 });
 
-test("The registry normalizes names when injecting", function() {
+QUnit.test("The registry normalizes names when injecting", function() {
   var registry = new Registry();
   var PostController = factory();
   var user = { name: 'Stef' };
@@ -143,7 +143,7 @@ test("The registry normalizes names when injecting", function() {
   deepEqual(registry.resolve('controller:post'), user, "Normalizes the name when injecting");
 });
 
-test("cannot register an `undefined` factory", function() {
+QUnit.test("cannot register an `undefined` factory", function() {
   var registry = new Registry();
 
   throws(function() {
@@ -151,7 +151,7 @@ test("cannot register an `undefined` factory", function() {
   }, '');
 });
 
-test("can re-register a factory", function() {
+QUnit.test("can re-register a factory", function() {
   var registry = new Registry();
   var FirstApple = factory('first');
   var SecondApple = factory('second');
@@ -162,7 +162,7 @@ test("can re-register a factory", function() {
   ok(registry.resolve('controller:apple').create() instanceof SecondApple);
 });
 
-test("cannot re-register a factory if it has been resolved", function() {
+QUnit.test("cannot re-register a factory if it has been resolved", function() {
   var registry = new Registry();
   var FirstApple = factory('first');
   var SecondApple = factory('second');
@@ -177,7 +177,7 @@ test("cannot re-register a factory if it has been resolved", function() {
   strictEqual(registry.resolve('controller:apple'), FirstApple);
 });
 
-test('registry.has should not accidentally cause injections on that factory to be run. (Mitigate merely on observing)', function() {
+QUnit.test('registry.has should not accidentally cause injections on that factory to be run. (Mitigate merely on observing)', function() {
   expect(1);
 
   var registry = new Registry();
@@ -195,7 +195,7 @@ test('registry.has should not accidentally cause injections on that factory to b
   ok(registry.has('controller:apple'));
 });
 
-test('once resolved, always return the same result', function() {
+QUnit.test('once resolved, always return the same result', function() {
   expect(1);
 
   var registry = new Registry();
@@ -213,7 +213,7 @@ test('once resolved, always return the same result', function() {
   equal(registry.resolve('models:bar'), Bar);
 });
 
-test("factory resolves are cached", function() {
+QUnit.test("factory resolves are cached", function() {
   var registry = new Registry();
   var PostController = factory();
   var resolveWasCalled = [];
@@ -230,7 +230,7 @@ test("factory resolves are cached", function() {
   deepEqual(resolveWasCalled, ['controller:post']);
 });
 
-test("factory for non extendables (MODEL) resolves are cached", function() {
+QUnit.test("factory for non extendables (MODEL) resolves are cached", function() {
   var registry = new Registry();
   var PostController = factory();
   var resolveWasCalled = [];
@@ -247,7 +247,7 @@ test("factory for non extendables (MODEL) resolves are cached", function() {
   deepEqual(resolveWasCalled, ['model:post']);
 });
 
-test("factory for non extendables resolves are cached", function() {
+QUnit.test("factory for non extendables resolves are cached", function() {
   var registry = new Registry();
   var PostController = {};
   var resolveWasCalled = [];
@@ -264,7 +264,7 @@ test("factory for non extendables resolves are cached", function() {
   deepEqual(resolveWasCalled, ['foo:post']);
 });
 
-test("registry.container creates an associated container", function() {
+QUnit.test("registry.container creates an associated container", function() {
   var registry = new Registry();
   var PostController = factory();
   registry.register('controller:post', PostController);
@@ -276,7 +276,7 @@ test("registry.container creates an associated container", function() {
   strictEqual(registry._defaultContainer, container, "_defaultContainer is set to the first created container and used for Ember 1.x Container compatibility");
 });
 
-test("`resolve` can be handled by a fallback registry", function() {
+QUnit.test("`resolve` can be handled by a fallback registry", function() {
   var fallback = new Registry();
 
   var registry = new Registry({ fallback: fallback });
@@ -290,7 +290,7 @@ test("`resolve` can be handled by a fallback registry", function() {
   ok(PostControllerFactory.create() instanceof  PostController, "The return of factory.create is an instance of PostController");
 });
 
-test("`has` can be handled by a fallback registry", function() {
+QUnit.test("`has` can be handled by a fallback registry", function() {
   var fallback = new Registry();
 
   var registry = new Registry({ fallback: fallback });
@@ -301,7 +301,7 @@ test("`has` can be handled by a fallback registry", function() {
   equal(registry.has('controller:post'), true, "Fallback registry is checked for registration");
 });
 
-test("`getInjections` includes injections from a fallback registry", function() {
+QUnit.test("`getInjections` includes injections from a fallback registry", function() {
   var fallback = new Registry();
   var registry = new Registry({ fallback: fallback });
 
@@ -312,7 +312,7 @@ test("`getInjections` includes injections from a fallback registry", function() 
   equal(registry.getInjections('model:user').length, 1, "Injections from the fallback registry are merged");
 });
 
-test("`getTypeInjections` includes type injections from a fallback registry", function() {
+QUnit.test("`getTypeInjections` includes type injections from a fallback registry", function() {
   var fallback = new Registry();
   var registry = new Registry({ fallback: fallback });
 
@@ -323,7 +323,7 @@ test("`getTypeInjections` includes type injections from a fallback registry", fu
   equal(registry.getTypeInjections('model').length, 1, "Injections from the fallback registry are merged");
 });
 
-test("`getFactoryInjections` includes factory injections from a fallback registry", function() {
+QUnit.test("`getFactoryInjections` includes factory injections from a fallback registry", function() {
   var fallback = new Registry();
   var registry = new Registry({ fallback: fallback });
 
@@ -335,7 +335,7 @@ test("`getFactoryInjections` includes factory injections from a fallback registr
 });
 
 
-test("`getFactoryTypeInjections` includes factory type injections from a fallback registry", function() {
+QUnit.test("`getFactoryTypeInjections` includes factory type injections from a fallback registry", function() {
   var fallback = new Registry();
   var registry = new Registry({ fallback: fallback });
 

--- a/packages/ember-application/tests/system/application_test.js
+++ b/packages/ember-application/tests/system/application_test.js
@@ -43,7 +43,7 @@ QUnit.module("Ember.Application", {
   }
 });
 
-test("you can make a new application in a non-overlapping element", function() {
+QUnit.test("you can make a new application in a non-overlapping element", function() {
   run(function() {
     app = Application.create({ rootElement: '#two', router: null });
   });
@@ -52,7 +52,7 @@ test("you can make a new application in a non-overlapping element", function() {
   ok(true, "should not raise");
 });
 
-test("you cannot make a new application that is a parent of an existing application", function() {
+QUnit.test("you cannot make a new application that is a parent of an existing application", function() {
   expectAssertion(function() {
     run(function() {
       Application.create({ rootElement: '#qunit-fixture' });
@@ -60,7 +60,7 @@ test("you cannot make a new application that is a parent of an existing applicat
   });
 });
 
-test("you cannot make a new application that is a descendent of an existing application", function() {
+QUnit.test("you cannot make a new application that is a descendent of an existing application", function() {
   expectAssertion(function() {
     run(function() {
       Application.create({ rootElement: '#one-child' });
@@ -68,7 +68,7 @@ test("you cannot make a new application that is a descendent of an existing appl
   });
 });
 
-test("you cannot make a new application that is a duplicate of an existing application", function() {
+QUnit.test("you cannot make a new application that is a duplicate of an existing application", function() {
   expectAssertion(function() {
     run(function() {
       Application.create({ rootElement: '#one' });
@@ -76,7 +76,7 @@ test("you cannot make a new application that is a duplicate of an existing appli
   });
 });
 
-test("you cannot make two default applications without a rootElement error", function() {
+QUnit.test("you cannot make two default applications without a rootElement error", function() {
   expectAssertion(function() {
     run(function() {
       Application.create({ router: false });
@@ -84,7 +84,7 @@ test("you cannot make two default applications without a rootElement error", fun
   });
 });
 
-test("acts like a namespace", function() {
+QUnit.test("acts like a namespace", function() {
   var lookup = Ember.lookup = {};
   var app;
 
@@ -106,7 +106,7 @@ QUnit.module("Ember.Application initialization", {
   }
 });
 
-test('initialized application go to initial route', function() {
+QUnit.test('initialized application go to initial route', function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'
@@ -128,7 +128,7 @@ test('initialized application go to initial route', function() {
   equal(jQuery('#qunit-fixture h1').text(), "Hi from index");
 });
 
-test("initialize application via initialize call", function() {
+QUnit.test("initialize application via initialize call", function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'
@@ -150,7 +150,7 @@ test("initialize application via initialize call", function() {
   equal(router.location instanceof NoneLocation, true, "Location was set from location implementation name");
 });
 
-test("initialize application with stateManager via initialize call from Router class", function() {
+QUnit.test("initialize application with stateManager via initialize call from Router class", function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'
@@ -170,7 +170,7 @@ test("initialize application with stateManager via initialize call from Router c
   equal(jQuery("#qunit-fixture h1").text(), "Hello!");
 });
 
-test("ApplicationView is inserted into the page", function() {
+QUnit.test("ApplicationView is inserted into the page", function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'
@@ -192,7 +192,7 @@ test("ApplicationView is inserted into the page", function() {
   equal(jQuery("#qunit-fixture h1").text(), "Hello!");
 });
 
-test("Minimal Application initialized with just an application template", function() {
+QUnit.test("Minimal Application initialized with just an application template", function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars">Hello World</script>');
   run(function () {
     app = Application.create({
@@ -203,7 +203,7 @@ test("Minimal Application initialized with just an application template", functi
   equal(trim(jQuery('#qunit-fixture').text()), 'Hello World');
 });
 
-test('enable log of libraries with an ENV var', function() {
+QUnit.test('enable log of libraries with an ENV var', function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -235,7 +235,7 @@ test('enable log of libraries with an ENV var', function() {
   Ember.debug = debug;
 });
 
-test('disable log version of libraries with an ENV var', function() {
+QUnit.test('disable log version of libraries with an ENV var', function() {
   var logged = false;
 
   Ember.LOG_VERSION = false;
@@ -259,7 +259,7 @@ test('disable log version of libraries with an ENV var', function() {
   ok(!logged, 'library version logging skipped');
 });
 
-test("can resolve custom router", function() {
+QUnit.test("can resolve custom router", function() {
   var CustomRouter = Router.extend();
 
   var CustomResolver = DefaultResolver.extend({
@@ -281,7 +281,7 @@ test("can resolve custom router", function() {
   ok(app.__container__.lookup('router:main') instanceof CustomRouter, 'application resolved the correct router');
 });
 
-test("throws helpful error if `app.then` is used", function() {
+QUnit.test("throws helpful error if `app.then` is used", function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'
@@ -293,7 +293,7 @@ test("throws helpful error if `app.then` is used", function() {
   }, /Do not use `.then` on an instance of Ember.Application.  Please use the `.ready` hook instead./);
 });
 
-test("registers controls onto to container", function() {
+QUnit.test("registers controls onto to container", function() {
   run(function() {
     app = Application.create({
       rootElement: '#qunit-fixture'

--- a/packages/ember-application/tests/system/controller_test.js
+++ b/packages/ember-application/tests/system/controller_test.js
@@ -10,7 +10,7 @@ import { computed } from "ember-metal/computed";
 
 QUnit.module("Controller dependencies");
 
-test("If a controller specifies a dependency, but does not have a container it should error", function() {
+QUnit.test("If a controller specifies a dependency, but does not have a container it should error", function() {
   var AController = Controller.extend({
     needs: 'posts'
   });
@@ -20,7 +20,7 @@ test("If a controller specifies a dependency, but does not have a container it s
   }, /specifies `needs`, but does not have a container. Please ensure this controller was instantiated with a container./);
 });
 
-test("If a controller specifies a dependency, it is accessible", function() {
+QUnit.test("If a controller specifies a dependency, it is accessible", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -36,7 +36,7 @@ test("If a controller specifies a dependency, it is accessible", function() {
   equal(postsController, postController.get('controllers.posts'), "controller.posts must be auto synthesized");
 });
 
-test("If a controller specifies an unavailable dependency, it raises", function() {
+QUnit.test("If a controller specifies an unavailable dependency, it raises", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -57,7 +57,7 @@ test("If a controller specifies an unavailable dependency, it raises", function(
   }, /controller:posts, controller:comments/);
 });
 
-test("Mixin sets up controllers if there is needs before calling super", function() {
+QUnit.test("Mixin sets up controllers if there is needs before calling super", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -79,7 +79,7 @@ test("Mixin sets up controllers if there is needs before calling super", functio
   deepEqual(['a','b','c'], container.lookup('controller:another').toArray());
 });
 
-test("raises if trying to get a controller that was not pre-defined in `needs`", function() {
+QUnit.test("raises if trying to get a controller that was not pre-defined in `needs`", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -104,7 +104,7 @@ test("raises if trying to get a controller that was not pre-defined in `needs`",
   'should throw if no such controller was needed');
 });
 
-test("setting the value of a controller dependency should not be possible", function() {
+QUnit.test("setting the value of a controller dependency should not be possible", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -127,7 +127,7 @@ test("setting the value of a controller dependency should not be possible", func
   equal(postController.get('controllers.posts.title'), "A Troll's Life", "can set the value of controllers.posts.title");
 });
 
-test("raises if a dependency with a period is requested", function() {
+QUnit.test("raises if a dependency with a period is requested", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -142,7 +142,7 @@ test("raises if a dependency with a period is requested", function() {
   'throws if periods used');
 });
 
-test("can unit test controllers with `needs` dependencies by stubbing their `controllers` properties", function() {
+QUnit.test("can unit test controllers with `needs` dependencies by stubbing their `controllers` properties", function() {
   expect(1);
 
   var BrotherController = Controller.extend({

--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -30,7 +30,7 @@ QUnit.module("Ember.Application Dependency Injection – customResolver", {
   }
 });
 
-test("a resolver can be supplied to application", function() {
+QUnit.test("a resolver can be supplied to application", function() {
   equal(jQuery("h1", application.rootElement).text(), "Fallback");
 });
 

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -117,14 +117,14 @@ test("the default resolver resolves container-registered helpers", function() {
 });
 
 test("the default resolver throws an error if the fullName to resolve is invalid", function() {
-  raises(function() { registry.resolve(undefined);}, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve(null);     }, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve('');       }, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve('');       }, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve(':');      }, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve('model');  }, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve('model:'); }, TypeError, /Invalid fullName/ );
-  raises(function() { registry.resolve(':type');  }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve(undefined);}, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve(null);     }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve('');       }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve('');       }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve(':');      }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve('model');  }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve('model:'); }, TypeError, /Invalid fullName/ );
+  throws(function() { registry.resolve(':type');  }, TypeError, /Invalid fullName/ );
 });
 
 test("the default resolver logs hits if `LOG_RESOLVER` is set", function() {

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -32,7 +32,7 @@ QUnit.module("Ember.Application Dependency Injection - default resolver", {
   }
 });
 
-test('the default resolver can look things up in other namespaces', function() {
+QUnit.test('the default resolver can look things up in other namespaces', function() {
   var UserInterface = Ember.lookup.UserInterface = Namespace.create();
   UserInterface.NavigationController = Controller.extend();
 
@@ -41,7 +41,7 @@ test('the default resolver can look things up in other namespaces', function() {
   ok(nav instanceof UserInterface.NavigationController, "the result should be an instance of the specified class");
 });
 
-test('the default resolver looks up templates in Ember.TEMPLATES', function() {
+QUnit.test('the default resolver looks up templates in Ember.TEMPLATES', function() {
   function fooTemplate() {}
   function fooBarTemplate() {}
   function fooBarBazTemplate() {}
@@ -55,7 +55,7 @@ test('the default resolver looks up templates in Ember.TEMPLATES', function() {
   equal(locator.lookup('template:fooBar.baz'), fooBarBazTemplate, "resolves template:foo_bar.baz");
 });
 
-test('the default resolver looks up basic name as no prefix', function() {
+QUnit.test('the default resolver looks up basic name as no prefix', function() {
   ok(Controller.detect(locator.lookup('controller:basic')), 'locator looksup correct controller');
 });
 
@@ -63,25 +63,25 @@ function detectEqual(first, second, message) {
   ok(first.detect(second), message);
 }
 
-test('the default resolver looks up arbitrary types on the namespace', function() {
+QUnit.test('the default resolver looks up arbitrary types on the namespace', function() {
   application.FooManager = EmberObject.extend({});
 
   detectEqual(application.FooManager, registry.resolver('manager:foo'), "looks up FooManager on application");
 });
 
-test("the default resolver resolves models on the namespace", function() {
+QUnit.test("the default resolver resolves models on the namespace", function() {
   application.Post = EmberObject.extend({});
 
   detectEqual(application.Post, locator.lookupFactory('model:post'), "looks up Post model on application");
 });
 
-test("the default resolver resolves *:main on the namespace", function() {
+QUnit.test("the default resolver resolves *:main on the namespace", function() {
   application.FooBar = EmberObject.extend({});
 
   detectEqual(application.FooBar, locator.lookupFactory('foo-bar:main'), "looks up FooBar type without name on application");
 });
 
-test("the default resolver resolves helpers", function() {
+QUnit.test("the default resolver resolves helpers", function() {
   expect(2);
 
   function fooresolvertestHelper() {
@@ -107,7 +107,7 @@ test("the default resolver resolves helpers", function() {
   barBazResolverTestHelper();
 });
 
-test("the default resolver resolves container-registered helpers", function() {
+QUnit.test("the default resolver resolves container-registered helpers", function() {
   function gooresolvertestHelper() { return 'GOO'; }
   function gooGazResolverTestHelper() { return 'GAZ'; }
   application.register('helper:gooresolvertest', gooresolvertestHelper);
@@ -116,7 +116,7 @@ test("the default resolver resolves container-registered helpers", function() {
   equal(gooGazResolverTestHelper, locator.lookup('helper:goo-baz-resolver-test'), "looks up gooGazResolverTestHelper helper");
 });
 
-test("the default resolver throws an error if the fullName to resolve is invalid", function() {
+QUnit.test("the default resolver throws an error if the fullName to resolve is invalid", function() {
   throws(function() { registry.resolve(undefined);}, TypeError, /Invalid fullName/ );
   throws(function() { registry.resolve(null);     }, TypeError, /Invalid fullName/ );
   throws(function() { registry.resolve('');       }, TypeError, /Invalid fullName/ );
@@ -127,7 +127,7 @@ test("the default resolver throws an error if the fullName to resolve is invalid
   throws(function() { registry.resolve(':type');  }, TypeError, /Invalid fullName/ );
 });
 
-test("the default resolver logs hits if `LOG_RESOLVER` is set", function() {
+QUnit.test("the default resolver logs hits if `LOG_RESOLVER` is set", function() {
   expect(3);
 
   application.LOG_RESOLVER = true;
@@ -143,7 +143,7 @@ test("the default resolver logs hits if `LOG_RESOLVER` is set", function() {
   registry.resolve('doo:scooby');
 });
 
-test("the default resolver logs misses if `LOG_RESOLVER` is set", function() {
+QUnit.test("the default resolver logs misses if `LOG_RESOLVER` is set", function() {
   expect(3);
 
   application.LOG_RESOLVER = true;
@@ -158,7 +158,7 @@ test("the default resolver logs misses if `LOG_RESOLVER` is set", function() {
   registry.resolve('doo:scooby');
 });
 
-test("doesn't log without LOG_RESOLVER", function() {
+QUnit.test("doesn't log without LOG_RESOLVER", function() {
   var infoCount = 0;
 
   application.ScoobyDoo = EmberObject.extend();
@@ -172,7 +172,7 @@ test("doesn't log without LOG_RESOLVER", function() {
   equal(infoCount, 0, 'Logger.info should not be called if LOG_RESOLVER is not set');
 });
 
-test("lookup description", function() {
+QUnit.test("lookup description", function() {
   application.toString = function() { return 'App'; };
 
   equal(registry.describe('controller:foo'), 'App.FooController', 'Type gets appended at the end');

--- a/packages/ember-application/tests/system/dependency_injection/normalization_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/normalization_test.js
@@ -15,7 +15,7 @@ QUnit.module("Ember.Application Dependency Injection – normalization", {
   }
 });
 
-test('normalization', function() {
+QUnit.test('normalization', function() {
   ok(registry.normalize, 'registry#normalize is present');
 
   equal(registry.normalize('foo:bar'), 'foo:bar');
@@ -35,7 +35,7 @@ test('normalization', function() {
   equal(registry.normalize('template:blog/posts_index'), 'template:blog/posts_index');
 });
 
-test('normalization is indempotent', function() {
+QUnit.test('normalization is indempotent', function() {
   var examples = ['controller:posts', 'controller:posts.post.index', 'controller:blog/posts.post_index', 'template:foo_bar'];
 
   forEach.call(examples, function (example) {

--- a/packages/ember-application/tests/system/dependency_injection/to_string_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/to_string_test.js
@@ -32,19 +32,19 @@ QUnit.module("Ember.Application Dependency Injection – toString", {
   }
 });
 
-test("factories", function() {
+QUnit.test("factories", function() {
   var PostFactory = App.__container__.lookupFactory('model:post');
   equal(PostFactory.toString(), 'App.Post', 'expecting the model to be post');
 });
 
-test("instances", function() {
+QUnit.test("instances", function() {
   var post = App.__container__.lookup('model:post');
   var guid = guidFor(post);
 
   equal(post.toString(), '<App.Post:' + guid + '>', 'expecting the model to be post');
 });
 
-test("with a custom resolver", function() {
+QUnit.test("with a custom resolver", function() {
   run(App, 'destroy');
 
   run(function() {

--- a/packages/ember-application/tests/system/dependency_injection_test.js
+++ b/packages/ember-application/tests/system/dependency_injection_test.js
@@ -39,7 +39,7 @@ QUnit.module("Ember.Application Dependency Injection", {
   }
 });
 
-test('container lookup is normalized', function() {
+QUnit.test('container lookup is normalized', function() {
   var dotNotationController = locator.lookup('controller:post.index');
   var camelCaseController = locator.lookup('controller:postIndex');
 
@@ -49,7 +49,7 @@ test('container lookup is normalized', function() {
   equal(dotNotationController, camelCaseController);
 });
 
-test('registered entities can be looked up later', function() {
+QUnit.test('registered entities can be looked up later', function() {
   equal(registry.resolve('model:person'), application.Person);
   equal(registry.resolve('model:user'), application.User);
   equal(registry.resolve('fruit:favorite'), application.Orange);
@@ -61,7 +61,7 @@ test('registered entities can be looked up later', function() {
 });
 
 
-test('injections', function() {
+QUnit.test('injections', function() {
   application.inject('model', 'fruit', 'fruit:favorite');
   application.inject('model:user', 'communication', 'communication:main');
 

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -17,7 +17,7 @@ QUnit.module("Ember.Application initializers", {
   }
 });
 
-test("initializers require proper 'name' and 'initialize' properties", function() {
+QUnit.test("initializers require proper 'name' and 'initialize' properties", function() {
   var MyApplication = Application.extend();
 
   expectAssertion(function() {
@@ -34,7 +34,7 @@ test("initializers require proper 'name' and 'initialize' properties", function(
 
 });
 
-test("initializers are passed a registry and App", function() {
+QUnit.test("initializers are passed a registry and App", function() {
   var MyApplication = Application.extend();
 
   MyApplication.initializer({
@@ -53,7 +53,7 @@ test("initializers are passed a registry and App", function() {
   });
 });
 
-test("initializers can be registered in a specified order", function() {
+QUnit.test("initializers can be registered in a specified order", function() {
   var order = [];
   var MyApplication = Application.extend();
   MyApplication.initializer({
@@ -114,7 +114,7 @@ test("initializers can be registered in a specified order", function() {
   deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
 });
 
-test("initializers can be registered in a specified order as an array", function() {
+QUnit.test("initializers can be registered in a specified order as an array", function() {
   var order = [];
   var MyApplication = Application.extend();
 
@@ -177,7 +177,7 @@ test("initializers can be registered in a specified order as an array", function
   deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
 });
 
-test("initializers can have multiple dependencies", function () {
+QUnit.test("initializers can have multiple dependencies", function () {
   var order = [];
   var a = {
     name: "a",
@@ -233,7 +233,7 @@ test("initializers can have multiple dependencies", function () {
   ok(indexOf.call(order, c.name) < indexOf.call(order, afterC.name), 'c < afterC');
 });
 
-test("initializers set on Application subclasses should not be shared between apps", function() {
+QUnit.test("initializers set on Application subclasses should not be shared between apps", function() {
   var firstInitializerRunCount = 0;
   var secondInitializerRunCount = 0;
   var FirstApp = Application.extend();
@@ -269,7 +269,7 @@ test("initializers set on Application subclasses should not be shared between ap
   equal(secondInitializerRunCount, 1, 'second initializer only was run');
 });
 
-test("initializers are concatenated", function() {
+QUnit.test("initializers are concatenated", function() {
   var firstInitializerRunCount = 0;
   var secondInitializerRunCount = 0;
   var FirstApp = Application.extend();
@@ -308,7 +308,7 @@ test("initializers are concatenated", function() {
   equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
 });
 
-test("initializers are per-app", function() {
+QUnit.test("initializers are per-app", function() {
   expect(0);
   var FirstApp = Application.extend();
   FirstApp.initializer({
@@ -324,7 +324,7 @@ test("initializers are per-app", function() {
 });
 
 if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
-  test("initializers should be executed in their own context", function() {
+  QUnit.test("initializers should be executed in their own context", function() {
     expect(1);
     var MyApplication = Application.extend();
 

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -18,7 +18,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     }
   });
 
-  test("initializers require proper 'name' and 'initialize' properties", function() {
+  QUnit.test("initializers require proper 'name' and 'initialize' properties", function() {
     var MyApplication = Application.extend();
 
     expectAssertion(function() {
@@ -35,7 +35,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
 
   });
 
-  test("initializers are passed an app instance", function() {
+  QUnit.test("initializers are passed an app instance", function() {
     var MyApplication = Application.extend();
 
     MyApplication.instanceInitializer({
@@ -53,7 +53,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     });
   });
 
-  test("initializers can be registered in a specified order", function() {
+  QUnit.test("initializers can be registered in a specified order", function() {
     var order = [];
     var MyApplication = Application.extend();
     MyApplication.instanceInitializer({
@@ -114,7 +114,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
   });
 
-  test("initializers can be registered in a specified order as an array", function() {
+  QUnit.test("initializers can be registered in a specified order as an array", function() {
     var order = [];
     var MyApplication = Application.extend();
 
@@ -177,7 +177,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
   });
 
-  test("initializers can have multiple dependencies", function () {
+  QUnit.test("initializers can have multiple dependencies", function () {
     var order = [];
     var a = {
       name: "a",
@@ -233,7 +233,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     ok(indexOf.call(order, c.name) < indexOf.call(order, afterC.name), 'c < afterC');
   });
 
-  test("initializers set on Application subclasses should not be shared between apps", function() {
+  QUnit.test("initializers set on Application subclasses should not be shared between apps", function() {
     var firstInitializerRunCount = 0;
     var secondInitializerRunCount = 0;
     var FirstApp = Application.extend();
@@ -269,7 +269,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     equal(secondInitializerRunCount, 1, 'second initializer only was run');
   });
 
-  test("initializers are concatenated", function() {
+  QUnit.test("initializers are concatenated", function() {
     var firstInitializerRunCount = 0;
     var secondInitializerRunCount = 0;
     var FirstApp = Application.extend();
@@ -308,7 +308,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
     equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
   });
 
-  test("initializers are per-app", function() {
+  QUnit.test("initializers are per-app", function() {
     expect(0);
     var FirstApp = Application.extend();
     FirstApp.instanceInitializer({
@@ -324,7 +324,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
   });
 
   if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
-    test("initializers should be executed in their own context", function() {
+    QUnit.test("initializers should be executed in their own context", function() {
       expect(1);
 
       var MyApplication = Application.extend();

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -77,7 +77,7 @@ function visit(path) {
   };
 }
 
-test("log class generation if logging enabled", function() {
+QUnit.test("log class generation if logging enabled", function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -90,7 +90,7 @@ test("log class generation if logging enabled", function() {
   });
 });
 
-test("do NOT log class generation if logging disabled", function() {
+QUnit.test("do NOT log class generation if logging disabled", function() {
   App.reopen({
     LOG_ACTIVE_GENERATION: false
   });
@@ -102,7 +102,7 @@ test("do NOT log class generation if logging disabled", function() {
   });
 });
 
-test("actively generated classes get logged", function() {
+QUnit.test("actively generated classes get logged", function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -119,7 +119,7 @@ test("actively generated classes get logged", function() {
   });
 });
 
-test("predefined classes do not get logged", function() {
+QUnit.test("predefined classes do not get logged", function() {
   App.ApplicationController = Controller.extend();
   App.PostsController = Controller.extend();
 
@@ -176,7 +176,7 @@ QUnit.module("Ember.Application – logging of view lookups", {
   }
 });
 
-test("log when template and view are missing when flag is active", function() {
+QUnit.test("log when template and view are missing when flag is active", function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -192,7 +192,7 @@ test("log when template and view are missing when flag is active", function() {
   });
 });
 
-test("do not log when template and view are missing when flag is not true", function() {
+QUnit.test("do not log when template and view are missing when flag is not true", function() {
   App.reopen({
     LOG_VIEW_LOOKUPS: false
   });
@@ -204,7 +204,7 @@ test("do not log when template and view are missing when flag is not true", func
   });
 });
 
-test("log which view is used with a template", function() {
+QUnit.test("log which view is used with a template", function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -222,7 +222,7 @@ test("log which view is used with a template", function() {
   });
 });
 
-test("do not log which views are used with templates when flag is not true", function() {
+QUnit.test("do not log which views are used with templates when flag is not true", function() {
   App.reopen({
     LOG_VIEW_LOOKUPS: false
   });

--- a/packages/ember-application/tests/system/readiness_test.js
+++ b/packages/ember-application/tests/system/readiness_test.js
@@ -58,7 +58,7 @@ QUnit.module("Application readiness", {
 // synchronously during the application's initialization, we get the same behavior as if
 // it was triggered after initialization.
 
-test("Ember.Application's ready event is called right away if jQuery is already ready", function() {
+QUnit.test("Ember.Application's ready event is called right away if jQuery is already ready", function() {
   jQuery.isReady = true;
 
   run(function() {
@@ -74,7 +74,7 @@ test("Ember.Application's ready event is called right away if jQuery is already 
   equal(readyWasCalled, 1, "application's ready was not called again");
 });
 
-test("Ember.Application's ready event is called after the document becomes ready", function() {
+QUnit.test("Ember.Application's ready event is called after the document becomes ready", function() {
   run(function() {
     application = Application.create({ router: false });
   });
@@ -86,7 +86,7 @@ test("Ember.Application's ready event is called after the document becomes ready
   equal(readyWasCalled, 1, "ready was called now that DOM is ready");
 });
 
-test("Ember.Application's ready event can be deferred by other components", function() {
+QUnit.test("Ember.Application's ready event can be deferred by other components", function() {
   run(function() {
     application = Application.create({ router: false });
     application.deferReadiness();
@@ -106,7 +106,7 @@ test("Ember.Application's ready event can be deferred by other components", func
   equal(readyWasCalled, 1, "ready was called now all readiness deferrals are advanced");
 });
 
-test("Ember.Application's ready event can be deferred by other components", function() {
+QUnit.test("Ember.Application's ready event can be deferred by other components", function() {
   jQuery.isReady = false;
 
   run(function() {

--- a/packages/ember-application/tests/system/reset_test.js
+++ b/packages/ember-application/tests/system/reset_test.js
@@ -26,7 +26,7 @@ QUnit.module("Ember.Application - resetting", {
   }
 });
 
-test("Brings its own run-loop if not provided", function() {
+QUnit.test("Brings its own run-loop if not provided", function() {
   application = run(Application, 'create');
   application.ready = function() {
     QUnit.start();
@@ -37,7 +37,7 @@ test("Brings its own run-loop if not provided", function() {
   application.reset();
 });
 
-test("does not bring its own run loop if one is already provided", function() {
+QUnit.test("does not bring its own run loop if one is already provided", function() {
   expect(3);
 
   var didBecomeReady = false;
@@ -61,7 +61,7 @@ test("does not bring its own run loop if one is already provided", function() {
   ok(didBecomeReady, 'app is ready');
 });
 
-test("When an application is reset, new instances of controllers are generated", function() {
+QUnit.test("When an application is reset, new instances of controllers are generated", function() {
   run(function() {
     application = Application.create();
     application.AcademicController = Controller.extend();
@@ -81,7 +81,7 @@ test("When an application is reset, new instances of controllers are generated",
   notStrictEqual(firstController, thirdController, "controllers looked up after the application is reset should not be the same instance");
 });
 
-test("When an application is reset, the eventDispatcher is destroyed and recreated", function() {
+QUnit.test("When an application is reset, the eventDispatcher is destroyed and recreated", function() {
   var eventDispatcherWasSetup, eventDispatcherWasDestroyed;
 
   eventDispatcherWasSetup = 0;
@@ -130,7 +130,7 @@ test("When an application is reset, the eventDispatcher is destroyed and recreat
   Registry.prototype.register = originalRegister;
 });
 
-test("When an application is reset, the ApplicationView is torn down", function() {
+QUnit.test("When an application is reset, the ApplicationView is torn down", function() {
   run(function() {
     application = Application.create();
     application.ApplicationView = View.extend({
@@ -151,7 +151,7 @@ test("When an application is reset, the ApplicationView is torn down", function(
   notStrictEqual(originalView, resettedView, "The view object has changed");
 });
 
-test("When an application is reset, the router URL is reset to `/`", function() {
+QUnit.test("When an application is reset, the router URL is reset to `/`", function() {
   var location, router;
 
   run(function() {
@@ -192,7 +192,7 @@ test("When an application is reset, the router URL is reset to `/`", function() 
   equal(get(applicationController, 'currentPath'), "one");
 });
 
-test("When an application with advance/deferReadiness is reset, the app does correctly become ready after reset", function() {
+QUnit.test("When an application with advance/deferReadiness is reset, the app does correctly become ready after reset", function() {
   var readyCallCount;
 
   readyCallCount = 0;
@@ -219,7 +219,7 @@ test("When an application with advance/deferReadiness is reset, the app does cor
   equal(readyCallCount, 2, 'ready was called twice');
 });
 
-test("With ember-data like initializer and constant", function() {
+QUnit.test("With ember-data like initializer and constant", function() {
   var readyCallCount;
 
   readyCallCount = 0;
@@ -264,7 +264,7 @@ test("With ember-data like initializer and constant", function() {
   ok(application.__container__.lookup("store:main"), 'store is still present');
 });
 
-test("Ensure that the hashchange event listener is removed", function() {
+QUnit.test("Ensure that the hashchange event listener is removed", function() {
   var listeners;
 
   jQuery(window).off('hashchange'); // ensure that any previous listeners are cleared

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -2,7 +2,7 @@ import Ember from 'ember-metal/core';
 
 QUnit.module('ember-debug');
 
-test('Ember.deprecate throws deprecation if second argument is falsy', function() {
+QUnit.test('Ember.deprecate throws deprecation if second argument is falsy', function() {
   expect(3);
 
   throws(function() {
@@ -18,7 +18,7 @@ test('Ember.deprecate throws deprecation if second argument is falsy', function(
   });
 });
 
-test('Ember.deprecate does not throw deprecation if second argument is a function and it returns true', function() {
+QUnit.test('Ember.deprecate does not throw deprecation if second argument is a function and it returns true', function() {
   expect(1);
 
   Ember.deprecate('Deprecation is thrown', function() {
@@ -28,7 +28,7 @@ test('Ember.deprecate does not throw deprecation if second argument is a functio
   ok(true, 'deprecation was not thrown');
 });
 
-test('Ember.deprecate throws if second argument is a function and it returns false', function() {
+QUnit.test('Ember.deprecate throws if second argument is a function and it returns false', function() {
   expect(1);
 
   throws(function() {
@@ -38,7 +38,7 @@ test('Ember.deprecate throws if second argument is a function and it returns fal
   });
 });
 
-test('Ember.deprecate does not throw deprecations if second argument is truthy', function() {
+QUnit.test('Ember.deprecate does not throw deprecations if second argument is truthy', function() {
   expect(1);
 
   Ember.deprecate('Deprecation is thrown', true);
@@ -48,7 +48,7 @@ test('Ember.deprecate does not throw deprecations if second argument is truthy',
   ok(true, 'deprecations were not thrown');
 });
 
-test('Ember.assert throws if second argument is falsy', function() {
+QUnit.test('Ember.assert throws if second argument is falsy', function() {
   expect(3);
 
   throws(function() {
@@ -64,7 +64,7 @@ test('Ember.assert throws if second argument is falsy', function() {
   });
 });
 
-test('Ember.assert does not throw if second argument is a function and it returns true', function() {
+QUnit.test('Ember.assert does not throw if second argument is a function and it returns true', function() {
   expect(1);
 
   Ember.assert('Assertion is thrown', function() {
@@ -74,7 +74,7 @@ test('Ember.assert does not throw if second argument is a function and it return
   ok(true, 'assertion was not thrown');
 });
 
-test('Ember.assert throws if second argument is a function and it returns false', function() {
+QUnit.test('Ember.assert throws if second argument is a function and it returns false', function() {
   expect(1);
 
   throws(function() {
@@ -84,7 +84,7 @@ test('Ember.assert throws if second argument is a function and it returns false'
   });
 });
 
-test('Ember.assert does not throw if second argument is truthy', function() {
+QUnit.test('Ember.assert does not throw if second argument is truthy', function() {
   expect(1);
 
   Ember.assert('Assertion is thrown', true);
@@ -94,7 +94,7 @@ test('Ember.assert does not throw if second argument is truthy', function() {
   ok(true, 'assertions were not thrown');
 });
 
-test('Ember.assert does not throw if second argument is an object', function() {
+QUnit.test('Ember.assert does not throw if second argument is an object', function() {
   expect(1);
   var Igor = Ember.Object.extend();
 

--- a/packages/ember-debug/tests/warn_if_using_stripped_feature_flags_test.js
+++ b/packages/ember-debug/tests/warn_if_using_stripped_feature_flags_test.js
@@ -43,7 +43,7 @@ QUnit.module("ember-debug - _warnIfUsingStrippedFeatureFlags", {
   }
 });
 
-test("Setting Ember.ENV.ENABLE_ALL_FEATURES truthy in non-canary, debug build causes a warning", function() {
+QUnit.test("Setting Ember.ENV.ENABLE_ALL_FEATURES truthy in non-canary, debug build causes a warning", function() {
   expect(1);
 
   Ember.ENV.ENABLE_ALL_FEATURES = true;
@@ -53,7 +53,7 @@ test("Setting Ember.ENV.ENABLE_ALL_FEATURES truthy in non-canary, debug build ca
   confirmWarns('Ember.ENV.ENABLE_ALL_FEATURES is only available in canary builds.');
 });
 
-test("Setting Ember.ENV.ENABLE_OPTIONAL_FEATURES truthy in non-canary, debug build causes a warning", function() {
+QUnit.test("Setting Ember.ENV.ENABLE_OPTIONAL_FEATURES truthy in non-canary, debug build causes a warning", function() {
   expect(1);
 
   Ember.ENV.ENABLE_ALL_FEATURES = false;
@@ -63,7 +63,7 @@ test("Setting Ember.ENV.ENABLE_OPTIONAL_FEATURES truthy in non-canary, debug bui
   confirmWarns('Ember.ENV.ENABLE_OPTIONAL_FEATURES is only available in canary builds.');
 });
 
-test("Enabling a FEATURES flag in non-canary, debug build causes a warning", function() {
+QUnit.test("Enabling a FEATURES flag in non-canary, debug build causes a warning", function() {
   expect(1);
 
   Ember.ENV.ENABLE_ALL_FEATURES = false;

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -32,18 +32,18 @@ QUnit.module("Container Debug Adapter", {
   }
 });
 
-test("the default ContainerDebugAdapter cannot catalog certain entries by type", function() {
+QUnit.test("the default ContainerDebugAdapter cannot catalog certain entries by type", function() {
   equal(adapter.canCatalogEntriesByType('model'), false, "canCatalogEntriesByType should return false for model");
   equal(adapter.canCatalogEntriesByType('template'), false, "canCatalogEntriesByType should return false for template");
 });
 
-test("the default ContainerDebugAdapter can catalog typical entries by type", function() {
+QUnit.test("the default ContainerDebugAdapter can catalog typical entries by type", function() {
   equal(adapter.canCatalogEntriesByType('controller'), true, "canCatalogEntriesByType should return true for controller");
   equal(adapter.canCatalogEntriesByType('route'), true, "canCatalogEntriesByType should return true for route");
   equal(adapter.canCatalogEntriesByType('view'), true, "canCatalogEntriesByType should return true for view");
 });
 
-test("the default ContainerDebugAdapter catalogs controller entries", function() {
+QUnit.test("the default ContainerDebugAdapter catalogs controller entries", function() {
   App.PostController = EmberController.extend();
   var controllerClasses = adapter.catalogEntriesByType('controller');
 

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -37,7 +37,7 @@ QUnit.module("Data Adapter", {
   }
 });
 
-test("Model types added with DefaultResolver", function() {
+QUnit.test("Model types added with DefaultResolver", function() {
   App.Post = Model.extend();
 
   adapter = App.__container__.lookup('data-adapter:main');
@@ -65,7 +65,7 @@ test("Model types added with DefaultResolver", function() {
   adapter.watchModelTypes(modelTypesAdded);
 });
 
-test("Model types added with custom container-debug-adapter", function() {
+QUnit.test("Model types added with custom container-debug-adapter", function() {
   var PostClass = Model.extend();
   var StubContainerDebugAdapter = DefaultResolver.extend({
     canCatalogEntriesByType: function(type) {
@@ -103,7 +103,7 @@ test("Model types added with custom container-debug-adapter", function() {
   adapter.watchModelTypes(modelTypesAdded);
 });
 
-test("Model Types Updated", function() {
+QUnit.test("Model Types Updated", function() {
   App.Post = Model.extend();
 
   adapter = App.__container__.lookup('data-adapter:main');
@@ -132,7 +132,7 @@ test("Model Types Updated", function() {
 
 });
 
-test("Records Added", function() {
+QUnit.test("Records Added", function() {
   expect(8);
   var countAdded = 1;
 
@@ -171,7 +171,7 @@ test("Records Added", function() {
   recordList.pushObject(post);
 });
 
-test("Observes and releases a record correctly", function() {
+QUnit.test("Observes and releases a record correctly", function() {
   var updatesCalled = 0;
   App.Post = Model.extend();
 

--- a/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
@@ -20,7 +20,7 @@ QUnit.module("ember-htmlbars: boolean attribute", {
   }
 });
 
-test("disabled property can be set true", function() {
+QUnit.test("disabled property can be set true", function() {
   view = EmberView.create({
     context: { isDisabled: true },
     template: compile("<input disabled={{isDisabled}}>")
@@ -32,7 +32,7 @@ test("disabled property can be set true", function() {
         'boolean property is set true');
 });
 
-test("disabled property can be set false with a blank string", function() {
+QUnit.test("disabled property can be set false with a blank string", function() {
   view = EmberView.create({
     context: { isDisabled: '' },
     template: compile("<input disabled={{isDisabled}}>")
@@ -44,7 +44,7 @@ test("disabled property can be set false with a blank string", function() {
         'boolean property is set false');
 });
 
-test("disabled property can be set false", function() {
+QUnit.test("disabled property can be set false", function() {
   view = EmberView.create({
     context: { isDisabled: false },
     template: compile("<input disabled={{isDisabled}}>")
@@ -57,7 +57,7 @@ test("disabled property can be set false", function() {
         'boolean property is set false');
 });
 
-test("disabled property can be set true with a string", function() {
+QUnit.test("disabled property can be set true with a string", function() {
   view = EmberView.create({
     context: { isDisabled: "oh, no a string" },
     template: compile("<input disabled={{isDisabled}}>")
@@ -69,7 +69,7 @@ test("disabled property can be set true with a string", function() {
         'boolean property is set true');
 });
 
-test("disabled attribute turns a value to a string", function() {
+QUnit.test("disabled attribute turns a value to a string", function() {
   view = EmberView.create({
     context: { isDisabled: false },
     template: compile("<input disabled='{{isDisabled}}'>")
@@ -81,7 +81,7 @@ test("disabled attribute turns a value to a string", function() {
         'boolean property is set true');
 });
 
-test("disabled attribute preserves a blank string value", function() {
+QUnit.test("disabled attribute preserves a blank string value", function() {
   view = EmberView.create({
     context: { isDisabled: '' },
     template: compile("<input disabled='{{isDisabled}}'>")

--- a/packages/ember-htmlbars/tests/attr_nodes/class_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/class_test.js
@@ -25,7 +25,7 @@ QUnit.module("ember-htmlbars: class attribute", {
   }
 });
 
-test("class renders before didInsertElement", function() {
+QUnit.test("class renders before didInsertElement", function() {
   var matchingElement;
   view = EmberView.create({
     didInsertElement: function() {
@@ -40,7 +40,7 @@ test("class renders before didInsertElement", function() {
   equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
 });
 
-test("class property can contain multiple classes", function() {
+QUnit.test("class property can contain multiple classes", function() {
   view = EmberView.create({
     context: { classes: 'large blue' },
     template: compile("<div class={{classes}}></div>")
@@ -53,7 +53,7 @@ test("class property can contain multiple classes", function() {
   ok(view.$('.blue')[0], 'second class found');
 });
 
-test("class property is removed when updated with a null value", function() {
+QUnit.test("class property is removed when updated with a null value", function() {
   view = EmberView.create({
     context: { class: 'large' },
     template: compile("<div class={{class}}></div>")
@@ -67,7 +67,7 @@ test("class property is removed when updated with a null value", function() {
   equal(view.element.firstChild.className, '', "attribute is removed");
 });
 
-test("class attribute concats bound values", function() {
+QUnit.test("class attribute concats bound values", function() {
   view = EmberView.create({
     context: { size: 'large', color: 'blue' },
     template: compile("<div class='{{size}} {{color}} round'></div>")
@@ -79,7 +79,7 @@ test("class attribute concats bound values", function() {
 
 if (isInlineIfEnabled) {
 
-test("class attribute accepts nested helpers, and updates", function() {
+QUnit.test("class attribute accepts nested helpers, and updates", function() {
   view = EmberView.create({
     context: {
       size: 'large',
@@ -101,7 +101,7 @@ test("class attribute accepts nested helpers, and updates", function() {
 
 }
 
-test("class attribute can accept multiple classes from a single value, and update", function() {
+QUnit.test("class attribute can accept multiple classes from a single value, and update", function() {
   view = EmberView.create({
     context: {
       size: 'large small'
@@ -117,7 +117,7 @@ test("class attribute can accept multiple classes from a single value, and updat
   ok(view.element.firstChild.className, 'medium', 'classes are updated');
 });
 
-test("class attribute can grok concatted classes, and update", function() {
+QUnit.test("class attribute can grok concatted classes, and update", function() {
   view = EmberView.create({
     context: {
       size: 'large',
@@ -135,7 +135,7 @@ test("class attribute can grok concatted classes, and update", function() {
   ok(view.element.firstChild.className, 'btn-large -post whoop', 'classes are updated');
 });
 
-test("class attribute stays in order", function() {
+QUnit.test("class attribute stays in order", function() {
   view = EmberView.create({
     context: {
       showA: 'a',

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -17,7 +17,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     }
   });
 
-  test("property is output", function() {
+  QUnit.test("property is output", function() {
     view = EmberView.create({
       context: { name: 'erik' },
       template: compile("<div data-name={{name}}>Hi!</div>")
@@ -27,7 +27,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "attribute is output");
   });
 
-  test("property set before didInsertElement", function() {
+  QUnit.test("property set before didInsertElement", function() {
     var matchingElement;
     view = EmberView.create({
       didInsertElement: function() {
@@ -42,7 +42,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
   });
 
-  test("quoted attributes are concatenated", function() {
+  QUnit.test("quoted attributes are concatenated", function() {
     view = EmberView.create({
       context: { firstName: 'max', lastName: 'jackson' },
       template: compile("<div data-name='{{firstName}} {{lastName}}'>Hi!</div>")
@@ -52,7 +52,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="max jackson">Hi!</div>', "attribute is output");
   });
 
-  test("quoted attributes are updated when changed", function() {
+  QUnit.test("quoted attributes are updated when changed", function() {
     view = EmberView.create({
       context: { firstName: 'max', lastName: 'jackson' },
       template: compile("<div data-name='{{firstName}} {{lastName}}'>Hi!</div>")
@@ -66,7 +66,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="james jackson">Hi!</div>', "attribute is output");
   });
 
-  test("quoted attributes are not removed when value is null", function() {
+  QUnit.test("quoted attributes are not removed when value is null", function() {
     view = EmberView.create({
       context: { firstName: 'max', lastName: 'jackson' },
       template: compile("<div data-name='{{firstName}}'>Hi!</div>")
@@ -80,7 +80,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equal(view.element.firstChild.getAttribute('data-name'), '', "attribute is output");
   });
 
-  test("unquoted attributes are removed when value is null", function() {
+  QUnit.test("unquoted attributes are removed when value is null", function() {
     view = EmberView.create({
       context: { firstName: 'max' },
       template: compile("<div data-name={{firstName}}>Hi!</div>")
@@ -94,7 +94,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     ok(!view.element.firstChild.hasAttribute('data-name'), "attribute is removed output");
   });
 
-  test("unquoted attributes that are null are not added", function() {
+  QUnit.test("unquoted attributes that are null are not added", function() {
     view = EmberView.create({
       context: { firstName: null },
       template: compile("<div data-name={{firstName}}>Hi!</div>")
@@ -104,7 +104,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div>Hi!</div>', "attribute is not present");
   });
 
-  test("unquoted attributes are added when changing from null", function() {
+  QUnit.test("unquoted attributes are added when changing from null", function() {
     view = EmberView.create({
       context: { firstName: null },
       template: compile("<div data-name={{firstName}}>Hi!</div>")
@@ -118,7 +118,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="max">Hi!</div>', "attribute is added output");
   });
 
-  test("property value is directly added to attribute", function() {
+  QUnit.test("property value is directly added to attribute", function() {
     view = EmberView.create({
       context: { name: '"" data-foo="blah"' },
       template: compile("<div data-name={{name}}>Hi!</div>")
@@ -128,7 +128,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equal(view.element.firstChild.getAttribute('data-name'), '"" data-foo="blah"', "attribute is output");
   });
 
-  test("path is output", function() {
+  QUnit.test("path is output", function() {
     view = EmberView.create({
       context: { name: { firstName: 'erik' } },
       template: compile("<div data-name={{name.firstName}}>Hi!</div>")
@@ -138,7 +138,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="erik">Hi!</div>', "attribute is output");
   });
 
-  test("changed property updates", function() {
+  QUnit.test("changed property updates", function() {
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,
@@ -153,7 +153,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', "attribute is updated output");
   });
 
-  test("updates are scheduled in the render queue", function() {
+  QUnit.test("updates are scheduled in the render queue", function() {
     expect(4);
 
     var context = EmberObject.create({ name: 'erik' });
@@ -180,7 +180,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     equalInnerHTML(view.element, '<div data-name="mmun">Hi!</div>', "attribute is updated output");
   });
 
-  test("updates fail silently after an element is destroyed", function() {
+  QUnit.test("updates fail silently after an element is destroyed", function() {
 
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
@@ -220,7 +220,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     }
   });
 
-  test('calls setAttribute for new values', function() {
+  QUnit.test('calls setAttribute for new values', function() {
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       renderer: renderer,
@@ -239,7 +239,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
     deepEqual(setAttributeCalls, expected);
   });
 
-  test('does not call setAttribute if the same value is set', function() {
+  QUnit.test('does not call setAttribute if the same value is set', function() {
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       renderer: renderer,

--- a/packages/ember-htmlbars/tests/attr_nodes/href_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/href_test.js
@@ -20,7 +20,7 @@ QUnit.module("ember-htmlbars: href attribute", {
   }
 });
 
-test("href is set", function() {
+QUnit.test("href is set", function() {
   view = EmberView.create({
     context: { url: 'http://example.com' },
     template: compile("<a href={{url}}></a>")

--- a/packages/ember-htmlbars/tests/attr_nodes/property_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/property_test.js
@@ -26,7 +26,7 @@ QUnit.module("ember-htmlbars: property", {
   }
 });
 
-test("maxlength sets the property and attribute", function() {
+QUnit.test("maxlength sets the property and attribute", function() {
   view = EmberView.create({
     context: { length: 5 },
     template: compile("<input maxlength={{length}}>")
@@ -39,7 +39,7 @@ test("maxlength sets the property and attribute", function() {
   equal(view.element.firstChild.maxLength, 1);
 });
 
-test("quoted maxlength sets the property and attribute", function() {
+QUnit.test("quoted maxlength sets the property and attribute", function() {
   view = EmberView.create({
     context: { length: 5 },
     template: compile("<input maxlength='{{length}}'>")
@@ -57,7 +57,7 @@ test("quoted maxlength sets the property and attribute", function() {
   }
 });
 
-test("array value can be set as property", function() {
+QUnit.test("array value can be set as property", function() {
   view = EmberView.create({
     context: {},
     template: compile("<input value={{items}}>")

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -51,7 +51,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
       return;
     }
 
-    test(subject.tag +" "+subject.attr+" is sanitized when using blacklisted protocol", function() {
+    QUnit.test(subject.tag +" "+subject.attr+" is sanitized when using blacklisted protocol", function() {
       view = EmberView.create({
         context: { url: 'javascript://example.com' },
         template: subject.unquotedTemplate
@@ -63,7 +63,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
              "attribute is output");
     });
 
-    test(subject.tag +" "+subject.attr+" is sanitized when using quoted non-whitelisted protocol", function() {
+    QUnit.test(subject.tag +" "+subject.attr+" is sanitized when using quoted non-whitelisted protocol", function() {
       view = EmberView.create({
         context: { url: 'javascript://example.com' },
         template: subject.quotedTemplate
@@ -75,7 +75,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
              "attribute is output");
     });
 
-    test(subject.tag +" "+subject.attr+" is not sanitized when using non-whitelisted protocol with a SafeString", function() {
+    QUnit.test(subject.tag +" "+subject.attr+" is not sanitized when using non-whitelisted protocol with a SafeString", function() {
       view = EmberView.create({
         context: { url: new SafeString('javascript://example.com') },
         template: subject.unquotedTemplate
@@ -93,7 +93,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
       }
     });
 
-    test(subject.tag+" "+subject.attr+" is sanitized when using quoted+concat non-whitelisted protocol", function() {
+    QUnit.test(subject.tag+" "+subject.attr+" is sanitized when using quoted+concat non-whitelisted protocol", function() {
       view = EmberView.create({
         context: { protocol: 'javascript:', path: '//example.com' },
         template: subject.multipartTemplate

--- a/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
@@ -20,7 +20,7 @@ QUnit.module("ember-htmlbars: svg attribute", {
   }
 });
 
-test("unquoted viewBox property is output", function() {
+QUnit.test("unquoted viewBox property is output", function() {
   var viewBoxString = '0 0 100 100';
   view = EmberView.create({
     context: { viewBoxString: viewBoxString },
@@ -34,7 +34,7 @@ test("unquoted viewBox property is output", function() {
   equal(view.element.getAttribute('svg'), null, "attribute is removed");
 });
 
-test("quoted viewBox property is output", function() {
+QUnit.test("quoted viewBox property is output", function() {
   var viewBoxString = '0 0 100 100';
   view = EmberView.create({
     context: { viewBoxString: viewBoxString },
@@ -45,7 +45,7 @@ test("quoted viewBox property is output", function() {
   equalInnerHTML(view.element, '<svg viewBox="'+viewBoxString+'"></svg>', "attribute is output");
 });
 
-test("quoted viewBox property is concat", function() {
+QUnit.test("quoted viewBox property is concat", function() {
   var viewBoxString = '100 100';
   view = EmberView.create({
     context: { viewBoxString: viewBoxString },
@@ -61,7 +61,7 @@ test("quoted viewBox property is concat", function() {
   equalInnerHTML(view.element, '<svg viewBox="0 0 '+newViewBoxString+'"></svg>', "attribute is output");
 });
 
-test("class is output", function() {
+QUnit.test("class is output", function() {
   view = EmberView.create({
     context: { color: 'blue' },
     template: compile("<svg class='{{color}} tall'></svg>")

--- a/packages/ember-htmlbars/tests/attr_nodes/value_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/value_test.js
@@ -19,7 +19,7 @@ QUnit.module("ember-htmlbars: value attribute", {
   }
 });
 
-test("property is output", function() {
+QUnit.test("property is output", function() {
   view = EmberView.create({
     context: { name: 'rick' },
     template: compile("<input value={{name}}>")
@@ -31,7 +31,7 @@ test("property is output", function() {
         'property is set true');
 });
 
-test("string property is output", function() {
+QUnit.test("string property is output", function() {
   view = EmberView.create({
     context: { name: 'rick' },
     template: compile("<input value='{{name}}'>")

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -33,7 +33,7 @@ QUnit.module("ember-htmlbars: Ember.Handlebars.get", {
   }
 });
 
-test('it can lookup a path from the current context', function() {
+QUnit.test('it can lookup a path from the current context', function() {
   expect(1);
 
   registry.register('helper:handlebars-get', function(path, options) {
@@ -55,7 +55,7 @@ test('it can lookup a path from the current context', function() {
   runAppend(view);
 });
 
-test('it can lookup a path from the current keywords', function() {
+QUnit.test('it can lookup a path from the current keywords', function() {
   expect(1);
 
   registry.register('helper:handlebars-get', function(path, options) {
@@ -77,7 +77,7 @@ test('it can lookup a path from the current keywords', function() {
   runAppend(view);
 });
 
-test('it can lookup a path from globals', function() {
+QUnit.test('it can lookup a path from globals', function() {
   expect(1);
 
   lookup.Blammo = { foo: 'blah' };
@@ -99,7 +99,7 @@ test('it can lookup a path from globals', function() {
   runAppend(view);
 });
 
-test('it raises a deprecation warning on use', function() {
+QUnit.test('it raises a deprecation warning on use', function() {
   expect(1);
 
   registry.register('helper:handlebars-get', function(path, options) {

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -24,7 +24,7 @@ QUnit.module('ember-htmlbars: Handlebars compatible helpers', {
   }
 });
 
-test('wraps provided function so that original path params are provided to the helper', function() {
+QUnit.test('wraps provided function so that original path params are provided to the helper', function() {
   expect(2);
 
   function someHelper(param1, param2, options) {
@@ -44,7 +44,7 @@ test('wraps provided function so that original path params are provided to the h
   runAppend(view);
 });
 
-test('combines `env` and `options` for the wrapped helper', function() {
+QUnit.test('combines `env` and `options` for the wrapped helper', function() {
   expect(1);
 
   function someHelper(options) {
@@ -63,7 +63,7 @@ test('combines `env` and `options` for the wrapped helper', function() {
   runAppend(view);
 });
 
-test('adds `hash` into options `options` for the wrapped helper', function() {
+QUnit.test('adds `hash` into options `options` for the wrapped helper', function() {
   expect(1);
 
   function someHelper(options) {
@@ -82,7 +82,7 @@ test('adds `hash` into options `options` for the wrapped helper', function() {
   runAppend(view);
 });
 
-test('bound `hash` params are provided with their original paths', function() {
+QUnit.test('bound `hash` params are provided with their original paths', function() {
   expect(1);
 
   function someHelper(options) {
@@ -101,7 +101,7 @@ test('bound `hash` params are provided with their original paths', function() {
   runAppend(view);
 });
 
-test('bound ordered params are provided with their original paths', function() {
+QUnit.test('bound ordered params are provided with their original paths', function() {
   expect(2);
 
   function someHelper(param1, param2, options) {
@@ -122,7 +122,7 @@ test('bound ordered params are provided with their original paths', function() {
   runAppend(view);
 });
 
-test('allows unbound usage within an element', function() {
+QUnit.test('allows unbound usage within an element', function() {
   expect(4);
 
   function someHelper(param1, param2, options) {
@@ -148,7 +148,7 @@ test('allows unbound usage within an element', function() {
   equal(view.$('.foo').length, 1, 'class attribute was added by helper');
 });
 
-test('registering a helper created from `Ember.Handlebars.makeViewHelper` does not double wrap the helper', function() {
+QUnit.test('registering a helper created from `Ember.Handlebars.makeViewHelper` does not double wrap the helper', function() {
   expect(1);
 
   var ViewHelperComponent = Component.extend({
@@ -167,7 +167,7 @@ test('registering a helper created from `Ember.Handlebars.makeViewHelper` does n
   equal(view.$().text(), 'woot!');
 });
 
-test('does not add `options.fn` if no block was specified', function() {
+QUnit.test('does not add `options.fn` if no block was specified', function() {
   expect(1);
 
   function someHelper(options) {
@@ -186,7 +186,7 @@ test('does not add `options.fn` if no block was specified', function() {
   runAppend(view);
 });
 
-test('does not return helper result if block was specified', function() {
+QUnit.test('does not return helper result if block was specified', function() {
   expect(1);
 
   function someHelper(options) {
@@ -207,7 +207,7 @@ test('does not return helper result if block was specified', function() {
   equal(view.$().text(), '');
 });
 
-test('allows usage of the template fn', function() {
+QUnit.test('allows usage of the template fn', function() {
   expect(1);
 
   function someHelper(options) {

--- a/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
@@ -21,7 +21,7 @@ QUnit.module('ember-htmlbars: makeViewHelper compat', {
   }
 });
 
-test('makeViewHelper', function() {
+QUnit.test('makeViewHelper', function() {
   expect(1);
 
   var ViewHelperComponent = Component.extend({

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -52,7 +52,7 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
   }
 });
 
-test("primitives should work correctly [DEPRECATED]", function() {
+QUnit.test("primitives should work correctly [DEPRECATED]", function() {
   expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
   expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
@@ -67,7 +67,7 @@ test("primitives should work correctly [DEPRECATED]", function() {
   equal(view.$().text(), 'inside-ifinside-withinside-ifinside-with');
 });
 
-test("should update bound helpers when properties change", function() {
+QUnit.test("should update bound helpers when properties change", function() {
   expectDeprecationInHTMLBars();
 
   helper('capitalize', function(value) {
@@ -90,7 +90,7 @@ test("should update bound helpers when properties change", function() {
   equal(view.$().text(), 'WES', "helper output updated");
 });
 
-test("should update bound helpers in a subexpression when properties change", function() {
+QUnit.test("should update bound helpers in a subexpression when properties change", function() {
   expectDeprecationInHTMLBars();
 
   helper('dasherize', function(value) {
@@ -111,7 +111,7 @@ test("should update bound helpers in a subexpression when properties change", fu
   equal(view.$('div[data-foo="not-thing"]').text(), 'notThing', "helper output is correct");
 });
 
-test("should allow for computed properties with dependencies", function() {
+QUnit.test("should allow for computed properties with dependencies", function() {
   expectDeprecationInHTMLBars();
 
   helper('capitalizeName', function(value) {
@@ -138,7 +138,7 @@ test("should allow for computed properties with dependencies", function() {
   equal(view.$().text(), 'WES', "helper output updated");
 });
 
-test("bound helpers should support options", function() {
+QUnit.test("bound helpers should support options", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
@@ -151,7 +151,7 @@ test("bound helpers should support options", function() {
   equal(view.$().text(), 'ababab', "helper output is correct");
 });
 
-test("bound helpers should support keywords", function() {
+QUnit.test("bound helpers should support keywords", function() {
   expectDeprecationInHTMLBars();
 
   helper('capitalize', function(value) {
@@ -168,7 +168,7 @@ test("bound helpers should support keywords", function() {
   equal(view.$().text(), 'AB', "helper output is correct");
 });
 
-test("bound helpers should support global paths [DEPRECATED]", function() {
+QUnit.test("bound helpers should support global paths [DEPRECATED]", function() {
   expectDeprecationInHTMLBars();
 
   helper('capitalize', function(value) {
@@ -188,7 +188,7 @@ test("bound helpers should support global paths [DEPRECATED]", function() {
   equal(view.$().text(), 'AB', "helper output is correct");
 });
 
-test("bound helper should support this keyword", function() {
+QUnit.test("bound helper should support this keyword", function() {
   expectDeprecationInHTMLBars();
 
   helper('capitalize', function(value) {
@@ -205,7 +205,7 @@ test("bound helper should support this keyword", function() {
   equal(view.$().text(), 'AB', "helper output is correct");
 });
 
-test("bound helpers should support bound options", function() {
+QUnit.test("bound helpers should support bound options", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
@@ -231,7 +231,7 @@ test("bound helpers should support bound options", function() {
   equal(view.$().text(), 'YESYES', "helper correctly re-rendered after both bound option and property changed");
 });
 
-test("bound helpers should support unquoted values as bound options", function() {
+QUnit.test("bound helpers should support unquoted values as bound options", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
@@ -258,7 +258,7 @@ test("bound helpers should support unquoted values as bound options", function()
 });
 
 
-test("bound helpers should support multiple bound properties", function() {
+QUnit.test("bound helpers should support multiple bound properties", function() {
   expectDeprecationInHTMLBars();
 
   helper('combine', function() {
@@ -290,7 +290,7 @@ test("bound helpers should support multiple bound properties", function() {
   equal(view.$().text(), 'WOOTYEAH', "helper correctly re-rendered after both bound helper properties changed");
 });
 
-test("bound helpers should expose property names in options.data.properties", function() {
+QUnit.test("bound helpers should expose property names in options.data.properties", function() {
   expectDeprecationInHTMLBars();
 
   helper('echo', function() {
@@ -320,7 +320,7 @@ test("bound helpers should expose property names in options.data.properties", fu
   equal(view.$().text(), 'thing1 thing2 thing3.foo', "helper output is correct");
 });
 
-test("bound helpers can be invoked with zero args", function() {
+QUnit.test("bound helpers can be invoked with zero args", function() {
   expectDeprecationInHTMLBars();
 
   helper('troll', function(options) {
@@ -337,7 +337,7 @@ test("bound helpers can be invoked with zero args", function() {
   equal(view.$().text(), 'TROLOLOL and bork', "helper output is correct");
 });
 
-test("bound helpers should not be invoked with blocks", function() {
+QUnit.test("bound helpers should not be invoked with blocks", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
@@ -350,7 +350,7 @@ test("bound helpers should not be invoked with blocks", function() {
   }, /registerBoundHelper-generated helpers do not support use with Handlebars blocks/i);
 });
 
-test("should observe dependent keys passed to registerBoundHelper", function() {
+QUnit.test("should observe dependent keys passed to registerBoundHelper", function() {
   try {
     expectDeprecationInHTMLBars();
 
@@ -390,7 +390,7 @@ test("should observe dependent keys passed to registerBoundHelper", function() {
   }
 });
 
-test("shouldn't treat raw numbers as bound paths", function() {
+QUnit.test("shouldn't treat raw numbers as bound paths", function() {
   expectDeprecationInHTMLBars();
 
   helper('sum', function(a, b) {
@@ -411,7 +411,7 @@ test("shouldn't treat raw numbers as bound paths", function() {
   equal(view.$().text(), '6 5 11', "helper still updates as expected");
 });
 
-test("shouldn't treat quoted strings as bound paths", function() {
+QUnit.test("shouldn't treat quoted strings as bound paths", function() {
   expectDeprecationInHTMLBars();
 
   var helperCount = 0;
@@ -437,7 +437,7 @@ test("shouldn't treat quoted strings as bound paths", function() {
   equal(helperCount, 5, "changing controller property with same name as quoted string doesn't re-render helper");
 });
 
-test("bound helpers can handle nulls in array (with primitives) [DEPRECATED]", function() {
+QUnit.test("bound helpers can handle nulls in array (with primitives) [DEPRECATED]", function() {
   expectDeprecationInHTMLBars();
 
   helper('reverse', function(val) {
@@ -465,7 +465,7 @@ test("bound helpers can handle nulls in array (with primitives) [DEPRECATED]", f
   equal(view.$().text(), '0|NOPE |NOPE false|NOPE OMG|GMO blorg|grolb 0|NOPE |NOPE false|NOPE OMG|GMO blorg|grolb ', "helper output is still correct");
 });
 
-test("bound helpers can handle nulls in array (with objects)", function() {
+QUnit.test("bound helpers can handle nulls in array (with objects)", function() {
   expectDeprecationInHTMLBars();
 
   helper('print-foo', function(val) {
@@ -490,7 +490,7 @@ test("bound helpers can handle nulls in array (with objects)", function() {
   equal(view.$().text(), '|NOPE 5|5 6|6 |NOPE 5|5 6|6 ', "helper output is correct");
 });
 
-test("bound helpers can handle `this` keyword when it's a non-object", function() {
+QUnit.test("bound helpers can handle `this` keyword when it's a non-object", function() {
   expectDeprecationInHTMLBars();
 
   helper("shout", function(value) {
@@ -519,7 +519,7 @@ test("bound helpers can handle `this` keyword when it's a non-object", function(
   equal(view.$().text(), 'wallace!', "helper output is correct");
 });
 
-test("should have correct argument types", function() {
+QUnit.test("should have correct argument types", function() {
   expectDeprecationInHTMLBars();
 
   helper('getType', function(value) {
@@ -536,7 +536,7 @@ test("should have correct argument types", function() {
   equal(view.$().text(), 'undefined, undefined, string, number, object', "helper output is correct");
 });
 
-test("when no parameters are bound, no new views are created", function() {
+QUnit.test("when no parameters are bound, no new views are created", function() {
   registerRepeatHelper();
   var originalRender = SimpleBoundView.prototype.render;
   var renderWasCalled = false;
@@ -560,7 +560,7 @@ test("when no parameters are bound, no new views are created", function() {
 });
 
 
-test('when no hash parameters are bound, no new views are created', function() {
+QUnit.test('when no hash parameters are bound, no new views are created', function() {
   registerRepeatHelper();
   var originalRender = SimpleBoundView.prototype.render;
   var renderWasCalled = false;

--- a/packages/ember-htmlbars/tests/compat/precompile_test.js
+++ b/packages/ember-htmlbars/tests/compat/precompile_test.js
@@ -7,17 +7,17 @@ var result;
 
 QUnit.module("ember-htmlbars: Ember.Handlebars.precompile");
 
-test("precompile creates an object when asObject isn't defined", function() {
+QUnit.test("precompile creates an object when asObject isn't defined", function() {
   result = precompile(template);
   equal(typeof(result), "object");
 });
 
-test("precompile creates an object when asObject is true", function() {
+QUnit.test("precompile creates an object when asObject is true", function() {
   result = precompile(template, true);
   equal(typeof(result), "object");
 });
 
-test("precompile creates a string when asObject is false", function() {
+QUnit.test("precompile creates a string when asObject is false", function() {
   result = precompile(template, false);
   equal(typeof(result), "string");
 });
@@ -25,7 +25,7 @@ test("precompile creates a string when asObject is false", function() {
 if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
 
-test("precompile creates an object when passed an AST", function() {
+QUnit.test("precompile creates an object when passed an AST", function() {
   var ast = parse(template);
   result = precompile(ast);
   equal(typeof(result), "object");

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -47,7 +47,7 @@ QUnit.module("ember-htmlbars: {{bind-attr}}", {
   }
 });
 
-test("should be able to bind element attributes using {{bind-attr}}", function() {
+QUnit.test("should be able to bind element attributes using {{bind-attr}}", function() {
   var template = compile('<img {{bind-attr src=view.content.url alt=view.content.title}}>');
 
   view = EmberView.create({
@@ -99,7 +99,7 @@ test("should be able to bind element attributes using {{bind-attr}}", function()
   equal(view.$('img').attr('alt'), "Nanananana Ember!", "updates alt attribute when title property is computed");
 });
 
-test("should be able to bind to view attributes with {{bind-attr}}", function() {
+QUnit.test("should be able to bind to view attributes with {{bind-attr}}", function() {
   view = EmberView.create({
     value: 'Test',
     template: compile('<img src="test.jpg" {{bind-attr alt=view.value}}>')
@@ -116,7 +116,7 @@ test("should be able to bind to view attributes with {{bind-attr}}", function() 
   equal(view.$('img').attr('alt'), "Updated", "updates value");
 });
 
-test("should be able to bind to globals with {{bind-attr}} (DEPRECATED)", function() {
+QUnit.test("should be able to bind to globals with {{bind-attr}} (DEPRECATED)", function() {
   TemplateTests.set('value', 'Test');
 
   view = EmberView.create({
@@ -130,7 +130,7 @@ test("should be able to bind to globals with {{bind-attr}} (DEPRECATED)", functi
   equal(view.$('img').attr('alt'), "Test", "renders initial value");
 });
 
-test("should not allow XSS injection via {{bind-attr}}", function() {
+QUnit.test("should not allow XSS injection via {{bind-attr}}", function() {
   view = EmberView.create({
     template: compile('<img src="test.jpg" {{bind-attr alt=view.content.value}}>'),
     content: {
@@ -145,7 +145,7 @@ test("should not allow XSS injection via {{bind-attr}}", function() {
   equal(view.$('img').attr('alt'), 'Trololol" onmouseover="alert(\'HAX!\');');
 });
 
-test("should be able to bind use {{bind-attr}} more than once on an element", function() {
+QUnit.test("should be able to bind use {{bind-attr}} more than once on an element", function() {
   var template = compile('<img {{bind-attr src=view.content.url}} {{bind-attr alt=view.content.title}}>');
 
   view = EmberView.create({
@@ -198,7 +198,7 @@ test("should be able to bind use {{bind-attr}} more than once on an element", fu
 
 });
 
-test("{{bindAttr}} is aliased to {{bind-attr}}", function() {
+QUnit.test("{{bindAttr}} is aliased to {{bind-attr}}", function() {
   expect(4);
 
   var originalBindAttr = helpers['bind-attr'];
@@ -237,7 +237,7 @@ test("{{bindAttr}} is aliased to {{bind-attr}}", function() {
   }
 });
 
-test("{{bindAttr}} can be used to bind attributes [DEPRECATED]", function() {
+QUnit.test("{{bindAttr}} can be used to bind attributes [DEPRECATED]", function() {
   expect(3);
 
   view = EmberView.create({
@@ -258,7 +258,7 @@ test("{{bindAttr}} can be used to bind attributes [DEPRECATED]", function() {
   equal(view.$('img').attr('alt'), "Updated", "updates value");
 });
 
-test("should be able to bind element attributes using {{bind-attr}} inside a block", function() {
+QUnit.test("should be able to bind element attributes using {{bind-attr}} inside a block", function() {
   var template = compile('{{#with view.content as image}}<img {{bind-attr src=image.url alt=image.title}}>{{/with}}');
 
   view = EmberView.create({
@@ -281,7 +281,7 @@ test("should be able to bind element attributes using {{bind-attr}} inside a blo
   equal(view.$('img').attr('alt'), "El logo de Eember", "updates alt attribute when content's title attribute changes");
 });
 
-test("should be able to bind class attribute with {{bind-attr}}", function() {
+QUnit.test("should be able to bind class attribute with {{bind-attr}}", function() {
   var template = compile('<img {{bind-attr class="view.foo"}}>');
 
   view = EmberView.create({
@@ -300,7 +300,7 @@ test("should be able to bind class attribute with {{bind-attr}}", function() {
   equal(view.element.firstChild.className, 'baz', 'updates rendered class');
 });
 
-test("should be able to bind unquoted class attribute with {{bind-attr}}", function() {
+QUnit.test("should be able to bind unquoted class attribute with {{bind-attr}}", function() {
   var template = compile('<img {{bind-attr class=view.foo}}>');
 
   view = EmberView.create({
@@ -319,7 +319,7 @@ test("should be able to bind unquoted class attribute with {{bind-attr}}", funct
   equal(view.$('img').attr('class'), 'baz', "updates class");
 });
 
-test("should be able to bind class attribute via a truthy property with {{bind-attr}}", function() {
+QUnit.test("should be able to bind class attribute via a truthy property with {{bind-attr}}", function() {
   var template = compile('<img {{bind-attr class="view.isNumber:is-truthy"}}>');
 
   view = EmberView.create({
@@ -338,7 +338,7 @@ test("should be able to bind class attribute via a truthy property with {{bind-a
   ok(view.element.firstChild.className !== 'is-truthy', 'removes class');
 });
 
-test("should be able to bind class to view attribute with {{bind-attr}}", function() {
+QUnit.test("should be able to bind class to view attribute with {{bind-attr}}", function() {
   var template = compile('<img {{bind-attr class="view.foo"}}>');
 
   view = EmberView.create({
@@ -357,7 +357,7 @@ test("should be able to bind class to view attribute with {{bind-attr}}", functi
   equal(view.$('img').attr('class'), 'baz', "updates class");
 });
 
-test("should not allow XSS injection via {{bind-attr}} with class", function() {
+QUnit.test("should not allow XSS injection via {{bind-attr}} with class", function() {
   view = EmberView.create({
     template: compile('<img {{bind-attr class="view.foo"}}>'),
     foo: '" onmouseover="alert(\'I am in your classes hacking your app\');'
@@ -371,7 +371,7 @@ test("should not allow XSS injection via {{bind-attr}} with class", function() {
   equal(view.$('img').attr('onmouseover'), undefined);
 });
 
-test("should be able to bind class attribute using ternary operator in {{bind-attr}}", function() {
+QUnit.test("should be able to bind class attribute using ternary operator in {{bind-attr}}", function() {
   var template = compile('<img {{bind-attr class="view.content.isDisabled:disabled:enabled"}} />');
   var content = EmberObject.create({
     isDisabled: true
@@ -395,7 +395,7 @@ test("should be able to bind class attribute using ternary operator in {{bind-at
   ok(view.$('img').hasClass('enabled'), 'enabled class is rendered');
 });
 
-test("should be able to add multiple classes using {{bind-attr class}}", function() {
+QUnit.test("should be able to add multiple classes using {{bind-attr class}}", function() {
   var template = compile('<div {{bind-attr class="view.content.isAwesomeSauce view.content.isAlsoCool view.content.isAmazing:amazing :is-super-duper view.content.isEnabled:enabled:disabled"}}></div>');
   var content = EmberObject.create({
     isAwesomeSauce: true,
@@ -431,7 +431,7 @@ test("should be able to add multiple classes using {{bind-attr class}}", functio
   ok(view.$('div').hasClass('disabled'), "falsy class in ternary classname definition is rendered");
 });
 
-test("should be able to bind classes to globals with {{bind-attr class}} (DEPRECATED)", function() {
+QUnit.test("should be able to bind classes to globals with {{bind-attr class}} (DEPRECATED)", function() {
   TemplateTests.set('isOpen', true);
 
   view = EmberView.create({
@@ -445,7 +445,7 @@ test("should be able to bind classes to globals with {{bind-attr class}} (DEPREC
   ok(view.$('img').hasClass('is-open'), "sets classname to the dasherized value of the global property");
 });
 
-test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]", function() {
+QUnit.test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]", function() {
   expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   view = EmberView.create({
@@ -461,7 +461,7 @@ test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]",
   ok(/three\.gif$/.test(images[2].src));
 });
 
-test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}} [DEPRECATED]", function() {
+QUnit.test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}} [DEPRECATED]", function() {
   expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
 
   view = EmberView.create({
@@ -476,7 +476,7 @@ test("should be able to bind classes to 'this' in an {{#each}} block with {{bind
   ok(view.$('li').eq(2).hasClass('c'), "sets classname to the value of the third item");
 });
 
-test("should be able to bind-attr to var in {{#each var in list}} block", function() {
+QUnit.test("should be able to bind-attr to var in {{#each var in list}} block", function() {
   view = EmberView.create({
     template: compile('{{#each image in view.images}}<img {{bind-attr src=image}}>{{/each}}'),
     images: A(['one.png', 'two.jpg', 'three.gif'])
@@ -500,7 +500,7 @@ test("should be able to bind-attr to var in {{#each var in list}} block", functi
   ok(/three\.gif$/.test(images[1].src));
 });
 
-test("should teardown observers from bind-attr on rerender", function() {
+QUnit.test("should teardown observers from bind-attr on rerender", function() {
   view = EmberView.create({
     template: compile('<span {{bind-attr class="view.foo" name=view.foo}}>wat</span>'),
     foo: 'bar'
@@ -517,7 +517,7 @@ test("should teardown observers from bind-attr on rerender", function() {
   equal(observersFor(view, 'foo').length, 1);
 });
 
-test("should keep class in the order it appears in", function() {
+QUnit.test("should keep class in the order it appears in", function() {
   view = EmberView.create({
     template: compile('<span {{bind-attr class=":foo :baz"}}></span>')
   });
@@ -527,7 +527,7 @@ test("should keep class in the order it appears in", function() {
   equal(view.element.firstChild.className, 'foo baz', 'classes are in expected order');
 });
 
-test('should allow either quoted or unquoted values', function() {
+QUnit.test('should allow either quoted or unquoted values', function() {
   view = EmberView.create({
     value: 'Test',
     source: 'test.jpg',
@@ -548,7 +548,7 @@ test('should allow either quoted or unquoted values', function() {
   equal(view.$('img').attr('src'), "test2.jpg", "updates value");
 });
 
-test("property before didInsertElement", function() {
+QUnit.test("property before didInsertElement", function() {
   var matchingElement;
   view = EmberView.create({
     name: 'bob',
@@ -561,7 +561,7 @@ test("property before didInsertElement", function() {
   equal(matchingElement.length, 1, 'element is in the DOM when didInsertElement');
 });
 
-test("asserts for <div class='foo' {{bind-attr class='bar'}}></div>", function() {
+QUnit.test("asserts for <div class='foo' {{bind-attr class='bar'}}></div>", function() {
   var template = compile('<div class="foo" {{bind-attr class=view.foo}}></div>');
 
   view = EmberView.create({
@@ -574,7 +574,7 @@ test("asserts for <div class='foo' {{bind-attr class='bar'}}></div>", function()
   }, /You cannot set `class` manually and via `{{bind-attr}}` helper on the same element/);
 });
 
-test("asserts for <div data-bar='foo' {{bind-attr data-bar='blah'}}></div>", function() {
+QUnit.test("asserts for <div data-bar='foo' {{bind-attr data-bar='blah'}}></div>", function() {
   var template = compile('<div data-bar="foo" {{bind-attr data-bar=view.blah}}></div>');
 
   view = EmberView.create({

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -55,7 +55,7 @@ QUnit.module("collection helper", {
   }
 });
 
-test("Collection views that specify an example view class have their children be of that class", function() {
+QUnit.test("Collection views that specify an example view class have their children be of that class", function() {
   var ExampleViewCollection = CollectionView.extend({
     itemViewClass: EmberView.extend({
       isCustom: true
@@ -74,7 +74,7 @@ test("Collection views that specify an example view class have their children be
   ok(firstGrandchild(view).isCustom, "uses the example view class");
 });
 
-test("itemViewClass works in the #collection helper with a global (DEPRECATED)", function() {
+QUnit.test("itemViewClass works in the #collection helper with a global (DEPRECATED)", function() {
   TemplateTests.ExampleItemView = EmberView.extend({
     isAlsoCustom: true
   });
@@ -97,7 +97,7 @@ test("itemViewClass works in the #collection helper with a global (DEPRECATED)",
   ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
 
-test("itemViewClass works in the #collection helper with a property", function() {
+QUnit.test("itemViewClass works in the #collection helper with a property", function() {
   var ExampleItemView = EmberView.extend({
     isAlsoCustom: true
   });
@@ -118,7 +118,7 @@ test("itemViewClass works in the #collection helper with a property", function()
   ok(firstGrandchild(view).isAlsoCustom, "uses the example view class specified in the #collection helper");
 });
 
-test("itemViewClass works in the #collection via container", function() {
+QUnit.test("itemViewClass works in the #collection via container", function() {
   registry.register('view:example-item', EmberView.extend({
     isAlsoCustom: true
   }));
@@ -138,7 +138,7 @@ test("itemViewClass works in the #collection via container", function() {
 });
 
 
-test("passing a block to the collection helper sets it as the template for example views", function() {
+QUnit.test("passing a block to the collection helper sets it as the template for example views", function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
@@ -154,7 +154,7 @@ test("passing a block to the collection helper sets it as the template for examp
   equal(view.$('label').length, 3, 'one label element is created for each content item');
 });
 
-test("collection helper should try to use container to resolve view", function() {
+QUnit.test("collection helper should try to use container to resolve view", function() {
   var registry = new Registry();
   var container = registry.container();
 
@@ -176,7 +176,7 @@ test("collection helper should try to use container to resolve view", function()
   equal(view.$('label').length, 3, 'one label element is created for each content item');
 });
 
-test("collection helper should accept relative paths", function() {
+QUnit.test("collection helper should accept relative paths", function() {
   view = EmberView.create({
     template: compile('{{#collection view.collection}} <label></label> {{/collection}}'),
     collection: CollectionView.extend({
@@ -190,7 +190,7 @@ test("collection helper should accept relative paths", function() {
   equal(view.$('label').length, 3, 'one label element is created for each content item');
 });
 
-test("empty views should be removed when content is added to the collection (regression, ht: msofaer)", function() {
+QUnit.test("empty views should be removed when content is added to the collection (regression, ht: msofaer)", function() {
   var EmptyView = EmberView.extend({
     template : compile("<td>No Rows Yet</td>")
   });
@@ -221,7 +221,7 @@ test("empty views should be removed when content is added to the collection (reg
   equal(view.$('tr:nth-child(1) td').text(), 'Go Away, Placeholder Row!', 'The content is the updated data.');
 });
 
-test("should be able to specify which class should be used for the empty view", function() {
+QUnit.test("should be able to specify which class should be used for the empty view", function() {
   var App;
 
   run(function() {
@@ -248,7 +248,7 @@ test("should be able to specify which class should be used for the empty view", 
   runDestroy(App);
 });
 
-test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {
+QUnit.test("if no content is passed, and no 'else' is specified, nothing is rendered", function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A()
@@ -264,7 +264,7 @@ test("if no content is passed, and no 'else' is specified, nothing is rendered",
   equal(view.$('li').length, 0, 'if no "else" is specified, nothing is rendered');
 });
 
-test("if no content is passed, and 'else' is specified, the else block is rendered", function() {
+QUnit.test("if no content is passed, and 'else' is specified, the else block is rendered", function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A()
@@ -280,7 +280,7 @@ test("if no content is passed, and 'else' is specified, the else block is render
   equal(view.$('li:has(del)').length, 1, 'the else block is rendered');
 });
 
-test("a block passed to a collection helper defaults to the content property of the context", function() {
+QUnit.test("a block passed to a collection helper defaults to the content property of the context", function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
@@ -301,7 +301,7 @@ test("a block passed to a collection helper defaults to the content property of 
   equal(view.$('li:nth-child(3) label').text(), 'baz');
 });
 
-test("a block passed to a collection helper defaults to the view", function() {
+QUnit.test("a block passed to a collection helper defaults to the view", function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
@@ -328,7 +328,7 @@ test("a block passed to a collection helper defaults to the view", function() {
   equal(view.$('label').length, 0, "all list item views should be removed from DOM");
 });
 
-test("should include an id attribute if id is set in the options hash", function() {
+QUnit.test("should include an id attribute if id is set in the options hash", function() {
   var CollectionTestView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
@@ -344,7 +344,7 @@ test("should include an id attribute if id is set in the options hash", function
   equal(view.$('ul#baz').length, 1, "adds an id attribute");
 });
 
-test("should give its item views the class specified by itemClass", function() {
+QUnit.test("should give its item views the class specified by itemClass", function() {
   var ItemClassTestCollectionView = CollectionView.extend({
     tagName: 'ul',
     content: A(['foo', 'bar', 'baz'])
@@ -359,7 +359,7 @@ test("should give its item views the class specified by itemClass", function() {
   equal(view.$('ul li.baz').length, 3, "adds class attribute");
 });
 
-test("should give its item views the classBinding specified by itemClassBinding", function() {
+QUnit.test("should give its item views the classBinding specified by itemClassBinding", function() {
   var ItemClassBindingTestCollectionView = CollectionView.extend({
     tagName: 'ul',
     content: A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })])
@@ -379,7 +379,7 @@ test("should give its item views the classBinding specified by itemClassBinding"
   // to introduce a new keyword that could be used from within `itemClassBinding`. For instance, `itemClassBinding="item.isBaz"`.
 });
 
-test("should give its item views the property specified by itemPropertyBinding", function() {
+QUnit.test("should give its item views the property specified by itemPropertyBinding", function() {
   var ItemPropertyBindingTestItemView = EmberView.extend({
     tagName: 'li'
   });
@@ -412,7 +412,7 @@ test("should give its item views the property specified by itemPropertyBinding",
   equal(view.$('ul li:first').text(), "yobaz", "change property of sub view");
 });
 
-test("should unsubscribe stream bindings", function() {
+QUnit.test("should unsubscribe stream bindings", function() {
   view = EmberView.create({
     baz: "baz",
     content: A([EmberObject.create(), EmberObject.create(), EmberObject.create()]),
@@ -432,7 +432,7 @@ test("should unsubscribe stream bindings", function() {
   equal(barStreamBinding.subscribers.length, 2*2, "removes 1 subscriber");
 });
 
-test("should work inside a bound {{#if}}", function() {
+QUnit.test("should work inside a bound {{#if}}", function() {
   var testData = A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })]);
   var IfTestCollectionView = CollectionView.extend({
     tagName: 'ul',
@@ -456,7 +456,7 @@ test("should work inside a bound {{#if}}", function() {
   equal(view.$('ul li').length, 3, "collection renders when conditional changes to true");
 });
 
-test("should pass content as context when using {{#each}} helper [DEPRECATED]", function() {
+QUnit.test("should pass content as context when using {{#each}} helper [DEPRECATED]", function() {
   view = EmberView.create({
     template: compile('{{#each view.releases}}Mac OS X {{version}}: {{name}} {{/each}}'),
 
@@ -477,7 +477,7 @@ test("should pass content as context when using {{#each}} helper [DEPRECATED]", 
   equal(view.$().text(), "Mac OS X 10.7: Lion Mac OS X 10.6: Snow Leopard Mac OS X 10.5: Leopard ", "prints each item in sequence");
 });
 
-test("should re-render when the content object changes", function() {
+QUnit.test("should re-render when the content object changes", function() {
   var RerenderTest = CollectionView.extend({
     tagName: 'ul',
     content: A()
@@ -502,7 +502,7 @@ test("should re-render when the content object changes", function() {
   equal(trim(view.$('li:eq(0)').text()), "ramalamadingdong");
 });
 
-test("select tagName on collection helper automatically sets child tagName to option", function() {
+QUnit.test("select tagName on collection helper automatically sets child tagName to option", function() {
   var RerenderTest = CollectionView.extend({
     content: A(['foo'])
   });
@@ -517,7 +517,7 @@ test("select tagName on collection helper automatically sets child tagName to op
   equal(view.$('option').length, 1, "renders the correct child tag name");
 });
 
-test("tagName works in the #collection helper", function() {
+QUnit.test("tagName works in the #collection helper", function() {
   var RerenderTest = CollectionView.extend({
     content: A(['foo', 'bar'])
   });
@@ -540,7 +540,7 @@ test("tagName works in the #collection helper", function() {
   equal(trim(view.$('li:eq(0)').text()), "bing");
 });
 
-test("should render nested collections", function() {
+QUnit.test("should render nested collections", function() {
   var registry = new Registry();
   var container = registry.container();
   registry.register('view:inner-list', CollectionView.extend({
@@ -566,7 +566,7 @@ test("should render nested collections", function() {
 
 });
 
-test("should render multiple, bound nested collections (#68)", function() {
+QUnit.test("should render multiple, bound nested collections (#68)", function() {
   var view;
 
   run(function() {
@@ -609,7 +609,7 @@ test("should render multiple, bound nested collections (#68)", function() {
   runDestroy(view);
 });
 
-test("should allow view objects to be swapped out without throwing an error (#78)", function() {
+QUnit.test("should allow view objects to be swapped out without throwing an error (#78)", function() {
   var view, dataset, secondDataset;
 
   run(function() {
@@ -656,7 +656,7 @@ test("should allow view objects to be swapped out without throwing an error (#78
   runDestroy(view);
 });
 
-test("context should be content", function() {
+QUnit.test("context should be content", function() {
   var view;
 
   registry = new Registry();

--- a/packages/ember-htmlbars/tests/helpers/component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/component_test.js
@@ -25,7 +25,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     }
   });
 
-  test("component helper with unquoted string is bound", function() {
+  QUnit.test("component helper with unquoted string is bound", function() {
     registry.register('template:components/foo-bar', compile('yippie! {{location}} {{yield}}'));
     registry.register('template:components/baz-qux', compile('yummy {{location}} {{yield}}'));
 
@@ -46,7 +46,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     equal(view.$().text(), 'yummy Loisaida arepas!', 'component was updated and re-rendered');
   });
 
-  test("component helper with actions", function() {
+  QUnit.test("component helper with actions", function() {
     registry.register('template:components/foo-bar', compile('yippie! {{yield}}'));
     registry.register('component:foo-bar', Ember.Component.extend({
       classNames: 'foo-bar',
@@ -84,7 +84,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     equal(actionTriggered, 1, 'action was triggered');
   });
 
-  test('component helper maintains expected logical parentView', function() {
+  QUnit.test('component helper maintains expected logical parentView', function() {
     registry.register('template:components/foo-bar', compile('yippie! {{yield}}'));
     var componentInstance;
     registry.register('component:foo-bar', Ember.Component.extend({
@@ -103,7 +103,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     equal(get(componentInstance, 'parentView'), view, 'component\'s parentView is the view invoking the helper');
   });
 
-  test("nested component helpers", function() {
+  QUnit.test("nested component helpers", function() {
     registry.register('template:components/foo-bar', compile('yippie! {{location}} {{yield}}'));
     registry.register('template:components/baz-qux', compile('yummy {{location}} {{yield}}'));
     registry.register('template:components/corge-grault', compile('delicious {{location}} {{yield}}'));
@@ -126,7 +126,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     equal(view.$().text(), 'delicious Loisaida yummy Loisaida arepas!', 'components were updated and re-rendered');
   });
 
-  test("component helper can be used with a quoted string (though you probably would not do this)", function() {
+  QUnit.test("component helper can be used with a quoted string (though you probably would not do this)", function() {
     registry.register('template:components/foo-bar', compile('yippie! {{location}} {{yield}}'));
 
     view = EmberView.create({
@@ -140,7 +140,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     equal(view.$().text(), 'yippie! Caracas arepas!', 'component was looked up and rendered');
   });
 
-  test("component with unquoted param resolving to non-existent component", function() {
+  QUnit.test("component with unquoted param resolving to non-existent component", function() {
     view = EmberView.create({
       container: container,
       dynamicComponent: 'does-not-exist',
@@ -153,7 +153,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     }, /HTMLBars error: Could not find component named "does-not-exist"./);
   });
 
-  test("component with quoted param for non-existent component", function() {
+  QUnit.test("component with quoted param for non-existent component", function() {
     view = EmberView.create({
       container: container,
       location: 'Caracas',

--- a/packages/ember-htmlbars/tests/helpers/debug_test.js
+++ b/packages/ember-htmlbars/tests/helpers/debug_test.js
@@ -28,7 +28,7 @@ QUnit.module("Handlebars {{log}} helper", {
   }
 });
 
-test("should be able to log multiple properties", function() {
+QUnit.test("should be able to log multiple properties", function() {
   var context = {
     value: 'one',
     valueTwo: 'two'
@@ -46,7 +46,7 @@ test("should be able to log multiple properties", function() {
   equal(logCalls[1], 'two');
 });
 
-test("should be able to log primitives", function() {
+QUnit.test("should be able to log primitives", function() {
   var context = {
     value: 'one',
     valueTwo: 'two'

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -58,12 +58,12 @@ function parseEach(str, useBlockParams) {
 
 QUnit.module("parseEach test helper");
 
-test("block param syntax substitution", function() {
+QUnit.test("block param syntax substitution", function() {
   equal(parseEach("{{#EACH|people|p}}p people{{/EACH}}", true), "{{#each people as |p|}}p people{{/each}}");
   equal(parseEach("{{#EACH|people|p|a='b' c='d'}}p people{{/EACH}}", true), "{{#each people a='b' c='d' as |p|}}p people{{/each}}");
 });
 
-test("non-block param syntax substitution", function() {
+QUnit.test("non-block param syntax substitution", function() {
   equal(parseEach("{{#EACH|people|p}}p people{{/EACH}}", false), "{{#each p in people}}p people{{/each}}");
   equal(parseEach("{{#EACH|people|p|a='b' c='d'}}p people{{/EACH}}", false), "{{#each p in people a='b' c='d'}}p people{{/each}}");
 });
@@ -131,11 +131,11 @@ var assertText = function(view, expectedText) {
   equal(view.$().text(), expectedText);
 };
 
-test("it renders the template for each item in an array", function() {
+QUnit.test("it renders the template for each item in an array", function() {
   assertHTML(view, "Steve HoltAnnabelle");
 });
 
-test("it updates the view if an item is added", function() {
+QUnit.test("it updates the view if an item is added", function() {
   run(function() {
     people.pushObject({ name: "Tom Dale" });
   });
@@ -144,7 +144,7 @@ test("it updates the view if an item is added", function() {
 });
 
 if (typeof Handlebars === "object") {
-  test("should be able to use standard Handlebars #each helper", function() {
+  QUnit.test("should be able to use standard Handlebars #each helper", function() {
     runDestroy(view);
 
     view = EmberView.create({
@@ -158,7 +158,7 @@ if (typeof Handlebars === "object") {
   });
 }
 
-test("it allows you to access the current context using {{this}}", function() {
+QUnit.test("it allows you to access the current context using {{this}}", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -171,7 +171,7 @@ test("it allows you to access the current context using {{this}}", function() {
   assertHTML(view, "Black FrancisJoey SantiagoKim DealDavid Lovering");
 });
 
-test("it updates the view if an item is removed", function() {
+QUnit.test("it updates the view if an item is removed", function() {
   run(function() {
     people.removeAt(0);
   });
@@ -179,7 +179,7 @@ test("it updates the view if an item is removed", function() {
   assertHTML(view, "Annabelle");
 });
 
-test("it updates the view if an item is replaced", function() {
+QUnit.test("it updates the view if an item is replaced", function() {
   run(function() {
     people.removeAt(0);
     people.insertAt(0, { name: "Kazuki" });
@@ -188,7 +188,7 @@ test("it updates the view if an item is replaced", function() {
   assertHTML(view, "KazukiAnnabelle");
 });
 
-test("can add and replace in the same runloop", function() {
+QUnit.test("can add and replace in the same runloop", function() {
   run(function() {
     people.pushObject({ name: "Tom Dale" });
     people.removeAt(0);
@@ -198,7 +198,7 @@ test("can add and replace in the same runloop", function() {
   assertHTML(view, "KazukiAnnabelleTom Dale");
 });
 
-test("can add and replace the object before the add in the same runloop", function() {
+QUnit.test("can add and replace the object before the add in the same runloop", function() {
   run(function() {
     people.pushObject({ name: "Tom Dale" });
     people.removeAt(1);
@@ -208,7 +208,7 @@ test("can add and replace the object before the add in the same runloop", functi
   assertHTML(view, "Steve HoltKazukiTom Dale");
 });
 
-test("can add and replace complicatedly", function() {
+QUnit.test("can add and replace complicatedly", function() {
   run(function() {
     people.pushObject({ name: "Tom Dale" });
     people.removeAt(1);
@@ -221,7 +221,7 @@ test("can add and replace complicatedly", function() {
   assertHTML(view, "Steve HoltKazukiTom DaleMcMunch");
 });
 
-test("can add and replace complicatedly harder", function() {
+QUnit.test("can add and replace complicatedly harder", function() {
   run(function() {
     people.pushObject({ name: "Tom Dale" });
     people.removeAt(1);
@@ -234,7 +234,7 @@ test("can add and replace complicatedly harder", function() {
   assertHTML(view, "Steve HoltKazukiFirestoneMcMunch");
 });
 
-test("it does not mark each option tag as selected", function() {
+QUnit.test("it does not mark each option tag as selected", function() {
   var selectView = EmberView.create({
     template: templateFor('<select id="people-select"><option value="">Please select a name</option>{{#each view.people}}<option {{bind-attr value=name}}>{{name}}</option>{{/each}}</select>'),
     people: people
@@ -257,7 +257,7 @@ test("it does not mark each option tag as selected", function() {
   runDestroy(selectView);
 });
 
-test("View should not use keyword incorrectly - Issue #1315", function() {
+QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -276,7 +276,7 @@ test("View should not use keyword incorrectly - Issue #1315", function() {
   equal(view.$().text(), 'X-1:One 2:Two Y-1:One 2:Two ');
 });
 
-test("it works inside a ul element", function() {
+QUnit.test("it works inside a ul element", function() {
   var ulView = EmberView.create({
     template: templateFor('<ul>{{#each view.people}}<li>{{name}}</li>{{/each}}</ul>'),
     people: people
@@ -295,7 +295,7 @@ test("it works inside a ul element", function() {
   runDestroy(ulView);
 });
 
-test("it works inside a table element", function() {
+QUnit.test("it works inside a table element", function() {
   var tableView = EmberView.create({
     template: templateFor('<table><tbody>{{#each view.people}}<tr><td>{{name}}</td></tr>{{/each}}</tbody></table>'),
     people: people
@@ -320,7 +320,7 @@ test("it works inside a table element", function() {
   runDestroy(tableView);
 });
 
-test("it supports itemController", function() {
+QUnit.test("it supports itemController", function() {
   var Controller = EmberController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name');
@@ -369,7 +369,7 @@ test("it supports itemController", function() {
   strictEqual(view._childViews[0]._arrayController.get('target'), parentController, "the target property of the child controllers are set correctly");
 });
 
-test("itemController specified in template gets a parentController property", function() {
+QUnit.test("itemController specified in template gets a parentController property", function() {
   // using an ObjectController for this test to verify that parentController does accidentally get set
   // on the proxied model.
   var Controller = ObjectController.extend({
@@ -399,7 +399,7 @@ test("itemController specified in template gets a parentController property", fu
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
 
-test("itemController specified in ArrayController gets a parentController property", function() {
+QUnit.test("itemController specified in ArrayController gets a parentController property", function() {
   var PersonController = ObjectController.extend({
         controllerName: computed(function() {
           return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
@@ -427,7 +427,7 @@ test("itemController specified in ArrayController gets a parentController proper
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
 
-test("itemController's parentController property, when the ArrayController has a parentController", function() {
+QUnit.test("itemController's parentController property, when the ArrayController has a parentController", function() {
   var PersonController = ObjectController.extend({
         controllerName: computed(function() {
           return "controller:" + get(this, 'model.name') + ' of ' + get(this, 'parentController.company');
@@ -460,7 +460,7 @@ test("itemController's parentController property, when the ArrayController has a
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
 
-test("it supports itemController when using a custom keyword", function() {
+QUnit.test("it supports itemController when using a custom keyword", function() {
   var Controller = EmberController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name');
@@ -492,7 +492,7 @@ test("it supports itemController when using a custom keyword", function() {
   equal(view.$().text(), "controller:Steve Holtcontroller:Annabelle");
 });
 
-test("it supports {{itemView=}}", function() {
+QUnit.test("it supports {{itemView=}}", function() {
   var itemView = EmberView.extend({
     template: templateFor('itemView:{{name}}')
   });
@@ -512,7 +512,7 @@ test("it supports {{itemView=}}", function() {
 });
 
 
-test("it defers all normalization of itemView names to the resolver", function() {
+QUnit.test("it defers all normalization of itemView names to the resolver", function() {
   var itemView = EmberView.extend({
     template: templateFor('itemView:{{name}}')
   });
@@ -533,7 +533,7 @@ test("it defers all normalization of itemView names to the resolver", function()
 
 });
 
-test("it supports {{itemViewClass=}} with global (DEPRECATED)", function() {
+QUnit.test("it supports {{itemViewClass=}} with global (DEPRECATED)", function() {
   runDestroy(view);
   view = EmberView.create({
     template: templateFor('{{each view.people itemViewClass=MyView}}'),
@@ -552,7 +552,7 @@ test("it supports {{itemViewClass=}} with global (DEPRECATED)", function() {
   assertText(view, "Steve HoltAnnabelle");
 });
 
-test("it supports {{itemViewClass=}} via container", function() {
+QUnit.test("it supports {{itemViewClass=}} via container", function() {
   runDestroy(view);
   view = EmberView.create({
     container: {
@@ -570,7 +570,7 @@ test("it supports {{itemViewClass=}} via container", function() {
   assertText(view, "Steve HoltAnnabelle");
 });
 
-test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function() {
+QUnit.test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function() {
   runDestroy(view);
   view = EmberView.create({
       template: templateFor('{{each view.people itemViewClass=MyView tagName="ul"}}'),
@@ -585,7 +585,7 @@ test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function() {
   equal(view.$('ul li').text(), 'Steve HoltAnnabelle');
 });
 
-test("it supports {{itemViewClass=}} with in format", function() {
+QUnit.test("it supports {{itemViewClass=}} with in format", function() {
 
   MyView = EmberView.extend({
     template: templateFor("{{person.name}}")
@@ -608,7 +608,7 @@ test("it supports {{itemViewClass=}} with in format", function() {
 
 });
 
-test("it supports {{emptyView=}}", function() {
+QUnit.test("it supports {{emptyView=}}", function() {
   var emptyView = EmberView.extend({
     template: templateFor('emptyView:sad panda')
   });
@@ -628,7 +628,7 @@ test("it supports {{emptyView=}}", function() {
   assertText(view, "emptyView:sad panda");
 });
 
-test("it defers all normalization of emptyView names to the resolver", function() {
+QUnit.test("it defers all normalization of emptyView names to the resolver", function() {
   var emptyView = EmberView.extend({
     template: templateFor('emptyView:sad panda')
   });
@@ -651,7 +651,7 @@ test("it defers all normalization of emptyView names to the resolver", function(
   runAppend(view);
 });
 
-test("it supports {{emptyViewClass=}} with global (DEPRECATED)", function() {
+QUnit.test("it supports {{emptyViewClass=}} with global (DEPRECATED)", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -672,7 +672,7 @@ test("it supports {{emptyViewClass=}} with global (DEPRECATED)", function() {
   assertText(view, "I'm empty");
 });
 
-test("it supports {{emptyViewClass=}} via container", function() {
+QUnit.test("it supports {{emptyViewClass=}} via container", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -691,7 +691,7 @@ test("it supports {{emptyViewClass=}} via container", function() {
   assertText(view, "I'm empty");
 });
 
-test("it supports {{emptyViewClass=}} with tagName (DEPRECATED)", function() {
+QUnit.test("it supports {{emptyViewClass=}} with tagName (DEPRECATED)", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -707,7 +707,7 @@ test("it supports {{emptyViewClass=}} with tagName (DEPRECATED)", function() {
   equal(view.$('b').text(), "I'm empty");
 });
 
-test("it supports {{emptyViewClass=}} with in format", function() {
+QUnit.test("it supports {{emptyViewClass=}} with in format", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -725,7 +725,7 @@ test("it supports {{emptyViewClass=}} with in format", function() {
   assertText(view, "I'm empty");
 });
 
-test("it supports {{else}}", function() {
+QUnit.test("it supports {{else}}", function() {
   runDestroy(view);
   view = EmberView.create({
     template: templateFor("{{#each view.items}}{{this}}{{else}}Nothing{{/each}}"),
@@ -743,7 +743,7 @@ test("it supports {{else}}", function() {
   assertHTML(view, "Nothing");
 });
 
-test("it works with the controller keyword", function() {
+QUnit.test("it works with the controller keyword", function() {
   runDestroy(view);
 
   var controller = ArrayController.create({
@@ -762,7 +762,7 @@ test("it works with the controller keyword", function() {
   equal(view.$().text(), "foobarbaz");
 });
 
-test("views inside #each preserve the new context [DEPRECATED]", function() {
+QUnit.test("views inside #each preserve the new context [DEPRECATED]", function() {
   runDestroy(view);
 
   var controller = A([{ name: "Adam" }, { name: "Steve" }]);
@@ -781,7 +781,7 @@ test("views inside #each preserve the new context [DEPRECATED]", function() {
   equal(view.$().text(), "AdamSteve");
 });
 
-test("single-arg each defaults to current context [DEPRECATED]", function() {
+QUnit.test("single-arg each defaults to current context [DEPRECATED]", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -796,7 +796,7 @@ test("single-arg each defaults to current context [DEPRECATED]", function() {
   equal(view.$().text(), "AdamSteve");
 });
 
-test("single-arg each will iterate over controller if present [DEPRECATED]", function() {
+QUnit.test("single-arg each will iterate over controller if present [DEPRECATED]", function() {
   runDestroy(view);
 
   view = EmberView.create({
@@ -827,7 +827,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     }
   });
 
-  test("#each accepts a name binding", function() {
+  QUnit.test("#each accepts a name binding", function() {
     view = EmberView.create({
       template: templateFor("{{#EACH|view.items|item}}{{view.title}} {{item}}{{/each}}", useBlockParams),
       title: "My Cool Each Test",
@@ -839,7 +839,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     equal(view.$().text(), "My Cool Each Test 1My Cool Each Test 2");
   });
 
-  test("#each accepts a name binding and does not change the context", function() {
+  QUnit.test("#each accepts a name binding and does not change the context", function() {
     var controller = EmberController.create({
       name: 'bob the controller'
     });
@@ -860,7 +860,7 @@ function testEachWithItem(moduleName, useBlockParams) {
   });
 
 
-  test("#each accepts a name binding and can display child properties", function() {
+  QUnit.test("#each accepts a name binding and can display child properties", function() {
     view = EmberView.create({
       template: templateFor("{{#EACH|view.items|item}}{{view.title}} {{item.name}}{{/each}}", useBlockParams),
       title: "My Cool Each Test",
@@ -872,7 +872,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     equal(view.$().text(), "My Cool Each Test 1My Cool Each Test 2");
   });
 
-  test("#each accepts 'this' as the right hand side", function() {
+  QUnit.test("#each accepts 'this' as the right hand side", function() {
     view = EmberView.create({
       template: templateFor("{{#EACH|this|item}}{{view.title}} {{item.name}}{{/each}}", useBlockParams),
       title: "My Cool Each Test",
@@ -885,7 +885,7 @@ function testEachWithItem(moduleName, useBlockParams) {
   });
 
   if (!useBlockParams) {
-    test("views inside #each preserve the new context [DEPRECATED]", function() {
+    QUnit.test("views inside #each preserve the new context [DEPRECATED]", function() {
       var controller = A([{ name: "Adam" }, { name: "Steve" }]);
 
       view = EmberView.create({
@@ -902,7 +902,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     });
   }
 
-  test("controller is assignable inside an #each", function() {
+  QUnit.test("controller is assignable inside an #each", function() {
     var controller = ArrayController.create({
       model: A([{ name: "Adam" }, { name: "Steve" }])
     });
@@ -918,7 +918,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     equal(view.$().text(), "AdamSteve");
   });
 
-  test("it doesn't assert when the morph tags have the same parent", function() {
+  QUnit.test("it doesn't assert when the morph tags have the same parent", function() {
     view = EmberView.create({
       controller: A(['Cyril', 'David']),
       template: templateFor('<table><tbody>{{#EACH|this|name}}<tr><td>{{name}}</td></tr>{{/each}}</tbody></table>', useBlockParams)
@@ -929,7 +929,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     ok(true, "No assertion from valid template");
   });
 
-  test("itemController specified in template with name binding does not change context", function() {
+  QUnit.test("itemController specified in template with name binding does not change context", function() {
     var Controller = EmberController.extend({
       controllerName: computed(function() {
         return "controller:"+this.get('model.name');
@@ -976,7 +976,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     strictEqual(view._childViews[0]._arrayController.get('target'), parentController, "the target property of the child controllers are set correctly");
   });
 
-  test("itemController specified in ArrayController with name binding does not change context", function() {
+  QUnit.test("itemController specified in ArrayController with name binding does not change context", function() {
     people = A([{ name: "Steve Holt" }, { name: "Annabelle" }]);
 
     var PersonController = EmberController.extend({
@@ -1009,7 +1009,7 @@ function testEachWithItem(moduleName, useBlockParams) {
   });
 
   if (!useBlockParams) {
-    test("{{each}} without arguments [DEPRECATED]", function() {
+    QUnit.test("{{each}} without arguments [DEPRECATED]", function() {
       expect(2);
 
       view = EmberView.create({
@@ -1024,7 +1024,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       equal(view.$().text(), "AdamSteve");
     });
 
-    test("{{each this}} without keyword [DEPRECATED]", function() {
+    QUnit.test("{{each this}} without keyword [DEPRECATED]", function() {
       expect(2);
 
       view = EmberView.create({
@@ -1042,7 +1042,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
   if (useBlockParams) {
     if (Ember.FEATURES.isEnabled('ember-htmlbars-each-with-index')) {
-      test("the index is passed as the second parameter to #each blocks", function() {
+      QUnit.test("the index is passed as the second parameter to #each blocks", function() {
         expect(3);
 
         var adam = { name: "Adam" };

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -38,7 +38,7 @@ QUnit.module("ember-htmlbars: {{#if}} and {{#unless}} helpers", {
   }
 });
 
-test("unless should keep the current context (#784) [DEPRECATED]", function() {
+QUnit.test("unless should keep the current context (#784) [DEPRECATED]", function() {
   view = EmberView.create({
     o: EmberObject.create({ foo: '42' }),
 
@@ -52,7 +52,7 @@ test("unless should keep the current context (#784) [DEPRECATED]", function() {
   equal(view.$().text(), 'foo: 42');
 });
 
-test("The `if` helper tests for `isTruthy` if available", function() {
+QUnit.test("The `if` helper tests for `isTruthy` if available", function() {
   view = EmberView.create({
     truthy: EmberObject.create({ isTruthy: true }),
     falsy: EmberObject.create({ isTruthy: false }),
@@ -65,7 +65,7 @@ test("The `if` helper tests for `isTruthy` if available", function() {
   equal(view.$().text(), 'Yep');
 });
 
-test("The `if` helper does not error on undefined", function() {
+QUnit.test("The `if` helper does not error on undefined", function() {
   view = EmberView.create({
     undefinedValue: undefined,
     template: compile('{{#if view.undefinedValue}}Yep{{/if}}{{#unbound if view.undefinedValue}}Yep{{/unbound}}')
@@ -76,7 +76,7 @@ test("The `if` helper does not error on undefined", function() {
   equal(view.$().text(), '');
 });
 
-test("The `unless` helper does not error on undefined", function() {
+QUnit.test("The `unless` helper does not error on undefined", function() {
   view = EmberView.create({
     undefinedValue: undefined,
     template: compile('{{#unless view.undefinedValue}}YepBound{{/unless}}{{#unbound unless view.undefinedValue}}YepUnbound{{/unbound}}')
@@ -87,7 +87,7 @@ test("The `unless` helper does not error on undefined", function() {
   equal(view.$().text(), 'YepBoundYepUnbound');
 });
 
-test("The `if` helper does not print the contents for an object proxy without content", function() {
+QUnit.test("The `if` helper does not print the contents for an object proxy without content", function() {
   view = EmberView.create({
     truthy: ObjectProxy.create({ content: {} }),
     falsy: ObjectProxy.create({ content: null }),
@@ -100,7 +100,7 @@ test("The `if` helper does not print the contents for an object proxy without co
   equal(view.$().text(), 'Yep');
 });
 
-test("The `if` helper updates if an object proxy gains or loses context", function() {
+QUnit.test("The `if` helper updates if an object proxy gains or loses context", function() {
   view = EmberView.create({
     proxy: ObjectProxy.create({ content: null }),
 
@@ -124,7 +124,7 @@ test("The `if` helper updates if an object proxy gains or loses context", functi
   equal(view.$().text(), '');
 });
 
-test("The `if` helper updates if an array is empty or not", function() {
+QUnit.test("The `if` helper updates if an array is empty or not", function() {
   view = EmberView.create({
     array: Ember.A(),
 
@@ -148,7 +148,7 @@ test("The `if` helper updates if an array is empty or not", function() {
   equal(view.$().text(), '');
 });
 
-test("The `if` helper updates when the value changes", function() {
+QUnit.test("The `if` helper updates when the value changes", function() {
   view = EmberView.create({
     conditional: true,
     template: compile('{{#if view.conditional}}Yep{{/if}}')
@@ -161,7 +161,7 @@ test("The `if` helper updates when the value changes", function() {
   equal(view.$().text(), '');
 });
 
-test("The `unbound if` helper does not update when the value changes", function() {
+QUnit.test("The `unbound if` helper does not update when the value changes", function() {
   view = EmberView.create({
     conditional: true,
     template: compile('{{#unbound if view.conditional}}Yep{{/unbound}}')
@@ -174,7 +174,7 @@ test("The `unbound if` helper does not update when the value changes", function(
   equal(view.$().text(), 'Yep');
 });
 
-test("The `unless` helper updates when the value changes", function() {
+QUnit.test("The `unless` helper updates when the value changes", function() {
   view = EmberView.create({
     conditional: false,
     template: compile('{{#unless view.conditional}}Nope{{/unless}}')
@@ -187,7 +187,7 @@ test("The `unless` helper updates when the value changes", function() {
   equal(view.$().text(), '');
 });
 
-test("The `unbound if` helper does not update when the value changes", function() {
+QUnit.test("The `unbound if` helper does not update when the value changes", function() {
   view = EmberView.create({
     conditional: false,
     template: compile('{{#unbound unless view.conditional}}Nope{{/unbound}}')
@@ -200,7 +200,7 @@ test("The `unbound if` helper does not update when the value changes", function(
   equal(view.$().text(), 'Nope');
 });
 
-test("The `unbound if` helper should work when its inverse is not present", function() {
+QUnit.test("The `unbound if` helper should work when its inverse is not present", function() {
   view = EmberView.create({
     conditional: false,
     template: compile('{{#unbound if view.conditional}}Yep{{/unbound}}')
@@ -209,7 +209,7 @@ test("The `unbound if` helper should work when its inverse is not present", func
   equal(view.$().text(), '');
 });
 
-test("The `if` helper ignores a controller option", function() {
+QUnit.test("The `if` helper ignores a controller option", function() {
   var lookupCalled = false;
 
   view = EmberView.create({
@@ -228,7 +228,7 @@ test("The `if` helper ignores a controller option", function() {
   equal(lookupCalled, false, 'controller option should NOT be used');
 });
 
-test('should not rerender if truthiness does not change', function() {
+QUnit.test('should not rerender if truthiness does not change', function() {
   var renderCount = 0;
 
   view = EmberView.create({
@@ -259,7 +259,7 @@ test('should not rerender if truthiness does not change', function() {
   equal(view.$('#first').text(), 'bam', 'renders block when condition is true');
 });
 
-test('should update the block when object passed to #unless helper changes', function() {
+QUnit.test('should update the block when object passed to #unless helper changes', function() {
   registry.register('template:advice', compile('<h1>{{#unless view.onDrugs}}{{view.doWellInSchool}}{{/unless}}</h1>'));
 
   view = EmberView.create({
@@ -291,7 +291,7 @@ test('should update the block when object passed to #unless helper changes', fun
   });
 });
 
-test('properties within an if statement should not fail on re-render', function() {
+QUnit.test('properties within an if statement should not fail on re-render', function() {
   view = EmberView.create({
     template: compile('{{#if view.value}}{{view.value}}{{/if}}'),
     value: null
@@ -314,7 +314,7 @@ test('properties within an if statement should not fail on re-render', function(
   equal(view.$().text(), '');
 });
 
-test('should update the block when object passed to #if helper changes', function() {
+QUnit.test('should update the block when object passed to #if helper changes', function() {
   registry.register('template:menu', compile('<h1>{{#if view.inception}}{{view.INCEPTION}}{{/if}}</h1>'));
 
   view = EmberView.create({
@@ -346,7 +346,7 @@ test('should update the block when object passed to #if helper changes', functio
   });
 });
 
-test('should update the block when object passed to #if helper changes and an inverse is supplied', function() {
+QUnit.test('should update the block when object passed to #if helper changes and an inverse is supplied', function() {
   registry.register('template:menu', compile('<h1>{{#if view.inception}}{{view.INCEPTION}}{{else}}{{view.SAD}}{{/if}}</h1>'));
 
   view = EmberView.create({
@@ -381,7 +381,7 @@ test('should update the block when object passed to #if helper changes and an in
   });
 });
 
-test('views within an if statement should be sane on re-render', function() {
+QUnit.test('views within an if statement should be sane on re-render', function() {
   view = EmberView.create({
     template: compile('{{#if view.display}}{{input}}{{/if}}'),
     display: false
@@ -404,7 +404,7 @@ test('views within an if statement should be sane on re-render', function() {
   ok(EmberView.views[textfield.attr('id')]);
 });
 
-test('the {{this}} helper should not fail on removal', function() {
+QUnit.test('the {{this}} helper should not fail on removal', function() {
   view = EmberView.create({
     context: 'abc',
     template: compile('{{#if view.show}}{{this}}{{/if}}'),
@@ -422,7 +422,7 @@ test('the {{this}} helper should not fail on removal', function() {
   equal(view.$().text(), '');
 });
 
-test('should update the block when object passed to #unless helper changes', function() {
+QUnit.test('should update the block when object passed to #unless helper changes', function() {
   registry.register('template:advice', compile('<h1>{{#unless view.onDrugs}}{{view.doWellInSchool}}{{/unless}}</h1>'));
 
   view = EmberView.create({
@@ -454,7 +454,7 @@ test('should update the block when object passed to #unless helper changes', fun
   });
 });
 
-test('properties within an if statement should not fail on re-render', function() {
+QUnit.test('properties within an if statement should not fail on re-render', function() {
   view = EmberView.create({
     template: compile('{{#if view.value}}{{view.value}}{{/if}}'),
     value: null
@@ -477,7 +477,7 @@ test('properties within an if statement should not fail on re-render', function(
   equal(view.$().text(), '');
 });
 
-test('should update the block when object passed to #if helper changes', function() {
+QUnit.test('should update the block when object passed to #if helper changes', function() {
   registry.register('template:menu', compile('<h1>{{#if view.inception}}{{view.INCEPTION}}{{/if}}</h1>'));
 
   view = EmberView.create({
@@ -509,7 +509,7 @@ test('should update the block when object passed to #if helper changes', functio
   });
 });
 
-test('should update the block when object passed to #if helper changes and an inverse is supplied', function() {
+QUnit.test('should update the block when object passed to #if helper changes and an inverse is supplied', function() {
   registry.register('template:menu', compile('<h1>{{#if view.inception}}{{view.INCEPTION}}{{else}}{{view.SAD}}{{/if}}</h1>'));
 
   view = EmberView.create({
@@ -544,7 +544,7 @@ test('should update the block when object passed to #if helper changes and an in
   });
 });
 
-test('the {{this}} helper should not fail on removal', function() {
+QUnit.test('the {{this}} helper should not fail on removal', function() {
   view = EmberView.create({
     context: 'abc',
     template: compile('{{#if view.show}}{{this}}{{/if}}'),
@@ -562,7 +562,7 @@ test('the {{this}} helper should not fail on removal', function() {
   equal(view.$().text(), '');
 });
 
-test('edge case: child conditional should not render children if parent conditional becomes false', function() {
+QUnit.test('edge case: child conditional should not render children if parent conditional becomes false', function() {
   var childCreated = false;
   var child = null;
 
@@ -595,7 +595,7 @@ test('edge case: child conditional should not render children if parent conditio
   equal(view.$().text(), '');
 });
 
-test('edge case: rerender appearance of inner virtual view', function() {
+QUnit.test('edge case: rerender appearance of inner virtual view', function() {
   view = EmberView.create({
     tagName: '',
     cond2: false,
@@ -613,7 +613,7 @@ test('edge case: rerender appearance of inner virtual view', function() {
 });
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
-  test("`if` helper with inline form: renders the second argument when conditional is truthy", function() {
+  QUnit.test("`if` helper with inline form: renders the second argument when conditional is truthy", function() {
     view = EmberView.create({
       conditional: true,
       template: compile('{{if view.conditional "truthy" "falsy"}}')
@@ -624,7 +624,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'truthy');
   });
 
-  test("`if` helper with inline form: renders the third argument when conditional is falsy", function() {
+  QUnit.test("`if` helper with inline form: renders the third argument when conditional is falsy", function() {
     view = EmberView.create({
       conditional: false,
       template: compile('{{if view.conditional "truthy" "falsy"}}')
@@ -635,7 +635,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'falsy');
   });
 
-  test("`if` helper with inline form: can omit the falsy argument", function() {
+  QUnit.test("`if` helper with inline form: can omit the falsy argument", function() {
     view = EmberView.create({
       conditional: true,
       template: compile('{{if view.conditional "truthy"}}')
@@ -646,7 +646,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'truthy');
   });
 
-  test("`if` helper with inline form: can omit the falsy argument and renders nothing when conditional is falsy", function() {
+  QUnit.test("`if` helper with inline form: can omit the falsy argument and renders nothing when conditional is falsy", function() {
     view = EmberView.create({
       conditional: false,
       template: compile('{{if view.conditional "truthy"}}')
@@ -657,7 +657,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), '');
   });
 
-  test("`if` helper with inline form: truthy and falsy arguments are changed if conditional changes", function() {
+  QUnit.test("`if` helper with inline form: truthy and falsy arguments are changed if conditional changes", function() {
     view = EmberView.create({
       conditional: true,
       template: compile('{{if view.conditional "truthy" "falsy"}}')
@@ -674,7 +674,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'falsy');
   });
 
-  test("`if` helper with inline form: can use truthy param as binding", function() {
+  QUnit.test("`if` helper with inline form: can use truthy param as binding", function() {
     view = EmberView.create({
       truthy: 'ok',
       conditional: true,
@@ -692,7 +692,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'yes');
   });
 
-  test("`if` helper with inline form: can use falsy param as binding", function() {
+  QUnit.test("`if` helper with inline form: can use falsy param as binding", function() {
     view = EmberView.create({
       truthy: 'ok',
       falsy: 'boom',
@@ -711,7 +711,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'no');
   });
 
-  test("`if` helper with inline form: raises when using more than three arguments", function() {
+  QUnit.test("`if` helper with inline form: raises when using more than three arguments", function() {
     view = EmberView.create({
       conditional: true,
       template: compile('{{if one two three four}}')
@@ -722,7 +722,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
   });
 
-  test("`if` helper with inline form: raises when using less than two arguments", function() {
+  QUnit.test("`if` helper with inline form: raises when using less than two arguments", function() {
     view = EmberView.create({
       conditional: true,
       template: compile('{{if one}}')
@@ -733,7 +733,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     }, /The inline form of the `if` and `unless` helpers expect two or three arguments/);
   });
 
-  test("`if` helper with inline form: works when used in a sub expression", function() {
+  QUnit.test("`if` helper with inline form: works when used in a sub expression", function() {
     view = EmberView.create({
       conditional: true,
       innerConditional: true,
@@ -745,7 +745,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'truthy');
   });
 
-  test("`if` helper with inline form: updates if condition changes in a sub expression", function() {
+  QUnit.test("`if` helper with inline form: updates if condition changes in a sub expression", function() {
     view = EmberView.create({
       conditional: true,
       innerConditional: true,
@@ -763,7 +763,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'innerFalsy');
   });
 
-  test("`if` helper with inline form: can use truthy param as binding in a sub expression", function() {
+  QUnit.test("`if` helper with inline form: can use truthy param as binding in a sub expression", function() {
     view = EmberView.create({
       conditional: true,
       innerConditional: true,
@@ -782,7 +782,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
     equal(view.$().text(), 'innerOk');
   });
 
-  test("`if` helper with inline form: respects isTruthy when object changes", function() {
+  QUnit.test("`if` helper with inline form: respects isTruthy when object changes", function() {
     view = EmberView.create({
       conditional: Ember.Object.create({ isTruthy: false }),
       template: compile('{{if view.conditional "truthy" "falsy"}}')
@@ -806,7 +806,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
 
   });
 
-  test("`if` helper with inline form: respects isTruthy when property changes", function() {
+  QUnit.test("`if` helper with inline form: respects isTruthy when property changes", function() {
     var candidate = Ember.Object.create({ isTruthy: false });
 
     view = EmberView.create({
@@ -832,7 +832,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
 
   });
 
-  test("`if` helper with inline form: respects length test when list content changes", function() {
+  QUnit.test("`if` helper with inline form: respects length test when list content changes", function() {
     var list = Ember.A();
 
     view = EmberView.create({
@@ -858,7 +858,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
 
   });
 
-  test("`if` helper with inline form: respects length test when list itself", function() {
+  QUnit.test("`if` helper with inline form: respects length test when list itself", function() {
     view = EmberView.create({
       conditional: [],
       template: compile('{{if view.conditional "truthy" "falsy"}}')

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -31,11 +31,11 @@ QUnit.module("{{input type='text'}}", {
   }
 });
 
-test("should insert a text field into DOM", function() {
+QUnit.test("should insert a text field into DOM", function() {
   equal(view.$('input').length, 1, "A single text field was inserted");
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+QUnit.test("should become disabled if the disabled attribute is true", function() {
   ok(view.$('input').is(':not(:disabled)'), "There are no disabled text fields");
 
   run(null, set, controller, 'disabled', true);
@@ -45,37 +45,37 @@ test("should become disabled if the disabled attribute is true", function() {
   ok(view.$('input').is(':not(:disabled)'), "There are no disabled text fields");
 });
 
-test("input value is updated when setting value property of view", function() {
+QUnit.test("input value is updated when setting value property of view", function() {
   equal(view.$('input').val(), "hello", "renders text field with value");
   run(null, set, controller, 'val', 'bye!');
   equal(view.$('input').val(), "bye!", "updates text field after value changes");
 });
 
-test("input placeholder is updated when setting placeholder property of view", function() {
+QUnit.test("input placeholder is updated when setting placeholder property of view", function() {
   equal(view.$('input').attr('placeholder'), "Enter some text", "renders text field with placeholder");
   run(null, set, controller, 'place', 'Text, please enter it');
   equal(view.$('input').attr('placeholder'), "Text, please enter it", "updates text field after placeholder changes");
 });
 
-test("input name is updated when setting name property of view", function() {
+QUnit.test("input name is updated when setting name property of view", function() {
   equal(view.$('input').attr('name'), "some-name", "renders text field with name");
   run(null, set, controller, 'name', 'other-name');
   equal(view.$('input').attr('name'), "other-name", "updates text field after name changes");
 });
 
-test("input maxlength is updated when setting maxlength property of view", function() {
+QUnit.test("input maxlength is updated when setting maxlength property of view", function() {
   equal(view.$('input').attr('maxlength'), "30", "renders text field with maxlength");
   run(null, set, controller, 'max', 40);
   equal(view.$('input').attr('maxlength'), "40", "updates text field after maxlength changes");
 });
 
-test("input size is updated when setting size property of view", function() {
+QUnit.test("input size is updated when setting size property of view", function() {
   equal(view.$('input').attr('size'), "30", "renders text field with size");
   run(null, set, controller, 'size', 40);
   equal(view.$('input').attr('size'), "40", "updates text field after size changes");
 });
 
-test("input tabindex is updated when setting tabindex property of view", function() {
+QUnit.test("input tabindex is updated when setting tabindex property of view", function() {
   equal(view.$('input').attr('tabindex'), "5", "renders text field with the tabindex");
   run(null, set, controller, 'tab', 3);
   equal(view.$('input').attr('tabindex'), "3", "updates text field after tabindex changes");
@@ -98,35 +98,35 @@ QUnit.module("{{input type='text'}} - static values", {
   }
 });
 
-test("should insert a text field into DOM", function() {
+QUnit.test("should insert a text field into DOM", function() {
   equal(view.$('input').length, 1, "A single text field was inserted");
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+QUnit.test("should become disabled if the disabled attribute is true", function() {
   ok(view.$('input').is(':disabled'), "The text field is disabled");
 });
 
-test("input value is updated when setting value property of view", function() {
+QUnit.test("input value is updated when setting value property of view", function() {
   equal(view.$('input').val(), "hello", "renders text field with value");
 });
 
-test("input placeholder is updated when setting placeholder property of view", function() {
+QUnit.test("input placeholder is updated when setting placeholder property of view", function() {
   equal(view.$('input').attr('placeholder'), "Enter some text", "renders text field with placeholder");
 });
 
-test("input name is updated when setting name property of view", function() {
+QUnit.test("input name is updated when setting name property of view", function() {
   equal(view.$('input').attr('name'), "some-name", "renders text field with name");
 });
 
-test("input maxlength is updated when setting maxlength property of view", function() {
+QUnit.test("input maxlength is updated when setting maxlength property of view", function() {
   equal(view.$('input').attr('maxlength'), "30", "renders text field with maxlength");
 });
 
-test("input size is updated when setting size property of view", function() {
+QUnit.test("input size is updated when setting size property of view", function() {
   equal(view.$('input').attr('size'), "30", "renders text field with size");
 });
 
-test("input tabindex is updated when setting tabindex property of view", function() {
+QUnit.test("input tabindex is updated when setting tabindex property of view", function() {
   equal(view.$('input').attr('tabindex'), "5", "renders text field with the tabindex");
 });
 
@@ -149,7 +149,7 @@ QUnit.module("{{input type='text'}} - dynamic type", {
   }
 });
 
-test("should insert a text field into DOM", function() {
+QUnit.test("should insert a text field into DOM", function() {
   equal(view.$('input').attr('type'), 'password', "a bound property can be used to determine type.");
 });
 
@@ -170,7 +170,7 @@ QUnit.module("{{input}} - default type", {
   }
 });
 
-test("should have the default type", function() {
+QUnit.test("should have the default type", function() {
   equal(view.$('input').attr('type'), 'text', "Has a default text type");
 });
 
@@ -195,29 +195,29 @@ QUnit.module("{{input type='checkbox'}}", {
   }
 });
 
-test("should append a checkbox", function() {
+QUnit.test("should append a checkbox", function() {
   equal(view.$('input[type=checkbox]').length, 1, "A single checkbox is added");
 });
 
-test("should begin disabled if the disabled attribute is true", function() {
+QUnit.test("should begin disabled if the disabled attribute is true", function() {
   ok(view.$('input').is(':not(:disabled)'), "The checkbox isn't disabled");
   run(null, set, controller, 'disabled', true);
   ok(view.$('input').is(':disabled'), "The checkbox is now disabled");
 });
 
-test("should support the tabindex property", function() {
+QUnit.test("should support the tabindex property", function() {
   equal(view.$('input').prop('tabindex'), '6', 'the initial checkbox tabindex is set in the DOM');
   run(null, set, controller, 'tab', 3);
   equal(view.$('input').prop('tabindex'), '3', 'the checkbox tabindex changes when it is changed in the view');
 });
 
-test("checkbox name is updated", function() {
+QUnit.test("checkbox name is updated", function() {
   equal(view.$('input').attr('name'), "hello", "renders checkbox with the name");
   run(null, set, controller, 'name', 'bye');
   equal(view.$('input').attr('name'), "bye", "updates checkbox after name changes");
 });
 
-test("checkbox checked property is updated", function() {
+QUnit.test("checkbox checked property is updated", function() {
   equal(view.$('input').prop('checked'), false, "the checkbox isn't checked yet");
   run(null, set, controller, 'val', true);
   equal(view.$('input').prop('checked'), true, "the checkbox is checked now");
@@ -236,7 +236,7 @@ QUnit.module("{{input type='checkbox'}} - prevent value= usage", {
   }
 });
 
-test("It asserts the presence of checked=", function() {
+QUnit.test("It asserts the presence of checked=", function() {
   expectAssertion(function() {
     runAppend(view);
   }, /you must use `checked=/);
@@ -262,13 +262,13 @@ QUnit.module("{{input type=boundType}}", {
   }
 });
 
-test("should append a checkbox", function() {
+QUnit.test("should append a checkbox", function() {
   equal(view.$('input[type=checkbox]').length, 1, "A single checkbox is added");
 });
 
 // Checking for the checked property is a good way to verify that the correct
 // view was used.
-test("checkbox checked property is updated", function() {
+QUnit.test("checkbox checked property is updated", function() {
   equal(view.$('input').prop('checked'), true, "the checkbox is checked");
 });
 
@@ -293,18 +293,18 @@ QUnit.module("{{input type='checkbox'}} - static values", {
   }
 });
 
-test("should begin disabled if the disabled attribute is true", function() {
+QUnit.test("should begin disabled if the disabled attribute is true", function() {
   ok(view.$().is(':not(:disabled)'), "The checkbox isn't disabled");
 });
 
-test("should support the tabindex property", function() {
+QUnit.test("should support the tabindex property", function() {
   equal(view.$('input').prop('tabindex'), '6', 'the initial checkbox tabindex is set in the DOM');
 });
 
-test("checkbox name is updated", function() {
+QUnit.test("checkbox name is updated", function() {
   equal(view.$('input').attr('name'), "hello", "renders checkbox with the name");
 });
 
-test("checkbox checked property is updated", function() {
+QUnit.test("checkbox checked property is updated", function() {
   equal(view.$('input').prop('checked'), false, "the checkbox isn't checked yet");
 });

--- a/packages/ember-htmlbars/tests/helpers/loc_test.js
+++ b/packages/ember-htmlbars/tests/helpers/loc_test.js
@@ -24,7 +24,7 @@ QUnit.module('ember-htmlbars: {{#loc}} helper', {
   }
 });
 
-test('let the original value through by default', function() {
+QUnit.test('let the original value through by default', function() {
   var view = buildView('{{loc "Hiya buddy!"}}');
   runAppend(view);
 
@@ -33,7 +33,7 @@ test('let the original value through by default', function() {
   runDestroy(view);
 });
 
-test('localize a simple string', function() {
+QUnit.test('localize a simple string', function() {
   var view = buildView('{{loc "_Howdy Friend"}}');
   runAppend(view);
 
@@ -42,7 +42,7 @@ test('localize a simple string', function() {
   runDestroy(view);
 });
 
-test('localize takes passed formats into an account', function() {
+QUnit.test('localize takes passed formats into an account', function() {
   var view = buildView('{{loc "%@, %@" "Hello" "Mr. Pitkin"}}');
   runAppend(view);
 
@@ -53,7 +53,7 @@ test('localize takes passed formats into an account', function() {
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
-test('localize throws an assertion if the second parameter is a binding', function() {
+QUnit.test('localize throws an assertion if the second parameter is a binding', function() {
   var view = buildView('{{loc "Hello %@" name}}', {
     name: 'Bob Foster'
   });
@@ -65,7 +65,7 @@ test('localize throws an assertion if the second parameter is a binding', functi
   runDestroy(view);
 });
 
-test('localize a binding throws an assertion', function() {
+QUnit.test('localize a binding throws an assertion', function() {
   var view = buildView('{{loc localizationKey}}', {
     localizationKey: 'villain'
   });

--- a/packages/ember-htmlbars/tests/helpers/log_test.js
+++ b/packages/ember-htmlbars/tests/helpers/log_test.js
@@ -26,7 +26,7 @@ QUnit.module('ember-htmlbars: {{#log}} helper', {
   }
 });
 
-test('should be able to log a property', function() {
+QUnit.test('should be able to log a property', function() {
   var context = {
     value: 'one'
   };
@@ -42,7 +42,7 @@ test('should be able to log a property', function() {
   equal(logCalls[0], 'one', 'should call log with value');
 });
 
-test('should be able to log a view property', function() {
+QUnit.test('should be able to log a view property', function() {
   view = EmberView.create({
     template: compile('{{log view.value}}'),
     value: 'one'
@@ -54,7 +54,7 @@ test('should be able to log a view property', function() {
   equal(logCalls[0], 'one', 'should call log with value');
 });
 
-test('should be able to log `this`', function() {
+QUnit.test('should be able to log `this`', function() {
   view = EmberView.create({
     context: 'one',
     template: compile('{{log this}}')

--- a/packages/ember-htmlbars/tests/helpers/partial_test.js
+++ b/packages/ember-htmlbars/tests/helpers/partial_test.js
@@ -24,7 +24,7 @@ QUnit.module("Support for {{partial}} helper", {
   }
 });
 
-test("should render other templates registered with the container", function() {
+QUnit.test("should render other templates registered with the container", function() {
   registry.register('template:_subTemplateFromContainer', compile('sub-template'));
 
   view = EmberView.create({
@@ -37,7 +37,7 @@ test("should render other templates registered with the container", function() {
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 });
 
-test("should render other slash-separated templates registered with the container", function() {
+QUnit.test("should render other slash-separated templates registered with the container", function() {
   registry.register('template:child/_subTemplateFromContainer', compile("sub-template"));
 
   view = EmberView.create({
@@ -50,7 +50,7 @@ test("should render other slash-separated templates registered with the containe
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 });
 
-test("should use the current view's context", function() {
+QUnit.test("should use the current view's context", function() {
   registry.register('template:_person_name', compile("{{firstName}} {{lastName}}"));
 
   view = EmberView.create({
@@ -67,7 +67,7 @@ test("should use the current view's context", function() {
   equal(trim(view.$().text()), "Who is Kris Selden?");
 });
 
-test("Quoteless parameters passed to {{template}} perform a bound property lookup of the partial name", function() {
+QUnit.test("Quoteless parameters passed to {{template}} perform a bound property lookup of the partial name", function() {
   registry.register('template:_subTemplate', compile("sub-template"));
   registry.register('template:_otherTemplate', compile("other-template"));
 

--- a/packages/ember-htmlbars/tests/helpers/sanitized_bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/sanitized_bind_attr_test.js
@@ -39,7 +39,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
       return;
     }
 
-    test("XSS - should not bind unsafe "+tagName+" "+attr+" values", function() {
+    QUnit.test("XSS - should not bind unsafe "+tagName+" "+attr+" values", function() {
       view = EmberView.create({
         template: template,
         badValue: "javascript:alert('XSS')"
@@ -52,7 +52,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
              "attribute is output");
     });
 
-    test("XSS - should not bind unsafe "+tagName+" "+attr+" values on rerender", function() {
+    QUnit.test("XSS - should not bind unsafe "+tagName+" "+attr+" values on rerender", function() {
       view = EmberView.create({
         template: template,
         badValue: "/sunshine/and/rainbows"
@@ -71,7 +71,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
              "attribute is output");
     });
 
-    test("should bind unsafe "+tagName+" "+attr+" values if they are SafeString", function() {
+    QUnit.test("should bind unsafe "+tagName+" "+attr+" values if they are SafeString", function() {
       view = EmberView.create({
         template: template,
         badValue: new SafeString("javascript:alert('XSS')")

--- a/packages/ember-htmlbars/tests/helpers/template_test.js
+++ b/packages/ember-htmlbars/tests/helpers/template_test.js
@@ -26,7 +26,7 @@ QUnit.module("Support for {{template}} helper", {
   }
 });
 
-test("should render other templates via the container (DEPRECATED)", function() {
+QUnit.test("should render other templates via the container (DEPRECATED)", function() {
   registry.register('template:sub_template_from_container', compile('sub-template'));
 
   view = EmberView.create({
@@ -41,7 +41,7 @@ test("should render other templates via the container (DEPRECATED)", function() 
   equal(trim(view.$().text()), "This sub-template is pretty great.");
 });
 
-test("should use the current view's context (DEPRECATED)", function() {
+QUnit.test("should use the current view's context (DEPRECATED)", function() {
   registry.register('template:person_name', compile("{{firstName}} {{lastName}}"));
 
   view = EmberView.create({

--- a/packages/ember-htmlbars/tests/helpers/text_area_test.js
+++ b/packages/ember-htmlbars/tests/helpers/text_area_test.js
@@ -29,17 +29,17 @@ QUnit.module("{{textarea}}", {
   }
 });
 
-test("Should insert a textarea", function() {
+QUnit.test("Should insert a textarea", function() {
   equal(textArea.$('textarea').length, 1, "There is a single textarea");
 });
 
-test("Should become disabled when the controller changes", function() {
+QUnit.test("Should become disabled when the controller changes", function() {
   ok(textArea.$('textarea').is(':not(:disabled)'), "Nothing is disabled yet");
   set(controller, 'disabled', true);
   ok(textArea.$('textarea').is(':disabled'), "The disabled attribute is updated");
 });
 
-test("Should bind its contents to the specified value", function() {
+QUnit.test("Should bind its contents to the specified value", function() {
   equal(textArea.$('textarea').val(), "Lorem ipsum dolor", "The contents are included");
   set(controller, 'val', "sit amet");
   equal(textArea.$('textarea').val(), "sit amet", "The new contents are included");

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -46,18 +46,18 @@ QUnit.module('ember-htmlbars: {{#unbound}} helper', {
   }
 });
 
-test('it should render the current value of a property on the context', function() {
+QUnit.test('it should render the current value of a property on the context', function() {
   equal(view.$().text(), 'BORK BORK', 'should render the current value of a property');
 });
 
-test('it should not re-render if the property changes', function() {
+QUnit.test('it should not re-render if the property changes', function() {
   run(function() {
     view.set('context.foo', 'OOF');
   });
   equal(view.$().text(), 'BORK BORK', 'should not re-render if the property changes');
 });
 
-test('it should throw the helper missing error if multiple properties are provided', function() {
+QUnit.test('it should throw the helper missing error if multiple properties are provided', function() {
   throws(function() {
     runAppend(EmberView.create({
       template: compile('{{unbound foo bar}}'),
@@ -69,7 +69,7 @@ test('it should throw the helper missing error if multiple properties are provid
   }, EmberError);
 });
 
-test('should property escape unsafe hrefs', function() {
+QUnit.test('should property escape unsafe hrefs', function() {
   /* jshint scripturl:true */
 
   expect(3);
@@ -137,7 +137,7 @@ QUnit.module("ember-htmlbars: {{#unbound boundHelper arg1 arg2... argN}} form: r
   }
 });
 
-test("should be able to render an unbound helper invocation", function() {
+QUnit.test("should be able to render an unbound helper invocation", function() {
   try {
     registerBoundHelper('repeat', function(value, options) {
       var count = options.hash.count;
@@ -170,7 +170,7 @@ test("should be able to render an unbound helper invocation", function() {
   }
 });
 
-test("should be able to render an bound helper invocation mixed with static values", function() {
+QUnit.test("should be able to render an bound helper invocation mixed with static values", function() {
   view = EmberView.create({
       template: compile('{{unbound surround prefix value "bar"}} {{surround prefix value "bar"}} {{unbound surround "bar" value suffix}} {{surround "bar" value suffix}}'),
       context: EmberObject.create({
@@ -190,7 +190,7 @@ test("should be able to render an bound helper invocation mixed with static valu
   equal(view.$().text(), "before-core-bar beforeChanged-coreChanged-bar bar-core-after bar-coreChanged-afterChanged", "only bound values change");
 });
 
-test("should be able to render unbound forms of multi-arg helpers", function() {
+QUnit.test("should be able to render unbound forms of multi-arg helpers", function() {
   view = EmberView.create({
     template: compile("{{fauxconcat foo bar bing}} {{unbound fauxconcat foo bar bing}}"),
     context: EmberObject.create({
@@ -210,7 +210,7 @@ test("should be able to render unbound forms of multi-arg helpers", function() {
   equal(view.$().text(), "aXc abc", "unbound helpers/properties stayed the same");
 });
 
-test("should be able to render an unbound helper invocation for helpers with dependent keys", function() {
+QUnit.test("should be able to render an unbound helper invocation for helpers with dependent keys", function() {
   view = EmberView.create({
     template: compile("{{capitalizeName person}} {{unbound capitalizeName person}} {{concatNames person}} {{unbound concatNames person}}"),
     context: EmberObject.create({
@@ -231,7 +231,7 @@ test("should be able to render an unbound helper invocation for helpers with dep
   equal(view.$().text(), "SALLY SHOOBY sallytaylor shoobytaylor", "only bound values change");
 });
 
-test("should be able to render an unbound helper invocation in #each helper", function() {
+QUnit.test("should be able to render an unbound helper invocation in #each helper", function() {
   view = EmberView.create({
     template: compile(
       ["{{#each person in people}}",
@@ -255,7 +255,7 @@ test("should be able to render an unbound helper invocation in #each helper", fu
   equal(view.$().text(), "SHOOBY SHOOBYCINDY CINDY", "unbound rendered correctly");
 });
 
-test("should be able to render an unbound helper invocation with bound hash options", function() {
+QUnit.test("should be able to render an unbound helper invocation with bound hash options", function() {
   try {
     Ember.Handlebars.registerBoundHelper('repeat', function(value) {
       return [].slice.call(arguments, 0, -1).join('');
@@ -285,7 +285,7 @@ test("should be able to render an unbound helper invocation with bound hash opti
   }
 });
 
-test("should be able to render bound form of a helper inside unbound form of same helper", function() {
+QUnit.test("should be able to render bound form of a helper inside unbound form of same helper", function() {
   view = EmberView.create({
     template: compile(
       ["{{#unbound if foo}}",
@@ -329,7 +329,7 @@ QUnit.module("ember-htmlbars: {{#unbound}} helper -- Container Lookup", {
   }
 });
 
-test("should lookup helpers in the container", function() {
+QUnit.test("should lookup helpers in the container", function() {
   expectDeprecationInHTMLBars();
 
   registry.register('helper:up-case', makeBoundHelper(function(value) {
@@ -355,7 +355,7 @@ test("should lookup helpers in the container", function() {
   equal(view.$().text(), "SUCH AWESOME", "only bound values change");
 });
 
-test("should be able to output a property without binding", function() {
+QUnit.test("should be able to output a property without binding", function() {
   var context = {
     content: EmberObject.create({
       anUnboundString: "No spans here, son."
@@ -372,7 +372,7 @@ test("should be able to output a property without binding", function() {
   equal(view.$('#first').html(), "No spans here, son.");
 });
 
-test("should be able to use unbound helper in #each helper", function() {
+QUnit.test("should be able to use unbound helper in #each helper", function() {
   view = EmberView.create({
     items: A(['a', 'b', 'c', 1, 2, 3]),
     template: compile('<ul>{{#each item in view.items}}<li>{{unbound item}}</li>{{/each}}</ul>')
@@ -384,7 +384,7 @@ test("should be able to use unbound helper in #each helper", function() {
   equal(view.$('li').children().length, 0, 'No markers');
 });
 
-test("should be able to use unbound helper in #each helper (with objects)", function() {
+QUnit.test("should be able to use unbound helper in #each helper (with objects)", function() {
   view = EmberView.create({
     items: A([{ wham: 'bam' }, { wham: 1 }]),
     template: compile('<ul>{{#each item in view.items}}<li>{{unbound item.wham}}</li>{{/each}}</ul>')
@@ -396,7 +396,7 @@ test("should be able to use unbound helper in #each helper (with objects)", func
   equal(view.$('li').children().length, 0, 'No markers');
 });
 
-test('should work properly with attributes', function() {
+QUnit.test('should work properly with attributes', function() {
   expect(4);
 
   view = EmberView.create({

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -62,7 +62,7 @@ QUnit.module("ember-htmlbars: {{#view}} helper", {
 });
 
 // https://github.com/emberjs/ember.js/issues/120
-test("should not enter an infinite loop when binding an attribute in Handlebars", function() {
+QUnit.test("should not enter an infinite loop when binding an attribute in Handlebars", function() {
   var LinkView = EmberView.extend({
     classNames: ['app-link'],
     tagName: 'a',
@@ -89,7 +89,7 @@ test("should not enter an infinite loop when binding an attribute in Handlebars"
   runDestroy(parentView);
 });
 
-test("By default view:toplevel is used", function() {
+QUnit.test("By default view:toplevel is used", function() {
   var DefaultView = viewClass({
     elementId: 'toplevel-view',
     template: compile('hello world')
@@ -115,7 +115,7 @@ test("By default view:toplevel is used", function() {
   equal(jQuery('#toplevel-view').text(), 'hello world');
 });
 
-test("By default, without a container, EmberView is used", function() {
+QUnit.test("By default, without a container, EmberView is used", function() {
   view = EmberView.extend({
     template: compile('{{view tagName="span"}}')
   }).create();
@@ -125,7 +125,7 @@ test("By default, without a container, EmberView is used", function() {
   ok(jQuery('#qunit-fixture').html().toUpperCase().match(/<SPAN/), 'contains view with span');
 });
 
-test("View lookup - App.FuView (DEPRECATED)", function() {
+QUnit.test("View lookup - App.FuView (DEPRECATED)", function() {
   Ember.lookup = {
     App: {
       FuView: viewClass({
@@ -146,7 +146,7 @@ test("View lookup - App.FuView (DEPRECATED)", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test("View lookup - 'fu'", function() {
+QUnit.test("View lookup - 'fu'", function() {
   var FuView = viewClass({
     elementId: "fu",
     template: compile("bro")
@@ -172,7 +172,7 @@ test("View lookup - 'fu'", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test("View lookup - 'fu' when fu is a property and a view name", function() {
+QUnit.test("View lookup - 'fu' when fu is a property and a view name", function() {
   var FuView = viewClass({
     elementId: "fu",
     template: compile("bro")
@@ -199,7 +199,7 @@ test("View lookup - 'fu' when fu is a property and a view name", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test("View lookup - view.computed", function() {
+QUnit.test("View lookup - view.computed", function() {
   var FuView = viewClass({
     elementId: "fu",
     template: compile("bro")
@@ -226,7 +226,7 @@ test("View lookup - view.computed", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-test("id bindings downgrade to one-time property lookup", function() {
+QUnit.test("id bindings downgrade to one-time property lookup", function() {
   view = EmberView.extend({
     template: compile("{{#view id=view.meshuggah}}{{view.parentView.meshuggah}}{{/view}}"),
     meshuggah: 'stengah'
@@ -239,7 +239,7 @@ test("id bindings downgrade to one-time property lookup", function() {
   equal(jQuery('#stengah').text(), 'omg', "id didn't change");
 });
 
-test("specifying `id` as a static value works properly", function() {
+QUnit.test("specifying `id` as a static value works properly", function() {
   view = EmberView.extend({
     template: compile("{{#view id='blah'}}{{view.parentView.meshuggah}}{{/view}}"),
     meshuggah: 'stengah'
@@ -250,7 +250,7 @@ test("specifying `id` as a static value works properly", function() {
   equal(view.$('#blah').text(), 'stengah', "id binding performed property lookup");
 });
 
-test("mixing old and new styles of property binding fires a warning, treats value as if it were quoted", function() {
+QUnit.test("mixing old and new styles of property binding fires a warning, treats value as if it were quoted", function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -276,7 +276,7 @@ test("mixing old and new styles of property binding fires a warning, treats valu
   Ember.warn = oldWarn;
 });
 
-test('"Binding"-suffixed bindings are runloop-synchronized', function() {
+QUnit.test('"Binding"-suffixed bindings are runloop-synchronized', function() {
   expect(5);
 
   var subview;
@@ -317,7 +317,7 @@ test('"Binding"-suffixed bindings are runloop-synchronized', function() {
   equal(get(subview, 'color'), 'persian rose', 'bound property is updated after runloop flush');
 });
 
-test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
+QUnit.test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
   expect(5);
 
   var subview;
@@ -358,7 +358,7 @@ test('Non-"Binding"-suffixed bindings are runloop-synchronized', function() {
   equal(get(subview, 'color'), 'persian rose', 'bound property is updated after runloop flush');
 });
 
-test("allows you to pass attributes that will be assigned to the class instance, like class=\"foo\"", function() {
+QUnit.test("allows you to pass attributes that will be assigned to the class instance, like class=\"foo\"", function() {
   expect(4);
 
   registry = new Registry();
@@ -378,7 +378,7 @@ test("allows you to pass attributes that will be assigned to the class instance,
   equal(jQuery('#bar').text(), 'Bar');
 });
 
-test("Should apply class without condition always", function() {
+QUnit.test("Should apply class without condition always", function() {
   view = EmberView.create({
     controller: Ember.Object.create(),
     template: compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
@@ -389,7 +389,7 @@ test("Should apply class without condition always", function() {
   ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
 });
 
-test("Should apply classes when bound controller.* property specified", function() {
+QUnit.test("Should apply classes when bound controller.* property specified", function() {
   view = EmberView.create({
     controller: {
       someProp: 'foo'
@@ -402,7 +402,7 @@ test("Should apply classes when bound controller.* property specified", function
   ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
 });
 
-test("Should apply classes when bound property specified", function() {
+QUnit.test("Should apply classes when bound property specified", function() {
   view = EmberView.create({
     controller: {
       someProp: 'foo'
@@ -415,7 +415,7 @@ test("Should apply classes when bound property specified", function() {
   ok(jQuery('#foo').hasClass('foo'), "Always applies classbinding without condition");
 });
 
-test("Should not apply classes when bound property specified is false", function() {
+QUnit.test("Should not apply classes when bound property specified is false", function() {
   view = EmberView.create({
     controller: {
       someProp: false
@@ -428,7 +428,7 @@ test("Should not apply classes when bound property specified is false", function
   ok(!jQuery('#foo').hasClass('some-prop'), "does not add class when value is falsey");
 });
 
-test("Should apply classes of the dasherized property name when bound property specified is true", function() {
+QUnit.test("Should apply classes of the dasherized property name when bound property specified is true", function() {
   view = EmberView.create({
     controller: {
       someProp: true
@@ -441,7 +441,7 @@ test("Should apply classes of the dasherized property name when bound property s
   ok(jQuery('#foo').hasClass('some-prop'), "adds dasherized class when value is true");
 });
 
-test("Should update classes from a bound property", function() {
+QUnit.test("Should update classes from a bound property", function() {
   var controller = {
     someProp: true
   };
@@ -468,7 +468,7 @@ test("Should update classes from a bound property", function() {
   ok(jQuery('#foo').hasClass('fooBar'), "changes property to string value (but does not dasherize)");
 });
 
-test("bound properties should be available in the view", function() {
+QUnit.test("bound properties should be available in the view", function() {
   var FuView = viewClass({
     elementId: 'fu',
     template: compile("{{view.foo}}")
@@ -499,7 +499,7 @@ test("bound properties should be available in the view", function() {
   equal(view.$('#fu').text(), 'second value');
 });
 
-test('should escape HTML in normal mustaches', function() {
+QUnit.test('should escape HTML in normal mustaches', function() {
   view = EmberView.create({
     template: compile('{{view.output}}'),
     output: 'you need to be more <b>bold</b>'
@@ -517,7 +517,7 @@ test('should escape HTML in normal mustaches', function() {
   equal(view.$('i').length, 0, 'does not create an element when value is updated');
 });
 
-test('should not escape HTML in triple mustaches', function() {
+QUnit.test('should not escape HTML in triple mustaches', function() {
   view = EmberView.create({
     template: compile('{{{view.output}}}'),
     output: 'you need to be more <b>bold</b>'
@@ -534,7 +534,7 @@ test('should not escape HTML in triple mustaches', function() {
   equal(view.$('i').length, 1, 'creates an element when value is updated');
 });
 
-test('should not escape HTML if string is a Handlebars.SafeString', function() {
+QUnit.test('should not escape HTML if string is a Handlebars.SafeString', function() {
   view = EmberView.create({
     template: compile('{{view.output}}'),
     output: new SafeString('you need to be more <b>bold</b>')
@@ -551,7 +551,7 @@ test('should not escape HTML if string is a Handlebars.SafeString', function() {
   equal(view.$('i').length, 1, 'creates an element when value is updated');
 });
 
-test('should teardown observers from bound properties on rerender', function() {
+QUnit.test('should teardown observers from bound properties on rerender', function() {
   view = EmberView.create({
     template: compile('{{view.foo}}'),
     foo: 'bar'
@@ -568,7 +568,7 @@ test('should teardown observers from bound properties on rerender', function() {
   equal(observersFor(view, 'foo').length, 1);
 });
 
-test('should update bound values after the view is removed and then re-appended', function() {
+QUnit.test('should update bound values after the view is removed and then re-appended', function() {
   view = EmberView.create({
     template: compile('{{#if view.showStuff}}{{view.boundValue}}{{else}}Not true.{{/if}}'),
     showStuff: true,
@@ -603,7 +603,7 @@ test('should update bound values after the view is removed and then re-appended'
   equal(trim(view.$().text()), 'bar');
 });
 
-test('views set the template of their children to a passed block', function() {
+QUnit.test('views set the template of their children to a passed block', function() {
   registry.register('template:parent', compile('<h1>{{#view}}<span>It worked!</span>{{/view}}</h1>'));
 
   view = EmberView.create({
@@ -615,7 +615,7 @@ test('views set the template of their children to a passed block', function() {
   ok(view.$('h1:has(span)').length === 1, "renders the passed template inside the parent template");
 });
 
-test('{{view}} should not override class bindings defined on a child view', function() {
+QUnit.test('{{view}} should not override class bindings defined on a child view', function() {
   var LabelView = EmberView.extend({
     container:         container,
     classNameBindings: ['something'],
@@ -640,7 +640,7 @@ test('{{view}} should not override class bindings defined on a child view', func
   ok(view.$('.visible').length > 0, 'class bindings are not overriden');
 });
 
-test('child views can be inserted using the {{view}} helper', function() {
+QUnit.test('child views can be inserted using the {{view}} helper', function() {
   registry.register('template:nester', compile('<h1 id="hello-world">Hello {{world}}</h1>{{view view.labelView}}'));
   registry.register('template:nested', compile('<div id="child-view">Goodbye {{cruel}} {{world}}</div>'));
 
@@ -670,7 +670,7 @@ test('child views can be inserted using the {{view}} helper', function() {
   ok(view.$().text().match(/Hello world!.*Goodbye cruel world\!/), 'parent view should appear before the child view');
 });
 
-test('should be able to explicitly set a view\'s context', function() {
+QUnit.test('should be able to explicitly set a view\'s context', function() {
   var context = EmberObject.create({
     test: 'test'
   });
@@ -690,7 +690,7 @@ test('should be able to explicitly set a view\'s context', function() {
   equal(view.$().text(), 'test');
 });
 
-test('Template views add an elementId to child views created using the view helper', function() {
+QUnit.test('Template views add an elementId to child views created using the view helper', function() {
   registry.register('template:parent', compile('<div>{{view view.childView}}</div>'));
   registry.register('template:child',  compile('I can\'t believe it\'s not butter.'));
 
@@ -711,7 +711,7 @@ test('Template views add an elementId to child views created using the view help
   equal(view.$().children().first().children().first().attr('id'), get(childView, 'elementId'));
 });
 
-test('Child views created using the view helper should have their parent view set properly', function() {
+QUnit.test('Child views created using the view helper should have their parent view set properly', function() {
   var template = '{{#view}}{{#view}}{{view}}{{/view}}{{/view}}';
 
   view = EmberView.create({
@@ -724,7 +724,7 @@ test('Child views created using the view helper should have their parent view se
   equal(childView, get(firstChild(childView), 'parentView'), 'parent view is correct');
 });
 
-test('Child views created using the view helper should have their IDs registered for events', function() {
+QUnit.test('Child views created using the view helper should have their IDs registered for events', function() {
   var template = '{{view}}{{view id="templateViewTest"}}';
 
   view = EmberView.create({
@@ -743,7 +743,7 @@ test('Child views created using the view helper should have their IDs registered
   equal(EmberView.views[id], childView, 'childView with passed ID is registered with View.views so that it can properly receive events from EventDispatcher');
 });
 
-test('Child views created using the view helper and that have a viewName should be registered as properties on their parentView', function() {
+QUnit.test('Child views created using the view helper and that have a viewName should be registered as properties on their parentView', function() {
   var template = '{{#view}}{{view viewName="ohai"}}{{/view}}';
 
   view = EmberView.create({
@@ -758,7 +758,7 @@ test('Child views created using the view helper and that have a viewName should 
   equal(get(parentView, 'ohai'), childView);
 });
 
-test('{{view}} id attribute should set id on layer', function() {
+QUnit.test('{{view}} id attribute should set id on layer', function() {
   registry.register('template:foo', compile('{{#view view.idView id="bar"}}baz{{/view}}'));
 
   var IdView = EmberView;
@@ -775,7 +775,7 @@ test('{{view}} id attribute should set id on layer', function() {
   equal(view.$('#bar').text(), 'baz', 'emits content');
 });
 
-test('{{view}} tag attribute should set tagName of the view', function() {
+QUnit.test('{{view}} tag attribute should set tagName of the view', function() {
   registry.register('template:foo', compile('{{#view view.tagView tag="span"}}baz{{/view}}'));
 
   var TagView = EmberView;
@@ -792,7 +792,7 @@ test('{{view}} tag attribute should set tagName of the view', function() {
   equal(view.$('span').text(), 'baz', 'emits content');
 });
 
-test('{{view}} class attribute should set class on layer', function() {
+QUnit.test('{{view}} class attribute should set class on layer', function() {
   registry.register('template:foo', compile('{{#view view.idView class="bar"}}baz{{/view}}'));
 
   var IdView = EmberView;
@@ -809,7 +809,7 @@ test('{{view}} class attribute should set class on layer', function() {
   equal(view.$('.bar').text(), 'baz', 'emits content');
 });
 
-test('{{view}} should not allow attributeBindings to be set', function() {
+QUnit.test('{{view}} should not allow attributeBindings to be set', function() {
   expectAssertion(function() {
     view = EmberView.create({
       template: compile('{{view attributeBindings="one two"}}')
@@ -818,7 +818,7 @@ test('{{view}} should not allow attributeBindings to be set', function() {
   }, /Setting 'attributeBindings' via template helpers is not allowed/);
 });
 
-test('{{view}} should be able to point to a local view', function() {
+QUnit.test('{{view}} should be able to point to a local view', function() {
   view = EmberView.create({
     template: compile('{{view view.common}}'),
 
@@ -832,7 +832,7 @@ test('{{view}} should be able to point to a local view', function() {
   equal(view.$().text(), 'common', 'tries to look up view name locally');
 });
 
-test('{{view}} should evaluate class bindings set to global paths DEPRECATED', function() {
+QUnit.test('{{view}} should evaluate class bindings set to global paths DEPRECATED', function() {
   var App;
 
   run(function() {
@@ -872,7 +872,7 @@ test('{{view}} should evaluate class bindings set to global paths DEPRECATED', f
   runDestroy(lookup.App);
 });
 
-test('{{view}} should evaluate class bindings set in the current context', function() {
+QUnit.test('{{view}} should evaluate class bindings set in the current context', function() {
   view = EmberView.create({
     isView:      true,
     isEditable:  true,
@@ -901,7 +901,7 @@ test('{{view}} should evaluate class bindings set in the current context', funct
   ok(view.$('input').hasClass('disabled'),    'evaluates ternary operator in classBindings');
 });
 
-test('{{view}} should evaluate class bindings set with either classBinding or classNameBindings from globals DEPRECATED', function() {
+QUnit.test('{{view}} should evaluate class bindings set with either classBinding or classNameBindings from globals DEPRECATED', function() {
   var App;
 
   run(function() {
@@ -940,7 +940,7 @@ test('{{view}} should evaluate class bindings set with either classBinding or cl
   runDestroy(lookup.App);
 });
 
-test('{{view}} should evaluate other attribute bindings set to global paths', function() {
+QUnit.test('{{view}} should evaluate other attribute bindings set to global paths', function() {
   run(function() {
     lookup.App = Namespace.create({
       name: 'myApp'
@@ -961,7 +961,7 @@ test('{{view}} should evaluate other attribute bindings set to global paths', fu
   runDestroy(lookup.App);
 });
 
-test('{{view}} should evaluate other attributes bindings set in the current context', function() {
+QUnit.test('{{view}} should evaluate other attributes bindings set in the current context', function() {
   view = EmberView.create({
     name: 'myView',
     textField: TextField,
@@ -973,7 +973,7 @@ test('{{view}} should evaluate other attributes bindings set in the current cont
   equal(view.$('input').val(), 'myView', 'evaluates attributes bound in the current context');
 });
 
-test('{{view}} should be able to bind class names to truthy properties', function() {
+QUnit.test('{{view}} should be able to bind class names to truthy properties', function() {
   registry.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy"}}foo{{/view}}'));
 
   var ClassBindingView = EmberView.extend();
@@ -996,7 +996,7 @@ test('{{view}} should be able to bind class names to truthy properties', functio
   equal(view.$('.is-truthy').length, 0, 'removes class name if bound property is set to falsey');
 });
 
-test('{{view}} should be able to bind class names to truthy or falsy properties', function() {
+QUnit.test('{{view}} should be able to bind class names to truthy or falsy properties', function() {
   registry.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy:is-falsy"}}foo{{/view}}'));
 
   var ClassBindingView = EmberView.extend();
@@ -1021,7 +1021,7 @@ test('{{view}} should be able to bind class names to truthy or falsy properties'
   equal(view.$('.is-falsy').length, 1, "sets class name to falsy value");
 });
 
-test('a view helper\'s bindings are to the parent context', function() {
+QUnit.test('a view helper\'s bindings are to the parent context', function() {
   var Subview = EmberView.extend({
     classNameBindings: ['color'],
     controller: EmberObject.create({
@@ -1047,7 +1047,7 @@ test('a view helper\'s bindings are to the parent context', function() {
   equal(view.$('h1 .mauve').text(), 'foo bar', 'renders property bound in template from subview context');
 });
 
-test('should expose a controller keyword when present on the view', function() {
+QUnit.test('should expose a controller keyword when present on the view', function() {
   var templateString = '{{controller.foo}}{{#view}}{{controller.baz}}{{/view}}';
   view = EmberView.create({
     container: container,
@@ -1084,7 +1084,7 @@ test('should expose a controller keyword when present on the view', function() {
   equal(view.$().text(), 'aString', 'renders the controller itself if no additional path is specified');
 });
 
-test('should expose a controller keyword that can be used in conditionals', function() {
+QUnit.test('should expose a controller keyword that can be used in conditionals', function() {
   var templateString = '{{#view}}{{#if controller}}{{controller.foo}}{{/if}}{{/view}}';
   view = EmberView.create({
     container: container,
@@ -1106,7 +1106,7 @@ test('should expose a controller keyword that can be used in conditionals', func
   equal(view.$().text(), '', 'updates the DOM when the controller is changed');
 });
 
-test('should expose a controller keyword that persists through Ember.ContainerView', function() {
+QUnit.test('should expose a controller keyword that persists through Ember.ContainerView', function() {
   var templateString = '{{view view.containerView}}';
   view = EmberView.create({
     containerView: ContainerView,
@@ -1132,7 +1132,7 @@ test('should expose a controller keyword that persists through Ember.ContainerVi
   equal(trim(viewInstanceToBeInserted.$().text()), 'bar', 'renders value from parent\'s controller');
 });
 
-test('should work with precompiled templates', function() {
+QUnit.test('should work with precompiled templates', function() {
   var templateString = precompile('{{view.value}}');
   var compiledTemplate = template(eval(templateString));
 
@@ -1152,7 +1152,7 @@ test('should work with precompiled templates', function() {
   equal(view.$().text(), 'updated', 'the precompiled template was updated');
 });
 
-test('bindings should be relative to the current context', function() {
+QUnit.test('bindings should be relative to the current context', function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -1173,7 +1173,7 @@ test('bindings should be relative to the current context', function() {
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
-test('bindings should respect keywords', function() {
+QUnit.test('bindings should respect keywords', function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -1197,7 +1197,7 @@ test('bindings should respect keywords', function() {
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
-test('should bind to the property if no registered helper found for a mustache without parameters', function() {
+QUnit.test('should bind to the property if no registered helper found for a mustache without parameters', function() {
   view = EmberView.createWithMixins({
     template: compile('{{view.foobarProperty}}'),
     foobarProperty: computed(function() {
@@ -1210,7 +1210,7 @@ test('should bind to the property if no registered helper found for a mustache w
   ok(view.$().text() === 'foobarProperty', 'Property was bound to correctly');
 });
 
-test('{{view}} should be able to point to a local instance of view', function() {
+QUnit.test('{{view}} should be able to point to a local instance of view', function() {
   view = EmberView.create({
     template: compile("{{view view.common}}"),
 
@@ -1223,7 +1223,7 @@ test('{{view}} should be able to point to a local instance of view', function() 
   equal(view.$().text(), "common", "tries to look up view name locally");
 });
 
-test("{{view}} should be able to point to a local instance of subclass of view", function() {
+QUnit.test("{{view}} should be able to point to a local instance of subclass of view", function() {
   var MyView = EmberView.extend();
   view = EmberView.create({
     template: compile("{{view view.subclassed}}"),
@@ -1236,7 +1236,7 @@ test("{{view}} should be able to point to a local instance of subclass of view",
   equal(view.$().text(), "subclassed", "tries to look up view name locally");
 });
 
-test("{{view}} asserts that a view class is present", function() {
+QUnit.test("{{view}} asserts that a view class is present", function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile("{{view view.notView}}"),
@@ -1250,7 +1250,7 @@ test("{{view}} asserts that a view class is present", function() {
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test("{{view}} asserts that a view class is present off controller", function() {
+QUnit.test("{{view}} asserts that a view class is present off controller", function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile("{{view notView}}"),
@@ -1266,7 +1266,7 @@ test("{{view}} asserts that a view class is present off controller", function() 
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test("{{view}} asserts that a view instance is present", function() {
+QUnit.test("{{view}} asserts that a view instance is present", function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile("{{view view.notView}}"),
@@ -1280,7 +1280,7 @@ test("{{view}} asserts that a view instance is present", function() {
   }, /must be a subclass or an instance of Ember.View/);
 });
 
-test("{{view}} asserts that a view subclass instance is present off controller", function() {
+QUnit.test("{{view}} asserts that a view subclass instance is present off controller", function() {
   var MyView = EmberObject.extend();
   view = EmberView.create({
     template: compile("{{view notView}}"),

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -39,11 +39,11 @@ function testWithAs(moduleName, templateString) {
     }
   });
 
-  test("it should support #with-as syntax", function() {
+  QUnit.test("it should support #with-as syntax", function() {
     equal(view.$().text(), "Señor Engineer: Tom Dale", "should be properly scoped");
   });
 
-  test("updating the context should update the alias", function() {
+  QUnit.test("updating the context should update the alias", function() {
     run(function() {
       view.set('context.person', {
         name: "Yehuda Katz"
@@ -53,7 +53,7 @@ function testWithAs(moduleName, templateString) {
     equal(view.$().text(), "Señor Engineer: Yehuda Katz", "should be properly scoped after updating");
   });
 
-  test("updating a property on the context should update the HTML", function() {
+  QUnit.test("updating a property on the context should update the HTML", function() {
     equal(view.$().text(), "Señor Engineer: Tom Dale", "precond - should be properly scoped after updating");
 
     run(function() {
@@ -63,7 +63,7 @@ function testWithAs(moduleName, templateString) {
     equal(view.$().text(), "Señor Engineer: Yehuda Katz", "should be properly scoped after updating");
   });
 
-  test("updating a property on the view should update the HTML", function() {
+  QUnit.test("updating a property on the view should update the HTML", function() {
     run(function() {
       view.set('context.title', "Señorette Engineer");
     });
@@ -96,11 +96,11 @@ QUnit.module("Multiple Handlebars {{with foo as bar}} helpers", {
   }
 });
 
-test("re-using the same variable with different #with blocks does not override each other", function() {
+QUnit.test("re-using the same variable with different #with blocks does not override each other", function() {
   equal(view.$().text(), "Admin: Tom Dale User: Yehuda Katz", "should be properly scoped");
 });
 
-test("the scoped variable is not available outside the {{with}} block.", function() {
+QUnit.test("the scoped variable is not available outside the {{with}} block.", function() {
   run(function() {
     view.set('template', compile("{{name}}-{{#with other as name}}{{name}}{{/with}}-{{name}}"));
     view.set('context', {
@@ -112,7 +112,7 @@ test("the scoped variable is not available outside the {{with}} block.", functio
   equal(view.$().text(), "Stef-Yehuda-Stef", "should be properly scoped after updating");
 });
 
-test("nested {{with}} blocks shadow the outer scoped variable properly.", function() {
+QUnit.test("nested {{with}} blocks shadow the outer scoped variable properly.", function() {
   run(function() {
     view.set('template', compile("{{#with first as ring}}{{ring}}-{{#with fifth as ring}}{{ring}}-{{#with ninth as ring}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}{{/with}}"));
     view.set('context', {
@@ -141,7 +141,7 @@ QUnit.module("Handlebars {{#with}} globals helper [DEPRECATED]", {
   }
 });
 
-test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
+QUnit.test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
   expectDeprecation(function() {
     runAppend(view);
   }, /Global lookup of Foo.bar from a Handlebars template is deprecated/);
@@ -157,7 +157,7 @@ test("it should support #with Foo.bar as qux [DEPRECATED]", function() {
 
 QUnit.module("Handlebars {{#with keyword as foo}}");
 
-test("it should support #with view as foo", function() {
+QUnit.test("it should support #with view as foo", function() {
   var view = EmberView.create({
     template: compile("{{#with view as myView}}{{myView.name}}{{/with}}"),
     name: "Sonics"
@@ -175,7 +175,7 @@ test("it should support #with view as foo", function() {
   runDestroy(view);
 });
 
-test("it should support #with name as food, then #with foo as bar", function() {
+QUnit.test("it should support #with name as food, then #with foo as bar", function() {
   var view = EmberView.create({
     template: compile("{{#with name as foo}}{{#with foo as bar}}{{bar}}{{/with}}{{/with}}"),
     context: { name: "caterpillar" }
@@ -195,7 +195,7 @@ test("it should support #with name as food, then #with foo as bar", function() {
 
 QUnit.module("Handlebars {{#with this as foo}}");
 
-test("it should support #with this as qux", function() {
+QUnit.test("it should support #with this as qux", function() {
   var view = EmberView.create({
     template: compile("{{#with this as person}}{{person.name}}{{/with}}"),
     controller: EmberObject.create({ name: "Los Pivots" })
@@ -215,7 +215,7 @@ test("it should support #with this as qux", function() {
 
 QUnit.module("Handlebars {{#with foo}} with defined controller");
 
-test("it should wrap context with object controller [DEPRECATED]", function() {
+QUnit.test("it should wrap context with object controller [DEPRECATED]", function() {
   expectDeprecation(objectControllerDeprecation);
 
   var Controller = ObjectController.extend({
@@ -274,7 +274,7 @@ test("it should wrap context with object controller [DEPRECATED]", function() {
 });
 
 /* requires each
-test("it should still have access to original parentController within an {{#each}}", function() {
+QUnit.test("it should still have access to original parentController within an {{#each}}", function() {
   var Controller = ObjectController.extend({
     controllerName: computed(function() {
       return "controller:"+this.get('model.name') + ' and ' + this.get('parentController.name');
@@ -307,7 +307,7 @@ test("it should still have access to original parentController within an {{#each
 });
 */
 
-test("it should wrap keyword with object controller [DEPRECATED]", function() {
+QUnit.test("it should wrap keyword with object controller [DEPRECATED]", function() {
   expectDeprecation(objectControllerDeprecation);
 
   var PersonController = ObjectController.extend({
@@ -361,7 +361,7 @@ test("it should wrap keyword with object controller [DEPRECATED]", function() {
   runDestroy(view);
 });
 
-test("destroys the controller generated with {{with foo controller='blah'}} [DEPRECATED]", function() {
+QUnit.test("destroys the controller generated with {{with foo controller='blah'}} [DEPRECATED]", function() {
   var destroyed = false;
   var Controller = EmberController.extend({
     willDestroy: function() {
@@ -397,7 +397,7 @@ test("destroys the controller generated with {{with foo controller='blah'}} [DEP
   ok(destroyed, 'controller was destroyed properly');
 });
 
-test("destroys the controller generated with {{with foo as bar controller='blah'}}", function() {
+QUnit.test("destroys the controller generated with {{with foo as bar controller='blah'}}", function() {
   var destroyed = false;
   var Controller = EmberController.extend({
     willDestroy: function() {
@@ -452,7 +452,7 @@ QUnit.module("{{#with}} helper binding to view keyword", {
   }
 });
 
-test("{{with}} helper can bind to keywords with 'as'", function() {
+QUnit.test("{{with}} helper can bind to keywords with 'as'", function() {
   equal(view.$().text(), "We have: this is from the view and this is from the context", "should render");
 });
 
@@ -482,11 +482,11 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
     }
   });
 
-  test("re-using the same variable with different #with blocks does not override each other", function() {
+  QUnit.test("re-using the same variable with different #with blocks does not override each other", function() {
     equal(view.$().text(), "Admin: Tom Dale User: Yehuda Katz", "should be properly scoped");
   });
 
-  test("the scoped variable is not available outside the {{with}} block.", function() {
+  QUnit.test("the scoped variable is not available outside the {{with}} block.", function() {
     run(function() {
       view.set('template', compile("{{name}}-{{#with other as |name|}}{{name}}{{/with}}-{{name}}"));
       view.set('context', {
@@ -498,7 +498,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-block-params')) {
     equal(view.$().text(), "Stef-Yehuda-Stef", "should be properly scoped after updating");
   });
 
-  test("nested {{with}} blocks shadow the outer scoped variable properly.", function() {
+  QUnit.test("nested {{with}} blocks shadow the outer scoped variable properly.", function() {
     run(function() {
       view.set('template', compile("{{#with first as |ring|}}{{ring}}-{{#with fifth as |ring|}}{{ring}}-{{#with ninth as |ring|}}{{ring}}-{{/with}}{{ring}}-{{/with}}{{ring}}{{/with}}"));
       view.set('context', {

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -35,7 +35,7 @@ QUnit.module("ember-htmlbars: Support for {{yield}} helper", {
   }
 });
 
-test("a view with a layout set renders its template where the {{yield}} helper appears", function() {
+QUnit.test("a view with a layout set renders its template where the {{yield}} helper appears", function() {
   var ViewWithLayout = EmberView.extend({
     layout: compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>')
   });
@@ -50,7 +50,7 @@ test("a view with a layout set renders its template where the {{yield}} helper a
   equal(view.$('div.wrapper div.page-body').length, 1, 'page-body is embedded within wrapping my-page');
 });
 
-test("block should work properly even when templates are not hard-coded", function() {
+QUnit.test("block should work properly even when templates are not hard-coded", function() {
   registry.register('template:nester', compile('<div class="wrapper"><h1>{{title}}</h1>{{yield}}</div>'));
   registry.register('template:nested', compile('{{#view "with-layout" title="My Fancy Page"}}<div class="page-body">Show something interesting here</div>{{/view}}'));
 
@@ -70,7 +70,7 @@ test("block should work properly even when templates are not hard-coded", functi
 
 });
 
-test("templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
+QUnit.test("templates should yield to block, when the yield is embedded in a hierarchy of virtual views", function() {
   var TimesView = EmberView.extend({
     layout: compile('<div class="times">{{#each item in view.index}}{{yield}}{{/each}}</div>'),
     n: null,
@@ -94,7 +94,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
   equal(view.$('div#container div.times-item').length, 5, 'times-item is embedded within wrapping container 5 times, as expected');
 });
 
-test("templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
+QUnit.test("templates should yield to block, when the yield is embedded in a hierarchy of non-virtual views", function() {
   var NestingView = EmberView.extend({
     layout: compile('{{#view tagName="div" classNames="nesting"}}{{yield}}{{/view}}')
   });
@@ -109,7 +109,7 @@ test("templates should yield to block, when the yield is embedded in a hierarchy
   equal(view.$('div#container div.nesting div#block').length, 1, 'nesting view yields correctly even within a view hierarchy in the nesting view');
 });
 
-test("block should not be required", function() {
+QUnit.test("block should not be required", function() {
   var YieldingView = EmberView.extend({
     layout: compile('{{#view tagName="div" classNames="yielding"}}{{yield}}{{/view}}')
   });
@@ -124,7 +124,7 @@ test("block should not be required", function() {
   equal(view.$('div#container div.yielding').length, 1, 'yielding view is rendered as expected');
 });
 
-test("yield uses the outer context", function() {
+QUnit.test("yield uses the outer context", function() {
   var component = Component.extend({
     boundText: "inner",
     layout: compile("<p>{{boundText}}</p><p>{{yield}}</p>")
@@ -141,7 +141,7 @@ test("yield uses the outer context", function() {
 });
 
 
-test("yield inside a conditional uses the outer context [DEPRECATED]", function() {
+QUnit.test("yield inside a conditional uses the outer context [DEPRECATED]", function() {
   var component = Component.extend({
     boundText: "inner",
     truthy: true,
@@ -161,7 +161,7 @@ test("yield inside a conditional uses the outer context [DEPRECATED]", function(
   equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, "Yield points at the right context");
 });
 
-test("outer keyword doesn't mask inner component property", function () {
+QUnit.test("outer keyword doesn't mask inner component property", function () {
   var component = Component.extend({
     item: "inner",
     layout: compile("<p>{{item}}</p><p>{{yield}}</p>")
@@ -177,7 +177,7 @@ test("outer keyword doesn't mask inner component property", function () {
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "inner component property isn't masked by outer keyword");
 });
 
-test("inner keyword doesn't mask yield property", function() {
+QUnit.test("inner keyword doesn't mask yield property", function() {
   var component = Component.extend({
     boundText: "inner",
     layout: compile("{{#with boundText as item}}<p>{{item}}</p><p>{{yield}}</p>{{/with}}")
@@ -193,7 +193,7 @@ test("inner keyword doesn't mask yield property", function() {
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, "outer property isn't masked by inner keyword");
 });
 
-test("can bind a keyword to a component and use it in yield", function() {
+QUnit.test("can bind a keyword to a component and use it in yield", function() {
   var component = Component.extend({
     content: null,
     layout: compile("<p>{{content}}</p><p>{{yield}}</p>")
@@ -218,7 +218,7 @@ test("can bind a keyword to a component and use it in yield", function() {
 if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
 
-test("yield uses the layout context for non component [DEPRECATED]", function() {
+QUnit.test("yield uses the layout context for non component [DEPRECATED]", function() {
   view = EmberView.create({
     controller: {
       boundText: "outer",
@@ -240,7 +240,7 @@ test("yield uses the layout context for non component [DEPRECATED]", function() 
 // jscs:enable validateIndentation
 }
 
-test("yield view should be a virtual view", function() {
+QUnit.test("yield view should be a virtual view", function() {
   var component = Component.extend({
     isParentComponent: true,
 
@@ -265,7 +265,7 @@ test("yield view should be a virtual view", function() {
 });
 
 
-test("adding a layout should not affect the context of normal views", function() {
+QUnit.test("adding a layout should not affect the context of normal views", function() {
   var parentView = EmberView.create({
     context: "ParentContext"
   });
@@ -295,7 +295,7 @@ test("adding a layout should not affect the context of normal views", function()
   runDestroy(parentView);
 });
 
-test("yield should work for views even if _parentView is null", function() {
+QUnit.test("yield should work for views even if _parentView is null", function() {
   view = EmberView.create({
     layout:   compile('Layout: {{yield}}'),
     template: compile("View Content")
@@ -318,7 +318,7 @@ QUnit.module("ember-htmlbars: Component {{yield}}", {
   }
 });
 
-test("yield with nested components (#3220)", function() {
+QUnit.test("yield with nested components (#3220)", function() {
   var count = 0;
   var InnerComponent = Component.extend({
     layout: compile("{{yield}}"),
@@ -351,7 +351,7 @@ test("yield with nested components (#3220)", function() {
   equal(view.$('div > span').text(), "Hello world");
 });
 
-test("yield works inside a conditional in a component that has Ember._Metamorph mixed in", function() {
+QUnit.test("yield works inside a conditional in a component that has Ember._Metamorph mixed in", function() {
   var component = Component.extend(Ember._Metamorph, {
     item: "inner",
     layout: compile("<p>{{item}}</p>{{#if item}}<p>{{yield}}</p>{{/if}}")
@@ -367,7 +367,7 @@ test("yield works inside a conditional in a component that has Ember._Metamorph 
   equal(view.$().text(), 'innerouter', "{{yield}} renders yielded content inside metamorph component");
 });
 
-test("view keyword works inside component yield", function () {
+QUnit.test("view keyword works inside component yield", function () {
   var component = Component.extend({
     layout: compile("<p>{{yield}}</p>")
   });

--- a/packages/ember-htmlbars/tests/hooks/component_test.js
+++ b/packages/ember-htmlbars/tests/hooks/component_test.js
@@ -31,7 +31,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
       }
     });
 
-    test("component is looked up from the container", function() {
+    QUnit.test("component is looked up from the container", function() {
       registry.register('template:components/foo-bar', compile('yippie!'));
 
       view = EmberView.create({
@@ -44,7 +44,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
       equal(view.$().text(), 'yippie!', 'component was looked up and rendered');
     });
 
-    test("asserts if component is not found", function() {
+    QUnit.test("asserts if component is not found", function() {
       view = EmberView.create({
         container: container,
         template: compile("<foo-bar />")

--- a/packages/ember-htmlbars/tests/hooks/element_test.js
+++ b/packages/ember-htmlbars/tests/hooks/element_test.js
@@ -15,7 +15,7 @@ QUnit.module('ember-htmlbars: element hook', {
   }
 });
 
-test('allows unbound usage within an element', function() {
+QUnit.test('allows unbound usage within an element', function() {
   expect(4);
 
   function someHelper(params, hash, options, env) {
@@ -41,7 +41,7 @@ test('allows unbound usage within an element', function() {
   equal(view.$('.foo').length, 1, 'class attribute was added by helper');
 });
 
-test('allows unbound usage within an element from property', function() {
+QUnit.test('allows unbound usage within an element from property', function() {
   expect(2);
 
   view = EmberView.create({
@@ -58,7 +58,7 @@ test('allows unbound usage within an element from property', function() {
   equal(view.$('.foo').length, 1, 'class attribute was added by helper');
 });
 
-test('allows unbound usage within an element creating multiple attributes', function() {
+QUnit.test('allows unbound usage within an element creating multiple attributes', function() {
   expect(2);
 
   view = EmberView.create({

--- a/packages/ember-htmlbars/tests/hooks/text_node_test.js
+++ b/packages/ember-htmlbars/tests/hooks/text_node_test.js
@@ -14,7 +14,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     }
   });
 
-  test("property is output", function() {
+  QUnit.test("property is output", function() {
     view = EmberView.create({
       context: { name: 'erik' },
       template: compile("ohai {{name}}")
@@ -24,7 +24,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     equalInnerHTML(view.element, 'ohai erik', "property is output");
   });
 
-  test("path is output", function() {
+  QUnit.test("path is output", function() {
     view = EmberView.create({
       context: { name: { firstName: 'erik' } },
       template: compile("ohai {{name.firstName}}")
@@ -34,7 +34,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     equalInnerHTML(view.element, 'ohai erik', "path is output");
   });
 
-  test("changed property updates", function() {
+  QUnit.test("changed property updates", function() {
     var context = EmberObject.create({ name: 'erik' });
     view = EmberView.create({
       context: context,

--- a/packages/ember-htmlbars/tests/htmlbars_test.js
+++ b/packages/ember-htmlbars/tests/htmlbars_test.js
@@ -8,7 +8,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
   QUnit.module("ember-htmlbars: main");
 
-  test("HTMLBars is present and can be executed", function() {
+  QUnit.test("HTMLBars is present and can be executed", function() {
     var template = compile("ohai");
 
     var env = merge({ dom: domHelper }, defaultEnv);

--- a/packages/ember-htmlbars/tests/integration/binding_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/binding_integration_test.js
@@ -33,7 +33,7 @@ QUnit.module('ember-htmlbars: binding integration', {
   }
 });
 
-test('should call a registered helper for mustache without parameters', function() {
+QUnit.test('should call a registered helper for mustache without parameters', function() {
   registerHelper('foobar', function() {
     return 'foobar';
   });
@@ -47,7 +47,7 @@ test('should call a registered helper for mustache without parameters', function
   ok(view.$().text() === 'foobar', 'Regular helper was invoked correctly');
 });
 
-test('should bind to the property if no registered helper found for a mustache without parameters', function() {
+QUnit.test('should bind to the property if no registered helper found for a mustache without parameters', function() {
   view = EmberView.createWithMixins({
     template: compile('{{view.foobarProperty}}'),
     foobarProperty: computed(function() {
@@ -60,7 +60,7 @@ test('should bind to the property if no registered helper found for a mustache w
   ok(view.$().text() === 'foobarProperty', 'Property was bound to correctly');
 });
 
-test("should be able to update when bound property updates", function() {
+QUnit.test("should be able to update when bound property updates", function() {
   MyApp.set('controller', EmberObject.create({ name: 'first' }));
 
   var View = EmberView.extend({
@@ -87,7 +87,7 @@ test("should be able to update when bound property updates", function() {
   equal(view.$('i').text(), 'second, second - computed', "view rerenders when bound properties change");
 });
 
-test('should cleanup bound properties on rerender', function() {
+QUnit.test('should cleanup bound properties on rerender', function() {
   view = EmberView.create({
     controller: EmberObject.create({ name: 'wycats' }),
     template: compile('{{name}}')
@@ -102,7 +102,7 @@ test('should cleanup bound properties on rerender', function() {
   equal(view._childViews.length, 1);
 });
 
-test("should update bound values after view's parent is removed and then re-appended", function() {
+QUnit.test("should update bound values after view's parent is removed and then re-appended", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var controller = EmberObject.create();
@@ -153,7 +153,7 @@ test("should update bound values after view's parent is removed and then re-appe
   runDestroy(parentView);
 });
 
-test('should accept bindings as a string or an Ember.Binding', function() {
+QUnit.test('should accept bindings as a string or an Ember.Binding', function() {
   var ViewWithBindings = EmberView.extend({
     oneWayBindingTestBinding: Binding.oneWay('context.direction'),
     twoWayBindingTestBinding: Binding.from('context.direction'),

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -44,7 +44,7 @@ QUnit.module("ember-htmlbars: block params", {
   }
 });
 
-test("basic block params usage", function() {
+QUnit.test("basic block params usage", function() {
   view = View.create({
     committer: { name: "rwjblue" },
     template: compile('{{#alias view.committer.name as |name|}}name: {{name}}, length: {{name.length}}{{/alias}}')
@@ -61,7 +61,7 @@ test("basic block params usage", function() {
   equal(view.$().text(), "name: krisselden, length: 10");
 });
 
-test("nested block params shadow correctly", function() {
+QUnit.test("nested block params shadow correctly", function() {
   view = View.create({
     context: { name: "ebryn" },
     committer1: { name: "trek" },
@@ -92,7 +92,7 @@ test("nested block params shadow correctly", function() {
   equal(view.$().text(), "ebryn[trek[machty]trek]ebryn[machty[trek]machty]ebryn");
 });
 
-test("components can yield values", function() {
+QUnit.test("components can yield values", function() {
   registry.register('template:components/x-alias', compile('{{yield param.name}}'));
 
   view = View.create({

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -25,7 +25,7 @@ QUnit.module('component - invocation', {
   }
 });
 
-test('non-block without properties', function() {
+QUnit.test('non-block without properties', function() {
   expect(1);
 
   registry.register('template:components/non-block', compile('In layout'));
@@ -40,7 +40,7 @@ test('non-block without properties', function() {
   equal(jQuery('#qunit-fixture').text(), 'In layout');
 });
 
-test('block without properties', function() {
+QUnit.test('block without properties', function() {
   expect(1);
 
   registry.register('template:components/with-block', compile('In layout - {{yield}}'));
@@ -55,7 +55,7 @@ test('block without properties', function() {
   equal(jQuery('#qunit-fixture').text(), 'In layout - In template');
 });
 
-test('non-block with properties', function() {
+QUnit.test('non-block with properties', function() {
   expect(1);
 
   registry.register('template:components/non-block', compile('In layout - someProp: {{someProp}}'));
@@ -70,7 +70,7 @@ test('non-block with properties', function() {
   equal(jQuery('#qunit-fixture').text(), 'In layout - someProp: something here');
 });
 
-test('block with properties', function() {
+QUnit.test('block with properties', function() {
   expect(1);
 
   registry.register('template:components/with-block', compile('In layout - someProp: {{someProp}} - {{yield}}'));

--- a/packages/ember-htmlbars/tests/integration/escape_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/escape_integration_test.js
@@ -16,7 +16,7 @@ QUnit.module('ember-htmlbars: Integration with Globals', {
   }
 });
 
-test('should read from a global-ish simple local path without deprecation', function() {
+QUnit.test('should read from a global-ish simple local path without deprecation', function() {
   view = EmberView.create({
     context: { NotGlobal: 'Gwar' },
     template: compile('{{NotGlobal}}')
@@ -28,7 +28,7 @@ test('should read from a global-ish simple local path without deprecation', func
   equal(view.$().text(), 'Gwar');
 });
 
-test('should read a number value', function() {
+QUnit.test('should read a number value', function() {
   var context = { aNumber: 1 };
   view = EmberView.create({
     context: context,
@@ -45,7 +45,7 @@ test('should read a number value', function() {
   equal(view.$().text(), '2');
 });
 
-test('should read an escaped number value', function() {
+QUnit.test('should read an escaped number value', function() {
   var context = { aNumber: 1 };
   view = EmberView.create({
     context: context,
@@ -62,7 +62,7 @@ test('should read an escaped number value', function() {
   equal(view.$().text(), '2');
 });
 
-test('should read from an Object.create(null)', function() {
+QUnit.test('should read from an Object.create(null)', function() {
   // Use ember's polyfill for Object.create
   var nullObject = o_create(null);
   nullObject['foo'] = 'bar';
@@ -81,7 +81,7 @@ test('should read from an Object.create(null)', function() {
   equal(view.$().text(), 'baz');
 });
 
-test('should escape HTML in primitive value contexts when using normal mustaches', function() {
+QUnit.test('should escape HTML in primitive value contexts when using normal mustaches', function() {
   view = EmberView.create({
     context: '<b>Max</b><b>James</b>',
     template: compile('{{this}}')
@@ -100,7 +100,7 @@ test('should escape HTML in primitive value contexts when using normal mustaches
   equal(view.$('i').length, 0, 'does not create an element when value is updated');
 });
 
-test('should not escape HTML in primitive value contexts when using triple mustaches', function() {
+QUnit.test('should not escape HTML in primitive value contexts when using triple mustaches', function() {
   view = EmberView.create({
     context: '<b>Max</b><b>James</b>',
     template: compile('{{{this}}}')

--- a/packages/ember-htmlbars/tests/integration/globals_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/globals_integration_test.js
@@ -20,7 +20,7 @@ QUnit.module('ember-htmlbars: Integration with Globals', {
   }
 });
 
-test('should read from globals (DEPRECATED)', function() {
+QUnit.test('should read from globals (DEPRECATED)', function() {
   Ember.lookup.Global = 'Klarg';
   view = EmberView.create({
     template: compile('{{Global}}')
@@ -33,7 +33,7 @@ test('should read from globals (DEPRECATED)', function() {
   equal(view.$().text(), Ember.lookup.Global);
 });
 
-test('should read from globals with a path (DEPRECATED)', function() {
+QUnit.test('should read from globals with a path (DEPRECATED)', function() {
   Ember.lookup.Global = { Space: 'Klarg' };
   view = EmberView.create({
     template: compile('{{Global.Space}}')
@@ -45,7 +45,7 @@ test('should read from globals with a path (DEPRECATED)', function() {
   equal(view.$().text(), Ember.lookup.Global.Space);
 });
 
-test('with context, should read from globals (DEPRECATED)', function() {
+QUnit.test('with context, should read from globals (DEPRECATED)', function() {
   Ember.lookup.Global = 'Klarg';
   view = EmberView.create({
     context: {},
@@ -58,7 +58,7 @@ test('with context, should read from globals (DEPRECATED)', function() {
   equal(view.$().text(), Ember.lookup.Global);
 });
 
-test('with context, should read from globals with a path (DEPRECATED)', function() {
+QUnit.test('with context, should read from globals with a path (DEPRECATED)', function() {
   Ember.lookup.Global = { Space: 'Klarg' };
   view = EmberView.create({
     context: {},

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -25,7 +25,7 @@ QUnit.module("ember-htmlbars: Ember.Select - usage inside templates", {
   }
 });
 
-test("works from a template with bindings", function() {
+QUnit.test("works from a template with bindings", function() {
   var Person = EmberObject.extend({
     id: null,
     firstName: null,
@@ -87,7 +87,7 @@ test("works from a template with bindings", function() {
   equal(select.get('selection'), erik, "Selection was maintained after new option was added");
 });
 
-test("upon content change, the DOM should reflect the selection (#481)", function() {
+QUnit.test("upon content change, the DOM should reflect the selection (#481)", function() {
   var userOne = { name: 'Mike', options: Ember.A(['a', 'b']), selectedOption: 'a' };
   var userTwo = { name: 'John', options: Ember.A(['c', 'd']), selectedOption: 'd' };
 
@@ -117,7 +117,7 @@ test("upon content change, the DOM should reflect the selection (#481)", functio
   equal(selectEl.selectedIndex, 1, "The DOM reflects the correct selection");
 });
 
-test("upon content change with Array-like content, the DOM should reflect the selection", function() {
+QUnit.test("upon content change with Array-like content, the DOM should reflect the selection", function() {
   var tom = { id: 4, name: 'Tom' };
   var sylvain = { id: 5, name: 'Sylvain' };
 
@@ -177,7 +177,7 @@ function testValueBinding(templateString) {
   equal(selectEl.selectedIndex, 1, "The DOM is updated to reflect the new selection");
 }
 
-test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (old xBinding='' syntax)", function() {
+QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (old xBinding='' syntax)", function() {
   testValueBinding(
     '{{view view.selectView viewName="select"' +
     '    contentBinding="view.collection"' +
@@ -188,7 +188,7 @@ test("select element should correctly initialize and update selectedIndex and bo
   );
 });
 
-test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (new quoteless binding shorthand)", function() {
+QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding (new quoteless binding shorthand)", function() {
   testValueBinding(
     '{{view view.selectView viewName="select"' +
     '    content=view.collection' +
@@ -227,7 +227,7 @@ function testSelectionBinding(templateString) {
   equal(select.$('option:eq(1)').prop('selected'), true, "Selected property is set to proper option");
 }
 
-test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (old xBinding='' syntax)", function() {
+QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (old xBinding='' syntax)", function() {
   testSelectionBinding(
     '{{view view.selectView viewName="select"' +
     '    contentBinding="view.collection"' +
@@ -238,7 +238,7 @@ test("select element should correctly initialize and update selectedIndex and bo
   );
 });
 
-test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (new quoteless binding shorthand)", function() {
+QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding (new quoteless binding shorthand)", function() {
   testSelectionBinding(
     '{{view view.selectView viewName="select"' +
     '    content=view.collection' +
@@ -249,7 +249,7 @@ test("select element should correctly initialize and update selectedIndex and bo
   );
 });
 
-test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding and optionValuePath with custom path", function() {
+QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding and optionValuePath with custom path", function() {
   var templateString = '{{view view.selectView viewName="select"' +
     '    content=view.collection' +
     '    optionLabelPath="content.name"' +

--- a/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
+++ b/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
@@ -12,7 +12,7 @@ QUnit.module("ember-htmlbars: tagless views should be able to add/remove child v
   }
 });
 
-test("can insert new child views after initial tagless view rendering", function() {
+QUnit.test("can insert new child views after initial tagless view rendering", function() {
   view = EmberView.create({
     shouldShow: false,
     array: Ember.A([1]),
@@ -38,7 +38,7 @@ test("can insert new child views after initial tagless view rendering", function
   equal(view.$().text(), '12');
 });
 
-test("can remove child views after initial tagless view rendering", function() {
+QUnit.test("can remove child views after initial tagless view rendering", function() {
   view = EmberView.create({
     shouldShow: false,
     array: Ember.A([]),

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -28,7 +28,7 @@ QUnit.module('ember-htmlbars: {{#with}} and {{#view}} integration', {
   }
 });
 
-test('View should update when the property used with the #with helper changes [DEPRECATED]', function() {
+QUnit.test('View should update when the property used with the #with helper changes [DEPRECATED]', function() {
   registry.register('template:foo', compile('<h1 id="first">{{#with view.content}}{{wham}}{{/with}}</h1>'));
 
   view = EmberView.create({
@@ -56,7 +56,7 @@ test('View should update when the property used with the #with helper changes [D
   equal(view.$('#first').text(), 'bazam', 'view updates when a bound property changes');
 });
 
-test('should expose a view keyword [DEPRECATED]', function() {
+QUnit.test('should expose a view keyword [DEPRECATED]', function() {
   var templateString = '{{#with view.differentContent}}{{view.foo}}{{#view baz="bang"}}{{view.baz}}{{/view}}{{/with}}';
   view = EmberView.create({
     container: container,
@@ -79,7 +79,7 @@ test('should expose a view keyword [DEPRECATED]', function() {
   equal(view.$().text(), 'barbang', 'renders values from view and child view');
 });
 
-test('bindings can be `this`, in which case they *are* the current context [DEPRECATED]', function() {
+QUnit.test('bindings can be `this`, in which case they *are* the current context [DEPRECATED]', function() {
   view = EmberView.create({
     museumOpen: true,
 
@@ -102,7 +102,7 @@ test('bindings can be `this`, in which case they *are* the current context [DEPR
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
-test('child views can be inserted inside a bind block', function() {
+QUnit.test('child views can be inserted inside a bind block', function() {
   registry.register('template:nester', compile('<h1 id="hello-world">Hello {{world}}</h1>{{view view.bqView}}'));
   registry.register('template:nested', compile('<div id="child-view">Goodbye {{#with content as thing}}{{thing.blah}} {{view view.otherView}}{{/with}} {{world}}</div>'));
   registry.register('template:other',  compile('cruel'));
@@ -142,7 +142,7 @@ test('child views can be inserted inside a bind block', function() {
   ok(view.$().text().match(/Hello world!.*Goodbye.*wot.*cruel.*world\!/), 'parent view should appear before the child view');
 });
 
-test('views render their template in the context of the parent view\'s context', function() {
+QUnit.test('views render their template in the context of the parent view\'s context', function() {
   registry.register('template:parent', compile('<h1>{{#with content as person}}{{#view}}{{person.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
 
   var context = {
@@ -162,7 +162,7 @@ test('views render their template in the context of the parent view\'s context',
   equal(view.$('h1').text(), 'Lana del Heeeyyyyyy', 'renders properties from parent context');
 });
 
-test('views make a view keyword available that allows template to reference view context', function() {
+QUnit.test('views make a view keyword available that allows template to reference view context', function() {
   registry.register('template:parent', compile('<h1>{{#with view.content as person}}{{#view person.subview}}{{view.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
 
   view = EmberView.create({

--- a/packages/ember-htmlbars/tests/system/bootstrap_test.js
+++ b/packages/ember-htmlbars/tests/system/bootstrap_test.js
@@ -42,26 +42,26 @@ function checkTemplate(templateName) {
   runDestroy(view);
 }
 
-test('template with data-template-name should add a new template to Ember.TEMPLATES', function() {
+QUnit.test('template with data-template-name should add a new template to Ember.TEMPLATES', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars" data-template-name="funkyTemplate">{{firstName}} takes {{drug}}</script>');
 
   checkTemplate('funkyTemplate');
 });
 
-test('template with id instead of data-template-name should add a new template to Ember.TEMPLATES', function() {
+QUnit.test('template with id instead of data-template-name should add a new template to Ember.TEMPLATES', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars" id="funkyTemplate" >{{firstName}} takes {{drug}}</script>');
 
   checkTemplate('funkyTemplate');
 });
 
-test('template without data-template-name or id should default to application', function() {
+QUnit.test('template without data-template-name or id should default to application', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars">{{firstName}} takes {{drug}}</script>');
 
   checkTemplate('application');
 });
 
 if (typeof Handlebars === 'object') {
-  test('template with type text/x-raw-handlebars should be parsed', function() {
+  QUnit.test('template with type text/x-raw-handlebars should be parsed', function() {
     jQuery('#qunit-fixture').html('<script type="text/x-raw-handlebars" data-template-name="funkyTemplate">{{name}}</script>');
 
     run(function() {
@@ -75,7 +75,7 @@ if (typeof Handlebars === 'object') {
   });
 }
 
-test('duplicated default application templates should throw exception', function() {
+QUnit.test('duplicated default application templates should throw exception', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars">first</script><script type="text/x-handlebars">second</script>');
 
   throws(function () {
@@ -85,7 +85,7 @@ test('duplicated default application templates should throw exception', function
   "duplicate templates should not be allowed");
 });
 
-test('default application template and id application template present should throw exception', function() {
+QUnit.test('default application template and id application template present should throw exception', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars">first</script><script type="text/x-handlebars" id="application">second</script>');
 
   throws(function () {
@@ -95,7 +95,7 @@ test('default application template and id application template present should th
   "duplicate templates should not be allowed");
 });
 
-test('default application template and data-template-name application template present should throw exception', function() {
+QUnit.test('default application template and data-template-name application template present should throw exception', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars">first</script><script type="text/x-handlebars" data-template-name="application">second</script>');
 
   throws(function () {
@@ -105,7 +105,7 @@ test('default application template and data-template-name application template p
   "duplicate templates should not be allowed");
 });
 
-test('duplicated template id should throw exception', function() {
+QUnit.test('duplicated template id should throw exception', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars" id="funkyTemplate">first</script><script type="text/x-handlebars" id="funkyTemplate">second</script>');
 
   throws(function () {
@@ -115,7 +115,7 @@ test('duplicated template id should throw exception', function() {
   "duplicate templates should not be allowed");
 });
 
-test('duplicated template data-template-name should throw exception', function() {
+QUnit.test('duplicated template data-template-name should throw exception', function() {
   jQuery('#qunit-fixture').html('<script type="text/x-handlebars" data-template-name="funkyTemplate">first</script><script type="text/x-handlebars" data-template-name="funkyTemplate">second</script>');
 
   throws(function () {
@@ -126,7 +126,7 @@ test('duplicated template data-template-name should throw exception', function()
 });
 
 if (Ember.component) {
-  test('registerComponents initializer', function() {
+  QUnit.test('registerComponents initializer', function() {
     Ember.TEMPLATES['components/x-apple'] = 'asdf';
 
     App = run(Ember.Application, 'create');
@@ -135,7 +135,7 @@ if (Ember.component) {
     ok(App.__container__.has('component:x-apple'), 'the container is aware of x-apple');
   });
 
-  test('registerComponents and generated components', function() {
+  QUnit.test('registerComponents and generated components', function() {
     Ember.TEMPLATES['components/x-apple'] = 'asdf';
 
     App = run(Ember.Application, 'create');
@@ -143,7 +143,7 @@ if (Ember.component) {
     equal(view.get('layoutName'), 'components/x-apple', 'has correct layout name');
   });
 
-  test('registerComponents and non-generated components', function() {
+  QUnit.test('registerComponents and non-generated components', function() {
     Ember.TEMPLATES['components/x-apple'] = 'asdf';
 
     run(function() {

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -21,7 +21,7 @@ function generateContainer() {
 
 QUnit.module('ember-htmlbars: lookupHelper hook');
 
-test('looks for helpers in the provided `env.helpers`', function() {
+QUnit.test('looks for helpers in the provided `env.helpers`', function() {
   var env = generateEnv({
     'flubarb': function() { }
   });
@@ -31,7 +31,7 @@ test('looks for helpers in the provided `env.helpers`', function() {
   equal(actual, env.helpers.flubarb, 'helpers are looked up on env');
 });
 
-test('returns undefined if no container exists (and helper is not found in env)', function() {
+QUnit.test('returns undefined if no container exists (and helper is not found in env)', function() {
   var env = generateEnv();
   var view = {};
 
@@ -40,7 +40,7 @@ test('returns undefined if no container exists (and helper is not found in env)'
   equal(actual, undefined, 'does not blow up if view does not have a container');
 });
 
-test('does not lookup in the container if the name does not contain a dash (and helper is not found in env)', function() {
+QUnit.test('does not lookup in the container if the name does not contain a dash (and helper is not found in env)', function() {
   var env = generateEnv();
   var view = {
     container: {
@@ -55,7 +55,7 @@ test('does not lookup in the container if the name does not contain a dash (and 
   equal(actual, undefined, 'does not blow up if view does not have a container');
 });
 
-test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
+QUnit.test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
   var env = generateEnv();
   var view = {
     container: generateContainer()
@@ -70,7 +70,7 @@ test('does a lookup in the container if the name contains a dash (and helper is 
   equal(actual, someName, 'does not wrap provided function if `isHTMLBars` is truthy');
 });
 
-test('wraps helper from container in a Handlebars compat helper', function() {
+QUnit.test('wraps helper from container in a Handlebars compat helper', function() {
   expect(2);
   var env = generateEnv();
   var view = {
@@ -98,7 +98,7 @@ test('wraps helper from container in a Handlebars compat helper', function() {
   ok(called, 'HTMLBars compatible wrapper is wraping the provided function');
 });
 
-test('asserts if component-lookup:main cannot be found', function() {
+QUnit.test('asserts if component-lookup:main cannot be found', function() {
   var env = generateEnv();
   var view = {
     container: generateContainer()
@@ -111,7 +111,7 @@ test('asserts if component-lookup:main cannot be found', function() {
   }, 'Could not find \'component-lookup:main\' on the provided container, which is necessary for performing component lookups');
 });
 
-test('registers a helper in the container if component is found', function() {
+QUnit.test('registers a helper in the container if component is found', function() {
   var env = generateEnv();
   var view = {
     container: generateContainer()

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -36,7 +36,7 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
   }
 });
 
-test("should update bound helpers in a subexpression when properties change", function() {
+QUnit.test("should update bound helpers in a subexpression when properties change", function() {
   registry.register('helper:x-dasherize', makeBoundHelper(function(params, hash, options, env) {
     return dasherize(params[0]);
   }));
@@ -56,7 +56,7 @@ test("should update bound helpers in a subexpression when properties change", fu
   equal(view.$('div[data-foo="not-thing"]').text(), 'notThing', "helper output is correct");
 });
 
-test("should update bound helpers when properties change", function() {
+QUnit.test("should update bound helpers when properties change", function() {
   registry.register('helper:x-capitalize', makeBoundHelper(function(params, hash, options, env) {
     return params[0].toUpperCase();
   }));
@@ -76,7 +76,7 @@ test("should update bound helpers when properties change", function() {
   equal(view.$().text(), 'WES', "helper output updated");
 });
 
-test("should update bound helpers when hash properties change", function() {
+QUnit.test("should update bound helpers when hash properties change", function() {
   registerRepeatHelper();
 
   view = EmberView.create({
@@ -97,7 +97,7 @@ test("should update bound helpers when hash properties change", function() {
   equal(view.$().text(), 'YoYoYoYoYo', "helper output updated");
 });
 
-test("bound helpers should support keywords", function() {
+QUnit.test("bound helpers should support keywords", function() {
   registry.register('helper:x-capitalize', makeBoundHelper(function(params, hash, options, env) {
     return params[0].toUpperCase();
   }));
@@ -113,7 +113,7 @@ test("bound helpers should support keywords", function() {
   equal(view.$().text(), 'AB', "helper output is correct");
 });
 
-test("bound helpers should not process `fooBinding` style hash properties", function() {
+QUnit.test("bound helpers should not process `fooBinding` style hash properties", function() {
   registry.register('helper:x-repeat', makeBoundHelper(function(params, hash, options, env) {
     equal(hash.timesBinding, "numRepeats");
   }));
@@ -130,7 +130,7 @@ test("bound helpers should not process `fooBinding` style hash properties", func
   runAppend(view);
 });
 
-test("bound helpers should support multiple bound properties", function() {
+QUnit.test("bound helpers should support multiple bound properties", function() {
 
   registry.register('helper:x-combine', makeBoundHelper(function(params, hash, options, env) {
     return params.join('');
@@ -161,7 +161,7 @@ test("bound helpers should support multiple bound properties", function() {
   equal(view.$().text(), 'WOOTYEAH', "helper correctly re-rendered after both bound helper properties changed");
 });
 
-test("bound helpers can be invoked with zero args", function() {
+QUnit.test("bound helpers can be invoked with zero args", function() {
   registry.register('helper:x-troll', makeBoundHelper(function(params, hash) {
     return hash.text || "TROLOLOL";
   }));
@@ -179,7 +179,7 @@ test("bound helpers can be invoked with zero args", function() {
   equal(view.$().text(), 'TROLOLOL and bork', "helper output is correct");
 });
 
-test("bound helpers should not be invoked with blocks", function() {
+QUnit.test("bound helpers should not be invoked with blocks", function() {
   registerRepeatHelper();
   view = EmberView.create({
     container: container,
@@ -192,7 +192,7 @@ test("bound helpers should not be invoked with blocks", function() {
   }, /makeBoundHelper generated helpers do not support use with blocks/i);
 });
 
-test("shouldn't treat raw numbers as bound paths", function() {
+QUnit.test("shouldn't treat raw numbers as bound paths", function() {
   registry.register('helper:x-sum', makeBoundHelper(function(params) {
     return params[0] + params[1];
   }));
@@ -212,7 +212,7 @@ test("shouldn't treat raw numbers as bound paths", function() {
   equal(view.$().text(), '6 5 11', "helper still updates as expected");
 });
 
-test("should have correct argument types", function() {
+QUnit.test("should have correct argument types", function() {
   registry.register('helper:get-type', makeBoundHelper(function(params) {
     return typeof params[0];
   }));
@@ -228,7 +228,7 @@ test("should have correct argument types", function() {
   equal(view.$().text(), 'undefined, undefined, string, number, object', "helper output is correct");
 });
 
-test("when no parameters are bound, no new views are created", function() {
+QUnit.test("when no parameters are bound, no new views are created", function() {
   registerRepeatHelper();
   var originalRender = SimpleBoundView.prototype.render;
   var renderWasCalled = false;
@@ -253,7 +253,7 @@ test("when no parameters are bound, no new views are created", function() {
 });
 
 
-test('when no hash parameters are bound, no new views are created', function() {
+QUnit.test('when no hash parameters are bound, no new views are created', function() {
   registerRepeatHelper();
   var originalRender = SimpleBoundView.prototype.render;
   var renderWasCalled = false;

--- a/packages/ember-htmlbars/tests/system/make_view_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_view_helper_test.js
@@ -2,7 +2,7 @@ import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 
 QUnit.module("ember-htmlbars: makeViewHelper");
 
-test("makes helpful assertion when called with invalid arguments", function() {
+QUnit.test("makes helpful assertion when called with invalid arguments", function() {
   var viewClass = { toString: function() { return 'Some Random Class'; } };
 
   var helper = makeViewHelper(viewClass);

--- a/packages/ember-htmlbars/tests/system/render_view_test.js
+++ b/packages/ember-htmlbars/tests/system/render_view_test.js
@@ -10,7 +10,7 @@ QUnit.module('ember-htmlbars: renderView', {
   }
 });
 
-test('default environment values are passed through', function() {
+QUnit.test('default environment values are passed through', function() {
   var keyNames = keys(defaultEnv);
   expect(keyNames.length);
 

--- a/packages/ember-htmlbars/tests/utils/string_test.js
+++ b/packages/ember-htmlbars/tests/utils/string_test.js
@@ -3,16 +3,16 @@ import { htmlSafe } from "ember-htmlbars/utils/string";
 
 QUnit.module('ember-htmlbars: SafeString');
 
-test("htmlSafe should return an instance of SafeString", function() {
+QUnit.test("htmlSafe should return an instance of SafeString", function() {
   var safeString = htmlSafe("you need to be more <b>bold</b>");
 
   ok(safeString instanceof SafeString, "should return SafeString");
 });
 
-test("htmlSafe should return an empty string for null", function() {
+QUnit.test("htmlSafe should return an empty string for null", function() {
   equal(htmlSafe(null).toString(), "", "should return an empty string");
 });
 
-test("htmlSafe should return an empty string for undefined", function() {
+QUnit.test("htmlSafe should return an empty string for undefined", function() {
   equal(htmlSafe().toString(), "", "should return an empty string");
 });

--- a/packages/ember-metal-views/tests/attributes_test.js
+++ b/packages/ember-metal-views/tests/attributes_test.js
@@ -6,7 +6,7 @@ import {
 
 testsFor("ember-metal-views - attributes");
 
-test('aliased attributeBindings', function() {
+QUnit.test('aliased attributeBindings', function() {
   var view = {
     isView: true,
     attributeBindings: ['isDisabled:disabled'],

--- a/packages/ember-metal-views/tests/children_test.js
+++ b/packages/ember-metal-views/tests/children_test.js
@@ -7,7 +7,7 @@ import {
 
 testsFor("ember-metal-views - children");
 
-test("a view can have child views", function() {
+QUnit.test("a view can have child views", function() {
   var view = {
     isView: true,
     tagName: 'ul',
@@ -20,7 +20,7 @@ test("a view can have child views", function() {
   equalHTML('qunit-fixture', "<ul><li>ohai</li></ul>");
 });
 
-test("didInsertElement fires after children are rendered", function() {
+QUnit.test("didInsertElement fires after children are rendered", function() {
   expect(2);
 
   var view = {

--- a/packages/ember-metal-views/tests/main_test.js
+++ b/packages/ember-metal-views/tests/main_test.js
@@ -15,7 +15,7 @@ testsFor("ember-metal-views", {
 });
 
 // Test the behavior of the helper createElement stub
-test("by default, view renders as a div", function() {
+QUnit.test("by default, view renders as a div", function() {
   view = { isView: true };
 
   appendTo(view);
@@ -23,7 +23,7 @@ test("by default, view renders as a div", function() {
 });
 
 // Test the behavior of the helper createElement stub
-test("tagName can be specified", function() {
+QUnit.test("tagName can be specified", function() {
   view = {
     isView: true,
     tagName: 'span'
@@ -35,7 +35,7 @@ test("tagName can be specified", function() {
 });
 
 // Test the behavior of the helper createElement stub
-test("textContent can be specified", function() {
+QUnit.test("textContent can be specified", function() {
   view = {
     isView: true,
     textContent: 'ohai <a>derp</a>'
@@ -47,7 +47,7 @@ test("textContent can be specified", function() {
 });
 
 // Test the behavior of the helper createElement stub
-test("innerHTML can be specified", function() {
+QUnit.test("innerHTML can be specified", function() {
   view = {
     isView: true,
     innerHTML: 'ohai <a>derp</a>'
@@ -59,7 +59,7 @@ test("innerHTML can be specified", function() {
 });
 
 // Test the behavior of the helper createElement stub
-test("innerHTML tr can be specified", function() {
+QUnit.test("innerHTML tr can be specified", function() {
   view = {
     isView: true,
     tagName: 'table',
@@ -72,7 +72,7 @@ test("innerHTML tr can be specified", function() {
 });
 
 // Test the behavior of the helper createElement stub
-test("element can be specified", function() {
+QUnit.test("element can be specified", function() {
   view = {
     isView: true,
     element: document.createElement('i')
@@ -83,7 +83,7 @@ test("element can be specified", function() {
   equalHTML('qunit-fixture', "<i></i>");
 });
 
-test("willInsertElement hook", function() {
+QUnit.test("willInsertElement hook", function() {
   expect(3);
 
   view = {
@@ -101,7 +101,7 @@ test("willInsertElement hook", function() {
   equalHTML('qunit-fixture', "<div>you gone and done inserted that element</div>");
 });
 
-test("didInsertElement hook", function() {
+QUnit.test("didInsertElement hook", function() {
   expect(3);
 
   view = {
@@ -119,7 +119,7 @@ test("didInsertElement hook", function() {
   equalHTML('qunit-fixture', "<div>you gone and done inserted that element</div>");
 });
 
-test("classNames - array", function() {
+QUnit.test("classNames - array", function() {
   view = {
     isView: true,
     classNames: ['foo', 'bar'],
@@ -130,7 +130,7 @@ test("classNames - array", function() {
   equalHTML('qunit-fixture', '<div class="foo bar">ohai</div>');
 });
 
-test("classNames - string", function() {
+QUnit.test("classNames - string", function() {
   view = {
     isView: true,
     classNames: 'foo bar',

--- a/packages/ember-metal/tests/accessors/get_path_test.js
+++ b/packages/ember-metal/tests/accessors/get_path_test.js
@@ -55,31 +55,31 @@ QUnit.module('Ember.get with path', moduleOpts);
 // LOCAL PATHS
 //
 
-test('[obj, foo] -> obj.foo', function() {
+QUnit.test('[obj, foo] -> obj.foo', function() {
   deepEqual(get(obj, 'foo'), obj.foo);
 });
 
-test('[obj, foo.bar] -> obj.foo.bar', function() {
+QUnit.test('[obj, foo.bar] -> obj.foo.bar', function() {
   deepEqual(get(obj, 'foo.bar'), obj.foo.bar);
 });
 
-test('[obj, foothis.bar] -> obj.foothis.bar', function() {
+QUnit.test('[obj, foothis.bar] -> obj.foothis.bar', function() {
   deepEqual(get(obj, 'foothis.bar'), obj.foothis.bar);
 });
 
-test('[obj, this.foo] -> obj.foo', function() {
+QUnit.test('[obj, this.foo] -> obj.foo', function() {
   deepEqual(get(obj, 'this.foo'), obj.foo);
 });
 
-test('[obj, this.foo.bar] -> obj.foo.bar', function() {
+QUnit.test('[obj, this.foo.bar] -> obj.foo.bar', function() {
   deepEqual(get(obj, 'this.foo.bar'), obj.foo.bar);
 });
 
-test('[obj, this.Foo.bar] -> (null)', function() {
+QUnit.test('[obj, this.Foo.bar] -> (null)', function() {
   deepEqual(get(obj, 'this.Foo.bar'), undefined);
 });
 
-test('[obj, falseValue.notDefined] -> (null)', function() {
+QUnit.test('[obj, falseValue.notDefined] -> (null)', function() {
   deepEqual(get(obj, 'falseValue.notDefined'), undefined);
 });
 
@@ -87,13 +87,13 @@ test('[obj, falseValue.notDefined] -> (null)', function() {
 // LOCAL PATHS WITH NO TARGET DEPRECATION
 //
 
-test('[null, length] returning data is deprecated', function() {
+QUnit.test('[null, length] returning data is deprecated', function() {
   expectGlobalContextDeprecation(function() {
     equal(5, get(null, 'localPathGlobal'));
   });
 });
 
-test('[length] returning data is deprecated', function() {
+QUnit.test('[length] returning data is deprecated', function() {
   expectGlobalContextDeprecation(function() {
     equal(5, get('localPathGlobal'));
   });
@@ -103,11 +103,11 @@ test('[length] returning data is deprecated', function() {
 // NO TARGET
 //
 
-test('[null, Foo] -> Foo', function() {
+QUnit.test('[null, Foo] -> Foo', function() {
   deepEqual(get('Foo'), Foo);
 });
 
-test('[null, Foo.bar] -> Foo.bar', function() {
+QUnit.test('[null, Foo.bar] -> Foo.bar', function() {
   deepEqual(get('Foo.bar'), Foo.bar);
 });
 

--- a/packages/ember-metal/tests/accessors/get_properties_test.js
+++ b/packages/ember-metal/tests/accessors/get_properties_test.js
@@ -2,7 +2,7 @@ import getProperties from "ember-metal/get_properties";
 
 QUnit.module('Ember.getProperties');
 
-test('can retrieve a hash of properties from an object via an argument list or array of property names', function() {
+QUnit.test('can retrieve a hash of properties from an object via an argument list or array of property names', function() {
   var obj = {
     firstName: "Steve",
     lastName: "Jobs",

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -12,7 +12,7 @@ import create from 'ember-metal/platform/create';
 
 QUnit.module('Ember.get');
 
-test('should get arbitrary properties on an object', function() {
+QUnit.test('should get arbitrary properties on an object', function() {
   var obj = {
     string: 'string',
     number: 23,
@@ -48,19 +48,19 @@ testBoth("should call unknownProperty on watched values if the value is undefine
   equal(get(obj, 'foo'), 'FOO', 'should return value from unknown');
 });
 
-test('warn on attempts to get a property of undefined', function() {
+QUnit.test('warn on attempts to get a property of undefined', function() {
   expectAssertion(function() {
     get(undefined, 'aProperty');
   }, /Cannot call get with 'aProperty' on an undefined object/i);
 });
 
-test('warn on attempts to get a property path of undefined', function() {
+QUnit.test('warn on attempts to get a property path of undefined', function() {
   expectAssertion(function() {
     get(undefined, 'aProperty.on.aPath');
   }, /Cannot call get with 'aProperty.on.aPath' on an undefined object/);
 });
 
-test('warn on attempts to get a falsy property', function() {
+QUnit.test('warn on attempts to get a falsy property', function() {
   var obj = {};
   expectAssertion(function() {
     get(obj, null);
@@ -80,7 +80,7 @@ test('warn on attempts to get a falsy property', function() {
 // BUGS
 //
 
-test('(regression) watched properties on unmodified inherited objects should still return their original value', function() {
+QUnit.test('(regression) watched properties on unmodified inherited objects should still return their original value', function() {
 
   var MyMixin = Mixin.create({
     someProperty: 'foo',
@@ -97,7 +97,7 @@ test('(regression) watched properties on unmodified inherited objects should sti
 
 QUnit.module("Ember.getWithDefault");
 
-test('should get arbitrary properties on an object', function() {
+QUnit.test('should get arbitrary properties on an object', function() {
   var obj = {
     string: 'string',
     number: 23,
@@ -121,7 +121,7 @@ test('should get arbitrary properties on an object', function() {
   equal(getWithDefault(obj, "not-present", "default"), "default", "non-present key retrieves the default");
 });
 
-test('should call unknownProperty if defined and value is undefined', function() {
+QUnit.test('should call unknownProperty if defined and value is undefined', function() {
 
   var obj = {
     count: 0,
@@ -161,7 +161,7 @@ testBoth("if unknownProperty is present, it is called", function(get, set) {
 // BUGS
 //
 
-test('(regression) watched properties on unmodified inherited objects should still return their original value', function() {
+QUnit.test('(regression) watched properties on unmodified inherited objects should still return their original value', function() {
 
   var MyMixin = Mixin.create({
     someProperty: 'foo',

--- a/packages/ember-metal/tests/accessors/is_global_path_test.js
+++ b/packages/ember-metal/tests/accessors/is_global_path_test.js
@@ -2,17 +2,17 @@ import { isGlobalPath } from "ember-metal/binding";
 
 QUnit.module('Ember.isGlobalPath');
 
-test("global path's are recognized", function() {
+QUnit.test("global path's are recognized", function() {
   ok(isGlobalPath('App.myProperty'));
   ok(isGlobalPath('App.myProperty.subProperty'));
 });
 
-test("if there is a 'this' in the path, it's not a global path", function() {
+QUnit.test("if there is a 'this' in the path, it's not a global path", function() {
   ok(!isGlobalPath('this.myProperty'));
   ok(!isGlobalPath('this'));
 });
 
-test("if the path starts with a lowercase character, it is not a global path", function() {
+QUnit.test("if the path starts with a lowercase character, it is not a global path", function() {
   ok(!isGlobalPath('myObj'));
   ok(!isGlobalPath('myObj.SecondProperty'));
 });

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -18,7 +18,7 @@ function hasMandatorySetter(object, property) {
 
 if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   if (hasPropertyAccessors) {
-    test('does not assert if property is not being watched', function() {
+    QUnit.test('does not assert if property is not being watched', function() {
       var obj = {
         someProp: null,
         toString: function() {
@@ -30,7 +30,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       equal(get(obj, 'someProp'), 'blastix');
     });
 
-    test('should not setup mandatory-setter if property is not writable', function() {
+    QUnit.test('should not setup mandatory-setter if property is not writable', function() {
       expect(6);
 
       var obj = { };
@@ -57,7 +57,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       ok(!hasMandatorySetter(obj, 'f'), 'mandatory-setter should not be installed');
     });
 
-    test('should not setup mandatory-setter if setter is already setup on property', function() {
+    QUnit.test('should not setup mandatory-setter if setter is already setup on property', function() {
       expect(2);
 
       var obj = { someProp: null };
@@ -74,7 +74,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       obj.someProp = 'foo-bar';
     });
 
-    test('should assert if set without Ember.set when property is being watched', function() {
+    QUnit.test('should assert if set without Ember.set when property is being watched', function() {
       var obj = {
         someProp: null,
         toString: function() {
@@ -89,7 +89,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       }, 'You must use Ember.set() to set the `someProp` property (of custom-object) to `foo-bar`.');
     });
 
-    test('should not assert if set with Ember.set when property is being watched', function() {
+    QUnit.test('should not assert if set with Ember.set when property is being watched', function() {
       var obj = {
         someProp: null,
         toString: function() {
@@ -103,7 +103,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       equal(get(obj, 'someProp'), 'foo-bar');
     });
 
-    test('does not setup mandatory-setter if non-configurable', function() {
+    QUnit.test('does not setup mandatory-setter if non-configurable', function() {
       var obj = {
         someProp: null,
         toString: function() {
@@ -123,7 +123,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
       ok(!('someProp' in meta.values), 'blastix');
     });
 
-    test('sets up mandatory-setter if property comes from prototype', function() {
+    QUnit.test('sets up mandatory-setter if property comes from prototype', function() {
       expect(2);
 
       var obj = {
@@ -145,7 +145,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
     });
   }
 } else {
-  test('does not assert', function() {
+  QUnit.test('does not assert', function() {
     var obj = {
       someProp: null,
       toString: function() {

--- a/packages/ember-metal/tests/accessors/normalize_tuple_test.js
+++ b/packages/ember-metal/tests/accessors/normalize_tuple_test.js
@@ -93,7 +93,7 @@ test('[obj, $foo.bar.baz] -> [$foo, bar.baz]', function() {
 //
 
 test('[null, Foo] -> EXCEPTION', function() {
-  raises(function() {
+  throws(function() {
     normalizeTuple(null, 'Foo');
   }, Error);
 });

--- a/packages/ember-metal/tests/accessors/normalize_tuple_test.js
+++ b/packages/ember-metal/tests/accessors/normalize_tuple_test.js
@@ -38,35 +38,35 @@ QUnit.module('normalizeTuple', moduleOpts);
 // LOCAL PATHS
 //
 
-test('[obj, foo] -> [obj, foo]', function() {
+QUnit.test('[obj, foo] -> [obj, foo]', function() {
   deepEqual(normalizeTuple(obj, 'foo'), [obj, 'foo']);
 });
 
-test('[obj, *] -> [obj, *]', function() {
+QUnit.test('[obj, *] -> [obj, *]', function() {
   deepEqual(normalizeTuple(obj, '*'), [obj, '*']);
 });
 
-test('[obj, foo.bar] -> [obj, foo.bar]', function() {
+QUnit.test('[obj, foo.bar] -> [obj, foo.bar]', function() {
   deepEqual(normalizeTuple(obj, 'foo.bar'), [obj, 'foo.bar']);
 });
 
-test('[obj, foo.*] -> [obj, foo.*]', function() {
+QUnit.test('[obj, foo.*] -> [obj, foo.*]', function() {
   deepEqual(normalizeTuple(obj, 'foo.*'), [obj, 'foo.*']);
 });
 
-test('[obj, foo.*.baz] -> [obj, foo.*.baz]', function() {
+QUnit.test('[obj, foo.*.baz] -> [obj, foo.*.baz]', function() {
   deepEqual(normalizeTuple(obj, 'foo.*.baz'), [obj, 'foo.*.baz']);
 });
 
-test('[obj, this.foo] -> [obj, foo]', function() {
+QUnit.test('[obj, this.foo] -> [obj, foo]', function() {
   deepEqual(normalizeTuple(obj, 'this.foo'), [obj, 'foo']);
 });
 
-test('[obj, this.foo.bar] -> [obj, foo.bar]', function() {
+QUnit.test('[obj, this.foo.bar] -> [obj, foo.bar]', function() {
   deepEqual(normalizeTuple(obj, 'this.foo.bar'), [obj, 'foo.bar']);
 });
 
-test('[obj, this.Foo.bar] -> [obj, Foo.bar]', function() {
+QUnit.test('[obj, this.Foo.bar] -> [obj, Foo.bar]', function() {
   deepEqual(normalizeTuple(obj, 'this.Foo.bar'), [obj, 'Foo.bar']);
 });
 
@@ -74,17 +74,17 @@ test('[obj, this.Foo.bar] -> [obj, Foo.bar]', function() {
 // GLOBAL PATHS
 //
 
-test('[obj, Foo] -> [obj, Foo]', function() {
+QUnit.test('[obj, Foo] -> [obj, Foo]', function() {
   expectDeprecation(function() {
     deepEqual(normalizeTuple(obj, 'Foo'), [obj, 'Foo']);
   }, "normalizeTuple will return 'Foo' as a non-global. This behavior will change in the future (issue #3852)");
 });
 
-test('[obj, Foo.bar] -> [Foo, bar]', function() {
+QUnit.test('[obj, Foo.bar] -> [Foo, bar]', function() {
   deepEqual(normalizeTuple(obj, 'Foo.bar'), [Foo, 'bar']);
 });
 
-test('[obj, $foo.bar.baz] -> [$foo, bar.baz]', function() {
+QUnit.test('[obj, $foo.bar.baz] -> [$foo, bar.baz]', function() {
   deepEqual(normalizeTuple(obj, '$foo.bar.baz'), [$foo, 'bar.baz']);
 });
 
@@ -92,12 +92,12 @@ test('[obj, $foo.bar.baz] -> [$foo, bar.baz]', function() {
 // NO TARGET
 //
 
-test('[null, Foo] -> EXCEPTION', function() {
+QUnit.test('[null, Foo] -> EXCEPTION', function() {
   throws(function() {
     normalizeTuple(null, 'Foo');
   }, Error);
 });
 
-test('[null, Foo.bar] -> [Foo, bar]', function() {
+QUnit.test('[null, Foo.bar] -> [Foo, bar]', function() {
   deepEqual(normalizeTuple(null, 'Foo.bar'), [Foo, 'bar']);
 });

--- a/packages/ember-metal/tests/accessors/set_path_test.js
+++ b/packages/ember-metal/tests/accessors/set_path_test.js
@@ -41,7 +41,7 @@ QUnit.module('set with path', {
   teardown: commonTeardown
 });
 
-test('[Foo, bar] -> Foo.bar', function() {
+QUnit.test('[Foo, bar] -> Foo.bar', function() {
   Ember.lookup.Foo = { toString: function() { return 'Foo'; } }; // Behave like an Ember.Namespace
 
   set(Ember.lookup.Foo, 'bar', 'baz');
@@ -52,22 +52,22 @@ test('[Foo, bar] -> Foo.bar', function() {
 //
 // LOCAL PATHS
 
-test('[obj, foo] -> obj.foo', function() {
+QUnit.test('[obj, foo] -> obj.foo', function() {
   set(obj, 'foo', "BAM");
   equal(get(obj, 'foo'), "BAM");
 });
 
-test('[obj, foo.bar] -> obj.foo.bar', function() {
+QUnit.test('[obj, foo.bar] -> obj.foo.bar', function() {
   set(obj, 'foo.bar', "BAM");
   equal(get(obj, 'foo.bar'), "BAM");
 });
 
-test('[obj, this.foo] -> obj.foo', function() {
+QUnit.test('[obj, this.foo] -> obj.foo', function() {
   set(obj, 'this.foo', "BAM");
   equal(get(obj, 'foo'), "BAM");
 });
 
-test('[obj, this.foo.bar] -> obj.foo.bar', function() {
+QUnit.test('[obj, this.foo.bar] -> obj.foo.bar', function() {
   set(obj, 'this.foo.bar', "BAM");
   equal(get(obj, 'foo.bar'), "BAM");
 });
@@ -76,7 +76,7 @@ test('[obj, this.foo.bar] -> obj.foo.bar', function() {
 // NO TARGET
 //
 
-test('[null, Foo.bar] -> Foo.bar', function() {
+QUnit.test('[null, Foo.bar] -> Foo.bar', function() {
   set(null, 'Foo.bar', "BAM");
   equal(get(Ember.lookup.Foo, 'bar'), "BAM");
 });
@@ -90,7 +90,7 @@ QUnit.module("set with path - deprecated", {
   teardown: commonTeardown
 });
 
-test('[null, bla] gives a proper exception message', function() {
+QUnit.test('[null, bla] gives a proper exception message', function() {
   var exceptionMessage = 'Property set failed: object in path \"bla\" could not be found or was destroyed.';
   try {
     set(null, 'bla', "BAM");
@@ -99,7 +99,7 @@ test('[null, bla] gives a proper exception message', function() {
   }
 });
 
-test('[obj, bla.bla] gives a proper exception message', function() {
+QUnit.test('[obj, bla.bla] gives a proper exception message', function() {
   var exceptionMessage = 'Property set failed: object in path \"bla\" could not be found or was destroyed.';
   try {
     set(obj, 'bla.bla', "BAM");
@@ -108,13 +108,13 @@ test('[obj, bla.bla] gives a proper exception message', function() {
   }
 });
 
-test('[obj, foo.baz.bat] -> EXCEPTION', function() {
+QUnit.test('[obj, foo.baz.bat] -> EXCEPTION', function() {
   throws(function() {
     set(obj, 'foo.baz.bat', "BAM");
   }, Error);
 });
 
-test('[obj, foo.baz.bat] -> EXCEPTION', function() {
+QUnit.test('[obj, foo.baz.bat] -> EXCEPTION', function() {
   trySet(obj, 'foo.baz.bat', "BAM");
   ok(true, "does not raise");
 });

--- a/packages/ember-metal/tests/accessors/set_path_test.js
+++ b/packages/ember-metal/tests/accessors/set_path_test.js
@@ -7,38 +7,39 @@ import { get } from 'ember-metal/property_get';
 var originalLookup = Ember.lookup;
 
 var obj;
-var moduleOpts = {
-  setup: function() {
-    obj = {
-      foo: {
-        bar: {
-          baz: { biff: 'BIFF' }
-        }
+function commonSetup() {
+  obj = {
+    foo: {
+      bar: {
+        baz: { biff: 'BIFF' }
       }
-    };
+    }
+  };
 
-    Ember.lookup = {
-      Foo: {
-        bar: {
-          baz: { biff: 'FooBiff' }
-        }
-      },
-
-      $foo: {
-        bar: {
-          baz: { biff: '$FOOBIFF' }
-        }
+  Ember.lookup = {
+    Foo: {
+      bar: {
+        baz: { biff: 'FooBiff' }
       }
-    };
-  },
+    },
 
-  teardown: function() {
-    obj = null;
-    Ember.lookup = originalLookup;
-  }
-};
+    $foo: {
+      bar: {
+        baz: { biff: '$FOOBIFF' }
+      }
+    }
+  };
+}
 
-QUnit.module('set with path', moduleOpts);
+function commonTeardown() {
+  obj = null;
+  Ember.lookup = originalLookup;
+}
+
+QUnit.module('set with path', {
+  setup: commonSetup,
+  teardown: commonTeardown
+});
 
 test('[Foo, bar] -> Foo.bar', function() {
   Ember.lookup.Foo = { toString: function() { return 'Foo'; } }; // Behave like an Ember.Namespace
@@ -85,12 +86,8 @@ test('[null, Foo.bar] -> Foo.bar', function() {
 //
 
 QUnit.module("set with path - deprecated", {
-  setup: function() {
-    moduleOpts.setup();
-  },
-  teardown: function() {
-    moduleOpts.teardown();
-  }
+  setup: commonSetup,
+  teardown: commonTeardown
 });
 
 test('[null, bla] gives a proper exception message', function() {
@@ -112,7 +109,7 @@ test('[obj, bla.bla] gives a proper exception message', function() {
 });
 
 test('[obj, foo.baz.bat] -> EXCEPTION', function() {
-  raises(function() {
+  throws(function() {
     set(obj, 'foo.baz.bat', "BAM");
   }, Error);
 });

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -3,7 +3,7 @@ import { set } from 'ember-metal/property_set';
 
 QUnit.module('set');
 
-test('should set arbitrary properties on an object', function() {
+QUnit.test('should set arbitrary properties on an object', function() {
   var obj = {
     string: 'string',
     number: 23,
@@ -27,7 +27,7 @@ test('should set arbitrary properties on an object', function() {
   }
 });
 
-test('should call setUnknownProperty if defined and value is undefined', function() {
+QUnit.test('should call setUnknownProperty if defined and value is undefined', function() {
 
   var obj = {
     count: 0,

--- a/packages/ember-metal/tests/alias_test.js
+++ b/packages/ember-metal/tests/alias_test.js
@@ -22,18 +22,18 @@ function incrementCount() {
   count++;
 }
 
-test('should proxy get to alt key', function() {
+QUnit.test('should proxy get to alt key', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
   equal(get(obj, 'bar'), 'FOO');
 });
 
-test('should proxy set to alt key', function() {
+QUnit.test('should proxy set to alt key', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
   set(obj, 'bar', 'BAR');
   equal(get(obj, 'foo.faz'), 'BAR');
 });
 
-test('basic lifecycle', function() {
+QUnit.test('basic lifecycle', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
   var m = meta(obj);
   addObserver(obj, 'bar', incrementCount);
@@ -42,7 +42,7 @@ test('basic lifecycle', function() {
   equal(m.deps['foo.faz'].bar, 0);
 });
 
-test('begins watching alt key as soon as alias is watched', function() {
+QUnit.test('begins watching alt key as soon as alias is watched', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
   addObserver(obj, 'bar', incrementCount);
   ok(isWatching(obj, 'foo.faz'));
@@ -50,7 +50,7 @@ test('begins watching alt key as soon as alias is watched', function() {
   equal(count, 1);
 });
 
-test('immediately sets up dependencies if already being watched', function() {
+QUnit.test('immediately sets up dependencies if already being watched', function() {
   addObserver(obj, 'bar', incrementCount);
   defineProperty(obj, 'bar', alias('foo.faz'));
   ok(isWatching(obj, 'foo.faz'));
@@ -58,7 +58,7 @@ test('immediately sets up dependencies if already being watched', function() {
   equal(count, 1);
 });
 
-test('setting alias on self should fail assertion', function() {
+QUnit.test('setting alias on self should fail assertion', function() {
   expectAssertion(function() {
     defineProperty(obj, 'bar', alias('bar'));
   }, "Setting alias 'bar' on self");

--- a/packages/ember-metal/tests/binding/connect_test.js
+++ b/packages/ember-metal/tests/binding/connect_test.js
@@ -104,7 +104,7 @@ testBoth('Calling connect more than once', function(get, set) {
   });
 });
 
-test('inherited bindings should sync on create', function() {
+QUnit.test('inherited bindings should sync on create', function() {
   var a;
   run(function () {
     var A = function() {

--- a/packages/ember-metal/tests/binding/one_way_test.js
+++ b/packages/ember-metal/tests/binding/one_way_test.js
@@ -18,7 +18,7 @@ QUnit.module('system/mixin/binding/oneWay_test', {
   }
 });
 
-test('oneWay(true) should only sync one way', function() {
+QUnit.test('oneWay(true) should only sync one way', function() {
   var binding;
   run(function() {
     binding = oneWay(MyApp, 'bar.value', 'foo.value');

--- a/packages/ember-metal/tests/cache_test.js
+++ b/packages/ember-metal/tests/cache_test.js
@@ -2,7 +2,7 @@ import Cache from "ember-metal/cache";
 
 QUnit.module("Cache");
 
-test("basic", function() {
+QUnit.test("basic", function() {
   var cache = new Cache(100, function(key) {
     return key.toUpperCase();
   });
@@ -12,7 +12,7 @@ test("basic", function() {
   equal(cache.get("foo"), "FOO");
 });
 
-test("caches computation correctly", function() {
+QUnit.test("caches computation correctly", function() {
   var count = 0;
   var cache = new Cache(100, function(key) {
     count++;
@@ -30,13 +30,13 @@ test("caches computation correctly", function() {
   equal(count, 2);
 });
 
-test("handles undefined value correctly", function() {
+QUnit.test("handles undefined value correctly", function() {
   var cache = new Cache(100, function(key) {});
 
   equal(cache.get("foo"), undefined);
 });
 
-test("continues working after reaching cache limit", function() {
+QUnit.test("continues working after reaching cache limit", function() {
   var cache = new Cache(3, function(key) {
     return key.toUpperCase();
   });

--- a/packages/ember-metal/tests/chains_test.js
+++ b/packages/ember-metal/tests/chains_test.js
@@ -4,7 +4,7 @@ import create from 'ember-metal/platform/create';
 
 QUnit.module("Chains");
 
-test("finishChains should properly copy chains from prototypes to instances", function() {
+QUnit.test("finishChains should properly copy chains from prototypes to instances", function() {
   function didChange() {}
 
   var obj = {};

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -882,7 +882,7 @@ testBoth('protects against setting', function(get, set) {
 
   equal(get(obj, 'bar'), 'barValue');
 
-  raises(function() {
+  throws(function() {
     set(obj, 'bar', 'newBar');
   }, /Cannot set read\-only property "bar" on object:/ );
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -47,11 +47,11 @@ var obj, count, Global, lookup;
 
 QUnit.module('computed');
 
-test('computed property should be an instance of descriptor', function() {
+QUnit.test('computed property should be an instance of descriptor', function() {
   ok(computed(function() {}) instanceof Descriptor);
 });
 
-test('defining computed property should invoke property on get', function() {
+QUnit.test('defining computed property should invoke property on get', function() {
 
   var obj = {};
   var count = 0;
@@ -64,7 +64,7 @@ test('defining computed property should invoke property on get', function() {
   equal(count, 1, 'should have invoked computed property');
 });
 
-test('defining computed property should invoke property on set', function() {
+QUnit.test('defining computed property should invoke property on set', function() {
 
   var obj = {};
   var count = 0;
@@ -198,14 +198,14 @@ testBoth('using get() and set()', function(get, set) {
 
 QUnit.module('computed - metadata');
 
-test("can set metadata on a computed property", function() {
+QUnit.test("can set metadata on a computed property", function() {
   var computedProperty = computed(function() { });
   computedProperty.meta({ key: 'keyValue' });
 
   equal(computedProperty.meta().key, 'keyValue', "saves passed meta hash to the _meta property");
 });
 
-test("meta should return an empty hash if no meta is set", function() {
+QUnit.test("meta should return an empty hash if no meta is set", function() {
   var computedProperty = computed(function() { });
   deepEqual(computedProperty.meta(), {}, "returned value is an empty hash");
 });
@@ -244,27 +244,27 @@ testBoth('modifying a cacheable property should update cache', function(get, set
   equal(count, 2, 'should not invoke again');
 });
 
-test('calling cacheable() on a computed property raises a deprecation', function() {
+QUnit.test('calling cacheable() on a computed property raises a deprecation', function() {
   var cp = new ComputedProperty(function() {});
   expectDeprecation(function() {
     cp.cacheable();
   }, 'ComputedProperty.cacheable() is deprecated. All computed properties are cacheable by default.');
 });
 
-test('passing cacheable in a the options to the CP constructor raises a deprecation', function() {
+QUnit.test('passing cacheable in a the options to the CP constructor raises a deprecation', function() {
   expectDeprecation(function() {
     new ComputedProperty(function() {}, { cacheable: true });
   }, "Passing opts.cacheable to the CP constructor is deprecated. Invoke `volatile()` on the CP instead.");
 });
 
-test('calling readOnly() on a computed property with arguments raises a deprecation', function() {
+QUnit.test('calling readOnly() on a computed property with arguments raises a deprecation', function() {
   var cp = new ComputedProperty(function() {});
   expectDeprecation(function() {
     cp.readOnly(true);
   }, 'Passing arguments to ComputedProperty.readOnly() is deprecated.');
 });
 
-test('passing readOnly in a the options to the CP constructor raises a deprecation', function() {
+QUnit.test('passing readOnly in a the options to the CP constructor raises a deprecation', function() {
   expectDeprecation(function() {
     new ComputedProperty(function() {}, { readOnly: false });
   }, "Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. Yo can invoke `readOnly()` on the CP to change this.");
@@ -645,7 +645,7 @@ testBoth('chained dependent keys should evaluate computed properties lazily', fu
 if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
   QUnit.module('computed - improved cp syntax');
 
-  test('setter and getters are passed using an object', function() {
+  QUnit.test('setter and getters are passed using an object', function() {
     var testObj = Ember.Object.extend({
       a: '1',
       b: '2',
@@ -670,7 +670,7 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
     ok(testObj.get('aInt') === 123, 'cp has been updated too');
   });
 
-  test('setter can be omited', function() {
+  QUnit.test('setter can be omited', function() {
     var testObj = Ember.Object.extend({
       a: '1',
       b: '2',
@@ -688,7 +688,7 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
     ok(testObj.get('aInt') === '123', 'cp has been updated too');
   });
 
-  test('the return value of the setter gets cached', function() {
+  QUnit.test('the return value of the setter gets cached', function() {
     var testObj = Ember.Object.extend({
       a: '1',
       sampleCP: computed('a', {
@@ -713,7 +713,7 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
 
 QUnit.module('computed edge cases');
 
-test('adding a computed property should show up in key iteration', function() {
+QUnit.test('adding a computed property should show up in key iteration', function() {
 
   var obj = {};
   defineProperty(obj, 'foo', computed(function() {}));
@@ -866,7 +866,7 @@ testBoth("when setting a value on a computed property that doesn't handle sets",
 
 QUnit.module('computed - readOnly');
 
-test('is chainable', function() {
+QUnit.test('is chainable', function() {
   var cp = computed(function() {}).readOnly();
 
   ok(cp instanceof Descriptor);

--- a/packages/ember-metal/tests/core/inspect_test.js
+++ b/packages/ember-metal/tests/core/inspect_test.js
@@ -3,50 +3,50 @@ import create from 'ember-metal/platform/create';
 
 QUnit.module("Ember.inspect");
 
-test("strings", function() {
+QUnit.test("strings", function() {
   equal(inspect("foo"), "foo");
 });
 
-test("numbers", function() {
+QUnit.test("numbers", function() {
   equal(inspect(2.6), "2.6");
 });
 
-test("null", function() {
+QUnit.test("null", function() {
   equal(inspect(null), "null");
 });
 
-test("undefined", function() {
+QUnit.test("undefined", function() {
   equal(inspect(undefined), "undefined");
 });
 
-test("true", function() {
+QUnit.test("true", function() {
   equal(inspect(true), "true");
 });
 
-test("false", function() {
+QUnit.test("false", function() {
   equal(inspect(false), "false");
 });
 
-test("object", function() {
+QUnit.test("object", function() {
   equal(inspect({}), "{}");
   equal(inspect({ foo: 'bar' }), "{foo: bar}");
   equal(inspect({ foo: function() { return this; } }), "{foo: function() { ... }}");
 });
 
-test("objects without a prototype", function() {
+QUnit.test("objects without a prototype", function() {
   var prototypelessObj = create(null);
   equal(inspect({ foo: prototypelessObj }), "{foo: [object Object]}");
 });
 
-test("array", function() {
+QUnit.test("array", function() {
   equal(inspect([1,2,3]), "[1,2,3]");
 });
 
-test("regexp", function() {
+QUnit.test("regexp", function() {
   equal(inspect(/regexp/), "/regexp/");
 });
 
-test("date", function() {
+QUnit.test("date", function() {
   var inspected = inspect(new Date("Sat Apr 30 2011 13:24:11"));
   ok(inspected.match(/Sat Apr 30/), "The inspected date has its date");
   ok(inspected.match(/2011/), "The inspected date has its year");

--- a/packages/ember-metal/tests/enumerable_utils_test.js
+++ b/packages/ember-metal/tests/enumerable_utils_test.js
@@ -2,7 +2,7 @@ import EnumerableUtils from 'ember-metal/enumerable_utils';
 
 QUnit.module('Ember.EnumerableUtils.intersection');
 
-test('returns an array of objects that appear in both enumerables', function() {
+QUnit.test('returns an array of objects that appear in both enumerables', function() {
   var a = [1,2,3];
   var b = [2,3,4];
   var result;
@@ -12,7 +12,7 @@ test('returns an array of objects that appear in both enumerables', function() {
   deepEqual(result, [2,3]);
 });
 
-test("large replace", function() {
+QUnit.test("large replace", function() {
   expect(0);
 
   // https://code.google.com/p/chromium/issues/detail?id=56588

--- a/packages/ember-metal/tests/error_test.js
+++ b/packages/ember-metal/tests/error_test.js
@@ -1,7 +1,7 @@
 QUnit.module("Ember Error Throwing");
 
 test("new Ember.Error displays provided message", function() {
-  raises(function() {
+  throws(function() {
     throw new Ember.Error('A Message');
   }, function(e) {
     return e.message === 'A Message';

--- a/packages/ember-metal/tests/error_test.js
+++ b/packages/ember-metal/tests/error_test.js
@@ -1,6 +1,6 @@
 QUnit.module("Ember Error Throwing");
 
-test("new Ember.Error displays provided message", function() {
+QUnit.test("new Ember.Error displays provided message", function() {
   throws(function() {
     throw new Ember.Error('A Message');
   }, function(e) {

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -14,7 +14,7 @@ import {
 
 QUnit.module('system/props/events_test');
 
-test('listener should receive event - removing should remove', function() {
+QUnit.test('listener should receive event - removing should remove', function() {
   var obj = {};
   var count = 0;
   var F = function() { count++; };
@@ -32,7 +32,7 @@ test('listener should receive event - removing should remove', function() {
   equal(count, 0, 'received event');
 });
 
-test('listeners should be inherited', function() {
+QUnit.test('listeners should be inherited', function() {
   var obj = {};
   var count = 0;
   var F = function() { count++; };
@@ -58,7 +58,7 @@ test('listeners should be inherited', function() {
 });
 
 
-test('adding a listener more than once should only invoke once', function() {
+QUnit.test('adding a listener more than once should only invoke once', function() {
 
   var obj = {};
   var count = 0;
@@ -70,7 +70,7 @@ test('adding a listener more than once should only invoke once', function() {
   equal(count, 1, 'should only invoke once');
 });
 
-test('adding a listener with a target should invoke with target', function() {
+QUnit.test('adding a listener with a target should invoke with target', function() {
   var obj = {};
   var target;
 
@@ -84,7 +84,7 @@ test('adding a listener with a target should invoke with target', function() {
   equal(target.count, 1, 'should invoke');
 });
 
-test('suspending a listener should not invoke during callback', function() {
+QUnit.test('suspending a listener should not invoke during callback', function() {
   var obj = {};
   var target, otherTarget;
 
@@ -120,7 +120,7 @@ test('suspending a listener should not invoke during callback', function() {
   equal(otherTarget.count, 3, 'should invoke');
 });
 
-test('adding a listener with string method should lookup method on event delivery', function() {
+QUnit.test('adding a listener with string method should lookup method on event delivery', function() {
   var obj = {};
   var target;
 
@@ -138,7 +138,7 @@ test('adding a listener with string method should lookup method on event deliver
   equal(target.count, 1, 'should invoke now');
 });
 
-test('calling sendEvent with extra params should be passed to listeners', function() {
+QUnit.test('calling sendEvent with extra params should be passed to listeners', function() {
 
   var obj = {};
   var params = null;
@@ -150,7 +150,7 @@ test('calling sendEvent with extra params should be passed to listeners', functi
   deepEqual(params, ['foo', 'bar'], 'params should be saved');
 });
 
-test('implementing sendEvent on object should invoke', function() {
+QUnit.test('implementing sendEvent on object should invoke', function() {
   var obj = {
     sendEvent: function(eventName, params) {
       equal(eventName, 'event!', 'eventName');
@@ -167,7 +167,7 @@ test('implementing sendEvent on object should invoke', function() {
   equal(obj.count, 2, 'should have invoked method & listener');
 });
 
-test('hasListeners tells you if there are listeners for a given event', function() {
+QUnit.test('hasListeners tells you if there are listeners for a given event', function() {
 
   var obj = {};
   var F = function() {};
@@ -190,7 +190,7 @@ test('hasListeners tells you if there are listeners for a given event', function
   equal(hasListeners(obj, 'event!'), true, 'has listeners');
 });
 
-test('calling removeListener without method should remove all listeners', function() {
+QUnit.test('calling removeListener without method should remove all listeners', function() {
   var obj = {};
   var F = function() {};
   var F2 = function() {};
@@ -207,7 +207,7 @@ test('calling removeListener without method should remove all listeners', functi
   equal(hasListeners(obj, 'event!'), false, 'has no more listeners');
 });
 
-test('while suspended, it should not be possible to add a duplicate listener', function() {
+QUnit.test('while suspended, it should not be possible to add a duplicate listener', function() {
   var obj = {};
   var target;
 
@@ -239,7 +239,7 @@ test('while suspended, it should not be possible to add a duplicate listener', f
   equal(meta(obj).listeners['event!'].length, 3, "a duplicate listener wasn't added");
 });
 
-test('a listener can be added as part of a mixin', function() {
+QUnit.test('a listener can be added as part of a mixin', function() {
   var triggered = 0;
   var MyMixin = Mixin.create({
     foo1: on('bar', function() {
@@ -258,7 +258,7 @@ test('a listener can be added as part of a mixin', function() {
   equal(triggered, 2, 'should invoke listeners');
 });
 
-test('a listener added as part of a mixin may be overridden', function() {
+QUnit.test('a listener added as part of a mixin may be overridden', function() {
 
   var triggered = 0;
   var FirstMixin = Mixin.create({

--- a/packages/ember-metal/tests/expand_properties_test.js
+++ b/packages/ember-metal/tests/expand_properties_test.js
@@ -12,7 +12,7 @@ QUnit.module('Property Brace Expansion Test', {
   }
 });
 
-test('Properties without expansions are unaffected', function() {
+QUnit.test('Properties without expansions are unaffected', function() {
   expect(1);
 
   expandProperties('a', addProperty);
@@ -22,7 +22,7 @@ test('Properties without expansions are unaffected', function() {
   deepEqual(['a', 'a.b', 'a.b.@each'].sort(), foundProperties.sort());
 });
 
-test('A single expansion at the end expands properly', function() {
+QUnit.test('A single expansion at the end expands properly', function() {
   expect(1);
 
   expandProperties('a.b.{c,d}', addProperty);
@@ -30,7 +30,7 @@ test('A single expansion at the end expands properly', function() {
   deepEqual(['a.b.c', 'a.b.d'].sort(), foundProperties.sort());
 });
 
-test('A property with only a brace expansion expands correctly', function() {
+QUnit.test('A property with only a brace expansion expands correctly', function() {
   expect(1);
 
   expandProperties('{a,b,c}', addProperty);
@@ -39,7 +39,7 @@ test('A property with only a brace expansion expands correctly', function() {
   deepEqual(expected.sort(), foundProperties.sort());
 });
 
-test('Expansions with single properties only expand once', function() {
+QUnit.test('Expansions with single properties only expand once', function() {
   expect(1);
 
   expandProperties('a.b.{c}.d.{e}', addProperty);
@@ -47,7 +47,7 @@ test('Expansions with single properties only expand once', function() {
   deepEqual(['a.b.c.d.e'], foundProperties);
 });
 
-test('A single brace expansion expands correctly', function() {
+QUnit.test('A single brace expansion expands correctly', function() {
   expect(1);
 
   expandProperties('a.{b,c,d}.e', addProperty);
@@ -56,7 +56,7 @@ test('A single brace expansion expands correctly', function() {
   deepEqual(expected.sort(), foundProperties.sort());
 });
 
-test('Multiple brace expansions work correctly', function() {
+QUnit.test('Multiple brace expansions work correctly', function() {
   expect(1);
 
   expandProperties('{a,b,c}.d.{e,f}.g', addProperty);
@@ -65,7 +65,7 @@ test('Multiple brace expansions work correctly', function() {
   deepEqual(expected.sort(), foundProperties.sort());
 });
 
-test('A property with only brace expansions expands correctly', function() {
+QUnit.test('A property with only brace expansions expands correctly', function() {
   expect(1);
 
   expandProperties('{a,b,c}.{d}.{e,f}', addProperty);

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -17,7 +17,7 @@ QUnit.module("Ember.FEATURES.isEnabled", {
   }
 });
 
-test("ENV.ENABLE_ALL_FEATURES", function() {
+QUnit.test("ENV.ENABLE_ALL_FEATURES", function() {
   Ember.ENV.ENABLE_ALL_FEATURES = true;
   Ember.FEATURES['fred'] = false;
   Ember.FEATURES['wilma'] = null;
@@ -27,7 +27,7 @@ test("ENV.ENABLE_ALL_FEATURES", function() {
   equal(isEnabled('betty'), true, "enables non-specified features");
 });
 
-test("ENV.ENABLE_OPTIONAL_FEATURES", function() {
+QUnit.test("ENV.ENABLE_OPTIONAL_FEATURES", function() {
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = true;
   Ember.FEATURES['fred'] = false;
   Ember.FEATURES['barney'] = true;
@@ -39,7 +39,7 @@ test("ENV.ENABLE_OPTIONAL_FEATURES", function() {
   equal(isEnabled('betty'),  undefined, "returns flag value if undefined");
 });
 
-test("isEnabled without ENV options", function() {
+QUnit.test("isEnabled without ENV options", function() {
   Ember.ENV.ENABLE_ALL_FEATURES = false;
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
 

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -9,11 +9,11 @@ import InjectedProperty from "ember-metal/injected_property";
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('InjectedProperty');
 
-  test('injected properties should be descriptors', function() {
+  QUnit.test('injected properties should be descriptors', function() {
     ok(new InjectedProperty() instanceof Descriptor);
   });
 
-  test('injected properties should be overridable', function() {
+  QUnit.test('injected properties should be overridable', function() {
     var obj = {};
     defineProperty(obj, 'foo', new InjectedProperty());
 
@@ -22,7 +22,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     equal(get(obj, 'foo'), 'bar', 'should return the overriden value');
   });
 
-  test("getting on an object without a container should fail assertion", function() {
+  QUnit.test("getting on an object without a container should fail assertion", function() {
     var obj = {};
     defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
 
@@ -31,7 +31,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     }, /Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container./);
   });
 
-  test("getting should return a lookup on the container", function() {
+  QUnit.test("getting should return a lookup on the container", function() {
     expect(2);
 
     var obj = {
@@ -47,7 +47,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
   });
 
-  test("omitting the lookup name should default to the property name", function() {
+  QUnit.test("omitting the lookup name should default to the property name", function() {
     var obj = {
       container: {
         lookup: function(key) {

--- a/packages/ember-metal/tests/instrumentation_test.js
+++ b/packages/ember-metal/tests/instrumentation_test.js
@@ -14,14 +14,14 @@ QUnit.module("Ember Instrumentation", {
   }
 });
 
-test("execute block even if no listeners", function() {
+QUnit.test("execute block even if no listeners", function() {
   var result = instrument("render", {}, function() {
     return "hello";
   });
   equal(result, "hello", 'called block');
 });
 
-test("subscribing to a simple path receives the listener", function() {
+QUnit.test("subscribing to a simple path receives the listener", function() {
   expect(12);
 
   var sentPayload = {};
@@ -62,7 +62,7 @@ test("subscribing to a simple path receives the listener", function() {
   });
 });
 
-test("returning a value from the before callback passes it to the after callback", function() {
+QUnit.test("returning a value from the before callback passes it to the after callback", function() {
   expect(2);
 
   var passthru1 = {};
@@ -89,7 +89,7 @@ test("returning a value from the before callback passes it to the after callback
   instrument("render", null, function() {});
 });
 
-test("instrument with 2 args (name, callback) no payload", function() {
+QUnit.test("instrument with 2 args (name, callback) no payload", function() {
   expect(1);
 
   subscribe("render", {
@@ -102,7 +102,7 @@ test("instrument with 2 args (name, callback) no payload", function() {
   instrument("render", function() {});
 });
 
-test("instrument with 3 args (name, callback, binding) no payload", function() {
+QUnit.test("instrument with 3 args (name, callback, binding) no payload", function() {
   expect(2);
 
   var binding = {};
@@ -119,7 +119,7 @@ test("instrument with 3 args (name, callback, binding) no payload", function() {
 });
 
 
-test("instrument with 3 args (name, payload, callback) with payload", function() {
+QUnit.test("instrument with 3 args (name, payload, callback) with payload", function() {
   expect(1);
 
   var expectedPayload = { hi: 1 };
@@ -133,7 +133,7 @@ test("instrument with 3 args (name, payload, callback) with payload", function()
   instrument("render", expectedPayload, function() {});
 });
 
-test("instrument with 4 args (name, payload, callback, binding) with payload", function() {
+QUnit.test("instrument with 4 args (name, payload, callback, binding) with payload", function() {
   expect(2);
 
   var expectedPayload = { hi: 1 };
@@ -151,7 +151,7 @@ test("instrument with 4 args (name, payload, callback, binding) with payload", f
 });
 
 
-test("raising an exception in the instrumentation attaches it to the payload", function() {
+QUnit.test("raising an exception in the instrumentation attaches it to the payload", function() {
   expect(2);
 
   var error = new Error("Instrumentation");
@@ -175,7 +175,7 @@ test("raising an exception in the instrumentation attaches it to the payload", f
   });
 });
 
-test("it is possible to add a new subscriber after the first instrument", function() {
+QUnit.test("it is possible to add a new subscriber after the first instrument", function() {
   instrument("render.handlebars", null, function() {});
 
   subscribe("render", {
@@ -190,7 +190,7 @@ test("it is possible to add a new subscriber after the first instrument", functi
   instrument("render.handlebars", null, function() {});
 });
 
-test("it is possible to remove a subscriber", function() {
+QUnit.test("it is possible to remove a subscriber", function() {
   expect(4);
 
   var count = 0;

--- a/packages/ember-metal/tests/is_blank_test.js
+++ b/packages/ember-metal/tests/is_blank_test.js
@@ -2,7 +2,7 @@ import isBlank from 'ember-metal/is_blank';
 
 QUnit.module("Ember.isBlank");
 
-test("Ember.isBlank", function() {
+QUnit.test("Ember.isBlank", function() {
   var string = "string";
   var fn = function() {};
   var object = { length: 0 };

--- a/packages/ember-metal/tests/is_empty_test.js
+++ b/packages/ember-metal/tests/is_empty_test.js
@@ -6,7 +6,7 @@ import {
 
 QUnit.module("Ember.isEmpty");
 
-test("Ember.isEmpty", function() {
+QUnit.test("Ember.isEmpty", function() {
   var string = "string";
   var fn = function() {};
   var object = { length: 0 };
@@ -24,14 +24,14 @@ test("Ember.isEmpty", function() {
   equal(true,  isEmpty(object),    "for an Object that has zero 'length'");
 });
 
-test("Ember.isEmpty Ember.Map", function() {
+QUnit.test("Ember.isEmpty Ember.Map", function() {
   var map = new Map();
   equal(true, isEmpty(map), "Empty map is empty");
   map.set('foo', 'bar');
   equal(false, isEmpty(map), "Map is not empty");
 });
 
-test("Ember.isEmpty Ember.OrderedSet", function() {
+QUnit.test("Ember.isEmpty Ember.OrderedSet", function() {
   var orderedSet = new OrderedSet();
   equal(true, isEmpty(orderedSet), "Empty ordered set is empty");
   orderedSet.add('foo');

--- a/packages/ember-metal/tests/is_none_test.js
+++ b/packages/ember-metal/tests/is_none_test.js
@@ -2,7 +2,7 @@ import isNone from 'ember-metal/is_none';
 
 QUnit.module("Ember.isNone");
 
-test("Ember.isNone", function() {
+QUnit.test("Ember.isNone", function() {
   var string = "string";
   var fn = function() {};
 

--- a/packages/ember-metal/tests/is_present_test.js
+++ b/packages/ember-metal/tests/is_present_test.js
@@ -2,7 +2,7 @@ import isPresent from 'ember-metal/is_present';
 
 QUnit.module("Ember.isPresent");
 
-test("Ember.isPresent", function() {
+QUnit.test("Ember.isPresent", function() {
   var string = "string";
   var fn = function() {};
   var object = { length: 0 };

--- a/packages/ember-metal/tests/keys_test.js
+++ b/packages/ember-metal/tests/keys_test.js
@@ -9,7 +9,7 @@ function K() { return this; }
 
 QUnit.module("Fetch Keys ");
 
-test("should get a key array for a specified object", function() {
+QUnit.test("should get a key array for a specified object", function() {
   var object1 = {};
 
   object1.names = "Rahul";
@@ -22,7 +22,7 @@ test("should get a key array for a specified object", function() {
 });
 
 // This test is for IE8.
-test("should get a key array for property that is named the same as prototype property", function() {
+QUnit.test("should get a key array for property that is named the same as prototype property", function() {
   var object1 = {
     toString: function() {}
   };
@@ -32,7 +32,7 @@ test("should get a key array for property that is named the same as prototype pr
   deepEqual(object2, ['toString']);
 });
 
-test('should not contain properties declared in the prototype', function () {
+QUnit.test('should not contain properties declared in the prototype', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -41,7 +41,7 @@ test('should not contain properties declared in the prototype', function () {
   deepEqual(keys(beer), []);
 });
 
-test('should return properties that were set after object creation', function () {
+QUnit.test('should return properties that were set after object creation', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -54,7 +54,7 @@ test('should return properties that were set after object creation', function ()
 
 QUnit.module('Keys behavior with observers');
 
-test('should not leak properties on the prototype', function () {
+QUnit.test('should not leak properties on the prototype', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -65,7 +65,7 @@ test('should not leak properties on the prototype', function () {
   removeObserver(beer, 'type', K);
 });
 
-test('observing a non existent property', function () {
+QUnit.test('observing a non existent property', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -81,7 +81,7 @@ test('observing a non existent property', function () {
   removeObserver(beer, 'brand', K);
 });
 
-test('with observers switched on and off', function () {
+QUnit.test('with observers switched on and off', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -93,7 +93,7 @@ test('with observers switched on and off', function () {
   deepEqual(keys(beer), []);
 });
 
-test('observers switched on and off with setter in between', function () {
+QUnit.test('observers switched on and off with setter in between', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 
@@ -106,7 +106,7 @@ test('observers switched on and off with setter in between', function () {
   deepEqual(keys(beer), ['type']);
 });
 
-test('observer switched on and off and then setter', function () {
+QUnit.test('observer switched on and off and then setter', function () {
   function Beer() { }
   Beer.prototype.type = 'ipa';
 

--- a/packages/ember-metal/tests/libraries_test.js
+++ b/packages/ember-metal/tests/libraries_test.js
@@ -15,7 +15,7 @@ QUnit.module('Libraries registry', {
   }
 });
 
-test('core libraries come before other libraries', function() {
+QUnit.test('core libraries come before other libraries', function() {
   expect(2);
 
   libs.register('my-lib', '2.0.0a');
@@ -25,7 +25,7 @@ test('core libraries come before other libraries', function() {
   equal(registry[1].name, 'my-lib');
 });
 
-test('only the first registration of a library is stored', function() {
+QUnit.test('only the first registration of a library is stored', function() {
   expect(3);
 
   libs.register('magic', 1.23);
@@ -36,7 +36,7 @@ test('only the first registration of a library is stored', function() {
   equal(registry.length, 1);
 });
 
-test('attempting to register a library that is already registered warns you', function() {
+QUnit.test('attempting to register a library that is already registered warns you', function() {
   if (EmberDev && EmberDev.runningProdBuild) {
     ok(true, 'Logging does not occur in production builds');
     return;
@@ -59,7 +59,7 @@ test('attempting to register a library that is already registered warns you', fu
   Ember.warn = oldWarn;
 });
 
-test('libraries can be de-registered', function() {
+QUnit.test('libraries can be de-registered', function() {
   expect(2);
 
   libs.register('lib1', '1.0.0b');
@@ -74,7 +74,7 @@ test('libraries can be de-registered', function() {
 });
 
 
-test('Libraries#each allows us to loop through each registered library (but is deprecated)', function() {
+QUnit.test('Libraries#each allows us to loop through each registered library (but is deprecated)', function() {
   expect(5);
 
   var items = [{ name: 'lib1', version: '1.0.0' }, { name: 'lib2', version: '2.0.0' }];

--- a/packages/ember-metal/tests/main_test.js
+++ b/packages/ember-metal/tests/main_test.js
@@ -2,7 +2,7 @@ import Ember from "ember-metal/core";
 
 QUnit.module('ember-metal/core/main');
 
-test('Ember registers itself', function() {
+QUnit.test('Ember registers itself', function() {
   var lib = Ember.libraries._registry[0];
 
   equal(lib.name, 'Ember');

--- a/packages/ember-metal/tests/map_test.js
+++ b/packages/ember-metal/tests/map_test.js
@@ -52,7 +52,7 @@ function testMap(nameAndFunc) {
     unboundThis = this;
   }());
 
-  test("set", function() {
+  QUnit.test("set", function() {
     map.set(object, "winning");
     map.set(number, "winning");
     map.set(string, "winning");
@@ -77,7 +77,7 @@ function testMap(nameAndFunc) {
     equal(map.has({}), false, "expected they key `{}` to not be present");
   });
 
-  test("set chaining", function() {
+  QUnit.test("set chaining", function() {
     map.set(object, "winning").
         set(number, "winning").
         set(string, "winning");
@@ -102,7 +102,7 @@ function testMap(nameAndFunc) {
     equal(map.has({}), false, "expected they key `{}` to not be present");
   });
 
-  test("with key with undefined value", function() {
+  QUnit.test("with key with undefined value", function() {
     map.set("foo", undefined);
 
     map.forEach(function(value, key) {
@@ -115,16 +115,16 @@ function testMap(nameAndFunc) {
     equal(map.size, 1);
   });
 
-  test("arity of forEach is 1 – es6 23.1.3.5", function() {
+  QUnit.test("arity of forEach is 1 – es6 23.1.3.5", function() {
     equal(map.forEach.length, 1, 'expected arity for map.forEach is 1');
   });
 
-  test("forEach throws without a callback as the first argument", function() {
+  QUnit.test("forEach throws without a callback as the first argument", function() {
 
     equal(map.forEach.length, 1, 'expected arity for map.forEach is 1');
   });
 
-  test("remove", function() {
+  QUnit.test("remove", function() {
     map.set(object, "winning");
     map.set(number, "winning");
     map.set(string, "winning");
@@ -141,12 +141,12 @@ function testMap(nameAndFunc) {
     mapHasEntries([]);
   });
 
-  test("has empty collection", function() {
+  QUnit.test("has empty collection", function() {
     equal(map.has('foo'), false);
     equal(map.has(), false);
   });
 
-  test("delete", function() {
+  QUnit.test("delete", function() {
     expectNoDeprecation();
 
     map.set(object, "winning");
@@ -163,7 +163,7 @@ function testMap(nameAndFunc) {
     mapHasEntries([]);
   });
 
-  test("copy and then update", function() {
+  QUnit.test("copy and then update", function() {
     map.set(object, "winning");
     map.set(number, "winning");
     map.set(string, "winning");
@@ -187,7 +187,7 @@ function testMap(nameAndFunc) {
     ], map2);
   });
 
-  test("copy and then delete", function() {
+  QUnit.test("copy and then delete", function() {
     map.set(object, "winning");
     map.set(number, "winning");
     map.set(string, "winning");
@@ -208,7 +208,7 @@ function testMap(nameAndFunc) {
   });
 
   if (hasPropertyAccessors) {
-    test("length", function() {
+    QUnit.test("length", function() {
       expectDeprecation('Usage of `length` is deprecated, use `size` instead.');
 
       //Add a key twice
@@ -244,7 +244,7 @@ function testMap(nameAndFunc) {
     });
   }
 
-  test("size", function() {
+  QUnit.test("size", function() {
     //Add a key twice
     equal(map.size, 0);
     map.set(string, "a string");
@@ -277,7 +277,7 @@ function testMap(nameAndFunc) {
     equal(map.size, 0);
   });
 
-  test("forEach without proper callback", function() {
+  QUnit.test("forEach without proper callback", function() {
     QUnit.throws(function() {
       map.forEach();
     }, '[object Undefined] is not a function');
@@ -304,7 +304,7 @@ function testMap(nameAndFunc) {
     }, '[object Object] is not a function');
   });
 
-  test("forEach basic", function() {
+  QUnit.test("forEach basic", function() {
     map.set("a", 1);
     map.set("b", 2);
     map.set("c", 3);
@@ -332,7 +332,7 @@ function testMap(nameAndFunc) {
 
   });
 
-  test("forEach basic /w context", function() {
+  QUnit.test("forEach basic /w context", function() {
     map.set("a", 1);
     map.set("b", 2);
     map.set("c", 3);
@@ -360,7 +360,7 @@ function testMap(nameAndFunc) {
     equal(iteration, 3, 'expected 3 iterations');
   });
 
-  test("forEach basic /w deletion while enumerating", function() {
+  QUnit.test("forEach basic /w deletion while enumerating", function() {
     map.set("a", 1);
     map.set("b", 2);
     map.set("c", 3);
@@ -390,7 +390,7 @@ function testMap(nameAndFunc) {
     equal(iteration, 2, 'expected 3 iterations');
   });
 
-  test("forEach basic /w addition while enumerating", function() {
+  QUnit.test("forEach basic /w addition while enumerating", function() {
     map.set("a", 1);
     map.set("b", 2);
     map.set("c", 3);
@@ -422,7 +422,7 @@ function testMap(nameAndFunc) {
     equal(iteration, 4, 'expected 3 iterations');
   });
 
-  test("clear", function() {
+  QUnit.test("clear", function() {
     var iterations = 0;
 
     map.set("a", 1);
@@ -446,7 +446,7 @@ function testMap(nameAndFunc) {
     equal(iterations, 0);
   });
 
-  test("-0", function() {
+  QUnit.test("-0", function() {
     equal(map.has(-0), false);
     equal(map.has(0), false);
 
@@ -463,7 +463,7 @@ function testMap(nameAndFunc) {
     });
   });
 
-  test("NaN", function() {
+  QUnit.test("NaN", function() {
     equal(map.has(NaN), false);
 
     map.set(NaN, 'not-a-number');
@@ -474,7 +474,7 @@ function testMap(nameAndFunc) {
 
   });
 
-  test("NaN Boxed", function() {
+  QUnit.test("NaN Boxed", function() {
     //jshint -W053
     var boxed = new Number(NaN);
     equal(map.has(boxed), false);
@@ -488,7 +488,7 @@ function testMap(nameAndFunc) {
     equal(map.get(boxed), 'not-a-number');
   });
 
-  test("0 value", function() {
+  QUnit.test("0 value", function() {
     var obj = {};
     equal(map.has(obj), false);
 
@@ -512,7 +512,7 @@ for (var i = 0;  i < varieties.length;  i++) {
 
 QUnit.module("MapWithDefault - default values");
 
-test("Retrieving a value that has not been set returns and sets a default value", function() {
+QUnit.test("Retrieving a value that has not been set returns and sets a default value", function() {
   var map = MapWithDefault.create({
     defaultValue: function(key) {
       return [key];
@@ -525,19 +525,19 @@ test("Retrieving a value that has not been set returns and sets a default value"
   strictEqual(value, map.get('ohai'));
 });
 
-test("Map.prototype.constructor", function() {
+QUnit.test("Map.prototype.constructor", function() {
   var map = new Map();
   equal(map.constructor, Map);
 });
 
-test("MapWithDefault.prototype.constructor", function() {
+QUnit.test("MapWithDefault.prototype.constructor", function() {
   var map = new MapWithDefault({
     defaultValue: function(key) { return key; }
   });
   equal(map.constructor, MapWithDefault);
 });
 
-test("Copying a MapWithDefault copies the default value", function() {
+QUnit.test("Copying a MapWithDefault copies the default value", function() {
   var map = MapWithDefault.create({
     defaultValue: function(key) {
       return [key];
@@ -576,7 +576,7 @@ QUnit.module("OrderedSet", {
   }
 });
 
-test("add returns the set", function() {
+QUnit.test("add returns the set", function() {
   var obj = {};
   equal(map.add(obj), map);
   equal(map.add(obj), map, 'when it is already in the set');

--- a/packages/ember-metal/tests/mixin/alias_method_test.js
+++ b/packages/ember-metal/tests/mixin/alias_method_test.js
@@ -12,7 +12,7 @@ function validateAliasMethod(obj) {
   equal(obj.barMethod(), 'FOO', 'obj.barMethod should be a copy of foo');
 }
 
-test('methods of another name are aliased when the mixin is applied', function() {
+QUnit.test('methods of another name are aliased when the mixin is applied', function() {
   var MyMixin = Mixin.create({
     fooMethod: function() { return 'FOO'; },
     barMethod: aliasMethod('fooMethod')
@@ -22,7 +22,7 @@ test('methods of another name are aliased when the mixin is applied', function()
   validateAliasMethod(obj);
 });
 
-test('should follow aliasMethods all the way down', function() {
+QUnit.test('should follow aliasMethods all the way down', function() {
   var MyMixin = Mixin.create({
     bar: aliasMethod('foo'), // put first to break ordered iteration
     baz: function() { return 'baz'; },
@@ -33,7 +33,7 @@ test('should follow aliasMethods all the way down', function() {
   equal(get(obj, 'bar')(), 'baz', 'should have followed aliasMethods');
 });
 
-test('should alias methods from other dependent mixins', function() {
+QUnit.test('should alias methods from other dependent mixins', function() {
   var BaseMixin = Mixin.create({
     fooMethod: function() { return 'FOO'; }
   });
@@ -46,7 +46,7 @@ test('should alias methods from other dependent mixins', function() {
   validateAliasMethod(obj);
 });
 
-test('should alias methods from other mixins applied at same time', function() {
+QUnit.test('should alias methods from other mixins applied at same time', function() {
   var BaseMixin = Mixin.create({
     fooMethod: function() { return 'FOO'; }
   });
@@ -59,7 +59,7 @@ test('should alias methods from other mixins applied at same time', function() {
   validateAliasMethod(obj);
 });
 
-test('should alias methods from mixins already applied on object', function() {
+QUnit.test('should alias methods from mixins already applied on object', function() {
   var BaseMixin = Mixin.create({
     quxMethod: function() { return 'qux'; }
   });

--- a/packages/ember-metal/tests/mixin/apply_test.js
+++ b/packages/ember-metal/tests/mixin/apply_test.js
@@ -8,7 +8,7 @@ QUnit.module('Ember.Mixin.apply');
 
 function K() {}
 
-test('using apply() should apply properties', function() {
+QUnit.test('using apply() should apply properties', function() {
   var MixinA = Mixin.create({ foo: 'FOO', baz: K });
   var obj = {};
   mixin(obj, MixinA);
@@ -17,7 +17,7 @@ test('using apply() should apply properties', function() {
   equal(get(obj, 'baz'), K, 'should apply foo');
 });
 
-test('applying anonymous properties', function() {
+QUnit.test('applying anonymous properties', function() {
   var obj = {};
   mixin(obj, {
     foo: 'FOO',
@@ -28,13 +28,13 @@ test('applying anonymous properties', function() {
   equal(get(obj, 'baz'), K, 'should apply foo');
 });
 
-test('applying null values', function() {
+QUnit.test('applying null values', function() {
   expectAssertion(function() {
     mixin({}, null);
   });
 });
 
-test('applying a property with an undefined value', function() {
+QUnit.test('applying a property with an undefined value', function() {
   var obj = { tagName: '' };
   mixin(obj, { tagName: undefined });
 

--- a/packages/ember-metal/tests/mixin/computed_test.js
+++ b/packages/ember-metal/tests/mixin/computed_test.js
@@ -8,7 +8,7 @@ function K() { return this; }
 
 QUnit.module('Mixin Computed Properties');
 
-test('overriding computed properties', function() {
+QUnit.test('overriding computed properties', function() {
   var MixinA, MixinB, MixinC, MixinD;
   var obj;
 
@@ -58,7 +58,7 @@ test('overriding computed properties', function() {
   equal(get(obj, 'aProp'), "objD", "should preserve original computed property");
 });
 
-test('calling set on overridden computed properties', function() {
+QUnit.test('calling set on overridden computed properties', function() {
   var SuperMixin, SubMixin;
   var obj;
 
@@ -100,7 +100,7 @@ test('calling set on overridden computed properties', function() {
   ok(superSetOccurred, 'should pass set to _super after getting');
 });
 
-test('setter behavior works properly when overriding computed properties', function() {
+QUnit.test('setter behavior works properly when overriding computed properties', function() {
   var obj = {};
 
   var MixinA = Mixin.create({

--- a/packages/ember-metal/tests/mixin/concatenated_properties_test.js
+++ b/packages/ember-metal/tests/mixin/concatenated_properties_test.js
@@ -6,7 +6,7 @@ import {
 
 QUnit.module('Mixin concatenatedProperties');
 
-test('defining concatenated properties should concat future version', function() {
+QUnit.test('defining concatenated properties should concat future version', function() {
 
   var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
@@ -21,7 +21,7 @@ test('defining concatenated properties should concat future version', function()
   deepEqual(get(obj, 'foo'), ['a', 'b', 'c', 'd', 'e', 'f']);
 });
 
-test('defining concatenated properties should concat future version', function() {
+QUnit.test('defining concatenated properties should concat future version', function() {
 
   var MixinA = Mixin.create({
     concatenatedProperties: null
@@ -37,7 +37,7 @@ test('defining concatenated properties should concat future version', function()
 });
 
 
-test('concatenatedProperties should be concatenated', function() {
+QUnit.test('concatenatedProperties should be concatenated', function() {
 
   var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
@@ -60,7 +60,7 @@ test('concatenatedProperties should be concatenated', function() {
   deepEqual(get(obj, 'bar'), [1,2,3,4,5,6], 'get bar');
 });
 
-test('adding a prop that is not an array should make array', function() {
+QUnit.test('adding a prop that is not an array should make array', function() {
 
   var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
@@ -75,7 +75,7 @@ test('adding a prop that is not an array should make array', function() {
   deepEqual(get(obj, 'foo'), [1,2,3,4]);
 });
 
-test('adding a prop that is not an array should make array', function() {
+QUnit.test('adding a prop that is not an array should make array', function() {
 
   var MixinA = Mixin.create({
     concatenatedProperties: ['foo'],
@@ -86,7 +86,7 @@ test('adding a prop that is not an array should make array', function() {
   deepEqual(get(obj, 'foo'), ['bar']);
 });
 
-test('adding a non-concatenable property that already has a defined value should result in an array with both values', function() {
+QUnit.test('adding a non-concatenable property that already has a defined value should result in an array with both values', function() {
 
   var mixinA = Mixin.create({
     foo: 1
@@ -101,7 +101,7 @@ test('adding a non-concatenable property that already has a defined value should
   deepEqual(get(obj, 'foo'), [1, 2]);
 });
 
-test('adding a concatenable property that already has a defined value should result in a concatenated value', function() {
+QUnit.test('adding a concatenable property that already has a defined value should result in a concatenated value', function() {
 
   var mixinA = Mixin.create({
     foobar: 'foo'

--- a/packages/ember-metal/tests/mixin/detect_test.js
+++ b/packages/ember-metal/tests/mixin/detect_test.js
@@ -2,7 +2,7 @@ import { Mixin } from "ember-metal/mixin";
 
 QUnit.module('Mixin.detect');
 
-test('detect() finds a directly applied mixin', function() {
+QUnit.test('detect() finds a directly applied mixin', function() {
 
   var MixinA = Mixin.create();
   var obj = {};
@@ -13,7 +13,7 @@ test('detect() finds a directly applied mixin', function() {
   equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
 });
 
-test('detect() finds nested mixins', function() {
+QUnit.test('detect() finds nested mixins', function() {
   var MixinA = Mixin.create({});
   var MixinB = Mixin.create(MixinA);
   var obj = {};
@@ -24,14 +24,14 @@ test('detect() finds nested mixins', function() {
   equal(MixinA.detect(obj), true, 'MixinA.detect(obj) after apply()');
 });
 
-test('detect() finds mixins on other mixins', function() {
+QUnit.test('detect() finds mixins on other mixins', function() {
   var MixinA = Mixin.create({});
   var MixinB = Mixin.create(MixinA);
   equal(MixinA.detect(MixinB), true, 'MixinA is part of MixinB');
   equal(MixinB.detect(MixinA), false, 'MixinB is not part of MixinA');
 });
 
-test('detect handles null values', function() {
+QUnit.test('detect handles null values', function() {
   var MixinA = Mixin.create();
   equal(MixinA.detect(null), false);
 });

--- a/packages/ember-metal/tests/mixin/introspection_test.js
+++ b/packages/ember-metal/tests/mixin/introspection_test.js
@@ -46,7 +46,7 @@ QUnit.module('Basic introspection', {
   }
 });
 
-test('Ember.mixins()', function() {
+QUnit.test('Ember.mixins()', function() {
 
   function mapGuids(ary) {
     return EnumerableUtils.map(ary, function(x) { return guidFor(x); });

--- a/packages/ember-metal/tests/mixin/merged_properties_test.js
+++ b/packages/ember-metal/tests/mixin/merged_properties_test.js
@@ -6,7 +6,7 @@ import {
 
 QUnit.module('Mixin mergedProperties');
 
-test('defining mergedProperties should merge future version', function() {
+QUnit.test('defining mergedProperties should merge future version', function() {
 
   var MixinA = Mixin.create({
     mergedProperties: ['foo'],
@@ -22,7 +22,7 @@ test('defining mergedProperties should merge future version', function() {
     { a: true, b: true, c: true, d: true, e: true, f: true });
 });
 
-test('defining mergedProperties on future mixin should merged into past', function() {
+QUnit.test('defining mergedProperties on future mixin should merged into past', function() {
 
   var MixinA = Mixin.create({
     foo: { a: true, b: true, c: true }
@@ -38,7 +38,7 @@ test('defining mergedProperties on future mixin should merged into past', functi
     { a: true, b: true, c: true, d: true, e: true, f: true });
 });
 
-test('defining mergedProperties with null properties should keep properties null', function() {
+QUnit.test('defining mergedProperties with null properties should keep properties null', function() {
 
   var MixinA = Mixin.create({
     mergedProperties: ['foo'],
@@ -53,7 +53,7 @@ test('defining mergedProperties with null properties should keep properties null
   equal(get(obj, 'foo'), null);
 });
 
-test("mergedProperties' properties can get overwritten", function() {
+QUnit.test("mergedProperties' properties can get overwritten", function() {
 
   var MixinA = Mixin.create({
     mergedProperties: ['foo'],
@@ -68,7 +68,7 @@ test("mergedProperties' properties can get overwritten", function() {
   deepEqual(get(obj, 'foo'), { a: 2 });
 });
 
-test('mergedProperties should be concatenated', function() {
+QUnit.test('mergedProperties should be concatenated', function() {
 
   var MixinA = Mixin.create({
     mergedProperties: ['foo'],
@@ -91,7 +91,7 @@ test('mergedProperties should be concatenated', function() {
   deepEqual(get(obj, 'bar'), { a: true, l: true, e: true, x: true }, "get bar");
 });
 
-test("mergedProperties should exist even if not explicitly set on create", function() {
+QUnit.test("mergedProperties should exist even if not explicitly set on create", function() {
 
   var AnObj = Ember.Object.extend({
     mergedProperties: ['options'],
@@ -113,7 +113,7 @@ test("mergedProperties should exist even if not explicitly set on create", funct
   equal(get(obj, "options").b.c, 'ccc');
 });
 
-test("mergedProperties' overwriting methods can call _super", function() {
+QUnit.test("mergedProperties' overwriting methods can call _super", function() {
 
   expect(4);
 
@@ -149,7 +149,7 @@ test("mergedProperties' overwriting methods can call _super", function() {
   equal(obj.foo.meth("WOOT"), "WAT");
 });
 
-test('Merging an Array should raise an error', function() {
+QUnit.test('Merging an Array should raise an error', function() {
 
   expect(1);
 

--- a/packages/ember-metal/tests/mixin/method_test.js
+++ b/packages/ember-metal/tests/mixin/method_test.js
@@ -6,7 +6,7 @@ import {
 
 QUnit.module('Mixin Methods');
 
-test('defining simple methods', function() {
+QUnit.test('defining simple methods', function() {
 
   var MixinA, obj, props;
 
@@ -24,7 +24,7 @@ test('defining simple methods', function() {
   equal(props._privateMethod(), 'privateMethod', 'privateMethod is func');
 });
 
-test('overriding public methods', function() {
+QUnit.test('overriding public methods', function() {
   var MixinA, MixinB, MixinD, MixinF, obj;
 
   MixinA = Mixin.create({
@@ -62,7 +62,7 @@ test('overriding public methods', function() {
 });
 
 
-test('overriding inherited objects', function() {
+QUnit.test('overriding inherited objects', function() {
 
   var cnt = 0;
   var MixinA = Mixin.create({
@@ -91,7 +91,7 @@ test('overriding inherited objects', function() {
   equal(cnt, 1, 'should not screw w/ parent obj');
 });
 
-test('Including the same mixin more than once will only run once', function() {
+QUnit.test('Including the same mixin more than once will only run once', function() {
   var cnt = 0;
   var MixinA = Mixin.create({
     foo: function() { cnt++; }
@@ -119,7 +119,7 @@ test('Including the same mixin more than once will only run once', function() {
   equal(cnt, 1, 'should invoke MixinA.foo one time');
 });
 
-test('_super from a single mixin with no superclass does not error', function() {
+QUnit.test('_super from a single mixin with no superclass does not error', function() {
   var MixinA = Mixin.create({
     foo: function() {
       this._super.apply(this, arguments);
@@ -133,7 +133,7 @@ test('_super from a single mixin with no superclass does not error', function() 
   ok(true);
 });
 
-test('_super from a first-of-two mixins with no superclass function does not error', function() {
+QUnit.test('_super from a first-of-two mixins with no superclass function does not error', function() {
   // _super was previously calling itself in the second assertion.
   // Use remaining count of calls to ensure it doesn't loop indefinitely.
   var remaining = 3;
@@ -164,7 +164,7 @@ test('_super from a first-of-two mixins with no superclass function does not err
 QUnit.module('Method Conflicts');
 
 
-test('overriding toString', function() {
+QUnit.test('overriding toString', function() {
   var MixinA = Mixin.create({
     toString: function() { return 'FOO'; }
   });
@@ -184,7 +184,7 @@ test('overriding toString', function() {
 
 QUnit.module('system/mixin/method_test BUGS');
 
-test('applying several mixins at once with sup already defined causes infinite loop', function() {
+QUnit.test('applying several mixins at once with sup already defined causes infinite loop', function() {
 
   var cnt = 0;
   var MixinA = Mixin.create({

--- a/packages/ember-metal/tests/mixin/reopen_test.js
+++ b/packages/ember-metal/tests/mixin/reopen_test.js
@@ -5,7 +5,7 @@ import Mixin from 'ember-metal/mixin';
 
 QUnit.module('Ember.Mixin#reopen');
 
-test('using reopen() to add more properties to a simple', function() {
+QUnit.test('using reopen() to add more properties to a simple', function() {
   var MixinA = Mixin.create({ foo: 'FOO', baz: 'BAZ' });
   MixinA.reopen({ bar: 'BAR', foo: 'FOO2' });
   var obj = {};
@@ -16,7 +16,7 @@ test('using reopen() to add more properties to a simple', function() {
   equal(get(obj, 'bar'), 'BAR', 'include MixinB props');
 });
 
-test('using reopen() and calling _super where there is not a super function does not cause infinite recursion', function() {
+QUnit.test('using reopen() and calling _super where there is not a super function does not cause infinite recursion', function() {
   var Taco = EmberObject.extend({
     createBreakfast: function() {
       // There is no original createBreakfast function.

--- a/packages/ember-metal/tests/mixin/required_test.js
+++ b/packages/ember-metal/tests/mixin/required_test.js
@@ -26,29 +26,29 @@ QUnit.module('Module.required', {
   }
 });
 
-test('applying a mixin to meet requirement', function() {
+QUnit.test('applying a mixin to meet requirement', function() {
   FinalMixin.apply(obj);
   PartialMixin.apply(obj);
   equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-test('combined mixins to meet requirement', function() {
+QUnit.test('combined mixins to meet requirement', function() {
   Mixin.create(PartialMixin, FinalMixin).apply(obj);
   equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-test('merged mixin', function() {
+QUnit.test('merged mixin', function() {
   Mixin.create(PartialMixin, { foo: 'FOO' }).apply(obj);
   equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-test('define property on source object', function() {
+QUnit.test('define property on source object', function() {
   obj.foo = 'FOO';
   PartialMixin.apply(obj);
   equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });
 
-test('using apply', function() {
+QUnit.test('using apply', function() {
   mixin(obj, PartialMixin, { foo: 'FOO' });
   equal(get(obj, 'foo'), 'FOO', 'should now be defined');
 });

--- a/packages/ember-metal/tests/mixin/without_test.js
+++ b/packages/ember-metal/tests/mixin/without_test.js
@@ -1,6 +1,6 @@
 import { Mixin } from 'ember-metal/mixin';
 
-test('without should create a new mixin excluding named properties', function() {
+QUnit.test('without should create a new mixin excluding named properties', function() {
 
   var MixinA = Mixin.create({
     foo: 'FOO',

--- a/packages/ember-metal/tests/performance_test.js
+++ b/packages/ember-metal/tests/performance_test.js
@@ -18,7 +18,7 @@ import { addObserver } from "ember-metal/observer";
 
 QUnit.module("Computed Properties - Number of times evaluated");
 
-test("computed properties that depend on multiple properties should run only once per run loop", function() {
+QUnit.test("computed properties that depend on multiple properties should run only once per run loop", function() {
   var obj = { a: 'a', b: 'b', c: 'c' };
   var cpCount = 0;
   var obsCount = 0;
@@ -48,7 +48,7 @@ test("computed properties that depend on multiple properties should run only onc
   equal(obsCount, 1, "The observer is only invoked once");
 });
 
-test("computed properties are not executed if they are the last segment of an observer chain pain", function() {
+QUnit.test("computed properties are not executed if they are the last segment of an observer chain pain", function() {
   var foo = { bar: { baz: { } } };
 
   var count = 0;

--- a/packages/ember-metal/tests/platform/create_test.js
+++ b/packages/ember-metal/tests/platform/create_test.js
@@ -2,7 +2,7 @@ import create from 'ember-metal/platform/create';
 
 QUnit.module("Ember.create()");
 
-test("should inherit the properties from the parent object", function() {
+QUnit.test("should inherit the properties from the parent object", function() {
   var obj = { foo: 'FOO' };
   var obj2 = create(obj);
   ok(obj !== obj2, 'should be a new instance');
@@ -14,7 +14,7 @@ test("should inherit the properties from the parent object", function() {
 });
 
 // NOTE: jshint may interfere with this test since it defines its own Object.create if missing
-test("passing additional property descriptors should define", function() {
+QUnit.test("passing additional property descriptors should define", function() {
   var obj = { foo: 'FOO', repl: 'obj' };
   var obj2 = create(obj, {
     bar: {
@@ -30,7 +30,7 @@ test("passing additional property descriptors should define", function() {
   equal(obj2.repl, 'obj2', 'should have replaced parent');
 });
 
-test("passing additional property descriptors should not pollute parent object", function() {
+QUnit.test("passing additional property descriptors should not pollute parent object", function() {
   var obj = { foo: 'FOO', repl: 'obj' };
   var obj2 = create(obj, {
     repl: {

--- a/packages/ember-metal/tests/platform/define_property_test.js
+++ b/packages/ember-metal/tests/platform/define_property_test.js
@@ -104,7 +104,7 @@ if (hasPropertyAccessors) {
 
   test('defining getter/setter along with writable', function() {
     var obj  ={};
-    raises(function() {
+    throws(function() {
       defineProperty(obj, 'foo', {
         enumerable: true,
         get: function() {},
@@ -116,7 +116,7 @@ if (hasPropertyAccessors) {
 
   test('defining getter/setter along with value', function() {
     var obj  ={};
-    raises(function() {
+    throws(function() {
       defineProperty(obj, 'foo', {
         enumerable: true,
         get: function() {},

--- a/packages/ember-metal/tests/platform/define_property_test.js
+++ b/packages/ember-metal/tests/platform/define_property_test.js
@@ -17,7 +17,7 @@ function isEnumerable(obj, keyName) {
 
 QUnit.module("defineProperty()");
 
-test("defining a simple property", function() {
+QUnit.test("defining a simple property", function() {
   var obj = {};
   defineProperty(obj, 'foo', {
     enumerable:   true,
@@ -32,7 +32,7 @@ test("defining a simple property", function() {
   equal(isEnumerable(obj, 'foo'), true, 'foo should be enumerable');
 });
 
-test('defining a read only property', function() {
+QUnit.test('defining a read only property', function() {
   var obj = {};
   defineProperty(obj, 'foo', {
     enumerable:   true,
@@ -57,7 +57,7 @@ test('defining a read only property', function() {
   }
 });
 
-test('defining a non enumerable property', function() {
+QUnit.test('defining a non enumerable property', function() {
   var obj = {};
   defineProperty(obj, 'foo', {
     enumerable:   false,
@@ -75,7 +75,7 @@ test('defining a non enumerable property', function() {
 // If accessors don't exist, behavior that relies on getters
 // and setters don't do anything
 if (hasPropertyAccessors) {
-  test('defining a getter/setter', function() {
+  QUnit.test('defining a getter/setter', function() {
     var obj = {};
     var getCnt = 0;
     var setCnt = 0;
@@ -102,7 +102,7 @@ if (hasPropertyAccessors) {
     equal(setCnt, 1, 'should have invoked setter');
   });
 
-  test('defining getter/setter along with writable', function() {
+  QUnit.test('defining getter/setter along with writable', function() {
     var obj  ={};
     throws(function() {
       defineProperty(obj, 'foo', {
@@ -114,7 +114,7 @@ if (hasPropertyAccessors) {
     }, Error, 'defining writable and get/set should throw exception');
   });
 
-  test('defining getter/setter along with value', function() {
+  QUnit.test('defining getter/setter along with value', function() {
     var obj  ={};
     throws(function() {
       defineProperty(obj, 'foo', {

--- a/packages/ember-metal/tests/properties_test.js
+++ b/packages/ember-metal/tests/properties_test.js
@@ -5,14 +5,14 @@ import { deprecateProperty } from "ember-metal/deprecate_property";
 
 QUnit.module('Ember.defineProperty');
 
-test('toString', function() {
+QUnit.test('toString', function() {
 
   var obj = {};
   defineProperty(obj, 'toString', undefined, function() { return 'FOO'; });
   equal(obj.toString(), 'FOO', 'should replace toString');
 });
 
-test("for data properties, didDefineProperty hook should be called if implemented", function() {
+QUnit.test("for data properties, didDefineProperty hook should be called if implemented", function() {
   expect(2);
 
   var obj = {
@@ -25,7 +25,7 @@ test("for data properties, didDefineProperty hook should be called if implemente
   defineProperty(obj, 'foo', undefined, "bar");
 });
 
-test("for descriptor properties, didDefineProperty hook should be called if implemented", function() {
+QUnit.test("for descriptor properties, didDefineProperty hook should be called if implemented", function() {
   expect(2);
 
   var computedProperty = computed(function() { return this; });
@@ -44,7 +44,7 @@ if (hasPropertyAccessors) {
 
   QUnit.module('Ember.deprecateProperty');
 
-  test("enables access to deprecated property and returns the value of the new property", function() {
+  QUnit.test("enables access to deprecated property and returns the value of the new property", function() {
     expect(3);
     var obj = { foo: 'bar' };
 
@@ -57,7 +57,7 @@ if (hasPropertyAccessors) {
     equal(obj.baz, obj.foo, 'baz and foo are equal');
   });
 
-  test("deprecatedKey is not enumerable", function() {
+  QUnit.test("deprecatedKey is not enumerable", function() {
     expect(2);
     var obj = { foo: 'bar', blammo: 'whammy' };
 
@@ -70,7 +70,7 @@ if (hasPropertyAccessors) {
     }
   });
 
-  test("enables setter to deprecated property and updates the value of the new property", function() {
+  QUnit.test("enables setter to deprecated property and updates the value of the new property", function() {
     expect(3);
     var obj = { foo: 'bar' };
 

--- a/packages/ember-metal/tests/props_helper.js
+++ b/packages/ember-metal/tests/props_helper.js
@@ -10,11 +10,11 @@ var testBoth = function(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  test(testname+' using getFromEmberMetal()/Ember.set()', function() {
+  QUnit.test(testname+' using getFromEmberMetal()/Ember.set()', function() {
     callback(emberget, emberset);
   });
 
-  test(testname+' using accessors', function() {
+  QUnit.test(testname+' using accessors', function() {
     if (Ember.USES_ACCESSORS) {
       callback(aget, aset);
     } else {
@@ -31,23 +31,23 @@ var testWithDefault = function(testname, callback) {
   function aget(x, y) { return x[y]; }
   function aset(x, y, z) { return (x[y] = z); }
 
-  test(testname+' using obj.get()', function() {
+  QUnit.test(testname+' using obj.get()', function() {
     callback(emberget, emberset);
   });
 
-  test(testname+' using obj.getWithDefault()', function() {
+  QUnit.test(testname+' using obj.getWithDefault()', function() {
     callback(getwithdefault, emberset);
   });
 
-  test(testname+' using getFromEmberMetal()', function() {
+  QUnit.test(testname+' using getFromEmberMetal()', function() {
     callback(emberget, emberset);
   });
 
-  test(testname+' using Ember.getWithDefault()', function() {
+  QUnit.test(testname+' using Ember.getWithDefault()', function() {
     callback(embergetwithdefault, emberset);
   });
 
-  test(testname+' using accessors', function() {
+  QUnit.test(testname+' using accessors', function() {
     if (Ember.USES_ACCESSORS) {
       callback(aget, aset);
     } else {

--- a/packages/ember-metal/tests/run_loop/add_queue_test.js
+++ b/packages/ember-metal/tests/run_loop/add_queue_test.js
@@ -13,13 +13,13 @@ QUnit.module('system/run_loop/add_queue_test', {
   }
 });
 
-test('adds a queue after a specified one', function() {
+QUnit.test('adds a queue after a specified one', function() {
   run._addQueue('testeroo', 'blork');
 
   equal(indexOf.call(queues, 'testeroo'), 1, "new queue was added after specified queue");
 });
 
-test('does not add the queue if it already exists', function() {
+QUnit.test('does not add the queue if it already exists', function() {
   run._addQueue('testeroo', 'blork');
   run._addQueue('testeroo', 'blork');
 

--- a/packages/ember-metal/tests/run_loop/debounce_test.js
+++ b/packages/ember-metal/tests/run_loop/debounce_test.js
@@ -11,7 +11,7 @@ QUnit.module('Ember.run.debounce', {
   }
 });
 
-test('Ember.run.debounce uses Backburner.debounce', function() {
+QUnit.test('Ember.run.debounce uses Backburner.debounce', function() {
   run.debounce(function() {});
   ok(wasCalled, 'Ember.run.debounce used');
 });

--- a/packages/ember-metal/tests/run_loop/once_test.js
+++ b/packages/ember-metal/tests/run_loop/once_test.js
@@ -2,7 +2,7 @@ import run from 'ember-metal/run_loop';
 
 QUnit.module('system/run_loop/once_test');
 
-test('calling invokeOnce more than once invokes only once', function() {
+QUnit.test('calling invokeOnce more than once invokes only once', function() {
 
   var count = 0;
   run(function() {
@@ -15,7 +15,7 @@ test('calling invokeOnce more than once invokes only once', function() {
   equal(count, 1, 'should have invoked once');
 });
 
-test('should differentiate based on target', function() {
+QUnit.test('should differentiate based on target', function() {
 
   var A = { count: 0 };
   var B = { count: 0 };
@@ -32,7 +32,7 @@ test('should differentiate based on target', function() {
 });
 
 
-test('should ignore other arguments - replacing previous ones', function() {
+QUnit.test('should ignore other arguments - replacing previous ones', function() {
 
   var A = { count: 0 };
   var B = { count: 0 };
@@ -48,7 +48,7 @@ test('should ignore other arguments - replacing previous ones', function() {
   equal(B.count, 40, 'should have invoked once on B');
 });
 
-test('should be inside of a runloop when running', function() {
+QUnit.test('should be inside of a runloop when running', function() {
 
   run(function() {
     run.once(function() {

--- a/packages/ember-metal/tests/run_loop/onerror_test.js
+++ b/packages/ember-metal/tests/run_loop/onerror_test.js
@@ -3,7 +3,7 @@ import run from 'ember-metal/run_loop';
 
 QUnit.module('system/run_loop/onerror_test');
 
-test('With Ember.onerror undefined, errors in Ember.run are thrown', function () {
+QUnit.test('With Ember.onerror undefined, errors in Ember.run are thrown', function () {
   var thrown = new Error('Boom!');
   var caught;
 
@@ -16,7 +16,7 @@ test('With Ember.onerror undefined, errors in Ember.run are thrown', function ()
   deepEqual(caught, thrown);
 });
 
-test('With Ember.onerror set, errors in Ember.run are caught', function () {
+QUnit.test('With Ember.onerror set, errors in Ember.run are caught', function () {
   var thrown = new Error('Boom!');
   var caught;
 

--- a/packages/ember-metal/tests/run_loop/run_bind_test.js
+++ b/packages/ember-metal/tests/run_loop/run_bind_test.js
@@ -2,7 +2,7 @@ import run from 'ember-metal/run_loop';
 
 QUnit.module('system/run_loop/run_bind_test');
 
-test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
+QUnit.test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
   expect(3);
 
   var obj = {
@@ -18,7 +18,7 @@ test('Ember.run.bind builds a run-loop wrapped callback handler', function() {
   equal(obj.value, 1);
 });
 
-test('Ember.run.bind keeps the async callback arguments', function() {
+QUnit.test('Ember.run.bind keeps the async callback arguments', function() {
   expect(4);
 
   var asyncCallback = function(increment, increment2, increment3) {

--- a/packages/ember-metal/tests/run_loop/run_test.js
+++ b/packages/ember-metal/tests/run_loop/run_test.js
@@ -2,7 +2,7 @@ import run from 'ember-metal/run_loop';
 
 QUnit.module('system/run_loop/run_test');
 
-test('Ember.run invokes passed function, returning value', function() {
+QUnit.test('Ember.run invokes passed function, returning value', function() {
   var obj = {
     foo: function() { return [this.bar, 'FOO']; },
     bar: 'BAR',

--- a/packages/ember-metal/tests/run_loop/schedule_test.js
+++ b/packages/ember-metal/tests/run_loop/schedule_test.js
@@ -2,7 +2,7 @@ import run from 'ember-metal/run_loop';
 
 QUnit.module('system/run_loop/schedule_test');
 
-test('scheduling item in queue should defer until finished', function() {
+QUnit.test('scheduling item in queue should defer until finished', function() {
   var cnt = 0;
 
   run(function() {
@@ -15,7 +15,7 @@ test('scheduling item in queue should defer until finished', function() {
 
 });
 
-test('nested runs should queue each phase independently', function() {
+QUnit.test('nested runs should queue each phase independently', function() {
   var cnt = 0;
 
   run(function() {
@@ -33,7 +33,7 @@ test('nested runs should queue each phase independently', function() {
 
 });
 
-test('prior queues should be flushed before moving on to next queue', function() {
+QUnit.test('prior queues should be flushed before moving on to next queue', function() {
   var order = [];
 
   run(function() {
@@ -67,7 +67,7 @@ test('prior queues should be flushed before moving on to next queue', function()
   deepEqual(order, ['sync', 'actions', 'sync', 'actions', 'destroy']);
 });
 
-test('makes sure it does not trigger an autorun during testing', function() {
+QUnit.test('makes sure it does not trigger an autorun during testing', function() {
   expectAssertion(function() {
     run.schedule('actions', function() {});
   }, /wrap any code with asynchronous side-effects in a run/);

--- a/packages/ember-metal/tests/run_loop/sync_test.js
+++ b/packages/ember-metal/tests/run_loop/sync_test.js
@@ -2,7 +2,7 @@ import run from 'ember-metal/run_loop';
 
 QUnit.module('system/run_loop/sync_test');
 
-test('sync() will immediately flush the sync queue only', function() {
+QUnit.test('sync() will immediately flush the sync queue only', function() {
   var cnt = 0;
 
   run(function() {
@@ -28,7 +28,7 @@ test('sync() will immediately flush the sync queue only', function() {
 
 });
 
-test('calling sync() outside a run loop does not cause an error', function() {
+QUnit.test('calling sync() outside a run loop does not cause an error', function() {
   expect(0);
 
   run.sync();

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -3,7 +3,7 @@ import EmberError from 'ember-metal/error';
 
 QUnit.module('system/run_loop/unwind_test');
 
-test('RunLoop unwinds despite unhandled exception', function() {
+QUnit.test('RunLoop unwinds despite unhandled exception', function() {
   var initialRunLoop = run.currentRunLoop;
 
   throws(function() {
@@ -23,7 +23,7 @@ test('RunLoop unwinds despite unhandled exception', function() {
 
 });
 
-test('run unwinds despite unhandled exception', function() {
+QUnit.test('run unwinds despite unhandled exception', function() {
   var initialRunLoop = run.currentRunLoop;
 
   throws(function() {

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -6,7 +6,7 @@ QUnit.module('system/run_loop/unwind_test');
 test('RunLoop unwinds despite unhandled exception', function() {
   var initialRunLoop = run.currentRunLoop;
 
-  raises(function() {
+  throws(function() {
     run(function() {
       run.schedule('actions', function() { throw new EmberError("boom!"); });
     });
@@ -26,7 +26,7 @@ test('RunLoop unwinds despite unhandled exception', function() {
 test('run unwinds despite unhandled exception', function() {
   var initialRunLoop = run.currentRunLoop;
 
-  raises(function() {
+  throws(function() {
     run(function() {
       throw new EmberError("boom!");
     });

--- a/packages/ember-metal/tests/set_properties_test.js
+++ b/packages/ember-metal/tests/set_properties_test.js
@@ -2,7 +2,7 @@ import setProperties from 'ember-metal/set_properties';
 
 QUnit.module('Ember.setProperties');
 
-test("supports setting multiple attributes at once", function() {
+QUnit.test("supports setting multiple attributes at once", function() {
   deepEqual(setProperties(null, null),    null, 'noop for null properties and null object');
   deepEqual(setProperties(undefined, undefined),    undefined, 'noop for undefined properties and undefined object');
 

--- a/packages/ember-metal/tests/streams/simple_stream_test.js
+++ b/packages/ember-metal/tests/streams/simple_stream_test.js
@@ -22,7 +22,7 @@ QUnit.module('Simple Stream', {
   }
 });
 
-test('supports a stream argument', function() {
+QUnit.test('supports a stream argument', function() {
   var stream = new SimpleStream(source);
   equal(stream.value(), "zlurp");
 
@@ -30,7 +30,7 @@ test('supports a stream argument', function() {
   equal(stream.value(), "blorg");
 });
 
-test('supports a non-stream argument', function() {
+QUnit.test('supports a non-stream argument', function() {
   var stream = new SimpleStream(value);
   equal(stream.value(), "zlurp");
 

--- a/packages/ember-metal/tests/streams/stream_binding_test.js
+++ b/packages/ember-metal/tests/streams/stream_binding_test.js
@@ -26,7 +26,7 @@ QUnit.module('Stream Binding', {
   }
 });
 
-test('basic', function() {
+QUnit.test('basic', function() {
   var binding = new StreamBinding(source);
 
   equal(binding.value(), "zlurp");
@@ -40,7 +40,7 @@ test('basic', function() {
   binding.destroy(); // destroy should not fail
 });
 
-test('the source stream can send values to a single subscriber', function() {
+QUnit.test('the source stream can send values to a single subscriber', function() {
   var binding = new StreamBinding(source);
   var obj = mixin({}, { toBinding: binding });
 
@@ -54,7 +54,7 @@ test('the source stream can send values to a single subscriber', function() {
   equal(get(obj, 'to'), "blorg", "value has synced after run loop");
 });
 
-test('the source stream can send values to multiple subscribers', function() {
+QUnit.test('the source stream can send values to multiple subscribers', function() {
   var binding = new StreamBinding(source);
   var obj1 = mixin({}, { toBinding: binding });
   var obj2 = mixin({}, { toBinding: binding });
@@ -72,7 +72,7 @@ test('the source stream can send values to multiple subscribers', function() {
   equal(get(obj2, 'to'), "blorg", "value has synced after run loop");
 });
 
-test('a subscriber can set the value on the source stream and notify the other subscribers', function() {
+QUnit.test('a subscriber can set the value on the source stream and notify the other subscribers', function() {
   var binding = new StreamBinding(source);
   var obj1 = mixin({}, { toBinding: binding });
   var obj2 = mixin({}, { toBinding: binding });
@@ -87,7 +87,7 @@ test('a subscriber can set the value on the source stream and notify the other s
   equal(source.value(), "blorg", "value has synced after run loop");
 });
 
-test('if source and subscribers sync value, source wins', function() {
+QUnit.test('if source and subscribers sync value, source wins', function() {
   var binding = new StreamBinding(source);
   var obj1 = mixin({}, { toBinding: binding });
   var obj2 = mixin({}, { toBinding: binding });
@@ -106,7 +106,7 @@ test('if source and subscribers sync value, source wins', function() {
   equal(get(obj3, 'to'), "hoopla", "value has synced after run loop");
 });
 
-test('the last value sent by the source wins', function() {
+QUnit.test('the last value sent by the source wins', function() {
   var binding = new StreamBinding(source);
   var obj = mixin({}, { toBinding: binding });
 
@@ -120,7 +120,7 @@ test('the last value sent by the source wins', function() {
   equal(get(obj, 'to'), "hoopla", "value has synced after run loop");
 });
 
-test('continues to notify subscribers after first consumption, even if not consumed', function() {
+QUnit.test('continues to notify subscribers after first consumption, even if not consumed', function() {
   var counter = 0;
   var binding = new StreamBinding(source);
 

--- a/packages/ember-metal/tests/utils/can_invoke_test.js
+++ b/packages/ember-metal/tests/utils/can_invoke_test.js
@@ -15,18 +15,18 @@ QUnit.module("Ember.canInvoke", {
   }
 });
 
-test("should return false if the object doesn't exist", function() {
+QUnit.test("should return false if the object doesn't exist", function() {
   equal(canInvoke(undefined, 'aMethodThatDoesNotExist'), false);
 });
 
-test("should return true if the method exists on the object", function() {
+QUnit.test("should return true if the method exists on the object", function() {
   equal(canInvoke(obj, 'aMethodThatExists'), true);
 });
 
-test("should return false if the method doesn't exist on the object", function() {
+QUnit.test("should return false if the method doesn't exist on the object", function() {
   equal(canInvoke(obj, 'aMethodThatDoesNotExist'), false);
 });
 
-test("should return false if the property exists on the object but is a non-function", function() {
+QUnit.test("should return false if the property exists on the object but is a non-function", function() {
   equal(canInvoke(obj, 'foobar'), false);
 });

--- a/packages/ember-metal/tests/utils/generate_guid_test.js
+++ b/packages/ember-metal/tests/utils/generate_guid_test.js
@@ -2,7 +2,7 @@ import { generateGuid } from "ember-metal/utils";
 
 QUnit.module("Ember.generateGuid");
 
-test("Prefix", function() {
+QUnit.test("Prefix", function() {
   var a = {};
 
   ok(generateGuid(a, 'tyrell').indexOf('tyrell') > -1, "guid can be prefixed");

--- a/packages/ember-metal/tests/utils/guid_for_test.js
+++ b/packages/ember-metal/tests/utils/guid_for_test.js
@@ -17,7 +17,7 @@ var nanGuid = function(obj) {
   ok(isNaN(parseInt(guidFor(obj), 0)), "guids for " + type + "don't parse to numbers");
 };
 
-test("Object", function() {
+QUnit.test("Object", function() {
   var a = {};
   var b = {};
 
@@ -26,7 +26,7 @@ test("Object", function() {
   nanGuid(a);
 });
 
-test("strings", function() {
+QUnit.test("strings", function() {
   var a = "string A";
   var aprime = "string A";
   var b = "String B";
@@ -37,7 +37,7 @@ test("strings", function() {
   nanGuid(a);
 });
 
-test("numbers", function() {
+QUnit.test("numbers", function() {
   var a = 23;
   var aprime = 23;
   var b = 34;
@@ -48,7 +48,7 @@ test("numbers", function() {
   nanGuid(a);
 });
 
-test("numbers", function() {
+QUnit.test("numbers", function() {
   var a = true;
   var aprime = true;
   var b = false;
@@ -60,7 +60,7 @@ test("numbers", function() {
   nanGuid(b);
 });
 
-test("null and undefined", function() {
+QUnit.test("null and undefined", function() {
   var a = null;
   var aprime = null;
   var b;
@@ -73,7 +73,7 @@ test("null and undefined", function() {
   nanGuid(b);
 });
 
-test("arrays", function() {
+QUnit.test("arrays", function() {
   var a = ["a", "b", "c"];
   var aprime = ["a", "b", "c"];
   var b = ["1", "2", "3"];

--- a/packages/ember-metal/tests/utils/is_array_test.js
+++ b/packages/ember-metal/tests/utils/is_array_test.js
@@ -3,7 +3,7 @@ QUnit.module("Ember Type Checking");
 
 var global = this;
 
-test("Ember.isArray", function() {
+QUnit.test("Ember.isArray", function() {
   var numarray      = [1,2,3];
   var number        = 23;
   var strarray      = ["Hello", "Hi"];

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -13,7 +13,7 @@ import {
 
 QUnit.module("Ember.meta");
 
-test("should return the same hash for an object", function() {
+QUnit.test("should return the same hash for an object", function() {
   var obj = {};
 
   meta(obj).foo = "bar";
@@ -23,7 +23,7 @@ test("should return the same hash for an object", function() {
 
 QUnit.module("Ember.metaPath");
 
-test("should not create nested objects if writable is false", function() {
+QUnit.test("should not create nested objects if writable is false", function() {
   var obj = {};
 
   ok(!meta(obj).foo, "precond - foo property on meta does not yet exist");
@@ -33,7 +33,7 @@ test("should not create nested objects if writable is false", function() {
   equal(meta(obj).foo, undefined, "foo property is not created");
 });
 
-test("should create nested objects if writable is true", function() {
+QUnit.test("should create nested objects if writable is true", function() {
   var obj = {};
 
   ok(!meta(obj).foo, "precond - foo property on meta does not yet exist");
@@ -44,7 +44,7 @@ test("should create nested objects if writable is true", function() {
   ok(meta(obj).foo.bar.baz['bat'] = true, "can set a property on the newly created hash");
 });
 
-test("getMeta and setMeta", function() {
+QUnit.test("getMeta and setMeta", function() {
   var obj = {};
 
   ok(!getMeta(obj, 'foo'), "precond - foo property on meta does not yet exist");
@@ -55,7 +55,7 @@ test("getMeta and setMeta", function() {
 QUnit.module("Ember.meta enumerable");
 
 if (canDefineNonEnumerableProperties) {
-  test("meta is not enumerable", function () {
+  QUnit.test("meta is not enumerable", function () {
     var proto, obj, props, prop;
     proto = { foo: 'bar' };
     meta(proto);
@@ -79,7 +79,7 @@ if (canDefineNonEnumerableProperties) {
   // Tests fix for https://github.com/emberjs/ember.js/issues/344
   // This is primarily for older browsers such as IE8
   if (Ember.imports.jQuery) {
-    test("meta is not jQuery.isPlainObject", function () {
+    QUnit.test("meta is not jQuery.isPlainObject", function () {
       var proto, obj;
       proto = { foo: 'bar' };
       equal(jQuery.isPlainObject(meta(proto)), false, 'meta should not be isPlainObject when meta property cannot be marked as enumerable: false');

--- a/packages/ember-metal/tests/utils/try_catch_finally_test.js
+++ b/packages/ember-metal/tests/utils/try_catch_finally_test.js
@@ -45,7 +45,7 @@ function callTryCatchFinallyWithError() {
   equal(errorWasThrown, true,  'error was thrown');
 }
 
-test("no failure", function() {
+QUnit.test("no failure", function() {
   equal(tryCatchFinally(tryable, catchable, finalizer), tryableResult, 'correct return value');
 
   equal(tryCount,      1, 'tryable was called once');
@@ -53,7 +53,7 @@ test("no failure", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("no failure, return from finally", function() {
+QUnit.test("no failure, return from finally", function() {
   finalizerResult = 'finalizer return value';
 
   equal(tryCatchFinally(tryable, catchable, finalizer), finalizerResult, 'correct return value');
@@ -63,7 +63,7 @@ test("no failure, return from finally", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("try failed", function() {
+QUnit.test("try failed", function() {
   tryable = function() {
     tryCount++;
     throw error;
@@ -78,7 +78,7 @@ test("try failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("catch failed", function() {
+QUnit.test("catch failed", function() {
   catchable = function() {
     catchCount++;
     throw error;
@@ -91,7 +91,7 @@ test("catch failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("try and catch failed", function() {
+QUnit.test("try and catch failed", function() {
   tryable = function() {
     tryCount++;
     throw error;
@@ -108,7 +108,7 @@ test("try and catch failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("finally failed", function() {
+QUnit.test("finally failed", function() {
   finalizer = function() {
     finalizeCount++;
     throw error;
@@ -121,7 +121,7 @@ test("finally failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("finally and try failed", function() {
+QUnit.test("finally and try failed", function() {
   tryable   = function() {
     tryCount++;
     throw error;
@@ -138,7 +138,7 @@ test("finally and try failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("finally, catch and try failed", function() {
+QUnit.test("finally, catch and try failed", function() {
   tryable   = function() {
     tryCount++;
     throw error;

--- a/packages/ember-metal/tests/utils/try_finally_test.js
+++ b/packages/ember-metal/tests/utils/try_finally_test.js
@@ -37,14 +37,14 @@ function callTryFinallyWithError() {
   equal(errorWasThrown, true,  'error was thrown');
 }
 
-test("no failure", function() {
+QUnit.test("no failure", function() {
   equal(tryFinally(tryable, finalizer), tryableResult, 'correct return value');
 
   equal(tryCount,      1, 'tryable was called once');
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("no failure, return from finally", function() {
+QUnit.test("no failure, return from finally", function() {
   finalizerResult = 'finalizer return value';
 
   equal(tryFinally(tryable, finalizer), finalizerResult, 'crrect return value');
@@ -53,7 +53,7 @@ test("no failure, return from finally", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("try failed", function() {
+QUnit.test("try failed", function() {
   tryable = function() {
     tryCount++;
     throw error;
@@ -65,7 +65,7 @@ test("try failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("finally failed", function() {
+QUnit.test("finally failed", function() {
   finalizer = function() {
     finalizeCount++;
     throw error;
@@ -77,7 +77,7 @@ test("finally failed", function() {
   equal(finalizeCount, 1, 'finalize was called once');
 });
 
-test("finally and try failed", function() {
+QUnit.test("finally and try failed", function() {
   tryable   = function() {
     tryCount++;
     throw error;

--- a/packages/ember-metal/tests/utils/try_invoke_test.js
+++ b/packages/ember-metal/tests/utils/try_invoke_test.js
@@ -15,18 +15,18 @@ QUnit.module("Ember.tryInvoke", {
   }
 });
 
-test("should return undefined when the object doesn't exist", function() {
+QUnit.test("should return undefined when the object doesn't exist", function() {
   equal(tryInvoke(undefined, 'aMethodThatDoesNotExist'), undefined);
 });
 
-test("should return undefined when asked to perform a method that doesn't exist on the object", function() {
+QUnit.test("should return undefined when asked to perform a method that doesn't exist on the object", function() {
   equal(tryInvoke(obj, 'aMethodThatDoesNotExist'), undefined);
 });
 
-test("should return what the method returns when asked to perform a method that exists on the object", function() {
+QUnit.test("should return what the method returns when asked to perform a method that exists on the object", function() {
   equal(tryInvoke(obj, 'aMethodThatExists'), true);
 });
 
-test("should return what the method returns when asked to perform a method that takes arguments and exists on the object", function() {
+QUnit.test("should return what the method returns when asked to perform a method that takes arguments and exists on the object", function() {
   equal(tryInvoke(obj, 'aMethodThatTakesArguments', [true, true]), true);
 });

--- a/packages/ember-metal/tests/utils/type_of_test.js
+++ b/packages/ember-metal/tests/utils/type_of_test.js
@@ -2,7 +2,7 @@ import { typeOf } from 'ember-metal/utils';
 
 QUnit.module("Ember Type Checking");
 
-test("Ember.typeOf", function() {
+QUnit.test("Ember.typeOf", function() {
   var MockedDate = function() { };
   MockedDate.prototype = new Date();
 

--- a/packages/ember-metal/tests/watching/is_watching_test.js
+++ b/packages/ember-metal/tests/watching/is_watching_test.js
@@ -25,7 +25,7 @@ function testObserver(setup, teardown, key) {
   equal(isWatching(obj, key), false, "isWatching is false after observers are removed");
 }
 
-test("isWatching is true for regular local observers", function() {
+QUnit.test("isWatching is true for regular local observers", function() {
   testObserver(function(obj, key, fn) {
     Mixin.create({
       didChange: observer(key, fn)
@@ -35,7 +35,7 @@ test("isWatching is true for regular local observers", function() {
   });
 });
 
-test("isWatching is true for nonlocal observers", function() {
+QUnit.test("isWatching is true for nonlocal observers", function() {
   testObserver(function(obj, key, fn) {
     addObserver(obj, key, obj, fn);
   }, function(obj, key, fn) {
@@ -43,7 +43,7 @@ test("isWatching is true for nonlocal observers", function() {
   });
 });
 
-test("isWatching is true for chained observers", function() {
+QUnit.test("isWatching is true for chained observers", function() {
   testObserver(function(obj, key, fn) {
     addObserver(obj, key + '.bar', obj, fn);
   }, function(obj, key, fn) {
@@ -51,7 +51,7 @@ test("isWatching is true for chained observers", function() {
   });
 });
 
-test("isWatching is true for computed properties", function() {
+QUnit.test("isWatching is true for computed properties", function() {
   testObserver(function(obj, key, fn) {
     defineProperty(obj, 'computed', computed(fn).property(key));
     get(obj, 'computed');
@@ -60,7 +60,7 @@ test("isWatching is true for computed properties", function() {
   });
 });
 
-test("isWatching is true for chained computed properties", function() {
+QUnit.test("isWatching is true for chained computed properties", function() {
   testObserver(function(obj, key, fn) {
     defineProperty(obj, 'computed', computed(fn).property(key + '.bar'));
     get(obj, 'computed');
@@ -71,7 +71,7 @@ test("isWatching is true for chained computed properties", function() {
 
 // can't watch length on Array - it is special...
 // But you should be able to watch a length property of an object
-test("isWatching is true for 'length' property on object", function() {
+QUnit.test("isWatching is true for 'length' property on object", function() {
   testObserver(function(obj, key, fn) {
     defineProperty(obj, 'length', null, '26.2 miles');
     addObserver(obj, 'length', obj, fn);

--- a/packages/ember-metal/tests/watching/unwatch_test.js
+++ b/packages/ember-metal/tests/watching/unwatch_test.js
@@ -67,7 +67,7 @@ testBoth('unwatching a regular property - regular get/set', function(get, set) {
   equal(didCount, 0, 'should NOT have invoked didCount');
 });
 
-test('unwatching should be nested', function() {
+QUnit.test('unwatching should be nested', function() {
 
   var obj = { foo: 'BIFF' };
   addListeners(obj, 'foo');

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -101,7 +101,7 @@ testBoth('watches should inherit', function(get, set) {
   equal(didCount, 2, 'should have invoked didCount once only');
 });
 
-test("watching an object THEN defining it should work also", function() {
+QUnit.test("watching an object THEN defining it should work also", function() {
   var obj = {};
   addListeners(obj, 'foo');
 
@@ -116,7 +116,7 @@ test("watching an object THEN defining it should work also", function() {
 
 });
 
-test("watching a chain then defining the property", function () {
+QUnit.test("watching a chain then defining the property", function () {
   var obj = {};
   var foo = { bar: 'bar' };
   addListeners(obj, 'foo.bar');
@@ -133,7 +133,7 @@ test("watching a chain then defining the property", function () {
   equal(didCount, 2, 'should have invoked didChange twice');
 });
 
-test("watching a chain then defining the nested property", function () {
+QUnit.test("watching a chain then defining the nested property", function () {
   var bar = {};
   var obj = { foo: bar };
   var baz = { baz: 'baz' };
@@ -193,7 +193,7 @@ testBoth('watching a global object that does not yet exist should queue', functi
   lookup['Global'] = Global = null; // reset
 });
 
-test('when watching a global object, destroy should remove chain watchers from the global object', function() {
+QUnit.test('when watching a global object, destroy should remove chain watchers from the global object', function() {
   lookup['Global'] = Global = { foo: 'bar' };
   var obj = {};
   addListeners(obj, 'Global.foo');
@@ -216,7 +216,7 @@ test('when watching a global object, destroy should remove chain watchers from t
   lookup['Global'] = Global = null; // reset
 });
 
-test('when watching another object, destroy should remove chain watchers from the other object', function() {
+QUnit.test('when watching another object, destroy should remove chain watchers from the other object', function() {
   var objA = {};
   var objB = { foo: 'bar' };
   objA.b = objB;

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -52,7 +52,7 @@ QUnit.module("ember-routing-htmlbars: action helper", {
   }
 });
 
-test("should output a data attribute with a guid", function() {
+QUnit.test("should output a data attribute with a guid", function() {
   view = EmberView.create({
     template: compile('<a href="#" {{action "edit"}}>edit</a>')
   });
@@ -62,7 +62,7 @@ test("should output a data attribute with a guid", function() {
   ok(view.$('a').attr('data-ember-action').match(/\d+/), "A data-ember-action attribute with a guid was added");
 });
 
-test("should by default register a click event", function() {
+QUnit.test("should by default register a click event", function() {
   var registeredEventName;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -78,7 +78,7 @@ test("should by default register a click event", function() {
   equal(registeredEventName, 'click', "The click event was properly registered");
 });
 
-test("should allow alternative events to be handled", function() {
+QUnit.test("should allow alternative events to be handled", function() {
   var registeredEventName;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -94,7 +94,7 @@ test("should allow alternative events to be handled", function() {
   equal(registeredEventName, 'mouseUp', "The alternative mouseUp event was properly registered");
 });
 
-test("should by default target the view's controller", function() {
+QUnit.test("should by default target the view's controller", function() {
   var registeredTarget;
   var controller = {};
 
@@ -112,7 +112,7 @@ test("should by default target the view's controller", function() {
   equal(registeredTarget, controller, "The controller was registered as the target");
 });
 
-test("Inside a yield, the target points at the original target", function() {
+QUnit.test("Inside a yield, the target points at the original target", function() {
   var watted = false;
 
   var component = EmberComponent.extend({
@@ -145,7 +145,7 @@ test("Inside a yield, the target points at the original target", function() {
 
 if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
-test("should target the current controller inside an {{each}} loop [DEPRECATED]", function() {
+QUnit.test("should target the current controller inside an {{each}} loop [DEPRECATED]", function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -179,7 +179,7 @@ test("should target the current controller inside an {{each}} loop [DEPRECATED]"
 // jscs:enable validateIndentation
 }
 
-test("should target the with-controller inside an {{#with controller='person'}} [DEPRECATED]", function() {
+QUnit.test("should target the with-controller inside an {{#with controller='person'}} [DEPRECATED]", function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -209,7 +209,7 @@ test("should target the with-controller inside an {{#with controller='person'}} 
   ok(registeredTarget instanceof PersonController, "the with-controller is the target of action");
 });
 
-test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
+QUnit.test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
   expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
   expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
@@ -247,7 +247,7 @@ test("should target the with-controller inside an {{each}} in a {{#with controll
   deepEqual(eventsCalled, ['robert', 'brian'], 'the events are fired properly');
 });
 
-test("should allow a target to be specified", function() {
+QUnit.test("should allow a target to be specified", function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function(actionName, options) {
@@ -269,7 +269,7 @@ test("should allow a target to be specified", function() {
   runDestroy(anotherTarget);
 });
 
-test("should lazily evaluate the target", function() {
+QUnit.test("should lazily evaluate the target", function() {
   var firstEdit = 0;
   var secondEdit = 0;
   var controller = {};
@@ -312,7 +312,7 @@ test("should lazily evaluate the target", function() {
   equal(secondEdit, 1);
 });
 
-test("should register an event handler", function() {
+QUnit.test("should register an event handler", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -335,7 +335,7 @@ test("should register an event handler", function() {
   ok(eventHandlerWasCalled, "The event handler was called");
 });
 
-test("handles whitelisted modifier keys", function() {
+QUnit.test("handles whitelisted modifier keys", function() {
   var eventHandlerWasCalled = false;
   var shortcutHandlerWasCalled = false;
 
@@ -370,7 +370,7 @@ test("handles whitelisted modifier keys", function() {
   ok(shortcutHandlerWasCalled, "The \"any\" shortcut's event handler was called");
 });
 
-test("should be able to use action more than once for the same event within a view", function() {
+QUnit.test("should be able to use action more than once for the same event within a view", function() {
   var editWasCalled = false;
   var deleteWasCalled = false;
   var originalEventHandlerWasCalled = false;
@@ -412,7 +412,7 @@ test("should be able to use action more than once for the same event within a vi
   equal(deleteWasCalled, false, "The delete action was not called");
 });
 
-test("the event should not bubble if `bubbles=false` is passed", function() {
+QUnit.test("the event should not bubble if `bubbles=false` is passed", function() {
   var editWasCalled = false;
   var deleteWasCalled = false;
   var originalEventHandlerWasCalled = false;
@@ -457,7 +457,7 @@ test("the event should not bubble if `bubbles=false` is passed", function() {
   equal(originalEventHandlerWasCalled, true, "The original event handler was called");
 });
 
-test("should work properly in an #each block", function() {
+QUnit.test("should work properly in an #each block", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -477,7 +477,7 @@ test("should work properly in an #each block", function() {
   ok(eventHandlerWasCalled, "The event handler was called");
 });
 
-test("should work properly in a {{#with foo as bar}} block", function() {
+QUnit.test("should work properly in a {{#with foo as bar}} block", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -497,7 +497,7 @@ test("should work properly in a {{#with foo as bar}} block", function() {
   ok(eventHandlerWasCalled, "The event handler was called");
 });
 
-test("should work properly in a #with block [DEPRECATED]", function() {
+QUnit.test("should work properly in a #with block [DEPRECATED]", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -519,7 +519,7 @@ test("should work properly in a #with block [DEPRECATED]", function() {
   ok(eventHandlerWasCalled, "The event handler was called");
 });
 
-test("should unregister event handlers on rerender", function() {
+QUnit.test("should unregister event handlers on rerender", function() {
   var eventHandlerWasCalled = false;
 
   view = EmberView.extend({
@@ -542,7 +542,7 @@ test("should unregister event handlers on rerender", function() {
   ok(ActionManager.registeredActions[newActionId], "After rerender completes, a new event handler was added");
 });
 
-test("should unregister event handlers on inside virtual views", function() {
+QUnit.test("should unregister event handlers on inside virtual views", function() {
   var things = Ember.A([
     {
       name: 'Thingy'
@@ -564,7 +564,7 @@ test("should unregister event handlers on inside virtual views", function() {
   ok(!ActionManager.registeredActions[actionId], "After the virtual view was destroyed, the action was unregistered");
 });
 
-test("should properly capture events on child elements of a container with an action", function() {
+QUnit.test("should properly capture events on child elements of a container with an action", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -583,7 +583,7 @@ test("should properly capture events on child elements of a container with an ac
   ok(eventHandlerWasCalled, "Event on a child element triggered the action of its parent");
 });
 
-test("should allow bubbling of events from action helper to original parent event", function() {
+QUnit.test("should allow bubbling of events from action helper to original parent event", function() {
   var eventHandlerWasCalled = false;
   var originalEventHandlerWasCalled = false;
 
@@ -604,7 +604,7 @@ test("should allow bubbling of events from action helper to original parent even
   ok(eventHandlerWasCalled && originalEventHandlerWasCalled, "Both event handlers were called");
 });
 
-test("should not bubble an event from action helper to original parent event if `bubbles=false` is passed", function() {
+QUnit.test("should not bubble an event from action helper to original parent event if `bubbles=false` is passed", function() {
   var eventHandlerWasCalled = false;
   var originalEventHandlerWasCalled = false;
 
@@ -626,7 +626,7 @@ test("should not bubble an event from action helper to original parent event if 
   ok(!originalEventHandlerWasCalled, "The parent handler was not called");
 });
 
-test("should allow 'send' as action name (#594)", function() {
+QUnit.test("should allow 'send' as action name (#594)", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -646,7 +646,7 @@ test("should allow 'send' as action name (#594)", function() {
 });
 
 
-test("should send the view, event and current context to the action", function() {
+QUnit.test("should send the view, event and current context to the action", function() {
   var passedTarget;
   var passedContext;
 
@@ -674,7 +674,7 @@ test("should send the view, event and current context to the action", function()
   strictEqual(passedContext, aContext, "the parameter is passed along");
 });
 
-test("should only trigger actions for the event they were registered on", function() {
+QUnit.test("should only trigger actions for the event they were registered on", function() {
   var editWasCalled = false;
 
   view = EmberView.extend({
@@ -689,7 +689,7 @@ test("should only trigger actions for the event they were registered on", functi
   ok(!editWasCalled, "The action wasn't called");
 });
 
-test("should unwrap controllers passed as a context", function() {
+QUnit.test("should unwrap controllers passed as a context", function() {
   var passedContext;
   var model = EmberObject.create();
   var controller = EmberController.extend({
@@ -713,7 +713,7 @@ test("should unwrap controllers passed as a context", function() {
   equal(passedContext, model, "the action was passed the unwrapped model");
 });
 
-test("should not unwrap controllers passed as `controller`", function() {
+QUnit.test("should not unwrap controllers passed as `controller`", function() {
   var passedContext;
   var model = EmberObject.create();
   var controller = EmberController.extend({
@@ -737,7 +737,7 @@ test("should not unwrap controllers passed as `controller`", function() {
   equal(passedContext, controller, "the action was passed the controller");
 });
 
-test("should allow multiple contexts to be specified", function() {
+QUnit.test("should allow multiple contexts to be specified", function() {
   var passedContexts;
   var models = [EmberObject.create(), EmberObject.create()];
 
@@ -763,7 +763,7 @@ test("should allow multiple contexts to be specified", function() {
   deepEqual(passedContexts, models, "the action was called with the passed contexts");
 });
 
-test("should allow multiple contexts to be specified mixed with string args", function() {
+QUnit.test("should allow multiple contexts to be specified mixed with string args", function() {
   var passedParams;
   var model = EmberObject.create();
 
@@ -788,7 +788,7 @@ test("should allow multiple contexts to be specified mixed with string args", fu
   deepEqual(passedParams, ["herp", model], "the action was called with the passed contexts");
 });
 
-test("it does not trigger action with special clicks", function() {
+QUnit.test("it does not trigger action with special clicks", function() {
   var showCalled = false;
 
   view = EmberView.create({
@@ -831,7 +831,7 @@ test("it does not trigger action with special clicks", function() {
   checkClick('which', undefined, true); // IE <9
 });
 
-test("it can trigger actions for keyboard events", function() {
+QUnit.test("it can trigger actions for keyboard events", function() {
   var showCalled = false;
 
   view = EmberView.create({
@@ -858,7 +858,7 @@ test("it can trigger actions for keyboard events", function() {
   ok(showCalled, "should call action with keyup");
 });
 
-test("a quoteless parameter should allow dynamic lookup of the actionName", function() {
+QUnit.test("a quoteless parameter should allow dynamic lookup of the actionName", function() {
   expect(4);
   var lastAction;
   var actionOrder = [];
@@ -909,7 +909,7 @@ test("a quoteless parameter should allow dynamic lookup of the actionName", func
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
-test("a quoteless parameter should lookup actionName in context [DEPRECATED]", function() {
+QUnit.test("a quoteless parameter should lookup actionName in context [DEPRECATED]", function() {
   expect(5);
   var lastAction;
   var actionOrder = [];
@@ -960,7 +960,7 @@ test("a quoteless parameter should lookup actionName in context [DEPRECATED]", f
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
-test("a quoteless parameter should resolve actionName, including path", function() {
+QUnit.test("a quoteless parameter should resolve actionName, including path", function() {
   expect(4);
   var lastAction;
   var actionOrder = [];
@@ -1009,7 +1009,7 @@ test("a quoteless parameter should resolve actionName, including path", function
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
-test("a quoteless parameter that does not resolve to a value asserts", function() {
+QUnit.test("a quoteless parameter that does not resolve to a value asserts", function() {
   var triggeredAction;
 
   view = EmberView.create({
@@ -1056,7 +1056,7 @@ QUnit.module("ember-routing-htmlbars: action helper - deprecated invoking direct
   }
 });
 
-test("should respect preventDefault=false option if provided", function() {
+QUnit.test("should respect preventDefault=false option if provided", function() {
   view = EmberView.create({
     template: compile("<a {{action 'show' preventDefault=false}}>Hi</a>")
   });

--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -15,7 +15,7 @@ QUnit.module("ember-routing-htmlbars: link-to helper", {
 });
 
 
-test("should be able to be inserted in DOM when the router is not present", function() {
+QUnit.test("should be able to be inserted in DOM when the router is not present", function() {
   var template = "{{#link-to 'index'}}Go to Index{{/link-to}}";
   view = EmberView.create({
     template: compile(template)
@@ -26,7 +26,7 @@ test("should be able to be inserted in DOM when the router is not present", func
   equal(view.$().text(), 'Go to Index');
 });
 
-test("re-renders when title changes", function() {
+QUnit.test("re-renders when title changes", function() {
   var template = "{{link-to title routeName}}";
   view = EmberView.create({
     controller: {
@@ -47,7 +47,7 @@ test("re-renders when title changes", function() {
   equal(view.$().text(), 'bar');
 });
 
-test("can read bound title", function() {
+QUnit.test("can read bound title", function() {
   var template = "{{link-to title routeName}}";
   view = EmberView.create({
     controller: {
@@ -62,7 +62,7 @@ test("can read bound title", function() {
   equal(view.$().text(), 'foo');
 });
 
-test("escaped inline form (double curlies) escapes link title", function() {
+QUnit.test("escaped inline form (double curlies) escapes link title", function() {
   view = EmberView.create({
     title: "<b>blah</b>",
     template: compile("{{link-to view.title}}")
@@ -73,7 +73,7 @@ test("escaped inline form (double curlies) escapes link title", function() {
   equal(view.$('b').length, 0, 'no <b> were found');
 });
 
-test("unescaped inline form (triple curlies) does not escape link title", function() {
+QUnit.test("unescaped inline form (triple curlies) does not escape link title", function() {
   view = EmberView.create({
     title: "<b>blah</b>",
     template: compile("{{{link-to view.title}}}")
@@ -84,7 +84,7 @@ test("unescaped inline form (triple curlies) does not escape link title", functi
   equal(view.$('b').length, 1, '<b> was found');
 });
 
-test("unwraps controllers", function() {
+QUnit.test("unwraps controllers", function() {
   var template = "{{#link-to 'index' view.otherController}}Text{{/link-to}}";
 
   view = EmberView.create({

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -40,7 +40,7 @@ QUnit.module("ember-routing-htmlbars: {{outlet}} helper", {
   }
 });
 
-test("view should support connectOutlet for the main outlet", function() {
+QUnit.test("view should support connectOutlet for the main outlet", function() {
   var template = "<h1>HI</h1>{{outlet}}";
   view = EmberView.create({
     template: compile(template)
@@ -60,7 +60,7 @@ test("view should support connectOutlet for the main outlet", function() {
   equal(trim(view.$().text()), 'HIBYE');
 });
 
-test("outlet should support connectOutlet in slots in prerender state", function() {
+QUnit.test("outlet should support connectOutlet in slots in prerender state", function() {
   var template = "<h1>HI</h1>{{outlet}}";
   view = EmberView.create({
     template: compile(template)
@@ -75,7 +75,7 @@ test("outlet should support connectOutlet in slots in prerender state", function
   equal(view.$().text(), 'HIBYE');
 });
 
-test("outlet should support an optional name", function() {
+QUnit.test("outlet should support an optional name", function() {
   var template = "<h1>HI</h1>{{outlet 'mainView'}}";
   view = EmberView.create({
     template: compile(template)
@@ -96,7 +96,7 @@ test("outlet should support an optional name", function() {
 });
 
 
-test("outlet should correctly lookup a view", function() {
+QUnit.test("outlet should correctly lookup a view", function() {
 
   var template,
       ContainerView,
@@ -132,7 +132,7 @@ test("outlet should correctly lookup a view", function() {
 
 });
 
-test("outlet should assert view is specified as a string", function() {
+QUnit.test("outlet should assert view is specified as a string", function() {
 
   var template = "<h1>HI</h1>{{outlet view=containerView}}";
 
@@ -149,7 +149,7 @@ test("outlet should assert view is specified as a string", function() {
 
 });
 
-test("outlet should assert view path is successfully resolved", function() {
+QUnit.test("outlet should assert view path is successfully resolved", function() {
 
   var template = "<h1>HI</h1>{{outlet view='someViewNameHere'}}";
 
@@ -166,7 +166,7 @@ test("outlet should assert view path is successfully resolved", function() {
 
 });
 
-test("outlet should support an optional view class", function() {
+QUnit.test("outlet should support an optional view class", function() {
   var template = "<h1>HI</h1>{{outlet viewClass=view.outletView}}";
   view = EmberView.create({
     template: compile(template),
@@ -192,7 +192,7 @@ test("outlet should support an optional view class", function() {
 });
 
 
-test("Outlets bind to the current view, not the current concrete view", function() {
+QUnit.test("Outlets bind to the current view, not the current concrete view", function() {
   var parentTemplate = "<h1>HI</h1>{{outlet}}";
   var middleTemplate = "<h2>MIDDLE</h2>{{outlet}}";
   var bottomTemplate = "<h3>BOTTOM</h3>";
@@ -223,7 +223,7 @@ test("Outlets bind to the current view, not the current concrete view", function
   equal(output, "BOTTOM", "all templates were rendered");
 });
 
-test("view should support disconnectOutlet for the main outlet", function() {
+QUnit.test("view should support disconnectOutlet for the main outlet", function() {
   var template = "<h1>HI</h1>{{outlet}}";
   view = EmberView.create({
     template: compile(template)
@@ -254,7 +254,7 @@ test("view should support disconnectOutlet for the main outlet", function() {
 if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
 
-test("Outlets bind to the current template's view, not inner contexts [DEPRECATED]", function() {
+QUnit.test("Outlets bind to the current template's view, not inner contexts [DEPRECATED]", function() {
   var parentTemplate = "<h1>HI</h1>{{#if view.alwaysTrue}}{{#with this}}{{outlet}}{{/with}}{{/if}}";
   var bottomTemplate = "<h3>BOTTOM</h3>";
 
@@ -282,7 +282,7 @@ test("Outlets bind to the current template's view, not inner contexts [DEPRECATE
 // jscs:enable validateIndentation
 }
 
-test("should support layouts", function() {
+QUnit.test("should support layouts", function() {
   var template = "{{outlet}}";
   var layout = "<h1>HI</h1>{{yield}}";
 
@@ -304,7 +304,7 @@ test("should support layouts", function() {
   equal(trim(view.$().text()), 'HIBYE');
 });
 
-test("should not throw deprecations if {{outlet}} is used without a name", function() {
+QUnit.test("should not throw deprecations if {{outlet}} is used without a name", function() {
   expectNoDeprecation();
   view = EmberView.create({
     template: compile("{{outlet}}")
@@ -312,7 +312,7 @@ test("should not throw deprecations if {{outlet}} is used without a name", funct
   runAppend(view);
 });
 
-test("should not throw deprecations if {{outlet}} is used with a quoted name", function() {
+QUnit.test("should not throw deprecations if {{outlet}} is used with a quoted name", function() {
   expectNoDeprecation();
   view = EmberView.create({
     template: compile("{{outlet \"foo\"}}")
@@ -321,7 +321,7 @@ test("should not throw deprecations if {{outlet}} is used with a quoted name", f
 });
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
-  test("should throw an assertion if {{outlet}} used with unquoted name", function() {
+  QUnit.test("should throw an assertion if {{outlet}} used with unquoted name", function() {
     view = EmberView.create({
       template: compile("{{outlet foo}}")
     });
@@ -330,7 +330,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
     }, "Using {{outlet}} with an unquoted name is not supported.");
   });
 } else {
-  test("should throw a deprecation if {{outlet}} is used with an unquoted name", function() {
+  QUnit.test("should throw a deprecation if {{outlet}} is used with an unquoted name", function() {
     view = EmberView.create({
       template: compile("{{outlet foo}}")
     });

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -66,7 +66,7 @@ QUnit.module("ember-routing-htmlbars: {{render}} helper", {
   }
 });
 
-test("{{render}} helper should render given template", function() {
+QUnit.test("{{render}} helper should render given template", function() {
   var template = "<h1>HI</h1>{{render 'home'}}";
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -82,7 +82,7 @@ test("{{render}} helper should render given template", function() {
   ok(container.lookup('router:main')._lookupActiveView('home'), 'should register home as active view');
 });
 
-test("{{render}} helper should have assertion if neither template nor view exists", function() {
+QUnit.test("{{render}} helper should have assertion if neither template nor view exists", function() {
   var template = "<h1>HI</h1>{{render 'oops'}}";
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -95,7 +95,7 @@ test("{{render}} helper should have assertion if neither template nor view exist
   }, 'You used `{{render \'oops\'}}`, but \'oops\' can not be found as either a template or a view.');
 });
 
-test("{{render}} helper should not have assertion if template is supplied in block-form", function() {
+QUnit.test("{{render}} helper should not have assertion if template is supplied in block-form", function() {
   var template = "<h1>HI</h1>{{#render 'good'}} {{name}}{{/render}}";
   var controller = EmberController.extend({ container: container });
   container._registry.register('controller:good', EmberController.extend({ name: 'Rob' }));
@@ -109,7 +109,7 @@ test("{{render}} helper should not have assertion if template is supplied in blo
   equal(view.$().text(), 'HI Rob');
 });
 
-test("{{render}} helper should not have assertion if view exists without a template", function() {
+QUnit.test("{{render}} helper should not have assertion if view exists without a template", function() {
   var template = "<h1>HI</h1>{{render 'oops'}}";
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -124,7 +124,7 @@ test("{{render}} helper should not have assertion if view exists without a templ
   equal(view.$().text(), 'HI');
 });
 
-test("{{render}} helper should render given template with a supplied model", function() {
+QUnit.test("{{render}} helper should render given template with a supplied model", function() {
   var template = "<h1>HI</h1>{{render 'post' post}}";
   var post = {
     title: "Rails is omakase"
@@ -165,7 +165,7 @@ test("{{render}} helper should render given template with a supplied model", fun
   }
 });
 
-test("{{render}} helper with a supplied model should not fire observers on the controller", function () {
+QUnit.test("{{render}} helper with a supplied model should not fire observers on the controller", function () {
   var template = "<h1>HI</h1>{{render 'post' post}}";
   var post = {
     title: "Rails is omakase"
@@ -195,7 +195,7 @@ test("{{render}} helper with a supplied model should not fire observers on the c
 
 });
 
-test("{{render}} helper should raise an error when a given controller name does not resolve to a controller", function() {
+QUnit.test("{{render}} helper should raise an error when a given controller name does not resolve to a controller", function() {
   var template = '<h1>HI</h1>{{render "home" controller="postss"}}';
   var controller = EmberController.extend({ container: container });
   container._registry.register('controller:posts', EmberArrayController.extend());
@@ -211,7 +211,7 @@ test("{{render}} helper should raise an error when a given controller name does 
   }, 'The controller name you supplied \'postss\' did not resolve to a controller.');
 });
 
-test("{{render}} helper should render with given controller", function() {
+QUnit.test("{{render}} helper should render with given controller", function() {
   var template = '<h1>HI</h1>{{render "home" controller="posts"}}';
   var controller = EmberController.extend({ container: container });
   container._registry.register('controller:posts', EmberArrayController.extend());
@@ -228,7 +228,7 @@ test("{{render}} helper should render with given controller", function() {
   equal(container.lookup('controller:posts'), renderedView.get('controller'), 'rendered with correct controller');
 });
 
-test("{{render}} helper should render a template without a model only once", function() {
+QUnit.test("{{render}} helper should render a template without a model only once", function() {
   var template = "<h1>HI</h1>{{render 'home'}}<hr/>{{render 'home'}}";
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -243,7 +243,7 @@ test("{{render}} helper should render a template without a model only once", fun
   }, /\{\{render\}\} helper once/i);
 });
 
-test("{{render}} helper should render templates with models multiple times", function() {
+QUnit.test("{{render}} helper should render templates with models multiple times", function() {
   var template = "<h1>HI</h1> {{render 'post' post1}} {{render 'post' post2}}";
   var post1 = {
     title: "Me first"
@@ -289,7 +289,7 @@ test("{{render}} helper should render templates with models multiple times", fun
   }
 });
 
-test("{{render}} helper should not leak controllers", function() {
+QUnit.test("{{render}} helper should not leak controllers", function() {
   var template = "<h1>HI</h1> {{render 'post' post1}}";
   var post1 = {
     title: "Me first"
@@ -321,7 +321,7 @@ test("{{render}} helper should not leak controllers", function() {
   ok(postController1.isDestroyed, 'expected postController to be destroyed');
 });
 
-test("{{render}} helper should not treat invocations with falsy contexts as context-less", function() {
+QUnit.test("{{render}} helper should not treat invocations with falsy contexts as context-less", function() {
   var template = "<h1>HI</h1> {{render 'post' zero}} {{render 'post' nonexistent}}";
 
   view = EmberView.create({
@@ -347,7 +347,7 @@ test("{{render}} helper should not treat invocations with falsy contexts as cont
   equal(postController2.get('model'), undefined);
 });
 
-test("{{render}} helper should render templates both with and without models", function() {
+QUnit.test("{{render}} helper should render templates both with and without models", function() {
   var template = "<h1>HI</h1> {{render 'post'}} {{render 'post' post}}";
   var post = {
     title: "Rails is omakase"
@@ -389,7 +389,7 @@ test("{{render}} helper should render templates both with and without models", f
   }
 });
 
-test("{{render}} helper should link child controllers to the parent controller", function() {
+QUnit.test("{{render}} helper should link child controllers to the parent controller", function() {
   var parentTriggered = 0;
 
   var template = '<h1>HI</h1>{{render "posts"}}';
@@ -426,7 +426,7 @@ test("{{render}} helper should link child controllers to the parent controller",
   equal(parentTriggered, 1, "The event bubbled to the parent");
 });
 
-test("{{render}} helper should be able to render a template again when it was removed", function() {
+QUnit.test("{{render}} helper should be able to render a template again when it was removed", function() {
   var template = "<h1>HI</h1>{{outlet}}";
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -456,7 +456,7 @@ test("{{render}} helper should be able to render a template again when it was re
   equal(view.$().text(), 'HI2BYE');
 });
 
-test("{{render}} works with dot notation", function() {
+QUnit.test("{{render}} works with dot notation", function() {
   var template = '<h1>BLOG</h1>{{render "blog.post"}}';
 
   var controller = EmberController.extend({ container: container });
@@ -476,7 +476,7 @@ test("{{render}} works with dot notation", function() {
   equal(container.lookup('controller:blog.post'), renderedView.get('controller'), 'rendered with correct controller');
 });
 
-test("{{render}} works with slash notation", function() {
+QUnit.test("{{render}} works with slash notation", function() {
   var template = '<h1>BLOG</h1>{{render "blog/post"}}';
 
   var controller = EmberController.extend({ container: container });
@@ -499,7 +499,7 @@ test("{{render}} works with slash notation", function() {
 if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
 
-test("throws an assertion if {{render}} is called with an unquoted template name", function() {
+QUnit.test("throws an assertion if {{render}} is called with an unquoted template name", function() {
   var template = '<h1>HI</h1>{{render home}}';
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -514,7 +514,7 @@ test("throws an assertion if {{render}} is called with an unquoted template name
   }, "The first argument of {{render}} must be quoted, e.g. {{render \"sidebar\"}}.");
 });
 
-test("throws an assertion if {{render}} is called with a literal for a model", function() {
+QUnit.test("throws an assertion if {{render}} is called with a literal for a model", function() {
   var template = '<h1>HI</h1>{{render "home" "model"}}';
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({
@@ -533,7 +533,7 @@ test("throws an assertion if {{render}} is called with a literal for a model", f
 } else {
 // jscs:disable validateIndentation
 
-test("Using quoteless templateName works properly (DEPRECATED)", function() {
+QUnit.test("Using quoteless templateName works properly (DEPRECATED)", function() {
   var template = '<h1>HI</h1>{{render home}}';
   var controller = EmberController.extend({ container: container });
   view = EmberView.create({

--- a/packages/ember-routing-views/tests/main_test.js
+++ b/packages/ember-routing-views/tests/main_test.js
@@ -3,7 +3,7 @@ import Ember from 'ember-metal/core';
 
 QUnit.module("ember-routing-views");
 
-test("exports correctly", function() {
+QUnit.test("exports correctly", function() {
   ok(Ember.LinkView, "LinkView is exported correctly");
   ok(Ember.OutletView, "OutletView is exported correctly");
 });

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -80,7 +80,7 @@ QUnit.module("Ember.AutoLocation", {
   }
 });
 
-test("_replacePath cannot be used to redirect to a different origin (website)", function() {
+QUnit.test("_replacePath cannot be used to redirect to a different origin (website)", function() {
   expect(1);
 
   var expectedURL;
@@ -99,7 +99,7 @@ test("_replacePath cannot be used to redirect to a different origin (website)", 
   AutoTestLocation._replacePath('//google.com');
 });
 
-test("AutoLocation.create() should return a HistoryLocation instance when pushStates are supported", function() {
+QUnit.test("AutoLocation.create() should return a HistoryLocation instance when pushStates are supported", function() {
   expect(2);
 
   mockBrowserLocation();
@@ -113,7 +113,7 @@ test("AutoLocation.create() should return a HistoryLocation instance when pushSt
   equal(location instanceof FakeHistoryLocation, true);
 });
 
-test("AutoLocation.create() should return a HashLocation instance when pushStates are not supported, but hashchange events are and the URL is already in the HashLocation format", function() {
+QUnit.test("AutoLocation.create() should return a HashLocation instance when pushStates are not supported, but hashchange events are and the URL is already in the HashLocation format", function() {
   expect(2);
 
   mockBrowserLocation({
@@ -129,7 +129,7 @@ test("AutoLocation.create() should return a HashLocation instance when pushState
   equal(location instanceof FakeHashLocation, true);
 });
 
-test("AutoLocation.create() should return a NoneLocation instance when neither history nor hashchange is supported.", function() {
+QUnit.test("AutoLocation.create() should return a NoneLocation instance when neither history nor hashchange is supported.", function() {
   expect(2);
 
   mockBrowserLocation({
@@ -145,7 +145,7 @@ test("AutoLocation.create() should return a NoneLocation instance when neither h
   equal(location instanceof FakeNoneLocation, true);
 });
 
-test("AutoLocation.create() should consider an index path (i.e. '/\') without any location.hash as OK for HashLocation", function() {
+QUnit.test("AutoLocation.create() should consider an index path (i.e. '/\') without any location.hash as OK for HashLocation", function() {
   expect(2);
 
   mockBrowserLocation({
@@ -167,7 +167,7 @@ test("AutoLocation.create() should consider an index path (i.e. '/\') without an
   equal(location instanceof FakeHashLocation, true);
 });
 
-test("Feature-detecting the history API", function() {
+QUnit.test("Feature-detecting the history API", function() {
   equal(supportsHistory("", { pushState: true }), true, "returns true if not Android Gingerbread and history.pushState exists");
   equal(supportsHistory("", {}), false, "returns false if history.pushState doesn't exist");
   equal(supportsHistory("", undefined), false, "returns false if history doesn't exist");
@@ -175,7 +175,7 @@ test("Feature-detecting the history API", function() {
                         false, "returns false if Android Gingerbread stock browser claiming to support pushState");
 });
 
-test("AutoLocation.create() should transform the URL for hashchange-only browsers viewing a HistoryLocation-formatted path", function() {
+QUnit.test("AutoLocation.create() should transform the URL for hashchange-only browsers viewing a HistoryLocation-formatted path", function() {
   expect(4);
 
   mockBrowserLocation({
@@ -202,7 +202,7 @@ test("AutoLocation.create() should transform the URL for hashchange-only browser
   equal(get(location, 'cancelRouterSetup'), true, 'cancelRouterSetup should be set so the router knows.');
 });
 
-test("AutoLocation.create() should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
+QUnit.test("AutoLocation.create() should replace the URL for pushState-supported browsers viewing a HashLocation-formatted url", function() {
   expect(2);
 
   mockBrowserLocation({
@@ -229,7 +229,7 @@ test("AutoLocation.create() should replace the URL for pushState-supported brows
   equal(get(location, 'implementation'), 'history');
 });
 
-test("Feature-Detecting onhashchange", function() {
+QUnit.test("Feature-Detecting onhashchange", function() {
   mockBrowserLocation();
 
   equal(supportsHashChange(undefined, { onhashchange: function() {} }), true, "When not in IE, use onhashchange existence as evidence of the feature");
@@ -238,7 +238,7 @@ test("Feature-Detecting onhashchange", function() {
   equal(supportsHashChange(8, { onhashchange: function() {} }), true, "When in IE8+, use onhashchange existence as evidence of the feature");
 });
 
-test("AutoLocation._getPath() should normalize location.pathname, making sure it always returns a leading slash", function() {
+QUnit.test("AutoLocation._getPath() should normalize location.pathname, making sure it always returns a leading slash", function() {
   expect(2);
 
   mockBrowserLocation({ pathname: 'test' });
@@ -248,20 +248,20 @@ test("AutoLocation._getPath() should normalize location.pathname, making sure it
   equal(AutoTestLocation._getPath(), '/test', 'When a leading slash is already there, it isn\'t added again');
 });
 
-test("AutoLocation._getHash() should be an alias to Ember.Location._getHash, otherwise it needs its own test!", function() {
+QUnit.test("AutoLocation._getHash() should be an alias to Ember.Location._getHash, otherwise it needs its own test!", function() {
   expect(1);
 
   equal(AutoTestLocation._getHash, EmberLocation._getHash);
 });
 
-test("AutoLocation._getQuery() should return location.search as-is", function() {
+QUnit.test("AutoLocation._getQuery() should return location.search as-is", function() {
   expect(1);
 
   mockBrowserLocation({ search: '?foo=bar' });
   equal(AutoTestLocation._getQuery(), '?foo=bar');
 });
 
-test("AutoLocation._getFullPath() should return full pathname including query and hash", function() {
+QUnit.test("AutoLocation._getFullPath() should return full pathname including query and hash", function() {
   expect(1);
 
   mockBrowserLocation({
@@ -274,7 +274,7 @@ test("AutoLocation._getFullPath() should return full pathname including query an
   equal(AutoTestLocation._getFullPath(), '/about?foo=bar#foo');
 });
 
-test("AutoLocation._getHistoryPath() should return a normalized, HistoryLocation-supported path", function() {
+QUnit.test("AutoLocation._getHistoryPath() should return a normalized, HistoryLocation-supported path", function() {
   expect(3);
 
   AutoTestLocation.rootURL = '/app/';
@@ -304,7 +304,7 @@ test("AutoLocation._getHistoryPath() should return a normalized, HistoryLocation
   equal(AutoTestLocation._getHistoryPath(), '/app/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
 });
 
-test("AutoLocation._getHashPath() should return a normalized, HashLocation-supported path", function() {
+QUnit.test("AutoLocation._getHashPath() should return a normalized, HashLocation-supported path", function() {
   expect(3);
 
   AutoTestLocation.rootURL = '/app/';
@@ -335,7 +335,7 @@ test("AutoLocation._getHashPath() should return a normalized, HashLocation-suppo
   equal(AutoTestLocation._getHashPath(), '/app/#/#about?foo=bar#foo', 'URLs with a hash not following #/ convention shouldn\'t be normalized as a route');
 });
 
-test("AutoLocation.create requires any rootURL given to end in a trailing forward slash", function() {
+QUnit.test("AutoLocation.create requires any rootURL given to end in a trailing forward slash", function() {
   expect(3);
   mockBrowserLocation();
 
@@ -360,7 +360,7 @@ test("AutoLocation.create requires any rootURL given to end in a trailing forwar
  are always kept, since we can't actually test them directly and we mock them
  both in all the tests above. Without these two, #9958 could happen again.
  */
-test("AutoLocation has valid references to window.location and window.history via environment", function() {
+QUnit.test("AutoLocation has valid references to window.location and window.history via environment", function() {
   expect(2);
 
   equal(AutoTestLocation._location, environment.location, 'AutoLocation._location === environment.location');

--- a/packages/ember-routing/tests/location/hash_location_test.js
+++ b/packages/ember-routing/tests/location/hash_location_test.js
@@ -54,7 +54,7 @@ QUnit.module("Ember.HashLocation", {
   }
 });
 
-test("HashLocation.getURL() returns the current url", function() {
+QUnit.test("HashLocation.getURL() returns the current url", function() {
   expect(1);
 
   createLocation({
@@ -64,7 +64,7 @@ test("HashLocation.getURL() returns the current url", function() {
   equal(location.getURL(), '/foo/bar');
 });
 
-test("HashLocation.getURL() includes extra hashes", function() {
+QUnit.test("HashLocation.getURL() includes extra hashes", function() {
   expect(1);
 
   createLocation({
@@ -74,7 +74,7 @@ test("HashLocation.getURL() includes extra hashes", function() {
   equal(location.getURL(), '/foo#bar#car');
 });
 
-test("HashLocation.getURL() assumes location.hash without #/ prefix is not a route path", function() {
+QUnit.test("HashLocation.getURL() assumes location.hash without #/ prefix is not a route path", function() {
   expect(1);
 
   createLocation({
@@ -84,7 +84,7 @@ test("HashLocation.getURL() assumes location.hash without #/ prefix is not a rou
   equal(location.getURL(), '/#foo#bar');
 });
 
-test("HashLocation.getURL() returns a normal forward slash when there is no location.hash", function() {
+QUnit.test("HashLocation.getURL() returns a normal forward slash when there is no location.hash", function() {
   expect(1);
 
   createLocation({
@@ -94,7 +94,7 @@ test("HashLocation.getURL() returns a normal forward slash when there is no loca
   equal(location.getURL(), '/');
 });
 
-test("HashLocation.setURL() correctly sets the url", function() {
+QUnit.test("HashLocation.setURL() correctly sets the url", function() {
   expect(2);
 
   createLocation();
@@ -105,7 +105,7 @@ test("HashLocation.setURL() correctly sets the url", function() {
   equal(get(location, 'lastSetURL'), '/bar');
 });
 
-test("HashLocation.replaceURL() correctly replaces to the path with a page reload", function() {
+QUnit.test("HashLocation.replaceURL() correctly replaces to the path with a page reload", function() {
   expect(2);
 
   createLocation({
@@ -121,7 +121,7 @@ test("HashLocation.replaceURL() correctly replaces to the path with a page reloa
   equal(get(location, 'lastSetURL'), '/foo');
 });
 
-test("HashLocation.onUpdateURL() registers a hashchange callback", function() {
+QUnit.test("HashLocation.onUpdateURL() registers a hashchange callback", function() {
   expect(3);
 
   var oldJquery = Ember.$;
@@ -149,7 +149,7 @@ test("HashLocation.onUpdateURL() registers a hashchange callback", function() {
   Ember.$ = oldJquery;
 });
 
-test("HashLocation.formatURL() prepends a # to the provided string", function() {
+QUnit.test("HashLocation.formatURL() prepends a # to the provided string", function() {
   expect(1);
 
   createLocation();
@@ -157,7 +157,7 @@ test("HashLocation.formatURL() prepends a # to the provided string", function() 
   equal(location.formatURL('/foo#bar'), '#/foo#bar');
 });
 
-test("HashLocation.willDestroy() cleans up hashchange event listener", function() {
+QUnit.test("HashLocation.willDestroy() cleans up hashchange event listener", function() {
   expect(2);
 
   var oldJquery = Ember.$;

--- a/packages/ember-routing/tests/location/history_location_test.js
+++ b/packages/ember-routing/tests/location/history_location_test.js
@@ -57,7 +57,7 @@ QUnit.module("Ember.HistoryLocation", {
   }
 });
 
-test("HistoryLocation initState does not get fired on init", function() {
+QUnit.test("HistoryLocation initState does not get fired on init", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -73,7 +73,7 @@ test("HistoryLocation initState does not get fired on init", function() {
   createLocation();
 });
 
-test("webkit doesn't fire popstate on page load", function() {
+QUnit.test("webkit doesn't fire popstate on page load", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -89,7 +89,7 @@ test("webkit doesn't fire popstate on page load", function() {
   location.initState();
 });
 
-test("base URL is removed when retrieving the current pathname", function() {
+QUnit.test("base URL is removed when retrieving the current pathname", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -111,7 +111,7 @@ test("base URL is removed when retrieving the current pathname", function() {
   location.initState();
 });
 
-test("base URL is preserved when moving around", function() {
+QUnit.test("base URL is preserved when moving around", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -130,7 +130,7 @@ test("base URL is preserved when moving around", function() {
   equal(location._historyState.path, '/base/one/two');
 });
 
-test("setURL continues to set even with a null state (iframes may set this)", function() {
+QUnit.test("setURL continues to set even with a null state (iframes may set this)", function() {
   expect(1);
 
   createLocation();
@@ -142,7 +142,7 @@ test("setURL continues to set even with a null state (iframes may set this)", fu
   equal(location._historyState.path, '/three/four');
 });
 
-test("replaceURL continues to set even with a null state (iframes may set this)", function() {
+QUnit.test("replaceURL continues to set even with a null state (iframes may set this)", function() {
   expect(1);
 
   createLocation();
@@ -154,7 +154,7 @@ test("replaceURL continues to set even with a null state (iframes may set this)"
   equal(location._historyState.path, '/three/four');
 });
 
-test("HistoryLocation.getURL() returns the current url, excluding both rootURL and baseURL", function() {
+QUnit.test("HistoryLocation.getURL() returns the current url, excluding both rootURL and baseURL", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -172,7 +172,7 @@ test("HistoryLocation.getURL() returns the current url, excluding both rootURL a
   equal(location.getURL(), '/foo/bar');
 });
 
-test("HistoryLocation.getURL() includes location.search", function() {
+QUnit.test("HistoryLocation.getURL() includes location.search", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -187,7 +187,7 @@ test("HistoryLocation.getURL() includes location.search", function() {
   equal(location.getURL(), '/foo/bar?time=morphin');
 });
 
-test("HistoryLocation.getURL() includes location.hash", function() {
+QUnit.test("HistoryLocation.getURL() includes location.hash", function() {
   expect(1);
 
   HistoryTestLocation.reopen({
@@ -202,7 +202,7 @@ test("HistoryLocation.getURL() includes location.hash", function() {
   equal(location.getURL(), '/foo/bar#pink-power-ranger');
 });
 
-test("HistoryLocation.getURL() includes location.hash and location.search", function() {
+QUnit.test("HistoryLocation.getURL() includes location.hash and location.search", function() {
   expect(1);
 
   HistoryTestLocation.reopen({

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -67,7 +67,7 @@ QUnit.module("Ember.controllerFor", {
   }
 });
 
-test("controllerFor should lookup for registered controllers", function() {
+QUnit.test("controllerFor should lookup for registered controllers", function() {
   var controller = controllerFor(container, 'app');
 
   equal(appController, controller, 'should find app controller');
@@ -86,32 +86,32 @@ QUnit.module("Ember.generateController", {
   }
 });
 
-test("generateController and generateControllerFactory are properties on the root namespace", function() {
+QUnit.test("generateController and generateControllerFactory are properties on the root namespace", function() {
   equal(Ember.generateController, generateController, 'should export generateController');
   equal(Ember.generateControllerFactory, generateControllerFactory, 'should export generateControllerFactory');
 });
 
-test("generateController should create Ember.Controller", function() {
+QUnit.test("generateController should create Ember.Controller", function() {
   var controller = generateController(container, 'home');
 
   ok(controller instanceof Controller, 'should create controller');
 });
 
-test("generateController should create Ember.ObjectController [DEPRECATED]", function() {
+QUnit.test("generateController should create Ember.ObjectController [DEPRECATED]", function() {
   var context = {};
   var controller = generateController(container, 'home', context);
 
   ok(controller instanceof ObjectController, 'should create controller');
 });
 
-test("generateController should create Ember.ArrayController", function() {
+QUnit.test("generateController should create Ember.ArrayController", function() {
   var context = Ember.A();
   var controller = generateController(container, 'home', context);
 
   ok(controller instanceof ArrayController, 'should create controller');
 });
 
-test("generateController should create App.Controller if provided", function() {
+QUnit.test("generateController should create App.Controller if provided", function() {
   var controller;
   namespace.Controller = Controller.extend();
 
@@ -120,7 +120,7 @@ test("generateController should create App.Controller if provided", function() {
   ok(controller instanceof namespace.Controller, 'should create controller');
 });
 
-test("generateController should create App.ObjectController if provided", function() {
+QUnit.test("generateController should create App.ObjectController if provided", function() {
   var context = {};
   var controller;
   namespace.ObjectController = ObjectController.extend();
@@ -131,7 +131,7 @@ test("generateController should create App.ObjectController if provided", functi
 
 });
 
-test("generateController should create App.ArrayController if provided", function() {
+QUnit.test("generateController should create App.ArrayController if provided", function() {
   var context = Ember.A();
   var controller;
   namespace.ArrayController = ArrayController.extend();

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -12,7 +12,7 @@ QUnit.module("Ember Router DSL", {
   }
 });
 
-test("should fail when using a reserved route name", function() {
+QUnit.test("should fail when using a reserved route name", function() {
   var reservedNames = ['array', 'basic', 'object'];
 
   expect(reservedNames.length * 2);
@@ -44,7 +44,7 @@ test("should fail when using a reserved route name", function() {
   });
 });
 
-test("should reset namespace if nested with resource", function() {
+QUnit.test("should reset namespace if nested with resource", function() {
   Router = Router.map(function() {
     this.resource('bleep', function() {
       this.resource('bloop', function() {
@@ -61,7 +61,7 @@ test("should reset namespace if nested with resource", function() {
   ok(router.router.recognizer.names['blork'], 'nested resources do not contain parent name');
 });
 
-test("should retain resource namespace if nested with routes", function() {
+QUnit.test("should retain resource namespace if nested with routes", function() {
   Router = Router.map(function() {
     this.route('bleep', function() {
       this.route('bloop', function() {
@@ -81,7 +81,7 @@ test("should retain resource namespace if nested with routes", function() {
 if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 // jscs:disable validateIndentation
 
-test("should add loading and error routes if _isRouterMapResult is true", function() {
+QUnit.test("should add loading and error routes if _isRouterMapResult is true", function() {
   Router.map(function() {
     this.route('blork');
   });
@@ -94,7 +94,7 @@ test("should add loading and error routes if _isRouterMapResult is true", functi
   ok(router.router.recognizer.names['blork_error'], 'error route was added');
 });
 
-test("should not add loading and error routes if _isRouterMapResult is false", function() {
+QUnit.test("should not add loading and error routes if _isRouterMapResult is false", function() {
   Router.map(function() {
     this.route('blork');
   });

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -20,7 +20,7 @@ QUnit.module("Ember.Route", {
   teardown: teardown
 });
 
-test("default store utilizes the container to acquire the model factory", function() {
+QUnit.test("default store utilizes the container to acquire the model factory", function() {
   expect(4);
 
   var Post = EmberObject.extend();
@@ -50,7 +50,7 @@ test("default store utilizes the container to acquire the model factory", functi
   equal(route.findModel('post', 1), post, '#findModel returns the correct post');
 });
 
-test("'store' can be injected by data persistence frameworks", function() {
+QUnit.test("'store' can be injected by data persistence frameworks", function() {
   expect(8);
   runDestroy(route);
 
@@ -80,7 +80,7 @@ test("'store' can be injected by data persistence frameworks", function() {
   equal(route.findModel('post', 1), post, '#findModel returns the correct post');
 });
 
-test("assert if 'store.find' method is not found", function() {
+QUnit.test("assert if 'store.find' method is not found", function() {
   expect(1);
   runDestroy(route);
 
@@ -98,7 +98,7 @@ test("assert if 'store.find' method is not found", function() {
   }, 'Post has no method `find`.');
 });
 
-test("asserts if model class is not found", function() {
+QUnit.test("asserts if model class is not found", function() {
   expect(1);
   runDestroy(route);
 
@@ -113,7 +113,7 @@ test("asserts if model class is not found", function() {
   }, "You used the dynamic segment post_id in your route undefined, but undefined.Post did not exist and you did not override your route's `model` hook.");
 });
 
-test("'store' does not need to be injected", function() {
+QUnit.test("'store' does not need to be injected", function() {
   expect(1);
 
   runDestroy(route);
@@ -132,7 +132,7 @@ test("'store' does not need to be injected", function() {
   ok(true, 'no error was raised');
 });
 
-test("modelFor doesn't require the router", function() {
+QUnit.test("modelFor doesn't require the router", function() {
   var registry = new Registry();
   var container = registry.container();
   route.container = container;
@@ -150,7 +150,7 @@ test("modelFor doesn't require the router", function() {
 });
 
 
-test(".send just calls an action if the router is absent", function() {
+QUnit.test(".send just calls an action if the router is absent", function() {
   expect(7);
   var route = EmberRoute.createWithMixins({
     actions: {
@@ -179,25 +179,25 @@ QUnit.module("Ember.Route serialize", {
   teardown: teardown
 });
 
-test("returns the models properties if params does not include *_id", function() {
+QUnit.test("returns the models properties if params does not include *_id", function() {
   var model = { id: 2, firstName: 'Ned', lastName: 'Ryerson' };
 
   deepEqual(route.serialize(model, ['firstName', 'lastName']), { firstName: 'Ned', lastName: 'Ryerson' }, "serialized correctly");
 });
 
-test("returns model.id if params include *_id", function() {
+QUnit.test("returns model.id if params include *_id", function() {
   var model = { id: 2 };
 
   deepEqual(route.serialize(model, ['post_id']), { post_id: 2 }, "serialized correctly");
 });
 
-test("returns checks for existence of model.post_id before trying model.id", function() {
+QUnit.test("returns checks for existence of model.post_id before trying model.id", function() {
   var model = { post_id: 3 };
 
   deepEqual(route.serialize(model, ['post_id']), { post_id: 3 }, "serialized correctly");
 });
 
-test("returns undefined if model is not set", function() {
+QUnit.test("returns undefined if model is not set", function() {
   equal(route.serialize(undefined, ['post_id']), undefined, "serialized correctly");
 });
 
@@ -224,7 +224,7 @@ QUnit.module("Ember.Route interaction", {
   }
 });
 
-test("controllerFor uses route's controllerName if specified", function() {
+QUnit.test("controllerFor uses route's controllerName if specified", function() {
   var testController = {};
   lookupHash['controller:test'] = testController;
 
@@ -236,7 +236,7 @@ test("controllerFor uses route's controllerName if specified", function() {
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('Route injected properties');
 
-  test("services can be injected into routes", function() {
+  QUnit.test("services can be injected into routes", function() {
     var registry = new Registry();
     var container = registry.container();
 

--- a/packages/ember-routing/tests/system/router_test.js
+++ b/packages/ember-routing/tests/system/router_test.js
@@ -33,19 +33,19 @@ QUnit.module("Ember Router", {
   }
 });
 
-test("can create a router without a container", function() {
+QUnit.test("can create a router without a container", function() {
   createRouter({ container: null });
 
   ok(true, 'no errors were thrown when creating without a container');
 });
 
-test("should not create a router.js instance upon init", function() {
+QUnit.test("should not create a router.js instance upon init", function() {
   var router = createRouter();
 
   ok(!router.router);
 });
 
-test("should destroy its location upon destroying the routers container.", function() {
+QUnit.test("should destroy its location upon destroying the routers container.", function() {
   var router = createRouter();
   var location = router.get('location');
 
@@ -54,7 +54,7 @@ test("should destroy its location upon destroying the routers container.", funct
   ok(location.isDestroyed, "location should be destroyed");
 });
 
-test("should instantiate its location with its `rootURL`", function() {
+QUnit.test("should instantiate its location with its `rootURL`", function() {
   var router = createRouter({
     rootURL: '/rootdir/'
   });
@@ -63,7 +63,7 @@ test("should instantiate its location with its `rootURL`", function() {
   equal(location.get('rootURL'), '/rootdir/');
 });
 
-test("Ember.AutoLocation._replacePath should be called with the right path", function() {
+QUnit.test("Ember.AutoLocation._replacePath should be called with the right path", function() {
   expect(1);
 
   var AutoTestLocation = copy(AutoLocation);
@@ -88,7 +88,7 @@ test("Ember.AutoLocation._replacePath should be called with the right path", fun
   });
 });
 
-test("Ember.Router._routePath should consume identical prefixes", function() {
+QUnit.test("Ember.Router._routePath should consume identical prefixes", function() {
   createRouter();
 
   expect(8);
@@ -115,7 +115,7 @@ test("Ember.Router._routePath should consume identical prefixes", function() {
   equal(routePath('foo.bar.baz', 'foo'), 'foo.bar.baz.foo');
 });
 
-test("Router should cancel routing setup when the Location class says so via cancelRouterSetup", function() {
+QUnit.test("Router should cancel routing setup when the Location class says so via cancelRouterSetup", function() {
   expect(0);
 
   var router;
@@ -138,7 +138,7 @@ test("Router should cancel routing setup when the Location class says so via can
   router.startRouting();
 });
 
-test("AutoLocation should replace the url when it's not in the preferred format", function() {
+QUnit.test("AutoLocation should replace the url when it's not in the preferred format", function() {
   expect(1);
 
   var AutoTestLocation = copy(AutoLocation);
@@ -164,7 +164,7 @@ test("AutoLocation should replace the url when it's not in the preferred format"
   });
 });
 
-test("Router#handleURL should remove any #hashes before doing URL transition", function() {
+QUnit.test("Router#handleURL should remove any #hashes before doing URL transition", function() {
   expect(2);
 
   var router = createRouter({

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -59,7 +59,7 @@ QUnit.module('computedMap', {
   }
 });
 
-test("it maps simple properties", function() {
+QUnit.test("it maps simple properties", function() {
   deepEqual(get(obj, 'mapped'), [1, 3, 2, 1]);
 
   run(function() {
@@ -75,7 +75,7 @@ test("it maps simple properties", function() {
   deepEqual(get(obj, 'mapped'), [1, 3, 2, 5]);
 });
 
-test("it caches properly", function() {
+QUnit.test("it caches properly", function() {
   var array = get(obj, 'array');
   get(obj, 'mapped');
 
@@ -92,7 +92,7 @@ test("it caches properly", function() {
   equal(userFnCalls, 5, "computedMap caches properly");
 });
 
-test("it maps simple unshifted properties", function() {
+QUnit.test("it maps simple unshifted properties", function() {
   var array = Ember.A([]);
 
   run(function() {
@@ -114,7 +114,7 @@ test("it maps simple unshifted properties", function() {
   deepEqual(get(obj, 'mapped'), ['A', 'B'], "properties unshifted in sequence are mapped correctly");
 });
 
-test("it passes the index to the callback", function() {
+QUnit.test("it passes the index to the callback", function() {
   var array = Ember.A(['a', 'b', 'c']);
 
   run(function() {
@@ -128,7 +128,7 @@ test("it passes the index to the callback", function() {
   deepEqual(get(obj, 'mapped'), [0, 1, 2], "index is passed to callback correctly");
 });
 
-test("it maps objects", function() {
+QUnit.test("it maps objects", function() {
   deepEqual(get(obj, 'mappedObjects'), [{ name: 'Robert' }, { name: 'Leanna' }]);
 
   run(function() {
@@ -150,7 +150,7 @@ test("it maps objects", function() {
   deepEqual(get(obj, 'mappedObjects'), [{ name: 'Stannis' }, { name: 'Eddard' }]);
 });
 
-test("it maps unshifted objects with property observers", function() {
+QUnit.test("it maps unshifted objects with property observers", function() {
   var array = Ember.A([]);
   var cObj = { v: 'c' };
 
@@ -192,7 +192,7 @@ QUnit.module('computedMapBy', {
   }
 });
 
-test("it maps properties", function() {
+QUnit.test("it maps properties", function() {
   get(obj, 'mapped');
 
   deepEqual(get(obj, 'mapped'), [1, 3, 2, 1]);
@@ -210,7 +210,7 @@ test("it maps properties", function() {
   deepEqual(get(obj, 'mapped'), [1, 3, 2, 5]);
 });
 
-test("it is observable", function() {
+QUnit.test("it is observable", function() {
   get(obj, 'mapped');
   var calls = 0;
 
@@ -248,13 +248,13 @@ QUnit.module('computedFilter', {
   }
 });
 
-test("it filters according to the specified filter function", function() {
+QUnit.test("it filters according to the specified filter function", function() {
   var filtered = get(obj, 'filtered');
 
   deepEqual(filtered, [2,4,6,8], "computedFilter filters by the specified function");
 });
 
-test("it passes the index to the callback", function() {
+QUnit.test("it passes the index to the callback", function() {
   var array = Ember.A(['a', 'b', 'c']);
 
   run(function() {
@@ -268,7 +268,7 @@ test("it passes the index to the callback", function() {
   deepEqual(get(obj, 'filtered'), ['b'], "index is passed to callback correctly");
 });
 
-test("it passes the array to the callback", function() {
+QUnit.test("it passes the array to the callback", function() {
   var array = Ember.A(['a', 'b', 'c']);
 
   run(function() {
@@ -282,7 +282,7 @@ test("it passes the array to the callback", function() {
   deepEqual(get(obj, 'filtered'), ['b'], "array is passed to callback correctly");
 });
 
-test("it caches properly", function() {
+QUnit.test("it caches properly", function() {
   var array = get(obj, 'array');
   get(obj, 'filtered');
 
@@ -299,7 +299,7 @@ test("it caches properly", function() {
   equal(userFnCalls, 9, "computedFilter caches properly");
 });
 
-test("it updates as the array is modified", function() {
+QUnit.test("it updates as the array is modified", function() {
   var array = get(obj, 'array');
   var filtered = get(obj, 'filtered');
 
@@ -322,7 +322,7 @@ test("it updates as the array is modified", function() {
   deepEqual(filtered, [2,6,8,12], "objects removed from the dependent array are removed from the computed array");
 });
 
-test("the dependent array can be cleared one at a time", function() {
+QUnit.test("the dependent array can be cleared one at a time", function() {
   var array = get(obj, 'array');
   var filtered = get(obj, 'filtered');
 
@@ -343,7 +343,7 @@ test("the dependent array can be cleared one at a time", function() {
   deepEqual(filtered, [], "filtered array cleared correctly");
 });
 
-test("the dependent array can be `clear`ed directly (#3272)", function() {
+QUnit.test("the dependent array can be `clear`ed directly (#3272)", function() {
   var array = get(obj, 'array');
   var filtered = get(obj, 'filtered');
 
@@ -356,7 +356,7 @@ test("the dependent array can be `clear`ed directly (#3272)", function() {
   deepEqual(filtered, [], "filtered array cleared correctly");
 });
 
-test("it updates as the array is replaced", function() {
+QUnit.test("it updates as the array is replaced", function() {
   get(obj, 'array');
   var filtered = get(obj, 'filtered');
 
@@ -389,7 +389,7 @@ QUnit.module('computedFilterBy', {
   }
 });
 
-test("properties can be filtered by truthiness", function() {
+QUnit.test("properties can be filtered by truthiness", function() {
   var array = get(obj, 'array');
   var as = get(obj, 'as');
   var bs = get(obj, 'bs');
@@ -426,7 +426,7 @@ test("properties can be filtered by truthiness", function() {
   deepEqual(bs.mapBy('name'), ['six'], "arrays computed by filtered property respond to array changes");
 });
 
-test("properties can be filtered by values", function() {
+QUnit.test("properties can be filtered by values", function() {
   var array = get(obj, 'array');
   var a1s = get(obj, 'a1s');
 
@@ -449,7 +449,7 @@ test("properties can be filtered by values", function() {
   deepEqual(a1s.mapBy('name'), ['one', 'two'], "arrays computed by matching value respond to modified properties");
 });
 
-test("properties values can be replaced", function() {
+QUnit.test("properties values can be replaced", function() {
   obj = EmberObject.createWithMixins({
       array: Ember.A([]),
       a1s: computedFilterBy('array', 'a', 1),
@@ -490,7 +490,7 @@ forEach.call([['uniq', computedUniq], ['union', computedUnion]], function (tuple
     }
   });
 
-  test("does not include duplicates", function() {
+  QUnit.test("does not include duplicates", function() {
     var array = get(obj, 'array');
     var array2 = get(obj, 'array2');
     get(obj, 'array3');
@@ -523,7 +523,7 @@ forEach.call([['uniq', computedUniq], ['union', computedUnion]], function (tuple
     deepEqual(union, [1,2,3,4,5,6,8,9,10,11], alias + " removes items when their last instance is gone");
   });
 
-  test("has set-union semantics", function() {
+  QUnit.test("has set-union semantics", function() {
     var array = get(obj, 'array');
     get(obj, 'array2');
     get(obj, 'array3');
@@ -544,7 +544,7 @@ forEach.call([['uniq', computedUniq], ['union', computedUnion]], function (tuple
     deepEqual(union, [1,4,5,6,7,8,9,10], "objects are removed when they are no longer in any dependent array");
   });
 
-  test("does not need to query the accumulated array while building it", function() {
+  QUnit.test("does not need to query the accumulated array while building it", function() {
     var indexOfCalls = [];
     var CountIndexOfCalls = Mixin.create({
       indexOf: function() {
@@ -579,7 +579,7 @@ QUnit.module('computed.intersect', {
   }
 });
 
-test("it has set-intersection semantics", function() {
+QUnit.test("it has set-intersection semantics", function() {
   get(obj, 'array');
   var array2 = get(obj, 'array2');
   var array3 = get(obj, 'array3');
@@ -631,7 +631,7 @@ QUnit.module('computedSetDiff', {
   }
 });
 
-test("it throws an error if given fewer or more than two dependent properties", function() {
+QUnit.test("it throws an error if given fewer or more than two dependent properties", function() {
   throws(function () {
     EmberObject.createWithMixins({
         array: Ember.A([1,2,3,4,5,6,7]),
@@ -651,7 +651,7 @@ test("it throws an error if given fewer or more than two dependent properties", 
 });
 
 
-test("it has set-diff semantics", function() {
+QUnit.test("it has set-diff semantics", function() {
   var array1 = get(obj, 'array');
   var array2 = get(obj, 'array2');
   var diff = get(obj, 'diff');
@@ -686,7 +686,7 @@ test("it has set-diff semantics", function() {
 
 
 function commonSortTests() {
-  test("arrays are initially sorted", function() {
+  QUnit.test("arrays are initially sorted", function() {
     run(function() {
       sorted = get(obj, 'sortedItems');
     });
@@ -694,7 +694,7 @@ function commonSortTests() {
     deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "array is initially sorted");
   });
 
-  test("changing the dependent array updates the sorted array", function() {
+  QUnit.test("changing the dependent array updates the sorted array", function() {
     run(function() {
       sorted = get(obj, 'sortedItems');
     });
@@ -716,7 +716,7 @@ function commonSortTests() {
     deepEqual(sorted.mapBy('fname'), ['Stannis', 'Ramsey', 'Roose', 'Theon'], "changing dependent array updates sorted array");
   });
 
-  test("adding to the dependent array updates the sorted array", function() {
+  QUnit.test("adding to the dependent array updates the sorted array", function() {
     run(function() {
       sorted = get(obj, 'sortedItems');
       items = get(obj, 'items');
@@ -731,7 +731,7 @@ function commonSortTests() {
     deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Tyrion', 'Bran', 'Robb'], "Adding to the dependent array updates the sorted array");
   });
 
-  test("removing from the dependent array updates the sorted array", function() {
+  QUnit.test("removing from the dependent array updates the sorted array", function() {
     run(function() {
       sorted = get(obj, 'sortedItems');
       items = get(obj, 'items');
@@ -746,7 +746,7 @@ function commonSortTests() {
     deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Robb'], "Removing from the dependent array updates the sorted array");
   });
 
-  test("distinct items may be sort-equal, although their relative order will not be guaranteed", function() {
+  QUnit.test("distinct items may be sort-equal, although their relative order will not be guaranteed", function() {
     var jaime, jaimeInDisguise;
 
     run(function() {
@@ -784,7 +784,7 @@ function commonSortTests() {
     deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "sorted array is updated");
   });
 
-  test("guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys", function() {
+  QUnit.test("guid sort-order fallback with a search proxy is not confused by non-search ObjectProxys", function() {
     var tyrion = { fname: "Tyrion", lname: "Lannister" };
     var tyrionInDisguise = ObjectProxy.create({
           fname: "Yollo",
@@ -837,7 +837,7 @@ QUnit.module('computedSort - sortProperties', {
 
 commonSortTests();
 
-test("updating sort properties updates the sorted array", function() {
+QUnit.test("updating sort properties updates the sorted array", function() {
   run(function() {
     sorted = get(obj, 'sortedItems');
   });
@@ -851,7 +851,7 @@ test("updating sort properties updates the sorted array", function() {
   deepEqual(sorted.mapBy('fname'), ['Robb', 'Jaime', 'Cersei', 'Bran'], "after updating sort properties array is updated");
 });
 
-test("updating sort properties in place updates the sorted array", function() {
+QUnit.test("updating sort properties in place updates the sorted array", function() {
   run(function() {
     sorted = get(obj, 'sortedItems');
     sortProps = get(obj, 'itemSorting');
@@ -867,7 +867,7 @@ test("updating sort properties in place updates the sorted array", function() {
   deepEqual(sorted.mapBy('fname'), ['Bran', 'Cersei', 'Jaime', 'Robb'], "after updating sort properties array is updated");
 });
 
-test("updating new sort properties in place updates the sorted array", function() {
+QUnit.test("updating new sort properties in place updates the sorted array", function() {
   run(function() {
     sorted = get(obj, 'sortedItems');
   });
@@ -890,7 +890,7 @@ test("updating new sort properties in place updates the sorted array", function(
   deepEqual(sorted.mapBy('fname'), ['Jaime', 'Cersei', 'Robb', 'Bran'], "after updating sort properties array is updated");
 });
 
-test("sort direction defaults to ascending", function() {
+QUnit.test("sort direction defaults to ascending", function() {
   run(function() {
     sorted = get(obj, 'sortedItems');
   });
@@ -904,7 +904,7 @@ test("sort direction defaults to ascending", function() {
   deepEqual(sorted.mapBy('fname'), ['Bran', 'Cersei', 'Jaime', 'Robb'], "sort direction defaults to ascending");
 });
 
-test("updating an item's sort properties updates the sorted array", function() {
+QUnit.test("updating an item's sort properties updates the sorted array", function() {
   var tyrionInDisguise;
 
   run(function() {
@@ -923,7 +923,7 @@ test("updating an item's sort properties updates the sorted array", function() {
   deepEqual(sorted.mapBy('fname'), ['Jaime', 'Tyrion', 'Bran', 'Robb'], "updating an item's sort properties updates the sorted array");
 });
 
-test("updating several of an item's sort properties updated the sorted array", function() {
+QUnit.test("updating several of an item's sort properties updated the sorted array", function() {
   var sansaInDisguise;
 
   run(function() {
@@ -945,7 +945,7 @@ test("updating several of an item's sort properties updated the sorted array", f
   deepEqual(sorted.mapBy('fname'), ['Jaime', 'Bran', 'Robb', 'Sansa'], "updating an item's sort properties updates the sorted array");
 });
 
-test("updating an item's sort properties does not error when binary search does a self compare (#3273)", function() {
+QUnit.test("updating an item's sort properties does not error when binary search does a self compare (#3273)", function() {
   var jaime, cersei;
 
   run(function() {
@@ -980,7 +980,7 @@ test("updating an item's sort properties does not error when binary search does 
   deepEqual(get(obj, 'sortedPeople'), [jaime, cersei], "array is sorted correctly");
 });
 
-test("property paths in sort properties update the sorted array", function () {
+QUnit.test("property paths in sort properties update the sorted array", function () {
   var jaime, cersei, sansa;
 
   run(function () {
@@ -1076,7 +1076,7 @@ QUnit.module('computedSort - sort function', {
 
 commonSortTests();
 
-test("changing item properties specified via @each triggers a resort of the modified item", function() {
+QUnit.test("changing item properties specified via @each triggers a resort of the modified item", function() {
   var tyrionInDisguise;
 
   run(function() {
@@ -1095,7 +1095,7 @@ test("changing item properties specified via @each triggers a resort of the modi
   deepEqual(sorted.mapBy('fname'), ['Jaime', 'Tyrion', 'Bran', 'Robb'], "updating a specified property on an item resorts it");
 });
 
-test("changing item properties not specified via @each does not trigger a resort", function() {
+QUnit.test("changing item properties not specified via @each does not trigger a resort", function() {
   var cersei;
 
   run(function() {
@@ -1145,7 +1145,7 @@ QUnit.module('computedSort - stability', {
   }
 });
 
-test("sorts correctly as only one property changes", function() {
+QUnit.test("sorts correctly as only one property changes", function() {
   var sorted;
   run(function() {
     sorted = obj.get('sortedItems');
@@ -1189,7 +1189,7 @@ QUnit.module('computedSort - concurrency', {
   }
 });
 
-test("sorts correctly when there are concurrent changes", function() {
+QUnit.test("sorts correctly when there are concurrent changes", function() {
   var sorted;
   run(function() {
     sorted = obj.get('sortedItems');
@@ -1205,7 +1205,7 @@ test("sorts correctly when there are concurrent changes", function() {
   deepEqual(sorted.mapBy('name'), ['A', 'D', 'B', 'C'], "final");
 });
 
-test("sorts correctly with a user-provided comparator when there are concurrent changes", function() {
+QUnit.test("sorts correctly with a user-provided comparator when there are concurrent changes", function() {
   var sorted;
   run(function() {
     sorted = obj.get('customSortedItems');
@@ -1240,7 +1240,7 @@ QUnit.module('computedMax', {
   }
 });
 
-test("max tracks the max number as objects are added", function() {
+QUnit.test("max tracks the max number as objects are added", function() {
   equal(get(obj, 'max'), 3, "precond - max is initially correct");
 
   run(function() {
@@ -1260,7 +1260,7 @@ test("max tracks the max number as objects are added", function() {
   equal(get(obj, 'max'), 5, "max does not update when a smaller number is added");
 });
 
-test("max recomputes when the current max is removed", function() {
+QUnit.test("max recomputes when the current max is removed", function() {
   equal(get(obj, 'max'), 3, "precond - max is initially correct");
 
   run(function() {
@@ -1293,7 +1293,7 @@ QUnit.module('computedMin', {
   }
 });
 
-test("min tracks the min number as objects are added", function() {
+QUnit.test("min tracks the min number as objects are added", function() {
   equal(get(obj, 'min'), 1, "precond - min is initially correct");
 
   run(function() {
@@ -1313,7 +1313,7 @@ test("min tracks the min number as objects are added", function() {
   equal(get(obj, 'min'), -2, "min does not update when a larger number is added");
 });
 
-test("min recomputes when the current min is removed", function() {
+QUnit.test("min recomputes when the current min is removed", function() {
   equal(get(obj, 'min'), 1, "precond - min is initially correct");
 
   run(function() {
@@ -1362,7 +1362,7 @@ QUnit.module('Ember.arrayComputed - mixed sugar', {
   }
 });
 
-test("filtering and sorting can be combined", function() {
+QUnit.test("filtering and sorting can be combined", function() {
   run(function() {
     items = get(obj, 'items');
     sorted = get(obj, 'sortedLannisters');
@@ -1379,7 +1379,7 @@ test("filtering and sorting can be combined", function() {
   deepEqual(sorted.mapBy('fname'), ['Cersei', 'Gerion', 'Jaime', 'Tywin'], "updates propagate to array");
 });
 
-test("filtering, sorting and reduce (max) can be combined", function() {
+QUnit.test("filtering, sorting and reduce (max) can be combined", function() {
   run(function() {
     items = get(obj, 'items');
   });
@@ -1431,7 +1431,7 @@ QUnit.module('Ember.arrayComputed - chains', {
   }
 });
 
-test("it can filter and sort when both depend on the same item property", function() {
+QUnit.test("it can filter and sort when both depend on the same item property", function() {
   run(function() {
     filtered = get(obj, 'filtered');
     sorted = get(obj, 'sorted');
@@ -1482,7 +1482,7 @@ QUnit.module('Chaining array and reduced CPs', {
   }
 });
 
-test("it computes interdependent array computed properties", function() {
+QUnit.test("it computes interdependent array computed properties", function() {
   get(obj, 'mapped');
 
   equal(get(obj, 'max'), 3, 'sanity - it properly computes the maximum value');
@@ -1518,12 +1518,12 @@ QUnit.module('computedSum', {
   }
 });
 
-test('sums the values in the dependentKey', function() {
+QUnit.test('sums the values in the dependentKey', function() {
   var sum = get(obj, 'total');
   equal(sum, 6, 'sums the values');
 });
 
-test('updates when array is modified', function() {
+QUnit.test('updates when array is modified', function() {
   var sum = function() {
     return get(obj, 'total');
   };

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -84,11 +84,11 @@ QUnit.module('arrayComputed', {
 });
 
 
-test("array computed properties are instances of ComputedProperty", function() {
+QUnit.test("array computed properties are instances of ComputedProperty", function() {
   ok(arrayComputed({}) instanceof ComputedProperty);
 });
 
-test("when the dependent array is null or undefined, `addedItem` is not called and only the initial value is returned", function() {
+QUnit.test("when the dependent array is null or undefined, `addedItem` is not called and only the initial value is returned", function() {
   obj = EmberObject.createWithMixins({
     numbers: null,
     doubledNumbers: arrayComputed('numbers', {
@@ -111,19 +111,19 @@ test("when the dependent array is null or undefined, `addedItem` is not called a
   equal(addCalls, 2, "`addedItem` is called when the dependent array is initially set");
 });
 
-test("on first retrieval, array computed properties are computed", function() {
+QUnit.test("on first retrieval, array computed properties are computed", function() {
   deepEqual(get(obj, 'evenNumbers'), [2,4,6], "array computed properties are correct on first invocation");
 });
 
-test("on first retrieval, array computed properties with multiple dependent keys are computed", function() {
+QUnit.test("on first retrieval, array computed properties with multiple dependent keys are computed", function() {
   deepEqual(get(obj, 'evenNumbersMultiDep'), [2, 4, 6, 8], "array computed properties are correct on first invocation");
 });
 
-test("on first retrieval, array computed properties dependent on nested objects are computed", function() {
+QUnit.test("on first retrieval, array computed properties dependent on nested objects are computed", function() {
   deepEqual(get(obj, 'evenNestedNumbers'), [2,4,6], "array computed properties are correct on first invocation");
 });
 
-test("after the first retrieval, array computed properties observe additions to dependent arrays", function() {
+QUnit.test("after the first retrieval, array computed properties observe additions to dependent arrays", function() {
   var numbers = get(obj, 'numbers');
       // set up observers
   var evenNumbers = get(obj, 'evenNumbers');
@@ -135,7 +135,7 @@ test("after the first retrieval, array computed properties observe additions to 
   deepEqual(evenNumbers, [2, 4, 6, 8], "array computed properties watch dependent arrays");
 });
 
-test("after the first retrieval, array computed properties observe removals from dependent arrays", function() {
+QUnit.test("after the first retrieval, array computed properties observe removals from dependent arrays", function() {
   var numbers = get(obj, 'numbers');
       // set up observers
   var evenNumbers = get(obj, 'evenNumbers');
@@ -147,7 +147,7 @@ test("after the first retrieval, array computed properties observe removals from
   deepEqual(evenNumbers, [2, 6], "array computed properties watch dependent arrays");
 });
 
-test("after first retrieval, array computed properties can observe properties on array items", function() {
+QUnit.test("after first retrieval, array computed properties can observe properties on array items", function() {
   var nestedNumbers = get(obj, 'nestedNumbers');
   var evenNestedNumbers = get(obj, 'evenNestedNumbers');
 
@@ -161,7 +161,7 @@ test("after first retrieval, array computed properties can observe properties on
   deepEqual(evenNestedNumbers, [2, 4, 6, 22], 'adds new number');
 });
 
-test("changes to array computed properties happen synchronously", function() {
+QUnit.test("changes to array computed properties happen synchronously", function() {
   var nestedNumbers = get(obj, 'nestedNumbers');
   var evenNestedNumbers = get(obj, 'evenNestedNumbers');
 
@@ -174,7 +174,7 @@ test("changes to array computed properties happen synchronously", function() {
   });
 });
 
-test("multiple dependent keys can be specified via brace expansion", function() {
+QUnit.test("multiple dependent keys can be specified via brace expansion", function() {
   var obj = EmberObject.createWithMixins({
     bar: Ember.A(),
     baz: Ember.A(),
@@ -210,7 +210,7 @@ test("multiple dependent keys can be specified via brace expansion", function() 
   deepEqual(get(obj, 'foo'), ['a:1', 'a:2', 'r:1', 'r:2'], "removed item from brace-expanded dependency");
 });
 
-test("multiple item property keys can be specified via brace expansion", function() {
+QUnit.test("multiple item property keys can be specified via brace expansion", function() {
   var expected = Ember.A();
   var item = { propA: 'A', propB: 'B', propC: 'C' };
   var obj = EmberObject.createWithMixins({
@@ -246,7 +246,7 @@ test("multiple item property keys can be specified via brace expansion", functio
   deepEqual(get(obj, 'foo'), expected, "not observing unspecified item properties");
 });
 
-test("doubly nested item property keys (@each.foo.@each) are not supported", function() {
+QUnit.test("doubly nested item property keys (@each.foo.@each) are not supported", function() {
   run(function() {
     obj = EmberObject.createWithMixins({
       peopleByOrdinalPosition: Ember.A([{ first: Ember.A([EmberObject.create({ name: "Jaime Lannister" })]) }]),
@@ -281,7 +281,7 @@ test("doubly nested item property keys (@each.foo.@each) are not supported", fun
   }, /Nested @each/, "doubly nested item property keys are not supported");
 });
 
-test("after the first retrieval, array computed properties observe dependent arrays", function() {
+QUnit.test("after the first retrieval, array computed properties observe dependent arrays", function() {
   get(obj, 'numbers');
   var evenNumbers = get(obj, 'evenNumbers');
 
@@ -294,7 +294,7 @@ test("after the first retrieval, array computed properties observe dependent arr
   deepEqual(evenNumbers, [20, 28], "array computed properties watch dependent arrays");
 });
 
-test("array observers are torn down when dependent arrays change", function() {
+QUnit.test("array observers are torn down when dependent arrays change", function() {
   var numbers = get(obj, 'numbers');
   get(obj, 'evenNumbers');
 
@@ -314,7 +314,7 @@ test("array observers are torn down when dependent arrays change", function() {
   equal(removeCalls, 0, 'remove is not called');
 });
 
-test("modifying properties on dependent array items triggers observers exactly once", function() {
+QUnit.test("modifying properties on dependent array items triggers observers exactly once", function() {
   var numbers = get(obj, 'numbers');
   var evenNumbers = get(obj, 'evenNumbers');
 
@@ -330,7 +330,7 @@ test("modifying properties on dependent array items triggers observers exactly o
   deepEqual(evenNumbers, [4,6,8,10], 'sanity check - dependent arrays are updated');
 });
 
-test("multiple array computed properties on the same object can observe dependent arrays", function() {
+QUnit.test("multiple array computed properties on the same object can observe dependent arrays", function() {
   var numbers = get(obj, 'numbers');
   var otherNumbers = get(obj, 'otherNumbers');
 
@@ -346,7 +346,7 @@ test("multiple array computed properties on the same object can observe dependen
   deepEqual(get(obj, 'evenNumbersMultiDep'), [2, 4, 6, 8, 12, 14], "evenNumbersMultiDep is updated");
 });
 
-test("an error is thrown when a reduceComputed is defined without an initialValue property", function() {
+QUnit.test("an error is thrown when a reduceComputed is defined without an initialValue property", function() {
   var defineExploder = function() {
     EmberObject.createWithMixins({
       collection: Ember.A(),
@@ -367,7 +367,7 @@ test("an error is thrown when a reduceComputed is defined without an initialValu
   throws(defineExploder, /declared\ without\ an\ initial\ value/, "an error is thrown when the reduceComputed is defined without an initialValue");
 });
 
-test("dependent arrays with multiple item properties are not double-counted", function() {
+QUnit.test("dependent arrays with multiple item properties are not double-counted", function() {
   var obj = EmberObject.extend({
     items: Ember.A([{ foo: true }, { bar: false }, { bar: true }]),
     countFooOrBar: reduceComputed({
@@ -393,7 +393,7 @@ test("dependent arrays with multiple item properties are not double-counted", fu
   equal(0, removeCalls, "no removes yet");
 });
 
-test("dependent arrays can use `replace` with an out of bounds index to add items", function() {
+QUnit.test("dependent arrays can use `replace` with an out of bounds index to add items", function() {
   var dependentArray = Ember.A();
   var array;
 
@@ -421,7 +421,7 @@ test("dependent arrays can use `replace` with an out of bounds index to add item
   deepEqual(array, [3, 4, 1, 2], "index < 0 treated as an unshift");
 });
 
-test("dependent arrays can use `replace` with a negative index to remove items indexed from the right", function() {
+QUnit.test("dependent arrays can use `replace` with a negative index to remove items indexed from the right", function() {
   var dependentArray = Ember.A([1,2,3,4,5]);
   var array;
 
@@ -445,7 +445,7 @@ test("dependent arrays can use `replace` with a negative index to remove items i
   deepEqual(array, [4,3], "index < 0 used as a right index for removal");
 });
 
-test("dependent arrays that call `replace` with an out of bounds index to remove items is a no-op", function() {
+QUnit.test("dependent arrays that call `replace` with an out of bounds index to remove items is a no-op", function() {
   var dependentArray = Ember.A([1, 2]);
   var array;
 
@@ -466,7 +466,7 @@ test("dependent arrays that call `replace` with an out of bounds index to remove
   dependentArray.replace(100, 2);
 });
 
-test("dependent arrays that call `replace` with a too-large removedCount a) works and b) still right-truncates", function() {
+QUnit.test("dependent arrays that call `replace` with a too-large removedCount a) works and b) still right-truncates", function() {
   var dependentArray = Ember.A([1, 2]);
   var array;
 
@@ -490,7 +490,7 @@ test("dependent arrays that call `replace` with a too-large removedCount a) work
   deepEqual(array, [2], "array was correctly right-truncated");
 });
 
-test("removedItem is not erroneously called for dependent arrays during a recomputation", function() {
+QUnit.test("removedItem is not erroneously called for dependent arrays during a recomputation", function() {
   function addedItem(array, item, changeMeta) {
     array.insertAt(changeMeta.index, item);
     return array;
@@ -547,7 +547,7 @@ QUnit.module('arrayComputed - recomputation DKs', {
   }
 });
 
-test("recomputations from `arrayComputed` observers add back dependent keys", function() {
+QUnit.test("recomputations from `arrayComputed` observers add back dependent keys", function() {
   var meta = metaFor(obj);
   get(obj, 'people');
   var titles;
@@ -605,7 +605,7 @@ QUnit.module('Ember.arryComputed - self chains', {
   }
 });
 
-test("@this can be used to treat the object as the array itself", function() {
+QUnit.test("@this can be used to treat the object as the array itself", function() {
   var names = get(obj, 'names');
 
   deepEqual(names, ['a', 'b'], "precond - names is initially correct");
@@ -647,7 +647,7 @@ QUnit.module('arrayComputed - changeMeta property observers', {
   }
 });
 
-test("changeMeta includes item and index", function() {
+QUnit.test("changeMeta includes item and index", function() {
   var expected, items, item;
 
   items = get(obj, 'items');
@@ -726,7 +726,7 @@ test("changeMeta includes item and index", function() {
   deepEqual(callbackItems, expected, "items removed from the array had observers removed");
 });
 
-test("changeMeta includes changedCount and arrayChanged", function() {
+QUnit.test("changeMeta includes changedCount and arrayChanged", function() {
   var obj = EmberObject.createWithMixins({
     letters: Ember.A(['a', 'b']),
     lettersArrayComputed: arrayComputed('letters', {
@@ -751,7 +751,7 @@ test("changeMeta includes changedCount and arrayChanged", function() {
   deepEqual(callbackItems, expected, "changeMeta has count and changed");
 });
 
-test("`updateIndexes` is not over-eager about skipping retain:n (#4620)", function() {
+QUnit.test("`updateIndexes` is not over-eager about skipping retain:n (#4620)", function() {
   var tracked = Ember.A();
   obj = EmberObject.extend({
     content: Ember.A([{ n: "one" }, { n: "two" }]),
@@ -788,7 +788,7 @@ test("`updateIndexes` is not over-eager about skipping retain:n (#4620)", functi
   deepEqual(tracked, ["+one@0", "+two@1", "-one@0", "-two@0", "+three@0"], "array handles a change when operations are delete:m retain:n-m");
 });
 
-test("when initialValue is undefined, everything works as advertised", function() {
+QUnit.test("when initialValue is undefined, everything works as advertised", function() {
   var chars = EmberObject.createWithMixins({
     letters: Ember.A(),
     firstUpper: reduceComputed('letters', {
@@ -841,7 +841,7 @@ QUnit.module('arrayComputed - completely invalidating dependencies', {
   }
 });
 
-test("non-array dependencies completely invalidate a reduceComputed CP", function() {
+QUnit.test("non-array dependencies completely invalidate a reduceComputed CP", function() {
   var dependentArray = Ember.A();
 
   obj = EmberObject.extend({
@@ -879,7 +879,7 @@ test("non-array dependencies completely invalidate a reduceComputed CP", functio
   equal(removeCalls, 0, "remove not called");
 });
 
-test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
+QUnit.test("array dependencies specified with `.[]` completely invalidate a reduceComputed CP", function() {
   var dependentArray = Ember.A();
   var totallyInvalidatingDependentArray = Ember.A();
 
@@ -920,7 +920,7 @@ test("array dependencies specified with `.[]` completely invalidate a reduceComp
   equal(removeCalls, 0, "remove not called");
 });
 
-test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
+QUnit.test("returning undefined in addedItem/removedItem completely invalidates a reduceComputed CP", function() {
   var dependentArray = Ember.A([3,2,1]);
   var counter = 0;
 
@@ -964,7 +964,7 @@ test("returning undefined in addedItem/removedItem completely invalidates a redu
 });
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.Array) {
-  test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
+  QUnit.test("reduceComputed complains about array dependencies that are not `Ember.Array`s", function() {
     var Type = EmberObject.extend({
       rc: reduceComputed('array', {
         initialValue: 0,
@@ -1025,7 +1025,7 @@ QUnit.module('arrayComputed - misc', {
   }
 });
 
-test("item property change flushes are gated by a semaphore", function() {
+QUnit.test("item property change flushes are gated by a semaphore", function() {
   obj.get('arrayCP');
   deepEqual(callbackItems, ['add:false', 'add:false'], "precond - calls are initially correct");
 

--- a/packages/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/array_controller_test.js
@@ -23,7 +23,7 @@ MutableArrayTests.extend({
   }
 }).run();
 
-test("defaults its `model` to an empty array", function () {
+QUnit.test("defaults its `model` to an empty array", function () {
   var Controller = ArrayController.extend();
   deepEqual(Controller.create().get("model"), [], "`ArrayController` defaults its model to an empty array");
   equal(Controller.create().get('firstObject'), undefined, 'can fetch firstObject');
@@ -31,7 +31,7 @@ test("defaults its `model` to an empty array", function () {
 });
 
 
-test("Ember.ArrayController length property works even if model was not set initially", function() {
+QUnit.test("Ember.ArrayController length property works even if model was not set initially", function() {
   var controller = ArrayController.create();
   controller.pushObject('item');
   equal(controller.get('length'), 1);

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -14,7 +14,7 @@ import { get } from "ember-metal/property_get";
 
 QUnit.module('Controller event handling');
 
-test("Action can be handled by a function on actions object", function() {
+QUnit.test("Action can be handled by a function on actions object", function() {
   expect(1);
   var TestController = Controller.extend({
     actions: {
@@ -28,7 +28,7 @@ test("Action can be handled by a function on actions object", function() {
 });
 
 // TODO: Can we support this?
-// test("Actions handlers can be configured to use another name", function() {
+// QUnit.test("Actions handlers can be configured to use another name", function() {
 //   expect(1);
 //   var TestController = Controller.extend({
 //     actionsProperty: 'actionHandlers',
@@ -42,7 +42,7 @@ test("Action can be handled by a function on actions object", function() {
 //   controller.send("poke");
 // });
 
-test("When `_actions` is provided, `actions` is left alone", function() {
+QUnit.test("When `_actions` is provided, `actions` is left alone", function() {
   expect(2);
   var TestController = Controller.extend({
     actions: ['foo', 'bar'],
@@ -57,7 +57,7 @@ test("When `_actions` is provided, `actions` is left alone", function() {
   equal('foo', controller.get("actions")[0], 'actions property is not untouched');
 });
 
-test("Actions object doesn't shadow a proxied object's 'actions' property", function() {
+QUnit.test("Actions object doesn't shadow a proxied object's 'actions' property", function() {
   expectDeprecation(objectControllerDeprecation);
 
   var TestController = ObjectController.extend({
@@ -74,7 +74,7 @@ test("Actions object doesn't shadow a proxied object's 'actions' property", func
   equal(controller.get("actions"), 'foo', "doesn't shadow the content's actions property");
 });
 
-test("A handled action can be bubbled to the target for continued processing", function() {
+QUnit.test("A handled action can be bubbled to the target for continued processing", function() {
   expect(2);
   var TestController = Controller.extend({
     actions: {
@@ -97,7 +97,7 @@ test("A handled action can be bubbled to the target for continued processing", f
   controller.send("poke");
 });
 
-test("Action can be handled by a superclass' actions object", function() {
+QUnit.test("Action can be handled by a superclass' actions object", function() {
   expect(4);
 
   var SuperController = Controller.extend({
@@ -138,7 +138,7 @@ QUnit.module('Controller deprecations');
 
 QUnit.module('Controller Content -> Model Alias');
 
-test("`model` is aliased as `content`", function() {
+QUnit.test("`model` is aliased as `content`", function() {
   expect(1);
   var controller = Controller.extend({
     model: 'foo-bar'
@@ -147,7 +147,7 @@ test("`model` is aliased as `content`", function() {
   equal(controller.get('content'), 'foo-bar', 'content is an alias of model');
 });
 
-test("`content` is moved to `model` when `model` is unset", function() {
+QUnit.test("`content` is moved to `model` when `model` is unset", function() {
   expect(2);
   var controller;
 
@@ -161,7 +161,7 @@ test("`content` is moved to `model` when `model` is unset", function() {
   equal(controller.get('content'), 'foo-bar', 'content is set properly');
 });
 
-test("specifying `content` (without `model` specified) results in deprecation", function() {
+QUnit.test("specifying `content` (without `model` specified) results in deprecation", function() {
   expect(1);
   var controller;
 
@@ -172,7 +172,7 @@ test("specifying `content` (without `model` specified) results in deprecation", 
   }, 'Do not specify `content` on a Controller, use `model` instead.');
 });
 
-test("specifying `content` (with `model` specified) does not result in deprecation", function() {
+QUnit.test("specifying `content` (with `model` specified) does not result in deprecation", function() {
   expect(3);
   expectNoDeprecation();
 
@@ -189,7 +189,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('Controller injected properties');
 
   if (!EmberDev.runningProdBuild) {
-    test("defining a controller on a non-controller should fail assertion", function() {
+    QUnit.test("defining a controller on a non-controller should fail assertion", function() {
       expectAssertion(function() {
         var registry = new Registry();
         var container = registry.container();
@@ -207,7 +207,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     });
   }
 
-  test("controllers can be injected into controllers", function() {
+  QUnit.test("controllers can be injected into controllers", function() {
     var registry = new Registry();
     var container = registry.container();
 
@@ -223,7 +223,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     equal(postsController, postController.get('postsController'), "controller.posts is injected");
   });
 
-  test("services can be injected into controllers", function() {
+  QUnit.test("services can be injected into controllers", function() {
     var registry = new Registry();
     var container = registry.container();
 

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -82,13 +82,13 @@ function createDynamicArrayController() {
   });
 }
 
-test("when no `itemController` is set, `objectAtContent` returns objects directly", function() {
+QUnit.test("when no `itemController` is set, `objectAtContent` returns objects directly", function() {
   createUnwrappedArrayController();
 
   strictEqual(arrayController.objectAtContent(1), jaime, "No controller is returned when itemController is not set");
 });
 
-test("when `itemController` is set, `objectAtContent` returns an instance of the controller", function() {
+QUnit.test("when `itemController` is set, `objectAtContent` returns an instance of the controller", function() {
   createArrayController();
 
   var jaimeController = arrayController.objectAtContent(1);
@@ -97,7 +97,7 @@ test("when `itemController` is set, `objectAtContent` returns an instance of the
 });
 
 
-test("when `idx` is out of range, `objectAtContent` does not create a controller", function() {
+QUnit.test("when `idx` is out of range, `objectAtContent` does not create a controller", function() {
   controllerClass.reopen({
     init: function() {
       ok(false, "Controllers should not be created when `idx` is out of range");
@@ -108,14 +108,14 @@ test("when `idx` is out of range, `objectAtContent` does not create a controller
   strictEqual(arrayController.objectAtContent(50), undefined, "no controllers are created for out of range indexes");
 });
 
-test("when the underlying object is null, a controller is still returned", function() {
+QUnit.test("when the underlying object is null, a controller is still returned", function() {
   createArrayController();
   arrayController.unshiftObject(null);
   var firstController = arrayController.objectAtContent(0);
   ok(controllerClass.detectInstance(firstController), "A controller is still created for null objects");
 });
 
-test("the target of item controllers is the parent controller", function() {
+QUnit.test("the target of item controllers is the parent controller", function() {
   createArrayController();
 
   var jaimeController = arrayController.objectAtContent(1);
@@ -123,7 +123,7 @@ test("the target of item controllers is the parent controller", function() {
   equal(jaimeController.get('target'), arrayController, "Item controllers' targets are their parent controller");
 });
 
-test("the parentController property of item controllers is set to the parent controller", function() {
+QUnit.test("the parentController property of item controllers is set to the parent controller", function() {
   createArrayController();
 
   var jaimeController = arrayController.objectAtContent(1);
@@ -131,13 +131,13 @@ test("the parentController property of item controllers is set to the parent con
   equal(jaimeController.get('parentController'), arrayController, "Item controllers' targets are their parent controller");
 });
 
-test("when the underlying object has not changed, `objectAtContent` always returns the same instance", function() {
+QUnit.test("when the underlying object has not changed, `objectAtContent` always returns the same instance", function() {
   createArrayController();
 
   strictEqual(arrayController.objectAtContent(1), arrayController.objectAtContent(1), "Controller instances are reused");
 });
 
-test("when the index changes, `objectAtContent` still returns the same instance", function() {
+QUnit.test("when the index changes, `objectAtContent` still returns the same instance", function() {
   createArrayController();
   var jaimeController = arrayController.objectAtContent(1);
   arrayController.unshiftObject(tyrion);
@@ -145,7 +145,7 @@ test("when the index changes, `objectAtContent` still returns the same instance"
   strictEqual(arrayController.objectAtContent(2), jaimeController, "Controller instances are reused");
 });
 
-test("when the underlying array changes, old subcontainers are destroyed", function() {
+QUnit.test("when the underlying array changes, old subcontainers are destroyed", function() {
   createArrayController();
   // cause some controllers to be instantiated
   arrayController.objectAtContent(1);
@@ -168,7 +168,7 @@ test("when the underlying array changes, old subcontainers are destroyed", funct
 });
 
 
-test("item controllers are created lazily", function() {
+QUnit.test("item controllers are created lazily", function() {
   createArrayController();
 
   equal(itemControllerCount, 0, "precond - no item controllers yet");
@@ -178,7 +178,7 @@ test("item controllers are created lazily", function() {
   equal(itemControllerCount, 1, "item controllers are created lazily");
 });
 
-test("when items are removed from the arrayController, their respective subcontainers are destroyed", function() {
+QUnit.test("when items are removed from the arrayController, their respective subcontainers are destroyed", function() {
   createArrayController();
   var jaimeController = arrayController.objectAtContent(1);
   var cerseiController = arrayController.objectAtContent(2);
@@ -195,7 +195,7 @@ test("when items are removed from the arrayController, their respective subconta
   equal(!!jaimeController.isDestroying, false, "Retained objects' containers are not cleaned up");
 });
 
-test("one cannot remove wrapped model directly when specifying `itemController`", function() {
+QUnit.test("one cannot remove wrapped model directly when specifying `itemController`", function() {
   createArrayController();
   var cerseiController = arrayController.objectAtContent(2);
 
@@ -210,7 +210,7 @@ test("one cannot remove wrapped model directly when specifying `itemController`"
   equal(arrayController.get('length'), 2, "can remove wrapper objects");
 });
 
-test("when items are removed from the underlying array, their respective subcontainers are destroyed", function() {
+QUnit.test("when items are removed from the underlying array, their respective subcontainers are destroyed", function() {
   createArrayController();
   var jaimeController = arrayController.objectAtContent(1);
   var cerseiController = arrayController.objectAtContent(2);
@@ -227,7 +227,7 @@ test("when items are removed from the underlying array, their respective subcont
   equal(!!cerseiController.isDestroyed, true, "Removed objects' containers are cleaned up");
 });
 
-test("`itemController` can be dynamic by overwriting `lookupItemController`", function() {
+QUnit.test("`itemController` can be dynamic by overwriting `lookupItemController`", function() {
   createDynamicArrayController();
 
   var tywinController = arrayController.objectAtContent(0);
@@ -237,7 +237,7 @@ test("`itemController` can be dynamic by overwriting `lookupItemController`", fu
   ok(otherControllerClass.detectInstance(jaimeController), "lookupItemController can return different classes for different objects");
 });
 
-test("when `idx` is out of range, `lookupItemController` is not called", function() {
+QUnit.test("when `idx` is out of range, `lookupItemController` is not called", function() {
   arrayController = ArrayController.create({
     container: container,
     lookupItemController: function(object) {
@@ -250,7 +250,7 @@ test("when `idx` is out of range, `lookupItemController` is not called", functio
   strictEqual(arrayController.objectAtContent(-1), undefined, "no controllers are created for indexes less than zero");
 });
 
-test("if `lookupItemController` returns a string, it must be resolvable by the container", function() {
+QUnit.test("if `lookupItemController` returns a string, it must be resolvable by the container", function() {
   arrayController = ArrayController.create({
     container: container,
     lookupItemController: function(object) {
@@ -266,7 +266,7 @@ test("if `lookupItemController` returns a string, it must be resolvable by the c
     "`lookupItemController` must return either null or a valid controller name");
 });
 
-test("target and parentController are set to the concrete parentController", function() {
+QUnit.test("target and parentController are set to the concrete parentController", function() {
   var parent = ArrayController.create({
 
   });
@@ -295,7 +295,7 @@ test("target and parentController are set to the concrete parentController", fun
 
 });
 
-test("array observers can invoke `objectAt` without overwriting existing item controllers", function() {
+QUnit.test("array observers can invoke `objectAt` without overwriting existing item controllers", function() {
   createArrayController();
 
   var tywinController = arrayController.objectAtContent(0);
@@ -321,7 +321,7 @@ test("array observers can invoke `objectAt` without overwriting existing item co
   equal(tywinController.get('model.name'), "Tywin", "Array observers calling `objectAt` does not overwrite existing controllers' model");
 });
 
-test("`itemController`'s life cycle should be entangled with its parent controller", function() {
+QUnit.test("`itemController`'s life cycle should be entangled with its parent controller", function() {
   createDynamicArrayController();
 
   var tywinController = arrayController.objectAtContent(0);
@@ -364,7 +364,7 @@ QUnit.module('Ember.ArrayController - itemController with arrayComputed', {
   }
 });
 
-test("item controllers can be used to provide properties for array computed macros", function() {
+QUnit.test("item controllers can be used to provide properties for array computed macros", function() {
   createArrayController();
 
   ok(compare(guidFor(cersei), guidFor(jaime)) < 0, "precond - guid tiebreaker would fail test");

--- a/packages/ember-runtime/tests/controllers/object_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/object_controller_test.js
@@ -6,7 +6,7 @@ import { observer } from 'ember-metal/mixin';
 
 QUnit.module("Ember.ObjectController");
 
-test("should be able to set the target property of an ObjectController", function() {
+QUnit.test("should be able to set the target property of an ObjectController", function() {
   expectDeprecation(objectControllerDeprecation);
 
   var controller = ObjectController.create();
@@ -17,7 +17,7 @@ test("should be able to set the target property of an ObjectController", functio
 });
 
 // See https://github.com/emberjs/ember.js/issues/5112
-test("can observe a path on an ObjectController", function() {
+QUnit.test("can observe a path on an ObjectController", function() {
   expectDeprecation(objectControllerDeprecation);
 
   var controller = ObjectController.extend({
@@ -27,7 +27,7 @@ test("can observe a path on an ObjectController", function() {
   ok(true, "should not fail");
 });
 
-test('accessing model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
+QUnit.test('accessing model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
   var controller;
 
   expectDeprecation(function() {
@@ -44,7 +44,7 @@ test('accessing model properties via proxy behavior results in a deprecation [DE
   }, /object proxying is deprecated\. Please use `model\.bar` instead\./);
 });
 
-test('setting model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
+QUnit.test('setting model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
   var controller;
 
   expectDeprecation(function() {
@@ -61,7 +61,7 @@ test('setting model properties via proxy behavior results in a deprecation [DEPR
   }, /object proxying is deprecated\. Please use `model\.bar` instead\./);
 });
 
-test('auto-generated controllers are not deprecated', function() {
+QUnit.test('auto-generated controllers are not deprecated', function() {
   expectNoDeprecation(function() {
     ObjectController.extend({
       isGenerated: true

--- a/packages/ember-runtime/tests/core/compare_test.js
+++ b/packages/ember-runtime/tests/core/compare_test.js
@@ -33,7 +33,7 @@ QUnit.module('Ember.compare()', {
   }
 });
 
-test('ordering should work', function() {
+QUnit.test('ordering should work', function() {
   var suspect, comparable, failureMessage,
       suspectIndex, comparableIndex;
 
@@ -54,7 +54,7 @@ test('ordering should work', function() {
   }
 });
 
-test('comparables should return values in the range of -1, 0, 1', function() {
+QUnit.test('comparables should return values in the range of -1, 0, 1', function() {
   var negOne = Comp.create({
     val: -1
   });

--- a/packages/ember-runtime/tests/core/copy_test.js
+++ b/packages/ember-runtime/tests/core/copy_test.js
@@ -3,20 +3,20 @@ import copy from "ember-runtime/copy";
 
 QUnit.module("Ember Copy Method");
 
-test("Ember.copy null", function() {
+QUnit.test("Ember.copy null", function() {
   var obj = { field: null };
 
   equal(copy(obj, true).field, null, "null should still be null");
 });
 
-test("Ember.copy date", function() {
+QUnit.test("Ember.copy date", function() {
   var date = new Date(2014, 7, 22);
   var dateCopy = copy(date);
 
   equal(date.getTime(), dateCopy.getTime(), "dates should be equivalent");
 });
 
-test("Ember.copy null prototype object", function() {
+QUnit.test("Ember.copy null prototype object", function() {
   var obj = create(null);
 
   obj.foo = 'bar';

--- a/packages/ember-runtime/tests/core/isEqual_test.js
+++ b/packages/ember-runtime/tests/core/isEqual_test.js
@@ -2,35 +2,35 @@ import {isEqual} from "ember-runtime/core";
 
 QUnit.module("isEqual");
 
-test("undefined and null", function() {
+QUnit.test("undefined and null", function() {
   ok(isEqual(undefined, undefined), "undefined is equal to undefined");
   ok(!isEqual(undefined, null),      "undefined is not equal to null");
   ok(isEqual(null, null),           "null is equal to null");
   ok(!isEqual(null, undefined),      "null is not equal to undefined");
 });
 
-test("strings should be equal", function() {
+QUnit.test("strings should be equal", function() {
   ok(!isEqual("Hello", "Hi"),    "different Strings are unequal");
   ok(isEqual("Hello", "Hello"), "same Strings are equal");
 });
 
-test("numericals should be equal", function() {
+QUnit.test("numericals should be equal", function() {
   ok(isEqual(24, 24), "same numbers are equal");
   ok(!isEqual(24, 21), "different numbers are inequal");
 });
 
-test("dates should be equal", function() {
+QUnit.test("dates should be equal", function() {
   ok(isEqual(new Date(1985, 7, 22), new Date(1985, 7, 22)), "same dates are equal");
   ok(!isEqual(new Date(2014, 7, 22), new Date(1985, 7, 22)), "different dates are not equal");
 });
 
-test("array should be equal", function() {
+QUnit.test("array should be equal", function() {
   // NOTE: We don't test for array contents -- that would be too expensive.
   ok(!isEqual([1,2], [1,2]), 'two array instances with the same values should not be equal');
   ok(!isEqual([1,2], [1]),   'two array instances with different values should not be equal');
 });
 
-test("first object implements isEqual should use it", function() {
+QUnit.test("first object implements isEqual should use it", function() {
   ok(isEqual({ isEqual: function() { return true; } }, null), 'should return true always');
 
   var obj = { isEqual: function() { return false; } };

--- a/packages/ember-runtime/tests/core/is_array_test.js
+++ b/packages/ember-runtime/tests/core/is_array_test.js
@@ -4,7 +4,7 @@ import ArrayProxy from "ember-runtime/system/array_proxy";
 
 QUnit.module("Ember Type Checking");
 
-test("Ember.isArray", function() {
+QUnit.test("Ember.isArray", function() {
   var arrayProxy = ArrayProxy.create({ content: Ember.A() });
 
   equal(isArray(arrayProxy), true, "[]");

--- a/packages/ember-runtime/tests/core/is_empty_test.js
+++ b/packages/ember-runtime/tests/core/is_empty_test.js
@@ -4,7 +4,7 @@ import ArrayProxy from "ember-runtime/system/array_proxy";
 
 QUnit.module("Ember.isEmpty");
 
-test("Ember.isEmpty", function() {
+QUnit.test("Ember.isEmpty", function() {
   var arrayProxy = ArrayProxy.create({ content: Ember.A() });
 
   equal(true,  isEmpty(arrayProxy), "for an ArrayProxy that has empty content");

--- a/packages/ember-runtime/tests/core/type_test.js
+++ b/packages/ember-runtime/tests/core/type_test.js
@@ -3,7 +3,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module("Ember Type Checking");
 
-test("Ember.typeOf", function() {
+QUnit.test("Ember.typeOf", function() {
   var a = null;
   var arr = [1,2,3];
   var obj = {};

--- a/packages/ember-runtime/tests/ext/mixin_test.js
+++ b/packages/ember-runtime/tests/ext/mixin_test.js
@@ -7,7 +7,7 @@ import run from "ember-metal/run_loop";
 
 QUnit.module('system/mixin/binding_test');
 
-test('Defining a property ending in Binding should setup binding when applied', function() {
+QUnit.test('Defining a property ending in Binding should setup binding when applied', function() {
 
   var MyMixin = Mixin.create({
     fooBinding: 'bar.baz'
@@ -24,7 +24,7 @@ test('Defining a property ending in Binding should setup binding when applied', 
 
 });
 
-test('Defining a property ending in Binding should apply to prototype children', function() {
+QUnit.test('Defining a property ending in Binding should apply to prototype children', function() {
   var MyMixin, obj, obj2;
 
   run(function() {

--- a/packages/ember-runtime/tests/ext/rsvp_test.js
+++ b/packages/ember-runtime/tests/ext/rsvp_test.js
@@ -5,7 +5,7 @@ import RSVP from "ember-runtime/ext/rsvp";
 
 QUnit.module('Ember.RSVP');
 
-test('Ensure that errors thrown from within a promise are sent to the console', function() {
+QUnit.test('Ensure that errors thrown from within a promise are sent to the console', function() {
   var error = new Error('Error thrown in a promise for testing purposes.');
 
   try {
@@ -54,7 +54,7 @@ QUnit.module("Deferred RSVP's async + Testing", {
   }
 });
 
-test("given `Ember.testing = true`, correctly informs the test suite about async steps", function() {
+QUnit.test("given `Ember.testing = true`, correctly informs the test suite about async steps", function() {
   expect(19);
 
   ok(!run.currentRunLoop, 'expect no run-loop');
@@ -109,7 +109,7 @@ test("given `Ember.testing = true`, correctly informs the test suite about async
   });
 });
 
-test('TransitionAborted errors are not re-thrown', function() {
+QUnit.test('TransitionAborted errors are not re-thrown', function() {
   expect(1);
   var fakeTransitionAbort = { name: 'TransitionAborted' };
 
@@ -118,7 +118,7 @@ test('TransitionAborted errors are not re-thrown', function() {
   ok(true, 'did not throw an error when dealing with TransitionAborted');
 });
 
-test('rejections like jqXHR which have errorThrown property work', function() {
+QUnit.test('rejections like jqXHR which have errorThrown property work', function() {
   expect(2);
 
   var wasEmberTesting = Ember.testing;
@@ -144,7 +144,7 @@ test('rejections like jqXHR which have errorThrown property work', function() {
 });
 
 
-test('rejections where the errorThrown is a string should wrap the sting in an error object', function() {
+QUnit.test('rejections where the errorThrown is a string should wrap the sting in an error object', function() {
   expect(2);
 
   var wasEmberTesting = Ember.testing;

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -11,7 +11,7 @@ import Object from "ember-runtime/system/object";
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('inject');
 
-  test("calling `inject` directly should error", function() {
+  QUnit.test("calling `inject` directly should error", function() {
     expectAssertion(function() {
       inject('foo');
     }, /Injected properties must be created through helpers/);
@@ -20,7 +20,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   if (!EmberDev.runningProdBuild) {
     // this check is done via an assertion which is stripped from
     // production builds
-    test("injection type validation is run when first looked up", function() {
+    QUnit.test("injection type validation is run when first looked up", function() {
       expect(1);
 
       createInjectionHelper('foo', function() {
@@ -41,7 +41,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     });
   }
 
-  test("attempting to inject a nonexistent container key should error", function() {
+  QUnit.test("attempting to inject a nonexistent container key should error", function() {
     var registry = new Registry();
     var container = registry.container();
     var AnObject = Object.extend({
@@ -56,7 +56,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
     }, /Attempting to inject an unknown injection: `bar:baz`/);
   });
 
-  test("factories should return a list of lazy injection full names", function() {
+  QUnit.test("factories should return a list of lazy injection full names", function() {
     var AnObject = Object.extend({
       foo: new InjectedProperty('foo', 'bar'),
       bar: new InjectedProperty('quux')

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/chained_test.js
@@ -18,7 +18,7 @@ import {addObserver}  from "ember-metal/observer";
 
 QUnit.module("Ember.Observable - Observing with @each");
 
-test("chained observers on enumerable properties are triggered when the observed property of any item changes", function() {
+QUnit.test("chained observers on enumerable properties are triggered when the observed property of any item changes", function() {
   var family = EmberObject.create({ momma: null });
   var momma = EmberObject.create({ children: [] });
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -71,24 +71,24 @@ QUnit.module("object.get()", {
 
 });
 
-test("should get normal properties", function() {
+QUnit.test("should get normal properties", function() {
   equal(object.get('normal'), 'value');
 });
 
-test("should call computed properties and return their result", function() {
+QUnit.test("should call computed properties and return their result", function() {
   equal(object.get("computed"), "value");
 });
 
-test("should return the function for a non-computed property", function() {
+QUnit.test("should return the function for a non-computed property", function() {
   var value = object.get("method");
   equal(typeOf(value), 'function');
 });
 
-test("should return null when property value is null", function() {
+QUnit.test("should return null when property value is null", function() {
   equal(object.get("nullProperty"), null);
 });
 
-test("should call unknownProperty when value is undefined", function() {
+QUnit.test("should call unknownProperty when value is undefined", function() {
   equal(object.get("unknown"), "unknown");
   equal(object.lastUnknownProperty, "unknown");
 });
@@ -125,51 +125,51 @@ QUnit.module("Ember.get()", {
   }
 });
 
-test("should get normal properties on Ember.Observable", function() {
+QUnit.test("should get normal properties on Ember.Observable", function() {
   equal(get(objectA, 'normal'), 'value');
 });
 
-test("should call computed properties on Ember.Observable and return their result", function() {
+QUnit.test("should call computed properties on Ember.Observable and return their result", function() {
   equal(get(objectA, "computed"), "value");
 });
 
-test("should return the function for a non-computed property on Ember.Observable", function() {
+QUnit.test("should return the function for a non-computed property on Ember.Observable", function() {
   var value = get(objectA, "method");
   equal(typeOf(value), 'function');
 });
 
-test("should return null when property value is null on Ember.Observable", function() {
+QUnit.test("should return null when property value is null on Ember.Observable", function() {
   equal(get(objectA, "nullProperty"), null);
 });
 
-test("should call unknownProperty when value is undefined on Ember.Observable", function() {
+QUnit.test("should call unknownProperty when value is undefined on Ember.Observable", function() {
   equal(get(object, "unknown"), "unknown");
   equal(object.lastUnknownProperty, "unknown");
 });
 
-test("should get normal properties on standard objects", function() {
+QUnit.test("should get normal properties on standard objects", function() {
   equal(get(objectB, 'normal'), 'value');
 });
 
-test("should return null when property is null on standard objects", function() {
+QUnit.test("should return null when property is null on standard objects", function() {
   equal(get(objectB, 'nullProperty'), null);
 });
 
 /*
-test("raise if the provided object is null", function() {
+QUnit.test("raise if the provided object is null", function() {
   throws(function() {
     get(null, 'key');
   });
 });
 */
 
-test("raise if the provided object is undefined", function() {
+QUnit.test("raise if the provided object is undefined", function() {
   expectAssertion(function() {
     get(undefined, 'key');
   }, /Cannot call get with 'key' on an undefined object/i);
 });
 
-test("should work when object is Ember (used in Ember.get)", function() {
+QUnit.test("should work when object is Ember (used in Ember.get)", function() {
   equal(get('Ember.RunLoop'), Ember.RunLoop, 'Ember.get');
   equal(get(Ember, 'RunLoop'), Ember.RunLoop, 'Ember.get(Ember, RunLoop)');
 });
@@ -184,7 +184,7 @@ QUnit.module("Ember.get() with paths", {
   }
 });
 
-test("should return a property at a given path relative to the lookup", function() {
+QUnit.test("should return a property at a given path relative to the lookup", function() {
   lookup.Foo = ObservableObject.create({
     Bar: ObservableObject.createWithMixins({
       Baz: computed(function() { return "blargh"; }).volatile()
@@ -194,7 +194,7 @@ test("should return a property at a given path relative to the lookup", function
   equal(get('Foo.Bar.Baz'), "blargh");
 });
 
-test("should return a property at a given path relative to the passed object", function() {
+QUnit.test("should return a property at a given path relative to the passed object", function() {
   var foo = ObservableObject.create({
     bar: ObservableObject.createWithMixins({
       baz: computed(function() { return "blargh"; }).volatile()
@@ -204,7 +204,7 @@ test("should return a property at a given path relative to the passed object", f
   equal(get(foo, 'bar.baz'), "blargh");
 });
 
-test("should return a property at a given path relative to the lookup - JavaScript hash", function() {
+QUnit.test("should return a property at a given path relative to the lookup - JavaScript hash", function() {
   lookup.Foo = {
     Bar: {
       Baz: "blargh"
@@ -214,7 +214,7 @@ test("should return a property at a given path relative to the lookup - JavaScri
   equal(get('Foo.Bar.Baz'), "blargh");
 });
 
-test("should return a property at a given path relative to the passed object - JavaScript hash", function() {
+QUnit.test("should return a property at a given path relative to the passed object - JavaScript hash", function() {
   var foo = {
     bar: {
       baz: "blargh"
@@ -272,38 +272,38 @@ QUnit.module("object.set()", {
 
 });
 
-test("should change normal properties and return this", function() {
+QUnit.test("should change normal properties and return this", function() {
   var ret = object.set("normal", "changed");
   equal(object.normal, "changed");
   equal(ret, object);
 });
 
-test("should call computed properties passing value and return this", function() {
+QUnit.test("should call computed properties passing value and return this", function() {
   var ret = object.set("computed", "changed");
   equal(object._computed, "changed");
   equal(ret, object);
 });
 
-test("should change normal properties when passing undefined", function() {
+QUnit.test("should change normal properties when passing undefined", function() {
   var ret = object.set('normal', undefined);
   equal(object.normal, undefined);
   equal(ret, object);
 });
 
-test("should replace the function for a non-computed property and return this", function() {
+QUnit.test("should replace the function for a non-computed property and return this", function() {
   var ret = object.set("method", "changed");
   equal(object._method, "method"); // make sure this was NOT run
   ok(typeOf(object.method) !== 'function');
   equal(ret, object);
 });
 
-test("should replace prover when property value is null", function() {
+QUnit.test("should replace prover when property value is null", function() {
   var ret = object.set("nullProperty", "changed");
   equal(object.nullProperty, "changed");
   equal(ret, object);
 });
 
-test("should call unknownProperty with value when property is undefined", function() {
+QUnit.test("should call unknownProperty with value when property is undefined", function() {
   var ret = object.set("unknown", "changed");
   equal(object._unknown, "changed");
   equal(ret, object);
@@ -393,7 +393,7 @@ QUnit.module("Computed properties", {
   }
 });
 
-test("getting values should call function return value", function() {
+QUnit.test("getting values should call function return value", function() {
 
   // get each property twice. Verify return.
   var keys = w('computed computedCached dependent dependentFront dependentCached');
@@ -414,7 +414,7 @@ test("getting values should call function return value", function() {
 
 });
 
-test("setting values should call function return value", function() {
+QUnit.test("setting values should call function return value", function() {
 
   // get each property twice. Verify return.
   var keys = w('computed dependent dependentFront computedCached dependentCached');
@@ -447,7 +447,7 @@ test("setting values should call function return value", function() {
 
 });
 
-test("notify change should clear cache", function() {
+QUnit.test("notify change should clear cache", function() {
 
   // call get several times to collect call count
   object.get('computedCached'); // should run func
@@ -460,7 +460,7 @@ test("notify change should clear cache", function() {
   equal(object.computedCachedCalls.length, 2, 'should have invoked method 2x');
 });
 
-test("change dependent should clear cache", function() {
+QUnit.test("change dependent should clear cache", function() {
 
   // call get several times to collect call count
   var ret1 = object.get('inc'); // should run func
@@ -471,7 +471,7 @@ test("change dependent should clear cache", function() {
   equal(object.get('inc'), ret1+1, 'should increment after dependent key changes'); // should run again
 });
 
-test("just notifying change of dependent should clear cache", function() {
+QUnit.test("just notifying change of dependent should clear cache", function() {
 
   // call get several times to collect call count
   var ret1 = object.get('inc'); // should run func
@@ -482,7 +482,7 @@ test("just notifying change of dependent should clear cache", function() {
   equal(object.get('inc'), ret1+1, 'should increment after dependent key changes'); // should run again
 });
 
-test("changing dependent should clear nested cache", function() {
+QUnit.test("changing dependent should clear nested cache", function() {
 
   // call get several times to collect call count
   var ret1 = object.get('nestedInc'); // should run func
@@ -494,7 +494,7 @@ test("changing dependent should clear nested cache", function() {
 
 });
 
-test("just notifying change of dependent should clear nested cache", function() {
+QUnit.test("just notifying change of dependent should clear nested cache", function() {
 
   // call get several times to collect call count
   var ret1 = object.get('nestedInc'); // should run func
@@ -509,7 +509,7 @@ test("just notifying change of dependent should clear nested cache", function() 
 
 // This verifies a specific bug encountered where observers for computed
 // properties would fire before their prop caches were cleared.
-test("change dependent should clear cache when observers of dependent are called", function() {
+QUnit.test("change dependent should clear cache when observers of dependent are called", function() {
 
   // call get several times to collect call count
   var ret1 = object.get('inc'); // should run func
@@ -525,7 +525,7 @@ test("change dependent should clear cache when observers of dependent are called
 
 });
 
-test('setting one of two computed properties that depend on a third property should clear the kvo cache', function() {
+QUnit.test('setting one of two computed properties that depend on a third property should clear the kvo cache', function() {
   // we have to call set twice to fill up the cache
   object.set('isOff', true);
   object.set('isOn', true);
@@ -536,7 +536,7 @@ test('setting one of two computed properties that depend on a third property sho
   equal(object.get('isOn'), false, 'object.isOn should be false');
 });
 
-test("dependent keys should be able to be specified as property paths", function() {
+QUnit.test("dependent keys should be able to be specified as property paths", function() {
   var depObj = ObservableObject.createWithMixins({
     menu: ObservableObject.create({
       price: 5
@@ -554,7 +554,7 @@ test("dependent keys should be able to be specified as property paths", function
   equal(depObj.get('menuPrice'), 6, "cache is properly invalidated after nested property changes");
 });
 
-test("nested dependent keys should propagate after they update", function() {
+QUnit.test("nested dependent keys should propagate after they update", function() {
   var bindObj;
   run(function () {
     lookup.DepObj = ObservableObject.createWithMixins({
@@ -591,7 +591,7 @@ test("nested dependent keys should propagate after they update", function() {
   equal(bindObj.get('price'), 15, "binding propagates after a middle dependent keys updates");
 });
 
-test("cacheable nested dependent keys should clear after their dependencies update", function() {
+QUnit.test("cacheable nested dependent keys should clear after their dependencies update", function() {
   ok(true);
 
   var DepObj;
@@ -686,7 +686,7 @@ QUnit.module("Observable objects & object properties ", {
 
 });
 
-test('incrementProperty and decrementProperty', function() {
+QUnit.test('incrementProperty and decrementProperty', function() {
   var newValue = object.incrementProperty('numberVal');
 
   equal(25, newValue, 'numerical value incremented');
@@ -742,13 +742,13 @@ test('incrementProperty and decrementProperty', function() {
   equal(25, newValue, 'Attempting to decrement by non-numeric values should not decrement value');
 });
 
-test('toggle function, should be boolean', function() {
+QUnit.test('toggle function, should be boolean', function() {
   equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
   equal(object.toggleProperty('toggleVal', true, false), object.get('toggleVal'));
   equal(object.toggleProperty('toggleVal', undefined, undefined), object.get('toggleVal'));
 });
 
-test('should notify array observer when array changes', function() {
+QUnit.test('should notify array observer when array changes', function() {
   get(object, 'normalArray').replace(0, 0, 6);
   equal(object.abnormal, 'notifiedObserver', 'observer should be notified');
 });
@@ -783,13 +783,13 @@ QUnit.module("object.addObserver()", {
   }
 });
 
-test("should register an observer for a property", function() {
+QUnit.test("should register an observer for a property", function() {
   ObjectC.addObserver('normal', ObjectC, 'action');
   ObjectC.set('normal', 'newValue');
   equal(ObjectC.normal1, 'newZeroValue');
 });
 
-test("should register an observer for a property - Special case of chained property", function() {
+QUnit.test("should register an observer for a property - Special case of chained property", function() {
   ObjectC.addObserver('objectE.propertyVal', ObjectC, 'chainedObserver');
   ObjectC.objectE.set('propertyVal', "chainedPropertyValue");
   equal('chainedPropertyObserved', ObjectC.normal2);
@@ -840,7 +840,7 @@ QUnit.module("object.removeObserver()", {
   }
 });
 
-test("should unregister an observer for a property", function() {
+QUnit.test("should unregister an observer for a property", function() {
   ObjectD.addObserver('normal', ObjectD, 'addAction');
   ObjectD.set('normal', 'newValue');
   equal(ObjectD.normal1, 'newZeroValue');
@@ -853,7 +853,7 @@ test("should unregister an observer for a property", function() {
 });
 
 
-test("should unregister an observer for a property - special case when key has a '.' in it.", function() {
+QUnit.test("should unregister an observer for a property - special case when key has a '.' in it.", function() {
   ObjectD.addObserver('objectF.propertyVal', ObjectD, 'removeChainedObserver');
   ObjectD.objectF.set('propertyVal', "chainedPropertyValue");
   ObjectD.removeObserver('objectF.propertyVal', ObjectD, 'removeChainedObserver');
@@ -865,7 +865,7 @@ test("should unregister an observer for a property - special case when key has a
 });
 
 
-test("removing an observer inside of an observer shouldn’t cause any problems", function() {
+QUnit.test("removing an observer inside of an observer shouldn’t cause any problems", function() {
   // The observable system should be protected against clients removing
   // observers in the middle of observer notification.
   var encounteredError = false;
@@ -914,7 +914,7 @@ QUnit.module("Bind function ", {
   }
 });
 
-test("should bind property with method parameter as undefined", function() {
+QUnit.test("should bind property with method parameter as undefined", function() {
   // creating binding
   run(function() {
     objectA.bind("name", "Namespace.objectB.normal", undefined);
@@ -933,7 +933,7 @@ test("should bind property with method parameter as undefined", function() {
 // SPECIAL CASES
 //
 
-test("changing chained observer object to null should not raise exception", function() {
+QUnit.test("changing chained observer object to null should not raise exception", function() {
 
   var obj = ObservableObject.create({
     foo: ObservableObject.create({

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -157,7 +157,7 @@ test("should return null when property is null on standard objects", function() 
 
 /*
 test("raise if the provided object is null", function() {
-  raises(function() {
+  throws(function() {
     get(null, 'key');
   });
 });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observersForKey_test.js
@@ -24,7 +24,7 @@ var ObservableObject = EmberObject.extend(Observable);
 
 QUnit.module("object.observesForKey()");
 
-test("should get observers", function() {
+QUnit.test("should get observers", function() {
   var o1 = ObservableObject.create({ foo: 100 });
   var o2 = ObservableObject.create({ func: function() {} });
   var o3 = ObservableObject.create({ func: function() {} });

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -58,7 +58,7 @@ QUnit.module("object.propertyChanges", {
   }
 });
 
-test("should observe the changes within the nested begin / end property changes", function() {
+QUnit.test("should observe the changes within the nested begin / end property changes", function() {
 
   //start the outer nest
   ObjectA.beginPropertyChanges();
@@ -81,7 +81,7 @@ test("should observe the changes within the nested begin / end property changes"
   equal(ObjectA.newFoo, "changedNewFooValue");
 });
 
-test("should observe the changes within the begin and end property changes", function() {
+QUnit.test("should observe the changes within the begin and end property changes", function() {
 
   ObjectA.beginPropertyChanges();
   ObjectA.set('foo', 'changeFooValue');
@@ -92,7 +92,7 @@ test("should observe the changes within the begin and end property changes", fun
   equal(ObjectA.prop, "changedPropValue");
 });
 
-test("should indicate that the property of an object has just changed", function() {
+QUnit.test("should indicate that the property of an object has just changed", function() {
   // indicate that property of foo will change to its subscribers
   ObjectA.propertyWillChange('foo');
 
@@ -109,7 +109,7 @@ test("should indicate that the property of an object has just changed", function
   equal(ObjectA.prop, 'changedPropValue');
 });
 
-test("should notify that the property of an object has changed", function() {
+QUnit.test("should notify that the property of an object has changed", function() {
   // Notify to its subscriber that the values of 'newFoo' will be changed. In this
   // case the observer is "newProp". Therefore this will call the notifyAction function
   // and value of "newProp" will be changed.
@@ -119,7 +119,7 @@ test("should notify that the property of an object has changed", function() {
   equal(ObjectA.newProp, 'changedNewPropValue');
 });
 
-test("should invalidate function property cache when notifyPropertyChange is called", function() {
+QUnit.test("should invalidate function property cache when notifyPropertyChange is called", function() {
 
   var a = ObservableObject.createWithMixins({
     _b: null,

--- a/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -58,11 +58,11 @@ QUnit.module("basic object binding", {
   }
 });
 
-test("binding should have synced on connect", function() {
+QUnit.test("binding should have synced on connect", function() {
   equal(get(toObject, "value"), "start", "toObject.value should match fromObject.value");
 });
 
-test("fromObject change should propagate to toObject only after flush", function() {
+QUnit.test("fromObject change should propagate to toObject only after flush", function() {
   run(function () {
     set(fromObject, "value", "change");
     equal(get(toObject, "value"), "start");
@@ -70,7 +70,7 @@ test("fromObject change should propagate to toObject only after flush", function
   equal(get(toObject, "value"), "change");
 });
 
-test("toObject change should propagate to fromObject only after flush", function() {
+QUnit.test("toObject change should propagate to fromObject only after flush", function() {
   run(function () {
     set(toObject, "value", "change");
     equal(get(fromObject, "value"), "start");
@@ -78,7 +78,7 @@ test("toObject change should propagate to fromObject only after flush", function
   equal(get(fromObject, "value"), "change");
 });
 
-test("deferred observing during bindings", function() {
+QUnit.test("deferred observing during bindings", function() {
 
   // setup special binding
   fromObject = EmberObject.create({
@@ -113,7 +113,7 @@ test("deferred observing during bindings", function() {
   equal(toObject.callCount, 2, 'should call observer twice');
 });
 
-test("binding disconnection actually works", function() {
+QUnit.test("binding disconnection actually works", function() {
   binding.disconnect(root);
   run(function () {
     set(fromObject, 'value', 'change');
@@ -140,7 +140,7 @@ QUnit.module("one way binding", {
   }
 });
 
-test("fromObject change should propagate after flush", function() {
+QUnit.test("fromObject change should propagate after flush", function() {
   run(function() {
     set(fromObject, "value", "change");
     equal(get(toObject, "value"), "start");
@@ -148,7 +148,7 @@ test("fromObject change should propagate after flush", function() {
   equal(get(toObject, "value"), "change");
 });
 
-test("toObject change should NOT propagate", function() {
+QUnit.test("toObject change should NOT propagate", function() {
   run(function() {
     set(toObject, "value", "change");
     equal(get(fromObject, "value"), "start");
@@ -189,7 +189,7 @@ QUnit.module("chained binding", {
   }
 });
 
-test("changing first output should propagate to third after flush", function() {
+QUnit.test("changing first output should propagate to third after flush", function() {
   run(function() {
     set(first, "output", "change");
     equal("change", get(first, "output"), "first.output");
@@ -235,7 +235,7 @@ QUnit.module("Custom Binding", {
   }
 });
 
-test("two bindings to the same value should sync in the order they are initialized", function() {
+QUnit.test("two bindings to the same value should sync in the order they are initialized", function() {
 
   run.begin();
 
@@ -296,7 +296,7 @@ QUnit.module("propertyNameBinding with longhand", {
   }
 });
 
-test("works with full path", function() {
+QUnit.test("works with full path", function() {
   run(function () {
     set(TestNamespace.fromObject, 'value', "updatedValue");
   });
@@ -310,7 +310,7 @@ test("works with full path", function() {
   equal(get(TestNamespace.toObject, 'value'), "newerValue");
 });
 
-test("works with local path", function() {
+QUnit.test("works with local path", function() {
   run(function () {
     set(TestNamespace.toObject, 'localValue', "updatedValue");
   });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -48,12 +48,12 @@ QUnit.module("A new EmberObject instance", {
 
 });
 
-test("Should return its properties when requested using EmberObject#get", function() {
+QUnit.test("Should return its properties when requested using EmberObject#get", function() {
   equal(get(obj, 'foo'), 'bar');
   equal(get(obj, 'total'), 12345);
 });
 
-test("Should allow changing of those properties by calling EmberObject#set", function() {
+QUnit.test("Should allow changing of those properties by calling EmberObject#set", function() {
   equal(get(obj, 'foo'), 'bar');
   equal(get(obj, 'total'), 12345);
 
@@ -101,19 +101,19 @@ QUnit.module("EmberObject observers", {
   }
 });
 
-test("Local observers work", function() {
+QUnit.test("Local observers work", function() {
   obj._normal = false;
   set(obj, "prop1", false);
   equal(obj._normal, true, "Normal observer did change.");
 });
 
-test("Global observers work", function() {
+QUnit.test("Global observers work", function() {
   obj._global = false;
   set(TestNamespace.obj, "value", "test2");
   equal(obj._global, true, "Global observer did change.");
 });
 
-test("Global+Local observer works", function() {
+QUnit.test("Global+Local observer works", function() {
   obj._both = false;
   set(obj, "prop1", false);
   equal(obj._both, true, "Both observer did change.");
@@ -141,12 +141,12 @@ QUnit.module("EmberObject superclass and subclasses", {
   }
 });
 
-test("Checking the detect() function on an object and its subclass", function() {
+QUnit.test("Checking the detect() function on an object and its subclass", function() {
   equal(obj.detect(obj1), true);
   equal(obj1.detect(obj), false);
 });
 
-test("Checking the detectInstance() function on an object and its subclass", function() {
+QUnit.test("Checking the detectInstance() function on an object and its subclass", function() {
   ok(EmberObject.detectInstance(obj.create()));
   ok(obj.detectInstance(obj.create()));
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
@@ -61,7 +61,7 @@ var bindModuleOpts = {
 
 QUnit.module("bind() method", bindModuleOpts);
 
-test("bind(TestNamespace.fromObject.bar) should follow absolute path", function() {
+QUnit.test("bind(TestNamespace.fromObject.bar) should follow absolute path", function() {
   run(function() {
     // create binding
     testObject.bind("foo", "TestNamespace.fromObject.bar");
@@ -73,7 +73,7 @@ test("bind(TestNamespace.fromObject.bar) should follow absolute path", function(
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
-test("bind(.bar) should bind to relative path", function() {
+QUnit.test("bind(.bar) should bind to relative path", function() {
   run(function() {
     // create binding
     testObject.bind("foo", "bar");
@@ -123,7 +123,7 @@ var fooBindingModuleOpts = {
 QUnit.module("fooBinding method", fooBindingModuleOpts);
 
 
-test("fooBinding: TestNamespace.fromObject.bar should follow absolute path", function() {
+QUnit.test("fooBinding: TestNamespace.fromObject.bar should follow absolute path", function() {
   // create binding
   run(function() {
     testObject = TestObject.createWithMixins({
@@ -137,7 +137,7 @@ test("fooBinding: TestNamespace.fromObject.bar should follow absolute path", fun
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
-test("fooBinding: .bar should bind to relative path", function() {
+QUnit.test("fooBinding: .bar should bind to relative path", function() {
   run(function() {
     testObject = TestObject.createWithMixins({
       fooBinding: "bar"
@@ -149,7 +149,7 @@ test("fooBinding: .bar should bind to relative path", function() {
   equal("changedValue", get(testObject, "foo"), "testObject.foo");
 });
 
-test('fooBinding: should disconnect bindings when destroyed', function () {
+QUnit.test('fooBinding: should disconnect bindings when destroyed', function () {
   run(function() {
     testObject = TestObject.createWithMixins({
       fooBinding: "TestNamespace.fromObject.bar"

--- a/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -28,7 +28,7 @@ QUnit.module("EmberObject Concatenated Properties", {
   }
 });
 
-test("concatenates instances", function() {
+QUnit.test("concatenates instances", function() {
   var obj = klass.create({
     values: ['d', 'e', 'f']
   });
@@ -39,7 +39,7 @@ test("concatenates instances", function() {
   deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
 });
 
-test("concatenates subclasses", function() {
+QUnit.test("concatenates subclasses", function() {
   var subKlass = klass.extend({
     values: ['d', 'e', 'f']
   });
@@ -51,7 +51,7 @@ test("concatenates subclasses", function() {
   deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
 });
 
-test("concatenates reopen", function() {
+QUnit.test("concatenates reopen", function() {
   klass.reopen({
     values: ['d', 'e', 'f']
   });
@@ -63,7 +63,7 @@ test("concatenates reopen", function() {
   deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
 });
 
-test("concatenates mixin", function() {
+QUnit.test("concatenates mixin", function() {
   var mixin = {
     values: ['d', 'e']
   };
@@ -78,7 +78,7 @@ test("concatenates mixin", function() {
   deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
 });
 
-test("concatenates reopen, subclass, and instance", function() {
+QUnit.test("concatenates reopen, subclass, and instance", function() {
   klass.reopen({ values: ['d'] });
   var subKlass = klass.extend({ values: ['e'] });
   var obj = subKlass.create({ values: ['f'] });
@@ -89,7 +89,7 @@ test("concatenates reopen, subclass, and instance", function() {
   deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
 });
 
-test("concatenates subclasses when the values are functions", function() {
+QUnit.test("concatenates subclasses when the values are functions", function() {
   var subKlass = klass.extend({
     functions: K
   });

--- a/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -43,7 +43,7 @@ QUnit.module("System:run_loop() - chained binding", {
   }
 });
 
-test("Should propagate bindings after the RunLoop completes (using Ember.RunLoop)", function() {
+QUnit.test("Should propagate bindings after the RunLoop completes (using Ember.RunLoop)", function() {
   run(function () {
 
     //Binding of output of MyApp.first object to input of MyApp.second object
@@ -75,7 +75,7 @@ test("Should propagate bindings after the RunLoop completes (using Ember.RunLoop
   equal(MyApp.second.get("output"), "change");
 });
 
-test("Should propagate bindings after the RunLoop completes", function() {
+QUnit.test("Should propagate bindings after the RunLoop completes", function() {
   run(function () {
     //Binding of output of MyApp.first object to input of MyApp.second object
     binding1 = Binding.from("first.output")

--- a/packages/ember-runtime/tests/legacy_1x/system/set_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/set_test.js
@@ -33,14 +33,14 @@ QUnit.module("creating Set instances", {
 
 });
 
-test("new Set() should create empty set", function() {
+QUnit.test("new Set() should create empty set", function() {
   ignoreDeprecation(function() {
     var set = new Set();
     equal(set.length, 0);
   });
 });
 
-test("new Set([1,2,3]) should create set with three items in them", function() {
+QUnit.test("new Set([1,2,3]) should create set with three items in them", function() {
   ignoreDeprecation(function() {
     var set = new Set(Ember.A([a,b,c]));
     equal(set.length, 3);
@@ -50,7 +50,7 @@ test("new Set([1,2,3]) should create set with three items in them", function() {
   });
 });
 
-test("new Set() should accept anything that implements EmberArray", function() {
+QUnit.test("new Set() should accept anything that implements EmberArray", function() {
   var arrayLikeObject = EmberObject.createWithMixins(EmberArray, {
     _content: [a,b,c],
     length: 3,
@@ -84,7 +84,7 @@ QUnit.module("Set.add + Set.contains", {
 
 });
 
-test("should add an EmberObject", function() {
+QUnit.test("should add an EmberObject", function() {
   var obj = EmberObject.create();
 
   var oldLength = set.length;
@@ -93,7 +93,7 @@ test("should add an EmberObject", function() {
   equal(set.length, oldLength+1, "new set length");
 });
 
-test("should add a regular hash", function() {
+QUnit.test("should add a regular hash", function() {
   var obj = {};
 
   var oldLength = set.length;
@@ -102,7 +102,7 @@ test("should add a regular hash", function() {
   equal(set.length, oldLength+1, "new set length");
 });
 
-test("should add a string", function() {
+QUnit.test("should add a string", function() {
   var obj = "String!";
 
   var oldLength = set.length;
@@ -111,7 +111,7 @@ test("should add a string", function() {
   equal(set.length, oldLength+1, "new set length");
 });
 
-test("should add a number", function() {
+QUnit.test("should add a number", function() {
   var obj = 23;
 
   var oldLength = set.length;
@@ -120,7 +120,7 @@ test("should add a number", function() {
   equal(set.length, oldLength+1, "new set length");
 });
 
-test("should add bools", function() {
+QUnit.test("should add bools", function() {
   var oldLength = set.length;
 
   set.add(true);
@@ -132,7 +132,7 @@ test("should add bools", function() {
   equal(set.length, oldLength+2, "new set length");
 });
 
-test("should add 0", function() {
+QUnit.test("should add 0", function() {
   var oldLength = set.length;
 
   set.add(0);
@@ -140,7 +140,7 @@ test("should add 0", function() {
   equal(set.length, oldLength+1, "new set length");
 });
 
-test("should add a function", function() {
+QUnit.test("should add a function", function() {
   var obj = function() { return "Test function"; };
 
   var oldLength = set.length;
@@ -149,19 +149,19 @@ test("should add a function", function() {
   equal(set.length, oldLength+1, "new set length");
 });
 
-test("should NOT add a null", function() {
+QUnit.test("should NOT add a null", function() {
   set.add(null);
   equal(set.length, 0);
   equal(set.contains(null), false);
 });
 
-test("should NOT add an undefined", function() {
+QUnit.test("should NOT add an undefined", function() {
   set.add(undefined);
   equal(set.length, 0);
   equal(set.contains(undefined), false);
 });
 
-test("adding an item, removing it, adding another item", function() {
+QUnit.test("adding an item, removing it, adding another item", function() {
   var item1 = "item1";
   var item2 = "item2";
 
@@ -195,7 +195,7 @@ QUnit.module("Set.remove + Set.contains", {
 
 });
 
-test("should remove an EmberObject and reduce length", function() {
+QUnit.test("should remove an EmberObject and reduce length", function() {
   var obj = EmberObject.create();
   set.add(obj);
   equal(set.contains(obj), true);
@@ -206,7 +206,7 @@ test("should remove an EmberObject and reduce length", function() {
   equal(set.length, oldLength-1, "should be 1 shorter");
 });
 
-test("should remove a regular hash and reduce length", function() {
+QUnit.test("should remove a regular hash and reduce length", function() {
   var obj = {};
   set.add(obj);
   equal(set.contains(obj), true);
@@ -217,7 +217,7 @@ test("should remove a regular hash and reduce length", function() {
   equal(set.length, oldLength-1, "should be 1 shorter");
 });
 
-test("should remove a string and reduce length", function() {
+QUnit.test("should remove a string and reduce length", function() {
   var obj = "String!";
   set.add(obj);
   equal(set.contains(obj), true);
@@ -228,7 +228,7 @@ test("should remove a string and reduce length", function() {
   equal(set.length, oldLength-1, "should be 1 shorter");
 });
 
-test("should remove a number and reduce length", function() {
+QUnit.test("should remove a number and reduce length", function() {
   var obj = 23;
   set.add(obj);
   equal(set.contains(obj), true);
@@ -239,7 +239,7 @@ test("should remove a number and reduce length", function() {
   equal(set.length, oldLength-1, "should be 1 shorter");
 });
 
-test("should remove a bools and reduce length", function() {
+QUnit.test("should remove a bools and reduce length", function() {
   var oldLength = set.length;
   set.remove(true);
   equal(set.contains(true), false, "should be removed");
@@ -250,14 +250,14 @@ test("should remove a bools and reduce length", function() {
   equal(set.length, oldLength-2, "should be 2 shorter");
 });
 
-test("should remove 0 and reduce length", function() {
+QUnit.test("should remove 0 and reduce length", function() {
   var oldLength = set.length;
   set.remove(0);
   equal(set.contains(0), false, "should be removed");
   equal(set.length, oldLength-1, "should be 1 shorter");
 });
 
-test("should remove a function and reduce length", function() {
+QUnit.test("should remove a function and reduce length", function() {
   var obj = function() { return "Test function"; };
   set.add(obj);
   equal(set.contains(obj), true);
@@ -268,19 +268,19 @@ test("should remove a function and reduce length", function() {
   equal(set.length, oldLength-1, "should be 1 shorter");
 });
 
-test("should NOT remove a null", function() {
+QUnit.test("should NOT remove a null", function() {
   var oldLength = set.length;
   set.remove(null);
   equal(set.length, oldLength);
 });
 
-test("should NOT remove an undefined", function() {
+QUnit.test("should NOT remove an undefined", function() {
   var oldLength = set.length;
   set.remove(undefined);
   equal(set.length, oldLength);
 });
 
-test("should ignore removing an object not in the set", function() {
+QUnit.test("should ignore removing an object not in the set", function() {
   var obj = EmberObject.create();
   var oldLength = set.length;
   set.remove(obj);
@@ -305,14 +305,14 @@ QUnit.module("Set.pop + Set.copy", {
   }
 });
 
-test("the pop() should remove an arbitrary object from the set", function() {
+QUnit.test("the pop() should remove an arbitrary object from the set", function() {
   var oldLength = set.length;
   var obj = set.pop();
   ok(!isNone(obj), 'pops up an item');
   equal(set.length, oldLength-1, 'length shorter by 1');
 });
 
-test("should pop false and 0", function() {
+QUnit.test("should pop false and 0", function() {
   ignoreDeprecation(function() {
     set = new Set(Ember.A([false]));
     ok(set.pop() === false, "should pop false");
@@ -322,7 +322,7 @@ test("should pop false and 0", function() {
   });
 });
 
-test("the copy() should return an identical set", function() {
+QUnit.test("the copy() should return an identical set", function() {
   var oldLength = set.length;
   var obj;
 

--- a/packages/ember-runtime/tests/mixins/action_handler_test.js
+++ b/packages/ember-runtime/tests/mixins/action_handler_test.js
@@ -3,7 +3,7 @@ import Controller from "ember-runtime/controllers/controller";
 
 QUnit.module("ActionHandler");
 
-test("passing a function for the actions hash triggers an assertion", function() {
+QUnit.test("passing a function for the actions hash triggers an assertion", function() {
   expect(1);
 
   var controller = Controller.extend({

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -67,7 +67,7 @@ ArrayTests.extend({
 
 }).run();
 
-test("the return value of slice has Ember.Array applied", function() {
+QUnit.test("the return value of slice has Ember.Array applied", function() {
   var x = EmberObject.createWithMixins(EmberArray, {
     length: 0
   });
@@ -75,7 +75,7 @@ test("the return value of slice has Ember.Array applied", function() {
   equal(EmberArray.detect(y), true, "mixin should be applied");
 });
 
-test("slice supports negative index arguments", function() {
+QUnit.test("slice supports negative index arguments", function() {
   var testArray = new TestArray([1,2,3,4]);
 
   deepEqual(testArray.slice(-2),      [3, 4],     'slice(-2)');
@@ -112,7 +112,7 @@ var obj, observer;
 
 QUnit.module('mixins/array/arrayContent[Will|Did]Change');
 
-test('should notify observers of []', function() {
+QUnit.test('should notify observers of []', function() {
 
   obj = DummyArray.createWithMixins({
     _count: 0,
@@ -152,7 +152,7 @@ QUnit.module('notify observers of length', {
   }
 });
 
-test('should notify observers when call with no params', function() {
+QUnit.test('should notify observers when call with no params', function() {
   obj.arrayContentWillChange();
   equal(obj._after, 0);
 
@@ -161,7 +161,7 @@ test('should notify observers when call with no params', function() {
 });
 
 // API variation that included items only
-test('should not notify when passed lengths are same', function() {
+QUnit.test('should not notify when passed lengths are same', function() {
   obj.arrayContentWillChange(0, 1, 1);
   equal(obj._after, 0);
 
@@ -169,7 +169,7 @@ test('should not notify when passed lengths are same', function() {
   equal(obj._after, 0);
 });
 
-test('should notify when passed lengths are different', function() {
+QUnit.test('should notify when passed lengths are different', function() {
   obj.arrayContentWillChange(0, 1, 2);
   equal(obj._after, 0);
 
@@ -209,7 +209,7 @@ QUnit.module('notify array observers', {
   }
 });
 
-test('should notify enumerable observers when called with no params', function() {
+QUnit.test('should notify enumerable observers when called with no params', function() {
   obj.arrayContentWillChange();
   deepEqual(observer._before, [obj, 0, -1, -1]);
 
@@ -218,7 +218,7 @@ test('should notify enumerable observers when called with no params', function()
 });
 
 // API variation that included items only
-test('should notify when called with same length items', function() {
+QUnit.test('should notify when called with same length items', function() {
   obj.arrayContentWillChange(0, 1, 1);
   deepEqual(observer._before, [obj, 0, 1, 1]);
 
@@ -226,7 +226,7 @@ test('should notify when called with same length items', function() {
   deepEqual(observer._after, [obj, 0, 1, 1]);
 });
 
-test('should notify when called with diff length items', function() {
+QUnit.test('should notify when called with diff length items', function() {
   obj.arrayContentWillChange(0, 2, 1);
   deepEqual(observer._before, [obj, 0, 2, 1]);
 
@@ -234,7 +234,7 @@ test('should notify when called with diff length items', function() {
   deepEqual(observer._after, [obj, 0, 2, 1]);
 });
 
-test('removing enumerable observer should disable', function() {
+QUnit.test('removing enumerable observer should disable', function() {
   obj.removeArrayObserver(observer);
   obj.arrayContentWillChange();
   deepEqual(observer._before, null);
@@ -274,7 +274,7 @@ QUnit.module('notify enumerable observers as well', {
   }
 });
 
-test('should notify enumerable observers when called with no params', function() {
+QUnit.test('should notify enumerable observers when called with no params', function() {
   obj.arrayContentWillChange();
   deepEqual(observer._before, [obj, null, null], 'before');
 
@@ -283,7 +283,7 @@ test('should notify enumerable observers when called with no params', function()
 });
 
 // API variation that included items only
-test('should notify when called with same length items', function() {
+QUnit.test('should notify when called with same length items', function() {
   obj.arrayContentWillChange(0, 1, 1);
   deepEqual(observer._before, [obj, ['ITEM-0'], 1], 'before');
 
@@ -291,7 +291,7 @@ test('should notify when called with same length items', function() {
   deepEqual(observer._after, [obj, 1, ['ITEM-0']], 'after');
 });
 
-test('should notify when called with diff length items', function() {
+QUnit.test('should notify when called with diff length items', function() {
   obj.arrayContentWillChange(0, 2, 1);
   deepEqual(observer._before, [obj, ['ITEM-0', 'ITEM-1'], 1], 'before');
 
@@ -299,7 +299,7 @@ test('should notify when called with diff length items', function() {
   deepEqual(observer._after, [obj, 2, ['ITEM-0']], 'after');
 });
 
-test('removing enumerable observer should disable', function() {
+QUnit.test('removing enumerable observer should disable', function() {
   obj.removeEnumerableObserver(observer);
   obj.arrayContentWillChange();
   deepEqual(observer._before, null, 'before');
@@ -329,7 +329,7 @@ QUnit.module('EmberArray.@each support', {
   }
 });
 
-test('adding an object should notify (@each)', function() {
+QUnit.test('adding an object should notify (@each)', function() {
 
   var called = 0;
 
@@ -351,7 +351,7 @@ test('adding an object should notify (@each)', function() {
 
 });
 
-test('adding an object should notify (@each.isDone)', function() {
+QUnit.test('adding an object should notify (@each.isDone)', function() {
 
   var called = 0;
 
@@ -372,7 +372,7 @@ test('adding an object should notify (@each.isDone)', function() {
 
 });
 
-test('using @each to observe arrays that does not return objects raise error', function() {
+QUnit.test('using @each to observe arrays that does not return objects raise error', function() {
 
   var called = 0;
 
@@ -400,7 +400,7 @@ test('using @each to observe arrays that does not return objects raise error', f
   equal(called, 0, 'not calls observer when object is pushed');
 });
 
-test('modifying the array should also indicate the isDone prop itself has changed', function() {
+QUnit.test('modifying the array should also indicate the isDone prop itself has changed', function() {
   // NOTE: we never actually get the '@each.isDone' property here.  This is
   // important because it tests the case where we don't have an isDone
   // EachArray materialized but just want to know when the property has

--- a/packages/ember-runtime/tests/mixins/comparable_test.js
+++ b/packages/ember-runtime/tests/mixins/comparable_test.js
@@ -31,7 +31,7 @@ QUnit.module("Comparable", {
 
 });
 
-test("should be comparable and return the correct result", function() {
+QUnit.test("should be comparable and return the correct result", function() {
   equal(Comparable.detect(r1), true);
   equal(compare(r1, r1), 0);
   equal(compare(r1, r2), -1);

--- a/packages/ember-runtime/tests/mixins/deferred_test.js
+++ b/packages/ember-runtime/tests/mixins/deferred_test.js
@@ -18,7 +18,7 @@ QUnit.module("Deferred", {
   }
 });
 
-test("can resolve deferred", function() {
+QUnit.test("can resolve deferred", function() {
   var deferred;
   var count = 0;
 
@@ -35,7 +35,7 @@ test("can resolve deferred", function() {
   equal(count, 1, "was fulfilled");
 });
 
-test("can reject deferred", function() {
+QUnit.test("can reject deferred", function() {
 
   var deferred;
   var count = 0;
@@ -53,7 +53,7 @@ test("can reject deferred", function() {
   equal(count, 1, "fail callback was called");
 });
 
-test("can resolve with then", function() {
+QUnit.test("can resolve with then", function() {
 
   var deferred;
   var count1 = 0;
@@ -75,7 +75,7 @@ test("can resolve with then", function() {
   equal(count2, 0, "then was not rejected");
 });
 
-test("can reject with then", function() {
+QUnit.test("can reject with then", function() {
 
   var deferred;
   var count1 = 0;
@@ -97,7 +97,7 @@ test("can reject with then", function() {
   equal(count2, 1, "then were rejected");
 });
 
-test("can call resolve multiple times", function() {
+QUnit.test("can call resolve multiple times", function() {
 
   var deferred;
   var count = 0;
@@ -119,7 +119,7 @@ test("can call resolve multiple times", function() {
   equal(count, 1, "calling resolve multiple times has no effect");
 });
 
-test("resolve prevent reject", function() {
+QUnit.test("resolve prevent reject", function() {
   var deferred;
   var resolved = false;
   var rejected = false;
@@ -141,7 +141,7 @@ test("resolve prevent reject", function() {
   equal(rejected, false, "is not rejected");
 });
 
-test("reject prevent resolve", function() {
+QUnit.test("reject prevent resolve", function() {
   var deferred;
   var resolved = false;
   var rejected = false;
@@ -163,7 +163,7 @@ test("reject prevent resolve", function() {
   equal(rejected, true, "is rejected");
 });
 
-test("will call callbacks if they are added after resolution", function() {
+QUnit.test("will call callbacks if they are added after resolution", function() {
 
   var deferred;
   var count1 = 0;
@@ -191,7 +191,7 @@ test("will call callbacks if they are added after resolution", function() {
   equal(count1, 2, "callbacks called after resolution");
 });
 
-test("then is chainable", function() {
+QUnit.test("then is chainable", function() {
   var deferred;
   var count = 0;
 
@@ -212,7 +212,7 @@ test("then is chainable", function() {
 
 
 
-test("can self fulfill", function() {
+QUnit.test("can self fulfill", function() {
   expect(1);
   var deferred;
 
@@ -228,7 +228,7 @@ test("can self fulfill", function() {
 });
 
 
-test("can self reject", function() {
+QUnit.test("can self reject", function() {
   expect(1);
   var deferred;
 
@@ -245,7 +245,7 @@ test("can self reject", function() {
   run(deferred, 'reject', deferred);
 });
 
-test("can fulfill to a custom value", function() {
+QUnit.test("can fulfill to a custom value", function() {
   expect(1);
   var deferred;
   var obj = {};
@@ -262,7 +262,7 @@ test("can fulfill to a custom value", function() {
 });
 
 
-test("can chain self fulfilling objects", function() {
+QUnit.test("can chain self fulfilling objects", function() {
   expect(2);
   var firstDeferred, secondDeferred;
 
@@ -284,7 +284,7 @@ test("can chain self fulfilling objects", function() {
   });
 });
 
-test("can do multi level assimilation", function() {
+QUnit.test("can do multi level assimilation", function() {
   expect(1);
   var firstDeferred, secondDeferred;
   var firstDeferredResolved = false;
@@ -307,7 +307,7 @@ test("can do multi level assimilation", function() {
 });
 
 
-test("can handle rejection without rejection handler", function() {
+QUnit.test("can handle rejection without rejection handler", function() {
   expect(2);
 
   var reason = 'some reason';
@@ -326,7 +326,7 @@ test("can handle rejection without rejection handler", function() {
   run(deferred, 'reject', reason);
 });
 
-test("can handle fulfillment without  fulfillment handler", function() {
+QUnit.test("can handle fulfillment without  fulfillment handler", function() {
   expect(2);
 
   var fulfillment = 'some fulfillment';
@@ -346,7 +346,7 @@ test("can handle fulfillment without  fulfillment handler", function() {
 });
 
 if (!EmberDev.runningProdBuild) {
-  test("causes a deprecation warning when used", function() {
+  QUnit.test("causes a deprecation warning when used", function() {
     var deferred, deprecationMade;
     var obj = {};
 

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -70,31 +70,31 @@ EnumerableTests.extend({
 
 QUnit.module('Ember.Enumerable');
 
-test("should apply Ember.Array to return value of map", function() {
+QUnit.test("should apply Ember.Array to return value of map", function() {
   var x = EmberObject.createWithMixins(Enumerable);
   var y = x.map(K);
   equal(EmberArray.detect(y), true, "should have mixin applied");
 });
 
-test("should apply Ember.Array to return value of filter", function() {
+QUnit.test("should apply Ember.Array to return value of filter", function() {
   var x = EmberObject.createWithMixins(Enumerable);
   var y = x.filter(K);
   equal(EmberArray.detect(y), true, "should have mixin applied");
 });
 
-test("should apply Ember.Array to return value of invoke", function() {
+QUnit.test("should apply Ember.Array to return value of invoke", function() {
   var x = EmberObject.createWithMixins(Enumerable);
   var y = x.invoke(K);
   equal(EmberArray.detect(y), true, "should have mixin applied");
 });
 
-test("should apply Ember.Array to return value of toArray", function() {
+QUnit.test("should apply Ember.Array to return value of toArray", function() {
   var x = EmberObject.createWithMixins(Enumerable);
   var y = x.toArray(K);
   equal(EmberArray.detect(y), true, "should have mixin applied");
 });
 
-test("should apply Ember.Array to return value of without", function() {
+QUnit.test("should apply Ember.Array to return value of without", function() {
   var x = EmberObject.createWithMixins(Enumerable, {
     contains: function() {
       return true;
@@ -104,13 +104,13 @@ test("should apply Ember.Array to return value of without", function() {
   equal(EmberArray.detect(y), true, "should have mixin applied");
 });
 
-test("should apply Ember.Array to return value of uniq", function() {
+QUnit.test("should apply Ember.Array to return value of uniq", function() {
   var x = EmberObject.createWithMixins(Enumerable);
   var y = x.uniq(K);
   equal(EmberArray.detect(y), true, "should have mixin applied");
 });
 
-test('any', function() {
+QUnit.test('any', function() {
   var kittens = Ember.A([{
     color: 'white'
   }, {
@@ -125,7 +125,7 @@ test('any', function() {
   equal(foundWhite2, true);
 });
 
-test('any with NaN', function() {
+QUnit.test('any with NaN', function() {
   var numbers = Ember.A([1,2,NaN,4]);
 
   var hasNaN = numbers.any(function(n) {
@@ -135,7 +135,7 @@ test('any with NaN', function() {
   equal(hasNaN, true, "works when matching NaN");
 });
 
-test('every', function() {
+QUnit.test('every', function() {
   var allColorsKittens = Ember.A([{
     color: 'white'
   }, {
@@ -183,7 +183,7 @@ var obj, observer;
 
 QUnit.module('mixins/enumerable/enumerableContentDidChange');
 
-test('should notify observers of []', function() {
+QUnit.test('should notify observers of []', function() {
 
   var obj = EmberObject.createWithMixins(Enumerable, {
     nextObject: function() {}, // avoid exceptions
@@ -223,7 +223,7 @@ QUnit.module('notify observers of length', {
   }
 });
 
-test('should notify observers when call with no params', function() {
+QUnit.test('should notify observers when call with no params', function() {
   obj.enumerableContentWillChange();
   equal(obj._after, 0);
 
@@ -232,7 +232,7 @@ test('should notify observers when call with no params', function() {
 });
 
 // API variation that included items only
-test('should not notify when passed arrays of same length', function() {
+QUnit.test('should not notify when passed arrays of same length', function() {
   var added = ['foo'];
   var removed = ['bar'];
 
@@ -243,7 +243,7 @@ test('should not notify when passed arrays of same length', function() {
   equal(obj._after, 0);
 });
 
-test('should notify when passed arrays of different length', function() {
+QUnit.test('should notify when passed arrays of different length', function() {
   var added = ['foo'];
   var removed = ['bar', 'baz'];
 
@@ -255,7 +255,7 @@ test('should notify when passed arrays of different length', function() {
 });
 
 // API variation passes indexes only
-test('should not notify when passed with indexes', function() {
+QUnit.test('should not notify when passed with indexes', function() {
   obj.enumerableContentWillChange(1, 1);
   equal(obj._after, 0);
 
@@ -263,7 +263,7 @@ test('should not notify when passed with indexes', function() {
   equal(obj._after, 0);
 });
 
-test('should notify when passed old index API with delta', function() {
+QUnit.test('should notify when passed old index API with delta', function() {
   obj.enumerableContentWillChange(1, 2);
   equal(obj._after, 0);
 
@@ -303,7 +303,7 @@ QUnit.module('notify enumerable observers', {
   }
 });
 
-test('should notify enumerable observers when called with no params', function() {
+QUnit.test('should notify enumerable observers when called with no params', function() {
   obj.enumerableContentWillChange();
   deepEqual(observer._before, [obj, null, null]);
 
@@ -312,7 +312,7 @@ test('should notify enumerable observers when called with no params', function()
 });
 
 // API variation that included items only
-test('should notify when called with same length items', function() {
+QUnit.test('should notify when called with same length items', function() {
   var added = ['foo'];
   var removed = ['bar'];
 
@@ -323,7 +323,7 @@ test('should notify when called with same length items', function() {
   deepEqual(observer._after, [obj, removed, added]);
 });
 
-test('should notify when called with diff length items', function() {
+QUnit.test('should notify when called with diff length items', function() {
   var added = ['foo', 'baz'];
   var removed = ['bar'];
 
@@ -334,7 +334,7 @@ test('should notify when called with diff length items', function() {
   deepEqual(observer._after, [obj, removed, added]);
 });
 
-test('should not notify when passed with indexes only', function() {
+QUnit.test('should not notify when passed with indexes only', function() {
   obj.enumerableContentWillChange(1, 2);
   deepEqual(observer._before, [obj, 1, 2]);
 
@@ -342,7 +342,7 @@ test('should not notify when passed with indexes only', function() {
   deepEqual(observer._after, [obj, 1, 2]);
 });
 
-test('removing enumerable observer should disable', function() {
+QUnit.test('removing enumerable observer should disable', function() {
   obj.removeEnumerableObserver(observer);
   obj.enumerableContentWillChange();
   deepEqual(observer._before, null);

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -5,7 +5,7 @@ import { testBoth } from "ember-metal/tests/props_helper";
 
 QUnit.module('mixins/observable');
 
-test('should be able to use getProperties to get a POJO of provided keys', function() {
+QUnit.test('should be able to use getProperties to get a POJO of provided keys', function() {
   var obj = EmberObject.create({
     firstName: "Steve",
     lastName: "Jobs",
@@ -17,7 +17,7 @@ test('should be able to use getProperties to get a POJO of provided keys', funct
   equal("Jobs", pojo.lastName);
 });
 
-test('should be able to use getProperties with array parameter to get a POJO of provided keys', function() {
+QUnit.test('should be able to use getProperties with array parameter to get a POJO of provided keys', function() {
   var obj = EmberObject.create({
     firstName: "Steve",
     lastName: "Jobs",
@@ -29,7 +29,7 @@ test('should be able to use getProperties with array parameter to get a POJO of 
   equal("Jobs", pojo.lastName);
 });
 
-test('should be able to use setProperties to set multiple properties at once', function() {
+QUnit.test('should be able to use setProperties to set multiple properties at once', function() {
   var obj = EmberObject.create({
     firstName: "Steve",
     lastName: "Jobs",
@@ -91,7 +91,7 @@ testBoth("should be able to retrieve cached values of computed properties withou
   equal(obj.cacheFor('bar'), undefined, "returns undefined if the value is not a computed property");
 });
 
-test('incrementProperty should work even if value is number in string', function() {
+QUnit.test('incrementProperty should work even if value is number in string', function() {
   var obj = EmberObject.create({
     age: "24"
   });

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -11,7 +11,7 @@ import * as RSVP from 'rsvp';
 
 var ObjectPromiseProxy;
 
-test("present on ember namespace", function() {
+QUnit.test("present on ember namespace", function() {
   ok(PromiseProxyMixin, "expected PromiseProxyMixin to exist");
 });
 
@@ -21,7 +21,7 @@ QUnit.module("Ember.PromiseProxy - ObjectProxy", {
   }
 });
 
-test("no promise, invoking then should raise", function() {
+QUnit.test("no promise, invoking then should raise", function() {
   var proxy = ObjectPromiseProxy.create();
 
   throws(function() {
@@ -29,7 +29,7 @@ test("no promise, invoking then should raise", function() {
   }, new RegExp("PromiseProxy's promise must be set"));
 });
 
-test("fulfillment", function() {
+QUnit.test("fulfillment", function() {
   var value = {
     firstName: 'stef',
     lastName: 'penner'
@@ -92,7 +92,7 @@ test("fulfillment", function() {
   // rest of the promise semantics are tested in directly in RSVP
 });
 
-test("rejection", function() {
+QUnit.test("rejection", function() {
   var reason = new Error("failure");
   var deferred = RSVP.defer();
   var proxy = ObjectPromiseProxy.create({
@@ -148,7 +148,7 @@ test("rejection", function() {
   equal(get(proxy, 'isFulfilled'), false,  'expects the proxy to indicate that it is not fulfilled');
 });
 
-test("unhandled rejects still propagate to RSVP.on('error', ...) ", function() {
+QUnit.test("unhandled rejects still propagate to RSVP.on('error', ...) ", function() {
   expect(1);
 
   RSVP.on('error', onerror);
@@ -181,7 +181,7 @@ test("unhandled rejects still propagate to RSVP.on('error', ...) ", function() {
   RSVP.off('error', onerror);
 });
 
-test("should work with promise inheritance", function() {
+QUnit.test("should work with promise inheritance", function() {
   function PromiseSubclass() {
     RSVP.Promise.apply(this, arguments);
   }
@@ -197,7 +197,7 @@ test("should work with promise inheritance", function() {
   ok(proxy.then() instanceof PromiseSubclass, 'promise proxy respected inheritance');
 });
 
-test("should reset isFulfilled and isRejected when promise is reset", function() {
+QUnit.test("should reset isFulfilled and isRejected when promise is reset", function() {
   var deferred = EmberRSVP.defer();
 
   var proxy = ObjectPromiseProxy.create({
@@ -232,7 +232,7 @@ test("should reset isFulfilled and isRejected when promise is reset", function()
   equal(get(proxy, 'isFulfilled'), false, 'expects the proxy to indicate that it is not fulfilled');
 });
 
-test("should have content when isFulfilled is set", function() {
+QUnit.test("should have content when isFulfilled is set", function() {
   var deferred = EmberRSVP.defer();
 
   var proxy = ObjectPromiseProxy.create({
@@ -246,7 +246,7 @@ test("should have content when isFulfilled is set", function() {
   run(deferred, 'resolve', true);
 });
 
-test("should have reason when isRejected is set", function() {
+QUnit.test("should have reason when isRejected is set", function() {
   var error = new Error('Y U REJECT?!?');
   var deferred = EmberRSVP.defer();
 

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -24,7 +24,7 @@ QUnit.module("Ember.PromiseProxy - ObjectProxy", {
 test("no promise, invoking then should raise", function() {
   var proxy = ObjectPromiseProxy.create();
 
-  raises(function() {
+  throws(function() {
     proxy.then(function() { return this; }, function() { return this; });
   }, new RegExp("PromiseProxy's promise must be set"));
 });

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -33,7 +33,7 @@ QUnit.module("Ember.Sortable with content", {
   }
 });
 
-test("if you do not specify `sortProperties` sortable have no effect", function() {
+QUnit.test("if you do not specify `sortProperties` sortable have no effect", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Dale', 'array is in it natural order');
 
@@ -49,7 +49,7 @@ test("if you do not specify `sortProperties` sortable have no effect", function(
   equal(sortedArrayController.objectAt(4).name, 'Scumbag Jackson', 'a new object was inserted in the natural order with empty array as sortProperties');
 });
 
-test("you can change sorted properties", function() {
+QUnit.test("you can change sorted properties", function() {
   sortedArrayController.set('sortProperties', ['id']);
 
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Dale', 'array is sorted by id');
@@ -67,7 +67,7 @@ test("you can change sorted properties", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 });
 
-test("changing sort order triggers observers", function() {
+QUnit.test("changing sort order triggers observers", function() {
   var observer;
   var changeCount = 0;
   observer = EmberObject.createWithMixins({
@@ -94,7 +94,7 @@ test("changing sort order triggers observers", function() {
   run(function() { observer.destroy(); });
 });
 
-test("changing sortProperties and sortAscending with setProperties, sortProperties appearing first", function() {
+QUnit.test("changing sortProperties and sortAscending with setProperties, sortProperties appearing first", function() {
   sortedArrayController.set('sortProperties', ['name']);
   sortedArrayController.set('sortAscending', false);
 
@@ -123,7 +123,7 @@ test("changing sortProperties and sortAscending with setProperties, sortProperti
 
 });
 
-test("changing sortProperties and sortAscending with setProperties, sortAscending appearing first", function() {
+QUnit.test("changing sortProperties and sortAscending with setProperties, sortAscending appearing first", function() {
   sortedArrayController.set('sortProperties', ['name']);
   sortedArrayController.set('sortAscending', false);
 
@@ -173,12 +173,12 @@ QUnit.module("Ember.Sortable with content and sortProperties", {
   }
 });
 
-test("sortable object will expose associated content in the right order", function() {
+QUnit.test("sortable object will expose associated content in the right order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'array is sorted by name');
 });
 
-test("you can add objects in sorted order", function() {
+QUnit.test("you can add objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
   unsortedArray.pushObject({ id: 4, name: 'Scumbag Chavard' });
@@ -192,7 +192,7 @@ test("you can add objects in sorted order", function() {
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
 });
 
-test("you can push objects in sorted order", function() {
+QUnit.test("you can push objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
   unsortedArray.pushObject({ id: 4, name: 'Scumbag Chavard' });
@@ -206,7 +206,7 @@ test("you can push objects in sorted order", function() {
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
 });
 
-test("you can unshift objects in sorted order", function() {
+QUnit.test("you can unshift objects in sorted order", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
   unsortedArray.unshiftObject({ id: 4, name: 'Scumbag Chavard' });
@@ -220,7 +220,7 @@ test("you can unshift objects in sorted order", function() {
   equal(sortedArrayController.objectAt(3).name, 'Scumbag Fucs', 'a new object added to controller was inserted according to given constraint');
 });
 
-test("addObject does not insert duplicates", function() {
+QUnit.test("addObject does not insert duplicates", function() {
   var sortedArrayProxy;
   var obj = {};
   sortedArrayProxy = ArrayProxy.createWithMixins(SortableMixin, {
@@ -234,7 +234,7 @@ test("addObject does not insert duplicates", function() {
   equal(sortedArrayProxy.get('length'), 1, 'array still has 1 item');
 });
 
-test("you can change a sort property and the content will rearrange", function() {
+QUnit.test("you can change a sort property and the content will rearrange", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
   equal(sortedArrayController.objectAt(0).name, 'Scumbag Bryn', 'bryn is first');
 
@@ -243,7 +243,7 @@ test("you can change a sort property and the content will rearrange", function()
   equal(sortedArrayController.objectAt(1).name, 'Scumbag Fucs', 'foucs is second');
 });
 
-test("you can change the position of the middle item", function() {
+QUnit.test("you can change the position of the middle item", function() {
   equal(sortedArrayController.get('length'), 3, 'array has 3 items');
 
   equal(sortedArrayController.objectAt(1).name, 'Scumbag Dale', 'Dale is second');
@@ -252,7 +252,7 @@ test("you can change the position of the middle item", function() {
   equal(sortedArrayController.objectAt(0).name, 'Alice', 'Alice (previously Dale) is first now');
 });
 
-test("don't remove and insert if position didn't change", function() {
+QUnit.test("don't remove and insert if position didn't change", function() {
   var insertItemSortedCalled = false;
 
   sortedArrayController.reopen({
@@ -269,7 +269,7 @@ test("don't remove and insert if position didn't change", function() {
   ok(!insertItemSortedCalled, "insertItemSorted should not have been called");
 });
 
-test("sortProperties observers removed on content removal", function() {
+QUnit.test("sortProperties observers removed on content removal", function() {
   var removedObject = unsortedArray.objectAt(2);
   equal(listenersFor(removedObject, 'name:change').length, 1,
     "Before removal, there should be one listener for sortProperty change.");
@@ -296,7 +296,7 @@ QUnit.module("Ember.Sortable with sortProperties", {
   }
 });
 
-test("you can set content later and it will be sorted", function() {
+QUnit.test("you can set content later and it will be sorted", function() {
   equal(sortedArrayController.get('length'), 0, 'array has 0 items');
 
   run(function() {
@@ -339,7 +339,7 @@ QUnit.module("Ember.Sortable with sortFunction and sortProperties", {
   }
 });
 
-test("you can sort with custom sorting function", function() {
+QUnit.test("you can sort with custom sorting function", function() {
   equal(sortedArrayController.get('length'), 0, 'array has 0 items');
 
   run(function() {
@@ -350,7 +350,7 @@ test("you can sort with custom sorting function", function() {
   equal(sortedArrayController.objectAt(0).name, 'Scumbag bryn', 'array is sorted by custom sort');
 });
 
-test("Ember.Sortable with sortFunction on ArrayProxy should work like ArrayController", function() {
+QUnit.test("Ember.Sortable with sortFunction on ArrayProxy should work like ArrayController", function() {
   run(function() {
     sortedArrayController = ArrayProxy.createWithMixins(SortableMixin, {
       sortProperties: ['name'],

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -13,7 +13,7 @@ QUnit.module("TargetActionSupport", {
   }
 });
 
-test("it should return false if no target or action are specified", function() {
+QUnit.test("it should return false if no target or action are specified", function() {
   expect(1);
 
   var obj = EmberObject.createWithMixins(TargetActionSupport);
@@ -21,7 +21,7 @@ test("it should return false if no target or action are specified", function() {
   ok(false === obj.triggerAction(), "no target or action was specified");
 });
 
-test("it should support actions specified as strings", function() {
+QUnit.test("it should support actions specified as strings", function() {
   expect(2);
 
   var obj = EmberObject.createWithMixins(TargetActionSupport, {
@@ -37,7 +37,7 @@ test("it should support actions specified as strings", function() {
   ok(true === obj.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should invoke the send() method on objects that implement it", function() {
+QUnit.test("it should invoke the send() method on objects that implement it", function() {
   expect(3);
 
   var obj = EmberObject.createWithMixins(TargetActionSupport, {
@@ -54,7 +54,7 @@ test("it should invoke the send() method on objects that implement it", function
   ok(true === obj.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should find targets specified using a property path", function() {
+QUnit.test("it should find targets specified using a property path", function() {
   expect(2);
 
   var Test = {};
@@ -74,7 +74,7 @@ test("it should find targets specified using a property path", function() {
   ok(true === myObj.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should use an actionContext object specified as a property on the object", function() {
+QUnit.test("it should use an actionContext object specified as a property on the object", function() {
   expect(2);
   var obj = EmberObject.createWithMixins(TargetActionSupport, {
         action: 'anEvent',
@@ -88,7 +88,7 @@ test("it should use an actionContext object specified as a property on the objec
   ok(true === obj.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should find an actionContext specified as a property path", function() {
+QUnit.test("it should find an actionContext specified as a property path", function() {
   expect(2);
 
   var Test = {};
@@ -107,7 +107,7 @@ test("it should find an actionContext specified as a property path", function() 
   ok(true === obj.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should use the target specified in the argument", function() {
+QUnit.test("it should use the target specified in the argument", function() {
   expect(2);
   var targetObj = EmberObject.create({
         anEvent: function() {
@@ -121,7 +121,7 @@ test("it should use the target specified in the argument", function() {
   ok(true === obj.triggerAction({ target: targetObj }), "a valid target and action were specified");
 });
 
-test("it should use the action specified in the argument", function() {
+QUnit.test("it should use the action specified in the argument", function() {
   expect(2);
 
   var obj = EmberObject.createWithMixins(TargetActionSupport, {
@@ -134,7 +134,7 @@ test("it should use the action specified in the argument", function() {
   ok(true === obj.triggerAction({ action: 'anEvent' }), "a valid target and action were specified");
 });
 
-test("it should use the actionContext specified in the argument", function() {
+QUnit.test("it should use the actionContext specified in the argument", function() {
   expect(2);
   var context = {};
   var obj = EmberObject.createWithMixins(TargetActionSupport, {
@@ -149,7 +149,7 @@ test("it should use the actionContext specified in the argument", function() {
   ok(true === obj.triggerAction({ actionContext: context }), "a valid target and action were specified");
 });
 
-test("it should allow multiple arguments from actionContext", function() {
+QUnit.test("it should allow multiple arguments from actionContext", function() {
   expect(3);
   var param1 = 'someParam';
   var param2 = 'someOtherParam';
@@ -166,7 +166,7 @@ test("it should allow multiple arguments from actionContext", function() {
   ok(true === obj.triggerAction({ actionContext: [param1, param2] }), "a valid target and action were specified");
 });
 
-test("it should use a null value specified in the actionContext argument", function() {
+QUnit.test("it should use a null value specified in the actionContext argument", function() {
   expect(2);
   var obj = EmberObject.createWithMixins(TargetActionSupport, {
     target: EmberObject.create({

--- a/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
@@ -37,7 +37,7 @@ suite.test("[].insertAt(200,X) => OUT_OF_RANGE_EXCEPTION exception", function() 
   var obj = this.newObject([]);
   var that = this;
 
-  raises(function() {
+  throws(function() {
     obj.insertAt(200, that.newFixture(1)[0]);
   }, Error);
 });
@@ -106,7 +106,7 @@ suite.test("[A].insertAt(200,X) => OUT_OF_RANGE exception", function() {
   var obj = this.newObject(this.newFixture(1));
   var that = this;
 
-  raises(function() {
+  throws(function() {
     obj.insertAt(200, that.newFixture(1)[0]);
   }, Error);
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/pushObjects.js
@@ -7,7 +7,7 @@ suite.module('pushObjects');
 suite.test("should raise exception if not Ember.Enumerable is passed to pushObjects", function() {
   var obj = this.newObject([]);
 
-  raises(function() {
+  throws(function() {
     obj.pushObjects("string");
   });
 });

--- a/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
@@ -28,7 +28,7 @@ suite.test("[X].removeAt(0) => [] + notify", function() {
 
 suite.test("[].removeAt(200) => OUT_OF_RANGE_EXCEPTION exception", function() {
   var obj = this.newObject([]);
-  raises(function() {
+  throws(function() {
     obj.removeAt(200);
   }, Error);
 });

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -99,9 +99,9 @@ Suite.reopenClass({
         var ctx = this;
 
         if (!func) {
-          test(name); // output warning
+          QUnit.test(name); // output warning
         } else {
-          test(name, function() { func.call(ctx); });
+          QUnit.test(name, function() { func.call(ctx); });
         }
       }
     });

--- a/packages/ember-runtime/tests/system/application/base_test.js
+++ b/packages/ember-runtime/tests/system/application/base_test.js
@@ -3,7 +3,7 @@ import Application from "ember-runtime/system/application";
 
 QUnit.module('Ember.Application');
 
-test('Ember.Application should be a subclass of Ember.Namespace', function() {
+QUnit.test('Ember.Application should be a subclass of Ember.Namespace', function() {
 
   ok(Namespace.detect(Application), 'Ember.Application subclass of Ember.Namespace');
 });

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -28,7 +28,7 @@ QUnit.module("ArrayProxy - arrangedContent", {
   }
 });
 
-test("addObject - adds to end of 'content' if not present", function() {
+QUnit.test("addObject - adds to end of 'content' if not present", function() {
   run(function() { array.addObject(3); });
   deepEqual(array.get('content'), [1,2,4,5,3], 'adds to end of content');
   deepEqual(array.get('arrangedContent'), [5,4,3,2,1], 'arrangedContent stays sorted');
@@ -37,137 +37,137 @@ test("addObject - adds to end of 'content' if not present", function() {
   deepEqual(array.get('content'), [1,2,4,5,3], 'does not add existing number to content');
 });
 
-test("addObjects - adds to end of 'content' if not present", function() {
+QUnit.test("addObjects - adds to end of 'content' if not present", function() {
   run(function() { array.addObjects([1,3,6]); });
   deepEqual(array.get('content'), [1,2,4,5,3,6], 'adds to end of content');
   deepEqual(array.get('arrangedContent'), [6,5,4,3,2,1], 'arrangedContent stays sorted');
 });
 
-test("compact - returns arrangedContent without nulls and undefined", function() {
+QUnit.test("compact - returns arrangedContent without nulls and undefined", function() {
   run(function() { array.set('content', Ember.A([1,3,null,2,undefined])); });
   deepEqual(array.compact(), [3,2,1]);
 });
 
-test("indexOf - returns index of object in arrangedContent", function() {
+QUnit.test("indexOf - returns index of object in arrangedContent", function() {
   equal(array.indexOf(4), 1, 'returns arranged index');
 });
 
-test("insertAt - raises, indeterminate behavior", function() {
+QUnit.test("insertAt - raises, indeterminate behavior", function() {
   throws(function() {
     run(function() { array.insertAt(2, 3); });
   });
 });
 
-test("lastIndexOf - returns last index of object in arrangedContent", function() {
+QUnit.test("lastIndexOf - returns last index of object in arrangedContent", function() {
   run(function() { array.pushObject(4); });
   equal(array.lastIndexOf(4), 2, 'returns last arranged index');
 });
 
-test("nextObject - returns object at index in arrangedContent", function() {
+QUnit.test("nextObject - returns object at index in arrangedContent", function() {
   equal(array.nextObject(1), 4, 'returns object at index');
 });
 
-test("objectAt - returns object at index in arrangedContent", function() {
+QUnit.test("objectAt - returns object at index in arrangedContent", function() {
   equal(array.objectAt(1), 4, 'returns object at index');
 });
 
 // Not sure if we need a specific test for it, since it's internal
-test("objectAtContent - returns object at index in arrangedContent", function() {
+QUnit.test("objectAtContent - returns object at index in arrangedContent", function() {
   equal(array.objectAtContent(1), 4, 'returns object at index');
 });
 
-test("objectsAt - returns objects at indices in arrangedContent", function() {
+QUnit.test("objectsAt - returns objects at indices in arrangedContent", function() {
   deepEqual(array.objectsAt([0,2,4]), [5,2,undefined], 'returns objects at indices');
 });
 
-test("popObject - removes last object in arrangedContent", function() {
+QUnit.test("popObject - removes last object in arrangedContent", function() {
   var popped;
   run(function() { popped = array.popObject(); });
   equal(popped, 1, 'returns last object');
   deepEqual(array.get('content'), [2,4,5], 'removes from content');
 });
 
-test("pushObject - adds to end of content even if it already exists", function() {
+QUnit.test("pushObject - adds to end of content even if it already exists", function() {
   run(function() { array.pushObject(1); });
   deepEqual(array.get('content'), [1,2,4,5,1], 'adds to end of content');
 });
 
-test("pushObjects - adds multiple to end of content even if it already exists", function() {
+QUnit.test("pushObjects - adds multiple to end of content even if it already exists", function() {
   run(function() { array.pushObjects([1,2,4]); });
   deepEqual(array.get('content'), [1,2,4,5,1,2,4], 'adds to end of content');
 });
 
-test("removeAt - removes from index in arrangedContent", function() {
+QUnit.test("removeAt - removes from index in arrangedContent", function() {
   run(function() { array.removeAt(1, 2); });
   deepEqual(array.get('content'), [1,5]);
 });
 
-test("removeObject - removes object from content", function() {
+QUnit.test("removeObject - removes object from content", function() {
   run(function() { array.removeObject(2); });
   deepEqual(array.get('content'), [1,4,5]);
 });
 
-test("removeObjects - removes objects from content", function() {
+QUnit.test("removeObjects - removes objects from content", function() {
   run(function() { array.removeObjects([2,4,6]); });
   deepEqual(array.get('content'), [1,5]);
 });
 
-test("replace - raises, indeterminate behavior", function() {
+QUnit.test("replace - raises, indeterminate behavior", function() {
   throws(function() {
     run(function() { array.replace(1, 2, [3]); });
   });
 });
 
-test("replaceContent - does a standard array replace on content", function() {
+QUnit.test("replaceContent - does a standard array replace on content", function() {
   run(function() { array.replaceContent(1, 2, [3]); });
   deepEqual(array.get('content'), [1,3,5]);
 });
 
-test("reverseObjects - raises, use Sortable#sortAscending", function() {
+QUnit.test("reverseObjects - raises, use Sortable#sortAscending", function() {
   throws(function() {
     run(function() { array.reverseObjects(); });
   });
 });
 
-test("setObjects - replaces entire content", function() {
+QUnit.test("setObjects - replaces entire content", function() {
   run(function() { array.setObjects([6,7,8]); });
   deepEqual(array.get('content'), [6,7,8], 'replaces content');
 });
 
-test("shiftObject - removes from start of arrangedContent", function() {
+QUnit.test("shiftObject - removes from start of arrangedContent", function() {
   var shifted;
   run(function() { shifted = array.shiftObject(); });
   equal(shifted, 5, 'returns first object');
   deepEqual(array.get('content'), [1,2,4], 'removes object from content');
 });
 
-test("slice - returns a slice of the arrangedContent", function() {
+QUnit.test("slice - returns a slice of the arrangedContent", function() {
   deepEqual(array.slice(1, 3), [4,2], 'returns sliced arrangedContent');
 });
 
-test("toArray - returns copy of arrangedContent", function() {
+QUnit.test("toArray - returns copy of arrangedContent", function() {
   deepEqual(array.toArray(), [5,4,2,1]);
 });
 
-test("unshiftObject - adds to start of content", function() {
+QUnit.test("unshiftObject - adds to start of content", function() {
   run(function() { array.unshiftObject(6); });
   deepEqual(array.get('content'), [6,1,2,4,5], 'adds to start of content');
 });
 
-test("unshiftObjects - adds to start of content", function() {
+QUnit.test("unshiftObjects - adds to start of content", function() {
   run(function() { array.unshiftObjects([6,7]); });
   deepEqual(array.get('content'), [6,7,1,2,4,5], 'adds to start of content');
 });
 
-test("without - returns arrangedContent without object", function() {
+QUnit.test("without - returns arrangedContent without object", function() {
   deepEqual(array.without(2), [5,4,1], 'returns arranged without object');
 });
 
-test("lastObject - returns last arranged object", function() {
+QUnit.test("lastObject - returns last arranged object", function() {
   equal(array.get('lastObject'), 1, 'returns last arranged object');
 });
 
-test("firstObject - returns first arranged object", function() {
+QUnit.test("firstObject - returns first arranged object", function() {
   equal(array.get('firstObject'), 5, 'returns first arranged object');
 });
 
@@ -187,17 +187,17 @@ QUnit.module("ArrayProxy - arrangedContent matching content", {
   }
 });
 
-test("insertAt - inserts object at specified index", function() {
+QUnit.test("insertAt - inserts object at specified index", function() {
   run(function() { array.insertAt(2, 3); });
   deepEqual(array.get('content'), [1,2,3,4,5]);
 });
 
-test("replace - does a standard array replace", function() {
+QUnit.test("replace - does a standard array replace", function() {
   run(function() { array.replace(1, 2, [3]); });
   deepEqual(array.get('content'), [1,3,5]);
 });
 
-test("reverseObjects - reverses content", function() {
+QUnit.test("reverseObjects - reverses content", function() {
   run(function() { array.reverseObjects(); });
   deepEqual(array.get('content'), [5,4,2,1]);
 });
@@ -231,72 +231,72 @@ QUnit.module("ArrayProxy - arrangedContent with transforms", {
   }
 });
 
-test("indexOf - returns index of object in arrangedContent", function() {
+QUnit.test("indexOf - returns index of object in arrangedContent", function() {
   equal(array.indexOf('4'), 1, 'returns arranged index');
 });
 
-test("lastIndexOf - returns last index of object in arrangedContent", function() {
+QUnit.test("lastIndexOf - returns last index of object in arrangedContent", function() {
   run(function() { array.pushObject(4); });
   equal(array.lastIndexOf('4'), 2, 'returns last arranged index');
 });
 
-test("nextObject - returns object at index in arrangedContent", function() {
+QUnit.test("nextObject - returns object at index in arrangedContent", function() {
   equal(array.nextObject(1), '4', 'returns object at index');
 });
 
-test("objectAt - returns object at index in arrangedContent", function() {
+QUnit.test("objectAt - returns object at index in arrangedContent", function() {
   equal(array.objectAt(1), '4', 'returns object at index');
 });
 
 // Not sure if we need a specific test for it, since it's internal
-test("objectAtContent - returns object at index in arrangedContent", function() {
+QUnit.test("objectAtContent - returns object at index in arrangedContent", function() {
   equal(array.objectAtContent(1), '4', 'returns object at index');
 });
 
-test("objectsAt - returns objects at indices in arrangedContent", function() {
+QUnit.test("objectsAt - returns objects at indices in arrangedContent", function() {
   deepEqual(array.objectsAt([0,2,4]), ['5','2',undefined], 'returns objects at indices');
 });
 
-test("popObject - removes last object in arrangedContent", function() {
+QUnit.test("popObject - removes last object in arrangedContent", function() {
   var popped;
   run(function() { popped = array.popObject(); });
   equal(popped, '1', 'returns last object');
   deepEqual(array.get('content'), [2,4,5], 'removes from content');
 });
 
-test("removeObject - removes object from content", function() {
+QUnit.test("removeObject - removes object from content", function() {
   run(function() { array.removeObject('2'); });
   deepEqual(array.get('content'), [1,4,5]);
 });
 
-test("removeObjects - removes objects from content", function() {
+QUnit.test("removeObjects - removes objects from content", function() {
   run(function() { array.removeObjects(['2','4','6']); });
   deepEqual(array.get('content'), [1,5]);
 });
 
-test("shiftObject - removes from start of arrangedContent", function() {
+QUnit.test("shiftObject - removes from start of arrangedContent", function() {
   var shifted;
   run(function() { shifted = array.shiftObject(); });
   equal(shifted, '5', 'returns first object');
   deepEqual(array.get('content'), [1,2,4], 'removes object from content');
 });
 
-test("slice - returns a slice of the arrangedContent", function() {
+QUnit.test("slice - returns a slice of the arrangedContent", function() {
   deepEqual(array.slice(1, 3), ['4','2'], 'returns sliced arrangedContent');
 });
 
-test("toArray - returns copy of arrangedContent", function() {
+QUnit.test("toArray - returns copy of arrangedContent", function() {
   deepEqual(array.toArray(), ['5','4','2','1']);
 });
 
-test("without - returns arrangedContent without object", function() {
+QUnit.test("without - returns arrangedContent without object", function() {
   deepEqual(array.without('2'), ['5','4','1'], 'returns arranged without object');
 });
 
-test("lastObject - returns last arranged object", function() {
+QUnit.test("lastObject - returns last arranged object", function() {
   equal(array.get('lastObject'), '1', 'returns last arranged object');
 });
 
-test("firstObject - returns first arranged object", function() {
+QUnit.test("firstObject - returns first arranged object", function() {
   equal(array.get('firstObject'), '5', 'returns first arranged object');
 });

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -53,7 +53,7 @@ test("indexOf - returns index of object in arrangedContent", function() {
 });
 
 test("insertAt - raises, indeterminate behavior", function() {
-  raises(function() {
+  throws(function() {
     run(function() { array.insertAt(2, 3); });
   });
 });
@@ -113,7 +113,7 @@ test("removeObjects - removes objects from content", function() {
 });
 
 test("replace - raises, indeterminate behavior", function() {
-  raises(function() {
+  throws(function() {
     run(function() { array.replace(1, 2, [3]); });
   });
 });
@@ -124,7 +124,7 @@ test("replaceContent - does a standard array replace on content", function() {
 });
 
 test("reverseObjects - raises, use Sortable#sortAscending", function() {
-  raises(function() {
+  throws(function() {
     run(function() { array.reverseObjects(); });
   });
 });

--- a/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_change_test.js
@@ -6,7 +6,7 @@ import ArrayController from "ember-runtime/controllers/array_controller";
 
 QUnit.module("ArrayProxy - content change");
 
-test("should update length for null content", function() {
+QUnit.test("should update length for null content", function() {
   var proxy = ArrayProxy.create({
         content: Ember.A([1,2,3])
       });
@@ -18,7 +18,7 @@ test("should update length for null content", function() {
   equal(proxy.get('length'), 0, "length updates");
 });
 
-test("The `arrangedContentWillChange` method is invoked before `content` is changed.", function() {
+QUnit.test("The `arrangedContentWillChange` method is invoked before `content` is changed.", function() {
   var callCount = 0;
   var expectedLength;
 
@@ -42,7 +42,7 @@ test("The `arrangedContentWillChange` method is invoked before `content` is chan
   equal(callCount, 1, "replacing the content array triggers the hook");
 });
 
-test("The `arrangedContentDidChange` method is invoked after `content` is changed.", function() {
+QUnit.test("The `arrangedContentDidChange` method is invoked after `content` is changed.", function() {
   var callCount = 0;
   var expectedLength;
 
@@ -68,7 +68,7 @@ test("The `arrangedContentDidChange` method is invoked after `content` is change
   equal(callCount, 1, "replacing the content array triggers the hook");
 });
 
-test("The ArrayProxy doesn't explode when assigned a destroyed object", function() {
+QUnit.test("The ArrayProxy doesn't explode when assigned a destroyed object", function() {
   var arrayController = ArrayController.create();
   var proxy = ArrayProxy.create();
 

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -4,7 +4,7 @@ import ArrayProxy from "ember-runtime/system/array_proxy";
 
 QUnit.module("Ember.ArrayProxy - content update");
 
-test("The `contentArrayDidChange` method is invoked after `content` is updated.", function() {
+QUnit.test("The `contentArrayDidChange` method is invoked after `content` is updated.", function() {
 
   var proxy;
   var observerCalled = false;

--- a/packages/ember-runtime/tests/system/lazy_load_test.js
+++ b/packages/ember-runtime/tests/system/lazy_load_test.js
@@ -3,7 +3,7 @@ import {onLoad, runLoadHooks} from "ember-runtime/system/lazy_load";
 
 QUnit.module("Lazy Loading");
 
-test("if a load hook is registered, it is executed when runLoadHooks are exected", function() {
+QUnit.test("if a load hook is registered, it is executed when runLoadHooks are exected", function() {
   var count = 0;
 
   run(function() {
@@ -19,7 +19,7 @@ test("if a load hook is registered, it is executed when runLoadHooks are exected
   equal(count, 1, "the object was passed into the load hook");
 });
 
-test("if runLoadHooks was already run, it executes newly added hooks immediately", function() {
+QUnit.test("if runLoadHooks was already run, it executes newly added hooks immediately", function() {
   var count = 0;
   run(function() {
     onLoad("__test_hook__", function(object) {
@@ -41,7 +41,7 @@ test("if runLoadHooks was already run, it executes newly added hooks immediately
   equal(count, 1, "the original object was passed into the load hook");
 });
 
-test("hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed", function() {
+QUnit.test("hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed", function() {
 
   // Note that the necessary code to perform this test is run before
   // the Ember lib is loaded in tests/index.html
@@ -54,7 +54,7 @@ test("hooks in ENV.EMBER_LOAD_HOOKS['hookName'] get executed", function() {
 });
 
 if (typeof window === 'object' && typeof window.dispatchEvent === 'function' && typeof CustomEvent === "function") {
-  test("load hooks trigger a custom event", function() {
+  QUnit.test("load hooks trigger a custom event", function() {
     var eventObject = "super duper awesome events";
 
     window.addEventListener('__test_hook_for_events__', function(e) {

--- a/packages/ember-runtime/tests/system/namespace/base_test.js
+++ b/packages/ember-runtime/tests/system/namespace/base_test.js
@@ -24,15 +24,15 @@ QUnit.module('Namespace', {
   }
 });
 
-test('Namespace should be a subclass of EmberObject', function() {
+QUnit.test('Namespace should be a subclass of EmberObject', function() {
   ok(EmberObject.detect(Namespace));
 });
 
-test("Namespace should be duck typed", function() {
+QUnit.test("Namespace should be duck typed", function() {
   ok(get(Namespace.create(), 'isNamespace'), "isNamespace property is true");
 });
 
-test('Namespace is found and named', function() {
+QUnit.test('Namespace is found and named', function() {
   var nsA = lookup.NamespaceA = Namespace.create();
   equal(nsA.toString(), "NamespaceA", "namespaces should have a name if they are on lookup");
 
@@ -40,7 +40,7 @@ test('Namespace is found and named', function() {
   equal(nsB.toString(), "NamespaceB", "namespaces work if created after the first namespace processing pass");
 });
 
-test("Classes under an Namespace are properly named", function() {
+QUnit.test("Classes under an Namespace are properly named", function() {
   var nsA = lookup.NamespaceA = Namespace.create();
   nsA.Foo = EmberObject.extend();
   equal(nsA.Foo.toString(), "NamespaceA.Foo", "Classes pick up their parent namespace");
@@ -59,12 +59,12 @@ test("Classes under an Namespace are properly named", function() {
 //  equal(Ember.TestObject.toString(), "Ember.TestObject", "class under Ember is given a string representation");
 //});
 
-test("Lowercase namespaces are no longer supported", function() {
+QUnit.test("Lowercase namespaces are no longer supported", function() {
   var nsC = lookup.namespaceC = Namespace.create();
   equal(nsC.toString(), undefined);
 });
 
-test("A namespace can be assigned a custom name", function() {
+QUnit.test("A namespace can be assigned a custom name", function() {
   var nsA = Namespace.create({
     name: "NamespaceA"
   });
@@ -80,7 +80,7 @@ test("A namespace can be assigned a custom name", function() {
   equal(nsB.Foo.toString(), "CustomNamespaceB.Foo", "The namespace's name is used when the namespace is in the lookup object");
 });
 
-test("Calling namespace.nameClasses() eagerly names all classes", function() {
+QUnit.test("Calling namespace.nameClasses() eagerly names all classes", function() {
   Ember.BOOTED = true;
 
   var namespace = lookup.NS = Namespace.create();
@@ -94,7 +94,7 @@ test("Calling namespace.nameClasses() eagerly names all classes", function() {
   equal(namespace.ClassB.toString(), "NS.ClassB");
 });
 
-test("A namespace can be looked up by its name", function() {
+QUnit.test("A namespace can be looked up by its name", function() {
   var NS = lookup.NS = Namespace.create();
   var UI = lookup.UI = Namespace.create();
   var CF = lookup.CF = Namespace.create();
@@ -104,21 +104,21 @@ test("A namespace can be looked up by its name", function() {
   equal(Namespace.byName('CF'), CF);
 });
 
-test("A nested namespace can be looked up by its name", function() {
+QUnit.test("A nested namespace can be looked up by its name", function() {
   var UI = lookup.UI = Namespace.create();
   UI.Nav = Namespace.create();
 
   equal(Namespace.byName('UI.Nav'), UI.Nav);
 });
 
-test("Destroying a namespace before caching lookup removes it from the list of namespaces", function() {
+QUnit.test("Destroying a namespace before caching lookup removes it from the list of namespaces", function() {
   var CF = lookup.CF = Namespace.create();
 
   run(CF, 'destroy');
   equal(Namespace.byName('CF'), undefined, "namespace can not be found after destroyed");
 });
 
-test("Destroying a namespace after looking up removes it from the list of namespaces", function() {
+QUnit.test("Destroying a namespace after looking up removes it from the list of namespaces", function() {
   var CF = lookup.CF = Namespace.create();
 
   equal(Namespace.byName('CF'), CF, "precondition - namespace can be looked up by name");

--- a/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
+++ b/packages/ember-runtime/tests/system/native_array/copyable_suite_test.js
@@ -29,7 +29,7 @@ CopyableTests.extend({
 
 QUnit.module("NativeArray Copyable");
 
-test("deep copy is respected", function() {
+QUnit.test("deep copy is respected", function() {
   var array = Ember.A([{ id: 1 }, { id: 2 }, { id: 3 }]);
 
   var copiedArray = array.copy(true);

--- a/packages/ember-runtime/tests/system/object/computed_test.js
+++ b/packages/ember-runtime/tests/system/object/computed_test.js
@@ -131,7 +131,7 @@ testWithDefault('complex dependent keys changing complex dependent keys', functi
   equal(get(obj2, 'foo'), 'BLARG 2', 'should invalidate property');
 });
 
-test("can retrieve metadata for a computed property", function() {
+QUnit.test("can retrieve metadata for a computed property", function() {
   var MyClass = EmberObject.extend({
     computedProperty: computed(function() {
     }).meta({ key: 'keyValue' })
@@ -157,7 +157,7 @@ test("can retrieve metadata for a computed property", function() {
   }, "metaForProperty() could not find a computed property with key 'staticProperty'.");
 });
 
-test("can iterate over a list of computed properties for a class", function() {
+QUnit.test("can iterate over a list of computed properties for a class", function() {
   var MyClass = EmberObject.extend({
     foo: computed(function() {
 
@@ -207,7 +207,7 @@ test("can iterate over a list of computed properties for a class", function() {
   deepEqual(list.sort(), ['bar', 'bat', 'baz', 'foo'], "all inherited properties are included");
 });
 
-test("list of properties updates when an additional property is added (such cache busting)", function() {
+QUnit.test("list of properties updates when an additional property is added (such cache busting)", function() {
   var MyClass = EmberObject.extend({
     foo: computed(K),
 

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -24,12 +24,12 @@ moduleOptions = {
 
 QUnit.module('EmberObject.create', moduleOptions);
 
-test("simple properties are set", function() {
+QUnit.test("simple properties are set", function() {
   var o = EmberObject.create({ ohai: 'there' });
   equal(o.get('ohai'), 'there');
 });
 
-test("calls computed property setters", function() {
+QUnit.test("calls computed property setters", function() {
   var MyClass = EmberObject.extend({
     foo: computed(function(key, val) {
       if (arguments.length === 2) { return val; }
@@ -42,7 +42,7 @@ test("calls computed property setters", function() {
 });
 
 if (Ember.FEATURES.isEnabled('mandatory-setter')) {
-  test("sets up mandatory setters for watched simple properties", function() {
+  QUnit.test("sets up mandatory setters for watched simple properties", function() {
 
     var MyClass = EmberObject.extend({
       foo: null,
@@ -68,7 +68,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   });
 }
 
-test("allows bindings to be defined", function() {
+QUnit.test("allows bindings to be defined", function() {
   var obj = EmberObject.create({
     foo: 'foo',
     barBinding: 'foo'
@@ -77,7 +77,7 @@ test("allows bindings to be defined", function() {
   equal(obj.get('bar'), 'foo', 'The binding value is correct');
 });
 
-test("calls setUnknownProperty if defined", function() {
+QUnit.test("calls setUnknownProperty if defined", function() {
   var setUnknownPropertyCalled = false;
 
   var MyClass = EmberObject.extend({
@@ -90,7 +90,7 @@ test("calls setUnknownProperty if defined", function() {
   ok(setUnknownPropertyCalled, 'setUnknownProperty was called');
 });
 
-test("throws if you try to define a computed property", function() {
+QUnit.test("throws if you try to define a computed property", function() {
   expectAssertion(function() {
     EmberObject.create({
       foo: computed(function() {})
@@ -98,7 +98,7 @@ test("throws if you try to define a computed property", function() {
   }, 'Ember.Object.create no longer supports defining computed properties. Define computed properties using extend() or reopen() before calling create().');
 });
 
-test("throws if you try to call _super in a method", function() {
+QUnit.test("throws if you try to call _super in a method", function() {
   expectAssertion(function() {
     EmberObject.create({
       foo: function() {
@@ -108,7 +108,7 @@ test("throws if you try to call _super in a method", function() {
   }, 'Ember.Object.create no longer supports defining methods that call _super.');
 });
 
-test("throws if you try to 'mixin' a definition", function() {
+QUnit.test("throws if you try to 'mixin' a definition", function() {
   var myMixin = Mixin.create({
     adder: function(arg1, arg2) {
       return arg1 + arg2;
@@ -121,7 +121,7 @@ test("throws if you try to 'mixin' a definition", function() {
 });
 
 // This test is for IE8.
-test("property name is the same as own prototype property", function() {
+QUnit.test("property name is the same as own prototype property", function() {
   var MyClass = EmberObject.extend({
     toString: function() { return 'MyClass'; }
   });
@@ -129,14 +129,14 @@ test("property name is the same as own prototype property", function() {
   equal(MyClass.create().toString(), 'MyClass', "should inherit property from the arguments of `EmberObject.create`");
 });
 
-test("inherits properties from passed in EmberObject", function() {
+QUnit.test("inherits properties from passed in EmberObject", function() {
   var baseObj = EmberObject.create({ foo: 'bar' });
   var secondaryObj = EmberObject.create(baseObj);
 
   equal(secondaryObj.foo, baseObj.foo, "Em.O.create inherits properties from EmberObject parameter");
 });
 
-test("throws if you try to pass anything a string as a parameter", function() {
+QUnit.test("throws if you try to pass anything a string as a parameter", function() {
   var expected = "EmberObject.create only accepts an objects.";
 
   throws(function() {
@@ -144,19 +144,19 @@ test("throws if you try to pass anything a string as a parameter", function() {
   }, expected);
 });
 
-test("EmberObject.create can take undefined as a parameter", function() {
+QUnit.test("EmberObject.create can take undefined as a parameter", function() {
   var o = EmberObject.create(undefined);
   deepEqual(EmberObject.create(), o);
 });
 
-test("EmberObject.create can take null as a parameter", function() {
+QUnit.test("EmberObject.create can take null as a parameter", function() {
   var o = EmberObject.create(null);
   deepEqual(EmberObject.create(), o);
 });
 
 QUnit.module('EmberObject.createWithMixins', moduleOptions);
 
-test("Creates a new object that contains passed properties", function() {
+QUnit.test("Creates a new object that contains passed properties", function() {
 
   var called = false;
   var obj = EmberObject.createWithMixins({
@@ -173,7 +173,7 @@ test("Creates a new object that contains passed properties", function() {
 // WORKING WITH MIXINS
 //
 
-test("Creates a new object that includes mixins and properties", function() {
+QUnit.test("Creates a new object that includes mixins and properties", function() {
 
   var MixinA = Mixin.create({ mixinA: 'A' });
   var obj = EmberObject.createWithMixins(MixinA, { prop: 'FOO' });
@@ -186,7 +186,7 @@ test("Creates a new object that includes mixins and properties", function() {
 // LIFECYCLE
 //
 
-test("Configures _super() on methods with override", function() {
+QUnit.test("Configures _super() on methods with override", function() {
   var completed = false;
   var MixinA = Mixin.create({ method: function() {} });
   var obj = EmberObject.createWithMixins(MixinA, {
@@ -200,7 +200,7 @@ test("Configures _super() on methods with override", function() {
   ok(completed, 'should have run method without error');
 });
 
-test("Calls init if defined", function() {
+QUnit.test("Calls init if defined", function() {
   var completed = false;
   EmberObject.createWithMixins({
     init: function() {
@@ -212,7 +212,7 @@ test("Calls init if defined", function() {
   ok(completed, 'should have run init without error');
 });
 
-test("Calls all mixin inits if defined", function() {
+QUnit.test("Calls all mixin inits if defined", function() {
   var completed = 0;
   var Mixin1 = Mixin.create({
     init: function() {
@@ -232,7 +232,7 @@ test("Calls all mixin inits if defined", function() {
   equal(completed, 2, 'should have called init for both mixins.');
 });
 
-test("Triggers init", function() {
+QUnit.test("Triggers init", function() {
   var completed = false;
   EmberObject.createWithMixins({
     markAsCompleted: on("init", function() {
@@ -243,7 +243,7 @@ test("Triggers init", function() {
   ok(completed, 'should have triggered init which should have run markAsCompleted');
 });
 
-test('creating an object with required properties', function() {
+QUnit.test('creating an object with required properties', function() {
   var ClassA = EmberObject.extend({
     foo: required()
   });
@@ -257,7 +257,7 @@ test('creating an object with required properties', function() {
 // BUGS
 //
 
-test('create should not break observed values', function() {
+QUnit.test('create should not break observed values', function() {
 
   var CountObject = EmberObject.extend({
     value: null,
@@ -281,7 +281,7 @@ test('create should not break observed values', function() {
   equal(obj._count, 1, 'should fire');
 });
 
-test('bindings on a class should only sync on instances', function() {
+QUnit.test('bindings on a class should only sync on instances', function() {
   Ember.lookup['TestObject'] = EmberObject.createWithMixins({
     foo: 'FOO'
   });
@@ -302,7 +302,7 @@ test('bindings on a class should only sync on instances', function() {
 });
 
 
-test('inherited bindings should only sync on instances', function() {
+QUnit.test('inherited bindings should only sync on instances', function() {
   var TestObject;
 
   Ember.lookup['TestObject'] = TestObject = EmberObject.createWithMixins({
@@ -336,7 +336,7 @@ test('inherited bindings should only sync on instances', function() {
 
 });
 
-test("created objects should not share a guid with their superclass", function() {
+QUnit.test("created objects should not share a guid with their superclass", function() {
   ok(guidFor(EmberObject), "EmberObject has a guid");
 
   var objA = EmberObject.createWithMixins();
@@ -345,7 +345,7 @@ test("created objects should not share a guid with their superclass", function()
   ok(guidFor(objA) !== guidFor(objB), "two instances do not share a guid");
 });
 
-test("ensure internal properties do not leak", function() {
+QUnit.test("ensure internal properties do not leak", function() {
   var obj = EmberObject.create({
     firstName: 'Joe',
     lastName:  'Black'

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -35,7 +35,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
     // MANDATORY_SETTER moves value to meta.values
     // a destroyed object removes meta but leaves the accessor
     // that looks it up
-    test("should raise an exception when modifying watched properties on a destroyed object", function() {
+    QUnit.test("should raise an exception when modifying watched properties on a destroyed object", function() {
       var obj = EmberObject.createWithMixins({
         foo: "bar",
         fooDidChange: observer('foo', function() { })
@@ -52,7 +52,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   }
 }
 
-test("observers should not fire after an object has been destroyed", function() {
+QUnit.test("observers should not fire after an object has been destroyed", function() {
   var count = 0;
   var obj = EmberObject.createWithMixins({
     fooDidChange: observer('foo', function() {
@@ -74,7 +74,7 @@ test("observers should not fire after an object has been destroyed", function() 
   equal(count, 1, "observer was not called after object was destroyed");
 });
 
-test("destroyed objects should not see each others changes during teardown but a long lived object should", function () {
+QUnit.test("destroyed objects should not see each others changes during teardown but a long lived object should", function () {
   var shouldChange = 0;
   var shouldNotChange = 0;
 
@@ -148,7 +148,7 @@ test("destroyed objects should not see each others changes during teardown but a
   equal(shouldChange, 1, 'long lived should see change in willDestroy');
 });
 
-test("bindings should be synced when are updated in the willDestroy hook", function() {
+QUnit.test("bindings should be synced when are updated in the willDestroy hook", function() {
   var bar = EmberObject.create({
     value: false,
     willDestroy: function() {

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -45,7 +45,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
         obj.destroy();
       });
 
-      raises(function() {
+      throws(function() {
         set(obj, 'foo', 'baz');
       }, Error, "raises an exception");
     });

--- a/packages/ember-runtime/tests/system/object/detectInstance_test.js
+++ b/packages/ember-runtime/tests/system/object/detectInstance_test.js
@@ -2,7 +2,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('system/object/detectInstance');
 
-test('detectInstance detects instances correctly', function() {
+QUnit.test('detectInstance detects instances correctly', function() {
 
   var A = EmberObject.extend();
   var B = A.extend();

--- a/packages/ember-runtime/tests/system/object/detect_test.js
+++ b/packages/ember-runtime/tests/system/object/detect_test.js
@@ -2,7 +2,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('system/object/detect');
 
-test('detect detects classes correctly', function() {
+QUnit.test('detect detects classes correctly', function() {
 
   var A = EmberObject.extend();
   var B = A.extend();

--- a/packages/ember-runtime/tests/system/object/events_test.js
+++ b/packages/ember-runtime/tests/system/object/events_test.js
@@ -3,7 +3,7 @@ import Evented from "ember-runtime/mixins/evented";
 
 QUnit.module("Object events");
 
-test("a listener can be added to an object", function() {
+QUnit.test("a listener can be added to an object", function() {
   var count = 0;
   var F = function() { count++; };
 
@@ -19,7 +19,7 @@ test("a listener can be added to an object", function() {
   equal(count, 2, "the event was triggered");
 });
 
-test("a listener can be added and removed automatically the first time it is triggered", function() {
+QUnit.test("a listener can be added and removed automatically the first time it is triggered", function() {
   var count = 0;
   var F = function() { count++; };
 
@@ -35,7 +35,7 @@ test("a listener can be added and removed automatically the first time it is tri
   equal(count, 1, "the event was not triggered again");
 });
 
-test("triggering an event can have arguments", function() {
+QUnit.test("triggering an event can have arguments", function() {
   var self, args;
 
   var obj = EmberObject.createWithMixins(Evented);
@@ -51,7 +51,7 @@ test("triggering an event can have arguments", function() {
   equal(self, obj);
 });
 
-test("a listener can be added and removed automatically and have arguments", function() {
+QUnit.test("a listener can be added and removed automatically and have arguments", function() {
   var self, args;
   var count = 0;
 
@@ -76,7 +76,7 @@ test("a listener can be added and removed automatically and have arguments", fun
   equal(self, obj);
 });
 
-test("binding an event can specify a different target", function() {
+QUnit.test("binding an event can specify a different target", function() {
   var self, args;
 
   var obj = EmberObject.createWithMixins(Evented);
@@ -93,7 +93,7 @@ test("binding an event can specify a different target", function() {
   equal(self, target);
 });
 
-test("a listener registered with one can take method as string and can be added with different target", function() {
+QUnit.test("a listener registered with one can take method as string and can be added with different target", function() {
   var count = 0;
   var target = {};
   target.fn = function() { count++; };
@@ -110,7 +110,7 @@ test("a listener registered with one can take method as string and can be added 
   equal(count, 1, "the event was not triggered again");
 });
 
-test("a listener registered with one can be removed with off", function() {
+QUnit.test("a listener registered with one can be removed with off", function() {
   var obj = EmberObject.createWithMixins(Evented, {
     F: function() {}
   });
@@ -127,7 +127,7 @@ test("a listener registered with one can be removed with off", function() {
   equal(obj.has('event!'), false, 'has no more events');
 });
 
-test("adding and removing listeners should be chainable", function() {
+QUnit.test("adding and removing listeners should be chainable", function() {
   var obj = EmberObject.createWithMixins(Evented);
   var F = function() {};
 

--- a/packages/ember-runtime/tests/system/object/extend_test.js
+++ b/packages/ember-runtime/tests/system/object/extend_test.js
@@ -3,14 +3,14 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('EmberObject.extend');
 
-test('Basic extend', function() {
+QUnit.test('Basic extend', function() {
   var SomeClass = EmberObject.extend({ foo: 'BAR' });
   ok(SomeClass.isClass, "A class has isClass of true");
   var obj = new SomeClass();
   equal(obj.foo, 'BAR');
 });
 
-test('Sub-subclass', function() {
+QUnit.test('Sub-subclass', function() {
   var SomeClass = EmberObject.extend({ foo: 'BAR' });
   var AnotherClass = SomeClass.extend({ bar: 'FOO' });
   var obj = new AnotherClass();
@@ -18,7 +18,7 @@ test('Sub-subclass', function() {
   equal(obj.bar, 'FOO');
 });
 
-test('Overriding a method several layers deep', function() {
+QUnit.test('Overriding a method several layers deep', function() {
   var SomeClass = EmberObject.extend({
     fooCnt: 0,
     foo: function() { this.fooCnt++; },
@@ -63,7 +63,7 @@ test('Overriding a method several layers deep', function() {
   equal(obj.barCnt, 2, 'should invoke both');
 });
 
-test('With concatenatedProperties', function() {
+QUnit.test('With concatenatedProperties', function() {
   var SomeClass = EmberObject.extend({ things: 'foo', concatenatedProperties: ['things'] });
   var AnotherClass = SomeClass.extend({ things: 'bar' });
   var YetAnotherClass = SomeClass.extend({ things: 'baz' });
@@ -75,7 +75,7 @@ test('With concatenatedProperties', function() {
   deepEqual(yetAnother.get('things'), ['foo', 'baz'], "subclass should have base class' and its own");
 });
 
-test('With concatenatedProperties class properties', function() {
+QUnit.test('With concatenatedProperties class properties', function() {
   var SomeClass = EmberObject.extend();
   SomeClass.reopenClass({
     concatenatedProperties: ['things'],

--- a/packages/ember-runtime/tests/system/object/reopenClass_test.js
+++ b/packages/ember-runtime/tests/system/object/reopenClass_test.js
@@ -3,7 +3,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('system/object/reopenClass');
 
-test('adds new properties to subclass', function() {
+QUnit.test('adds new properties to subclass', function() {
 
   var Subclass = EmberObject.extend();
   Subclass.reopenClass({
@@ -15,7 +15,7 @@ test('adds new properties to subclass', function() {
   equal(get(Subclass, 'bar'), 'BAR', 'Adds property');
 });
 
-test('class properties inherited by subclasses', function() {
+QUnit.test('class properties inherited by subclasses', function() {
 
   var Subclass = EmberObject.extend();
   Subclass.reopenClass({

--- a/packages/ember-runtime/tests/system/object/reopen_test.js
+++ b/packages/ember-runtime/tests/system/object/reopen_test.js
@@ -3,7 +3,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('system/core_object/reopen');
 
-test('adds new properties to subclass instance', function() {
+QUnit.test('adds new properties to subclass instance', function() {
 
   var Subclass = EmberObject.extend();
   Subclass.reopen({
@@ -15,7 +15,7 @@ test('adds new properties to subclass instance', function() {
   equal(get(new Subclass(), 'bar'), 'BAR', 'Adds property');
 });
 
-test('reopened properties inherited by subclasses', function() {
+QUnit.test('reopened properties inherited by subclasses', function() {
 
   var Subclass = EmberObject.extend();
   var SubSub = Subclass.extend();
@@ -30,7 +30,7 @@ test('reopened properties inherited by subclasses', function() {
   equal(get(new SubSub(), 'bar'), 'BAR', 'Adds property');
 });
 
-test('allows reopening already instantiated classes', function() {
+QUnit.test('allows reopening already instantiated classes', function() {
   var Subclass = EmberObject.extend();
 
   Subclass.create();

--- a/packages/ember-runtime/tests/system/object/strict-mode-test.js
+++ b/packages/ember-runtime/tests/system/object/strict-mode-test.js
@@ -2,7 +2,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('strict mode tests');
 
-test('__superWrapper does not throw errors in strict mode', function() {
+QUnit.test('__superWrapper does not throw errors in strict mode', function() {
   var Foo = EmberObject.extend({
     blah: function() {
       return 'foo';

--- a/packages/ember-runtime/tests/system/object/subclasses_test.js
+++ b/packages/ember-runtime/tests/system/object/subclasses_test.js
@@ -4,7 +4,7 @@ import EmberObject from "ember-runtime/system/object";
 
 QUnit.module('system/object/subclasses');
 
-test('chains should copy forward to subclasses when prototype created', function () {
+QUnit.test('chains should copy forward to subclasses when prototype created', function () {
   var ObjectWithChains, objWithChains, SubWithChains, SubSub, subSub;
   run(function () {
     ObjectWithChains = EmberObject.extend({

--- a/packages/ember-runtime/tests/system/object/toString_test.js
+++ b/packages/ember-runtime/tests/system/object/toString_test.js
@@ -15,7 +15,7 @@ QUnit.module('system/object/toString', {
   }
 });
 
-test("toString() returns the same value if called twice", function() {
+QUnit.test("toString() returns the same value if called twice", function() {
   var Foo = Namespace.create();
   Foo.toString = function() { return "Foo"; };
 
@@ -32,7 +32,7 @@ test("toString() returns the same value if called twice", function() {
   equal(Foo.Bar.toString(), "Foo.Bar");
 });
 
-test("toString on a class returns a useful value when nested in a namespace", function() {
+QUnit.test("toString on a class returns a useful value when nested in a namespace", function() {
   var obj;
 
   var Foo = Namespace.create();
@@ -54,13 +54,13 @@ test("toString on a class returns a useful value when nested in a namespace", fu
   equal(obj.toString(), "<Foo.Bar:" + guidFor(obj) + ">");
 });
 
-test("toString on a namespace finds the namespace in Ember.lookup", function() {
+QUnit.test("toString on a namespace finds the namespace in Ember.lookup", function() {
   var Foo = lookup.Foo = Namespace.create();
 
   equal(Foo.toString(), "Foo");
 });
 
-test("toString on a namespace finds the namespace in Ember.lookup", function() {
+QUnit.test("toString on a namespace finds the namespace in Ember.lookup", function() {
   var Foo = lookup.Foo = Namespace.create();
   var obj;
 
@@ -72,13 +72,13 @@ test("toString on a namespace finds the namespace in Ember.lookup", function() {
   equal(obj.toString(), "<Foo.Bar:" + guidFor(obj) + ">");
 });
 
-test("toString on a namespace falls back to modulePrefix, if defined", function() {
+QUnit.test("toString on a namespace falls back to modulePrefix, if defined", function() {
   var Foo = Namespace.create({ modulePrefix: 'foo' });
 
   equal(Foo.toString(), "foo");
 });
 
-test('toString includes toStringExtension if defined', function() {
+QUnit.test('toString includes toStringExtension if defined', function() {
   var Foo = EmberObject.extend({
         toStringExtension: function() {
           return "fooey";

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -115,7 +115,7 @@ testBoth("should work with watched properties", function(get, set) {
   equal(get(content2, 'lastName'), 'Katzdale');
 });
 
-test("set and get should work with paths", function () {
+QUnit.test("set and get should work with paths", function () {
   var content = { foo: { bar: 'baz' } };
   var proxy = ObjectProxy.create({ content: content });
   var count = 0;

--- a/packages/ember-runtime/tests/system/set/extra_test.js
+++ b/packages/ember-runtime/tests/system/set/extra_test.js
@@ -5,7 +5,7 @@ import Set from "ember-runtime/system/set";
 
 QUnit.module('Set.init');
 
-test('passing an array to new Set() should instantiate w/ items', function() {
+QUnit.test('passing an array to new Set() should instantiate w/ items', function() {
   var aSet;
 
   var ary  = [1,2,3];
@@ -25,7 +25,7 @@ test('passing an array to new Set() should instantiate w/ items', function() {
 
 QUnit.module('Set.clear');
 
-test('should clear a set of its content', function() {
+QUnit.test('should clear a set of its content', function() {
   var aSet;
   var count = 0;
 
@@ -56,7 +56,7 @@ test('should clear a set of its content', function() {
 
 QUnit.module('Set.pop');
 
-test('calling pop should return an object and remove it', function() {
+QUnit.test('calling pop should return an object and remove it', function() {
   var aSet, obj;
   var count = 0;
 
@@ -81,7 +81,7 @@ test('calling pop should return an object and remove it', function() {
 
 QUnit.module('Set aliases');
 
-test('method aliases', function() {
+QUnit.test('method aliases', function() {
   var aSet;
 
   ignoreDeprecation(function() {

--- a/packages/ember-runtime/tests/system/string/camelize_test.js
+++ b/packages/ember-runtime/tests/system/string/camelize_test.js
@@ -4,47 +4,47 @@ import {camelize} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.camelize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.camelize is not modified without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.camelize is not modified without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.camelize, 'String.prototype helper disabled');
   });
 }
 
-test("camelize normal string", function() {
+QUnit.test("camelize normal string", function() {
   deepEqual(camelize('my favorite items'), 'myFavoriteItems');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('my favorite items'.camelize(), 'myFavoriteItems');
   }
 });
 
-test("camelize capitalized string", function() {
+QUnit.test("camelize capitalized string", function() {
   deepEqual(camelize('I Love Ramen'), 'iLoveRamen');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('I Love Ramen'.camelize(), 'iLoveRamen');
   }
 });
 
-test("camelize dasherized string", function() {
+QUnit.test("camelize dasherized string", function() {
   deepEqual(camelize('css-class-name'), 'cssClassName');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('css-class-name'.camelize(), 'cssClassName');
   }
 });
 
-test("camelize underscored string", function() {
+QUnit.test("camelize underscored string", function() {
   deepEqual(camelize('action_name'), 'actionName');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action_name'.camelize(), 'actionName');
   }
 });
 
-test("camelize dot notation string", function() {
+QUnit.test("camelize dot notation string", function() {
   deepEqual(camelize('action.name'), 'actionName');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action.name'.camelize(), 'actionName');
   }
 });
 
-test("does nothing with camelcased string", function() {
+QUnit.test("does nothing with camelcased string", function() {
   deepEqual(camelize('innerHTML'), 'innerHTML');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('innerHTML'.camelize(), 'innerHTML');

--- a/packages/ember-runtime/tests/system/string/capitalize_test.js
+++ b/packages/ember-runtime/tests/system/string/capitalize_test.js
@@ -4,40 +4,40 @@ import {capitalize} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.capitalize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.capitalize is not modified without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.capitalize is not modified without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.capitalize, 'String.prototype helper disabled');
   });
 }
 
-test("capitalize normal string", function() {
+QUnit.test("capitalize normal string", function() {
   deepEqual(capitalize('my favorite items'), 'My favorite items');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('my favorite items'.capitalize(), 'My favorite items');
   }
 });
 
-test("capitalize dasherized string", function() {
+QUnit.test("capitalize dasherized string", function() {
   deepEqual(capitalize('css-class-name'), 'Css-class-name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('css-class-name'.capitalize(), 'Css-class-name');
   }
 });
 
-test("capitalize underscored string", function() {
+QUnit.test("capitalize underscored string", function() {
   deepEqual(capitalize('action_name'), 'Action_name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action_name'.capitalize(), 'Action_name');
   }
 });
 
-test("capitalize camelcased string", function() {
+QUnit.test("capitalize camelcased string", function() {
   deepEqual(capitalize('innerHTML'), 'InnerHTML');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('innerHTML'.capitalize(), 'InnerHTML');
   }
 });
 
-test("does nothing with capitalized string", function() {
+QUnit.test("does nothing with capitalized string", function() {
   deepEqual(capitalize('Capitalized string'), 'Capitalized string');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('Capitalized string'.capitalize(), 'Capitalized string');

--- a/packages/ember-runtime/tests/system/string/classify_test.js
+++ b/packages/ember-runtime/tests/system/string/classify_test.js
@@ -4,33 +4,33 @@ import {classify} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.classify');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.classify is not modified without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.classify is not modified without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.classify, 'String.prototype helper disabled');
   });
 }
 
-test("classify normal string", function() {
+QUnit.test("classify normal string", function() {
   deepEqual(classify('my favorite items'), 'MyFavoriteItems');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('my favorite items'.classify(), 'MyFavoriteItems');
   }
 });
 
-test("classify dasherized string", function() {
+QUnit.test("classify dasherized string", function() {
   deepEqual(classify('css-class-name'), 'CssClassName');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('css-class-name'.classify(), 'CssClassName');
   }
 });
 
-test("classify underscored string", function() {
+QUnit.test("classify underscored string", function() {
   deepEqual(classify('action_name'), 'ActionName');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action_name'.classify(), 'ActionName');
   }
 });
 
-test("does nothing with classified string", function() {
+QUnit.test("does nothing with classified string", function() {
   deepEqual(classify('InnerHTML'), 'InnerHTML');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('InnerHTML'.classify(), 'InnerHTML');

--- a/packages/ember-runtime/tests/system/string/dasherize_test.js
+++ b/packages/ember-runtime/tests/system/string/dasherize_test.js
@@ -4,40 +4,40 @@ import {dasherize} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.dasherize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.dasherize is not modified without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.dasherize is not modified without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.dasherize, 'String.prototype helper disabled');
   });
 }
 
-test("dasherize normal string", function() {
+QUnit.test("dasherize normal string", function() {
   deepEqual(dasherize('my favorite items'), 'my-favorite-items');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('my favorite items'.dasherize(), 'my-favorite-items');
   }
 });
 
-test("does nothing with dasherized string", function() {
+QUnit.test("does nothing with dasherized string", function() {
   deepEqual(dasherize('css-class-name'), 'css-class-name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('css-class-name'.dasherize(), 'css-class-name');
   }
 });
 
-test("dasherize underscored string", function() {
+QUnit.test("dasherize underscored string", function() {
   deepEqual(dasherize('action_name'), 'action-name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action_name'.dasherize(), 'action-name');
   }
 });
 
-test("dasherize camelcased string", function() {
+QUnit.test("dasherize camelcased string", function() {
   deepEqual(dasherize('innerHTML'), 'inner-html');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('innerHTML'.dasherize(), 'inner-html');
   }
 });
 
-test("dasherize string that is the property name of Object.prototype", function() {
+QUnit.test("dasherize string that is the property name of Object.prototype", function() {
   deepEqual(dasherize('toString'), 'to-string');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('toString'.dasherize(), 'to-string');

--- a/packages/ember-runtime/tests/system/string/decamelize_test.js
+++ b/packages/ember-runtime/tests/system/string/decamelize_test.js
@@ -4,40 +4,40 @@ import {decamelize} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.decamelize');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.decamelize is not modified without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.decamelize is not modified without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.decamelize, 'String.prototype helper disabled');
   });
 }
 
-test("does nothing with normal string", function() {
+QUnit.test("does nothing with normal string", function() {
   deepEqual(decamelize('my favorite items'), 'my favorite items');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('my favorite items'.decamelize(), 'my favorite items');
   }
 });
 
-test("does nothing with dasherized string", function() {
+QUnit.test("does nothing with dasherized string", function() {
   deepEqual(decamelize('css-class-name'), 'css-class-name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('css-class-name'.decamelize(), 'css-class-name');
   }
 });
 
-test("does nothing with underscored string", function() {
+QUnit.test("does nothing with underscored string", function() {
   deepEqual(decamelize('action_name'), 'action_name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action_name'.decamelize(), 'action_name');
   }
 });
 
-test("converts a camelized string into all lower case separated by underscores.", function() {
+QUnit.test("converts a camelized string into all lower case separated by underscores.", function() {
   deepEqual(decamelize('innerHTML'), 'inner_html');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('innerHTML'.decamelize(), 'inner_html');
   }
 });
 
-test("decamelizes strings with numbers", function() {
+QUnit.test("decamelizes strings with numbers", function() {
   deepEqual(decamelize('size160Url'), 'size160_url');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('size160Url'.decamelize(), 'size160_url');

--- a/packages/ember-runtime/tests/system/string/fmt_string_test.js
+++ b/packages/ember-runtime/tests/system/string/fmt_string_test.js
@@ -4,26 +4,26 @@ import {fmt} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.fmt');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.fmt is not modified without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.fmt is not modified without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.fmt, 'String.prototype helper disabled');
   });
 }
 
-test("'Hello %@ %@'.fmt('John', 'Doe') => 'Hello John Doe'", function() {
+QUnit.test("'Hello %@ %@'.fmt('John', 'Doe') => 'Hello John Doe'", function() {
   equal(fmt('Hello %@ %@', ['John', 'Doe']), 'Hello John Doe');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('Hello %@ %@'.fmt('John', 'Doe'), 'Hello John Doe');
   }
 });
 
-test("'Hello %@2 %@1'.fmt('John', 'Doe') => 'Hello Doe John'", function() {
+QUnit.test("'Hello %@2 %@1'.fmt('John', 'Doe') => 'Hello Doe John'", function() {
   equal(fmt('Hello %@2 %@1', ['John', 'Doe']), 'Hello Doe John');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('Hello %@2 %@1'.fmt('John', 'Doe'), 'Hello Doe John');
   }
 });
 
-test("'%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight') => 'Eight Seven Six Five Four Three Two One'", function() {
+QUnit.test("'%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight') => 'Eight Seven Six Five Four Three Two One'", function() {
   equal(fmt('%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01', ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight']), 'Eight Seven Six Five Four Three Two One');
 
   if (Ember.EXTEND_PROTOTYPES) {
@@ -31,14 +31,14 @@ test("'%@08 %@07 %@06 %@05 %@04 %@03 %@02 %@01'.fmt('One', 'Two', 'Three', 'Four
   }
 });
 
-test("'data: %@'.fmt({ id: 3 }) => 'data: {id: 3}'", function() {
+QUnit.test("'data: %@'.fmt({ id: 3 }) => 'data: {id: 3}'", function() {
   equal(fmt('data: %@', [{ id: 3 }]), 'data: {id: 3}');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('data: %@'.fmt({ id: 3 }), 'data: {id: 3}');
   }
 });
 
-test("works with argument form", function() {
+QUnit.test("works with argument form", function() {
   equal(fmt('%@', 'John'), 'John');
   equal(fmt('%@ %@', ['John'], 'Doe'), '[John] Doe');
 });

--- a/packages/ember-runtime/tests/system/string/loc_test.js
+++ b/packages/ember-runtime/tests/system/string/loc_test.js
@@ -20,40 +20,40 @@ QUnit.module('EmberStringUtils.loc', {
 });
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.loc is not available without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.loc is not available without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.loc, 'String.prototype helper disabled');
   });
 }
 
-test("'_Hello World'.loc() => 'Bonjour le monde'", function() {
+QUnit.test("'_Hello World'.loc() => 'Bonjour le monde'", function() {
   equal(loc('_Hello World'), 'Bonjour le monde');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('_Hello World'.loc(), 'Bonjour le monde');
   }
 });
 
-test("'_Hello %@ %@'.loc('John', 'Doe') => 'Bonjour John Doe'", function() {
+QUnit.test("'_Hello %@ %@'.loc('John', 'Doe') => 'Bonjour John Doe'", function() {
   equal(loc('_Hello %@ %@', ['John', 'Doe']), 'Bonjour John Doe');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('_Hello %@ %@'.loc('John', 'Doe'), 'Bonjour John Doe');
   }
 });
 
-test("'_Hello %@# %@#'.loc('John', 'Doe') => 'Bonjour Doe John'", function() {
+QUnit.test("'_Hello %@# %@#'.loc('John', 'Doe') => 'Bonjour Doe John'", function() {
   equal(loc('_Hello %@# %@#', ['John', 'Doe']), 'Bonjour Doe John');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('_Hello %@# %@#'.loc('John', 'Doe'), 'Bonjour Doe John');
   }
 });
 
-test("'_Not In Strings'.loc() => '_Not In Strings'", function() {
+QUnit.test("'_Not In Strings'.loc() => '_Not In Strings'", function() {
   equal(loc('_Not In Strings'), '_Not In Strings');
   if (Ember.EXTEND_PROTOTYPES) {
     equal('_Not In Strings'.loc(), '_Not In Strings');
   }
 });
 
-test("works with argument form", function() {
+QUnit.test("works with argument form", function() {
   equal(loc('_Hello %@', 'John'), 'Bonjour John');
   equal(loc('_Hello %@ %@', ['John'], 'Doe'), 'Bonjour [John] Doe');
 });

--- a/packages/ember-runtime/tests/system/string/underscore_test.js
+++ b/packages/ember-runtime/tests/system/string/underscore_test.js
@@ -4,33 +4,33 @@ import {underscore} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.underscore');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.underscore is not available without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.underscore is not available without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.underscore, 'String.prototype helper disabled');
   });
 }
 
-test("with normal string", function() {
+QUnit.test("with normal string", function() {
   deepEqual(underscore('my favorite items'), 'my_favorite_items');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('my favorite items'.underscore(), 'my_favorite_items');
   }
 });
 
-test("with dasherized string", function() {
+QUnit.test("with dasherized string", function() {
   deepEqual(underscore('css-class-name'), 'css_class_name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('css-class-name'.underscore(), 'css_class_name');
   }
 });
 
-test("does nothing with underscored string", function() {
+QUnit.test("does nothing with underscored string", function() {
   deepEqual(underscore('action_name'), 'action_name');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('action_name'.underscore(), 'action_name');
   }
 });
 
-test("with camelcased string", function() {
+QUnit.test("with camelcased string", function() {
   deepEqual(underscore('innerHTML'), 'inner_html');
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('innerHTML'.underscore(), 'inner_html');

--- a/packages/ember-runtime/tests/system/string/w_test.js
+++ b/packages/ember-runtime/tests/system/string/w_test.js
@@ -4,26 +4,26 @@ import {w} from "ember-runtime/system/string";
 QUnit.module('EmberStringUtils.w');
 
 if (!Ember.EXTEND_PROTOTYPES && !Ember.EXTEND_PROTOTYPES.String) {
-  test("String.prototype.w is not available without EXTEND_PROTOTYPES", function() {
+  QUnit.test("String.prototype.w is not available without EXTEND_PROTOTYPES", function() {
     ok("undefined" === typeof String.prototype.w, 'String.prototype helper disabled');
   });
 }
 
-test("'one two three'.w() => ['one','two','three']", function() {
+QUnit.test("'one two three'.w() => ['one','two','three']", function() {
   deepEqual(w('one two three'), ['one','two','three']);
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('one two three'.w(), ['one','two','three']);
   }
 });
 
-test("'one    two    three'.w() with extra spaces between words => ['one','two','three']", function() {
+QUnit.test("'one    two    three'.w() with extra spaces between words => ['one','two','three']", function() {
   deepEqual(w('one   two  three'), ['one','two','three']);
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('one   two  three'.w(), ['one','two','three']);
   }
 });
 
-test("'one two three'.w() with tabs", function() {
+QUnit.test("'one two three'.w() with tabs", function() {
   deepEqual(w('one\ttwo  three'), ['one','two','three']);
   if (Ember.EXTEND_PROTOTYPES) {
     deepEqual('one\ttwo  three'.w(), ['one','two','three']);

--- a/packages/ember-runtime/tests/system/subarray_test.js
+++ b/packages/ember-runtime/tests/system/subarray_test.js
@@ -17,13 +17,13 @@ function operationsString() {
   return str.substring(1);
 }
 
-test("Subarray operations are initially retain:n", function() {
+QUnit.test("Subarray operations are initially retain:n", function() {
   subarray = new SubArray(10);
 
   equal(operationsString(), "r:10", "subarray operations are initially retain n");
 });
 
-test("Retains compose with retains on insert", function() {
+QUnit.test("Retains compose with retains on insert", function() {
   subarray.addItem(0, true);
   subarray.addItem(1, true);
   subarray.addItem(2, true);
@@ -31,7 +31,7 @@ test("Retains compose with retains on insert", function() {
   equal(operationsString(), "r:3", "Retains compose with retains on insert.");
 });
 
-test("Retains compose with retains on removal", function() {
+QUnit.test("Retains compose with retains on removal", function() {
   subarray.addItem(0, true);
   subarray.addItem(1, false);
   subarray.addItem(2, true);
@@ -43,7 +43,7 @@ test("Retains compose with retains on removal", function() {
   equal(operationsString(), "r:2", "Retains compose with retains on removal.");
 });
 
-test("Filters compose with filters on insert", function() {
+QUnit.test("Filters compose with filters on insert", function() {
   subarray.addItem(0, false);
   subarray.addItem(1, false);
   subarray.addItem(2, false);
@@ -51,7 +51,7 @@ test("Filters compose with filters on insert", function() {
   equal(operationsString(), "f:3", "Retains compose with retains on insert.");
 });
 
-test("Filters compose with filters on removal", function() {
+QUnit.test("Filters compose with filters on removal", function() {
   subarray.addItem(0, false);
   subarray.addItem(1, true);
   subarray.addItem(2, false);
@@ -63,7 +63,7 @@ test("Filters compose with filters on removal", function() {
   equal(operationsString(), "f:2", "Filters compose with filters on removal.");
 });
 
-test("Filters split retains", function() {
+QUnit.test("Filters split retains", function() {
   subarray.addItem(0, true);
   subarray.addItem(1, true);
   subarray.addItem(1, false);
@@ -71,7 +71,7 @@ test("Filters split retains", function() {
   equal(operationsString(), "r:1 f:1 r:1", "Filters split retains.");
 });
 
-test("Retains split filters", function() {
+QUnit.test("Retains split filters", function() {
   subarray.addItem(0, false);
   subarray.addItem(1, false);
   subarray.addItem(1, true);
@@ -79,7 +79,7 @@ test("Retains split filters", function() {
   equal(operationsString(), "f:1 r:1 f:1", "Retains split filters.");
 });
 
-test("`addItem` returns the index of the item in the subarray", function() {
+QUnit.test("`addItem` returns the index of the item in the subarray", function() {
   equal(subarray.addItem(0, true), 0, "`addItem` returns the index of the item in the subarray");
   subarray.addItem(1, false);
   equal(subarray.addItem(2, true), 1, "`addItem` returns the index of the item in the subarray");
@@ -87,11 +87,11 @@ test("`addItem` returns the index of the item in the subarray", function() {
   equal(operationsString(), "r:1 f:1 r:1", "Operations are correct.");
 });
 
-test("`addItem` returns -1 if the new item is not in the subarray", function() {
+QUnit.test("`addItem` returns -1 if the new item is not in the subarray", function() {
   equal(subarray.addItem(0, false), -1, "`addItem` returns -1 if the item is not in the subarray");
 });
 
-test("`removeItem` returns the index of the item in the subarray", function() {
+QUnit.test("`removeItem` returns the index of the item in the subarray", function() {
   subarray.addItem(0, true);
   subarray.addItem(1, false);
   subarray.addItem(2, true);
@@ -100,21 +100,21 @@ test("`removeItem` returns the index of the item in the subarray", function() {
   equal(subarray.removeItem(0), 0, "`removeItem` returns the index of the item in the subarray");
 });
 
-test("`removeItem` returns -1 if the item was not in the subarray", function() {
+QUnit.test("`removeItem` returns -1 if the item was not in the subarray", function() {
   subarray.addItem(0, true);
   subarray.addItem(1, false);
 
   equal(subarray.removeItem(1), -1, "`removeItem` returns -1 if the item is not in the subarray");
 });
 
-test("`removeItem` raises a sensible exception when there are no operations in the subarray", function() {
+QUnit.test("`removeItem` raises a sensible exception when there are no operations in the subarray", function() {
   var subarrayExploder = function() {
     subarray.removeItem(9);
   };
   throws(subarrayExploder, /never\ been\ added/, "`removeItem` raises a sensible exception when there are no operations in the subarray");
 });
 
-test("left composition does not confuse a subsequent right non-composition", function() {
+QUnit.test("left composition does not confuse a subsequent right non-composition", function() {
   subarray.addItem(0, true);
   subarray.addItem(1, false);
   subarray.addItem(2, true);

--- a/packages/ember-runtime/tests/system/tracked_array_test.js
+++ b/packages/ember-runtime/tests/system/tracked_array_test.js
@@ -7,13 +7,13 @@ var DELETE = TrackedArray.DELETE;
 
 QUnit.module('Ember.TrackedArray');
 
-test("operations for a tracked array of length n are initially retain:n", function() {
+QUnit.test("operations for a tracked array of length n are initially retain:n", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   equal("r:4", trackedArray.toString(), "initial mutation is retain n");
 });
 
-test("insert zero items is a no-op", function() {
+QUnit.test("insert zero items is a no-op", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(2, []);
@@ -23,7 +23,7 @@ test("insert zero items is a no-op", function() {
   deepEqual(trackedArray._operations[0].items, [1,2,3,4], "after a no-op, existing operation has right items");
 });
 
-test("inserts can split retains", function() {
+QUnit.test("inserts can split retains", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(2, ['a']);
@@ -35,7 +35,7 @@ test("inserts can split retains", function() {
   deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
 });
 
-test("inserts can expand (split/compose) inserts", function() {
+QUnit.test("inserts can expand (split/compose) inserts", function() {
   trackedArray = new TrackedArray([]);
 
   trackedArray.addItems(0, [1,2,3,4]);
@@ -46,7 +46,7 @@ test("inserts can expand (split/compose) inserts", function() {
   deepEqual(trackedArray._operations[0].items, [1,2,'a',3,4], "expanded inserts have the right items");
 });
 
-test("inserts left of inserts compose", function() {
+QUnit.test("inserts left of inserts compose", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(2, ['b']);
@@ -59,7 +59,7 @@ test("inserts left of inserts compose", function() {
   deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
 });
 
-test("inserts right of inserts compose", function() {
+QUnit.test("inserts right of inserts compose", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(2, ['a']);
@@ -72,7 +72,7 @@ test("inserts right of inserts compose", function() {
   deepEqual(trackedArray._operations[2].items, [3,4], "split retains have the right items");
 });
 
-test("delete zero items is a no-op", function() {
+QUnit.test("delete zero items is a no-op", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(2, []);
@@ -82,7 +82,7 @@ test("delete zero items is a no-op", function() {
   deepEqual(trackedArray._operations[0].items, [1,2,3,4], "after a no-op, existing operation has right items");
 });
 
-test("deletes compose with several inserts and retains", function() {
+QUnit.test("deletes compose with several inserts and retains", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(4, ['e']);
@@ -95,7 +95,7 @@ test("deletes compose with several inserts and retains", function() {
   equal(trackedArray.toString(), "d:4", "deletes compose with several inserts and retains");
 });
 
-test("deletes compose with several inserts and retains and an adjacent delete", function() {
+QUnit.test("deletes compose with several inserts and retains and an adjacent delete", function() {
   trackedArray = new TrackedArray([1,2,3,4,5]);
 
   trackedArray.removeItems(0, 1);
@@ -109,7 +109,7 @@ test("deletes compose with several inserts and retains and an adjacent delete", 
   equal(trackedArray.toString(), "d:5", "deletes compose with several inserts, retains, and a single prior delete");
 });
 
-test("deletes compose with several inserts and retains and can reduce the last one", function() {
+QUnit.test("deletes compose with several inserts and retains and can reduce the last one", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(4, ['e', 'f']);
@@ -123,7 +123,7 @@ test("deletes compose with several inserts and retains and can reduce the last o
   deepEqual(trackedArray._operations[1].items, ['f'], "last mutation's items is correct");
 });
 
-test("deletes can split retains", function() {
+QUnit.test("deletes can split retains", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
   trackedArray.removeItems(0, 2);
 
@@ -131,7 +131,7 @@ test("deletes can split retains", function() {
   deepEqual(trackedArray._operations[1].items, [3,4], "retains reduced by delete have the right items");
 });
 
-test("deletes can trim retains on the right", function() {
+QUnit.test("deletes can trim retains on the right", function() {
   trackedArray = new TrackedArray([1,2,3]);
   trackedArray.removeItems(2, 1);
 
@@ -139,7 +139,7 @@ test("deletes can trim retains on the right", function() {
   deepEqual(trackedArray._operations[0].items, [1,2], "retains reduced by delete have the right items");
 });
 
-test("deletes can trim retains on the left", function() {
+QUnit.test("deletes can trim retains on the left", function() {
   trackedArray = new TrackedArray([1,2,3]);
   trackedArray.removeItems(0, 1);
 
@@ -147,7 +147,7 @@ test("deletes can trim retains on the left", function() {
   deepEqual(trackedArray._operations[1].items, [2,3], "retains reduced by delete have the right items");
 });
 
-test("deletes can split inserts", function() {
+QUnit.test("deletes can split inserts", function() {
   trackedArray = new TrackedArray([]);
   trackedArray.addItems(0, ['a','b','c']);
   trackedArray.removeItems(0, 1);
@@ -156,7 +156,7 @@ test("deletes can split inserts", function() {
   deepEqual(trackedArray._operations[0].items, ['b', 'c'], "inserts reduced by delete have the right items");
 });
 
-test("deletes can trim inserts on the right", function() {
+QUnit.test("deletes can trim inserts on the right", function() {
   trackedArray = new TrackedArray([]);
   trackedArray.addItems(0, ['a','b','c']);
   trackedArray.removeItems(2, 1);
@@ -165,7 +165,7 @@ test("deletes can trim inserts on the right", function() {
   deepEqual(trackedArray._operations[0].items, ['a', 'b'], "inserts reduced by delete have the right items");
 });
 
-test("deletes can trim inserts on the left", function() {
+QUnit.test("deletes can trim inserts on the left", function() {
   trackedArray = new TrackedArray([]);
   trackedArray.addItems(0, ['a','b','c']);
   trackedArray.removeItems(0, 1);
@@ -174,7 +174,7 @@ test("deletes can trim inserts on the left", function() {
   deepEqual(trackedArray._operations[0].items, ['b', 'c'], "inserts reduced by delete have the right items");
 });
 
-test("deletes can trim inserts on the left while composing with a delete on the left", function() {
+QUnit.test("deletes can trim inserts on the left while composing with a delete on the left", function() {
   trackedArray = new TrackedArray(['a']);
   trackedArray.removeItems(0, 1);
   trackedArray.addItems(0, ['b', 'c']);
@@ -184,7 +184,7 @@ test("deletes can trim inserts on the left while composing with a delete on the 
   deepEqual(trackedArray._operations[1].items, ['c'], "inserts reduced by delete have the right items");
 });
 
-test("deletes can reduce an insert or retain, compose with several mutations of different types and reduce the last mutation if it is non-delete", function() {
+QUnit.test("deletes can reduce an insert or retain, compose with several mutations of different types and reduce the last mutation if it is non-delete", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
 
   trackedArray.addItems(4, ['e', 'f']);    // 1234ef
@@ -199,12 +199,12 @@ test("deletes can reduce an insert or retain, compose with several mutations of 
   deepEqual(trackedArray._operations[2].items, ['f'], "last reduced mutation's items is correct");
 });
 
-test("removeItems returns the removed items", function() {
+QUnit.test("removeItems returns the removed items", function() {
   trackedArray = new TrackedArray([1,2,3,4]);
   deepEqual(trackedArray.removeItems(1, 2), [2,3], "`removeItems` returns the removed items");
 });
 
-test("apply invokes the callback with each group of items and the mutation's calculated offset", function() {
+QUnit.test("apply invokes the callback with each group of items and the mutation's calculated offset", function() {
   var i = 0;
   trackedArray = new TrackedArray([1,2,3,4]);
 

--- a/packages/ember-template-compiler/tests/plugins/transform-each-in-to-hash-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-each-in-to-hash-test.js
@@ -2,7 +2,7 @@ import { compile } from "ember-template-compiler";
 
 QUnit.module('ember-template-compiler: transform-each-in-to-hash');
 
-test('cannot use block params and keyword syntax together', function() {
+QUnit.test('cannot use block params and keyword syntax together', function() {
   expect(1);
 
   throws(function() {

--- a/packages/ember-template-compiler/tests/plugins/transform-with-as-to-hash-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-with-as-to-hash-test.js
@@ -2,7 +2,7 @@ import { compile } from "ember-template-compiler";
 
 QUnit.module('ember-template-compiler: transform-with-as-to-hash');
 
-test('cannot use block params and keyword syntax together', function() {
+QUnit.test('cannot use block params and keyword syntax together', function() {
   expect(1);
 
   throws(function() {

--- a/packages/ember-template-compiler/tests/plugins_test.js
+++ b/packages/ember-template-compiler/tests/plugins_test.js
@@ -16,7 +16,7 @@ QUnit.module("ember-htmlbars: Ember.HTMLBars.registerASTPlugin", {
   }
 });
 
-test("registering a plugin adds it to htmlbars-compiler options", function() {
+QUnit.test("registering a plugin adds it to htmlbars-compiler options", function() {
   expect(2);
 
   function TestPlugin() {
@@ -34,7 +34,7 @@ test("registering a plugin adds it to htmlbars-compiler options", function() {
   compile('some random template');
 });
 
-test('registering an unknown type throws an error', function() {
+QUnit.test('registering an unknown type throws an error', function() {
   throws(function() {
     registerPlugin('asdf', "whatever");
   }, /Attempting to register "whatever" as "asdf" which is not a valid HTMLBars plugin type./);

--- a/packages/ember-template-compiler/tests/system/compile_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_test.js
@@ -8,7 +8,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 QUnit.module('ember-htmlbars: compile');
 
-test('compiles the provided template with htmlbars', function() {
+QUnit.test('compiles the provided template with htmlbars', function() {
   var templateString = "{{foo}} -- {{some-bar blah='foo'}}";
 
   var actual = compile(templateString);
@@ -17,7 +17,7 @@ test('compiles the provided template with htmlbars', function() {
   equal(actual.toString(), expected.toString(), 'compile function matches content with htmlbars compile');
 });
 
-test('calls template on the compiled function', function() {
+QUnit.test('calls template on the compiled function', function() {
   var templateString = "{{foo}} -- {{some-bar blah='foo'}}";
 
   var actual = compile(templateString);

--- a/packages/ember-template-compiler/tests/system/template_test.js
+++ b/packages/ember-template-compiler/tests/system/template_test.js
@@ -5,7 +5,7 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
 QUnit.module('ember-htmlbars: template');
 
-test('sets `isTop` on the provided function', function() {
+QUnit.test('sets `isTop` on the provided function', function() {
   function test() { }
 
   template(test);
@@ -13,7 +13,7 @@ test('sets `isTop` on the provided function', function() {
   equal(test.isTop, true, 'sets isTop on the provided function');
 });
 
-test('sets `isMethod` on the provided function', function() {
+QUnit.test('sets `isMethod` on the provided function', function() {
   function test() { }
 
   template(test);

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -90,7 +90,7 @@ QUnit.module("ember-testing Acceptance", {
   }
 });
 
-test("helpers can be chained with then", function() {
+QUnit.test("helpers can be chained with then", function() {
   expect(5);
 
   currentRoute = 'index';
@@ -116,7 +116,7 @@ test("helpers can be chained with then", function() {
 
 // Keep this for backwards compatibility
 
-test("helpers can be chained to each other", function() {
+QUnit.test("helpers can be chained to each other", function() {
   expect(5);
 
   currentRoute = 'index';
@@ -139,7 +139,7 @@ test("helpers can be chained to each other", function() {
   });
 });
 
-test("helpers don't need to be chained", function() {
+QUnit.test("helpers don't need to be chained", function() {
   expect(3);
 
   currentRoute = 'index';
@@ -162,7 +162,7 @@ test("helpers don't need to be chained", function() {
   });
 });
 
-test("Nested async helpers", function() {
+QUnit.test("Nested async helpers", function() {
   expect(3);
 
   currentRoute = 'index';
@@ -187,7 +187,7 @@ test("Nested async helpers", function() {
   });
 });
 
-test("Multiple nested async helpers", function() {
+QUnit.test("Multiple nested async helpers", function() {
   expect(2);
 
   visit('/posts');
@@ -205,7 +205,7 @@ test("Multiple nested async helpers", function() {
   });
 });
 
-test("Helpers nested in thens", function() {
+QUnit.test("Helpers nested in thens", function() {
   expect(3);
 
   currentRoute = 'index';
@@ -230,7 +230,7 @@ test("Helpers nested in thens", function() {
   });
 });
 
-test("Aborted transitions are not logged via Ember.Test.adapter#exception", function () {
+QUnit.test("Aborted transitions are not logged via Ember.Test.adapter#exception", function () {
   expect(0);
 
   Test.adapter = QUnitAdapter.create({
@@ -242,7 +242,7 @@ test("Aborted transitions are not logged via Ember.Test.adapter#exception", func
   visit("/abort_transition");
 });
 
-test("Unhandled exceptions are logged via Ember.Test.adapter#exception", function () {
+QUnit.test("Unhandled exceptions are logged via Ember.Test.adapter#exception", function () {
   expect(2);
 
   var asyncHandled;
@@ -262,7 +262,7 @@ test("Unhandled exceptions are logged via Ember.Test.adapter#exception", functio
   asyncHandled = click(".does-not-exist");
 });
 
-test("Unhandled exceptions in `andThen` are logged via Ember.Test.adapter#exception", function () {
+QUnit.test("Unhandled exceptions in `andThen` are logged via Ember.Test.adapter#exception", function () {
   expect(1);
 
   Test.adapter = QUnitAdapter.create({
@@ -278,7 +278,7 @@ test("Unhandled exceptions in `andThen` are logged via Ember.Test.adapter#except
   });
 });
 
-test("should not start routing on the root URL when visiting another", function() {
+QUnit.test("should not start routing on the root URL when visiting another", function() {
   visit('/posts');
 
   andThen(function() {
@@ -288,7 +288,7 @@ test("should not start routing on the root URL when visiting another", function(
   });
 });
 
-test("only enters the index route once when visiting /", function() {
+QUnit.test("only enters the index route once when visiting /", function() {
   visit('/');
 
   andThen(function() {

--- a/packages/ember-testing/tests/adapters/adapter_test.js
+++ b/packages/ember-testing/tests/adapters/adapter_test.js
@@ -21,7 +21,7 @@ QUnit.module("ember-testing Adapter", {
 //   equal(adapter.asyncEnd, K);
 // });
 
-test("exception throws", function() {
+QUnit.test("exception throws", function() {
   var error = "Hai";
   var thrown;
 

--- a/packages/ember-testing/tests/adapters/qunit_test.js
+++ b/packages/ember-testing/tests/adapters/qunit_test.js
@@ -12,7 +12,7 @@ QUnit.module("ember-testing QUnitAdapter", {
   }
 });
 
-test("asyncStart calls stop", function() {
+QUnit.test("asyncStart calls stop", function() {
   var originalStop = QUnit.stop;
   try {
     QUnit.stop = function() {
@@ -24,7 +24,7 @@ test("asyncStart calls stop", function() {
   }
 });
 
-test("asyncEnd calls start", function() {
+QUnit.test("asyncEnd calls start", function() {
   var originalStart = QUnit.start;
   try {
     QUnit.start = function() {
@@ -36,7 +36,7 @@ test("asyncEnd calls start", function() {
   }
 });
 
-test("exception causes a failing assertion", function() {
+QUnit.test("exception causes a failing assertion", function() {
   var error = { err: 'hai' };
   var originalOk = window.ok;
   try {

--- a/packages/ember-testing/tests/adapters_test.js
+++ b/packages/ember-testing/tests/adapters_test.js
@@ -19,7 +19,7 @@ QUnit.module("ember-testing Adapters", {
   }
 });
 
-test("Setting a test adapter manually", function() {
+QUnit.test("Setting a test adapter manually", function() {
   expect(1);
   var CustomAdapter;
 
@@ -38,7 +38,7 @@ test("Setting a test adapter manually", function() {
   Test.adapter.asyncStart();
 });
 
-test("QUnitAdapter is used by default", function() {
+QUnit.test("QUnitAdapter is used by default", function() {
   expect(1);
 
   Test.adapter = null;

--- a/packages/ember-testing/tests/helper_registration_test.js
+++ b/packages/ember-testing/tests/helper_registration_test.js
@@ -43,7 +43,7 @@ QUnit.module("Test - registerHelper/unregisterHelper", {
   }
 });
 
-test("Helper gets registered", function() {
+QUnit.test("Helper gets registered", function() {
   expect(2);
 
   registerHelper();
@@ -53,7 +53,7 @@ test("Helper gets registered", function() {
   ok(helperContainer.boot);
 });
 
-test("Helper is ran when called", function() {
+QUnit.test("Helper is ran when called", function() {
   expect(1);
 
   registerHelper();
@@ -64,7 +64,7 @@ test("Helper is ran when called", function() {
   });
 });
 
-test("Helper can be unregistered", function() {
+QUnit.test("Helper can be unregistered", function() {
   expect(4);
 
   registerHelper();

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -94,7 +94,7 @@ QUnit.module("ember-testing: Helper setup", {
   teardown: function() { cleanup(); }
 });
 
-test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
+QUnit.test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
   App = run(EmberApplication, EmberApplication.create);
   assertNoHelpers(App);
 
@@ -105,7 +105,7 @@ test("Ember.Application#injectTestHelpers/#removeTestHelpers", function() {
   assertNoHelpers(App);
 });
 
-test("Ember.Application#setupForTesting", function() {
+QUnit.test("Ember.Application#setupForTesting", function() {
   run(function() {
     App = EmberApplication.create();
     App.setupForTesting();
@@ -114,7 +114,7 @@ test("Ember.Application#setupForTesting", function() {
   equal(App.__container__.lookup('router:main').location.implementation, 'none');
 });
 
-test("Ember.Application.setupForTesting sets the application to `testing`.", function() {
+QUnit.test("Ember.Application.setupForTesting sets the application to `testing`.", function() {
   run(function() {
     App = EmberApplication.create();
     App.setupForTesting();
@@ -123,7 +123,7 @@ test("Ember.Application.setupForTesting sets the application to `testing`.", fun
   equal(App.testing, true, "Application instance is set to testing.");
 });
 
-test("Ember.Application.setupForTesting leaves the system in a deferred state.", function() {
+QUnit.test("Ember.Application.setupForTesting leaves the system in a deferred state.", function() {
   run(function() {
     App = EmberApplication.create();
     App.setupForTesting();
@@ -132,7 +132,7 @@ test("Ember.Application.setupForTesting leaves the system in a deferred state.",
   equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
 });
 
-test("App.reset() after Application.setupForTesting leaves the system in a deferred state.", function() {
+QUnit.test("App.reset() after Application.setupForTesting leaves the system in a deferred state.", function() {
   run(function() {
     App = EmberApplication.create();
     App.setupForTesting();
@@ -144,7 +144,7 @@ test("App.reset() after Application.setupForTesting leaves the system in a defer
   equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
 });
 
-test("Ember.Application#setupForTesting attaches ajax listeners", function() {
+QUnit.test("Ember.Application#setupForTesting attaches ajax listeners", function() {
   var documentEvents;
 
   documentEvents = jQuery._data(document, 'events');
@@ -166,7 +166,7 @@ test("Ember.Application#setupForTesting attaches ajax listeners", function() {
   equal(documentEvents['ajaxComplete'].length, 1, 'calling injectTestHelpers registers an ajaxComplete handler');
 });
 
-test("Ember.Application#setupForTesting attaches ajax listeners only once", function() {
+QUnit.test("Ember.Application#setupForTesting attaches ajax listeners only once", function() {
   var documentEvents;
 
   documentEvents = jQuery._data(document, 'events');
@@ -191,7 +191,7 @@ test("Ember.Application#setupForTesting attaches ajax listeners only once", func
   equal(documentEvents['ajaxComplete'].length, 1, 'calling injectTestHelpers registers an ajaxComplete handler');
 });
 
-test("Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers", function() {
+QUnit.test("Ember.Application#injectTestHelpers calls callbacks registered with onInjectHelpers", function() {
   var injected = 0;
 
   Test.onInjectHelpers(function() {
@@ -210,7 +210,7 @@ test("Ember.Application#injectTestHelpers calls callbacks registered with onInje
   equal(injected, 1, 'onInjectHelpers are called after injectTestHelpers');
 });
 
-test("Ember.Application#injectTestHelpers adds helpers to provided object.", function() {
+QUnit.test("Ember.Application#injectTestHelpers adds helpers to provided object.", function() {
   var helpers = {};
 
   run(function() {
@@ -225,7 +225,7 @@ test("Ember.Application#injectTestHelpers adds helpers to provided object.", fun
   assertNoHelpers(App, helpers);
 });
 
-test("Ember.Application#removeTestHelpers resets the helperContainer's original values", function() {
+QUnit.test("Ember.Application#removeTestHelpers resets the helperContainer's original values", function() {
   var helpers = { visit: 'snazzleflabber' };
 
   run(function() {
@@ -250,7 +250,7 @@ QUnit.module("ember-testing: Helper methods", {
   }
 });
 
-test("`wait` respects registerWaiters", function() {
+QUnit.test("`wait` respects registerWaiters", function() {
   expect(3);
 
   var counter=0;
@@ -278,7 +278,7 @@ test("`wait` respects registerWaiters", function() {
   });
 });
 
-test("`visit` advances readiness.", function() {
+QUnit.test("`visit` advances readiness.", function() {
   expect(2);
 
   equal(App._readinessDeferrals, 1, "App is in deferred state after setupForTesting.");
@@ -288,7 +288,7 @@ test("`visit` advances readiness.", function() {
   });
 });
 
-test("`wait` helper can be passed a resolution value", function() {
+QUnit.test("`wait` helper can be passed a resolution value", function() {
   expect(4);
 
   var promise, wait;
@@ -316,7 +316,7 @@ test("`wait` helper can be passed a resolution value", function() {
 
 });
 
-test("`click` triggers appropriate events in order", function() {
+QUnit.test("`click` triggers appropriate events in order", function() {
   expect(5);
 
   var click, wait, events;
@@ -389,7 +389,7 @@ test("`click` triggers appropriate events in order", function() {
   });
 });
 
-test("`wait` waits for outstanding timers", function() {
+QUnit.test("`wait` waits for outstanding timers", function() {
   expect(1);
 
   var wait_done = false;
@@ -406,7 +406,7 @@ test("`wait` waits for outstanding timers", function() {
 });
 
 
-test("`wait` respects registerWaiters with optional context", function() {
+QUnit.test("`wait` respects registerWaiters with optional context", function() {
   expect(3);
 
   var obj = {
@@ -435,7 +435,7 @@ test("`wait` respects registerWaiters with optional context", function() {
   });
 });
 
-test("`wait` does not error if routing has not begun", function() {
+QUnit.test("`wait` does not error if routing has not begun", function() {
   expect(1);
 
   App.testHelpers.wait().then(function() {
@@ -443,7 +443,7 @@ test("`wait` does not error if routing has not begun", function() {
   });
 });
 
-test("`triggerEvent accepts an optional options hash without context", function() {
+QUnit.test("`triggerEvent accepts an optional options hash without context", function() {
   expect(3);
 
   var triggerEvent, wait, event;
@@ -472,7 +472,7 @@ test("`triggerEvent accepts an optional options hash without context", function(
   });
 });
 
-test("`triggerEvent can limit searching for a selector to a scope", function() {
+QUnit.test("`triggerEvent can limit searching for a selector to a scope", function() {
   expect(2);
 
   var triggerEvent, wait, event;
@@ -500,7 +500,7 @@ test("`triggerEvent can limit searching for a selector to a scope", function() {
   });
 });
 
-test("`triggerEvent` can be used to trigger arbitrary events", function() {
+QUnit.test("`triggerEvent` can be used to trigger arbitrary events", function() {
   expect(2);
 
   var triggerEvent, wait, event;
@@ -528,7 +528,7 @@ test("`triggerEvent` can be used to trigger arbitrary events", function() {
   });
 });
 
-test("`fillIn` takes context into consideration", function() {
+QUnit.test("`fillIn` takes context into consideration", function() {
   expect(2);
   var fillIn, find, visit, andThen;
 
@@ -551,7 +551,7 @@ test("`fillIn` takes context into consideration", function() {
   });
 });
 
-test("`fillIn` focuses on the element", function() {
+QUnit.test("`fillIn` focuses on the element", function() {
   expect(2);
   var fillIn, find, visit, andThen;
 
@@ -582,7 +582,7 @@ test("`fillIn` focuses on the element", function() {
 });
 
 if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
-  test("`check` ensures checkboxes are `checked` state for checkboxes", function() {
+  QUnit.test("`check` ensures checkboxes are `checked` state for checkboxes", function() {
     expect(2);
     var check, find, visit, andThen;
 
@@ -606,7 +606,7 @@ if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
     });
   });
 
-  test("`uncheck` ensures checkboxes are not `checked`", function() {
+  QUnit.test("`uncheck` ensures checkboxes are not `checked`", function() {
     expect(2);
     var uncheck, find, visit, andThen;
 
@@ -630,7 +630,7 @@ if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
     });
   });
 
-  test("`check` asserts the selected inputs are checkboxes", function() {
+  QUnit.test("`check` asserts the selected inputs are checkboxes", function() {
     var check, visit;
 
     App.IndexView = EmberView.extend({
@@ -649,7 +649,7 @@ if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
     });
   });
 
-  test("`uncheck` asserts the selected inputs are checkboxes", function() {
+  QUnit.test("`uncheck` asserts the selected inputs are checkboxes", function() {
     var visit, uncheck;
 
     App.IndexView = EmberView.extend({
@@ -669,7 +669,7 @@ if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
   });
 }
 
-test("`triggerEvent accepts an optional options hash and context", function() {
+QUnit.test("`triggerEvent accepts an optional options hash and context", function() {
   expect(3);
 
   var triggerEvent, wait, event;
@@ -716,7 +716,7 @@ QUnit.module("ember-testing debugging helpers", {
   }
 });
 
-test("pauseTest pauses", function() {
+QUnit.test("pauseTest pauses", function() {
   expect(1);
   function fakeAdapterAsyncStart() {
     ok(true, 'Async start should be called');
@@ -754,7 +754,7 @@ QUnit.module("ember-testing routing helpers", {
   }
 });
 
-test("currentRouteName for '/'", function() {
+QUnit.test("currentRouteName for '/'", function() {
   expect(3);
 
   App.testHelpers.visit('/').then(function() {
@@ -765,7 +765,7 @@ test("currentRouteName for '/'", function() {
 });
 
 
-test("currentRouteName for '/posts'", function() {
+QUnit.test("currentRouteName for '/posts'", function() {
   expect(3);
 
   App.testHelpers.visit('/posts').then(function() {
@@ -775,7 +775,7 @@ test("currentRouteName for '/posts'", function() {
   });
 });
 
-test("currentRouteName for '/posts/new'", function() {
+QUnit.test("currentRouteName for '/posts/new'", function() {
   expect(3);
 
   App.testHelpers.visit('/posts/new').then(function() {
@@ -795,7 +795,7 @@ QUnit.module("ember-testing pendingAjaxRequests", {
   }
 });
 
-test("pendingAjaxRequests is maintained for ajaxSend and ajaxComplete events", function() {
+QUnit.test("pendingAjaxRequests is maintained for ajaxSend and ajaxComplete events", function() {
   equal(Test.pendingAjaxRequests, 0);
   var xhr = { some: 'xhr' };
   jQuery(document).trigger('ajaxSend', xhr);
@@ -804,7 +804,7 @@ test("pendingAjaxRequests is maintained for ajaxSend and ajaxComplete events", f
   equal(Test.pendingAjaxRequests, 0, 'Ember.Test.pendingAjaxRequests was decremented');
 });
 
-test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesting calls", function() {
+QUnit.test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesting calls", function() {
   equal(Test.pendingAjaxRequests, 0);
   var xhr = { some: 'xhr' };
   jQuery(document).trigger('ajaxSend', xhr);
@@ -822,7 +822,7 @@ test("pendingAjaxRequests is ignores ajaxComplete events from past setupForTesti
   equal(Test.pendingAjaxRequests, 1, 'Ember.Test.pendingAjaxRequests is not impressed with your unexpected complete');
 });
 
-test("pendingAjaxRequests is reset by setupForTesting", function() {
+QUnit.test("pendingAjaxRequests is reset by setupForTesting", function() {
   Test.pendingAjaxRequests = 1;
   run(function() {
     setupForTesting();
@@ -894,7 +894,7 @@ QUnit.module("ember-testing async router", {
   }
 });
 
-test("currentRouteName for '/user'", function() {
+QUnit.test("currentRouteName for '/user'", function() {
   expect(4);
 
   App.testHelpers.visit('/user').then(function() {
@@ -905,7 +905,7 @@ test("currentRouteName for '/user'", function() {
   });
 });
 
-test("currentRouteName for '/user/profile'", function() {
+QUnit.test("currentRouteName for '/user/profile'", function() {
   expect(4);
 
   App.testHelpers.visit('/user/profile').then(function() {
@@ -947,7 +947,7 @@ QUnit.module('can override built-in helpers', {
   }
 });
 
-test("can override visit helper", function() {
+QUnit.test("can override visit helper", function() {
   expect(1);
 
   Test.registerHelper('visit', function() {
@@ -958,7 +958,7 @@ test("can override visit helper", function() {
   App.testHelpers.visit();
 });
 
-test("can override find helper", function() {
+QUnit.test("can override find helper", function() {
   expect(1);
 
   Test.registerHelper('find', function() {

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -74,7 +74,7 @@ QUnit.module("ember-testing Integration", {
   }
 });
 
-test("template is bound to empty array of people", function() {
+QUnit.test("template is bound to empty array of people", function() {
   App.Person.find = function() {
     return Ember.A();
   };
@@ -85,7 +85,7 @@ test("template is bound to empty array of people", function() {
   });
 });
 
-test("template is bound to array of 2 people", function() {
+QUnit.test("template is bound to array of 2 people", function() {
   App.Person.find = function() {
     var people = Ember.A();
     var first = App.Person.create({ firstName: "x" });
@@ -101,7 +101,7 @@ test("template is bound to array of 2 people", function() {
   });
 });
 
-test("template is again bound to empty array of people", function() {
+QUnit.test("template is again bound to empty array of people", function() {
   App.Person.find = function() {
     return Ember.A();
   };
@@ -112,7 +112,7 @@ test("template is again bound to empty array of people", function() {
   });
 });
 
-test("`visit` can be called without advancedReadiness.", function() {
+QUnit.test("`visit` can be called without advancedReadiness.", function() {
   App.Person.find = function() {
     return Ember.A();
   };

--- a/packages/ember-views/tests/mixins/view_target_action_support_test.js
+++ b/packages/ember-views/tests/mixins/view_target_action_support_test.js
@@ -4,7 +4,7 @@ import ViewTargetActionSupport from "ember-views/mixins/view_target_action_suppo
 
 QUnit.module("ViewTargetActionSupport");
 
-test("it should return false if no action is specified", function() {
+QUnit.test("it should return false if no action is specified", function() {
   expect(1);
 
   var view = View.createWithMixins(ViewTargetActionSupport, {
@@ -14,7 +14,7 @@ test("it should return false if no action is specified", function() {
   ok(false === view.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should support actions specified as strings", function() {
+QUnit.test("it should support actions specified as strings", function() {
   expect(2);
 
   var view = View.createWithMixins(ViewTargetActionSupport, {
@@ -29,7 +29,7 @@ test("it should support actions specified as strings", function() {
   ok(true === view.triggerAction(), "a valid target and action were specified");
 });
 
-test("it should invoke the send() method on the controller with the view's context", function() {
+QUnit.test("it should invoke the send() method on the controller with the view's context", function() {
   expect(3);
 
   var view = View.createWithMixins(ViewTargetActionSupport, {

--- a/packages/ember-views/tests/streams/class_string_for_value_test.js
+++ b/packages/ember-views/tests/streams/class_string_for_value_test.js
@@ -2,37 +2,37 @@ import { classStringForValue } from "ember-views/streams/class_name_binding";
 
 QUnit.module("EmberView - classStringForValue");
 
-test("returns dasherized version of last path part if value is true", function() {
+QUnit.test("returns dasherized version of last path part if value is true", function() {
   equal(classStringForValue("propertyName", true), "property-name", "class is dasherized");
   equal(classStringForValue("content.propertyName", true), "property-name", "class is dasherized");
 });
 
-test("returns className if value is true and className is specified", function() {
+QUnit.test("returns className if value is true and className is specified", function() {
   equal(classStringForValue("propertyName", true, "truthyClass"), "truthyClass", "returns className if given");
   equal(classStringForValue("content.propertyName", true, "truthyClass"), "truthyClass", "returns className if given");
 });
 
-test("returns falsyClassName if value is false and falsyClassName is specified", function() {
+QUnit.test("returns falsyClassName if value is false and falsyClassName is specified", function() {
   equal(classStringForValue("propertyName", false, "truthyClass", "falsyClass"), "falsyClass", "returns falsyClassName if given");
   equal(classStringForValue("content.propertyName", false, "truthyClass", "falsyClass"), "falsyClass", "returns falsyClassName if given");
 });
 
-test("returns null if value is false and falsyClassName is not specified", function() {
+QUnit.test("returns null if value is false and falsyClassName is not specified", function() {
   equal(classStringForValue("propertyName", false, "truthyClass"), null, "returns null if falsyClassName is not specified");
   equal(classStringForValue("content.propertyName", false, "truthyClass"), null, "returns null if falsyClassName is not specified");
 });
 
-test("returns null if value is false", function() {
+QUnit.test("returns null if value is false", function() {
   equal(classStringForValue("propertyName", false), null, "returns null if value is false");
   equal(classStringForValue("content.propertyName", false), null, "returns null if value is false");
 });
 
-test("returns null if value is true and className is not specified and falsyClassName is specified", function() {
+QUnit.test("returns null if value is true and className is not specified and falsyClassName is specified", function() {
   equal(classStringForValue("propertyName", true, undefined, "falsyClassName"), null, "returns null if value is true");
   equal(classStringForValue("content.propertyName", true, undefined, "falsyClassName"), null, "returns null if value is true");
 });
 
-test("returns the value if the value is truthy", function() {
+QUnit.test("returns the value if the value is truthy", function() {
   equal(classStringForValue("propertyName", "myString"), "myString", "returns value if the value is truthy");
   equal(classStringForValue("content.propertyName", "myString"), "myString", "returns value if the value is truthy");
 
@@ -40,12 +40,12 @@ test("returns the value if the value is truthy", function() {
   equal(classStringForValue("content.propertyName", 123), 123, "returns value if the value is truthy");
 });
 
-test("treat empty array as falsy value and return null", function() {
+QUnit.test("treat empty array as falsy value and return null", function() {
   equal(classStringForValue("propertyName", [], "truthyClass"), null, "returns null if value is false");
   equal(classStringForValue("content.propertyName", [], "truthyClass"), null, "returns null if value is false");
 });
 
-test("treat non-empty array as truthy value and return the className if specified", function() {
+QUnit.test("treat non-empty array as truthy value and return the className if specified", function() {
   equal(classStringForValue("propertyName", ['emberjs'], "truthyClass"), "truthyClass", "returns className if given");
   equal(classStringForValue("content.propertyName", ['emberjs'], "truthyClass"), "truthyClass", "returns className if given");
 });

--- a/packages/ember-views/tests/streams/parse_property_path_test.js
+++ b/packages/ember-views/tests/streams/parse_property_path_test.js
@@ -2,7 +2,7 @@ import { parsePropertyPath } from "ember-views/streams/class_name_binding";
 
 QUnit.module("EmberView - parsePropertyPath");
 
-test("it works with a simple property path", function() {
+QUnit.test("it works with a simple property path", function() {
   var parsed = parsePropertyPath("simpleProperty");
 
   equal(parsed.path, "simpleProperty", "path is parsed correctly");
@@ -11,7 +11,7 @@ test("it works with a simple property path", function() {
   equal(parsed.classNames, "", "there is no classNames");
 });
 
-test("it works with a more complex property path", function() {
+QUnit.test("it works with a more complex property path", function() {
   var parsed = parsePropertyPath("content.simpleProperty");
 
   equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
@@ -20,7 +20,7 @@ test("it works with a more complex property path", function() {
   equal(parsed.classNames, "", "there is no classNames");
 });
 
-test("className is extracted", function() {
+QUnit.test("className is extracted", function() {
   var parsed = parsePropertyPath("content.simpleProperty:class");
 
   equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
@@ -29,7 +29,7 @@ test("className is extracted", function() {
   equal(parsed.classNames, ":class", "there is a classNames");
 });
 
-test("falsyClassName is extracted", function() {
+QUnit.test("falsyClassName is extracted", function() {
   var parsed = parsePropertyPath("content.simpleProperty:class:falsyClass");
 
   equal(parsed.path, "content.simpleProperty", "path is parsed correctly");
@@ -38,7 +38,7 @@ test("falsyClassName is extracted", function() {
   equal(parsed.classNames, ":class:falsyClass", "there is a classNames");
 });
 
-test("it works with an empty true class", function() {
+QUnit.test("it works with an empty true class", function() {
   var parsed = parsePropertyPath("content.simpleProperty::falsyClass");
 
   equal(parsed.path, "content.simpleProperty", "path is parsed correctly");

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -27,7 +27,7 @@ QUnit.module("EventDispatcher", {
   }
 });
 
-test("should dispatch events to views", function() {
+QUnit.test("should dispatch events to views", function() {
   var receivedEvent;
   var parentMouseDownCalled = 0;
   var childKeyDownCalled = 0;
@@ -84,7 +84,7 @@ test("should dispatch events to views", function() {
   equal(parentKeyDownCalled, 0, "does not call keyDown on parent if child handles event");
 });
 
-test("should not dispatch events to views not inDOM", function() {
+QUnit.test("should not dispatch events to views not inDOM", function() {
   var receivedEvent;
 
   view = View.createWithMixins({
@@ -121,7 +121,7 @@ test("should not dispatch events to views not inDOM", function() {
   $element.remove();
 });
 
-test("should send change events up view hierarchy if view contains form elements", function() {
+QUnit.test("should send change events up view hierarchy if view contains form elements", function() {
   var receivedEvent;
   view = View.create({
     render: function(buffer) {
@@ -142,7 +142,7 @@ test("should send change events up view hierarchy if view contains form elements
   equal(receivedEvent.target, jQuery('#is-done')[0], "target property is the element that was clicked");
 });
 
-test("events should stop propagating if the view is destroyed", function() {
+QUnit.test("events should stop propagating if the view is destroyed", function() {
   var parentViewReceived, receivedEvent;
 
   var parentView = ContainerView.create({
@@ -178,7 +178,7 @@ test("events should stop propagating if the view is destroyed", function() {
   ok(!parentViewReceived, "parent view does not receive the event");
 });
 
-test('should not interfere with event propagation of virtualViews', function() {
+QUnit.test('should not interfere with event propagation of virtualViews', function() {
   var receivedEvent;
 
   var view = View.create({
@@ -202,7 +202,7 @@ test('should not interfere with event propagation of virtualViews', function() {
   deepEqual(receivedEvent && receivedEvent.target, jQuery('#propagate-test-div')[0], 'target property is the element that was clicked');
 });
 
-test("should dispatch events to nearest event manager", function() {
+QUnit.test("should dispatch events to nearest event manager", function() {
   var receivedEvent=0;
   view = ContainerView.create({
     render: function(buffer) {
@@ -226,7 +226,7 @@ test("should dispatch events to nearest event manager", function() {
   equal(receivedEvent, 1, "event should go to manager and not view");
 });
 
-test("event manager should be able to re-dispatch events to view", function() {
+QUnit.test("event manager should be able to re-dispatch events to view", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var receivedEvent=0;
@@ -268,7 +268,7 @@ test("event manager should be able to re-dispatch events to view", function() {
   equal(receivedEvent, 2, "event should go to manager and not view");
 });
 
-test("event handlers should be wrapped in a run loop", function() {
+QUnit.test("event handlers should be wrapped in a run loop", function() {
   expect(1);
 
   view = View.createWithMixins({
@@ -303,7 +303,7 @@ QUnit.module("EventDispatcher#setup", {
   }
 });
 
-test("additional events which should be listened on can be passed", function () {
+QUnit.test("additional events which should be listened on can be passed", function () {
   expect(1);
 
   run(function () {
@@ -320,7 +320,7 @@ test("additional events which should be listened on can be passed", function () 
   jQuery("#leView").trigger("myevent");
 });
 
-test("additional events and rootElement can be specified", function () {
+QUnit.test("additional events and rootElement can be specified", function () {
   expect(3);
 
   jQuery("#qunit-fixture").append("<div class='custom-root'></div>");

--- a/packages/ember-views/tests/system/ext_test.js
+++ b/packages/ember-views/tests/system/ext_test.js
@@ -3,7 +3,7 @@ import View from "ember-views/views/view";
 
 QUnit.module("Ember.View additions to run queue");
 
-test("View hierarchy is done rendering to DOM when functions queued in afterRender execute", function() {
+QUnit.test("View hierarchy is done rendering to DOM when functions queued in afterRender execute", function() {
   var didInsert = 0;
   var childView = View.create({
     elementId: 'child_view',

--- a/packages/ember-views/tests/system/jquery_ext_test.js
+++ b/packages/ember-views/tests/system/jquery_ext_test.js
@@ -42,7 +42,7 @@ QUnit.module("EventDispatcher", {
 });
 
 if (canDataTransfer) {
-  test("jQuery.event.fix copies over the dataTransfer property", function() {
+  QUnit.test("jQuery.event.fix copies over the dataTransfer property", function() {
     var originalEvent;
     var receivedEvent;
 
@@ -58,7 +58,7 @@ if (canDataTransfer) {
     equal(receivedEvent.dataTransfer, originalEvent.dataTransfer, "copies dataTransfer property to jQuery event");
   });
 
-  test("drop handler should receive event with dataTransfer property", function() {
+  QUnit.test("drop handler should receive event with dataTransfer property", function() {
     var receivedEvent;
     var dropCalled = 0;
 

--- a/packages/ember-views/tests/system/render_buffer_test.js
+++ b/packages/ember-views/tests/system/render_buffer_test.js
@@ -20,7 +20,7 @@ function createRenderBuffer(tagName, contextualElement) {
   return buffer;
 }
 
-test("RenderBuffers raise a deprecation warning without a contextualElement", function() {
+QUnit.test("RenderBuffers raise a deprecation warning without a contextualElement", function() {
   var buffer = createRenderBuffer('div');
   expectDeprecation(function() {
     buffer.generateElement();
@@ -29,7 +29,7 @@ test("RenderBuffers raise a deprecation warning without a contextualElement", fu
   }, /The render buffer expects an outer contextualElement to exist/);
 });
 
-test("reset RenderBuffers raise a deprecation warning without a contextualElement", function() {
+QUnit.test("reset RenderBuffers raise a deprecation warning without a contextualElement", function() {
   var buffer = createRenderBuffer('div', document.body);
   buffer.reset('span');
   expectDeprecation(function() {
@@ -39,7 +39,7 @@ test("reset RenderBuffers raise a deprecation warning without a contextualElemen
   }, /The render buffer expects an outer contextualElement to exist/);
 });
 
-test("RenderBuffers combine strings", function() {
+QUnit.test("RenderBuffers combine strings", function() {
   var buffer = createRenderBuffer('div', document.body);
   buffer.generateElement();
 
@@ -51,7 +51,7 @@ test("RenderBuffers combine strings", function() {
   equal(el.childNodes[0].nodeValue, 'ab', "Multiple pushes should concatenate");
 });
 
-test("RenderBuffers push fragments", function() {
+QUnit.test("RenderBuffers push fragments", function() {
   var buffer = createRenderBuffer('div', document.body);
   var fragment = document.createElement('span');
   buffer.generateElement();
@@ -63,7 +63,7 @@ test("RenderBuffers push fragments", function() {
   equal(el.childNodes[0].tagName, 'SPAN', "Fragment is pushed into the buffer");
 });
 
-test("RenderBuffers cannot push fragments when something else is in the buffer", function() {
+QUnit.test("RenderBuffers cannot push fragments when something else is in the buffer", function() {
   var buffer = createRenderBuffer('div', document.body);
   var fragment = document.createElement('span');
   buffer.generateElement();
@@ -74,7 +74,7 @@ test("RenderBuffers cannot push fragments when something else is in the buffer",
   });
 });
 
-test("RenderBuffers cannot push strings after fragments", function() {
+QUnit.test("RenderBuffers cannot push strings after fragments", function() {
   var buffer = createRenderBuffer('div', document.body);
   var fragment = document.createElement('span');
   buffer.generateElement();
@@ -85,7 +85,7 @@ test("RenderBuffers cannot push strings after fragments", function() {
   });
 });
 
-test("value of 0 is included in output", function() {
+QUnit.test("value of 0 is included in output", function() {
   var buffer, el;
   buffer = createRenderBuffer('input', document.body);
   buffer.prop('value', 0);
@@ -94,7 +94,7 @@ test("value of 0 is included in output", function() {
   strictEqual(el.value, '0', "generated element has value of '0'");
 });
 
-test("sets attributes with camelCase", function() {
+QUnit.test("sets attributes with camelCase", function() {
   var buffer = createRenderBuffer('div', document.body);
   var content = "javascript:someCode()"; //jshint ignore:line
 
@@ -104,7 +104,7 @@ test("sets attributes with camelCase", function() {
   strictEqual(el.getAttribute('onClick'), content, "attribute with camelCase was set");
 });
 
-test("prevents XSS injection via `id`", function() {
+QUnit.test("prevents XSS injection via `id`", function() {
   var buffer = createRenderBuffer('div', document.body);
 
   buffer.id('hacked" megahax="yes');
@@ -114,7 +114,7 @@ test("prevents XSS injection via `id`", function() {
   equal(el.id, 'hacked" megahax="yes');
 });
 
-test("prevents XSS injection via `attr`", function() {
+QUnit.test("prevents XSS injection via `attr`", function() {
   var buffer = createRenderBuffer('div', document.body);
 
   buffer.attr('id', 'trololol" onmouseover="pwn()');
@@ -128,7 +128,7 @@ test("prevents XSS injection via `attr`", function() {
   equal(el.getAttribute('class'), "hax><img src=\"trollface.png\"");
 });
 
-test("prevents XSS injection via `addClass`", function() {
+QUnit.test("prevents XSS injection via `addClass`", function() {
   var buffer = createRenderBuffer('div', document.body);
 
   buffer.addClass('megahax" xss="true');
@@ -138,7 +138,7 @@ test("prevents XSS injection via `addClass`", function() {
   equal(el.getAttribute('class'), 'megahax" xss="true');
 });
 
-test("prevents XSS injection via `style`", function() {
+QUnit.test("prevents XSS injection via `style`", function() {
   var buffer = createRenderBuffer('div', document.body);
 
   buffer.style('color', 'blue;" xss="true" style="color:red');
@@ -157,7 +157,7 @@ test("prevents XSS injection via `style`", function() {
   equal(el.getAttribute('style'), div.getAttribute('style'));
 });
 
-test("prevents XSS injection via `tagName`", function() {
+QUnit.test("prevents XSS injection via `tagName`", function() {
   var buffer = createRenderBuffer('cool-div><div xss="true"', document.body);
   try {
     buffer.generateElement();
@@ -167,7 +167,7 @@ test("prevents XSS injection via `tagName`", function() {
   }
 });
 
-test("handles null props - Issue #2019", function() {
+QUnit.test("handles null props - Issue #2019", function() {
   var buffer = createRenderBuffer('div', document.body);
 
   buffer.prop('value', null);
@@ -175,7 +175,7 @@ test("handles null props - Issue #2019", function() {
   equal(buffer.element().tagName, 'DIV', 'div exists');
 });
 
-test("handles browsers like Firefox < 11 that don't support outerHTML Issue #1952", function() {
+QUnit.test("handles browsers like Firefox < 11 that don't support outerHTML Issue #1952", function() {
   var buffer = createRenderBuffer('div', document.body);
   buffer.generateElement();
   // Make sure element.outerHTML is falsy to trigger the fallback.
@@ -185,7 +185,7 @@ test("handles browsers like Firefox < 11 that don't support outerHTML Issue #195
   equal(trim(buffer.string().toLowerCase()), elementStub);
 });
 
-test("lets `setClasses` and `addClass` work together", function() {
+QUnit.test("lets `setClasses` and `addClass` work together", function() {
   var buffer = createRenderBuffer('div', document.body);
   buffer.setClasses(['foo', 'bar']);
   buffer.addClass('baz');
@@ -196,7 +196,7 @@ test("lets `setClasses` and `addClass` work together", function() {
   equal(el.getAttribute('class'), 'foo bar baz');
 });
 
-test("generates text and a div and text", function() {
+QUnit.test("generates text and a div and text", function() {
   var div = document.createElement('div');
   var buffer = createRenderBuffer(undefined, div);
   buffer.buffer = 'Howdy<div>Nick</div>Cage';
@@ -209,7 +209,7 @@ test("generates text and a div and text", function() {
 });
 
 
-test("generates a tr from a tr innerString", function() {
+QUnit.test("generates a tr from a tr innerString", function() {
   var table = document.createElement('table');
   var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<tr></tr>';
@@ -218,7 +218,7 @@ test("generates a tr from a tr innerString", function() {
   equal(el.childNodes[0].tagName.toLowerCase(), 'tr');
 });
 
-test("generates a tr from a tr innerString with leading <script", function() {
+QUnit.test("generates a tr from a tr innerString with leading <script", function() {
   var table = document.createElement('table');
   var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<script></script><tr></tr>';
@@ -227,7 +227,7 @@ test("generates a tr from a tr innerString with leading <script", function() {
   equal(el.childNodes[1].tagName.toLowerCase(), 'tr');
 });
 
-test("generates a tr from a tr innerString with leading comment", function() {
+QUnit.test("generates a tr from a tr innerString with leading comment", function() {
   var table = document.createElement('table');
   var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<!-- blargh! --><tr></tr>';
@@ -236,7 +236,7 @@ test("generates a tr from a tr innerString with leading comment", function() {
   equal(el.childNodes[1].tagName, 'TR');
 });
 
-test("generates a tr from a tr innerString on rerender", function() {
+QUnit.test("generates a tr from a tr innerString on rerender", function() {
   var buffer = createRenderBuffer('table', document.body);
   buffer.generateElement();
   buffer.buffer = '<tr></tr>';
@@ -245,7 +245,7 @@ test("generates a tr from a tr innerString on rerender", function() {
   equal(el.childNodes[0].tagName.toLowerCase(), 'tr');
 });
 
-test("generates a tbody from a tbody innerString", function() {
+QUnit.test("generates a tbody from a tbody innerString", function() {
   var table = document.createElement('table');
   var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<tbody><tr></tr></tbody>';
@@ -254,7 +254,7 @@ test("generates a tbody from a tbody innerString", function() {
   equal(el.childNodes[0].tagName, 'TBODY');
 });
 
-test("generates a col from a col innerString", function() {
+QUnit.test("generates a col from a col innerString", function() {
   var table = document.createElement('table');
   var buffer = createRenderBuffer(undefined, table);
   buffer.buffer = '<col></col>';
@@ -265,7 +265,7 @@ test("generates a col from a col innerString", function() {
 
 QUnit.module("RenderBuffer - without tagName");
 
-test("It is possible to create a RenderBuffer without a tagName", function() {
+QUnit.test("It is possible to create a RenderBuffer without a tagName", function() {
   var buffer = createRenderBuffer(undefined, document.body);
   buffer.push('a');
   buffer.push('b');
@@ -280,7 +280,7 @@ test("It is possible to create a RenderBuffer without a tagName", function() {
 
 QUnit.module("RenderBuffer#element");
 
-test("properly handles old IE's zero-scope bug", function() {
+QUnit.test("properly handles old IE's zero-scope bug", function() {
   var buffer = createRenderBuffer('div', document.body);
   buffer.generateElement();
   buffer.push('<script></script>foo');
@@ -294,7 +294,7 @@ if ('namespaceURI' in document.createElement('div')) {
 
   QUnit.module("RenderBuffer namespaces");
 
-  test("properly makes a content string SVG namespace inside an SVG tag", function() {
+  QUnit.test("properly makes a content string SVG namespace inside an SVG tag", function() {
     var buffer = createRenderBuffer('svg', document.body);
     buffer.generateElement();
     buffer.push('<path></path>foo');
@@ -307,7 +307,7 @@ if ('namespaceURI' in document.createElement('div')) {
     equal(element.childNodes[0].namespaceURI, svgNamespace, 'element is svg namespace');
   });
 
-  test("properly makes a path element svg namespace inside SVG context", function() {
+  QUnit.test("properly makes a path element svg namespace inside SVG context", function() {
     var buffer = createRenderBuffer('path', document.createElementNS(svgNamespace, 'svg'));
     buffer.generateElement();
     buffer.push('<g></g>');
@@ -320,7 +320,7 @@ if ('namespaceURI' in document.createElement('div')) {
     equal(element.childNodes[0].namespaceURI, svgNamespace, 'element is svg namespace');
   });
 
-  test("properly makes a foreignObject svg namespace inside SVG context", function() {
+  QUnit.test("properly makes a foreignObject svg namespace inside SVG context", function() {
     var buffer = createRenderBuffer('foreignObject', document.createElementNS(svgNamespace, 'svg'));
     buffer.generateElement();
     buffer.push('<div></div>');
@@ -333,7 +333,7 @@ if ('namespaceURI' in document.createElement('div')) {
     equal(element.childNodes[0].namespaceURI, xhtmlNamespace, 'element is xhtml namespace');
   });
 
-  test("properly makes a div xhtml namespace inside foreignObject context", function() {
+  QUnit.test("properly makes a div xhtml namespace inside foreignObject context", function() {
     var buffer = createRenderBuffer('div', document.createElementNS(svgNamespace, 'foreignObject'));
     buffer.generateElement();
     buffer.push('<div></div>');

--- a/packages/ember-views/tests/system/sanitize_attribute_value_test.js
+++ b/packages/ember-views/tests/system/sanitize_attribute_value_test.js
@@ -12,7 +12,7 @@ for (var i = 0, l = goodProtocols.length; i < l; i++) {
 }
 
 function buildProtocolTest(protocol) {
-  test('allows ' + protocol + ' protocol when element is not provided', function() {
+  QUnit.test('allows ' + protocol + ' protocol when element is not provided', function() {
     expect(1);
 
     var expected = protocol + '://foo.com';
@@ -22,7 +22,7 @@ function buildProtocolTest(protocol) {
   });
 }
 
-test('blocks javascript: protocol', function() {
+QUnit.test('blocks javascript: protocol', function() {
   /* jshint scripturl:true */
 
   expect(1);
@@ -33,7 +33,7 @@ test('blocks javascript: protocol', function() {
   equal(actual, 'unsafe:' + expected, 'protocol escaped');
 });
 
-test('blocks blacklisted protocols', function() {
+QUnit.test('blocks blacklisted protocols', function() {
   /* jshint scripturl:true */
 
   expect(1);
@@ -44,7 +44,7 @@ test('blocks blacklisted protocols', function() {
   equal(actual, 'unsafe:' + expected, 'protocol escaped');
 });
 
-test('does not block SafeStrings', function() {
+QUnit.test('does not block SafeStrings', function() {
   /* jshint scripturl:true */
 
   expect(1);

--- a/packages/ember-views/tests/system/view_utils_test.js
+++ b/packages/ember-views/tests/system/view_utils_test.js
@@ -33,7 +33,7 @@ QUnit.module("ViewUtils", {
 });
 
 
-test("getViewClientRects", function() {
+QUnit.test("getViewClientRects", function() {
   if (!hasGetClientRects || !ClientRectListCtor) {
     ok(true, "The test environment does not support the DOM API required to run this test.");
     return;
@@ -50,7 +50,7 @@ test("getViewClientRects", function() {
   ok(Ember.ViewUtils.getViewClientRects(view) instanceof ClientRectListCtor);
 });
 
-test("getViewBoundingClientRect", function() {
+QUnit.test("getViewBoundingClientRect", function() {
   if (!hasGetBoundingClientRect || !ClientRectCtor) {
     ok(true, "The test environment does not support the DOM API required to run this test.");
     return;

--- a/packages/ember-views/tests/views/checkbox_test.js
+++ b/packages/ember-views/tests/views/checkbox_test.js
@@ -32,7 +32,7 @@ QUnit.module("Ember.Checkbox", {
   }
 });
 
-test("should begin disabled if the disabled attribute is true", function() {
+QUnit.test("should begin disabled if the disabled attribute is true", function() {
   checkboxView = Checkbox.create({});
 
   checkboxView.set('disabled', true);
@@ -41,7 +41,7 @@ test("should begin disabled if the disabled attribute is true", function() {
   ok(checkboxView.$().is(":disabled"));
 });
 
-test("should become disabled if the disabled attribute is changed", function() {
+QUnit.test("should become disabled if the disabled attribute is changed", function() {
   checkboxView = Checkbox.create({});
 
   append();
@@ -54,7 +54,7 @@ test("should become disabled if the disabled attribute is changed", function() {
   ok(checkboxView.$().is(":not(:disabled)"));
 });
 
-test("should begin indeterminate if the indeterminate attribute is true", function() {
+QUnit.test("should begin indeterminate if the indeterminate attribute is true", function() {
   checkboxView = Checkbox.create({});
 
   checkboxView.set('indeterminate', true);
@@ -63,7 +63,7 @@ test("should begin indeterminate if the indeterminate attribute is true", functi
   equal(checkboxView.$().prop('indeterminate'), true, "Checkbox should be indeterminate");
 });
 
-test("should become indeterminate if the indeterminate attribute is changed", function() {
+QUnit.test("should become indeterminate if the indeterminate attribute is changed", function() {
   checkboxView = Checkbox.create({});
 
   append();
@@ -77,7 +77,7 @@ test("should become indeterminate if the indeterminate attribute is changed", fu
   equal(checkboxView.$().prop('indeterminate'), false, "Checkbox should not be indeterminate");
 });
 
-test("should support the tabindex property", function() {
+QUnit.test("should support the tabindex property", function() {
   checkboxView = Checkbox.create({});
 
   run(function() { checkboxView.set('tabindex', 6); });
@@ -89,7 +89,7 @@ test("should support the tabindex property", function() {
   equal(checkboxView.$().prop('tabindex'), '3', 'the checkbox tabindex changes when it is changed in the view');
 });
 
-test("checkbox name is updated when setting name property of view", function() {
+QUnit.test("checkbox name is updated when setting name property of view", function() {
   checkboxView = Checkbox.create({});
 
   run(function() { checkboxView.set('name', 'foo'); });
@@ -102,7 +102,7 @@ test("checkbox name is updated when setting name property of view", function() {
   equal(checkboxView.$().attr('name'), "bar", "updates checkbox after name changes");
 });
 
-test("checked property mirrors input value", function() {
+QUnit.test("checked property mirrors input value", function() {
   checkboxView = Checkbox.create({});
   run(function() { checkboxView.append(); });
 
@@ -125,7 +125,7 @@ test("checked property mirrors input value", function() {
   equal(checkboxView.$().prop('checked'), false, "changing the value property changes the DOM");
 });
 
-test("checking the checkbox updates the value", function() {
+QUnit.test("checking the checkbox updates the value", function() {
   checkboxView = Checkbox.create({ checked: true });
   append();
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -31,7 +31,7 @@ QUnit.module("CollectionView", {
   }
 });
 
-test("should render a view for each item in its content array", function() {
+QUnit.test("should render a view for each item in its content array", function() {
   view = CollectionView.create({
     content: Ember.A([1, 2, 3, 4])
   });
@@ -42,7 +42,7 @@ test("should render a view for each item in its content array", function() {
   equal(view.$('div').length, 4);
 });
 
-test("should render the emptyView if content array is empty (view class)", function() {
+QUnit.test("should render the emptyView if content array is empty (view class)", function() {
   view = CollectionView.create({
     tagName: 'del',
     content: Ember.A(),
@@ -62,7 +62,7 @@ test("should render the emptyView if content array is empty (view class)", funct
   ok(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, "displays empty view");
 });
 
-test("should render the emptyView if content array is empty (view instance)", function() {
+QUnit.test("should render the emptyView if content array is empty (view instance)", function() {
   view = CollectionView.create({
     tagName: 'del',
     content: Ember.A(),
@@ -82,7 +82,7 @@ test("should render the emptyView if content array is empty (view instance)", fu
   ok(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, "displays empty view");
 });
 
-test("should be able to override the tag name of itemViewClass even if tag is in default mapping", function() {
+QUnit.test("should be able to override the tag name of itemViewClass even if tag is in default mapping", function() {
   view = CollectionView.create({
     tagName: 'del',
     content: Ember.A(['NEWS GUVNAH']),
@@ -102,7 +102,7 @@ test("should be able to override the tag name of itemViewClass even if tag is in
   ok(view.$().find('kbd:contains("NEWS GUVNAH")').length, "displays the item view with proper tag name");
 });
 
-test("should allow custom item views by setting itemViewClass", function() {
+QUnit.test("should allow custom item views by setting itemViewClass", function() {
   var passedContents = [];
   view = CollectionView.create({
     content: Ember.A(['foo', 'bar', 'baz']),
@@ -126,7 +126,7 @@ test("should allow custom item views by setting itemViewClass", function() {
   });
 });
 
-test("should insert a new item in DOM when an item is added to the content array", function() {
+QUnit.test("should insert a new item in DOM when an item is added to the content array", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
 
   view = CollectionView.create({
@@ -154,7 +154,7 @@ test("should insert a new item in DOM when an item is added to the content array
   equal(trim(view.$(':nth-child(2)').text()), 'quux');
 });
 
-test("should remove an item from DOM when an item is removed from the content array", function() {
+QUnit.test("should remove an item from DOM when an item is removed from the content array", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
 
   view = CollectionView.create({
@@ -184,7 +184,7 @@ test("should remove an item from DOM when an item is removed from the content ar
   });
 });
 
-test("it updates the view if an item is replaced", function() {
+QUnit.test("it updates the view if an item is replaced", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
@@ -214,7 +214,7 @@ test("it updates the view if an item is replaced", function() {
   });
 });
 
-test("can add and replace in the same runloop", function() {
+QUnit.test("can add and replace in the same runloop", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
@@ -246,7 +246,7 @@ test("can add and replace in the same runloop", function() {
 
 });
 
-test("can add and replace the object before the add in the same runloop", function() {
+QUnit.test("can add and replace the object before the add in the same runloop", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
@@ -277,7 +277,7 @@ test("can add and replace the object before the add in the same runloop", functi
   });
 });
 
-test("can add and replace complicatedly", function() {
+QUnit.test("can add and replace complicatedly", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
@@ -310,7 +310,7 @@ test("can add and replace complicatedly", function() {
   });
 });
 
-test("can add and replace complicatedly harder", function() {
+QUnit.test("can add and replace complicatedly harder", function() {
   var content = Ember.A(['foo', 'bar', 'baz']);
   view = CollectionView.create({
     content: content,
@@ -344,7 +344,7 @@ test("can add and replace complicatedly harder", function() {
   });
 });
 
-test("should allow changes to content object before layer is created", function() {
+QUnit.test("should allow changes to content object before layer is created", function() {
   view = CollectionView.create({
     content: null
   });
@@ -360,7 +360,7 @@ test("should allow changes to content object before layer is created", function(
   ok(view.$().children().length);
 });
 
-test("should fire life cycle events when elements are added and removed", function() {
+QUnit.test("should fire life cycle events when elements are added and removed", function() {
   var view;
   var didInsertElement = 0;
   var willDestroyElement = 0;
@@ -445,7 +445,7 @@ test("should fire life cycle events when elements are added and removed", functi
   equal(destroy, 8);
 });
 
-test("should allow changing content property to be null", function() {
+QUnit.test("should allow changing content property to be null", function() {
   view = CollectionView.create({
     content: Ember.A([1, 2, 3]),
 
@@ -467,7 +467,7 @@ test("should allow changing content property to be null", function() {
   equal(trim(view.$().children().text()), "(empty)", "should display empty view");
 });
 
-test("should allow items to access to the CollectionView's current index in the content array", function() {
+QUnit.test("should allow items to access to the CollectionView's current index in the content array", function() {
   view = CollectionView.create({
     content: Ember.A(['zero', 'one', 'two']),
     itemViewClass: View.extend({
@@ -486,7 +486,7 @@ test("should allow items to access to the CollectionView's current index in the 
   deepEqual(view.$(':nth-child(3)').text(), "2");
 });
 
-test("should allow declaration of itemViewClass as a string", function() {
+QUnit.test("should allow declaration of itemViewClass as a string", function() {
   var container = {
     lookupFactory: function() {
       return Ember.View.extend();
@@ -506,7 +506,7 @@ test("should allow declaration of itemViewClass as a string", function() {
   equal(view.$('.ember-view').length, 3);
 });
 
-test("should not render the emptyView if content is emptied and refilled in the same run loop", function() {
+QUnit.test("should not render the emptyView if content is emptied and refilled in the same run loop", function() {
   view = CollectionView.create({
     tagName: 'div',
     content: Ember.A(['NEWS GUVNAH']),
@@ -533,7 +533,7 @@ test("should not render the emptyView if content is emptied and refilled in the 
   equal(view.$().find('kbd:contains("OY SORRY GUVNAH")').length, 0);
 });
 
-test("a array_proxy that backs an sorted array_controller that backs a collection view functions properly", function() {
+QUnit.test("a array_proxy that backs an sorted array_controller that backs a collection view functions properly", function() {
 
   var array = Ember.A([{ name: "Other Katz" }]);
   var arrayProxy = ArrayProxy.create({ content: array });
@@ -564,7 +564,7 @@ test("a array_proxy that backs an sorted array_controller that backs a collectio
   });
 });
 
-test("when a collection view is emptied, deeply nested views elements are not removed from the DOM and then destroyed again", function() {
+QUnit.test("when a collection view is emptied, deeply nested views elements are not removed from the DOM and then destroyed again", function() {
   var assertProperDestruction = Mixin.create({
     destroyElement: function() {
       if (this._state === 'inDOM') {
@@ -604,7 +604,7 @@ test("when a collection view is emptied, deeply nested views elements are not re
   });
 });
 
-test("should render the emptyView if content array is empty and emptyView is given as string", function() {
+QUnit.test("should render the emptyView if content array is empty and emptyView is given as string", function() {
   Ember.lookup = {
     App: {
       EmptyView: View.extend({
@@ -629,7 +629,7 @@ test("should render the emptyView if content array is empty and emptyView is giv
   ok(view.$().find('kbd:contains("THIS IS AN EMPTY VIEW")').length, "displays empty view");
 });
 
-test("should lookup against the container if itemViewClass is given as a string", function() {
+QUnit.test("should lookup against the container if itemViewClass is given as a string", function() {
   var ItemView = View.extend({
     render: function(buf) {
       buf.push(get(this, 'content'));
@@ -659,7 +659,7 @@ test("should lookup against the container if itemViewClass is given as a string"
   }
 });
 
-test("should lookup only global path against the container if itemViewClass is given as a string", function() {
+QUnit.test("should lookup only global path against the container if itemViewClass is given as a string", function() {
   var ItemView = View.extend({
     render: function(buf) {
       buf.push(get(this, 'content'));
@@ -689,7 +689,7 @@ test("should lookup only global path against the container if itemViewClass is g
   }
 });
 
-test("should lookup against the container and render the emptyView if emptyView is given as string and content array is empty ", function() {
+QUnit.test("should lookup against the container and render the emptyView if emptyView is given as string and content array is empty ", function() {
   var EmptyView = View.extend({
     tagName: 'kbd',
     render: function(buf) {
@@ -721,7 +721,7 @@ test("should lookup against the container and render the emptyView if emptyView 
   }
 });
 
-test("should lookup from only global path against the container if emptyView is given as string and content array is empty ", function() {
+QUnit.test("should lookup from only global path against the container if emptyView is given as string and content array is empty ", function() {
   var EmptyView = View.extend({
     render: function(buf) {
       buf.push("EMPTY");

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -25,15 +25,15 @@ QUnit.module("Ember.Component", {
   }
 });
 
-test("The context of an Ember.Component is itself", function() {
+QUnit.test("The context of an Ember.Component is itself", function() {
   strictEqual(component, component.get('context'), "A component's context is itself");
 });
 
-test("The controller (target of `action`) of an Ember.Component is itself", function() {
+QUnit.test("The controller (target of `action`) of an Ember.Component is itself", function() {
   strictEqual(component, component.get('controller'), "A component's controller is itself");
 });
 
-test("A templateName specified to a component is moved to the layoutName", function() {
+QUnit.test("A templateName specified to a component is moved to the layoutName", function() {
   expectDeprecation(/Do not specify templateName on a Component, use layoutName instead/);
   component = Component.extend({
     templateName: 'blah-blah'
@@ -42,7 +42,7 @@ test("A templateName specified to a component is moved to the layoutName", funct
   equal(component.get('layoutName'), 'blah-blah', "The layoutName now contains the templateName specified.");
 });
 
-test("A template specified to a component is moved to the layout", function() {
+QUnit.test("A template specified to a component is moved to the layout", function() {
   expectDeprecation(/Do not specify template on a Component, use layout instead/);
   component = Component.extend({
     template: 'blah-blah'
@@ -51,7 +51,7 @@ test("A template specified to a component is moved to the layout", function() {
   equal(component.get('layout'), 'blah-blah', "The layoutName now contains the templateName specified.");
 });
 
-test("A template specified to a component is deprecated", function() {
+QUnit.test("A template specified to a component is deprecated", function() {
   expectDeprecation(function() {
     component = Component.extend({
       template: 'blah-blah'
@@ -59,7 +59,7 @@ test("A template specified to a component is deprecated", function() {
   }, 'Do not specify template on a Component, use layout instead.');
 });
 
-test("A templateName specified to a component is deprecated", function() {
+QUnit.test("A templateName specified to a component is deprecated", function() {
   expectDeprecation(function() {
     component = Component.extend({
       templateName: 'blah-blah'
@@ -67,7 +67,7 @@ test("A templateName specified to a component is deprecated", function() {
   }, 'Do not specify templateName on a Component, use layoutName instead.');
 });
 
-test("Specifying both templateName and layoutName to a component is NOT deprecated", function() {
+QUnit.test("Specifying both templateName and layoutName to a component is NOT deprecated", function() {
   expectNoDeprecation();
   component = Component.extend({
     templateName: 'blah-blah',
@@ -78,7 +78,7 @@ test("Specifying both templateName and layoutName to a component is NOT deprecat
   equal(get(component, 'layoutName'), 'hum-drum');
 });
 
-test("Specifying a templateName on a component with a layoutName specified in a superclass is NOT deprecated", function() {
+QUnit.test("Specifying a templateName on a component with a layoutName specified in a superclass is NOT deprecated", function() {
   expectNoDeprecation();
   var Parent = Component.extend({
     layoutName: 'hum-drum'
@@ -122,12 +122,12 @@ QUnit.module("Ember.Component - Actions", {
   }
 });
 
-test("Calling sendAction on a component without an action defined does nothing", function() {
+QUnit.test("Calling sendAction on a component without an action defined does nothing", function() {
   component.sendAction();
   equal(sendCount, 0, "addItem action was not invoked");
 });
 
-test("Calling sendAction on a component with an action defined calls send on the controller", function() {
+QUnit.test("Calling sendAction on a component with an action defined calls send on the controller", function() {
   set(component, 'action', "addItem");
 
   component.sendAction();
@@ -136,7 +136,7 @@ test("Calling sendAction on a component with an action defined calls send on the
   equal(actionCounts['addItem'], 1, "addItem event was sent once");
 });
 
-test("Calling sendAction with a named action uses the component's property as the action name", function() {
+QUnit.test("Calling sendAction with a named action uses the component's property as the action name", function() {
   set(component, 'playing', "didStartPlaying");
   set(component, 'action', "didDoSomeBusiness");
 
@@ -156,7 +156,7 @@ test("Calling sendAction with a named action uses the component's property as th
   equal(actionCounts['didDoSomeBusiness'], 1, "default action was sent");
 });
 
-test("Calling sendAction when the action name is not a string raises an exception", function() {
+QUnit.test("Calling sendAction when the action name is not a string raises an exception", function() {
   set(component, 'action', {});
   set(component, 'playing', {});
 
@@ -169,7 +169,7 @@ test("Calling sendAction when the action name is not a string raises an exceptio
   });
 });
 
-test("Calling sendAction on a component with a context", function() {
+QUnit.test("Calling sendAction on a component with a context", function() {
   set(component, 'playing', "didStartPlaying");
 
   var testContext = { song: 'She Broke My Ember' };
@@ -179,7 +179,7 @@ test("Calling sendAction on a component with a context", function() {
   deepEqual(actionArguments, [testContext], "context was sent with the action");
 });
 
-test("Calling sendAction on a component with multiple parameters", function() {
+QUnit.test("Calling sendAction on a component with multiple parameters", function() {
   set(component, 'playing', "didStartPlaying");
 
   var firstContext  = { song: 'She Broke My Ember' };
@@ -193,7 +193,7 @@ test("Calling sendAction on a component with multiple parameters", function() {
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('Ember.Component - injected properties');
 
-  test("services can be injected into components", function() {
+  QUnit.test("services can be injected into components", function() {
     var registry = new Registry();
     var container = registry.container();
 
@@ -213,7 +213,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
 
 QUnit.module('Ember.Component - subscribed and sent actions trigger errors');
 
-test('something', function() {
+QUnit.test('something', function() {
   expect(2);
 
   var appComponent = Component.extend({
@@ -231,7 +231,7 @@ test('something', function() {
   }, /had no action handler for: baz/, 'asdf');
 });
 
-test('component with target', function() {
+QUnit.test('component with target', function() {
   expect(2);
 
   var target = {

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -21,7 +21,7 @@ QUnit.module("ember-views/views/container_view_test", {
   }
 });
 
-test("should be able to insert views after the DOM representation is created", function() {
+QUnit.test("should be able to insert views after the DOM representation is created", function() {
   container = ContainerView.create({
     classNameBindings: ['name'],
     name: 'foo',
@@ -52,7 +52,7 @@ test("should be able to insert views after the DOM representation is created", f
 
 });
 
-test("should be able to observe properties that contain child views", function() {
+QUnit.test("should be able to observe properties that contain child views", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   run(function() {
@@ -77,7 +77,7 @@ test("should be able to observe properties that contain child views", function()
   equal(container.get('displayIsDisplayed'), false, "can bind to child view");
 });
 
-test("childViews inherit their parents iocContainer, and retain the original container even when moved", function() {
+QUnit.test("childViews inherit their parents iocContainer, and retain the original container even when moved", function() {
   container = ContainerView.create({
     container: {}
   });
@@ -103,7 +103,7 @@ test("childViews inherit their parents iocContainer, and retain the original con
   equal(get(view, 'container'), container.container, "still inherits its original parentViews iocContainer");
 });
 
-test("should set the parentView property on views that are added to the child views array", function() {
+QUnit.test("should set the parentView property on views that are added to the child views array", function() {
   container = ContainerView.create();
 
   var ViewKlass = View.extend({
@@ -161,7 +161,7 @@ test("should set the parentView property on views that are added to the child vi
   });
 });
 
-test("should trigger parentViewDidChange when parentView is changed", function() {
+QUnit.test("should trigger parentViewDidChange when parentView is changed", function() {
   container = ContainerView.create();
 
   var secondContainer = ContainerView.create();
@@ -184,7 +184,7 @@ test("should trigger parentViewDidChange when parentView is changed", function()
   });
 });
 
-test("should be able to push initial views onto the ContainerView and have it behave", function() {
+QUnit.test("should be able to push initial views onto the ContainerView and have it behave", function() {
   var Container = ContainerView.extend({
     init: function () {
       this._super.apply(this, arguments);
@@ -241,7 +241,7 @@ test("should be able to push initial views onto the ContainerView and have it be
   run(container, 'destroy');
 });
 
-test("views that are removed from a ContainerView should have their child views cleared", function() {
+QUnit.test("views that are removed from a ContainerView should have their child views cleared", function() {
   container = ContainerView.create();
   view = View.createWithMixins({
     remove: function() {
@@ -266,7 +266,7 @@ test("views that are removed from a ContainerView should have their child views 
   equal(container.$().html(),'', "the child view is removed from the DOM");
 });
 
-test("if a ContainerView starts with an empty currentView, nothing is displayed", function() {
+QUnit.test("if a ContainerView starts with an empty currentView, nothing is displayed", function() {
   container = ContainerView.create();
 
   run(function() {
@@ -277,7 +277,7 @@ test("if a ContainerView starts with an empty currentView, nothing is displayed"
   equal(get(container, 'childViews.length'), 0, "should not have any child views");
 });
 
-test("if a ContainerView starts with a currentView, it is rendered as a child view", function() {
+QUnit.test("if a ContainerView starts with a currentView, it is rendered as a child view", function() {
   var controller = Controller.create();
   container = ContainerView.create({
     controller: controller
@@ -305,7 +305,7 @@ test("if a ContainerView starts with a currentView, it is rendered as a child vi
   equal(read(mainView._keywords.view), mainView, 'view keyword is setup');
 });
 
-test("if a ContainerView is created with a currentView, it is rendered as a child view", function() {
+QUnit.test("if a ContainerView is created with a currentView, it is rendered as a child view", function() {
   var context = null;
   var mainView = View.create({
     template: function(ctx, opts) {
@@ -334,7 +334,7 @@ test("if a ContainerView is created with a currentView, it is rendered as a chil
   equal(read(mainView._keywords.view), mainView, 'view keyword is setup');
 });
 
-test("if a ContainerView starts with no currentView and then one is set, the ContainerView is updated", function() {
+QUnit.test("if a ContainerView starts with no currentView and then one is set, the ContainerView is updated", function() {
   var context = null;
   var mainView = View.create({
     template: function(ctx, opts) {
@@ -369,7 +369,7 @@ test("if a ContainerView starts with no currentView and then one is set, the Con
   equal(read(mainView._keywords.view), mainView, 'view keyword is setup');
 });
 
-test("if a ContainerView starts with a currentView and then is set to null, the ContainerView is updated", function() {
+QUnit.test("if a ContainerView starts with a currentView and then is set to null, the ContainerView is updated", function() {
   var context = null;
   var mainView = View.create({
     template: function(ctx, opts) {
@@ -406,7 +406,7 @@ test("if a ContainerView starts with a currentView and then is set to null, the 
   equal(get(container, 'childViews.length'), 0, "should not have any child views");
 });
 
-test("if a ContainerView starts with a currentView and then is set to null, the ContainerView is updated and the previous currentView is destroyed", function() {
+QUnit.test("if a ContainerView starts with a currentView and then is set to null, the ContainerView is updated and the previous currentView is destroyed", function() {
   var context = null;
   var mainView = View.create({
     template: function(ctx, opts) {
@@ -445,7 +445,7 @@ test("if a ContainerView starts with a currentView and then is set to null, the 
   equal(get(container, 'childViews.length'), 0, "should not have any child views");
 });
 
-test("if a ContainerView starts with a currentView and then a different currentView is set, the old view is destroyed and the new one is added", function() {
+QUnit.test("if a ContainerView starts with a currentView and then a different currentView is set, the old view is destroyed and the new one is added", function() {
   container = ContainerView.create();
   var mainView = View.create({
     template: function() {
@@ -497,7 +497,7 @@ test("if a ContainerView starts with a currentView and then a different currentV
   equal(trim(container.$().text()), "This is the tertiary view.", "should render its child");
 });
 
-test("should be able to modify childViews many times during an run loop", function () {
+QUnit.test("should be able to modify childViews many times during an run loop", function () {
 
   container = ContainerView.create();
 
@@ -535,7 +535,7 @@ test("should be able to modify childViews many times during an run loop", functi
   equal(trim(container.$().text()), 'onetwothree');
 });
 
-test("should be able to modify childViews then remove the ContainerView in same run loop", function () {
+QUnit.test("should be able to modify childViews then remove the ContainerView in same run loop", function () {
   container = ContainerView.create();
 
   run(function() {
@@ -558,7 +558,7 @@ test("should be able to modify childViews then remove the ContainerView in same 
   equal(count, 0, 'did not render child');
 });
 
-test("should be able to modify childViews then destroy the ContainerView in same run loop", function () {
+QUnit.test("should be able to modify childViews then destroy the ContainerView in same run loop", function () {
   container = ContainerView.create();
 
   run(function() {
@@ -582,7 +582,7 @@ test("should be able to modify childViews then destroy the ContainerView in same
 });
 
 
-test("should be able to modify childViews then rerender the ContainerView in same run loop", function () {
+QUnit.test("should be able to modify childViews then rerender the ContainerView in same run loop", function () {
   container = ContainerView.create();
 
   run(function() {
@@ -608,7 +608,7 @@ test("should be able to modify childViews then rerender the ContainerView in sam
   equal(trim(container.$().text()), 'child');
 });
 
-test("should be able to modify childViews then rerender then modify again the ContainerView in same run loop", function () {
+QUnit.test("should be able to modify childViews then rerender then modify again the ContainerView in same run loop", function () {
   container = ContainerView.create();
 
   run(function() {
@@ -636,7 +636,7 @@ test("should be able to modify childViews then rerender then modify again the Co
   equal(trim(container.$().text()), 'onetwo');
 });
 
-test("should be able to modify childViews then rerender again the ContainerView in same run loop and then modify again", function () {
+QUnit.test("should be able to modify childViews then rerender again the ContainerView in same run loop and then modify again", function () {
   container = ContainerView.create();
 
   run(function() {
@@ -674,7 +674,7 @@ test("should be able to modify childViews then rerender again the ContainerView 
   equal(trim(container.$().text()), 'onetwo');
 });
 
-test("should invalidate `element` on itself and childViews when being rendered by ensureChildrenAreInDOM", function () {
+QUnit.test("should invalidate `element` on itself and childViews when being rendered by ensureChildrenAreInDOM", function () {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var root = ContainerView.create();
@@ -702,7 +702,7 @@ test("should invalidate `element` on itself and childViews when being rendered b
   });
 });
 
-test("Child view can only be added to one container at a time", function () {
+QUnit.test("Child view can only be added to one container at a time", function () {
   expect(2);
 
   container = ContainerView.create();
@@ -735,7 +735,7 @@ test("Child view can only be added to one container at a time", function () {
   });
 });
 
-test("if a containerView appends a child in its didInsertElement event, the didInsertElement event of the child view should be fired once", function () {
+QUnit.test("if a containerView appends a child in its didInsertElement event, the didInsertElement event of the child view should be fired once", function () {
 
   var counter = 0;
   var root = ContainerView.create({});
@@ -775,7 +775,7 @@ test("if a containerView appends a child in its didInsertElement event, the didI
 });
 
 
-test("ContainerView is observable [DEPRECATED]", function() {
+QUnit.test("ContainerView is observable [DEPRECATED]", function() {
   container = ContainerView.create();
   var observerFired = false;
   expectDeprecation(function() {

--- a/packages/ember-views/tests/views/instrumentation_test.js
+++ b/packages/ember-views/tests/views/instrumentation_test.js
@@ -43,7 +43,7 @@ QUnit.module("EmberView#instrumentation", {
   }
 });
 
-test("generates the proper instrumentation details when called directly", function() {
+QUnit.test("generates the proper instrumentation details when called directly", function() {
   var payload = {};
 
   view.instrumentDetails(payload);
@@ -51,7 +51,7 @@ test("generates the proper instrumentation details when called directly", functi
   confirmPayload(payload, view);
 });
 
-test("should add ember-view to views", function() {
+QUnit.test("should add ember-view to views", function() {
   run(view, 'createElement');
 
   confirmPayload(beforeCalls[0], view);

--- a/packages/ember-views/tests/views/metamorph_view_test.js
+++ b/packages/ember-views/tests/views/metamorph_view_test.js
@@ -32,7 +32,7 @@ QUnit.module("Metamorph views", {
   }
 });
 
-test("a Metamorph view is not a view's parentView", function() {
+QUnit.test("a Metamorph view is not a view's parentView", function() {
   childView = EmberView.create({
     render: function(buffer) {
       buffer.push("<p>Bye bros</p>");
@@ -90,13 +90,13 @@ QUnit.module("Metamorph views correctly handle DOM", {
   }
 });
 
-test("a metamorph view generates without a DOM node", function() {
+QUnit.test("a metamorph view generates without a DOM node", function() {
   var meta = jQuery("> h2", "#" + get(view, 'elementId'));
 
   equal(meta.length, 1, "The metamorph element should be directly inside its parent");
 });
 
-test("a metamorph view can be removed from the DOM", function() {
+QUnit.test("a metamorph view can be removed from the DOM", function() {
   run(function() {
     metamorphView.destroy();
   });
@@ -105,7 +105,7 @@ test("a metamorph view can be removed from the DOM", function() {
   equal(meta.length, 0, "the associated DOM was removed");
 });
 
-test("a metamorph view can be rerendered", function() {
+QUnit.test("a metamorph view can be rerendered", function() {
   equal(jQuery('#from-meta').text(), "Jason", "precond - renders to the DOM");
 
   set(metamorphView, 'powerRanger', 'Trini');
@@ -120,7 +120,7 @@ test("a metamorph view can be rerendered", function() {
 // Redefining without setup/teardown
 QUnit.module("Metamorph views correctly handle DOM");
 
-test("a metamorph view calls its children's willInsertElement and didInsertElement", function() {
+QUnit.test("a metamorph view calls its children's willInsertElement and didInsertElement", function() {
   var parentView;
   var willInsertElementCalled = false;
   var didInsertElementCalled = false;
@@ -160,7 +160,7 @@ test("a metamorph view calls its children's willInsertElement and didInsertEleme
 
 });
 
-test("replacing a Metamorph should invalidate childView elements", function() {
+QUnit.test("replacing a Metamorph should invalidate childView elements", function() {
   var elementOnDidInsert;
 
   view = EmberView.create({
@@ -192,7 +192,7 @@ test("replacing a Metamorph should invalidate childView elements", function() {
   run(function() { view.destroy(); });
 });
 
-test("trigger rerender of parent and SimpleBoundView", function () {
+QUnit.test("trigger rerender of parent and SimpleBoundView", function () {
   var view = EmberView.create({
     show: true,
     foo: 'bar',
@@ -215,7 +215,7 @@ test("trigger rerender of parent and SimpleBoundView", function () {
   });
 });
 
-test("re-rendering and then changing the property does not raise an exception", function() {
+QUnit.test("re-rendering and then changing the property does not raise an exception", function() {
   view = EmberView.create({
     show: true,
     foo: 'bar',

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -34,17 +34,17 @@ function selectedOptions() {
   return select.get('childViews').mapBy('selected');
 }
 
-test("has 'ember-view' and 'ember-select' CSS classes", function() {
+QUnit.test("has 'ember-view' and 'ember-select' CSS classes", function() {
   deepEqual(select.get('classNames'), ['ember-view', 'ember-select']);
 });
 
-test("should render", function() {
+QUnit.test("should render", function() {
   append();
 
   ok(select.$().length, "Select renders");
 });
 
-test("should begin disabled if the disabled attribute is true", function() {
+QUnit.test("should begin disabled if the disabled attribute is true", function() {
   select.set('disabled', true);
   append();
 
@@ -53,14 +53,14 @@ test("should begin disabled if the disabled attribute is true", function() {
 
 // Browsers before IE10 do not support the required property.
 if (document && ('required' in document.createElement('input'))) {
-  test("should begin required if the required attribute is true", function() {
+  QUnit.test("should begin required if the required attribute is true", function() {
     select.set('required', true);
     append();
 
     ok(select.element.required, 'required property is truthy');
   });
 
-  test("should become required if the required attribute is changed", function() {
+  QUnit.test("should become required if the required attribute is changed", function() {
     append();
     ok(!select.element.required, 'required property is falsy');
 
@@ -72,7 +72,7 @@ if (document && ('required' in document.createElement('input'))) {
   });
 }
 
-test("should become disabled if the disabled attribute is changed", function() {
+QUnit.test("should become disabled if the disabled attribute is changed", function() {
   append();
   ok(!select.element.disabled, 'disabled property is falsy');
 
@@ -83,7 +83,7 @@ test("should become disabled if the disabled attribute is changed", function() {
   ok(!select.element.disabled, 'disabled property is falsy');
 });
 
-test("can have options", function() {
+QUnit.test("can have options", function() {
   select.set('content', Ember.A([1, 2, 3]));
 
   append();
@@ -94,7 +94,7 @@ test("can have options", function() {
 });
 
 
-test("select tabindex is updated when setting tabindex property of view", function() {
+QUnit.test("select tabindex is updated when setting tabindex property of view", function() {
   run(function() { select.set('tabindex', '4'); });
   append();
 
@@ -105,7 +105,7 @@ test("select tabindex is updated when setting tabindex property of view", functi
   equal(select.$().attr('tabindex'), "1", "updates select after tabindex changes");
 });
 
-test("select name is updated when setting name property of view", function() {
+QUnit.test("select name is updated when setting name property of view", function() {
   run(function() { select.set('name', 'foo'); });
   append();
 
@@ -116,7 +116,7 @@ test("select name is updated when setting name property of view", function() {
   equal(select.$().attr('name'), "bar", "updates select after name changes");
 });
 
-test("can specify the property path for an option's label and value", function() {
+QUnit.test("can specify the property path for an option's label and value", function() {
   select.set('content', Ember.A([
     { id: 1, firstName: 'Yehuda' },
     { id: 2, firstName: 'Tom' }
@@ -133,7 +133,7 @@ test("can specify the property path for an option's label and value", function()
   deepEqual(map(select.$('option').toArray(), function(el) { return jQuery(el).attr('value'); }), ["1", "2"], "Options should have values");
 });
 
-test("can retrieve the current selected option when multiple=false", function() {
+QUnit.test("can retrieve the current selected option when multiple=false", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
 
@@ -149,7 +149,7 @@ test("can retrieve the current selected option when multiple=false", function() 
   equal(select.get('selection'), tom, "On change, the new option should be selected");
 });
 
-test("can retrieve the current selected options when multiple=true", function() {
+QUnit.test("can retrieve the current selected options when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -175,7 +175,7 @@ test("can retrieve the current selected options when multiple=true", function() 
   deepEqual(select.get('selection'), [tom, david], "On change, the new options should be selected");
 });
 
-test("selection can be set when multiple=false", function() {
+QUnit.test("selection can be set when multiple=false", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
 
@@ -194,7 +194,7 @@ test("selection can be set when multiple=false", function() {
   equal(select.$()[0].selectedIndex, 0, "After changing it, selection should be correct");
 });
 
-test("selection can be set from a Promise when multiple=false", function() {
+QUnit.test("selection can be set from a Promise when multiple=false", function() {
   expect(1);
 
   var yehuda = { id: 1, firstName: 'Yehuda' };
@@ -211,7 +211,7 @@ test("selection can be set from a Promise when multiple=false", function() {
   equal(select.$()[0].selectedIndex, 1, "Should select from Promise content");
 });
 
-test("selection from a Promise don't overwrite newer selection once resolved, when multiple=false", function() {
+QUnit.test("selection from a Promise don't overwrite newer selection once resolved, when multiple=false", function() {
   expect(1);
 
   var yehuda = { id: 1, firstName: 'Yehuda' };
@@ -244,7 +244,7 @@ test("selection from a Promise don't overwrite newer selection once resolved, wh
   append();
 });
 
-test("selection from a Promise resolving to null should not select when multiple=false", function() {
+QUnit.test("selection from a Promise resolving to null should not select when multiple=false", function() {
   expect(1);
 
   var yehuda = { id: 1, firstName: 'Yehuda' };
@@ -261,7 +261,7 @@ test("selection from a Promise resolving to null should not select when multiple
   equal(select.$()[0].selectedIndex, -1, "Should not select any object when the Promise resolve to null");
 });
 
-test("selection can be set when multiple=true", function() {
+QUnit.test("selection can be set when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -282,7 +282,7 @@ test("selection can be set when multiple=true", function() {
   deepEqual(select.get('selection'), [yehuda], "After changing it, selection should be correct");
 });
 
-test("selection can be set when multiple=true and prompt", function() {
+QUnit.test("selection can be set when multiple=true and prompt", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -306,7 +306,7 @@ test("selection can be set when multiple=true and prompt", function() {
   deepEqual(select.get('selection'), [yehuda], "After changing it, selection should be correct");
 });
 
-test("multiple selections can be set when multiple=true", function() {
+QUnit.test("multiple selections can be set when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -332,7 +332,7 @@ test("multiple selections can be set when multiple=true", function() {
     "After changing it, selection should be correct");
 });
 
-test("multiple selections can be set by changing in place the selection array when multiple=true", function() {
+QUnit.test("multiple selections can be set by changing in place the selection array when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -361,7 +361,7 @@ test("multiple selections can be set by changing in place the selection array wh
 });
 
 
-test("multiple selections can be set indirectly via bindings and in-place when multiple=true (issue #1058)", function() {
+QUnit.test("multiple selections can be set indirectly via bindings and in-place when multiple=true (issue #1058)", function() {
   var indirectContent = EmberObject.create();
 
   var tom = { id: 2, firstName: 'Tom' };
@@ -402,7 +402,7 @@ test("multiple selections can be set indirectly via bindings and in-place when m
   deepEqual(select.get('selection'), [cyril], "After updating bound selection, selection should be correct");
 });
 
-test("select with group can group options", function() {
+QUnit.test("select with group can group options", function() {
   var content = Ember.A([
     { firstName: 'Yehuda', organization: 'Tilde' },
     { firstName: 'Tom', organization: 'Tilde' },
@@ -429,7 +429,7 @@ test("select with group can group options", function() {
   equal(trim(select.$('optgroup').last().text()), 'Keith');
 });
 
-test("select with group doesn't break options", function() {
+QUnit.test("select with group doesn't break options", function() {
   var content = Ember.A([
     { id: 1, firstName: 'Yehuda', organization: 'Tilde' },
     { id: 2, firstName: 'Tom', organization: 'Tilde' },
@@ -458,7 +458,7 @@ test("select with group doesn't break options", function() {
   deepEqual(select.get('selection'), content.get('firstObject'));
 });
 
-test("select with group observes its content", function() {
+QUnit.test("select with group observes its content", function() {
   var wycats = { firstName: 'Yehuda', organization: 'Tilde' };
   var content = Ember.A([
     wycats
@@ -489,7 +489,7 @@ test("select with group observes its content", function() {
   equal(labels.join(''), 'YehudaKeith');
 });
 
-test("select with group whose content is undefined doesn't breaks", function() {
+QUnit.test("select with group whose content is undefined doesn't breaks", function() {
 
   var content;
   run(function() {
@@ -503,7 +503,7 @@ test("select with group whose content is undefined doesn't breaks", function() {
   equal(select.$('optgroup').length, 0);
 });
 
-test("selection uses the same array when multiple=true", function() {
+QUnit.test("selection uses the same array when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -530,7 +530,7 @@ test("selection uses the same array when multiple=true", function() {
   deepEqual(selection, [tom,david], "On change the original selection array is updated");
 });
 
-test("Ember.SelectedOption knows when it is selected when multiple=false", function() {
+QUnit.test("Ember.SelectedOption knows when it is selected when multiple=false", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -552,7 +552,7 @@ test("Ember.SelectedOption knows when it is selected when multiple=false", funct
   deepEqual(selectedOptions(), [false, false, false, true], "After changing it, selection should be correct");
 });
 
-test("Ember.SelectedOption knows when it is selected when multiple=true", function() {
+QUnit.test("Ember.SelectedOption knows when it is selected when multiple=true", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
   var david = { id: 3, firstName: 'David' };
@@ -576,7 +576,7 @@ test("Ember.SelectedOption knows when it is selected when multiple=true", functi
   deepEqual(selectedOptions(), [false, true, true, false], "After changing it, selection should be correct");
 });
 
-test("Ember.SelectedOption knows when it is selected when multiple=true and options are primitives", function() {
+QUnit.test("Ember.SelectedOption knows when it is selected when multiple=true and options are primitives", function() {
   run(function() {
     select.set('content', Ember.A([1, 2, 3, 4]));
     select.set('multiple', true);
@@ -592,7 +592,7 @@ test("Ember.SelectedOption knows when it is selected when multiple=true and opti
   deepEqual(selectedOptions(), [false, true, true, false], "After changing it, selection should be correct");
 });
 
-test("a prompt can be specified", function() {
+QUnit.test("a prompt can be specified", function() {
   var yehuda = { id: 1, firstName: 'Yehuda' };
   var tom = { id: 2, firstName: 'Tom' };
 
@@ -626,7 +626,7 @@ test("a prompt can be specified", function() {
   equal(select.get('selection'), tom, "Properly accounts for the prompt when DOM change occurs");
 });
 
-test("handles null content", function() {
+QUnit.test("handles null content", function() {
   append();
 
   run(function() {
@@ -645,7 +645,7 @@ test("handles null content", function() {
   equal(select.get('element').selectedIndex, -1, "should have no selection");
 });
 
-test("valueBinding handles 0 as initiated value (issue #2763)", function() {
+QUnit.test("valueBinding handles 0 as initiated value (issue #2763)", function() {
   var indirectData = EmberObject.create({
     value: 0
   });
@@ -668,7 +668,7 @@ test("valueBinding handles 0 as initiated value (issue #2763)", function() {
   equal(select.get('value'), 0, "Value property should equal 0");
 });
 
-test("should be able to select an option and then reselect the prompt", function() {
+QUnit.test("should be able to select an option and then reselect the prompt", function() {
   run(function() {
     select.set('content', Ember.A(['one', 'two', 'three']));
     select.set('prompt', 'Select something');
@@ -686,7 +686,7 @@ test("should be able to select an option and then reselect the prompt", function
   equal(select.$()[0].selectedIndex, 0);
 });
 
-test("should be able to get the current selection's value", function() {
+QUnit.test("should be able to get the current selection's value", function() {
   run(function() {
     select.set('content', Ember.A([
       { label: 'Yehuda Katz', value: 'wycats' },
@@ -703,7 +703,7 @@ test("should be able to get the current selection's value", function() {
   equal(select.get('value'), 'wycats');
 });
 
-test("should be able to set the current selection by value", function() {
+QUnit.test("should be able to set the current selection by value", function() {
   var ebryn = { label: 'Erik Bryn', value: 'ebryn' };
 
   run(function() {

--- a/packages/ember-views/tests/views/simple_bound_view_test.js
+++ b/packages/ember-views/tests/views/simple_bound_view_test.js
@@ -3,7 +3,7 @@ import SimpleBoundView from "ember-views/views/simple_bound_view";
 
 QUnit.module('SimpleBoundView');
 
-test('does not render if update is triggered by normalizedValue is the same as the previous normalizedValue', function() {
+QUnit.test('does not render if update is triggered by normalizedValue is the same as the previous normalizedValue', function() {
   var value = null;
   var obj = { 'foo': 'bar' };
   var lazyValue = new Stream(function() {

--- a/packages/ember-views/tests/views/text_area_test.js
+++ b/packages/ember-views/tests/views/text_area_test.js
@@ -35,14 +35,14 @@ QUnit.module("TextArea", {
   }
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+QUnit.test("should become disabled if the disabled attribute is true", function() {
   textArea.set('disabled', true);
   append();
 
   ok(textArea.$().is(":disabled"));
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+QUnit.test("should become disabled if the disabled attribute is true", function() {
   append();
   ok(textArea.$().is(":not(:disabled)"));
 
@@ -53,7 +53,7 @@ test("should become disabled if the disabled attribute is true", function() {
   ok(textArea.$().is(":not(:disabled)"));
 });
 
-test("input value is updated when setting value property of view", function() {
+QUnit.test("input value is updated when setting value property of view", function() {
   run(function() {
     set(textArea, 'value', 'foo');
     textArea.append();
@@ -66,7 +66,7 @@ test("input value is updated when setting value property of view", function() {
   equal(textArea.$().val(), "bar", "updates text field after value changes");
 });
 
-test("input placeholder is updated when setting placeholder property of view", function() {
+QUnit.test("input placeholder is updated when setting placeholder property of view", function() {
   run(function() {
     set(textArea, 'placeholder', 'foo');
     textArea.append();
@@ -79,7 +79,7 @@ test("input placeholder is updated when setting placeholder property of view", f
   equal(textArea.$().attr('placeholder'), "bar", "updates text area after placeholder changes");
 });
 
-test("input name is updated when setting name property of view", function() {
+QUnit.test("input name is updated when setting name property of view", function() {
   run(function() {
     set(textArea, 'name', 'foo');
     textArea.append();
@@ -92,7 +92,7 @@ test("input name is updated when setting name property of view", function() {
   equal(textArea.$().attr('name'), "bar", "updates text area after name changes");
 });
 
-test("input maxlength is updated when setting maxlength property of view", function() {
+QUnit.test("input maxlength is updated when setting maxlength property of view", function() {
   run(function() {
     set(textArea, 'maxlength', '300');
     textArea.append();
@@ -105,7 +105,7 @@ test("input maxlength is updated when setting maxlength property of view", funct
   equal(textArea.$().attr('maxlength'), "400", "updates text area after maxlength changes");
 });
 
-test("input rows is updated when setting rows property of view", function() {
+QUnit.test("input rows is updated when setting rows property of view", function() {
   run(function() {
     set(textArea, 'rows', '3');
     textArea.append();
@@ -118,7 +118,7 @@ test("input rows is updated when setting rows property of view", function() {
   equal(textArea.$().attr('rows'), "4", "updates text area after rows changes");
 });
 
-test("input cols is updated when setting cols property of view", function() {
+QUnit.test("input cols is updated when setting cols property of view", function() {
   run(function() {
     set(textArea, 'cols', '30');
     textArea.append();
@@ -131,7 +131,7 @@ test("input cols is updated when setting cols property of view", function() {
   equal(textArea.$().attr('cols'), "40", "updates text area after cols changes");
 });
 
-test("input tabindex is updated when setting tabindex property of view", function() {
+QUnit.test("input tabindex is updated when setting tabindex property of view", function() {
   run(function() {
     set(textArea, 'tabindex', '4');
     textArea.append();
@@ -144,7 +144,7 @@ test("input tabindex is updated when setting tabindex property of view", functio
   equal(textArea.$().attr('tabindex'), "1", "updates text area after tabindex changes");
 });
 
-test("input title is updated when setting title property of view", function() {
+QUnit.test("input title is updated when setting title property of view", function() {
   run(function() {
     set(textArea, 'title', 'FooTitle');
     textArea.append();
@@ -155,7 +155,7 @@ test("input title is updated when setting title property of view", function() {
   equal(textArea.$().attr('title'), 'BarTitle', "updates text area after title changes");
 });
 
-test("value binding works properly for inputs that haven't been created", function() {
+QUnit.test("value binding works properly for inputs that haven't been created", function() {
   run(function() {
     textArea.destroy(); // destroy existing textarea
     textArea = TextArea.createWithMixins({
@@ -179,7 +179,7 @@ test("value binding works properly for inputs that haven't been created", functi
 });
 
 forEach.call(['cut', 'paste', 'input'], function(eventName) {
-  test("should update the value on " + eventName + " events", function() {
+  QUnit.test("should update the value on " + eventName + " events", function() {
 
     run(function() {
       textArea.append();
@@ -194,7 +194,7 @@ forEach.call(['cut', 'paste', 'input'], function(eventName) {
   });
 });
 
-test("should call the insertNewline method when return key is pressed", function() {
+QUnit.test("should call the insertNewline method when return key is pressed", function() {
   var wasCalled;
   var event = EmberObject.create({
     keyCode: 13
@@ -210,7 +210,7 @@ test("should call the insertNewline method when return key is pressed", function
   ok(wasCalled, "invokes insertNewline method");
 });
 
-test("should call the cancel method when escape key is pressed", function() {
+QUnit.test("should call the cancel method when escape key is pressed", function() {
   var wasCalled;
   var event = EmberObject.create({
     keyCode: 27

--- a/packages/ember-views/tests/views/text_field_test.js
+++ b/packages/ember-views/tests/views/text_field_test.js
@@ -79,14 +79,14 @@ QUnit.module("Ember.TextField", {
   }
 });
 
-test("should become disabled if the disabled attribute is true before append", function() {
+QUnit.test("should become disabled if the disabled attribute is true before append", function() {
   textField.set('disabled', true);
   append();
 
   ok(textField.$().is(":disabled"));
 });
 
-test("should become disabled if the disabled attribute is true", function() {
+QUnit.test("should become disabled if the disabled attribute is true", function() {
   append();
   ok(textField.$().is(":not(:disabled)"));
 
@@ -97,7 +97,7 @@ test("should become disabled if the disabled attribute is true", function() {
   ok(textField.$().is(":not(:disabled)"));
 });
 
-test("input value is updated when setting value property of view", function() {
+QUnit.test("input value is updated when setting value property of view", function() {
   run(function() {
     set(textField, 'value', 'foo');
     textField.append();
@@ -110,7 +110,7 @@ test("input value is updated when setting value property of view", function() {
   equal(textField.$().val(), "bar", "updates text field after value changes");
 });
 
-test("input placeholder is updated when setting placeholder property of view", function() {
+QUnit.test("input placeholder is updated when setting placeholder property of view", function() {
   run(function() {
     set(textField, 'placeholder', 'foo');
     textField.append();
@@ -123,7 +123,7 @@ test("input placeholder is updated when setting placeholder property of view", f
   equal(textField.$().attr('placeholder'), "bar", "updates text field after placeholder changes");
 });
 
-test("input name is updated when setting name property of view", function() {
+QUnit.test("input name is updated when setting name property of view", function() {
   run(function() {
     set(textField, 'name', 'foo');
     textField.append();
@@ -136,7 +136,7 @@ test("input name is updated when setting name property of view", function() {
   equal(textField.$().attr('name'), "bar", "updates text field after name changes");
 });
 
-test("input maxlength is updated when setting maxlength property of view", function() {
+QUnit.test("input maxlength is updated when setting maxlength property of view", function() {
   run(function() {
     set(textField, 'maxlength', '30');
     textField.append();
@@ -149,7 +149,7 @@ test("input maxlength is updated when setting maxlength property of view", funct
   equal(textField.$().attr('maxlength'), "40", "updates text field after maxlength changes");
 });
 
-test("input size is updated when setting size property of view", function() {
+QUnit.test("input size is updated when setting size property of view", function() {
   run(function() {
     set(textField, 'size', '30');
     textField.append();
@@ -162,7 +162,7 @@ test("input size is updated when setting size property of view", function() {
   equal(textField.$().attr('size'), "40", "updates text field after size changes");
 });
 
-test("input tabindex is updated when setting tabindex property of view", function() {
+QUnit.test("input tabindex is updated when setting tabindex property of view", function() {
   run(function() {
     set(textField, 'tabindex', '5');
     textField.append();
@@ -175,7 +175,7 @@ test("input tabindex is updated when setting tabindex property of view", functio
   equal(textField.$().attr('tabindex'), "3", "updates text field after tabindex changes");
 });
 
-test("input title is updated when setting title property of view", function() {
+QUnit.test("input title is updated when setting title property of view", function() {
   run(function() {
     set(textField, 'title', 'FooTitle');
     textField.append();
@@ -188,7 +188,7 @@ test("input title is updated when setting title property of view", function() {
   equal(textField.$().attr('title'), "BarTitle", "updates text field after title changes");
 });
 
-test("input type is configurable when creating view", function() {
+QUnit.test("input type is configurable when creating view", function() {
   run(function() {
     set(textField, 'type', 'password');
     textField.append();
@@ -197,7 +197,7 @@ test("input type is configurable when creating view", function() {
   equal(textField.$().attr('type'), 'password', "renders text field with type");
 });
 
-test("value binding works properly for inputs that haven't been created", function() {
+QUnit.test("value binding works properly for inputs that haven't been created", function() {
 
   run(function() {
     textField.destroy(); // destroy existing textField
@@ -221,7 +221,7 @@ test("value binding works properly for inputs that haven't been created", functi
   equal(textField.$().val(), 'ohai', "value is reflected in the input element once it is created");
 });
 
-test("value binding sets value on the element", function() {
+QUnit.test("value binding sets value on the element", function() {
   run(function() {
     textField.destroy(); // destroy existing textField
     textField = TextField.createWithMixins({
@@ -251,7 +251,7 @@ test("value binding sets value on the element", function() {
   equal(textField.$().val(), 'via view', "dom property was properly updated via view");
 });
 
-test("should call the insertNewline method when return key is pressed", function() {
+QUnit.test("should call the insertNewline method when return key is pressed", function() {
   var wasCalled;
   var event = EmberObject.create({
     keyCode: 13
@@ -267,7 +267,7 @@ test("should call the insertNewline method when return key is pressed", function
   ok(wasCalled, "invokes insertNewline method");
 });
 
-test("should call the cancel method when escape key is pressed", function() {
+QUnit.test("should call the cancel method when escape key is pressed", function() {
   var wasCalled;
   var event = EmberObject.create({
     keyCode: 27
@@ -283,7 +283,7 @@ test("should call the cancel method when escape key is pressed", function() {
   ok(wasCalled, "invokes cancel method");
 });
 
-test("should send an action if one is defined when the return key is pressed", function() {
+QUnit.test("should send an action if one is defined when the return key is pressed", function() {
   expect(2);
 
   var StubController = EmberObject.extend({
@@ -307,7 +307,7 @@ test("should send an action if one is defined when the return key is pressed", f
   textField.trigger('keyUp', event);
 });
 
-test("should send an action on keyPress if one is defined with onEvent=keyPress", function() {
+QUnit.test("should send an action on keyPress if one is defined with onEvent=keyPress", function() {
   expect(2);
 
   var StubController = EmberObject.extend({
@@ -333,7 +333,7 @@ test("should send an action on keyPress if one is defined with onEvent=keyPress"
 });
 
 
-test("bubbling of handled actions can be enabled via bubbles property", function() {
+QUnit.test("bubbling of handled actions can be enabled via bubbles property", function() {
   textField.set('bubbles', true);
   textField.set('action', 'didTriggerAction');
 
@@ -390,7 +390,7 @@ QUnit.module("Ember.TextField - Action events", {
   }
 });
 
-test("when the text field is blurred, the `focus-out` action is sent to the controller", function() {
+QUnit.test("when the text field is blurred, the `focus-out` action is sent to the controller", function() {
   expect(1);
 
   textField = TextField.create({
@@ -406,7 +406,7 @@ test("when the text field is blurred, the `focus-out` action is sent to the cont
 
 });
 
-test("when the text field is focused, the `focus-in` action is sent to the controller", function() {
+QUnit.test("when the text field is focused, the `focus-in` action is sent to the controller", function() {
   expect(1);
 
   textField = TextField.create({
@@ -423,7 +423,7 @@ test("when the text field is focused, the `focus-in` action is sent to the contr
 
 });
 
-test("when the user presses a key, the `key-press` action is sent to the controller", function() {
+QUnit.test("when the user presses a key, the `key-press` action is sent to the controller", function() {
   expect(1);
 
   textField = TextField.create({
@@ -441,7 +441,7 @@ test("when the user presses a key, the `key-press` action is sent to the control
 
 });
 
-test("when the user inserts a new line, the `insert-newline` action is sent to the controller", function() {
+QUnit.test("when the user inserts a new line, the `insert-newline` action is sent to the controller", function() {
   expect(1);
 
   textField = TextField.create({
@@ -460,7 +460,7 @@ test("when the user inserts a new line, the `insert-newline` action is sent to t
 });
 
 
-test("when the user presses the `enter` key, the `enter` action is sent to the controller", function() {
+QUnit.test("when the user presses the `enter` key, the `enter` action is sent to the controller", function() {
   expect(1);
 
   textField = TextField.create({
@@ -478,7 +478,7 @@ test("when the user presses the `enter` key, the `enter` action is sent to the c
 
 });
 
-test("when the user hits escape, the `escape-press` action is sent to the controller", function() {
+QUnit.test("when the user hits escape, the `escape-press` action is sent to the controller", function() {
   expect(1);
 
   textField = TextField.create({
@@ -496,7 +496,7 @@ test("when the user hits escape, the `escape-press` action is sent to the contro
 
 });
 
-test("when the user presses a key, the `key-down` action is sent to the controller", function() {
+QUnit.test("when the user presses a key, the `key-down` action is sent to the controller", function() {
   expect(3);
   var event;
 
@@ -521,7 +521,7 @@ test("when the user presses a key, the `key-down` action is sent to the controll
   });
 });
 
-test("when the user releases a key, the `key-up` action is sent to the controller", function() {
+QUnit.test("when the user releases a key, the `key-up` action is sent to the controller", function() {
   expect(3);
   var event;
 
@@ -546,7 +546,7 @@ test("when the user releases a key, the `key-up` action is sent to the controlle
   });
 });
 
-test('should not reset cursor position when text field receives keyUp event', function() {
+QUnit.test('should not reset cursor position when text field receives keyUp event', function() {
   view = TextField.create({
     value: 'Broseidon, King of the Brocean'
   });

--- a/packages/ember-views/tests/views/view/actions_test.js
+++ b/packages/ember-views/tests/views/view/actions_test.js
@@ -14,7 +14,7 @@ QUnit.module("View action handling", {
   }
 });
 
-test("Action can be handled by a function on actions object", function() {
+QUnit.test("Action can be handled by a function on actions object", function() {
   expect(1);
   view = View.extend({
     actions: {
@@ -26,7 +26,7 @@ test("Action can be handled by a function on actions object", function() {
   view.send("poke");
 });
 
-test("A handled action can be bubbled to the target for continued processing", function() {
+QUnit.test("A handled action can be bubbled to the target for continued processing", function() {
   expect(2);
   view = View.extend({
     actions: {
@@ -46,7 +46,7 @@ test("A handled action can be bubbled to the target for continued processing", f
   view.send("poke");
 });
 
-test("Action can be handled by a superclass' actions object", function() {
+QUnit.test("Action can be handled by a superclass' actions object", function() {
   expect(4);
 
   var SuperView = View.extend({
@@ -83,7 +83,7 @@ test("Action can be handled by a superclass' actions object", function() {
   view.send("baz");
 });
 
-test("Actions cannot be provided at create time", function() {
+QUnit.test("Actions cannot be provided at create time", function() {
   expectAssertion(function() {
     view = View.create({
       actions: {

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -19,7 +19,7 @@ QUnit.module("EmberView - append() and appendTo()", {
   }
 });
 
-test("should be added to the specified element when calling appendTo()", function() {
+QUnit.test("should be added to the specified element when calling appendTo()", function() {
   jQuery("#qunit-fixture").html('<div id="menu"></div>');
 
   view = View.create();
@@ -34,7 +34,7 @@ test("should be added to the specified element when calling appendTo()", functio
   ok(viewElem.length > 0, "creates and appends the view's element");
 });
 
-test("should be added to the document body when calling append()", function() {
+QUnit.test("should be added to the document body when calling append()", function() {
   view = View.create({
     render: function(buffer) {
       buffer.push("foo bar baz");
@@ -51,7 +51,7 @@ test("should be added to the document body when calling append()", function() {
   ok(viewElem.length > 0, "creates and appends the view's element");
 });
 
-test("raises an assert when a target does not exist in the DOM", function() {
+QUnit.test("raises an assert when a target does not exist in the DOM", function() {
   view = View.create();
 
   expectAssertion(function() {
@@ -61,7 +61,7 @@ test("raises an assert when a target does not exist in the DOM", function() {
   });
 });
 
-test("append calls willInsertElement and didInsertElement callbacks", function() {
+QUnit.test("append calls willInsertElement and didInsertElement callbacks", function() {
   var willInsertElementCalled = false;
   var willInsertElementCalledInChild = false;
   var didInsertElementCalled = false;
@@ -93,7 +93,7 @@ test("append calls willInsertElement and didInsertElement callbacks", function()
   ok(didInsertElementCalled, "didInsertElement called");
 });
 
-test("remove removes an element from the DOM", function() {
+QUnit.test("remove removes an element from the DOM", function() {
   willDestroyCalled = 0;
 
   view = View.create({
@@ -120,7 +120,7 @@ test("remove removes an element from the DOM", function() {
   equal(willDestroyCalled, 1, "the willDestroyElement hook was called once");
 });
 
-test("destroy more forcibly removes the view", function() {
+QUnit.test("destroy more forcibly removes the view", function() {
   willDestroyCalled = 0;
 
   view = View.create({
@@ -167,7 +167,7 @@ QUnit.module("EmberView - append() and appendTo() in a view hierarchy", {
   }
 });
 
-test("should be added to the specified element when calling appendTo()", function() {
+QUnit.test("should be added to the specified element when calling appendTo()", function() {
   jQuery("#qunit-fixture").html('<div id="menu"></div>');
 
   view = View.create();
@@ -182,7 +182,7 @@ test("should be added to the specified element when calling appendTo()", functio
   ok(viewElem.length > 0, "creates and appends the view's element");
 });
 
-test("should be added to the document body when calling append()", function() {
+QUnit.test("should be added to the document body when calling append()", function() {
   jQuery("#qunit-fixture").html('<div id="menu"></div>');
 
   view = View.create();
@@ -222,7 +222,7 @@ QUnit.module("EmberView - removing views in a view hierarchy", {
   }
 });
 
-test("remove removes child elements from the DOM", function() {
+QUnit.test("remove removes child elements from the DOM", function() {
   ok(!get(childView, 'element'), "precond - should not have an element");
 
   run(function() {
@@ -242,7 +242,7 @@ test("remove removes child elements from the DOM", function() {
   equal(willDestroyCalled, 1, "the willDestroyElement hook was called once");
 });
 
-test("destroy more forcibly removes child views", function() {
+QUnit.test("destroy more forcibly removes child views", function() {
   ok(!get(childView, 'element'), "precond - should not have an element");
 
   run(function() {
@@ -264,7 +264,7 @@ test("destroy more forcibly removes child views", function() {
   equal(willDestroyCalled, 1, "the willDestroyElement hook was called once on children");
 });
 
-test("destroy removes a child view from its parent", function() {
+QUnit.test("destroy removes a child view from its parent", function() {
   ok(!get(childView, 'element'), "precond - should not have an element");
 
   run(function() {

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -28,7 +28,7 @@ QUnit.module("EmberView - Attribute Bindings", {
   }
 });
 
-test("should render attribute bindings", function() {
+QUnit.test("should render attribute bindings", function() {
   view = EmberView.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
     attributeBindings: ['type', 'isDisabled:disabled', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
@@ -57,7 +57,7 @@ test("should render attribute bindings", function() {
   ok(!view.$().attr('notNumber'), "removes notNumber attribute when NaN");
 });
 
-test("should normalize case for attribute bindings", function() {
+QUnit.test("should normalize case for attribute bindings", function() {
   view = EmberView.create({
     tagName: 'input',
     attributeBindings: ['disAbled'],
@@ -72,7 +72,7 @@ test("should normalize case for attribute bindings", function() {
   ok(view.$().prop('disabled'), "sets property with correct case");
 });
 
-test("should update attribute bindings", function() {
+QUnit.test("should update attribute bindings", function() {
   view = EmberView.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified', 'canIgnore'],
     attributeBindings: ['type', 'isDisabled:disabled', 'exploded', 'destroyed', 'exists', 'nothing', 'notDefined', 'notNumber', 'explosions'],
@@ -123,7 +123,7 @@ test("should update attribute bindings", function() {
   ok(!view.$().attr('notNumber'), "removes notNumber attribute when NaN");
 });
 
-test("should update attribute bindings on svg", function() {
+QUnit.test("should update attribute bindings on svg", function() {
   view = EmberView.create({
     attributeBindings: ['viewBox'],
     viewBox: null
@@ -145,7 +145,7 @@ test("should update attribute bindings on svg", function() {
 // This comes into play when using the {{#each}} helper. If the
 // passed array item is a String, it will be converted into a
 // String object instead of a normal string.
-test("should allow binding to String objects", function() {
+QUnit.test("should allow binding to String objects", function() {
   view = EmberView.create({
     attributeBindings: ['foo'],
     // JSHint doesn't like `new String` so we'll create it the same way it gets created in practice
@@ -166,7 +166,7 @@ test("should allow binding to String objects", function() {
   ok(!view.$().attr('foo'), "removes foo attribute when false");
 });
 
-test("should teardown observers on rerender", function() {
+QUnit.test("should teardown observers on rerender", function() {
   view = EmberView.create({
     attributeBindings: ['foo'],
     classNameBindings: ['foo'],
@@ -184,7 +184,7 @@ test("should teardown observers on rerender", function() {
   equal(observersFor(view, 'foo').length, 2);
 });
 
-test("handles attribute bindings for properties", function() {
+QUnit.test("handles attribute bindings for properties", function() {
   view = EmberView.create({
     attributeBindings: ['checked'],
     checked: null
@@ -207,7 +207,7 @@ test("handles attribute bindings for properties", function() {
   equal(!!view.$().prop('checked'), false, 'changes to unchecked');
 });
 
-test("handles `undefined` value for properties", function() {
+QUnit.test("handles `undefined` value for properties", function() {
   view = EmberView.create({
     attributeBindings: ['value'],
     value: "test"
@@ -224,7 +224,7 @@ test("handles `undefined` value for properties", function() {
   equal(!!view.$().prop('value'), false, "value is not defined");
 });
 
-test("handles null value for attributes on text fields", function() {
+QUnit.test("handles null value for attributes on text fields", function() {
   view = EmberView.create({
     tagName: 'input',
     attributeBindings: ['value']
@@ -243,7 +243,7 @@ test("handles null value for attributes on text fields", function() {
   equal(!!view.$().prop('value'), false, "value is not defined");
 });
 
-test("handles a 0 value attribute on text fields", function() {
+QUnit.test("handles a 0 value attribute on text fields", function() {
   view = EmberView.create({
     tagName: 'input',
     attributeBindings: ['value']
@@ -260,7 +260,7 @@ test("handles a 0 value attribute on text fields", function() {
   strictEqual(view.$().prop('value'), "0", "value should be 0");
 });
 
-test("attributeBindings should not fail if view has been removed", function() {
+QUnit.test("attributeBindings should not fail if view has been removed", function() {
   run(function() {
     view = EmberView.create({
       attributeBindings: ['checked'],
@@ -284,7 +284,7 @@ test("attributeBindings should not fail if view has been removed", function() {
   ok(!error, error);
 });
 
-test("attributeBindings should not fail if view has been destroyed", function() {
+QUnit.test("attributeBindings should not fail if view has been destroyed", function() {
   run(function() {
     view = EmberView.create({
       attributeBindings: ['checked'],
@@ -308,7 +308,7 @@ test("attributeBindings should not fail if view has been destroyed", function() 
   ok(!error, error);
 });
 
-test("asserts if an attributeBinding is setup on class", function() {
+QUnit.test("asserts if an attributeBinding is setup on class", function() {
   view = EmberView.create({
     attributeBindings: ['class']
   });
@@ -318,7 +318,7 @@ test("asserts if an attributeBinding is setup on class", function() {
   }, 'You cannot use class as an attributeBinding, use classNameBindings instead.');
 });
 
-test("blacklists href bindings based on protocol", function() {
+QUnit.test("blacklists href bindings based on protocol", function() {
   /* jshint scripturl:true */
 
   view = EmberView.create({

--- a/packages/ember-views/tests/views/view/child_views_test.js
+++ b/packages/ember-views/tests/views/view/child_views_test.js
@@ -30,7 +30,7 @@ QUnit.module('tests/views/view/child_views_tests.js', {
 // parent element
 
 // no parent element, no buffer, no element
-test("should render an inserted child view when the child is inserted before a DOM element is created", function() {
+QUnit.test("should render an inserted child view when the child is inserted before a DOM element is created", function() {
   run(function() {
     parentView.append();
   });
@@ -38,7 +38,7 @@ test("should render an inserted child view when the child is inserted before a D
   equal(parentView.$().text(), 'Ember', 'renders the child view after the parent view');
 });
 
-test("should not duplicate childViews when rerendering", function() {
+QUnit.test("should not duplicate childViews when rerendering", function() {
 
   var Inner = EmberView.extend({
     template: function() { return ''; }

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -15,7 +15,7 @@ QUnit.module("EmberView - Class Name Bindings", {
   }
 });
 
-test("should apply bound class names to the element", function() {
+QUnit.test("should apply bound class names to the element", function() {
   view = EmberView.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
                         'canIgnore', 'messages.count', 'messages.resent:is-resent',
@@ -55,7 +55,7 @@ test("should apply bound class names to the element", function() {
   ok(!view.$().hasClass('disabled'), "does not add class name for negated binding");
 });
 
-test("should add, remove, or change class names if changed after element is created", function() {
+QUnit.test("should add, remove, or change class names if changed after element is created", function() {
   view = EmberView.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
                         'canIgnore', 'messages.count', 'messages.resent:is-resent',
@@ -98,7 +98,7 @@ test("should add, remove, or change class names if changed after element is crea
   ok(view.$().hasClass('disabled'), "adds negated class name for negated binding");
 });
 
-test(":: class name syntax works with an empty true class", function() {
+QUnit.test(":: class name syntax works with an empty true class", function() {
   view = EmberView.create({
     isEnabled: false,
     classNameBindings: ['isEnabled::not-enabled']
@@ -113,7 +113,7 @@ test(":: class name syntax works with an empty true class", function() {
   equal(view.$().attr('class'), 'ember-view', "no class is added when property is true and the class is empty");
 });
 
-test("classNames should not be duplicated on rerender", function() {
+QUnit.test("classNames should not be duplicated on rerender", function() {
   run(function() {
     view = EmberView.create({
       classNameBindings: ['priority'],
@@ -135,7 +135,7 @@ test("classNames should not be duplicated on rerender", function() {
   equal(view.$().attr('class'), 'ember-view high');
 });
 
-test("classNameBindings should work when the binding property is updated and the view has been removed of the DOM", function() {
+QUnit.test("classNameBindings should work when the binding property is updated and the view has been removed of the DOM", function() {
   run(function() {
     view = EmberView.create({
       classNameBindings: ['priority'],
@@ -164,7 +164,7 @@ test("classNameBindings should work when the binding property is updated and the
 
 });
 
-test("classNames removed by a classNameBindings observer should not re-appear on rerender", function() {
+QUnit.test("classNames removed by a classNameBindings observer should not re-appear on rerender", function() {
   view = EmberView.create({
     classNameBindings: ['isUrgent'],
     isUrgent: true
@@ -189,7 +189,7 @@ test("classNames removed by a classNameBindings observer should not re-appear on
   equal(view.$().attr('class'), 'ember-view');
 });
 
-test("classNameBindings lifecycle test", function() {
+QUnit.test("classNameBindings lifecycle test", function() {
   run(function() {
     view = EmberView.create({
       classNameBindings: ['priority'],
@@ -214,7 +214,7 @@ test("classNameBindings lifecycle test", function() {
   equal(isWatching(view, 'priority'), false);
 });
 
-test("classNameBindings should not fail if view has been removed", function() {
+QUnit.test("classNameBindings should not fail if view has been removed", function() {
   run(function() {
     view = EmberView.create({
       classNameBindings: ['priority'],
@@ -238,7 +238,7 @@ test("classNameBindings should not fail if view has been removed", function() {
   ok(!error, error);
 });
 
-test("classNameBindings should not fail if view has been destroyed", function() {
+QUnit.test("classNameBindings should not fail if view has been destroyed", function() {
   run(function() {
     view = EmberView.create({
       classNameBindings: ['priority'],
@@ -262,7 +262,7 @@ test("classNameBindings should not fail if view has been destroyed", function() 
   ok(!error, error);
 });
 
-test("Providing a binding with a space in it asserts", function() {
+QUnit.test("Providing a binding with a space in it asserts", function() {
   view = EmberView.create({
     classNameBindings: 'i:think:i am:so:clever'
   });

--- a/packages/ember-views/tests/views/view/context_test.js
+++ b/packages/ember-views/tests/views/view/context_test.js
@@ -5,7 +5,7 @@ import ContainerView from "ember-views/views/container_view";
 
 QUnit.module("EmberView - context property");
 
-test("setting a controller on an inner view should change it context", function() {
+QUnit.test("setting a controller on an inner view should change it context", function() {
   var App = {};
   var a = { name: 'a' };
   var b = { name: 'b' };

--- a/packages/ember-views/tests/views/view/controller_test.js
+++ b/packages/ember-views/tests/views/view/controller_test.js
@@ -4,7 +4,7 @@ import ContainerView from "ember-views/views/container_view";
 
 QUnit.module("Ember.View - controller property");
 
-test("controller property should be inherited from nearest ancestor with controller", function() {
+QUnit.test("controller property should be inherited from nearest ancestor with controller", function() {
   var grandparent = ContainerView.create();
   var parent = ContainerView.create();
   var child = ContainerView.create();

--- a/packages/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages/ember-views/tests/views/view/create_child_view_test.js
@@ -23,7 +23,7 @@ QUnit.module("EmberView#createChildView", {
   }
 });
 
-test("should create view from class with any passed attributes", function() {
+QUnit.test("should create view from class with any passed attributes", function() {
   var attrs = {
     foo: "baz"
   };
@@ -36,14 +36,14 @@ test("should create view from class with any passed attributes", function() {
   ok(!attrs.parentView, "the original attributes hash was not mutated");
 });
 
-test("should set newView.parentView to receiver", function() {
+QUnit.test("should set newView.parentView to receiver", function() {
   newView = view.createChildView(myViewClass);
 
   equal(newView.container, container, 'expects to share container with parent');
   equal(get(newView, 'parentView'), view, 'newView.parentView == view');
 });
 
-test("should create property on parentView to a childView instance if provided a viewName", function() {
+QUnit.test("should create property on parentView to a childView instance if provided a viewName", function() {
   var attrs = {
     viewName: "someChildView"
   };
@@ -54,7 +54,7 @@ test("should create property on parentView to a childView instance if provided a
   equal(get(view, 'someChildView'), newView);
 });
 
-test("should update a view instances attributes, including the _parentView and container properties", function() {
+QUnit.test("should update a view instances attributes, including the _parentView and container properties", function() {
   var attrs = {
     foo: "baz"
   };
@@ -69,7 +69,7 @@ test("should update a view instances attributes, including the _parentView and c
   deepEqual(newView, myView);
 });
 
-test("should create from string via container lookup", function() {
+QUnit.test("should create from string via container lookup", function() {
   var ChildViewClass = EmberView.extend();
   var fullName = 'view:bro';
 
@@ -87,7 +87,7 @@ test("should create from string via container lookup", function() {
   equal(newView._parentView, view, 'expects to have the correct parent');
 });
 
-test("should assert when trying to create childView from string, but no such view is registered", function() {
+QUnit.test("should assert when trying to create childView from string, but no such view is registered", function() {
   view.container.lookupFactory = function() {};
 
   expectAssertion(function() {

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -14,7 +14,7 @@ QUnit.module("Ember.View#createElement", {
   }
 });
 
-test("returns the receiver", function() {
+QUnit.test("returns the receiver", function() {
   var ret;
 
   view = EmberView.create();
@@ -26,7 +26,7 @@ test("returns the receiver", function() {
   equal(ret, view, 'returns receiver');
 });
 
-test('should assert if `tagName` is an empty string and `classNameBindings` are specified', function() {
+QUnit.test('should assert if `tagName` is an empty string and `classNameBindings` are specified', function() {
   expect(1);
 
   view = EmberView.create({
@@ -42,7 +42,7 @@ test('should assert if `tagName` is an empty string and `classNameBindings` are 
   }, /You cannot use `classNameBindings` on a tag-less view/);
 });
 
-test("calls render and turns resultant string into element", function() {
+QUnit.test("calls render and turns resultant string into element", function() {
   view = EmberView.create({
     tagName: 'span',
 
@@ -63,7 +63,7 @@ test("calls render and turns resultant string into element", function() {
   equal(elem.tagName.toString().toLowerCase(), 'span', 'has tagName from view');
 });
 
-test("calls render and parses the buffer string in the right context", function() {
+QUnit.test("calls render and parses the buffer string in the right context", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.create({
@@ -91,7 +91,7 @@ test("calls render and parses the buffer string in the right context", function(
   equalHTML(elem.childNodes, '<script></script><tr><td>snorfblax</td></tr>', 'has innerHTML from context');
 });
 
-test("does not wrap many tr children in tbody elements", function() {
+QUnit.test("does not wrap many tr children in tbody elements", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.create({
@@ -124,7 +124,7 @@ test("does not wrap many tr children in tbody elements", function() {
   equal(elem.tagName.toString().toLowerCase(), 'table', 'has tagName from view');
 });
 
-test("generated element include HTML from child views as well", function() {
+QUnit.test("generated element include HTML from child views as well", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.create({

--- a/packages/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages/ember-views/tests/views/view/destroy_element_test.js
@@ -13,7 +13,7 @@ QUnit.module("EmberView#destroyElement", {
   }
 });
 
-test("if it has no element, does nothing", function() {
+QUnit.test("if it has no element, does nothing", function() {
   var callCount = 0;
   view = EmberView.create({
     willDestroyElement: function() { callCount++; }
@@ -28,7 +28,7 @@ test("if it has no element, does nothing", function() {
   equal(callCount, 0, 'did not invoke callback');
 });
 
-test("if it has a element, calls willDestroyElement on receiver and child views then deletes the element", function() {
+QUnit.test("if it has a element, calls willDestroyElement on receiver and child views then deletes the element", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var parentCount = 0;
@@ -60,7 +60,7 @@ test("if it has a element, calls willDestroyElement on receiver and child views 
   ok(!get(get(view, 'childViews').objectAt(0), 'element'), 'child no longer has an element');
 });
 
-test("returns receiver", function() {
+QUnit.test("returns receiver", function() {
   var ret;
   view = EmberView.create();
 
@@ -72,7 +72,7 @@ test("returns receiver", function() {
   equal(ret, view, 'returns receiver');
 });
 
-test("removes element from parentNode if in DOM", function() {
+QUnit.test("removes element from parentNode if in DOM", function() {
   view = EmberView.create();
 
   run(function() {

--- a/packages/ember-views/tests/views/view/destroy_test.js
+++ b/packages/ember-views/tests/views/view/destroy_test.js
@@ -4,7 +4,7 @@ import EmberView from "ember-views/views/view";
 
 QUnit.module("Ember.View#destroy");
 
-test("should teardown viewName on parentView when childView is destroyed", function() {
+QUnit.test("should teardown viewName on parentView when childView is destroyed", function() {
   var viewName = "someChildView";
   var parentView = EmberView.create();
   var childView = parentView.createChildView(EmberView, { viewName: viewName });

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -55,7 +55,7 @@ Ember.runInDebug(function() {
       view.appendTo('#qunit-fixture');
     });
 
-    raises(function() {
+    throws(function() {
       view.set('elementId', 'two');
     }, "raises elementId changed exception");
 

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -16,13 +16,13 @@ QUnit.module("Ember.View#element", {
   }
 });
 
-test("returns null if the view has no element and no parent view", function() {
+QUnit.test("returns null if the view has no element and no parent view", function() {
   view = EmberView.create();
   equal(get(view, 'parentView'), null, 'precond - has no parentView');
   equal(get(view, 'element'), null, 'has no element');
 });
 
-test("returns null if the view has no element and parent view has no element", function() {
+QUnit.test("returns null if the view has no element and parent view has no element", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   parentView = ContainerView.create({
@@ -35,7 +35,7 @@ test("returns null if the view has no element and parent view has no element", f
   equal(get(view, 'element'), null, ' has no element');
 });
 
-test("returns element if you set the value", function() {
+QUnit.test("returns element if you set the value", function() {
   view = EmberView.create();
   equal(get(view, 'element'), null, 'precond- has no element');
 
@@ -46,7 +46,7 @@ test("returns element if you set the value", function() {
 });
 
 Ember.runInDebug(function() {
-  test("should not allow the elementId to be changed after inserted", function() {
+  QUnit.test("should not allow the elementId to be changed after inserted", function() {
     view = EmberView.create({
       elementId: 'one'
     });

--- a/packages/ember-views/tests/views/view/evented_test.js
+++ b/packages/ember-views/tests/views/view/evented_test.js
@@ -12,7 +12,7 @@ QUnit.module("EmberView evented helpers", {
   }
 });
 
-test("fire should call method sharing event name if it exists on the view", function() {
+QUnit.test("fire should call method sharing event name if it exists on the view", function() {
   var eventFired = false;
 
   view = EmberView.create({
@@ -32,7 +32,7 @@ test("fire should call method sharing event name if it exists on the view", func
   equal(eventFired, true, "fired the view method sharing the event name");
 });
 
-test("fire does not require a view method with the same name", function() {
+QUnit.test("fire does not require a view method with the same name", function() {
   var eventFired = false;
 
   view = EmberView.create({

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -20,7 +20,7 @@ QUnit.module("EmberView.create", {
   }
 });
 
-test("registers view in the global views hash using layerId for event targeted", function() {
+QUnit.test("registers view in the global views hash using layerId for event targeted", function() {
   view = EmberView.create();
   run(function() {
     view.appendTo('#qunit-fixture');
@@ -30,7 +30,7 @@ test("registers view in the global views hash using layerId for event targeted",
 
 QUnit.module("EmberView.createWithMixins");
 
-test("should warn if a computed property is used for classNames", function() {
+QUnit.test("should warn if a computed property is used for classNames", function() {
   expectAssertion(function() {
     EmberView.createWithMixins({
       elementId: 'test',
@@ -41,7 +41,7 @@ test("should warn if a computed property is used for classNames", function() {
   }, /Only arrays of static class strings.*For dynamic classes/i);
 });
 
-test("should warn if a non-array is used for classNameBindings", function() {
+QUnit.test("should warn if a non-array is used for classNameBindings", function() {
   expectAssertion(function() {
     EmberView.createWithMixins({
       elementId: 'test',
@@ -52,7 +52,7 @@ test("should warn if a non-array is used for classNameBindings", function() {
   }, /Only arrays are allowed/i);
 });
 
-test("creates a renderer if one is not provided", function() {
+QUnit.test("creates a renderer if one is not provided", function() {
   var childView;
 
   view = EmberView.create({

--- a/packages/ember-views/tests/views/view/inject_test.js
+++ b/packages/ember-views/tests/views/view/inject_test.js
@@ -6,7 +6,7 @@ import View from "ember-views/views/view";
 if (Ember.FEATURES.isEnabled('ember-metal-injected-properties')) {
   QUnit.module('EmberView - injected properties');
 
-  test("services can be injected into views", function() {
+  QUnit.test("services can be injected into views", function() {
     var registry = new Registry();
     var container = registry.container();
 

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -15,7 +15,7 @@ QUnit.module("EmberView#isVisible", {
   }
 });
 
-test("should hide views when isVisible is false", function() {
+QUnit.test("should hide views when isVisible is false", function() {
   view = EmberView.create({
     isVisible: false
   });
@@ -36,7 +36,7 @@ test("should hide views when isVisible is false", function() {
   });
 });
 
-test("should hide element if isVisible is false before element is created", function() {
+QUnit.test("should hide element if isVisible is false before element is created", function() {
   view = EmberView.create({
     isVisible: false
   });
@@ -107,7 +107,7 @@ QUnit.module("EmberView#isVisible with Container", {
   }
 });
 
-test("view should be notified after isVisible is set to false and the element has been hidden", function() {
+QUnit.test("view should be notified after isVisible is set to false and the element has been hidden", function() {
   run(function() {
     view = View.create({ isVisible: false });
     view.append();
@@ -125,7 +125,7 @@ test("view should be notified after isVisible is set to false and the element ha
   equal(grandchildBecameVisible, 1);
 });
 
-test("view should be notified after isVisible is set to false and the element has been hidden", function() {
+QUnit.test("view should be notified after isVisible is set to false and the element has been hidden", function() {
   view = View.create({ isVisible: true });
   var childView = view.get('childViews').objectAt(0);
 
@@ -145,7 +145,7 @@ test("view should be notified after isVisible is set to false and the element ha
   equal(grandchildBecameHidden, 1);
 });
 
-test("view should be notified after isVisible is set to true and the element has been shown", function() {
+QUnit.test("view should be notified after isVisible is set to true and the element has been shown", function() {
   view = View.create({ isVisible: false });
 
   run(function() {
@@ -165,7 +165,7 @@ test("view should be notified after isVisible is set to true and the element has
   equal(grandchildBecameVisible, 1);
 });
 
-test("if a view descends from a hidden view, making isVisible true should not trigger becameVisible", function() {
+QUnit.test("if a view descends from a hidden view, making isVisible true should not trigger becameVisible", function() {
   view = View.create({ isVisible: true });
   var childView = view.get('childViews').objectAt(0);
 
@@ -194,7 +194,7 @@ test("if a view descends from a hidden view, making isVisible true should not tr
   equal(grandchildBecameVisible, 0, "the grandchild did not become visible");
 });
 
-test("if a child view becomes visible while its parent is hidden, if its parent later becomes visible, it receives a becameVisible callback", function() {
+QUnit.test("if a child view becomes visible while its parent is hidden, if its parent later becomes visible, it receives a becameVisible callback", function() {
   view = View.create({ isVisible: false });
   var childView = view.get('childViews').objectAt(0);
 

--- a/packages/ember-views/tests/views/view/jquery_test.js
+++ b/packages/ember-views/tests/views/view/jquery_test.js
@@ -23,7 +23,7 @@ QUnit.module("EmberView#$", {
   }
 });
 
-test("returns undefined if no element", function() {
+QUnit.test("returns undefined if no element", function() {
   var view = EmberView.create();
   ok(!get(view, 'element'), 'precond - should have no element');
   equal(view.$(), undefined, 'should return undefined');
@@ -34,7 +34,7 @@ test("returns undefined if no element", function() {
   });
 });
 
-test("returns jQuery object selecting element if provided", function() {
+QUnit.test("returns jQuery object selecting element if provided", function() {
   ok(get(view, 'element'), 'precond - should have element');
 
   var jquery = view.$();
@@ -42,7 +42,7 @@ test("returns jQuery object selecting element if provided", function() {
   equal(jquery[0], get(view, 'element'), 'element should be element');
 });
 
-test("returns jQuery object selecting element inside element if provided", function() {
+QUnit.test("returns jQuery object selecting element inside element if provided", function() {
   ok(get(view, 'element'), 'precond - should have element');
 
   var jquery = view.$('span');
@@ -50,7 +50,7 @@ test("returns jQuery object selecting element inside element if provided", funct
   equal(jquery[0].parentNode, get(view, 'element'), 'element should be in element');
 });
 
-test("returns empty jQuery object if filter passed that does not match item in parent", function() {
+QUnit.test("returns empty jQuery object if filter passed that does not match item in parent", function() {
   ok(get(view, 'element'), 'precond - should have element');
 
   var jquery = view.$('body'); // would normally work if not scoped to view

--- a/packages/ember-views/tests/views/view/layout_test.js
+++ b/packages/ember-views/tests/views/view/layout_test.js
@@ -21,7 +21,7 @@ QUnit.module("EmberView - Layout Functionality", {
   }
 });
 
-test("Layout views return throw if their layout cannot be found", function() {
+QUnit.test("Layout views return throw if their layout cannot be found", function() {
   view = EmberView.create({
     layoutName: 'cantBeFound',
     container: { lookup: function() { } }
@@ -32,7 +32,7 @@ test("Layout views return throw if their layout cannot be found", function() {
   }, /cantBeFound/);
 });
 
-test("should call the function of the associated layout", function() {
+QUnit.test("should call the function of the associated layout", function() {
   var templateCalled = 0;
   var layoutCalled = 0;
 
@@ -53,7 +53,7 @@ test("should call the function of the associated layout", function() {
   equal(layoutCalled, 1, "layout is called when layout is present");
 });
 
-test("should call the function of the associated template with itself as the context", function() {
+QUnit.test("should call the function of the associated template with itself as the context", function() {
   registry.register('template:testTemplate', function(dataSource) {
     return "<h1 id='twas-called'>template was called for " + get(dataSource, 'personName') + "</h1>";
   });
@@ -74,7 +74,7 @@ test("should call the function of the associated template with itself as the con
   equal("template was called for Tom DAAAALE", view.$('#twas-called').text(), "the named template was called with the view as the data source");
 });
 
-test("should fall back to defaultTemplate if neither template nor templateName are provided", function() {
+QUnit.test("should fall back to defaultTemplate if neither template nor templateName are provided", function() {
   var View;
 
   View = EmberView.extend({
@@ -94,7 +94,7 @@ test("should fall back to defaultTemplate if neither template nor templateName a
   equal("template was called for Tom DAAAALE", view.$('#twas-called').text(), "the named template was called with the view as the data source");
 });
 
-test("should not use defaultLayout if layout is provided", function() {
+QUnit.test("should not use defaultLayout if layout is provided", function() {
   var View;
 
   View = EmberView.extend({
@@ -111,7 +111,7 @@ test("should not use defaultLayout if layout is provided", function() {
   equal("foo", view.$().text(), "default layout was not printed");
 });
 
-test("the template property is available to the layout template", function() {
+QUnit.test("the template property is available to the layout template", function() {
   view = EmberView.create({
     template: function(context, options) {
       options.data.buffer.push(" derp");

--- a/packages/ember-views/tests/views/view/nearest_of_type_test.js
+++ b/packages/ember-views/tests/views/view/nearest_of_type_test.js
@@ -21,7 +21,7 @@ QUnit.module("View#nearest*", {
     }
   });
 
-  test("nearestOfType should find the closest view by view class", function() {
+  QUnit.test("nearestOfType should find the closest view by view class", function() {
     var child;
 
     run(function() {
@@ -33,7 +33,7 @@ QUnit.module("View#nearest*", {
     equal(child.nearestOfType(Parent), parentView, "finds closest view in the hierarchy by class");
   });
 
-  test("nearestOfType should find the closest view by mixin", function() {
+  QUnit.test("nearestOfType should find the closest view by mixin", function() {
     var child;
 
     run(function() {
@@ -45,7 +45,7 @@ QUnit.module("View#nearest*", {
     equal(child.nearestOfType(Mixin), parentView, "finds closest view in the hierarchy by class");
   });
 
-  test("nearestWithProperty should search immediate parent", function() {
+  QUnit.test("nearestWithProperty should search immediate parent", function() {
     var childView;
 
     view = View.create({
@@ -65,7 +65,7 @@ QUnit.module("View#nearest*", {
 
   });
 
-  test("nearestChildOf should be deprecated", function() {
+  QUnit.test("nearestChildOf should be deprecated", function() {
     var child;
 
     run(function() {

--- a/packages/ember-views/tests/views/view/nested_view_ordering_test.js
+++ b/packages/ember-views/tests/views/view/nested_view_ordering_test.js
@@ -20,7 +20,7 @@ QUnit.module("EmberView - Nested View Ordering", {
   }
 });
 
-test("should call didInsertElement on child views before parent", function() {
+QUnit.test("should call didInsertElement on child views before parent", function() {
   var insertedLast;
 
   view = EmberView.create({

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -25,17 +25,17 @@ QUnit.module("View#removeChild", {
   }
 });
 
-test("returns receiver", function() {
+QUnit.test("returns receiver", function() {
   equal(parentView.removeChild(child), parentView, 'receiver');
 });
 
-test("removes child from parent.childViews array", function() {
+QUnit.test("removes child from parent.childViews array", function() {
   ok(indexOf(get(parentView, 'childViews'), child)>=0, 'precond - has child in childViews array before remove');
   parentView.removeChild(child);
   ok(indexOf(get(parentView, 'childViews'), child)<0, 'removed child');
 });
 
-test("sets parentView property to null", function() {
+QUnit.test("sets parentView property to null", function() {
   ok(get(child, 'parentView'), 'precond - has parentView');
   parentView.removeChild(child);
   ok(!get(child, 'parentView'), 'parentView is now null');
@@ -62,14 +62,14 @@ QUnit.module("View#removeAllChildren", {
   }
 });
 
-test("removes all child views", function() {
+QUnit.test("removes all child views", function() {
   equal(get(view, 'childViews.length'), 3, 'precond - has child views');
 
   view.removeAllChildren();
   equal(get(view, 'childViews.length'), 0, 'removed all children');
 });
 
-test("returns receiver", function() {
+QUnit.test("returns receiver", function() {
   equal(view.removeAllChildren(), view, 'receiver');
 });
 
@@ -86,7 +86,7 @@ QUnit.module("View#removeFromParent", {
   }
 });
 
-test("removes view from parent view", function() {
+QUnit.test("removes view from parent view", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   parentView = ContainerView.create({ childViews: [View] });
@@ -108,7 +108,7 @@ test("removes view from parent view", function() {
   equal(parentView.$('div').length, 0, "removes DOM element from parent");
 });
 
-test("returns receiver", function() {
+QUnit.test("returns receiver", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   parentView = ContainerView.create({ childViews: [View] });
@@ -120,7 +120,7 @@ test("returns receiver", function() {
   equal(removed, child, 'receiver');
 });
 
-test("does nothing if not in parentView", function() {
+QUnit.test("does nothing if not in parentView", function() {
   child = View.create();
 
   // monkey patch for testing...
@@ -134,7 +134,7 @@ test("does nothing if not in parentView", function() {
 });
 
 
-test("the DOM element is gone after doing append and remove in two separate runloops", function() {
+QUnit.test("the DOM element is gone after doing append and remove in two separate runloops", function() {
   view = View.create();
   run(function() {
     view.append();
@@ -147,7 +147,7 @@ test("the DOM element is gone after doing append and remove in two separate runl
   ok(viewElem.length === 0, "view's element doesn't exist in DOM");
 });
 
-test("the DOM element is gone after doing append and remove in a single runloop", function() {
+QUnit.test("the DOM element is gone after doing append and remove in a single runloop", function() {
   view = View.create();
   run(function() {
     view.append();

--- a/packages/ember-views/tests/views/view/render_test.js
+++ b/packages/ember-views/tests/views/view/render_test.js
@@ -20,7 +20,7 @@ QUnit.module("EmberView#render", {
   }
 });
 
-test("default implementation does not render child views", function() {
+QUnit.test("default implementation does not render child views", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var rendered = 0;
@@ -51,7 +51,7 @@ test("default implementation does not render child views", function() {
 
 });
 
-test("should invoke renderChildViews if layer is destroyed then re-rendered", function() {
+QUnit.test("should invoke renderChildViews if layer is destroyed then re-rendered", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var rendered = 0;
@@ -94,7 +94,7 @@ test("should invoke renderChildViews if layer is destroyed then re-rendered", fu
   });
 });
 
-test("should render child views with a different tagName", function() {
+QUnit.test("should render child views with a different tagName", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.create({
@@ -112,7 +112,7 @@ test("should render child views with a different tagName", function() {
   equal(view.$('aside').length, 1);
 });
 
-test("should add ember-view to views", function() {
+QUnit.test("should add ember-view to views", function() {
   view = EmberView.create();
 
   run(function() {
@@ -122,7 +122,7 @@ test("should add ember-view to views", function() {
   ok(view.$().hasClass('ember-view'), "the view has ember-view");
 });
 
-test("should allow tagName to be a computed property [DEPRECATED]", function() {
+QUnit.test("should allow tagName to be a computed property [DEPRECATED]", function() {
   view = EmberView.extend({
     tagName: computed(function() {
       return 'span';
@@ -144,7 +144,7 @@ test("should allow tagName to be a computed property [DEPRECATED]", function() {
   equal(view.element.tagName, 'SPAN', "the tagName cannot be changed after initial render");
 });
 
-test("should allow hX tags as tagName", function() {
+QUnit.test("should allow hX tags as tagName", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.create({
@@ -162,7 +162,7 @@ test("should allow hX tags as tagName", function() {
   ok(view.$('h3').length, "does not render the h3 tag correctly");
 });
 
-test("should not add role attribute unless one is specified", function() {
+QUnit.test("should not add role attribute unless one is specified", function() {
   view = EmberView.create();
 
   run(function() {
@@ -172,7 +172,7 @@ test("should not add role attribute unless one is specified", function() {
   ok(view.$().attr('role') === undefined, "does not have a role attribute");
 });
 
-test("should re-render if the context is changed", function() {
+QUnit.test("should re-render if the context is changed", function() {
   view = EmberView.create({
     elementId: 'template-context-test',
     context: { foo: "bar" },
@@ -197,7 +197,7 @@ test("should re-render if the context is changed", function() {
   equal(jQuery('#qunit-fixture #template-context-test').text(), "bang baz", "re-renders the view with the updated context");
 });
 
-test("renders contained view with omitted start tag and parent view context", function() {
+QUnit.test("renders contained view with omitted start tag and parent view context", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   view = ContainerView.createWithMixins({
@@ -219,7 +219,7 @@ test("renders contained view with omitted start tag and parent view context", fu
   equal(view.element.childNodes[0].tagName, 'TR', 'inner view is tr');
 });
 
-test("renders a contained view with omitted start tag and tagless parent view context", function() {
+QUnit.test("renders a contained view with omitted start tag and tagless parent view context", function() {
   view = EmberView.createWithMixins({
     tagName: 'table',
     template: compile("{{view view.pivot}}"),

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -18,7 +18,7 @@ QUnit.module("EmberView - replaceIn()", {
   }
 });
 
-test("should be added to the specified element when calling replaceIn()", function() {
+QUnit.test("should be added to the specified element when calling replaceIn()", function() {
   jQuery("#qunit-fixture").html('<div id="menu"></div>');
 
   view = View.create();
@@ -33,7 +33,7 @@ test("should be added to the specified element when calling replaceIn()", functi
   ok(viewElem.length > 0, "creates and replaces the view's element");
 });
 
-test("raises an assert when a target does not exist in the DOM", function() {
+QUnit.test("raises an assert when a target does not exist in the DOM", function() {
   view = View.create();
 
   expectAssertion(function() {
@@ -44,7 +44,7 @@ test("raises an assert when a target does not exist in the DOM", function() {
 });
 
 
-test("should remove previous elements when calling replaceIn()", function() {
+QUnit.test("should remove previous elements when calling replaceIn()", function() {
   jQuery("#qunit-fixture").html('<div id="menu"><p>Foo</p></div>');
   var viewElem = jQuery('#menu').children();
 
@@ -60,7 +60,7 @@ test("should remove previous elements when calling replaceIn()", function() {
 
 });
 
-test("should move the view to the inDOM state after replacing", function() {
+QUnit.test("should move the view to the inDOM state after replacing", function() {
   jQuery("#qunit-fixture").html('<div id="menu"></div>');
   view = View.create();
 
@@ -90,7 +90,7 @@ QUnit.module("EmberView - replaceIn() in a view hierarchy", {
   }
 });
 
-test("should be added to the specified element when calling replaceIn()", function() {
+QUnit.test("should be added to the specified element when calling replaceIn()", function() {
   jQuery("#qunit-fixture").html('<div id="menu"></div>');
 
   view = View.create();

--- a/packages/ember-views/tests/views/view/state_deprecation_test.js
+++ b/packages/ember-views/tests/views/view/state_deprecation_test.js
@@ -13,7 +13,7 @@ QUnit.module("views/view/state_deprecation", {
 });
 
 if (hasPropertyAccessors) {
-  test("view.state should be an alias of view._state with a deprecation", function() {
+  QUnit.test("view.state should be an alias of view._state with a deprecation", function() {
     expect(2);
     view = EmberView.create();
 
@@ -22,7 +22,7 @@ if (hasPropertyAccessors) {
     }, 'Usage of `state` is deprecated, use `_state` instead.');
   });
 
-  test("view.states should be an alias of view._states with a deprecation", function() {
+  QUnit.test("view.states should be an alias of view._states with a deprecation", function() {
     expect(2);
     view = EmberView.create();
 
@@ -32,7 +32,7 @@ if (hasPropertyAccessors) {
   });
 }
 
-test("no deprecation is printed if view.state or view._state is not looked up", function() {
+QUnit.test("no deprecation is printed if view.state or view._state is not looked up", function() {
   expect(2);
   expectNoDeprecation();
 

--- a/packages/ember-views/tests/views/view/stream_test.js
+++ b/packages/ember-views/tests/views/view/stream_test.js
@@ -11,7 +11,7 @@ QUnit.module("ember-views: streams", {
   }
 });
 
-test("can return a stream that is notified of changes", function() {
+QUnit.test("can return a stream that is notified of changes", function() {
   expect(2);
 
   view = EmberView.create({
@@ -31,7 +31,7 @@ test("can return a stream that is notified of changes", function() {
   run(view, 'set', 'controller.name', 'Max');
 });
 
-test("a single stream is used for the same path", function() {
+QUnit.test("a single stream is used for the same path", function() {
   expect(2);
 
   var stream1, stream2;
@@ -53,7 +53,7 @@ test("a single stream is used for the same path", function() {
   equal(stream1, stream2, 'streams "" and "this"  should be the same object');
 });
 
-test("the stream returned is labeled with the requested path", function() {
+QUnit.test("the stream returned is labeled with the requested path", function() {
   expect(2);
   var stream;
 

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -248,7 +248,7 @@ test("should throw an assertion if no container has been set", function() {
     templateName: 'foobar'
   });
 
-  raises(function() {
+  throws(function() {
     view = View.create();
     run(function() {
       view.createElement();

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -21,7 +21,7 @@ QUnit.module("EmberView - Template Functionality", {
   }
 });
 
-test("Template views return throw if their template cannot be found", function() {
+QUnit.test("Template views return throw if their template cannot be found", function() {
   view = EmberView.create({
     templateName: 'cantBeFound',
     container: { lookup: function() { } }
@@ -33,7 +33,7 @@ test("Template views return throw if their template cannot be found", function()
 });
 
 if (typeof Handlebars === "object") {
-  test("should allow standard Handlebars template usage", function() {
+  QUnit.test("should allow standard Handlebars template usage", function() {
     view = EmberView.create({
       context: { name: "Erik" },
       template: Handlebars.compile("Hello, {{name}}")
@@ -47,7 +47,7 @@ if (typeof Handlebars === "object") {
   });
 }
 
-test("should call the function of the associated template", function() {
+QUnit.test("should call the function of the associated template", function() {
   registry.register('template:testTemplate', function() {
     return "<h1 id='twas-called'>template was called</h1>";
   });
@@ -64,7 +64,7 @@ test("should call the function of the associated template", function() {
   ok(view.$('#twas-called').length, "the named template was called");
 });
 
-test("should call the function of the associated template with itself as the context", function() {
+QUnit.test("should call the function of the associated template with itself as the context", function() {
   registry.register('template:testTemplate', function(dataSource) {
     return "<h1 id='twas-called'>template was called for " + get(dataSource, 'personName') + "</h1>";
   });
@@ -85,7 +85,7 @@ test("should call the function of the associated template with itself as the con
   equal("template was called for Tom DAAAALE", view.$('#twas-called').text(), "the named template was called with the view as the data source");
 });
 
-test("should fall back to defaultTemplate if neither template nor templateName are provided", function() {
+QUnit.test("should fall back to defaultTemplate if neither template nor templateName are provided", function() {
   var View;
 
   View = EmberView.extend({
@@ -105,7 +105,7 @@ test("should fall back to defaultTemplate if neither template nor templateName a
   equal("template was called for Tom DAAAALE", view.$('#twas-called').text(), "the named template was called with the view as the data source");
 });
 
-test("should not use defaultTemplate if template is provided", function() {
+QUnit.test("should not use defaultTemplate if template is provided", function() {
   var View;
 
   View = EmberView.extend({
@@ -121,7 +121,7 @@ test("should not use defaultTemplate if template is provided", function() {
   equal("foo", view.$().text(), "default template was not printed");
 });
 
-test("should not use defaultTemplate if template is provided", function() {
+QUnit.test("should not use defaultTemplate if template is provided", function() {
   var View;
 
   registry.register('template:foobar', function() { return 'foo'; });
@@ -140,7 +140,7 @@ test("should not use defaultTemplate if template is provided", function() {
   equal("foo", view.$().text(), "default template was not printed");
 });
 
-test("should render an empty element if no template is specified", function() {
+QUnit.test("should render an empty element if no template is specified", function() {
   view = EmberView.create();
   run(function() {
     view.createElement();
@@ -149,7 +149,7 @@ test("should render an empty element if no template is specified", function() {
   equal(view.$().html(), '', "view div should be empty");
 });
 
-test("should provide a controller to the template if a controller is specified on the view", function() {
+QUnit.test("should provide a controller to the template if a controller is specified on the view", function() {
   expect(7);
 
   var Controller1 = EmberObject.extend({
@@ -240,7 +240,7 @@ test("should provide a controller to the template if a controller is specified o
   });
 });
 
-test("should throw an assertion if no container has been set", function() {
+QUnit.test("should throw an assertion if no container has been set", function() {
   expect(1);
   var View;
 

--- a/packages/ember-views/tests/views/view/transition_to_deprecation_test.js
+++ b/packages/ember-views/tests/views/view/transition_to_deprecation_test.js
@@ -12,7 +12,7 @@ QUnit.module('views/view/transition_to_deprecation', {
   }
 });
 
-test('deprecates when calling transitionTo', function() {
+QUnit.test('deprecates when calling transitionTo', function() {
   expect(1);
 
   view = EmberView.create();
@@ -22,7 +22,7 @@ test('deprecates when calling transitionTo', function() {
   }, '');
 });
 
-test("doesn't deprecate when calling _transitionTo", function() {
+QUnit.test("doesn't deprecate when calling _transitionTo", function() {
   expect(1);
 
   view = EmberView.create();

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -59,7 +59,7 @@ test("should throw an exception if trying to append a child before rendering has
     view = EmberView.create();
   });
 
-  raises(function() {
+  throws(function() {
     view.appendChild(EmberView, {});
   }, null, "throws an error when calling appendChild()");
 });
@@ -128,7 +128,7 @@ test("appendChild should work inside a template", function() {
 });
 
 test("rerender should throw inside a template", function() {
-  raises(function() {
+  throws(function() {
     run(function() {
       var renderCount = 0;
       view = EmberView.create({
@@ -211,7 +211,7 @@ test("should throw an exception when calling appendChild when DOM element exists
     view.append();
   });
 
-  raises(function() {
+  throws(function() {
     view.appendChild(EmberView, {
       template: tmpl("Ah ah ah! You didn't say the magic word!")
     });
@@ -293,7 +293,7 @@ test("should throw an exception if trying to append an element that is already i
 
   ok(view.get('element'), "precond - creates DOM element");
 
-  raises(function() {
+  throws(function() {
     run(function() {
       view.append();
     });
@@ -315,7 +315,7 @@ test("should throw an exception when calling appendChild after view is destroyed
     view.destroy();
   });
 
-  raises(function() {
+  throws(function() {
     view.appendChild(EmberView, {
       template: tmpl("Ah ah ah! You didn't say the magic word!")
     });
@@ -335,7 +335,7 @@ test("should throw an exception when rerender is called after view is destroyed"
     view.destroy();
   });
 
-  raises(function() {
+  throws(function() {
     view.rerender();
   }, null, "throws an exception when calling rerender");
 });
@@ -353,7 +353,7 @@ test("should throw an exception when destroyElement is called after view is dest
     view.destroy();
   });
 
-  raises(function() {
+  throws(function() {
     view.destroyElement();
   }, null, "throws an exception when calling destroyElement");
 });

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -28,7 +28,7 @@ function tmpl(str) {
   };
 }
 
-test("should create and append a DOM element after bindings have synced", function() {
+QUnit.test("should create and append a DOM element after bindings have synced", function() {
   var ViewTest;
 
   lookup.ViewTest = ViewTest = {};
@@ -54,7 +54,7 @@ test("should create and append a DOM element after bindings have synced", functi
   equal(view.$().text(), 'controllerPropertyValue', "renders and appends after bindings have synced");
 });
 
-test("should throw an exception if trying to append a child before rendering has begun", function() {
+QUnit.test("should throw an exception if trying to append a child before rendering has begun", function() {
   run(function() {
     view = EmberView.create();
   });
@@ -64,7 +64,7 @@ test("should throw an exception if trying to append a child before rendering has
   }, null, "throws an error when calling appendChild()");
 });
 
-test("should not affect rendering if rerender is called before initial render happens", function() {
+QUnit.test("should not affect rendering if rerender is called before initial render happens", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl("Rerender me!")
@@ -77,7 +77,7 @@ test("should not affect rendering if rerender is called before initial render ha
   equal(view.$().text(), "Rerender me!", "renders correctly if rerender is called first");
 });
 
-test("should not affect rendering if destroyElement is called before initial render happens", function() {
+QUnit.test("should not affect rendering if destroyElement is called before initial render happens", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl("Don't destroy me!")
@@ -104,7 +104,7 @@ QUnit.module("views/view/view_lifecycle_test - in render", {
   }
 });
 
-test("appendChild should work inside a template", function() {
+QUnit.test("appendChild should work inside a template", function() {
   run(function() {
     view = EmberView.create({
       template: function(context, options) {
@@ -127,7 +127,7 @@ test("appendChild should work inside a template", function() {
      "The appended child is visible");
 });
 
-test("rerender should throw inside a template", function() {
+QUnit.test("rerender should throw inside a template", function() {
   throws(function() {
     run(function() {
       var renderCount = 0;
@@ -166,7 +166,7 @@ QUnit.module("views/view/view_lifecycle_test - hasElement", {
   }
 });
 
-test("createElement puts the view into the hasElement state", function() {
+QUnit.test("createElement puts the view into the hasElement state", function() {
   view = EmberView.create({
     render: function(buffer) { buffer.push('hello'); }
   });
@@ -178,7 +178,7 @@ test("createElement puts the view into the hasElement state", function() {
   equal(view.currentState, view._states.hasElement, "the view is in the hasElement state");
 });
 
-test("trigger rerender on a view in the hasElement state doesn't change its state to inDOM", function() {
+QUnit.test("trigger rerender on a view in the hasElement state doesn't change its state to inDOM", function() {
   view = EmberView.create({
     render: function(buffer) { buffer.push('hello'); }
   });
@@ -202,7 +202,7 @@ QUnit.module("views/view/view_lifecycle_test - in DOM", {
   }
 });
 
-test("should throw an exception when calling appendChild when DOM element exists", function() {
+QUnit.test("should throw an exception when calling appendChild when DOM element exists", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl("Wait for the kick")
@@ -218,7 +218,7 @@ test("should throw an exception when calling appendChild when DOM element exists
   }, null, "throws an exception when calling appendChild after element is created");
 });
 
-test("should replace DOM representation if rerender() is called after element is created", function() {
+QUnit.test("should replace DOM representation if rerender() is called after element is created", function() {
   run(function() {
     view = EmberView.create({
       template: function(context, options) {
@@ -246,7 +246,7 @@ test("should replace DOM representation if rerender() is called after element is
   equal(view.$().text(), "Do not taunt happy fun ball", "rerenders DOM element when rerender() is called");
 });
 
-test("should destroy DOM representation when destroyElement is called", function() {
+QUnit.test("should destroy DOM representation when destroyElement is called", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl("Don't fear the reaper")
@@ -264,7 +264,7 @@ test("should destroy DOM representation when destroyElement is called", function
   ok(!view.get('element'), "destroys view when destroyElement() is called");
 });
 
-test("should destroy DOM representation when destroy is called", function() {
+QUnit.test("should destroy DOM representation when destroy is called", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl("<div id='warning'>Don't fear the reaper</div>")
@@ -282,7 +282,7 @@ test("should destroy DOM representation when destroy is called", function() {
   ok(jQuery('#warning').length === 0, "destroys element when destroy() is called");
 });
 
-test("should throw an exception if trying to append an element that is already in DOM", function() {
+QUnit.test("should throw an exception if trying to append an element that is already in DOM", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl('Broseidon, King of the Brocean')
@@ -302,7 +302,7 @@ test("should throw an exception if trying to append an element that is already i
 
 QUnit.module("views/view/view_lifecycle_test - destroyed");
 
-test("should throw an exception when calling appendChild after view is destroyed", function() {
+QUnit.test("should throw an exception when calling appendChild after view is destroyed", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl("Wait for the kick")
@@ -322,7 +322,7 @@ test("should throw an exception when calling appendChild after view is destroyed
   }, null, "throws an exception when calling appendChild");
 });
 
-test("should throw an exception when rerender is called after view is destroyed", function() {
+QUnit.test("should throw an exception when rerender is called after view is destroyed", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl('foo')
@@ -340,7 +340,7 @@ test("should throw an exception when rerender is called after view is destroyed"
   }, null, "throws an exception when calling rerender");
 });
 
-test("should throw an exception when destroyElement is called after view is destroyed", function() {
+QUnit.test("should throw an exception when destroyElement is called after view is destroyed", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl('foo')
@@ -358,7 +358,7 @@ test("should throw an exception when destroyElement is called after view is dest
   }, null, "throws an exception when calling destroyElement");
 });
 
-test("trigger rerender on a view in the inDOM state keeps its state as inDOM", function() {
+QUnit.test("trigger rerender on a view in the inDOM state keeps its state as inDOM", function() {
   run(function() {
     view = EmberView.create({
       template: tmpl('foo')

--- a/packages/ember-views/tests/views/view/virtual_views_test.js
+++ b/packages/ember-views/tests/views/view/virtual_views_test.js
@@ -14,7 +14,7 @@ QUnit.module("virtual views", {
   }
 });
 
-test("a virtual view does not appear as a view's parentView", function() {
+QUnit.test("a virtual view does not appear as a view's parentView", function() {
   rootView = EmberView.create({
     elementId: 'root-view',
 
@@ -54,7 +54,7 @@ test("a virtual view does not appear as a view's parentView", function() {
   equal(children.objectAt(0), childView, "the child element skips through the virtual view");
 });
 
-test("when a virtual view's child views change, the parent's childViews should reflect", function() {
+QUnit.test("when a virtual view's child views change, the parent's childViews should reflect", function() {
   rootView = EmberView.create({
     elementId: 'root-view',
 

--- a/packages/ember/tests/application_lifecycle.js
+++ b/packages/ember/tests/application_lifecycle.js
@@ -39,7 +39,7 @@ function handleURL(path) {
 }
 
 
-test("Resetting the application allows controller properties to be set when a route deactivates", function() {
+QUnit.test("Resetting the application allows controller properties to be set when a route deactivates", function() {
   App.Router.map(function() {
     this.route('home', { path: '/' });
   });
@@ -76,7 +76,7 @@ test("Resetting the application allows controller properties to be set when a ro
   equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), null);
 });
 
-test("Destroying the application resets the router before the container is destroyed", function() {
+QUnit.test("Destroying the application resets the router before the container is destroyed", function() {
   App.Router.map(function() {
     this.route('home', { path: '/' });
   });

--- a/packages/ember/tests/component_registration_test.js
+++ b/packages/ember/tests/component_registration_test.js
@@ -65,12 +65,12 @@ function boot(callback) {
   });
 }
 
-test("The helper becomes the body of the component", function() {
+QUnit.test("The helper becomes the body of the component", function() {
   boot();
   equal(Ember.$('div.ember-view > div.ember-view', '#qunit-fixture').text(), "hello world", "The component is composed correctly");
 });
 
-test("If a component is registered, it is used", function() {
+QUnit.test("If a component is registered, it is used", function() {
   boot(function() {
     registry.register('component:expand-it', Ember.Component.extend({
       classNames: 'testing123'
@@ -81,7 +81,7 @@ test("If a component is registered, it is used", function() {
 });
 
 
-test("Late-registered components can be rendered with custom `template` property (DEPRECATED)", function() {
+QUnit.test("Late-registered components can be rendered with custom `template` property (DEPRECATED)", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>there goes {{my-hero}}</div>");
 
@@ -98,7 +98,7 @@ test("Late-registered components can be rendered with custom `template` property
   ok(!helpers['my-hero'], "Component wasn't saved to global helpers hash");
 });
 
-test("Late-registered components can be rendered with template registered on the container", function() {
+QUnit.test("Late-registered components can be rendered with template registered on the container", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{sally-rutherford}}-{{#sally-rutherford}}!!!{{/sally-rutherford}}</div>");
 
@@ -111,7 +111,7 @@ test("Late-registered components can be rendered with template registered on the
   ok(!helpers['sally-rutherford'], "Component wasn't saved to global helpers hash");
 });
 
-test("Late-registered components can be rendered with ONLY the template registered on the container", function() {
+QUnit.test("Late-registered components can be rendered with ONLY the template registered on the container", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>hello world {{borf-snorlax}}-{{#borf-snorlax}}!!!{{/borf-snorlax}}</div>");
 
@@ -123,7 +123,7 @@ test("Late-registered components can be rendered with ONLY the template register
   ok(!helpers['borf-snorlax'], "Component wasn't saved to global helpers hash");
 });
 
-test("Component-like invocations are treated as bound paths if neither template nor component are registered on the container", function() {
+QUnit.test("Component-like invocations are treated as bound paths if neither template nor component are registered on the container", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{user-name}} hello {{api-key}} world</div>");
 
@@ -136,7 +136,7 @@ test("Component-like invocations are treated as bound paths if neither template 
   equal(Ember.$('#wrapper').text(), "machty hello  world", "The component is composed correctly");
 });
 
-test("Assigning templateName to a component should setup the template as a layout (DEPRECATED)", function() {
+QUnit.test("Assigning templateName to a component should setup the template as a layout (DEPRECATED)", function() {
   expect(2);
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>");
@@ -158,7 +158,7 @@ test("Assigning templateName to a component should setup the template as a layou
   equal(Ember.$('#wrapper').text(), "inner-outer", "The component is composed correctly");
 });
 
-test("Assigning templateName and layoutName should use the templates specified", function() {
+QUnit.test("Assigning templateName and layoutName should use the templates specified", function() {
   expect(1);
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{my-component}}</div>");
@@ -184,7 +184,7 @@ if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
 // jscs:disable validateIndentation
   // ember-htmlbars doesn't throw an exception when a helper is not found
 
-test('Using name of component that does not exist', function () {
+QUnit.test('Using name of component that does not exist', function () {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#no-good}} {{/no-good}}</div>");
 
   throws(function () {
@@ -200,7 +200,7 @@ QUnit.module("Application Lifecycle - Component Context", {
   teardown: cleanup
 });
 
-test("Components with a block should have the proper content when a template is provided", function() {
+QUnit.test("Components with a block should have the proper content when a template is provided", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>");
   Ember.TEMPLATES['components/my-component'] = compile("{{text}}-{{yield}}");
 
@@ -217,7 +217,7 @@ test("Components with a block should have the proper content when a template is 
   equal(Ember.$('#wrapper').text(), "inner-outer", "The component is composed correctly");
 });
 
-test("Components with a block should yield the proper content without a template provided", function() {
+QUnit.test("Components with a block should yield the proper content without a template provided", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>");
 
   boot(function() {
@@ -233,7 +233,7 @@ test("Components with a block should yield the proper content without a template
   equal(Ember.$('#wrapper').text(), "outer", "The component is composed correctly");
 });
 
-test("Components without a block should have the proper content when a template is provided", function() {
+QUnit.test("Components without a block should have the proper content when a template is provided", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{my-component}}</div>");
   Ember.TEMPLATES['components/my-component'] = compile("{{text}}");
 
@@ -250,7 +250,7 @@ test("Components without a block should have the proper content when a template 
   equal(Ember.$('#wrapper').text(), "inner", "The component is composed correctly");
 });
 
-test("Components without a block should have the proper content", function() {
+QUnit.test("Components without a block should have the proper content", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{my-component}}</div>");
 
   boot(function() {
@@ -268,7 +268,7 @@ test("Components without a block should have the proper content", function() {
   equal(Ember.$('#wrapper').text(), "Some text inserted by jQuery", "The component is composed correctly");
 });
 
-test("properties of a component  without a template should not collide with internal structures", function() {
+QUnit.test("properties of a component  without a template should not collide with internal structures", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{my-component data=foo}}</div>");
 
   boot(function() {
@@ -287,7 +287,7 @@ test("properties of a component  without a template should not collide with inte
   equal(Ember.$('#wrapper').text(), "Some text inserted by jQuery", "The component is composed correctly");
 });
 
-test("Components trigger actions in the parents context when called from within a block", function() {
+QUnit.test("Components trigger actions in the parents context when called from within a block", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}<a href='#' id='fizzbuzz' {{action 'fizzbuzz'}}>Fizzbuzz</a>{{/my-component}}</div>");
 
   boot(function() {
@@ -307,7 +307,7 @@ test("Components trigger actions in the parents context when called from within 
   });
 });
 
-test("Components trigger actions in the components context when called from within its template", function() {
+QUnit.test("Components trigger actions in the components context when called from within its template", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{#my-component}}{{text}}{{/my-component}}</div>");
   Ember.TEMPLATES['components/my-component'] = compile("<a href='#' id='fizzbuzz' {{action 'fizzbuzz'}}>Fizzbuzz</a>");
 

--- a/packages/ember/tests/global-api-test.js
+++ b/packages/ember/tests/global-api-test.js
@@ -3,7 +3,7 @@ import "ember";
 QUnit.module("Global API Tests");
 
 function confirmExport(property) {
-  test('confirm ' + property + ' is exported', function() {
+  QUnit.test('confirm ' + property + ' is exported', function() {
     ok(Ember.get(window, property) + ' is exported propertly');
   });
 }

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -51,7 +51,7 @@ var boot = function(callback) {
   });
 };
 
-test("Unbound dashed helpers registered on the container can be late-invoked", function() {
+QUnit.test("Unbound dashed helpers registered on the container can be late-invoked", function() {
 
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf YES}}</div>");
 
@@ -66,7 +66,7 @@ test("Unbound dashed helpers registered on the container can be late-invoked", f
 });
 
   // need to make `makeBoundHelper` for HTMLBars
-test("Bound helpers registered on the container can be late-invoked", function() {
+QUnit.test("Bound helpers registered on the container can be late-invoked", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-reverse}} {{x-reverse foo}}</div>");
 
   boot(function() {
@@ -85,7 +85,7 @@ if (!Ember.FEATURES.isEnabled('ember-htmlbars')) {
 
   // we have unit tests for this in ember-htmlbars/tests/system/lookup-helper
   // and we are not going to recreate the handlebars helperMissing concept
-test("Undashed helpers registered on the container can not (presently) be invoked", function() {
+QUnit.test("Undashed helpers registered on the container can not (presently) be invoked", function() {
 
   var realHelperMissing = helpers.helperMissing;
   helpers.helperMissing = function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -91,7 +91,7 @@ QUnit.module("The {{link-to}} helper", {
   teardown: sharedTeardown
 });
 
-test("The {{link-to}} helper moves into the named route", function() {
+QUnit.test("The {{link-to}} helper moves into the named route", function() {
   Router.map(function(match) {
     this.route("about");
   });
@@ -115,7 +115,7 @@ test("The {{link-to}} helper moves into the named route", function() {
   equal(Ember.$('#home-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
 });
 
-test("The {{link-to}} helper supports URL replacement", function() {
+QUnit.test("The {{link-to}} helper supports URL replacement", function() {
 
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'about' id='about-link' replace=true}}About{{/link-to}}");
 
@@ -140,7 +140,7 @@ test("The {{link-to}} helper supports URL replacement", function() {
   equal(replaceCount, 1, 'replaceURL should be called once');
 });
 
-test("the {{link-to}} helper doesn't add an href when the tagName isn't 'a'", function() {
+QUnit.test("the {{link-to}} helper doesn't add an href when the tagName isn't 'a'", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'about' id='about-link' tagName='div'}}About{{/link-to}}");
 
   Router.map(function() {
@@ -157,7 +157,7 @@ test("the {{link-to}} helper doesn't add an href when the tagName isn't 'a'", fu
 });
 
 
-test("the {{link-to}} applies a 'disabled' class when disabled", function () {
+QUnit.test("the {{link-to}} applies a 'disabled' class when disabled", function () {
   Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link" disabledWhen="shouldDisable"}}About{{/link-to}}');
   App.IndexController = Ember.Controller.extend({
     shouldDisable: true
@@ -176,7 +176,7 @@ test("the {{link-to}} applies a 'disabled' class when disabled", function () {
   equal(Ember.$('#about-link.disabled', '#qunit-fixture').length, 1, "The link is disabled when its disabledWhen is true");
 });
 
-test("the {{link-to}} doesn't apply a 'disabled' class if disabledWhen is not provided", function () {
+QUnit.test("the {{link-to}} doesn't apply a 'disabled' class if disabledWhen is not provided", function () {
   Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link"}}About{{/link-to}}');
 
   Router.map(function() {
@@ -192,7 +192,7 @@ test("the {{link-to}} doesn't apply a 'disabled' class if disabledWhen is not pr
   ok(!Ember.$('#about-link', '#qunit-fixture').hasClass("disabled"), "The link is not disabled if disabledWhen not provided");
 });
 
-test("the {{link-to}} helper supports a custom disabledClass", function () {
+QUnit.test("the {{link-to}} helper supports a custom disabledClass", function () {
   Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link" disabledWhen="shouldDisable" disabledClass="do-not-want"}}About{{/link-to}}');
   App.IndexController = Ember.Controller.extend({
     shouldDisable: true
@@ -212,7 +212,7 @@ test("the {{link-to}} helper supports a custom disabledClass", function () {
 
 });
 
-test("the {{link-to}} helper does not respond to clicks when disabled", function () {
+QUnit.test("the {{link-to}} helper does not respond to clicks when disabled", function () {
   Ember.TEMPLATES.index = compile('{{#link-to "about" id="about-link" disabledWhen="shouldDisable"}}About{{/link-to}}');
   App.IndexController = Ember.Controller.extend({
     shouldDisable: true
@@ -235,7 +235,7 @@ test("the {{link-to}} helper does not respond to clicks when disabled", function
   equal(Ember.$('h3:contains(About)', '#qunit-fixture').length, 0, "Transitioning did not occur");
 });
 
-test("The {{link-to}} helper supports a custom activeClass", function() {
+QUnit.test("The {{link-to}} helper supports a custom activeClass", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'about' id='about-link'}}About{{/link-to}}{{#link-to 'index' id='self-link' activeClass='zomg-active'}}Self{{/link-to}}");
 
   Router.map(function() {
@@ -253,7 +253,7 @@ test("The {{link-to}} helper supports a custom activeClass", function() {
   equal(Ember.$('#about-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
 });
 
-test("The {{link-to}} helper supports leaving off .index for nested routes", function() {
+QUnit.test("The {{link-to}} helper supports leaving off .index for nested routes", function() {
   Router.map(function() {
     this.resource("about", function() {
       this.route("item");
@@ -271,7 +271,7 @@ test("The {{link-to}} helper supports leaving off .index for nested routes", fun
   equal(normalizeUrl(Ember.$('#item a', '#qunit-fixture').attr('href')), '/about');
 });
 
-test("The {{link-to}} helper supports currentWhen (DEPRECATED)", function() {
+QUnit.test("The {{link-to}} helper supports currentWhen (DEPRECATED)", function() {
   expectDeprecation('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.');
 
   Router.map(function(match) {
@@ -294,7 +294,7 @@ test("The {{link-to}} helper supports currentWhen (DEPRECATED)", function() {
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active since current-when is a parent route");
 });
 
-test("The {{link-to}} helper supports custom, nested, current-when", function() {
+QUnit.test("The {{link-to}} helper supports custom, nested, current-when", function() {
   Router.map(function(match) {
     this.resource("index", { path: "/" }, function() {
       this.route("about");
@@ -315,7 +315,7 @@ test("The {{link-to}} helper supports custom, nested, current-when", function() 
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active since current-when is a parent route");
 });
 
-test("The {{link-to}} helper does not disregard current-when when it is given explicitly for a resource", function() {
+QUnit.test("The {{link-to}} helper does not disregard current-when when it is given explicitly for a resource", function() {
   Router.map(function(match) {
     this.resource("index", { path: "/" }, function() {
       this.route("about");
@@ -338,7 +338,7 @@ test("The {{link-to}} helper does not disregard current-when when it is given ex
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, "The link is active when current-when is given for explicitly for a resource");
 });
 
-test("The {{link-to}} helper supports multiple current-when routes", function() {
+QUnit.test("The {{link-to}} helper supports multiple current-when routes", function() {
   Router.map(function(match) {
     this.resource("index", { path: "/" }, function() {
       this.route("about");
@@ -373,7 +373,7 @@ test("The {{link-to}} helper supports multiple current-when routes", function() 
   equal(Ember.$('#link3.active', '#qunit-fixture').length, 0, "The link is not active since current-when does not contain the active route");
 });
 
-test("The {{link-to}} helper defaults to bubbling", function() {
+QUnit.test("The {{link-to}} helper defaults to bubbling", function() {
   Ember.TEMPLATES.about = compile("<div {{action 'hide'}}>{{#link-to 'about.contact' id='about-contact'}}About{{/link-to}}</div>{{outlet}}");
   Ember.TEMPLATES['about/contact'] = compile("<h1 id='contact'>Contact</h1>");
 
@@ -408,7 +408,7 @@ test("The {{link-to}} helper defaults to bubbling", function() {
   equal(hidden, 1, "The link bubbles");
 });
 
-test("The {{link-to}} helper supports bubbles=false", function() {
+QUnit.test("The {{link-to}} helper supports bubbles=false", function() {
   Ember.TEMPLATES.about = compile("<div {{action 'hide'}}>{{#link-to 'about.contact' id='about-contact' bubbles=false}}About{{/link-to}}</div>{{outlet}}");
   Ember.TEMPLATES['about/contact'] = compile("<h1 id='contact'>Contact</h1>");
 
@@ -443,7 +443,7 @@ test("The {{link-to}} helper supports bubbles=false", function() {
   equal(hidden, 0, "The link didn't bubble");
 });
 
-test("The {{link-to}} helper moves into the named route with context", function() {
+QUnit.test("The {{link-to}} helper moves into the named route with context", function() {
   Router.map(function(match) {
     this.route("about");
     this.resource("item", { path: "/item/:id" });
@@ -498,7 +498,7 @@ test("The {{link-to}} helper moves into the named route with context", function(
   equal(Ember.$('p', '#qunit-fixture').text(), "Erik Brynroflsson", "The name is correct");
 });
 
-test("The {{link-to}} helper binds some anchor html tag common attributes", function() {
+QUnit.test("The {{link-to}} helper binds some anchor html tag common attributes", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'index' id='self-link' title='title-attr' rel='rel-attr' tabindex='-1'}}Self{{/link-to}}");
   bootApplication();
 
@@ -512,7 +512,7 @@ test("The {{link-to}} helper binds some anchor html tag common attributes", func
   equal(link.attr('tabindex'), '-1', "The self-link contains tabindex attribute");
 });
 
-test("The {{link-to}} helper supports `target` attribute", function() {
+QUnit.test("The {{link-to}} helper supports `target` attribute", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'index' id='self-link' target='_blank'}}Self{{/link-to}}");
   bootApplication();
 
@@ -524,7 +524,7 @@ test("The {{link-to}} helper supports `target` attribute", function() {
   equal(link.attr('target'), '_blank', "The self-link contains `target` attribute");
 });
 
-test("The {{link-to}} helper does not call preventDefault if `target` attribute is provided", function() {
+QUnit.test("The {{link-to}} helper does not call preventDefault if `target` attribute is provided", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'index' id='self-link' target='_blank'}}Self{{/link-to}}");
   bootApplication();
 
@@ -538,7 +538,7 @@ test("The {{link-to}} helper does not call preventDefault if `target` attribute 
   equal(event.isDefaultPrevented(), false, "should not preventDefault when target attribute is specified");
 });
 
-test("The {{link-to}} helper should preventDefault when `target = _self`", function() {
+QUnit.test("The {{link-to}} helper should preventDefault when `target = _self`", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#link-to 'index' id='self-link' target='_self'}}Self{{/link-to}}");
   bootApplication();
 
@@ -552,7 +552,7 @@ test("The {{link-to}} helper should preventDefault when `target = _self`", funct
   equal(event.isDefaultPrevented(), true, "should preventDefault when target attribute is `_self`");
 });
 
-test("The {{link-to}} helper should not transition if target is not equal to _self or empty", function() {
+QUnit.test("The {{link-to}} helper should not transition if target is not equal to _self or empty", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'about' id='about-link' replace=true target='_blank'}}About{{/link-to}}");
 
   Router.map(function() {
@@ -572,7 +572,7 @@ test("The {{link-to}} helper should not transition if target is not equal to _se
   notEqual(container.lookup('controller:application').get('currentRouteName'), 'about', 'link-to should not transition if target is not equal to _self or empty');
 });
 
-test("The {{link-to}} helper accepts string/numeric arguments", function() {
+QUnit.test("The {{link-to}} helper accepts string/numeric arguments", function() {
   Router.map(function() {
     this.route('filter', { path: '/filters/:filter' });
     this.route('post',   { path: '/post/:post_id' });
@@ -599,7 +599,7 @@ test("The {{link-to}} helper accepts string/numeric arguments", function() {
   equal(normalizeUrl(Ember.$('#repo-object-link', '#qunit-fixture').attr('href')), "/repo/ember/ember.js");
 });
 
-test("Issue 4201 - Shorthand for route.index shouldn't throw errors about context arguments", function() {
+QUnit.test("Issue 4201 - Shorthand for route.index shouldn't throw errors about context arguments", function() {
   expect(2);
   Router.map(function() {
     this.resource('lobby', function() {
@@ -625,7 +625,7 @@ test("Issue 4201 - Shorthand for route.index shouldn't throw errors about contex
 
 });
 
-test("The {{link-to}} helper unwraps controllers", function() {
+QUnit.test("The {{link-to}} helper unwraps controllers", function() {
 
   if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
     expect(4);
@@ -666,7 +666,7 @@ test("The {{link-to}} helper unwraps controllers", function() {
   Ember.$('#link', '#qunit-fixture').trigger('click');
 });
 
-test("The {{link-to}} helper doesn't change view context", function() {
+QUnit.test("The {{link-to}} helper doesn't change view context", function() {
   App.IndexView = Ember.View.extend({
     elementId: 'index',
     name: 'test',
@@ -684,7 +684,7 @@ test("The {{link-to}} helper doesn't change view context", function() {
   equal(Ember.$('#index', '#qunit-fixture').text(), 'test-Link: test-test', "accesses correct view");
 });
 
-test("Quoteless route param performs property lookup", function() {
+QUnit.test("Quoteless route param performs property lookup", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'index' id='string-link'}}string{{/link-to}}{{#link-to foo id='path-link'}}path{{/link-to}}{{#link-to view.foo id='view-link'}}{{view.foo}}{{/link-to}}");
 
   function assertEquality(href) {
@@ -722,7 +722,7 @@ test("Quoteless route param performs property lookup", function() {
   assertEquality('/about');
 });
 
-test("link-to with null/undefined dynamic parameters are put in a loading state", function() {
+QUnit.test("link-to with null/undefined dynamic parameters are put in a loading state", function() {
 
   expect(19);
 
@@ -811,7 +811,7 @@ test("link-to with null/undefined dynamic parameters are put in a loading state"
   Ember.Logger.warn = oldWarn;
 });
 
-test("The {{link-to}} helper refreshes href element when one of params changes", function() {
+QUnit.test("The {{link-to}} helper refreshes href element when one of params changes", function() {
   Router.map(function() {
     this.route('post', { path: '/posts/:post_id' });
   });
@@ -841,7 +841,7 @@ test("The {{link-to}} helper refreshes href element when one of params changes",
   equal(Ember.$('#post', '#qunit-fixture').attr('href'), '#', 'href attr becomes # when one of the arguments in nullified');
 });
 
-test("The {{link-to}} helper's bound parameter functionality works as expected in conjunction with an ObjectProxy/Controller", function() {
+QUnit.test("The {{link-to}} helper's bound parameter functionality works as expected in conjunction with an ObjectProxy/Controller", function() {
   expectDeprecation(objectControllerDeprecation);
 
   Router.map(function() {
@@ -871,7 +871,7 @@ test("The {{link-to}} helper's bound parameter functionality works as expected i
   equal(normalizeUrl($link.attr('href')), '/posts/2', 'self link updated to post 2');
 });
 
-test("{{linkTo}} is aliased", function() {
+QUnit.test("{{linkTo}} is aliased", function() {
   Ember.TEMPLATES.index = compile("<h3>Home</h3>{{#linkTo 'about' id='about-link' replace=true}}About{{/linkTo}}");
 
   Router.map(function() {
@@ -893,7 +893,7 @@ test("{{linkTo}} is aliased", function() {
   equal(container.lookup('controller:application').get('currentRouteName'), 'about', 'linkTo worked properly');
 });
 
-test("The {{link-to}} helper is active when a resource is active", function() {
+QUnit.test("The {{link-to}} helper is active when a resource is active", function() {
   Router.map(function() {
     this.resource("about", function() {
       this.route("item");
@@ -918,7 +918,7 @@ test("The {{link-to}} helper is active when a resource is active", function() {
 
 });
 
-test("The {{link-to}} helper works in an #each'd array of string route names", function() {
+QUnit.test("The {{link-to}} helper works in an #each'd array of string route names", function() {
   Router.map(function() {
     this.route('foo');
     this.route('bar');
@@ -962,7 +962,7 @@ test("The {{link-to}} helper works in an #each'd array of string route names", f
   linksEqual(Ember.$('a', '#qunit-fixture'), ["/bar", "/rar", "/bar", "/rar", "/rar", "/foo"]);
 });
 
-test("The non-block form {{link-to}} helper moves into the named route", function() {
+QUnit.test("The non-block form {{link-to}} helper moves into the named route", function() {
   expect(3);
   Router.map(function(match) {
     this.route("contact");
@@ -982,7 +982,7 @@ test("The non-block form {{link-to}} helper moves into the named route", functio
   equal(Ember.$('#home-link:not(.active)', '#qunit-fixture').length, 1, "The other link was rendered without active class");
 });
 
-test("The non-block form {{link-to}} helper updates the link text when it is a binding", function() {
+QUnit.test("The non-block form {{link-to}} helper updates the link text when it is a binding", function() {
   expect(8);
   Router.map(function(match) {
     this.route("contact");
@@ -1030,7 +1030,7 @@ test("The non-block form {{link-to}} helper updates the link text when it is a b
   equal(Ember.$('#contact-link:contains(Robert)', '#qunit-fixture').length, 1, "The link title is correctly updated when the route changes");
 });
 
-test("The non-block form {{link-to}} helper moves into the named route with context", function() {
+QUnit.test("The non-block form {{link-to}} helper moves into the named route with context", function() {
   expect(5);
   Router.map(function(match) {
     this.route("item", { path: "/item/:id" });
@@ -1072,7 +1072,7 @@ test("The non-block form {{link-to}} helper moves into the named route with cont
 
 });
 
-test("The non-block form {{link-to}} performs property lookup", function() {
+QUnit.test("The non-block form {{link-to}} performs property lookup", function() {
   Ember.TEMPLATES.index = compile("{{link-to 'string' 'index' id='string-link'}}{{link-to path foo id='path-link'}}{{link-to view.foo view.foo id='view-link'}}");
 
   function assertEquality(href) {
@@ -1110,7 +1110,7 @@ test("The non-block form {{link-to}} performs property lookup", function() {
   assertEquality('/about');
 });
 
-test("The non-block form {{link-to}} protects against XSS", function() {
+QUnit.test("The non-block form {{link-to}} protects against XSS", function() {
   Ember.TEMPLATES.application = compile("{{link-to display 'index' id='link'}}");
 
   App.ApplicationController = Ember.Controller.extend({
@@ -1132,7 +1132,7 @@ test("The non-block form {{link-to}} protects against XSS", function() {
   equal(Ember.$('b', '#qunit-fixture').length, 0);
 });
 
-test("the {{link-to}} helper calls preventDefault", function() {
+QUnit.test("the {{link-to}} helper calls preventDefault", function() {
   Router.map(function() {
     this.route("about");
   });
@@ -1147,7 +1147,7 @@ test("the {{link-to}} helper calls preventDefault", function() {
   equal(event.isDefaultPrevented(), true, "should preventDefault");
 });
 
-test("the {{link-to}} helper does not call preventDefault if `preventDefault=false` is passed as an option", function() {
+QUnit.test("the {{link-to}} helper does not call preventDefault if `preventDefault=false` is passed as an option", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'about' id='about-link' preventDefault=false}}About{{/link-to}}");
 
   Router.map(function() {
@@ -1164,7 +1164,7 @@ test("the {{link-to}} helper does not call preventDefault if `preventDefault=fal
   equal(event.isDefaultPrevented(), false, "should not preventDefault");
 });
 
-test("the {{link-to}} helper does not throw an error if its route has exited", function() {
+QUnit.test("the {{link-to}} helper does not throw an error if its route has exited", function() {
   expect(0);
 
   Ember.TEMPLATES.application = compile("{{#link-to 'index' id='home-link'}}Home{{/link-to}}{{#link-to 'post' defaultPost id='default-post-link'}}Default Post{{/link-to}}{{#if currentPost}}{{#link-to 'post' id='post-link'}}Post{{/link-to}}{{/if}}");
@@ -1195,7 +1195,7 @@ test("the {{link-to}} helper does not throw an error if its route has exited", f
   });
 });
 
-test("{{link-to}} active property respects changing parent route context", function() {
+QUnit.test("{{link-to}} active property respects changing parent route context", function() {
   Ember.TEMPLATES.application = compile(
     "{{link-to 'OMG' 'things' 'omg' id='omg-link'}} " +
     "{{link-to 'LOL' 'things' 'lol' id='lol-link'}} ");
@@ -1219,7 +1219,7 @@ test("{{link-to}} active property respects changing parent route context", funct
 
 });
 
-test("{{link-to}} populates href with default query param values even without query-params object", function() {
+QUnit.test("{{link-to}} populates href with default query param values even without query-params object", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: '123'
@@ -1230,7 +1230,7 @@ test("{{link-to}} populates href with default query param values even without qu
   equal(Ember.$('#the-link').attr('href'), "/", "link has right href");
 });
 
-test("{{link-to}} populates href with default query param values with empty query-params object", function() {
+QUnit.test("{{link-to}} populates href with default query param values with empty query-params object", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: '123'
@@ -1241,7 +1241,7 @@ test("{{link-to}} populates href with default query param values with empty quer
   equal(Ember.$('#the-link').attr('href'), "/", "link has right href");
 });
 
-test("{{link-to}} populates href with supplied query param values", function() {
+QUnit.test("{{link-to}} populates href with supplied query param values", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: '123'
@@ -1252,7 +1252,7 @@ test("{{link-to}} populates href with supplied query param values", function() {
   equal(Ember.$('#the-link').attr('href'), "/?foo=456", "link has right href");
 });
 
-test("{{link-to}} populates href with partially supplied query param values", function() {
+QUnit.test("{{link-to}} populates href with partially supplied query param values", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo', 'bar'],
     foo: '123',
@@ -1264,7 +1264,7 @@ test("{{link-to}} populates href with partially supplied query param values", fu
   equal(Ember.$('#the-link').attr('href'), "/?foo=456", "link has right href");
 });
 
-test("{{link-to}} populates href with partially supplied query param values, but omits if value is default value", function() {
+QUnit.test("{{link-to}} populates href with partially supplied query param values, but omits if value is default value", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo', 'bar'],
     foo: '123',
@@ -1276,7 +1276,7 @@ test("{{link-to}} populates href with partially supplied query param values, but
   equal(Ember.$('#the-link').attr('href'), "/", "link has right href");
 });
 
-test("{{link-to}} populates href with fully supplied query param values", function() {
+QUnit.test("{{link-to}} populates href with fully supplied query param values", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo', 'bar'],
     foo: '123',
@@ -1315,7 +1315,7 @@ QUnit.module("The {{link-to}} helper: invoking with query params", {
   teardown: sharedTeardown
 });
 
-test("doesn't update controller QP properties on current route when invoked", function() {
+QUnit.test("doesn't update controller QP properties on current route when invoked", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'index' id='the-link'}}Index{{/link-to}}");
   bootApplication();
 
@@ -1324,7 +1324,7 @@ test("doesn't update controller QP properties on current route when invoked", fu
   deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, "controller QP properties not");
 });
 
-test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
+QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj)", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'index' (query-params) id='the-link'}}Index{{/link-to}}");
   bootApplication();
 
@@ -1333,14 +1333,14 @@ test("doesn't update controller QP properties on current route when invoked (emp
   deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, "controller QP properties not");
 });
 
-test("link-to with no params throws", function() {
+QUnit.test("link-to with no params throws", function() {
   Ember.TEMPLATES.index = compile("{{#link-to id='the-link'}}Index{{/link-to}}");
   expectAssertion(function() {
     bootApplication();
   }, /one or more/);
 });
 
-test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
+QUnit.test("doesn't update controller QP properties on current route when invoked (empty query-params obj, inferred route)", function() {
   Ember.TEMPLATES.index = compile("{{#link-to (query-params) id='the-link'}}Index{{/link-to}}");
   bootApplication();
 
@@ -1349,7 +1349,7 @@ test("doesn't update controller QP properties on current route when invoked (emp
   deepEqual(indexController.getProperties('foo', 'bar'), { foo: '123', bar: 'abc' }, "controller QP properties not");
 });
 
-test("updates controller QP properties on current route when invoked", function() {
+QUnit.test("updates controller QP properties on current route when invoked", function() {
   Ember.TEMPLATES.index = compile("{{#link-to 'index' (query-params foo='456') id='the-link'}}Index{{/link-to}}");
   bootApplication();
 
@@ -1358,7 +1358,7 @@ test("updates controller QP properties on current route when invoked", function(
   deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, "controller QP properties updated");
 });
 
-test("updates controller QP properties on current route when invoked (inferred route)", function() {
+QUnit.test("updates controller QP properties on current route when invoked (inferred route)", function() {
   Ember.TEMPLATES.index = compile("{{#link-to (query-params foo='456') id='the-link'}}Index{{/link-to}}");
   bootApplication();
 
@@ -1367,7 +1367,7 @@ test("updates controller QP properties on current route when invoked (inferred r
   deepEqual(indexController.getProperties('foo', 'bar'), { foo: '456', bar: 'abc' }, "controller QP properties updated");
 });
 
-test("updates controller QP properties on other route after transitioning to that route", function() {
+QUnit.test("updates controller QP properties on other route after transitioning to that route", function() {
   Router.map(function() {
     this.route('about');
   });
@@ -1383,7 +1383,7 @@ test("updates controller QP properties on other route after transitioning to tha
   equal(container.lookup('controller:application').get('currentPath'), "about");
 });
 
-test("supplied QP properties can be bound", function() {
+QUnit.test("supplied QP properties can be bound", function() {
   var indexController = container.lookup('controller:index');
   Ember.TEMPLATES.index = compile("{{#link-to (query-params foo=boundThing) id='the-link'}}Index{{/link-to}}");
 
@@ -1394,7 +1394,7 @@ test("supplied QP properties can be bound", function() {
   equal(Ember.$('#the-link').attr('href'), '/?foo=ASL');
 });
 
-test("supplied QP properties can be bound (booleans)", function() {
+QUnit.test("supplied QP properties can be bound (booleans)", function() {
   var indexController = container.lookup('controller:index');
   Ember.TEMPLATES.index = compile("{{#link-to (query-params abool=boundThing) id='the-link'}}Index{{/link-to}}");
 
@@ -1409,7 +1409,7 @@ test("supplied QP properties can be bound (booleans)", function() {
   deepEqual(indexController.getProperties('foo', 'bar', 'abool'), { foo: '123', bar: 'abc', abool: false });
 });
 
-test("href updates when unsupplied controller QP props change", function() {
+QUnit.test("href updates when unsupplied controller QP props change", function() {
   var indexController = container.lookup('controller:index');
   Ember.TEMPLATES.index = compile("{{#link-to (query-params foo='lol') id='the-link'}}Index{{/link-to}}");
 
@@ -1422,7 +1422,7 @@ test("href updates when unsupplied controller QP props change", function() {
   equal(Ember.$('#the-link').attr('href'), '/?bar=BORF&foo=lol');
 });
 
-test("The {{link-to}} applies activeClass when query params are not changed", function() {
+QUnit.test("The {{link-to}} applies activeClass when query params are not changed", function() {
   Ember.TEMPLATES.index = compile(
     "{{#link-to (query-params foo='cat') id='cat-link'}}Index{{/link-to}} " +
     "{{#link-to (query-params foo='dog') id='dog-link'}}Index{{/link-to}} " +
@@ -1512,7 +1512,7 @@ test("The {{link-to}} applies activeClass when query params are not changed", fu
   shouldNotBeActive('#change-search-same-sort-child-and-parent');
 });
 
-test("The {{link-to}} applies active class when query-param is number", function() {
+QUnit.test("The {{link-to}} applies active class when query-param is number", function() {
   Ember.TEMPLATES.index = compile(
     "{{#link-to (query-params page=pageNumber) id='page-link'}}Index{{/link-to}} ");
 
@@ -1529,7 +1529,7 @@ test("The {{link-to}} applies active class when query-param is number", function
   shouldBeActive('#page-link');
 });
 
-test("The {{link-to}} applies active class when query-param is array", function() {
+QUnit.test("The {{link-to}} applies active class when query-param is array", function() {
   Ember.TEMPLATES.index = compile(
     "{{#link-to (query-params pages=pagesArray) id='array-link'}}Index{{/link-to}} " +
     "{{#link-to (query-params pages=biggerArray) id='bigger-link'}}Index{{/link-to}} " +
@@ -1561,7 +1561,7 @@ test("The {{link-to}} applies active class when query-param is array", function(
   shouldNotBeActive('#empty-link');
 });
 
-test("The {{link-to}} helper applies active class to parent route", function() {
+QUnit.test("The {{link-to}} helper applies active class to parent route", function() {
   App.Router.map(function() {
     this.resource('parent', function() {
       this.route('child');
@@ -1589,7 +1589,7 @@ test("The {{link-to}} helper applies active class to parent route", function() {
   shouldNotBeActive('#parent-link-qp');
 });
 
-test("The {{link-to}} helper disregards query-params in activeness computation when current-when specified", function() {
+QUnit.test("The {{link-to}} helper disregards query-params in activeness computation when current-when specified", function() {
   App.Router.map(function() {
     this.route('parent');
   });
@@ -1681,11 +1681,11 @@ if (!Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
     }
   });
 
-  test("invoking a link-to with a slow promise eager updates url", function() {
+  QUnit.test("invoking a link-to with a slow promise eager updates url", function() {
     basicEagerURLUpdateTest(false);
   });
 
-  test("when link-to eagerly updates url, the path it provides does NOT include the rootURL", function() {
+  QUnit.test("when link-to eagerly updates url, the path it provides does NOT include the rootURL", function() {
     expect(2);
 
     // HistoryLocation is the only Location class that will cause rootURL to be
@@ -1732,11 +1732,11 @@ if (!Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
     equal(router.get('location.path'), '/about');
   });
 
-  test("non `a` tags also eagerly update URL", function() {
+  QUnit.test("non `a` tags also eagerly update URL", function() {
     basicEagerURLUpdateTest(true);
   });
 
-  test("invoking a link-to with a promise that rejects on the run loop doesn't update url", function() {
+  QUnit.test("invoking a link-to with a promise that rejects on the run loop doesn't update url", function() {
     App.AboutRoute = Ember.Route.extend({
       model: function() {
         return Ember.RSVP.reject();
@@ -1751,7 +1751,7 @@ if (!Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
     equal(router.get('location.path'), '', 'url was not updated');
   });
 
-  test("invoking a link-to whose transition gets aborted in will transition doesn't update the url", function() {
+  QUnit.test("invoking a link-to whose transition gets aborted in will transition doesn't update the url", function() {
     App.IndexRoute = Ember.Route.extend({
       actions: {
         willTransition: function(transition) {
@@ -1803,7 +1803,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
     }
   });
 
-  test("while a transition is underway", function() {
+  QUnit.test("while a transition is underway", function() {
     expect(18);
     bootApplication();
 

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -70,7 +70,7 @@ QUnit.module("Homepage Example", {
 });
 
 
-test("The example renders correctly", function() {
+QUnit.test("The example renders correctly", function() {
   Ember.run(App, 'advanceReadiness');
 
   equal($fixture.find('h1:contains(People)').length, 1);

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -89,7 +89,7 @@ QUnit.module("Basic Routing", {
   }
 });
 
-test("warn on URLs not included in the route set", function () {
+QUnit.test("warn on URLs not included in the route set", function () {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -104,7 +104,7 @@ test("warn on URLs not included in the route set", function () {
   }, "The URL '/what-is-this-i-dont-even' did not match any routes in your application");
 });
 
-test("The Homepage", function() {
+QUnit.test("The Homepage", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -126,7 +126,7 @@ test("The Homepage", function() {
   equal(Ember.$('h3:contains(Hours)', '#qunit-fixture').length, 1, "The home template was rendered");
 });
 
-test("The Home page and the Camelot page with multiple Router.map calls", function() {
+QUnit.test("The Home page and the Camelot page with multiple Router.map calls", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -168,7 +168,7 @@ test("The Home page and the Camelot page with multiple Router.map calls", functi
   equal(Ember.$('h3:contains(Hours)', '#qunit-fixture').length, 1, "The home template was rendered");
 });
 
-test("The Homepage register as activeView", function() {
+QUnit.test("The Homepage register as activeView", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
     this.route("homepage");
@@ -190,7 +190,7 @@ test("The Homepage register as activeView", function() {
   equal(router._lookupActiveView('home'), undefined, '`home` active view is disconnected');
 });
 
-test("The Homepage with explicit template name in renderTemplate", function() {
+QUnit.test("The Homepage with explicit template name in renderTemplate", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -206,7 +206,7 @@ test("The Homepage with explicit template name in renderTemplate", function() {
   equal(Ember.$('h3:contains(Megatroll)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("An alternate template will pull in an alternate controller", function() {
+QUnit.test("An alternate template will pull in an alternate controller", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -228,7 +228,7 @@ test("An alternate template will pull in an alternate controller", function() {
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from homepage)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("An alternate template will pull in an alternate controller instead of controllerName", function() {
+QUnit.test("An alternate template will pull in an alternate controller instead of controllerName", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -257,7 +257,7 @@ test("An alternate template will pull in an alternate controller instead of cont
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from homepage)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("The template will pull in an alternate controller via key/value", function() {
+QUnit.test("The template will pull in an alternate controller via key/value", function() {
   Router.map(function() {
     this.route("homepage", { path: "/" });
   });
@@ -279,7 +279,7 @@ test("The template will pull in an alternate controller via key/value", function
   equal(Ember.$('h3:contains(Megatroll) + p:contains(Comes from home.)', '#qunit-fixture').length, 1, "The homepage template was rendered from data from the HomeController");
 });
 
-test("The Homepage with explicit template name in renderTemplate and controller", function() {
+QUnit.test("The Homepage with explicit template name in renderTemplate and controller", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -301,7 +301,7 @@ test("The Homepage with explicit template name in renderTemplate and controller"
   equal(Ember.$('h3:contains(Megatroll) + p:contains(YES I AM HOME)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("Model passed via renderTemplate model is set as controller's model", function() {
+QUnit.test("Model passed via renderTemplate model is set as controller's model", function() {
   Ember.TEMPLATES['bio'] = compile("<p>{{model.name}}</p>");
 
   App.BioController = Ember.Controller.extend();
@@ -323,7 +323,7 @@ test("Model passed via renderTemplate model is set as controller's model", funct
   equal(Ember.$('p:contains(emberjs)', '#qunit-fixture').length, 1, "Passed model was set as controllers model");
 });
 
-test("Renders correct view with slash notation", function() {
+QUnit.test("Renders correct view with slash notation", function() {
   Ember.TEMPLATES['home/page'] = compile("<p>{{view.name}}</p>");
 
   Router.map(function() {
@@ -345,7 +345,7 @@ test("Renders correct view with slash notation", function() {
   equal(Ember.$('p:contains(Home/Page)', '#qunit-fixture').length, 1, "The homepage template was rendered");
 });
 
-test("Renders the view given in the view option", function() {
+QUnit.test("Renders the view given in the view option", function() {
   Ember.TEMPLATES['home'] = compile("<p>{{view.name}}</p>");
 
   Router.map(function() {
@@ -367,7 +367,7 @@ test("Renders the view given in the view option", function() {
   equal(Ember.$('p:contains(Home/Page)', '#qunit-fixture').length, 1, "The homepage view was rendered");
 });
 
-test('render does not replace templateName if user provided', function() {
+QUnit.test('render does not replace templateName if user provided', function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -387,7 +387,7 @@ test('render does not replace templateName if user provided', function() {
   equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
 });
 
-test('render does not replace template if user provided', function () {
+QUnit.test('render does not replace template if user provided', function () {
   Router.map(function () {
     this.route("home", { path: "/" });
   });
@@ -407,7 +407,7 @@ test('render does not replace template if user provided', function () {
   equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
 });
 
-test('render uses templateName from route', function() {
+QUnit.test('render uses templateName from route', function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -426,7 +426,7 @@ test('render uses templateName from route', function() {
   equal(Ember.$('p', '#qunit-fixture').text(), "THIS IS THE REAL HOME", "The homepage template was rendered");
 });
 
-test('defining templateName allows other templates to be rendered', function() {
+QUnit.test('defining templateName allows other templates to be rendered', function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -463,7 +463,7 @@ test('defining templateName allows other templates to be rendered', function() {
 
 });
 
-test('Specifying a name to render should have precedence over everything else', function() {
+QUnit.test('Specifying a name to render should have precedence over everything else', function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -502,7 +502,7 @@ test('Specifying a name to render should have precedence over everything else', 
   equal(Ember.$('span', '#qunit-fixture').text(), "Outertroll", "The homepage view was used");
 });
 
-test("The Homepage with a `setupController` hook", function() {
+QUnit.test("The Homepage with a `setupController` hook", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -526,7 +526,7 @@ test("The Homepage with a `setupController` hook", function() {
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
 
-test("The route controller is still set when overriding the setupController hook", function() {
+QUnit.test("The route controller is still set when overriding the setupController hook", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -545,7 +545,7 @@ test("The route controller is still set when overriding the setupController hook
   deepEqual(container.lookup('route:home').controller, container.lookup('controller:home'), "route controller is the home controller");
 });
 
-test("The route controller can be specified via controllerName", function() {
+QUnit.test("The route controller can be specified via controllerName", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -568,7 +568,7 @@ test("The route controller can be specified via controllerName", function() {
   equal(Ember.$('p', '#qunit-fixture').text(), "foo", "The homepage template was rendered with data from the custom controller");
 });
 
-test("The route controller specified via controllerName is used in render", function() {
+QUnit.test("The route controller specified via controllerName is used in render", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -594,7 +594,7 @@ test("The route controller specified via controllerName is used in render", func
   equal(Ember.$('p', '#qunit-fixture').text(), "alternative home: foo", "The homepage template was rendered with data from the custom controller");
 });
 
-test("The route controller specified via controllerName is used in render even when a controller with the routeName is available", function() {
+QUnit.test("The route controller specified via controllerName is used in render even when a controller with the routeName is available", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -621,7 +621,7 @@ test("The route controller specified via controllerName is used in render even w
   equal(Ember.$('p', '#qunit-fixture').text(), "home: myController", "The homepage template was rendered with data from the custom controller");
 });
 
-test("The Homepage with a `setupController` hook modifying other controllers", function() {
+QUnit.test("The Homepage with a `setupController` hook modifying other controllers", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -645,7 +645,7 @@ test("The Homepage with a `setupController` hook modifying other controllers", f
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
 
-test("The Homepage with a computed context that does not get overridden", function() {
+QUnit.test("The Homepage with a computed context that does not get overridden", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -669,7 +669,7 @@ test("The Homepage with a computed context that does not get overridden", functi
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the context intact");
 });
 
-test("The Homepage getting its controller context via model", function() {
+QUnit.test("The Homepage getting its controller context via model", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -699,7 +699,7 @@ test("The Homepage getting its controller context via model", function() {
   equal(Ember.$('ul li', '#qunit-fixture').eq(2).text(), "Sunday: Noon to 6pm", "The template was rendered with the hours context");
 });
 
-test("The Specials Page getting its controller context by deserializing the params hash", function() {
+QUnit.test("The Specials Page getting its controller context by deserializing the params hash", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
     this.resource("special", { path: "/specials/:menu_item_id" });
@@ -730,7 +730,7 @@ test("The Specials Page getting its controller context by deserializing the para
   equal(Ember.$('p', '#qunit-fixture').text(), "1", "The model was used to render the template");
 });
 
-test("The Specials Page defaults to looking models up via `find`", function() {
+QUnit.test("The Specials Page defaults to looking models up via `find`", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
     this.resource("special", { path: "/specials/:menu_item_id" });
@@ -764,7 +764,7 @@ test("The Specials Page defaults to looking models up via `find`", function() {
   equal(Ember.$('p', '#qunit-fixture').text(), "1", "The model was used to render the template");
 });
 
-test("The Special Page returning a promise puts the app into a loading state until the promise is resolved", function() {
+QUnit.test("The Special Page returning a promise puts the app into a loading state until the promise is resolved", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
     this.resource("special", { path: "/specials/:menu_item_id" });
@@ -816,7 +816,7 @@ test("The Special Page returning a promise puts the app into a loading state unt
   equal(Ember.$('p', '#qunit-fixture').text(), "1", "The app is now in the specials state");
 });
 
-test("The loading state doesn't get entered for promises that resolve on the same run loop", function() {
+QUnit.test("The loading state doesn't get entered for promises that resolve on the same run loop", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
     this.resource("special", { path: "/specials/:menu_item_id" });
@@ -894,7 +894,7 @@ asyncTest("The Special page returning an error fires the error hook on SpecialRo
 });
 */
 
-test("The Special page returning an error invokes SpecialRoute's error handler", function() {
+QUnit.test("The Special page returning an error invokes SpecialRoute's error handler", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
     this.resource("special", { path: "/specials/:menu_item_id" });
@@ -979,11 +979,11 @@ function testOverridableErrorHandler(handlersName) {
   });
 }
 
-test("ApplicationRoute's default error handler can be overridden", function() {
+QUnit.test("ApplicationRoute's default error handler can be overridden", function() {
   testOverridableErrorHandler('actions');
 });
 
-test("ApplicationRoute's default error handler can be overridden (with DEPRECATED `events`)", function() {
+QUnit.test("ApplicationRoute's default error handler can be overridden (with DEPRECATED `events`)", function() {
   ignoreDeprecation(function() {
     testOverridableErrorHandler('events');
   });
@@ -1336,7 +1336,7 @@ asyncTest("Events defined in `events` object are triggered on the current state 
   action.handler(event);
 });
 
-test("Events can be handled by inherited event handlers", function() {
+QUnit.test("Events can be handled by inherited event handlers", function() {
 
   expect(4);
 
@@ -1457,7 +1457,7 @@ asyncTest("actions can be triggered with multiple arguments", function() {
   action.handler(event);
 });
 
-test("transitioning multiple times in a single run loop only sets the URL once", function() {
+QUnit.test("transitioning multiple times in a single run loop only sets the URL once", function() {
   Router.map(function() {
     this.route("root", { path: "/" });
     this.route("foo");
@@ -1484,7 +1484,7 @@ test("transitioning multiple times in a single run loop only sets the URL once",
   equal(router.get('location').getURL(), "/bar");
 });
 
-test('navigating away triggers a url property change', function() {
+QUnit.test('navigating away triggers a url property change', function() {
 
   expect(3);
 
@@ -1507,7 +1507,7 @@ test('navigating away triggers a url property change', function() {
   });
 });
 
-test("using replaceWith calls location.replaceURL if available", function() {
+QUnit.test("using replaceWith calls location.replaceURL if available", function() {
   var setCount = 0;
   var replaceCount = 0;
 
@@ -1544,7 +1544,7 @@ test("using replaceWith calls location.replaceURL if available", function() {
   equal(router.get('location').getURL(), "/foo");
 });
 
-test("using replaceWith calls setURL if location.replaceURL is not defined", function() {
+QUnit.test("using replaceWith calls setURL if location.replaceURL is not defined", function() {
   var setCount = 0;
 
   Router.reopen({
@@ -1573,7 +1573,7 @@ test("using replaceWith calls setURL if location.replaceURL is not defined", fun
   equal(router.get('location').getURL(), "/foo");
 });
 
-test("Route inherits model from parent route", function() {
+QUnit.test("Route inherits model from parent route", function() {
   expect(9);
 
   Router.map(function() {
@@ -1648,7 +1648,7 @@ test("Route inherits model from parent route", function() {
   handleURL("/posts/3/shares/3");
 });
 
-test("Resource inherits model from parent resource", function() {
+QUnit.test("Resource inherits model from parent resource", function() {
   expect(6);
 
   Router.map(function() {
@@ -1695,7 +1695,7 @@ test("Resource inherits model from parent resource", function() {
   handleURL("/posts/3/comments");
 });
 
-test("It is possible to get the model from a parent route", function() {
+QUnit.test("It is possible to get the model from a parent route", function() {
   expect(9);
 
   Router.map(function() {
@@ -1741,7 +1741,7 @@ test("It is possible to get the model from a parent route", function() {
   handleURL("/posts/3/comments");
 });
 
-test("A redirection hook is provided", function() {
+QUnit.test("A redirection hook is provided", function() {
   Router.map(function() {
     this.route("choose", { path: "/" });
     this.route("home");
@@ -1771,7 +1771,7 @@ test("A redirection hook is provided", function() {
   equal(router.container.lookup('controller:application').get('currentPath'), 'home');
 });
 
-test("Redirecting from the middle of a route aborts the remainder of the routes", function() {
+QUnit.test("Redirecting from the middle of a route aborts the remainder of the routes", function() {
   expect(3);
 
   Router.map(function() {
@@ -1806,7 +1806,7 @@ test("Redirecting from the middle of a route aborts the remainder of the routes"
   equal(router.get('location').getURL(), "/home");
 });
 
-test("Redirecting to the current target in the middle of a route does not abort initial routing", function() {
+QUnit.test("Redirecting to the current target in the middle of a route does not abort initial routing", function() {
   expect(5);
 
   Router.map(function() {
@@ -1846,7 +1846,7 @@ test("Redirecting to the current target in the middle of a route does not abort 
 
 });
 
-test("Redirecting to the current target with a different context aborts the remainder of the routes", function() {
+QUnit.test("Redirecting to the current target with a different context aborts the remainder of the routes", function() {
   expect(4);
 
   Router.map(function() {
@@ -1890,7 +1890,7 @@ test("Redirecting to the current target with a different context aborts the rema
   equal(router.get('location').getURL(), "/foo/bar/2/baz");
 });
 
-test("Transitioning from a parent event does not prevent currentPath from being set", function() {
+QUnit.test("Transitioning from a parent event does not prevent currentPath from being set", function() {
   Router.map(function() {
     this.resource("foo", function() {
       this.resource("bar", function() {
@@ -1924,7 +1924,7 @@ test("Transitioning from a parent event does not prevent currentPath from being 
   equal(router.get('location').getURL(), "/foo/qux");
 });
 
-test("Generated names can be customized when providing routes with dot notation", function() {
+QUnit.test("Generated names can be customized when providing routes with dot notation", function() {
   expect(4);
 
   Ember.TEMPLATES.index = compile("<div>Index</div>");
@@ -1970,7 +1970,7 @@ test("Generated names can be customized when providing routes with dot notation"
   equal(Ember.$('.main .middle .bottom p', '#qunit-fixture').text(), "BarBazBottom!", "The templates were rendered into their appropriate parents");
 });
 
-test("Child routes render into their parent route's template by default", function() {
+QUnit.test("Child routes render into their parent route's template by default", function() {
   Ember.TEMPLATES.index = compile("<div>Index</div>");
   Ember.TEMPLATES.application = compile("<h1>Home</h1><div class='main'>{{outlet}}</div>");
   Ember.TEMPLATES.top = compile("<div class='middle'>{{outlet}}</div>");
@@ -1992,7 +1992,7 @@ test("Child routes render into their parent route's template by default", functi
   equal(Ember.$('.main .middle .bottom p', '#qunit-fixture').text(), "Bottom!", "The templates were rendered into their appropriate parents");
 });
 
-test("Child routes render into specified template", function() {
+QUnit.test("Child routes render into specified template", function() {
   Ember.TEMPLATES.index = compile("<div>Index</div>");
   Ember.TEMPLATES.application = compile("<h1>Home</h1><div class='main'>{{outlet}}</div>");
   Ember.TEMPLATES.top = compile("<div class='middle'>{{outlet}}</div>");
@@ -2021,7 +2021,7 @@ test("Child routes render into specified template", function() {
   equal(Ember.$('.main .middle > p', '#qunit-fixture').text(), "Bottom!", "The template was rendered into the top template");
 });
 
-test("Rendering into specified template with slash notation", function() {
+QUnit.test("Rendering into specified template with slash notation", function() {
   Ember.TEMPLATES['person/profile'] = compile("profile {{outlet}}");
   Ember.TEMPLATES['person/details'] = compile("details!");
 
@@ -2041,7 +2041,7 @@ test("Rendering into specified template with slash notation", function() {
   equal(Ember.$('#qunit-fixture:contains(profile details!)').length, 1, "The templates were rendered");
 });
 
-test("Parent route context change", function() {
+QUnit.test("Parent route context change", function() {
   var editCount = 0;
   var editedPostIds = Ember.A();
 
@@ -2111,7 +2111,7 @@ test("Parent route context change", function() {
   deepEqual(editedPostIds, ['1', '2'], 'modelFor posts.post returns the right context');
 });
 
-test("Router accounts for rootURL on page load when using history location", function() {
+QUnit.test("Router accounts for rootURL on page load when using history location", function() {
   var rootURL = window.location.pathname + '/app';
   var postsTemplateRendered = false;
   var setHistory, HistoryTestLocation;
@@ -2166,7 +2166,7 @@ test("Router accounts for rootURL on page load when using history location", fun
   ok(postsTemplateRendered, "Posts route successfully stripped from rootURL");
 });
 
-test("The rootURL is passed properly to the location implementation", function() {
+QUnit.test("The rootURL is passed properly to the location implementation", function() {
   expect(1);
   var rootURL = "/blahzorz";
   var HistoryTestLocation;
@@ -2192,7 +2192,7 @@ test("The rootURL is passed properly to the location implementation", function()
 });
 
 
-test("Only use route rendered into main outlet for default into property on child", function() {
+QUnit.test("Only use route rendered into main outlet for default into property on child", function() {
   Ember.TEMPLATES.application = compile("{{outlet 'menu'}}{{outlet}}");
   Ember.TEMPLATES.posts = compile("{{outlet}}");
   Ember.TEMPLATES['posts/index'] = compile("postsIndex");
@@ -2231,7 +2231,7 @@ test("Only use route rendered into main outlet for default into property on chil
   equal(Ember.$('p.posts-index:contains(postsIndex)', '#qunit-fixture').length, 1, "The posts/index template was rendered");
 });
 
-test("Generating a URL should not affect currentModel", function() {
+QUnit.test("Generating a URL should not affect currentModel", function() {
   Router.map(function() {
     this.route("post", { path: "/posts/:post_id" });
   });
@@ -2261,7 +2261,7 @@ test("Generating a URL should not affect currentModel", function() {
 });
 
 
-test("Generated route should be an instance of App.Route if provided", function() {
+QUnit.test("Generated route should be an instance of App.Route if provided", function() {
   var generatedRoute;
 
   Router.map(function() {
@@ -2280,7 +2280,7 @@ test("Generated route should be an instance of App.Route if provided", function(
 
 });
 
-test("Nested index route is not overriden by parent's implicit index route", function() {
+QUnit.test("Nested index route is not overriden by parent's implicit index route", function() {
   Router.map(function() {
     this.resource('posts', function() {
       this.route('index', { path: ':category' });
@@ -2302,7 +2302,7 @@ test("Nested index route is not overriden by parent's implicit index route", fun
   deepEqual(router.location.path, '/posts/emberjs');
 });
 
-test("Application template does not duplicate when re-rendered", function() {
+QUnit.test("Application template does not duplicate when re-rendered", function() {
   Ember.TEMPLATES.application = compile("<h3>I Render Once</h3>{{outlet}}");
 
   Router.map(function() {
@@ -2323,7 +2323,7 @@ test("Application template does not duplicate when re-rendered", function() {
   equal(Ember.$('h3:contains(I Render Once)').size(), 1);
 });
 
-test("Child routes should render inside the application template if the application template causes a redirect", function() {
+QUnit.test("Child routes should render inside the application template if the application template causes a redirect", function() {
   Ember.TEMPLATES.application = compile("<h3>App</h3> {{outlet}}");
   Ember.TEMPLATES.posts = compile("posts");
 
@@ -2343,7 +2343,7 @@ test("Child routes should render inside the application template if the applicat
   equal(Ember.$('#qunit-fixture > div').text(), "App posts");
 });
 
-test("The template is not re-rendered when the route's context changes", function() {
+QUnit.test("The template is not re-rendered when the route's context changes", function() {
   Router.map(function() {
     this.route("page", { path: "/page/:name" });
   });
@@ -2386,7 +2386,7 @@ test("The template is not re-rendered when the route's context changes", functio
 });
 
 
-test("The template is not re-rendered when two routes present the exact same template, view, & controller", function() {
+QUnit.test("The template is not re-rendered when two routes present the exact same template, view, & controller", function() {
   Router.map(function() {
     this.route("first");
     this.route("second");
@@ -2461,7 +2461,7 @@ test("The template is not re-rendered when two routes present the exact same tem
   equal(insertionCount, 2, "view should have inserted a second time");
 });
 
-test("ApplicationRoute with model does not proxy the currentPath", function() {
+QUnit.test("ApplicationRoute with model does not proxy the currentPath", function() {
   var model = {};
   var currentPath;
 
@@ -2481,7 +2481,7 @@ test("ApplicationRoute with model does not proxy the currentPath", function() {
   equal('currentPath' in model, false, 'should have defined currentPath on controller');
 });
 
-test("Promises encountered on app load put app into loading state until resolved", function() {
+QUnit.test("Promises encountered on app load put app into loading state until resolved", function() {
 
   expect(2);
 
@@ -2503,7 +2503,7 @@ test("Promises encountered on app load put app into loading state until resolved
   equal(Ember.$('p', '#qunit-fixture').text(), "INDEX", "The index route is display.");
 });
 
-test("Route should tear down multiple outlets", function() {
+QUnit.test("Route should tear down multiple outlets", function() {
   Ember.TEMPLATES.application = compile("{{outlet 'menu'}}{{outlet}}{{outlet 'footer'}}");
   Ember.TEMPLATES.posts = compile("{{outlet}}");
   Ember.TEMPLATES.users = compile("users");
@@ -2566,7 +2566,7 @@ test("Route should tear down multiple outlets", function() {
 });
 
 
-test("Route supports clearing outlet explicitly", function() {
+QUnit.test("Route supports clearing outlet explicitly", function() {
   Ember.TEMPLATES.application = compile("{{outlet}}{{outlet 'modal'}}");
   Ember.TEMPLATES.posts = compile("{{outlet}}");
   Ember.TEMPLATES.users = compile("users");
@@ -2649,7 +2649,7 @@ test("Route supports clearing outlet explicitly", function() {
   equal(Ember.$('div.posts-extra:contains(postsExtra)', '#qunit-fixture').length, 0, "The posts/extra template was removed");
 });
 
-test("Route supports clearing outlet using string parameter", function() {
+QUnit.test("Route supports clearing outlet using string parameter", function() {
   Ember.TEMPLATES.application = compile("{{outlet}}{{outlet 'modal'}}");
   Ember.TEMPLATES.posts = compile("{{outlet}}");
   Ember.TEMPLATES.users = compile("users");
@@ -2704,7 +2704,7 @@ test("Route supports clearing outlet using string parameter", function() {
   equal(Ember.$('div.posts-modal:contains(postsModal)', '#qunit-fixture').length, 0, "The posts/modal template was removed");
 });
 
-test("Route silently fails when cleaning an outlet from an inactive view", function() {
+QUnit.test("Route silently fails when cleaning an outlet from an inactive view", function() {
   expect(1); // handleURL
 
   Ember.TEMPLATES.application = compile("{{outlet}}");
@@ -2739,7 +2739,7 @@ test("Route silently fails when cleaning an outlet from an inactive view", funct
 });
 
 if (Ember.FEATURES.isEnabled('ember-router-willtransition')) {
-  test("Router `willTransition` hook passes in cancellable transition", function() {
+  QUnit.test("Router `willTransition` hook passes in cancellable transition", function() {
     // Should hit willTransition 3 times, once for the initial route, and then 2 more times
     // for the two handleURL calls below
     expect(3);
@@ -2786,7 +2786,7 @@ if (Ember.FEATURES.isEnabled('ember-router-willtransition')) {
   });
 }
 
-test("Aborting/redirecting the transition in `willTransition` prevents LoadingRoute from being entered", function() {
+QUnit.test("Aborting/redirecting the transition in `willTransition` prevents LoadingRoute from being entered", function() {
   expect(8);
 
   Router.map(function() {
@@ -2855,7 +2855,7 @@ test("Aborting/redirecting the transition in `willTransition` prevents LoadingRo
   Ember.run(deferred.resolve);
 });
 
-test("`didTransition` event fires on the router", function() {
+QUnit.test("`didTransition` event fires on the router", function() {
   expect(3);
 
   Router.map(function() {
@@ -2877,7 +2877,7 @@ test("`didTransition` event fires on the router", function() {
 
   Ember.run(router, 'transitionTo', 'nork');
 });
-test("`didTransition` can be reopened", function() {
+QUnit.test("`didTransition` can be reopened", function() {
   expect(1);
 
   Router.map(function() {
@@ -2894,7 +2894,7 @@ test("`didTransition` can be reopened", function() {
   bootApplication();
 });
 
-test("`activate` event fires on the route", function() {
+QUnit.test("`activate` event fires on the route", function() {
   expect(2);
 
   var eventFired = 0;
@@ -2922,7 +2922,7 @@ test("`activate` event fires on the route", function() {
   Ember.run(router, 'transitionTo', 'nork');
 });
 
-test("`deactivate` event fires on the route", function() {
+QUnit.test("`deactivate` event fires on the route", function() {
   expect(2);
 
   var eventFired = 0;
@@ -2952,7 +2952,7 @@ test("`deactivate` event fires on the route", function() {
   Ember.run(router, 'transitionTo', 'dork');
 });
 
-test("Actions can be handled by inherited action handlers", function() {
+QUnit.test("Actions can be handled by inherited action handlers", function() {
 
   expect(4);
 
@@ -2991,7 +2991,7 @@ test("Actions can be handled by inherited action handlers", function() {
   router.send("baz");
 });
 
-test("currentRouteName is a property installed on ApplicationController that can be used in transitionTo", function() {
+QUnit.test("currentRouteName is a property installed on ApplicationController that can be used in transitionTo", function() {
 
   expect(24);
 
@@ -3032,7 +3032,7 @@ test("currentRouteName is a property installed on ApplicationController that can
   transitionAndCheck('each.other', 'be.excellent.to.each.other', 'each.other');
 });
 
-test("Route model hook finds the same model as a manual find", function() {
+QUnit.test("Route model hook finds the same model as a manual find", function() {
   var Post;
   App.Post = Ember.Object.extend();
   App.Post.reopenClass({
@@ -3053,7 +3053,7 @@ test("Route model hook finds the same model as a manual find", function() {
   equal(App.Post, Post);
 });
 
-test("Can register an implementation via Ember.Location.registerImplementation (DEPRECATED)", function() {
+QUnit.test("Can register an implementation via Ember.Location.registerImplementation (DEPRECATED)", function() {
   var TestLocation = Ember.NoneLocation.extend({
     implementation: 'test'
   });
@@ -3071,7 +3071,7 @@ test("Can register an implementation via Ember.Location.registerImplementation (
   equal(router.get('location.implementation'), 'test', 'custom location implementation can be registered with registerImplementation');
 });
 
-test("Ember.Location.registerImplementation is deprecated", function() {
+QUnit.test("Ember.Location.registerImplementation is deprecated", function() {
   var TestLocation = Ember.NoneLocation.extend({
     implementation: 'test'
   });
@@ -3081,7 +3081,7 @@ test("Ember.Location.registerImplementation is deprecated", function() {
   }, "Using the Ember.Location.registerImplementation is no longer supported. Register your custom location implementation with the container instead.");
 });
 
-test("Routes can refresh themselves causing their model hooks to be re-run", function() {
+QUnit.test("Routes can refresh themselves causing their model hooks to be re-run", function() {
   Router.map(function() {
     this.resource('parent', { path: '/parent/:parent_id' }, function() {
       this.route('child');
@@ -3134,7 +3134,7 @@ test("Routes can refresh themselves causing their model hooks to be re-run", fun
   equal(childcount, 2);
 });
 
-test("Specifying non-existent controller name in route#render throws", function() {
+QUnit.test("Specifying non-existent controller name in route#render throws", function() {
   expect(1);
 
   Router.map(function() {
@@ -3154,7 +3154,7 @@ test("Specifying non-existent controller name in route#render throws", function(
   bootApplication();
 });
 
-test("Redirecting with null model doesn't error out", function() {
+QUnit.test("Redirecting with null model doesn't error out", function() {
   Router.map(function() {
     this.route("home", { path: '/' });
     this.route("about", { path: '/about/:hurhurhur' });
@@ -3179,7 +3179,7 @@ test("Redirecting with null model doesn't error out", function() {
   equal(router.get('location.path'), "/about/TreeklesMcGeekles");
 });
 
-test("rejecting the model hooks promise with a non-error prints the `message` property", function() {
+QUnit.test("rejecting the model hooks promise with a non-error prints the `message` property", function() {
   var rejectedMessage = 'OMG!! SOOOOOO BAD!!!!';
   var rejectedStack   = 'Yeah, buddy: stack gets printed too.';
 
@@ -3202,7 +3202,7 @@ test("rejecting the model hooks promise with a non-error prints the `message` pr
   bootApplication();
 });
 
-test("rejecting the model hooks promise with no reason still logs error", function() {
+QUnit.test("rejecting the model hooks promise with no reason still logs error", function() {
   Router.map(function() {
     this.route("wowzers", { path: "/" });
   });
@@ -3220,7 +3220,7 @@ test("rejecting the model hooks promise with no reason still logs error", functi
   bootApplication();
 });
 
-test("rejecting the model hooks promise with a string shows a good error", function() {
+QUnit.test("rejecting the model hooks promise with a string shows a good error", function() {
   var originalLoggerError = Ember.Logger.error;
   var rejectedMessage = "Supercalifragilisticexpialidocious";
 
@@ -3244,7 +3244,7 @@ test("rejecting the model hooks promise with a string shows a good error", funct
   Ember.Logger.error = originalLoggerError;
 });
 
-test("willLeave, willChangeContext, willChangeModel actions don't fire unless feature flag enabled", function() {
+QUnit.test("willLeave, willChangeContext, willChangeModel actions don't fire unless feature flag enabled", function() {
   expect(1);
 
   App.Router.map(function() {
@@ -3273,7 +3273,7 @@ test("willLeave, willChangeContext, willChangeModel actions don't fire unless fe
   Ember.run(router, 'transitionTo', 'about');
 });
 
-test("Errors in transitionTo within redirect hook are logged", function() {
+QUnit.test("Errors in transitionTo within redirect hook are logged", function() {
   expect(3);
   var actual = [];
 
@@ -3300,7 +3300,7 @@ test("Errors in transitionTo within redirect hook are logged", function() {
   ok(actual[0][1].match(/More context objects were passed than there are dynamic segments for the route: stink-bomb/), 'the error is printed');
 });
 
-test("Errors in transition show error template if available", function() {
+QUnit.test("Errors in transition show error template if available", function() {
   Ember.TEMPLATES.error = compile("<div id='error'>Error!</div>");
 
   Router.map(function() {
@@ -3319,7 +3319,7 @@ test("Errors in transition show error template if available", function() {
   equal(Ember.$('#error').length, 1, "Error template was rendered.");
 });
 
-test("Route#resetController gets fired when changing models and exiting routes", function() {
+QUnit.test("Route#resetController gets fired when changing models and exiting routes", function() {
   expect(4);
 
   Router.map(function() {
@@ -3362,7 +3362,7 @@ test("Route#resetController gets fired when changing models and exiting routes",
   deepEqual(calls, [['reset', 'c'], ['reset', 'a'], ['setup', 'out']]);
 });
 
-test("Exception during initialization of non-initial route is not swallowed", function() {
+QUnit.test("Exception during initialization of non-initial route is not swallowed", function() {
   Router.map(function() {
     this.route('boom');
   });
@@ -3378,7 +3378,7 @@ test("Exception during initialization of non-initial route is not swallowed", fu
 });
 
 
-test("Exception during load of non-initial route is not swallowed", function() {
+QUnit.test("Exception during load of non-initial route is not swallowed", function() {
   Router.map(function() {
     this.route('boom');
   });
@@ -3400,7 +3400,7 @@ test("Exception during load of non-initial route is not swallowed", function() {
   });
 });
 
-test("Exception during initialization of initial route is not swallowed", function() {
+QUnit.test("Exception during initialization of initial route is not swallowed", function() {
   Router.map(function() {
     this.route('boom', { path: '/' });
   });
@@ -3414,7 +3414,7 @@ test("Exception during initialization of initial route is not swallowed", functi
   }, /\bboom\b/);
 });
 
-test("Exception during load of initial route is not swallowed", function() {
+QUnit.test("Exception during load of initial route is not swallowed", function() {
   Router.map(function() {
     this.route('boom', { path: '/' });
   });

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -120,7 +120,7 @@ QUnit.module("Routing w/ Query Params", {
   }
 });
 
-test("Single query params can be set", function() {
+QUnit.test("Single query params can be set", function() {
   Router.map(function() {
     this.route("home", { path: '/' });
   });
@@ -142,7 +142,7 @@ test("Single query params can be set", function() {
   equal(router.get('location.path'), "/?foo=987");
 });
 
-test("Query params can map to different url keys", function() {
+QUnit.test("Query params can map to different url keys", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: [{ foo: 'other_foo', bar: { as: 'other_bar' } }],
     foo: "FOO",
@@ -167,7 +167,7 @@ test("Query params can map to different url keys", function() {
 });
 
 
-test("Routes have overridable serializeQueryParamKey hook", function() {
+QUnit.test("Routes have overridable serializeQueryParamKey hook", function() {
   App.IndexRoute = Ember.Route.extend({
     serializeQueryParamKey: Ember.String.dasherize
   });
@@ -186,7 +186,7 @@ test("Routes have overridable serializeQueryParamKey hook", function() {
   equal(router.get('location.path'), "/?fun-times=woot");
 });
 
-test("No replaceURL occurs on startup because default values don't show up in URL", function() {
+QUnit.test("No replaceURL occurs on startup because default values don't show up in URL", function() {
   expect(0);
 
   App.IndexController = Ember.Controller.extend({
@@ -199,7 +199,7 @@ test("No replaceURL occurs on startup because default values don't show up in UR
   bootApplication();
 });
 
-test("Can override inherited QP behavior by specifying queryParams as a computed property", function() {
+QUnit.test("Can override inherited QP behavior by specifying queryParams as a computed property", function() {
   expect(0);
   var SharedMixin = Ember.Mixin.create({
     queryParams: ['a'],
@@ -220,7 +220,7 @@ test("Can override inherited QP behavior by specifying queryParams as a computed
   Ember.run(indexController, 'set', 'a', 1);
 });
 
-test("model hooks receives query params", function() {
+QUnit.test("model hooks receives query params", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['omg'],
     omg: 'lol'
@@ -237,7 +237,7 @@ test("model hooks receives query params", function() {
   equal(router.get('location.path'), "");
 });
 
-test("controllers won't be eagerly instantiated by internal query params logic", function() {
+QUnit.test("controllers won't be eagerly instantiated by internal query params logic", function() {
   expect(10);
   Router.map(function() {
     this.resource('cats', function() {
@@ -329,7 +329,7 @@ test("controllers won't be eagerly instantiated by internal query params logic",
   equal(router.get('location.path'), "/cats?name=domino", 'url is correct');
 });
 
-test("model hooks receives query params (overridden by incoming url value)", function() {
+QUnit.test("model hooks receives query params (overridden by incoming url value)", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['omg'],
     omg: 'lol'
@@ -347,7 +347,7 @@ test("model hooks receives query params (overridden by incoming url value)", fun
   equal(router.get('location.path'), "/?omg=yes");
 });
 
-test("Route#paramsFor fetches query params", function() {
+QUnit.test("Route#paramsFor fetches query params", function() {
   expect(1);
 
   Router.map(function() {
@@ -369,7 +369,7 @@ test("Route#paramsFor fetches query params", function() {
   bootApplication();
 });
 
-test("Route#paramsFor fetches falsy query params", function() {
+QUnit.test("Route#paramsFor fetches falsy query params", function() {
   expect(1);
 
   App.IndexController = Ember.Controller.extend({
@@ -387,7 +387,7 @@ test("Route#paramsFor fetches falsy query params", function() {
   bootApplication();
 });
 
-test("model hook can query prefix-less application params", function() {
+QUnit.test("model hook can query prefix-less application params", function() {
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['appomg'],
     appomg: 'applol'
@@ -416,7 +416,7 @@ test("model hook can query prefix-less application params", function() {
   equal(router.get('location.path'), "");
 });
 
-test("model hook can query prefix-less application params (overridden by incoming url value)", function() {
+QUnit.test("model hook can query prefix-less application params (overridden by incoming url value)", function() {
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['appomg'],
     appomg: 'applol'
@@ -446,7 +446,7 @@ test("model hook can query prefix-less application params (overridden by incomin
   equal(router.get('location.path'), "/?appomg=appyes&omg=yes");
 });
 
-test("can opt into full transition by setting refreshModel in route queryParams", function() {
+QUnit.test("can opt into full transition by setting refreshModel in route queryParams", function() {
   expect(6);
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['appomg'],
@@ -495,7 +495,7 @@ test("can opt into full transition by setting refreshModel in route queryParams"
   equal(indexModelCount, 2);
 });
 
-test("Use Ember.get to retrieve query params 'refreshModel' configuration", function() {
+QUnit.test("Use Ember.get to retrieve query params 'refreshModel' configuration", function() {
   expect(6);
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['appomg'],
@@ -544,7 +544,7 @@ test("Use Ember.get to retrieve query params 'refreshModel' configuration", func
   equal(indexModelCount, 2);
 });
 
-test("can use refreshModel even w URL changes that remove QPs from address bar", function() {
+QUnit.test("can use refreshModel even w URL changes that remove QPs from address bar", function() {
   expect(4);
 
   App.IndexController = Ember.Controller.extend({
@@ -581,7 +581,7 @@ test("can use refreshModel even w URL changes that remove QPs from address bar",
   equal(indexController.get('omg'), 'lol');
 });
 
-test("warn user that routes query params configuration must be an Object, not an Array", function() {
+QUnit.test("warn user that routes query params configuration must be an Object, not an Array", function() {
   expect(1);
 
   App.ApplicationRoute = Ember.Route.extend({
@@ -595,7 +595,7 @@ test("warn user that routes query params configuration must be an Object, not an
   }, 'You passed in `[{"commitBy":{"replace":true}}]` as the value for `queryParams` but `queryParams` cannot be an Array');
 });
 
-test("can opt into a replace query by specifying replace:true in the Router config hash", function() {
+QUnit.test("can opt into a replace query by specifying replace:true in the Router config hash", function() {
   expect(2);
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['alex'],
@@ -619,7 +619,7 @@ test("can opt into a replace query by specifying replace:true in the Router conf
   setAndFlush(appController, 'alex', 'wallace');
 });
 
-test("Route query params config can be configured using property name instead of URL key", function() {
+QUnit.test("Route query params config can be configured using property name instead of URL key", function() {
   expect(2);
   App.ApplicationController = Ember.Controller.extend({
     queryParams: [
@@ -644,7 +644,7 @@ test("Route query params config can be configured using property name instead of
   setAndFlush(appController, 'commitBy', 'igor_seb');
 });
 
-test("An explicit replace:false on a changed QP always wins and causes a pushState", function() {
+QUnit.test("An explicit replace:false on a changed QP always wins and causes a pushState", function() {
   expect(3);
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['alex', 'steely'],
@@ -676,7 +676,7 @@ test("An explicit replace:false on a changed QP always wins and causes a pushSta
   Ember.run(appController, 'setProperties', { alex: 'sriracha' });
 });
 
-test("can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent", function() {
+QUnit.test("can opt into full transition by setting refreshModel in route queryParams when transitioning from child to parent", function() {
   Ember.TEMPLATES.parent = compile('{{outlet}}');
   Ember.TEMPLATES['parent/child'] = compile("{{link-to 'Parent' 'parent' (query-params foo='change') id='parent-link'}}");
 
@@ -715,7 +715,7 @@ test("can opt into full transition by setting refreshModel in route queryParams 
   equal(parentModelCount, 2);
 });
 
-test("Use Ember.get to retrieve query params 'replace' configuration", function() {
+QUnit.test("Use Ember.get to retrieve query params 'replace' configuration", function() {
   expect(2);
   App.ApplicationController = Ember.Controller.extend({
     queryParams: ['alex'],
@@ -740,7 +740,7 @@ test("Use Ember.get to retrieve query params 'replace' configuration", function(
   setAndFlush(appController, 'alex', 'wallace');
 });
 
-test("can override incoming QP values in setupController", function() {
+QUnit.test("can override incoming QP values in setupController", function() {
   expect(3);
 
   App.Router.map(function() {
@@ -771,7 +771,7 @@ test("can override incoming QP values in setupController", function() {
   equal(router.get('location.path'), "/?omg=OVERRIDE");
 });
 
-test("can override incoming QP array values in setupController", function() {
+QUnit.test("can override incoming QP array values in setupController", function() {
   expect(3);
 
   App.Router.map(function() {
@@ -802,7 +802,7 @@ test("can override incoming QP array values in setupController", function() {
   equal(router.get('location.path'), "/?omg=" + encodeURIComponent(JSON.stringify(['OVERRIDE'])));
 });
 
-test("URL transitions that remove QPs still register as QP changes", function() {
+QUnit.test("URL transitions that remove QPs still register as QP changes", function() {
   expect(2);
 
   App.IndexController = Ember.Controller.extend({
@@ -819,7 +819,7 @@ test("URL transitions that remove QPs still register as QP changes", function() 
   equal(indexController.get('omg'), 'lol');
 });
 
-test("Subresource naming style is supported", function() {
+QUnit.test("Subresource naming style is supported", function() {
 
   Router.map(function() {
     this.resource('abc.def', { path: '/abcdef' }, function() {
@@ -850,7 +850,7 @@ test("Subresource naming style is supported", function() {
   equal(router.get('location.path'), "/abcdef/zoo?bar=456&foo=123");
 });
 
-test("transitionTo supports query params", function() {
+QUnit.test("transitionTo supports query params", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: 'lol'
@@ -870,7 +870,7 @@ test("transitionTo supports query params", function() {
   equal(router.get('location.path'), "/?foo=false", "shorhand supported (bool)");
 });
 
-test("transitionTo supports query params (multiple)", function() {
+QUnit.test("transitionTo supports query params (multiple)", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo', 'bar'],
     foo: 'lol',
@@ -891,7 +891,7 @@ test("transitionTo supports query params (multiple)", function() {
   equal(router.get('location.path'), "/?foo=false", "shorhand supported (bool)");
 });
 
-test("setting controller QP to empty string doesn't generate null in URL", function() {
+QUnit.test("setting controller QP to empty string doesn't generate null in URL", function() {
   expect(1);
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
@@ -905,7 +905,7 @@ test("setting controller QP to empty string doesn't generate null in URL", funct
   setAndFlush(controller, 'foo', '');
 });
 
-test("A default boolean value deserializes QPs as booleans rather than strings", function() {
+QUnit.test("A default boolean value deserializes QPs as booleans rather than strings", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: false
@@ -927,7 +927,7 @@ test("A default boolean value deserializes QPs as booleans rather than strings",
   equal(controller.get('foo'), false);
 });
 
-test("Query param without value are empty string", function() {
+QUnit.test("Query param without value are empty string", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: ''
@@ -940,7 +940,7 @@ test("Query param without value are empty string", function() {
   equal(controller.get('foo'), "");
 });
 
-test("Array query params can be set", function() {
+QUnit.test("Array query params can be set", function() {
   Router.map(function() {
     this.route("home", { path: '/' });
   });
@@ -962,7 +962,7 @@ test("Array query params can be set", function() {
   equal(router.get('location.path'), "/?foo=%5B3%2C4%5D");
 });
 
-test("(de)serialization: arrays", function() {
+QUnit.test("(de)serialization: arrays", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: [1]
@@ -980,7 +980,7 @@ test("(de)serialization: arrays", function() {
   equal(router.get('location.path'), "/?foo=%5B%5D", "longform supported");
 });
 
-test("Url with array query param sets controller property to array", function() {
+QUnit.test("Url with array query param sets controller property to array", function() {
   App.IndexController = Ember.Controller.extend({
     queryParams: ['foo'],
     foo: ''
@@ -993,7 +993,7 @@ test("Url with array query param sets controller property to array", function() 
   deepEqual(controller.get('foo'), ["1","2","3"]);
 });
 
-test("Array query params can be pushed/popped", function() {
+QUnit.test("Array query params can be pushed/popped", function() {
   Router.map(function() {
     this.route("home", { path: '/' });
   });
@@ -1035,7 +1035,7 @@ test("Array query params can be pushed/popped", function() {
   deepEqual(controller.foo, ['lol', 1]);
 });
 
-test("Overwriting with array with same content shouldn't refire update", function() {
+QUnit.test("Overwriting with array with same content shouldn't refire update", function() {
   expect(3);
   var modelCount = 0;
 
@@ -1063,7 +1063,7 @@ test("Overwriting with array with same content shouldn't refire update", functio
   equal(router.get('location.path'), "");
 });
 
-test("Defaulting to params hash as the model should not result in that params object being watched", function() {
+QUnit.test("Defaulting to params hash as the model should not result in that params object being watched", function() {
   expect(1);
 
   Router.map(function() {
@@ -1091,7 +1091,7 @@ test("Defaulting to params hash as the model should not result in that params ob
   Ember.run(router, 'transitionTo', 'other');
 });
 
-test("A child of a resource route still defaults to parent route's model even if the child route has a query param", function() {
+QUnit.test("A child of a resource route still defaults to parent route's model even if the child route has a query param", function() {
   expect(1);
 
   App.IndexController = Ember.Controller.extend({
@@ -1113,7 +1113,7 @@ test("A child of a resource route still defaults to parent route's model even if
   bootApplication();
 });
 
-test("opting into replace does not affect transitions between routes", function() {
+QUnit.test("opting into replace does not affect transitions between routes", function() {
   expect(5);
   Ember.TEMPLATES.application = compile(
     "{{link-to 'Foo' 'foo' id='foo-link'}}" +
@@ -1158,7 +1158,7 @@ test("opting into replace does not affect transitions between routes", function(
   Ember.run(Ember.$('#bar-link'), 'click');
 });
 
-test("Undefined isn't deserialized into a string", function() {
+QUnit.test("Undefined isn't deserialized into a string", function() {
   expect(3);
   Router.map(function() {
     this.route("example");
@@ -1187,7 +1187,7 @@ test("Undefined isn't deserialized into a string", function() {
   equal(get(controller, 'foo'), undefined);
 });
 
-test("query params have been set by the time setupController is called", function() {
+QUnit.test("query params have been set by the time setupController is called", function() {
   expect(1);
 
   App.ApplicationController = Ember.Controller.extend({
@@ -1206,7 +1206,7 @@ test("query params have been set by the time setupController is called", functio
 });
 
 var testParamlessLinks = function(routeName) {
-  test("param-less links in an app booted with query params in the URL don't reset the query params: " + routeName, function() {
+  QUnit.test("param-less links in an app booted with query params in the URL don't reset the query params: " + routeName, function() {
     expect(1);
 
     Ember.TEMPLATES[routeName] = compile("{{link-to 'index' 'index' id='index-link'}}");
@@ -1288,7 +1288,7 @@ QUnit.module("Model Dep Query Params", {
   }
 });
 
-test("query params have 'model' stickiness by default", function() {
+QUnit.test("query params have 'model' stickiness by default", function() {
   this.boot();
 
   Ember.run(this.$link1, 'click');
@@ -1310,7 +1310,7 @@ test("query params have 'model' stickiness by default", function() {
   equal(this.$link3.attr('href'), '/a/a-3');
 });
 
-test("query params have 'model' stickiness by default (url changes)", function() {
+QUnit.test("query params have 'model' stickiness by default (url changes)", function() {
 
   this.boot();
 
@@ -1345,7 +1345,7 @@ test("query params have 'model' stickiness by default (url changes)", function()
 });
 
 
-test("query params have 'model' stickiness by default (params-based transitions)", function() {
+QUnit.test("query params have 'model' stickiness by default (params-based transitions)", function() {
   Ember.TEMPLATES.application = compile("{{#each a in articles}} {{link-to 'Article' 'article' a.id id=a.id}} {{/each}}");
 
   this.boot();
@@ -1391,7 +1391,7 @@ test("query params have 'model' stickiness by default (params-based transitions)
   equal(this.$link3.attr('href'), '/a/a-3?q=hay');
 });
 
-test("'controller' stickiness shares QP state between models", function() {
+QUnit.test("'controller' stickiness shares QP state between models", function() {
   App.ArticleController.reopen({
     queryParams: { q: { scope: 'controller' } }
   });
@@ -1435,7 +1435,7 @@ test("'controller' stickiness shares QP state between models", function() {
   equal(this.$link3.attr('href'), '/a/a-3?q=woot&z=123');
 });
 
-test("'model' stickiness is scoped to current or first dynamic parent route", function() {
+QUnit.test("'model' stickiness is scoped to current or first dynamic parent route", function() {
   this.boot();
 
   Ember.run(router, 'transitionTo', 'comments', 'a-1');
@@ -1459,7 +1459,7 @@ test("'model' stickiness is scoped to current or first dynamic parent route", fu
   equal(router.get('location.path'), '/a/a-1/comments?page=3');
 });
 
-test("can reset query params using the resetController hook", function() {
+QUnit.test("can reset query params using the resetController hook", function() {
   App.Router.map(function() {
     this.resource('article', { path: '/a/:id' }, function() {
       this.resource('comments');
@@ -1504,7 +1504,7 @@ test("can reset query params using the resetController hook", function() {
   equal(Ember.$('#two').attr('href'), "/a/a-2/comments");
 });
 
-test("can unit test without bucket cache", function() {
+QUnit.test("can unit test without bucket cache", function() {
   var controller = container.lookup('controller:article');
   controller._bucketCache = null;
 
@@ -1533,7 +1533,7 @@ QUnit.module("Query Params - overlapping query param property names", {
   }
 });
 
-test("can remap same-named qp props", function() {
+QUnit.test("can remap same-named qp props", function() {
   App.ParentController = Ember.Controller.extend({
     queryParams: { page: 'parentPage' },
     page: 1
@@ -1576,7 +1576,7 @@ test("can remap same-named qp props", function() {
   equal(router.get('location.path'), '/parent/child');
 });
 
-test("query params in the same route hierarchy with the same url key get auto-scoped", function() {
+QUnit.test("query params in the same route hierarchy with the same url key get auto-scoped", function() {
   App.ParentController = Ember.Controller.extend({
     queryParams: { foo: 'shared' },
     foo: 1
@@ -1593,7 +1593,7 @@ test("query params in the same route hierarchy with the same url key get auto-sc
   }, "You're not allowed to have more than one controller property map to the same query param key, but both `parent:foo` and `parent.child:bar` map to `shared`. You can fix this by mapping one of the controller properties to a different query param key via the `as` config option, e.g. `foo: { as: 'other-foo' }`");
 });
 
-test("Support shared but overridable mixin pattern", function() {
+QUnit.test("Support shared but overridable mixin pattern", function() {
 
   var HasPage = Ember.Mixin.create({
     queryParams: 'page',

--- a/packages/ember/tests/routing/router_map_test.js
+++ b/packages/ember/tests/routing/router_map_test.js
@@ -51,7 +51,7 @@ QUnit.module("Router.map", {
   }
 });
 
-test("Router.map returns an Ember Router class", function () {
+QUnit.test("Router.map returns an Ember Router class", function () {
   expect(1);
 
   var ret = App.Router.map(function() {
@@ -61,7 +61,7 @@ test("Router.map returns an Ember Router class", function () {
   ok(Ember.Router.detect(ret));
 });
 
-test("Router.map can be called multiple times", function () {
+QUnit.test("Router.map can be called multiple times", function () {
   expect(4);
 
   Ember.TEMPLATES.hello = compile("Hello!");

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -72,7 +72,7 @@ QUnit.module("Loading/Error Substates", {
   }
 });
 
-test("Slow promise from a child route of application enters nested loading state", function() {
+QUnit.test("Slow promise from a child route of application enters nested loading state", function() {
 
   var broModel = {};
   var broDeferred = Ember.RSVP.defer();
@@ -103,7 +103,7 @@ test("Slow promise from a child route of application enters nested loading state
   equal(Ember.$('#app', '#qunit-fixture').text(), "BRO", "bro template has loaded and replaced loading template");
 });
 
-test("Slow promises waterfall on startup", function() {
+QUnit.test("Slow promises waterfall on startup", function() {
 
   expect(7);
 
@@ -158,7 +158,7 @@ test("Slow promises waterfall on startup", function() {
   equal(Ember.$('#app', '#qunit-fixture').text(), "GRANDMA MOM SALLY", "Sally template displayed");
 });
 
-test("ApplicationRoute#currentPath reflects loading state path", function() {
+QUnit.test("ApplicationRoute#currentPath reflects loading state path", function() {
 
   expect(4);
 
@@ -192,7 +192,7 @@ test("ApplicationRoute#currentPath reflects loading state path", function() {
   equal(appController.get('currentPath'), "grandma.mom", "currentPath reflects final state");
 });
 
-test("Slow promises returned from ApplicationRoute#model don't enter LoadingRoute", function() {
+QUnit.test("Slow promises returned from ApplicationRoute#model don't enter LoadingRoute", function() {
 
   expect(2);
 
@@ -218,7 +218,7 @@ test("Slow promises returned from ApplicationRoute#model don't enter LoadingRout
   equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
 });
 
-test("Don't enter loading route unless either route or template defined", function() {
+QUnit.test("Don't enter loading route unless either route or template defined", function() {
 
   delete templates.loading;
 
@@ -243,7 +243,7 @@ test("Don't enter loading route unless either route or template defined", functi
   equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
 });
 
-test("Enter loading route if only LoadingRoute defined", function() {
+QUnit.test("Enter loading route if only LoadingRoute defined", function() {
 
   delete templates.loading;
 
@@ -273,7 +273,7 @@ test("Enter loading route if only LoadingRoute defined", function() {
   equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
 });
 
-test("Enter child loading state of pivot route", function() {
+QUnit.test("Enter child loading state of pivot route", function() {
 
   expect(4);
 
@@ -317,7 +317,7 @@ test("Enter child loading state of pivot route", function() {
   equal(appController.get('currentPath'), "grandma.smells", "Finished transition");
 });
 
-test("Loading actions bubble to root, but don't enter substates above pivot", function() {
+QUnit.test("Loading actions bubble to root, but don't enter substates above pivot", function() {
 
   expect(6);
 
@@ -373,7 +373,7 @@ test("Loading actions bubble to root, but don't enter substates above pivot", fu
   equal(appController.get('currentPath'), "grandma.smells", "Finished transition");
 });
 
-test("Default error event moves into nested route", function() {
+QUnit.test("Default error event moves into nested route", function() {
 
   expect(5);
 
@@ -418,7 +418,7 @@ test("Default error event moves into nested route", function() {
 
 if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
 
-  test("Slow promises returned from ApplicationRoute#model enter ApplicationLoadingRoute if present", function() {
+  QUnit.test("Slow promises returned from ApplicationRoute#model enter ApplicationLoadingRoute if present", function() {
 
     expect(2);
 
@@ -448,7 +448,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
   });
 
-  test("Slow promises returned from ApplicationRoute#model enter application_loading if template present", function() {
+  QUnit.test("Slow promises returned from ApplicationRoute#model enter application_loading if template present", function() {
 
     expect(3);
 
@@ -485,7 +485,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "INDEX");
   });
 
-  test("Default error event moves into nested route, prioritizing more specifically named error route", function() {
+  QUnit.test("Default error event moves into nested route, prioritizing more specifically named error route", function() {
 
     expect(5);
 
@@ -533,7 +533,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(appController.get('currentPath'), 'grandma.mom_error', "Initial route fully loaded");
   });
 
-  test("Prioritized substate entry works with preserved-namespace nested resources", function() {
+  QUnit.test("Prioritized substate entry works with preserved-namespace nested resources", function() {
 
     expect(2);
 
@@ -568,7 +568,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "YAY");
   });
 
-  test("Prioritized loading substate entry works with preserved-namespace nested routes", function() {
+  QUnit.test("Prioritized loading substate entry works with preserved-namespace nested routes", function() {
 
     expect(2);
 
@@ -602,7 +602,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "YAY");
   });
 
-  test("Prioritized error substate entry works with preserved-namespace nested routes", function() {
+  QUnit.test("Prioritized error substate entry works with preserved-namespace nested routes", function() {
 
     expect(1);
 
@@ -633,7 +633,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "FOOBAR ERROR: did it broke?", "foo.bar_error was entered (as opposed to something like foo/foo/bar_error)");
   });
 
-  test("Prioritized loading substate entry works with auto-generated index routes", function() {
+  QUnit.test("Prioritized loading substate entry works with auto-generated index routes", function() {
 
     expect(2);
 
@@ -673,7 +673,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "YAY");
   });
 
-  test("Prioritized error substate entry works with auto-generated index routes", function() {
+  QUnit.test("Prioritized error substate entry works with auto-generated index routes", function() {
 
     expect(1);
 
@@ -710,7 +710,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
     equal(Ember.$('#app', '#qunit-fixture').text(), "FOO ERROR: did it broke?", "foo.index_error was entered");
   });
 
-  test("Rejected promises returned from ApplicationRoute transition into top-level application_error", function() {
+  QUnit.test("Rejected promises returned from ApplicationRoute transition into top-level application_error", function() {
 
     expect(2);
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -99,11 +99,6 @@
           return originalTypeof.call(this, obj);
         };
 
-        // raises is deprecated, but we likely want to keep it around for our es3
-        // test runs.
-        QUnit.constructor.prototype.raises = QUnit['throws'];
-        window.raises = QUnit['throws'];
-
         QUnit.jsDump.parsers.emberObject = function(obj) {
           return obj.toString();
         };


### PR DESCRIPTION
- Remove `raises` alias (no longer needed with ES3 safe processing).
- Replace `window.test` with `QUnit.test`.

Starting towards QUnit 2.0 compatibility.  [Read here for more details.](http://qunitjs.com/upgrade-guide-2.x/)
