### PR TITLE
[BUGFIX beta] Unify AST plugin location display.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -1007,7 +1007,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     var template;
     expectDeprecation(function() {
       template = templateFor('{{#EACH|people|person|itemController="person"}}{{controllerName}} - {{person.controllerName}} - {{/each}}', useBlockParams);
-    }, /Using 'itemController' with '{{each}}' @L1/);
+    }, /Using 'itemController' with '{{each}}'/);
 
     view = EmberView.create({
       template,

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -205,7 +205,7 @@ QUnit.test("input tabindex is updated when setting tabindex property of view", f
 QUnit.test('specifying `on="someevent" action="foo"` triggers the action', function() {
   expect(2);
   runDestroy(view);
-  expectDeprecation(`Using '{{input on="focus-in" action="doFoo"}} 'foo.hbs' @L1:C0 is deprecated. Please use '{{input focus-in="doFoo"}}' instead.`);
+  expectDeprecation(`Using '{{input on="focus-in" action="doFoo"}}' ('foo.hbs' @ L1:C0) is deprecated. Please use '{{input focus-in="doFoo"}}' instead.`);
 
   controller = {
     send(actionName, value, sender) {

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -243,7 +243,7 @@ QUnit.test("mixing old and new styles of property binding fires a warning, treat
   let compiled;
   expectDeprecation(function() {
     compiled = compile("{{#view borfBinding=view.snork}}<p id='lol'>{{view.borf}}</p>{{/view}}");
-  }, "You're using legacy binding syntax: borfBinding=view.snork @ 1:8 in (inline). Please replace with borf=view.snork");
+  }, "You're using legacy binding syntax: borfBinding=view.snork (L1:C8) . Please replace with borf=view.snork");
 
   view = EmberView.extend({
     template: compiled,
@@ -271,7 +271,7 @@ QUnit.test('"Binding"-suffixed bindings are runloop-synchronized [DEPRECATED]', 
   let compiled;
   expectDeprecation(function() {
     compiled = compile('<h1>{{view view.Subview colorBinding="view.color"}}</h1>');
-  }, `You're using legacy binding syntax: colorBinding="view.color" @ 1:24 in (inline). Please replace with color=view.color`);
+  }, `You're using legacy binding syntax: colorBinding="view.color" (L1:C24) . Please replace with color=view.color`);
 
   var View = EmberView.extend({
     color: "mauve",
@@ -826,7 +826,7 @@ QUnit.test('{{view}} should not allow attributeBindings to be set', function() {
       template: compile('{{view attributeBindings="one two"}}')
     });
     runAppend(view);
-  }, "Setting 'attributeBindings' via template helpers is not allowed @ 1:7 in (inline)");
+  }, /Setting 'attributeBindings' via template helpers is not allowed/);
 });
 
 QUnit.test('{{view}} should be able to point to a local view', function() {

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -26,7 +26,7 @@ function testWithAs(moduleName, templateString, deprecated) {
       if (deprecated) {
         expectDeprecation(function() {
           template = compile(templateString);
-        }, "Using {{with}} without block syntax is deprecated. Please use standard block form (`{{#with foo as |bar|}}`) instead.");
+        }, "Using {{with}} without block syntax (L1:C0) is deprecated. Please use standard block form (`{{#with foo as |bar|}}`) instead.");
       } else {
         template = compile(templateString);
       }

--- a/packages/ember-htmlbars/tests/integration/select_in_template_test.js
+++ b/packages/ember-htmlbars/tests/integration/select_in_template_test.js
@@ -240,7 +240,7 @@ function testValueBinding(templateString) {
 }
 
 QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using valueBinding [DEPRECATED]", function() {
-  expectDeprecation(`You're using legacy binding syntax: valueBinding="view.val" @ 1:176 in (inline). Please replace with value=view.val`);
+  expectDeprecation(`You're using legacy binding syntax: valueBinding="view.val" (L1:C176) . Please replace with value=view.val`);
 
   testValueBinding(
     '{{view view.selectView viewName="select"' +
@@ -292,7 +292,7 @@ function testSelectionBinding(templateString) {
 }
 
 QUnit.test("select element should correctly initialize and update selectedIndex and bound properties when using selectionBinding [DEPRECATED]", function() {
-  expectDeprecation(`You're using legacy binding syntax: contentBinding="view.collection" @ 1:44 in (inline). Please replace with content=view.collection`);
+  expectDeprecation(`You're using legacy binding syntax: contentBinding="view.collection" (L1:C44) . Please replace with content=view.collection`);
 
   testSelectionBinding(
     '{{view view.selectView viewName="select"' +

--- a/packages/ember-template-compiler/lib/plugins/transform-bind-attr-to-attributes.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-bind-attr-to-attributes.js
@@ -5,6 +5,7 @@
 
 import Ember from "ember-metal/core"; // Ember.assert
 import { dasherize } from "ember-template-compiler/system/string";
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
 
 /**
   An HTMLBars AST transformation that replaces all instances of
@@ -161,20 +162,7 @@ TransformBindAttrToAttributes.prototype.parseClass = function parseClass(value) 
 function isBindAttrModifier(modifier, moduleName) {
   var name = modifier.path.original;
 
-  let { column, line } = modifier.path.loc.start || {};
-  let moduleInfo = '';
-
-  if (moduleName) {
-    moduleInfo +=  `'${moduleName}' @ `;
-  }
-
-  if (line && column) {
-    moduleInfo += `L${line}:C${column}`;
-  }
-
-  if (moduleInfo) {
-    moduleInfo = `(${moduleInfo}) `;
-  }
+  let moduleInfo = calculateLocationDisplay(moduleName, modifier.path.loc);
 
   if (name === 'bind-attr' || name === 'bindAttr') {
     Ember.deprecate(

--- a/packages/ember-template-compiler/lib/plugins/transform-each-into-collection.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-into-collection.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-metal/core';
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
 
 export default function TransformEachIntoCollection(options) {
   this.options = options;
@@ -6,7 +7,7 @@ export default function TransformEachIntoCollection(options) {
 }
 
 TransformEachIntoCollection.prototype.transform = function TransformEachIntoCollection_transform(ast) {
-  var options = this.options;
+  var moduleName = this.options.moduleName;
   var b = this.syntax.builders;
   var walker = new this.syntax.Walker();
 
@@ -14,18 +15,10 @@ TransformEachIntoCollection.prototype.transform = function TransformEachIntoColl
     let legacyHashKey = validate(node);
     if (!legacyHashKey) { return; }
 
-    let { column, line } = legacyHashKey.loc.start || {};
-    let moduleInfo = '';
-    if (options.moduleName) {
-      moduleInfo +=  `'${options.moduleName}' `;
-    }
-
-    if (line && column) {
-      moduleInfo += `@L${line}:C${column}`;
-    }
+    let moduleInfo = calculateLocationDisplay(moduleName, legacyHashKey.loc);
 
     Ember.deprecate(
-      `Using '${legacyHashKey.key}' with '{{each}}' ${moduleInfo} is deprecated.  Please refactor to a component.`
+      `Using '${legacyHashKey.key}' with '{{each}}' ${moduleInfo}is deprecated.  Please refactor to a component.`
     );
 
     let list = node.params.shift();

--- a/packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js
@@ -1,3 +1,5 @@
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
+
 /**
  @module ember
  @submodule ember-htmlbars
@@ -36,6 +38,7 @@ TransformInputOnToOnEvent.prototype.transform = function TransformInputOnToOnEve
   const pluginContext = this;
   const b = pluginContext.syntax.builders;
   const walker = new pluginContext.syntax.Walker();
+  const moduleName = pluginContext.options.moduleName;
 
   walker.visit(ast, function(node) {
     if (pluginContext.validate(node)) {
@@ -43,11 +46,11 @@ TransformInputOnToOnEvent.prototype.transform = function TransformInputOnToOnEve
       let on = hashPairForKey(node.hash, 'on');
       let onEvent = hashPairForKey(node.hash, 'onEvent');
       let normalizedOn = on || onEvent;
-      let moduleInfo = pluginContext.calculateModuleInfo(node.loc);
+      let moduleInfo = calculateLocationDisplay(moduleName, node.loc);
 
       if (normalizedOn && normalizedOn.value.type !== 'StringLiteral') {
         Ember.deprecate(
-          `Using a dynamic value for '#{normalizedOn.key}=' with the '{{input}}' helper ${moduleInfo} is deprecated.`
+          `Using a dynamic value for '#{normalizedOn.key}=' with the '{{input}}' helper ${moduleInfo}is deprecated.`
         );
 
         normalizedOn.key = 'onEvent';
@@ -59,7 +62,7 @@ TransformInputOnToOnEvent.prototype.transform = function TransformInputOnToOnEve
 
       if (!action) {
         Ember.deprecate(
-          `Using '{{input ${normalizedOn.key}="${normalizedOn.value.value}" ...}}' without specifying an action ${moduleInfo} will do nothing.`
+          `Using '{{input ${normalizedOn.key}="${normalizedOn.value.value}" ...}}' without specifying an action ${moduleInfo}will do nothing.`
         );
 
         return; // exit early, if no action was available there is nothing to do
@@ -76,7 +79,7 @@ TransformInputOnToOnEvent.prototype.transform = function TransformInputOnToOnEve
       let expected = `${normalizedOn ? normalizedOn.value.value : 'enter'}="${action.value.original}"`;
 
       Ember.deprecate(
-        `Using '{{input ${specifiedOn}action="${action.value.original}"}} ${moduleInfo} is deprecated. Please use '{{input ${expected}}}' instead.`
+        `Using '{{input ${specifiedOn}action="${action.value.original}"}}' ${moduleInfo}is deprecated. Please use '{{input ${expected}}}' instead.`
       );
       if (!normalizedOn) {
         normalizedOn = b.pair('onEvent', b.string('enter'));
@@ -100,20 +103,6 @@ TransformInputOnToOnEvent.prototype.validate = function TransformWithAsToHash_va
         hashPairForKey(node.hash, 'on') ||
         hashPairForKey(node.hash, 'onEvent')
     );
-};
-
-TransformInputOnToOnEvent.prototype.calculateModuleInfo = function TransformInputOnToOnEvent_calculateModuleInfo(loc) {
-  let { column, line } = loc.start || {};
-  let moduleInfo = '';
-  if (this.options.moduleName) {
-    moduleInfo +=  `'${this.options.moduleName}' `;
-  }
-
-  if (line !== undefined && column !== undefined) {
-    moduleInfo += `@L${line}:C${column}`;
-  }
-
-  return moduleInfo;
 };
 
 function hashPairForKey(hash, key) {

--- a/packages/ember-template-compiler/lib/plugins/transform-old-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-binding-syntax.js
@@ -1,10 +1,13 @@
 import Ember from 'ember-metal/core';
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
 
-export default function TransformOldBindingSyntax() {
+export default function TransformOldBindingSyntax(options) {
   this.syntax = null;
+  this.options = options;
 }
 
 TransformOldBindingSyntax.prototype.transform = function TransformOldBindingSyntax_transform(ast) {
+  var moduleName = this.options.moduleName;
   var b = this.syntax.builders;
   var walker = new this.syntax.Walker();
 
@@ -14,13 +17,7 @@ TransformOldBindingSyntax.prototype.transform = function TransformOldBindingSynt
     each(node.hash.pairs, function(pair) {
       let { key, value } = pair;
 
-      var sourceInformation = '';
-
-      if (pair.loc) {
-        let { start, source } = pair.loc;
-
-        sourceInformation = `@ ${start.line}:${start.column} in ${source || '(inline)'}`;
-      }
+      var sourceInformation = calculateLocationDisplay(moduleName, pair.loc);
 
       if (key === 'classBinding') { return; }
 

--- a/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-old-class-binding-syntax.js
@@ -1,12 +1,15 @@
 import Ember from 'ember-metal/core';
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
 
-export default function TransformOldClassBindingSyntax() {
+export default function TransformOldClassBindingSyntax(options) {
   this.syntax = null;
+  this.options = options;
 }
 
 TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassBindingSyntax_transform(ast) {
   var b = this.syntax.builders;
   var walker = new this.syntax.Walker();
+  var moduleName = this.options.moduleName;
 
   walker.visit(ast, function(node) {
     if (!validate(node)) { return; }
@@ -43,13 +46,7 @@ TransformOldClassBindingSyntax.prototype.transform = function TransformOldClassB
 
     each(allOfTheMicrosyntaxes, ({ value, loc }) => {
       let sexprs = [];
-
-      let sourceInformation = "";
-      if (loc) {
-        let { start, source } = loc;
-
-        sourceInformation = `@ ${start.line}:${start.column} in ${source || '(inline)'}`;
-      }
+      let sourceInformation = calculateLocationDisplay(moduleName, loc);
 
       // TODO: Parse the microsyntax and offer the correct information
       Ember.deprecate(`You're using legacy class binding syntax: classBinding=${exprToString(value)} ${sourceInformation}. Please replace with class=""`);
@@ -135,4 +132,3 @@ function exprToString(expr) {
     case 'PathExpression': return expr.original;
   }
 }
-

--- a/packages/ember-template-compiler/lib/plugins/transform-with-as-to-hash.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-with-as-to-hash.js
@@ -3,6 +3,8 @@
 @submodule ember-htmlbars
 */
 
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
+
 /**
   An HTMLBars AST transformation that replaces all instances of
 
@@ -44,10 +46,11 @@ TransformWithAsToHash.prototype.transform = function TransformWithAsToHash_trans
         throw new Error('You cannot use keyword (`{{with foo as bar}}`) and block params (`{{with foo as |bar|}}`) at the same time.');
       }
 
+      let moduleInfo = calculateLocationDisplay(moduleName, node.program.loc);
+
       Ember.deprecate(
-        "Using {{with}} without block syntax is deprecated. " +
+        "Using {{with}} without block syntax " + moduleInfo + "is deprecated. " +
         "Please use standard block form (`{{#with foo as |bar|}}`) " +
-        (moduleName ? " in `" + moduleName + "` " : "") +
         "instead.",
         false,
         { url: "http://emberjs.com/deprecations/v1.x/#toc_code-as-code-sytnax-for-code-with-code" }

--- a/packages/ember-template-compiler/lib/system/calculate-location-display.js
+++ b/packages/ember-template-compiler/lib/system/calculate-location-display.js
@@ -1,0 +1,22 @@
+export default function calculateLocationDisplay(moduleName, _loc) {
+  let loc = _loc || {};
+  let { column, line } = loc.start || {};
+  let moduleInfo = '';
+  if (moduleName) {
+    moduleInfo +=  `'${moduleName}' `;
+  }
+
+  if (line !== undefined && column !== undefined) {
+    if (moduleName) {
+      // only prepend @ if the moduleName was present
+      moduleInfo += '@ ';
+    }
+    moduleInfo += `L${line}:C${column}`;
+  }
+
+  if (moduleInfo) {
+    moduleInfo = `(${moduleInfo}) `;
+  }
+
+  return moduleInfo;
+}

--- a/packages/ember-template-compiler/tests/plugins/transform-each-into-collection-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-each-into-collection-test.js
@@ -12,7 +12,7 @@ function testBlockForm(attr) {
       compile(`\n\n    {{#each model ${attr}="foo" as |item|}}{{item}}{{/each}}`, {
         moduleName: 'lol-wat-app/index/template'
       });
-    }, `Using '${attr}' with '{{each}}' 'lol-wat-app/index/template' @L3:C18 is deprecated.  Please refactor to a component.`);
+    }, `Using '${attr}' with '{{each}}' ('lol-wat-app/index/template' @ L3:C18) is deprecated.  Please refactor to a component.`);
   });
 }
 
@@ -24,7 +24,7 @@ function testNonBlockForm(attr) {
       compile(`\n\n    {{each model ${attr}="foo"}}`, {
         moduleName: 'lol-wat-app/index/template'
       });
-    }, `Using '${attr}' with '{{each}}' 'lol-wat-app/index/template' @L3:C17 is deprecated.  Please refactor to a component.`);
+    }, `Using '${attr}' with '{{each}}' ('lol-wat-app/index/template' @ L3:C17) is deprecated.  Please refactor to a component.`);
   });
 }
 

--- a/packages/ember-template-compiler/tests/plugins/transform-input-on-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-input-on-test.js
@@ -9,7 +9,7 @@ QUnit.test("Using `action` without `on` provides a deprecation", function() {
     compile('{{input action="foo"}}', {
       moduleName: 'foo/bar/baz'
     });
-  }, `Using '{{input action="foo"}} 'foo/bar/baz' @L1:C0 is deprecated. Please use '{{input enter="foo"}}' instead.`);
+  }, `Using '{{input action="foo"}}' ('foo/bar/baz' @ L1:C0) is deprecated. Please use '{{input enter="foo"}}' instead.`);
 });
 
 QUnit.test("Using `action` with `on` provides a deprecation", function() {
@@ -19,7 +19,7 @@ QUnit.test("Using `action` with `on` provides a deprecation", function() {
     compile('{{input on="focus-in" action="foo"}}', {
       moduleName: 'foo/bar/baz'
     });
-  }, `Using '{{input on="focus-in" action="foo"}} 'foo/bar/baz' @L1:C0 is deprecated. Please use '{{input focus-in="foo"}}' instead.`);
+  }, `Using '{{input on="focus-in" action="foo"}}' ('foo/bar/baz' @ L1:C0) is deprecated. Please use '{{input focus-in="foo"}}' instead.`);
 });
 
 QUnit.test("Using `on='keyPress'` does not clobber `keyPress`", function() {
@@ -29,7 +29,7 @@ QUnit.test("Using `on='keyPress'` does not clobber `keyPress`", function() {
     compile('{{input on="keyPress" action="foo"}}', {
       moduleName: 'foo/bar/baz'
     });
-  }, `Using '{{input on="keyPress" action="foo"}} 'foo/bar/baz' @L1:C0 is deprecated. Please use '{{input key-press="foo"}}' instead.`);
+  }, `Using '{{input on="keyPress" action="foo"}}' ('foo/bar/baz' @ L1:C0) is deprecated. Please use '{{input key-press="foo"}}' instead.`);
 });
 
 QUnit.test("Using `on='foo'` without `action='asdf'` raises specific deprecation", function() {
@@ -39,5 +39,5 @@ QUnit.test("Using `on='foo'` without `action='asdf'` raises specific deprecation
     compile('{{input on="asdf"}}', {
       moduleName: 'foo/bar/baz'
     });
-  }, `Using '{{input on="asdf" ...}}' without specifying an action 'foo/bar/baz' @L1:C0 will do nothing.`);
+  }, `Using '{{input on="asdf" ...}}' without specifying an action ('foo/bar/baz' @ L1:C0) will do nothing.`);
 });

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -100,7 +100,7 @@ QUnit.test("{{#each}} inside outlet can have an itemController", function(assert
         <p>hi</p>
       {{/each}}
     `);
-  }, `Using 'itemController' with '{{each}}' @L2:C20 is deprecated.  Please refactor to a component.`);
+  }, `Using 'itemController' with '{{each}}' (L2:C20) is deprecated.  Please refactor to a component.`);
 
   App.IndexController = Ember.Controller.extend({
     model: Ember.A([1, 2, 3])


### PR DESCRIPTION
Fixes a number of AST walker deprecations that were previously always displaying `inline` instead
of the module name.
