### PR TITLE
Get further on classNameBindings

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/-normalize-class.js
+++ b/packages/ember-htmlbars/lib/helpers/-normalize-class.js
@@ -1,3 +1,5 @@
+import { dasherize } from "ember-runtime/system/string";
+
 /** @private
   This private helper is used by ComponentNode to convert the classNameBindings
   microsyntax into a class name.
@@ -6,13 +8,31 @@
   series of attribute nodes that use this helper.
 */
 export default function normalizeClass(params, hash) {
-  var value = params[0];
+  var [propName, value] = params;
+  var { activeClass, inactiveClass } = hash;
 
-  if (typeof value === 'string') {
+  // When using the colon syntax, evaluate the truthiness or falsiness
+  // of the value to determine which className to return
+  if (activeClass || inactiveClass) {
+    if (!!value) {
+      return activeClass;
+    } else {
+      return inactiveClass;
+    }
+
+  // If value is a Boolean and true, return the dasherized property
+  // name.
+  } else if (value === true) {
+    return dasherize(propName);
+
+  // If the value is not false, undefined, or null, return the current
+  // value of the property.
+  } else if (value !== false && value != null) {
     return value;
-  } else if (!!value) {
-    return hash.activeClass;
+
+  // Nothing to display. Return null so that the old class is removed
+  // but no new class is added.
   } else {
-    return hash.inactiveClass;
+    return null;
   }
 }

--- a/packages/ember-htmlbars/lib/hooks/subexpr.js
+++ b/packages/ember-htmlbars/lib/hooks/subexpr.js
@@ -67,7 +67,7 @@ merge(SubexprStream.prototype, {
       params[i] = read(sourceParams[i]);
     }
 
-    for (var prop in hash) {
+    for (var prop in sourceHash) {
       hash[prop] = read(sourceHash[prop]);
     }
 

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -158,21 +158,12 @@ function normalizeClass(component, attrs) {
   if (classNameBindings) {
     for (i=0, l=classNameBindings.length; i<l; i++) {
       var className = classNameBindings[i];
-      var microsyntax = className.split(':');
-      var prop = 'view.' + microsyntax[0];
-      var activeClass, inactiveClass;
-
-      if (microsyntax.length === 1) {
-        activeClass = prop;
-      } else if (microsyntax.length === 2) {
-        activeClass = microsyntax[1];
-      } else {
-        activeClass = microsyntax[1];
-        inactiveClass = microsyntax[2];
-      }
+      var [propName, activeClass, inactiveClass] = className.split(':');
+      var prop = 'view.' + propName;
 
       normalizedClass.push(['subexpr', '-normalize-class', [
         // params
+        ['value', propName],
         ['get', prop]
       ], [
         // hash

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -15,7 +15,7 @@ QUnit.module("EmberView - Class Name Bindings", {
   }
 });
 
-QUnit.skip("should apply bound class names to the element", function() {
+QUnit.test("should apply bound class names to the element", function() {
   view = EmberView.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
                         'canIgnore', 'messages.count', 'messages.resent:is-resent',
@@ -55,7 +55,7 @@ QUnit.skip("should apply bound class names to the element", function() {
   ok(!view.$().hasClass('disabled'), "does not add class name for negated binding");
 });
 
-QUnit.skip("should add, remove, or change class names if changed after element is created", function() {
+QUnit.test("should add, remove, or change class names if changed after element is created", function() {
   view = EmberView.create({
     classNameBindings: ['priority', 'isUrgent', 'isClassified:classified',
                         'canIgnore', 'messages.count', 'messages.resent:is-resent',


### PR DESCRIPTION
This gets the bulk of the classNameBindings syntax working (2 additional tests passing).

The logic added to `-normalize-class` is stolen almost verbatim from `class_name_binding.js`. I believe this file can be removed.

A couple of other tests around `classNameBindings` are failing because spaces are being added to classes when returning nothing from `normalizeClass`. These remain skipped for now.
