### PR TITLE
Allow bound outlet names

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/real_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/real_outlet.js
@@ -5,7 +5,6 @@
 
 import { get } from "ember-metal/property_get";
 import ComponentNode from "ember-htmlbars/system/component-node";
-import { isStream } from "ember-metal/streams/utils";
 import topLevelViewTemplate from "ember-htmlbars/templates/top-level-view";
 topLevelViewTemplate.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
@@ -17,12 +16,6 @@ export default {
   setupState(state, env, scope, params, hash) {
     var outletState = env.outletState;
     var read = env.hooks.getValue;
-
-    Ember.assert(
-      "Using {{outlet}} with an unquoted name is not supported.",
-      !params[0] || !isStream(params[0])
-    );
-
     var outletName = read(params[0]) || 'main';
     var selectedOutletState = outletState[outletName];
 

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -239,12 +239,48 @@ QUnit.test("should not throw deprecations if {{outlet}} is used with a quoted na
   runAppend(top);
 });
 
-QUnit.test("should throw an assertion if {{outlet}} used with unquoted name", function() {
-  top.setOutletState(withTemplate("{{outlet foo}}"));
-  expectAssertion(function() {
-    runAppend(top);
-  }, "Using {{outlet}} with an unquoted name is not supported.");
+QUnit.test("{{outlet}} should work with an unquoted name", function() {
+  var routerState = {
+    render: {
+      controller: Ember.Controller.create({
+        outletName: 'magical'
+      }),
+      template: compile('{{outlet outletName}}')
+    },
+    outlets: {
+      magical: withTemplate("It's magic")
+    }
+  };
+
+  top.setOutletState(routerState);
+  runAppend(top);
+
+  equal(top.$().text().trim(), "It's magic");
 });
+
+QUnit.test("{{outlet}} should rerender when bound name changes", function() {
+  var routerState = {
+    render: {
+      controller: Ember.Controller.create({
+        outletName: 'magical'
+      }),
+      template: compile('{{outlet outletName}}')
+    },
+    outlets: {
+      magical: withTemplate("It's magic"),
+      second: withTemplate("second")
+    }
+  };
+
+  top.setOutletState(routerState);
+  runAppend(top);
+  equal(top.$().text().trim(), "It's magic");
+  run(function() {
+    routerState.render.controller.set('outletName', 'second');
+  });
+  equal(top.$().text().trim(), "second");
+});
+
 
 function withTemplate(string) {
   return {


### PR DESCRIPTION
Bound outlet names actually work fine without any additional work. They
were just disallowed due to a very old assert that was introduced back
when we were first standardizing the use of quoted strings to represent
literals.

This drops the assertion and adds a test that shows bound outlet names
work.
