### PR TITLE
Consistently use `parentView` over `_parentView`

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/action_test.js
@@ -162,7 +162,7 @@ QUnit.test("should target the current controller inside an {{each}} loop [DEPREC
   equal(registeredTarget, itemController, "the item controller is the target of action");
 });
 
-QUnit.skip("should target the with-controller inside an {{#with controller='person'}} [DEPRECATED]", function() {
+QUnit.test("should target the with-controller inside an {{#with controller='person'}} [DEPRECATED]", function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function({ node }) {

--- a/packages/ember-views/lib/system/render_buffer.js
+++ b/packages/ember-views/lib/system/render_buffer.js
@@ -272,7 +272,7 @@ RenderBuffer.prototype = {
       var ref = el.querySelector('#morph-'+i);
 
       Ember.assert('An error occurred while setting up template bindings. Please check ' +
-                   (((childView && childView._parentView && childView._parentView._debugTemplateName ? '"' + childView._parentView._debugTemplateName + '" template ' : ''))
+                   (((childView && childView.parentView && childView._parentView._debugTemplateName ? '"' + childView._parentView._debugTemplateName + '" template ' : ''))
                    )  + 'for invalid markup or bindings within HTML comments.',
                    ref);
 

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -233,7 +233,7 @@ var ContainerView = View.extend(MutableArray, {
   _currentViewDidChange: observer('currentView', function() {
     var currentView = get(this, 'currentView');
     if (currentView) {
-      Ember.assert("You tried to set a current view that already has a parent. Make sure you don't have multiple outlets in the same view.", !currentView._parentView);
+      Ember.assert("You tried to set a current view that already has a parent. Make sure you don't have multiple outlets in the same view.", !currentView.parentView);
       this.pushObject(currentView);
     }
   }),
@@ -271,7 +271,7 @@ var ContainerView = View.extend(MutableArray, {
     this.notifyPropertyChange('childViews');
     this.arrayContentDidChange(idx, removedCount, addedCount);
 
-    //Ember.assert("You can't add a child to a container - the child is already a child of another view", emberA(addedViews).every(function(item) { return !item._parentView || item._parentView === self; }));
+    //Ember.assert("You can't add a child to a container - the child is already a child of another view", emberA(addedViews).every(function(item) { return !item.parentView || item.parentView === self; }));
 
     set(this, 'length', childViews.length);
 

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -36,7 +36,7 @@ merge(inDOM, {
     if (!childViews.length) { childViews = view.childViews = childViews.slice(); }
     childViews.push(attrNode);
 
-    attrNode._parentView = view;
+    attrNode.parentView = view;
     view.renderer.appendAttrTo(attrNode, view.element, attrNode.attrName);
 
     view.propertyDidChange('childViews');

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -876,7 +876,7 @@ var View = CoreView.extend(
       return;
     }
 
-    this._renderer.renderTree(this, this._parentView);
+    this._renderer.renderTree(this, this.parentView);
   },
 
   /**

--- a/packages/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages/ember-views/tests/views/view/create_child_view_test.js
@@ -54,7 +54,7 @@ QUnit.test("should create property on parentView to a childView instance if prov
   equal(get(view, 'someChildView'), newView);
 });
 
-QUnit.skip("should update a view instances attributes, including the _parentView and container properties", function() {
+QUnit.test("should update a view instances attributes, including the parentView and container properties", function() {
   var attrs = {
     foo: "baz"
   };
@@ -63,13 +63,13 @@ QUnit.skip("should update a view instances attributes, including the _parentView
   newView = view.createChildView(myView, attrs);
 
   equal(newView.container, container, 'expects to share container with parent');
-  equal(newView._parentView, view, 'expects to have the correct parent');
+  equal(newView.parentView, view, 'expects to have the correct parent');
   equal(get(newView, 'foo'), 'baz', 'view did get custom attributes');
 
   deepEqual(newView, myView);
 });
 
-QUnit.skip("should create from string via container lookup", function() {
+QUnit.test("should create from string via container lookup", function() {
   var ChildViewClass = EmberView.extend();
   var fullName = 'view:bro';
 
@@ -84,7 +84,7 @@ QUnit.skip("should create from string via container lookup", function() {
   newView = view.createChildView('bro');
 
   equal(newView.container, container, 'expects to share container with parent');
-  equal(newView._parentView, view, 'expects to have the correct parent');
+  equal(newView.parentView, view, 'expects to have the correct parent');
 });
 
 QUnit.test("should assert when trying to create childView from string, but no such view is registered", function() {


### PR DESCRIPTION
It seems like view#_parentView has been superseded by view#parentView. Making these properties consistent fixes a few tests.

Is it worth added backwards compatibility for `_privateView`?
