### PR TITLE
Return truthy value from Ember.assert

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -37,6 +37,7 @@ Ember Debug
   @param {Boolean|Function} test Must be truthy for the assertion to pass. If
     falsy, an exception will be thrown. If this is a function, it will be executed and
     its return value will be used as condition.
+  @return {Object} the result of the truthy value if the test condition succeeds.
 */
 Ember.assert = function(desc, test) {
   var throwAssertion;
@@ -50,6 +51,8 @@ Ember.assert = function(desc, test) {
   if (throwAssertion) {
     throw new EmberError("Assertion Failed: " + desc);
   }
+  
+  return throwAssertion;
 };
 
 


### PR DESCRIPTION
When using Ember.assert, sometimes it can be handy to assert a value when assigning to a var. for instance, I frequently run into cases like this:

```
Ember.assert('name is required!', person.name);
var name = person.name;
```

I could clean this up into a one-liner like so:

```
var name = Ember.assert('name is required!', person.name);
```

This is how Guava's [preconditions](http://docs.guava-libraries.googlecode.com/git-history/release/javadoc/com/google/common/base/Preconditions.html#checkNotNull%28T%29) library works, and I find it quite handy.
