### PR TITLE
Style cleanup on chains.js

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -1,8 +1,8 @@
 import Ember from "ember-metal/core"; // warn, assert, etc;
-import {get, normalizeTuple} from "ember-metal/property_get";
-import {meta as metaFor} from "ember-metal/utils";
-import {forEach} from "ember-metal/array";
-import {watchKey, unwatchKey} from "ember-metal/watch_key";
+import { get, normalizeTuple } from "ember-metal/property_get";
+import { meta as metaFor } from "ember-metal/utils";
+import { forEach } from "ember-metal/array";
+import { watchKey, unwatchKey } from "ember-metal/watch_key";
 
 var warn = Ember.warn;
 var FIRST_KEY = /^([^\.]+)/;
@@ -11,13 +11,19 @@ function firstKey(path) {
   return path.match(FIRST_KEY)[0];
 }
 
+function isObject(obj) {
+  return obj && (typeof obj === 'object');
+}
+
 var pendingQueue = [];
 
 // attempts to add the pendingQueue chains again. If some of them end up
 // back in the queue and reschedule is true, schedules a timeout to try
 // again.
 export function flushPendingChains() {
-  if (pendingQueue.length === 0) { return; } // nothing to do
+  if (pendingQueue.length === 0) {
+    return;
+  }
 
   var queue = pendingQueue;
   pendingQueue = [];
@@ -31,7 +37,9 @@ export function flushPendingChains() {
 }
 
 function addChainWatcher(obj, keyName, node) {
-  if (!obj || ('object' !== typeof obj)) { return; } // nothing to do
+  if (!isObject(obj)) {
+    return;
+  }
 
   var m = metaFor(obj);
   var nodes = m.chainWatchers;
@@ -48,10 +56,14 @@ function addChainWatcher(obj, keyName, node) {
 }
 
 function removeChainWatcher(obj, keyName, node) {
-  if (!obj || 'object' !== typeof obj) { return; } // nothing to do
+  if (!isObject(obj)) {
+    return;
+  }
 
   var m = obj['__ember_meta__'];
-  if (m && !m.hasOwnProperty('chainWatchers')) { return; } // nothing to do
+  if (m && !m.hasOwnProperty('chainWatchers')) {
+    return;
+  }
 
   var nodes = m && m.chainWatchers;
 
@@ -80,9 +92,9 @@ function ChainNode(parent, key, value) {
   // It is false for the root of a chain (because we have no parent)
   // and for global paths (because the parent node is the object with
   // the observer on it)
-  this._watching = value===undefined;
+  this._watching = (value === undefined);
 
-  this._value  = value;
+  this._value = value;
   this._paths = {};
   if (this._watching) {
     this._object = parent.value();
@@ -101,17 +113,15 @@ function ChainNode(parent, key, value) {
   }
 }
 
-var ChainNodePrototype = ChainNode.prototype;
-
 function lazyGet(obj, key) {
   if (!obj) {
-    return undefined;
+    return;
   }
 
   var meta = obj['__ember_meta__'];
   // check if object meant only to be a prototype
   if (meta && meta.proto === obj) {
-    return undefined;
+    return;
   }
 
   if (key === "@each") {
@@ -125,238 +135,241 @@ function lazyGet(obj, key) {
     if (meta.cache && key in meta.cache) {
       return meta.cache[key];
     } else {
-      return undefined;
+      return;
     }
   }
 
   return get(obj, key);
 }
 
-ChainNodePrototype.value = function() {
-  if (this._value === undefined && this._watching) {
-    var obj = this._parent.value();
-    this._value = lazyGet(obj, this._key);
-  }
-  return this._value;
-};
-
-ChainNodePrototype.destroy = function() {
-  if (this._watching) {
-    var obj = this._object;
-    if (obj) {
-      removeChainWatcher(obj, this._key, this);
+ChainNode.prototype = {
+  value() {
+    if (this._value === undefined && this._watching) {
+      var obj = this._parent.value();
+      this._value = lazyGet(obj, this._key);
     }
-    this._watching = false; // so future calls do nothing
-  }
-};
+    return this._value;
+  },
 
-// copies a top level object only
-ChainNodePrototype.copy = function(obj) {
-  var ret = new ChainNode(null, null, obj);
-  var paths = this._paths;
-  var path;
-
-  for (path in paths) {
-    // this check will also catch non-number vals.
-    if (paths[path] <= 0) {
-      continue;
+  destroy() {
+    if (this._watching) {
+      var obj = this._object;
+      if (obj) {
+        removeChainWatcher(obj, this._key, this);
+      }
+      this._watching = false; // so future calls do nothing
     }
-    ret.add(path);
-  }
-  return ret;
-};
+  },
 
-// called on the root node of a chain to setup watchers on the specified
-// path.
-ChainNodePrototype.add = function(path) {
-  var obj, tuple, key, src, paths;
+  // copies a top level object only
+  copy(obj) {
+    var ret = new ChainNode(null, null, obj);
+    var paths = this._paths;
+    var path;
 
-  paths = this._paths;
-  paths[path] = (paths[path] || 0) + 1;
-
-  obj = this.value();
-  tuple = normalizeTuple(obj, path);
-
-  // the path was a local path
-  if (tuple[0] && tuple[0] === obj) {
-    path = tuple[1];
-    key  = firstKey(path);
-    path = path.slice(key.length+1);
-
-  // global path, but object does not exist yet.
-  // put into a queue and try to connect later.
-  } else if (!tuple[0]) {
-    pendingQueue.push([this, path]);
-    tuple.length = 0;
-    return;
-
-  // global path, and object already exists
-  } else {
-    src  = tuple[0];
-    key  = path.slice(0, 0-(tuple[1].length+1));
-    path = tuple[1];
-  }
-
-  tuple.length = 0;
-  this.chain(key, path, src);
-};
-
-// called on the root node of a chain to teardown watcher on the specified
-// path
-ChainNodePrototype.remove = function(path) {
-  var obj, tuple, key, src, paths;
-
-  paths = this._paths;
-  if (paths[path] > 0) {
-    paths[path]--;
-  }
-
-  obj = this.value();
-  tuple = normalizeTuple(obj, path);
-  if (tuple[0] === obj) {
-    path = tuple[1];
-    key  = firstKey(path);
-    path = path.slice(key.length+1);
-  } else {
-    src  = tuple[0];
-    key  = path.slice(0, 0-(tuple[1].length+1));
-    path = tuple[1];
-  }
-
-  tuple.length = 0;
-  this.unchain(key, path);
-};
-
-ChainNodePrototype.count = 0;
-
-ChainNodePrototype.chain = function(key, path, src) {
-  var chains = this._chains;
-  var node;
-  if (!chains) {
-    chains = this._chains = {};
-  }
-
-  node = chains[key];
-  if (!node) {
-    node = chains[key] = new ChainNode(this, key, src);
-  }
-  node.count++; // count chains...
-
-  // chain rest of path if there is one
-  if (path) {
-    key = firstKey(path);
-    path = path.slice(key.length+1);
-    node.chain(key, path); // NOTE: no src means it will observe changes...
-  }
-};
-
-ChainNodePrototype.unchain = function(key, path) {
-  var chains = this._chains;
-  var node = chains[key];
-
-  // unchain rest of path first...
-  if (path && path.length > 1) {
-    var nextKey  = firstKey(path);
-    var nextPath = path.slice(nextKey.length + 1);
-    node.unchain(nextKey, nextPath);
-  }
-
-  // delete node if needed.
-  node.count--;
-  if (node.count<=0) {
-    delete chains[node._key];
-    node.destroy();
-  }
-
-};
-
-ChainNodePrototype.willChange = function(events) {
-  var chains = this._chains;
-  if (chains) {
-    for (var key in chains) {
-      if (!chains.hasOwnProperty(key)) {
+    for (path in paths) {
+      // this check will also catch non-number vals.
+      if (paths[path] <= 0) {
         continue;
       }
-      chains[key].willChange(events);
+      ret.add(path);
     }
-  }
+    return ret;
+  },
 
-  if (this._parent) {
-    this._parent.chainWillChange(this, this._key, 1, events);
-  }
-};
+  // called on the root node of a chain to setup watchers on the specified
+  // path.
+  add(path) {
+    var obj, tuple, key, src, paths;
 
-ChainNodePrototype.chainWillChange = function(chain, path, depth, events) {
-  if (this._key) {
-    path = this._key + '.' + path;
-  }
+    paths = this._paths;
+    paths[path] = (paths[path] || 0) + 1;
 
-  if (this._parent) {
-    this._parent.chainWillChange(this, path, depth+1, events);
-  } else {
-    if (depth > 1) {
-      events.push(this.value(), path);
+    obj = this.value();
+    tuple = normalizeTuple(obj, path);
+
+    // the path was a local path
+    if (tuple[0] && tuple[0] === obj) {
+      path = tuple[1];
+      key  = firstKey(path);
+      path = path.slice(key.length + 1);
+
+    // global path, but object does not exist yet.
+    // put into a queue and try to connect later.
+    } else if (!tuple[0]) {
+      pendingQueue.push([this, path]);
+      tuple.length = 0;
+      return;
+
+    // global path, and object already exists
+    } else {
+      src  = tuple[0];
+      key  = path.slice(0, 0 - (tuple[1].length + 1));
+      path = tuple[1];
     }
-    path = 'this.' + path;
-    if (this._paths[path] > 0) {
-      events.push(this.value(), path);
+
+    tuple.length = 0;
+    this.chain(key, path, src);
+  },
+
+  // called on the root node of a chain to teardown watcher on the specified
+  // path
+  remove(path) {
+    var obj, tuple, key, src, paths;
+
+    paths = this._paths;
+    if (paths[path] > 0) {
+      paths[path]--;
     }
-  }
-};
 
-ChainNodePrototype.chainDidChange = function(chain, path, depth, events) {
-  if (this._key) {
-    path = this._key + '.' + path;
-  }
-
-  if (this._parent) {
-    this._parent.chainDidChange(this, path, depth+1, events);
-  } else {
-    if (depth > 1) {
-      events.push(this.value(), path);
+    obj = this.value();
+    tuple = normalizeTuple(obj, path);
+    if (tuple[0] === obj) {
+      path = tuple[1];
+      key  = firstKey(path);
+      path = path.slice(key.length + 1);
+    } else {
+      src  = tuple[0];
+      key  = path.slice(0, 0 - (tuple[1].length + 1));
+      path = tuple[1];
     }
-    path = 'this.' + path;
-    if (this._paths[path] > 0) {
-      events.push(this.value(), path);
+
+    tuple.length = 0;
+    this.unchain(key, path);
+  },
+
+  count: 0,
+
+  chain(key, path, src) {
+    var chains = this._chains;
+    var node;
+    if (!chains) {
+      chains = this._chains = {};
     }
-  }
-};
 
-ChainNodePrototype.didChange = function(events) {
-  // invalidate my own value first.
-  if (this._watching) {
-    var obj = this._parent.value();
-    if (obj !== this._object) {
-      removeChainWatcher(this._object, this._key, this);
-      this._object = obj;
-      addChainWatcher(obj, this._key, this);
+    node = chains[key];
+    if (!node) {
+      node = chains[key] = new ChainNode(this, key, src);
     }
-    this._value  = undefined;
+    node.count++; // count chains...
 
-    // Special-case: the EachProxy relies on immediate evaluation to
-    // establish its observers.
-    if (this._parent && this._parent._key === '@each') {
-      this.value();
+    // chain rest of path if there is one
+    if (path) {
+      key = firstKey(path);
+      path = path.slice(key.length + 1);
+      node.chain(key, path); // NOTE: no src means it will observe changes...
     }
-  }
+  },
 
-  // then notify chains...
-  var chains = this._chains;
-  if (chains) {
-    for (var key in chains) {
-      if (!chains.hasOwnProperty(key)) { continue; }
-      chains[key].didChange(events);
+  unchain(key, path) {
+    var chains = this._chains;
+    var node = chains[key];
+
+    // unchain rest of path first...
+    if (path && path.length > 1) {
+      var nextKey  = firstKey(path);
+      var nextPath = path.slice(nextKey.length + 1);
+      node.unchain(nextKey, nextPath);
     }
-  }
 
-  // if no events are passed in then we only care about the above wiring update
-  if (events === null) {
-    return;
-  }
+    // delete node if needed.
+    node.count--;
+    if (node.count <= 0) {
+      delete chains[node._key];
+      node.destroy();
+    }
+  },
 
-  // and finally tell parent about my path changing...
-  if (this._parent) {
-    this._parent.chainDidChange(this, this._key, 1, events);
+  willChange(events) {
+    var chains = this._chains;
+    if (chains) {
+      for (var key in chains) {
+        if (!chains.hasOwnProperty(key)) {
+          continue;
+        }
+        chains[key].willChange(events);
+      }
+    }
+
+    if (this._parent) {
+      this._parent.chainWillChange(this, this._key, 1, events);
+    }
+  },
+
+  chainWillChange(chain, path, depth, events) {
+    if (this._key) {
+      path = this._key + '.' + path;
+    }
+
+    if (this._parent) {
+      this._parent.chainWillChange(this, path, depth + 1, events);
+    } else {
+      if (depth > 1) {
+        events.push(this.value(), path);
+      }
+      path = 'this.' + path;
+      if (this._paths[path] > 0) {
+        events.push(this.value(), path);
+      }
+    }
+  },
+
+  chainDidChange(chain, path, depth, events) {
+    if (this._key) {
+      path = this._key + '.' + path;
+    }
+
+    if (this._parent) {
+      this._parent.chainDidChange(this, path, depth + 1, events);
+    } else {
+      if (depth > 1) {
+        events.push(this.value(), path);
+      }
+      path = 'this.' + path;
+      if (this._paths[path] > 0) {
+        events.push(this.value(), path);
+      }
+    }
+  },
+
+  didChange(events) {
+    // invalidate my own value first.
+    if (this._watching) {
+      var obj = this._parent.value();
+      if (obj !== this._object) {
+        removeChainWatcher(this._object, this._key, this);
+        this._object = obj;
+        addChainWatcher(obj, this._key, this);
+      }
+      this._value  = undefined;
+
+      // Special-case: the EachProxy relies on immediate evaluation to
+      // establish its observers.
+      if (this._parent && this._parent._key === '@each') {
+        this.value();
+      }
+    }
+
+    // then notify chains...
+    var chains = this._chains;
+    if (chains) {
+      for (var key in chains) {
+        if (!chains.hasOwnProperty(key)) {
+          continue;
+        }
+        chains[key].didChange(events);
+      }
+    }
+
+    // if no events are passed in then we only care about the above wiring update
+    if (events === null) {
+      return;
+    }
+
+    // and finally tell parent about my path changing...
+    if (this._parent) {
+      this._parent.chainDidChange(this, this._key, 1, events);
+    }
   }
 };
 
@@ -376,7 +389,7 @@ export function finishChains(obj) {
 
         chainNodes = chainWatchers[key];
         if (chainNodes) {
-          for (var i=0,l=chainNodes.length;i<l;i++) {
+          for (var i = 0, l = chainNodes.length; i < l; i++) {
             chainNodes[i].didChange(null);
           }
         }


### PR DESCRIPTION
- Avoid one-liner if statements
- Whitespace fixes
- Use ES2015 properties shorthand syntax
- Use `return;` instead of `return undefined;`
- Extract `isObject` function

Diff without whitespace: https://github.com/emberjs/ember.js/pull/10700/files?w=1
