### PR TITLE
[BUGFIX release] Fix an issue with bindings inside of a yielded template when the yield helper is nested inside of another view

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/content.js
+++ b/packages/ember-htmlbars/lib/hooks/content.js
@@ -22,7 +22,7 @@ export default function content(env, morph, view, path) {
   }
 
   if (isStream(result)) {
-    appendSimpleBoundView(view, morph, result);
+    appendSimpleBoundView(env.data.view, morph, result);
   } else {
     morph.setContent(result);
   }

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -284,6 +284,21 @@ QUnit.test("yield should work for views even if _parentView is null", function()
 
 });
 
+QUnit.test("simple bindings inside of a yielded template should work properly when the yield is nested inside of another view", function() {
+  view = EmberView.create({
+    layout:   compile('{{#if view.falsy}}{{else}}{{yield}}{{/if}}'),
+    template: compile("{{view.text}}"),
+    text: "ohai"
+  });
+
+  run(function() {
+    view.createElement();
+  });
+
+  equal(view.$().text(), "ohai");
+});
+
+
 QUnit.module("ember-htmlbars: Component {{yield}}", {
   setup: function() {},
   teardown: function() {


### PR DESCRIPTION
@mmun @rwjblue 

JSBin showing working 1.9 behavior: http://emberjs.jsbin.com/kejicegowi/1/edit
JSBin showing broken 1.10 behavior: http://emberjs.jsbin.com/pugeweloke/1/edit
