### PR TITLE
Consolidate duplicated method

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -288,35 +288,17 @@ ChainNode.prototype = {
     }
 
     if (this._parent) {
-      this._parent.chainWillChange(this, this._key, 1, events);
+      this._parent.notifyChainChange(this, this._key, 1, events);
     }
   },
 
-  chainWillChange(chain, path, depth, events) {
+  notifyChainChange(chain, path, depth, events) {
     if (this._key) {
       path = this._key + '.' + path;
     }
 
     if (this._parent) {
-      this._parent.chainWillChange(this, path, depth + 1, events);
-    } else {
-      if (depth > 1) {
-        events.push(this.value(), path);
-      }
-      path = 'this.' + path;
-      if (this._paths[path] > 0) {
-        events.push(this.value(), path);
-      }
-    }
-  },
-
-  chainDidChange(chain, path, depth, events) {
-    if (this._key) {
-      path = this._key + '.' + path;
-    }
-
-    if (this._parent) {
-      this._parent.chainDidChange(this, path, depth + 1, events);
+      this._parent.notifyChainChange(this, path, depth + 1, events);
     } else {
       if (depth > 1) {
         events.push(this.value(), path);
@@ -364,7 +346,7 @@ ChainNode.prototype = {
 
     // and finally tell parent about my path changing...
     if (this._parent) {
-      this._parent.chainDidChange(this, this._key, 1, events);
+      this._parent.notifyChainChange(this, this._key, 1, events);
     }
   }
 };


### PR DESCRIPTION
@krisselden Since you merged the last PR, I thought I would push my luck and try to get another one in to keep working on the clarity in the chains logic.

In this case I consolidated `chainWillChange` and `chainDidChange` into one method since the two were identical.

I know that having two similar code paths can be good for optimization if it results in more consistent set of arguments passed to each function. However, it doesn't appear that these two methods were serving that purpose.
