### PR TITLE
[DOC] update query param docs to add 'as' key

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -46,7 +46,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
   /**
     Configuration hash for this route's queryParams. The possible
     configuration options and their defaults are as follows
-    (assuming a query param whose URL key is `page`):
+    (assuming a query param whose controller property is `page`):
 
     ```javascript
     queryParams: {
@@ -70,7 +70,12 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
         // hash location equivalent), which causes no browser history
         // item to be added. This options name and default value are
         // the same as the `link-to` helper's `replace` option.
-        replace: false
+        replace: false,
+
+        // By default, the query param URL key is the same name as
+        // the controller property name. Use `as` to specify a
+        // different URL key.
+        as: 'page'
       }
     }
     ```


### PR DESCRIPTION
I noticed that when using query params, you could either specify them in the form `queryParams: { 'foo': 'otherFoo' }` or `queryParams: { 'foo': {replaceState: true} }` but in the latter there didn't seem to be a way to change the URL key. I found that the `as` key is used internally; is it intended to be internal-only or can it be exposed as part of the API? If it can be used, I can open a similar pull request in the Guide.
