### PR TITLE
[BUGFIX release] Allow `{{render}}` helper to give template to view.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/helpers/render.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/render.js
@@ -4,6 +4,7 @@
 */
 
 import Ember from "ember-metal/core"; // assert, deprecate
+import { get } from "ember-metal/property_get";
 import EmberError from "ember-metal/error";
 import { camelize } from "ember-runtime/system/string";
 import generateController from "ember-routing/system/generate_controller";
@@ -135,6 +136,9 @@ export function renderHelper(params, hash, options, env) {
   view = container.lookup('view:' + name);
   if (!view) {
     view = container.lookup('view:default');
+  }
+  var viewHasTemplateSpecified = !!get(view, 'template');
+  if (!viewHasTemplateSpecified) {
     template = template || container.lookup(templateName);
   }
 

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -555,3 +555,20 @@ QUnit.test("{{render}} helper should let view provide its own template", functio
 
   equal(view.$().text(), 'Hello other!');
 });
+
+QUnit.test("{{render}} helper should not require view to provide its own template", function() {
+  var template = "{{render 'fish'}}";
+  var controller = EmberController.extend({ container: container });
+  view = EmberView.create({
+    controller: controller.create(),
+    template: compile(template)
+  });
+
+  container._registry.register('template:fish', compile('Hello fish!'));
+
+  container._registry.register('view:fish', EmberView.extend());
+
+  runAppend(view);
+
+  equal(view.$().text(), 'Hello fish!');
+});


### PR DESCRIPTION
The fix for https://github.com/emberjs/ember.js/issues/10710 (https://github.com/emberjs/ember.js/pull/10712) caused a regression for folks that depended on the prior behavior where the `{{render}}` helper always gave the view it finds a template with the name specified.

This restores that behavior.

Fixes #10760.
