### PR TITLE
Implement {{get}} Keyword

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -278,3 +278,35 @@ for a detailed explanation.
   compatible with action subexpressions.
 
   Per RFC [#50](https://github.com/emberjs/rfcs/pull/50)
+
+* `ember-htmlbars-get-helper`
+
+  The Syntax: `{{get object path}}`
+
+  A new keyword/helper that can be used to allow your object and/or key
+  values to be dynamic.
+
+  Example:
+  ```js
+
+  context = {
+    displayedPropertyTitle: 'First Name',
+    displayedPropertyKey: 'firstName'
+  };
+  ```  
+
+  ```hbs
+  <h2>{{displayedPropertyTitle}}</h2>
+
+  <ul>
+  {{#each people as |person|}}
+    <li>{{get person displayedPropertyKey}}</li>
+  {{/each}}
+  </ul>
+  ```
+
+  This allows the template to provide `displayedPropertyTitle`
+  and `displayedPropertyKey` to render a list for a single property
+  for each person.. E.g. a list of all `firstNames`, or `lastNames`, or `ages`.
+
+  Addd in [#11196](https://github.com/emberjs/ember.js/pull/11196)

--- a/features.json
+++ b/features.json
@@ -18,7 +18,8 @@
     "ember-views-component-block-info": true,
     "ember-routing-core-outlet": null,
     "ember-libraries-isregistered": null,
-    "ember-routing-htmlbars-improved-actions": true
+    "ember-routing-htmlbars-improved-actions": true,
+    "ember-htmlbars-get-helper": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -80,6 +80,7 @@ import legacyYield from "ember-htmlbars/keywords/legacy-yield";
 import mut, { privateMut } from "ember-htmlbars/keywords/mut";
 import each from "ember-htmlbars/keywords/each";
 import readonly from "ember-htmlbars/keywords/readonly";
+import getKeyword from "ember-htmlbars/keywords/get";
 
 registerKeyword('debugger', debuggerKeyword);
 registerKeyword('with', withKeyword);
@@ -99,6 +100,9 @@ registerKeyword('mut', mut);
 registerKeyword('@mut', privateMut);
 registerKeyword('each', each);
 registerKeyword('readonly', readonly);
+if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+  registerKeyword('get', getKeyword);
+}
 
 export default {
   hooks: emberHooks,

--- a/packages/ember-htmlbars/lib/helpers/-get.js
+++ b/packages/ember-htmlbars/lib/helpers/-get.js
@@ -1,0 +1,13 @@
+/** @private
+  this private helper is used in conjuntion with the get keyword
+*/
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+
+  var getHelper = function getHelper([value]) {
+    return value;
+  };
+
+}
+
+export default getHelper;

--- a/packages/ember-htmlbars/lib/keywords/get.js
+++ b/packages/ember-htmlbars/lib/keywords/get.js
@@ -1,0 +1,91 @@
+import Stream from "ember-metal/streams/stream";
+import { labelFor } from "ember-metal/streams/utils";
+import { read, isStream } from "ember-metal/streams/utils";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import SafeString from "htmlbars-util/safe-string";
+
+if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+
+  var getKeyword = function getKeyword(morph, env, scope, params, hash, template, inverse, visitor) {
+    var objParam = params[0];
+    var pathParam = params[1];
+
+    Ember.assert("The first argument to {{get}} must be a stream", isStream(objParam));
+    Ember.assert("{{get}} requires at least two arguments", params.length > 1);
+
+    var getStream = new GetStream(objParam, pathParam);
+
+    if (morph === null) {
+      return getStream;
+    } else {
+      env.hooks.inline(morph, env, scope, '-get', [getStream], hash, visitor);
+    }
+
+    return true;
+  };
+
+  var workaroundValue = function workaroundValue(value) {
+    // this is used to compensate for the following line of code
+    //     if (result && result.value) {
+    // in the 'inline' hook. If the stream returns a falsy value after
+    // previously returning a truthy value, this line causes the value not
+    // to be updated
+
+    // so for falsey values we need to enforce something that evalutes to
+    // truthy but returns an empty string.
+
+    // this can be removed if the `inline` hook handles it.
+
+    return value || new SafeString('');
+  };
+
+
+  var GetStream = function GetStream(obj, path) {
+    this.init('(get '+labelFor(obj)+' '+labelFor(path)+')');
+
+    this.objectParam = obj;
+    this.pathParam = path;
+    this.lastPathValue = undefined;
+    this.valueDep = this.addMutableDependency();
+
+    this.addDependency(path);
+
+    // This next line is currently only required when the keyword
+    // is executed in a subexpression. More investigation required
+    // to remove the additional dependency
+    this.addDependency(obj);
+  };
+
+  GetStream.prototype = create(Stream.prototype);
+
+  merge(GetStream.prototype, {
+    updateValueDependency() {
+      var pathValue = read(this.pathParam);
+
+      if (this.lastPathValue !== pathValue) {
+        if (typeof pathValue === 'string') {
+          this.valueDep.replace(this.objectParam.get(pathValue));
+        } else {
+          this.valueDep.replace();
+        }
+
+        this.lastPathValue = pathValue;
+      }
+    },
+
+    compute() {
+      this.updateValueDependency();
+      return workaroundValue(this.valueDep.getValue());
+    },
+
+    setValue(value) {
+      this.updateValueDependency();
+      this.valueDep.setValue(value);
+    }
+
+  });
+
+}
+
+export default getKeyword;

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -27,6 +27,7 @@ import normalizeClassHelper from "ember-htmlbars/helpers/-normalize-class";
 import concatHelper from "ember-htmlbars/helpers/-concat";
 import joinClassesHelper from "ember-htmlbars/helpers/-join-classes";
 import legacyEachWithControllerHelper from "ember-htmlbars/helpers/-legacy-each-with-controller";
+import getHelper from "ember-htmlbars/helpers/-get";
 import DOMHelper from "ember-htmlbars/system/dom-helper";
 
 // importing adds template bootstrapping
@@ -51,6 +52,9 @@ registerHelper('-normalize-class', normalizeClassHelper);
 registerHelper('-concat', concatHelper);
 registerHelper('-join-classes', joinClassesHelper);
 registerHelper('-legacy-each-with-controller', legacyEachWithControllerHelper);
+if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+  registerHelper('-get', getHelper);
+}
 
 Ember.HTMLBars = {
   _registerHelper: registerHelper,

--- a/packages/ember-htmlbars/tests/helpers/get_test.js
+++ b/packages/ember-htmlbars/tests/helpers/get_test.js
@@ -1,0 +1,299 @@
+import run from "ember-metal/run_loop";
+import { Registry } from "ember-runtime/system/container";
+import compile from "ember-template-compiler/system/compile";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import EmberView from "ember-views/views/view";
+
+var view, registry, container;
+
+// jscs:disable validateIndentation
+if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+
+QUnit.module("ember-htmlbars: {{get}} helper", {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('template', { instantiate: false });
+  },
+  teardown() {
+    run(function() {
+      Ember.TEMPLATES = {};
+    });
+    runDestroy(view);
+    runDestroy(container);
+    registry = container = view = null;
+  }
+});
+
+QUnit.test('should be able to get an object value with a static key', function() {
+  var context = {
+    colors: { apple: 'red', banana: 'yellow' }
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors \'apple\'}}] [{{if true (get colors \'apple\')}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\' for {{get colors \'apple\'}}');
+
+  run(function() {
+    view.set('context.colors', { apple: 'green', banana: 'purple' });
+  });
+
+  equal(view.$().text(), '[green] [green]', 'should return \'green\' for {{get colors \'apple\'}}');
+});
+
+QUnit.test('should be able to get an object value with a bound/dynamic key', function() {
+  var context = {
+    colors: { apple: 'red', banana: 'yellow' },
+    key: 'apple'
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors key}}] [{{if true (get colors key)}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\' for {{get colors key}}  (key = \'apple\')');
+
+  run(function() {
+    view.set('context.key', 'banana');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'red\' for {{get colors key}} (key = \'banana\')');
+
+  run(function() {
+    view.set('context.colors', { apple: 'green', banana: 'purple' });
+  });
+
+  equal(view.$().text(), '[purple] [purple]', 'should return \'purple\' for {{get colors key}} (key = \'banana\')');
+
+  run(function() {
+    view.set('context.key', 'apple');
+  });
+
+  equal(view.$().text(), '[green] [green]', 'should return \'green\' for {{get colors key}} (key = \'apple\')');
+
+});
+
+QUnit.test('should be able to get an object value with a GetStream key', function() {
+  var context = {
+    colors: { apple: 'red', banana: 'yellow' },
+    key: 'key1',
+    possibleKeys: { key1: 'apple', key2: 'banana' }
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors (get possibleKeys key)}}] [{{if true (get colors (get possibleKeys key))}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\'');
+
+  run(function() {
+    view.set('context.key', 'key2');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'red\' for {{get colors key}} (key = \'banana\')');
+
+  run(function() {
+    view.set('context.colors', { apple: 'green', banana: 'purple' });
+  });
+
+  equal(view.$().text(), '[purple] [purple]', 'should return \'purple\'');
+
+  run(function() {
+    view.set('context.key', 'key1');
+  });
+
+  equal(view.$().text(), '[green] [green]', 'should return \'green\'');
+
+});
+
+QUnit.test('should be able to get an object value with a GetStream value and bound/dynamic key', function() {
+  var context = {
+    possibleValues: {
+      colors1: { apple: 'red', banana: 'yellow' },
+      colors2: { apple: 'green', banana: 'purple' }
+    },
+    objectKey: 'colors1',
+    key: 'apple'
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get (get possibleValues objectKey) key}}] [{{if true (get (get possibleValues objectKey) key)}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors2');
+  });
+
+  equal(view.$().text(), '[green] [green]', 'should return \'green\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors1');
+  });
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\'');
+
+  run(function() {
+    view.set('context.key', 'banana');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'yellow\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors2');
+  });
+
+  equal(view.$().text(), '[purple] [purple]', 'should return \'purple\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors1');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'yellow\'');
+
+});
+
+QUnit.test('should be able to get an object value with a GetStream value and GetStream key', function() {
+  var context = {
+    possibleValues: {
+      colors1: { apple: 'red', banana: 'yellow' },
+      colors2: { apple: 'green', banana: 'purple' }
+    },
+    objectKey: 'colors1',
+    possibleKeys: {
+      key1: 'apple',
+      key2: 'banana'
+    },
+    key: 'key1'
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get (get possibleValues objectKey) (get possibleKeys key)}}] [{{if true (get (get possibleValues objectKey) (get possibleKeys key))}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors2');
+  });
+
+  equal(view.$().text(), '[green] [green]', 'should return \'green\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors1');
+  });
+
+  equal(view.$().text(), '[red] [red]', 'should return \'red\'');
+
+  run(function() {
+    view.set('context.key', 'key2');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'yellow\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors2');
+  });
+
+  equal(view.$().text(), '[purple] [purple]', 'should return \'purple\'');
+
+  run(function() {
+    view.set('context.objectKey', 'colors1');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'yellow\'');
+
+});
+
+QUnit.test('should handle object values as nulls', function() {
+  var context = {
+    colors: null
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors \'apple\'}}] [{{if true (get colors \'apple\')}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[] []', 'should return \'\' for {{get colors \'apple\'}} (colors = null)');
+
+  run(function() {
+    view.set('context.colors', { apple: 'green', banana: 'purple' });
+  });
+
+  equal(view.$().text(), '[green] [green]', 'should return \'green\' for {{get colors \'apple\'}} (colors = { apple: \'green\', banana: \'purple\' })');
+
+  run(function() {
+    view.set('context.colors', null);
+  });
+
+  equal(view.$().text(), '[] []', 'should return \'\' for {{get colors \'apple\'}} (colors = null)');
+});
+
+QUnit.test('should handle object keys as nulls', function() {
+  var context = {
+    colors: { apple: 'red', banana: 'yellow' },
+    key: null
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors key}}] [{{if true (get colors key)}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[] []', 'should return \'\' for {{get colors key}}  (key = null)');
+
+  run(function() {
+    view.set('context.key', 'banana');
+  });
+
+  equal(view.$().text(), '[yellow] [yellow]', 'should return \'yellow\' for {{get colors key}} (key = \'banana\')');
+
+  run(function() {
+    view.set('context.key', null);
+  });
+
+  equal(view.$().text(), '[] []', 'should return \'\' for {{get colors key}}  (key = null)');
+
+});
+
+QUnit.test('should handle object values and keys as nulls', function() {
+  var context = {
+    colors: null,
+    key: null
+  };
+
+  view = EmberView.create({
+    context: context,
+    template: compile('[{{get colors key}}] [{{if true (get colors key)}}]')
+  });
+
+  runAppend(view);
+
+  equal(view.$().text(), '[] []', 'should return \'\' for {{get colors key}}  (colors=null, key = null)');
+});
+
+}
+// jscs:enable validateIndentation


### PR DESCRIPTION
First rough shot at implementing the {{get}} keyword. Originally a helper it now needs to be a keyword to function correctly.

This work has come off the back of #11051 as well as a few comments from @wycats and @mmun about providing [ember-get-helper](https://github.com/jmurphyau/ember-get-helper) directly in Ember.
