### PR TITLE
[DOC] closes #10777 document mixins used in Ember.View

### DIFF
--- a/packages/ember-views/lib/mixins/attribute_bindings_support.js
+++ b/packages/ember-views/lib/mixins/attribute_bindings_support.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import { Mixin } from "ember-metal/mixin";
 import AttrNode from "ember-views/attr_nodes/attr_node";
 import { defineProperty } from "ember-metal/properties";
@@ -7,6 +11,10 @@ import { set } from "ember-metal/property_set";
 
 var EMPTY_ARRAY = [];
 
+/**
+  @class AttributeBindingsSupport
+  @namespace Ember
+*/
 var AttributeBindingsSupport = Mixin.create({
   concatenatedProperties: ['attributeBindings'],
 

--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import Ember from 'ember-metal/core';
 import { Mixin } from "ember-metal/mixin";
 import { A as emberA } from "ember-runtime/system/native_array";
@@ -17,6 +21,10 @@ import {
 
 var EMPTY_ARRAY = [];
 
+/**
+  @class ClassNamesSupport
+  @namespace Ember
+*/
 var ClassNamesSupport = Mixin.create({
   concatenatedProperties: ['classNames', 'classNameBindings'],
 

--- a/packages/ember-views/lib/mixins/instrumentation_support.js
+++ b/packages/ember-views/lib/mixins/instrumentation_support.js
@@ -1,7 +1,15 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";
 import { get } from "ember-metal/property_get";
 
+/**
+  @class InstrumentationSupport
+  @namespace Ember
+*/
 var InstrumentationSupport = Mixin.create({
   /**
     Used to identify this view during debugging

--- a/packages/ember-views/lib/mixins/legacy_view_support.js
+++ b/packages/ember-views/lib/mixins/legacy_view_support.js
@@ -1,7 +1,15 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import Ember from 'ember-metal/core';
 import { Mixin } from "ember-metal/mixin";
 import { get } from "ember-metal/property_get";
 
+/**
+  @class LegacyViewSupport
+  @namespace Ember
+*/
 var LegacyViewSupport = Mixin.create({
   beforeRender(buffer) {},
 

--- a/packages/ember-views/lib/mixins/template_rendering_support.js
+++ b/packages/ember-views/lib/mixins/template_rendering_support.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import { Mixin } from "ember-metal/mixin";
 import { get } from "ember-metal/property_get";
 
@@ -10,6 +14,10 @@ function renderView(view, buffer, template) {
   _renderView(view, buffer, template);
 }
 
+/**
+  @class TemplateRenderingSupport
+  @namespace Ember
+*/
 var TemplateRenderingSupport = Mixin.create({
   /**
     Called on your view when it should push strings of HTML into a

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import Ember from 'ember-metal/core';
 import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";
@@ -8,6 +12,10 @@ import EmberError from "ember-metal/error";
 import { forEach, removeObject } from "ember-metal/enumerable_utils";
 import { A as emberA } from "ember-runtime/system/native_array";
 
+/**
+  @class ViewChildViewsSupport
+  @namespace Ember
+*/
 var childViewsProperty = computed(function() {
   var childViews = this._childViews;
   var ret = emberA();

--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -1,8 +1,16 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 
+/**
+  @class ViewsContextSupport
+  @namespace Ember
+*/
 var ViewContextSupport = Mixin.create({
   /**
     The object from which templates should access properties.

--- a/packages/ember-views/lib/mixins/visibility_support.js
+++ b/packages/ember-views/lib/mixins/visibility_support.js
@@ -1,3 +1,7 @@
+/**
+@module ember
+@submodule ember-views
+*/
 import {
   Mixin,
   observer
@@ -7,6 +11,10 @@ import run from "ember-metal/run_loop";
 
 function K() { return this; }
 
+/**
+  @class VisibilitySupport
+  @namespace Ember
+*/
 var VisibilitySupport = Mixin.create({
   /**
     If `false`, the view will appear hidden in DOM.

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -666,6 +666,14 @@ var EMPTY_ARRAY = [];
   @class View
   @namespace Ember
   @extends Ember.CoreView
+  @uses Ember.ViewContextSupport
+  @uses Ember.ViewChildViewsSupport
+  @uses Ember.TemplateRenderingSupport
+  @uses Ember.ClassNamesSupport
+  @uses Ember.AttributeBindingsSupport
+  @uses Ember.LegacyViewSupport
+  @uses Ember.InstrumentationSupport
+  @uses Ember.VisibilitySupport
 */
 // jscs:disable validateIndentation
 var View = CoreView.extend(


### PR DESCRIPTION
The following mixins were not included.
- ViewStreamSupport
- ViewKeywordSupport
- ViewStateSupport
