### PR TITLE
Alias computed.setDiff to computed.difference.

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -581,6 +581,19 @@ export function setDiff(setAProperty, setBProperty) {
   });
 }
 
+/**
+  Alias for [Ember.computed.setDiff](/api/#method_computed_setDiff).
+
+  @method difference
+  @for Ember.computed
+  @param {String} setAProperty
+  @param {String} setBProperty
+  @return {Ember.ComputedProperty} computes a new array with all the
+  items from the first dependent array that are not in the second
+  dependent array
+*/
+export var difference = setDiff;
+
 function binarySearch(array, item, low, high) {
   var mid, midItem, res, guidMid, guidItem;
 

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -71,6 +71,7 @@ import {
   map,
   sort,
   setDiff,
+  difference,
   mapBy,
   mapProperty,
   filter,
@@ -136,6 +137,7 @@ EmComputed.max = max;
 EmComputed.map = map;
 EmComputed.sort = sort;
 EmComputed.setDiff = setDiff;
+EmComputed.difference = difference;
 EmComputed.mapBy = mapBy;
 EmComputed.mapProperty = mapProperty;
 EmComputed.filter = filter;

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -19,6 +19,7 @@ import {
   map as computedMap,
   sort as computedSort,
   setDiff as computedSetDiff,
+  difference as computedDifference,
   mapBy as computedMapBy,
   filter as computedFilter,
   filterBy as computedFilterBy,
@@ -614,40 +615,45 @@ QUnit.test("it has set-intersection semantics", function() {
 });
 
 
-QUnit.module('computedSetDiff', {
-  setup: function() {
-    run(function() {
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([1,2,3,4,5,6,7]),
-        array2: Ember.A([3,4,5,10]),
-        diff: computedSetDiff('array', 'array2')
+forEach.call([['difference', computedDifference], ['setDiff', computedSetDiff]], function (tuple) {
+  var alias  = tuple[0];
+  var testedFunc = tuple[1];
+
+  QUnit.module('computed.' + alias, {
+    setup: function() {
+      run(function() {
+        obj = EmberObject.createWithMixins({
+          array: Ember.A([1,2,3,4,5,6,7]),
+          array2: Ember.A([3,4,5,10]),
+          diff: testedFunc('array', 'array2')
+        });
       });
-    });
-  },
-  teardown: function() {
-    run(function() {
-      obj.destroy();
-    });
-  }
-});
+    },
+    teardown: function() {
+      run(function() {
+        obj.destroy();
+      });
+    }
+  });
 
-QUnit.test("it throws an error if given fewer or more than two dependent properties", function() {
-  throws(function () {
-    EmberObject.createWithMixins({
-        array: Ember.A([1,2,3,4,5,6,7]),
-        array2: Ember.A([3,4,5]),
-        diff: computedSetDiff('array')
-    });
-  }, /requires exactly two dependent arrays/, "setDiff requires two dependent arrays");
+  QUnit.test("it throws an error if given fewer or more than two dependent properties", function() {
+    throws(function () {
+      EmberObject.createWithMixins({
+          array: Ember.A([1,2,3,4,5,6,7]),
+          array2: Ember.A([3,4,5]),
+          diff: testedFunc('array')
+      });
+    }, /requires exactly two dependent arrays/, alias + " requires two dependent arrays");
 
-  throws(function () {
-    EmberObject.createWithMixins({
-        array: Ember.A([1,2,3,4,5,6,7]),
-        array2: Ember.A([3,4,5]),
-        array3: Ember.A([7]),
-        diff: computedSetDiff('array', 'array2', 'array3')
-    });
-  }, /requires exactly two dependent arrays/, "setDiff requires two dependent arrays");
+    throws(function () {
+      EmberObject.createWithMixins({
+          array: Ember.A([1,2,3,4,5,6,7]),
+          array2: Ember.A([3,4,5]),
+          array3: Ember.A([7]),
+          diff: computedSetDiff('array', 'array2', 'array3')
+      });
+    }, /requires exactly two dependent arrays/, alias + " requires two dependent arrays");
+  });
 });
 
 


### PR DESCRIPTION
We have `computed.intersect` and `computed.union` defined, so we should have `computed.difference` as well, as `setDiff` isn't as obvious as the other set methods.

Note that this implementation is intended to be as similar as possible to the alias of `computed.uniq` to `computed.union`. This includes testing both `computedSetDiff` and `computedDifference` with the old `setDiff` tests in a `forEach` loop.
