### PR TITLE
Clarifies intent of `states.inactive`

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -371,7 +371,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
   _reset(isExiting, transition) {
     var controller = this.controller;
 
-    controller._qpDelegate = get(this, '_qp.states.inactive');
+    controller._qpDelegate = null;
 
     this.resetController(controller, isExiting, transition);
   },
@@ -715,7 +715,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
           }
         }
 
-        controller._qpDelegate = get(this, '_qp.states.inactive');
+        controller._qpDelegate = null;
 
         var thisQueryParamChanged = (svalue !== qp.svalue);
         if (thisQueryParamChanged) {


### PR DESCRIPTION
`states.inactive` is just a clever (and expensive) way of saying `null`. This also saves you the time of wonder where the h**\* `states.inactive` is defined.
