### PR TITLE
Deprecate {{each}} hash arguments that trigger usage of LegacyEachView.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -927,7 +927,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     ok(true, "No assertion from valid template");
   });
 
-  QUnit.test("itemController specified in template with name binding does not change context", function() {
+  QUnit.test("itemController specified in template with name binding does not change context [DEPRECATED]", function() {
     var Controller = EmberController.extend({
       controllerName: computed(function() {
         return "controller:"+this.get('model.name');
@@ -948,9 +948,14 @@ function testEachWithItem(moduleName, useBlockParams) {
 
     registry.register('controller:array', ArrayController.extend());
 
+    var template;
+    expectDeprecation(function() {
+      template = templateFor('{{#EACH|people|person|itemController="person"}}{{controllerName}} - {{person.controllerName}} - {{/each}}', useBlockParams);
+    }, /Using 'itemController' with '{{each}}' @L1/);
+
     view = EmberView.create({
+      template,
       container: container,
-      template: templateFor('{{#EACH|people|person|itemController="person"}}{{controllerName}} - {{person.controllerName}} - {{/each}}', useBlockParams),
       controller: parentController
     });
 

--- a/packages/ember-template-compiler/tests/plugins/transform-each-into-collection-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-each-into-collection-test.js
@@ -1,0 +1,36 @@
+import { compile } from "ember-template-compiler";
+
+QUnit.module('ember-template-compiler: transform-each-into-collection');
+
+let deprecatedAttrs = ['itemController', 'itemView', 'itemViewClass', 'tagName', 'emptyView', 'emptyViewClass'];
+
+function testBlockForm(attr) {
+  QUnit.test(`Using the '${attr}' hash argument with a block results in a deprecation`, function() {
+    expect(1);
+
+    expectDeprecation(function() {
+      compile(`\n\n    {{#each model ${attr}="foo" as |item|}}{{item}}{{/each}}`, {
+        moduleName: 'lol-wat-app/index/template'
+      });
+    }, `Using '${attr}' with '{{each}}' 'lol-wat-app/index/template' @L3:C18 is deprecated.  Please refactor to a component.`);
+  });
+}
+
+function testNonBlockForm(attr) {
+  QUnit.test(`Using the '${attr}' hash argument in non-block form results in a deprecation`, function() {
+    expect(1);
+
+    expectDeprecation(function() {
+      compile(`\n\n    {{each model ${attr}="foo"}}`, {
+        moduleName: 'lol-wat-app/index/template'
+      });
+    }, `Using '${attr}' with '{{each}}' 'lol-wat-app/index/template' @L3:C17 is deprecated.  Please refactor to a component.`);
+  });
+}
+
+for (let i = 0, l = deprecatedAttrs.length; i < l; i++) {
+  let attr = deprecatedAttrs[i];
+
+  testBlockForm(attr);
+  testNonBlockForm(attr);
+}

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -94,11 +94,13 @@ QUnit.test('the controller property is provided to route driven views', function
 // (i.e., not inside a view or component) did not have access to a container and
 // would raise an exception.
 QUnit.test("{{#each}} inside outlet can have an itemController", function(assert) {
-  templates.index = compile(`
-    {{#each model itemController='thing'}}
-      <p>hi</p>
-    {{/each}}
-  `);
+  expectDeprecation(function() {
+    templates.index = compile(`
+      {{#each model itemController='thing'}}
+        <p>hi</p>
+      {{/each}}
+    `);
+  }, `Using 'itemController' with '{{each}}' @L2:C20 is deprecated.  Please refactor to a component.`);
 
   App.IndexController = Ember.Controller.extend({
     model: Ember.A([1, 2, 3])
@@ -111,13 +113,15 @@ QUnit.test("{{#each}} inside outlet can have an itemController", function(assert
   assert.equal($fixture.find('p').length, 3, "the {{#each}} rendered without raising an exception");
 });
 
-QUnit.test("", function(assert) {
-  templates.index = compile(`
-    {{#each model itemController='thing'}}
-      {{controller}}
-      <p><a {{action 'checkController' controller}}>Click me</a></p>
-    {{/each}}
-  `);
+QUnit.test("actions within a context shifting {{each}} with `itemController` [DEPRECATED]", function(assert) {
+  expectDeprecation(function() {
+    templates.index = compile(`
+      {{#each model itemController='thing'}}
+        {{controller}}
+        <p><a {{action 'checkController' controller}}>Click me</a></p>
+      {{/each}}
+    `);
+  });
 
   App.IndexRoute = Ember.Route.extend({
     model: function() {


### PR DESCRIPTION
This includes:
- `itemController`
- `tagName`
- `itemView`
- `itemViewClass`

The deprecation happens at template compile time, and includes the module name, line number, and column of the `{{each}}` invocation.
