### PR TITLE
[FEATURE ember-application-instance-initializers] Deprecation is never thrown on lookup/lookupFactory

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -178,7 +178,7 @@ Registry.prototype = {
     Ember.assert('Create a container on the registry (with `registry.container()`) before calling `lookup`.', this._defaultContainer);
 
     if (instanceInitializersFeatureEnabled) {
-      Ember.deprecate('`lookup` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', { url: "http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers" });
+      Ember.deprecate('`lookup` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', false, { url: "http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers" });
     }
 
     return this._defaultContainer.lookup(fullName, options);
@@ -188,7 +188,7 @@ Registry.prototype = {
     Ember.assert('Create a container on the registry (with `registry.container()`) before calling `lookupFactory`.', this._defaultContainer);
 
     if (instanceInitializersFeatureEnabled) {
-      Ember.deprecate('`lookupFactory` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', { url: "http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers" });
+      Ember.deprecate('`lookupFactory` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', false, { url: "http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers" });
     }
 
     return this._defaultContainer.lookupFactory(fullName);

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -344,3 +344,49 @@ if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
     });
   });
 }
+
+if (Ember.FEATURES.isEnabled("ember-application-instance-initializers")) {
+  QUnit.test("initializers should throw a deprecation warning when performing a lookup on the registry", function() {
+    expect(1);
+
+    var MyApplication = Application.extend();
+
+    MyApplication.initializer({
+      name: 'initializer',
+      initialize(registry, application) {
+        registry.lookup('router:main');
+      }
+    });
+
+    expectDeprecation(function() {
+      run(function() {
+        app = MyApplication.create({
+          router: false,
+          rootElement: '#qunit-fixture'
+        });
+      });
+    }, /`lookup` was called on a Registry\. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container\./);
+  });
+
+  QUnit.test("initializers should throw a deprecation warning when performing a factory lookup on the registry", function() {
+    expect(1);
+
+    var MyApplication = Application.extend();
+
+    MyApplication.initializer({
+      name: 'initializer',
+      initialize(registry, application) {
+        registry.lookupFactory('application:controller');
+      }
+    });
+
+    expectDeprecation(function() {
+      run(function() {
+        app = MyApplication.create({
+          router: false,
+          rootElement: '#qunit-fixture'
+        });
+      });
+    }, /`lookupFactory` was called on a Registry\. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container\./);
+  });
+}


### PR DESCRIPTION
The deprecation is never thrown when calling `lookup` or `lookupFactory` on a registry because `Ember.deprecate` is called with an options argument but no deprecation test (the options argument is incorrectly interpreted as a truthy test value).
