### PR TITLE
[DOC release] Remove obsolete instructions for building API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ example:
   * [Ember.js Views](http://localhost:4200/tests/index.html?package=ember-views)
   * [Ember.js Handlebars](http://localhost:4200/tests/index.html?package=ember-handlebars)
 
-To test multiple packages, you can separate them with commas. 
+To test multiple packages, you can separate them with commas.
 
 You can also pass `jquery=VERSION` in the test URL to test different
 versions of jQuery.
@@ -50,36 +50,3 @@ versions of jQuery.
 2. Run `npm test` to run a basic test suite or run `TEST_SUITE=all npm test` to
    run a more comprehensive suite.
 
-# Building API Docs
-
-The Ember.js API Docs provide a detailed collection of methods, classes,
-and viewable source code.
-
-NOTE: Requires node.js to generate.
-
-See <http://emberjs.com/> for annotated introductory documentation.
-
-## Setup Additional Repos
-
-To preview or build the API documentation, you will need to setup
-the `website` and `data` repos in addition to this repo.
-
-* Clone `https://github.com/emberjs/website.git` at the same level as the
-  main Ember repo.
-
-* Clone `https://github.com/emberjs/data.git` at the same level as the main
-  Ember repo. Make sure to follow the setup steps in the Ember Data repo,
-  which includes installing npm modules.
-
-## Preview API Documentation
-
-* From the website repo, run `bundle exec rake preview`.
-
-* The docs will be available at <http://localhost:4567/api>.
-
-## Build API Documentation
-
-* From the website repo, run `bundle exec rake build`.
-
-* The website, along with documentation, will be built into the `build`
-  directory.


### PR DESCRIPTION
Currently, the method for generating API docs is to follow the instructions
in emberjs/website, however this will be changing shortly due to emberjs/api.emberjs.com

I think it is better to not have this documentation then have it wrong.
