### PR TITLE
Ensure debug statements are properly stripped from production builds.

### DIFF
--- a/features.json
+++ b/features.json
@@ -22,10 +22,16 @@
   },
   "debugStatements": [
     "Ember.warn",
+    "Ember.default.warn",
     "Ember.assert",
+    "Ember.default.assert",
     "Ember.deprecate",
+    "Ember.default.deprecate",
     "Ember.debug",
+    "Ember.default.debug",
     "Ember.Logger.info",
-    "Ember.runInDebug"
+    "Ember.default.Logger.info",
+    "Ember.runInDebug",
+    "Ember.default.runInDebug"
   ]
 }


### PR DESCRIPTION
Fixed upstream in https://github.com/thomasboyt/defeatureify/issues/14, and published as v0.2.2.

Fixes https://github.com/emberjs/ember.js/issues/10347.
