### PR TITLE
Enable sourcemap support for Ember development.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 
 env:
   global:
+    - DISABLE_SOURCE_MAPS=true
     - BROCCOLI_ENV=production
     - S3_BUILD_CACHE_BUCKET=emberjs-build-cache
     - S3_BUCKET_NAME=builds.emberjs.com

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.0.33",
+    "emberjs-build": "0.0.36",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",


### PR DESCRIPTION
This is useful while developing on Ember, and we may possibly publish the maps to `bower`, S3, etc in the future, but we need to be careful to not cause many errors/warnings while building Ember CLI (if the `.map` file is referenced but not present it causes a console warning).
