### PR TITLE
[BUGFIX beta] Pass label to Ember.Test.Promise

### DIFF
--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -173,9 +173,11 @@ var Test = {
     @public
     @method promise
     @param {Function} resolver The function used to resolve the promise.
+    @param {String} label An optional string for identifying the promise.
   */
-  promise(resolver) {
-    return new Test.Promise(resolver);
+  promise(resolver, label) {
+    var fullLabel = `Ember.Test.promise: ${label || "<Unknown Promise>"}`;
+    return new Test.Promise(resolver, fullLabel);
   },
 
   /**


### PR DESCRIPTION
This allows promises used in testing code to be labeled:

Example:

``` javascript
return Ember.Test.promise((resolve) => Ember.run.later(resolve, 1000), "Stall tests for 1 second");
```
