### PR TITLE
[BUGFIX beta] fix passing array argument to action helper

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/closure-action.js
@@ -63,7 +63,8 @@ function createClosureAction(target, action, valuePath, actionArguments) {
     closureAction = function() {
       var args = actionArguments;
       if (arguments.length > 0) {
-        args = actionArguments.concat(...arguments);
+        var passedArguments = Array.prototype.slice.apply(arguments);
+        args = actionArguments.concat(passedArguments);
       }
       if (valuePath && args.length > 0) {
         args[0] = get(args[0], valuePath);

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -164,6 +164,42 @@ if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
     innerComponent.fireAction();
   });
 
+  QUnit.test("array arguments are passed correctly to action", function(assert) {
+    assert.expect(3);
+
+    const first = 'foo';
+    const second = [3, 5];
+    const third = [4, 9];
+
+    innerComponent = EmberComponent.extend({
+      fireAction() {
+        this.attrs.submit(second, third);
+      }
+    }).create();
+
+    outerComponent = EmberComponent.extend({
+      layout: compile(`
+        {{view innerComponent submit=(action outerSubmit first)}}
+      `),
+      innerComponent,
+      value: '',
+      outerSubmit(actualFirst, actualSecond, actualThird) {
+        assert.equal(actualFirst, first, 'action has the correct first arg');
+        assert.equal(actualSecond, second, 'action has the correct second arg');
+        assert.equal(actualThird, third, 'action has the correct third arg');
+      }
+    }).create();
+
+    runAppend(outerComponent);
+
+    run(function() {
+      outerComponent.set('first', first);
+      outerComponent.set('second', second);
+    });
+
+    innerComponent.fireAction();
+  });
+
   QUnit.test("mut values can be wrapped in actions, are settable", function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
Currently, given an action with at least one wrapped closure argument, calling that action with an array argument causes the elements of that array get flattened into individual arguments for the handler:

``` js
///app/components/inner-component.js
export default Ember.Component.extend({
  click() {
    this.sendAction('someAction', [3, 4, 5]);
  }
});
```

``` hbs
{{!-- app/templates/components/outer-component.hbs --}}

{{inner-component someAction=(action "foo" "bar")}}
```

``` js
///app/components/outer-component.js
export default Ember.Component.extend({
  actions: {
    foo(arg1, arg2, arg3, arg4) {
      // arg1 === "foo"
      // arg2 === 3
      // arg3 === 4
      // arg4 === 5
    }
  }
});
```

The `foo` handler should instead be receiving two arguments, `"bar"`, and `[3, 4, 5]`.
