### PR TITLE
[BUGFIX beta] Don't dispatch new lifecycle hooks to views

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -98,7 +98,6 @@ ViewNodeManager.prototype.render = function(env, attrs, visitor) {
     if (component) {
       var snapshot = takeSnapshot(attrs);
       env.renderer.setAttrs(this.component, snapshot);
-      env.renderer.willCreateElement(component);
       env.renderer.willRender(component);
       env.renderedViews.push(component.elementId);
     }
@@ -145,10 +144,6 @@ ViewNodeManager.prototype.rerender = function(env, attrs, visitor) {
     }
     if (this.block) {
       this.block(newEnv, [], undefined, this.renderNode, this.scope, visitor);
-    }
-
-    if (component) {
-      env.lifecycleHooks.push({ type: 'didUpdate', view: component });
     }
 
     return newEnv;

--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -176,7 +176,7 @@ QUnit.test('lifecycle hooks are invoked in a predictable order', function() {
 
   // Because the `twitter` attr is only used by the topmost component,
   // and not passed down, we do not expect to see lifecycle hooks
-  // called for child components. If the `willReceiveAttrs` hook used
+  // called for child components. If the `didReceiveAttrs` hook used
   // the new attribute to rerender itself imperatively, that would result
   // in lifecycle hooks being invoked for the child.
 

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -116,9 +116,6 @@ Renderer.prototype.createElement =
     this.prerenderTopLevelView(view, morph);
   };
 
-// inBuffer
-Renderer.prototype.willCreateElement = function (/*view*/) {};
-
 Renderer.prototype.didCreateElement = function (view, element) {
   if (element) {
     view.element = element;
@@ -160,10 +157,6 @@ Renderer.prototype.didRender = function (view) {
 };
 
 Renderer.prototype.updateAttrs = function (view, attrs) {
-  if (view.willReceiveAttrs) {
-    view.willReceiveAttrs(attrs);
-  }
-
   this.setAttrs(view, attrs);
 }; // setting new attrs
 
@@ -175,8 +168,8 @@ Renderer.prototype.componentUpdateAttrs = function (component, oldAttrs, newAttr
 };
 
 Renderer.prototype.willUpdate = function (view, attrs) {
-  if (view.willUpdate) {
-    view.willUpdate(attrs);
+  if (view._willUpdate) {
+    view._willUpdate(attrs);
   }
 };
 
@@ -185,8 +178,8 @@ Renderer.prototype.componentWillUpdate = function (component) {
 };
 
 Renderer.prototype.willRender = function (view) {
-  if (view.willRender) {
-    view.willRender();
+  if (view._willRender) {
+    view._willRender();
   }
 };
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -401,7 +401,7 @@ var CollectionView = ContainerView.extend({
     return view;
   },
 
-  willRender: function() {
+  _willRender: function() {
     var attrs = this.attrs;
     var itemProps = buildItemViewProps(this._itemViewTemplate, attrs);
     this._itemViewProps = itemProps;

--- a/packages/ember-views/lib/views/legacy_each_view.js
+++ b/packages/ember-views/lib/views/legacy_each_view.js
@@ -27,7 +27,7 @@ export default View.extend({
     return controller;
   }),
 
-  willUpdate(attrs) {
+  _willUpdate(attrs) {
     let itemController = this.getAttrFor(attrs, 'itemController');
 
     if (itemController) {

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -37,7 +37,7 @@ var SelectOption = View.extend({
 
   content: null,
 
-  willRender() {
+  _willRender() {
     this.labelPathDidChange();
     this.valuePathDidChange();
   },
@@ -651,7 +651,7 @@ var Select = View.extend({
     }
   },
 
-  willRender() {
+  _willRender() {
     this._setDefaults();
   },
 

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -512,7 +512,7 @@ QUnit.test("should be able to modify childViews then rerender then modify again 
 
   var Child = View.extend({
     count: 0,
-    willRender: function() {
+    _willRender() {
       this.count++;
     },
     template: compile('{{view.label}}')
@@ -541,7 +541,7 @@ QUnit.test("should be able to modify childViews then rerender again the Containe
 
   var Child = View.extend({
     count: 0,
-    willRender() {
+    _willRender() {
       this.count++;
     },
     template: compile('{{view.label}}')


### PR DESCRIPTION
Patch for #11143

Since 84c2875, the lifecycle hooks are inconsistent between views and
components. For example, the `willReceiveAttrs` hook has been renamed to
`didReceiveAttrs` on components but not on views. Talked to @wycats about it,
the plan is "to remove all of the new lifecycle hooks from views", because
"views are sufficiently crazy that I don't want to try to mix in new semantics".

In this commit:
- [x] :scissors: `didUpdate` from `View`s
- [x] :scissors: `willReceiveAttrs` from `View`s
- [x] Rename `willRender` to `_willRender` on `View`s (for now)
- [x] Rename `willUpdate` to `_willUpdate` on `View`s (for now)

TODO:
- [ ] Refactor internal `View`s to not use `_willRender`
- [ ] Refactor internal `View`s to not use `_willUpdate`
- [ ] :scissors: `_willRender` from `View`s
- [ ] :scissors: `_willUpdate` from `View`s

@wycats can you c/d if this is on the right track?
