### PR TITLE
[BUGFIX #10371] Display warning when an explicit index route is defined with a path different than '/' or ''

### DIFF
--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -51,8 +51,12 @@ DSL.prototype = {
   },
 
   push: function(url, name, callback) {
-    var parts = name.split('.');
-    if (url === "" || url === "/" || parts[parts.length-1] === "index") { this.explicitIndex = true; }
+    var lastPart = name.slice(name.lastIndexOf('.') + 1);
+
+    Ember.warn("You are defining an 'index' route with a path different than '/'. Ember will not generate the default URL handler for the parent route. (You will probably get UnrecognizedURLError exceptions).",
+      url === "" || url === "/" || lastPart !== "index");
+
+    if (url === "" || url === "/" || lastPart === "index") { this.explicitIndex = true; }
 
     this.matches.push([url, name, callback]);
   },
@@ -116,4 +120,3 @@ DSL.map = function(callback) {
   callback.call(dsl);
   return dsl;
 };
-

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -110,7 +110,7 @@ QUnit.test("should not add loading and error routes if _isRouterMapResult is fal
 });
 
 QUnit.test("should show warning if an explicit index route is defined with path different than '/' or ''", function() {
-  expect(0);
+  expect(1);
   Ember.warn = function(msg, test) {
     if (!test) {
       equal(msg, "You are defining an 'index' route with a path different than '/'. Ember will not generate the default URL handler for the parent route. (You will probably get UnrecognizedURLError exceptions).");

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -110,7 +110,7 @@ QUnit.test("should not add loading and error routes if _isRouterMapResult is fal
 });
 
 QUnit.test("should show warning if an explicit index route is defined with path different than '/' or ''", function() {
-
+  expect(0);
   Ember.warn = function(msg, test) {
     if (!test) {
       equal(msg, "You are defining an 'index' route with a path different than '/'. Ember will not generate the default URL handler for the parent route. (You will probably get UnrecognizedURLError exceptions).");

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -1,13 +1,15 @@
 import EmberRouter from "ember-routing/system/router";
 import { forEach } from "ember-metal/enumerable_utils";
 
-var Router;
+var Router, oldWarn;
 
 QUnit.module("Ember Router DSL", {
   setup: function() {
+    oldWarn = Ember.warn;
     Router = EmberRouter.extend();
   },
   teardown: function() {
+    Ember.warn = oldWarn;
     Router = null;
   }
 });
@@ -105,6 +107,25 @@ QUnit.test("should not add loading and error routes if _isRouterMapResult is fal
   ok(router.router.recognizer.names['blork'], 'main route was created');
   ok(!router.router.recognizer.names['blork_loading'], 'loading route was not added');
   ok(!router.router.recognizer.names['blork_error'], 'error route was not added');
+});
+
+QUnit.test("should show warning if an explicit index route is defined with path different than '/' or ''", function() {
+
+  Ember.warn = function(msg, test) {
+    if (!test) {
+      equal(msg, "You are defining an 'index' route with a path different than '/'. Ember will not generate the default URL handler for the parent route. (You will probably get UnrecognizedURLError exceptions).");
+    }
+  };
+
+  Router.map(function() {
+    this.resource('posts', function() {
+      this.route('index');
+    });
+  });
+
+  var router = Router.create();
+  router._initRouterJs(false);
+
 });
 
 // jscs:enable validateIndentation


### PR DESCRIPTION
Details are in this Issue: https://github.com/emberjs/ember.js/issues/10371

Basically the idea is to show a WARN for each explicit index route defined with a path different than "/" or the empty one "". Such routes prevent Ember to match the expecting URLs for resources.  
