### PR TITLE
Ensure `{{else}}` block is rendered for `{{with}}`.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -68,5 +68,9 @@ export default function withHelper(params, hash, options) {
 
       this.yield([], self);
     }
+  } else {
+    if (options.inverse.yield) {
+      options.inverse.yield();
+    }
   }
 }

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -538,3 +538,14 @@ QUnit.test("{{with}} block should not render if passed variable is falsey", func
   runAppend(view);
   equal(view.$().text(), "", "should not render the inner template");
 });
+
+QUnit.test("{{with}} block should render else block if passed variable is falsey #11118", function () {
+  view = EmberView.create({
+    template: compile("{{#with foo as |bar|}}Don't render me{{else}}Please render!{{/with}}"),
+    context: {
+      foo: null
+    }
+  });
+  runAppend(view);
+  equal(view.$().text(), "Please render!", "should not render the inner template");
+});


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/11118.
