### PR TITLE
Enable Safari tests.

### DIFF
--- a/bin/run-sauce-tests.js
+++ b/bin/run-sauce-tests.js
@@ -41,7 +41,7 @@ RSVP.resolve()
     // calling testem directly here instead of `ember test` so that
     // we do not have to do a double build (by the time this is run
     // we have already ran `ember build`).
-    return run('./node_modules/.bin/testem', [ 'ci' ]);
+    return run('./node_modules/.bin/testem', [ 'ci', '--port', '7000' ]);
   })
   .finally(function() {
     return run('./node_modules/.bin/ember', [ 'stop-sauce-connect' ]);

--- a/testem.json
+++ b/testem.json
@@ -41,6 +41,7 @@
   "launch_in_ci": [
     "SL_Chrome_Current",
     "SL_IE_11",
-    "SL_IE_10"
+    "SL_IE_10",
+    "SL_Safari_Current"
   ]
 }


### PR DESCRIPTION
Needed to change the `testem` port to one that Sauce Labs forwards to localhost in the OSX VM.
