### PR TITLE
Action subexpression simply reads off actions, no send

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -6,6 +6,7 @@ import {
 } from "ember-metal/streams/utils";
 import keys from 'ember-metal/keys';
 import { symbol } from "ember-metal/utils";
+import { get } from "ember-metal/property_get";
 
 export const INVOKE = symbol("INVOKE");
 
@@ -20,7 +21,6 @@ export default function closureAction(morph, env, scope, params, hash, template,
     var actionArguments = readArray(params.slice(1, params.length));
 
     var target, action, valuePath;
-    var firstArgumentOffset = 0;
     if (rawAction[INVOKE]) {
       // on-change={{action (mut name)}}
       target = rawAction;
@@ -33,13 +33,15 @@ export default function closureAction(morph, env, scope, params, hash, template,
       action = read(rawAction);
       if (typeof action === 'string') {
         // on-change={{action 'setName'}}
-        actionArguments.unshift(action);
-        firstArgumentOffset++;
         if (hash.target) {
           // on-change={{action 'setName' target=alternativeComponent}}
           target = read(hash.target);
         }
-        action = target.send;
+        if (target.actions) {
+          action = target.actions[action];
+        } else {
+          action = target._actions[action];
+        }
       }
     }
 
@@ -49,28 +51,28 @@ export default function closureAction(morph, env, scope, params, hash, template,
       valuePath = read(hash.value);
     }
 
-    return createClosureAction(target, action, valuePath, firstArgumentOffset, actionArguments);
+    return createClosureAction(target, action, valuePath, actionArguments);
   });
 }
 
-function createClosureAction(target, action, valuePath, firstArgumentOffset, actionArguments) {
+function createClosureAction(target, action, valuePath, actionArguments) {
   if (actionArguments.length > 0) {
     return function() {
       var args = actionArguments;
       if (arguments.length > 0) {
-        args = actionArguments.concat(Array.prototype.slice.apply(arguments));
+        args = actionArguments.concat(...arguments);
       }
-      if (valuePath && args[firstArgumentOffset]) {
-        args[firstArgumentOffset] = Ember.get(args[firstArgumentOffset], valuePath);
+      if (valuePath && args.length > 0) {
+        args[0] = get(args[0], valuePath);
       }
       return action.apply(target, args);
     };
   } else {
     return function() {
       var args = arguments;
-      if (valuePath && args[firstArgumentOffset]) {
+      if (valuePath && args.length > 0) {
         args = Array.prototype.slice.apply(args);
-        args[firstArgumentOffset] = Ember.get(args[firstArgumentOffset], valuePath);
+        args[0] = get(args[0], valuePath);
       }
       return action.apply(target, args);
     };

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -1,6 +1,7 @@
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
 import EmberComponent from "ember-views/views/component";
+import { computed } from "ember-metal/computed";
 
 import {
   runAppend,
@@ -217,15 +218,17 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
     });
   });
 
-  QUnit.test("action can create closures over sendAction", function(assert) {
-    assert.expect(2);
+  QUnit.test("action can create closures over actions", function(assert) {
+    assert.expect(3);
 
     var first = 'raging robert';
     var second = 'mild machty';
+    var returnValue = 'butch brian';
 
     innerComponent = EmberComponent.extend({
       fireAction() {
-        this.attrs.submit(second);
+        var actualReturnedValue = this.attrs.submit(second);
+        assert.equal(actualReturnedValue, returnValue, 'return value is present');
       }
     }).create();
 
@@ -238,6 +241,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
         outerAction(actualFirst, actualSecond) {
           assert.equal(actualFirst, first, 'first argument is correct');
           assert.equal(actualSecond, second, 'second argument is correct');
+          return returnValue;
         }
       }
     }).create();
@@ -249,7 +253,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
     });
   });
 
-  QUnit.test("action can create closures over sendAction with target", function(assert) {
+  QUnit.test("action can create closures over actions with target", function(assert) {
     assert.expect(1);
 
     innerComponent = EmberComponent.extend({
@@ -263,13 +267,15 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
         {{view innerComponent submit=(action 'outerAction' target=otherComponent)}}
       `),
       innerComponent,
-      otherComponent: EmberComponent.extend({
-        actions: {
-          outerAction(actualFirst, actualSecond) {
-            assert.ok(true, 'action called on otherComponent');
+      otherComponent: computed(function() {
+        return {
+          actions: {
+            outerAction(actualFirst, actualSecond) {
+              assert.ok(true, 'action called on otherComponent');
+            }
           }
-        }
-      }).create()
+        };
+      })
     }).create();
 
     runAppend(outerComponent);
@@ -279,7 +285,7 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
     });
   });
 
-  QUnit.test("value can be used with action over sendAction", function(assert) {
+  QUnit.test("value can be used with action over actions", function(assert) {
     assert.expect(1);
 
     const newValue = 'yelping yehuda';


### PR DESCRIPTION
Remove the use of `send` from actions, instead just rely on a convention of `(action 'foo')` reading `foo` off of the target's `actions` property.

Notably, the `actions` property on controllers and components (things with `TargetActionSupport`) is re-written as `_actions` in practice. This code checks `actions.foo` first and if there is nothing there falls back to `_actions.foo`.

Importantly, this brings us return values for string-argument actions on a component. For example:

``` hbs
{{my-form submit=(action 'save')}}
```

``` js
export default Ember.Component.extend({
  click() {
    this.attrs.submit().finally(function() {
      // something after the save completes.
    });
  }
});
```

With targeting, it also allows services to be action targets:

``` js
export default Ember.Service.extend({
  actions: {
    refresh() {
      // something
    }
  }
});
```

``` hbs
{{my-form submit=(action 'refresh' target=sessionService)}}
```
