### PR TITLE
[DOC] fix generated href in link-to documentation

### DIFF
--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -191,7 +191,7 @@ import 'ember-htmlbars';
   ```
 
   ```html
-  <a href="/hamster-photos/42/comment/718">
+  <a href="/hamster-photos/42/comments/718">
     A+++ would snuggle again.
   </a>
   ```


### PR DESCRIPTION
makes the generated href match the example router, which has path `{path: "comments/:comment_id"}`
