### PR TITLE
Use ember-cli-dependency-checker to help folks with dependency issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bower": "~1.3.2",
     "chalk": "^0.5.1",
     "ember-cli": "0.1.15",
+    "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
     "emberjs-build": "0.0.31",


### PR DESCRIPTION
This will provide a helpful error message when we update packages and contributors don't notice or realize that NPM doesn't always handle it properly.

When something is at the wrong version:

```
% ember s
version: 0.1.15

Missing npm packages:
Package: htmlbars
  * Specified: 0.11.1
  * Installed: 0.10.0

Run `npm install` to install missing dependencies.
```

When something is missing:

```
% ember s
version: 0.1.15

Missing bower packages:
Package: qunit
  * Specified: ~1.17.1
  * Installed: (not installed)

Run `bower install` to install missing dependencies.
```
