### PR TITLE
Use `buildMeta` compile option to embed metadata into templates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.15",
+    "htmlbars": "0.13.16",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-htmlbars/lib/keywords/real_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/real_outlet.js
@@ -6,7 +6,7 @@
 import { get } from "ember-metal/property_get";
 import ComponentNode from "ember-htmlbars/system/component-node";
 import topLevelViewTemplate from "ember-htmlbars/templates/top-level-view";
-topLevelViewTemplate.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
+topLevelViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
 export default {
   willRender(renderNode, env) {

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -51,7 +51,7 @@ import { readHash, readArray } from "ember-metal/streams/utils";
 */
 export default function makeBoundHelper(fn) {
   return new Helper(function(params, hash, templates) {
-    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !templates.template.revision);
+    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !templates.template.meta);
     return fn(readArray(params), readHash(hash));
   });
 }

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -14,7 +14,7 @@ import inject from "ember-runtime/inject";
 import ControllerMixin from "ember-runtime/mixins/controller";
 
 import linkToTemplate from "ember-htmlbars/templates/link-to";
-linkToTemplate.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
+linkToTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
 var linkViewClassNameBindings = ['active', 'loading', 'disabled'];
 if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {

--- a/packages/ember-routing-views/lib/views/outlet.js
+++ b/packages/ember-routing-views/lib/views/outlet.js
@@ -5,7 +5,7 @@
 
 import View from "ember-views/views/view";
 import topLevelViewTemplate from "ember-htmlbars/templates/top-level-view";
-topLevelViewTemplate.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
+topLevelViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
 export var CoreOutletView = View.extend({
   defaultTemplate: topLevelViewTemplate,

--- a/packages/ember-template-compiler/lib/system/compile_options.js
+++ b/packages/ember-template-compiler/lib/system/compile_options.js
@@ -24,9 +24,16 @@ export default function(_options) {
     options = {};
   }
 
-  options.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
   options.disableComponentGeneration = disableComponentGeneration;
   options.plugins = plugins;
+
+  options.buildMeta = function buildMeta(program) {
+    return {
+      revision: 'Ember@VERSION_STRING_PLACEHOLDER',
+      loc: program.loc,
+      moduleName: options.moduleName
+    };
+  };
 
   return options;
 }

--- a/packages/ember-template-compiler/tests/system/compile_test.js
+++ b/packages/ember-template-compiler/tests/system/compile_test.js
@@ -28,7 +28,7 @@ QUnit.test('includes the current revision in the compiled template', function() 
 
   var actual = compile(templateString);
 
-  equal(actual.revision, 'Ember@VERSION_STRING_PLACEHOLDER', 'revision is included in generated template');
+  equal(actual.meta.revision, 'Ember@VERSION_STRING_PLACEHOLDER', 'revision is included in generated template');
 });
 
 QUnit.test('the template revision is different than the HTMLBars default revision', function() {
@@ -37,7 +37,7 @@ QUnit.test('the template revision is different than the HTMLBars default revisio
   var actual = compile(templateString);
   var expected = htmlbarsCompile(templateString);
 
-  ok(actual.revision !== expected.revision, 'revision differs from default');
+  ok(actual.meta.revision !== expected.meta.revision, 'revision differs from default');
 });
 
 QUnit.test('{{with}} template deprecation includes moduleName if provided', function() {

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -11,7 +11,7 @@ import {
 } from "ember-metal/mixin";
 
 import containerViewTemplate from "ember-htmlbars/templates/container-view";
-containerViewTemplate.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
+containerViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
 /**
 @module ember


### PR DESCRIPTION
Adds `buildMeta` callback to `compile` options.

Sample output:

``` javascript
(function() {
  return {
    meta: {
      "isHTMLBars": true,
      "revision": "SOME@REVISION",
      "moduleName": "my-app-name/templates/foo",
      "loc": {"source":null,"start":{"line":1,"column":0},"end":{"line":1,"column":14}}
    },
    arity: 0,
    cachedFragment: null,
    hasRendered: false,
    buildFragment: function buildFragment(dom) {
      var el0 = dom.createDocumentFragment();
      var el1 = dom.createTextNode("Howdy ");
      dom.appendChild(el0, el1);
      var el1 = dom.createComment("");
      dom.appendChild(el0, el1);
      return el0;
    },
    buildRenderNodes: function buildRenderNodes(dom, fragment, contextualElement) {
      var morphs = new Array(1);
      morphs[0] = dom.createMorphAt(fragment,1,1,contextualElement);
      dom.insertBoundary(fragment, null);
      return morphs;
    },
    statements: [
      ["content","name"]
    ],
    locals: [],
    templates: []
  };
}())
```

---

Builds upon the work in the following upstream PRs:
- https://github.com/tildeio/htmlbars/pull/343
- https://github.com/tildeio/htmlbars/pull/342
