### PR TITLE
[BUGFIX beta] Include all files in jspm package

### DIFF
--- a/config/package_manager_files/package.json
+++ b/config/package_manager_files/package.json
@@ -18,7 +18,6 @@
     "registry": "jspm",
     "dependencies": {
       "jquery": "github:components/jquery@^2.1.3"
-    },
-    "files": ["ember.debug.js", "ember.prod.js", "ember-template-compiler.js"]
+    }
   }
 }


### PR DESCRIPTION
This causes jspm to simply install all files. No more missing sourcemaps.
