### PR TITLE
[BUGFIX beta] Remove access to `this` in HTMLBars helpers.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -49,7 +49,7 @@ export default function makeBoundHelper(fn, compatMode) {
   }
 
   function helperFunc(params, hash, options, env) {
-    var view = this;
+    var view = env.data.view;
     var numParams = params.length;
     var param;
 

--- a/packages/ember-htmlbars/lib/helpers/bind-attr.js
+++ b/packages/ember-htmlbars/lib/helpers/bind-attr.js
@@ -147,7 +147,7 @@ function bindAttrHelper(params, hash, options, env) {
 
   Ember.assert("You must specify at least one hash argument to bind-attr", !!keys(hash).length);
 
-  var view = this;
+  var view = env.data.view;
 
   // Handle classes differently, as we can bind multiple classes
   var classNameBindings = hash['class'];

--- a/packages/ember-htmlbars/lib/helpers/collection.js
+++ b/packages/ember-htmlbars/lib/helpers/collection.js
@@ -228,7 +228,7 @@ export function collectionHelper(params, hash, options, env) {
   }
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }
 
-  var viewOptions = mergeViewBindings(this, {}, itemHash);
+  var viewOptions = mergeViewBindings(view, {}, itemHash);
 
   if (hash.itemClassBinding) {
     var itemClassBindings = hash.itemClassBinding.split(' ');

--- a/packages/ember-htmlbars/lib/helpers/component.js
+++ b/packages/ember-htmlbars/lib/helpers/component.js
@@ -65,8 +65,9 @@ export function componentHelper(params, hash, options, env) {
     params.length === 1
   );
 
+  var view = env.data.view;
   var componentNameParam = params[0];
-  var container = this.container || read(this._keywords.view).container;
+  var container = view.container || read(view._keywords.view).container;
 
   var props = {
     helperName: options.helperName || 'component'
@@ -85,8 +86,8 @@ export function componentHelper(params, hash, options, env) {
     if (!viewClass) {
       throw new EmberError('HTMLBars error: Could not find component named "' + componentNameParam + '".');
     }
-    mergeViewBindings(this, props, hash);
+    mergeViewBindings(view, props, hash);
   }
 
-  appendTemplatedView(this, options.morph, viewClass, props);
+  appendTemplatedView(view, options.morph, viewClass, props);
 }

--- a/packages/ember-htmlbars/lib/helpers/debugger.js
+++ b/packages/ember-htmlbars/lib/helpers/debugger.js
@@ -49,10 +49,10 @@ import Logger from "ember-metal/logger";
   @for Ember.Handlebars.helpers
   @param {String} property
 */
-export function debuggerHelper() {
+export function debuggerHelper(params, hash, options, env) {
 
   /* jshint unused: false */
-  var view = this;
+  var view = env.data.view;
 
   /* jshint unused: false */
   var context = view.get('context');

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -157,8 +157,9 @@ import EachView from "ember-views/views/each";
   @param [options.itemController] {String} name of a controller to be created for each item
 */
 function eachHelper(params, hash, options, env) {
+  var view = env.data.view;
   var helperName = 'each';
-  var path = params[0] || this.getStream('');
+  var path = params[0] || view.getStream('');
 
   Ember.assert(
     "If you pass more than one argument to the each helper, " +

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -17,7 +17,7 @@ import emptyTemplate from "ember-htmlbars/templates/empty";
 */
 function ifHelper(params, hash, options, env) {
   var helperName = options.helperName || 'if';
-  return appendConditional(this, false, helperName, params, hash, options, env);
+  return appendConditional(false, helperName, params, hash, options, env);
 }
 
 /**
@@ -26,7 +26,7 @@ function ifHelper(params, hash, options, env) {
 */
 function unlessHelper(params, hash, options, env) {
   var helperName = options.helperName || 'unless';
-  return appendConditional(this, true, helperName, params, hash, options, env);
+  return appendConditional(true, helperName, params, hash, options, env);
 }
 
 
@@ -37,7 +37,9 @@ function assertInlineIfNotEnabled() {
   );
 }
 
-function appendConditional(view, inverted, helperName, params, hash, options, env) {
+function appendConditional(inverted, helperName, params, hash, options, env) {
+  var view = env.data.view;
+
   if (options.isBlock) {
     return appendBlockConditional(view, inverted, helperName, params, hash, options, env);
   } else {

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -49,5 +49,5 @@ export function locHelper(params, hash, options, env) {
     return true;
   })());
 
-  return loc.apply(this, params);
+  return loc.apply(env.data.view, params);
 }

--- a/packages/ember-htmlbars/lib/helpers/partial.js
+++ b/packages/ember-htmlbars/lib/helpers/partial.js
@@ -49,17 +49,18 @@ import lookupPartial from "ember-views/system/lookup_partial";
 */
 
 export function partialHelper(params, hash, options, env) {
+  var view = env.data.view;
   var templateName = params[0];
 
   if (isStream(templateName)) {
-    this.appendChild(BoundPartialView, {
+    view.appendChild(BoundPartialView, {
       _morph: options.morph,
-      _context: get(this, 'context'),
+      _context: get(view, 'context'),
       templateNameStream: templateName,
       helperName: options.helperName || 'partial'
     });
   } else {
-    var template = lookupPartial(this, templateName);
-    return template.render(this, env, options.morph.contextualElement);
+    var template = lookupPartial(view, templateName);
+    return template.render(view, env, options.morph.contextualElement);
   }
 }

--- a/packages/ember-htmlbars/lib/helpers/unbound.js
+++ b/packages/ember-htmlbars/lib/helpers/unbound.js
@@ -40,14 +40,15 @@ export function unboundHelper(params, hash, options, env) {
   } else {
     options.helperName = options.helperName || 'unbound';
 
+    var view = env.data.view;
     var helperName = params[0]._label;
-    var helper = lookupHelper(helperName, this, env);
+    var helper = lookupHelper(helperName, view, env);
 
     if (!helper) {
       throw new EmberError('HTMLBars error: Could not find component or helper named ' + helperName + '.');
     }
 
-    return helper.helperFunction.call(this, readParams(params), readHash(hash, this), options, env);
+    return helper.helperFunction.call(this, readParams(params), readHash(hash, view), options, env);
   }
 }
 

--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -191,7 +191,8 @@ export function viewHelper(params, hash, options, env) {
     params.length <= 2
   );
 
-  var container = this.container || read(this._keywords.view).container;
+  var view = env.data.view;
+  var container = view.container || read(view._keywords.view).container;
   var viewClassOrInstance;
   if (params.length === 0) {
     if (container) {
@@ -211,6 +212,6 @@ export function viewHelper(params, hash, options, env) {
     props.template = options.template;
   }
 
-  mergeViewBindings(this, props, hash);
-  appendTemplatedView(this, options.morph, viewClassOrInstance, props);
+  mergeViewBindings(view, props, hash);
+  appendTemplatedView(view, options.morph, viewClassOrInstance, props);
 }

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -65,6 +65,7 @@ export function withHelper(params, hash, options, env) {
     !!options.template
   );
 
+  var view = env.data.view;
   var preserveContext;
 
   if (options.template.blockParams) {
@@ -79,11 +80,11 @@ export function withHelper(params, hash, options, env) {
     preserveContext = false;
   }
 
-  this.appendChild(WithView, {
+  view.appendChild(WithView, {
     _morph: options.morph,
     withValue: params[0],
     preserveContext: preserveContext,
-    previousContext: this.get('context'),
+    previousContext: view.get('context'),
     controllerName: hash.controller,
     mainTemplate: options.template,
     inverseTemplate: options.inverse,

--- a/packages/ember-htmlbars/lib/helpers/yield.js
+++ b/packages/ember-htmlbars/lib/helpers/yield.js
@@ -90,18 +90,19 @@ import { get } from "ember-metal/property_get";
   @return {String} HTML string
 */
 export function yieldHelper(params, hash, options, env) {
-  var view = this;
+  var view = env.data.view;
+  var layoutView = view;
 
   // Yea gods
-  while (view && !get(view, 'layout')) {
-    if (view._contextView) {
-      view = view._contextView;
+  while (layoutView && !get(layoutView, 'layout')) {
+    if (layoutView._contextView) {
+      layoutView = layoutView._contextView;
     } else {
-      view = view._parentView;
+      layoutView = layoutView._parentView;
     }
   }
 
-  Ember.assert("You called yield in a template that was not a layout", !!view);
+  Ember.assert("You called yield in a template that was not a layout", !!layoutView);
 
-  return view._yield(this, env, options.morph, params);
+  return layoutView._yield(view, env, options.morph, params);
 }

--- a/packages/ember-htmlbars/lib/hooks/block.js
+++ b/packages/ember-htmlbars/lib/hooks/block.js
@@ -18,7 +18,7 @@ export default function block(env, morph, view, path, params, hash, template, in
     inverse: inverse,
     isBlock: true
   };
-  var result = helper.helperFunction.call(view, params, hash, options, env);
+  var result = helper.helperFunction.call(undefined, params, hash, options, env);
 
   if (isStream(result)) {
     appendSimpleBoundView(view, morph, result);

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -11,6 +11,6 @@ export default function component(env, morph, view, tagName, attrs, template) {
 
   Ember.assert('You specified `' + tagName + '` in your template, but a component for `' + tagName + '` could not be found.', !!helper);
 
-  return helper.helperFunction.call(view, [], attrs, { morph: morph, template: template }, env);
+  return helper.helperFunction.call(undefined, [], attrs, { morph: morph, template: template }, env);
 }
 

--- a/packages/ember-htmlbars/lib/hooks/content.js
+++ b/packages/ember-htmlbars/lib/hooks/content.js
@@ -16,7 +16,7 @@ export default function content(env, morph, view, path) {
       morph: morph,
       isInline: true
     };
-    result = helper.helperFunction.call(view, [], {}, options, env);
+    result = helper.helperFunction.call(undefined, [], {}, options, env);
   } else {
     result = view.getStream(path);
   }

--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -15,7 +15,7 @@ export default function element(env, domElement, view, path, params, hash) { //j
     var options = {
       element: domElement
     };
-    valueOrLazyValue = helper.helperFunction.call(view, params, hash, options, env);
+    valueOrLazyValue = helper.helperFunction.call(undefined, params, hash, options, env);
   } else {
     valueOrLazyValue = view.getStream(path);
   }

--- a/packages/ember-htmlbars/lib/hooks/inline.js
+++ b/packages/ember-htmlbars/lib/hooks/inline.js
@@ -12,7 +12,7 @@ export default function inline(env, morph, view, path, params, hash) {
 
   Ember.assert("A helper named '"+path+"' could not be found", helper);
 
-  var result = helper.helperFunction.call(view, params, hash, { morph: morph }, env);
+  var result = helper.helperFunction.call(undefined, params, hash, { morph: morph }, env);
 
   if (isStream(result)) {
     appendSimpleBoundView(view, morph, result);

--- a/packages/ember-htmlbars/lib/hooks/subexpr.js
+++ b/packages/ember-htmlbars/lib/hooks/subexpr.js
@@ -13,6 +13,6 @@ export default function subexpr(env, view, path, params, hash) {
   var options = {
     isInline: true
   };
-  return helper.helperFunction.call(view, params, hash, options, env);
+  return helper.helperFunction.call(undefined, params, hash, options, env);
 }
 

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -60,7 +60,7 @@ import {
 */
 export default function makeBoundHelper(fn) {
   function helperFunc(params, hash, options, env) {
-    var view = this;
+    var view = env.data.view;
     var numParams = params.length;
     var param, prop;
 

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -10,7 +10,9 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 var registry, container, view;
 
 function aliasHelper(params, hash, options, env) {
-  this.appendChild(View, {
+  var view = env.data.view;
+
+  view.appendChild(View, {
     isVirtual: true,
     _morph: options.morph,
     template: options.template,

--- a/packages/ember-routing-htmlbars/lib/helpers/action.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/action.js
@@ -279,14 +279,14 @@ ActionHelper.registerAction = function(actionNameOrStream, options, allowedKeys)
   @param {Hash} options
 */
 export function actionHelper(params, hash, options, env) {
-
+  var view = env.data.view;
   var target;
   if (!hash.target) {
-    target = this.getStream('controller');
+    target = view.getStream('controller');
   } else if (isStream(hash.target)) {
     target = hash.target;
   } else {
-    target = this.getStream(hash.target);
+    target = view.getStream(hash.target);
   }
 
   // Ember.assert("You specified a quoteless path to the {{action}} helper which did not resolve to an action name (a string). Perhaps you meant to use a quoted actionName? (e.g. {{action 'save'}}).", !params[0].isStream);
@@ -295,7 +295,7 @@ export function actionHelper(params, hash, options, env) {
   var actionOptions = {
     eventName: hash.on || "click",
     parameters: params.slice(1),
-    view: this,
+    view: view,
     bubbles: hash.bubbles,
     preventDefault: hash.preventDefault,
     target: target,

--- a/packages/ember-routing-htmlbars/lib/helpers/outlet.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/outlet.js
@@ -72,6 +72,7 @@ export function outletHelper(params, hash, options, env) {
   var viewName;
   var viewClass;
   var viewFullName;
+  var view = env.data.view;
 
   Ember.assert(
     "Using {{outlet}} with an unquoted name is not supported.",
@@ -93,11 +94,11 @@ export function outletHelper(params, hash, options, env) {
     );
     Ember.assert(
       "The view name you supplied '" + viewName + "' did not resolve to a view.",
-      this.container._registry.has(viewFullName)
+      view.container._registry.has(viewFullName)
     );
   }
 
-  viewClass = viewName ? this.container.lookupFactory(viewFullName) : hash.viewClass || this.container.lookupFactory('view:-outlet');
+  viewClass = viewName ? view.container.lookupFactory(viewFullName) : hash.viewClass || view.container.lookupFactory('view:-outlet');
   hash._outletName = property;
   options.helperName = options.helperName || 'outlet';
   return env.helpers.view.helperFunction.call(this, [viewClass], hash, options, env);

--- a/packages/ember-routing-htmlbars/lib/helpers/render.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/render.js
@@ -85,12 +85,13 @@ You could render it inside the `post` template using the `render` helper.
   @return {String} HTML string
 */
 export function renderHelper(params, hash, options, env) {
+  var currentView = env.data.view;
   var container, router, controller, view, initialContext;
 
   var name = params[0];
   var context = params[1];
 
-  container = this._keywords.controller.value().container;
+  container = currentView._keywords.controller.value().container;
   router = container.lookup('router:main');
 
   Ember.assert(
@@ -144,7 +145,7 @@ export function renderHelper(params, hash, options, env) {
     controllerFullName = 'controller:' + controllerName;
   }
 
-  var parentController = this._keywords.controller.value();
+  var parentController = currentView._keywords.controller.value();
 
   // choose name
   if (params.length > 1) {
@@ -190,6 +191,6 @@ export function renderHelper(params, hash, options, env) {
     helperName: 'render "' + name + '"'
   };
 
-  mergeViewBindings(this, props, hash);
-  appendTemplatedView(this, options.morph, view, props);
+  mergeViewBindings(currentView, props, hash);
+  appendTemplatedView(currentView, options.morph, view, props);
 }


### PR DESCRIPTION
The value of `this` in a helper has changed at least twice (likely more). This updates the HTMLBars hooks to call each helper with an `undefined` context. The main purpose of this is to pave the way for another refactoring of the view + helper layer that uses `this` for a different purpose.

To fix any usages of `this` in a helper, you can access the `view` from `env.data.view` instead.
