### PR TITLE
[BUGFIX beta] Ember.OutletView was unintentionally not exported

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -47,7 +47,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
   @extends Ember.View
   @see {Handlebars.helpers.link-to}
 **/
-var LinkView = Ember.LinkView = EmberComponent.extend({
+var LinkView = EmberComponent.extend({
   tagName: 'a',
 
   /**

--- a/packages/ember-routing-views/tests/main_test.js
+++ b/packages/ember-routing-views/tests/main_test.js
@@ -1,4 +1,3 @@
-import "ember-routing-views";
 import Ember from 'ember-metal/core';
 
 QUnit.module("ember-routing-views");

--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -8,6 +8,7 @@ import "ember-application";
 import "ember-extension-support";
 import "ember-htmlbars";
 import "ember-routing-htmlbars";
+import "ember-routing-views";
 
 import environment from "ember-metal/environment";
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';


### PR DESCRIPTION
`ember-routing-views/main` was only getting required by tests, not by the actual build.

As far as I can tell from crawling the commit logs, this has never actually worked before.
