### PR TITLE
Fix basic Fastboot usage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",
     "rsvp": "~3.0.6",
-    "simple-dom": "^0.1.1",
+    "simple-dom": "^0.2.3",
     "testem": "^0.8.0-0"
   }
 }

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -252,6 +252,7 @@ export function createComponent(_component, isAngleBracket, _props, renderNode, 
     props._isAngleBracket = true;
   }
 
+  props.renderer = props.parentView ? props.parentView.renderer : env.container.lookup('renderer:-dom');
   let component = _component.create(props);
 
   // for the fallback case

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -171,6 +171,7 @@ export function createOrUpdateComponent(component, options, createOptions, rende
 
     mergeBindings(props, shadowedAttrs(proto, snapshot));
     props.container = options.parentView ? options.parentView.container : env.container;
+    props.renderer = options.parentView ? options.parentView.renderer : props.container && props.container.lookup('renderer:-dom');
 
     if (proto.controller !== defaultController || hasSuppliedController) {
       delete props._context;

--- a/packages/ember-htmlbars/lib/system/bootstrap.js
+++ b/packages/ember-htmlbars/lib/system/bootstrap.js
@@ -74,8 +74,8 @@ function _bootstrap() {
   bootstrap(jQuery(document));
 }
 
-function registerComponentLookup(registry) {
-  registry.register('component-lookup:main', ComponentLookup);
+function registerComponentLookup(app) {
+  app.registry.register('component-lookup:main', ComponentLookup);
 }
 
 /*
@@ -95,9 +95,8 @@ onLoad('Ember.Application', function(Application) {
     initialize: environment.hasDOM ? _bootstrap : function() { }
   });
 
-  Application.initializer({
+  Application.instanceInitializer({
     name: 'registerComponentLookup',
-    after: 'domTemplates',
     initialize: registerComponentLookup
   });
 });

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -167,7 +167,7 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
     assert.ok(serializer.serialize(view.element).match(/<h1>Hello World<\/h1>/));
   });
 
-  QUnit.skip("It is possible to render a view with a nested {{view}} helper in Node", function(assert) {
+  QUnit.test("It is possible to render a view with a nested {{view}} helper in Node", function(assert) {
     var View = Ember.Component.extend({
       renderer: new Ember.View._Renderer(new DOMHelper(new SimpleDOM.Document())),
       layout: compile("<h1>Hello {{#if hasExistence}}{{location}}{{/if}}</h1> <div>{{view bar}}</div>"),
@@ -178,9 +178,7 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
       })
     });
 
-    var view = View.create({
-      _domHelper: new DOMHelper(new SimpleDOM.Document())
-    });
+    var view = View.create();
 
     run(view, view.createElement);
 
@@ -188,7 +186,7 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
     assert.ok(serializer.serialize(view.element).match(/<h1>Hello World<\/h1> <div><div id="(.*)" class="ember-view"><p>The files are \*inside\* the computer\?\!<\/p><\/div><\/div>/));
   });
 
-  QUnit.skip("It is possible to render a view with {{link-to}} in Node", function(assert) {
+  QUnit.test("It is possible to render a view with {{link-to}} in Node", function(assert) {
     run(function() {
       app = createApplication();
 
@@ -205,11 +203,11 @@ if (canUseInstanceInitializers && canUseApplicationVisit) {
     return app.visit('/').then(function(instance) {
       var element = renderToElement(instance);
 
-      assertHTMLMatches(assert, element.firstChild, /^<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" class="ember-view" href="\/photos">Go to photos<\/a><\/h1><\/div>$/);
+      assertHTMLMatches(assert, element.firstChild, /^<div id="ember\d+" class="ember-view"><h1><a id="ember\d+" href="\/photos" class="ember-view">Go to photos<\/a><\/h1><\/div>$/);
     });
   });
 
-  QUnit.skip("It is possible to render outlets in Node", function(assert) {
+  QUnit.test("It is possible to render outlets in Node", function(assert) {
     run(function() {
       app = createApplication();
 


### PR DESCRIPTION
- Update to latest simple-dom.
- Ensure `renderer` is passed through to views/components created.

Thanks to @code0100fun for fixing things upstream in simple-dom!

Fixes #11115.
