### PR TITLE
[BUGFIX beta] added assertion to tell users their arrays need to be wrapped in Ember.A for the #each helper

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -276,32 +276,34 @@ QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
   equal(view.$().text(), 'X-1:One 2:Two Y-1:One 2:Two ');
 });
 
-if (Ember.EXTEND_PROTOTYPES) {
-  QUnit.test("it should not give ye olde assertion error", function() {
-    var goodView = EmberView.create({
-      template: templateFor('<div>{{#each host in view.funnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
-      funnyHosts: ["Conan O'Brien", "Jimmy Kimmel", "David Letterman"]
+Ember.runInDebug(function() {
+  if (Ember.EXTEND_PROTOTYPES) {
+    QUnit.test("it should not give ye olde assertion error", function() {
+      var goodView = EmberView.create({
+        template: templateFor('<div>{{#each host in view.funnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
+        funnyHosts: ["Conan O'Brien", "Jimmy Kimmel", "David Letterman"]
+      });
+
+      runAppend(goodView);
+
+      equal(goodView.$('span').length, 3, "renders two <span> elements");
+
+      runDestroy(goodView);
     });
+  } else {
+    QUnit.test("it should give the proper assertion error - Issue #3734 from ember-cli", function() {
+      var badView = EmberView.create({
+        template: templateFor('<div>{{#each host in view.unfunnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
+        unfunnyHosts: ["Jimmy Fallon"]
+      });
 
-    runAppend(goodView);
-
-    equal(goodView.$('span').length, 3, "renders two <span> elements");
-
-    runDestroy(goodView);
-  });
-} else {
-  QUnit.test("it should give the proper assertion error - Issue #3734 from ember-cli", function() {
-    var badView = EmberView.create({
-      template: templateFor('<div>{{#each host in view.unfunnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
-      unfunnyHosts: ["Jimmy Fallon"]
+      throws(function() {
+        runAppend(badView);
+        runDestroy(badView);
+      }, /false and you forgot to wrap your array in Ember\.A/);
     });
-
-    throws(function() {
-      runAppend(badView);
-      runDestroy(badView);
-    }, /false and you forgot to wrap your array in Ember\.A/);
-  });
-}
+  }
+});
 
 QUnit.test("it works inside a ul element", function() {
   var ulView = EmberView.create({

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -297,10 +297,10 @@ Ember.runInDebug(function() {
         unfunnyHosts: ["Jimmy Fallon"]
       });
 
-      throws(function() {
+      expectAssertion(function() {
         runAppend(badView);
-        runDestroy(badView);
       }, /false and you forgot to wrap your array in Ember\.A/);
+      runDestroy(badView);
     });
   }
 });

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -276,6 +276,20 @@ QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
   equal(view.$().text(), 'X-1:One 2:Two Y-1:One 2:Two ');
 });
 
+QUnit.test("it should give the proper assertion error - Issue #3734 from ember-cli", function() {
+  equal(Ember.EXTEND_PROTOTYPES, false, "Ember should not be extending prototypes");
+
+  throws(function() {
+    var badView = EmberView.create({
+      template: templateFor('<div>{{#each host in view.unfunnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
+      unfunnyHosts: ["Jimmy Fallon"]
+    });
+
+    runAppend(badView);
+    runDestroy(badView);
+  }, /false and you forgot to wrap your array in Ember.A()/);
+});
+
 QUnit.test("it works inside a ul element", function() {
   var ulView = EmberView.create({
     template: templateFor('<ul>{{#each view.people}}<li>{{name}}</li>{{/each}}</ul>'),

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -299,7 +299,7 @@ Ember.runInDebug(function() {
 
       expectAssertion(function() {
         runAppend(badView);
-      }, /false and you forgot to wrap your array in Ember\.A/);
+      }, /and you forgot to wrap your array in Ember\.A/);
       runDestroy(badView);
     });
   }

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -276,19 +276,32 @@ QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
   equal(view.$().text(), 'X-1:One 2:Two Y-1:One 2:Two ');
 });
 
-QUnit.test("it should give the proper assertion error - Issue #3734 from ember-cli", function() {
-  equal(Ember.EXTEND_PROTOTYPES, false, "Ember should not be extending prototypes");
+if (Ember.EXTEND_PROTOTYPES) {
+  QUnit.test("it should not give ye olde assertion error", function() {
+    var goodView = EmberView.create({
+      template: templateFor('<div>{{#each host in view.funnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
+      funnyHosts: ["Conan O'Brien", "Jimmy Kimmel", "David Letterman"]
+    });
 
-  throws(function() {
+    runAppend(goodView);
+
+    equal(goodView.$('span').length, 3, "renders two <span> elements");
+
+    runDestroy(goodView);
+  });
+} else {
+  QUnit.test("it should give the proper assertion error - Issue #3734 from ember-cli", function() {
     var badView = EmberView.create({
       template: templateFor('<div>{{#each host in view.unfunnyHosts}}<span>{{host}}</span>{{/each}}</div>'),
       unfunnyHosts: ["Jimmy Fallon"]
     });
 
-    runAppend(badView);
-    runDestroy(badView);
-  }, /false and you forgot to wrap your array in Ember.A()/);
-});
+    throws(function() {
+      runAppend(badView);
+      runDestroy(badView);
+    }, /false and you forgot to wrap your array in Ember\.A/);
+  });
+}
 
 QUnit.test("it works inside a ul element", function() {
   var ulView = EmberView.create({

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -1,3 +1,4 @@
+/*globals EmberDev */
 /*jshint newcap:false*/
 import Ember from "ember-metal/core"; // Ember.lookup;
 import EmberObject from "ember-runtime/system/object";
@@ -276,7 +277,7 @@ QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
   equal(view.$().text(), 'X-1:One 2:Two Y-1:One 2:Two ');
 });
 
-Ember.runInDebug(function() {
+if (EmberDev && !EmberDev.runningProdBuild) {
   if (Ember.EXTEND_PROTOTYPES) {
     QUnit.test("it should not give ye olde assertion error", function() {
       var goodView = EmberView.create({
@@ -303,7 +304,7 @@ Ember.runInDebug(function() {
       runDestroy(badView);
     });
   }
-});
+}
 
 QUnit.test("it works inside a ul element", function() {
   var ulView = EmberView.create({

--- a/packages/ember-views/lib/views/each.js
+++ b/packages/ember-views/lib/views/each.js
@@ -53,17 +53,38 @@ export default CollectionView.extend(_Metamorph, {
   },
 
   _assertArrayLike(content) {
+    var theArrayStr;
+    var shouldShowError;
+    var hasDetectedArray;
+
     Ember.assert(fmt("The value that #each loops over must be an Array. You " +
                      "passed %@, but it should have been an ArrayController",
                      [content.constructor]),
                      !ControllerMixin.detect(content) ||
                        (content && content.isGenerated) ||
                        content instanceof ArrayController);
+
+    hasDetectedArray = EmberArray.detect(content);
+    if (ControllerMixin.detect(content) && content.get('model') !== undefined) {
+      theArrayStr = fmt("'%@' (wrapped in %@)", [content.get('model'), content]);
+      shouldShowError = !Ember.EXTEND_PROTOTYPES &&
+                        Array.isArray(content.get("model")) &&
+                        !hasDetectedArray;
+    } else {
+      theArrayStr = fmt("%@", [content]);
+      shouldShowError = !Ember.EXTEND_PROTOTYPES &&
+                        Array.isArray(content) &&
+                        !hasDetectedArray;
+    }
+
+    Ember.assert(fmt("You passed in an array $@, but Ember.EXTEND_PROTOTYPES is " +
+                     "false and you forgot to wrap your array in Ember.A()",
+                     [theArrayStr]),
+                     !shouldShowError);
+
     Ember.assert(fmt("The value that #each loops over must be an Array. You passed %@",
-                     [(ControllerMixin.detect(content) &&
-                       content.get('model') !== undefined) ?
-                       fmt("'%@' (wrapped in %@)", [content.get('model'), content]) : content]),
-                     EmberArray.detect(content));
+                     [theArrayStr]),
+                     hasDetectedArray);
   },
 
   disableContentObservers(callback) {

--- a/packages/ember-views/lib/views/each.js
+++ b/packages/ember-views/lib/views/each.js
@@ -7,7 +7,9 @@ import { Binding } from "ember-metal/binding";
 import ControllerMixin from "ember-runtime/mixins/controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import EmberArray from "ember-runtime/mixins/array";
-
+import {
+  isArray
+} from "ember-metal/utils";
 import {
   addObserver,
   removeObserver,
@@ -68,12 +70,12 @@ export default CollectionView.extend(_Metamorph, {
     if (ControllerMixin.detect(content) && content.get('model') !== undefined) {
       theArrayStr = fmt("'%@' (wrapped in %@)", [content.get('model'), content]);
       shouldShowError = !Ember.EXTEND_PROTOTYPES &&
-                        Array.isArray(content.get("model")) &&
+                        isArray(content.get("model")) &&
                         !hasDetectedArray;
     } else {
       theArrayStr = fmt("%@", [content]);
       shouldShowError = !Ember.EXTEND_PROTOTYPES &&
-                        Array.isArray(content) &&
+                        isArray(content) &&
                         !hasDetectedArray;
     }
 


### PR DESCRIPTION
This is in reference to: https://github.com/ember-cli/ember-cli/issues/3734

Where an user (usually an addon developer) would have the each helper complain that the array he passed in is not an array because prototype extensions are not enabled by default anymore in ember-cli scaffolded addons. This assertion message now suggests a solution to his woes.
