### PR TITLE
Update emberjs-build to v0.0.28.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -9,6 +9,7 @@ var EmberBuild = require('emberjs-build');
 var packages   = require('./lib/packages');
 
 var emberBuild = new EmberBuild({
+  htmlbars: require('htmlbars'),
   packages: packages
 });
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ember-cli": "0.1.12",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.0.27",
+    "emberjs-build": "0.0.28",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",


### PR DESCRIPTION
Provides local copy of HTMLBars, so that we do not have to update in
both Ember and emberjs-builds in the future.
