### PR TITLE
[BUGFIX beta] Remove incorrect assertion

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1994,8 +1994,6 @@ function buildRenderOptions(route, namePassed, isDefaultRender, name, options) {
     }
   }
 
-  Ember.assert("An outlet ("+outlet+") was specified but was not found.", outlet === 'main' || into);
-
   var parent;
   if (into && (parent = parentRoute(route)) && into === parentRoute(route).routeName) {
     into = undefined;


### PR DESCRIPTION
This assertion was left over from before the outlet refactor. It no longer makes sense here, and triggers when it shouldn't. The corresponding correct assertion now happens in appendLiveRoute in `ember-routing/lib/system/router.js` instead.

Closes #10611.
