### PR TITLE
Allow usage of limited ES2015 sematics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.11"
+  - "0.10"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.0.32",
+    "emberjs-build": "0.0.33",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",

--- a/packages/ember-application/lib/main.js
+++ b/packages/ember-application/lib/main.js
@@ -9,9 +9,9 @@ Ember Application
 @requires ember-views, ember-routing
 */
 
+import DefaultResolver from 'ember-application/system/resolver';
 import {
-  Resolver,
-  default as DefaultResolver
+  Resolver
 } from 'ember-application/system/resolver';
 import Application from 'ember-application/system/application';
 import 'ember-application/ext/controller'; // side effect of extending ControllerMixin

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -1,5 +1,5 @@
 import run from "ember-metal/run_loop";
-import { default as EmberController } from "ember-runtime/controllers/controller";
+import EmberController from "ember-runtime/controllers/controller";
 import "ember-extension-support"; // Must be required to export Ember.ContainerDebugAdapter
 import Application from "ember-application/system/application";
 

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -7,7 +7,7 @@ import _MetamorphView from "ember-views/views/metamorph_view";
 import { computed } from "ember-metal/computed";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import { A } from "ember-runtime/system/native_array";
-import { default as EmberController } from "ember-runtime/controllers/controller";
+import EmberController from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import { Registry } from "ember-runtime/system/container";
 

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -1,5 +1,4 @@
 /*globals EmberDev */
-import { set } from "ember-metal/property_set";
 import EmberView from "ember-views/views/view";
 import Registry from "container/registry";
 import run from "ember-metal/run_loop";

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -5,8 +5,8 @@ import EmberObject from "ember-runtime/system/object";
 import { computed } from "ember-metal/computed";
 import { set } from "ember-metal/property_set";
 import { get } from "ember-metal/property_get";
+import ObjectController from "ember-runtime/controllers/object_controller";
 import {
-  default as ObjectController,
   objectControllerDeprecation
 } from "ember-runtime/controllers/object_controller";
 import EmberController from 'ember-runtime/controllers/controller';

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -8,9 +8,9 @@ import { set } from "ember-metal/property_set";
 import { A } from "ember-runtime/system/native_array";
 import Component from "ember-views/views/component";
 import EmberError from "ember-metal/error";
+import helpers from "ember-htmlbars/helpers";
 import {
-  registerHelper,
-  default as helpers
+  registerHelper
 } from "ember-htmlbars/helpers";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 

--- a/packages/ember-htmlbars/tests/hooks/element_test.js
+++ b/packages/ember-htmlbars/tests/hooks/element_test.js
@@ -1,6 +1,6 @@
 import EmberView from "ember-views/views/view";
+import helpers from "ember-htmlbars/helpers";
 import {
-  default as helpers,
   registerHelper
 } from "ember-htmlbars/helpers";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -66,6 +66,10 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
   };
 }
 
+// This is super annoying, but required until
+// https://github.com/babel/babel/issues/906 is resolved
+; // jshint ignore:line
+
 export function unwatchKey(obj, keyName, meta) {
   var m = meta || metaFor(obj);
   var watching = m.watching;

--- a/packages/ember-routing-htmlbars/lib/helpers/render.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/render.js
@@ -6,9 +6,9 @@
 import Ember from "ember-metal/core"; // assert, deprecate
 import EmberError from "ember-metal/error";
 import { camelize } from "ember-runtime/system/string";
+import generateController from "ember-routing/system/generate_controller";
 import {
-  generateControllerFactory,
-  default as generateController
+  generateControllerFactory
 } from "ember-routing/system/generate_controller";
 import { isStream } from "ember-metal/streams/utils";
 import mergeViewBindings from "ember-htmlbars/system/merge-view-bindings";

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -6,7 +6,7 @@ import ActionManager from "ember-views/system/action_manager";
 
 import { Registry } from "ember-runtime/system/container";
 import EmberObject from "ember-runtime/system/object";
-import { default as EmberController } from "ember-runtime/controllers/controller";
+import EmberController from "ember-runtime/controllers/controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 
 import compile from "ember-template-compiler/system/compile";
@@ -14,9 +14,9 @@ import EmberView from "ember-views/views/view";
 import EmberComponent from "ember-views/views/component";
 import jQuery from "ember-views/system/jquery";
 
+import helpers from "ember-htmlbars/helpers";
 import {
-  registerHelper,
-  default as helpers
+  registerHelper
 } from "ember-htmlbars/helpers";
 
 import {

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -6,7 +6,7 @@ import { observer } from 'ember-metal/mixin';
 
 import Namespace from "ember-runtime/system/namespace";
 
-import { default as EmberController } from "ember-runtime/controllers/controller";
+import EmberController from "ember-runtime/controllers/controller";
 import EmberArrayController from "ember-runtime/controllers/array_controller";
 
 import { registerHelper } from "ember-htmlbars/helpers";

--- a/packages/ember-routing/lib/main.js
+++ b/packages/ember-routing/lib/main.js
@@ -18,9 +18,9 @@ import HashLocation from "ember-routing/location/hash_location";
 import HistoryLocation from "ember-routing/location/history_location";
 import AutoLocation from "ember-routing/location/auto_location";
 
+import generateController from "ember-routing/system/generate_controller";
 import {
-  generateControllerFactory,
-  default as generateController
+  generateControllerFactory
 } from "ember-routing/system/generate_controller";
 import controllerFor from "ember-routing/system/controller_for";
 import RouterDSL from "ember-routing/system/dsl";

--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -7,14 +7,12 @@ import Registry from 'container/registry';
 import Namespace from "ember-runtime/system/namespace";
 import { classify } from "ember-runtime/system/string";
 import Controller from "ember-runtime/controllers/controller";
-import {
-  default as ObjectController
-} from "ember-runtime/controllers/object_controller";
+import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import controllerFor from "ember-routing/system/controller_for";
+import generateController from "ember-routing/system/generate_controller";
 import {
-  generateControllerFactory,
-  default as generateController
+  generateControllerFactory
 } from "ember-routing/system/generate_controller";
 
 var buildContainer = function(namespace) {

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -2,8 +2,8 @@
 
 import Controller from "ember-runtime/controllers/controller";
 import Service from "ember-runtime/system/service";
+import ObjectController from "ember-runtime/controllers/object_controller";
 import {
-  default as ObjectController,
   objectControllerDeprecation
 } from "ember-runtime/controllers/object_controller";
 import Mixin from "ember-metal/mixin";

--- a/packages/ember-runtime/tests/controllers/object_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/object_controller_test.js
@@ -1,5 +1,5 @@
+import ObjectController from "ember-runtime/controllers/object_controller";
 import {
-  default as ObjectController,
   objectControllerDeprecation
 } from "ember-runtime/controllers/object_controller";
 import { observer } from 'ember-metal/mixin';

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -1,9 +1,9 @@
 /* global EmberDev */
 
 import InjectedProperty from "ember-metal/injected_property";
+import inject from "ember-runtime/inject";
 import {
-  createInjectionHelper,
-  default as inject
+  createInjectionHelper
 } from "ember-runtime/inject";
 import { Registry } from "ember-runtime/system/container";
 import Object from "ember-runtime/system/object";

--- a/packages/ember-runtime/tests/mixins/promise_proxy_test.js
+++ b/packages/ember-runtime/tests/mixins/promise_proxy_test.js
@@ -3,8 +3,8 @@ import {get} from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 import PromiseProxyMixin from "ember-runtime/mixins/promise_proxy";
+import EmberRSVP from "ember-runtime/ext/rsvp";
 import {
-  default as EmberRSVP,
   onerrorDefault
 } from "ember-runtime/ext/rsvp";
 import * as RSVP from 'rsvp';

--- a/packages/ember-template-compiler/tests/plugins_test.js
+++ b/packages/ember-template-compiler/tests/plugins_test.js
@@ -1,5 +1,5 @@
+import plugins from "ember-template-compiler/plugins";
 import {
-  default as plugins,
   registerPlugin
 } from "ember-template-compiler/plugins";
 import compile from "ember-template-compiler/system/compile";

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -39,8 +39,8 @@ import TextField from "ember-views/views/text_field";
 import TextArea from "ember-views/views/text_area";
 
 import SimpleBoundView from "ember-views/views/simple_bound_view";
+import _MetamorphView from "ember-views/views/metamorph_view";
 import {
-  default as _MetamorphView,
   _Metamorph
 } from "ember-views/views/metamorph_view";
 import {

--- a/packages/ember-views/lib/views/each.js
+++ b/packages/ember-views/lib/views/each.js
@@ -15,8 +15,8 @@ import {
   removeBeforeObserver
 } from "ember-metal/observer";
 
+import _MetamorphView from "ember-views/views/metamorph_view";
 import {
-  default as _MetamorphView,
   _Metamorph
 } from "ember-views/views/metamorph_view";
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -30,7 +30,10 @@ import CoreView from "ember-views/views/core_view";
 import ViewStreamSupport from "ember-views/mixins/view_stream_support";
 import ViewKeywordSupport from "ember-views/mixins/view_keyword_support";
 import ViewContextSupport from "ember-views/mixins/view_context_support";
-import { default as ViewChildViewsSupport, childViewsProperty } from "ember-views/mixins/view_child_views_support";
+import ViewChildViewsSupport from "ember-views/mixins/view_child_views_support";
+import {
+  childViewsProperty
+} from "ember-views/mixins/view_child_views_support";
 import ViewStateSupport from "ember-views/mixins/view_state_support";
 import TemplateRenderingSupport from "ember-views/mixins/template_rendering_support";
 import ClassNamesSupport from "ember-views/mixins/class_names_support";


### PR DESCRIPTION
emberjs-build now uses Babel and a whitelist of transforms during transpilation.

Current whitelisted transforms are:
- [es6.templateLiterals](http://babeljs.io/docs/learn-es6/#template-strings)
- [es6.parameters.rest](http://babeljs.io/docs/learn-es6/#default-rest-spread)
- [es6.arrowFunctions](http://babeljs.io/docs/learn-es6/#arrows)

Additional transforms can be added to the whitelist [here](https://github.com/emberjs/emberjs-build/blob/72244cbc501adf1266bad941c9d2227308b93629/lib/utils/transpile-es6.js#L18), but will only be accepted if they are guaranteed to be ES3 safe.
