### PR TITLE
Fix replace in

### DIFF
--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -171,8 +171,8 @@ Renderer.prototype.appendAttrTo =
 Renderer.prototype.replaceIn =
   function Renderer_replaceIn(view, target) {
     var morph;
-    if (target.firstNode) {
-      morph = this._dom.createMorph(target, target.firstNode, target.lastNode);
+    if (target.firstChild) {
+      morph = this._dom.createMorph(target, target.firstChild, target.lastChild);
     } else {
       morph = this._dom.appendMorph(target);
     }

--- a/packages/ember-views/tests/views/view/replace_in_test.js
+++ b/packages/ember-views/tests/views/view/replace_in_test.js
@@ -45,18 +45,26 @@ QUnit.test("raises an assert when a target does not exist in the DOM", function(
 
 
 QUnit.test("should remove previous elements when calling replaceIn()", function() {
-  jQuery("#qunit-fixture").html('<div id="menu"><p>Foo</p></div>');
-  var viewElem = jQuery('#menu').children();
+  jQuery("#qunit-fixture").html(`
+    <div id="menu">
+      <p id="child"></p>
+    </div>
+  `);
 
   view = View.create();
 
-  ok(viewElem.length === 1, "should have one element");
+  var originalChild = jQuery('#child');
+  ok(originalChild.length === 1, "precond - target starts with child element");
 
   run(function() {
     view.replaceIn('#menu');
   });
 
-  ok(viewElem.length === 1, "should have one element");
+  originalChild = jQuery('#child');
+  ok(originalChild.length === 0, "target's original child was removed");
+
+  var newChild = jQuery('#menu').children();
+  ok(newChild.length === 1, "target has new child element");
 
 });
 


### PR DESCRIPTION
Resolves #10881

The original test failed to reload the child elements after replacing and did not detect this regression. I fixed and refactored this test for clarity.
