### PR TITLE
[BUGFIX release] Prevent assertion for falsey ArrayController models.

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -212,7 +212,7 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
       Ember.assert(
         'ArrayController expects `model` to implement the Ember.Array mixin. ' +
         'This can often be fixed by wrapping your model with `Ember.A()`.',
-        EmberArray.detect(value)
+        EmberArray.detect(value) || !value
       );
 
       return value;

--- a/packages/ember-runtime/tests/controllers/array_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/array_controller_test.js
@@ -61,3 +61,16 @@ QUnit.test('works properly when model is set to a plain array', function() {
     }, /ArrayController expects `model` to implement the Ember.Array mixin. This can often be fixed by wrapping your model with `Ember\.A\(\)`./);
   }
 });
+
+QUnit.test('works properly when model is set to `null`', function() {
+  var controller = ArrayController.create();
+
+  set(controller, 'model', null);
+  equal(get(controller, 'model'), null, "can set model to `null`");
+
+  set(controller, 'model', undefined);
+  equal(get(controller, 'model'), undefined, "can set model to `undefined`");
+
+  set(controller, 'model', false);
+  equal(get(controller, 'model'), false, "can set model to `undefined`");
+});


### PR DESCRIPTION
Allow `{{each foos itemController="foo" as |foo|}}` when `foos` is `undefined`, `null`, `false`, or `[]`.

Fixes #10796.
