### PR TITLE
Get more tests with view#remove working

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/destroy-render-node.js
@@ -4,6 +4,10 @@
 */
 
 export default function destroyRenderNode(renderNode) {
+  if (renderNode.emberView) {
+    renderNode.emberView.destroy();
+  }
+
   var state = renderNode.state;
   if (!state) { return; }
 

--- a/packages/ember-htmlbars/lib/hooks/will-cleanup-tree.js
+++ b/packages/ember-htmlbars/lib/hooks/will-cleanup-tree.js
@@ -1,6 +1,6 @@
-export default function willCleanupTree(env, morph) {
+export default function willCleanupTree(env, morph, destroySelf) {
   var view = morph.emberView;
-  if (view && view.parentView) {
+  if (destroySelf && view && view.parentView) {
     view.parentView.removeChild(view);
   }
 

--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -30,8 +30,6 @@ proto.cleanup = function() {
       view.ownerView.isDestroyingSubtree = true;
       if (view.parentView) { view.parentView.removeChild(view); }
     }
-
-    view.destroy();
   }
 
   var toDestroy = this.emberToDestroy;

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -36,8 +36,12 @@ Renderer.prototype.prerenderTopLevelView =
 
 Renderer.prototype.renderTopLevelView =
   function Renderer_renderTopLevelView(view, renderNode) {
-    this.prerenderTopLevelView(view, renderNode);
-    this.dispatchLifecycleHooks(view.env);
+    // Check to see if insertion has been canceled
+    if (view._willInsert) {
+      view._willInsert = false;
+      this.prerenderTopLevelView(view, renderNode);
+      this.dispatchLifecycleHooks(view.env);
+    }
   };
 
 Renderer.prototype.revalidateTopLevelView =
@@ -81,6 +85,7 @@ Renderer.prototype.appendTo =
   function Renderer_appendTo(view, target) {
     var morph = this._dom.appendMorph(target);
     morph.ownerNode = morph;
+    view._willInsert = true;
     run.scheduleOnce('render', this, this.renderTopLevelView, view, morph);
   };
 
@@ -88,6 +93,7 @@ Renderer.prototype.replaceIn =
   function Renderer_replaceIn(view, target) {
     var morph = this._dom.replaceContentWithMorph(target);
     morph.ownerNode = morph;
+    view._willInsert = true;
     run.scheduleOnce('render', this, this.renderTopLevelView, view, morph);
   };
 

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -189,7 +189,7 @@ Renderer.prototype.renderElementRemoval =
     if (view._willRemoveElement) {
       view._willRemoveElement = false;
 
-      if (view.lastResult) {
+      if (view.renderNode) {
         view.renderNode.clear();
       }
       this.didDestroyElement(view);

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1060,6 +1060,9 @@ var View = CoreView.extend(
     // In the interim, we will just re-render if that happens. It is more
     // important than elements get garbage collected.
     if (!this.removedFromDOM) { this.destroyElement(); }
+
+    // Set flag to avoid future renders
+    this._willInsert = false;
   },
 
   /**

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -98,9 +98,11 @@ QUnit.test("should not dispatch events to views not inDOM", function() {
 
   var $element = view.$();
 
-  // TODO change this test not to use private API
-  // Force into preRender
-  view.renderer.remove(view, false, true);
+  run(function() {
+    // TODO change this test not to use private API
+    // Force into preRender
+    view.renderer.remove(view, false, true);
+  });
 
   $element.trigger('mousedown');
 

--- a/packages/ember-views/tests/views/view/append_to_test.js
+++ b/packages/ember-views/tests/views/view/append_to_test.js
@@ -186,7 +186,7 @@ QUnit.test("trigger rerender of parent and SimpleBoundView", function () {
   });
 });
 
-QUnit.skip("remove removes an element from the DOM", function() {
+QUnit.test("remove removes an element from the DOM", function() {
   willDestroyCalled = 0;
 
   view = View.create({
@@ -213,7 +213,7 @@ QUnit.skip("remove removes an element from the DOM", function() {
   equal(willDestroyCalled, 1, "the willDestroyElement hook was called once");
 });
 
-QUnit.skip("destroy more forcibly removes the view", function() {
+QUnit.test("destroy more forcibly removes the view", function() {
   willDestroyCalled = 0;
 
   view = View.create({
@@ -315,7 +315,7 @@ QUnit.module("EmberView - removing views in a view hierarchy", {
   }
 });
 
-QUnit.skip("remove removes child elements from the DOM", function() {
+QUnit.test("remove removes child elements from the DOM", function() {
   ok(!get(childView, 'element'), "precond - should not have an element");
 
   run(function() {
@@ -335,7 +335,7 @@ QUnit.skip("remove removes child elements from the DOM", function() {
   equal(willDestroyCalled, 1, "the willDestroyElement hook was called once");
 });
 
-QUnit.skip("destroy more forcibly removes child views", function() {
+QUnit.test("destroy more forcibly removes child views", function() {
   ok(!get(childView, 'element'), "precond - should not have an element");
 
   run(function() {

--- a/packages/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages/ember-views/tests/views/view/destroy_element_test.js
@@ -28,7 +28,7 @@ QUnit.test("if it has no element, does nothing", function() {
   equal(callCount, 0, 'did not invoke callback');
 });
 
-QUnit.skip("if it has a element, calls willDestroyElement on receiver and child views then deletes the element", function() {
+QUnit.test("if it has a element, calls willDestroyElement on receiver and child views then deletes the element", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   var parentCount = 0;
@@ -72,7 +72,7 @@ QUnit.test("returns receiver", function() {
   equal(ret, view, 'returns receiver');
 });
 
-QUnit.skip("removes element from parentNode if in DOM", function() {
+QUnit.test("removes element from parentNode if in DOM", function() {
   view = EmberView.create();
 
   run(function() {

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -86,7 +86,7 @@ QUnit.module("View#removeFromParent", {
   }
 });
 
-QUnit.skip("removes view from parent view", function() {
+QUnit.test("removes view from parent view", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   parentView = ContainerView.create({ childViews: [View] });

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -134,7 +134,7 @@ QUnit.test("does nothing if not in parentView", function() {
 });
 
 
-QUnit.skip("the DOM element is gone after doing append and remove in two separate runloops", function() {
+QUnit.test("the DOM element is gone after doing append and remove in two separate runloops", function() {
   view = View.create();
   run(function() {
     view.append();

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -147,7 +147,7 @@ QUnit.test("the DOM element is gone after doing append and remove in two separat
   ok(viewElem.length === 0, "view's element doesn't exist in DOM");
 });
 
-QUnit.skip("the DOM element is gone after doing append and remove in a single runloop", function() {
+QUnit.test("the DOM element is gone after doing append and remove in a single runloop", function() {
   view = View.create();
   run(function() {
     view.append();

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -248,7 +248,7 @@ QUnit.skip("should replace DOM representation if rerender() is called after elem
   equal(view.$().text(), "Do not taunt happy fun ball", "rerenders DOM element when rerender() is called");
 });
 
-QUnit.skip("should destroy DOM representation when destroyElement is called", function() {
+QUnit.test("should destroy DOM representation when destroyElement is called", function() {
   run(function() {
     view = EmberView.create({
       template: compile("Don't fear the reaper")


### PR DESCRIPTION
I'm looking for some feedback on this PR.  I implemented some of the `view#remove` functionality. When I started this, I was expecting to use `clearMorph` and various callback hooks from HTMLbars.

https://github.com/tildeio/htmlbars/blob/master/packages/htmlbars-util/lib/template-utils.js#L64

However I couldn't figure out a way to clear the elements without destroying the views. In this PR I used the `clear()` method on the renderNode, and ran `willDestroyElement` and `didDestroyElement` callbacks in the `renderer`.

edit: I'm feeling more confident about this PR as I've continued to work on it.  This gets 10 more view-related tests passing.
