### PR TITLE
Fix "Duplicated import ('set')" build error with newest esperanto.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -1,5 +1,4 @@
 /*globals EmberDev */
-import { set } from "ember-metal/property_set";
 import EmberView from "ember-views/views/view";
 import Registry from "container/registry";
 import run from "ember-metal/run_loop";


### PR DESCRIPTION
A duplicate property_set import is causing a build failure when building with the newest esperanto.
https://github.com/esperantojs/esperanto/issues/95
