### PR TITLE
[BUGFIX beta] Fix ArrayController when model isn't an Ember.Array.

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -14,6 +14,7 @@ import SortableMixin from 'ember-runtime/mixins/sortable';
 import ControllerMixin from 'ember-runtime/mixins/controller';
 import { computed } from 'ember-metal/computed';
 import EmberError from 'ember-metal/error';
+import EmberArray from 'ember-runtime/mixins/array';
 
 
 /**
@@ -203,7 +204,17 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
     this._subControllers = [];
   },
 
-  model: computed(function () {
+  model: computed(function (key, value) {
+    if (arguments.length > 1) {
+      Ember.assert(
+        'ArrayController expects `model` to implement the Ember.Array mixin. ' +
+        'This can often be fixed by wrapping your model with `Ember.A()`.',
+        EmberArray.detect(value)
+      );
+
+      return value;
+    }
+
     return Ember.A();
   }),
 

--- a/packages/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/array_controller_test.js
@@ -1,6 +1,8 @@
 import Ember from 'ember-metal/core';
 import MutableArrayTests from 'ember-runtime/tests/suites/mutable_array';
 import ArrayController from "ember-runtime/controllers/array_controller";
+import { set } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
 
 QUnit.module("ember-runtime/controllers/array_controller_test");
 
@@ -23,6 +25,8 @@ MutableArrayTests.extend({
   }
 }).run();
 
+QUnit.module("ember-runtime: array_controller");
+
 QUnit.test("defaults its `model` to an empty array", function () {
   var Controller = ArrayController.extend();
   deepEqual(Controller.create().get("model"), [], "`ArrayController` defaults its model to an empty array");
@@ -30,9 +34,30 @@ QUnit.test("defaults its `model` to an empty array", function () {
   equal(Controller.create().get('lastObject'), undefined, 'can fetch lastObject');
 });
 
-
 QUnit.test("Ember.ArrayController length property works even if model was not set initially", function() {
   var controller = ArrayController.create();
   controller.pushObject('item');
   equal(controller.get('length'), 1);
+});
+
+QUnit.test('works properly when model is set to an Ember.A()', function() {
+  var controller = ArrayController.create();
+
+  set(controller, 'model', Ember.A(['red', 'green']));
+
+  deepEqual(get(controller, 'model'), ['red', 'green'], "can set model as an Ember.Array");
+});
+
+QUnit.test('works properly when model is set to a plain array', function() {
+  var controller = ArrayController.create();
+
+  if (Ember.EXTEND_PROTOTYPES) {
+    set(controller, 'model', ['red', 'green']);
+
+    deepEqual(get(controller, 'model'), ['red', 'green'], "can set model as a plain array");
+  } else {
+    expectAssertion(function() {
+      set(controller, 'model', ['red', 'green']);
+    }, /ArrayController expects `model` to implement the Ember.Array mixin. This can often be fixed by wrapping your model with `Ember\.A\(\)`./);
+  }
 });


### PR DESCRIPTION
In the simplest case, having a route like the following:

``` javascript
export default Ember.Route.extend({
  model: function() {
    return ['red', 'green', 'blue'];
  }
});
```

Throws a very unhelpful error when prototype extensions are not enabled.

This ensures that a helpful assertion is thrown when the model does not extend from the `Ember.Array` mixin.

Fixes #10590.
