### PR TITLE
[BUGFIX beta] getRoot scope.locals lookup shouldn't rely on truthiness

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/get-root.js
+++ b/packages/ember-htmlbars/lib/hooks/get-root.js
@@ -16,7 +16,7 @@ export default function getRoot(scope, key) {
     return [!!(scope.blocks.default && scope.blocks.default.arity)];
   } else if (isGlobal(key) && Ember.lookup[key]) {
     return [getGlobal(key)];
-  } else if (scope.locals[key]) {
+  } else if (key in scope.locals) {
     return [scope.locals[key]];
   } else {
     return [getKey(scope, key)];


### PR DESCRIPTION
AFAIK, this isn't breaking anything right now because the `bindLocal()` hook [wraps locals](https://github.com/emberjs/ember.js/blob/bfcc15ee3ac2b2b3e4dad6aa0d7a447936302f5a/packages/ember-htmlbars/lib/hooks/bind-local.js#L21) in a Stream (objects are truthy obv), however when someone is using the private APIs to do naughty stuff like pass around POJOs or primitives, this conditional check fails sometimes because the value might not be truthy, like a number zero or a boolean false, etc.

soooo tl;dr, this PR is for people like me who are poking with the internals and discovered something I need but technically isn't required by normal Ember usage. That said, this reliance on truthiness could bite us later in a refactor and I think it's best to be explicit _just in case_.
