### PR TITLE
[BUGFIX beta] Warn rather than raise readOnly CPs

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -218,7 +218,7 @@ ComputedPropertyPrototype.volatile = function() {
 ComputedPropertyPrototype.readOnly = function(readOnly) {
   Ember.deprecate('Passing arguments to ComputedProperty.readOnly() is deprecated.', arguments.length === 0);
   this._readOnly = readOnly === undefined || !!readOnly; // Force to true once this deprecation is gone
-  Ember.assert("Computed properties that define a setter cannot be read-only", !(this._readOnly && this._setter));
+  Ember.deprecate("Computed properties that define a setter should not be marked read-only", !(this._readOnly && this._setter));
   return this;
 };
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -900,13 +900,13 @@ QUnit.test('is chainable', function() {
   ok(cp instanceof ComputedProperty);
 });
 
-QUnit.test('throws assertion if called over a CP with a setter', function() {
-  expectAssertion(function() {
+QUnit.test('warns if called over a CP with a setter', function() {
+  expectDeprecation(function() {
     computed({
       get: function() { },
       set: function() { }
     }).readOnly();
-  }, /Computed properties that define a setter cannot be read-only/);
+  }, /Computed properties that define a setter should not be marked read-only/);
 });
 
 testBoth('protects against setting', function(get, set) {


### PR DESCRIPTION
Previously, CPs with setters would raise an exception if they were
marked as readOnly. This change broke Semantic Versioning because
it caused working app code to break.

For example, if you had a computed property that was read-only, but you
happened to include a second `value` argument out of habit or
convention, this change would cause your previously-functioning app to
break:

```
computed(function(key, value) {
  // value is unused
}).readOnly()
```

The above code example will cause an exception to be raised.

In Ember 2.0 we can change this deprecation back to an assertion.
