### PR TITLE
Implement Ember.Helper: RFC#53.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -310,3 +310,8 @@ for a detailed explanation.
   for each person.. E.g. a list of all `firstNames`, or `lastNames`, or `ages`.
 
   Addd in [#11196](https://github.com/emberjs/ember.js/pull/11196)
+
+* `ember-htmlbars-helper`
+
+  Implements RFC https://github.com/emberjs/rfcs/pull/53, a public helper
+  api.

--- a/features.json
+++ b/features.json
@@ -20,7 +20,8 @@
     "ember-routing-route-configured-query-params": null,
     "ember-libraries-isregistered": null,
     "ember-routing-htmlbars-improved-actions": true,
-    "ember-htmlbars-get-helper": null
+    "ember-htmlbars-get-helper": null,
+    "ember-htmlbars-helper": true
   },
   "debugStatements": [
     "Ember.warn",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.25",
+    "htmlbars": "0.13.28",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1016,7 +1016,6 @@ Application.reopenClass({
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
 
     registry.register('application:main', namespace, { instantiate: false });
 

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -15,7 +15,6 @@ import EmberObject from 'ember-runtime/system/object';
 import Namespace from 'ember-runtime/system/namespace';
 import helpers from 'ember-htmlbars/helpers';
 import validateType from 'ember-application/utils/validate-type';
-import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 export var Resolver = EmberObject.extend({
   /*
@@ -375,11 +374,7 @@ export default EmberObject.extend({
     @public
   */
   resolveHelper(parsedName) {
-    var resolved = this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
-    if (resolved && !resolved.isHelperFactory && !resolved.isHelperInstance && !resolved.isHTMLBars && typeof resolved === 'function') {
-      resolved = new HandlebarsCompatibleHelper(resolved);
-    }
-    return resolved;
+    return this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
   },
   /**
     Look up the specified object (from parsedName) on the appropriate

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -15,6 +15,7 @@ import EmberObject from 'ember-runtime/system/object';
 import Namespace from 'ember-runtime/system/namespace';
 import helpers from 'ember-htmlbars/helpers';
 import validateType from 'ember-application/utils/validate-type';
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 export var Resolver = EmberObject.extend({
   /*
@@ -374,7 +375,11 @@ export default EmberObject.extend({
     @public
   */
   resolveHelper(parsedName) {
-    return this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
+    var resolved = this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
+    if (resolved && !resolved.isHelperFactory && !resolved.isHelperInstance && !resolved.isHTMLBars && typeof resolved === 'function') {
+      resolved = new HandlebarsCompatibleHelper(resolved);
+    }
+    return resolved;
   },
   /**
     Look up the specified object (from parsedName) on the appropriate

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -10,7 +10,6 @@ import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import Application from "ember-application/system/application";
 import Helper, { helper as makeHelper } from "ember-htmlbars/helper";
-import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 import makeHandlebarsBoundHelper from "ember-htmlbars/compat/make-bound-helper";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 import makeHTMLBarsBoundHelper from "ember-htmlbars/system/make_bound_helper";
@@ -145,7 +144,7 @@ QUnit.test("the default resolver resolves helpers on the namespace", function() 
 
   equal(resolvedShorthand, ShorthandHelper, 'resolve fetches the shorthand helper factory');
   equal(resolvedComplete, CompleteHelper, 'resolve fetches the complete helper factory');
-  ok(resolvedLegacy instanceof HandlebarsCompatibleHelper, 'legacy function helper is wrapped in HandlebarsCompatibleHelper');
+  ok(typeof resolvedLegacy === 'function', 'legacy function helper is resolved');
   equal(resolvedView, ViewHelper, 'resolves view helper');
   equal(resolvedLegacyHTMLBars, LegacyHTMLBarsBoundHelper, 'resolves legacy HTMLBars bound helper');
   equal(resolvedLegacyHandlebars, LegacyHandlebarsBoundHelper, 'resolves legacy Handlebars bound helper');

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -9,7 +9,7 @@ import Service from "ember-runtime/system/service";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import Application from "ember-application/system/application";
-import Helper from "ember-htmlbars/helper";
+import Helper, { helper as makeHelper } from "ember-htmlbars/helper";
 import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 import makeHandlebarsBoundHelper from "ember-htmlbars/compat/make-bound-helper";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
@@ -107,7 +107,7 @@ QUnit.test("the default resolver resolves helpers", function() {
 });
 
 QUnit.test("the default resolver resolves container-registered helpers", function() {
-  let shorthandHelper = Helper.helper(function() {});
+  let shorthandHelper = makeHelper(function() {});
   let helper = Helper.extend();
 
   application.register('helper:shorthand', shorthandHelper);
@@ -122,7 +122,7 @@ QUnit.test("the default resolver resolves container-registered helpers", functio
 });
 
 QUnit.test("the default resolver resolves helpers on the namespace", function() {
-  let ShorthandHelper = Helper.helper(function() {});
+  let ShorthandHelper = makeHelper(function() {});
   let CompleteHelper = Helper.extend();
   let LegacyBareFunctionHelper = function() {};
   let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(function() {});

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -1,0 +1,25 @@
+import Object from "ember-runtime/system/object";
+
+// Ember.Helper.extend({ compute(params, hash) {} });
+var Helper = Object.extend({
+  isHelper: true,
+  recompute() {
+    this._stream.notify();
+  }
+});
+
+Helper.reopenClass({
+  isHelperFactory: true
+});
+
+// Ember.Helper.helper(function(params, hash) {});
+export function helper(helperFn) {
+  return {
+    isHelperInstance: true,
+    compute: helperFn
+  };
+}
+
+Helper.helper = helper;
+
+export default Helper;

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -20,6 +20,4 @@ export function helper(helperFn) {
   };
 }
 
-Helper.helper = helper;
-
 export default Helper;

--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -5,6 +5,7 @@
 
 import { findHelper } from "ember-htmlbars/system/lookup-helper";
 import { handleRedirect } from "htmlbars-runtime/hooks";
+import { buildHelperStream } from "ember-htmlbars/system/invoke-helper";
 
 var fakeElement;
 
@@ -32,7 +33,8 @@ export default function emberElement(morph, env, scope, path, params, hash, visi
   var result;
   var helper = findHelper(path, scope.self, env);
   if (helper) {
-    result = env.hooks.invokeHelper(null, env, scope, null, params, hash, helper, { element: morph.element }).value;
+    var helperStream = buildHelperStream(helper, params, hash, { element: morph.element }, env, scope);
+    result = helperStream.value();
   } else {
     result = env.hooks.get(env, scope, path);
   }

--- a/packages/ember-htmlbars/lib/hooks/has-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/has-helper.js
@@ -1,5 +1,17 @@
-import { findHelper } from "ember-htmlbars/system/lookup-helper";
+import { validateLazyHelperName } from "ember-htmlbars/system/lookup-helper";
 
 export default function hasHelperHook(env, scope, helperName) {
-  return !!findHelper(helperName, scope.self, env);
+  if (env.helpers[helperName]) {
+    return true;
+  }
+
+  var container = env.container;
+  if (validateLazyHelperName(helperName, container, env.hooks.keywords)) {
+    var containerName = 'helper:' + helperName;
+    if (container._registry.has(containerName)) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -31,7 +31,7 @@ import legacyEachWithKeywordHelper from "ember-htmlbars/helpers/-legacy-each-wit
 import getHelper from "ember-htmlbars/helpers/-get";
 import htmlSafeHelper from "ember-htmlbars/helpers/-html-safe";
 import DOMHelper from "ember-htmlbars/system/dom-helper";
-import Helper from "ember-htmlbars/helper";
+import Helper, { helper as makeHelper } from "ember-htmlbars/helper";
 
 // importing adds template bootstrapping
 // initializer to enable embedded templates
@@ -72,4 +72,7 @@ Ember.HTMLBars = {
   DOMHelper
 };
 
-Ember.Helper = Helper;
+if (Ember.FEATURES.isEnabled('ember-htmlbars-helpers')) {
+  Helper.helper = makeHelper;
+  Ember.Helper = Helper;
+}

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -31,6 +31,7 @@ import legacyEachWithKeywordHelper from "ember-htmlbars/helpers/-legacy-each-wit
 import getHelper from "ember-htmlbars/helpers/-get";
 import htmlSafeHelper from "ember-htmlbars/helpers/-html-safe";
 import DOMHelper from "ember-htmlbars/system/dom-helper";
+import Helper from "ember-htmlbars/helper";
 
 // importing adds template bootstrapping
 // initializer to enable embedded templates
@@ -70,3 +71,5 @@ Ember.HTMLBars = {
   registerPlugin: registerPlugin,
   DOMHelper
 };
+
+Ember.Helper = Helper;

--- a/packages/ember-htmlbars/lib/streams/built-in-helper.js
+++ b/packages/ember-htmlbars/lib/streams/built-in-helper.js
@@ -1,0 +1,27 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import {
+  getArrayValues,
+  getHashValues
+} from "ember-htmlbars/streams/utils";
+
+export default function BuiltInHelperStream(helper, params, hash, templates, env, scope, context, label) {
+  this.init(label);
+  this.helper = helper;
+  this.params = params;
+  this.templates = templates;
+  this.env = env;
+  this.scope = scope;
+  this.hash = hash;
+  this.context = context;
+}
+
+BuiltInHelperStream.prototype = create(Stream.prototype);
+
+merge(BuiltInHelperStream.prototype, {
+  compute() {
+    // Using call and undefined is probably not needed, these are only internal
+    return this.helper.call(this.context, getArrayValues(this.params), getHashValues(this.hash), this.templates, this.env, this.scope);
+  }
+});

--- a/packages/ember-htmlbars/lib/streams/compat-helper.js
+++ b/packages/ember-htmlbars/lib/streams/compat-helper.js
@@ -1,0 +1,22 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+
+export default function CompatHelperStream(helper, params, hash, templates, env, scope, label) {
+  this.init(label);
+  this.helper = helper.helperFunction;
+  this.params = params;
+  this.templates = templates;
+  this.env = env;
+  this.scope = scope;
+  this.hash = hash;
+}
+
+CompatHelperStream.prototype = create(Stream.prototype);
+
+merge(CompatHelperStream.prototype, {
+  compute() {
+    // Using call and undefined is probably not needed, these are only internal
+    return this.helper.call(undefined, this.params, this.hash, this.templates, this.env, this.scope);
+  }
+});

--- a/packages/ember-htmlbars/lib/streams/helper-factory.js
+++ b/packages/ember-htmlbars/lib/streams/helper-factory.js
@@ -1,0 +1,35 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import {
+  getArrayValues,
+  getHashValues
+} from "ember-htmlbars/streams/utils";
+
+export default function HelperFactoryStream(helperFactory, params, hash, label) {
+  this.init(label);
+  this.helperFactory = helperFactory;
+  this.params = params;
+  this.hash = hash;
+  this.linkable = true;
+  this.helper = null;
+}
+
+HelperFactoryStream.prototype = create(Stream.prototype);
+
+merge(HelperFactoryStream.prototype, {
+  compute() {
+    if (!this.helper) {
+      this.helper = this.helperFactory.create({ _stream: this });
+    }
+    return this.helper.compute(getArrayValues(this.params), getHashValues(this.hash));
+  },
+  deactivate() {
+    this.super$deactivate();
+    if (this.helper) {
+      this.helper.destroy();
+      this.helper = null;
+    }
+  },
+  super$deactivate: HelperFactoryStream.prototype.deactivate
+});

--- a/packages/ember-htmlbars/lib/streams/helper-instance.js
+++ b/packages/ember-htmlbars/lib/streams/helper-instance.js
@@ -1,0 +1,23 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import {
+  getArrayValues,
+  getHashValues
+} from "ember-htmlbars/streams/utils";
+
+export default function HelperInstanceStream(helper, params, hash, label) {
+  this.init(label);
+  this.helper = helper;
+  this.params = params;
+  this.hash = hash;
+  this.linkable = true;
+}
+
+HelperInstanceStream.prototype = create(Stream.prototype);
+
+merge(HelperInstanceStream.prototype, {
+  compute() {
+    return this.helper.compute(getArrayValues(this.params), getHashValues(this.hash));
+  }
+});

--- a/packages/ember-htmlbars/lib/streams/utils.js
+++ b/packages/ember-htmlbars/lib/streams/utils.js
@@ -1,0 +1,21 @@
+import getValue from "ember-htmlbars/hooks/get-value";
+
+// We don't want to leak mutable cells into helpers, which
+// are pure functions that can only work with values.
+export function getArrayValues(params) {
+  let out = [];
+  for (let i=0, l=params.length; i<l; i++) {
+    out.push(getValue(params[i]));
+  }
+
+  return out;
+}
+
+export function getHashValues(hash) {
+  let out = {};
+  for (let prop in hash) {
+    out[prop] = getValue(hash[prop]);
+  }
+
+  return out;
+}

--- a/packages/ember-htmlbars/lib/system/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/system/invoke-helper.js
@@ -1,0 +1,17 @@
+import HelperInstanceStream from "ember-htmlbars/streams/helper-instance";
+import HelperFactoryStream from "ember-htmlbars/streams/helper-factory";
+import BuiltInHelperStream from "ember-htmlbars/streams/built-in-helper";
+import CompatHelperStream from "ember-htmlbars/streams/compat-helper";
+
+export function buildHelperStream(helper, params, hash, templates, env, scope, context, label) {
+  Ember.assert("Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.", !helper.isHelperInstance || !helper.isHelperFactory && !templates.template.meta);
+  if (helper.isHelperFactory) {
+    return new HelperFactoryStream(helper, params, hash, label);
+  } else if (helper.isHelperInstance) {
+    return new HelperInstanceStream(helper, params, hash, label);
+  } else if (helper.helperFunction) {
+    return new CompatHelperStream(helper, params, hash, templates, env, scope, label);
+  } else {
+    return new BuiltInHelperStream(helper, params, hash, templates, env, scope, context, label);
+  }
+}

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -3,7 +3,7 @@
 @submodule ember-htmlbars
 */
 
-import Helper from "ember-htmlbars/helper";
+import { helper } from "ember-htmlbars/helper";
 
 /**
   Create a bound helper. Accepts a function that receives the ordered and hash parameters
@@ -49,5 +49,5 @@ import Helper from "ember-htmlbars/helper";
   @since 1.10.0
 */
 export default function makeBoundHelper(fn) {
-  return Helper.helper(fn);
+  return helper(fn);
 }

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -3,8 +3,7 @@
 @submodule ember-htmlbars
 */
 
-import Helper from "ember-htmlbars/system/helper";
-import { readHash, readArray } from "ember-metal/streams/utils";
+import Helper from "ember-htmlbars/helper";
 
 /**
   Create a bound helper. Accepts a function that receives the ordered and hash parameters
@@ -50,8 +49,5 @@ import { readHash, readArray } from "ember-metal/streams/utils";
   @since 1.10.0
 */
 export default function makeBoundHelper(fn) {
-  return new Helper(function(params, hash, templates) {
-    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !templates.template.meta);
-    return fn(readArray(params), readHash(hash));
-  });
+  return Helper.helper(fn);
 }

--- a/packages/ember-htmlbars/lib/utils/is-component.js
+++ b/packages/ember-htmlbars/lib/utils/is-component.js
@@ -3,7 +3,7 @@
 @submodule ember-htmlbars
 */
 
-import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
+import { CONTAINS_DASH_CACHE } from "ember-htmlbars/system/lookup-helper";
 
 /*
  Given a path name, returns whether or not a component with that
@@ -12,7 +12,7 @@ import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
 export default function isComponent(env, scope, path) {
   var container = env.container;
   if (!container) { return false; }
-  if (ISNT_HELPER_CACHE.get(path)) { return false; }
+  if (!CONTAINS_DASH_CACHE.get(path)) { return false; }
   return container._registry.has('component:' + path) ||
          container._registry.has('template:components/' + path);
 }

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -3,6 +3,7 @@ import EmberView from "ember-views/views/view";
 import handlebarsGet from "ember-htmlbars/compat/handlebars-get";
 import { Registry } from "ember-runtime/system/container";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -17,7 +18,6 @@ QUnit.module("ember-htmlbars: compat - Ember.Handlebars.get", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('view:toplevel', EmberView.extend());
   },
 
@@ -34,13 +34,13 @@ QUnit.module("ember-htmlbars: compat - Ember.Handlebars.get", {
 QUnit.test('it can lookup a path from the current context', function() {
   expect(1);
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     ignoreDeprecation(function() {
       equal(handlebarsGet(context, path, options), 'bar');
     });
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -56,13 +56,13 @@ QUnit.test('it can lookup a path from the current context', function() {
 QUnit.test('it can lookup a path from the current keywords', function() {
   expect(1);
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     ignoreDeprecation(function() {
       equal(handlebarsGet(context, path, options), 'bar');
     });
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -80,13 +80,13 @@ QUnit.test('it can lookup a path from globals', function() {
 
   lookup.Blammo = { foo: 'blah' };
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     ignoreDeprecation(function() {
       equal(handlebarsGet(context, path, options), lookup.Blammo.foo);
     });
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -100,13 +100,13 @@ QUnit.test('it can lookup a path from globals', function() {
 QUnit.test('it raises a deprecation warning on use', function() {
   expect(1);
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     expectDeprecation(function() {
       handlebarsGet(context, path, options);
     }, 'Usage of Ember.Handlebars.get is deprecated, use a Component or Ember.Handlebars.makeBoundHelper instead.');
-  });
+  }));
 
   view = EmberView.create({
     container: container,

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -11,6 +11,7 @@ import compile from "ember-template-compiler/system/compile";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import Registry from "container/registry";
 import ComponentLookup from 'ember-views/component_lookup';
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 var view, registry, container;
 
@@ -21,7 +22,6 @@ QUnit.module('ember-htmlbars: compat - Handlebars compatible helpers', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
   teardown() {
@@ -102,9 +102,9 @@ QUnit.test('has the correct options.data.view within a components layout', funct
   }));
 
   registry.register('template:components/foo-bar', compile('{{my-thing}}'));
-  registry.register('helper:my-thing', function(options) {
+  registry.register('helper:my-thing', new HandlebarsCompatibleHelper(function(options) {
     equal(options.data.view, component, 'passed in view should match the current component');
-  });
+  }));
 
   view = EmberView.create({
     container,

--- a/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
@@ -11,7 +11,6 @@ QUnit.module('ember-htmlbars: compat - makeViewHelper compat', {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -1,0 +1,360 @@
+import Component from "ember-views/views/component";
+import Helper from "ember-htmlbars/helper";
+import compile from "ember-template-compiler/system/compile";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import Registry from "container/registry";
+import run from "ember-metal/run_loop";
+import ComponentLookup from "ember-views/component_lookup";
+
+let registry, container, component;
+
+QUnit.module('ember-htmlbars: custom app helpers', {
+  setup() {
+    registry = new Registry();
+    registry.optionsForType('template', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
+    container = registry.container();
+  },
+
+  teardown() {
+    runDestroy(component);
+    runDestroy(container);
+    registry = container = component = null;
+  }
+});
+
+QUnit.test('dashed shorthand helper is resolved from container', function() {
+  var HelloWorld = Helper.helper(function() {
+    return 'hello world';
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), 'hello world');
+});
+
+QUnit.test('dashed helper is resolved from container', function() {
+  var HelloWorld = Helper.extend({
+    compute() {
+      return 'hello world';
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), 'hello world');
+});
+
+QUnit.test('dashed helper can recompute a new value', function() {
+  var destroyCount = 0;
+  var count = 0;
+  var helper;
+  var HelloWorld = Helper.extend({
+    init() {
+      this._super(...arguments);
+      helper = this;
+    },
+    compute() {
+      return ++count;
+    },
+    destroy() {
+      destroyCount++;
+      this._super();
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    helper.recompute();
+  });
+  equal(component.$().text(), '2');
+  equal(destroyCount, 0, 'destroy is not called on recomputation');
+});
+
+QUnit.test('dashed shorthand helper is called for param changes', function() {
+  var count = 0;
+  var HelloWorld = Helper.helper(function() {
+    return ++count;
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    component.set('name', 'sal');
+  });
+  equal(component.$().text(), '2');
+});
+
+QUnit.test('dashed helper compute is called for param changes', function() {
+  var count = 0;
+  var createCount = 0;
+  var HelloWorld = Helper.extend({
+    init() {
+      this._super(...arguments);
+      // FIXME: Ideally, the helper instance does not need to be recreated
+      // for change of params.
+      createCount++;
+    },
+    compute() {
+      return ++count;
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    component.set('name', 'sal');
+  });
+  equal(component.$().text(), '2');
+  equal(createCount, 1, 'helper is only created once');
+});
+
+QUnit.test('dashed shorthand helper receives params, hash', function() {
+  var params, hash;
+  var HelloWorld = Helper.helper(function(_params, _hash) {
+    params = _params;
+    hash = _hash;
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name "rich" last="sam"}}')
+  }).create();
+
+  runAppend(component);
+
+  equal(params[0], 'bob', 'first argument is bob');
+  equal(params[1], 'rich', 'second argument is rich');
+  equal(hash.last, 'sam', 'hash.last argument is sam');
+});
+
+QUnit.test('dashed helper receives params, hash', function() {
+  var params, hash;
+  var HelloWorld = Helper.extend({
+    compute(_params, _hash) {
+      params = _params;
+      hash = _hash;
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name "rich" last="sam"}}')
+  }).create();
+
+  runAppend(component);
+
+  equal(params[0], 'bob', 'first argument is bob');
+  equal(params[1], 'rich', 'second argument is rich');
+  equal(hash.last, 'sam', 'hash.last argument is sam');
+});
+
+QUnit.test('dashed helper usable in subexpressions', function() {
+  var JoinWords = Helper.extend({
+    compute(params) {
+      return params.join(' ');
+    }
+  });
+  registry.register('helper:join-words', JoinWords);
+  component = Component.extend({
+    container,
+    layout: compile(
+      `{{join-words "Who"
+                   (join-words "overcomes" "by")
+                   "force"
+                   (join-words (join-words "hath overcome but" "half"))
+                   (join-words "his" (join-words "foe"))}}`)
+  }).create();
+
+  runAppend(component);
+
+  equal(component.$().text(),
+    'Who overcomes by force hath overcome but half his foe');
+});
+
+QUnit.test('dashed helper not usable with a block', function() {
+  var SomeHelper = Helper.helper(function() {});
+  registry.register('helper:some-helper', SomeHelper);
+  component = Component.extend({
+    container,
+    layout: compile(`{{#some-helper}}{{/some-helper}}`)
+  }).create();
+
+  expectAssertion(function() {
+    runAppend(component);
+  }, /Helpers may not be used in the block form/);
+});
+
+QUnit.test('dashed helper is torn down', function() {
+  var destroyCalled = 0;
+  var SomeHelper = Helper.extend({
+    destroy() {
+      destroyCalled++;
+      this._super.apply(this, arguments);
+    },
+    compute() {
+      return 'must define a compute';
+    }
+  });
+  registry.register('helper:some-helper', SomeHelper);
+  component = Component.extend({
+    container,
+    layout: compile(`{{some-helper}}`)
+  }).create();
+
+  runAppend(component);
+  runDestroy(component);
+
+  equal(destroyCalled, 1, 'destroy called once');
+});
+
+QUnit.test('dashed helper used in subexpression can recompute', function() {
+  var helper;
+  var phrase = 'overcomes by';
+  var DynamicSegment = Helper.extend({
+    init() {
+      this._super(...arguments);
+      helper = this;
+    },
+    compute() {
+      return phrase;
+    }
+  });
+  var JoinWords = Helper.extend({
+    compute(params) {
+      return params.join(' ');
+    }
+  });
+  registry.register('helper:dynamic-segment', DynamicSegment);
+  registry.register('helper:join-words', JoinWords);
+  component = Component.extend({
+    container,
+    layout: compile(
+      `{{join-words "Who"
+                   (dynamic-segment)
+                   "force"
+                   (join-words (join-words "hath overcome but" "half"))
+                   (join-words "his" (join-words "foe"))}}`)
+  }).create();
+
+  runAppend(component);
+
+  equal(component.$().text(),
+    'Who overcomes by force hath overcome but half his foe');
+
+  phrase = 'believes his';
+  Ember.run(function() {
+    helper.recompute();
+  });
+
+  equal(component.$().text(),
+    'Who believes his force hath overcome but half his foe');
+});
+
+QUnit.test('dashed helper used in subexpression can recompute component', function() {
+  var helper;
+  var phrase = 'overcomes by';
+  var DynamicSegment = Helper.extend({
+    init() {
+      this._super(...arguments);
+      helper = this;
+    },
+    compute() {
+      return phrase;
+    }
+  });
+  var JoinWords = Helper.extend({
+    compute(params) {
+      return params.join(' ');
+    }
+  });
+  registry.register('component-lookup:main', ComponentLookup);
+  registry.register('component:some-component', Ember.Component.extend({
+    layout: compile('{{first}} {{second}} {{third}} {{fourth}} {{fifth}}')
+  }));
+  registry.register('helper:dynamic-segment', DynamicSegment);
+  registry.register('helper:join-words', JoinWords);
+  component = Component.extend({
+    container,
+    layout: compile(
+      `{{some-component first="Who"
+                   second=(dynamic-segment)
+                   third="force"
+                   fourth=(join-words (join-words "hath overcome but" "half"))
+                   fifth=(join-words "his" (join-words "foe"))}}`)
+  }).create();
+
+  runAppend(component);
+
+  equal(component.$().text(),
+    'Who overcomes by force hath overcome but half his foe');
+
+  phrase = 'believes his';
+  Ember.run(function() {
+    helper.recompute();
+  });
+
+  equal(component.$().text(),
+    'Who believes his force hath overcome but half his foe');
+});
+
+QUnit.test('dashed helper used in subexpression is destroyed', function() {
+  var destroyCount = 0;
+  var DynamicSegment = Helper.extend({
+    phrase: 'overcomes by',
+    compute() {
+      return this.phrase;
+    },
+    destroy() {
+      destroyCount++;
+      this._super(...arguments);
+    }
+  });
+  var JoinWords = Helper.helper(function(params) {
+    return params.join(' ');
+  });
+  registry.register('helper:dynamic-segment', DynamicSegment);
+  registry.register('helper:join-words', JoinWords);
+  component = Component.extend({
+    container,
+    layout: compile(
+      `{{join-words "Who"
+                   (dynamic-segment)
+                   "force"
+                   (join-words (join-words "hath overcome but" "half"))
+                   (join-words "his" (join-words "foe"))}}`)
+  }).create();
+
+  runAppend(component);
+  runDestroy(component);
+
+  equal(destroyCount, 1, 'destroy is called after a view is destroyed');
+});

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -1,5 +1,5 @@
 import Component from "ember-views/views/component";
-import Helper from "ember-htmlbars/helper";
+import Helper, { helper as makeHelper } from "ember-htmlbars/helper";
 import compile from "ember-template-compiler/system/compile";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import Registry from "container/registry";
@@ -24,7 +24,7 @@ QUnit.module('ember-htmlbars: custom app helpers', {
 });
 
 QUnit.test('dashed shorthand helper is resolved from container', function() {
-  var HelloWorld = Helper.helper(function() {
+  var HelloWorld = makeHelper(function() {
     return 'hello world';
   });
   registry.register('helper:hello-world', HelloWorld);
@@ -87,7 +87,7 @@ QUnit.test('dashed helper can recompute a new value', function() {
 
 QUnit.test('dashed shorthand helper is called for param changes', function() {
   var count = 0;
-  var HelloWorld = Helper.helper(function() {
+  var HelloWorld = makeHelper(function() {
     return ++count;
   });
   registry.register('helper:hello-world', HelloWorld);
@@ -137,7 +137,7 @@ QUnit.test('dashed helper compute is called for param changes', function() {
 
 QUnit.test('dashed shorthand helper receives params, hash', function() {
   var params, hash;
-  var HelloWorld = Helper.helper(function(_params, _hash) {
+  var HelloWorld = makeHelper(function(_params, _hash) {
     params = _params;
     hash = _hash;
   });
@@ -201,7 +201,7 @@ QUnit.test('dashed helper usable in subexpressions', function() {
 });
 
 QUnit.test('dashed helper not usable with a block', function() {
-  var SomeHelper = Helper.helper(function() {});
+  var SomeHelper = makeHelper(function() {});
   registry.register('helper:some-helper', SomeHelper);
   component = Component.extend({
     container,
@@ -338,7 +338,7 @@ QUnit.test('dashed helper used in subexpression is destroyed', function() {
       this._super(...arguments);
     }
   });
-  var JoinWords = Helper.helper(function(params) {
+  var JoinWords = makeHelper(function(params) {
     return params.join(' ');
   });
   registry.register('helper:dynamic-segment', DynamicSegment);

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -482,7 +482,6 @@ QUnit.module("ember-htmlbars: {{#unbound}} helper -- Container Lookup", {
     Ember.lookup = lookup = { Ember: Ember };
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -49,7 +49,6 @@ QUnit.module("ember-htmlbars: {{#view}} helper", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('view:toplevel', EmberView.extend());
     registry.register('component-lookup:main', ComponentLookup);
   },

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -22,7 +22,6 @@ QUnit.module("ember-htmlbars: block params", {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/component_element_id_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_element_id_test.js
@@ -14,7 +14,6 @@ QUnit.module('ember-htmlbars: component elementId', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -17,7 +17,6 @@ function commonSetup() {
   registry.optionsForType('component', { singleton: false });
   registry.optionsForType('view', { singleton: false });
   registry.optionsForType('template', { instantiate: false });
-  registry.optionsForType('helper', { instantiate: false });
   registry.register('component-lookup:main', ComponentLookup);
 }
 

--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -17,7 +17,6 @@ QUnit.module('component - lifecycle hooks', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('component-lookup:main', ComponentLookup);
 
     hooks = [];

--- a/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
+++ b/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
@@ -17,7 +17,6 @@ QUnit.module('component - mutable bindings', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/void-element-component-test.js
+++ b/packages/ember-htmlbars/tests/integration/void-element-component-test.js
@@ -14,7 +14,6 @@ QUnit.module('ember-htmlbars: components for void elements', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -2,6 +2,7 @@ import lookupHelper, { findHelper } from "ember-htmlbars/system/lookup-helper";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
 import Helper, { helper as makeHelper } from "ember-htmlbars/helper";
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 function generateEnv(helpers, container) {
   return {
@@ -95,7 +96,7 @@ QUnit.test('looks up a shorthand helper in the container', function() {
 });
 
 QUnit.test('fails with a useful error when resolving a function', function() {
-  expect(1);
+  expect(2);
   var container = generateContainer();
   var env = generateEnv(null, container);
   var view = {
@@ -105,7 +106,9 @@ QUnit.test('fails with a useful error when resolving a function', function() {
   function someName() {}
   view.container._registry.register('helper:some-name', someName);
 
-  expectAssertion(function() {
-    lookupHelper('some-name', view, env);
-  }, /The factory for "some-name" is not an Ember helper/);
+  var actual;
+  expectDeprecation(function() {
+    actual = lookupHelper('some-name', view, env);
+  }, /helper "some-name" is a deprecated bare function helper/);
+  ok(actual instanceof HandlebarsCompatibleHelper, 'function looks up as compat helper');
 });

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -1,7 +1,7 @@
 import lookupHelper, { findHelper } from "ember-htmlbars/system/lookup-helper";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
-import Component from "ember-views/views/component";
+import Helper from "ember-htmlbars/helper";
 
 function generateEnv(helpers, container) {
   return {
@@ -15,7 +15,6 @@ function generateContainer() {
   var registry = new Registry();
   var container = registry.container();
 
-  registry.optionsForType('helper', { instantiate: false });
   registry.register('component-lookup:main', ComponentLookup);
 
   return container;
@@ -64,16 +63,15 @@ QUnit.test('does a lookup in the container if the name contains a dash (and help
     container: container
   };
 
-  function someName() {}
-  someName.isHTMLBars = true;
+  var someName = Helper.extend();
   view.container._registry.register('helper:some-name', someName);
 
   var actual = lookupHelper('some-name', view, env);
 
-  equal(actual, someName, 'does not wrap provided function if `isHTMLBars` is truthy');
+  ok(someName.detect(actual), 'helper is an instance of the helper class');
 });
 
-QUnit.test('wraps helper from container in a Handlebars compat helper', function() {
+QUnit.test('looks up a shorthand helper in the container', function() {
   expect(2);
   var container = generateContainer();
   var env = generateEnv(null, container);
@@ -85,50 +83,29 @@ QUnit.test('wraps helper from container in a Handlebars compat helper', function
   function someName() {
     called = true;
   }
-  view.container._registry.register('helper:some-name', someName);
+  view.container._registry.register('helper:some-name', Helper.helper(someName));
 
   var actual = lookupHelper('some-name', view, env);
 
-  ok(actual.isHTMLBars, 'wraps provided helper in an HTMLBars compatible helper');
+  ok(actual.isHelperInstance, 'is a helper');
 
-  var fakeParams = [];
-  var fakeHash = {};
-  var fakeOptions = {
-    morph: { update() { } },
-    template: {},
-    inverse: {}
-  };
-  var fakeEnv = { };
-  var fakeScope = { };
-  actual.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv, fakeScope);
+  actual.compute([], {});
 
   ok(called, 'HTMLBars compatible wrapper is wraping the provided function');
 });
 
-QUnit.test('asserts if component-lookup:main cannot be found', function() {
+QUnit.test('fails with a useful error when resolving a function', function() {
+  expect(1);
   var container = generateContainer();
   var env = generateEnv(null, container);
   var view = {
     container: container
   };
 
-  view.container._registry.unregister('component-lookup:main');
+  function someName() {}
+  view.container._registry.register('helper:some-name', someName);
 
   expectAssertion(function() {
     lookupHelper('some-name', view, env);
-  }, 'Could not find \'component-lookup:main\' on the provided container, which is necessary for performing component lookups');
-});
-
-QUnit.test('registers a helper in the container if component is found', function() {
-  var container = generateContainer();
-  var env = generateEnv(null, container);
-  var view = {
-    container: container
-  };
-
-  view.container._registry.register('component:some-name', Component);
-
-  lookupHelper('some-name', view, env);
-
-  ok(view.container.lookup('helper:some-name'), 'new helper was registered');
+  }, /The factory for "some-name" is not an Ember helper/);
 });

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -1,7 +1,7 @@
 import lookupHelper, { findHelper } from "ember-htmlbars/system/lookup-helper";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
-import Helper from "ember-htmlbars/helper";
+import Helper, { helper as makeHelper } from "ember-htmlbars/helper";
 
 function generateEnv(helpers, container) {
   return {
@@ -83,7 +83,7 @@ QUnit.test('looks up a shorthand helper in the container', function() {
   function someName() {
     called = true;
   }
-  view.container._registry.register('helper:some-name', Helper.helper(someName));
+  view.container._registry.register('helper:some-name', makeHelper(someName));
 
   var actual = lookupHelper('some-name', view, env);
 

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -21,7 +21,6 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
   },
 
   teardown() {
@@ -192,7 +191,7 @@ QUnit.test("bound helpers should not be invoked with blocks", function() {
 
   expectAssertion(function() {
     runAppend(view);
-  }, /makeBoundHelper generated helpers do not support use with blocks/i);
+  }, /Helpers may not be used in the block form/);
 });
 
 QUnit.test("shouldn't treat raw numbers as bound paths", function() {

--- a/packages/ember-htmlbars/tests/system/make_view_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_view_helper_test.js
@@ -10,7 +10,6 @@ QUnit.module("ember-htmlbars: makeViewHelper", {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
   },
   teardown() {
     runDestroy(view);

--- a/packages/ember-metal/lib/streams/key-stream.js
+++ b/packages/ember-metal/lib/streams/key-stream.js
@@ -59,7 +59,7 @@ merge(KeyStream.prototype, {
 
     var object = this.sourceDep.getValue();
     if (object !== this.observedObject) {
-      this.deactivate();
+      this._clearObservedObject();
 
       if (object && typeof object === 'object') {
         addObserver(object, this.key, this, this.notify);
@@ -70,13 +70,16 @@ merge(KeyStream.prototype, {
 
   _super$deactivate: Stream.prototype.deactivate,
 
-  deactivate() {
-    this._super$deactivate();
-
+  _clearObservedObject() {
     if (this.observedObject) {
       removeObserver(this.observedObject, this.key, this, this.notify);
       this.observedObject = null;
     }
+  },
+
+  deactivate() {
+    this._super$deactivate();
+    this._clearObservedObject();
   }
 });
 

--- a/packages/ember-metal/lib/streams/stream.js
+++ b/packages/ember-metal/lib/streams/stream.js
@@ -180,7 +180,7 @@ Stream.prototype = {
 
   revalidate(value) {
     if (value !== this.observedProxy) {
-      this.deactivate();
+      this._clearObservedProxy();
 
       ProxyMixin = ProxyMixin || Ember.__loader.require('ember-runtime/mixins/-proxy').default;
 
@@ -191,11 +191,15 @@ Stream.prototype = {
     }
   },
 
-  deactivate() {
+  _clearObservedProxy() {
     if (this.observedProxy) {
       removeObserver(this.observedProxy, 'content', this, this.notify);
       this.observedProxy = null;
     }
+  },
+
+  deactivate() {
+    this._clearObservedProxy();
   },
 
   compute() {

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,13 +1,12 @@
 import Ember from 'ember-metal/core';
 import EmberObject from "ember-runtime/system/object";
-import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
+import { CONTAINS_DASH_CACHE } from "ember-htmlbars/system/lookup-helper";
 
 export default EmberObject.extend({
   invalidName(name) {
-    var invalidName = ISNT_HELPER_CACHE.get(name);
-
-    if (invalidName) {
+    if (!CONTAINS_DASH_CACHE.get(name)) {
       Ember.assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`);
+      return true;
     }
   },
 

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -1,6 +1,7 @@
 import "ember";
 
 import EmberHandlebars from "ember-htmlbars/compat";
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 var compile, helpers, makeBoundHelper;
 compile = EmberHandlebars.compile;
@@ -56,13 +57,13 @@ var boot = function(callback) {
 };
 
 QUnit.test("Unbound dashed helpers registered on the container can be late-invoked", function() {
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf 'YES'}}</div>");
+  let helper = new HandlebarsCompatibleHelper(function(val) {
+    return arguments.length > 1 ? val : "BORF";
+  });
 
-  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf YES}}</div>");
-
-  boot(function() {
-    registry.register('helper:x-borf', function(val) {
-      return arguments.length > 1 ? val : "BORF";
-    });
+  boot(() => {
+    registry.register('helper:x-borf', helper);
   });
 
   equal(Ember.$('#wrapper').text(), "BORF YES", "The helper was invoked from the container");
@@ -120,4 +121,25 @@ QUnit.test("Undashed helpers registered on the container can not (presently) be 
       }));
     });
   }, /A helper named 'omg' could not be found/);
+});
+
+QUnit.test("Helpers can receive injections", function() {
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{full-name}}</div>");
+
+  var serviceCalled = false;
+  boot(function() {
+    registry.register('service:name-builder', Ember.Service.extend({
+      build() {
+        serviceCalled = true;
+      }
+    }));
+    registry.register('helper:full-name', Ember.Helper.extend({
+      nameBuilder: Ember.inject.service('name-builder'),
+      compute() {
+        this.get('nameBuilder').build();
+      }
+    }));
+  });
+
+  ok(serviceCalled, 'service was injected, method called');
 });

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -2,6 +2,7 @@ import "ember";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
+import Helper from "ember-htmlbars/helper";
 
 var compile, helpers, makeBoundHelper;
 compile = EmberHandlebars.compile;
@@ -133,7 +134,7 @@ QUnit.test("Helpers can receive injections", function() {
         serviceCalled = true;
       }
     }));
-    registry.register('helper:full-name', Ember.Helper.extend({
+    registry.register('helper:full-name', Helper.extend({
       nameBuilder: Ember.inject.service('name-builder'),
       compute() {
         this.get('nameBuilder').build();


### PR DESCRIPTION
Implements https://github.com/emberjs/rfcs/pull/53, new helpers.

For example:

``` js
// app/helpers/full-name.js
import Ember from "ember";

export default Ember.Helper.extend({
  nameBuilder: Ember.inject.service(),
  compute(params) {
    const builder = this.get('nameBuilder');
    return builder.fullName(params[0], params[1]);
  }
});
```

TODO:
- [x] When looking up a helper in dev mode, catch any error about a bare function being registered into the container and rephrase it to be more kind: `A bare function was resolved as a helper: This is not supported. Please upgrade your resolver, or use "Ember.Helper.build"`
- [x] ~~Create an `ember-helper` package?~~
- [x] Can the class based helpers manage their own lifecycle (use the same instance across multiple param and hash updates)?
- [x] export the `Ember.Helper` global
- [x] test usage in subexpressions
- [x] test assertion when used with a block
- [x] revert to `lookupFactory` instead of `lookup` for helpers 
- [x] rebase/squash
- [x] test calling `recompute` on `b` in `(a (b (c)))`
- [x] test teardown of `b` in `(a (b (c)))`

A followup PR should deprecate these legacy APIs in 1.13.1:
- `Ember.Handlebars.makeBoundHelper`
- `Ember.HTMLBars.makeBoundHelper` (private)
- bare functions returned as helpers (`HandlebarsCompatibleHelper`)
