### PR TITLE
Ensure docs are not detected for deprecation mixins.

### DIFF
--- a/packages/ember-runtime/lib/mixins/controller_content_model_alias_deprecation.js
+++ b/packages/ember-runtime/lib/mixins/controller_content_model_alias_deprecation.js
@@ -1,7 +1,7 @@
 import Ember from 'ember-metal/core'; // Ember.deprecate
 import { Mixin } from 'ember-metal/mixin';
 
-/**
+/*
   The ControllerContentModelAliasDeprecation mixin is used to provide a useful
   deprecation warning when specifying `content` directly on a `Ember.Controller`
   (without also specifying `model`).

--- a/packages/ember-views/lib/mixins/component_template_deprecation.js
+++ b/packages/ember-views/lib/mixins/component_template_deprecation.js
@@ -2,7 +2,7 @@ import Ember from 'ember-metal/core'; // Ember.deprecate
 import { get } from "ember-metal/property_get";
 import { Mixin } from 'ember-metal/mixin';
 
-/**
+/*
   The ComponentTemplateDeprecation mixin is used to provide a useful
   deprecation warning when using either `template` or `templateName` with
   a component. The `template` and `templateName` properties specified at


### PR DESCRIPTION
Some of the docs were removed in #10671, but they would still be picked up by YUIDoc unless we change `/**` to `/*`.
