### PR TITLE
Remove `_pCacheMeta` property on controllers, which appears to just be leftover from an earlier time.

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -13,7 +13,7 @@ import ControllerMixin from "ember-runtime/mixins/controller";
 */
 
 ControllerMixin.reopen({
-  concatenatedProperties: ['queryParams', '_pCacheMeta'],
+  concatenatedProperties: ['queryParams'],
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
https://github.com/emberjs/ember.js/search?utf8=%E2%9C%93&q=_pCacheMeta
