### PR TITLE
[BUGFIX beta] Fix assertion to make sure doesn't affect old CP syntax

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -218,7 +218,7 @@ ComputedPropertyPrototype.volatile = function() {
 ComputedPropertyPrototype.readOnly = function(readOnly) {
   Ember.deprecate('Passing arguments to ComputedProperty.readOnly() is deprecated.', arguments.length === 0);
   this._readOnly = readOnly === undefined || !!readOnly; // Force to true once this deprecation is gone
-  Ember.assert("Computed properties that define a setter cannot be read-only", !(this._readOnly && this._setter));
+  Ember.assert("Computed properties that define a setter using the new syntax cannot be read-only", !(this._readOnly && this._setter && this._setter !== this._getter));
   return this;
 };
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -900,13 +900,19 @@ QUnit.test('is chainable', function() {
   ok(cp instanceof ComputedProperty);
 });
 
-QUnit.test('throws assertion if called over a CP with a setter', function() {
+QUnit.test('throws assertion if called over a CP with a setter defined with the new syntax', function() {
   expectAssertion(function() {
     computed({
       get: function() { },
       set: function() { }
     }).readOnly();
-  }, /Computed properties that define a setter cannot be read-only/);
+  }, /Computed properties that define a setter using the new syntax cannot be read-only/);
+});
+
+QUnit.test('doesn\'t throws assertion if called over a CP with a setter defined with the old syntax', function() {
+  expectDeprecation(function() {
+    computed(function(key, value) {}).readOnly();
+  }, /same function as getter and setter/);
 });
 
 testBoth('protects against setting', function(get, set) {


### PR DESCRIPTION
In #10761 I introduced an assertion was raised on `readOnly` when the function has a setter. 
While this is a reasonable check, it is a breaking change for people using the old CP syntax. 

This assertion is only thrown if the getter and setter functions are different, so won't affect existing users.

/cc @tomdale 
