### PR TITLE
Refine component lifecycle hooks

### DIFF
--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -7,9 +7,16 @@ function EmberMorph(DOMHelper, contextualElement) {
   this.HTMLBarsMorph$constructor(DOMHelper, contextualElement);
 
   this.emberView = null;
-  this.emberComponent = null;
   this.emberToDestroy = null;
   this.streamUnsubscribers = null;
+
+  // A component can become dirty either because one of its
+  // attributes changed, or because it was re-rendered. If any part
+  // of the component's template changes through observation, it has
+  // re-rendered from the perpsective of the programming model. This
+  // flag is set to true whenever a component becomes dirty because
+  // one of its attributes changed, which also triggers the attribute
+  // update flag (didUpdateAttrs).
   this.shouldReceiveAttrs = false;
 }
 

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -203,7 +203,6 @@ export function createOrUpdateComponent(component, options, createOptions, rende
   }
 
   component._renderNode = renderNode;
-  renderNode.emberComponent = component;
   renderNode.emberView = component;
   return component;
 }

--- a/packages/ember-htmlbars/lib/utils/subscribe.js
+++ b/packages/ember-htmlbars/lib/utils/subscribe.js
@@ -8,6 +8,11 @@ export default function subscribe(node, scope, stream) {
   unsubscribers.push(stream.subscribe(function() {
     node.isDirty = true;
 
+    // Whenever a render node directly inside a component becomes
+    // dirty, we want to invoke the willRenderElement and
+    // didRenderElement lifecycle hooks. From the perspective of the
+    // programming model, whenever anything in the DOM changes, a
+    // "re-render" has occured.
     if (component && component._renderNode) {
       component._renderNode.isDirty = true;
     }

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -88,11 +88,11 @@ QUnit.test('non-block with properties on attrs and component class', function() 
 
 QUnit.test('rerendering component with attrs from parent', function() {
   var willUpdate = 0;
-  var willReceiveAttrs = 0;
+  var didReceiveAttrs = 0;
 
   registry.register('component:non-block', Component.extend({
-    willReceiveAttrs() {
-      willReceiveAttrs++;
+    didReceiveAttrs() {
+      didReceiveAttrs++;
     },
 
     willUpdate() {
@@ -109,6 +109,8 @@ QUnit.test('rerendering component with attrs from parent', function() {
 
   runAppend(view);
 
+  equal(didReceiveAttrs, 1, "The didReceiveAttrs hook fired");
+
   equal(jQuery('#qunit-fixture').text(), 'In layout - someProp: wycats');
 
   run(function() {
@@ -116,13 +118,13 @@ QUnit.test('rerendering component with attrs from parent', function() {
   });
 
   equal(jQuery('#qunit-fixture').text(), 'In layout - someProp: tomdale');
-  equal(willReceiveAttrs, 1, "The willReceiveAttrs hook fired");
+  equal(didReceiveAttrs, 2, "The didReceiveAttrs hook fired again");
   equal(willUpdate, 1, "The willUpdate hook fired once");
 
   Ember.run(view, 'rerender');
 
   equal(jQuery('#qunit-fixture').text(), 'In layout - someProp: tomdale');
-  equal(willReceiveAttrs, 2, "The willReceiveAttrs hook fired again");
+  equal(didReceiveAttrs, 3, "The didReceiveAttrs hook fired again");
   equal(willUpdate, 2, "The willUpdate hook fired again");
 });
 

--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -45,27 +45,40 @@ QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
     return Component.extend({
       init() {
         this.label = label;
-        pushHook(label, 'init');
         components[label] = this;
         this._super.apply(this, arguments);
       },
-      willReceiveAttrs(nextAttrs) {
-        pushHook(label, 'willReceiveAttrs', nextAttrs);
+
+      didInitAttrs(options) {
+        pushHook(label, 'didInitAttrs', options);
       },
-      willUpdate() {
-        pushHook(label, 'willUpdate');
+
+      didUpdateAttrs(options) {
+        pushHook(label, 'didUpdateAttrs', options);
       },
-      didUpdate() {
-        pushHook(label, 'didUpdate');
+
+      willUpdate(options) {
+        pushHook(label, 'willUpdate', options);
       },
-      didInsertElement() {
-        pushHook(label, 'didInsertElement');
+
+      didReceiveAttrs(nextAttrs) {
+        pushHook(label, 'didReceiveAttrs', nextAttrs);
       },
+
       willRender() {
         pushHook(label, 'willRender');
       },
+
       didRender() {
         pushHook(label, 'didRender');
+      },
+
+      didInsertElement() {
+        pushHook(label, 'didInsertElement');
+      },
+
+      didUpdate(options) {
+        pushHook(label, 'didUpdate', options);
       }
     });
   }
@@ -89,10 +102,14 @@ QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
   ok(component, "The component was inserted");
   equal(jQuery('#qunit-fixture').text(), 'Twitter: @tomdale Name: Tom Dale Website: tomdale.net');
 
+  let topAttrs = { attrs: { twitter: "@tomdale" } };
+  let middleAttrs = { attrs: { name: "Tom Dale" } };
+  let bottomAttrs = { attrs: { website: "tomdale.net" } };
+
   deepEqual(hooks, [
-    hook('top', 'init'), hook('top', 'willRender'),
-    hook('middle', 'init'), hook('middle', 'willRender'),
-    hook('bottom', 'init'), hook('bottom', 'willRender'),
+    hook('top', 'didInitAttrs', topAttrs), hook('top', 'didReceiveAttrs', topAttrs), hook('top', 'willRender'),
+    hook('middle', 'didInitAttrs', middleAttrs), hook('middle', 'didReceiveAttrs', middleAttrs), hook('middle', 'willRender'),
+    hook('bottom', 'didInitAttrs', bottomAttrs), hook('bottom', 'didReceiveAttrs', bottomAttrs), hook('bottom', 'willRender'),
     hook('bottom', 'didInsertElement'), hook('bottom', 'didRender'),
     hook('middle', 'didInsertElement'), hook('middle', 'didRender'),
     hook('top', 'didInsertElement'), hook('top', 'didRender')
@@ -115,13 +132,15 @@ QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
     components.middle.rerender();
   });
 
+  bottomAttrs = { oldAttrs: { website: "tomdale.net" }, newAttrs: { website: "tomdale.net" } };
+
   deepEqual(hooks, [
     hook('middle', 'willUpdate'), hook('middle', 'willRender'),
-    hook('bottom', 'willUpdate'),
 
-    hook('bottom', 'willReceiveAttrs', { website: "tomdale.net" }),
+    hook('bottom', 'didUpdateAttrs', bottomAttrs),
+    hook('bottom', 'didReceiveAttrs', bottomAttrs),
 
-    hook('bottom', 'willRender'),
+    hook('bottom', 'willUpdate'), hook('bottom', 'willRender'),
 
     hook('bottom', 'didUpdate'), hook('bottom', 'didRender'),
     hook('middle', 'didUpdate'), hook('middle', 'didRender')
@@ -133,18 +152,18 @@ QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
     components.top.rerender();
   });
 
+  middleAttrs = { oldAttrs: { name: "Tom Dale" }, newAttrs: { name: "Tom Dale" } };
+
   deepEqual(hooks, [
     hook('top', 'willUpdate'), hook('top', 'willRender'),
 
-    hook('middle', 'willUpdate'),
-    hook('middle', 'willReceiveAttrs', { name: "Tom Dale" }),
-    hook('middle', 'willRender'),
+    hook('middle', 'didUpdateAttrs', middleAttrs), hook('middle', 'didReceiveAttrs', middleAttrs),
+    hook('middle', 'willUpdate'), hook('middle', 'willRender'),
 
-    hook('bottom', 'willUpdate'),
-    hook('bottom', 'willReceiveAttrs', { website: "tomdale.net" }),
-    hook('bottom', 'willRender'),
-
+    hook('bottom', 'didUpdateAttrs', bottomAttrs), hook('bottom', 'didReceiveAttrs', bottomAttrs),
+    hook('bottom', 'willUpdate'), hook('bottom', 'willRender'),
     hook('bottom', 'didUpdate'), hook('bottom', 'didRender'),
+
     hook('middle', 'didUpdate'), hook('middle', 'didRender'),
     hook('top', 'didUpdate'), hook('top', 'didRender')
   ]);
@@ -162,8 +181,9 @@ QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
   // in lifecycle hooks being invoked for the child.
 
   deepEqual(hooks, [
+    hook('top', 'didUpdateAttrs', { oldAttrs: { twitter: "@tomdale" }, newAttrs: { twitter: "@hipstertomdale" } }),
+    hook('top', 'didReceiveAttrs', { oldAttrs: { twitter: "@tomdale" }, newAttrs: { twitter: "@hipstertomdale" } }),
     hook('top', 'willUpdate'),
-    hook('top', 'willReceiveAttrs', { twitter: "@hipstertomdale" }),
     hook('top', 'willRender'),
     hook('top', 'didUpdate'), hook('top', 'didRender')
   ]);
@@ -176,27 +196,40 @@ QUnit.test('passing values through attrs causes lifecycle hooks to fire if the a
     return Component.extend({
       init() {
         this.label = label;
-        pushHook(label, 'init');
         components[label] = this;
         this._super.apply(this, arguments);
       },
-      willReceiveAttrs(nextAttrs) {
-        pushHook(label, 'willReceiveAttrs', nextAttrs);
+
+      didInitAttrs(options) {
+        pushHook(label, 'didInitAttrs', options);
       },
-      willUpdate() {
-        pushHook(label, 'willUpdate');
+
+      didUpdateAttrs(options) {
+        pushHook(label, 'didUpdateAttrs', options);
       },
-      didUpdate() {
-        pushHook(label, 'didUpdate');
+
+      willUpdate(options) {
+        pushHook(label, 'willUpdate', options);
       },
-      didInsertElement() {
-        pushHook(label, 'didInsertElement');
+
+      didReceiveAttrs(nextAttrs) {
+        pushHook(label, 'didReceiveAttrs', nextAttrs);
       },
+
       willRender() {
         pushHook(label, 'willRender');
       },
+
       didRender() {
         pushHook(label, 'didRender');
+      },
+
+      didInsertElement() {
+        pushHook(label, 'didInsertElement');
+      },
+
+      didUpdate(options) {
+        pushHook(label, 'didUpdate', options);
       }
     });
   }
@@ -220,10 +253,14 @@ QUnit.test('passing values through attrs causes lifecycle hooks to fire if the a
   ok(component, "The component was inserted");
   equal(jQuery('#qunit-fixture').text(), 'Top: Middle: Bottom: @tomdale');
 
+  let topAttrs = { attrs: { twitter: "@tomdale" } };
+  let middleAttrs = { attrs: { twitterTop: "@tomdale" } };
+  let bottomAttrs = { attrs: { twitterMiddle: "@tomdale" } };
+
   deepEqual(hooks, [
-    hook('top', 'init'), hook('top', 'willRender'),
-    hook('middle', 'init'), hook('middle', 'willRender'),
-    hook('bottom', 'init'), hook('bottom', 'willRender'),
+    hook('top', 'didInitAttrs', topAttrs), hook('top', 'didReceiveAttrs', topAttrs), hook('top', 'willRender'),
+    hook('middle', 'didInitAttrs', middleAttrs), hook('middle', 'didReceiveAttrs', middleAttrs), hook('middle', 'willRender'),
+    hook('bottom', 'didInitAttrs', bottomAttrs), hook('bottom', 'didReceiveAttrs', bottomAttrs), hook('bottom', 'willRender'),
     hook('bottom', 'didInsertElement'), hook('bottom', 'didRender'),
     hook('middle', 'didInsertElement'), hook('middle', 'didRender'),
     hook('top', 'didInsertElement'), hook('top', 'didRender')
@@ -238,20 +275,49 @@ QUnit.test('passing values through attrs causes lifecycle hooks to fire if the a
   // Because the `twitter` attr is used by the all of the components,
   // the lifecycle hooks are invoked for all components.
 
+
+  topAttrs = { oldAttrs: { twitter: "@tomdale" }, newAttrs: { twitter: "@hipstertomdale" } };
+  middleAttrs = { oldAttrs: { twitterTop: "@tomdale" }, newAttrs: { twitterTop: "@hipstertomdale" } };
+  bottomAttrs = { oldAttrs: { twitterMiddle: "@tomdale" }, newAttrs: { twitterMiddle: "@hipstertomdale" } };
+
   deepEqual(hooks, [
-    hook('top', 'willUpdate'),
-    hook('top', 'willReceiveAttrs', { twitter: "@hipstertomdale" }),
-    hook('top', 'willRender'),
+    hook('top', 'didUpdateAttrs', topAttrs), hook('top', 'didReceiveAttrs', topAttrs),
+    hook('top', 'willUpdate'), hook('top', 'willRender'),
 
-    hook('middle', 'willUpdate'),
-    hook('middle', 'willReceiveAttrs', { twitterTop: "@hipstertomdale" }),
-    hook('middle', 'willRender'),
+    hook('middle', 'didUpdateAttrs', middleAttrs), hook('middle', 'didReceiveAttrs', middleAttrs),
+    hook('middle', 'willUpdate'), hook('middle', 'willRender'),
 
-    hook('bottom', 'willUpdate'),
-    hook('bottom', 'willReceiveAttrs', { twitterMiddle: "@hipstertomdale" }),
-    hook('bottom', 'willRender'),
-
+    hook('bottom', 'didUpdateAttrs', bottomAttrs), hook('bottom', 'didReceiveAttrs', bottomAttrs),
+    hook('bottom', 'willUpdate'), hook('bottom', 'willRender'),
     hook('bottom', 'didUpdate'), hook('bottom', 'didRender'),
+
+    hook('middle', 'didUpdate'), hook('middle', 'didRender'),
+    hook('top', 'didUpdate'), hook('top', 'didRender')
+  ]);
+
+  hooks = [];
+
+  // In this case, because the attrs are passed down, all child components are invoked.
+
+  run(function() {
+    view.rerender();
+  });
+
+  topAttrs = { oldAttrs: { twitter: "@hipstertomdale" }, newAttrs: { twitter: "@hipstertomdale" } };
+  middleAttrs = { oldAttrs: { twitterTop: "@hipstertomdale" }, newAttrs: { twitterTop: "@hipstertomdale" } };
+  bottomAttrs = { oldAttrs: { twitterMiddle: "@hipstertomdale" }, newAttrs: { twitterMiddle: "@hipstertomdale" } };
+
+  deepEqual(hooks, [
+    hook('top', 'didUpdateAttrs', topAttrs), hook('top', 'didReceiveAttrs', topAttrs),
+    hook('top', 'willUpdate'), hook('top', 'willRender'),
+
+    hook('middle', 'didUpdateAttrs', middleAttrs), hook('middle', 'didReceiveAttrs', middleAttrs),
+    hook('middle', 'willUpdate'), hook('middle', 'willRender'),
+
+    hook('bottom', 'didUpdateAttrs', bottomAttrs), hook('bottom', 'didReceiveAttrs', bottomAttrs),
+    hook('bottom', 'willUpdate'), hook('bottom', 'willRender'),
+    hook('bottom', 'didUpdate'), hook('bottom', 'didRender'),
+
     hook('middle', 'didUpdate'), hook('middle', 'didRender'),
     hook('top', 'didUpdate'), hook('top', 'didRender')
   ]);
@@ -279,91 +345,6 @@ QUnit.test("changing a component's displayed properties inside didInsertElement(
   });
 });
 
-QUnit.test('manually re-rendering in `willReceiveAttrs` triggers lifecycle hooks on the child even if the nodes were not dirty', function() {
-  var components = {};
-
-  function component(label) {
-    return Component.extend({
-      init() {
-        this.label = label;
-        pushHook(label, 'init');
-        components[label] = this;
-        this._super.apply(this, arguments);
-      },
-      willReceiveAttrs(nextAttrs) {
-        this.rerender();
-        pushHook(label, 'willReceiveAttrs', nextAttrs);
-      },
-      willUpdate() {
-        pushHook(label, 'willUpdate');
-      },
-      didUpdate() {
-        pushHook(label, 'didUpdate');
-      },
-      didInsertElement() {
-        pushHook(label, 'didInsertElement');
-      },
-      willRender() {
-        pushHook(label, 'willRender');
-      },
-      didRender() {
-        pushHook(label, 'didRender');
-      }
-    });
-  }
-
-  registry.register('component:the-top', component('top'));
-  registry.register('component:the-middle', component('middle'));
-  registry.register('component:the-bottom', component('bottom'));
-
-  registry.register('template:components/the-top', compile('Twitter: {{attrs.twitter}} {{the-middle name="Tom Dale"}}'));
-  registry.register('template:components/the-middle', compile('Name: {{attrs.name}} {{the-bottom website="tomdale.net"}}'));
-  registry.register('template:components/the-bottom', compile('Website: {{attrs.website}}'));
-
-  view = EmberView.extend({
-    template: compile('{{the-top twitter=(readonly view.twitter)}}'),
-    twitter: "@tomdale",
-    container: container
-  }).create();
-
-  runAppend(view);
-
-  ok(component, "The component was inserted");
-  equal(jQuery('#qunit-fixture').text(), 'Twitter: @tomdale Name: Tom Dale Website: tomdale.net');
-
-  deepEqual(hooks, [
-    hook('top', 'init'), hook('top', 'willRender'),
-    hook('middle', 'init'), hook('middle', 'willRender'),
-    hook('bottom', 'init'), hook('bottom', 'willRender'),
-    hook('bottom', 'didInsertElement'), hook('bottom', 'didRender'),
-    hook('middle', 'didInsertElement'), hook('middle', 'didRender'),
-    hook('top', 'didInsertElement'), hook('top', 'didRender')
-  ]);
-
-  hooks = [];
-
-  run(function() {
-    view.set('twitter', '@hipstertomdale');
-  });
-
-  // Because each `willReceiveAttrs` hook triggered a downstream
-  // rerender, lifecycle hooks are invoked on all child components.
-
-  deepEqual(hooks, [
-    hook('top', 'willUpdate'),
-    hook('top', 'willReceiveAttrs', { twitter: "@hipstertomdale" }),
-    hook('top', 'willRender'),
-
-    hook('middle', 'willUpdate'),
-    hook('middle', 'willReceiveAttrs', { name: "Tom Dale" }),
-    hook('middle', 'willRender'),
-
-    hook('bottom', 'willUpdate'),
-    hook('bottom', 'willReceiveAttrs', { website: "tomdale.net" }),
-    hook('bottom', 'willRender'),
-
-    hook('bottom', 'didUpdate'), hook('bottom', 'didRender'),
-    hook('middle', 'didUpdate'), hook('middle', 'didRender'),
-    hook('top', 'didUpdate'), hook('top', 'didRender')
-  ]);
-});
+// TODO: Write a test that involves deep mutability: the component plucks something
+// from inside the attrs hash out into state and passes it as attrs into a child
+// component. The hooks should run correctly.

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -137,6 +137,12 @@ Renderer.prototype.setAttrs = function (view, attrs) {
   set(view, 'attrs', attrs);
 }; // set attrs the first time
 
+Renderer.prototype.componentInitAttrs = function (component, attrs) {
+  set(component, 'attrs', attrs);
+  component.trigger('didInitAttrs', { attrs });
+  component.trigger('didReceiveAttrs', { attrs });
+}; // set attrs the first time
+
 Renderer.prototype.didInsertElement = function (view) {
   if (view._transitionTo) {
     view._transitionTo('inDOM');
@@ -161,16 +167,31 @@ Renderer.prototype.updateAttrs = function (view, attrs) {
   this.setAttrs(view, attrs);
 }; // setting new attrs
 
+Renderer.prototype.componentUpdateAttrs = function (component, oldAttrs, newAttrs) {
+  set(component, 'attrs', newAttrs);
+
+  component.trigger('didUpdateAttrs', { oldAttrs, newAttrs });
+  component.trigger('didReceiveAttrs', { oldAttrs, newAttrs });
+};
+
 Renderer.prototype.willUpdate = function (view, attrs) {
   if (view.willUpdate) {
     view.willUpdate(attrs);
   }
 };
 
+Renderer.prototype.componentWillUpdate = function (component) {
+  component.trigger('willUpdate');
+};
+
 Renderer.prototype.willRender = function (view) {
   if (view.willRender) {
     view.willRender();
   }
+};
+
+Renderer.prototype.componentWillRender = function (component) {
+  component.trigger('willRender');
 };
 
 Renderer.prototype.remove = function (view, shouldDestroy) {


### PR DESCRIPTION
This commit refines the lifecycle hooks to more completely support the
use-cases.

On first render (in order):
- `didInitAttrs` runs after `attrs` is guaranteed to be up to date. This
  is more reliable than trying to ensure that `attrs` are always
  available on `init`.
- `didReceiveAttrs` runs after `didInitAttrs` (it also runs on
  subsequent re-renders, which is useful for logic that is the same
  on all renders).
- `willRender` runs before the template is rendered. It runs when the
  template is updated for any reason (both initial and re-render, and
  regardless of whether the change was caused by an attrs change or
  re-render).
- `didInsertElement` runs after the template has rendered and the
  element is in the DOM.
- `didRender` runs after `didInsertElement` (it also runs on subsequent
  re-renders).

On re-render (in order):
- `didUpdateAttrs` runs when the attributes of a component have changed
  (but not when the component is re-rendered, via `component.rerender`,
  `component.set`, or changes in models or services used by the
  template).
- `didReceiveAttrs`, same as above.
- `willUpdate` runs when the component is re-rendering for any reason,
  including `component.rerender()`, `component.set()` or changes in
  models or services used by the template.
- `willRender`, same as above
- `didUpdate` runs after the template has re-rendered and the DOM is
  now up to date.
- `didRender`, same as above.

Note that a component is re-rendered whenever:
1. any of its attributes change
2. `component.set()` is called
3. `component.rerender()` is called
4. a property on a model or service used by the template has changed
   (including through computed properties).

Because of the Glimmer engine, these re-renders are fast, and avoid
unnecessary work.
