### PR TITLE
[BUGFIX beta] Failing test for two-way binding through CP

### DIFF
--- a/packages/ember-views/tests/compat/attrs_proxy_test.js
+++ b/packages/ember-views/tests/compat/attrs_proxy_test.js
@@ -7,6 +7,7 @@ import { set } from "ember-metal/property_set";
 import { get } from "ember-metal/property_get";
 import { observer } from "ember-metal/mixin";
 import { on } from "ember-metal/events";
+import { computed } from "ember-metal/computed";
 
 var view, registry, container;
 
@@ -100,4 +101,43 @@ QUnit.test('an observer on an attribute in the root of the component is fired wh
   });
 
   equal(view.$().text(), 'qux - 2', 'observer is fired on update');
+});
+
+QUnit.test('a two way binding flows upstream through a CP', function() {
+  expect(3);
+
+  var innerView;
+  registry.register('view:foo', View.extend({
+    init() {
+      this._super.apply(this, arguments);
+      innerView = this;
+    },
+    template: compile(''),
+    bar: computed({
+      get() {
+        return this._bar;
+      },
+      set(key, value) {
+        this._bar = value;
+        return this._bar;
+      }
+    })
+  }));
+
+  view = View.extend({
+    container: registry.container(),
+    baz: 'baz',
+    template: compile('{{view "foo" bar=view.baz}}')
+  }).create();
+
+  runAppend(view);
+
+  equal(view.get('baz'), 'baz', 'precond - initial CP value is baz');
+
+  run(function() {
+    set(innerView, 'bar', 'qux');
+  });
+
+  equal(innerView.get('bar'), 'qux', 'set CP is set');
+  equal(view.get('baz'), 'qux', 'set CP propagates upstream');
 });


### PR DESCRIPTION
Two way binding when a CP is present on the inner view does not propagate changes to the outer view.
