### PR TITLE
isVisible fixes

### DIFF
--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -140,7 +140,14 @@ function normalizeComponentAttributes(component, attrs) {
   }
 
   if (component.isVisible === false) {
-    normalized.style = ['value', "display: none;"];
+    var hiddenStyle = ['value', "display: none;"];
+    var existingStyle = normalized.style;
+
+    if (existingStyle) {
+      normalized.style = ['subexpr', '-concat', [existingStyle, hiddenStyle], ['separator', ' ']];
+    } else {
+      normalized.style = hiddenStyle;
+    }
   }
 
   return normalized;

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -17,7 +17,7 @@ export default function buildComponentTemplate(componentInfo, attrs, content) {
 
   layoutTemplate = componentInfo.layout;
 
-  if (layoutTemplate) {
+  if (layoutTemplate && layoutTemplate.raw) {
     blockToRender = createLayoutBlock(layoutTemplate.raw, blockToRender, content.self, component || null, attrs);
   }
 

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -139,6 +139,10 @@ function normalizeComponentAttributes(component, attrs) {
     normalized.class = normalizedClass;
   }
 
+  if (component.isVisible === false) {
+    normalized.style = ['value', "display: none;"];
+  }
+
   return normalized;
 }
 

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -16,7 +16,7 @@ QUnit.module("EmberView#isVisible", {
   }
 });
 
-QUnit.skip("should hide views when isVisible is false", function() {
+QUnit.test("should hide views when isVisible is false", function() {
   view = EmberView.create({
     isVisible: false
   });
@@ -37,7 +37,7 @@ QUnit.skip("should hide views when isVisible is false", function() {
   });
 });
 
-QUnit.skip("should hide element if isVisible is false before element is created", function() {
+QUnit.test("should hide element if isVisible is false before element is created", function() {
   view = EmberView.create({
     isVisible: false
   });

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -71,6 +71,20 @@ QUnit.test("should hide element if isVisible is false before element is created"
   });
 });
 
+QUnit.test("doesn't overwrite existing style attribute bindings", function() {
+  view = EmberView.create({
+    isVisible: false,
+    attributeBindings: ['style'],
+    style: 'color: blue;'
+  });
+
+  run(function() {
+    view.append();
+  });
+
+  equal(view.$().attr('style'), 'color: blue; display: none;', "has concatenated style attribute");
+});
+
 QUnit.module("EmberView#isVisible with Container", {
   setup() {
     expectDeprecation("Setting `childViews` on a Container is deprecated.");

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -108,7 +108,7 @@ QUnit.module("EmberView#isVisible with Container", {
   }
 });
 
-QUnit.skip("view should be notified after isVisible is set to false and the element has been hidden", function() {
+QUnit.test("view should be notified after isVisible is set to false and the element has been hidden", function() {
   run(function() {
     view = View.create({ isVisible: false });
     view.append();
@@ -126,7 +126,7 @@ QUnit.skip("view should be notified after isVisible is set to false and the elem
   equal(grandchildBecameVisible, 1);
 });
 
-QUnit.skip("view should be notified after isVisible is set to false and the element has been hidden", function() {
+QUnit.test("view should be notified after isVisible is set to false and the element has been hidden", function() {
   run(function() {
     view = View.create({ isVisible: false });
     view.append();
@@ -144,7 +144,7 @@ QUnit.skip("view should be notified after isVisible is set to false and the elem
   equal(grandchildBecameVisible, 1);
 });
 
-QUnit.skip("view should be notified after isVisible is set to false and the element has been hidden", function() {
+QUnit.test("view should be notified after isVisible is set to false and the element has been hidden", function() {
   view = View.create({ isVisible: true });
   //var childView = view.get('childViews').objectAt(0);
 
@@ -161,7 +161,7 @@ QUnit.skip("view should be notified after isVisible is set to false and the elem
   ok(view.$().is(':hidden'), "precond - view is now hidden");
 });
 
-QUnit.skip("view should be notified after isVisible is set to true and the element has been shown", function() {
+QUnit.test("view should be notified after isVisible is set to true and the element has been shown", function() {
   view = View.create({ isVisible: false });
 
   run(function() {
@@ -181,7 +181,7 @@ QUnit.skip("view should be notified after isVisible is set to true and the eleme
   equal(grandchildBecameVisible, 1);
 });
 
-QUnit.skip("if a view descends from a hidden view, making isVisible true should not trigger becameVisible", function() {
+QUnit.test("if a view descends from a hidden view, making isVisible true should not trigger becameVisible", function() {
   view = View.create({ isVisible: true });
   var childView = view.get('childViews').objectAt(0);
 
@@ -210,7 +210,7 @@ QUnit.skip("if a view descends from a hidden view, making isVisible true should 
   equal(grandchildBecameVisible, 0, "the grandchild did not become visible");
 });
 
-QUnit.skip("if a child view becomes visible while its parent is hidden, if its parent later becomes visible, it receives a becameVisible callback", function() {
+QUnit.test("if a child view becomes visible while its parent is hidden, if its parent later becomes visible, it receives a becameVisible callback", function() {
   view = View.create({ isVisible: false });
   var childView = view.get('childViews').objectAt(0);
 


### PR DESCRIPTION
A couple small additions got the isVisible tests passing.

The first change sets the initial style value based on the `isVisible` property. One potential problem with this is that if someone has `attributeBindings` for style setup, then `isVisible` will stomp on the style property with `display: none` when the component is rendered. However, when `isVisible` becomes true, the style from attributeBindings is restored. Really one could argue that this isn't a problem, but I went ahead and added a test and a fix for this in the 3rd commit.

Most of the "isVisible with Container" tests were failing because a view had a template method that returned a raw string. Adding an additional check for `layoutTemplate.raw` before attempting to setup `blockToRender` worked around this issue.
