### PR TITLE
Ensure {{view}} instantiated views are provided with a `controller`.

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -12,6 +12,10 @@ export default {
   setupState(state, env, scope, params, hash) {
     var read = env.hooks.getValue;
     var viewClassOrInstance = state.viewClassOrInstance;
+
+    // if parentView exists, use its controller (the default
+    // behavior), otherwise use `scope.self` as the controller
+    var controller = scope.view ? null : read(scope.self);
     if (!viewClassOrInstance) {
       viewClassOrInstance = getView(read(params[0]), env.container);
     }
@@ -19,6 +23,7 @@ export default {
     return {
       manager: state.manager,
       parentView: scope.view,
+      controller,
       viewClassOrInstance
     };
   },
@@ -44,7 +49,15 @@ export default {
     var state = node.state;
     var parentView = state.parentView;
 
-    var options = { component: node.state.viewClassOrInstance, layout: null };
+    var options = {
+      component: node.state.viewClassOrInstance,
+      layout: null
+    };
+
+    if (node.state.controller) {
+      options.createOptions = { _controller: node.state.controller };
+    }
+
     var nodeManager = ViewNodeManager.create(node, env, hash, options, parentView, null, scope, template);
     state.manager = nodeManager;
 

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -189,7 +189,6 @@ export function createOrUpdateComponent(component, options, renderNode, env, att
   let hasSuppliedController = 'controller' in attrs;
 
   props.attrs = snapshot;
-
   if (component.create) {
     let proto = component.proto();
     mergeBindings(props, shadowedAttrs(proto, snapshot));

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -41,10 +41,6 @@ ViewNodeManager.create = function(renderNode, env, attrs, found, parentView, pat
   if (found.component) {
     var options = { parentView: parentView };
 
-    if (found.createOptions) {
-      merge(options, found.createOptions);
-    }
-
     if (attrs && attrs.id) { options.elementId = getValue(attrs.id); }
     if (attrs && attrs.tagName) { options.tagName = getValue(attrs.tagName); }
     if (attrs && attrs._defaultTagName) { options._defaultTagName = getValue(attrs._defaultTagName); }
@@ -58,7 +54,7 @@ ViewNodeManager.create = function(renderNode, env, attrs, found, parentView, pat
       options._context = getValue(found.self);
     }
 
-    component = componentInfo.component = createOrUpdateComponent(found.component, options, renderNode, env, attrs);
+    component = componentInfo.component = createOrUpdateComponent(found.component, options, found.createOptions, renderNode, env, attrs);
 
     let layout = get(component, 'layout');
     if (layout) {
@@ -171,16 +167,20 @@ ViewNodeManager.prototype.rerender = function(env, attrs, visitor) {
   }, this);
 };
 
-export function createOrUpdateComponent(component, options, renderNode, env, attrs = {}) {
+export function createOrUpdateComponent(component, options, createOptions, renderNode, env, attrs = {}) {
   let snapshot = takeSnapshot(attrs);
   let props = merge({}, options);
   let defaultController = View.proto().controller;
-  let hasSuppliedController = 'controller' in attrs;
+  let hasSuppliedController = 'controller' in attrs || 'controller' in props;
 
   props.attrs = snapshot;
-
   if (component.create) {
     let proto = component.proto();
+
+    if (createOptions) {
+      merge(props, createOptions);
+    }
+
     mergeBindings(props, shadowedAttrs(proto, snapshot));
     props.container = options.parentView ? options.parentView.container : env.container;
 

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -18,7 +18,7 @@ export function renderHTMLBarsBlock(view, block, renderNode) {
   };
 
   view.env = env;
-  createOrUpdateComponent(view, {}, renderNode, env);
+  createOrUpdateComponent(view, {}, null, renderNode, env);
   var nodeManager = new ViewNodeManager(view, null, renderNode, block, view.tagName !== '');
 
   nodeManager.render(env, {});

--- a/packages/ember-views/tests/views/view/context_test.js
+++ b/packages/ember-views/tests/views/view/context_test.js
@@ -40,4 +40,3 @@ QUnit.test("setting a controller on an inner view should change it context", fun
     outerView.destroy();
   });
 });
-

--- a/packages/ember/tests/integration/view_test.js
+++ b/packages/ember/tests/integration/view_test.js
@@ -1,0 +1,72 @@
+import compile from "ember-template-compiler/system/compile";
+import run from "ember-metal/run_loop";
+
+var App, registry;
+
+function setupExample() {
+  // setup templates
+  Ember.TEMPLATES.application = compile("{{outlet}}", { moduleName: 'application' });
+  Ember.TEMPLATES.index = compile("<h1>Node 1</h1>", { moduleName: 'index' });
+  Ember.TEMPLATES.posts = compile("<h1>Node 1</h1>", { moduleName: 'posts' });
+
+  App.Router.map(function() {
+    this.route('posts');
+  });
+}
+
+function handleURL(path) {
+  var router = App.__container__.lookup('router:main');
+  return run(router, 'handleURL', path);
+}
+
+QUnit.module("View Integration", {
+  setup() {
+    run(function() {
+      App = Ember.Application.create({
+        rootElement: '#qunit-fixture'
+      });
+      App.deferReadiness();
+
+      App.Router.reopen({
+        location: 'none'
+      });
+
+      registry = App.__container__._registry;
+    });
+
+    setupExample();
+  },
+
+  teardown() {
+    run(App, 'destroy');
+    App = null;
+    Ember.TEMPLATES = {};
+  }
+});
+
+QUnit.test("invoking `{{view}} from a non-view backed (aka only template) template provides the correct controller to the view instance`", function(assert) {
+  var controllerInMyFoo, indexController;
+
+  Ember.TEMPLATES.index = compile('{{view "my-foo"}}', { moduleName: 'my-foo' });
+
+  registry.register('view:my-foo', Ember.View.extend({
+    init() {
+      this._super(...arguments);
+
+      controllerInMyFoo = this.get('controller');
+    }
+  }));
+
+  registry.register('controller:index', Ember.Controller.extend({
+    init() {
+      this._super(...arguments);
+
+      indexController = this;
+    }
+  }));
+
+  run(App, 'advanceReadiness');
+  handleURL('/');
+
+  assert.strictEqual(controllerInMyFoo, indexController, 'controller is provided to `{{view}}`');
+});


### PR DESCRIPTION
Prior to Glimmer, every template was backed by an Ember.View instance.
After Glimmer work has landed, if a view/component JS module was not found
the template will be rendered without a backing Ember.View/Ember.Component.
Under normal circumstances that is a wonderful thing, and results in significant
performance boosts.

The bug that this PR is addresses only occurs when the `{{view}}` keyword is invoked
from within a non View backed template.  In that case `controller` is `null`.

---

Fixes https://github.com/emberjs/ember.js/issues/11098.
