### PR TITLE
Add test for broken {{link-to}} behavior in beta

### DIFF
--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -920,6 +920,41 @@ QUnit.test("The {{link-to}} helper is active when a resource is active", functio
 
 });
 
+QUnit.test("The {{link-to}} helper is active after a slow router transition", function() {
+  Router.map(function() {
+    this.resource("about", function() {
+      this.route("item");
+    });
+  });
+
+
+
+  Ember.TEMPLATES.about = compile("<div id='about'>{{#link-to 'about' id='about-link'}}About{{/link-to}} {{#link-to 'about.item' id='item-link'}}Item{{/link-to}} {{outlet}}</div>");
+  Ember.TEMPLATES['about/item'] = compile(" ");
+  Ember.TEMPLATES['about/index'] = compile(" ");
+
+  App.AboutRoute = Ember.Route.extend({
+    model: function() {
+      return new Ember.RSVP.Promise(function(resolve) {
+        setTimeout(resolve, 2);
+      });
+    }
+  });
+
+  bootApplication();
+
+  Ember.run(router, 'handleURL', '/about');
+
+  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, "The about resource link is active");
+  equal(Ember.$('#item-link.active', '#qunit-fixture').length, 0, "The item route link is inactive");
+
+  Ember.run(router, 'handleURL', '/about/item');
+
+  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, "The about resource link is active");
+  equal(Ember.$('#item-link.active', '#qunit-fixture').length, 1, "The item route link is active");
+
+});
+
 QUnit.test("The {{link-to}} helper works in an #each'd array of string route names", function() {
   Router.map(function() {
     this.route('foo');


### PR DESCRIPTION
Beginning around 1.11.0-beta.1 and continuing on in canary the {{link-to}} helper does not apply the `active` class when transitioning into a route that returns a promise. In some cases it appears that it adds the `active` class when it should be removing it.

![active](https://cloud.githubusercontent.com/assets/322706/6605410/cd658c80-c7fd-11e4-939f-328e9544a8ad.gif)

Related issue: https://github.com/emberjs/ember.js/issues/10421
Related issue (likely): https://github.com/emberjs/ember.js/issues/10557
