### PR TITLE
[BUGFIX release] Fix for URL problem using currentURL() acceptance test helper

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -57,13 +57,15 @@ function focus(el) {
 
 function visit(app, url) {
   var router = app.__container__.lookup('router:main');
+  app.boot().then(function() {
+    router.location.setURL(url);
+  });
 
   if (app._readinessDeferrals > 0) {
     router['initialURL'] = url;
     run(app, 'advanceReadiness');
     delete router['initialURL'];
   } else {
-    router.location.setURL(url);
     run(app.__deprecatedInstance__, 'handleURL', url);
   }
 

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -12,7 +12,7 @@ import RSVP from "ember-runtime/ext/rsvp";
 //ES6TODO: we need {{link-to}}  and {{outlet}} to exist here
 import "ember-routing"; //ES6TODO: fixme?
 
-var App, find, click, fillIn, currentRoute, visit, originalAdapter, andThen, indexHitCount;
+var App, find, click, fillIn, currentRoute, currentURL, visit, originalAdapter, andThen, indexHitCount;
 
 QUnit.module("ember-testing Acceptance", {
   setup() {
@@ -83,6 +83,7 @@ QUnit.module("ember-testing Acceptance", {
     fillIn = window.fillIn;
     visit = window.visit;
     andThen = window.andThen;
+    currentURL = window.currentURL;
 
     originalAdapter = Test.adapter;
   },
@@ -99,12 +100,13 @@ QUnit.module("ember-testing Acceptance", {
 });
 
 QUnit.test("helpers can be chained with then", function() {
-  expect(5);
+  expect(6);
 
   currentRoute = 'index';
 
   visit('/posts').then(function() {
     equal(currentRoute, 'posts', "Successfully visited posts route");
+    equal(currentURL(), '/posts', "posts URL is correct");
     return click('a:contains("Comments")');
   }).then(function() {
     equal(currentRoute, 'comments', "visit chained with click");
@@ -125,7 +127,7 @@ QUnit.test("helpers can be chained with then", function() {
 // Keep this for backwards compatibility
 
 QUnit.test("helpers can be chained to each other", function() {
-  expect(5);
+  expect(7);
 
   currentRoute = 'index';
 
@@ -134,6 +136,7 @@ QUnit.test("helpers can be chained to each other", function() {
   .fillIn('.ember-text-field', "hello")
   .then(function() {
     equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(currentURL(), '/comments', "Comments URL is correct");
     equal(jQuery('.ember-text-field').val(), 'hello', "Fillin successfully works");
     find('.ember-text-field').one('keypress', function(e) {
       equal(e.keyCode, 13, "keyevent chained with correct keyCode.");
@@ -144,11 +147,12 @@ QUnit.test("helpers can be chained to each other", function() {
   .visit('/posts')
   .then(function() {
     equal(currentRoute, 'posts', "Thens can also be chained to helpers");
+    equal(currentURL(), '/posts', "URL is set correct on chained helpers");
   });
 });
 
 QUnit.test("helpers don't need to be chained", function() {
-  expect(3);
+  expect(5);
 
   currentRoute = 'index';
 
@@ -160,6 +164,7 @@ QUnit.test("helpers don't need to be chained", function() {
 
   andThen(function() {
     equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(currentURL(), '/comments', "Comments URL is correct");
     equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
   });
 
@@ -167,11 +172,12 @@ QUnit.test("helpers don't need to be chained", function() {
 
   andThen(function() {
     equal(currentRoute, 'posts');
+    equal(currentURL(), '/posts');
   });
 });
 
 QUnit.test("Nested async helpers", function() {
-  expect(3);
+  expect(5);
 
   currentRoute = 'index';
 
@@ -185,6 +191,7 @@ QUnit.test("Nested async helpers", function() {
 
   andThen(function() {
     equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(currentURL(), '/comments', "Comments URL is correct");
     equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
   });
 
@@ -192,11 +199,12 @@ QUnit.test("Nested async helpers", function() {
 
   andThen(function() {
     equal(currentRoute, 'posts');
+    equal(currentURL(), '/posts');
   });
 });
 
 QUnit.test("Multiple nested async helpers", function() {
-  expect(2);
+  expect(3);
 
   visit('/posts');
 
@@ -210,11 +218,12 @@ QUnit.test("Multiple nested async helpers", function() {
   andThen(function() {
     equal(find('.ember-text-field').val(), 'goodbye', "Fillin successfully works");
     equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(currentURL(), '/comments', "Comments URL is correct");
   });
 });
 
 QUnit.test("Helpers nested in thens", function() {
-  expect(3);
+  expect(5);
 
   currentRoute = 'index';
 
@@ -228,6 +237,7 @@ QUnit.test("Helpers nested in thens", function() {
 
   andThen(function() {
     equal(currentRoute, 'comments', "Successfully visited comments route");
+    equal(currentURL(), '/comments', "Comments URL is correct");
     equal(find('.ember-text-field').val(), 'hello', "Fillin successfully works");
   });
 
@@ -235,6 +245,7 @@ QUnit.test("Helpers nested in thens", function() {
 
   andThen(function() {
     equal(currentRoute, 'posts');
+    equal(currentURL(), '/posts', "Posts URL is correct");
   });
 });
 
@@ -287,16 +298,21 @@ QUnit.test("Unhandled exceptions in `andThen` are logged via Ember.Test.adapter#
 });
 
 QUnit.test("should not start routing on the root URL when visiting another", function() {
+  expect(4);
+
   visit('/posts');
 
   andThen(function() {
     ok(find('#comments-link'), 'found comments-link');
     equal(currentRoute, 'posts', "Successfully visited posts route");
+    equal(currentURL(), '/posts', "Posts URL is correct");
     equal(indexHitCount, 0, 'should not hit index route when visiting another route');
   });
 });
 
 QUnit.test("only enters the index route once when visiting /", function() {
+  expect(1);
+
   visit('/');
 
   andThen(function() {
@@ -305,6 +321,8 @@ QUnit.test("only enters the index route once when visiting /", function() {
 });
 
 QUnit.test("test must not finish while asyncHelpers are pending", function () {
+  expect(2);
+
   var async = 0;
   var innerRan = false;
 


### PR DESCRIPTION
Hello there, 

We attempted an upgrade to Ember 1.12 today and encountered an issue with using `currentURL()` in our acceptance tests. This problem, or something similar, has been reported in #10850, #10784, and most recently in #11175.

Digging in showed that it isn't so much that `currentURL()` isn't returning the correct url but that `visit()` isn't setting the url. 

I've added failing tests in `ember-testing/tests/acceptance_test.js` (and added some missing `expect`s). The actual fix, as I mention in my commit messages, is based on my limited understanding of the router, application, and application instance lifecycle. From the commits:

> It turns out that this isn't so much a problem with currentURL as it is
> the visit helper. When the lazy router location work was completed in
> 8e130e5 the call to `router.location.setURL()` was moved down in the
> else case after checking for readiness deferrals. The problem seems to be
> a timing issue with the call to setupRouter after the application is
> marked ready. The initialURL, while set, doesn't give us a reliable URL
> during tests.
> 
> The fix suggested here is based on my limited understanding of the
> lifecycle of the router during boot time. This passes the newly added
> url helper tests as well as the existing tests in the test suite.
> 
> If it isn't 'the fix' perhaps it can point a way to the real deal.

I'm happy to revise, edit, cleanup, or whatever is needed. Please ask if you have any questions.

Thanks for a fantastic project and I hope this helps.
