### PR TITLE
Fix documentation for {{each}} and {{with}} helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ publish_to_bower/
 bower_components/
 npm-debug.log
 .ember-cli
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ publish_to_bower/
 bower_components/
 npm-debug.log
 .ember-cli
-*.swp

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -53,7 +53,7 @@ import normalizeSelf from "ember-htmlbars/utils/normalize-self";
   ```javascript
   App.NoPeopleView = Ember.View.extend({
     tagName: 'li',
-    template: 'No person is available, sorry'
+    template: '<p>No person is available, sorry</p>'
   });
   ```
 

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -45,34 +45,11 @@ import normalizeSelf from "ember-htmlbars/utils/normalize-self";
   {{/each}}
   ```
 
-  ### Specifying an alternative view for no items (else)
-
-  The `emptyViewClass` option provides the same flexibility to the `{{else}}`
-  case of the each helper.
-
-  ```javascript
-  App.NoPeopleView = Ember.View.extend({
-    tagName: 'li',
-    template: '<p>No person is available, sorry</p>'
-  });
-  ```
-
-  ```handlebars
-  <ul>
-    {{#each developers emptyViewClass="no-people" as |developer|}}
-      <li>{{developer.name}}</li>
-    {{/each}}
-  </ul>
-  ```
-
   @method each
   @for Ember.Handlebars.helpers
   @param [name] {String} name for item (used with `as`)
   @param [path] {String} path
   @param [options] {Object} Handlebars key/value pairs of options
-  @param [options.itemViewClass] {String} a path to a view class used for each item
-  @param [options.emptyViewClass] {String} a path to a view class used for each item
-  @param [options.itemController] {String} name of a controller to be created for each item
 */
 export default function eachHelper(params, hash, blocks) {
   var list = params[0];

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -45,55 +45,6 @@ import normalizeSelf from "ember-htmlbars/utils/normalize-self";
   {{/each}}
   ```
 
-  ### Specifying an alternative view for each item
-
-  `itemViewClass` can control which view will be used during the render of each
-  item's template. The following template:
-
-  ```handlebars
-  <ul>
-    {{#each developers itemViewClass="person" as |developer|}}
-      {{developer.name}}
-    {{/each}}
-  </ul>
-  ```
-
-  Will use the following view for each item:
-
-  ```javascript
-  App.PersonView = Ember.View.extend({
-    tagName: 'li'
-  });
-  ```
-
-  Resulting in HTML output that looks like the following:
-
-  ```html
-  <ul>
-    <li class="ember-view">Yehuda</li>
-    <li class="ember-view">Tom</li>
-    <li class="ember-view">Paul</li>
-  </ul>
-  ```
-
-  `itemViewClass` also enables a non-block form of `{{each}}`. The view
-  must [provide its own template](/api/classes/Ember.View.html#toc_templates)
-  and then the block should be dropped. An example that outputs the same HTML
-  as the previous one:
-
-  ```javascript
-  App.PersonView = Ember.View.extend({
-    tagName: 'li',
-    template: '{{developer.name}}'
-  });
-  ```
-
-  ```handlebars
-  <ul>
-    {{each developers itemViewClass="person" as |developer|}}
-  </ul>
-  ```
-
   ### Specifying an alternative view for no items (else)
 
   The `emptyViewClass` option provides the same flexibility to the `{{else}}`

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -2,6 +2,151 @@ import { get } from "ember-metal/property_get";
 import { forEach } from "ember-metal/enumerable_utils";
 import normalizeSelf from "ember-htmlbars/utils/normalize-self";
 
+/**
+  The `{{#each}}` helper loops over elements in a collection. It is an extension
+  of the base Handlebars `{{#each}}` helper.
+
+  The default behavior of `{{#each}}` is to yield its inner block once for every
+  item in an array.
+
+  ```javascript
+  var developers = [{name: 'Yehuda'},{name: 'Tom'}, {name: 'Paul'}];
+  ```
+
+  ```handlebars
+  {{#each developers as |person|}}
+    {{person.name}}
+    {{! `this` is whatever it was outside the #each }}
+  {{/each}}
+  ```
+
+  The same rules apply to arrays of primitives.
+
+  ```javascript
+  var developerNames = ['Yehuda', 'Tom', 'Paul']
+  ```
+
+  ```handlebars
+  {{#each developerNames as |name|}}
+    {{name}}
+  {{/each}}
+  ```
+
+  ### {{else}} condition
+
+  `{{#each}}` can have a matching `{{else}}`. The contents of this block will render
+  if the collection is empty.
+
+  ```handlebars
+  {{#each developers as |person|}}
+    {{person.name}}
+  {{else}}
+    <p>Sorry, nobody is available for this task.</p>
+  {{/each}}
+  ```
+
+  ### Specifying an alternative view for each item
+
+  `itemViewClass` can control which view will be used during the render of each
+  item's template. The following template:
+
+  ```handlebars
+  <ul>
+    {{#each developers itemViewClass="person" as |developer|}}
+      {{developer.name}}
+    {{/each}}
+  </ul>
+  ```
+
+  Will use the following view for each item:
+
+  ```javascript
+  App.PersonView = Ember.View.extend({
+    tagName: 'li'
+  });
+  ```
+
+  Resulting in HTML output that looks like the following:
+
+  ```html
+  <ul>
+    <li class="ember-view">Yehuda</li>
+    <li class="ember-view">Tom</li>
+    <li class="ember-view">Paul</li>
+  </ul>
+  ```
+
+  `itemViewClass` also enables a non-block form of `{{each}}`. The view
+  must [provide its own template](/api/classes/Ember.View.html#toc_templates)
+  and then the block should be dropped. An example that outputs the same HTML
+  as the previous one:
+
+  ```javascript
+  App.PersonView = Ember.View.extend({
+    tagName: 'li',
+    template: '{{developer.name}}'
+  });
+  ```
+
+  ```handlebars
+  <ul>
+    {{each developers itemViewClass="person" as |developer|}}
+  </ul>
+  ```
+
+  ### Specifying an alternative view for no items (else)
+
+  The `emptyViewClass` option provides the same flexibility to the `{{else}}`
+  case of the each helper.
+
+  ```javascript
+  App.NoPeopleView = Ember.View.extend({
+    tagName: 'li',
+    template: 'No person is available, sorry'
+  });
+  ```
+
+  ```handlebars
+  <ul>
+    {{#each developers emptyViewClass="no-people" as |developer|}}
+      <li>{{developer.name}}</li>
+    {{/each}}
+  </ul>
+  ```
+
+  ### Wrapping each item in a controller
+
+  Controllers in Ember manage state and decorate data. In many cases,
+  providing a controller for each item in a list can be useful.
+  An item that is passed to an item controller will be set as the `model` property
+  on the controller.
+
+  This allows state and decoration to be added to the controller
+  while any other property lookups can be delegated to the model. An example:
+
+  ```javascript
+  App.RecruitController = Ember.Controller.extend({
+    isAvailableForHire: function() {
+      return !this.get('model.isEmployed') && this.get('model.isSeekingWork');
+    }.property('model.isEmployed', 'model.isSeekingWork')
+  })
+  ```
+
+  ```handlebars
+  {{#each developers itemController="recruit" as |person|}}
+    {{person.model.name}} {{#if person.isAvailableForHire}}Hire me!{{/if}}
+  {{/each}}
+  ```
+
+  @method each
+  @for Ember.Handlebars.helpers
+  @param [name] {String} name for item (used with `as`)
+  @param [path] {String} path
+  @param [options] {Object} Handlebars key/value pairs of options
+  @param [options.itemViewClass] {String} a path to a view class used for each item
+  @param [options.emptyViewClass] {String} a path to a view class used for each item
+  @param [options.itemController] {String} name of a controller to be created for each item
+*/
 export default function eachHelper(params, hash, blocks) {
   var list = params[0];
   var keyPath = hash.key;

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -65,30 +65,6 @@ import normalizeSelf from "ember-htmlbars/utils/normalize-self";
   </ul>
   ```
 
-  ### Wrapping each item in a controller
-
-  Controllers in Ember manage state and decorate data. In many cases,
-  providing a controller for each item in a list can be useful.
-  An item that is passed to an item controller will be set as the `model` property
-  on the controller.
-
-  This allows state and decoration to be added to the controller
-  while any other property lookups can be delegated to the model. An example:
-
-  ```javascript
-  App.RecruitController = Ember.Controller.extend({
-    isAvailableForHire: function() {
-      return !this.get('model.isEmployed') && this.get('model.isSeekingWork');
-    }.property('model.isEmployed', 'model.isSeekingWork')
-  })
-  ```
-
-  ```handlebars
-  {{#each developers itemController="recruit" as |person|}}
-    {{person.model.name}} {{#if person.isAvailableForHire}}Hire me!{{/if}}
-  {{/each}}
-  ```
-
   @method each
   @for Ember.Handlebars.helpers
   @param [name] {String} name for item (used with `as`)

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -10,35 +10,56 @@ import shouldDisplay from "ember-views/streams/should_display";
   Use the `{{with}}` helper when you want to alias a property to a new name. This is helpful
   for semantic clarity as it allows you to retain default scope or to reference a property from another
   `{{with}}` block.
+
   If the aliased property is "falsey", for example: `false`, `undefined` `null`, `""`, `0` or
   an empty array, the block will not be rendered.
+
   ```handlebars
-  // will only render if user.posts contains items
+  {{! Will only render if user.posts contains items}}
   {{#with user.posts as |blogPosts|}}
     <div class="notice">
       There are {{blogPosts.length}} blog posts written by {{user.name}}.
     </div>
-    {{#each post in blogPosts}}
+    {{#each blogPosts as |post|}}
       <li>{{post.title}}</li>
     {{/each}}
   {{/with}}
   ```
+
   Without the `as` operator, it would be impossible to reference `user.name` in the example above.
+
   NOTE: The alias should not reuse a name from the bound property path.
-  For example: `{{#with foo.bar as foo}}` is not supported because it attempts to alias using
-  the first part of the property path, `foo`. Instead, use `{{#with foo.bar as baz}}`.
+  For example: `{{#with foo.bar as |foo|}}` is not supported because it attempts to alias using
+  the first part of the property path, `foo`. Instead, use `{{#with foo.bar as |baz|}}`.
+
   ### `controller` option
-  Adding `controller='something'` instructs the `{{with}}` helper to create and use an instance of
-  the specified controller wrapping the aliased keyword.
-  This is very similar to using an `itemController` option with the `{{each}}` helper.
+
+  Adding `controller='someController'` instructs the `{{with}}` helper to create and use an instance of
+  the specified controller wrapping the aliased keyword.  This is very similar to using an
+  `itemController` option with the [{{each}}](/api/classes/Ember.Handlebars.helpers.html#method_each) helper.
+
+  ```javascript
+  App.UserBlogPostsController = Ember.Controller.extend({
+    isProlificBlogger: function() {
+      return this.get('model.length') > 5;
+    }.property('model.length')
+  })
+  ```
+
   ```handlebars
   {{#with users.posts controller='userBlogPosts' as |posts|}}
-    {{!- `posts` is wrapped in our controller instance }}
+    {{! `posts` is wrapped in our controller instance }}
+    {{#if isProlificBlogger}}
+      {{user.name}} has written more than {{posts.model.length}} blog posts!
+    {{else}}
+      {{user.name}} has only written {{posts.model.length}} blog posts. 
+    {{/if}}
   {{/with}}
   ```
-  In the above example, the `posts` keyword is now wrapped in the `userBlogPost` controller,
-  which provides an elegant way to decorate the context with custom
-  functions/properties.
+
+  In the above example, the `posts` keyword is now wrapped in the `userBlogPosts` controller,
+  which provides an elegant way to decorate the context with custom functions/properties.
+
   @method with
   @for Ember.Handlebars.helpers
   @param {Function} context

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -32,34 +32,6 @@ import shouldDisplay from "ember-views/streams/should_display";
   For example: `{{#with foo.bar as |foo|}}` is not supported because it attempts to alias using
   the first part of the property path, `foo`. Instead, use `{{#with foo.bar as |baz|}}`.
 
-  ### `controller` option
-
-  Adding `controller='someController'` instructs the `{{with}}` helper to create and use an instance of
-  the specified controller wrapping the aliased keyword.  This is very similar to using an
-  `itemController` option with the [{{each}}](/api/classes/Ember.Handlebars.helpers.html#method_each) helper.
-
-  ```javascript
-  App.UserBlogPostsController = Ember.Controller.extend({
-    isProlificBlogger: function() {
-      return this.get('model.length') > 5;
-    }.property('model.length')
-  })
-  ```
-
-  ```handlebars
-  {{#with users.posts controller='userBlogPosts' as |posts|}}
-    {{! `posts` is wrapped in our controller instance }}
-    {{#if isProlificBlogger}}
-      {{user.name}} has written more than {{posts.model.length}} blog posts!
-    {{else}}
-      {{user.name}} has only written {{posts.model.length}} blog posts.
-    {{/if}}
-  {{/with}}
-  ```
-
-  In the above example, the `posts` keyword is now wrapped in the `userBlogPosts` controller,
-  which provides an elegant way to decorate the context with custom functions/properties.
-
   @method with
   @for Ember.Handlebars.helpers
   @param {Function} context

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -52,7 +52,7 @@ import shouldDisplay from "ember-views/streams/should_display";
     {{#if isProlificBlogger}}
       {{user.name}} has written more than {{posts.model.length}} blog posts!
     {{else}}
-      {{user.name}} has only written {{posts.model.length}} blog posts. 
+      {{user.name}} has only written {{posts.model.length}} blog posts.
     {{/if}}
   {{/with}}
   ```


### PR DESCRIPTION
Addresses https://github.com/emberjs/ember.js/issues/10994.
## {{each}} helper

Restored the original documentation from 1.11 with the following changes:
- Updated to block params syntax (e.g. replace `{{#each post in posts}}` with `{{#each posts as |post|}}`
- Removed mentions of `ObjectController` and replace with `Controller`.
- Replaced `{{crossLink}}` helpers with links to relevant documentation.
## {{with}} helper
- Updated to block params syntax
- Expanded the example for the section about the `controller` option
## Comment about documentation of parameters

I still think in both cases the description of the parameters are unclear and I think this holds for all helpers. Like the `{{each}}` helper documents the parameters `name` and `path` but it's not clear how they're used and what they represent.

Instead, would it make sense to document the syntax of the helpers with a sort of grammar? I like how MDN documents the formal syntax of CSS rules. For instance, the formal syntax of the `box-shadow` rule is as follows (https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#Formal_syntax):

```
none | [inset? && [ <offset-x> <offset-y> <blur-radius>? <spread-radius>? <color>? ] ]#
```

Using this for helpers you could have something as follows for `{{each}}`:

```
{{each <array> [itemViewClass="<item-view-class>"]? [emptyViewClass="<empty-view-class>"]? [itemController="<item-controller>"]? as |<item>|}}
```

In any case, correct me if I'm wrong but I don't think that in their current format, the documentation of the parameters are particularly useful to most of the Ember.js users.
