### PR TITLE
[BUGFIX beta] remove internal uses of Ember.String.fmt

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/bind-attr.js
+++ b/packages/ember-htmlbars/lib/helpers/bind-attr.js
@@ -5,7 +5,6 @@
 
 import Ember from "ember-metal/core"; // Ember.assert
 
-import { fmt } from "ember-runtime/system/string";
 import AttrNode from "ember-views/attr_nodes/attr_node";
 import LegacyBindAttrNode from "ember-views/attr_nodes/legacy_bind";
 import keys from "ember-metal/keys";
@@ -181,8 +180,8 @@ function bindAttrHelper(params, hash, options, env) {
       lazyValue = path;
     } else {
       Ember.assert(
-        fmt("You must provide an expression as the value of bound attribute." +
-            " You specified: %@=%@", [attr, path]),
+        "You must provide an expression as the value of bound attribute." +
+        ` You specified: ${attr}=${path}`,
         typeof path === 'string'
       );
       lazyValue = view.getStream(path);

--- a/packages/ember-htmlbars/lib/helpers/collection.js
+++ b/packages/ember-htmlbars/lib/helpers/collection.js
@@ -5,7 +5,6 @@
 
 import Ember from "ember-metal/core"; // Ember.assert, Ember.deprecate
 import { IS_BINDING } from "ember-metal/mixin";
-import { fmt } from "ember-runtime/system/string";
 import { get } from "ember-metal/property_get";
 import CollectionView from "ember-views/views/collection_view";
 import { readViewFactory } from "ember-views/streams/utils";
@@ -161,7 +160,7 @@ export function collectionHelper(params, hash, options, env) {
   var collectionClass;
   if (path) {
     collectionClass = readViewFactory(path, container);
-    Ember.assert(fmt("%@ #collection: Could not find collection class %@", [data.view, path]), !!collectionClass);
+    Ember.assert(`${data.view} #collection: Could not find collection class ${path}`, !!collectionClass);
   } else {
     collectionClass = CollectionView;
   }
@@ -185,7 +184,7 @@ export function collectionHelper(params, hash, options, env) {
     itemViewClass = container.lookupFactory('view:'+itemViewClass);
   }
 
-  Ember.assert(fmt("%@ #collection: Could not find itemViewClass %@", [data.view, itemViewClass]), !!itemViewClass);
+  Ember.assert(`${data.view} #collection: Could not find itemViewClass ${itemViewClass}`, !!itemViewClass);
 
   delete hash.itemViewClass;
   delete hash.itemView;

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -672,5 +672,5 @@ QUnit.test('specifying `<div {{bind-attr style=userValue}}></div>` works properl
 
   runAppend(view);
 
-  deepEqual(warnings, [ ]);
+  deepEqual(warnings, []);
 });

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -8,7 +8,6 @@ import _MetamorphView from 'ember-views/views/metamorph_view';
 import compile from "ember-template-compiler/system/compile";
 
 import { set } from 'ember-metal/property_set';
-import { fmt } from 'ember-runtime/system/string';
 import { typeOf } from 'ember-metal/utils';
 import { forEach } from 'ember-metal/enumerable_utils';
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
@@ -281,7 +280,7 @@ QUnit.test('should update the block when object passed to #unless helper changes
       set(view, 'onDrugs', val);
     });
 
-    equal(view.$('h1').text(), 'Eat your vegetables', fmt('renders block when conditional is "%@"; %@', [String(val), typeOf(val)]));
+    equal(view.$('h1').text(), 'Eat your vegetables', `renders block when conditional is "${String(val)}"; ${typeOf(val)}`);
 
     run(function() {
       set(view, 'onDrugs', true);
@@ -336,7 +335,7 @@ QUnit.test('should update the block when object passed to #if helper changes', f
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), '', fmt('hides block when conditional is "%@"', [String(val)]));
+    equal(view.$('h1').text(), '', `hides block when conditional is "${String(val)}"`);
 
     run(function() {
       set(view, 'inception', true);
@@ -371,7 +370,7 @@ QUnit.test('should update the block when object passed to #if helper changes and
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), 'BOONG?', fmt('renders alternate if %@', [String(val)]));
+    equal(view.$('h1').text(), 'BOONG?', `renders alternate if ${String(val)}`);
 
     run(function() {
       set(view, 'inception', true);
@@ -444,7 +443,7 @@ QUnit.test('should update the block when object passed to #unless helper changes
       set(view, 'onDrugs', val);
     });
 
-    equal(view.$('h1').text(), 'Eat your vegetables', fmt('renders block when conditional is "%@"; %@', [String(val), typeOf(val)]));
+    equal(view.$('h1').text(), 'Eat your vegetables', `renders block when conditional is "${String(val)}"; ${typeOf(val)}`);
 
     run(function() {
       set(view, 'onDrugs', true);
@@ -499,7 +498,7 @@ QUnit.test('should update the block when object passed to #if helper changes', f
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), '', fmt('hides block when conditional is "%@"', [String(val)]));
+    equal(view.$('h1').text(), '', `hides block when conditional is "${String(val)}"`);
 
     run(function() {
       set(view, 'inception', true);
@@ -534,7 +533,7 @@ QUnit.test('should update the block when object passed to #if helper changes and
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), 'BOONG?', fmt('renders alternate if %@', [String(val)]));
+    equal(view.$('h1').text(), 'BOONG?', `renders alternate if ${String(val)}`);
 
     run(function() {
       set(view, 'inception', true);

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -9,7 +9,6 @@ import { get } from "ember-metal/property_get";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
 import { computed } from "ember-metal/computed";
-import { fmt } from "ember-runtime/system/string";
 import keys from "ember-metal/keys";
 import { isSimpleClick } from "ember-views/system/utils";
 import EmberComponent from "ember-views/views/component";
@@ -499,10 +498,9 @@ var LinkView = EmberComponent.extend({
 
     if (!namedRoute) { return; }
 
-    Ember.assert(fmt("The attempt to link-to route '%@' failed. " +
-                     "The router did not find '%@' in its possible routes: '%@'",
-                     [namedRoute, namedRoute, keys(router.router.recognizer.names).join("', '")]),
-                     router.hasRoute(namedRoute));
+    Ember.assert(`The attempt to link-to route '${namedRoute}' failed. ` +
+                 `The router did not find '${namedRoute}' in its possible routes: '${keys(router.router.recognizer.names).join("', '")}'`,
+                 router.hasRoute(namedRoute));
 
     if (!paramsAreLoaded(resolvedParams.models)) { return; }
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -7,7 +7,6 @@ import { computed } from "ember-metal/computed";
 import merge from "ember-metal/merge";
 import run from "ember-metal/run_loop";
 
-import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import Evented from "ember-runtime/mixins/evented";
 import EmberRouterDSL from "ember-routing/system/dsl";
@@ -498,12 +497,14 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     for (var key in groupedByUrlKey) {
       var qps = groupedByUrlKey[key];
-      Ember.assert(fmt("You're not allowed to have more than one controller " +
-                       "property map to the same query param key, but both " +
-                       "`%@` and `%@` map to `%@`. You can fix this by mapping " +
-                       "one of the controller properties to a different query " +
-                       "param key via the `as` config option, e.g. `%@: { as: 'other-%@' }`",
-                       [qps[0].qp.fprop, qps[1] ? qps[1].qp.fprop : "", qps[0].qp.urlKey, qps[0].qp.prop, qps[0].qp.prop]), qps.length <= 1);
+      Ember.assert("You're not allowed to have more than one controller " +
+                   "property map to the same query param key, but both " +
+                   `"${qps[0].qp.fprop}" and "${qps[1] ? qps[1].qp.fprop : ""}" ` +
+                   `map to "${qps[0].qp.urlKey}". You can fix this by mapping ` +
+                   "one of the controller properties to a different query " +
+                   'param key via the "as" config option, e.g. ' +
+                   `"${qps[0].qp.prop}: { as: 'other-${qps[0].qp.prop}' }"`,
+                   qps.length <= 1);
       var qp = qps[0].qp;
       queryParams[qp.urlKey] = qp.route.serializeQueryParam(qps[0].value, qp.urlKey, qp.type);
     }

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -20,7 +20,6 @@ import {
 import { computed } from "ember-metal/computed";
 import { defineProperty } from "ember-metal/properties";
 import { Mixin, observer } from "ember-metal/mixin";
-import { fmt } from "ember-runtime/system/string";
 
 function contentPropertyWillChange(content, contentKey) {
   var key = contentKey.slice(8); // remove "content."
@@ -74,8 +73,8 @@ export default Mixin.create({
     var content = get(this, 'content');
     if (content) {
       Ember.deprecate(
-        fmt('You attempted to access `%@` from `%@`, but object proxying is deprecated. ' +
-            'Please use `model.%@` instead.', [key, this, key]),
+        `You attempted to access "${key}" from "${this}", but object proxying is deprecated. ` +
+        `Please use "model.${key}" instead.`,
         !this.isController
       );
       return get(content, key);
@@ -92,12 +91,12 @@ export default Mixin.create({
     }
 
     var content = get(this, 'content');
-    Ember.assert(fmt("Cannot delegate set('%@', %@) to the 'content' property of" +
-                     " object proxy %@: its 'content' is undefined.", [key, value, this]), content);
+    Ember.assert(`Cannot delegate set("${key}", ${value}) to the "content" property of` +
+                 ` object proxy ${this}: its "content" is undefined.`, content);
 
     Ember.deprecate(
-      fmt('You attempted to set `%@` from `%@`, but object proxying is deprecated. ' +
-          'Please use `model.%@` instead.', [key, this, key]),
+      `You attempted to set "${key}" from "${this}", but object proxying is deprecated. ` +
+      `Please use "model.${key}" instead.`,
       !this.isController
     );
     return set(content, key, value);

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -7,7 +7,6 @@
 import { get } from "ember-metal/property_get";
 import { Mixin } from "ember-metal/mixin";
 import { Freezable } from "ember-runtime/mixins/freezable";
-import { fmt } from "ember-runtime/system/string";
 import EmberError from 'ember-metal/error';
 
 
@@ -57,7 +56,7 @@ export default Mixin.create({
     if (Freezable && Freezable.detect(this)) {
       return get(this, 'isFrozen') ? this : this.copy().freeze();
     } else {
-      throw new EmberError(fmt("%@ does not support freezing", [this]));
+      throw new EmberError(`${this} does not support freezing`);
     }
   }
 });

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -16,7 +16,6 @@ import EmberError from "ember-metal/error";
 import EmberObject from "ember-runtime/system/object";
 import MutableArray from "ember-runtime/mixins/mutable_array";
 import Enumerable from "ember-runtime/mixins/enumerable";
-import { fmt } from "ember-runtime/system/string";
 import alias from "ember-metal/alias";
 
 /**
@@ -185,8 +184,8 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     var content = get(this, 'content');
 
     if (content) {
-      Ember.assert(fmt('ArrayProxy expects an Array or ' +
-        'Ember.ArrayProxy, but you passed %@', [typeof content]),
+      Ember.assert('ArrayProxy expects an Array or ' +
+        `Ember.ArrayProxy, but you passed ${typeof content}`,
         isArray(content) || content.isDestroyed);
 
       content.addArrayObserver(this, {
@@ -222,8 +221,8 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     var arrangedContent = get(this, 'arrangedContent');
 
     if (arrangedContent) {
-      Ember.assert(fmt('ArrayProxy expects an Array or ' +
-        'Ember.ArrayProxy, but you passed %@', [typeof arrangedContent]),
+      Ember.assert('ArrayProxy expects an Array or ' +
+        `Ember.ArrayProxy, but you passed ${typeof arrangedContent}`,
         isArray(arrangedContent) || arrangedContent.isDestroyed);
 
       arrangedContent.addArrayObserver(this, {

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -8,7 +8,6 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { guidFor } from "ember-metal/utils";
 import isNone from 'ember-metal/is_none';
-import { fmt } from "ember-runtime/system/string";
 import CoreObject from "ember-runtime/system/core_object";
 import MutableEnumerable from "ember-runtime/mixins/mutable_enumerable";
 import Enumerable from "ember-runtime/mixins/enumerable";
@@ -496,6 +495,6 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     for (idx = 0; idx < len; idx++) {
       array[idx] = this[idx];
     }
-    return fmt("Ember.Set<%@>", [array.join(',')]);
+    return `Ember.Set<${array.join(',')}>`;
   }
 });

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -151,6 +151,7 @@ export default {
     @param {String} str The string to format
     @param {Array} formats An array of parameters to interpolate into string.
     @return {String} formatted string
+    @deprecated Use ES6 template strings instead: https://babeljs.io/docs/learn-es6/#template-strings');
   */
   fmt: fmt,
 

--- a/packages/ember-runtime/tests/controllers/object_controller_test.js
+++ b/packages/ember-runtime/tests/controllers/object_controller_test.js
@@ -41,7 +41,7 @@ QUnit.test('accessing model properties via proxy behavior results in a deprecati
 
   expectDeprecation(function() {
     controller.get('bar');
-  }, /object proxying is deprecated\. Please use `model\.bar` instead\./);
+  }, /object proxying is deprecated\. Please use "model\.bar" instead\./);
 });
 
 QUnit.test('setting model properties via proxy behavior results in a deprecation [DEPRECATED]', function() {
@@ -58,7 +58,7 @@ QUnit.test('setting model properties via proxy behavior results in a deprecation
 
   expectDeprecation(function() {
     controller.set('bar', 'derp');
-  }, /object proxying is deprecated\. Please use `model\.bar` instead\./);
+  }, /object proxying is deprecated\. Please use "model\.bar" instead\./);
 });
 
 QUnit.test('auto-generated controllers are not deprecated', function() {

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -5,7 +5,6 @@ import run from 'ember-metal/run_loop';
 import { typeOf } from 'ember-metal/utils';
 import { observer } from 'ember-metal/mixin';
 import {
-  fmt,
   w
 } from "ember-runtime/system/string";
 import EmberObject from 'ember-runtime/system/object';
@@ -431,17 +430,17 @@ QUnit.test("getting values should call function return value", function() {
   var keys = w('computed computedCached dependent dependentFront dependentCached');
 
   forEach(keys, function(key) {
-    equal(object.get(key), key, fmt('Try #1: object.get(%@) should run function', [key]));
-    equal(object.get(key), key, fmt('Try #2: object.get(%@) should run function', [key]));
+    equal(object.get(key), key, `Try #1: object.get(${key}) should run function`);
+    equal(object.get(key), key, `Try #2: object.get(${key}) should run function`);
   });
 
   // verify each call count.  cached should only be called once
   forEach(w('computedCalls dependentFrontCalls dependentCalls'), function(key) {
-    equal(object[key].length, 2, fmt('non-cached property %@ should be called 2x', [key]));
+    equal(object[key].length, 2, `non-cached property ${key} should be called`);
   });
 
   forEach(w('computedCachedCalls dependentCachedCalls'), function(key) {
-    equal(object[key].length, 1, fmt('non-cached property %@ should be called 1x', [key]));
+    equal(object[key].length, 1, `non-cached property ${key} should be called`);
   });
 
 });
@@ -454,11 +453,11 @@ QUnit.test("setting values should call function return value", function() {
 
   forEach(keys, function(key) {
 
-    equal(object.set(key, values[0]), object, fmt('Try #1: object.set(%@, %@) should run function', [key, values[0]]));
+    equal(object.set(key, values[0]), object, `Try #1: object.set(${key}, ${values[0]}) should run function`);
 
-    equal(object.set(key, values[1]), object, fmt('Try #2: object.set(%@, %@) should run function', [key, values[1]]));
+    equal(object.set(key, values[1]), object, `Try #2: object.set(${key}, ${values[1]}) should run function`);
 
-    equal(object.set(key, values[1]), object, fmt('Try #3: object.set(%@, %@) should not run function since it is setting same value as before', [key, values[1]]));
+    equal(object.set(key, values[1]), object, `Try #3: object.set(${key}, ${values[1]}) should not run function since it is setting same value as before`);
 
   });
 
@@ -471,9 +470,9 @@ QUnit.test("setting values should call function return value", function() {
     // Cached properties first check their cached value before setting the
     // property. Other properties blindly call set.
     expectedLength = 3;
-    equal(calls.length, expectedLength, fmt('set(%@) should be called the right amount of times', [key]));
+    equal(calls.length, expectedLength, `set(${key}) should be called the right amount of times`);
     for (idx=0;idx<2;idx++) {
-      equal(calls[idx], values[idx], fmt('call #%@ to set(%@) should have passed value %@', [idx+1, key, values[idx]]));
+      equal(calls[idx], values[idx], `call #${idx+1} to set(${key}) should have passed value ${values[idx]}`);
     }
   });
 

--- a/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -1,5 +1,4 @@
 import {get} from 'ember-metal/property_get';
-import EmberStringUtils from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
 
 /*
@@ -36,7 +35,7 @@ QUnit.test("concatenates instances", function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test("concatenates subclasses", function() {
@@ -48,7 +47,7 @@ QUnit.test("concatenates subclasses", function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test("concatenates reopen", function() {
@@ -60,7 +59,7 @@ QUnit.test("concatenates reopen", function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test("concatenates mixin", function() {
@@ -75,7 +74,7 @@ QUnit.test("concatenates mixin", function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test("concatenates reopen, subclass, and instance", function() {
@@ -86,7 +85,7 @@ QUnit.test("concatenates reopen, subclass, and instance", function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt("should concatenate values property (expected: %@, got: %@)", [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values}`);
 });
 
 QUnit.test("concatenates subclasses when the values are functions", function() {
@@ -98,8 +97,5 @@ QUnit.test("concatenates subclasses when the values are functions", function() {
   var values = get(obj, 'functions');
   var expected = [K, K];
 
-  deepEqual(values, expected, EmberStringUtils.fmt("should concatenate functions property (expected: %@, got: %@)", [expected, values]));
+  deepEqual(values, expected, `should concatenate functions property (expected: ${expected}, got: ${values}`);
 });
-
-
-

--- a/packages/ember-runtime/tests/suites/array/indexOf.js
+++ b/packages/ember-runtime/tests/suites/array/indexOf.js
@@ -1,5 +1,4 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {fmt} from "ember-runtime/system/string";
 
 var suite = SuiteModuleBuilder.create();
 
@@ -12,7 +11,7 @@ suite.test("should return index of object", function() {
   var idx;
 
   for (idx=0;idx<len;idx++) {
-    equal(obj.indexOf(expected[idx]), idx, fmt('obj.indexOf(%@) should match idx', [expected[idx]]));
+    equal(obj.indexOf(expected[idx]), idx, `obj.indexOf(${expected[idx]}) should match idx`);
   }
 
 });

--- a/packages/ember-runtime/tests/suites/array/lastIndexOf.js
+++ b/packages/ember-runtime/tests/suites/array/lastIndexOf.js
@@ -1,5 +1,4 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {fmt} from "ember-runtime/system/string";
 
 var suite = SuiteModuleBuilder.create();
 
@@ -13,7 +12,7 @@ suite.test("should return index of object's last occurrence", function() {
 
   for (idx=0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx]), idx,
-      fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
+      `obj.lastIndexOf(${expected[idx]}) should match idx`);
   }
 
 });
@@ -26,7 +25,7 @@ suite.test("should return index of object's last occurrence even startAt search 
 
   for (idx=0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len), idx,
-      fmt('obj.lastIndexOfs(%@) should match idx', [expected[idx]]));
+      `obj.lastIndexOfs(${expected[idx]}) should match idx`);
   }
 
 });
@@ -39,7 +38,7 @@ suite.test("should return index of object's last occurrence even startAt search 
 
   for (idx=0;idx<len;idx++) {
     equal(obj.lastIndexOf(expected[idx], len + 1), idx,
-      fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
+      `obj.lastIndexOf(${expected[idx]}) should match idx`);
   }
 
 });

--- a/packages/ember-runtime/tests/suites/array/objectAt.js
+++ b/packages/ember-runtime/tests/suites/array/objectAt.js
@@ -1,5 +1,4 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {fmt} from "ember-runtime/system/string";
 
 var suite = SuiteModuleBuilder.create();
 
@@ -12,7 +11,7 @@ suite.test("should return object at specified index", function() {
   var idx;
 
   for (idx=0;idx<len;idx++) {
-    equal(obj.objectAt(idx), expected[idx], fmt('obj.objectAt(%@) should match', [idx]));
+    equal(obj.objectAt(idx), expected[idx], `obj.objectAt(${idx}) should match`);
   }
 
 });

--- a/packages/ember-runtime/tests/system/object_proxy_test.js
+++ b/packages/ember-runtime/tests/system/object_proxy_test.js
@@ -36,7 +36,7 @@ testBoth("should proxy properties to content", function(get, set) {
   equal(get(proxy, 'firstName'), undefined, 'get on proxy without content should return undefined');
   expectAssertion(function () {
     set(proxy, 'firstName', 'Foo');
-  }, /Cannot delegate set\('firstName', Foo\) to the 'content'/i);
+  }, /Cannot delegate set\("firstName", Foo\) to the "content"/i);
 
   set(proxy, 'content', content);
 

--- a/packages/ember-views/lib/attr_nodes/legacy_bind.js
+++ b/packages/ember-views/lib/attr_nodes/legacy_bind.js
@@ -4,7 +4,6 @@
 */
 
 import AttrNode from "./attr_node";
-import { fmt } from "ember-runtime/system/string";
 import { typeOf } from "ember-metal/utils";
 import { read } from "ember-metal/streams/utils";
 import o_create from "ember-metal/platform/create";
@@ -30,7 +29,7 @@ LegacyBindAttrNode.prototype.render = function render(buffer) {
     value = '';
   }
 
-  Ember.assert(fmt("Attributes must be numbers, strings or booleans, not %@", [value]),
+  Ember.assert(`Attributes must be numbers, strings or booleans, not ${value}`,
                value === null || value === undefined || typeOf(value) === 'number' || typeOf(value) === 'string' || typeOf(value) === 'boolean' || !!(value && value.toHTML));
 
   if (this.lastValue !== null || value !== null) {
@@ -41,4 +40,3 @@ LegacyBindAttrNode.prototype.render = function render(buffer) {
 };
 
 export default LegacyBindAttrNode;
-

--- a/packages/ember-views/lib/streams/utils.js
+++ b/packages/ember-views/lib/streams/utils.js
@@ -1,7 +1,6 @@
 import Ember from "ember-metal/core";
 import { get } from "ember-metal/property_get";
 import { isGlobal } from "ember-metal/path_cache";
-import { fmt } from "ember-runtime/system/string";
 import { read, isStream } from "ember-metal/streams/utils";
 import View from "ember-views/views/view";
 import ControllerMixin from "ember-runtime/mixins/controller";
@@ -22,7 +21,7 @@ export function readViewFactory(object, container) {
     viewClass = value;
   }
 
-  Ember.assert(fmt(value+" must be a subclass or an instance of Ember.View, not %@", [viewClass]), View.detect(viewClass) || View.detectInstance(viewClass));
+  Ember.assert(value + ` must be a subclass or an instance of Ember.View, not ${viewClass}`, View.detect(viewClass) || View.detectInstance(viewClass));
 
   return viewClass;
 }

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -9,7 +9,6 @@ import { set } from "ember-metal/property_set";
 import isNone from 'ember-metal/is_none';
 import run from "ember-metal/run_loop";
 import { typeOf } from "ember-metal/utils";
-import { fmt } from "ember-runtime/system/string";
 import EmberObject from "ember-runtime/system/object";
 import jQuery from "ember-views/system/jquery";
 import ActionManager from "ember-views/system/action_manager";
@@ -142,7 +141,7 @@ export default EmberObject.extend({
 
     rootElement = jQuery(get(this, 'rootElement'));
 
-    Ember.assert(fmt('You cannot use the same root element (%@) multiple times in an Ember.Application', [rootElement.selector || rootElement[0].tagName]), !rootElement.is('.ember-application'));
+    Ember.assert(`You cannot use the same root element (${rootElement.selector || rootElement[0].tagName}) multiple times in an Ember.Application`, !rootElement.is('.ember-application'));
     Ember.assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest('.ember-application').length);
     Ember.assert('You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application', !rootElement.find('.ember-application').length);
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -8,7 +8,6 @@ import Ember from "ember-metal/core"; // Ember.assert
 import { isGlobalPath } from "ember-metal/binding";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import { fmt } from "ember-runtime/system/string";
 import ContainerView from "ember-views/views/container_view";
 import CoreView from "ember-views/views/core_view";
 import View from "ember-views/views/view";
@@ -273,7 +272,7 @@ var CollectionView = ContainerView.extend({
     @method _assertArrayLike
   */
   _assertArrayLike(content) {
-    Ember.assert(fmt("an Ember.CollectionView's content must implement Ember.Array. You passed %@", [content]), EmberArray.detect(content));
+    Ember.assert(`an Ember.CollectionView's content must implement Ember.Array. You passed ${content}`, EmberArray.detect(content));
   },
 
   /**

--- a/packages/ember-views/lib/views/each.js
+++ b/packages/ember-views/lib/views/each.js
@@ -1,5 +1,4 @@
 import Ember from "ember-metal/core";
-import { fmt } from "ember-runtime/system/string";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import CollectionView from "ember-views/views/collection_view";
@@ -53,17 +52,16 @@ export default CollectionView.extend(_Metamorph, {
   },
 
   _assertArrayLike(content) {
-    Ember.assert(fmt("The value that #each loops over must be an Array. You " +
-                     "passed %@, but it should have been an ArrayController",
-                     [content.constructor]),
-                     !ControllerMixin.detect(content) ||
-                       (content && content.isGenerated) ||
-                       content instanceof ArrayController);
-    Ember.assert(fmt("The value that #each loops over must be an Array. You passed %@",
-                     [(ControllerMixin.detect(content) &&
-                       content.get('model') !== undefined) ?
-                       fmt("'%@' (wrapped in %@)", [content.get('model'), content]) : content]),
-                     EmberArray.detect(content));
+    Ember.assert("The value that #each loops over must be an Array. You " +
+                 `passed ${content.constructor}, but it should have been an ArrayController`,
+                 !ControllerMixin.detect(content) ||
+                 (content && content.isGenerated) ||
+                 content instanceof ArrayController);
+    Ember.assert("The value that #each loops over must be an Array. You passed " +
+                 (ControllerMixin.detect(content) &&
+                   content.get('model') !== undefined) ?
+                   `'${content.get('model')}' (wrapped in ${content})` : content,
+                 EmberArray.detect(content));
   },
 
   disableContentObservers(callback) {

--- a/packages/ember-views/lib/views/states/destroying.js
+++ b/packages/ember-views/lib/views/states/destroying.js
@@ -1,6 +1,5 @@
 import merge from "ember-metal/merge";
 import create from 'ember-metal/platform/create';
-import {fmt} from "ember-runtime/system/string";
 import _default from "ember-views/views/states/default";
 import EmberError from "ember-metal/error";
 /**
@@ -14,15 +13,14 @@ var destroying = create(_default);
 
 merge(destroying, {
   appendChild() {
-    throw new EmberError(fmt(destroyingError, ['appendChild']));
+    throw new EmberError(`${destroyingError} appendChild`);
   },
   rerender() {
-    throw new EmberError(fmt(destroyingError, ['rerender']));
+    throw new EmberError(`${destroyingError} rerender`);
   },
   destroyElement() {
-    throw new EmberError(fmt(destroyingError, ['destroyElement']));
+    throw new EmberError(`${destroyingError} destroyElement`);
   }
 });
 
 export default destroying;
-

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -4,7 +4,6 @@ import { get } from "ember-metal/property_get";
 import run from "ember-metal/run_loop";
 import { forEach } from "ember-metal/enumerable_utils";
 import { Mixin } from "ember-metal/mixin";
-import { fmt } from "ember-runtime/system/string";
 import ArrayProxy from "ember-runtime/system/array_proxy";
 import ArrayController from "ember-runtime/controllers/array_controller";
 import jQuery from "ember-views/system/jquery";
@@ -181,7 +180,7 @@ QUnit.test("should remove an item from DOM when an item is removed from the cont
   });
 
   forEach(content, function(item, idx) {
-    equal(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text(), item);
+    equal(view.$(`:nth-child(${String(idx+1)})`).text(), item);
   });
 });
 
@@ -211,7 +210,7 @@ QUnit.test("it updates the view if an item is replaced", function() {
   });
 
   forEach(content, function(item, idx) {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, "postcond - correct array update");
+    equal(trim(view.$(`:nth-child(${String(idx+1)})`).text()), item, "postcond - correct array update");
   });
 });
 
@@ -242,7 +241,7 @@ QUnit.test("can add and replace in the same runloop", function() {
   });
 
   forEach(content, function(item, idx) {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, "postcond - correct array update");
+    equal(trim(view.$(`:nth-child(${String(idx+1)})`).text()), item, "postcond - correct array update");
   });
 
 });
@@ -274,7 +273,7 @@ QUnit.test("can add and replace the object before the add in the same runloop", 
   });
 
   forEach(content, function(item, idx) {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, "postcond - correct array update");
+    equal(trim(view.$(`:nth-child(${String(idx+1)})`).text()), item, "postcond - correct array update");
   });
 });
 
@@ -307,7 +306,7 @@ QUnit.test("can add and replace complicatedly", function() {
   });
 
   forEach(content, function(item, idx) {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, "postcond - correct array update: "+item.name+"!="+view.$(fmt(':nth-child(%@)', [String(idx+1)])).text());
+    equal(trim(view.$(`:nth-child(${String(idx+1)})`).text()), item, "postcond - correct array update: "+item.name+"!="+view.$(`:nth-child(${String(idx+1)})`).text());
   });
 });
 
@@ -341,7 +340,7 @@ QUnit.test("can add and replace complicatedly harder", function() {
   });
 
   forEach(content, function(item, idx) {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx+1)])).text()), item, "postcond - correct array update");
+    equal(trim(view.$(`:nth-child(${String(idx+1)})`).text()), item, "postcond - correct array update");
   });
 });
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1614,7 +1614,7 @@ QUnit.test("query params in the same route hierarchy with the same url key get a
   var self = this;
   expectAssertion(function() {
     self.boot();
-  }, "You're not allowed to have more than one controller property map to the same query param key, but both `parent:foo` and `parent.child:bar` map to `shared`. You can fix this by mapping one of the controller properties to a different query param key via the `as` config option, e.g. `foo: { as: 'other-foo' }`");
+  }, `You're not allowed to have more than one controller property map to the same query param key, but both "parent:foo" and "parent.child:bar" map to "shared". You can fix this by mapping one of the controller properties to a different query param key via the "as" config option, e.g. "foo: { as: 'other-foo' }"`);
 });
 
 QUnit.test("Support shared but overridable mixin pattern", function() {


### PR DESCRIPTION
In ES6, template strings are available so Ember.String.fmt can be
deprecated. This commit removes these usages and adds a JSDoc annotation
for deprecation.

fixes #10848 

~~In ES6, template strings are available so Ember.String.fmt can be
deprecated. This commit warns against these usages so that they can be
safely migrated.~~

~~(I did try making this call `Ember.deprecate`, but too many tests fail when doing so. Would like help on this PR if that should be used instead.)~~
