### PR TITLE
[BUGFIX release] always pass instance to instance initializers

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -664,9 +664,7 @@ var Application = Namespace.extend(DeferredMixin, {
     function handleReset() {
       run(instance, 'destroy');
 
-      this.buildDefaultInstance();
-
-      run.schedule('actions', this, 'domReady');
+      run.schedule('actions', this, 'domReady', this.buildDefaultInstance());
     }
 
     run.join(this, handleReset);

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -362,4 +362,26 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
       });
     });
   }
+
+  QUnit.test("Initializers get an instance on app reset", function() {
+    expect(2);
+
+    var MyApplication = Application.extend();
+
+    MyApplication.instanceInitializer({
+      name: 'giveMeAnInstance',
+      initialize(instance) {
+        ok(!!instance, 'Initializer got an instance');
+      }
+    });
+
+    run(function() {
+      app = MyApplication.create({
+        router: false,
+        rootElement: '#qunit-fixture'
+      });
+    });
+
+    run(app, 'reset');
+  });
 }


### PR DESCRIPTION
`Ember.Application#reset` runs instance initializers without passing the instance.
