### PR TITLE
[DOC] Add link to the guides in deprecation warning

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -117,7 +117,9 @@ function ComputedProperty(config, opts) {
       config.__ember_arity = config.length;
       this._getter = config;
       if (config.__ember_arity > 1) {
-        Ember.deprecate("Using the same function as getter and setter is deprecated");
+        Ember.deprecate("Using the same function as getter and setter is deprecated.", false, {
+          url: "http://emberjs.com/deprecations/v1.x/#toc_deprecate-using-the-same-function-as-getter-and-setter-in-computed-properties"
+        });
         this._setter = config;
       }
     } else {


### PR DESCRIPTION
Improved deprecation message with link to the _deprecations_ section in the guides.
The entry in the guides is already merged but not yet online.
