### PR TITLE
Restore hyphen requirement for component lookup.

### DIFF
--- a/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/custom_resolver_test.js
@@ -14,7 +14,11 @@ QUnit.module("Ember.Application Dependency Injection – customResolver", {
       resolveTemplate(resolvable) {
         var resolvedTemplate = this._super(resolvable);
         if (resolvedTemplate) { return resolvedTemplate; }
-        return fallbackTemplate;
+        if (resolvable.fullNameWithoutType === 'application') {
+          return fallbackTemplate;
+        } else {
+          return;
+        }
       }
     });
 
@@ -34,4 +38,3 @@ QUnit.module("Ember.Application Dependency Injection – customResolver", {
 QUnit.test("a resolver can be supplied to application", function() {
   equal(jQuery("h1", application.rootElement).text(), "Fallback");
 });
-

--- a/packages/ember-htmlbars/tests/integration/component_lookup_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lookup_test.js
@@ -1,0 +1,41 @@
+import EmberView from "ember-views/views/view";
+import Registry from "container/registry";
+import compile from "ember-template-compiler/system/compile";
+import ComponentLookup from 'ember-views/component_lookup';
+//import Component from "ember-views/views/component";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var registry, container, view;
+
+QUnit.module('component - lookup', {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('component', { singleton: false });
+    registry.optionsForType('view', { singleton: false });
+    registry.optionsForType('template', { instantiate: false });
+    registry.optionsForType('helper', { instantiate: false });
+    registry.register('component-lookup:main', ComponentLookup);
+  },
+
+  teardown() {
+    runDestroy(container);
+    runDestroy(view);
+    registry = container = view = null;
+  }
+});
+
+QUnit.test('dashless components should not be found', function() {
+  expect(1);
+
+  registry.register('template:components/dashless', compile('Do not render me!'));
+
+  view = EmberView.extend({
+    template: compile('{{dashless}}'),
+    container: container
+  }).create();
+
+  expectAssertion(function() {
+    runAppend(view);
+  }, /You canot use 'dashless' as a component name. Component names must contain a hyphen./);
+});

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,6 +1,16 @@
+import Ember from 'ember-metal/core';
 import EmberObject from "ember-runtime/system/object";
+import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
 
 export default EmberObject.extend({
+  invalidName(name) {
+    var invalidName = ISNT_HELPER_CACHE.get(name);
+
+    if (invalidName) {
+      Ember.assert(`You canot use '${name}' as a component name. Component names must contain a hyphen.`);
+    }
+  },
+
   lookupFactory(name, container) {
 
     container = container || this.container;
@@ -27,11 +37,19 @@ export default EmberObject.extend({
   },
 
   componentFor(name, container) {
+    if (this.invalidName(name)) {
+      return;
+    }
+
     var fullName = 'component:' + name;
     return container.lookupFactory(fullName);
   },
 
   layoutFor(name, container) {
+    if (this.invalidName(name)) {
+      return;
+    }
+
     var templateFullName = 'template:components/' + name;
     return container.lookup(templateFullName);
   }


### PR DESCRIPTION
Fixes #11040.
