### PR TITLE
Move `view.renderNode` to `view._renderNode`.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -153,10 +153,10 @@ ComponentNodeManager.prototype.rerender = function(env, attrs, visitor) {
     // Notify component that it has become dirty and is about to change.
     env.renderer.willUpdate(component, snapshot);
 
-    if (component.renderNode.shouldReceiveAttrs) {
+    if (component._renderNode.shouldReceiveAttrs) {
       env.renderer.updateAttrs(component, snapshot);
       setProperties(component, mergeBindings({}, shadowedAttrs(component, snapshot)));
-      component.renderNode.shouldReceiveAttrs = false;
+      component._renderNode.shouldReceiveAttrs = false;
     }
 
     env.renderer.willRender(component);
@@ -207,7 +207,7 @@ export function createOrUpdateComponent(component, options, renderNode, env, att
     }
   }
 
-  component.renderNode = renderNode;
+  component._renderNode = renderNode;
   renderNode.emberComponent = component;
   renderNode.emberView = component;
   return component;
@@ -262,4 +262,3 @@ function mergeBindings(target, attrs) {
 
   return target;
 }
-

--- a/packages/ember-htmlbars/lib/system/component-node.js
+++ b/packages/ember-htmlbars/lib/system/component-node.js
@@ -143,10 +143,10 @@ ComponentNode.prototype.rerender = function(env, attrs, visitor) {
     // Notify component that it has become dirty and is about to change.
     env.renderer.willUpdate(component, snapshot);
 
-    if (component.renderNode.shouldReceiveAttrs) {
+    if (component._renderNode.shouldReceiveAttrs) {
       env.renderer.updateAttrs(component, snapshot);
       setProperties(component, mergeBindings({}, shadowedAttrs(component, snapshot)));
-      component.renderNode.shouldReceiveAttrs = false;
+      component._renderNode.shouldReceiveAttrs = false;
     }
 
     env.renderer.willRender(component);
@@ -196,7 +196,7 @@ export function createOrUpdateComponent(component, options, renderNode, env, att
     }
   }
 
-  component.renderNode = renderNode;
+  component._renderNode = renderNode;
   renderNode.emberComponent = component;
   renderNode.emberView = component;
   return component;

--- a/packages/ember-htmlbars/lib/utils/subscribe.js
+++ b/packages/ember-htmlbars/lib/utils/subscribe.js
@@ -8,8 +8,8 @@ export default function subscribe(node, scope, stream) {
   unsubscribers.push(stream.subscribe(function() {
     node.isDirty = true;
 
-    if (component && component.renderNode) {
-      component.renderNode.isDirty = true;
+    if (component && component._renderNode) {
+      component._renderNode.isDirty = true;
     }
 
     if (node.state.manager) {

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -19,7 +19,7 @@ Renderer.prototype.prerenderTopLevelView =
       throw new Error("You cannot insert a View that has already been rendered");
     }
     view.ownerView = renderNode.emberView = view;
-    view.renderNode = renderNode;
+    view._renderNode = renderNode;
 
     var layout = get(view, 'layout');
     var template = get(view, 'template');
@@ -49,8 +49,8 @@ Renderer.prototype.renderTopLevelView =
 Renderer.prototype.revalidateTopLevelView =
   function Renderer_revalidateTopLevelView(view) {
     // This guard prevents revalidation on an already-destroyed view.
-    if (view.renderNode.lastResult) {
-      view.renderNode.lastResult.revalidate(view.env);
+    if (view._renderNode.lastResult) {
+      view._renderNode.lastResult.revalidate(view.env);
       // supports createElement, which operates without moving the view into
       // the inDOM state.
       if (view._state === 'inDOM') {
@@ -202,8 +202,8 @@ Renderer.prototype.renderElementRemoval =
     if (view._willRemoveElement) {
       view._willRemoveElement = false;
 
-      if (view.renderNode) {
-        view.renderNode.clear();
+      if (view._renderNode) {
+        view._renderNode.clear();
       }
       this.didDestroyElement(view);
     }

--- a/packages/ember-views/lib/system/utils.js
+++ b/packages/ember-views/lib/system/utils.js
@@ -17,8 +17,8 @@ export function isSimpleClick(event) {
 */
 function getViewRange(view) {
   var range = document.createRange();
-  range.setStartBefore(view.renderNode.firstNode);
-  range.setEndAfter(view.renderNode.lastNode);
+  range.setStartBefore(view._renderNode.firstNode);
+  range.setEndAfter(view._renderNode.lastNode);
   return range;
 }
 

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -116,9 +116,9 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     if (!this.ownerView.isDestroyingSubtree) {
       this.ownerView.isDestroyingSubtree = true;
       if (parent) { parent.removeChild(this); }
-      if (this.renderNode) {
+      if (this._renderNode) {
         Ember.assert("BUG: Render node exists without concomitant env.", this.ownerView.env);
-        internal.clearMorph(this.renderNode, this.ownerView.env, true);
+        internal.clearMorph(this._renderNode, this.ownerView.env, true);
       }
       this.ownerView.isDestroyingSubtree = false;
     }

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -31,7 +31,7 @@ merge(hasElement, {
   rerender(view) {
     view.renderer.ensureViewNotRendering(view);
 
-    var renderNode = view.renderNode;
+    var renderNode = view._renderNode;
 
     renderNode.isDirty = true;
     internal.visitChildren(renderNode.childNodes, function(node) {

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1292,7 +1292,7 @@ var View = CoreView.extend(
     @return String
   */
   readDOMAttr(name) {
-    let attr = this.renderNode.childNodes.filter(node => node.attrName === name)[0];
+    let attr = this._renderNode.childNodes.filter(node => node.attrName === name)[0];
     if (!attr) { return null; }
     return attr.getContent();
   },

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -408,7 +408,7 @@ QUnit.test("asserts if an attributeBinding is setup on class", function() {
 
   // Remove render node to avoid "Render node exists without concomitant env"
   // assertion on teardown.
-  view.renderNode = null;
+  view._renderNode = null;
 });
 
 QUnit.test("blacklists href bindings based on protocol", function() {

--- a/packages/ember-views/tests/views/view/class_name_bindings_test.js
+++ b/packages/ember-views/tests/views/view/class_name_bindings_test.js
@@ -275,6 +275,5 @@ QUnit.test("Providing a binding with a space in it asserts", function() {
 
   // Remove render node to avoid "Render node exists without concomitant env"
   // assertion on teardown.
-  view.renderNode = null;
+  view._renderNode = null;
 });
-

--- a/packages/ember-views/tests/views/view/create_element_test.js
+++ b/packages/ember-views/tests/views/view/create_element_test.js
@@ -43,7 +43,7 @@ QUnit.test('should assert if `tagName` is an empty string and `classNameBindings
   }, /You cannot use `classNameBindings` on a tag-less component/);
 
   // Prevent further assertions
-  view.renderNode = null;
+  view._renderNode = null;
 });
 
 QUnit.test("calls render and turns resultant string into element", function() {

--- a/packages/ember-views/tests/views/view/template_test.js
+++ b/packages/ember-views/tests/views/view/template_test.js
@@ -153,5 +153,5 @@ QUnit.test("should throw an assertion if no container has been set", function() 
     });
   }, /Container was not found when looking up a views template./);
 
-  view.renderNode = null;
+  view._renderNode = null;
 });


### PR DESCRIPTION
This is definitely considered a private API.
