### PR TITLE
Remove Ember.Descriptor from exports

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -108,7 +108,6 @@ function UNDEFINED() { }
 
   @class ComputedProperty
   @namespace Ember
-  @extends Ember.Descriptor
   @constructor
 */
 function ComputedProperty(config, opts) {

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -9,7 +9,6 @@ import create from "ember-metal/platform/create";
 
   @class InjectedProperty
   @namespace Ember
-  @extends Ember.Descriptor
   @constructor
   @param {String} type The container type the property will lookup
   @param {String} name (optional) The name the property will lookup, defaults

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -303,7 +303,6 @@ Ember.beginPropertyChanges = beginPropertyChanges;
 Ember.endPropertyChanges = endPropertyChanges;
 Ember.changeProperties = changeProperties;
 
-Ember.Descriptor     = Descriptor;
 Ember.defineProperty = defineProperty;
 
 Ember.set    = set;

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -770,7 +770,6 @@ Alias.prototype = new Descriptor();
   @method aliasMethod
   @for Ember
   @param {String} methodName name of the method to alias
-  @return {Ember.Descriptor}
 */
 export function aliasMethod(methodName) {
   return new Alias(methodName);

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -16,13 +16,6 @@ import { overrideChains } from "ember-metal/property_events";
 /**
   Objects of this type can implement an interface to respond to requests to
   get and set. The default implementation handles simple properties.
-
-  You generally won't need to create or subclass this directly.
-
-  @class Descriptor
-  @namespace Ember
-  @private
-  @constructor
 */
 export function Descriptor() {
   this.isDescriptor = true;
@@ -55,7 +48,7 @@ export function DEFAULT_GETTER_FUNCTION(name) {
   properties and other special descriptors.
 
   Normally this method takes only three parameters. However if you pass an
-  instance of `Ember.Descriptor` as the third param then you can pass an
+  instance of `Descriptor` as the third param then you can pass an
   optional value as the fourth parameter. This is often more efficient than
   creating new descriptor hashes for each property.
 
@@ -84,7 +77,7 @@ export function DEFAULT_GETTER_FUNCTION(name) {
   @for Ember
   @param {Object} obj the object to define this property on. This may be a prototype.
   @param {String} keyName the name of the property
-  @param {Ember.Descriptor} [desc] an instance of `Ember.Descriptor` (typically a
+  @param {Descriptor} [desc] an instance of `Descriptor` (typically a
     computed property) or an ES5 descriptor.
     You must provide this or `data` but not both.
   @param {*} [data] something other than a descriptor, that will


### PR DESCRIPTION
This has been documented as a private API so I don't believe we
need a deprecation.
