### PR TITLE
[BUGFIX release] Set isVirtual on attr_nodes instead of blanking classNameBindings

### DIFF
--- a/packages/ember-views/lib/attr_nodes/attr_node.js
+++ b/packages/ember-views/lib/attr_nodes/attr_node.js
@@ -17,9 +17,8 @@ function AttrNode(attrName, attrValue) {
 AttrNode.prototype.init = function init(attrName, simpleAttrValue){
   this.isView = true;
 
-  // That these semantics are used is very unfortunate.
   this.tagName = '';
-  this.classNameBindings = [];
+  this.isVirtual = true;
 
   this.attrName = attrName;
   this.attrValue = simpleAttrValue;
@@ -60,6 +59,15 @@ AttrNode.prototype.destroy = function render() {
 
   var parent = this._parentView;
   if (parent) { parent.removeChild(this); }
+};
+
+AttrNode.prototype.propertyDidChange = function render() {
+};
+
+AttrNode.prototype._notifyBecameHidden = function render() {
+};
+
+AttrNode.prototype._notifyBecameVisible = function render() {
 };
 
 export default AttrNode;

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -3,6 +3,7 @@ import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
+import compile from "ember-template-compiler/system/compile";
 
 var View, view, parentBecameVisible, childBecameVisible, grandchildBecameVisible;
 var parentBecameHidden, childBecameHidden, grandchildBecameHidden;
@@ -126,8 +127,28 @@ test("view should be notified after isVisible is set to false and the element ha
 });
 
 test("view should be notified after isVisible is set to false and the element has been hidden", function() {
-  view = View.create({ isVisible: true });
-  var childView = view.get('childViews').objectAt(0);
+  run(function() {
+    view = View.create({ isVisible: false });
+    view.append();
+  });
+
+  ok(view.$().is(':hidden'), "precond - view is hidden when appended");
+
+  run(function() {
+    view.set('isVisible', true);
+  });
+
+  ok(view.$().is(':visible'), "precond - view is now visible");
+  equal(parentBecameVisible, 1);
+  equal(childBecameVisible, 1);
+  equal(grandchildBecameVisible, 1);
+});
+
+test("view should change visibility with a virtual childView", function() {
+  view = View.create({
+    isVisible: true,
+    template: compile('<div {{bind-attr bing="tweep"}}></div>')
+  });
 
   run(function() {
     view.append();
@@ -136,13 +157,10 @@ test("view should be notified after isVisible is set to false and the element ha
   ok(view.$().is(':visible'), "precond - view is visible when appended");
 
   run(function() {
-    childView.set('isVisible', false);
+    view.set('isVisible', false);
   });
 
-  ok(childView.$().is(':hidden'), "precond - view is now hidden");
-
-  equal(childBecameHidden, 1);
-  equal(grandchildBecameHidden, 1);
+  ok(view.$().is(':hidden'), "precond - view is now hidden");
 });
 
 test("view should be notified after isVisible is set to true and the element has been shown", function() {


### PR DESCRIPTION
attr_nodes were not virtual, but simply ducked a few virtual APIs. There are a few hooks that may be called on them despite this.

This adds those hooks and tests the `isVisible` case. There is a second case described in #10502 that refers to a situation where attr nodes get added to `_childViews` on a container view along side concrete views. I've not been able to recreate this in a test, but this should address it regardless.

The patch here is messy, but all of this code is refactored with Glimmer.
