### PR TITLE
Cleanup router setup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#f4bd6a2df221240ed36d140f0c53c036a7ecacad",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
-    "router.js": "https://github.com/tildeio/router.js.git#72eb0d336c1c3b7ad3965198b330fe148d935efe",
+    "router.js": "https://github.com/tildeio/router.js.git#75ec7fa0c7ee21e14a5d1acbbdb7b14ec8e03590",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#1a1ef3e1806be21dd554d285521abc0b13cdfe20"
   }


### PR DESCRIPTION
This commits cleans up the code that initializes the ember router and router.js microlib. It uses a new version of router.js that supports passing in options to the constructor so that we can avoid the pattern of twiddling state after construction (even though router.js still supports setting these props after the fact for any tests that desire it).
