### PR TITLE
[BUGFIX release] Fix get with empty string

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -11,6 +11,7 @@ import {
 } from "ember-metal/path_cache";
 import { hasPropertyAccessors } from "ember-metal/platform/define_property";
 import { symbol } from "ember-metal/utils";
+import isNone from 'ember-metal/is_none';
 
 var FIRST_KEY = /^([^\.]+)/;
 
@@ -62,7 +63,7 @@ export function get(obj, keyName) {
   Ember.assert(`Cannot call get with ${keyName} key.`, !!keyName);
   Ember.assert(`Cannot call get with '${keyName}' on an undefined object.`, obj !== undefined);
 
-  if (!obj) {
+  if (isNone(obj)) {
     return _getPath(obj, keyName);
   }
 

--- a/packages/ember-metal/tests/accessors/get_path_test.js
+++ b/packages/ember-metal/tests/accessors/get_path_test.js
@@ -17,6 +17,7 @@ var moduleOpts = {
         }
       },
       falseValue: false,
+      emptyString: '',
       Wuz: {
         nar: 'foo'
       }
@@ -77,6 +78,10 @@ QUnit.test('[obj, this.Foo.bar] -> (undefined)', function() {
 
 QUnit.test('[obj, falseValue.notDefined] -> (undefined)', function() {
   equal(get(obj, 'falseValue.notDefined'), undefined);
+});
+
+QUnit.test('[obj, emptyString.length] -> 0', function() {
+  equal(get(obj, 'emptyString.length'), 0);
 });
 
 // ..........................................................


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/11204

The change introduced here: https://github.com/emberjs/ember.js/commit/1a3dde2ef03a63db1bb0e5b41fad57f0744fc438#diff-1b9682e6b936bfe3101e35ff6e574957R61 introduced this issue because it assumed that a falsey `obj` always meant it was not present. However if `obj` is a string it can be both falsey and present.
