### PR TITLE
[BUGFIX beta] Deprecate `{{link-to}}` unwrapping a controllers model.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -288,6 +288,7 @@ import 'ember-htmlbars';
 */
 function linkToHelper(params, hash, options, env) {
   var queryParamsObject;
+  var view = env.data.view;
 
   Ember.assert("You must provide one or more parameters to the link-to helper.", params.length);
 
@@ -321,6 +322,8 @@ function linkToHelper(params, hash, options, env) {
 
       if (!lazyValue._isController) {
         while (ControllerMixin.detect(lazyValue.value())) {
+          Ember.deprecate('Providing `{{link-to}}` with a param that is wrapped in a controller is deprecated. Please update `' + view + '` to use `{{link-to "post" someController.model}}` instead.');
+
           lazyValue = lazyValue.get('model');
         }
       }

--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -95,7 +95,9 @@ QUnit.test("unwraps controllers", function() {
     template: compile(template)
   });
 
-  runAppend(view);
+  expectDeprecation(function() {
+    runAppend(view);
+  }, /Providing `{{link-to}}` with a param that is wrapped in a controller is deprecated./);
 
   equal(view.$().text(), 'Text');
 });

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -628,9 +628,9 @@ QUnit.test("Issue 4201 - Shorthand for route.index shouldn't throw errors about 
 QUnit.test("The {{link-to}} helper unwraps controllers", function() {
 
   if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
-    expect(4);
-  } else {
     expect(5);
+  } else {
+    expect(6);
   }
 
   Router.map(function() {
@@ -659,7 +659,9 @@ QUnit.test("The {{link-to}} helper unwraps controllers", function() {
   Ember.TEMPLATES.filter = compile('<p>{{model.filter}}</p>');
   Ember.TEMPLATES.index = compile('{{#link-to "filter" this id="link"}}Filter{{/link-to}}');
 
-  bootApplication();
+  expectDeprecation(function() {
+    bootApplication();
+  }, /Providing `{{link-to}}` with a param that is wrapped in a controller is deprecated./);
 
   Ember.run(function() { router.handleURL("/"); });
 


### PR DESCRIPTION
This dovetails with the proxying deprecations, and will allow a bit of cleanup in the link-to helper later.
