### PR TITLE
[BUGFIX release] Ensure that inline {{link-to}} does not cause a crash.

### DIFF
--- a/packages/ember-htmlbars/lib/templates/link-to-escaped.hbs
+++ b/packages/ember-htmlbars/lib/templates/link-to-escaped.hbs
@@ -1,0 +1,1 @@
+{{linkTitle}}

--- a/packages/ember-htmlbars/lib/templates/link-to-unescaped.hbs
+++ b/packages/ember-htmlbars/lib/templates/link-to-unescaped.hbs
@@ -1,0 +1,1 @@
+{{{linkTitle}}}

--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -5,8 +5,10 @@
 
 import Ember from "ember-metal/core"; // assert
 import { LinkView } from "ember-routing-views/views/link";
-import { read, isStream } from "ember-metal/streams/utils";
+import { isStream } from "ember-metal/streams/utils";
 import ControllerMixin from "ember-runtime/mixins/controller";
+import inlineEscapedLinkTo from "ember-htmlbars/templates/link-to-escaped";
+import inlineUnescapedLinkTo from "ember-htmlbars/templates/link-to-unescaped";
 
 // We need the HTMLBars view helper from ensure ember-htmlbars.
 // This ensures it is loaded first:
@@ -304,22 +306,13 @@ function linkToHelper(params, hash, options, env) {
     var linkTitle = params.shift();
     var parseTextAsHTML = options.morph.parseTextAsHTML;
 
-    if (isStream(linkTitle)) {
-      hash.linkTitle = { stream: linkTitle };
+    if (parseTextAsHTML) {
+      hash.layout = inlineUnescapedLinkTo;
+    } else {
+      hash.layout = inlineEscapedLinkTo;
     }
 
-    options.template = {
-      isHTMLBars: true,
-      revision: 'Ember@VERSION_STRING_PLACEHOLDER',
-      render: function(view, env) {
-        var value = read(linkTitle) || "";
-        if (parseTextAsHTML) {
-          return value;
-        } else {
-          return env.dom.createTextNode(value);
-        }
-      }
-    };
+    hash.linkTitle = linkTitle;
   }
 
   for (var i = 0; i < params.length; i++) {

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -238,13 +238,7 @@ var LinkView = EmberComponent.extend({
   _setupPathObservers: function() {
     var params = this.params;
 
-    var scheduledRerender = this._wrapAsScheduled(this.rerender);
     var scheduledParamsChanged = this._wrapAsScheduled(this._paramsChanged);
-
-    if (this.linkTitle) {
-      var linkTitle = this.linkTitle.stream || this.linkTitle;
-      subscribe(linkTitle, scheduledRerender, this);
-    }
 
     for (var i = 0; i < params.length; i++) {
       subscribe(params[i], scheduledParamsChanged, this);


### PR DESCRIPTION
Fixes #10360.
