### PR TITLE
Throw when rerender called after rendering

### DIFF
--- a/packages/ember-htmlbars/lib/system/component-node.js
+++ b/packages/ember-htmlbars/lib/system/component-node.js
@@ -89,6 +89,7 @@ ComponentNode.prototype.render = function(env, attrs, visitor) {
     var snapshot = readHash(attrs);
     env.renderer.setAttrs(this.component, snapshot);
     env.renderer.willRender(component);
+    env.renderedViews.push(component.elementId);
   }
 
   if (this.block) {
@@ -123,6 +124,8 @@ ComponentNode.prototype.rerender = function(env, attrs, visitor) {
     }
 
     env.renderer.willRender(component);
+
+    env.renderedViews.push(component.elementId);
   }
 
   if (this.block) {

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -23,6 +23,7 @@ export default function renderView(view, buffer, template) {
 export function renderHTMLBarsBlock(view, block, renderNode) {
   var env = {
     lifecycleHooks: [],
+    renderedViews: [],
     view: view,
     outletState: view.outletState,
     container: view.container,

--- a/packages/ember-views/lib/views/states/default.js
+++ b/packages/ember-views/lib/views/states/default.js
@@ -26,6 +26,8 @@ export default {
   cleanup() { } ,
   destroyElement() { },
 
-  rerender() { },
+  rerender(view) {
+    view.renderer.ensureViewNotRendering(view);
+  },
   invokeObserver() { }
 };

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -29,6 +29,8 @@ merge(hasElement, {
   // once the view has been inserted into the DOM, rerendering is
   // deferred to allow bindings to synchronize.
   rerender(view) {
+    view.renderer.ensureViewNotRendering(view);
+
     var renderNode = view.renderNode;
 
     renderNode.isDirty = true;


### PR DESCRIPTION
Just before a block is rendered, views are put into a renderedViews list. When `rerender` is called, this list is checked to ensure the view being rerendered has not already been rendered.

/cc @wycats @mmun for review.
