### PR TITLE
Remove non-HTMLBars template path.

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -775,11 +775,7 @@ var View = CoreView.extend(
     var template = get(this, 'template');
 
     if (template) {
-      if (template.isHTMLBars) {
-        return template.render(context, options, { contextualElement: morph.contextualElement }).fragment;
-      } else {
-        return template(context, options);
-      }
+      return template.render(context, options, { contextualElement: morph.contextualElement }).fragment;
     }
   },
 


### PR DESCRIPTION
Manually writing template functions is largely unsupported already.  This change removes a guard/check for `isHTMLBars` (we intend to stop stamping all templates with this flag in the future).
