### PR TITLE
Allow `hidepassed` to be toggled.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,5 @@
 module.exports = function(app) {
   app.get('/', function(req, res){
-    res.redirect('/tests/index.html');
+    res.redirect('/tests/index.html?hidepassed');
   });
 };

--- a/tests/index.html
+++ b/tests/index.html
@@ -111,8 +111,6 @@
 
         // Tests should time out after 5 seconds
         QUnit.config.testTimeout = 7500;
-        // Hide passed tests by default
-        QUnit.config.hidepassed = true;
         // Handle testing feature flags
         QUnit.config.urlConfig.push({ id: 'enableoptionalfeatures', label: "Enable Opt Features"});
         // Handle extending prototypes


### PR DESCRIPTION
Previously, `hidepassed` was forced to `true` as a way to make it the default behavior. This had the negative result of making it pretty difficult to actually see which assertions/tests were actually passing (since we hardcode the value to `true` any refreshes of the page cause it to hide the tests again).

This removes the hard-coding, but adds `?hidepassed` to the default redirect. This should have the same general result, but still allow unhiding tests/assertions much easier.
