### PR TITLE
some cleanup

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -145,19 +145,18 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
   @deprecated
   @property template
   */
-  template: computed({
-    get: function() {
+  template: computed('templateName', {
+    get() {
       var templateName = get(this, 'templateName');
       var template = this.templateForName(templateName, 'template');
 
       Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
-
       return template || get(this, 'defaultTemplate');
     },
-    set: function(key, value) {
+    set(key, value) {
       return value;
     }
-  }).property('templateName'),
+  }),
 
   /**
   Specifying a components `templateName` is deprecated without also
@@ -199,10 +198,10 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     @type Ember.Controller
     @default null
   */
-  targetObject: computed(function(key) {
+  targetObject: computed('_parentView', function(key) {
     var parentView = this._parentView;
     return parentView ? get(parentView, 'controller') : null;
-  }).property('_parentView'),
+  }),
 
   /**
     Triggers a named action on the controller context where the component is used if

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -738,13 +738,13 @@ var View = CoreView.extend(
   */
 
   template: computed('templateName', {
-    get: function() {
+    get() {
       var templateName = get(this, 'templateName');
       var template = this.templateForName(templateName, 'template');
       Ember.assert("You specified the templateName " + templateName + " for " + this + ", but it did not exist.", !templateName || !!template);
       return template || get(this, 'defaultTemplate');
     },
-    set: function(key, value) {
+    set(key, value) {
       if (value !== undefined) { return value; }
       return get(this, key);
     }
@@ -764,14 +764,14 @@ var View = CoreView.extend(
     @property layout
     @type Function
   */
-  layout: computed(function(key) {
+  layout: computed('layoutName', function(key) {
     var layoutName = get(this, 'layoutName');
     var layout = this.templateForName(layoutName, 'layout');
 
     Ember.assert("You specified the layoutName " + layoutName + " for " + this + ", but it did not exist.", !layoutName || !!layout);
 
     return layout || get(this, 'defaultLayout');
-  }).property('layoutName'),
+  }),
 
   _yield(context, options, morph) {
     var template = get(this, 'template');


### PR DESCRIPTION
- computed(dk, fn) over computed(fn).property
- concise literals for those cp
