### PR TITLE
[BUGFIX beta] Remove deprecation for `classBinding` and `classNameBindings`.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -370,12 +370,10 @@ QUnit.test("allows you to pass attributes that will be assigned to the class ins
 });
 
 QUnit.test("Should apply class without condition always", function() {
-  expectDeprecation(function() {
-    view = EmberView.create({
-      controller: Ember.Object.create(),
-      template: compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
-    });
-  }, /legacy class binding syntax/);
+  view = EmberView.create({
+    controller: Ember.Object.create(),
+    template: compile('{{#view id="foo" classBinding=":foo"}} Foo{{/view}}')
+  });
 
   runAppend(view);
 
@@ -855,12 +853,10 @@ QUnit.test('{{view}} should evaluate class bindings set to global paths DEPRECAT
     });
   });
 
-  expectDeprecation(function() {
-    view = EmberView.create({
-      textField: TextField,
-      template: compile('{{view view.textField class="unbound" classBinding="App.isGreat:great App.directClass App.isApp App.isEnabled:enabled:disabled"}}')
-    });
-  }, /legacy class binding/);
+  view = EmberView.create({
+    textField: TextField,
+    template: compile('{{view view.textField class="unbound" classBinding="App.isGreat:great App.directClass App.isApp App.isEnabled:enabled:disabled"}}')
+  });
 
   expectDeprecation(function() {
     runAppend(view);
@@ -886,16 +882,14 @@ QUnit.test('{{view}} should evaluate class bindings set to global paths DEPRECAT
 });
 
 QUnit.test('{{view}} should evaluate class bindings set in the current context', function() {
-  expectDeprecation(function() {
-    view = EmberView.create({
-      isView:      true,
-      isEditable:  true,
-      directClass: 'view-direct',
-      isEnabled: true,
-      textField: TextField,
-      template: compile('{{view view.textField class="unbound" classBinding="view.isEditable:editable view.directClass view.isView view.isEnabled:enabled:disabled"}}')
-    });
-  }, /legacy class binding syntax/);
+  view = EmberView.create({
+    isView:      true,
+    isEditable:  true,
+    directClass: 'view-direct',
+    isEnabled: true,
+    textField: TextField,
+    template: compile('{{view view.textField class="unbound" classBinding="view.isEditable:editable view.directClass view.isView view.isEnabled:enabled:disabled"}}')
+  });
 
   runAppend(view);
 
@@ -926,12 +920,10 @@ QUnit.test('{{view}} should evaluate class bindings set with either classBinding
     });
   });
 
-  expectDeprecation(function() {
-    view = EmberView.create({
-      textField: TextField,
-      template: compile('{{view view.textField class="unbound" classBinding="App.isGreat:great App.isEnabled:enabled:disabled" classNameBindings="App.isGreat:really-great App.isEnabled:really-enabled:really-disabled"}}')
-    });
-  }, /legacy class binding/);
+  view = EmberView.create({
+    textField: TextField,
+    template: compile('{{view view.textField class="unbound" classBinding="App.isGreat:great App.isEnabled:enabled:disabled" classNameBindings="App.isGreat:really-great App.isEnabled:really-enabled:really-disabled"}}')
+  });
 
   expectDeprecation(function() {
     runAppend(view);
@@ -996,9 +988,7 @@ QUnit.test('{{view}} should evaluate other attributes bindings set in the curren
 });
 
 QUnit.test('{{view}} should be able to bind class names to truthy properties', function() {
-  expectDeprecation(function() {
-    registry.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy"}}foo{{/view}}'));
-  }, /legacy class binding syntax/);
+  registry.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy"}}foo{{/view}}'));
 
   var ClassBindingView = EmberView.extend();
 
@@ -1021,9 +1011,7 @@ QUnit.test('{{view}} should be able to bind class names to truthy properties', f
 });
 
 QUnit.test('{{view}} should be able to bind class names to truthy or falsy properties', function() {
-  expectDeprecation(function() {
-    registry.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy:is-falsy"}}foo{{/view}}'));
-  }, /legacy class binding syntax/);
+  registry.register('template:template', compile('{{#view view.classBindingView classBinding="view.number:is-truthy:is-falsy"}}foo{{/view}}'));
 
   var ClassBindingView = EmberView.extend();
 

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
@@ -1,6 +1,3 @@
-import Ember from 'ember-metal/core';
-import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
-
 export default function TransformOldClassBindingSyntax(options) {
   this.syntax = null;
   this.options = options;
@@ -9,7 +6,6 @@ export default function TransformOldClassBindingSyntax(options) {
 TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassBindingSyntax_transform(ast) {
   var b = this.syntax.builders;
   var walker = new this.syntax.Walker();
-  var moduleName = this.options.moduleName;
 
   walker.visit(ast, function(node) {
     if (!validate(node)) { return; }
@@ -46,10 +42,8 @@ TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassB
 
     each(allOfTheMicrosyntaxes, ({ value, loc }) => {
       let sexprs = [];
-      let sourceInformation = calculateLocationDisplay(moduleName, loc);
-
-      // TODO: Parse the microsyntax and offer the correct information
-      Ember.deprecate(`You're using legacy class binding syntax: classBinding=${exprToString(value)} ${sourceInformation}. Please replace with class=""`);
+      // TODO: add helpful deprecation when both `classNames` and `classNameBindings` can
+      // be removed.
 
       if (value.type === 'StringLiteral') {
         let microsyntax = parseMicrosyntax(value.original);
@@ -124,11 +118,4 @@ function parseMicrosyntax(string) {
   }
 
   return segments;
-}
-
-function exprToString(expr) {
-  switch (expr.type) {
-    case 'StringLiteral': return `"${expr.original}"`;
-    case 'PathExpression': return expr.original;
-  }
 }


### PR DESCRIPTION
We ultimately want to deprecate `classBinding` and `classNameBindings` in favor of using
angle bracket component invocation.

At this time, the angle bracket invocation syntax is not enabled by default, and we do not want folks to have to refactor their templates twice.

Closes https://github.com/emberjs/ember.js/issues/11263.
