### PR TITLE
[BUGFIX release] `Ember.inject.controller()` works for all Controller types.

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -18,7 +18,7 @@ var Controller = EmberObject.extend(Mixin);
 
 function controllerInjectionHelper(factory) {
   Ember.assert("Defining an injected controller property on a " +
-               "non-controller is not allowed.", Controller.detect(factory));
+               "non-controller is not allowed.", Mixin.detect(factory.PrototypeMixin));
 }
 
 /**

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -3,6 +3,7 @@
 import Controller from "ember-runtime/controllers/controller";
 import Service from "ember-runtime/system/service";
 import ObjectController from "ember-runtime/controllers/object_controller";
+import ArrayController from "ember-runtime/controllers/array_controller";
 import {
   objectControllerDeprecation
 } from "ember-runtime/controllers/object_controller";
@@ -221,6 +222,42 @@ QUnit.test("controllers can be injected into controllers", function() {
 
   equal(postsController, postController.get('postsController'), "controller.posts is injected");
 });
+
+QUnit.test("controllers can be injected into ObjectControllers", function() {
+  var registry = new Registry();
+  var container = registry.container();
+
+  registry.register('controller:post', Controller.extend({
+    postsController: inject.controller('posts')
+  }));
+
+  registry.register('controller:posts', ObjectController.extend());
+
+  var postController = container.lookup('controller:post');
+  var postsController;
+  expectDeprecation(function() {
+    postsController = container.lookup('controller:posts');
+  }, objectControllerDeprecation);
+
+  equal(postsController, postController.get('postsController'), "controller.posts is injected");
+});
+
+QUnit.test("controllers can be injected into ArrayControllers", function() {
+  var registry = new Registry();
+  var container = registry.container();
+
+  registry.register('controller:post', Controller.extend({
+    postsController: inject.controller('posts')
+  }));
+
+  registry.register('controller:posts', ArrayController.extend());
+
+  var postController = container.lookup('controller:post');
+  var postsController = container.lookup('controller:posts');
+
+  equal(postsController, postController.get('postsController'), "controller.posts is injected");
+});
+
 
 QUnit.test("services can be injected into controllers", function() {
   var registry = new Registry();


### PR DESCRIPTION
Fixes #10610
Fixes #10605
