### PR TITLE
[BUGFIX beta] Handle mut cell action names. Fixes #11176

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -10,6 +10,18 @@ import isNone from 'ember-metal/is_none';
 
 import { computed } from "ember-metal/computed";
 
+import { MUTABLE_CELL } from "ember-views/compat/attrs-proxy";
+
+function validateAction(component, actionName) {
+  if (actionName && actionName[MUTABLE_CELL]) {
+    actionName = actionName.value;
+  }
+  Ember.assert("The default action was triggered on the component " + component.toString() +
+               ", but the action name (" + actionName + ") was not a string.",
+               isNone(actionName) || typeof actionName === 'string' || typeof actionName === 'function');
+  return actionName;
+}
+
 /**
 @module ember
 @submodule ember-views
@@ -262,17 +274,10 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
 
     // Send the default action
     if (action === undefined) {
-      actionName = get(this, 'action');
-      Ember.assert("The default action was triggered on the component " + this.toString() +
-                   ", but the action name (" + actionName + ") was not a string.",
-                   isNone(actionName) || typeof actionName === 'string' || typeof actionName === 'function');
-    } else {
-      actionName = get(this, 'attrs.' + action) || get(this, action);
-      Ember.assert("The " + action + " action was triggered on the component " +
-                   this.toString() + ", but the action name (" + actionName +
-                   ") was not a string.",
-                   isNone(actionName) || typeof actionName === 'string' || typeof actionName === 'function');
+      action = 'action';
     }
+    actionName = get(this, 'attrs.' + action) || get(this, action);
+    actionName = validateAction(this, actionName);
 
     // If no action name for that action could be found, just abort.
     if (actionName === undefined) { return; }

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -9,6 +9,8 @@ import { get } from "ember-metal/property_get";
 import EmberView from "ember-views/views/view";
 import Component from "ember-views/views/component";
 
+import { MUTABLE_CELL } from "ember-views/compat/attrs-proxy";
+
 var a_slice = Array.prototype.slice;
 
 var component, controller, actionCounts, sendCount, actionArguments;
@@ -153,6 +155,20 @@ QUnit.test("Calling sendAction on a component with a function calls the function
   });
 
   component.sendAction('action', argument);
+});
+
+QUnit.test("Calling sendAction on a component with a mut attr calls the function with arguments", function() {
+  var mut = {
+    value: 'didStartPlaying',
+    [MUTABLE_CELL]: true
+  };
+  set(component, 'playing', null);
+  set(component, 'attrs', { playing: mut });
+
+  component.sendAction('playing');
+
+  equal(sendCount, 1, "send was called once");
+  equal(actionCounts['didStartPlaying'], 1, "named action was sent");
 });
 
 QUnit.test("Calling sendAction with a named action uses the component's property as the action name", function() {


### PR DESCRIPTION
a `mut` or auto-mut passed as an action name was not correctly handled.
