### PR TITLE
Add a better deprecation for `{{bind-attr}}`.

### DIFF
--- a/packages/ember-template-compiler/tests/plugins/transform-bind-attr-to-attributes-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-bind-attr-to-attributes-test.js
@@ -6,8 +6,10 @@ QUnit.test("Using the `bind-attr` helper throws a deprecation", function() {
   expect(1);
 
   expectDeprecation(function() {
-    compile('<div {{bind-attr class=view.foo}}></div>');
-  }, /The `bind-attr` helper is deprecated in favor of HTMLBars-style bound attributes/);
+    compile('<div {{bind-attr class=view.foo}}></div>', {
+      moduleName: 'foo/bar/baz'
+    });
+  }, "The `bind-attr` helper ('foo/bar/baz' @ L1:C7) is deprecated in favor of HTMLBars-style bound attributes.");
 });
 
 QUnit.test("Using the `bindAttr` helper throws a deprecation", function() {
@@ -15,7 +17,7 @@ QUnit.test("Using the `bindAttr` helper throws a deprecation", function() {
 
   expectDeprecation(function() {
     compile('<div {{bindAttr class=view.foo}}></div>');
-  }, /The `bindAttr` helper is deprecated in favor of HTMLBars-style bound attributes/);
+  }, "The `bindAttr` helper (L1:C7) is deprecated in favor of HTMLBars-style bound attributes.");
 });
 
 QUnit.test("asserts for <div class='foo' {{bind-attr class='bar'}}></div>", function() {


### PR DESCRIPTION
Example deprecation:

```
The `bind-attr` helper ('my-app-name/templates/index' @ L1:C7) is deprecated in favor of HTMLBars-style bound attributes");
```

Fixes https://github.com/emberjs/ember.js/issues/11133.
