### PR TITLE
Fix async test helpers

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -4,6 +4,7 @@ import EmberError from "ember-metal/error";
 import run from "ember-metal/run_loop";
 import jQuery from "ember-views/system/jquery";
 import Test from "ember-testing/test";
+import RSVP from "ember-runtime/ext/rsvp";
 
 /**
 * @module ember
@@ -12,7 +13,6 @@ import Test from "ember-testing/test";
 
 var helper = Test.registerHelper;
 var asyncHelper = Test.registerAsyncHelper;
-var countAsync = 0;
 
 function currentRouteName(app) {
   var appController = app.__container__.lookup('controller:application');
@@ -199,12 +199,7 @@ function andThen(app, callback) {
 }
 
 function wait(app, value) {
-  return Test.promise(function(resolve) {
-    // If this is the first async promise, kick off the async test
-    if (++countAsync === 1) {
-      Test.adapter.asyncStart();
-    }
-
+  return new RSVP.Promise(function(resolve) {
     // Every 10ms, poll for the async thing to have finished
     var watcher = setInterval(function() {
       var router = app.__container__.lookup('router:main');
@@ -227,11 +222,6 @@ function wait(app, value) {
       }
       // Stop polling
       clearInterval(watcher);
-
-      // If this is the last async promise, end the async test
-      if (--countAsync === 0) {
-        Test.adapter.asyncEnd();
-      }
 
       // Synchronously resolve the promise
       run(null, resolve, value);

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -281,7 +281,7 @@ function helper(app, name) {
 
   return function() {
     var args = slice.call(arguments);
-    var lastPromise = Test.lastPromise;
+    var lastPromise;
 
     args.unshift(app);
 
@@ -292,35 +292,28 @@ function helper(app, name) {
       return fn.apply(app, args);
     }
 
-    if (!lastPromise) {
-      // It's the first async helper in current context
-      lastPromise = fn.apply(app, args);
-    } else {
-      // wait for last helper's promise to resolve and then
-      // execute. To be safe, we need to tell the adapter we're going
-      // asynchronous here, because fn may not be invoked before we
-      // return.
-      Test.adapter.asyncStart();
-      run(function() {
-        lastPromise = Test.resolve(lastPromise).then(function() {
-          try {
-            return fn.apply(app, args);
-          } finally {
-            Test.adapter.asyncEnd();
-          }
-        });
-      });
-    }
+    lastPromise = run(function() {
+      return Test.resolve(Test.lastPromise);
+    });
 
-    return lastPromise;
+    // wait for last helper's promise to resolve and then
+    // execute. To be safe, we need to tell the adapter we're going
+    // asynchronous here, because fn may not be invoked before we
+    // return.
+    Test.adapter.asyncStart();
+    return lastPromise.then(function() {
+      return fn.apply(app, args);
+    }).finally(function() {
+      Test.adapter.asyncEnd();
+    });
   };
 }
 
 function run(fn) {
   if (!emberRun.currentRunLoop) {
-    emberRun(fn);
+    return emberRun(fn);
   } else {
-    fn();
+    return fn();
   }
 }
 
@@ -484,6 +477,7 @@ Test.Promise = function() {
 
 Test.Promise.prototype = create(RSVP.Promise.prototype);
 Test.Promise.prototype.constructor = Test.Promise;
+Test.Promise.resolve = Test.resolve;
 
 // Patch `then` to isolate async methods
 // specifically `Ember.Test.lastPromise`
@@ -500,7 +494,6 @@ Test.Promise.prototype.then = function(onSuccess, onFailure) {
 // 1. Set `Ember.Test.lastPromise` to null
 // 2. Invoke method
 // 3. Return the last promise created during method
-// 4. Restore `Ember.Test.lastPromise` to original value
 function isolate(fn, val) {
   var value, lastPromise;
 
@@ -510,6 +503,7 @@ function isolate(fn, val) {
   value = fn(val);
 
   lastPromise = Test.lastPromise;
+  Test.lastPromise = null;
 
   // If the method returned a promise
   // return that promise. If not,
@@ -517,12 +511,11 @@ function isolate(fn, val) {
   if ((value && (value instanceof Test.Promise)) || !lastPromise) {
     return value;
   } else {
-    run(function() {
-      lastPromise = Test.resolve(lastPromise).then(function() {
+    return run(function() {
+      return Test.resolve(lastPromise).then(function() {
         return value;
       });
     });
-    return lastPromise;
   }
 }
 

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -7,6 +7,7 @@ import "ember-testing/initializers"; // ensure the initializer is setup
 import EmberApplication from "ember-application/system/application";
 import EmberRoute from "ember-routing/system/route";
 import compile from "ember-template-compiler/system/compile";
+import RSVP from "ember-runtime/ext/rsvp";
 
 //ES6TODO: we need {{link-to}}  and {{outlet}} to exist here
 import "ember-routing"; //ES6TODO: fixme?
@@ -70,7 +71,7 @@ QUnit.module("ember-testing Acceptance", {
     });
 
     Test.registerAsyncHelper('slowHelper', function() {
-      return Test.promise(function(resolve) {
+      return new RSVP.Promise(function(resolve) {
         setTimeout(resolve, 10);
       });
     });

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -643,9 +643,9 @@ if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
     visit = App.testHelpers.visit;
 
     visit('/').then(function() {
-      expectAssertion(function() {
-        check('#text');
-      }, /must be a checkbox/);
+      check('#text').catch(function(error) {
+        ok(/must be a checkbox/.test(error.message));
+      });
     });
   });
 
@@ -662,9 +662,9 @@ if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
     uncheck = App.testHelpers.uncheck;
 
     visit('/').then(function() {
-      expectAssertion(function() {
-        uncheck('#text');
-      }, /must be a checkbox/);
+      uncheck('#text').catch(function(error) {
+        ok(/must be a checkbox/.test(error.message));
+      });
     });
   });
 }


### PR DESCRIPTION
Refactored async helpers to be more robust and fixed some issues with the previous implementation. Before now you couldn't block an async helper by returning any promise.

This didn't work (but now does):

``` javascript
Ember.Test.registerAsyncHelper('sleep', function(app, duration) {
  return new Ember.RSVP.Promise(function(resolve) {
    setTimeout(resolve, duration);
  });
});
```

The only two ways that worked were returning `wait` or using `Ember.Test.promise` which shouldn't be public api.

``` javascript
Ember.Test.registerAsyncHelper('sleep', function(app, duration) {
  let promise = new Ember.RSVP.Promise(function(resolve) {
    setTimeout(resolve, duration);
  });
  return wait(promise);
});

Ember.Test.registerAsyncHelper('sleep', function(app, duration) {
  return Ember.Test.promise(function(resolve) {
    setTimeout(resolve, duration);
  });
});
```

Some async helpers were also accidentally triggered synchronously if they were the first helper in a test. People should not rely on this behavior, so now all async helpers are triggered asynchronously. (The checkbox helpers were relying on this unwanted behavior so I fixed them).
