### PR TITLE
outlet keywords must pass the template to render as template

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/real_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/real_outlet.js
@@ -62,9 +62,10 @@ export default {
 
     var options = {
       component: ViewClass,
-      layout: toRender.template,
       self: toRender.controller
     };
+
+    template = template || toRender.template && toRender.template.raw;
 
     if (LOG_VIEW_LOOKUPS && ViewClass) {
       Ember.Logger.info("Rendering " + toRender.name + " with " + ViewClass, { fullName: 'view:' + toRender.name });

--- a/packages/ember-htmlbars/lib/system/component-node.js
+++ b/packages/ember-htmlbars/lib/system/component-node.js
@@ -61,7 +61,7 @@ ComponentNode.create = function(renderNode, env, attrs, found, parentView, path,
       if (!contentTemplate) {
         let template = get(component, 'template');
         if (template) {
-          Ember.deprecate("Using deprecated `template` property on a Component.");
+          Ember.deprecate("Using deprecated `template` property on a " + (component.isView ? 'View' : 'Component') + ".");
           contentTemplate = template.raw;
         }
       }

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -200,7 +200,7 @@ QUnit.test("Outlets bind to the current template's view, not inner contexts [DEP
 });
 
 QUnit.test("should support layouts [DEPRECATED]", function() {
-  expectDeprecation(/Using deprecated `template` property on a Component/);
+  expectDeprecation(/Using deprecated `template` property on a View/);
   var template = "{{outlet}}";
   var layout = "<h1>HI</h1>{{yield}}";
   var routerState = {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -442,8 +442,7 @@ QUnit.test('defining templateName allows other templates to be rendered', functi
 
 });
 
-QUnit.test('Specifying a name to render should have precedence over everything else [DEPRECATED]', function() {
-  expectDeprecation(/Using deprecated `template` property on a Component/);
+QUnit.test('Specifying a name to render should have precedence over everything else', function() {
   Router.map(function() {
     this.route("home", { path: "/" });
   });
@@ -3901,6 +3900,19 @@ QUnit.test("Can disconnect from nested render helpers", function() {
   equal(Ember.$('#qunit-fixture .bar').text(), 'other');
   Ember.run(router, 'send', 'disconnect');
   equal(Ember.$('#qunit-fixture .bar').text(), '');
+});
+
+QUnit.test("Can render with layout", function() {
+  Ember.TEMPLATES.application = compile('{{outlet}}');
+  Ember.TEMPLATES.index = compile('index-template');
+  Ember.TEMPLATES['my-layout'] = compile('my-layout [{{yield}}]');
+
+  App.IndexView = Ember.View.extend({
+    layoutName: 'my-layout'
+  });
+
+  bootApplication();
+  equal(Ember.$('#qunit-fixture').text(), 'my-layout [index-template]');
 });
 
 QUnit.test("Components inside an outlet have their didInsertElement hook invoked when the route is displayed", function(assert) {


### PR DESCRIPTION
Previously, they were passing it as layout which smashed a layout that may have existed on the view being rendered.
