### PR TITLE
Ember.DefaultResolver resolves with hyphens

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -140,6 +140,12 @@ export default EmberObject.extend({
         });
       }
 
+      if (name.indexOf('-') > -1) {
+        result = result.replace(/-(.)/g, function(m) {
+          return m.charAt(1).toUpperCase();
+        });
+      }
+
       return type + ':' + result;
     } else {
       return fullName;

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -106,6 +106,12 @@ QUnit.test("the default resolver resolves container-registered helpers", functio
   equal(gooGazResolverTestHelper, locator.lookup('helper:goo-baz-resolver-test'), "looks up gooGazResolverTestHelper helper");
 });
 
+QUnit.test("the default resolver resolves to the same instance no matter the notation ", function() {
+  application.NestedPostController = Controller.extend({});
+
+  equal(locator.lookup('controller:nested-post'), locator.lookup('controller:nested_post'), "looks up NestedPost controller on application");
+});
+
 QUnit.test("the default resolver throws an error if the fullName to resolve is invalid", function() {
   throws(function() { registry.resolve(undefined);}, TypeError, /Invalid fullName/ );
   throws(function() { registry.resolve(null);     }, TypeError, /Invalid fullName/ );

--- a/packages/ember-application/tests/system/dependency_injection/normalization_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/normalization_test.js
@@ -23,14 +23,18 @@ QUnit.test('normalization', function() {
   equal(registry.normalize('controller:posts'), 'controller:posts');
   equal(registry.normalize('controller:posts_index'), 'controller:postsIndex');
   equal(registry.normalize('controller:posts.index'), 'controller:postsIndex');
+  equal(registry.normalize('controller:posts-index'), 'controller:postsIndex');
   equal(registry.normalize('controller:posts.post.index'), 'controller:postsPostIndex');
   equal(registry.normalize('controller:posts_post.index'), 'controller:postsPostIndex');
   equal(registry.normalize('controller:posts.post_index'), 'controller:postsPostIndex');
+  equal(registry.normalize('controller:posts.post-index'), 'controller:postsPostIndex');
   equal(registry.normalize('controller:postsIndex'), 'controller:postsIndex');
   equal(registry.normalize('controller:blogPosts.index'), 'controller:blogPostsIndex');
   equal(registry.normalize('controller:blog/posts.index'), 'controller:blog/postsIndex');
+  equal(registry.normalize('controller:blog/posts-index'), 'controller:blog/postsIndex');
   equal(registry.normalize('controller:blog/posts.post.index'), 'controller:blog/postsPostIndex');
   equal(registry.normalize('controller:blog/posts_post.index'), 'controller:blog/postsPostIndex');
+  equal(registry.normalize('controller:blog/posts_post-index'), 'controller:blog/postsPostIndex');
 
   equal(registry.normalize('template:blog/posts_index'), 'template:blog/posts_index');
 });


### PR DESCRIPTION
As per https://github.com/emberjs/ember.js/issues/10511,

here's the tests and fix so that Ember.DefaultResolver can resolve to the same objects whether the hyphen/underscore/dot notation is used.
