### PR TITLE
Add Ember load hook

### DIFF
--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -10,6 +10,7 @@ import "ember-htmlbars";
 import "ember-routing-htmlbars";
 
 import environment from "ember-metal/environment";
+import { runLoadHooks } from 'ember-runtime/system/lazy_load';
 
 if (Ember.__loader.registry['ember-template-compiler']) {
   requireModule('ember-template-compiler');
@@ -20,6 +21,8 @@ if (Ember.__loader.registry['ember-template-compiler']) {
 if (Ember.__loader.registry['ember-testing']) {
   requireModule('ember-testing');
 }
+
+runLoadHooks('Ember');
 
 /**
 Ember


### PR DESCRIPTION
Ember Inspector currently relies on `Ember.Application` load hook to start, but assumes all of Ember is loaded (for example uses `Ember.RSVP`). We are currently relying on the chance that `Ember.Application` module will be the last to load, and the inspector will break whenever the dependency order is shifted. After this we'll be able to listen to the `Ember` hook instead.
