### PR TITLE
remove bad advice.

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -479,9 +479,7 @@ Registry.prototype = {
     var fullNameType = fullName.split(':')[0];
     if (fullNameType === type) {
       throw new Error('Cannot inject a `' + fullName +
-      '` on other ' + type +
-      '(s). Register the `' + fullName +
-      '` as a different type and perform the typeInjection.');
+      '` on other ' + type + '(s).');
     }
 
     var injections = this._typeInjections[type] ||

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -56,7 +56,7 @@ QUnit.test("Throw exception when trying to inject `type:thing` on all type(s)", 
 
   throws(function() {
     registry.typeInjection('controller', 'injected', 'controller:post');
-  }, 'Cannot inject a `controller:post` on other controller(s). Register the `controller:post` as a different type and perform the typeInjection.');
+  }, 'Cannot inject a `controller:post` on other controller(s).');
 });
 
 QUnit.test("The registry can take a hook to resolve factories lazily", function() {


### PR DESCRIPTION
If someone is running into this scenario they are creating a cycle.
Constructor injections cannot absorb cycles. The advice given suggests
the user re-class the entity, by means of register but this will likely
lead them down an ever worse path. As the user will likely now end-up
with two discrete instances when they intend to only have one.

The solutions are:
- inject explicitly `registry.inject('service:bar', 'baz', 'service:baz')`
- use the declarative `Ember.inject.*` which is lazy and obsorbs
  cycles
