### PR TITLE
[Bugfix beta] ensure scheduleOnce has a stable function + context

### DIFF
--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -31,16 +31,10 @@ merge(hasElement, {
   // deferred to allow bindings to synchronize.
   rerender(view) {
     if (view._root._morph && !view._elementInserted) {
-      throw new EmberError("Something you did caused a view to re-render after it rendered but before it was inserted into the DOM.");
+      throw new EmberError('Something you did caused a view to re-render after it rendered but before it was inserted into the DOM.');
     }
-    // TODO: should be scheduled with renderer
-    run.scheduleOnce('render', function () {
-      if (view.isDestroying) {
-        return;
-      }
 
-      view._renderer.renderTree(view, view._parentView);
-    });
+    run.scheduleOnce('render', view, '_rerender');
   },
 
   // once the view is already in the DOM, destroying it removes it

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -913,6 +913,19 @@ var View = CoreView.extend(
     return this.currentState.rerender(this);
   },
 
+  /*
+   * @private
+   *
+   * @method _rerender
+   */
+  _rerender() {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
+    this._renderer.renderTree(this, this._parentView);
+  },
+
   /**
     Given a property name, returns a dasherized version of that
     property name if the property evaluates to a non-falsy value.


### PR DESCRIPTION
The run-loop _once_ methods, detect uniqueness based on function identity.
If we pass an anonymous function each time its identity constantly changes.

``` js
Ember.run.scheduleOnce(queue, function() { });  // will invoke the callback once per schedule

function stableCallback() { }
Ember.run.scheduleOnce(queue, stableCallback); // will invoke the callback once per run-loop, regardless of schedules
```

Not only does this mean that the `once` requirement is not actually respected –
in theory allowing repeated re-renders – but we incur the penalty of ensuring 
once-ness, which isn’t always costly but in this case can be.

``` js
// does a linear search across all queued functions to check uniqueness
// this can be a large search space
// implementation: https://github.com/ebryn/backburner.js/blob/7b14e2e3ea9b8e1b7329c0b61f652a888d6e49bd/lib/backburner/queue.js#L26-L41
Ember.run.scheduleOne(queueName, fn); 

// does a linear search across queued functions only for this emberObject to check uniqueness
// this is typically a very small search space
// implementation: https://github.com/ebryn/backburner.js/blob/7b14e2e3ea9b8e1b7329c0b61f652a888d6e49bd/lib/backburner/queue.js#L63-L80 
Ember.run.scheduleOne(queueName, emberObject, fn);
```

Unfortunately, this won’t make a drastic improvement for all apps,
but if an app did hit this scenario it will make a difference
