### PR TITLE
prevent accidental publishing to canary/others by contributors

### DIFF
--- a/bin/bower_ember_build
+++ b/bin/bower_ember_build
@@ -16,6 +16,17 @@ echo -e "COMPONENTS_EMBER_REPO_SLUG: ${COMPONENTS_EMBER_REPO_SLUG}\n"
 echo -e "INCLUDED_FILES: ${INCLUDED_FILES}\n"
 echo -e "CURRENT_BRANCH: ${TRAVIS_BRANCH}\n"
 
+if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+  echo "not publishing because this is a pull request."
+  exit 0
+fi
+
+if [[ -z $GH_TOKEN ]]; then
+  echo "secure environment variables not detected."
+  echo "not a repo owner, exiting."
+  exit 0
+fi
+
 # Set channel to publish to.  If no suitable branch is found exit successfully.
 case $TRAVIS_BRANCH in
   "master" )


### PR DESCRIPTION
From the Travis CI docs:

http://docs.travis-ci.com/user/ci-environment/

For builds not triggered by a pull request this is the name of the
branch currently being built; whereas for builds triggered by a pull
request this is the name of the branch targeted by the pull request (in
many cases this will be master, which will publish to "canary").

This was building for branches not intended to be published because they
were opened as a pull request against master (which set `$TRAVIS_BRANCH`
to `master` when a pull request was opened). As Ember core contributors
frequently work off the main repository this is an unwanted side effect.
