### PR TITLE
Implement angle-bracket components

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -1,12 +1,20 @@
 import ComponentNodeManager from "ember-htmlbars/node-managers/component-node-manager";
 
-export default function componentHook(renderNode, env, scope, tagName, params, attrs, templates, visitor) {
+export default function componentHook(renderNode, env, scope, _tagName, params, attrs, templates, visitor) {
   var state = renderNode.state;
 
   // Determine if this is an initial render or a re-render
   if (state.manager) {
     state.manager.rerender(env, attrs, visitor);
     return;
+  }
+
+  let tagName = _tagName;
+  let isAngleBracket = false;
+
+  if (tagName.charAt(0) === '<') {
+    tagName = tagName.slice(1, -1);
+    isAngleBracket = true;
   }
 
   var read = env.hooks.getValue;
@@ -18,6 +26,7 @@ export default function componentHook(renderNode, env, scope, tagName, params, a
     attrs,
     parentView,
     templates,
+    isAngleBracket,
     parentScope: scope
   });
 

--- a/packages/ember-metal/lib/streams/utils.js
+++ b/packages/ember-metal/lib/streams/utils.js
@@ -185,6 +185,9 @@ export function concat(array, separator) {
       subscribe(array[i], stream.notify, stream);
     }
 
+    // used by angle bracket components to detect an attribute was provided
+    // as a string literal
+    stream.isConcat = true;
     return stream;
   } else {
     return array.join(separator);

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -14,6 +14,7 @@ import TransformOldClassBindingSyntax from "ember-template-compiler/plugins/tran
 import TransformItemClass from "ember-template-compiler/plugins/transform-item-class";
 import TransformComponentAttrsIntoMut from "ember-template-compiler/plugins/transform-component-attrs-into-mut";
 import TransformComponentCurlyToReadonly from "ember-template-compiler/plugins/transform-component-curly-to-readonly";
+import TransformAngleBracketComponents from "ember-template-compiler/plugins/transform-angle-bracket-components";
 
 // used for adding Ember.Handlebars.compile for backwards compat
 import "ember-template-compiler/compat";
@@ -28,6 +29,7 @@ registerPlugin('ast', TransformOldClassBindingSyntax);
 registerPlugin('ast', TransformItemClass);
 registerPlugin('ast', TransformComponentAttrsIntoMut);
 registerPlugin('ast', TransformComponentCurlyToReadonly);
+registerPlugin('ast', TransformAngleBracketComponents);
 
 export {
   _Ember,

--- a/packages/ember-template-compiler/lib/plugins/transform-angle-bracket-components.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-angle-bracket-components.js
@@ -1,0 +1,27 @@
+function TransformAngleBracketComponents() {
+  // set later within HTMLBars to the syntax package
+  this.syntax = null;
+}
+
+/**
+  @private
+  @method transform
+  @param {AST} The AST to be transformed.
+*/
+TransformAngleBracketComponents.prototype.transform = function TransformBindAttrToAttributes_transform(ast) {
+  var walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    node.tag = `<${node.tag}>`;
+  });
+
+  return ast;
+};
+
+function validate(node) {
+  return node.type === 'ComponentNode';
+}
+
+export default TransformAngleBracketComponents;

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -60,7 +60,7 @@ let AttrsProxyMixin = {
   },
 
   willWatchProperty(key) {
-    if (key === 'attrs') { return; }
+    if (this._isAngleBracket || key === 'attrs') { return; }
 
     let attrsKey = `attrs.${key}`;
     addBeforeObserver(this, attrsKey, null, attrsWillChange);
@@ -68,7 +68,7 @@ let AttrsProxyMixin = {
   },
 
   didUnwatchProperty(key) {
-    if (key === 'attrs') { return; }
+    if (this._isAngleBracket || key === 'attrs') { return; }
 
     let attrsKey = `attrs.${key}`;
     removeBeforeObserver(this, attrsKey, null, attrsWillChange);
@@ -76,6 +76,8 @@ let AttrsProxyMixin = {
   },
 
   legacyDidReceiveAttrs: on('didReceiveAttrs', function() {
+    if (this._isAngleBracket) { return; }
+
     var keys = objectKeys(this.attrs);
 
     for (var i=0, l=keys.length; i<l; i++) {
@@ -88,6 +90,8 @@ let AttrsProxyMixin = {
   }),
 
   unknownProperty(key) {
+    if (this._isAngleBracket) { return; }
+
     var attrs = get(this, 'attrs');
 
     if (attrs && key in attrs) {
@@ -110,6 +114,8 @@ let AttrsProxyMixin = {
 };
 
 AttrsProxyMixin[PROPERTY_DID_CHANGE] = function(key) {
+  if (this._isAngleBracket) { return; }
+
   if (this.currentState) {
     this.currentState.legacyPropertyDidChange(this, key);
   }

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -3,7 +3,7 @@ import getValue from "ember-htmlbars/hooks/get-value";
 import { get } from "ember-metal/property_get";
 import { isGlobal } from "ember-metal/path_cache";
 
-export default function buildComponentTemplate({ component, layout }, attrs, content) {
+export default function buildComponentTemplate({ component, layout, isAngleBracket}, attrs, content) {
   var blockToRender, tagName, meta;
 
   if (component === undefined) {
@@ -26,7 +26,7 @@ export default function buildComponentTemplate({ component, layout }, attrs, con
     // element. We use `manualElement` to create a template that represents
     // the wrapping element and yields to the previous block.
     if (tagName !== '') {
-      var attributes = normalizeComponentAttributes(component, attrs);
+      var attributes = normalizeComponentAttributes(component, isAngleBracket, attrs);
       var elementTemplate = internal.manualElement(tagName, attributes);
       elementTemplate.meta = meta;
 
@@ -113,7 +113,7 @@ function tagNameFor(view) {
 
 // Takes a component and builds a normalized set of attribute
 // bindings consumable by HTMLBars' `attribute` hook.
-function normalizeComponentAttributes(component, attrs) {
+function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   var normalized = {};
   var attributeBindings = component.attributeBindings;
   var i, l;
@@ -143,6 +143,17 @@ function normalizeComponentAttributes(component, attrs) {
       Ember.assert('You cannot use class as an attributeBinding, use classNameBindings instead.', attrName !== 'class');
 
       normalized[attrName] = expression;
+    }
+  }
+
+  if (isAngleBracket) {
+    for (var prop in attrs) {
+      let val = attrs[prop];
+      if (!val) { continue; }
+
+      if (typeof val === 'string' || val.isConcat) {
+        normalized[prop] = ['value', val];
+      }
     }
   }
 

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -53,7 +53,7 @@ test('allows enabling of features', function() {
     templateCompiler._Ember.FEATURES['ember-htmlbars-component-generation'] = true;
 
     templateOutput = templateCompiler.precompile('<some-thing></some-thing>');
-    ok(templateOutput.indexOf('["component","some-thing",[],0]') > -1, 'component generation can be enabled');
+    ok(templateOutput.indexOf('["component","<some-thing>",[],0]') > -1, 'component generation can be enabled');
   } else {
     ok(true, 'cannot test features in feature stripped build');
   }


### PR DESCRIPTION
This commit adds support for angle-bracket components, including a number of changes from curlies as discussed:
1. `<my-component>` is inserted with a tagName of `my-component` into the
   DOM. We plan to support an opt-out in the future (possibly along the
   line of the web-component `is=` feature).
2. Attributes specified as strings (with “quotation marks”) are inserted
   into the DOM as attributes. For the most part, this eliminates the
   need for `attributeBindings`.
3. Angle bracket components do not support attrs at the top-level (the
   entire attrs proxy functionality is disabled).
4. A number of other legacy behaviors are removed, such as `controller=`
   and string rendering.
5. Attributes are read-only values by default.

We plan to do a more aggressive disabling of legacy functionality; you should assume that by the time Ember 1.13 ships, there will be no deprecated functionality supported with angle bracket components.

From a high-level, angle bracket components are a coarse-grained opt-in for Ember 2.0 functionality.
