### PR TITLE
[FEATURE ember-htmlbars-each-helper-index-plus-one]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -310,3 +310,17 @@ for a detailed explanation.
   for each person.. E.g. a list of all `firstNames`, or `lastNames`, or `ages`.
 
   Addd in [#11196](https://github.com/emberjs/ember.js/pull/11196)
+  
+* `ember-htmlbars-each-helper-index-plus-one`
+  	
+  Adds a the result of `index + 1` (1-based index) as the third block param to the `{{#each}}` helper.
+  	
+  Example:
+
+  ```hbs
+  <ul>
+  {{#each pages as |page index pageNumber|}}
+    <li>Page: {{pageNumber}}</li>
+  {{/each}}
+  </ul>
+  ```

--- a/features.json
+++ b/features.json
@@ -19,7 +19,8 @@
     "ember-routing-core-outlet": null,
     "ember-libraries-isregistered": null,
     "ember-routing-htmlbars-improved-actions": true,
-    "ember-htmlbars-get-helper": null
+    "ember-htmlbars-get-helper": null,
+    "ember-htmlbars-each-helper-index-plus-one": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -65,7 +65,12 @@ export default function eachHelper(params, hash, blocks) {
       }
 
       var key = keyPath ? get(item, keyPath) : String(i);
-      blocks.template.yieldItem(key, [item, i], self);
+      var blockArguments = [item, i];
+      if (Ember.FEATURES.isEnabled('ember-htmlbars-each-helper-index-plus-one')) {
+        blockArguments.push(i + 1);
+      }
+
+      blocks.template.yieldItem(key, blockArguments, self);
     });
   } else if (blocks.inverse.yield) {
     blocks.inverse.yield();

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -1151,6 +1151,30 @@ function testEachWithItem(moduleName, useBlockParams) {
       });
       equal(view.$().text(), "0. Bob1. Steve");
     });
+
+    if (Ember.FEATURES.isEnabled('ember-htmlbars-each-helper-index-plus-one')) {
+      QUnit.test("the result of (index + 1) is passed as the third parameter to #each blocks", function() {
+        expect(3);
+
+        var adam = { name: "Adam" };
+        view = EmberView.create({
+          controller: A([adam, { name: "Steve" }]),
+          template: templateFor('{{#each this as |person index oneBasedIndex|}}{{oneBasedIndex}}. {{person.name}}{{/each}}', true)
+        });
+        runAppend(view);
+        equal(view.$().text(), "1. Adam2. Steve");
+
+        run(function() {
+          view.get('controller').unshiftObject({ name: "Bob" });
+        });
+        equal(view.$().text(), "1. Bob2. Adam3. Steve");
+
+        run(function() {
+          view.get('controller').removeObject(adam);
+        });
+        equal(view.$().text(), "1. Bob2. Steve");
+      });
+    }
   }
 }
 


### PR DESCRIPTION
1-based index, which IMO is much more commonly desired than zero-based for presentation. Since we don't ship with a built-in helper to `input + 1`, this seems natural.

``` hbs
<ul>
{{#each pages as |page index pageNumber|}}
  <li>Page: {{pageNumber}}</li>
{{/each}}
</ul>
```
