### PR TITLE
[BUGFIX beta] Deprecate `{{each foo in bar}}`.

### DIFF
--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -484,7 +484,7 @@ QUnit.test("bound helpers can handle nulls in array (with primitives) [DEPRECATE
     controller: EmberObject.create({
       things: A([null, 0, undefined, false, "OMG"])
     }),
-    template: compile("{{#each things}}{{this}}|{{reverse this}} {{/each}}{{#each thing in things}}{{thing}}|{{reverse thing}} {{/each}}")
+    template: compile("{{#each things}}{{this}}|{{reverse this}} {{/each}}{{#each things as |thing|}}{{thing}}|{{reverse thing}} {{/each}}")
   });
 
   expectDeprecation(function() {
@@ -512,7 +512,7 @@ QUnit.test("bound helpers can handle nulls in array (with objects)", function() 
     controller: EmberObject.create({
       things: A([null, { foo: 5 }])
     }),
-    template: compile("{{#each things}}{{foo}}|{{print-foo this}} {{/each}}{{#each thing in things}}{{thing.foo}}|{{print-foo thing}} {{/each}}")
+    template: compile("{{#each things}}{{foo}}|{{print-foo this}} {{/each}}{{#each things as |thing|}}{{thing.foo}}|{{print-foo thing}} {{/each}}")
   });
 
   expectDeprecation(function() {

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -71,7 +71,15 @@ QUnit.test("non-block param syntax substitution", function() {
 });
 
 function templateFor(templateString, useBlockParams) {
-  return compile(parseEach(templateString, useBlockParams));
+  var parsedTemplateString = parseEach(templateString, useBlockParams);
+  var template;
+
+  if (!useBlockParams) {
+    expectDeprecation(/use the block param form/);
+  }
+  template = compile(parsedTemplateString);
+
+  return template;
 }
 
 var originalLookup = Ember.lookup;
@@ -81,7 +89,7 @@ QUnit.module("the #each helper [DEPRECATED]", {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
 
-    template = templateFor("{{#each view.people}}{{name}}{{/each}}");
+    template = compile("{{#each view.people}}{{name}}{{/each}}");
     people = A([{ name: "Steve Holt" }, { name: "Annabelle" }]);
 
     registry = new Registry();
@@ -96,13 +104,13 @@ QUnit.module("the #each helper [DEPRECATED]", {
       people: people
     });
 
-    templateMyView = templateFor("{{name}}");
+    templateMyView = compile("{{name}}");
     lookup.MyView = MyView = EmberView.extend({
       template: templateMyView
     });
     registry.register('view:my-view', MyView);
 
-    templateMyEmptyView = templateFor("I'm empty");
+    templateMyEmptyView = compile("I'm empty");
     lookup.MyEmptyView = MyEmptyView = EmberView.extend({
       template: templateMyEmptyView
     });
@@ -166,7 +174,7 @@ QUnit.test("it allows you to access the current context using {{this}}", functio
   runDestroy(view);
 
   view = EmberView.create({
-    template: templateFor("{{#each view.people}}{{this}}{{/each}}"),
+    template: compile("{{#each view.people}}{{this}}{{/each}}"),
     people: A(['Black Francis', 'Joey Santiago', 'Kim Deal', 'David Lovering'])
   });
 
@@ -240,7 +248,7 @@ QUnit.test("can add and replace complicatedly harder", function() {
 
 QUnit.test("it does not mark each option tag as selected", function() {
   var selectView = EmberView.create({
-    template: templateFor('<select id="people-select"><option value="">Please select a name</option>{{#each view.people}}<option {{bind-attr value=name}}>{{name}}</option>{{/each}}</select>'),
+    template: compile('<select id="people-select"><option value="">Please select a name</option>{{#each view.people}}<option {{bind-attr value=name}}>{{name}}</option>{{/each}}</select>'),
     people: people
   });
 
@@ -266,7 +274,7 @@ QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
 
   view = EmberView.create({
     container: container,
-    template: templateFor('{{#each view.content as |value|}}{{value}}-{{#each view.options as |option|}}{{option.value}}:{{option.label}} {{/each}}{{/each}}'),
+    template: compile('{{#each view.content as |value|}}{{value}}-{{#each view.options as |option|}}{{option.value}}:{{option.label}} {{/each}}{{/each}}'),
 
     content: A(['X', 'Y']),
     options: A([
@@ -282,7 +290,7 @@ QUnit.test("View should not use keyword incorrectly - Issue #1315", function() {
 
 QUnit.test("it works inside a ul element", function() {
   var ulView = EmberView.create({
-    template: templateFor('<ul>{{#each view.people}}<li>{{name}}</li>{{/each}}</ul>'),
+    template: compile('<ul>{{#each view.people}}<li>{{name}}</li>{{/each}}</ul>'),
     people: people
   });
 
@@ -301,7 +309,7 @@ QUnit.test("it works inside a ul element", function() {
 
 QUnit.test("it works inside a table element", function() {
   var tableView = EmberView.create({
-    template: templateFor('<table><tbody>{{#each view.people}}<tr><td>{{name}}</td></tr>{{/each}}</tbody></table>'),
+    template: compile('<table><tbody>{{#each view.people}}<tr><td>{{name}}</td></tr>{{/each}}</tbody></table>'),
     people: people
   });
 
@@ -341,7 +349,7 @@ QUnit.test("it supports itemController", function() {
 
   view = EmberView.create({
     container: container,
-    template: templateFor('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
+    template: compile('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
     people: people,
     controller: parentController
   });
@@ -384,7 +392,7 @@ QUnit.test("itemController should not affect the DOM structure", function() {
 
   view = EmberView.create({
     container: container,
-    template: templateFor(
+    template: compile(
       '<div id="a">{{#each view.people itemController="person" as |person|}}{{person.name}}{{/each}}</div>' +
         '<div id="b">{{#each view.people as |person|}}{{person.name}}{{/each}}</div>'
     ),
@@ -416,7 +424,7 @@ QUnit.test("itemController specified in template gets a parentController propert
 
   view = EmberView.create({
     container: container,
-    template: templateFor('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
+    template: compile('{{#each view.people itemController="person"}}{{controllerName}}{{/each}}'),
     people: people,
     controller: parentController
   });
@@ -446,7 +454,7 @@ QUnit.test("itemController specified in ArrayController gets a parentController 
 
   view = EmberView.create({
     container: container,
-    template: templateFor('{{#each}}{{controllerName}}{{/each}}'),
+    template: compile('{{#each}}{{controllerName}}{{/each}}'),
     controller: container.lookup('controller:people')
   });
 
@@ -479,7 +487,7 @@ QUnit.test("itemController's parentController property, when the ArrayController
   runDestroy(view);
   view = EmberView.create({
     container: container,
-    template: templateFor('{{#each}}{{controllerName}}{{/each}}'),
+    template: compile('{{#each}}{{controllerName}}{{/each}}'),
     controller: container.lookup('controller:people')
   });
 
@@ -489,46 +497,15 @@ QUnit.test("itemController's parentController property, when the ArrayController
   equal(view.$().text(), "controller:Steve Holt of Yappcontroller:Annabelle of Yapp");
 });
 
-QUnit.test("it supports itemController when using a custom keyword", function() {
-  var Controller = EmberController.extend({
-    controllerName: computed(function() {
-      return "controller:"+this.get('model.name');
-    })
-  });
-
-  registry.register('controller:array', ArrayController.extend());
-
-  runDestroy(view);
-  view = EmberView.create({
-    container: container,
-    template: templateFor('{{#each person in view.people itemController="person"}}{{person.controllerName}}{{/each}}'),
-    people: people,
-    controller: {
-      container: container
-    }
-  });
-
-  registry.register('controller:person', Controller);
-
-  runAppend(view);
-
-  equal(view.$().text(), "controller:Steve Holtcontroller:Annabelle");
-
-  run(function() {
-    view.rerender();
-  });
-
-  equal(view.$().text(), "controller:Steve Holtcontroller:Annabelle");
-});
 
 QUnit.test("it supports {{itemView=}}", function() {
   var itemView = EmberView.extend({
-    template: templateFor('itemView:{{name}}')
+    template: compile('itemView:{{name}}')
   });
 
   runDestroy(view);
   view = EmberView.create({
-    template: templateFor('{{each view.people itemView="anItemView"}}'),
+    template: compile('{{each view.people itemView="anItemView"}}'),
     people: people,
     container: container
   });
@@ -543,12 +520,12 @@ QUnit.test("it supports {{itemView=}}", function() {
 
 QUnit.test("it defers all normalization of itemView names to the resolver", function() {
   var itemView = EmberView.extend({
-    template: templateFor('itemView:{{name}}')
+    template: compile('itemView:{{name}}')
   });
 
   runDestroy(view);
   view = EmberView.create({
-    template: templateFor('{{each view.people itemView="an-item-view"}}'),
+    template: compile('{{each view.people itemView="an-item-view"}}'),
     people: people,
     container: container
   });
@@ -562,7 +539,7 @@ QUnit.test("it defers all normalization of itemView names to the resolver", func
 QUnit.test("it supports {{itemViewClass=}} with global (DEPRECATED)", function() {
   runDestroy(view);
   view = EmberView.create({
-    template: templateFor('{{each view.people itemViewClass=MyView}}'),
+    template: compile('{{each view.people itemViewClass=MyView}}'),
     people: people,
     container: container
   });
@@ -580,7 +557,7 @@ QUnit.test("it supports {{itemViewClass=}} via container", function() {
   runDestroy(view);
   view = EmberView.create({
     container: container,
-    template: templateFor('{{each view.people itemViewClass="my-view"}}'),
+    template: compile('{{each view.people itemViewClass="my-view"}}'),
     people: people
   });
 
@@ -592,7 +569,7 @@ QUnit.test("it supports {{itemViewClass=}} via container", function() {
 QUnit.test("it supports {{itemViewClass=}} with each view tagName (DEPRECATED)", function() {
   runDestroy(view);
   view = EmberView.create({
-    template: templateFor('{{each view.people itemViewClass=MyView tagName="ul"}}'),
+    template: compile('{{each view.people itemViewClass=MyView tagName="ul"}}'),
     people: people,
     container: container
   });
@@ -610,7 +587,7 @@ QUnit.test("it supports {{itemViewClass=}} with tagName in itemViewClass (DEPREC
   }));
 
   view = EmberView.create({
-    template: templateFor('<ul>{{#each view.people itemViewClass="li-view" as |item|}}{{item.name}}{{/each}}</ul>'),
+    template: compile('<ul>{{#each view.people itemViewClass="li-view" as |item|}}{{item.name}}{{/each}}</ul>'),
     people: people,
     container: container
   });
@@ -626,7 +603,7 @@ QUnit.test("it supports {{itemViewClass=}} with {{else}} block (DEPRECATED)", fu
   runDestroy(view);
 
   view = EmberView.create({
-    template: templateFor(`
+    template: compile(`
       {{~#each view.people itemViewClass="my-view" as |item|~}}
         {{item.name}}
       {{~else~}}
@@ -644,11 +621,11 @@ QUnit.test("it supports {{itemViewClass=}} with {{else}} block (DEPRECATED)", fu
 QUnit.test("it supports non-context switching with {{itemViewClass=}} (DEPRECATED)", function() {
   runDestroy(view);
   registry.register('view:foo-view', EmberView.extend({
-    template: templateFor(`{{person.name}}`)
+    template: compile(`{{person.name}}`)
   }));
 
   view = EmberView.create({
-    template: templateFor(`{{each person in view.people itemViewClass="foo-view"}}`),
+    template: compile(`{{each person in view.people itemViewClass="foo-view"}}`),
     people: people,
     container: container
   });
@@ -659,13 +636,13 @@ QUnit.test("it supports non-context switching with {{itemViewClass=}} (DEPRECATE
 
 QUnit.test("it supports {{emptyView=}}", function() {
   var emptyView = EmberView.extend({
-    template: templateFor('emptyView:sad panda')
+    template: compile('emptyView:sad panda')
   });
 
   runDestroy(view);
 
   view = EmberView.create({
-    template: templateFor('{{each view.people emptyView="anEmptyView"}}'),
+    template: compile('{{each view.people emptyView="anEmptyView"}}'),
     people: A(),
     container: container
   });
@@ -679,13 +656,13 @@ QUnit.test("it supports {{emptyView=}}", function() {
 
 QUnit.test("it defers all normalization of emptyView names to the resolver", function() {
   var emptyView = EmberView.extend({
-    template: templateFor('emptyView:sad panda')
+    template: compile('emptyView:sad panda')
   });
 
   runDestroy(view);
 
   view = EmberView.create({
-    template: templateFor('{{each view.people emptyView="an-empty-view"}}'),
+    template: compile('{{each view.people emptyView="an-empty-view"}}'),
     people: A(),
     container: container
   });
@@ -701,7 +678,7 @@ QUnit.test("it supports {{emptyViewClass=}} with global (DEPRECATED)", function(
   runDestroy(view);
 
   view = EmberView.create({
-    template: templateFor('{{each view.people emptyViewClass=MyEmptyView}}'),
+    template: compile('{{each view.people emptyViewClass=MyEmptyView}}'),
     people: A(),
     container: container
   });
@@ -720,7 +697,7 @@ QUnit.test("it supports {{emptyViewClass=}} via container", function() {
 
   view = EmberView.create({
     container: container,
-    template: templateFor('{{each view.people emptyViewClass="my-empty-view"}}'),
+    template: compile('{{each view.people emptyViewClass="my-empty-view"}}'),
     people: A()
   });
 
@@ -733,7 +710,7 @@ QUnit.test("it supports {{emptyViewClass=}} with tagName (DEPRECATED)", function
   runDestroy(view);
 
   view = EmberView.create({
-    template: templateFor('{{each view.people emptyViewClass=MyEmptyView tagName="b"}}'),
+    template: compile('{{each view.people emptyViewClass=MyEmptyView tagName="b"}}'),
     people: A(),
     container: container
   });
@@ -749,7 +726,7 @@ QUnit.test("it supports {{emptyViewClass=}} with in format", function() {
 
   view = EmberView.create({
     container: container,
-    template: templateFor('{{each person in view.people emptyViewClass="my-empty-view"}}'),
+    template: compile('{{each person in view.people emptyViewClass="my-empty-view"}}'),
     people: A()
   });
 
@@ -761,7 +738,7 @@ QUnit.test("it supports {{emptyViewClass=}} with in format", function() {
 QUnit.test("it uses {{else}} when replacing model with an empty array", function() {
   runDestroy(view);
   view = EmberView.create({
-    template: templateFor("{{#each view.items}}{{this}}{{else}}Nothing{{/each}}"),
+    template: compile("{{#each view.items}}{{this}}{{else}}Nothing{{/each}}"),
     items: A(['one', 'two'])
   });
 
@@ -780,7 +757,7 @@ QUnit.test("it uses {{else}} when removing all items in an array", function() {
   var items = A(['one', 'two']);
   runDestroy(view);
   view = EmberView.create({
-    template: templateFor("{{#each view.items}}{{this}}{{else}}Nothing{{/each}}"),
+    template: compile("{{#each view.items}}{{this}}{{else}}Nothing{{/each}}"),
     items
   });
 
@@ -807,7 +784,7 @@ QUnit.test("it works with the controller keyword", function() {
   view = EmberView.create({
     container: container,
     controller: controller,
-    template: templateFor("{{#view}}{{#each controller}}{{this}}{{/each}}{{/view}}")
+    template: compile("{{#view}}{{#each controller}}{{this}}{{/each}}{{/view}}")
   });
 
   runAppend(view);
@@ -823,7 +800,7 @@ QUnit.test("views inside #each preserve the new context [DEPRECATED]", function(
   view = EmberView.create({
     container: container,
     controller: controller,
-    template: templateFor('{{#each controller}}{{#view}}{{name}}{{/view}}{{/each}}')
+    template: compile('{{#each controller}}{{#view}}{{name}}{{/view}}{{/each}}')
   });
 
 
@@ -839,7 +816,7 @@ QUnit.test("single-arg each defaults to current context [DEPRECATED]", function(
 
   view = EmberView.create({
     context: A([{ name: "Adam" }, { name: "Steve" }]),
-    template: templateFor('{{#each}}{{name}}{{/each}}')
+    template: compile('{{#each}}{{name}}{{/each}}')
   });
 
   expectDeprecation(function() {
@@ -854,7 +831,7 @@ QUnit.test("single-arg each will iterate over controller if present [DEPRECATED]
 
   view = EmberView.create({
     controller: A([{ name: "Adam" }, { name: "Steve" }]),
-    template: templateFor('{{#each}}{{name}}{{/each}}'),
+    template: compile('{{#each}}{{name}}{{/each}}'),
     container: container
   });
 
@@ -945,7 +922,7 @@ function testEachWithItem(moduleName, useBlockParams) {
       view = EmberView.create({
         container: container,
         controller: controller,
-        template: templateFor('{{#each controller}}{{#view}}{{name}}{{/view}}{{/each}}', useBlockParams)
+        template: compile('{{#each controller}}{{#view}}{{name}}{{/view}}{{/each}}', useBlockParams)
       });
 
       expectDeprecation(function() {
@@ -1076,7 +1053,7 @@ function testEachWithItem(moduleName, useBlockParams) {
     var list = [{ key: "adam", name: "Adam" }, { key: "steve", name: "Steve" }];
     view = EmberView.create({
       queries: list,
-      template: templateFor('{{#each view.queries key="key" as |query|}}{{query.name}}{{/each}}', true)
+      template: compile('{{#each view.queries key="key" as |query|}}{{query.name}}{{/each}}', true)
     });
     runAppend(view);
     equal(view.$().text(), "AdamSteve");
@@ -1103,7 +1080,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       view = EmberView.create({
         controller: A([{ name: "Adam" }, { name: "Steve" }]),
-        template: templateFor('{{#each}}{{name}}{{/each}}', useBlockParams)
+        template: compile('{{#each}}{{name}}{{/each}}')
       });
 
       expectDeprecation(function() {
@@ -1118,7 +1095,7 @@ function testEachWithItem(moduleName, useBlockParams) {
 
       view = EmberView.create({
         controller: A([{ name: "Adam" }, { name: "Steve" }]),
-        template: templateFor('{{#each this}}{{name}}{{/each}}', useBlockParams)
+        template: compile('{{#each this}}{{name}}{{/each}}')
       });
 
       expectDeprecation(function() {

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -84,7 +84,7 @@ QUnit.test('should property escape unsafe hrefs', function() {
   runDestroy(view);
 
   view = EmberView.create({
-    template: compile('<ul>{{#each person in view.people}}<a href="{{unbound person.url}}">{{person.name}}</a>{{/each}}</ul>'),
+    template: compile('<ul>{{#each view.people as |person|}}<a href="{{unbound person.url}}">{{person.name}}</a>{{/each}}</ul>'),
     people: A([{
       name: 'Bob',
       url: 'javascript:bob-is-cool'
@@ -398,7 +398,7 @@ QUnit.test("should be able to render an unbound helper invocation for helpers wi
 QUnit.test("should be able to render an unbound helper invocation in #each helper", function() {
   view = EmberView.create({
     template: compile(
-      ["{{#each person in people}}",
+      ["{{#each people as |person|}}",
         "{{capitalize person.firstName}} {{unbound capitalize person.firstName}}",
         "{{/each}}"].join("")),
     context: {
@@ -539,7 +539,7 @@ QUnit.test("should be able to output a property without binding", function() {
 QUnit.test("should be able to use unbound helper in #each helper", function() {
   view = EmberView.create({
     items: A(['a', 'b', 'c', 1, 2, 3]),
-    template: compile('<ul>{{#each item in view.items}}<li>{{unbound item}}</li>{{/each}}</ul>')
+    template: compile('<ul>{{#each view.items as |item|}}<li>{{unbound item}}</li>{{/each}}</ul>')
   });
 
   runAppend(view);
@@ -551,7 +551,7 @@ QUnit.test("should be able to use unbound helper in #each helper", function() {
 QUnit.test("should be able to use unbound helper in #each helper (with objects)", function() {
   view = EmberView.create({
     items: A([{ wham: 'bam' }, { wham: 1 }]),
-    template: compile('<ul>{{#each item in view.items}}<li>{{unbound item.wham}}</li>{{/each}}</ul>')
+    template: compile('<ul>{{#each view.items as |item|}}<li>{{unbound item.wham}}</li>{{/each}}</ul>')
   });
 
   runAppend(view);
@@ -564,7 +564,7 @@ QUnit.test('should work properly with attributes', function() {
   expect(4);
 
   view = EmberView.create({
-    template: compile('<ul>{{#each person in view.people}}<li class="{{unbound person.cool}}">{{person.name}}</li>{{/each}}</ul>'),
+    template: compile('<ul>{{#each view.people as |person|}}<li class="{{unbound person.cool}}">{{person.name}}</li>{{/each}}</ul>'),
     people: A([{
       name: 'Bob',
       cool: 'not-cool'

--- a/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
+++ b/packages/ember-htmlbars/tests/integration/tagless_views_rerender_test.js
@@ -17,7 +17,7 @@ QUnit.test("can insert new child views after initial tagless view rendering", fu
     shouldShow: false,
     array: Ember.A([1]),
 
-    template: compile('{{#if view.shouldShow}}{{#each item in view.array}}{{item}}{{/each}}{{/if}}')
+    template: compile('{{#if view.shouldShow}}{{#each view.array as |item|}}{{item}}{{/each}}{{/if}}')
   });
 
   runAppend(view);
@@ -43,7 +43,7 @@ QUnit.test("can remove child views after initial tagless view rendering", functi
     shouldShow: false,
     array: Ember.A([]),
 
-    template: compile('{{#if view.shouldShow}}{{#each item in view.array}}{{item}}{{/each}}{{/if}}')
+    template: compile('{{#if view.shouldShow}}{{#each view.array as |item|}}{{item}}{{/each}}{{/if}}')
   });
 
   runAppend(view);

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -450,7 +450,7 @@ QUnit.test("should work properly in an #each block", function() {
   view = EmberView.create({
     controller: controller,
     items: Ember.A([1, 2, 3, 4]),
-    template: compile('{{#each item in view.items}}<a href="#" {{action "edit"}}>click me</a>{{/each}}')
+    template: compile('{{#each view.items as |item|}}<a href="#" {{action "edit"}}>click me</a>{{/each}}')
   });
 
   runAppend(view);
@@ -537,7 +537,7 @@ QUnit.test("should unregister event handlers on inside virtual views", function(
     }
   ]);
   view = EmberView.create({
-    template: compile('{{#each thing in view.things}}<a href="#" {{action "edit"}}>click me</a>{{/each}}'),
+    template: compile('{{#each view.things as |thing|}}<a href="#" {{action "edit"}}>click me</a>{{/each}}'),
     things: things
   });
 

--- a/packages/ember-template-compiler/lib/plugins/transform-each-in-to-block-params.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-each-in-to-block-params.js
@@ -1,3 +1,5 @@
+import Ember from "ember-metal/core";
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
 /**
 @module ember
 @submodule ember-htmlbars
@@ -22,9 +24,10 @@
   @class TransformEachInToBlockParams
   @private
 */
-function TransformEachInToBlockParams() {
+function TransformEachInToBlockParams(options) {
   // set later within HTMLBars to the syntax package
   this.syntax = null;
+  this.options = options;
 }
 
 /**
@@ -35,26 +38,38 @@ function TransformEachInToBlockParams() {
 TransformEachInToBlockParams.prototype.transform = function TransformEachInToBlockParams_transform(ast) {
   var b = this.syntax.builders;
   var walker = new this.syntax.Walker();
+  var moduleName = this.options.moduleName;
 
   walker.visit(ast, function(node) {
     if (validate(node)) {
 
       var removedParams = node.params.splice(0, 2);
       var keyword = removedParams[0].original;
+      let moduleInfo;
 
       if (node.type === 'BlockStatement') {
+        moduleInfo = calculateLocationDisplay(moduleName, node.program.loc);
+
         if (node.program.blockParams.length) {
-          throw new Error('You cannot use keyword (`{{each foo in bar}}`) and block params (`{{each bar as |foo|}}`) at the same time.');
+          throw new Error('You cannot use keyword (`{{each foo in bar}}`) and block params (`{{each bar as |foo|}}`) at the same time ' + moduleInfo + '.');
         }
 
         node.program.blockParams = [keyword];
       } else {
+        moduleInfo = calculateLocationDisplay(moduleName, node.loc);
+
         node.hash.pairs.push(b.pair(
           'keyword',
           b.string(keyword)
         ));
       }
 
+      Ember.deprecate(
+        `Using the '{{each item in model}}' form of the {{each}} helper ${moduleInfo}is deprecated. ` +
+          `Please use the block param form instead ('{{each model as |item|}}').`,
+        false,
+        { url: 'http://emberjs.com/guides/deprecations/#toc_code-in-code-syntax-for-code-each-code' }
+      );
     }
   });
 

--- a/packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-input-on-to-onEvent.js
@@ -1,3 +1,4 @@
+import Ember from "ember-metal/core";
 import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
 
 /**

--- a/packages/ember-template-compiler/tests/plugins/transform-each-in-to-block-params-test.js
+++ b/packages/ember-template-compiler/tests/plugins/transform-each-in-to-block-params-test.js
@@ -7,5 +7,21 @@ QUnit.test('cannot use block params and keyword syntax together', function() {
 
   throws(function() {
     compile('{{#each thing in controller as |other-thing|}}{{thing}}-{{other-thing}}{{/each}}', true);
-  }, /You cannot use keyword \(`{{each foo in bar}}`\) and block params \(`{{each bar as \|foo\|}}`\) at the same time\./);
+  }, /You cannot use keyword \(`{{each foo in bar}}`\) and block params \(`{{each bar as \|foo\|}}`\) at the same time\ ./);
+});
+
+QUnit.test('using {{each in}} syntax is deprecated for blocks', function() {
+  expect(1);
+
+  expectDeprecation(function() {
+    compile('\n\n   {{#each foo in model}}{{/each}}', { moduleName: 'foo/bar/baz' });
+  }, `Using the '{{each item in model}}' form of the {{each}} helper ('foo/bar/baz' @ L3:C3) is deprecated. Please use the block param form instead ('{{each model as |item|}}').`);
+});
+
+QUnit.test('using {{each in}} syntax is deprecated for non-block statemens', function() {
+  expect(1);
+
+  expectDeprecation(function() {
+    compile('\n\n   {{each foo in model}}', { moduleName: 'foo/bar/baz' });
+  }, `Using the '{{each item in model}}' form of the {{each}} helper ('foo/bar/baz' @ L3:C3) is deprecated. Please use the block param form instead ('{{each model as |item|}}').`);
 });

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -9,7 +9,7 @@ var App, $fixture;
 function setupExample() {
   // setup templates
   Ember.TEMPLATES.application = compile("{{outlet}}");
-  Ember.TEMPLATES.index = compile("<h1>People</h1><ul>{{#each person in model}}<li>Hello, <b>{{person.fullName}}</b>!</li>{{/each}}</ul>");
+  Ember.TEMPLATES.index = compile("<h1>People</h1><ul>{{#each model as |person|}}<li>Hello, <b>{{person.fullName}}</b>!</li>{{/each}}</ul>");
 
 
   App.Person = Ember.Object.extend({

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -497,7 +497,7 @@ QUnit.test("The Homepage with a `setupController` hook", function() {
   });
 
   Ember.TEMPLATES.home = compile(
-    "<ul>{{#each entry in hours}}<li>{{entry}}</li>{{/each}}</ul>"
+    "<ul>{{#each hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>"
   );
 
   bootApplication();
@@ -616,7 +616,7 @@ QUnit.test("The Homepage with a `setupController` hook modifying other controlle
   });
 
   Ember.TEMPLATES.home = compile(
-    "<ul>{{#each entry in hours}}<li>{{entry}}</li>{{/each}}</ul>"
+    "<ul>{{#each hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>"
   );
 
   bootApplication();
@@ -640,7 +640,7 @@ QUnit.test("The Homepage with a computed context that does not get overridden", 
   });
 
   Ember.TEMPLATES.home = compile(
-    "<ul>{{#each passage in model}}<li>{{passage}}</li>{{/each}}</ul>"
+    "<ul>{{#each model as |passage|}}<li>{{passage}}</li>{{/each}}</ul>"
   );
 
   bootApplication();
@@ -670,7 +670,7 @@ QUnit.test("The Homepage getting its controller context via model", function() {
   });
 
   Ember.TEMPLATES.home = compile(
-    "<ul>{{#each entry in hours}}<li>{{entry}}</li>{{/each}}</ul>"
+    "<ul>{{#each hours as |entry|}}<li>{{entry}}</li>{{/each}}</ul>"
   );
 
   bootApplication();

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1289,7 +1289,7 @@ QUnit.module("Model Dep Query Params", {
       page: 1
     });
 
-    Ember.TEMPLATES.application = compile("{{#each a in articles}} {{link-to 'Article' 'article' a id=a.id}} {{/each}} {{outlet}}");
+    Ember.TEMPLATES.application = compile("{{#each articles as |a|}} {{link-to 'Article' 'article' a id=a.id}} {{/each}} {{outlet}}");
 
     this.boot = function() {
       bootApplication();
@@ -1370,7 +1370,7 @@ QUnit.test("query params have 'model' stickiness by default (url changes)", func
 
 
 QUnit.test("query params have 'model' stickiness by default (params-based transitions)", function() {
-  Ember.TEMPLATES.application = compile("{{#each a in articles}} {{link-to 'Article' 'article' a.id id=a.id}} {{/each}}");
+  Ember.TEMPLATES.application = compile("{{#each articles as |a|}} {{link-to 'Article' 'article' a.id id=a.id}} {{/each}}");
 
   this.boot();
 


### PR DESCRIPTION
Closes #10583.
