### PR TITLE
Improving `EmberError`

### DIFF
--- a/packages/ember-metal/lib/error.js
+++ b/packages/ember-metal/lib/error.js
@@ -18,7 +18,7 @@ var errorProps = [
   @extends Error
   @constructor
 */
-function EmberError() {
+var EmberError = function() {
   var tmp = Error.apply(this, arguments);
 
   // Adds a `stack` property to the given error object that will yield the
@@ -29,14 +29,42 @@ function EmberError() {
   // This is useful because we can hide Ember implementation details
   // that are not very helpful for the user.
   if (Error.captureStackTrace) {
-    Error.captureStackTrace(this, Ember.Error);
+    Error.captureStackTrace(this, Error);
   }
+
   // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
   for (var idx = 0; idx < errorProps.length; idx++) {
     this[errorProps[idx]] = tmp[errorProps[idx]];
   }
-}
+};
 
-EmberError.prototype = create(Error.prototype);
+EmberError.prototype.init = function(options) {
+  if (options) {
+    for (var key in options) {
+      this[key] = options[key];
+    }
+  }
+};
+
+EmberError.prototype.extend = function() {
+  var constructor = this;
+
+  function Class() {
+    var length = arguments.length;
+
+    if (length === 0) {
+      this.init();
+    } else if (length === 1) {
+      this.init(arguments[0]);
+    } else {
+      this.init.apply(this, arguments);
+    }
+  }
+
+  Class.prototype = create(constructor.prototype);
+  Class.prototype.constructor = Class;
+
+  return Class;
+};
 
 export default EmberError;

--- a/packages/ember-metal/tests/accessors/set_path_test.js
+++ b/packages/ember-metal/tests/accessors/set_path_test.js
@@ -2,6 +2,7 @@ import {
   set,
   trySet
 } from 'ember-metal/property_set';
+import EmberError from 'ember-metal/error';
 import { get } from 'ember-metal/property_get';
 
 var originalLookup = Ember.lookup;
@@ -108,7 +109,7 @@ QUnit.test('[obj, bla.bla] gives a proper exception message', function() {
 QUnit.test('[obj, foo.baz.bat] -> EXCEPTION', function() {
   throws(function() {
     set(obj, 'foo.baz.bat', "BAM");
-  }, Error);
+  }, EmberError);
 });
 
 QUnit.test('[obj, foo.baz.bat] -> EXCEPTION', function() {

--- a/packages/ember-metal/tests/run_loop/unwind_test.js
+++ b/packages/ember-metal/tests/run_loop/unwind_test.js
@@ -10,7 +10,7 @@ QUnit.test('RunLoop unwinds despite unhandled exception', function() {
     run(function() {
       run.schedule('actions', function() { throw new EmberError("boom!"); });
     });
-  }, Error, "boom!");
+  }, EmberError, "boom!");
 
   // The real danger at this point is that calls to autorun will stick
   // tasks into the already-dead runloop, which will never get
@@ -38,4 +38,3 @@ QUnit.test('run unwinds despite unhandled exception', function() {
   run.currentRunLoop = initialRunLoop;
 
 });
-

--- a/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/insertAt.js
@@ -1,5 +1,6 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
 import {get} from "ember-metal/property_get";
+import EmberError from 'ember-metal/error';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -39,7 +40,7 @@ suite.test("[].insertAt(200,X) => OUT_OF_RANGE_EXCEPTION exception", function() 
 
   throws(function() {
     obj.insertAt(200, that.newFixture(1)[0]);
-  }, Error);
+  }, EmberError);
 });
 
 suite.test("[A].insertAt(0, X) => [X,A] + notify", function() {
@@ -108,7 +109,7 @@ suite.test("[A].insertAt(200,X) => OUT_OF_RANGE exception", function() {
 
   throws(function() {
     obj.insertAt(200, that.newFixture(1)[0]);
-  }, Error);
+  }, EmberError);
 });
 
 suite.test("[A,B,C].insertAt(0,X) => [X,A,B,C] + notify", function() {

--- a/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
+++ b/packages/ember-runtime/tests/suites/mutable_array/removeAt.js
@@ -1,5 +1,6 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
 import {get} from "ember-metal/property_get";
+import EmberError from 'ember-metal/error';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -30,7 +31,7 @@ suite.test("[].removeAt(200) => OUT_OF_RANGE_EXCEPTION exception", function() {
   var obj = this.newObject([]);
   throws(function() {
     obj.removeAt(200);
-  }, Error);
+  }, EmberError);
 });
 
 suite.test("[A,B].removeAt(0) => [B] + notify", function() {

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -10,6 +10,7 @@ import {
 import objectKeys from "ember-metal/keys";
 import { testBoth } from "ember-metal/tests/props_helper";
 import EmberObject from "ember-runtime/system/object";
+import EmberError from "ember-metal/error";
 
 QUnit.module('ember-runtime/system/object/destroy_test');
 
@@ -47,7 +48,7 @@ if (Ember.FEATURES.isEnabled('mandatory-setter')) {
 
       throws(function() {
         set(obj, 'foo', 'baz');
-      }, Error, "raises an exception");
+      }, EmberError, "raises an exception");
     });
   }
 }


### PR DESCRIPTION
This is allow to subclass `Ember.Error` in `Ember Data`.

Some of the things that we plan on doing for Error Handling in Ember Data are covered [here](https://github.com/emberjs/data/issues/2840).
