### PR TITLE
[WIP] Add FeatureFlag for force autogenerated controllers to be basic controllers

### DIFF
--- a/features.json
+++ b/features.json
@@ -17,7 +17,8 @@
     "ember-application-visit": null,
     "ember-views-component-block-info": null,
     "ember-routing-core-outlet": null,
-    "ember-libraries-isregistered": null
+    "ember-libraries-isregistered": null,
+    "ember-force-basic-controller": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -26,12 +26,16 @@ import { isArray } from "ember-runtime/utils";
 export function generateControllerFactory(container, controllerName, context) {
   var Factory, fullName, factoryName, controllerType;
 
-  if (context && isArray(context)) {
-    controllerType = 'array';
-  } else if (context) {
-    controllerType = 'object';
-  } else {
+  if (Ember.FEATURES.isEnabled('ember-force-basic-controller')) {
     controllerType = 'basic';
+  } else {
+    if (context && isArray(context)) {
+      controllerType = 'array';
+    } else if (context) {
+      controllerType = 'object';
+    } else {
+      controllerType = 'basic';
+    }
   }
 
   factoryName = `controller:${controllerType}`;


### PR DESCRIPTION
_This is a WIP (failing tests). I'd like to poll if you think this is a good addition to help in the migration path to ember 2.0_

ATM, the base type of the autogenerated controllers dependes on the value returned by the `model` hook. When it's an object, Ember generates an ObjectController. When it's an array, an ArrayController, and defaults to the base Ember.Controller otherwise.

Controller proxying its deprecated and will be removed in Ember 2.0, and using the base controller has been encouraged for a while now. This feature flag let's the user opt-in to never generate Object/Array
Controllers.
