### PR TITLE
Improved sauce test / re-enable safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "route-recognizer": "0.1.5",
     "rsvp": "~3.0.6",
     "simple-dom": "^0.1.1",
-    "testem": "^0.7.6"
+    "testem": "^0.8.0-0"
   }
 }

--- a/testem.json
+++ b/testem.json
@@ -40,6 +40,7 @@
   "launch_in_dev": [],
   "launch_in_ci": [
     "SL_Chrome_Current",
+    "SL_Safari_Current",
     "SL_IE_11",
     "SL_IE_10",
     "SL_IE_9"


### PR DESCRIPTION
The new testem version should improve sauce reliability. Re-enabled
safari

@rwjblue hope this helps with sauce.

Testem PR https://github.com/airportyh/testem/pull/534
