### PR TITLE
Fixes typo in enumerable > reject() documentation

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -405,7 +405,7 @@ export default Mixin.create({
 
   /**
     Returns an array with all of the items in the enumeration where the passed
-    function returns false for. This method is the inverse of filter().
+    function returns true. This method is the inverse of filter().
 
     The callback method you provide should have the following signature (all
     parameters are optional):


### PR DESCRIPTION
Documention currently states the opposite for how reject() works. If the passed function returns true, then the item is rejected.
