### PR TITLE
[WIP] RFC12: Getter CP readOnly by default

### DIFF
--- a/features.json
+++ b/features.json
@@ -18,7 +18,8 @@
     "ember-application-visit": null,
     "ember-views-component-block-info": null,
     "ember-routing-core-outlet": null,
-    "ember-libraries-isregistered": null
+    "ember-libraries-isregistered": null,
+    "getter-cp-readonly": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -67,6 +67,15 @@ var defaultControllersComputedProperty = computed(function() {
   };
 });
 
+if (Ember.FEATURES.isEnabled("getter-cp-readonly")) {
+  // TODO: This only is necesary in tests, because we want to allow people
+  // to stub they `needs`. In any other situation I can think about this is
+  // not desirable.
+  //
+  // How to enable this in tests only?
+  defaultControllersComputedProperty.overridable();
+}
+
 /**
   @class ControllerMixin
   @namespace Ember

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -250,6 +250,7 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
   @chainable
 */
 ComputedPropertyPrototype.overridable = function() {
+  Ember.assert('Overridable cannot be used on computed properties that define a setter', !this._setter);
   this._readOnly = false;
   return this;
 };

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -144,8 +144,12 @@ function ComputedProperty(config, opts) {
   Ember.deprecate("Passing opts.cacheable to the CP constructor is deprecated. Invoke `volatile()` on the CP instead.", !opts || !opts.hasOwnProperty('cacheable'));
   this._cacheable = (opts && opts.cacheable !== undefined) ? opts.cacheable : true;   // TODO: Set always to `true` once this deprecation is gone.
   this._dependentKeys = opts && opts.dependentKeys;
-  Ember.deprecate("Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. You can invoke `readOnly()` on the CP to change this.", !opts || !opts.hasOwnProperty('readOnly'));
-  this._readOnly = opts && (opts.readOnly !== undefined || !!opts.readOnly) || false; // TODO: Set always to `false` once this deprecation is gone.
+  if (Ember.FEATURES.isEnabled("getter-cp-readonly")) {
+    this._readOnly = !this._setter;
+  } else {
+    Ember.deprecate("Passing opts.readOnly to the CP constructor is deprecated. All CPs are writable by default. You can invoke `readOnly()` on the CP to change this.", !opts || !opts.hasOwnProperty('readOnly'));
+    this._readOnly = opts && (opts.readOnly !== undefined || !!opts.readOnly) || false; // TODO: Set always to `false` once this deprecation is gone.
+  }
 }
 
 ComputedProperty.prototype = new Descriptor();

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -226,34 +226,36 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
   return this;
 };
 
-/**
-  Call on a computed property to set it into overridable mode. When in this
-  mode the computed property will allow to be replaced by a different value.
-  Note that when overriden the computed property will no longer track changes
-  in its dependent keys.
+if (Ember.FEATURES.isEnabled("getter-cp-readonly")) {
+  /**
+    Call on a computed property to set it into overridable mode. When in this
+    mode the computed property will allow to be replaced by a different value.
+    Note that when overriden the computed property will no longer track changes
+    in its dependent keys.
 
-  ```javascript
-  var Person = Ember.Object.extend({
-    guid: function() {
-      return 'guid-guid-guid';
-    }.property().overridable()
-  });
+    ```javascript
+    var Person = Ember.Object.extend({
+      guid: function() {
+        return 'guid-guid-guid';
+      }.property().overridable()
+    });
 
-  var person = Person.create();
+    var person = Person.create();
 
-  person.set('guid', 'new-guid');
-  person.get('guid') // 'new-guid'
-  ```
+    person.set('guid', 'new-guid');
+    person.get('guid') // 'new-guid'
+    ```
 
-  @method overridable
-  @return {Ember.ComputedProperty} this
-  @chainable
-*/
-ComputedPropertyPrototype.overridable = function() {
-  Ember.assert('Overridable cannot be used on computed properties that define a setter', !this._setter);
-  this._readOnly = false;
-  return this;
-};
+    @method overridable
+    @return {Ember.ComputedProperty} this
+    @chainable
+  */
+  ComputedPropertyPrototype.overridable = function() {
+    Ember.assert('Overridable cannot be used on computed properties that define a setter', !this._setter);
+    this._readOnly = false;
+    return this;
+  };
+}
 
 /**
   Sets the dependent keys on this computed property. Pass any number of

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -227,6 +227,34 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
 };
 
 /**
+  Call on a computed property to set it into overridable mode. When in this
+  mode the computed property will allow to be replaced by a different value.
+  Note that when overriden the computed property will no longer track changes
+  in its dependent keys.
+
+  ```javascript
+  var Person = Ember.Object.extend({
+    guid: function() {
+      return 'guid-guid-guid';
+    }.property().overridable()
+  });
+
+  var person = Person.create();
+
+  person.set('guid', 'new-guid');
+  person.get('guid') // 'new-guid'
+  ```
+
+  @method overridable
+  @return {Ember.ComputedProperty} this
+  @chainable
+*/
+ComputedPropertyPrototype.overridable = function() {
+  this._readOnly = false;
+  return this;
+};
+
+/**
   Sets the dependent keys on this computed property. Pass any number of
   arguments containing key paths that this computed property depends on.
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -735,6 +735,29 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
 }
 
 // ..........................................................
+// RFC #12: Getter CPs readonly by default
+//
+
+// if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
+//   if (Ember.FEATURES.isEnabled("getter-cp-readonly")) {
+//     QUnit.module('computed - getter CPs readonly by default');
+
+//     QUnit.test('getter-only computed properties cannot be set by default', function() {
+//       var testObject = Ember.Object.extend({
+//         age: 25,
+//         isOld: computed('age', {
+//           get: function() { return this.get('age') >= 30; }
+//         }).create()
+//       });
+
+//       throws(function() {
+//         set(testObject, 'isOld', true);
+//       }, /Cannot set read-only property "isOld" on object:/);
+//     });
+//   }
+// }
+
+// ..........................................................
 // BUGS
 //
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -700,10 +700,10 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
       })
     }).create();
 
-    ok(testObj.get('aInt') === 1, 'getter works');
-    ok(testObj.get('a') === '1');
-    testObj.set('aInt', '123');
-    ok(testObj.get('aInt') === '123', 'cp has been updated too');
+    equal(testObj.get('aInt'), 1, 'getter works');
+    equal(testObj.get('a'), '1');
+    testObj.set('a', '999');
+    equal(testObj.get('aInt'), '999', 'cp has been updated too');
   });
 
   QUnit.test('the return value of the setter gets cached', function() {

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -782,6 +782,21 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
       set(testObject, 'isOld', true);
       ok(true, 'No errors were thrown');
     });
+
+    QUnit.test('computed properties with a setter cannot be marked as overridable', function() {
+      throws(function() {
+        var testObject = Ember.Object.extend({
+          age: 25,
+          isOld: computed('age', {
+            get: function() { return this.get('age') >= 30; },
+            set: function(key, value) {
+              this.set('age', value ? 40 : 20);
+              return value;
+            }
+          }).overridable();
+        }).create();
+      }, /Overridable cannot be used on computed properties that define a setter/);
+    });
   }
 }
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -782,7 +782,7 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
     });
 
     QUnit.test('overridable called on a CP with a setter throws an error', function() {
-      throws(function() {
+      expectAssertion(function() {
         Ember.Object.extend({
           isOld: computed('age', {
             get: function() { },
@@ -792,24 +792,23 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
       }, /Overridable cannot be used on computed properties that define a setter/);
     });
 
-    // QUnit.test('readOnly called on a CP with no setter throws an error', function() {
-    //   throws(function() {
-    //     Ember.Object.extend({
-    //       isOld: computed('age', function() { return true; }).readOnly()
-    //     });
-    //   }, /Computed properties with no setter defined are already readOnly by default/);
-    // });
+    QUnit.test("readOnly called on a CP with no setter don't raise an error, although is redundant", function() {
+      Ember.Object.extend({
+        isOld: computed('age', function() { return true; }).readOnly()
+      });
+      ok(true, "No errors were thrown");
+    });
 
-    // QUnit.test('readOnly called on a CP with a setter throws an error', function() {
-    //   throws(function() {
-    //     Ember.Object.extend({
-    //       isOld: computed('age', {
-    //         get: function() { },
-    //         set: function() { }
-    //       }).readOnly()
-    //     });
-    //   }, /Computed properties with a setter defined cannot be marked as readOnly/);
-    // });
+    QUnit.test('readOnly called on a CP with a setter throws an error', function() {
+      expectAssertion(function() {
+        Ember.Object.extend({
+          isOld: computed('age', {
+            get: function() { },
+            set: function() { }
+          }).readOnly()
+        });
+      }, /Computed properties that define a setter cannot be read-only/);
+    });
   }
 }
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -771,45 +771,45 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
       ok(true, 'No errors were thrown');
     });
 
-    QUnit.test('computed properties with a getter marked as overridable can be set', function() {
-      var testObject = Ember.Object.extend({
-        isOld: computed('age', function() { return false; }).overridable()
-      }).create();
+    // QUnit.test('computed properties with a getter marked as overridable can be set', function() {
+    //   var testObject = Ember.Object.extend({
+    //     isOld: computed('age', function() { return false; }).overridable()
+    //   }).create();
 
-      set(testObject, 'isOld', true);
-      ok(true, 'No errors were thrown');
-      ok(get(testObject, 'isOld'), 'The property has been overrided');
-    });
+    //   set(testObject, 'isOld', true);
+    //   ok(true, 'No errors were thrown');
+    //   ok(get(testObject, 'isOld'), 'The property has been overrided');
+    // });
 
-    QUnit.test('computed properties with a setter cannot be marked as overridable', function() {
-      throws(function() {
-        Ember.Object.extend({
-          isOld: computed('age', {
-            get: function() { },
-            set: function() { }
-          }).overridable()
-        });
-      }, /Overridable cannot be used on computed properties that define a setter/);
-    });
+    // QUnit.test('overridable called on a CP with a setter throws an error', function() {
+    //   throws(function() {
+    //     Ember.Object.extend({
+    //       isOld: computed('age', {
+    //         get: function() { },
+    //         set: function() { }
+    //       }).overridable()
+    //     });
+    //   }, /Overridable cannot be used on computed properties that define a setter/);
+    // });
 
-    QUnit.test('readOnly called over a CP with no getter throws an error', function() {
-      throws(function() {
-        Ember.Object.extend({
-          isOld: computed('age', function() { return true; }).readOnly()
-        });
-      }, /Computed properties with no setter defined are already readOnly by default/);
-    });
+    // QUnit.test('readOnly called on a CP with no setter throws an error', function() {
+    //   throws(function() {
+    //     Ember.Object.extend({
+    //       isOld: computed('age', function() { return true; }).readOnly()
+    //     });
+    //   }, /Computed properties with no setter defined are already readOnly by default/);
+    // });
 
-    QUnit.test('readOnly called over a CP with a getter throws an error', function() {
-      throws(function() {
-        Ember.Object.extend({
-          isOld: computed('age', {
-            get: function() { },
-            set: function() { }
-          }).readOnly()
-        });
-      }, /Computed properties with a setter defined cannot be marked as readOnly/);
-    });
+    // QUnit.test('readOnly called on a CP with a setter throws an error', function() {
+    //   throws(function() {
+    //     Ember.Object.extend({
+    //       isOld: computed('age', {
+    //         get: function() { },
+    //         set: function() { }
+    //       }).readOnly()
+    //     });
+    //   }, /Computed properties with a setter defined cannot be marked as readOnly/);
+    // });
   }
 }
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -771,26 +771,26 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
       ok(true, 'No errors were thrown');
     });
 
-    // QUnit.test('computed properties with a getter marked as overridable can be set', function() {
-    //   var testObject = Ember.Object.extend({
-    //     isOld: computed('age', function() { return false; }).overridable()
-    //   }).create();
+    QUnit.test('computed properties with a getter marked as overridable can be set', function() {
+      var testObject = Ember.Object.extend({
+        isOld: computed('age', function() { return false; }).overridable()
+      }).create();
 
-    //   set(testObject, 'isOld', true);
-    //   ok(true, 'No errors were thrown');
-    //   ok(get(testObject, 'isOld'), 'The property has been overrided');
-    // });
+      set(testObject, 'isOld', true);
+      ok(true, 'No errors were thrown');
+      ok(get(testObject, 'isOld'), 'The property has been overrided');
+    });
 
-    // QUnit.test('overridable called on a CP with a setter throws an error', function() {
-    //   throws(function() {
-    //     Ember.Object.extend({
-    //       isOld: computed('age', {
-    //         get: function() { },
-    //         set: function() { }
-    //       }).overridable()
-    //     });
-    //   }, /Overridable cannot be used on computed properties that define a setter/);
-    // });
+    QUnit.test('overridable called on a CP with a setter throws an error', function() {
+      throws(function() {
+        Ember.Object.extend({
+          isOld: computed('age', {
+            get: function() { },
+            set: function() { }
+          }).overridable()
+        });
+      }, /Overridable cannot be used on computed properties that define a setter/);
+    });
 
     // QUnit.test('readOnly called on a CP with no setter throws an error', function() {
     //   throws(function() {

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -773,29 +773,42 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
 
     QUnit.test('computed properties with a getter marked as overridable can be set', function() {
       var testObject = Ember.Object.extend({
-        age: 25,
-        isOld: computed('age', {
-          get: function() { return this.get('age') >= 30; }
-        }).overridable()
+        isOld: computed('age', function() { return false; }).overridable()
       }).create();
 
       set(testObject, 'isOld', true);
       ok(true, 'No errors were thrown');
+      ok(get(testObject, 'isOld'), 'The property has been overrided');
     });
 
     QUnit.test('computed properties with a setter cannot be marked as overridable', function() {
       throws(function() {
-        var testObject = Ember.Object.extend({
-          age: 25,
+        Ember.Object.extend({
           isOld: computed('age', {
-            get: function() { return this.get('age') >= 30; },
-            set: function(key, value) {
-              this.set('age', value ? 40 : 20);
-              return value;
-            }
-          }).overridable();
-        }).create();
+            get: function() { },
+            set: function() { }
+          }).overridable()
+        });
       }, /Overridable cannot be used on computed properties that define a setter/);
+    });
+
+    QUnit.test('readOnly called over a CP with no getter throws an error', function() {
+      throws(function() {
+        Ember.Object.extend({
+          isOld: computed('age', function() { return true; }).readOnly()
+        });
+      }, /Computed properties with no setter defined are already readOnly by default/);
+    });
+
+    QUnit.test('readOnly called over a CP with a getter throws an error', function() {
+      throws(function() {
+        Ember.Object.extend({
+          isOld: computed('age', {
+            get: function() { },
+            set: function() { }
+          }).readOnly()
+        });
+      }, /Computed properties with a setter defined cannot be marked as readOnly/);
     });
   }
 }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -738,24 +738,52 @@ if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
 // RFC #12: Getter CPs readonly by default
 //
 
-// if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
-//   if (Ember.FEATURES.isEnabled("getter-cp-readonly")) {
-//     QUnit.module('computed - getter CPs readonly by default');
+if (Ember.FEATURES.isEnabled("new-computed-syntax")) {
+  if (Ember.FEATURES.isEnabled("getter-cp-readonly")) {
+    QUnit.module('computed - getter CPs readonly by default');
 
-//     QUnit.test('getter-only computed properties cannot be set by default', function() {
-//       var testObject = Ember.Object.extend({
-//         age: 25,
-//         isOld: computed('age', {
-//           get: function() { return this.get('age') >= 30; }
-//         }).create()
-//       });
+    QUnit.test('computed properties with only a getter cannot be set', function() {
+      var testObject = Ember.Object.extend({
+        age: 25,
+        isOld: computed('age', {
+          get: function() { return this.get('age') >= 30; }
+        })
+      }).create();
 
-//       throws(function() {
-//         set(testObject, 'isOld', true);
-//       }, /Cannot set read-only property "isOld" on object:/);
-//     });
-//   }
-// }
+      throws(function() {
+        set(testObject, 'isOld', true);
+      }, /Cannot set read-only property "isOld" on object:/);
+    });
+
+    QUnit.test('computed properties with a getter can be set', function() {
+      var testObject = Ember.Object.extend({
+        age: 25,
+        isOld: computed('age', {
+          get: function() { return this.get('age') >= 30; },
+          set: function(key, value) {
+            this.set('age', value ? 40 : 20);
+            return value;
+          }
+        })
+      }).create();
+
+      set(testObject, 'isOld', true);
+      ok(true, 'No errors were thrown');
+    });
+
+    QUnit.test('computed properties with a getter marked as overridable can be set', function() {
+      var testObject = Ember.Object.extend({
+        age: 25,
+        isOld: computed('age', {
+          get: function() { return this.get('age') >= 30; }
+        }).overridable()
+      }).create();
+
+      set(testObject, 'isOld', true);
+      ok(true, 'No errors were thrown');
+    });
+  }
+}
 
 // ..........................................................
 // BUGS


### PR DESCRIPTION
Early WIP of [RFC 12](https://github.com/emberjs/rfcs/pull/12)

There is quite a lot of failing tests because they relay on overriding computed properties for mocking. Not sure what is the best approach on this. 

P.e, is quite common to stub the `controllers` property of controllers that specify a `needs`, but outside testing seems a bad to allow that property to be overridable
