### PR TITLE
If last param to a link-to is a stream unwrap it for QP test

### DIFF
--- a/packages/ember-routing-htmlbars/lib/helpers/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/link-to.js
@@ -294,6 +294,10 @@ function linkToHelper(params, hash, options, env) {
 
   var lastParam = params[params.length - 1];
 
+  if (isStream(lastParam)) {
+    lastParam = lastParam.value();
+  }
+
   if (lastParam && lastParam.isQueryParams) {
     hash.queryParamsObject = queryParamsObject = params.pop();
   }


### PR DESCRIPTION
Not sure if this would be accepted which is why I haven't written any tests yet. Basically I'm trying to pass an already built `QueryParams` object into a component so it can be used in a `link-to` helper. Since when used in the compnoent's template the object is a stream it gets treated as a context object and not used for query params.
