### PR TITLE
[Bugfix] {{#with}} helper should not render if passed variable is falsey

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -4,6 +4,7 @@
 */
 
 import normalizeSelf from "ember-htmlbars/utils/normalize-self";
+import shouldDisplay from "ember-views/streams/should_display";
 
 /**
   Use the `{{with}}` helper when you want to aliases the to a new name. It's helpful
@@ -44,24 +45,26 @@ import normalizeSelf from "ember-htmlbars/utils/normalize-self";
 */
 
 export default function withHelper(params, hash, options) {
-  var preserveContext = false;
+  if (shouldDisplay(params[0])) {
+    var preserveContext = false;
 
-  if (options.template.arity !== 0) {
-    preserveContext = true;
-  }
-
-  if (preserveContext) {
-    this.yield([params[0]]);
-  } else {
-    let self = normalizeSelf(params[0]);
-    if (hash.controller) {
-      self = {
-        hasBoundController: true,
-        controller: hash.controller,
-        self: self
-      };
+    if (options.template.arity !== 0) {
+      preserveContext = true;
     }
 
-    this.yield([], self);
+    if (preserveContext) {
+      this.yield([params[0]]);
+    } else {
+      let self = normalizeSelf(params[0]);
+      if (hash.controller) {
+        self = {
+          hasBoundController: true,
+          controller: hash.controller,
+          self: self
+        };
+      }
+
+      this.yield([], self);
+    }
   }
 }

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -527,3 +527,14 @@ QUnit.test("nested {{with}} blocks shadow the outer scoped variable properly.", 
   runAppend(view);
   equal(view.$().text(), "Limbo-Wrath-Treachery-Wrath-Limbo", "should be properly scoped after updating");
 });
+
+QUnit.test("{{with}} block should not render if passed variable is falsey", function () {
+  view = EmberView.create({
+    template: compile("{{#with foo as |bar|}}Don't render me{{/with}}"),
+    context: {
+      foo: null
+    }
+  });
+  runAppend(view);
+  equal(view.$().text(), "", "should not render the inner template");
+});


### PR DESCRIPTION
Tried out Glimmer in my app and found that `{{#with bar as |foo|}}` blocks would still render their templates if `bar` is falsey, which on release, they don't. Thought I would have a go at a fix.

JSBins:  [Release](http://emberjs.jsbin.com/sukepajicu/1/edit) - [Canary](http://emberjs.jsbin.com/lohepulohu/2/edit)

First actual code PR so, let me know if their's anything additional I need to do.
