### PR TITLE
Stop exporting private views

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -7,6 +7,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { A } from "ember-runtime/system/native_array";
 import Component from "ember-views/views/component";
+import { _Metamorph } from "ember-views/views/metamorph_view";
 import EmberError from "ember-metal/error";
 import helpers from "ember-htmlbars/helpers";
 import {
@@ -354,8 +355,8 @@ QUnit.test("yield with nested components (#3220)", function() {
   equal(view.$('div > span').text(), "Hello world");
 });
 
-QUnit.test("yield works inside a conditional in a component that has Ember._Metamorph mixed in", function() {
-  var component = Component.extend(Ember._Metamorph, {
+QUnit.test("yield works inside a conditional in a component that has _Metamorph mixed in", function() {
+  var component = Component.extend(_Metamorph, {
     item: "inner",
     layout: compile("<p>{{item}}</p>{{#if item}}<p>{{yield}}</p>{{/if}}")
   });

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -38,11 +38,6 @@ import TextSupport from "ember-views/mixins/text_support";
 import TextField from "ember-views/views/text_field";
 import TextArea from "ember-views/views/text_area";
 
-import SimpleBoundView from "ember-views/views/simple_bound_view";
-import _MetamorphView from "ember-views/views/metamorph_view";
-import {
-  _Metamorph
-} from "ember-views/views/metamorph_view";
 import {
   Select,
   SelectOption,
@@ -78,9 +73,6 @@ Ember.Checkbox = Checkbox;
 Ember.TextField = TextField;
 Ember.TextArea = TextArea;
 
-Ember._SimpleBoundView = SimpleBoundView;
-Ember._MetamorphView = _MetamorphView;
-Ember._Metamorph = _Metamorph;
 Ember.Select = Select;
 Ember.SelectOption = SelectOption;
 Ember.SelectOptgroup = SelectOptgroup;

--- a/packages/ember-views/lib/views/metamorph_view.js
+++ b/packages/ember-views/lib/views/metamorph_view.js
@@ -9,14 +9,6 @@ import { Mixin } from "ember-metal/mixin";
 @submodule ember-views
 */
 
-// The `morph` and `outerHTML` properties are internal only
-// and not observable.
-
-/**
-  @class _Metamorph
-  @namespace Ember
-  @private
-*/
 export var _Metamorph = Mixin.create({
   isVirtual: true,
   tagName: '',
@@ -30,11 +22,4 @@ export var _Metamorph = Mixin.create({
   }
 });
 
-/**
-  @class _MetamorphView
-  @namespace Ember
-  @extends Ember.View
-  @uses Ember._Metamorph
-  @private
-*/
 export default View.extend(_Metamorph);


### PR DESCRIPTION
A deprecation warning should not be necessary as these are private APIs.
