### PR TITLE
Deprecate direct use of CoreView

### DIFF
--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -24,7 +24,7 @@ import {
   states
 } from "ember-views/views/states";
 
-import CoreView from "ember-views/views/core_view";
+import { DeprecatedCoreView } from "ember-views/views/core_view";
 import View from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 import CollectionView from "ember-views/views/collection_view";
@@ -68,7 +68,7 @@ ViewUtils.isSimpleClick = isSimpleClick;
 ViewUtils.getViewClientRects = getViewClientRects;
 ViewUtils.getViewBoundingClientRect = getViewBoundingClientRect;
 
-Ember.CoreView = CoreView;
+Ember.CoreView = DeprecatedCoreView;
 Ember.View = View;
 Ember.View.states = states;
 Ember.View.cloneStates = cloneStates;

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -34,6 +34,7 @@ var renderer;
   @class CoreView
   @namespace Ember
   @extends Ember.Object
+  @deprecated Use `Ember.View` instead.
   @uses Ember.Evented
   @uses Ember.ActionHandler
 */
@@ -151,6 +152,13 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
 
 CoreView.reopenClass({
   isViewClass: true
+});
+
+export var DeprecatedCoreView = CoreView.extend({
+  init: function() {
+    Ember.deprecate('Ember.CoreView is deprecated. Please use Ember.View.', false);
+    this._super.apply(this, arguments);
+  }
 });
 
 export default CoreView;

--- a/packages/ember-views/tests/views/exports_test.js
+++ b/packages/ember-views/tests/views/exports_test.js
@@ -1,0 +1,9 @@
+import Ember from "ember-views";
+
+QUnit.module("ember-view exports");
+
+QUnit.test("should export a disabled CoreView", function() {
+  expectDeprecation(function() {
+    Ember.CoreView.create();
+  }, 'Ember.CoreView is deprecated. Please use Ember.View.');
+});


### PR DESCRIPTION
I'm not 100% sure this is worth it since we do plan to deprecate View altogether.
