### PR TITLE
[BUGFIX beta] Ensure wrapped errors are logged properly.

### DIFF
--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -760,8 +760,14 @@ var defaultActionHandlers = {
   }
 };
 
-function logError(error, initialMessage) {
+function logError(_error, initialMessage) {
   var errorArgs = [];
+  var error;
+  if (_error && typeof _error === 'object' && typeof _error.errorThrown === 'object') {
+    error = _error.errorThrown;
+  } else {
+    error = _error;
+  }
 
   if (initialMessage) { errorArgs.push(initialMessage); }
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3196,6 +3196,31 @@ QUnit.test("rejecting the model hooks promise with a non-error prints the `messa
   bootApplication();
 });
 
+QUnit.test("rejecting the model hooks promise with an error with `errorThrown` property prints `errorThrown.message` property", function() {
+  var rejectedMessage = 'OMG!! SOOOOOO BAD!!!!';
+  var rejectedStack   = 'Yeah, buddy: stack gets printed too.';
+
+  Router.map(function() {
+    this.route("yippie", { path: "/" });
+  });
+
+  Ember.Logger.error = function(initialMessage, errorMessage, errorStack) {
+    equal(initialMessage, 'Error while processing route: yippie', 'a message with the current route name is printed');
+    equal(errorMessage, rejectedMessage, "the rejected reason's message property is logged");
+    equal(errorStack, rejectedStack, "the rejected reason's stack property is logged");
+  };
+
+  App.YippieRoute = Ember.Route.extend({
+    model: function() {
+      return Ember.RSVP.reject({
+        errorThrown: { message: rejectedMessage, stack: rejectedStack }
+      });
+    }
+  });
+
+  bootApplication();
+});
+
 QUnit.test("rejecting the model hooks promise with no reason still logs error", function() {
   Router.map(function() {
     this.route("wowzers", { path: "/" });


### PR DESCRIPTION
ember-data and ic-ajax tag rejections with jqxhr’s with the original error when possible. This error is appended as jqxhr.errorThrown. Logging this error, dramatically improves debugability of request related transition failures

before:

![screen shot 2015-02-16 at 7 52 46 am](https://cloud.githubusercontent.com/assets/1377/6214892/d54b3b70-b5b0-11e4-8ff9-75321d3787bc.png)

after:
![screen shot 2015-02-16 at 7 51 53 am](https://cloud.githubusercontent.com/assets/1377/6214879/c232a1b8-b5b0-11e4-94b9-17254a8644c6.png)
