### PR TITLE
[BUGFIX beta] Allow feature flags to be merged.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ env:
     - TEST_SUITE=built-tests EMBER_ENV=production DISABLE_JSCS=true DISABLE_JSHINT=true
     - TEST_SUITE=old-jquery
     - TEST_SUITE=extend-prototypes
-    - TEST_SUITE=node EMBER_ENV=production DISABLE_JSCS=true DISABLE_JSHINT=true
+    - TEST_SUITE=node DISABLE_JSCS=true DISABLE_JSHINT=true
     - TEST_SUITE=sauce

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ember-cli-sauce": "^1.0.0",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.0.46",
+    "emberjs-build": "0.0.47",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -94,11 +94,14 @@ if ('undefined' === typeof Ember.ENV.DISABLE_RANGE_API) {
   @static
   @since 1.1.0
 */
+Ember.FEATURES = DEFAULT_FEATURES; //jshint ignore:line
 
-Ember.FEATURES = Ember.ENV.FEATURES;
-
-if (!Ember.FEATURES) {
-  Ember.FEATURES = DEFAULT_FEATURES; //jshint ignore:line
+if (Ember.ENV.FEATURES) {
+  for (var feature in Ember.ENV.FEATURES) {
+    if (Ember.ENV.FEATURES.hasOwnProperty(feature)) {
+      Ember.FEATURES[feature] = Ember.ENV.FEATURES[feature];
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Previously, having `EmberENV.FEATURES` specified as an empty object (the default for ember-cli), meant that development builds of Ember would not have ANY feature flags (even those that are supposed to be always enabled).

This changes that, by starting with the default features listing and only changing those that are specified.

Closes #10901.
