### PR TITLE
Move instrumentation to the node managers

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/collection.js
+++ b/packages/ember-htmlbars/lib/keywords/collection.js
@@ -5,7 +5,7 @@
 
 import { readViewFactory } from "ember-views/streams/utils";
 import CollectionView from "ember-views/views/collection_view";
-import ComponentNode from "ember-htmlbars/system/component-node";
+import ViewNodeManager from "ember-htmlbars/node-managers/view-node-manager";
 import objectKeys from "ember-metal/keys";
 import { assign } from "ember-metal/merge";
 
@@ -48,7 +48,7 @@ export default {
       hash.emptyViewClass = hash.emptyView;
     }
 
-    var componentNode = ComponentNode.create(node, env, hash, options, parentView, null, scope, template);
+    var componentNode = ViewNodeManager.create(node, env, hash, options, parentView, null, scope, template);
     state.manager = componentNode;
 
     componentNode.render(env, hash, visitor);

--- a/packages/ember-htmlbars/lib/keywords/customized_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/customized_outlet.js
@@ -3,7 +3,7 @@
 @submodule ember-htmlbars
 */
 
-import ComponentNode from "ember-htmlbars/system/component-node";
+import ViewNodeManager from "ember-htmlbars/node-managers/view-node-manager";
 import { readViewFactory } from "ember-views/streams/utils";
 import { isStream } from "ember-metal/streams/utils";
 
@@ -25,7 +25,7 @@ export default {
     var options = {
       component: state.viewClass
     };
-    var componentNode = ComponentNode.create(renderNode, env, hash, options, parentView, null, null, null);
+    var componentNode = ViewNodeManager.create(renderNode, env, hash, options, parentView, null, null, null);
     state.manager = componentNode;
     componentNode.render(env, hash, visitor);
   }

--- a/packages/ember-htmlbars/lib/keywords/real_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/real_outlet.js
@@ -4,7 +4,7 @@
 */
 
 import { get } from "ember-metal/property_get";
-import ComponentNode from "ember-htmlbars/system/component-node";
+import ViewNodeManager from "ember-htmlbars/node-managers/view-node-manager";
 import topLevelViewTemplate from "ember-htmlbars/templates/top-level-view";
 topLevelViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
@@ -67,7 +67,7 @@ export default {
       Ember.Logger.info("Rendering " + toRender.name + " with " + ViewClass, { fullName: 'view:' + toRender.name });
     }
 
-    var componentNode = ComponentNode.create(renderNode, env, {}, options, parentView, null, null, template);
+    var componentNode = ViewNodeManager.create(renderNode, env, {}, options, parentView, null, null, template);
     state.manager = componentNode;
 
     componentNode.render(env, hash, visitor);

--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -5,7 +5,7 @@
 
 import { readViewFactory } from "ember-views/streams/utils";
 import EmberView from "ember-views/views/view";
-import ComponentNode from "ember-htmlbars/system/component-node";
+import ViewNodeManager from "ember-htmlbars/node-managers/view-node-manager";
 import objectKeys from "ember-metal/keys";
 
 export default {
@@ -45,7 +45,7 @@ export default {
     var parentView = state.parentView;
 
     var options = { component: node.state.viewClassOrInstance, layout: null };
-    var componentNode = ComponentNode.create(node, env, hash, options, parentView, null, scope, template);
+    var componentNode = ViewNodeManager.create(node, env, hash, options, parentView, null, scope, template);
     state.manager = componentNode;
 
     componentNode.render(env, hash, visitor);

--- a/packages/ember-htmlbars/lib/system/instrumentation-support.js
+++ b/packages/ember-htmlbars/lib/system/instrumentation-support.js
@@ -1,0 +1,41 @@
+import {
+  _instrumentStart,
+  subscribers
+} from "ember-metal/instrumentation";
+
+/**
+ * Provides instrumentation for node managers.
+ *
+ * Wrap your node manager's render and re-render methods
+ * with this function.
+ *
+ * @param {Object} component Component or View instance (optional)
+ * @param {Function} callback The function to instrument
+ * @param {Object} context The context to call the function with
+ * @return {Object} Return value from the invoked callback
+ */
+export function instrument(component, callback, context) {
+  var instrumentName, val, details, end;
+  // Only instrument if there's at least one subscriber.
+  if (subscribers.length) {
+    if (component) {
+      instrumentName = component.instrumentName;
+    } else {
+      instrumentName = 'node';
+    }
+    details = {};
+    if (component) {
+      component.instrumentDetails(details);
+    }
+    end = _instrumentStart('render.' + instrumentName, function viewInstrumentDetails() {
+      return details;
+    });
+    val = callback.call(context);
+    if (end) {
+      end();
+    }
+    return val;
+  } else {
+    return callback.call(context);
+  }
+}

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -1,5 +1,5 @@
 import defaultEnv from "ember-htmlbars/env";
-import ComponentNode, { createOrUpdateComponent } from "ember-htmlbars/system/component-node";
+import ViewNodeManager, { createOrUpdateComponent } from "ember-htmlbars/node-managers/view-node-manager";
 
 // This function only gets called once per render of a "root view" (`appendTo`). Otherwise,
 // HTMLBars propagates the existing env and renders templates for a given render node.
@@ -19,7 +19,7 @@ export function renderHTMLBarsBlock(view, block, renderNode) {
 
   view.env = env;
   createOrUpdateComponent(view, {}, renderNode, env);
-  var componentNode = new ComponentNode(view, null, renderNode, block, view.tagName !== '');
+  var componentNode = new ViewNodeManager(view, null, renderNode, block, view.tagName !== '');
 
   componentNode.render(env, {});
 }

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -1,10 +1,6 @@
 import run from "ember-metal/run_loop";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import {
-  _instrumentStart,
-  subscribers
-} from "ember-metal/instrumentation";
 import buildComponentTemplate from "ember-views/system/build-component-template";
 import { indexOf } from "ember-metal/enumerable_utils";
 //import { deprecation } from "ember-views/compat/attrs-proxy";
@@ -120,15 +116,8 @@ Renderer.prototype.createElement =
     this.prerenderTopLevelView(view, morph);
   };
 
-Renderer.prototype.willCreateElement = function (view) {
-  if (subscribers.length && view.instrumentDetails) {
-    view._instrumentEnd = _instrumentStart('render.'+view.instrumentName, function viewInstrumentDetails() {
-      var details = {};
-      view.instrumentDetails(details);
-      return details;
-    });
-  }
-}; // inBuffer
+// inBuffer
+Renderer.prototype.willCreateElement = function (/*view*/) {};
 
 Renderer.prototype.didCreateElement = function (view, element) {
   if (element) {
@@ -137,9 +126,6 @@ Renderer.prototype.didCreateElement = function (view, element) {
 
   if (view._transitionTo) {
     view._transitionTo('hasElement');
-  }
-  if (view._instrumentEnd) {
-    view._instrumentEnd();
   }
 }; // hasElement
 
@@ -209,7 +195,7 @@ Renderer.prototype.renderElementRemoval =
     }
   };
 
-Renderer.prototype.willRemoveElement = function (view) {};
+Renderer.prototype.willRemoveElement = function (/*view*/) {};
 
 Renderer.prototype.willDestroyElement = function (view) {
   if (view._willDestroyElement) {

--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -6,7 +6,7 @@ import { isStream, read } from "ember-metal/streams/utils";
 import { camelize } from "ember-runtime/system/string";
 import generateController from "ember-routing/system/generate_controller";
 import { generateControllerFactory } from "ember-routing/system/generate_controller";
-import ComponentNode from "ember-htmlbars/system/component-node";
+import ViewNodeManager from "ember-htmlbars/node-managers/view-node-manager";
 
 export default {
   willRender(renderNode, env) {
@@ -164,7 +164,7 @@ export default {
       options.component = view;
     }
 
-    var componentNode = ComponentNode.create(node, env, hash, options, state.parentView, null, null, template);
+    var componentNode = ViewNodeManager.create(node, env, hash, options, state.parentView, null, null, template);
     state.manager = componentNode;
 
     if (router && params.length === 1) {

--- a/packages/ember/tests/view_instrumentation_test.js
+++ b/packages/ember/tests/view_instrumentation_test.js
@@ -1,0 +1,64 @@
+import EmberHandlebars from "ember-htmlbars/compat";
+import run from "ember-metal/run_loop";
+import $ from "ember-views/system/jquery";
+import { subscribe, unsubscribe } from "ember-metal/instrumentation";
+
+var compile = EmberHandlebars.compile;
+
+var App, $fixture;
+
+function setupExample() {
+  // setup templates
+  Ember.TEMPLATES.application = compile("{{outlet}}");
+  Ember.TEMPLATES.index = compile("<h1>Node 1</h1>");
+  Ember.TEMPLATES.posts = compile("<h1>Node 1</h1>");
+
+  App.Router.map(function() {
+    this.route('posts');
+  });
+}
+
+function handleURL(path) {
+  var router = App.__container__.lookup('router:main');
+  return run(router, 'handleURL', path);
+}
+
+QUnit.module("View Instrumentation", {
+  setup() {
+    run(function() {
+      App = Ember.Application.create({
+        rootElement: '#qunit-fixture'
+      });
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+    });
+
+    $fixture = $('#qunit-fixture');
+    setupExample();
+  },
+
+  teardown() {
+    run(App, 'destroy');
+    App = null;
+    Ember.TEMPLATES = {};
+  }
+});
+
+QUnit.test("Nodes without view instances are instrumented", function(assert) {
+  var called = false;
+  var subscriber = subscribe('render', {
+    before() {
+      called = true;
+    },
+    after() {}
+  });
+  run(App, 'advanceReadiness');
+  assert.ok(called, 'Instrumentation called on first render');
+  called = false;
+  handleURL('/posts');
+  assert.ok(called, 'instrumentation called on transition to non-view backed route');
+  unsubscribe(subscriber);
+});


### PR DESCRIPTION
Components that don't have a view instance don't go through the renderer. This insures instrumentation is invoked anyway.

Also moved system/component-node to node-managers/view-node-manager
