### PR TITLE
Disable dynamically changing views with `{{view}}` keyword.

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -11,11 +11,15 @@ import objectKeys from "ember-metal/keys";
 export default {
   setupState(state, env, scope, params, hash) {
     var read = env.hooks.getValue;
+    var viewClassOrInstance = state.viewClassOrInstance;
+    if (!viewClassOrInstance) {
+      viewClassOrInstance = getView(read(params[0]), env.container);
+    }
 
     return {
       manager: state.manager,
       parentView: scope.view,
-      viewClassOrInstance: getView(read(params[0]), env.container)
+      viewClassOrInstance
     };
   },
 

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -1404,3 +1404,31 @@ QUnit.test('Specifying `id` to {{view}} does not allow bound id changes.', funct
 
   equal(view.$('#bar #view-id').text(), 'baz', 'the views id property is not changed');
 });
+
+QUnit.test("using a bound view name does not change on view name property changes", function() {
+  registry.register('view:foo', viewClass({
+    elementId: 'foo'
+  }));
+
+  registry.register('view:bar', viewClass({
+    elementId: 'bar'
+  }));
+
+  view = EmberView.extend({
+    container,
+    elementId: 'parent',
+    viewName: 'foo',
+    template: compile("{{view view.viewName}}")
+  }).create();
+
+  runAppend(view);
+
+  equal(view.$('#foo').length, 1, 'moving from falsey to truthy causes the viewName to be looked up and rendered');
+
+  run(function() {
+    set(view, 'viewName', 'bar');
+  });
+
+  equal(view.$('#bar').length, 0, 'changing the viewName string after it was initially rendered does not render the new viewName');
+  equal(view.$('#foo').length, 1, 'the originally rendered view is still present');
+});


### PR DESCRIPTION
The recent Glimmer refactor made dynamic `{{view viewName}}` work when the `viewName` property changed (it would teardown the previous view and render a new one).

This is a nice feature (and we may want to bring it back), but it should be feature flagged and communicated properly to users.

Fixes #11053.
