### PR TITLE
Assert that readOnly isn't called over CPs with setter

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -218,6 +218,7 @@ ComputedPropertyPrototype.volatile = function() {
 ComputedPropertyPrototype.readOnly = function(readOnly) {
   Ember.deprecate('Passing arguments to ComputedProperty.readOnly() is deprecated.', arguments.length === 0);
   this._readOnly = readOnly === undefined || !!readOnly; // Force to true once this deprecation is gone
+  Ember.assert("Computed properties that define a setter cannot be read-only", !(this._readOnly && this._setter));
   return this;
 };
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -900,6 +900,15 @@ QUnit.test('is chainable', function() {
   ok(cp instanceof ComputedProperty);
 });
 
+QUnit.test('throws assertion if called over a CP with a setter', function() {
+  expectAssertion(function() {
+    computed({
+      get: function() { },
+      set: function() { }
+    }).readOnly();
+  }, /Computed properties that define a setter cannot be read-only/);
+});
+
 testBoth('protects against setting', function(get, set) {
   var obj = {  };
 


### PR DESCRIPTION
In preparation for https://github.com/emberjs/rfcs/pull/12 

Ensure that an error is thrown is `readOnly` is invoked over CP's that defines a setter function. It is conceptually absurd.
