### PR TITLE
[BUGFIX release] undefined and values in bind-attr shoud remove attributes

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -586,3 +586,29 @@ QUnit.test("asserts for <div data-bar='foo' {{bind-attr data-bar='blah'}}></div>
     runAppend(view);
   }, /You cannot set `data-bar` manually and via `{{bind-attr}}` helper on the same element/);
 });
+
+QUnit.test("src attribute bound to undefined is not present", function() {
+  var template = compile("<img {{bind-attr src=view.undefinedValue}}>");
+
+  view = EmberView.create({
+    template: template,
+    undefinedValue: undefined
+  });
+
+  runAppend(view);
+
+  ok(!view.element.hasAttribute('src'), "src attribute not present");
+});
+
+QUnit.test("src attribute bound to null is not present", function() {
+  var template = compile("<img {{bind-attr src=view.nullValue}}>");
+
+  view = EmberView.create({
+    template: template,
+    nullValue: null
+  });
+
+  runAppend(view);
+
+  ok(!view.element.hasAttribute('src'), "src attribute not present");
+});

--- a/packages/ember-views/lib/attr_nodes/legacy_bind.js
+++ b/packages/ember-views/lib/attr_nodes/legacy_bind.js
@@ -22,7 +22,11 @@ LegacyBindAttrNode.prototype.render = function render(buffer) {
   }
   var value = read(this.attrValue);
 
-  if (this.attrName === 'value' && (value === null || value === undefined)) {
+  if (value === undefined) {
+    value = null;
+  }
+
+  if (this.attrName === 'value' && value === null) {
     value = '';
   }
 


### PR DESCRIPTION
With bind-attr, an undefined value should mean "remove this attribute". This restores that functionality. For attrs set by setAttribute, `null` will remove them.

Closes https://github.com/emberjs/ember.js/issues/10395
