### PR TITLE
[BUGFIX beta] Add a test confirming bound attr syntax can set any types

### DIFF
--- a/packages/ember-htmlbars/tests/attr_nodes/property_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/property_test.js
@@ -57,5 +57,17 @@ test("quoted maxlength sets the property and attribute", function() {
   }
 });
 
+test("array value can be set as property", function() {
+  view = EmberView.create({
+    context: {},
+    template: compile("<input value={{items}}>")
+  });
+
+  appendView(view);
+
+  Ember.run(view, view.set, 'context.items', [4,5]);
+  ok(true, "no legacy assertion prohibited setting an array");
+});
+
 // jscs:enable validateIndentation
 }


### PR DESCRIPTION
Add a test to cover https://github.com/emberjs/ember.js/pull/10344. Any type can be bound with html syntax bindings.
