### PR TITLE
Update emberjs-build to 0.0.43.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.0.39",
+    "emberjs-build": "0.0.43",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -1,3 +1,5 @@
+/*globals EmberDev */
+
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
@@ -45,7 +47,7 @@ QUnit.test("returns element if you set the value", function() {
   equal(get(view, 'element'), dom, 'now has set element');
 });
 
-Ember.runInDebug(function() {
+if (EmberDev && !EmberDev.runningProdBuild) {
   QUnit.test("should not allow the elementId to be changed after inserted", function() {
     view = EmberView.create({
       elementId: 'one'
@@ -61,5 +63,4 @@ Ember.runInDebug(function() {
 
     equal(view.get('elementId'), 'one', 'elementId is still "one"');
   });
-});
-
+}


### PR DESCRIPTION
Compare view:

https://github.com/emberjs/emberjs-build/compare/v0.0.39...v0.0.43

Major changes:
- Update JSCS to latest version
- Allow template compilation to use `Ember.deprecate`.
  - Add `ember-metal` to `ember-template-compiler.js`
  - Add `ember-debug` into `ember-template-compiler.js`
