### PR TITLE
Fix positionalParams when using {{component}} helper

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -2,7 +2,8 @@ export default {
   setupState(lastState, env, scope, params, hash) {
     let state = {
       componentPath: env.hooks.getValue(params[0]),
-      manager: lastState && lastState.manager
+      manager: lastState && lastState.manager,
+      isComponentHelper: true
     };
 
     return state;

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -92,9 +92,13 @@ ComponentNodeManager.create = function(renderNode, env, options) {
     renderNode.emberView = component;
 
     if (component.positionalParams) {
+      // if the component is rendered via {{component}} helper, the first
+      // element of `params` is the name of the component, so we need to
+      // skip that when the positional parameters are constructed
+      let paramsStartIndex = renderNode.state.isComponentHelper ? 1 : 0;
       let pp = component.positionalParams;
       for (let i=0; i<pp.length; i++) {
-        attrs[pp[i]] = params[i];
+        attrs[pp[i]] = params[paramsStartIndex + i];
       }
     }
   }

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -273,3 +273,30 @@ QUnit.test('dynamic positional parameters', function() {
   });
 
 });
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
+  QUnit.test('{{component}} helper works with positional params', function() {
+    registry.register('template:components/sample-component', compile('{{attrs.name}}{{attrs.age}}'));
+    registry.register('component:sample-component', Component.extend({
+      positionalParams: ['name', 'age']
+    }));
+
+    view = EmberView.extend({
+      layout: compile('{{component "sample-component" myName myAge}}'),
+      container: container,
+      context: {
+        myName: 'Quint',
+        myAge: 4
+      }
+    }).create();
+
+    runAppend(view);
+    equal(jQuery('#qunit-fixture').text(), 'Quint4');
+    run(function() {
+      Ember.set(view.context, 'myName', 'Edward');
+      Ember.set(view.context, 'myAge', '5');
+    });
+
+    equal(jQuery('#qunit-fixture').text(), 'Edward5');
+  });
+}


### PR DESCRIPTION
Since the first parameter passed to the `{{component}}` helper is the
name of the component which shall be rendered, this needs to be
considered when the positionalParams are constructed for the specific
component.
