### PR TITLE
ember-cli-sauce v1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ after_success:
 script:
   - npm test
 
-after_script:
-    - ember stop-sauce-connect
-
 branches:
   only:
     - master

--- a/bin/run-sauce-tests.js
+++ b/bin/run-sauce-tests.js
@@ -35,7 +35,7 @@ function run(command, _args) {
 
 RSVP.resolve()
   .then(function() {
-    return run('./node_modules/.bin/ember', [ 'start-sauce-connect' ]);
+    return run('./node_modules/.bin/ember', [ 'sauce:connect' ]);
   })
   .then(function() {
     // calling testem directly here instead of `ember test` so that
@@ -44,7 +44,7 @@ RSVP.resolve()
     return run('./node_modules/.bin/testem', [ 'ci', '--port', '7000' ]);
   })
   .finally(function() {
-    return run('./node_modules/.bin/ember', [ 'stop-sauce-connect' ]);
+    return run('./node_modules/.bin/ember', [ 'sauce:disconnect' ]);
   })
   .catch(function() {
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chalk": "^0.5.1",
     "ember-cli": "^0.2.0",
     "ember-cli-dependency-checker": "0.0.7",
-    "ember-cli-sauce": "^1.0.0",
+    "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "^0.4.0",
     "ember-publisher": "0.0.7",
     "emberjs-build": "0.1.1",

--- a/testem.json
+++ b/testem.json
@@ -5,35 +5,35 @@
   "parallel": 4,
   "launchers": {
     "SL_Chrome_Current": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b chrome --no-ct -u <url>",
+      "command": "ember sauce:launch -b chrome --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_Firefox_Current": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b firefox -v 34 --no-ct -u <url>",
+      "command": "ember sauce:launch -b firefox -v 34 --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_Safari_Current": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b safari -v 8 --no-ct -u <url>",
+      "command": "ember sauce:launch -b safari -v 8 --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_Safari_Last": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b safari -v 7 --no-ct -u <url>",
+      "command": "ember sauce:launch -b safari -v 7 --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_IE_11": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 11 --no-ct -u <url>",
+      "command": "ember sauce:launch -b 'internet explorer' -v 11 --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_IE_10": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 10 --no-ct -u <url>",
+      "command": "ember sauce:launch -b 'internet explorer' -v 10 --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_IE_9": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 9 --no-ct -u <url>",
+      "command": "ember sauce:launch -b 'internet explorer' -v 9 --no-ct -u <url>",
       "protocol": "tap"
     },
     "SL_IE_8": {
-      "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 8 --no-ct -u <url>",
+      "command": "ember sauce:launch -b 'internet explorer' -v 8 --no-ct -u <url>",
       "protocol": "tap"
     }
   },


### PR DESCRIPTION
Use the new `ember sauce:launch`
Replaced start & stop with prefixed commands
Removed duplicated stop
