### PR TITLE
Introduce routing service

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -4,11 +4,32 @@ import EmberView from "ember-views/views/view";
 import compile from "ember-template-compiler/system/compile";
 import { set } from "ember-metal/property_set";
 import Controller from "ember-runtime/controllers/controller";
+import { Registry } from "ember-runtime/system/container";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import EmberObject from "ember-runtime/system/object";
 
 var view;
+var container;
+var registry = new Registry();
+
+// These tests don't rely on the routing service, but LinkView makes
+// some assumptions that it will exist. This small stub service ensures
+// that the LinkView can render without raising an exception.
+//
+// TODO: Add tests that test actual behavior. Currently, all behavior
+// is tested integration-style in the `ember` package.
+registry.register('service:-routing', EmberObject.extend({
+  availableRoutes: function() { return ['index']; },
+  hasRoute: function(name) { return name === 'index'; },
+  isActiveForRoute: function() { return true; },
+  generateURL: function() { return "/"; }
+}));
 
 QUnit.module("ember-routing-htmlbars: link-to helper", {
+  setup: function() {
+    container = registry.container();
+  },
+
   teardown: function() {
     runDestroy(view);
   }
@@ -18,7 +39,8 @@ QUnit.module("ember-routing-htmlbars: link-to helper", {
 QUnit.test("should be able to be inserted in DOM when the router is not present", function() {
   var template = "{{#link-to 'index'}}Go to Index{{/link-to}}";
   view = EmberView.create({
-    template: compile(template)
+    template: compile(template),
+    container: container
   });
 
   runAppend(view);
@@ -33,7 +55,8 @@ QUnit.test("re-renders when title changes", function() {
       title: 'foo',
       routeName: 'index'
     },
-    template: compile(template)
+    template: compile(template),
+    container: container
   });
 
   runAppend(view);
@@ -54,7 +77,8 @@ QUnit.test("can read bound title", function() {
       title: 'foo',
       routeName: 'index'
     },
-    template: compile(template)
+    template: compile(template),
+    container: container
   });
 
   runAppend(view);
@@ -65,7 +89,8 @@ QUnit.test("can read bound title", function() {
 QUnit.test("escaped inline form (double curlies) escapes link title", function() {
   view = EmberView.create({
     title: "<b>blah</b>",
-    template: compile("{{link-to view.title}}")
+    template: compile("{{link-to view.title}}"),
+    container: container
   });
 
   runAppend(view);
@@ -76,7 +101,8 @@ QUnit.test("escaped inline form (double curlies) escapes link title", function()
 QUnit.test("unescaped inline form (triple curlies) does not escape link title", function() {
   view = EmberView.create({
     title: "<b>blah</b>",
-    template: compile("{{{link-to view.title}}}")
+    template: compile("{{{link-to view.title}}}"),
+    container: container
   });
 
   runAppend(view);
@@ -92,7 +118,8 @@ QUnit.test("unwraps controllers", function() {
       model: 'foo'
     }),
 
-    template: compile(template)
+    template: compile(template),
+    container: container
   });
 
   expectDeprecation(function() {

--- a/packages/ember-routing/lib/initializers/routing-service.js
+++ b/packages/ember-routing/lib/initializers/routing-service.js
@@ -1,0 +1,14 @@
+import { onLoad } from "ember-runtime/system/lazy_load";
+import RoutingService from "ember-routing/services/routing";
+
+onLoad('Ember.Application', function(Application) {
+  Application.initializer({
+    name: 'routing-service',
+    initialize: function(registry) {
+      // Register the routing service...
+      registry.register('service:-routing', RoutingService);
+      // Then inject the app router into it
+      registry.injection('service:-routing', 'router', 'router:main');
+    }
+  });
+});

--- a/packages/ember-routing/lib/main.js
+++ b/packages/ember-routing/lib/main.js
@@ -27,6 +27,8 @@ import RouterDSL from "ember-routing/system/dsl";
 import Router from "ember-routing/system/router";
 import Route from "ember-routing/system/route";
 
+import "ember-routing/initializers/routing-service";
+
 Ember.Location = EmberLocation;
 Ember.AutoLocation = AutoLocation;
 Ember.HashLocation = HashLocation;

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -1,0 +1,102 @@
+/**
+@module ember
+@submodule ember-routing
+*/
+
+import Service from "ember-runtime/system/service";
+
+import { get } from "ember-metal/property_get";
+import { readOnly } from "ember-metal/computed_macros";
+import { routeArgs } from "ember-routing/utils";
+import keys from "ember-metal/keys";
+import merge from "ember-metal/merge";
+
+/** @private
+  The Routing service is used by LinkView, and provides facilities for
+  the component/view layer to interact with the router.
+
+  While still private, this service can eventually be opened up, and provides
+  the set of API needed for components to control routing without interacting
+  with router internals.
+*/
+
+var RoutingService = Service.extend({
+  router: null,
+
+  targetState: readOnly('router.targetState'),
+  currentState: readOnly('router.currentState'),
+  currentRouteName: readOnly('router.currentRouteName'),
+
+  availableRoutes: function() {
+    return keys(get(this, 'router').router.recognizer.names);
+  },
+
+  hasRoute: function(routeName) {
+    return get(this, 'router').hasRoute(routeName);
+  },
+
+  transitionTo: function(routeName, models, queryParams, shouldReplace) {
+    var router = get(this, 'router');
+
+    var transition = router._doTransition(routeName, models, queryParams);
+
+    if (shouldReplace) {
+      transition.method('replace');
+    }
+  },
+
+  normalizeQueryParams: function(routeName, models, queryParams) {
+    get(this, 'router')._prepareQueryParams(routeName, models, queryParams);
+  },
+
+  generateURL: function(routeName, models, queryParams) {
+    var router = get(this, 'router');
+
+    var visibleQueryParams = {};
+    merge(visibleQueryParams, queryParams);
+
+    this.normalizeQueryParams(routeName, models, visibleQueryParams);
+
+    var args = routeArgs(routeName, models, visibleQueryParams);
+    return router.generate.apply(router, args);
+  },
+
+  isActiveForRoute: function(params, routeName, routerState, isCurrentWhenSpecified) {
+    var router = get(this, 'router');
+    var contexts = params.models;
+
+    var handlers = router.router.recognizer.handlersFor(routeName);
+    var leafName = handlers[handlers.length-1].handler;
+    var maximumContexts = numberOfContextsAcceptedByHandler(routeName, handlers);
+
+    // NOTE: any ugliness in the calculation of activeness is largely
+    // due to the fact that we support automatic normalizing of
+    // `resource` -> `resource.index`, even though there might be
+    // dynamic segments / query params defined on `resource.index`
+    // which complicates (and makes somewhat ambiguous) the calculation
+    // of activeness for links that link to `resource` instead of
+    // directly to `resource.index`.
+
+    // if we don't have enough contexts revert back to full route name
+    // this is because the leaf route will use one of the contexts
+    if (contexts.length > maximumContexts) {
+      routeName = leafName;
+    }
+
+    return routerState.isActiveIntent(routeName, contexts, params.queryParams, !isCurrentWhenSpecified);
+  }
+});
+
+var numberOfContextsAcceptedByHandler = function(handler, handlerInfos) {
+  var req = 0;
+  for (var i = 0, l = handlerInfos.length; i < l; i++) {
+    req = req + handlerInfos[i].names.length;
+    if (handlerInfos[i].handler === handler) {
+      break;
+    }
+  }
+
+  return req;
+};
+
+export default RoutingService;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -875,12 +875,14 @@ function updatePaths(router) {
   }
 
   set(appController, 'currentPath', path);
+  set(router, 'currentPath', path);
 
   if (!('currentRouteName' in appController)) {
     defineProperty(appController, 'currentRouteName');
   }
 
   set(appController, 'currentRouteName', infos[infos.length - 1].name);
+  set(router, 'currentRouteName', infos[infos.length - 1].name);
 }
 
 EmberRouter.reopenClass({


### PR DESCRIPTION
This commit introduces a new routing service, so that we can decouple `LinkView` from knowing about the actual router’s internals.

Before this commit, LinkView tried to find the router off of its controller, and looked up the application controller to get current router state. This commit creates an initial API for working with a single uniform service that provides the information.

The implementation of the routing service is not yet ready to be made a public API, but it should be possible to expose once it stabilizes further. The long-term goal is to provide a robust enough service that end users could relatively easily implement their own LinkView using public APIs.
