### PR TITLE
[BUGFIX beta] fix broken query params on ObjectController fixes #10733

### DIFF
--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -26,6 +26,7 @@ export var objectControllerDeprecation = 'Ember.ObjectController is deprecated, 
 **/
 export default ObjectProxy.extend(ControllerMixin, {
   init() {
+    this._super();
     Ember.deprecate(objectControllerDeprecation, this.isGenerated);
   }
 });

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -120,6 +120,30 @@ QUnit.module("Routing w/ Query Params", {
   }
 });
 
+QUnit.test("Single query params can be set on ObjectController [DEPRECATED]", function() {
+  expectDeprecation("Ember.ObjectController is deprecated, please use Ember.Controller and use `model.propertyName`.");
+
+  Router.map(function() {
+    this.route("home", { path: '/' });
+  });
+
+  App.HomeController = Ember.ObjectController.extend({
+    queryParams: ['foo'],
+    foo: "123"
+  });
+
+  bootApplication();
+
+  var controller = container.lookup('controller:home');
+
+  setAndFlush(controller, 'foo', '456');
+
+  equal(router.get('location.path'), "/?foo=456");
+
+  setAndFlush(controller, 'foo', '987');
+  equal(router.get('location.path'), "/?foo=987");
+});
+
 QUnit.test("Single query params can be set", function() {
   Router.map(function() {
     this.route("home", { path: '/' });


### PR DESCRIPTION
When the deprecation was added to `ObjectController`'s `init()`, `_super()` wasn't called which seems to have broken query param support in 1.11.0-beta5.

Fixes #10733
