### PR TITLE
Ensure AutoLocation returns concreteImplementation's return values.

### DIFF
--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -156,7 +156,7 @@ function delegateToConcreteImplementation(methodName) {
   return function() {
     var concreteImplementation = get(this, 'concreteImplementation');
     Ember.assert("AutoLocation's detect() method should be called before calling any other hooks.", !!concreteImplementation);
-    tryInvoke(concreteImplementation, methodName, arguments);
+    return tryInvoke(concreteImplementation, methodName, arguments);
   };
 }
 

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -60,6 +60,24 @@ QUnit.module("Ember.AutoLocation", {
   }
 });
 
+QUnit.test("AutoLocation should return concrete implementation's value for `getURL`", function() {
+  expect(1);
+
+  var browserLocation = mockBrowserLocation();
+  var browserHistory = mockBrowserHistory();
+
+  location = createLocation(browserLocation, browserHistory);
+  location.detect();
+
+  var concreteImplementation = get(location, 'concreteImplementation');
+
+  concreteImplementation.getURL = function() {
+    return '/lincoln/park';
+  };
+
+  equal(location.getURL(), '/lincoln/park');
+});
+
 QUnit.test("AutoLocation should use a HistoryLocation instance when pushStates is supported", function() {
   expect(1);
 


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/10396.
