### PR TITLE
Deprecation cleanup (push block params, change CP url)

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -163,7 +163,7 @@ function eachHelper(params, hash, options, env) {
 
   Ember.assert(
     "If you pass more than one argument to the each helper, " +
-    "it must be in the form #each foo in bar",
+    "it must be in the form {{#each foo in bar}}",
     params.length <= 1
   );
 
@@ -176,7 +176,7 @@ function eachHelper(params, hash, options, env) {
 
   Ember.deprecate(
     "Using the context switching form of {{each}} is deprecated. " +
-    "Please use the keyword form (`{{#each foo in bar}}`) instead.",
+    "Please use the block param form (`{{#each bar as |foo|}}`) instead.",
     hash.keyword === true || typeof hash.keyword === 'string',
     { url: 'http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope' }
   );

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -13,12 +13,12 @@ import WithView from "ember-views/views/with_view";
 
   ```handlebars
   // posts might not be
-  {{#with user.posts as blogPosts}}
+  {{#with user.posts as |blogPosts|}}
     <div class="notice">
       There are {{blogPosts.length}} blog posts written by {{user.name}}.
     </div>
 
-    {{#each post in blogPosts}}
+    {{#each blogPosts as |post|}}
       <li>{{post.title}}</li>
     {{/each}}
   {{/with}}
@@ -27,7 +27,7 @@ import WithView from "ember-views/views/with_view";
   Without the `as` operator, it would be impossible to reference `user.name` in the example above.
 
   NOTE: The alias should not reuse a name from the bound property path.
-  For example: `{{#with foo.bar as foo}}` is not supported because it attempts to alias using
+  For example: `{{#with foo as |foo.bar|}}` is not supported because it attempts to alias using
   the first part of the property path, `foo`. Instead, use `{{#with foo.bar as baz}}`.
 
   ### `controller` option
@@ -55,8 +55,7 @@ import WithView from "ember-views/views/with_view";
 */
 export function withHelper(params, hash, options, env) {
   Ember.assert(
-    "{{#with foo}} must be called with a single argument or the use the " +
-    "{{#with foo as bar}} syntax",
+    "{{#with}} must be called with an argument. For example, `{{#with foo as |bar|}}{{/with}}`",
     params.length === 1
   );
 
@@ -73,7 +72,7 @@ export function withHelper(params, hash, options, env) {
   } else {
     Ember.deprecate(
       "Using the context switching form of `{{with}}` is deprecated. " +
-      "Please use the keyword form (`{{with foo as bar}}`) instead.",
+      "Please use the block param form (`{{#with bar as |foo|}}`) instead.",
       false,
       { url: 'http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope' }
     );

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -53,8 +53,8 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
 });
 
 QUnit.test("primitives should work correctly [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
-  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
+  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   view = EmberView.create({
     prims: Ember.A(["string", 12]),
@@ -453,7 +453,7 @@ QUnit.test("bound helpers can handle nulls in array (with primitives) [DEPRECATE
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(view.$().text(), '|NOPE 0|NOPE |NOPE false|NOPE OMG|GMO |NOPE 0|NOPE |NOPE false|NOPE OMG|GMO ', "helper output is correct");
 
@@ -481,7 +481,7 @@ QUnit.test("bound helpers can handle nulls in array (with objects)", function() 
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(view.$().text(), '|NOPE 5|5 |NOPE 5|5 ', "helper output is correct");
 

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -446,7 +446,7 @@ QUnit.test("should be able to bind classes to globals with {{bind-attr class}} (
 });
 
 QUnit.test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   view = EmberView.create({
     template: compile('{{#each view.images}}<img {{bind-attr src=this}}>{{/each}}'),
@@ -462,7 +462,7 @@ QUnit.test("should be able to bind-attr to 'this' in an {{#each}} block [DEPRECA
 });
 
 QUnit.test("should be able to bind classes to 'this' in an {{#each}} block with {{bind-attr class}} [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   view = EmberView.create({
     template: compile('{{#each view.items}}<li {{bind-attr class="this"}}>Item</li>{{/each}}'),

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -481,7 +481,7 @@ QUnit.test("should pass content as context when using {{#each}} helper [DEPRECAT
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(view.$().text(), "Mac OS X 10.7: Lion Mac OS X 10.6: Snow Leopard Mac OS X 10.5: Leopard ", "prints each item in sequence");
 });

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -106,7 +106,7 @@ QUnit.module("the #each helper [DEPRECATED]", {
 
     expectDeprecation(function() {
       runAppend(view);
-    }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+    }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
   },
 
   teardown() {
@@ -769,7 +769,7 @@ QUnit.test("views inside #each preserve the new context [DEPRECATED]", function(
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -784,7 +784,7 @@ QUnit.test("single-arg each defaults to current context [DEPRECATED]", function(
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -799,7 +799,7 @@ QUnit.test("single-arg each will iterate over controller if present [DEPRECATED]
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(view.$().text(), "AdamSteve");
 });
@@ -889,7 +889,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       expectDeprecation(function() {
         runAppend(view);
-      }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+      }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
       equal(view.$().text(), "AdamSteve");
     });
@@ -1012,7 +1012,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       expectDeprecation(function() {
         runAppend(view);
-      }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+      }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
       equal(view.$().text(), "AdamSteve");
     });
@@ -1027,7 +1027,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       expectDeprecation(function() {
         runAppend(view);
-      }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+      }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
       equal(view.$().text(), "AdamSteve");
     });

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -47,7 +47,7 @@ QUnit.test("unless should keep the current context (#784) [DEPRECATED]", functio
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   equal(view.$().text(), 'foo: 42');
 });

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -244,7 +244,7 @@ QUnit.test("it should wrap context with object controller [DEPRECATED]", functio
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   equal(view.$().text(), "controller:Steve Holt and Bob Loblaw");
 
@@ -390,7 +390,7 @@ QUnit.test("destroys the controller generated with {{with foo controller='blah'}
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   runDestroy(view);
 

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -156,7 +156,7 @@ QUnit.test("yield inside a conditional uses the outer context [DEPRECATED]", fun
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, "Yield points at the right context");
 });

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -43,7 +43,7 @@ QUnit.test('View should update when the property used with the #with helper chan
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   equal(view.$('#first').text(), 'bam', 'precond - view renders Handlebars template');
 
@@ -74,7 +74,7 @@ QUnit.test('should expose a view keyword [DEPRECATED]', function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   equal(view.$().text(), 'barbang', 'renders values from view and child view');
 });
@@ -97,7 +97,7 @@ QUnit.test('bindings can be `this`, in which case they *are* the current context
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -118,7 +118,7 @@ function ComputedProperty(config, opts) {
       this._getter = config;
       if (config.__ember_arity > 1) {
         Ember.deprecate("Using the same function as getter and setter is deprecated.", false, {
-          url: "http://emberjs.com/deprecations/v1.x/#toc_deprecate-using-the-same-function-as-getter-and-setter-in-computed-properties"
+          url: "http://emberjs.com/deprecations/v1.x/#toc_computed-properties-with-a-shared-getter-and-setter"
         });
         this._setter = config;
       }

--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -170,7 +170,7 @@ QUnit.test("should target the current controller inside an {{each}} loop [DEPREC
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   equal(registeredTarget, itemController, "the item controller is the target of action");
 });
@@ -200,14 +200,14 @@ QUnit.test("should target the with-controller inside an {{#with controller='pers
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   ok(registeredTarget instanceof PersonController, "the with-controller is the target of action");
 });
 
 QUnit.test("should target the with-controller inside an {{each}} in a {{#with controller='person'}} [DEPRECATED]", function() {
-  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
-  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  expectDeprecation('Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
+  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   var eventsCalled = [];
 
@@ -508,7 +508,7 @@ QUnit.test("should work properly in a #with block [DEPRECATED]", function() {
 
   expectDeprecation(function() {
     runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
+  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   view.$('a').trigger('click');
 
@@ -939,7 +939,7 @@ QUnit.test("a quoteless parameter should lookup actionName in context [DEPRECATE
       view.set('controller', controller);
       view.appendTo('#qunit-fixture');
     });
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   var testBoundAction = function(propertyValue) {
     run(function() {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -939,7 +939,7 @@ QUnit.test("The {{link-to}} helper works in an #each'd array of string route nam
 
   expectDeprecation(function() {
     bootApplication();
-  }, 'Using the context switching form of {{each}} is deprecated. Please use the keyword form (`{{#each foo in bar}}`) instead.');
+  }, 'Using the context switching form of {{each}} is deprecated. Please use the block param form (`{{#each bar as |foo|}}`) instead.');
 
   function linksEqual($links, expected) {
     equal($links.length, expected.length, "Has correct number of links");


### PR DESCRIPTION
- Use the block params versions of `each` and `with` when deprecating.
- Update the URL for CP deprecation to match the updated website in https://github.com/emberjs/website/pull/2101
