### PR TITLE
Ensure components for void tagNames do not have childNodes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.19",
+    "htmlbars": "0.13.20",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-htmlbars/tests/integration/void-element-component-test.js
+++ b/packages/ember-htmlbars/tests/integration/void-element-component-test.js
@@ -1,0 +1,47 @@
+import EmberView from "ember-views/views/view";
+import { Registry } from "ember-runtime/system/container";
+import compile from 'ember-template-compiler/system/compile';
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import ComponentLookup from 'ember-views/component_lookup';
+import Component from "ember-views/views/component";
+
+var registry, container, view;
+
+QUnit.module('ember-htmlbars: components for void elements', {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('component', { singleton: false });
+    registry.optionsForType('view', { singleton: false });
+    registry.optionsForType('template', { instantiate: false });
+    registry.optionsForType('helper', { instantiate: false });
+    registry.register('component-lookup:main', ComponentLookup);
+  },
+
+  teardown() {
+    runDestroy(container);
+    runDestroy(view);
+    registry = container = view = null;
+  }
+});
+
+QUnit.test('a void element does not have childNodes', function() {
+  var component;
+  registry.register('component:x-foo', Component.extend({
+    tagName: 'input',
+
+    init() {
+      this._super(...arguments);
+      component = this;
+    }
+  }));
+
+  view = EmberView.create({
+    container: container,
+    template: compile('{{x-foo}}')
+  });
+
+  runAppend(view);
+
+  deepEqual(component.element.childNodes.length, 0, 'no childNodes are added for `<input>`');
+});


### PR DESCRIPTION
The main work was done upstream in https://github.com/tildeio/htmlbars/issues/346.  

Fixes #11157.
