### PR TITLE
__deprecatedInstance__ is not available when autoboot is disabled, durin...

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -762,7 +762,10 @@ var Application = Namespace.extend(DeferredMixin, {
     Ember.BOOTED = false;
     this._bootPromise = null;
     this._bootResolver = null;
-    this.__deprecatedInstance__.destroy();
+
+    if (this.__deprecatedInstance__) {
+      this.__deprecatedInstance__.destroy();
+    }
   },
 
   initializer(options) {

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -109,6 +109,8 @@ QUnit.module("App boot", {
   },
 
   teardown: function() {
+    Ember.run(app, 'destroy');
+
     delete global.Ember;
 
     // clear the previously cached version of this module


### PR DESCRIPTION
...g app.visit

As it is deprecated, I do not feel the new API app.visit must support it. But maybe @tomdale  or @dgeb can share there thoughts.
