### PR TITLE
[BUGFIX beta] Resolve bootResolver before starting routing

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -718,6 +718,8 @@ var Application = Namespace.extend(DeferredMixin, {
     @method didBecomeReady
   */
   didBecomeReady() {
+    this._bootResolver.resolve();
+
     if (this.autoboot) {
       if (environment.hasDOM) {
         this.__deprecatedInstance__.setupEventDispatcher();
@@ -734,8 +736,6 @@ var Application = Namespace.extend(DeferredMixin, {
 
       this.resolve(this);
     }
-
-    this._bootResolver.resolve();
   },
 
   /**


### PR DESCRIPTION
`didBecomeReady` was starting the routing before actually resolving the bootResolver #11172
