### PR TITLE
[BUGFIX release] Fix Ember.Handlebars comaptible helpers.

### DIFF
--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -49,6 +49,12 @@ function HandlebarsCompatibleHelper(fn) {
       handlebarsOptions.fn = function() {
         blockResult = options.template.render(context, env, options.morph.contextualElement);
       };
+
+      if (options.inverse) {
+        handlebarsOptions.inverse = function() {
+          blockResult = options.inverse.render(context, env, options.morph.contextualElement);
+        };
+      }
     }
 
     for (var prop in hash) {

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -33,7 +33,7 @@ function calculateCompatType(item) {
 function HandlebarsCompatibleHelper(fn) {
   this.helperFunction = function helperFunc(params, hash, options, env) {
     var param, blockResult, fnResult;
-    var context = this;
+    var context = env.data.view;
     var handlebarsOptions = {
       hash: { },
       types: new Array(params.length),

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -225,6 +225,27 @@ QUnit.test('allows usage of the template fn', function() {
   equal(view.$().text(), 'foo');
 });
 
+QUnit.test('allows usage of the template inverse', function() {
+  expect(1);
+
+  function someHelper(options) {
+    options.inverse();
+  }
+
+  registerHandlebarsCompatibleHelper('test', someHelper);
+
+  view = EmberView.create({
+    controller: {
+      value: 'foo'
+    },
+    template: compile('{{#test}}Nothing to see here.{{else}}{{value}}{{/test}}')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), 'foo');
+});
+
 QUnit.test('ordered param types are added to options.types', function() {
   expect(3);
 

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -217,7 +217,7 @@ QUnit.test('allows usage of the template fn', function() {
     controller: {
       value: 'foo'
     },
-    template: compile('{{#test}}foo{{/test}}')
+    template: compile('{{#test}}{{value}}{{/test}}')
   });
 
   runAppend(view);

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -5,7 +5,8 @@ import Component from "ember-views/views/component";
 
 function generateEnv(helpers) {
   return {
-    helpers: (helpers ? helpers : {})
+    helpers: (helpers ? helpers : {}),
+    data: { view: { } }
   };
 }
 
@@ -92,7 +93,11 @@ QUnit.test('wraps helper from container in a Handlebars compat helper', function
   var fakeOptions = {
     morph: { update() { } }
   };
-  var fakeEnv = {};
+  var fakeEnv = {
+    data: {
+      view: { }
+    }
+  };
   actual.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv);
 
   ok(called, 'HTMLBars compatible wrapper is wraping the provided function');


### PR DESCRIPTION
Allows usage of dynamic content in the `fn` and `inverse` templates.

Fixes #10812.
