### PR TITLE
Fix spelling error in CP readOnly deprecation tests.

### DIFF
--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -267,7 +267,7 @@ QUnit.test('calling readOnly() on a computed property with arguments raises a de
 QUnit.test('passing readOnly in a the options to the CP constructor raises a deprecation', function() {
   expectDeprecation(function() {
     new ComputedProperty(function() {}, { readOnly: false });
-  }, "Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. Yo can invoke `readOnly()` on the CP to change this.");
+  }, "Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. You can invoke `readOnly()` on the CP to change this.");
 });
 
 testBoth('inherited property should not pick up cache', function(get, set) {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/10540 failed the build, the deprecation was being tested and that message no longer matches.
