### PR TITLE
[FEATURE ember-htmlbars-component-generation] Disabled by default.

### DIFF
--- a/features.json
+++ b/features.json
@@ -3,7 +3,7 @@
     "features-stripped-test": null,
     "ember-routing-named-substates": true,
     "mandatory-setter": "development-only",
-    "ember-htmlbars-component-generation": true,
+    "ember-htmlbars-component-generation": null,
     "ember-htmlbars-component-helper": true,
     "ember-htmlbars-inline-if-helper": true,
     "ember-htmlbars-attribute-syntax": true,


### PR DESCRIPTION
A number of issues have been discovered for this feature that make it clear that further consideration is needed before enabling by default.
- Cannot use angle-bracket invocation in contexts that require specific tags.  For example: you cannot use `<table><custom-row model=stuff /></table>` because in a `<table>` context like this, you can only use `<tr>`
- Need to treat `<some-thing />` as blockless and `<some-thing></some-thing>` as having a block. Both scenarios are considered block invocation today.
- Cannot use angle-bracket invocation to use components in a subdirectory.
- Other things...

A more thorough review of what this means for future timing will be coming in a blog post by @wycats shortly...
