### PR TITLE
[BUGFIX beta] fix named outlet rendering in topmost view

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1957,16 +1957,8 @@ function buildRenderOptions(route, namePassed, isDefaultRender, name, options) {
 
   Ember.assert("An outlet ("+outlet+") was specified but was not found.", outlet === 'main' || into);
 
-  Ember.assert(
-    "You attempted to render into '" + into + "' but it was not found",
-    !into || Ember.A(route.router.router.state.handlerInfos).any(function(info) {
-      return Ember.A(info.handler.connections || []).any(function(conn) {
-        return conn.name === into;
-      });
-    })
-  );
-
-  if (into && into === parentRoute(route).routeName) {
+  var parent;
+  if (into && (parent = parentRoute(route)) && into === parentRoute(route).routeName) {
     into = undefined;
   }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -191,7 +191,6 @@ var EmberRouter = EmberObject.extend(Evented, {
   _setOutlets: function() {
     var handlerInfos = this.router.currentHandlerInfos;
     var route;
-    var parentRoute;
     var defaultParentState;
     var liveRoutes = null;
 
@@ -201,21 +200,15 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     for (var i = 0; i < handlerInfos.length; i++) {
       route = handlerInfos[i].handler;
-
-      var connections = (route.connections.length > 0) ? route.connections : [{
-          name: route.routeName,
-          outlet: 'main'
-      }];
-
+      var connections = normalizedConnections(route);
       var ownState;
       for (var j = 0; j < connections.length; j++) {
-        var appended = appendLiveRoute(liveRoutes, route, parentRoute, defaultParentState, connections[j]);
+        var appended = appendLiveRoute(liveRoutes, defaultParentState, connections[j]);
         liveRoutes = appended.liveRoutes;
         if (appended.ownState.render.name === route.routeName) {
           ownState = appended.ownState;
         }
       }
-      parentRoute = route;
       defaultParentState = ownState;
     }
     if (!this._toplevelView) {
@@ -994,6 +987,7 @@ function forEachQueryParam(router, targetRouteName, queryParams, callback) {
 }
 
 function findLiveRoute(liveRoutes, name) {
+  if (!liveRoutes) { return; }
   var stack = [liveRoutes];
   while (stack.length > 0) {
     var test = stack.shift();
@@ -1007,17 +1001,12 @@ function findLiveRoute(liveRoutes, name) {
   }
 }
 
-function appendLiveRoute(liveRoutes, route, parentRoute, defaultParentState, renderOptions) {
-  var targetName;
+function appendLiveRoute(liveRoutes, defaultParentState, renderOptions) {
   var target;
   var myState = {
     render: renderOptions,
     outlets: create(null)
   };
-  if (!parentRoute) {
-    liveRoutes = myState;
-  }
-  targetName = renderOptions.into || (parentRoute && parentRoute.routeName);
   if (renderOptions.into) {
     target = findLiveRoute(liveRoutes, renderOptions.into);
   } else {
@@ -1025,6 +1014,9 @@ function appendLiveRoute(liveRoutes, route, parentRoute, defaultParentState, ren
   }
   if (target) {
     set(target.outlets, renderOptions.outlet, myState);
+  } else {
+    Ember.assert("You attempted to render into '" + renderOptions.into + "' but it was not found", !renderOptions.into);
+    liveRoutes = myState;
   }
   return {
     liveRoutes: liveRoutes,
@@ -1032,6 +1024,34 @@ function appendLiveRoute(liveRoutes, route, parentRoute, defaultParentState, ren
   };
 }
 
+function normalizedConnections(route) {
+  var connections = route.connections;
+  var mainConnections = [];
+  var otherConnections = [];
+
+  for (var i = 0; i < connections.length; i++) {
+    var connection = connections[i];
+    if (connection.outlet === 'main') {
+      mainConnections.push(connection);
+    } else {
+      otherConnections.push(connection);
+    }
+  }
+
+  if (mainConnections.length === 0) {
+    // There's always an entry to represent the route, even if it
+    // doesn't actually render anything into its own
+    // template. This gives other routes a place to target.
+    mainConnections.push({
+      name: route.routeName,
+      outlet: 'main'
+    });
+  }
+
+  // We process main connections first, because a main connection may
+  // be targeted by other connections.
+  return mainConnections.concat(otherConnections);
+}
 
 
 export default EmberRouter;

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3479,3 +3479,74 @@ QUnit.test("Can rerender application view multiple times when it contains an out
 
   equal(Ember.$('#qunit-fixture').text(), "AppHello world", "third render");
 });
+
+QUnit.test("Can render into a named outlet at the top level", function() {
+  Ember.TEMPLATES.application = compile("A-{{outlet}}-B-{{outlet \"other\"}}-C");
+  Ember.TEMPLATES.modal = compile("Hello world");
+  Ember.TEMPLATES.index = compile("The index");
+
+  registry.register('route:application', Ember.Route.extend({
+    renderTemplate: function() {
+      this.render();
+      this.render('modal', {
+        into: 'application',
+        outlet: 'other'
+      });
+    }
+  }));
+
+  bootApplication();
+
+  equal(Ember.$('#qunit-fixture').text(), "A-The index-B-Hello world-C", "initial render");
+});
+
+QUnit.test("Can render into a named outlet at the top level, with empty main outlet", function() {
+  Ember.TEMPLATES.application = compile("A-{{outlet}}-B-{{outlet \"other\"}}-C");
+  Ember.TEMPLATES.modal = compile("Hello world");
+
+  Router.map(function() {
+    this.route('hasNoTemplate', { path: '/' });
+  });
+
+  registry.register('route:application', Ember.Route.extend({
+    renderTemplate: function() {
+      this.render();
+      this.render('modal', {
+        into: 'application',
+        outlet: 'other'
+      });
+    }
+  }));
+
+  bootApplication();
+
+  equal(Ember.$('#qunit-fixture').text(), "A--B-Hello world-C", "initial render");
+});
+
+
+QUnit.test("Can render into a named outlet at the top level, later", function() {
+  Ember.TEMPLATES.application = compile("A-{{outlet}}-B-{{outlet \"other\"}}-C");
+  Ember.TEMPLATES.modal = compile("Hello world");
+  Ember.TEMPLATES.index = compile("The index");
+
+  registry.register('route:application', Ember.Route.extend({
+    actions: {
+      launch: function() {
+        this.render('modal', {
+          into: 'application',
+          outlet: 'other'
+        });
+      }
+    }
+  }));
+
+  bootApplication();
+
+  equal(Ember.$('#qunit-fixture').text(), "A-The index-B--C", "initial render");
+
+  Ember.run(router, 'send', 'launch');
+
+  //debugger;
+  //router._setOutlets();
+  equal(Ember.$('#qunit-fixture').text(), "A-The index-B-Hello world-C", "second render");
+});


### PR DESCRIPTION
Closes #10416, plus another bug that I found while making sure we had good test coverage of this area.
- Don't assume any route rendering `{into:...}` always has a parent route.
- Allow `render` to target non-default outlets in the current route even when you haven't rendered anything to the main outlet.
