### PR TITLE
Move beforeRender/afterRender into the legacy bin

### DIFF
--- a/packages/ember-views/lib/mixins/legacy_view_support.js
+++ b/packages/ember-views/lib/mixins/legacy_view_support.js
@@ -3,6 +3,10 @@ import { Mixin } from "ember-metal/mixin";
 import { get } from "ember-metal/property_get";
 
 var LegacyViewSupport = Mixin.create({
+  beforeRender: function(buffer) {},
+
+  afterRender: function(buffer) {},
+
   mutateChildViews: function(callback) {
     var childViews = this._childViews;
     var idx = childViews.length;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1174,10 +1174,6 @@ var View = CoreView.extend(
   */
   parentViewDidChange: K,
 
-  beforeRender: function(buffer) {},
-
-  afterRender: function(buffer) {},
-
   applyAttributesToBuffer: function(buffer) {
     // Creates observers for all registered class name and attribute bindings,
     // then adds them to the element.


### PR DESCRIPTION
As requested by @krisselden 

@mmun @rwjblue 
