### PR TITLE
[DOC] Use `as |obj|` syntax for #each examples

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -1,7 +1,161 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
 import { get } from "ember-metal/property_get";
 import { forEach } from "ember-metal/enumerable_utils";
 import normalizeSelf from "ember-htmlbars/utils/normalize-self";
 
+/**
+  The `{{#each}}` helper loops over elements in a collection. It is an extension
+  of the base Handlebars `{{#each}}` helper.
+
+  The default behavior of `{{#each}}` is to yield its inner block once for every
+  item in an array.
+
+  ```javascript
+  var developers = [{name: 'Yehuda'},{name: 'Tom'}, {name: 'Paul'}];
+  ```
+
+  ```handlebars
+  {{#each developers as |person|}}
+    {{person.name}}
+    {{! `this` is whatever it was outside the #each }}
+  {{/each}}
+  ```
+
+  The same rules apply to arrays of primitives, but the items may need to be
+  references with `{{this}}`.
+
+  ```javascript
+  var developerNames = ['Yehuda', 'Tom', 'Paul'];
+  ```
+
+  ```handlebars
+  {{#each developerNames as |name|}}
+    {{name}}
+  {{/each}}
+  ```
+
+  ### {{else}} condition
+
+  `{{#each}}` can have a matching `{{else}}`. The contents of this block will render
+  if the collection is empty.
+
+  ```
+  {{#each developers as |person|}}
+    {{person.name}}
+  {{else}}
+    <p>Sorry, nobody is available for this task.</p>
+  {{/each}}
+  ```
+
+  ### Specifying an alternative view for each item
+
+  `itemViewClass` can control which view will be used during the render of each
+  item's template.
+
+  The following template:
+
+  ```handlebars
+  <ul>
+  {{#each developers itemViewClass="person" as |developer|}}
+    {{developer.name}}
+  {{/each}}
+  </ul>
+  ```
+
+  Will use the following view for each item
+
+  ```javascript
+  App.PersonView = Ember.View.extend({
+    tagName: 'li'
+  });
+  ```
+
+  Resulting in HTML output that looks like the following:
+
+  ```html
+  <ul>
+    <li class="ember-view">Yehuda</li>
+    <li class="ember-view">Tom</li>
+    <li class="ember-view">Paul</li>
+  </ul>
+  ```
+
+  `itemViewClass` also enables a non-block form of `{{each}}`. The view
+  must {{#crossLink "Ember.View/toc_templates"}}provide its own template{{/crossLink}},
+  and then the block should be dropped. An example that outputs the same HTML
+  as the previous one:
+
+  ```javascript
+  App.PersonView = Ember.View.extend({
+    tagName: 'li',
+    template: '{{developer.name}}'
+  });
+  ```
+
+  ```handlebars
+  <ul>
+    {{each developers itemViewClass="person" as |developer|}}
+  </ul>
+  ```
+
+  ### Specifying an alternative view for no items (else)
+
+  The `emptyViewClass` option provides the same flexibility to the `{{else}}`
+  case of the each helper.
+
+  ```javascript
+  App.NoPeopleView = Ember.View.extend({
+    tagName: 'li',
+    template: 'No person is available, sorry'
+  });
+  ```
+
+  ```handlebars
+  <ul>
+  {{#each developers emptyViewClass="no-people" as |developer|}}
+    <li>{{developer.name}}</li>
+  {{/each}}
+  </ul>
+  ```
+
+  ### Wrapping each item in a controller
+
+  Controllers in Ember manage state and decorate data. In many cases,
+  providing a controller for each item in a list can be useful.
+  Specifically, an {{#crossLink "Ember.ObjectController"}}Ember.ObjectController{{/crossLink}}
+  should probably be used. Item controllers are passed the item they
+  will present as a `model` property, and an object controller will
+  proxy property lookups to `model` for us.
+
+  This allows state and decoration to be added to the controller
+  while any other property lookups are delegated to the model. An example:
+
+  ```javascript
+  App.RecruitController = Ember.ObjectController.extend({
+    isAvailableForHire: function() {
+      return !this.get('isEmployed') && this.get('isSeekingWork');
+    }.property('isEmployed', 'isSeekingWork')
+  })
+  ```
+
+  ```handlebars
+  {{#each developers itemController="recruit" as |person|}}
+    {{person.name}} {{#if person.isAvailableForHire}}Hire me!{{/if}}
+  {{/each}}
+  ```
+
+  @method each
+  @for Ember.Handlebars.helpers
+  @param [name] {String} name for item (used with `in`)
+  @param [path] {String} path
+  @param [options] {Object} Handlebars key/value pairs of options
+  @param [options.itemViewClass] {String} a path to a view class used for each item
+  @param [options.emptyViewClass] {String} a path to a view class used for each item
+  @param [options.itemController] {String} name of a controller to be created for each item
+*/
 export default function eachHelper(params, hash, blocks) {
   var list = params[0];
   var keyPath = hash.key;


### PR DESCRIPTION
The parameters still needs some work though, as well as the helper itself since it says that it requires the `{{#each item in list}}` form.
