### PR TITLE
Reduce dependency on ArrayComputed and ReduceComputed

### DIFF
--- a/packages/ember-metal/lib/enumerable_utils.js
+++ b/packages/ember-metal/lib/enumerable_utils.js
@@ -66,7 +66,7 @@ export function filter(obj, callback, thisArg) {
  * uses `Ember.ArrayPolyfill`'s-indexOf method when necessary.
  *
  * @method indexOf
- * @param {Object} obj The object to call indexOn on
+ * @param {Object} obj The object to call indexOf on
  * @param {Function} callback The callback to execute
  * @param {Object} index The index to start searching from
  *

--- a/packages/ember-runtime/tests/controllers/item_controller_class_test.js
+++ b/packages/ember-runtime/tests/controllers/item_controller_class_test.js
@@ -9,6 +9,7 @@ import ArrayController from "ember-runtime/controllers/array_controller";
 import Controller from "ember-runtime/controllers/controller";
 import {sort} from "ember-runtime/computed/reduce_computed_macros";
 import Registry from "container/registry";
+import { map } from "ember-metal/enumerable_utils";
 
 var lannisters, arrayController, controllerClass, otherControllerClass, registry, container, itemControllerCount,
     tywin, jaime, cersei, tyrion;
@@ -374,5 +375,9 @@ QUnit.test("item controllers can be used to provide properties for array compute
     sorted: sort('@this', 'sortProperties')
   });
 
-  deepEqual(arrayController.get('sorted').mapProperty('model.name'), ['Jaime', 'Cersei'], "ArrayController items can be sorted on itemController properties");
+  var sortedNames = map(arrayController.get('sorted'), function(item) {
+    return get(item, 'model.name');
+  });
+
+  deepEqual(sortedNames, ['Jaime', 'Cersei'], "ArrayController items can be sorted on itemController properties");
 });


### PR DESCRIPTION
**DO NOT MERGE YET**

This removes the dependency of the Ember.computed array macros on ArrayComputed and ReduceComputed. The new path is currently slower but significantly less complex. Once Glimmer is merged (#10501) the slowness introduced by this PR is unlikely to cause problems.

This PR also removes all internal dependencies on ArrayComputed and ReduceComputed allowing these methods to be removed entirely from core. (If desired, we can make a plugin for them.)

_KNOWN DIFFERENCES/ISSUES_
- Not everything returns an `Ember.A` anymore.
- Resulting arrays are no longer modified in place
- Ordering of some methods like `union` and `intersect` may be different than before. I think this is acceptable since sorting isn't part of the API contract for these.
- Property sorting code probably causes more churn than the previous version. I think we should deprecate this behavior.

_TODO_
- [ ] Add deprecation warnings
- [ ] Consider moving the reduce shim to EnumerableUtils and/or an array shim
