### PR TITLE
[FEATURE ternary computed macro]

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -28,6 +28,10 @@ function generateComputedWithProperties(macro) {
   };
 }
 
+function toBool(dependentKey) {
+  return !!get(this, dependentKey);
+}
+
 /**
   A computed property that returns true if the value of the dependent
   property is null, an empty string, empty array, or empty function.
@@ -182,7 +186,7 @@ export function not(dependentKey) {
 */
 export function bool(dependentKey) {
   return computed(dependentKey, function() {
-    return !!get(this, dependentKey);
+    return toBool.call(this, dependentKey);
   });
 }
 
@@ -711,5 +715,39 @@ export function deprecatingAlias(dependentKey) {
       set(this, dependentKey, value);
       return value;
     }
+  });
+}
+
+/**
+  A computed property that is used as follows:
+
+  dependentProperty ? valueIfDependentPropertyTrue : valueIfDependentPropertyFalse
+
+  Example
+
+  ```javascript
+  var Hamster = Ember.Object.extend({
+    eyesOpen: true,
+    state: Ember.computed.ternary('eyesOpen', 'wide awake', 'sleepy')
+  });
+
+  var hamster = Hamster.create();
+
+  hamster.get('state'); // wide awake
+  hamster.set('eyesOpen', false);
+  hamster.get('state'); // sleepy
+  ```
+
+  @method ternary
+  @for Ember.computed
+  @param {String} dependentKey
+  @param {String|Number|Object} truthyValue
+  @param {String|Number|Object} falseyValue
+  @return {Ember.ComputedProperty} computed property which returns a value
+  based on the boolean condition of the dependentProperty
+*/
+export function ternary(dependentKey, truthyValue, falseyValue) {
+  return computed(dependentKey, function() {
+    return toBool.call(this, dependentKey) ? truthyValue : falseyValue;
   });
 }

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -25,7 +25,8 @@ import {
   and,
   or,
   any,
-  collect
+  collect,
+  ternary
 } from "ember-metal/computed_macros";
 import alias from 'ember-metal/alias';
 
@@ -1200,6 +1201,17 @@ testBoth('computed.collect', function(get, set) {
   set(obj, 'three', a);
 
   deepEqual(get(obj, 'all'), [0, 'bar', a, true], 'have all of them');
+});
+
+testBoth('computed.ternary', function(get, set) {
+  var obj = { isLocked: false };
+  defineProperty(obj, 'status', ternary('isLocked', 'Locked', 'Unlocked'));
+
+  equal(get(obj, 'status'), 'Unlocked', 'is unlocked (falseyValue) since dependentProperty is false');
+
+  set(obj, 'isLocked', true);
+
+  equal(get(obj, 'status'), 'Locked', 'is locked (truthyValue) since dependentProperty is true');
 });
 
 testBoth('computed.oneWay', function(get, set) {


### PR DESCRIPTION
Ternary as a computed macro `dependentPropertyCondition ? truthyValue : falseyValue`

Just want to get my feet wet in the Ember code. Found this as a common case in my codebase, let me know what you all think. :smile: 
