### PR TITLE
[BUGFIX beta] Ensure 'use strict'; remover comments are not stripped.

### DIFF
--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -1,7 +1,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 //
-// REMOVE_USE_STRICT: true
+"REMOVE_USE_STRICT: true";
 
 import o_create from "ember-metal/platform/create";
 import {

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -1,7 +1,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 //
-// REMOVE_USE_STRICT: true
+"REMOVE_USE_STRICT: true";
 
 /**
 @module ember-metal

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -1,7 +1,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 //
-// REMOVE_USE_STRICT: true
+"REMOVE_USE_STRICT: true";
 
 /**
 @module ember

--- a/packages/ember-metal/lib/platform/create.js
+++ b/packages/ember-metal/lib/platform/create.js
@@ -1,8 +1,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 //
-// REMOVE_USE_STRICT: true
-//
+"REMOVE_USE_STRICT: true";
 
 import defineProperties from 'ember-metal/platform/define_properties';
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -1,7 +1,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 //
-// REMOVE_USE_STRICT: true
+"REMOVE_USE_STRICT: true";
 
 import Ember from "ember-metal/core";
 import o_create from 'ember-metal/platform/create';

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -1,7 +1,7 @@
 // Remove "use strict"; from transpiled module until
 // https://bugs.webkit.org/show_bug.cgi?id=138038 is fixed
 //
-// REMOVE_USE_STRICT: true
+"REMOVE_USE_STRICT: true";
 
 /**
   @module ember


### PR DESCRIPTION
Somewhere throughout our build pipeline, leading comments are being stripped. This meant that the `REMOVE_USE_STRICT` comments could not be found, and the modules were still in strict mode when they should not have been.
