### PR TITLE
[BUGFIX] Add test for Ember.VERSION SemVer validity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember",
   "license": "MIT",
-  "version": "2.0.0-beta.1+canary",
+  "version": "2.0.0-canary",
   "scripts": {
     "build": "ember build --environment production",
     "postinstall": "bower install",
@@ -19,7 +19,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "^0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.1.1",
+    "emberjs-build": "0.1.2",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",

--- a/packages/ember-metal/tests/main_test.js
+++ b/packages/ember-metal/tests/main_test.js
@@ -1,5 +1,8 @@
 import Ember from "ember-metal/core";
 
+// From sindresourhus/semver-regex https://github.com/sindresorhus/semver-regex/blob/795b05628d96597ebcbe6d31ef4a432858365582/index.js#L3
+var SEMVER_REGEX = /^\bv?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b$/;
+
 QUnit.module('ember-metal/core/main');
 
 QUnit.test('Ember registers itself', function() {
@@ -7,5 +10,25 @@ QUnit.test('Ember registers itself', function() {
 
   equal(lib.name, 'Ember');
   equal(lib.version, Ember.VERSION);
+});
+
+QUnit.test("Ember.VERSION is in alignment with SemVer v2.0.0", function () {
+  ok(SEMVER_REGEX.test(Ember.VERSION), `Ember.VERSION (${Ember.VERSION})is valid SemVer v2.0.0`);
+});
+
+QUnit.test("SEMVER_REGEX properly validates and invalidates version numbers", function () {
+  function validateVersionString(versionString, expectedResult) {
+    equal(SEMVER_REGEX.test(versionString), expectedResult);
+  }
+
+  // Postive test cases
+  validateVersionString('1.11.3', true);
+  validateVersionString('1.0.0-beta.16.1', true);
+  validateVersionString('1.12.1+canary.aba1412', true);
+  validateVersionString('2.0.0-beta.1+canary.bb344775', true);
+
+  // Negative test cases
+  validateVersionString('1.11.3.aba18a', false);
+  validateVersionString('1.11', false);
 });
 


### PR DESCRIPTION
Bug Report: #11256 

Related: https://github.com/cibernox/git-repo-version/pull/7 https://github.com/emberjs/emberjs-build/pull/99

TODO: 
- [x] Test to validate a given version
- [x] Upgrade ember-build [to include the fix for future versions of Ember](//github.com/emberjs/emberjs-build/pull/99)
- [x] A couple of additional tests to prove that this regex works 
