### PR TITLE
Maintain `childViews` array.

### DIFF
--- a/packages/ember-htmlbars/lib/morphs/attr-morph.js
+++ b/packages/ember-htmlbars/lib/morphs/attr-morph.js
@@ -12,8 +12,8 @@ export var styleWarning = '' +
 
 function EmberAttrMorph(element, attrName, domHelper, namespace) {
   HTMLBarsAttrMorph.call(this, element, attrName, domHelper, namespace);
-
   this.streamUnsubscribers = null;
+  this.isAttrMorph = true;
 }
 
 var proto = EmberAttrMorph.prototype = o_create(HTMLBarsAttrMorph.prototype);

--- a/packages/ember-htmlbars/lib/morphs/morph.js
+++ b/packages/ember-htmlbars/lib/morphs/morph.js
@@ -7,6 +7,7 @@ let guid = 1;
 function EmberMorph(DOMHelper, contextualElement) {
   this.HTMLBarsMorph$constructor(DOMHelper, contextualElement);
 
+  this.isElementMorph = true;
   this.emberView = null;
   this.emberToDestroy = null;
   this.streamUnsubscribers = null;

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -70,8 +70,6 @@ ViewNodeManager.create = function(renderNode, env, attrs, found, parentView, pat
     } else {
       componentInfo.layout = getTemplate(component) || componentInfo.layout;
     }
-
-    renderNode.emberView = component;
   }
 
   Ember.assert("BUG: ViewNodeManager.create can take a scope or a self, but not both", !(contentScope && found.self));

--- a/packages/ember-htmlbars/tests/helpers/collection_test.js
+++ b/packages/ember-htmlbars/tests/helpers/collection_test.js
@@ -24,13 +24,13 @@ var TemplateTests, registry, container, lookup;
 
 
 function nthChild(view, nth) {
-  return get(view, 'childViews').objectAt(nth || 0);
+  return get(view, 'childViews')[nth || 0];
 }
 
 var firstChild = nthChild;
 
 function firstGrandchild(view) {
-  return get(get(view, 'childViews').objectAt(0), 'childViews').objectAt(0);
+  return get(get(view, 'childViews')[0], 'childViews')[0];
 }
 
 QUnit.module("collection helper", {

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -378,7 +378,7 @@ QUnit.test("it supports itemController", function() {
 
   assertText(view, "controller:Trek Glowackicontroller:Geoffrey Grosenbach");
 
-  strictEqual(view.childViews[0].get('_arrayController.target'), parentController, "the target property of the child controllers are set correctly");
+  strictEqual(get(view, 'childViews')[0].get('_arrayController.target'), parentController, "the target property of the child controllers are set correctly");
 });
 
 QUnit.test("itemController should not affect the DOM structure", function() {
@@ -1044,7 +1044,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
     assertText(view, "controller:parentController - controller:Trek Glowacki - controller:parentController - controller:Geoffrey Grosenbach - ");
 
-    strictEqual(view.childViews[0].get('_arrayController.target'), parentController, "the target property of the child controllers are set correctly");
+    strictEqual(get(view, 'childViews')[0].get('_arrayController.target'), parentController, "the target property of the child controllers are set correctly");
   });
 
   QUnit.test("itemController specified in ArrayController with name binding does not change context", function() {

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -116,7 +116,7 @@ QUnit.test("cursor position is not lost when updating content", function() {
   // set the cursor position to 3 (no selection)
   run(function() {
     input.value = 'derp';
-    view.childViews[0]._elementValueDidChange();
+    view.get('childViews')[0]._elementValueDidChange();
     input.selectionStart = 3;
     input.selectionEnd = 3;
   });

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -27,11 +27,11 @@ var view, originalLookup, registry, container, lookup;
 var trim = jQuery.trim;
 
 function firstGrandchild(view) {
-  return get(get(view, 'childViews').objectAt(0), 'childViews').objectAt(0);
+  return get(get(view, 'childViews')[0], 'childViews')[0];
 }
 
 function nthChild(view, nth) {
-  return get(view, 'childViews').objectAt(nth || 0);
+  return get(view, 'childViews')[nth || 0];
 }
 
 function viewClass(options) {
@@ -715,7 +715,7 @@ QUnit.test('Template views add an elementId to child views created using the vie
 
   runAppend(view);
 
-  var childView = get(view, 'childViews.firstObject');
+  var childView = get(view, 'childViews')[0];
   equal(view.$().children().first().children().first().attr('id'), get(childView, 'elementId'));
 });
 
@@ -1157,7 +1157,7 @@ QUnit.test('should expose a controller keyword that persists through Ember.Conta
 
   runAppend(view);
 
-  var containerView = get(view, 'childViews.firstObject');
+  var containerView = get(view, 'childViews')[0];
   var viewInstanceToBeInserted = EmberView.create({
     template: compile('{{controller.foo}}')
   });

--- a/packages/ember-htmlbars/tests/integration/will-destroy-element-hook-test.js
+++ b/packages/ember-htmlbars/tests/integration/will-destroy-element-hook-test.js
@@ -44,7 +44,6 @@ QUnit.test('willDestroyElement is only called once when a component leaves scope
   runAppend(component);
 
   assert.equal(component.$().text(), 'Truthy', 'precond - truthy template is displayed');
-  assert.equal(component.get('childViews.length'), 1);
 
   run(function() {
     set(component, 'switch', false);

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -75,6 +75,7 @@ Renderer.prototype.dispatchLifecycleHooks =
       }
 
       this.didRender(hook.view);
+      this.internalDidRender(hook.view);
     }
 
     ownerView._dispatching = null;
@@ -157,6 +158,10 @@ Renderer.prototype.didUpdate = function (view) {
 
 Renderer.prototype.didRender = function (view) {
   if (view.trigger) { view.trigger('didRender'); }
+};
+
+Renderer.prototype.internalDidRender = function (view) {
+  if (view.trigger) { view.trigger('_internalDidRender'); }
 };
 
 Renderer.prototype.updateAttrs = function (view, attrs) {

--- a/packages/ember-views/lib/mixins/legacy_view_support.js
+++ b/packages/ember-views/lib/mixins/legacy_view_support.js
@@ -17,12 +17,12 @@ var LegacyViewSupport = Mixin.create({
   afterRender(buffer) {},
 
   walkChildViews(callback) {
-    var childViews = this.childViews.slice();
+    var childViews = get(this, 'childViews').slice();
 
     while (childViews.length) {
       var view = childViews.pop();
       callback(view);
-      childViews.push(...view.childViews);
+      childViews.push(...get(view, 'childViews'));
     }
   },
 

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -4,8 +4,6 @@
 */
 import Ember from 'ember-metal/core';
 import { Mixin } from "ember-metal/mixin";
-import { removeObject } from "ember-metal/enumerable_utils";
-import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import setProperties from "ember-metal/set_properties";
 import { computed } from "ember-metal/computed";
@@ -48,7 +46,7 @@ var ViewChildViewsSupport = Mixin.create({
       }
     }
 
-    return Ember.A(childViews);
+    return childViews;
   }),
 
   init() {

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -300,7 +300,10 @@ var ContainerView = View.extend(MutableArray, {
         this.renderer.didDestroyElement(childViews[i]);
       }
     }
-  })
+  }),
+
+  // override default hook which notifies `childViews` property
+  _internalDidRender() { }
 });
 
 export default ContainerView;

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -28,22 +28,7 @@ merge(inDOM, {
 
   exit(view) {
     view._unregister();
-  },
-
-  appendAttr(view, attrNode) {
-    var childViews = view.childViews;
-
-    if (!childViews.length) { childViews = view.childViews = childViews.slice(); }
-    childViews.push(attrNode);
-
-    attrNode.parentView = view;
-    view.renderer.appendAttrTo(attrNode, view.element, attrNode.attrName);
-
-    view.propertyDidChange('childViews');
-
-    return attrNode;
   }
-
 });
 
 export default inDOM;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -924,7 +924,7 @@ var View = CoreView.extend(
   },
 
   forEachChildView(callback) {
-    var childViews = this.childViews;
+    var childViews = get(this, 'childViews');
 
     if (!childViews) { return this; }
 

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -32,7 +32,7 @@ function append() {
 }
 
 function selectedOptions() {
-  return select.get('childViews').mapBy('selected');
+  return Ember.A(select.get('childViews')).mapBy('selected');
 }
 
 QUnit.test('using the Ember.Select global is deprecated', function(assert) {

--- a/packages/ember-views/tests/views/view/destroy_element_test.js
+++ b/packages/ember-views/tests/views/view/destroy_element_test.js
@@ -57,7 +57,7 @@ QUnit.test("if it has a element, calls willDestroyElement on receiver and child 
   equal(parentCount, 1, 'invoked destroy element on the parent');
   equal(childCount, 1, 'invoked destroy element on the child');
   ok(!get(view, 'element'), 'view no longer has element');
-  ok(!get(get(view, 'childViews').objectAt(0), 'element'), 'child no longer has an element');
+  ok(!get(get(view, 'childViews')[0], 'element'), 'child no longer has an element');
 });
 
 QUnit.test("returns receiver", function() {

--- a/packages/ember-views/tests/views/view/element_test.js
+++ b/packages/ember-views/tests/views/view/element_test.js
@@ -30,7 +30,7 @@ QUnit.test("returns null if the view has no element and parent view has no eleme
   parentView = ContainerView.create({
     childViews: [EmberView.extend()]
   });
-  view = get(parentView, 'childViews').objectAt(0);
+  view = get(parentView, 'childViews')[0];
 
   equal(get(view, 'parentView'), parentView, 'precond - has parent view');
   equal(get(parentView, 'element'), null, 'parentView has no element');

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -200,7 +200,6 @@ QUnit.test("view should be notified after isVisible is set to false and the elem
 
 QUnit.test("view should be notified after isVisible is set to false and the element has been hidden", function() {
   view = View.create({ isVisible: true });
-  //var childView = view.get('childViews').objectAt(0);
 
   run(function() {
     view.append();
@@ -237,7 +236,7 @@ QUnit.test("view should be notified after isVisible is set to true and the eleme
 
 QUnit.test("if a view descends from a hidden view, making isVisible true should not trigger becameVisible", function() {
   view = View.create({ isVisible: true });
-  var childView = view.get('childViews').objectAt(0);
+  var childView = view.get('childViews')[0];
 
   run(function() {
     view.append();
@@ -266,7 +265,7 @@ QUnit.test("if a view descends from a hidden view, making isVisible true should 
 
 QUnit.test("if a child view becomes visible while its parent is hidden, if its parent later becomes visible, it receives a becameVisible callback", function() {
   view = View.create({ isVisible: false });
-  var childView = view.get('childViews').objectAt(0);
+  var childView = view.get('childViews')[0];
 
   run(function() {
     view.append();

--- a/packages/ember-views/tests/views/view/remove_test.js
+++ b/packages/ember-views/tests/views/view/remove_test.js
@@ -15,7 +15,7 @@ QUnit.module("View#removeChild", {
     expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
     parentView = ContainerView.create({ childViews: [View] });
-    child = get(parentView, 'childViews').objectAt(0);
+    child = get(parentView, 'childViews')[0];
   },
   teardown() {
     run(function() {
@@ -90,7 +90,7 @@ QUnit.test("removes view from parent view", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   parentView = ContainerView.create({ childViews: [View] });
-  child = get(parentView, 'childViews').objectAt(0);
+  child = get(parentView, 'childViews')[0];
   ok(get(child, 'parentView'), 'precond - has parentView');
 
   run(function() {
@@ -112,7 +112,7 @@ QUnit.test("returns receiver", function() {
   expectDeprecation("Setting `childViews` on a Container is deprecated.");
 
   parentView = ContainerView.create({ childViews: [View] });
-  child = get(parentView, 'childViews').objectAt(0);
+  child = get(parentView, 'childViews')[0];
   var removed = run(function() {
     return child.removeFromParent();
   });


### PR DESCRIPTION
The node-managers ensure that `willDestroyElement` (and other hooks) are called properly (by walking the much more precise `view._renderNode` tree), having the renderer's `willDestroyElement` also traverse `childViews` leads to `willDestroyElement` getting called twice in cases other than those for `ContainerView`.

Fixes #11077.
