### PR TITLE
[DOC release] Fix tiny grammar mistakes in Ember.PromiseProxy docs

### DIFF
--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -34,7 +34,7 @@ function tap(proxy, promise) {
 }
 
 /**
-  A low level mixin making ObjectProxy, ObjectController or ArrayController's promise aware.
+  A low level mixin making ObjectProxy, ObjectController or ArrayControllers promise-aware.
 
   ```javascript
   var ObjectPromiseController = Ember.ObjectController.extend(Ember.PromiseProxyMixin);


### PR DESCRIPTION
This is a super tiny fix for a few grammar mistakes in Ember.PromiseProxy. I honestly debated about submitting the pull request. Feel free to toss this one out. If this was a waste of your time, I apologize.
