### PR TITLE
[Doc release] Fix typo in component lookup assert

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_lookup_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lookup_test.js
@@ -36,5 +36,5 @@ QUnit.test('dashless components should not be found', function() {
 
   expectAssertion(function() {
     runAppend(view);
-  }, /You canot use 'dashless' as a component name. Component names must contain a hyphen./);
+  }, /You cannot use 'dashless' as a component name. Component names must contain a hyphen./);
 });

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -7,7 +7,7 @@ export default EmberObject.extend({
     var invalidName = ISNT_HELPER_CACHE.get(name);
 
     if (invalidName) {
-      Ember.assert(`You canot use '${name}' as a component name. Component names must contain a hyphen.`);
+      Ember.assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`);
     }
   },
 


### PR DESCRIPTION
“canot” => “cannot”
