### PR TITLE
Fix a test for view controller property

### DIFF
--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -8,6 +8,7 @@ import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import LegacyViewSupport from "ember-views/mixins/legacy_view_support";
 import { observer } from "ember-metal/mixin";
+import { on } from "ember-metal/events";
 
 var ViewContextSupport = Mixin.create(LegacyViewSupport, {
   /**
@@ -94,6 +95,10 @@ var ViewContextSupport = Mixin.create(LegacyViewSupport, {
 
   _legacyControllerDidChange: observer('controller', function() {
     this.walkChildViews(view => view.notifyPropertyChange('controller'));
+  }),
+
+  _notifyControllerChange: on('parentViewDidChange', function() {
+    this.notifyPropertyChange('controller');
   })
 });
 

--- a/packages/ember-views/tests/views/view/controller_test.js
+++ b/packages/ember-views/tests/views/view/controller_test.js
@@ -4,7 +4,7 @@ import ContainerView from "ember-views/views/container_view";
 
 QUnit.module("Ember.View - controller property");
 
-QUnit.skip("controller property should be inherited from nearest ancestor with controller", function() {
+QUnit.test("controller property should be inherited from nearest ancestor with controller", function() {
   var grandparent = ContainerView.create();
   var parent = ContainerView.create();
   var child = ContainerView.create();


### PR DESCRIPTION
~~It is tempting to add an observer or use a dependent key for ‘childViews’ on the `controller` computed property in ‘view_context_support.js’. However, doing this results in a lot of MANDITORY_SETTER errors since there are a few places in the code that set ‘childViews’ directly.~~

Notify the view of a possible controller change when its parentView changes.
