### PR TITLE
Explicit renderToElement API

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1008,9 +1008,7 @@ var View = CoreView.extend(
   renderToElement: function() {
     var element = this.renderer._dom.createElement('body');
 
-    run(this, function() {
-      this.renderer.appendTo(this, element);
-    });
+    this.renderer.appendTo(this, element);
 
     return element;
   },

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -993,6 +993,29 @@ var View = CoreView.extend(
   },
 
   /**
+    @private
+
+    Renders the view into `body` element and returns the element.
+
+    This method is useful if you want to render the view into an element that
+    is not in the document's body. Instead, a new `body` element, detached from
+    the DOM is returned. FastBoot uses this to serialize the rendered view into
+    a string for transmission over the network.
+
+    @method renderToElement
+    @return {HTMLBodyElement} element
+  */
+  renderToElement: function() {
+    var element = this.renderer._dom.createElement('body');
+
+    run(this, function() {
+      this.renderer.appendTo(this, element);
+    });
+
+    return element;
+  },
+
+  /**
     Replaces the content of the specified parent element with this view's
     element. If the view does not have an HTML representation yet,
     the element will be generated automatically.
@@ -1087,7 +1110,8 @@ var View = CoreView.extend(
 
   /**
     Creates a DOM representation of the view and all of its child views by
-    recursively calling the `render()` method.
+    recursively calling the `render()` method. Once the element is created,
+    it sets the `element` property of the view to the rendered element.
 
     After the element has been inserted into the DOM, `didInsertElement` will
     be called on this view and all of its child views.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -995,21 +995,52 @@ var View = CoreView.extend(
   /**
     @private
 
-    Renders the view into `body` element and returns the element.
+    Creates a new DOM element, renders the view into it, then returns the
+    element.
+
+    By default, the element created and rendered into will be a `BODY` element,
+    since this is the default context that views are rendered into when being
+    inserted directly into the DOM.
+
+    ```js
+    var element = view.renderToElement();
+    element.tagName; // => "BODY"
+    ```
+
+    You can override the kind of element rendered into and returned by
+    specifying an optional tag name as the first argument.
+
+    ```js
+    var element = view.renderToElement('table');
+    element.tagName; // => "TABLE"
+    ```
 
     This method is useful if you want to render the view into an element that
     is not in the document's body. Instead, a new `body` element, detached from
     the DOM is returned. FastBoot uses this to serialize the rendered view into
     a string for transmission over the network.
 
+    ```js
+    app.visit('/').then(function(instance) {
+      var element;
+      Ember.run(function() {
+        element = renderToElement(instance);
+      });
+
+      res.send(serialize(element));
+    });
+    ```
+
     @method renderToElement
+    @param {String} tagName The tag of the element to create and render into. Defaults to "body".
     @return {HTMLBodyElement} element
   */
-  renderToElement: function() {
-    var element = this.renderer._dom.createElement('body');
+  renderToElement: function(tagName) {
+    tagName = tagName || 'body';
+
+    var element = this.renderer._dom.createElement(tagName);
 
     this.renderer.appendTo(this, element);
-
     return element;
   },
 

--- a/packages/ember-views/tests/views/view/render_to_element_test.js
+++ b/packages/ember-views/tests/views/view/render_to_element_test.js
@@ -1,0 +1,55 @@
+import { get } from "ember-metal/property_get";
+import run from "ember-metal/run_loop";
+import EmberView from "ember-views/views/view";
+
+import compile from "ember-template-compiler/system/compile";
+
+var View, view;
+
+QUnit.module("EmberView - renderToElement()", {
+  setup: function() {
+    View = EmberView.extend({
+      template: compile('<h1>hello world</h1> goodbye world')
+    });
+  },
+
+  teardown: function() {
+    run(function() {
+      if (!view.isDestroyed) { view.destroy(); }
+    });
+  }
+});
+
+QUnit.test("should render into and return a body element", function() {
+  view = View.create();
+
+  ok(!get(view, 'element'), "precond - should not have an element");
+
+  var element;
+
+  run(function() {
+    element = view.renderToElement();
+  });
+
+  equal(element.tagName, "BODY", "returns a body element");
+  equal(element.firstChild.tagName, "DIV", "renders the view div");
+  equal(element.firstChild.firstChild.tagName, "H1", "renders the view div");
+  equal(element.firstChild.firstChild.nextSibling.textContent, " goodbye world", "renders the text node");
+});
+
+QUnit.test("should create and render into an element with a provided tagName", function() {
+  view = View.create();
+
+  ok(!get(view, 'element'), "precond - should not have an element");
+
+  var element;
+
+  run(function() {
+    element = view.renderToElement('div');
+  });
+
+  equal(element.tagName, "DIV", "returns a body element");
+  equal(element.firstChild.tagName, "DIV", "renders the view div");
+  equal(element.firstChild.firstChild.tagName, "H1", "renders the view div");
+  equal(element.firstChild.firstChild.nextSibling.textContent, " goodbye world", "renders the text node");
+});

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -82,6 +82,15 @@ function registerTemplates(app, templates) {
   });
 }
 
+function renderToElement(instance) {
+  var element;
+  Ember.run(function() {
+    element = instance.view.renderToElement();
+  });
+
+  return element;
+}
+
 function assertHTMLMatches(actualElement, expectedHTML) {
   var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
   var serialized = serializer.serialize(actualElement);
@@ -180,7 +189,7 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
     app.visit('/').then(function(instance) {
       QUnit.start();
 
-      var element = instance.view.renderToElement();
+      var element = renderToElement(instance);
 
       assertHTMLMatches(element.firstChild, /^<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" class="ember-view" href="\/photos">Go to photos<\/a><\/h1><\/div>$/);
     });
@@ -211,7 +220,7 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
     app.visit('/').then(function(instance) {
       QUnit.start();
 
-      var element = instance.view.renderToElement();
+      var element = renderToElement(instance);
 
       assertHTMLMatches(element.firstChild, /<div id="ember(.*)" class="ember-view"><p><span>index<\/span><\/p><\/div>/);
     });
@@ -219,7 +228,7 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
     app.visit('/photos').then(function(instance) {
       QUnit.start();
 
-      var element = instance.view.renderToElement();
+      var element = renderToElement(instance);
 
       assertHTMLMatches(element.firstChild, /<div id="ember(.*)" class="ember-view"><p><em>photos<\/em><\/p><\/div>/);
     });

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -64,7 +64,7 @@ function registerDOMHelper(app) {
     initialize: function(app) {
       app.registry.register('renderer:-dom', {
         create: function() {
-          return new Ember.View._Renderer(domHelper);
+          return new Ember.View._Renderer(domHelper, false);
         }
       });
     }

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -28,186 +28,11 @@ var compile = require(path.join(distPath, 'ember-template-compiler')).compile;
 Ember.testing = true;
 var DOMHelper = Ember.View.DOMHelper;
 var SimpleDOM = require('simple-dom');
+var URL = require('url');
 
-QUnit.module("App boot");
+var run = Ember.run;
 
-if (canUseInstanceInitializers && canUseApplicationVisit) {
-
-  QUnit.test("App is created without throwing an exception", function() {
-    var App;
-    var domHelper = new DOMHelper(new SimpleDOM.Document());
-
-    Ember.run(function() {
-
-      App = createApplication();
-
-      App.instanceInitializer({
-        name: 'stub-renderer',
-        initialize: function(app) {
-          app.registry.register('renderer:-dom', {
-            create: function() {
-              return new Ember.View._Renderer(domHelper);
-            }
-          });
-        }
-      });
-
-      App.visit('/');
-    });
-
-    QUnit.ok(App);
-  });
-
-  QUnit.test("It is possible to render a view with {{link-to}} in Node", function() {
-    QUnit.stop();
-
-    var run = Ember.run;
-    var app;
-    var URL = require('url');
-    var document = new SimpleDOM.Document();
-
-    var domHelper = new DOMHelper(document);
-    domHelper.protocolForURL = function(url) {
-      var protocol = URL.parse(url).protocol;
-      return (protocol == null) ? ':' : protocol;
-    };
-
-    run(function() {
-      app = createApplication();
-
-      app.Router.map(function() {
-        this.route('photos');
-      });
-
-      app.instanceInitializer({
-        name: 'register-application-template',
-        initialize: function(app) {
-          app.registry.register('renderer:-dom', {
-            create: function() {
-              return new Ember.View._Renderer(domHelper);
-            }
-          });
-          app.registry.register('template:application', compile("<h1>{{#link-to 'photos'}}Go to photos{{/link-to}}</h1>"));
-        }
-      });
-    });
-
-    app.visit('/').then(function(instance) {
-      QUnit.start();
-
-      var morph = {
-        contextualElement: document.body,
-        setContent: function(element) {
-          this.element = element;
-        }
-      };
-
-      var view = instance.view;
-
-      view._morph = morph;
-
-      var renderer = view.renderer;
-
-      run(function() {
-        renderer.renderTree(view);
-      });
-
-      var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-      var serialized = serializer.serialize(morph.element);
-      ok(serialized.match(/href="\/photos"/), "Rendered output contains /photos: " + serialized);
-    });
-  });
-}
-
-QUnit.test("It is possible to render a view in Node", function() {
-  var View = Ember.View.extend({
-    renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
-    template: compile("<h1>Hello</h1>")
-  });
-
-  var morph = {
-    contextualElement: {},
-    setContent: function(element) {
-      this.element = element;
-    }
-  };
-
-  var view = View.create({
-    _domHelper: new DOMHelper(new SimpleDOM.Document()),
-    _morph: morph
-  });
-
-  var renderer = view.renderer;
-
-  Ember.run(function() {
-    renderer.renderTree(view);
-  });
-
-  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-  ok(serializer.serialize(morph.element).match(/<h1>Hello<\/h1>/));
-});
-
-QUnit.test("It is possible to render a view with curlies in Node", function() {
-  var View = Ember.Component.extend({
-    renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
-    layout: compile("<h1>Hello {{location}}</h1>"),
-    location: "World"
-  });
-
-  var morph = {
-    contextualElement: {},
-    setContent: function(element) {
-      this.element = element;
-    }
-  };
-
-  var view = View.create({
-    _domHelper: new DOMHelper(new SimpleDOM.Document()),
-    _morph: morph
-  });
-
-  var renderer = view.renderer;
-
-  Ember.run(function() {
-    renderer.renderTree(view);
-  });
-
-  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-  ok(serializer.serialize(morph.element).match(/<h1>Hello World<\/h1>/));
-});
-
-QUnit.test("It is possible to render a view with a nested {{view}} helper in Node", function() {
-  var View = Ember.Component.extend({
-    renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
-    layout: compile("<h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1> <div>{{view bar}}</div>"),
-    location: "World",
-    hasExistence: true,
-    bar: Ember.View.extend({
-      template: compile("<p>The files are *inside* the computer?!</p>")
-    })
-  });
-
-  var morph = {
-    contextualElement: {},
-    setContent: function(element) {
-      this.element = element;
-    }
-  };
-
-  var view = View.create({
-    _domHelper: new DOMHelper(new SimpleDOM.Document()),
-    _morph: morph
-  });
-
-  var renderer = view.renderer;
-
-  Ember.run(function() {
-    renderer.renderTree(view);
-  });
-
-  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
-  ok(serializer.serialize(morph.element).match(/<h1>Hello World<\/h1> <div><div id="(.*)" class="ember-view"><p>The files are \*inside\* the computer\?\!<\/p><\/div><\/div>/));
-});
+var domHelper = createDOMHelper();
 
 function createApplication() {
   var App = Ember.Application.extend().create({
@@ -219,4 +44,184 @@ function createApplication() {
   });
 
   return App;
+}
+
+function createDOMHelper() {
+  var document = new SimpleDOM.Document();
+  var domHelper = new DOMHelper(document);
+
+  domHelper.protocolForURL = function(url) {
+    var protocol = URL.parse(url).protocol;
+    return (protocol == null) ? ':' : protocol;
+  };
+
+  return domHelper;
+}
+
+function registerDOMHelper(app) {
+  app.instanceInitializer({
+    name: 'register-dom-helper',
+    initialize: function(app) {
+      app.registry.register('renderer:-dom', {
+        create: function() {
+          return new Ember.View._Renderer(domHelper);
+        }
+      });
+    }
+  });
+}
+
+function registerTemplates(app, templates) {
+  app.instanceInitializer({
+    name: 'register-application-template',
+    initialize: function(app) {
+      for (var key in templates) {
+        app.registry.register('template:' + key, compile(templates[key]));
+      }
+    }
+  });
+}
+
+function assertHTMLMatches(actualElement, expectedHTML) {
+  var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+  var serialized = serializer.serialize(actualElement);
+  ok(serialized.match(expectedHTML), serialized + " matches " + expectedHTML);
+}
+
+
+QUnit.module("App boot");
+
+if (canUseInstanceInitializers && canUseApplicationVisit) {
+  QUnit.test("App is created without throwing an exception", function() {
+    var app;
+
+    Ember.run(function() {
+      app = createApplication();
+      registerDOMHelper(app);
+
+      app.visit('/');
+    });
+
+    QUnit.ok(app);
+  });
+
+  QUnit.test("It is possible to render a view in Node", function() {
+    var View = Ember.View.extend({
+      renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
+      template: compile("<h1>Hello</h1>")
+    });
+
+    var view = View.create({
+      _domHelper: new DOMHelper(new SimpleDOM.Document()),
+    });
+
+    run(view, view.createElement);
+
+    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    ok(serializer.serialize(view.element).match(/<h1>Hello<\/h1>/));
+  });
+
+  QUnit.test("It is possible to render a view with curlies in Node", function() {
+    var View = Ember.Component.extend({
+      renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
+      layout: compile("<h1>Hello {{location}}</h1>"),
+      location: "World"
+    });
+
+    var view = View.create({
+      _domHelper: new DOMHelper(new SimpleDOM.Document())
+    });
+
+    run(view, view.createElement);
+
+    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    ok(serializer.serialize(view.element).match(/<h1>Hello World<\/h1>/));
+  });
+
+  QUnit.test("It is possible to render a view with a nested {{view}} helper in Node", function() {
+    var View = Ember.Component.extend({
+      renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
+      layout: compile("<h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1> <div>{{view bar}}</div>"),
+      location: "World",
+      hasExistence: true,
+      bar: Ember.View.extend({
+        template: compile("<p>The files are *inside* the computer?!</p>")
+      })
+    });
+
+    var view = View.create({
+      _domHelper: new DOMHelper(new SimpleDOM.Document())
+    });
+
+    run(view, view.createElement);
+
+    var serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    ok(serializer.serialize(view.element).match(/<h1>Hello World<\/h1> <div><div id="(.*)" class="ember-view"><p>The files are \*inside\* the computer\?\!<\/p><\/div><\/div>/));
+  });
+
+  QUnit.test("It is possible to render a view with {{link-to}} in Node", function() {
+    QUnit.stop();
+
+    var app;
+
+    run(function() {
+      app = createApplication();
+
+      app.Router.map(function() {
+        this.route('photos');
+      });
+
+      registerDOMHelper(app);
+      registerTemplates(app, {
+        application: "<h1>{{#link-to 'photos'}}Go to photos{{/link-to}}</h1>"
+      });
+    });
+
+    app.visit('/').then(function(instance) {
+      QUnit.start();
+
+      var element = instance.view.renderToElement();
+
+      assertHTMLMatches(element.firstChild, /^<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" class="ember-view" href="\/photos">Go to photos<\/a><\/h1><\/div>$/);
+    });
+  });
+
+  QUnit.test("It is possible to render outlets in Node", function() {
+    QUnit.stop();
+    QUnit.stop();
+
+    var run = Ember.run;
+    var app;
+
+    run(function() {
+      app = createApplication();
+
+      app.Router.map(function() {
+        this.route('photos');
+      });
+
+      registerDOMHelper(app);
+      registerTemplates(app, {
+        application: "<p>{{outlet}}</p>",
+        index: "<span>index</span>",
+        photos: "<em>photos</em>"
+      });
+    });
+
+    app.visit('/').then(function(instance) {
+      QUnit.start();
+
+      var element = instance.view.renderToElement();
+
+      assertHTMLMatches(element.firstChild, /<div id="ember(.*)" class="ember-view"><p><span>index<\/span><\/p><\/div>/);
+    });
+
+    app.visit('/photos').then(function(instance) {
+      QUnit.start();
+
+      var element = instance.view.renderToElement();
+
+      assertHTMLMatches(element.firstChild, /<div id="ember(.*)" class="ember-view"><p><em>photos<\/em><\/p><\/div>/);
+    });
+  });
 }


### PR DESCRIPTION
The previous Node rendering tests were fairly brittle due to them faking out a Morph and overriding Ember.View’s `_morph` property. Indeed, this was just a short-term hack and the actual FastBoot API departed from it.

Because of test brittleness, the recent outlet refactor inadvertently broke FastBoot without triggering any failing tests. The root cause of the failure was because changed the application’s root view to be tag-less, breaking the assumption that the root view would always have an element.

This commit makes explicit the API for rendering an an application’s view hierarchy into an element detached from the document body.

In particular, the existing implementation of `appendTo` is unsuitable because it relies on jQuery to normalize selectors into elements. In FastBoot, jQuery is not available.

Instead, we introduce a new `renderToElement` method that creates a new, detached `body` element and instructs Ember to render the view inside that element. Once rendering is complete, the `body` element is
returned. Consumers of the API can use the contents of that element however they wish without modifying the stateful document body.

Additionally, by making the tests use the same API as FastBoot, we can ensure future commits do not break FastBoot rendering.
