### PR TITLE
[Bugfix beta] Component.prototype.layout is now settable.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -764,14 +764,16 @@ var View = CoreView.extend(
     @property layout
     @type Function
   */
-  layout: computed(function(key) {
+  layout: computed('layoutName', function(key, value) {
+    if (arguments.length > 1) { return value; }
+
     var layoutName = get(this, 'layoutName');
     var layout = this.templateForName(layoutName, 'layout');
 
     Ember.assert("You specified the layoutName " + layoutName + " for " + this + ", but it did not exist.", !layoutName || !!layout);
 
     return layout || get(this, 'defaultLayout');
-  }).property('layoutName'),
+  }),
 
   _yield(context, options, morph) {
     var template = get(this, 'template');

--- a/packages/ember-views/tests/views/view/layout_test.js
+++ b/packages/ember-views/tests/views/view/layout_test.js
@@ -53,6 +53,59 @@ QUnit.test("should call the function of the associated layout", function() {
   equal(layoutCalled, 1, "layout is called when layout is present");
 });
 
+QUnit.test("changing layoutName after setting layoutName continous to work", function() {
+  var layoutCalled = 0;
+  var otherLayoutCalled = 0;
+
+  registry.register('template:layout', function() { layoutCalled++; });
+  registry.register('template:other-layout', function() { otherLayoutCalled++; });
+
+  view = EmberView.create({
+    container: container,
+    layoutName: 'layout'
+  });
+
+  run(view, 'createElement');
+  equal(layoutCalled, 1, "layout is called when layout is present");
+  equal(otherLayoutCalled, 0, "otherLayout is not yet called");
+
+  run(() => {
+    view.set('layoutName', 'other-layout');
+    view.rerender();
+  });
+
+  equal(layoutCalled, 1, "layout is called when layout is present");
+  equal(otherLayoutCalled, 1, "otherLayoutis called when layoutName changes, and explicit rerender occurs");
+});
+
+QUnit.test("changing layoutName after setting layout CP continous to work", function() {
+  var layoutCalled = 0;
+  var otherLayoutCalled = 0;
+  function otherLayout() {
+    otherLayoutCalled++;
+  }
+
+  registry.register('template:other-layout', otherLayout);
+
+  view = EmberView.create({
+    container: container,
+    layout() {
+      layoutCalled++;
+    }
+  });
+
+  run(view, 'createElement');
+  run(() => {
+    view.set('layoutName', 'other-layout');
+    view.rerender();
+  });
+
+  equal(view.get('layout'), otherLayout);
+
+  equal(layoutCalled, 1, "layout is called when layout is present");
+  equal(otherLayoutCalled, 1, "otherLayoutis called when layoutName changes, and explicit rerender occurs");
+});
+
 QUnit.test("should call the function of the associated template with itself as the context", function() {
   registry.register('template:testTemplate', function(dataSource) {
     return "<h1 id='twas-called'>template was called for " + get(dataSource, 'personName') + "</h1>";


### PR DESCRIPTION
## this is for the beta branch

Previously setting `layout` would replace the underlying CP. This would prevent `layoutName` from working when a component had an existing template.
