### PR TITLE
[BUGFIX beta] Make the component helper able to deal with dynamically set falsey values.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/component_test.js
@@ -153,6 +153,26 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
     }, /HTMLBars error: Could not find component named "does-not-exist"./);
   });
 
+  QUnit.test("component with unquoted param resolving to a component, then non-existent component", function() {
+    registry.register('template:components/foo-bar', compile('yippie! {{location}} {{yield}}'));
+    view = EmberView.create({
+      container: container,
+      dynamicComponent: 'foo-bar',
+      location: 'Caracas',
+      template: compile('{{#component view.dynamicComponent location=view.location}}arepas!{{/component}}')
+    });
+
+    runAppend(view);
+
+    equal(view.$().text(), 'yippie! Caracas arepas!', 'component was looked up and rendered');
+
+    Ember.run(function() {
+      set(view, "dynamicComponent", undefined);
+    });
+
+    equal(view.$().text(), '', 'component correctly deals with falsey values set post-render');
+  });
+
   QUnit.test("component with quoted param for non-existent component", function() {
     view = EmberView.create({
       container: container,

--- a/packages/ember-views/lib/views/bound_component_view.js
+++ b/packages/ember-views/lib/views/bound_component_view.js
@@ -4,33 +4,35 @@
 */
 
 import { _Metamorph } from "ember-views/views/metamorph_view";
-import { read, chain, subscribe, unsubscribe } from "ember-metal/streams/utils";
+import { read, subscribe, unsubscribe } from "ember-metal/streams/utils";
 import { readComponentFactory } from "ember-views/streams/utils";
 import mergeViewBindings from "ember-htmlbars/system/merge-view-bindings";
 import EmberError from "ember-metal/error";
 import ContainerView from "ember-views/views/container_view";
+import View from "ember-views/views/view";
 
 export default ContainerView.extend(_Metamorph, {
   init() {
     this._super(...arguments);
-    var componentNameStream = this._boundComponentOptions.componentNameStream;
-    var container = this.container;
-    this.componentClassStream = chain(componentNameStream, function() {
-      return readComponentFactory(componentNameStream, container);
-    });
+    this.componentNameStream = this._boundComponentOptions.componentNameStream;
 
-    subscribe(this.componentClassStream, this._updateBoundChildComponent, this);
+    subscribe(this.componentNameStream, this._updateBoundChildComponent, this);
     this._updateBoundChildComponent();
   },
   willDestroy() {
-    unsubscribe(this.componentClassStream, this._updateBoundChildComponent, this);
+    unsubscribe(this.componentNameStream, this._updateBoundChildComponent, this);
     this._super(...arguments);
   },
   _updateBoundChildComponent() {
     this.replace(0, 1, [this._createNewComponent()]);
   },
   _createNewComponent() {
-    var componentClass = read(this.componentClassStream);
+    var componentName = read(this.componentNameStream);
+    if (!componentName) {
+      return this.createChildView(View);
+    }
+
+    var componentClass = readComponentFactory(componentName, this.container);
     if (!componentClass) {
       throw new EmberError('HTMLBars error: Could not find component named "' + read(this._boundComponentOptions.componentNameStream) + '".');
     }
@@ -39,7 +41,7 @@ export default ContainerView.extend(_Metamorph, {
 
     var prop;
     for (prop in hash) {
-      if (prop === '_boundComponentOptions' || prop === 'componentClassStream') { continue; }
+      if (prop === '_boundComponentOptions' || prop === 'componentNameStream') { continue; }
       hashForComponent[prop] = hash[prop];
     }
 


### PR DESCRIPTION
The `{{component}}` helper as it stands is vulnerable to a bound value being updated to `undefined` (or any falsey value) and then throwing an error, as it previously conflated the component name with a component class. This addresses that by decoupling the component name and class and checking each condition individually. The test fails without the patch, and all other tests pass.

@lukemelia should review this. Related to #10739, it fixes the symptom, not the problem (though there are related bugs, @samselikoff). Glimmer fixes the problem by walking the tree.
