### PR TITLE
Components fail to rerender if their props change during children's rendering

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -451,3 +451,103 @@ QUnit.test('implementing `render` allows pushing into a string buffer', function
 
   equal(view.$('#zomg').text(), 'Whoop!');
 });
+
+QUnit.test("comopnent should rerender when a property is changed during children's rendering", function() {
+  var outer, middle;
+
+  registry.register('component:x-outer', Component.extend({
+    value: 1,
+    grabReference: Ember.on('init', function() {
+      outer = this;
+    })
+  }));
+
+  registry.register('component:x-middle', Component.extend({
+    grabReference: Ember.on('init', function() {
+      middle = this;
+    })
+  }));
+
+  registry.register('component:x-inner', Component.extend({
+    pushDataUp: Ember.observer('value', function() {
+      middle.set('value', this.get('value'));
+    })
+  }));
+
+  registry.register('template:components/x-outer', compile('{{#x-middle}}{{x-inner value=value}}{{/x-middle}}'));
+  registry.register('template:components/x-middle', compile('<div id="middle-value">{{value}}</div>{{yield}}'));
+  registry.register('template:components/x-inner', compile('<div id="inner-value">{{value}}</div>'));
+
+
+  view = EmberView.extend({
+    template: compile('{{x-outer}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  equal(view.$('#inner-value').text(), '1', 'initial render of inner');
+  equal(view.$('#middle-value').text(), '1', 'initial render of middle');
+
+  run(() => outer.set('value', 2));
+
+  equal(view.$('#inner-value').text(), '2', 'second render of inner');
+  equal(view.$('#middle-value').text(), '2', 'second render of middle');
+
+  run(() => outer.set('value', 3));
+
+  equal(view.$('#inner-value').text(), '3', 'third render of inner');
+  equal(view.$('#middle-value').text(), '3', 'third render of middle');
+
+});
+
+QUnit.test("comopnent should rerender when a property (with a default) is changed during children's rendering", function() {
+  var outer, middle;
+
+  registry.register('component:x-outer', Component.extend({
+    value: 1,
+    grabReference: Ember.on('init', function() {
+      outer = this;
+    })
+  }));
+
+  registry.register('component:x-middle', Component.extend({
+    value: null,
+    grabReference: Ember.on('init', function() {
+      middle = this;
+    })
+  }));
+
+  registry.register('component:x-inner', Component.extend({
+    value: null,
+    pushDataUp: Ember.observer('value', function() {
+      middle.set('value', this.get('value'));
+    })
+  }));
+
+  registry.register('template:components/x-outer', compile('{{#x-middle}}{{x-inner value=value}}{{/x-middle}}'));
+  registry.register('template:components/x-middle', compile('<div id="middle-value">{{value}}</div>{{yield}}'));
+  registry.register('template:components/x-inner', compile('<div id="inner-value">{{value}}</div>'));
+
+
+  view = EmberView.extend({
+    template: compile('{{x-outer}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  equal(view.$('#inner-value').text(), '1', 'initial render of inner');
+  equal(view.$('#middle-value').text(), '1', 'initial render of middle');
+
+  run(() => outer.set('value', 2));
+
+  equal(view.$('#inner-value').text(), '2', 'second render of inner');
+  equal(view.$('#middle-value').text(), '2', 'second render of middle');
+
+  run(() => outer.set('value', 3));
+
+  equal(view.$('#inner-value').text(), '3', 'third render of inner');
+  equal(view.$('#middle-value').text(), '3', 'third render of middle');
+
+});


### PR DESCRIPTION
If a component's property gets changed while it's children are rendering, we never rerender it, resulting in stale data in the DOM. This can result in DOM that seems to "lag behind" each change to the data, and I suspect it is the same issue that @wagenet hit while updating an app to glimmer.

"data-up" is an anti-pattern that we're strictly curtailing in Ember 2.0. But in the interests of avoiding regressions in 1.13, we need to make this behavior work.

I provided two variations on the failing test because they both fail differently in interesting ways.
