### PR TITLE
[FEATURE ember-routing-core-outlet] Expose CoreOutletView

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,6 +5,17 @@ for a detailed explanation.
 
 ## Feature Flags
 
+* `ember-routing-core-outlet`
+
+  Provides a non-virtual version of OutletView named
+  CoreOutletView. You would use CoreOutletView just like you're use
+  OutletView: by extending it with whatever behavior you want and then
+  passing it to the `{{outlet}}` helper's `view` property.
+
+  The only difference between them is that OutletView has no element
+  of its own (it is a "virtual" view), whereas CoreOutletView has an
+  element.
+
 * `ember-application-visit`
 
   Provides an API for creating an application instance and specifying

--- a/features.json
+++ b/features.json
@@ -16,7 +16,8 @@
     "ember-application-initializer-context": null,
     "ember-router-willtransition": true,
     "ember-application-visit": null,
-    "ember-views-component-block-info": null
+    "ember-views-component-block-info": null,
+    "ember-routing-core-outlet": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing-views/lib/main.js
+++ b/packages/ember-routing-views/lib/main.js
@@ -9,9 +9,15 @@ Ember Routing Views
 import Ember from "ember-metal/core";
 
 import { LinkView } from "ember-routing-views/views/link";
-import { OutletView } from "ember-routing-views/views/outlet";
+import {
+  OutletView,
+  CoreOutletView
+} from "ember-routing-views/views/outlet";
 
 Ember.LinkView = LinkView;
 Ember.OutletView = OutletView;
+if (Ember.FEATURES.isEnabled('ember-routing-core-outlet')) {
+  Ember.CoreOutletView = CoreOutletView;
+}
 
 export default Ember;


### PR DESCRIPTION
Addons like liquid-fire that want to provide extended outlet behavior
using non-virtual views used to be able to just extend `ContainerView`,
because `OutletView` was implemented as just
`ContainerView.extend(_Metamorph)`.

But now that we've moved a bunch of the outlet rendering logic into the
outlet view itself, the only way to implement a non-virtual outlet is to
use `CoreOutletView`, which is not exposed outside of Ember.

`CoreOutletView` and `OutletView` are identical except for the fact that one
is virtual and one is not, so the exposed API surface is not
meaningfully increasing.
