### PR TITLE
Fix UnrecognizedURLError inheritance via router.js update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "backburner": "https://github.com/ebryn/backburner.js.git#f4bd6a2df221240ed36d140f0c53c036a7ecacad",
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
-    "router.js": "https://github.com/tildeio/router.js.git#2a21f87512b259bdbb13e3b9faa1e06a898e5c1c",
+    "router.js": "https://github.com/tildeio/router.js.git#5081e7a5e3b0985608224f2f86e1a5c5c15e2662",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
     "ember-dev": "https://github.com/emberjs/ember-dev.git#1a1ef3e1806be21dd554d285521abc0b13cdfe20"
   }


### PR DESCRIPTION
This fixes the failing `warn on URLs not included in the route set` test.

Which was suspiciously not failing on travis, possibly due to caching.
