### PR TITLE
Cache `bower_components`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+    - bower_components
 
 install:
   - "npm install"


### PR DESCRIPTION
This removes some extra hits to Github (and hopefully allows our tests to work a bit better/faster with the ongoing DDoS).
