### PR TITLE
Try triggerAction using sendAction's action

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -274,16 +274,18 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
                    isNone(actionName) || typeof actionName === 'string' || typeof actionName === 'function');
     }
 
-    // If no action name for that action could be found, just abort.
-    if (typeof actionName === 'undefined') {
-      Ember.warn("No action name could be found for the (" + action ? action : "action" +
-                 ") action on the component " + this.toString() + ".");
-      return;
-    }
-
     if (typeof actionName === 'function') {
       actionName.apply(null, contexts);
-    } else {
+    } else if (typeof actionName === 'undefined' && typeof action === 'string') {
+      try {
+        this.triggerAction({
+          action: action,
+          actionContext: contexts
+        });
+      } catch (exception) {
+        // Some sort of messaging needed here?
+      }
+    } else if (typeof actionName === 'string') {
       this.triggerAction({
         action: actionName,
         actionContext: contexts

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -275,7 +275,11 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     }
 
     // If no action name for that action could be found, just abort.
-    if (actionName === undefined) { return; }
+    if (typeof actionName === 'undefined') {
+      Ember.warn("No action name could be found for the (" + action ? action : "action" +
+                 ") action on the component " + this.toString() + ".");
+      return;
+    }
 
     if (typeof actionName === 'function') {
       actionName.apply(null, contexts);


### PR DESCRIPTION
When the actionName lookup on the current component is undefined, attempt to call triggerAction using the action's original lookup value.

This is an alternative to https://github.com/emberjs/ember.js/pull/11122
