### PR TITLE
Validate Ember object types in resolver

### DIFF
--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -14,6 +14,7 @@ import {
 import EmberObject from 'ember-runtime/system/object';
 import Namespace from 'ember-runtime/system/namespace';
 import helpers from 'ember-htmlbars/helpers';
+import validateType from 'ember-application/utils/validate-type';
 
 export var Resolver = EmberObject.extend({
   /**
@@ -170,6 +171,10 @@ export default EmberObject.extend({
 
     if (parsedName.root && parsedName.root.LOG_RESOLVER) {
       this._logLookup(resolved, parsedName);
+    }
+
+    if (resolved) {
+      validateType(resolved, parsedName);
     }
 
     return resolved;

--- a/packages/ember-application/lib/utils/validate-type.js
+++ b/packages/ember-application/lib/utils/validate-type.js
@@ -1,0 +1,25 @@
+/**
+@module ember
+@submodule ember-application
+*/
+
+let VALIDATED_TYPES = {
+  route:     ['isRouteFactory',     'Ember.Route'],
+  component: ['isComponentFactory', 'Ember.Component'],
+  view:      ['isViewFactory',      'Ember.View'],
+  service:   ['isServiceFactory',   'Ember.Service']
+};
+
+export default function validateType(resolvedType, parsedName) {
+  let validationAttributes = VALIDATED_TYPES[parsedName.type];
+
+  if (!validationAttributes) {
+    return;
+  }
+
+  let [factoryFlag, expectedType] = validationAttributes;
+
+  Ember.assert(`Expected ${parsedName.fullName} to resolve to an ${expectedType} but instead it was ${resolvedType}.`, function() {
+    return resolvedType[factoryFlag];
+  });
+}

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -1,7 +1,13 @@
 import Ember from "ember-metal/core"; // Ember.TEMPLATES
 import run from "ember-metal/run_loop";
+import { forEach } from "ember-metal/enumerable_utils";
+import { capitalize } from "ember-runtime/system/string";
 import Logger from "ember-metal/logger";
 import Controller from "ember-runtime/controllers/controller";
+import Route from "ember-routing/system/route";
+import Component from "ember-views/views/component";
+import View from "ember-views/views/view";
+import Service from "ember-runtime/system/service";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import Application from "ember-application/system/application";
@@ -169,4 +175,35 @@ QUnit.test("lookup description", function() {
   equal(registry.describe('controller:foo.bar'), 'App.FooBarController', 'dots are removed');
   equal(registry.describe('model:foo'), 'App.Foo', "models don't get appended at the end");
 
+});
+
+QUnit.test("validating resolved objects", function() {
+  let types = ['route', 'component', 'view', 'service'];
+
+  // Valid setup
+  application.FooRoute = Route.extend();
+  application.FooComponent = Component.extend();
+  application.FooView = View.extend();
+  application.FooService = Service.extend();
+
+  forEach(types, function(type) {
+    // No errors when resolving correct object types
+    registry.resolve(`${type}:foo`);
+
+    // Unregister to clear cache
+    registry.unregister(`${type}:foo`);
+  });
+
+  // Invalid setup
+  application.FooRoute = Component.extend();
+  application.FooComponent = View.extend();
+  application.FooView = Service.extend();
+  application.FooService = Route.extend();
+
+  forEach(types, function(type) {
+    let matcher = new RegExp(`to resolve to an Ember.${capitalize(type)}`);
+    expectAssertion(function() {
+      registry.resolve(`${type}:foo`);
+    }, matcher, `Should assert for ${type}`);
+  });
 });

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1931,6 +1931,10 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
   }
 });
 
+Route.reopenClass({
+  isRouteFactory: true
+});
+
 var defaultQPMeta = {
   qps: [],
   map: {},

--- a/packages/ember-runtime/lib/system/service.js
+++ b/packages/ember-runtime/lib/system/service.js
@@ -37,4 +37,10 @@ createInjectionHelper('service');
   @extends Ember.Object
   @since 1.10.0
 */
-export default Object.extend();
+const Service = Object.extend();
+
+Service.reopenClass({
+  isServiceFactory: true
+});
+
+export default Service;

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -90,7 +90,7 @@ var ViewChildViewsSupport = Mixin.create({
     var view;
     attrs.renderer = this.renderer;
 
-    if (maybeViewClass.isViewClass) {
+    if (maybeViewClass.isViewFactory) {
       attrs.container = this.container;
 
       view = maybeViewClass.create(attrs);

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -390,4 +390,8 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
   */
 });
 
+Component.reopenClass({
+  isComponentFactory: true
+});
+
 export default Component;

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -132,7 +132,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
 });
 
 CoreView.reopenClass({
-  isViewClass: true
+  isViewFactory: true
 });
 
 export var DeprecatedCoreView = CoreView.extend({


### PR DESCRIPTION
@rwjblue This is to address https://github.com/emberjs/ember.js/issues/11212.

This commit adds assertions to ensure that some key object types
are validated when they are resolved:
- Routes
- Components
- Views
- Services

I did not add a validation for controller classes because the
implementation for detection would need to be a little different (can't
simply use #detect). Also some of Ember's tests play fast (and loose)
with with the types of things they try to pass off as controllers. For
now I don't think this additional validation is worth adding given
imminent demise of Controllers.
