### PR TITLE
Lock esperanto down to 0.6.17.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
     "emberjs-build": "0.0.43",
+    "esperanto": "0.6.17",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",


### PR DESCRIPTION
We can remove once https://github.com/esperantojs/esperanto/issues/130 is fixed.
