### PR TITLE
Fix lazy module cycle support

### DIFF
--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -5,7 +5,6 @@ var mainContext = this;
 
   Ember = this.Ember = this.Ember || {};
   if (typeof Ember === 'undefined') { Ember = {}; };
-  function UNDEFINED() { }
 
   if (typeof Ember.__loader === 'undefined') {
     var registry = {};
@@ -26,12 +25,13 @@ var mainContext = this;
     };
 
     requirejs = require = requireModule = function(name) {
-      var s = seen[name];
+      var exports = seen[name];
 
-      if (s !== undefined) { return seen[name]; }
-      if (s === UNDEFINED) { return undefined;  }
+      if (exports !== undefined) {
+        return exports;
+      }
 
-      seen[name] = {};
+      exports = seen[name] = {};
 
       if (!registry[name]) {
         throw new Error('Could not find module ' + name);
@@ -41,20 +41,19 @@ var mainContext = this;
       var deps = mod.deps;
       var callback = mod.callback;
       var reified = [];
-      var exports;
       var length = deps.length;
 
       for (var i=0; i<length; i++) {
         if (deps[i] === 'exports') {
-          reified.push(exports = {});
+          reified.push(exports);
         } else {
           reified.push(requireModule(resolve(deps[i], name)));
         }
       }
 
-      var value = length === 0 ? callback.call(this) : callback.apply(this, reified);
+      callback.apply(this, reified);
 
-      return seen[name] = exports || (value === undefined ? UNDEFINED : value);
+      return exports;
     };
 
     function resolve(child, name) {


### PR DESCRIPTION
Fixes a bug in the loader where the pre-allocated exports hash intended to break cycles (see [code](https://github.com/emberjs/ember.js/blob/3bb454762ce7d62f03bb6f778f9a3831829b72fa/packages/loader/lib/main.js#L34)) is overwritten by the new `exports` object (see [code](https://github.com/emberjs/ember.js/blob/3bb454762ce7d62f03bb6f778f9a3831829b72fa/packages/loader/lib/main.js#L49)).

The problem occurs when recursing on dependencies (see [code](https://github.com/emberjs/ember.js/blob/3bb454762ce7d62f03bb6f778f9a3831829b72fa/packages/loader/lib/main.js#L51)) because during this time the `seen` cache may be pointing at the pre-allocated exports hash.

Merging this PR will fix fully async cycles, like

``` js
// a.js
import B from "b";

export default class A {
  makeB() { return new B(); }
}
```

``` js
// b.js
import A from "a";

export default class B {
  makeA() { return new A(); }
}
```

but does not fix half-async cycles, like

``` js
// a.js
import B from "b";

export default class A {
  makeB() { return new B(); }
}
```

``` js
// b.js
import A from "a";

export default class B extends A { }
```

Without late bindings, the success of loading half-async cycles depends on the order that they are imported.