### PR TITLE
Grab bag of IE8/IE9 fixes.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -369,7 +369,7 @@ QUnit.test("placeholder attribute bound to undefined is not present", function()
 
   run(null, set, view, 'controller.someThingNotThere', 'foo');
 
-  equal(view.element.childNodes[1].placeholder, 'foo', "attribute is present");
+  equal(view.element.childNodes[1].getAttribute('placeholder'), 'foo', "attribute is present");
 });
 
 QUnit.test("placeholder attribute bound to null is not present", function() {
@@ -386,5 +386,5 @@ QUnit.test("placeholder attribute bound to null is not present", function() {
 
   run(null, set, view, 'controller.someNullProperty', 'foo');
 
-  equal(view.element.childNodes[1].placeholder, 'foo', "attribute is present");
+  equal(view.element.childNodes[1].getAttribute('placeholder'), 'foo', "attribute is present");
 });

--- a/packages/ember-views/tests/test-helpers/get-element-style.js
+++ b/packages/ember-views/tests/test-helpers/get-element-style.js
@@ -1,0 +1,10 @@
+export default function(element) {
+  var style = element.getAttribute('style');
+  style = style.toUpperCase(); // IE8 keeps this is uppercase, so lets just upcase them all
+
+  if (style !== '' && style.slice(-1) !== ';') {
+    style += ';'; // IE8 drops the trailing so lets add it back
+  }
+
+  return style;
+}

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -10,6 +10,7 @@ import ArrayController from "ember-runtime/controllers/array_controller";
 import jQuery from "ember-views/system/jquery";
 import CollectionView from "ember-views/views/collection_view";
 import View from "ember-views/views/view";
+import getElementStyle from 'ember-views/tests/test-helpers/get-element-style';
 
 var trim = jQuery.trim;
 var view;
@@ -762,7 +763,9 @@ QUnit.test('Collection with style attribute supports changing content', function
     view.appendTo('#qunit-fixture');
   });
 
-  equal(view.$().attr('style'), 'width: 100px;', "width is applied to the element");
+  var style = getElementStyle(view.element);
+
+  equal(style, 'WIDTH: 100PX;', "width is applied to the element");
 
   run(function() {
     view.get('content').pushObject('baz');

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -7,6 +7,7 @@ import Controller from "ember-runtime/controllers/controller";
 import jQuery from "ember-views/system/jquery";
 import View from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
+import getElementStyle from 'ember-views/tests/test-helpers/get-element-style';
 
 var trim = jQuery.trim;
 var container, view, otherContainer;
@@ -819,13 +820,13 @@ QUnit.test('ContainerView supports bound style attribute', function() {
     container.appendTo('#qunit-fixture');
   });
 
-  equal(container.$().attr('style'), 'width: 100px;', "width is applied to the element");
+  equal(getElementStyle(container.element), 'WIDTH: 100PX;', "width is applied to the element");
 
   run(function() {
     container.set('style', 'width: 200px;');
   });
 
-  equal(container.$().attr('style'), 'width: 200px;', "width is applied to the element");
+  equal(getElementStyle(container.element), 'WIDTH: 200PX;', "width is applied to the element");
 });
 
 QUnit.test('ContainerView supports changing children with style attribute', function() {
@@ -838,7 +839,7 @@ QUnit.test('ContainerView supports changing children with style attribute', func
     container.appendTo('#qunit-fixture');
   });
 
-  equal(container.$().attr('style'), 'width: 100px;', "width is applied to the element");
+  equal(getElementStyle(container.element), 'WIDTH: 100PX;', "width is applied to the element");
 
   view = View.create();
 

--- a/packages/ember-views/tests/views/view/render_to_element_test.js
+++ b/packages/ember-views/tests/views/view/render_to_element_test.js
@@ -34,7 +34,7 @@ QUnit.test("should render into and return a body element", function() {
   equal(element.tagName, "BODY", "returns a body element");
   equal(element.firstChild.tagName, "DIV", "renders the view div");
   equal(element.firstChild.firstChild.tagName, "H1", "renders the view div");
-  equal(element.firstChild.firstChild.nextSibling.textContent, " goodbye world", "renders the text node");
+  equal(element.firstChild.firstChild.nextSibling.nodeValue, " goodbye world", "renders the text node");
 });
 
 QUnit.test("should create and render into an element with a provided tagName", function() {
@@ -51,5 +51,5 @@ QUnit.test("should create and render into an element with a provided tagName", f
   equal(element.tagName, "DIV", "returns a body element");
   equal(element.firstChild.tagName, "DIV", "renders the view div");
   equal(element.firstChild.firstChild.tagName, "H1", "renders the view div");
-  equal(element.firstChild.firstChild.nextSibling.textContent, " goodbye world", "renders the text node");
+  equal(element.firstChild.firstChild.nextSibling.nodeValue, " goodbye world", "renders the text node");
 });

--- a/testem.json
+++ b/testem.json
@@ -41,6 +41,7 @@
   "launch_in_ci": [
     "SL_Chrome_Current",
     "SL_IE_11",
-    "SL_IE_10"
+    "SL_IE_10",
+    "SL_IE_9"
   ]
 }


### PR DESCRIPTION
- Enable IE9 in cross-browser tests.
- Fix placeholder attribute tests for IE9 --  Under IE9 accessing `node.placeholder` does not return the value (it is always `undefined`). This works in all other browsers (including IE8).  Grrrr.  Switching to using `node.getAttribute('placeholder')` fixes the issue.
- `Node.textContent` doesn't work on IE8. Use `Node.nodeValue` instead.
- Normalize style attribute values for tests (IE8 capitalizes and strips trailing semicolon).
