### PR TITLE
[BUGFIX beta] Add test for unbound use with a container

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.20",
+    "htmlbars": "0.13.21",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -106,6 +106,30 @@ QUnit.test('should property escape unsafe hrefs', function() {
   }
 });
 
+QUnit.module('ember-htmlbars: {{#unbound}} helper with container present', {
+  setup() {
+    Ember.lookup = lookup = { Ember: Ember };
+
+    view = EmberView.create({
+      container: new Registry().container,
+      template: compile('{{unbound foo}}'),
+      context: EmberObject.create({
+        foo: 'bleep'
+      })
+    });
+  },
+
+  teardown() {
+    runDestroy(view);
+    Ember.lookup = originalLookup;
+  }
+});
+
+QUnit.test('it should render the current value of a property path on the context', function() {
+  runAppend(view);
+  equal(view.$().text(), 'bleep', 'should render the current value of a property path');
+});
+
 QUnit.module('ember-htmlbars: {{#unbound}} subexpression', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };


### PR DESCRIPTION
Tests were passing in this case because a container was not present. With a container, unbound should still work.

This test is fixed by https://github.com/tildeio/htmlbars/pull/347
