### PR TITLE
[BUGFIX beta] Deprecate using `fooBinding` with non-quoted values.

### DIFF
--- a/packages/ember-htmlbars/lib/system/merge-view-bindings.js
+++ b/packages/ember-htmlbars/lib/system/merge-view-bindings.js
@@ -31,7 +31,7 @@ function mergeGenericViewBindings(view, props, hash) {
       if (typeof value === 'string') {
         props[key] = view._getBindingForStream(value);
       } else if (isStream(value)) {
-        Ember.warn(
+        Ember.deprecate(
           "You're attempting to render a view by passing " + key + " " +
           "to a view helper without a quoted value, but this syntax is " +
           "ambiguous. You should either surround " + key + "'s value in " +

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -391,7 +391,7 @@ QUnit.test("should give its item views the property specified by itemPropertyBin
         return ItemPropertyBindingTestItemView;
       }
     },
-    template: compile('{{#collection contentBinding="view.content" tagName="ul" itemViewClass="item-property-binding-test-item-view" itemPropertyBinding="view.baz" preserveContext=false}}{{view.property}}{{/collection}}')
+    template: compile('{{#collection contentBinding="view.content" tagName="ul" itemViewClass="item-property-binding-test-item-view" itemProperty=view.baz preserveContext=false}}{{view.property}}{{/collection}}')
   });
 
   runAppend(view);
@@ -413,7 +413,7 @@ QUnit.test("should unsubscribe stream bindings", function() {
   view = EmberView.create({
     baz: "baz",
     content: A([EmberObject.create(), EmberObject.create(), EmberObject.create()]),
-    template: compile('{{#collection contentBinding="view.content" itemPropertyBinding="view.baz"}}{{view.property}}{{/collection}}')
+    template: compile('{{#collection contentBinding="view.content" itemProperty=view.baz}}{{view.property}}{{/collection}}')
   });
 
   runAppend(view);

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -268,7 +268,9 @@ QUnit.test("mixing old and new styles of property binding fires a warning, treat
     snork: "nerd"
   }).create();
 
-  runAppend(view);
+  expectDeprecation(function() {
+    runAppend(view);
+  }, /You're attempting to render a view by passing borfBinding to a view helper without a quoted value, but this syntax is ambiguous. You should either surround borfBinding's value in quotes or remove `Binding` from borfBinding./);
 
   equal(jQuery('#lol').text(), "nerd", "awkward mixed syntax treated like binding");
 


### PR DESCRIPTION
This was previously generating a warning, but not a deprecation. This sets the stage to remove the fallback in Ember 2.0.
