### PR TITLE
Pass event as context to input helper key-press action

### DIFF
--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -326,10 +326,10 @@ function sendAction(eventName, view, event) {
   // it's also a method name that consumes the event (and therefore
   // incompatible with sendAction semantics).
   if (on === eventName || (on === 'keyPress' && eventName === 'key-press')) {
-    view.sendAction('action', value);
+    view.sendAction('action', value, event);
   }
 
-  view.sendAction(eventName, value);
+  view.sendAction(eventName, value, event);
 
   if (action || on === eventName) {
     if (!get(view, 'bubbles')) {


### PR DESCRIPTION
The key-up and key-down input helper actions already do this.
