### PR TITLE
Completely remove the concept of isVirtual

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -24,7 +24,6 @@ import DOMHelper from "ember-htmlbars/system/dom-helper";
 import SelectView from "ember-views/views/select";
 import { OutletView } from "ember-routing-views/views/outlet";
 import EmberView from "ember-views/views/view";
-import _MetamorphView from "ember-views/views/metamorph_view";
 import EventDispatcher from "ember-views/system/event_dispatcher";
 import jQuery from "ember-views/system/jquery";
 import Route from "ember-routing/system/route";
@@ -1014,7 +1013,6 @@ Application.reopenClass({
 
     registry.injection('view', '_viewRegistry', '-view-registry:main');
 
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
 
     registry.register('route:basic', Route, { instantiate: false });

--- a/packages/ember-htmlbars/lib/system/component-node.js
+++ b/packages/ember-htmlbars/lib/system/component-node.js
@@ -164,10 +164,8 @@ export function createOrUpdateComponent(component, options, renderNode, env, att
   if (options.parentView) {
     options.parentView.appendChild(component);
 
-    // don't set the property on a virtual view, as they are invisible to
-    // consumers of the view API
     if (options.viewName) {
-      set(get(options.parentView, 'concreteView'), options.viewName, component);
+      set(options.parentView, options.viewName, component);
     }
   }
 

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -1,5 +1,4 @@
 import Ember from "ember-metal/core"; // Ember.lookup
-import _MetamorphView from "ember-views/views/metamorph_view";
 import EmberView from "ember-views/views/view";
 import handlebarsGet from "ember-htmlbars/compat/handlebars-get";
 import { Registry } from "ember-runtime/system/container";
@@ -19,7 +18,6 @@ QUnit.module("ember-htmlbars: compat - Ember.Handlebars.get", {
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
     registry.optionsForType('helper', { instantiate: false });
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
   },
 

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -5,7 +5,6 @@ import Ember from "ember-metal/core"; // Ember.lookup
 import run from "ember-metal/run_loop";
 import Namespace from "ember-runtime/system/namespace";
 import EmberView from "ember-views/views/view";
-import _MetamorphView from "ember-views/views/metamorph_view";
 import EmberObject from "ember-runtime/system/object";
 import { A } from "ember-runtime/system/native_array";
 import { computed } from "ember-metal/computed";
@@ -35,7 +34,6 @@ QUnit.module("ember-htmlbars: {{bind-attr}} [DEPRECATED]", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
 
     warnings = [];

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -41,7 +41,6 @@ QUnit.module("collection helper", {
     container = registry.container();
 
     registry.optionsForType('template', { instantiate: false });
-    // registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
   },
 

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -3,7 +3,6 @@ import Ember from "ember-metal/core"; // Ember.lookup;
 import EmberObject from "ember-runtime/system/object";
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
-import _MetamorphView from "ember-views/views/metamorph_view";
 import LegacyEachView from "ember-views/views/legacy_each_view";
 import { computed } from "ember-metal/computed";
 import ArrayController from "ember-runtime/controllers/array_controller";
@@ -88,7 +87,6 @@ QUnit.module("the #each helper [DEPRECATED]", {
     registry = new Registry();
     container = registry.container();
 
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
     registry.register('view:-legacy-each', LegacyEachView);
 
@@ -574,8 +572,6 @@ QUnit.test("it supports {{itemViewClass=}} with tagName (DEPRECATED)", function(
     container: container
   });
 
-  //expectDeprecation(/Supplying a tagName to Metamorph views is unreliable and is deprecated./);
-
   runAppend(view);
   equal(view.$('ul').length, 1, 'rendered ul tag');
   equal(view.$('ul li').length, 2, 'rendered 2 li tags');
@@ -680,8 +676,6 @@ QUnit.test("it supports {{emptyViewClass=}} with tagName (DEPRECATED)", function
     people: A(),
     container: container
   });
-
-  //expectDeprecation(/Supplying a tagName to Metamorph views is unreliable and is deprecated./);
 
   runAppend(view);
 
@@ -796,7 +790,6 @@ function testEachWithItem(moduleName, useBlockParams) {
       registry = new Registry();
       container = registry.container();
 
-      registry.register('view:default', _MetamorphView);
       registry.register('view:toplevel', EmberView.extend());
     },
     teardown() {

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -4,7 +4,6 @@ import { Registry } from "ember-runtime/system/container";
 import EmberView from "ember-views/views/view";
 import ObjectProxy from "ember-runtime/system/object_proxy";
 import EmberObject from "ember-runtime/system/object";
-import _MetamorphView from 'ember-views/views/metamorph_view';
 import compile from "ember-template-compiler/system/compile";
 
 import { set } from 'ember-metal/property_set';
@@ -24,7 +23,6 @@ QUnit.module("ember-htmlbars: {{#if}} and {{#unless}} helpers", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
   },
 

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -7,7 +7,6 @@ import TextField from 'ember-views/views/text_field';
 import Namespace from 'ember-runtime/system/namespace';
 import EmberObject from 'ember-runtime/system/object';
 import ContainerView from 'ember-views/views/container_view';
-import _MetamorphView from 'ember-views/views/metamorph_view';
 import SafeString from 'htmlbars-util/safe-string';
 import precompile from 'ember-template-compiler/compat/precompile';
 import compile from "ember-template-compiler/system/compile";
@@ -49,7 +48,6 @@ QUnit.module("ember-htmlbars: {{#view}} helper", {
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
     registry.optionsForType('helper', { instantiate: false });
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
   },
 

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -3,7 +3,6 @@ import jQuery from 'ember-views/system/jquery';
 import EmberView from 'ember-views/views/view';
 import { Registry } from "ember-runtime/system/container";
 import EmberObject from 'ember-runtime/system/object';
-import _MetamorphView from 'ember-views/views/metamorph_view';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 
@@ -17,7 +16,6 @@ QUnit.module('ember-htmlbars: {{#with}} and {{#view}} integration', {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.register('view:default', _MetamorphView);
     registry.register('view:toplevel', EmberView.extend());
   },
 

--- a/packages/ember-routing-htmlbars/tests/utils.js
+++ b/packages/ember-routing-htmlbars/tests/utils.js
@@ -10,7 +10,6 @@ import Controller from "ember-runtime/controllers/controller";
 import ObjectController from "ember-runtime/controllers/object_controller";
 import ArrayController from "ember-runtime/controllers/array_controller";
 
-import _MetamorphView from "ember-views/views/metamorph_view";
 import EmberView from "ember-views/views/view";
 import EmberRouter from "ember-routing/system/router";
 import {
@@ -56,7 +55,6 @@ function buildRegistry(namespace) {
   registry.register("controller:object", ObjectController, { instantiate: false });
   registry.register("controller:array", ArrayController, { instantiate: false });
 
-  registry.register("view:default", _MetamorphView);
   registry.register("view:toplevel", EmberView.extend());
   registry.register("view:-outlet", OutletView);
   registry.register("view:core-outlet", CoreOutletView);

--- a/packages/ember-routing-views/lib/views/outlet.js
+++ b/packages/ember-routing-views/lib/views/outlet.js
@@ -4,8 +4,6 @@
 */
 
 import View from "ember-views/views/view";
-import { _Metamorph } from "ember-views/views/metamorph_view";
-
 import topLevelViewTemplate from "ember-htmlbars/templates/top-level-view";
 topLevelViewTemplate.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
@@ -40,4 +38,4 @@ export var CoreOutletView = View.extend({
   }
 });
 
-export var OutletView = CoreOutletView.extend(_Metamorph);
+export var OutletView = CoreOutletView.extend({ tagName: '' });

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -356,24 +356,20 @@ var EmberRouter = EmberObject.extend(Evented, {
     this.reset();
   },
 
-  _lookupActiveView(templateName) {
-    var active = this._activeViews[templateName];
-    return active && active[0];
+  _lookupActiveComponentNode(templateName) {
+    return this._activeViews[templateName];
   },
 
-  _connectActiveView(templateName, view) {
-    var existing = this._activeViews[templateName];
+  _connectActiveComponentNode(templateName, componentNode) {
+    Ember.assert('cannot connect an activeView that already exists', !this._activeViews[templateName]);
 
-    if (existing) {
-      existing[0].off('willDestroyElement', this, existing[1]);
-    }
-
+    var _activeViews = this._activeViews;
     function disconnectActiveView() {
-      delete this._activeViews[templateName];
+      delete _activeViews[templateName];
     }
 
-    this._activeViews[templateName] = [view, disconnectActiveView];
-    view.one('willDestroyElement', this, disconnectActiveView);
+    this._activeViews[templateName] = componentNode;
+    componentNode.renderNode.addDestruction({ destroy: disconnectActiveView });
   },
 
   _setupLocation() {

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -95,10 +95,8 @@ var ViewChildViewsSupport = Mixin.create({
 
       view = maybeViewClass.create(attrs);
 
-      // don't set the property on a virtual view, as they are invisible to
-      // consumers of the view API
       if (view.viewName) {
-        set(get(this, 'concreteView'), view.viewName, view);
+        set(this, view.viewName, view);
       }
     } else if ('string' === typeof maybeViewClass) {
       var fullName = 'view:' + maybeViewClass;

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -9,7 +9,6 @@ import Evented from "ember-runtime/mixins/evented";
 import ActionHandler from "ember-runtime/mixins/action_handler";
 
 import { get } from "ember-metal/property_get";
-import { computed } from "ember-metal/computed";
 
 import { typeOf } from "ember-metal/utils";
 import { internal } from "htmlbars-runtime";
@@ -40,7 +39,6 @@ var renderer;
 */
 var CoreView = EmberObject.extend(Evented, ActionHandler, {
   isView: true,
-  isVirtual: false,
 
   _states: cloneStates(states),
 
@@ -73,15 +71,6 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
   parentView: null,
 
   _state: null,
-
-  // return the current view, not including virtual views
-  concreteView: computed('parentView', function() {
-    if (!this.isVirtual) {
-      return this;
-    } else {
-      return get(this, 'parentView.concreteView');
-    }
-  }),
 
   instrumentName: 'core_view',
 

--- a/packages/ember-views/lib/views/metamorph_view.js
+++ b/packages/ember-views/lib/views/metamorph_view.js
@@ -18,7 +18,6 @@ import { Mixin } from "ember-metal/mixin";
   @private
 */
 export var _Metamorph = Mixin.create({
-  isVirtual: true,
   tagName: '',
 
   instrumentName: 'metamorph',

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -15,7 +15,7 @@ merge(inDOM, {
   enter(view) {
     // Register the view for event handling. This hash is used by
     // Ember.EventDispatcher to dispatch incoming events.
-    if (!view.isVirtual) {
+    if (view.tagName !== '') {
       view._register();
     }
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1253,7 +1253,7 @@ var View = CoreView.extend(
     @private
   */
   init() {
-    if (!this.isVirtual && !this.elementId) {
+    if (this.tagName !== '' && !this.elementId) {
       this.elementId = guidFor(this);
     }
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -180,6 +180,7 @@ QUnit.skip('should not interfere with event propagation of virtualViews', functi
   var receivedEvent;
 
   var view = View.create({
+    // FIXME: isVirtual is no longer a thing
     isVirtual: true,
     render(buffer) {
       buffer.push('<div id="propagate-test-div"></div>');

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -3856,7 +3856,7 @@ QUnit.test("Can disconnect from the render helper's children", function() {
   equal(Ember.$('#qunit-fixture .foo .index').text(), '');
 });
 
-QUnit.skip("Can render({into:...}) nested render helpers", function() {
+QUnit.test("Can render({into:...}) nested render helpers", function() {
   Ember.TEMPLATES.application = compile('{{render "foo"}}');
   Ember.TEMPLATES.foo = compile('<div class="foo">{{render "bar"}}</div>');
   Ember.TEMPLATES.bar = compile('<div class="bar">{{outlet}}</div>');
@@ -3884,7 +3884,7 @@ QUnit.skip("Can render({into:...}) nested render helpers", function() {
   equal(Ember.$('#qunit-fixture .bar').text(), 'baz');
 });
 
-QUnit.skip("Can disconnect from nested render helpers", function() {
+QUnit.test("Can disconnect from nested render helpers", function() {
   Ember.TEMPLATES.application = compile('{{render "foo"}}');
   Ember.TEMPLATES.foo = compile('<div class="foo">{{render "bar"}}</div>');
   Ember.TEMPLATES.bar = compile('<div class="bar">{{outlet}}</div>');


### PR DESCRIPTION
MetamorphView (and the Metamorph mixin) are the final bastion of virtual views. This commit removes much of their use.

MetamorphView had two behaviors: First, it was tagless. Second, it was not included in the view hierarchy. The first concept (taglessness) is still valid in Ember post-Glimmer. For this, we use `tagName: ''`.

The second concept (virtual views) is not longer present. So views which previously used MetamorphView will not longer be able to escape the view hierarchy. In most cases, the intent was likely to be tagless and being virtual was simply a side effect.

OutletView and EachView will now be present in childViews and will be parentViews.

`{{render` used to always create a view. Now, it will only create a view if one is set by the user. By default it is only a componentNode and has no view at all.

The final spot MetamorphViews are used it for the default itemView and emptyView on EachView. This should be easy to address in a manner similar to {{render: If the user does not specify a view, none should be required.

After this, MetamorphView will no longer be used by internals.
