### PR TITLE
Adding positional parameter support to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.12",
+    "htmlbars": "git://github.com/ef4/htmlbars#component-params-prebuilt",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -1,6 +1,6 @@
 import ComponentNodeManager from "ember-htmlbars/node-managers/component-node-manager";
 
-export default function componentHook(renderNode, env, scope, tagName, attrs, template, visitor) {
+export default function componentHook(renderNode, env, scope, tagName, params, attrs, template, visitor) {
   var state = renderNode.state;
 
   // Determine if this is an initial render or a re-render
@@ -14,6 +14,7 @@ export default function componentHook(renderNode, env, scope, tagName, attrs, te
 
   var manager = ComponentNodeManager.create(renderNode, env, {
     tagName,
+    params,
     attrs,
     parentView,
     template,

--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -22,6 +22,6 @@ export default {
       return;
     }
 
-    env.hooks.component(morph, env, scope, componentPath, hash, template, visitor);
+    env.hooks.component(morph, env, scope, componentPath, params, hash, template, visitor);
   }
 };

--- a/packages/ember-htmlbars/lib/keywords/input.js
+++ b/packages/ember-htmlbars/lib/keywords/input.js
@@ -13,7 +13,7 @@ export default {
   },
 
   render(morph, env, scope, params, hash, template, inverse, visitor) {
-    env.hooks.component(morph, env, scope, morph.state.componentName, hash, template, visitor);
+    env.hooks.component(morph, env, scope, morph.state.componentName, params, hash, template, visitor);
   },
 
   rerender(...args) {

--- a/packages/ember-htmlbars/lib/keywords/textarea.js
+++ b/packages/ember-htmlbars/lib/keywords/textarea.js
@@ -4,6 +4,6 @@
 */
 
 export default function textarea(morph, env, scope, originalParams, hash, template, inverse, visitor) {
-  env.hooks.component(morph, env, scope, '-text-area', hash, template, visitor);
+  env.hooks.component(morph, env, scope, '-text-area', originalParams, hash, template, visitor);
   return true;
 }

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -28,6 +28,7 @@ export default ComponentNodeManager;
 
 ComponentNodeManager.create = function(renderNode, env, options) {
   let { tagName,
+        params,
         attrs,
         parentView,
         parentScope,
@@ -89,6 +90,13 @@ ComponentNodeManager.create = function(renderNode, env, options) {
     }
 
     renderNode.emberView = component;
+
+    if (component.positionalParams) {
+      let pp = component.positionalParams;
+      for (let i=0; i<pp.length; i++) {
+        attrs[pp[i]] = params[i];
+      }
+    }
   }
 
   var results = buildComponentTemplate({ layout: layout, component: component }, attrs, {

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -233,3 +233,43 @@ if (Ember.FEATURES.isEnabled('ember-views-component-block-info')) {
     equal(jQuery('#qunit-fixture').text(), 'In block No Block Param!');
   });
 }
+
+QUnit.test('static positional parameters', function() {
+  registry.register('template:components/sample-component', compile('{{attrs.name}}{{attrs.age}}'));
+  registry.register('component:sample-component', Component.extend({
+    positionalParams: ['name', 'age']
+  }));
+
+  view = EmberView.extend({
+    layout: compile('{{sample-component "Quint" 4}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  equal(jQuery('#qunit-fixture').text(), 'Quint4');
+});
+
+QUnit.test('dynamic positional parameters', function() {
+  registry.register('template:components/sample-component', compile('{{attrs.name}}{{attrs.age}}'));
+  registry.register('component:sample-component', Component.extend({
+    positionalParams: ['name', 'age']
+  }));
+
+  view = EmberView.extend({
+    layout: compile('{{sample-component myName myAge}}'),
+    container: container,
+    context: {
+      myName: 'Quint',
+      myAge: 4
+    }
+  }).create();
+
+  runAppend(view);
+  equal(jQuery('#qunit-fixture').text(), 'Quint4');
+  run(function() {
+    Ember.set(view.context, 'myName', 'Edward');
+    Ember.set(view.context, 'myAe', '5');
+  });
+
+});

--- a/packages/ember-routing-htmlbars/lib/keywords/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/link-to.js
@@ -297,7 +297,7 @@ export default {
 
     attrs.escaped = !morph.parseTextAsHTML;
 
-    env.hooks.component(morph, env, scope, '-link-to', attrs, template, visitor);
+    env.hooks.component(morph, env, scope, '-link-to', params, attrs, template, visitor);
   },
 
   rerender(morph, env, scope, params, hash, template, inverse, visitor) {


### PR DESCRIPTION
A longstanding pattern is to use helpers to simulate components with
positional parameters. But under Glimmer, helpers are pure functions, so
this doesn't work anymore.

Thankfully, we can do something even better, which is to stop wrapping
components in helpers just to get positional params, and instead make
components that can natively accept positional params. That's what this
PR does.

To use, you define your component like:

``` js
Ember.Component.extend({
  positionalParams: ['name', 'city']
});
```

Then you can invoke it like:

``` handlebars
{{my-component "Ed" "Somerville"}}
```

Which is (nearly`*`) equivalent to:

``` handlebars
{{my-component name="Ed" city="Somerville"}}
```

This depends on [a corresponding change in htmlbars](https://github.com/tildeio/htmlbars/compare/master...ef4:component-params).

`*` The one caveat is that as a new feature, this does not get the legacy auto-`mut` support that normal attributes get.
