### PR TITLE
[BUGFIX]: use setter to set controller property on route

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1050,7 +1050,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     // Assign the route's controller so that it can more easily be
     // referenced in action handlers
-    this.controller = controller;
+    set(this, 'controller', controller);
 
     if (this.setupControllers) {
       Ember.deprecate("Ember.Route.setupControllers is deprecated. Please use Ember.Route.setupController(controller, model) instead.");


### PR DESCRIPTION
Received this error when trying to call `refresh()` on my route:

```
Error while processing route: invitations.index Assertion Failed: You must use Ember.set() to set the `controller` property (of <aappname@route:invitations/index::ember921>) to `<appname@controller:invitations/index::ember862>`. Error: Assertion Failed: You must use Ember.set() to set the `controller` property (of <appname@route:invitations/index::ember921>) to `<appname@controller:invitations/index::ember862>`.
    at new Error (native)
    at Error.EmberError (http://localhost:4200/assets/vendor.js:27294:23)
    at Object.Ember.assert (http://localhost:4200/assets/vendor.js:17447:15)
    at SETTER_FUNCTION [as controller] (http://localhost:4200/assets/vendor.js:30616:15)
    at EmberObject.extend.setup (http://localhost:4200/assets/vendor.js:38119:25)
    at applyHook (http://localhost:4200/assets/vendor.js:61204:30)
    at callHook (http://localhost:4200/assets/vendor.js:61198:14)
    at handlerEnteredOrUpdated (http://localhost:4200/assets/vendor.js:59957:7)
    at http://localhost:4200/assets/vendor.js:59920:18
    at forEach (http://localhost:4200/assets/vendor.js:61088:54)
```
