### PR TITLE
[BUGFIX beta] Update supportsHistory to use Modernizr latest

### DIFF
--- a/packages/ember-routing/lib/location/util.js
+++ b/packages/ember-routing/lib/location/util.js
@@ -77,24 +77,25 @@ export function supportsHashChange(documentMode, global) {
 
 /*
   `userAgent` is a user agent string. We use user agent testing here, because
-  the stock Android browser in Gingerbread has a buggy versions of this API,
-  Before feature detecting, we blacklist a browser identifying as both Android 2
-  and Mobile Safari, but not Chrome.
+  the stock Android browser is known to have buggy versions of the History API,
+  in some Android versions.
 
   @private
   @function supportsHistory
 */
 export function supportsHistory(userAgent, history) {
   // Boosted from Modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
-  // The stock browser on Android 2.2 & 2.3 returns positive on history support
+  // The stock browser on Android 2.2 & 2.3, and 4.0.x returns positive on history support
   // Unfortunately support is really buggy and there is no clean way to detect
   // these bugs, so we fall back to a user agent sniff :(
 
-  // We only want Android 2, stock browser, and not Chrome which identifies
-  // itself as 'Mobile Safari' as well
-  if (userAgent.indexOf('Android 2') !== -1 &&
+  // We only want Android 2 and 4.0, stock browser, and not Chrome which identifies
+  // itself as 'Mobile Safari' as well, nor Windows Phone.
+  if ((userAgent.indexOf('Android 2.') !== -1 ||
+      (userAgent.indexOf('Android 4.0') !== -1)) &&
       userAgent.indexOf('Mobile Safari') !== -1 &&
-      userAgent.indexOf('Chrome') === -1) {
+      userAgent.indexOf('Chrome') === -1 &&
+      userAgent.indexOf('Windows Phone') === -1) {
     return false;
   }
 

--- a/packages/ember-routing/tests/location/util_test.js
+++ b/packages/ember-routing/tests/location/util_test.js
@@ -80,11 +80,58 @@ QUnit.test("Feature-Detecting onhashchange", function() {
   equal(supportsHashChange(8, { onhashchange() {} }), true, "When in IE8+, use onhashchange existence as evidence of the feature");
 });
 
+// jscs:disable
 QUnit.test("Feature-detecting the history API", function() {
   equal(supportsHistory("", { pushState: true }), true, "returns true if not Android Gingerbread and history.pushState exists");
   equal(supportsHistory("", {}), false, "returns false if history.pushState doesn't exist");
   equal(supportsHistory("", undefined), false, "returns false if history doesn't exist");
-  equal(supportsHistory("Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1", { pushState: true }),
-                        false, "returns false if Android Gingerbread stock browser claiming to support pushState");
+
+  equal(
+    supportsHistory(
+      "Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+      { pushState: true }
+    ),
+    false,
+    "returns false if Android 2.x stock browser (not Chrome) claiming to support pushState"
+  );
+
+  equal(
+    supportsHistory(
+      "Mozilla/5.0 (Linux; U; Android 4.0.3; nl-nl; GT-N7000 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+      { pushState: true }
+    ),
+    false,
+    "returns false for Android 4.0.x stock browser (not Chrome) claiming to support pushState"
+  );
+
+  equal(
+    supportsHistory(
+      "Mozilla/5.0 (Linux; U; Android 20.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+      { pushState: true }
+    ),
+    true,
+    "returns true if Android version begins with 2, but is greater than 2"
+  );
+
+  equal(
+    supportsHistory(
+      "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19",
+      { pushState: true }
+    ),
+    true,
+    "returns true for Chrome (not stock browser) on Android 4.0.x"
+  );
+  
+  // Windows Phone UA and History API: https://github.com/Modernizr/Modernizr/issues/1471
+  equal(
+    supportsHistory(
+      "Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Virtual) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537",
+      { pushState: true }
+    ),
+    true,
+    "returns true for Windows Phone 8.1 with misleading user agent string"
+  );
+
 });
+// jscs:enable
 


### PR DESCRIPTION
The existing supportsHistory check was borrowed from an older
version of Modernizr. This updates the check from the latest
Modernizr history detect[1], to do more thorough User Agent sniffing
:-(.

[1] https://github.com/Modernizr/Modernizr/blob/cc5340e99402d24ede04d9f8a2a38ce8ca4f47ec/feature-detects/history.js
