### PR TITLE
Fix for issue with Em.computed.sort observers

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -513,11 +513,13 @@ function ReduceComputedProperty(options) {
         var previousDependentArray = meta.dependentArrays[dependentKey];
 
         if (dependentArray === previousDependentArray) {
+
           // The array may be the same, but our item property keys may have
           // changed, so we set them up again.  We can't easily tell if they've
           // changed: the array may be the same object, but with different
           // contents.
           if (cp._previousItemPropertyKeys[dependentKey]) {
+            meta.dependentArraysObserver.teardownPropertyObservers(dependentKey, cp._previousItemPropertyKeys[dependentKey]);
             delete cp._previousItemPropertyKeys[dependentKey];
             meta.dependentArraysObserver.setupPropertyObservers(dependentKey, cp._itemPropertyKeys[dependentKey]);
           }

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -837,6 +837,34 @@ QUnit.module('computedSort - sortProperties', {
 
 commonSortTests();
 
+QUnit.test("updating sort properties detaches observers for old sort properties", function() {
+  var objectToRemove = get(obj, 'items').objectAt(3);
+
+  run(function() {
+    sorted = get(obj, 'sortedItems');
+  });
+
+  deepEqual(sorted.mapBy('fname'), ['Cersei', 'Jaime', 'Bran', 'Robb'], "precond - array is initially sorted");
+
+  run(function() {
+    set(obj, 'itemSorting', Ember.A(['fname:desc']));
+  });
+
+  deepEqual(sorted.mapBy('fname'), ['Robb', 'Jaime', 'Cersei', 'Bran'], "after updating sort properties array is updated");
+
+  run(function() {
+    get(obj, 'items').removeObject(objectToRemove);
+  });
+
+  deepEqual(sorted.mapBy('fname'), ['Robb', 'Jaime', 'Cersei'], "after removing item array is updated");
+
+  run(function() {
+    set(objectToRemove, 'lname', 'Updated-Stark');
+  });
+
+  deepEqual(sorted.mapBy('fname'), ['Robb', 'Jaime', 'Cersei'], "after changing removed item array is not updated");
+});
+
 QUnit.test("updating sort properties updates the sorted array", function() {
   run(function() {
     sorted = get(obj, 'sortedItems');


### PR DESCRIPTION
Item property observers are not detached when 'sortProperties' array is changing. In some cases it causes exception when an item is being changed.

Here is an example that recreates the issue. http://emberjs.jsbin.com/zobufohete/1/edit (use chrome inspector to see the exception)
