### PR TITLE
[BUGFIX canary] Prevent unknown input types from erroring.

### DIFF
--- a/packages/ember-views/tests/views/text_field_test.js
+++ b/packages/ember-views/tests/views/text_field_test.js
@@ -561,3 +561,15 @@ QUnit.test('should not reset cursor position when text field receives keyUp even
 
   equal(caretPosition(view.$()), 5, 'The keyUp event should not result in the cursor being reset due to the bind-attr observers');
 });
+
+QUnit.test('an unsupported type defaults to `text`', function() {
+  view = TextField.create({
+    type: 'blahblah'
+  });
+
+  equal(get(view, 'type'), 'text', 'should default to text if the type is not a valid type');
+
+  appendView(view);
+
+  equal(view.element.type, 'text');
+});


### PR DESCRIPTION
Browsers support various values for `type`, and generally auto-correct to just `"text"` if an unknown type is set via standard HTML.

Unfortunately, the same auto-correct behavior does not apply when setting the attribute directly, and in some circumstances throw an error where the type is not valid.

Specifically, the following throws an error in IE10:

``` javascript
var e = document.createElement('input');

e.type = 'search';
```

However the following HTML would auto-correct to `"text"`:

``` html
<input type="search">
```

---

This PR adds a feature detect to see if a given type can be set to `input`. If setting the type results in the value, then we use it otherwise we default to `"text"`.

Fixes #10458.
