### PR TITLE
Remove Safari from Sauce Labs runs.

### DIFF
--- a/testem.json
+++ b/testem.json
@@ -41,7 +41,6 @@
   "launch_in_ci": [
     "SL_Chrome_Current",
     "SL_IE_11",
-    "SL_IE_10",
-    "SL_Safari_Current"
+    "SL_IE_10"
   ]
 }


### PR DESCRIPTION
It has provent to be unstable.  Specifically, the `unsafe:` protocol
prefixes that we add for JS attribute sanitization cause the tests to
restart from the beginning (not really sure why). You can see this in
action in the following video:

https://assets.saucelabs.com/jobs/8e88992e101541a1b441139894233203/video_8e88992e101541a1b441139894233203.flv
