### PR TITLE
Use nicer ES6 syntax for get/set on CPs

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -675,12 +675,12 @@ export function readOnly(dependentKey) {
 */
 export function defaultTo(defaultPath) {
   return computed({
-    get: function(key) {
+    get(key) {
       Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
       return get(this, defaultPath);
     },
 
-    set: function(key, newValue, cachedValue) {
+    set(key, newValue, cachedValue) {
       Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
       return newValue != null ? newValue : get(this, defaultPath);
     }
@@ -702,11 +702,11 @@ export function defaultTo(defaultPath) {
 */
 export function deprecatingAlias(dependentKey) {
   return computed(dependentKey, {
-    get: function(key) {
+    get(key) {
       Ember.deprecate(`Usage of \`${key}\` is deprecated, use \`${dependentKey}\` instead.`);
       return get(this, dependentKey);
     },
-    set: function(key, value) {
+    set(key, value) {
       Ember.deprecate(`Usage of \`${key}\` is deprecated, use \`${dependentKey}\` instead.`);
       set(this, dependentKey, value);
       return value;

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -271,10 +271,10 @@ var LinkView = EmberComponent.extend({
     @property disabled
   */
   disabled: computed({
-    get: function(key, value) {
+    get(key, value) {
       return false;
     },
-    set: function(key, value) {
+    set(key, value) {
       if (value !== undefined) { this.set('_isDisabled', value); }
 
       return value ? get(this, 'disabledClass') : false;

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -205,10 +205,10 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
   },
 
   model: computed({
-    get: function(key) {
+    get(key) {
       return Ember.A();
     },
-    set: function(key, value) {
+    set(key, value) {
       Ember.assert(
         'ArrayController expects `model` to implement the Ember.Array mixin. ' +
         'This can often be fixed by wrapping your model with `Ember.A()`.',

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -168,10 +168,10 @@ export default Mixin.create(Enumerable, {
     @return this
   */
   '[]': computed({
-    get: function(key) {
+    get(key) {
       return this;
     },
-    set: function(key, value) {
+    set(key, value) {
       this.replace(0, get(this, 'length'), value);
       return this;
     }

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -957,7 +957,7 @@ export default Mixin.create({
     @return this
   */
   '[]': computed({
-    get: function(key) { return this; }
+    get(key) { return this; }
   }),
 
   // ..........................................................

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -157,10 +157,10 @@ export default Mixin.create({
     @property promise
   */
   promise: computed({
-    get: function() {
+    get() {
       throw new EmberError("PromiseProxy's promise must be set");
     },
-    set: function(key, promise) {
+    set(key, promise) {
       return tap(this, promise);
     }
   }),

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -162,7 +162,7 @@ export default Mixin.create(MutableEnumerable, {
     @property arrangedContent
   */
   arrangedContent: computed('content', 'sortProperties.@each', {
-    get: function(key) {
+    get(key) {
       var content = get(this, 'content');
       var isSorted = get(this, 'isSorted');
       var sortProperties = get(this, 'sortProperties');

--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -25,10 +25,10 @@ var ViewContextSupport = Mixin.create({
     @type Object
   */
   context: computed({
-    get: function() {
+    get() {
       return get(this, '_context');
     },
-    set: function(key, value) {
+    set(key, value) {
       set(this, '_context', value);
       return value;
     }
@@ -53,7 +53,7 @@ var ViewContextSupport = Mixin.create({
     @private
   */
   _context: computed({
-    get: function() {
+    get() {
       var parentView, controller;
 
       if (controller = get(this, 'controller')) {
@@ -66,7 +66,7 @@ var ViewContextSupport = Mixin.create({
       }
       return null;
     },
-    set: function(key, value) {
+    set(key, value) {
       return value;
     }
   }),
@@ -81,14 +81,14 @@ var ViewContextSupport = Mixin.create({
     @type Object
   */
   controller: computed({
-    get: function() {
+    get() {
       if (this._controller) {
         return this._controller;
       }
 
       return this._parentView ? get(this._parentView, 'controller') : null;
     },
-    set: function(_, value) {
+    set(_, value) {
       this._controller = value;
       return value;
     }

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -417,11 +417,11 @@ var Select = View.extend({
     @default null
   */
   value: computed({
-    get: function(key) {
+    get(key) {
       var valuePath = get(this, '_valuePath');
       return valuePath ? get(this, 'selection.' + valuePath) : get(this, 'selection');
     },
-    set: function(key, value) {
+    set(key, value) {
       return value;
     }
   }).property('_valuePath', 'selection'),

--- a/packages/ember-views/lib/views/text_field.js
+++ b/packages/ember-views/lib/views/text_field.js
@@ -38,11 +38,11 @@ function canSetTypeOfInput(type) {
 function getTypeComputed() {
   if (Ember.FEATURES.isEnabled('new-computed-syntax')) {
     return computed({
-      get: function() {
+      get() {
         return 'text';
       },
 
-      set: function(key, value) {
+      set(key, value) {
         var type = 'text';
 
         if (canSetTypeOfInput(value)) {


### PR DESCRIPTION
Small cleanup. Nicer syntax and functions defined with es6 syntax are named.
