### PR TITLE
Implement {{each-in}} helper

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -117,6 +117,33 @@ for a detailed explanation.
 
   Added in [#9721](https://github.com/emberjs/ember.js/pull/9721).
 
+* `ember-htmlbars-each-in`
+
+  Adds a helper for enumerating over the properties of an object in a
+  Handlebars templates. For example, given this data:
+
+  ```javascript
+  {
+    "Item 1": 1234,
+    "Item 2": 3456
+  }
+  ```
+
+  And this template:
+
+  ```handlebars
+  {{#each-in items as |key value|}}
+    <p>{{key}}: {{value}}</p>
+  {{/each-in}}
+  ```
+
+  The following output would be produced:
+
+  ```html
+  <p>Item 1: 1234</p>
+  <p>Item 2: 3456</p>
+  ```
+
 * `ember-routing-transitioning-classes`
 
   Disables eager URL updates during slow transitions in favor of new CSS

--- a/features.json
+++ b/features.json
@@ -7,6 +7,7 @@
     "ember-htmlbars-component-helper": true,
     "ember-htmlbars-inline-if-helper": true,
     "ember-htmlbars-attribute-syntax": true,
+    "ember-htmlbars-each-in": null,
     "ember-routing-transitioning-classes": true,
     "ember-testing-checkbox-helpers": null,
     "ember-metal-stream": null,

--- a/packages/ember-htmlbars/lib/helpers/each-in.js
+++ b/packages/ember-htmlbars/lib/helpers/each-in.js
@@ -1,8 +1,20 @@
 if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
-  var eachInHelper = function([ object ]) {
-    for (var prop in object) {
-      if (!object.hasOwnProperty(prop)) { continue; }
-      this.yieldItem(prop, [prop, object[prop]]);
+  var shouldDisplay = function(object) {
+    if (object === undefined || object === null) {
+      return false;
+    }
+
+    return true;
+  };
+
+  var eachInHelper = function([ object ], hash, blocks) {
+    if (shouldDisplay(object)) {
+      for (var prop in object) {
+        if (!object.hasOwnProperty(prop)) { continue; }
+        blocks.template.yieldItem(prop, [prop, object[prop]]);
+      }
+    } else if (blocks.inverse.yield) {
+      blocks.inverse.yield();
     }
   };
 }

--- a/packages/ember-htmlbars/lib/helpers/each-in.js
+++ b/packages/ember-htmlbars/lib/helpers/each-in.js
@@ -1,0 +1,10 @@
+if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
+  var eachInHelper = function([ object ]) {
+    for (var prop in object) {
+      if (!object.hasOwnProperty(prop)) { continue; }
+      this.yieldItem(prop, [prop, object[prop]]);
+    }
+  };
+}
+
+export default eachInHelper;

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -21,6 +21,7 @@ import withHelper from "ember-htmlbars/helpers/with";
 import locHelper from "ember-htmlbars/helpers/loc";
 import logHelper from "ember-htmlbars/helpers/log";
 import eachHelper from "ember-htmlbars/helpers/each";
+import eachInHelper from "ember-htmlbars/helpers/each-in";
 import bindAttrClassHelper from "ember-htmlbars/helpers/-bind-attr-class";
 import normalizeClassHelper from "ember-htmlbars/helpers/-normalize-class";
 import concatHelper from "ember-htmlbars/helpers/-concat";
@@ -42,6 +43,9 @@ registerHelper('with', withHelper);
 registerHelper('loc', locHelper);
 registerHelper('log', logHelper);
 registerHelper('each', eachHelper);
+if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
+  registerHelper('each-in', eachInHelper);
+}
 registerHelper('-bind-attr-class', bindAttrClassHelper);
 registerHelper('-normalize-class', normalizeClassHelper);
 registerHelper('-concat', concatHelper);

--- a/packages/ember-htmlbars/tests/helpers/each_in_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_in_test.js
@@ -67,8 +67,8 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
     run(function() {
       component.set('categories', {
         "Programming Languages": 199303,
-        "Good Programming Languages": 0.2 + 0.4,
-        "Bad Programming Languages": 0
+        "Good Programming Languages": 123,
+        "Bad Programming Languages": 456
       });
     });
 
@@ -76,9 +76,9 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
     assert.equal(component.$('li').first().text(),
       "Programming Languages: 199303", "renders first item correctly after rerender");
     assert.equal(component.$('li:eq(1)').text(),
-      "Good Programming Languages: 0.6000000000000001", "renders second item correctly after rerender");
+      "Good Programming Languages: 123", "renders second item correctly after rerender");
     assert.equal(component.$('li:eq(2)').text(),
-      "Bad Programming Languages: 0", "renders third item correctly after rerender");
+      "Bad Programming Languages: 456", "renders third item correctly after rerender");
   });
 
   QUnit.test("it only iterates over an object's own properties", function(assert) {
@@ -129,5 +129,35 @@ if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
 
     run(() => component.rerender());
     assert.equal(component.$('li').length, 0, "nothing is rendered if the object is not passed after rerender");
+  });
+
+  QUnit.test("it supports rendering an inverse", function(assert) {
+    let categories = null;
+
+    renderTemplate(`
+      <ul class="categories">
+      {{#each-in categories as |category count|}}
+        <li>{{category}}: {{count}}</li>
+      {{else}}
+        <li>No categories.</li>
+      {{/each-in}}
+      </ul>
+    `, { categories });
+
+    assert.equal(component.$('li').length, 1, "one li is rendered");
+    assert.equal(component.$('li').text(), "No categories.", "the inverse is rendered");
+
+    run(() => component.rerender());
+    assert.equal(component.$('li').length, 1, "one li is rendered");
+    assert.equal(component.$('li').text(), "No categories.", "the inverse is rendered");
+
+    run(() => {
+      component.set('categories', {
+        "First Category": 123
+      });
+    });
+
+    assert.equal(component.$('li').length, 1, "one li is rendered");
+    assert.equal(component.$('li').text(), "First Category: 123", "the list is rendered after being set");
   });
 }

--- a/packages/ember-htmlbars/tests/helpers/each_in_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_in_test.js
@@ -1,0 +1,133 @@
+import Component from "ember-views/views/component";
+import compile from "ember-template-compiler/system/compile";
+import run from "ember-metal/run_loop";
+import create from "ember-metal/platform/create";
+
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var component;
+
+QUnit.module("ember-htmlbars: {{#each-in}} helper", {
+  teardown() {
+    if (component) { runDestroy(component); }
+  }
+});
+
+function renderTemplate(_template, props) {
+  let template = compile(_template);
+
+  component = Component.create(props, {
+    layout: template
+  });
+
+  runAppend(component);
+}
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
+  QUnit.test("it renders the template for each item in a hash", function(assert) {
+    let categories = {
+      "Smartphones": 8203,
+      "JavaScript Frameworks": Infinity
+    };
+
+    renderTemplate(`
+      <ul class="categories">
+      {{#each-in categories as |category count|}}
+        <li>{{category}}: {{count}}</li>
+      {{/each-in}}
+      </ul>
+    `, { categories });
+
+    assert.equal(component.$('li').length, 2, "renders 2 lis");
+    assert.equal(component.$('li').first().text(),
+      "Smartphones: 8203", "renders first item correctly");
+    assert.equal(component.$('li:eq(1)').text(),
+      "JavaScript Frameworks: Infinity", "renders second item correctly");
+
+    run(function() {
+      component.rerender();
+    });
+
+    assert.equal(component.$('li').length, 2, "renders 2 lis after rerender");
+    assert.equal(component.$('li').first().text(),
+      "Smartphones: 8203", "renders first item correctly after rerender");
+    assert.equal(component.$('li:eq(1)').text(),
+      "JavaScript Frameworks: Infinity", "renders second item correctly after rerender");
+
+    run(function() {
+      component.set('categories', {
+        "Smartphones": 100
+      });
+    });
+
+    assert.equal(component.$('li').length, 1, "removes unused item after data changes");
+    assert.equal(component.$('li').first().text(),
+      "Smartphones: 100", "correctly updates item after data changes");
+
+    run(function() {
+      component.set('categories', {
+        "Programming Languages": 199303,
+        "Good Programming Languages": 0.2 + 0.4,
+        "Bad Programming Languages": 0
+      });
+    });
+
+    assert.equal(component.$('li').length, 3, "renders 3 lis after updating data");
+    assert.equal(component.$('li').first().text(),
+      "Programming Languages: 199303", "renders first item correctly after rerender");
+    assert.equal(component.$('li:eq(1)').text(),
+      "Good Programming Languages: 0.6000000000000001", "renders second item correctly after rerender");
+    assert.equal(component.$('li:eq(2)').text(),
+      "Bad Programming Languages: 0", "renders third item correctly after rerender");
+  });
+
+  QUnit.test("it only iterates over an object's own properties", function(assert) {
+    let protoCategories = {
+      "Smartphones": 8203,
+      "JavaScript Frameworks": Infinity
+    };
+
+    let categories = create(protoCategories);
+    categories["Televisions"] = 183;
+    categories["Alarm Clocks"] = 999;
+
+    renderTemplate(`
+      <ul class="categories">
+      {{#each-in categories as |category count|}}
+        <li>{{category}}: {{count}}</li>
+      {{/each-in}}
+      </ul>
+    `, { categories });
+
+    assert.equal(component.$('li').length, 2, "renders 2 lis");
+    assert.equal(component.$('li').first().text(),
+      "Televisions: 183", "renders first item correctly");
+    assert.equal(component.$('li:eq(1)').text(),
+      "Alarm Clocks: 999", "renders second item correctly");
+
+    run(() => component.rerender());
+
+    assert.equal(component.$('li').length, 2, "renders 2 lis after rerender");
+    assert.equal(component.$('li').first().text(),
+      "Televisions: 183", "renders first item correctly after rerender");
+    assert.equal(component.$('li:eq(1)').text(),
+      "Alarm Clocks: 999", "renders second item correctly after rerender");
+  });
+
+  QUnit.test("it emits nothing if the passed argument is not an object", function(assert) {
+    let categories = null;
+
+    renderTemplate(`
+      <ul class="categories">
+      {{#each-in categories as |category count|}}
+        <li>{{category}}: {{count}}</li>
+      {{/each-in}}
+      </ul>
+    `, { categories });
+
+    assert.equal(component.$('li').length, 0, "nothing is rendered if the object is not passed");
+
+    run(() => component.rerender());
+    assert.equal(component.$('li').length, 0, "nothing is rendered if the object is not passed after rerender");
+  });
+}


### PR DESCRIPTION
The {{each-in}} helper is similar to {{each}}, but instead of enumerating array items, it enumerates the properties of an object.

If {{each}} is a for loop, you can think of {{each-in}} as a for-in loop.
