### PR TITLE
Revert stream dependencies

### DIFF
--- a/packages/ember-metal/lib/streams/stream_binding.js
+++ b/packages/ember-metal/lib/streams/stream_binding.js
@@ -12,7 +12,7 @@ function StreamBinding(stream) {
   this.senderContext = undefined;
   this.senderValue = undefined;
 
-  this.addDependency(stream, this._onNotify, this);
+  stream.subscribe(this._onNotify, this);
 }
 
 StreamBinding.prototype = create(Stream.prototype);
@@ -62,6 +62,15 @@ merge(StreamBinding.prototype, {
     this.state = 'clean';
 
     this.notifyExcept(senderCallback, senderContext);
+  },
+
+  _super$destroy: Stream.prototype.destroy,
+
+  destroy: function() {
+    if (this._super$destroy()) {
+      this.stream.unsubscribe(this._onNotify, this);
+      return true;
+    }
   }
 });
 

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -169,15 +169,17 @@ export function scanHash(hash) {
                   replaced by the current value of the stream
  */
 export function concat(array, separator) {
+  // TODO: Create subclass ConcatStream < Stream. Defer
+  // subscribing to streams until the value() is called.
   var hasStream = scanArray(array);
   if (hasStream) {
     var i, l;
     var stream = new Stream(function() {
-      return concat(readArray(array), separator);
+      return readArray(array).join(separator);
     });
 
     for (i = 0, l=array.length; i < l; i++) {
-      stream.addDependency(array[i]);
+      subscribe(array[i], stream.notify, stream);
     }
 
     return stream;

--- a/packages/ember-views/lib/streams/key_stream.js
+++ b/packages/ember-views/lib/streams/key_stream.js
@@ -9,7 +9,7 @@ import {
   removeObserver
 } from "ember-metal/observer";
 import Stream from "ember-metal/streams/stream";
-import { read } from "ember-metal/streams/utils";
+import { read, isStream } from "ember-metal/streams/utils";
 
 function KeyStream(source, key) {
   Ember.assert("KeyStream error: key must be a non-empty string", typeof key === 'string' && key.length > 0);
@@ -17,42 +17,35 @@ function KeyStream(source, key) {
 
   this.init();
   this.source = source;
-  this.addDependency(source);
   this.obj = undefined;
   this.key = key;
+
+  if (isStream(source)) {
+    source.subscribe(this._didChange, this);
+  }
 }
 
 KeyStream.prototype = create(Stream.prototype);
 
 merge(KeyStream.prototype, {
   valueFn() {
-    if (this.obj) {
-      return get(this.obj, this.key);
-    }
-  },
-
-  revalidate() {
     var prevObj = this.obj;
     var nextObj = read(this.source);
 
     if (nextObj !== prevObj) {
       if (prevObj && typeof prevObj === 'object') {
-        removeObserver(prevObj, this.key, this, this.notify);
+        removeObserver(prevObj, this.key, this, this._didChange);
+      }
+
+      if (nextObj && typeof nextObj === 'object') {
+        addObserver(nextObj, this.key, this, this._didChange);
       }
 
       this.obj = nextObj;
     }
-  },
 
-  becameActive() {
-    if (this.obj && typeof this.obj === 'object') {
-      addObserver(this.obj, this.key, this, this.notify);
-    }
-  },
-
-  becameInactive() {
-    if (this.obj && typeof this.obj === 'object') {
-      removeObserver(this.obj, this.key, this, this.notify);
+    if (nextObj) {
+      return get(nextObj, this.key);
     }
   },
 
@@ -68,17 +61,35 @@ merge(KeyStream.prototype, {
     var prevSource = this.source;
 
     if (nextSource !== prevSource) {
-      this.dependency.replace(nextSource);
+      if (isStream(prevSource)) {
+        prevSource.unsubscribe(this._didChange, this);
+      }
+
+      if (isStream(nextSource)) {
+        nextSource.subscribe(this._didChange, this);
+      }
 
       this.source = nextSource;
       this.notify();
     }
   },
 
+  _didChange: function() {
+    this.notify();
+  },
+
   _super$destroy: Stream.prototype.destroy,
 
   destroy() {
     if (this._super$destroy()) {
+      if (isStream(this.source)) {
+        this.source.unsubscribe(this._didChange, this);
+      }
+
+      if (this.obj && typeof this.obj === 'object') {
+        removeObserver(this.obj, this.key, this, this._didChange);
+      }
+
       this.source = undefined;
       this.obj = undefined;
       return true;

--- a/packages/ember-views/tests/streams/key_stream_test.js
+++ b/packages/ember-views/tests/streams/key_stream_test.js
@@ -1,0 +1,131 @@
+import { set } from "ember-metal/property_set";
+import Stream from "ember-metal/streams/stream";
+import KeyStream from "ember-views/streams/key_stream";
+
+var source, object, count;
+
+function incrementCount() {
+  count++;
+}
+
+QUnit.module('KeyStream', {
+  setup: function() {
+    count = 0;
+    object = { name: "mmun" };
+
+    source = new Stream(function() {
+      return object;
+    });
+
+    source.setValue = function(value) {
+      object = value;
+      this.notify();
+    };
+  },
+  teardown: function() {
+    count = undefined;
+    object = undefined;
+    source = undefined;
+  }
+});
+
+QUnit.test("can be instantiated manually", function() {
+  var nameStream = new KeyStream(source, 'name');
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+});
+
+QUnit.test("can be instantiated via `Stream.prototype.get`", function() {
+  var nameStream = source.get('name');
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+});
+
+QUnit.test("is notified when the observed object's property is mutated", function() {
+  var nameStream = source.get('name');
+  nameStream.subscribe(incrementCount);
+
+  equal(count, 0, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  set(object, 'name', "wycats");
+
+  equal(count, 1, "Subscribers called correct number of times");
+  equal(nameStream.value(), "wycats", "Stream value is correct");
+});
+
+QUnit.test("is notified when the source stream's value changes to a new object", function() {
+  var nameStream = source.get('name');
+  nameStream.subscribe(incrementCount);
+
+  equal(count, 0, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  object = { name: "wycats" };
+  source.setValue(object);
+
+  equal(count, 1, "Subscribers called correct number of times");
+  equal(nameStream.value(), "wycats", "Stream value is correct");
+
+  set(object, 'name', "kris");
+
+  equal(count, 2, "Subscribers called correct number of times");
+  equal(nameStream.value(), "kris", "Stream value is correct");
+});
+
+QUnit.test("is notified when the source stream's value changes to the same object", function() {
+  var nameStream = source.get('name');
+  nameStream.subscribe(incrementCount);
+
+  equal(count, 0, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  source.setValue(object);
+
+  equal(count, 1, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  set(object, 'name', "kris");
+
+  equal(count, 2, "Subscribers called correct number of times");
+  equal(nameStream.value(), "kris", "Stream value is correct");
+});
+
+QUnit.test("is notified when setSource is called with a new stream whose value is a new object", function() {
+  var nameStream = source.get('name');
+  nameStream.subscribe(incrementCount);
+
+  equal(count, 0, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  object = { name: "wycats" };
+  nameStream.setSource(new Stream(function() {
+    return object;
+  }));
+
+  equal(count, 1, "Subscribers called correct number of times");
+  equal(nameStream.value(), "wycats", "Stream value is correct");
+
+  set(object, 'name', "kris");
+
+  equal(count, 2, "Subscribers called correct number of times");
+  equal(nameStream.value(), "kris", "Stream value is correct");
+});
+
+QUnit.test("is notified when setSource is called with a new stream whose value is the same object", function() {
+  var nameStream = source.get('name');
+  nameStream.subscribe(incrementCount);
+
+  equal(count, 0, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  nameStream.setSource(new Stream(function() {
+    return object;
+  }));
+
+  equal(count, 1, "Subscribers called correct number of times");
+  equal(nameStream.value(), "mmun", "Stream value is correct");
+
+  set(object, 'name', "kris");
+
+  equal(count, 2, "Subscribers called correct number of times");
+  equal(nameStream.value(), "kris", "Stream value is correct");
+});


### PR DESCRIPTION
This reverts commit 01a0198. These code paths were not adequately tested and this commit led to some
regressions. I've included tests that capture the regressions.

This refactor will be fixed and merged again in the glimmer branch.

Closes #10539 and #10564.
