### PR TITLE
Avoid wrapping (action 'save') as a mutable cell.

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/mut.js
+++ b/packages/ember-htmlbars/lib/keywords/mut.js
@@ -5,7 +5,7 @@ import ProxyStream from "ember-metal/streams/proxy-stream";
 import { isStream } from "ember-metal/streams/utils";
 import Stream from "ember-metal/streams/stream";
 import { MUTABLE_CELL } from "ember-views/compat/attrs-proxy";
-import { INVOKE } from "ember-routing-htmlbars/keywords/closure-action";
+import { INVOKE, ACTION } from "ember-routing-htmlbars/keywords/closure-action";
 
 export let MUTABLE_REFERENCE = symbol("MUTABLE_REFERENCE");
 
@@ -62,9 +62,14 @@ MutStream.prototype = create(ProxyStream.prototype);
 merge(MutStream.prototype, {
   cell() {
     let source = this;
+    let value = source.value();
+
+    if (value && value[ACTION]) {
+      return value;
+    }
 
     let val = {
-      value: source.value(),
+      value,
       update(val) {
         source.setValue(val);
       }

--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -9,6 +9,7 @@ import { symbol } from "ember-metal/utils";
 import { get } from "ember-metal/property_get";
 
 export const INVOKE = symbol("INVOKE");
+export const ACTION = symbol('ACTION');
 
 export default function closureAction(morph, env, scope, params, hash, template, inverse, visitor) {
   return new Stream(function() {
@@ -56,8 +57,10 @@ export default function closureAction(morph, env, scope, params, hash, template,
 }
 
 function createClosureAction(target, action, valuePath, actionArguments) {
+  var closureAction;
+
   if (actionArguments.length > 0) {
-    return function() {
+    closureAction = function() {
       var args = actionArguments;
       if (arguments.length > 0) {
         args = actionArguments.concat(...arguments);
@@ -68,7 +71,7 @@ function createClosureAction(target, action, valuePath, actionArguments) {
       return action.apply(target, args);
     };
   } else {
-    return function() {
+    closureAction = function() {
       var args = arguments;
       if (valuePath && args.length > 0) {
         args = Array.prototype.slice.apply(args);
@@ -77,4 +80,8 @@ function createClosureAction(target, action, valuePath, actionArguments) {
       return action.apply(target, args);
     };
   }
+
+  closureAction[ACTION] = true;
+
+  return closureAction;
 }

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -381,4 +381,52 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
     });
   });
 
+  QUnit.test("action closure does not get auto-mut wrapped", function(assert) {
+    assert.expect(3);
+
+    var first = 'raging robert';
+    var second = 'mild machty';
+    var returnValue = 'butch brian';
+
+    innerComponent = Ember.Component.extend({
+      middleComponent,
+
+      fireAction() {
+        var actualReturnedValue = this.attrs.submit(second);
+        assert.equal(actualReturnedValue, returnValue, 'return value is present');
+      }
+    }).create();
+
+    var middleComponent = EmberComponent.extend({
+      innerComponent,
+
+      layout: compile(`
+        {{view innerComponent submit=attrs.submit}}
+      `)
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      middleComponent,
+
+      layout: compile(`
+        {{view middleComponent submit=(action 'outerAction' '${first}')}}
+      `),
+
+      actions: {
+        outerAction(actualFirst, actualSecond) {
+          assert.equal(actualFirst, first, 'first argument is correct');
+          assert.equal(actualSecond, second, 'second argument is correct');
+
+          return returnValue;
+        }
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      innerComponent.fireAction();
+    });
+  });
+
 }


### PR DESCRIPTION
Prior to this when passing actions down more than one layer, the path expression at the middle layer would be re-written as a mutable cell. This means that you can no longer call `this.attrs.someAction()` and would instead have to call `this.attrs.someAction.value()`.

This change avoids returning the wrapped object when the upstream streams value is the return value from `(action` invocation.
