### PR TITLE
Disable deprecation instructing folks to use `attrs.*`.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/get-root.js
+++ b/packages/ember-htmlbars/lib/hooks/get-root.js
@@ -31,7 +31,8 @@ function getKey(scope, key) {
   var self = scope.self || scope.locals.view;
 
   if (scope.attrs && key in scope.attrs) {
-    Ember.deprecate("You accessed the `" + key + "` attribute directly. Please use `attrs." + key + "` instead.");
+    // TODO: attrs
+    // Ember.deprecate("You accessed the `" + key + "` attribute directly. Please use `attrs." + key + "` instead.");
     return scope.attrs[key];
   } else if (self) {
     return self.getKey(key);

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -128,7 +128,8 @@ QUnit.test('rerendering component with attrs from parent', function() {
 
 
 QUnit.test('[DEPRECATED] non-block with properties on self', function() {
-  expectDeprecation("You accessed the `someProp` attribute directly. Please use `attrs.someProp` instead.");
+  // TODO: attrs
+  // expectDeprecation("You accessed the `someProp` attribute directly. Please use `attrs.someProp` instead.");
 
   registry.register('template:components/non-block', compile('In layout - someProp: {{someProp}}'));
 
@@ -158,7 +159,8 @@ QUnit.test('block with properties on attrs', function() {
 });
 
 QUnit.test('[DEPRECATED] block with properties on self', function() {
-  expectDeprecation("You accessed the `someProp` attribute directly. Please use `attrs.someProp` instead.");
+  // TODO: attrs
+  // expectDeprecation("You accessed the `someProp` attribute directly. Please use `attrs.someProp` instead.");
 
   registry.register('template:components/with-block', compile('In layout - someProp: {{someProp}} - {{yield}}'));
 

--- a/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
+++ b/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
@@ -28,7 +28,8 @@ QUnit.module('component - mutable bindings', {
 });
 
 QUnit.test('a simple mutable binding propagates properly [DEPRECATED]', function(assert) {
-  expectDeprecation();
+  // TODO: attrs
+  // expectDeprecation();
 
   var bottom;
 

--- a/packages/ember-views/tests/compat/attrs_proxy_test.js
+++ b/packages/ember-views/tests/compat/attrs_proxy_test.js
@@ -39,7 +39,8 @@ QUnit.test('works with properties setup in root of view', function() {
 });
 
 QUnit.test('works with undefined attributes', function() {
-  expectDeprecation();
+  // TODO: attrs
+  // expectDeprecation();
 
   var childView;
   registry.register('view:foo', View.extend({


### PR DESCRIPTION
Using `attrs.*` is definitely a good thing, but the transition plan is not fully fleshed out. Disable the deprecation until we have documented the transition plan.
