### PR TITLE
Fallback to "-text-field" component name for unrecognized input type

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/input.js
+++ b/packages/ember-htmlbars/lib/keywords/input.js
@@ -2,12 +2,13 @@ import Ember from "ember-metal/core";
 
 export default {
   setupState(lastState, env, scope, params, hash) {
-    var type = env.hooks.getValue(hash.type) || 'text';
+    var type = env.hooks.getValue(hash.type);
+    var componentName = componentNameMap[type] || defaultComponentName;
 
     Ember.assert("{{input type='checkbox'}} does not support setting `value=someBooleanValue`;" +
                  " you must use `checked=someBooleanValue` instead.", !(type === 'checkbox' && hash.hasOwnProperty('value')));
 
-    return { componentName: classification[type] };
+    return { componentName };
   },
 
   render(morph, env, scope, params, hash, template, inverse, visitor) {
@@ -20,8 +21,8 @@ export default {
   }
 };
 
-var classification = {
-  'text': '-text-field',
-  'password': '-text-field',
+var defaultComponentName = "-text-field";
+
+var componentNameMap = {
   'checkbox': '-checkbox'
 };


### PR DESCRIPTION
Previously, using an input type not in the map (such as `{{input type="email"}}`) would
cause an exception. This renames the `classification` var to more
expressive `componentNameMap`, and turns the map into a whitelist for
non-default component names only. Any value of "type" not in that map (or
no value for "type") will use the default "-text-field" component name.
