### PR TITLE
Deprecate the non-block {{with}} syntax

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -28,7 +28,7 @@ import WithView from "ember-views/views/with_view";
 
   NOTE: The alias should not reuse a name from the bound property path.
   For example: `{{#with foo as |foo.bar|}}` is not supported because it attempts to alias using
-  the first part of the property path, `foo`. Instead, use `{{#with foo.bar as baz}}`.
+  the first part of the property path, `foo`. Instead, use `{{#with foo.bar as |baz|}}`.
 
   ### `controller` option
 
@@ -38,7 +38,7 @@ import WithView from "ember-views/views/with_view";
   This is very similar to using an `itemController` option with the `{{each}}` helper.
 
   ```handlebars
-  {{#with users.posts as posts controller='userBlogPosts'}}
+  {{#with users.posts controller='userBlogPosts' as |posts|}}
     {{!- `posts` is wrapped in our controller instance }}
   {{/with}}
   ```

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -71,7 +71,7 @@ QUnit.test('it can lookup a path from the current keywords', function() {
     controller: {
       foo: 'bar'
     },
-    template: compile('{{#with foo as bar}}{{handlebars-get "bar"}}{{/with}}')
+    template: compile('{{#with foo as |bar|}}{{handlebars-get "bar"}}{{/with}}')
   });
 
   runAppend(view);

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -259,7 +259,7 @@ QUnit.test("{{bindAttr}} can be used to bind attributes [DEPRECATED]", function(
 });
 
 QUnit.test("should be able to bind element attributes using {{bind-attr}} inside a block", function() {
-  var template = compile('{{#with view.content as image}}<img {{bind-attr src=image.url alt=image.title}}>{{/with}}');
+  var template = compile('{{#with view.content as |image|}}<img {{bind-attr src=image.url alt=image.title}}>{{/with}}');
 
   view = EmberView.create({
     template: template,

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -169,7 +169,7 @@ QUnit.test("outer keyword doesn't mask inner component property", function () {
 
   view = EmberView.create({
     controller: { boundText: "outer", component: component },
-    template: compile('{{#with boundText as item}}{{#view component}}{{item}}{{/view}}{{/with}}')
+    template: compile('{{#with boundText as |item|}}{{#view component}}{{item}}{{/view}}{{/with}}')
   });
 
   runAppend(view);
@@ -180,7 +180,7 @@ QUnit.test("outer keyword doesn't mask inner component property", function () {
 QUnit.test("inner keyword doesn't mask yield property", function() {
   var component = Component.extend({
     boundText: "inner",
-    layout: compile("{{#with boundText as item}}<p>{{item}}</p><p>{{yield}}</p>{{/with}}")
+    layout: compile("{{#with boundText as |item|}}<p>{{item}}</p><p>{{yield}}</p>{{/with}}")
   });
 
   view = EmberView.create({
@@ -201,7 +201,7 @@ QUnit.test("can bind a keyword to a component and use it in yield", function() {
 
   view = EmberView.create({
     controller: { boundText: "outer", component: component },
-    template: compile('{{#with boundText as item}}{{#view component content=item}}{{item}}{{/view}}{{/with}}')
+    template: compile('{{#with boundText as |item|}}{{#view component content=item}}{{item}}{{/view}}{{/with}}')
   });
 
   runAppend(view);

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -104,7 +104,7 @@ QUnit.test('bindings can be `this`, in which case they *are* the current context
 
 QUnit.test('child views can be inserted inside a bind block', function() {
   registry.register('template:nester', compile('<h1 id="hello-world">Hello {{world}}</h1>{{view view.bqView}}'));
-  registry.register('template:nested', compile('<div id="child-view">Goodbye {{#with content as thing}}{{thing.blah}} {{view view.otherView}}{{/with}} {{world}}</div>'));
+  registry.register('template:nested', compile('<div id="child-view">Goodbye {{#with content as |thing|}}{{thing.blah}} {{view view.otherView}}{{/with}} {{world}}</div>'));
   registry.register('template:other', compile('cruel'));
 
   var context = {
@@ -143,7 +143,7 @@ QUnit.test('child views can be inserted inside a bind block', function() {
 });
 
 QUnit.test('views render their template in the context of the parent view\'s context', function() {
-  registry.register('template:parent', compile('<h1>{{#with content as person}}{{#view}}{{person.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
+  registry.register('template:parent', compile('<h1>{{#with content as |person|}}{{#view}}{{person.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
 
   var context = {
     content: {
@@ -163,7 +163,7 @@ QUnit.test('views render their template in the context of the parent view\'s con
 });
 
 QUnit.test('views make a view keyword available that allows template to reference view context', function() {
-  registry.register('template:parent', compile('<h1>{{#with view.content as person}}{{#view person.subview}}{{view.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
+  registry.register('template:parent', compile('<h1>{{#with view.content as |person|}}{{#view person.subview}}{{view.firstName}} {{person.lastName}}{{/view}}{{/with}}</h1>'));
 
   view = EmberView.create({
     container: container,

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -473,7 +473,7 @@ QUnit.test("should work properly in an #each block", function() {
   ok(eventHandlerWasCalled, "The event handler was called");
 });
 
-QUnit.test("should work properly in a {{#with foo as bar}} block", function() {
+QUnit.test("should work properly in a {{#with foo as |bar|}} block", function() {
   var eventHandlerWasCalled = false;
 
   var controller = EmberController.extend({
@@ -483,7 +483,7 @@ QUnit.test("should work properly in a {{#with foo as bar}} block", function() {
   view = EmberView.create({
     controller: controller,
     something: { ohai: 'there' },
-    template: compile('{{#with view.something as somethingElse}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
+    template: compile('{{#with view.something as |somethingElse|}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
   });
 
   runAppend(view);

--- a/packages/ember-template-compiler/lib/plugins/transform-with-as-to-hash.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-with-as-to-hash.js
@@ -42,6 +42,13 @@ TransformWithAsToHash.prototype.transform = function TransformWithAsToHash_trans
         throw new Error('You cannot use keyword (`{{with foo as bar}}`) and block params (`{{with foo as |bar|}}`) at the same time.');
       }
 
+      Ember.deprecate(
+        "Using {{with}} without block syntax is deprecated. " +
+        "Please use standard block form (`{{#with foo as |bar|}}`) instead.",
+        false,
+        { url: "http://emberjs.com/deprecations/v1.x/#toc_code-as-code-sytnax-for-code-with-code" }
+      );
+
       var removedParams = node.sexpr.params.splice(1, 2);
       var keyword = removedParams[1].original;
       node.program.blockParams = [keyword];


### PR DESCRIPTION
Depends on merge of https://github.com/emberjs/guides/pull/63
