### PR TITLE
[BUGFIX beta] Make new outlets fastboot-compatible

### DIFF
--- a/packages/ember-routing-views/lib/views/outlet.js
+++ b/packages/ember-routing-views/lib/views/outlet.js
@@ -24,7 +24,7 @@ export var CoreOutletView = ContainerView.extend({
     return parent;
   },
 
-  _linkParent: Ember.on('didInsertElement', function() {
+  _linkParent: Ember.on('init', 'parentViewDidChange', function() {
     var parent = this._parentOutlet();
     if (parent) {
       parent._childOutlets.push(this);


### PR DESCRIPTION
At the request of @tomdale I updated my refactored outlet implementation
to not depend on didInsertElement, so that it's easier to integrate with FastBoot™.

It only required a very tiny change.
