### PR TITLE
Make it easier to write lazy streams

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -430,7 +430,8 @@ QUnit.test("should unsubscribe stream bindings", function() {
 });
 
 function countSubscribers(stream) {
-  var count = 0, subscriber = stream.subscriberHead;
+  var count = 0;
+  var subscriber = stream.subscriberHead;
 
   while (subscriber) {
     count++;

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -420,14 +420,25 @@ QUnit.test("should unsubscribe stream bindings", function() {
 
   var barStreamBinding = view._streamBindings['view.baz'];
 
-  equal(barStreamBinding.subscribers.length, 3*2, "adds 3 subscribers");
+  equal(countSubscribers(barStreamBinding), 3, "adds 3 subscribers");
 
   run(function() {
     view.get('content').popObject();
   });
 
-  equal(barStreamBinding.subscribers.length, 2*2, "removes 1 subscriber");
+  equal(countSubscribers(barStreamBinding), 2, "removes 1 subscriber");
 });
+
+function countSubscribers(stream) {
+  var count = 0, subscriber = stream.subscriberHead;
+
+  while (subscriber) {
+    count++;
+    subscriber = subscriber.next;
+  }
+
+  return count;
+}
 
 QUnit.test("should work inside a bound {{#if}}", function() {
   var testData = A([EmberObject.create({ isBaz: false }), EmberObject.create({ isBaz: true }), EmberObject.create({ isBaz: true })]);

--- a/packages/ember-metal/lib/streams/simple.js
+++ b/packages/ember-metal/lib/streams/simple.js
@@ -6,10 +6,7 @@ import { read, isStream } from "ember-metal/streams/utils";
 function SimpleStream(source) {
   this.init();
   this.source = source;
-
-  if (isStream(source)) {
-    source.subscribe(this._didChange, this);
-  }
+  this.dependency = this.addDependency(this.source);
 }
 
 SimpleStream.prototype = create(Stream.prototype);
@@ -30,30 +27,16 @@ merge(SimpleStream.prototype, {
   setSource: function(nextSource) {
     var prevSource = this.source;
     if (nextSource !== prevSource) {
-      if (isStream(prevSource)) {
-        prevSource.unsubscribe(this._didChange, this);
-      }
-
-      if (isStream(nextSource)) {
-        nextSource.subscribe(this._didChange, this);
-      }
-
+      this.dependency.replace(nextSource);
       this.source = nextSource;
       this.notify();
     }
-  },
-
-  _didChange: function() {
-    this.notify();
   },
 
   _super$destroy: Stream.prototype.destroy,
 
   destroy: function() {
     if (this._super$destroy()) {
-      if (isStream(this.source)) {
-        this.source.unsubscribe(this._didChange, this);
-      }
       this.source = undefined;
       return true;
     }

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -30,6 +30,59 @@ Subscriber.prototype.removeFrom = function(stream) {
   } else {
     stream.subscriberTail = prev;
   }
+
+  stream.maybeDeactivate();
+};
+
+function Dependency(dependent, stream, callback, context) {
+  this.next = null;
+  this.prev = null;
+  this.dependent = dependent;
+  this.stream = stream;
+  this.callback = callback;
+  this.context = context;
+  this.unsubscription = null;
+}
+
+Dependency.prototype.subscribe = function() {
+  this.unsubscribe = this.stream.subscribe(this.callback, this.context);
+};
+
+Dependency.prototype.unsubscribe = function() {
+  this.unsubscription();
+  this.unsubscription = null;
+};
+
+Dependency.prototype.removeFrom = function(stream) {
+  var next = this.next;
+  var prev = this.prev;
+
+  if (prev) {
+    prev.next = next;
+  } else {
+    stream.dependencyHead = next;
+  }
+
+  if (next) {
+    next.prev = prev;
+  } else {
+    stream.dependencyTail = prev;
+  }
+
+  if (this.unsubscription) {
+    this.unsubscribe();
+  }
+};
+
+Dependency.prototype.replace = function(stream, callback, context) {
+  this.stream = stream;
+  this.callback = callback;
+  this.context = context;
+
+  if (this.unsubscription) {
+    this.unsubscribe();
+    this.subscribe();
+  }
 };
 
 /**
@@ -51,8 +104,13 @@ Stream.prototype = {
     this.cache = undefined;
     this.subscriberHead = null;
     this.subscriberTail = null;
+    this.dependencyHead = null;
+    this.dependencyTail = null;
+    this.dependency = null;
     this.children = undefined;
     this._label = undefined;
+    this.isActive = false;
+    this.gotValueWhileInactive = false;
   },
 
   get: function(path) {
@@ -78,16 +136,97 @@ Stream.prototype = {
   },
 
   value: function() {
+    if (!this.isActive) {
+      this.gotValueWhileInactive = true;
+      this.revalidate();
+      return this.valueFn();
+    }
+
     if (this.state === 'clean') {
       return this.cache;
     } else if (this.state === 'dirty') {
+      this.revalidate();
+      var value = this.valueFn();
       this.state = 'clean';
-      return this.cache = this.valueFn();
+      this.cache = value;
+      return value;
     }
     // TODO: Ensure value is never called on a destroyed stream
     // so that we can uncomment this assertion.
     //
     // Ember.assert("Stream error: value was called in an invalid state: " + this.state);
+  },
+
+  addDependency: function(stream, callback, context) {
+    if (!stream || !stream.isStream) {
+      return;
+    }
+
+    if (callback === undefined) {
+      callback = this.notify;
+      context = this;
+    }
+
+    var dependency = new Dependency(this, stream, callback, context);
+
+    if (this.isActive) {
+      dependency.subscribe();
+    }
+
+    if (this.dependencyHead === null) {
+      this.dependencyHead = this.dependencyTail = dependency;
+    } else {
+      var tail = this.dependencyTail;
+      tail.next = dependency;
+      dependency.prev = tail;
+      this.dependencyTail = dependency;
+    }
+
+    return dependency;
+  },
+
+  subscribeDependencies: function() {
+    var dependency = this.dependencyHead;
+    while (dependency) {
+      var next = dependency.next;
+      dependency.subscribe();
+      dependency = next;
+    }
+  },
+
+  unsubscribeDependencies: function() {
+    var dependency = this.dependencyHead;
+    while (dependency) {
+      var next = dependency.next;
+      dependency.unsubscribe();
+      dependency = next;
+    }
+  },
+
+  becameActive: function() {},
+  becameInactive: function() {},
+
+  // This method is invoked when the value function is called and when
+  // a stream becomes active. This allows changes to be made to a stream's
+  // input, and only do any work in response if the stream has subscribers
+  // or if someone actually gets the stream's value.
+  revalidate: function() {},
+
+  maybeActivate: function() {
+    if (this.subscriberHead && !this.isActive) {
+      this.isActive = true;
+      this.subscribeDependencies();
+      this.revalidate();
+      this.becameActive();
+    }
+  },
+
+  maybeDeactivate: function() {
+    if (!this.subscriberHead && this.isActive) {
+      this.isActive = false;
+      this.unsubscribeDependencies();
+      this.becameInactive();
+    }
   },
 
   valueFn: function() {
@@ -103,7 +242,8 @@ Stream.prototype = {
   },
 
   notifyExcept: function(callbackToSkip, contextToSkip) {
-    if (this.state === 'clean') {
+    if (this.state === 'clean' || this.gotValueWhileInactive) {
+      this.gotValueWhileInactive = false;
       this.state = 'dirty';
       this._notifySubscribers(callbackToSkip, contextToSkip);
     }
@@ -113,6 +253,7 @@ Stream.prototype = {
     var subscriber = new Subscriber(callback, context, this);
     if (this.subscriberHead === null) {
       this.subscriberHead = this.subscriberTail = subscriber;
+      this.maybeActivate();
     } else {
       var tail = this.subscriberTail;
       tail.next = subscriber;
@@ -169,6 +310,8 @@ Stream.prototype = {
       }
 
       this.subscriberHead = this.subscriberTail = null;
+      this.maybeDeactivate();
+      this.dependencies = null;
 
       return true;
     }

--- a/packages/ember-metal/lib/streams/stream_binding.js
+++ b/packages/ember-metal/lib/streams/stream_binding.js
@@ -12,7 +12,7 @@ function StreamBinding(stream) {
   this.senderContext = undefined;
   this.senderValue = undefined;
 
-  stream.subscribe(this._onNotify, this);
+  this.addDependency(stream, this._onNotify, this);
 }
 
 StreamBinding.prototype = create(Stream.prototype);
@@ -62,15 +62,6 @@ merge(StreamBinding.prototype, {
     this.state = 'clean';
 
     this.notifyExcept(senderCallback, senderContext);
-  },
-
-  _super$destroy: Stream.prototype.destroy,
-
-  destroy: function() {
-    if (this._super$destroy()) {
-      this.stream.unsubscribe(this._onNotify, this);
-      return true;
-    }
   }
 });
 

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -169,17 +169,15 @@ export function scanHash(hash) {
                   replaced by the current value of the stream
  */
 export function concat(array, separator) {
-  // TODO: Create subclass ConcatStream < Stream. Defer
-  // subscribing to streams until the value() is called.
   var hasStream = scanArray(array);
   if (hasStream) {
     var i, l;
     var stream = new Stream(function() {
-      return readArray(array).join(separator);
+      return concat(readArray(array), separator);
     });
 
     for (i = 0, l=array.length; i < l; i++) {
-      subscribe(array[i], stream.notify, stream);
+      stream.addDependency(array[i]);
     }
 
     return stream;

--- a/packages/ember-views/lib/streams/key_stream.js
+++ b/packages/ember-views/lib/streams/key_stream.js
@@ -9,7 +9,7 @@ import {
   removeObserver
 } from "ember-metal/observer";
 import Stream from "ember-metal/streams/stream";
-import { read, isStream } from "ember-metal/streams/utils";
+import { read } from "ember-metal/streams/utils";
 
 function KeyStream(source, key) {
   Ember.assert("KeyStream error: key must be a non-empty string", typeof key === 'string' && key.length > 0);
@@ -17,35 +17,42 @@ function KeyStream(source, key) {
 
   this.init();
   this.source = source;
+  this.addDependency(source);
   this.obj = undefined;
   this.key = key;
-
-  if (isStream(source)) {
-    source.subscribe(this._didChange, this);
-  }
 }
 
 KeyStream.prototype = create(Stream.prototype);
 
 merge(KeyStream.prototype, {
   valueFn: function() {
+    if (this.obj) {
+      return get(this.obj, this.key);
+    }
+  },
+
+  revalidate: function() {
     var prevObj = this.obj;
     var nextObj = read(this.source);
 
     if (nextObj !== prevObj) {
       if (prevObj && typeof prevObj === 'object') {
-        removeObserver(prevObj, this.key, this, this._didChange);
-      }
-
-      if (nextObj && typeof nextObj === 'object') {
-        addObserver(nextObj, this.key, this, this._didChange);
+        removeObserver(prevObj, this.key, this, this.notify);
       }
 
       this.obj = nextObj;
     }
+  },
 
-    if (nextObj) {
-      return get(nextObj, this.key);
+  becameActive: function() {
+    if (this.obj && typeof this.obj === 'object') {
+      addObserver(this.obj, this.key, this, this.notify);
+    }
+  },
+
+  becameInactive: function() {
+    if (this.obj && typeof this.obj === 'object') {
+      removeObserver(this.obj, this.key, this, this.notify);
     }
   },
 
@@ -61,35 +68,17 @@ merge(KeyStream.prototype, {
     var prevSource = this.source;
 
     if (nextSource !== prevSource) {
-      if (isStream(prevSource)) {
-        prevSource.unsubscribe(this._didChange, this);
-      }
-
-      if (isStream(nextSource)) {
-        nextSource.subscribe(this._didChange, this);
-      }
+      this.dependency.replace(nextSource);
 
       this.source = nextSource;
       this.notify();
     }
   },
 
-  _didChange: function() {
-    this.notify();
-  },
-
   _super$destroy: Stream.prototype.destroy,
 
   destroy: function() {
     if (this._super$destroy()) {
-      if (isStream(this.source)) {
-        this.source.unsubscribe(this._didChange, this);
-      }
-
-      if (this.obj && typeof this.obj === 'object') {
-        removeObserver(this.obj, this.key, this, this._didChange);
-      }
-
       this.source = undefined;
       this.obj = undefined;
       return true;


### PR DESCRIPTION
This PR incorporates stream-list.

This commit manages a lifecycle for streams. If a stream has no
subscribers, it is considered "inactive". When a stream gets
subscribers, it becomes "active".

A stream can register dependencies on other streams regardless of
whether the stream itself is active. When the stream becomes active, the
dependency will activate its subscriptions. When the stream becomes
inactive, the dependency will deactivate its subscriptions.

When a stream is destroyed, it automatically deactivates the
subscriptions of all dependencies.

This commit also add a new "revalidate" hook for streams, which gets
invoked when the `valueFn` is called, and right before a stream becomes
active. This hook can be used to tear down any state on the old value of
a dependent stream. For example, the `KeyStream` uses this hook to tear
down observers when the backing object for the stream has changed.
