### PR TITLE
Set a default selected object, if no "prompt" exists or if no default selection binding exists.

### DIFF
--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -553,6 +553,14 @@ var Select = View.extend({
     }
   },
 
+  _change() {
+    if (get(this, 'multiple')) {
+      this._changeMultiple();
+    } else {
+      this._changeSingle();
+    }
+  },
+
   _changeSingle() {
     var selectedIndex = this.$()[0].selectedIndex;
     var content = get(this, 'content');

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -545,7 +545,10 @@ var Select = View.extend({
       if (multiple) { this._changeMultiple(); }
       else {
         if (prompt) { this._changeSingle(); }
-        else { set(this, 'selection', content.objectAt(0)); }
+        else {
+          if (!content) { set(this, 'selection', null); }
+          else { set(this, 'selection', content.objectAt(0)); }
+        }
       }
     }
   },

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -503,14 +503,6 @@ var Select = View.extend({
   */
   optionView: SelectOption,
 
-  _change() {
-    if (get(this, 'multiple')) {
-      this._changeMultiple();
-    } else {
-      this._changeSingle();
-    }
-  },
-
   selectionDidChange: observer('selection.@each', function() {
     var selection = get(this, 'selection');
     if (get(this, 'multiple')) {
@@ -550,10 +542,10 @@ var Select = View.extend({
     if (!isNone(selection)) { this.selectionDidChange(); }
     if (!isNone(value)) { this.valueDidChange(); }
     if (isNone(selection)) {
-      if (!prompt && !multiple) {
-        property_set.set(this, 'selection', content.objectAt(0));
-      } else {
-        this._change();
+      if (multiple) { this._changeMultiple(); }
+      else {
+        if (prompt) { this._changeSingle(); }
+        else { set(this, 'selection', content.firstObject); }
       }
     }
   },

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -542,12 +542,17 @@ var Select = View.extend({
     if (!isNone(selection)) { this.selectionDidChange(); }
     if (!isNone(value)) { this.valueDidChange(); }
     if (isNone(selection)) {
-      if (multiple) { this._changeMultiple(); }
-      else {
-        if (prompt) { this._changeSingle(); }
-        else {
-          if (!content || !get(content, 'length')) { return; }
-          else { set(this, 'selection', content.objectAt(0)); }
+      if (multiple) {
+        this._changeMultiple();
+      } else {
+        if (prompt) {
+          this._changeSingle();
+        } else {
+          if (!content || !get(content, 'length')) {
+            set(this, 'selection', null);
+          } else {
+            set(this, 'selection', content.objectAt(0));
+          }
         }
       }
     }

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -545,10 +545,10 @@ var Select = View.extend({
       if (multiple) {
         this._changeMultiple();
       } else {
-        if (prompt) {
+        if (!isNone(prompt)) {
           this._changeSingle();
         } else {
-          if (!content || !get(content, 'length')) {
+          if (isNone(content) || isNone(get(content, 'length'))) {
             set(this, 'selection', null);
           } else {
             set(this, 'selection', content.objectAt(0));

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -546,7 +546,7 @@ var Select = View.extend({
       else {
         if (prompt) { this._changeSingle(); }
         else {
-          if (!content) { set(this, 'selection', null); }
+          if (!content || !get(content, 'length')) { return; }
           else { set(this, 'selection', content.objectAt(0)); }
         }
       }

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -545,7 +545,7 @@ var Select = View.extend({
       if (multiple) { this._changeMultiple(); }
       else {
         if (prompt) { this._changeSingle(); }
-        else { set(this, 'selection', content.firstObject); }
+        else { set(this, 'selection', content.objectAt(0)); }
       }
     }
   },

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -562,7 +562,7 @@ var Select = View.extend({
       return;
     }
 
-    if (prompt) { selectedIndex -= 1; }
+    if (prompt) {selectedIndex -= 1; } else { selectedIndex = 0; }
     set(this, 'selection', content.objectAt(selectedIndex));
   },
 

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -543,11 +543,18 @@ var Select = View.extend({
   _setDefaults() {
     var selection = get(this, 'selection');
     var value = get(this, 'value');
+    var prompt = get(this, 'prompt');
+    var multiple = get(this, 'multiple');
+    var content = get(this, 'content');
 
     if (!isNone(selection)) { this.selectionDidChange(); }
     if (!isNone(value)) { this.valueDidChange(); }
     if (isNone(selection)) {
-      this._change();
+      if (!prompt && !multiple) {
+        property_set.set(this, 'selection', content.objectAt(0));
+      } else {
+        this._change();
+      }
     }
   },
 
@@ -562,7 +569,7 @@ var Select = View.extend({
       return;
     }
 
-    if (prompt) {selectedIndex -= 1; } else { selectedIndex = 0; }
+    if (prompt) {selectedIndex -= 1; }
     set(this, 'selection', content.objectAt(selectedIndex));
   },
 


### PR DESCRIPTION
Related to issue: https://github.com/emberjs/ember.js/issues/10984

This workaround should solve an issue where an `Ember.Select` will default to the last array object (or `<option>`) in certain browsers.

THis issue would occur for single type Ember.Selects which have no "prompt" property defined, and a selection or value property bound to a null value.

This is done in the `_setDefault()` method, and only `on('didInsertElement')`.. allowing all the correct observers to fire and not interfere with subsequest selection changes.
