### PR TITLE
Add a warning to sendAction

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -275,7 +275,11 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     }
 
     // If no action name for that action could be found, just abort.
-    if (actionName === undefined) { return; }
+    if (typeof actionName === 'undefined') {
+      Ember.warn("No action name could be found for the (" + action ? action : "action" +
+                 ") action on the component " + this.toString() + ".");
+      return;
+    }
 
     if (typeof actionName === 'function') {
       actionName.apply(null, contexts);


### PR DESCRIPTION
If `actionName` is undefined, sendAction is currently silently aborted. For new users, it is very easy to get confused when calling `this.sendAction('foo')` does not execute a `foo` action on a parent component.

Alternative: https://github.com/emberjs/ember.js/pull/11123
