### PR TITLE
`targetObject` for components invoked with {{view}} is correct.

### DIFF
--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -27,7 +27,11 @@ var TargetActionSupport = Mixin.create({
   action: null,
   actionContext: null,
 
-  targetObject: computed(function() {
+  targetObject: computed('target', function() {
+    if (this._targetObject) {
+      return this._targetObject;
+    }
+
     var target = get(this, 'target');
 
     if (typeof target === 'string') {
@@ -40,7 +44,7 @@ var TargetActionSupport = Mixin.create({
     } else {
       return target;
     }
-  }).property('target'),
+  }),
 
   actionContextObject: computed(function() {
     var actionContext = get(this, 'actionContext');

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -171,7 +171,8 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     @type Ember.Controller
     @default null
   */
-  targetObject: computed('parentView', function(key) {
+  targetObject: computed('controller', function(key) {
+    if (this._targetObject) { return this._targetObject; }
     if (this._controller) { return this._controller; }
     var parentView = get(this, 'parentView');
     return parentView ? get(parentView, 'controller') : null;


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/11088.
