### PR TITLE
Export private LegacyEachView.

### DIFF
--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -44,6 +44,7 @@ import {
 } from "ember-views/views/select";
 import "ember-views/initializers/components";
 import _MetamorphView, { _Metamorph } from "ember-views/compat/metamorph_view";
+import LegacyEachView from "ember-views/views/legacy_each_view";
 
 // END IMPORTS
 
@@ -88,6 +89,7 @@ Ember.EventDispatcher = EventDispatcher;
 // Deprecated:
 Ember._Metamorph = _Metamorph;
 Ember._MetamorphView = _MetamorphView;
+Ember._LegacyEachView = LegacyEachView;
 
 // END EXPORTS
 


### PR DESCRIPTION
Since we are looking this up from the container, we need to export so
ember-test-helpers can register with the testing isolatedContainer.

Without this registration, it is not possible to unit test a view/component
with certain types of `{{each}}` in them.
