### PR TITLE
[BUGFIX beta] fix Em.computed.sort leaking listeners

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -763,7 +763,7 @@ function propertySort(itemsKey, sortPropertiesKey) {
           changeMeta.property.itemPropertyKey(itemsKey, sortProperty);
         });
 
-        sortPropertyDefinitions.addObserver('@each', this, updateSortPropertiesOnce);
+        this.addObserver(sortPropertiesKey + '.@each', this, updateSortPropertiesOnce);
       }
 
       function updateSortPropertiesOnce() {

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -980,6 +980,46 @@ QUnit.test("updating an item's sort properties does not error when binary search
   deepEqual(get(obj, 'sortedPeople'), [jaime, cersei], "array is sorted correctly");
 });
 
+QUnit.test("array observers do not leak", function() {
+  var jaime;
+
+  var daria = EmberObject.create({
+    name: 'Daria'
+  });
+
+  var jane = EmberObject.create({
+    name: 'Jane'
+  });
+
+  var sisters = Ember.A([jane, daria]);
+  var sortProps;
+
+  run(function() {
+    sortProps = Ember.A(['name']);
+    jaime = EmberObject.createWithMixins({
+      sisters: sisters,
+      sortedPeople: computedSort('sisters', 'sortProps'),
+      sortProps: sortProps
+    });
+  });
+
+  run(function() {
+    jaime.get('sortedPeople');
+    jaime.destroy();
+  });
+
+  run(function() {
+    try {
+      sortProps.pushObject({
+        name: 'Anna'
+      });
+      ok(true);
+    } catch (e) {
+      ok(false, e);
+    }
+  });
+});
+
 QUnit.test("property paths in sort properties update the sorted array", function () {
   var jaime, cersei, sansa;
 


### PR DESCRIPTION
First commit will be a failing test case, second is the fix.

When an object is torn down, it should remove the array observers from
the sortProperties array. Unfortunately, they are currently not removed.

If `sortProperties` is on the prototype (e.g. an array literal when
using `extend` or `createWithMixins`, these event listeners can never
be garbage collected.

This doesn't tend to be as much of an issue in production but can really start to slow tests down.

The current workaround is to wrap the array literal in a computed property:

``` javascript

var MyObj = Ember.Object.extend({
  sortPropertiest: Ember.computed(function(){
    return ['firstName'];
  })
})
```
