### PR TITLE
[BUGFIX beta] Add support for inspecting Symbols

### DIFF
--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -799,7 +799,8 @@ export function inspect(obj) {
     return '[' + obj + ']';
   }
   // for non objects
-  if (typeof obj !== 'object') {
+  var type = typeof obj;
+  if (type !== 'object' && type !== 'symbol') {
     return ''+obj;
   }
   // overridden toString

--- a/packages/ember-metal/tests/utils_test.js
+++ b/packages/ember-metal/tests/utils_test.js
@@ -1,0 +1,16 @@
+import { inspect } from 'ember-metal/utils';
+
+QUnit.module("Ember Metal Utils");
+
+QUnit.test("inspect outputs the toString() representation of Symbols", function() {
+  // Symbol is not defined on pre-ES2015 runtimes, so this let's us safely test
+  // for it's existence (where a simple `if (Symbol)` would ReferenceError)
+  let Symbol = Symbol || null;
+
+  if (Symbol) {
+    let symbol = Symbol('test');
+    equal(inspect(symbol), 'Symbol(test)');
+  } else {
+    expect(0);
+  }
+});


### PR DESCRIPTION
True Symbols cannot be coerced to a string, and typeof returns 'symbol'. This caused the inspect function treat it as a non-object is technically correct, since it's a new primitive type).

Adds an additional check to ensure the inspected value is not a Symbol before attempting string coercion. Symbols will fail, and fall through to the toString() implementation, which is the desired output.

**Note** because the unit tests seem to run in Node 0.10.x, which doesn't support Symbols, I'm not sure how to test this. I have a test case ready, but I can't actually run it because of the lack of Symbol support. Open to suggestions on how to tackle that.
