### PR TITLE
[FEATURE] Improved closure based actions per RFC #50

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -266,3 +266,13 @@ for a detailed explanation.
   ```
 
   Addd in [#10461](https://github.com/emberjs/ember.js/pull/10461)
+
+* `ember-routing-htmlbars-improved-actions`
+
+  Using the `(action` subexpression, allow for the creation of closure-wrapped
+  callbacks to pass into downstream components. The returned value of
+  the `(action` subexpression (or `submit={{action 'save'}}` style subexpression)
+  is a function. mut objects expose an `INVOKE` interface making them
+  compatible with action subexpressions.
+
+  Per RFC [#50](https://github.com/emberjs/rfcs/pull/50)

--- a/features.json
+++ b/features.json
@@ -17,7 +17,8 @@
     "ember-application-visit": null,
     "ember-views-component-block-info": null,
     "ember-routing-core-outlet": null,
-    "ember-libraries-isregistered": null
+    "ember-libraries-isregistered": null,
+    "ember-routing-htmlbars-improved-actions": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-htmlbars/lib/keywords/mut.js
+++ b/packages/ember-htmlbars/lib/keywords/mut.js
@@ -3,6 +3,7 @@ import merge from "ember-metal/merge";
 import { symbol } from "ember-metal/utils";
 import ProxyStream from "ember-metal/streams/proxy-stream";
 import { MUTABLE_CELL } from "ember-views/compat/attrs-proxy";
+import { INVOKE } from "ember-routing-htmlbars/keywords/closure-action";
 
 export let MUTABLE_REFERENCE = symbol("MUTABLE_REFERENCE");
 
@@ -52,11 +53,14 @@ merge(MutStream.prototype, {
     let val = {
       value: source.value(),
       update(val) {
-        source.sourceDep.setValue(val);
+        source.setValue(val);
       }
     };
 
     val[MUTABLE_CELL] = true;
     return val;
+  },
+  [INVOKE](val) {
+    this.setValue(val);
   }
 });

--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -3,12 +3,8 @@
 @submodule ember-htmlbars
 */
 
-import Ember from "ember-metal/core"; // assert
-import { uuid } from "ember-metal/utils";
-import run from "ember-metal/run_loop";
-import { readUnwrappedModel } from "ember-views/streams/utils";
-import { isSimpleClick } from "ember-views/system/utils";
-import ActionManager from "ember-views/system/action_manager";
+import { keyword } from "htmlbars-runtime/hooks";
+import closureAction from "ember-routing-htmlbars/keywords/closure-action";
 
 /**
   The `{{action}}` helper provides a useful shortcut for registering an HTML
@@ -173,128 +169,16 @@ import ActionManager from "ember-views/system/action_manager";
   @param {Object} [context]*
   @param {Hash} options
 */
-export default {
-  setupState: function(state, env, scope, params, hash) {
-    var getStream = env.hooks.get;
-    var read = env.hooks.getValue;
-
-    var actionName = read(params[0]);
-
-    Ember.assert("You specified a quoteless path to the {{action}} helper " +
-                 "which did not resolve to an action name (a string). " +
-                 "Perhaps you meant to use a quoted actionName? (e.g. {{action 'save'}}).",
-                 typeof actionName === 'string');
-
-    var actionArgs = [];
-    for (var i = 1, l = params.length; i < l; i++) {
-      actionArgs.push(readUnwrappedModel(params[i]));
+export default function(morph, env, scope, params, hash, template, inverse, visitor) {
+  if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+    if (morph) {
+      keyword('@element_action', morph, env, scope, params, hash, template, inverse, visitor);
+      return true;
     }
 
-    var target;
-    if (hash.target) {
-      if (typeof hash.target === 'string') {
-        target = read(getStream(env, scope, hash.target));
-      } else {
-        target = read(hash.target);
-      }
-    } else {
-      target = read(scope.locals.controller) || read(scope.self);
-    }
-
-    return { actionName, actionArgs, target };
-  },
-
-  isStable: function(state, env, scope, params, hash) {
-    return true;
-  },
-
-  render: function(node, env, scope, params, hash, template, inverse, visitor) {
-    var actionId = ActionHelper.registerAction({
-      node: node,
-      eventName: hash.on || "click",
-      bubbles: hash.bubbles,
-      preventDefault: hash.preventDefault,
-      withKeyCode: hash.withKeyCode,
-      allowedKeys: hash.allowedKeys
-    });
-
-    node.cleanup = function() {
-      ActionHelper.unregisterAction(actionId);
-    };
-
-    env.dom.setAttribute(node.element, 'data-ember-action', actionId);
-  }
-};
-
-export var ActionHelper = {};
-
-// registeredActions is re-exported for compatibility with older plugins
-// that were using this undocumented API.
-ActionHelper.registeredActions = ActionManager.registeredActions;
-
-ActionHelper.registerAction = function({ node, eventName, preventDefault, bubbles, allowedKeys }) {
-  var actionId = uuid();
-
-  ActionManager.registeredActions[actionId] = {
-    eventName,
-    handler(event) {
-      if (!isAllowedEvent(event, allowedKeys)) {
-        return true;
-      }
-
-      if (preventDefault !== false) {
-        event.preventDefault();
-      }
-
-      if (bubbles === false) {
-        event.stopPropagation();
-      }
-
-      let { target, actionName, actionArgs } = node.state;
-
-      run(function runRegisteredAction() {
-        if (target.send) {
-          target.send.apply(target, [actionName, ...actionArgs]);
-        } else {
-          Ember.assert(
-            "The action '" + actionName + "' did not exist on " + target,
-            typeof target[actionName] === 'function'
-          );
-
-          target[actionName].apply(target, actionArgs);
-        }
-      });
-    }
-  };
-
-  return actionId;
-};
-
-ActionHelper.unregisterAction = function(actionId) {
-  delete ActionManager.registeredActions[actionId];
-};
-
-var MODIFIERS = ["alt", "shift", "meta", "ctrl"];
-var POINTER_EVENT_TYPE_REGEX = /^click|mouse|touch/;
-
-function isAllowedEvent(event, allowedKeys) {
-  if (typeof allowedKeys === "undefined") {
-    if (POINTER_EVENT_TYPE_REGEX.test(event.type)) {
-      return isSimpleClick(event);
-    } else {
-      allowedKeys = '';
-    }
-  }
-
-  if (allowedKeys.indexOf("any") >= 0) {
+    return closureAction(morph, env, scope, params, hash, template, inverse, visitor);
+  } else {
+    keyword('@element_action', morph, env, scope, params, hash, template, inverse, visitor);
     return true;
   }
-
-  for (var i=0, l=MODIFIERS.length;i<l;i++) {
-    if (event[MODIFIERS[i] + "Key"] && allowedKeys.indexOf(MODIFIERS[i]) === -1) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -1,0 +1,76 @@
+import Stream from "ember-metal/streams/stream";
+import { map } from "ember-metal/array";
+import {
+  read,
+  readArray
+} from "ember-metal/streams/utils";
+import keys from 'ember-metal/keys';
+import { symbol } from "ember-metal/utils";
+
+export const INVOKE = symbol("INVOKE");
+
+export default function closureAction(morph, env, scope, params, hash, template, inverse, visitor) {
+  return new Stream(function() {
+    map.call(params, this.addDependency, this);
+    map.call(keys(hash), (item) => {
+      this.addDependency(item);
+    });
+
+    var rawAction = params[0];
+    var actionArguments = readArray(params.slice(1, params.length));
+
+    var target, action, valuePath;
+    if (rawAction[INVOKE]) {
+      // on-change={{action (mut name)}}
+      target = rawAction;
+      action = rawAction[INVOKE];
+    } else {
+      // on-change={{action setName}}
+      // element-space actions look to "controller" then target. Here we only
+      // look to "target".
+      target = read(scope.self);
+      action = read(rawAction);
+      if (typeof action === 'string') {
+        // on-change={{action 'setName'}}
+        actionArguments.unshift(action);
+        if (hash.target) {
+          // on-change={{action 'setName' target=alternativeComponent}}
+          target = read(hash.target);
+        }
+        action = target.send;
+      }
+    }
+
+    if (hash.value) {
+      // <button on-keypress={{action (mut name) value="which"}}
+      // on-keypress is not even an Ember feature yet
+      valuePath = read(hash.value);
+    }
+
+    return createClosureAction(target, action, valuePath, actionArguments);
+  });
+}
+
+function createClosureAction(target, action, valuePath, actionArguments) {
+  if (actionArguments.length > 0) {
+    return function() {
+      var args = actionArguments;
+      if (arguments.length > 0) {
+        args = actionArguments.concat(Array.prototype.slice.apply(arguments));
+      }
+      if (valuePath && args.length > 0) {
+        args[0] = Ember.get(args[0], valuePath);
+      }
+      return action.apply(target, args);
+    };
+  } else {
+    return function() {
+      var args = arguments;
+      if (valuePath && args.length > 0) {
+        args = Array.prototype.slice.apply(args);
+        args[0] = Ember.get(args[0], valuePath);
+      }
+      return action.apply(target, args);
+    };
+  }
+}

--- a/packages/ember-routing-htmlbars/lib/keywords/element-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/element-action.js
@@ -1,0 +1,145 @@
+import Ember from "ember-metal/core"; // assert
+import { uuid } from "ember-metal/utils";
+import run from "ember-metal/run_loop";
+import { readUnwrappedModel } from "ember-views/streams/utils";
+import { isSimpleClick } from "ember-views/system/utils";
+import ActionManager from "ember-views/system/action_manager";
+
+export default {
+  setupState: function(state, env, scope, params, hash) {
+    var getStream = env.hooks.get;
+    var read = env.hooks.getValue;
+
+    var actionName = read(params[0]);
+
+    if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+      Ember.assert("You specified a quoteless path to the {{action}} helper " +
+                   "which did not resolve to an action name (a string). " +
+                   "Perhaps you meant to use a quoted actionName? (e.g. {{action 'save'}}).",
+                   typeof actionName === 'string' || typeof actionName === 'function');
+    } else {
+      Ember.assert("You specified a quoteless path to the {{action}} helper " +
+                   "which did not resolve to an action name (a string). " +
+                   "Perhaps you meant to use a quoted actionName? (e.g. {{action 'save'}}).",
+                   typeof actionName === 'string');
+    }
+
+    var actionArgs = [];
+    for (var i = 1, l = params.length; i < l; i++) {
+      actionArgs.push(readUnwrappedModel(params[i]));
+    }
+
+    var target;
+    if (hash.target) {
+      if (typeof hash.target === 'string') {
+        target = read(getStream(env, scope, hash.target));
+      } else {
+        target = read(hash.target);
+      }
+    } else {
+      target = read(scope.locals.controller) || read(scope.self);
+    }
+
+    return { actionName, actionArgs, target };
+  },
+
+  isStable: function(state, env, scope, params, hash) {
+    return true;
+  },
+
+  render: function(node, env, scope, params, hash, template, inverse, visitor) {
+    var actionId = ActionHelper.registerAction({
+      node: node,
+      eventName: hash.on || "click",
+      bubbles: hash.bubbles,
+      preventDefault: hash.preventDefault,
+      withKeyCode: hash.withKeyCode,
+      allowedKeys: hash.allowedKeys
+    });
+
+    node.cleanup = function() {
+      ActionHelper.unregisterAction(actionId);
+    };
+
+    env.dom.setAttribute(node.element, 'data-ember-action', actionId);
+  }
+};
+
+export var ActionHelper = {};
+
+// registeredActions is re-exported for compatibility with older plugins
+// that were using this undocumented API.
+ActionHelper.registeredActions = ActionManager.registeredActions;
+
+ActionHelper.registerAction = function({ node, eventName, preventDefault, bubbles, allowedKeys }) {
+  var actionId = uuid();
+
+  ActionManager.registeredActions[actionId] = {
+    eventName,
+    handler(event) {
+      if (!isAllowedEvent(event, allowedKeys)) {
+        return true;
+      }
+
+      if (preventDefault !== false) {
+        event.preventDefault();
+      }
+
+      if (bubbles === false) {
+        event.stopPropagation();
+      }
+
+      let { target, actionName, actionArgs } = node.state;
+
+      run(function runRegisteredAction() {
+        if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+          if (typeof actionName === 'function') {
+            actionName.apply(target, actionArgs);
+            return;
+          }
+        }
+        if (target.send) {
+          target.send.apply(target, [actionName, ...actionArgs]);
+        } else {
+          Ember.assert(
+            "The action '" + actionName + "' did not exist on " + target,
+            typeof target[actionName] === 'function'
+          );
+
+          target[actionName].apply(target, actionArgs);
+        }
+      });
+    }
+  };
+
+  return actionId;
+};
+
+ActionHelper.unregisterAction = function(actionId) {
+  delete ActionManager.registeredActions[actionId];
+};
+
+var MODIFIERS = ["alt", "shift", "meta", "ctrl"];
+var POINTER_EVENT_TYPE_REGEX = /^click|mouse|touch/;
+
+function isAllowedEvent(event, allowedKeys) {
+  if (typeof allowedKeys === "undefined") {
+    if (POINTER_EVENT_TYPE_REGEX.test(event.type)) {
+      return isSimpleClick(event);
+    } else {
+      allowedKeys = '';
+    }
+  }
+
+  if (allowedKeys.indexOf("any") >= 0) {
+    return true;
+  }
+
+  for (var i=0, l=MODIFIERS.length;i<l;i++) {
+    if (event[MODIFIERS[i] + "Key"] && allowedKeys.indexOf(MODIFIERS[i]) === -1) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/ember-routing-htmlbars/lib/main.js
+++ b/packages/ember-routing-htmlbars/lib/main.js
@@ -14,12 +14,14 @@ import { registerKeyword } from "ember-htmlbars/keywords";
 
 import { queryParamsHelper } from "ember-routing-htmlbars/helpers/query-params";
 import action from "ember-routing-htmlbars/keywords/action";
+import elementAction from "ember-routing-htmlbars/keywords/element-action";
 import linkTo from "ember-routing-htmlbars/keywords/link-to";
 import render from "ember-routing-htmlbars/keywords/render";
 
 registerHelper('query-params', queryParamsHelper);
 
 registerKeyword('action', action);
+registerKeyword('@element_action', elementAction);
 registerKeyword('link-to', linkTo);
 registerKeyword('render', render);
 

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -1,0 +1,343 @@
+import run from "ember-metal/run_loop";
+import compile from "ember-template-compiler/system/compile";
+import EmberComponent from "ember-views/views/component";
+
+import {
+  runAppend,
+  runDestroy
+} from "ember-runtime/tests/utils";
+
+var innerComponent, outerComponent;
+
+if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+
+  QUnit.module("ember-routing-htmlbars: action helper", {
+    setup() {
+    },
+
+    teardown() {
+      runDestroy(innerComponent);
+      runDestroy(outerComponent);
+    }
+  });
+
+  QUnit.test("action should be called", function(assert) {
+    assert.expect(1);
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit();
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile("{{view innerComponent submit=(action outerSubmit)}}"),
+      innerComponent,
+      outerSubmit() {
+        assert.ok(true, 'action is called');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("action value is returned", function(assert) {
+    assert.expect(1);
+
+    var returnedValue = 'terrible tom';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        var actualReturnedValue = this.attrs.submit();
+        assert.equal(actualReturnedValue, returnedValue, 'action can return to caller');
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile("{{view innerComponent submit=(action outerSubmit)}}"),
+      innerComponent,
+      outerSubmit() {
+        return returnedValue;
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("action should be called on the correct scope", function(assert) {
+    assert.expect(1);
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit();
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile("{{view innerComponent submit=(action outerSubmit)}}"),
+      innerComponent,
+      isOuterComponent: true,
+      outerSubmit() {
+        assert.ok(this.isOuterComponent, 'action has the correct context');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("arguments to action are passed, curry", function(assert) {
+    assert.expect(4);
+
+    const first = 'mitch';
+    const second =  'martin';
+    const third = 'matt';
+    const fourth = 'wacky wycats';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit(fourth);
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      third,
+      layout: compile(`
+        {{view innerComponent submit=(action (action outerSubmit "${first}") "${second}" third)}}
+      `),
+      innerComponent,
+      outerSubmit(actualFirst, actualSecond, actualThird, actualFourth) {
+        assert.equal(actualFirst, first, 'action has the correct first arg');
+        assert.equal(actualSecond, second, 'action has the correct second arg');
+        assert.equal(actualThird, third, 'action has the correct third arg');
+        assert.equal(actualFourth, fourth, 'action has the correct fourth arg');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("arguments to action are bound", function(assert) {
+    assert.expect(1);
+
+    const value = 'lazy leah';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit();
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action outerSubmit value)}}
+      `),
+      innerComponent,
+      value: '',
+      outerSubmit(actualValue) {
+        assert.equal(actualValue, value, 'action has the correct first arg');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      outerComponent.set('value', value);
+    });
+
+    innerComponent.fireAction();
+  });
+
+  QUnit.test("mut values can be wrapped in actions, are settable", function(assert) {
+    assert.expect(1);
+
+    var newValue = 'trollin trek';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit(newValue);
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action (mut outerMut))}}
+      `),
+      innerComponent,
+      outerMut: 'patient peter'
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+      assert.equal(outerComponent.get('outerMut'), newValue, 'mut value is set');
+    });
+  });
+
+  QUnit.test("mut values can be wrapped in actions, are settable with a curry", function(assert) {
+    assert.expect(1);
+
+    var newValue = 'trollin trek';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit();
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action (mut outerMut) '${newValue}')}}
+      `),
+      innerComponent,
+      outerMut: 'patient peter'
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+      assert.equal(outerComponent.get('outerMut'), newValue, 'mut value is set');
+    });
+  });
+
+  QUnit.test("action can create closures over sendAction", function(assert) {
+    assert.expect(2);
+
+    var first = 'raging robert';
+    var second = 'mild machty';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit(second);
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action 'outerAction' '${first}')}}
+      `),
+      innerComponent,
+      actions: {
+        outerAction(actualFirst, actualSecond) {
+          assert.equal(actualFirst, first, 'first argument is correct');
+          assert.equal(actualSecond, second, 'second argument is correct');
+        }
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("action can create closures over sendAction with target", function(assert) {
+    assert.expect(1);
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit();
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action 'outerAction' target=otherComponent)}}
+      `),
+      innerComponent,
+      otherComponent: EmberComponent.extend({
+        actions: {
+          outerAction(actualFirst, actualSecond) {
+            assert.ok(true, 'action called on otherComponent');
+          }
+        }
+      }).create()
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("action will read the value of a first property", function(assert) {
+    assert.expect(1);
+
+    const newValue = 'irate igor';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit({
+          readProp: newValue
+        });
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action outerAction value="readProp")}}
+      `),
+      innerComponent,
+      outerAction(actualNewValue) {
+        assert.equal(actualNewValue, newValue, 'property is read');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+  QUnit.test("action will read the value of a curried first argument property", function(assert) {
+    assert.expect(1);
+
+    const newValue = 'kissing kris';
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit();
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action outerAction objectArgument value="readProp")}}
+      `),
+      innerComponent,
+      objectArgument: {
+        readProp: newValue
+      },
+      outerAction(actualNewValue) {
+        assert.equal(actualNewValue, newValue, 'property is read');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
+}

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -14,7 +14,7 @@ import EmberView from "ember-views/views/view";
 import EmberComponent from "ember-views/views/component";
 import jQuery from "ember-views/system/jquery";
 
-import { ActionHelper } from "ember-routing-htmlbars/keywords/action";
+import { ActionHelper } from "ember-routing-htmlbars/keywords/element-action";
 import { deprecation as eachDeprecation } from "ember-htmlbars/helpers/each";
 
 import {
@@ -623,7 +623,7 @@ QUnit.test("should allow 'send' as action name (#594)", function() {
 
   view = EmberView.create({
     controller: controller,
-    template: compile('<a href="#" {{action "send" }}>send</a>')
+    template: compile('<a href="#" {{action "send"}}>send</a>')
   });
 
   runAppend(view);
@@ -950,7 +950,7 @@ QUnit.test("a quoteless parameter should lookup actionName in context [DEPRECATE
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
-QUnit.test("a quoteless parameter should resolve actionName, including path", function() {
+QUnit.test("a quoteless string parameter should resolve actionName, including path", function() {
   expect(4);
   var lastAction;
   var actionOrder = [];
@@ -1000,6 +1000,36 @@ QUnit.test("a quoteless parameter should resolve actionName, including path", fu
 
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
+
+if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+
+  QUnit.test("a quoteless function parameter should be called, including arguments", function() {
+    expect(2);
+
+    var arg = 'rough ray';
+
+    view = EmberView.create({
+      template: compile(`<a {{action submit '${arg}'}}></a>`)
+    });
+
+    var controller = EmberController.extend({
+      submit(actualArg) {
+        ok(true, 'submit function called');
+        equal(actualArg, arg, 'argument passed');
+      }
+    }).create();
+
+    run(function() {
+      view.set('controller', controller);
+      view.appendTo('#qunit-fixture');
+    });
+
+    run(function() {
+      view.$("a").click();
+    });
+  });
+
+}
 
 QUnit.test("a quoteless parameter that does not resolve to a value asserts", function() {
 


### PR DESCRIPTION
RFC [#50](https://github.com/emberjs/rfcs/pull/50) ([rendered html](https://github.com/emberjs/rfcs/blob/action/active/0000-improved-actions.md))

Introduce a new way to use actions:

``` js
export default Ember.Controller.extend({
  actions: {
    save(model) {
      model.save();
    }
  }
});
```

``` hbs
{{my-form submit=(action "save" model)}}
```

``` js
export default Ember.Component.extend({
  click() {
    this.attrs.submit();
  }
});
```

Please see the RFC for more details about the API.

TODO:
- [x] Add some tests around the binding of arguments
- [x] Implement `value=`
