### PR TITLE
[BUGFIX beta] Do not trigger style warning for `isVisible`.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/-html-safe.js
+++ b/packages/ember-htmlbars/lib/helpers/-html-safe.js
@@ -1,0 +1,11 @@
+import SafeString from "htmlbars-util/safe-string";
+
+/**
+ This private helper is used internally to handle `isVisible: false` for
+ Ember.View and Ember.Component.
+
+ @private
+ */
+export default function htmlSafeHelper([ value ]) {
+  return new SafeString(value);
+}

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -29,6 +29,7 @@ import joinClassesHelper from "ember-htmlbars/helpers/-join-classes";
 import legacyEachWithControllerHelper from "ember-htmlbars/helpers/-legacy-each-with-controller";
 import legacyEachWithKeywordHelper from "ember-htmlbars/helpers/-legacy-each-with-keyword";
 import getHelper from "ember-htmlbars/helpers/-get";
+import htmlSafeHelper from "ember-htmlbars/helpers/-html-safe";
 import DOMHelper from "ember-htmlbars/system/dom-helper";
 
 // importing adds template bootstrapping
@@ -57,6 +58,7 @@ registerHelper('-legacy-each-with-keyword', legacyEachWithKeywordHelper);
 if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
   registerHelper('-get', getHelper);
 }
+registerHelper('-html-safe', htmlSafeHelper);
 
 Ember.HTMLBars = {
   _registerHelper: registerHelper,

--- a/packages/ember-htmlbars/tests/helpers/-html-safe-test.js
+++ b/packages/ember-htmlbars/tests/helpers/-html-safe-test.js
@@ -1,0 +1,57 @@
+/* globals EmberDev */
+import { Registry } from "ember-runtime/system/container";
+import Component from "ember-views/views/component";
+import compile from "ember-template-compiler/system/compile";
+
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+
+var component, registry, container, warnings, originalWarn;
+
+QUnit.module("ember-htmlbars: {{-html-safe}} helper", {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('helper', { instantiate: false });
+
+    warnings = [];
+    originalWarn = Ember.warn;
+    Ember.warn = function(message, test) {
+      if (!test) {
+        warnings.push(message);
+      }
+    };
+  },
+
+  teardown() {
+    runDestroy(container);
+    runDestroy(component);
+    Ember.warn = originalWarn;
+  }
+});
+
+QUnit.test('adds the attribute to the element', function() {
+  component = Component.create({
+    container,
+
+    template: compile(`<div style={{-html-safe "display: none;"}}></div>`)
+  });
+
+  runAppend(component);
+
+  equal(component.$('div').css('display'), 'none', 'attribute was set');
+});
+
+if (!EmberDev.runningProdBuild) {
+
+  QUnit.test('adds the attribute to the element', function() {
+    component = Component.create({
+      container,
+
+      template: compile(`<div style={{-html-safe "display: none;"}}></div>`)
+    });
+
+    runAppend(component);
+
+    deepEqual(warnings, [], 'no warnings were triggered');
+  });
+}

--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -176,7 +176,7 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   }
 
   if (get(component, 'isVisible') === false) {
-    var hiddenStyle = ['value', "display: none;"];
+    var hiddenStyle = ['subexpr', '-html-safe', ['display: none;'], []];
     var existingStyle = normalized.style;
 
     if (existingStyle) {

--- a/packages/ember-views/tests/views/view/is_visible_test.js
+++ b/packages/ember-views/tests/views/view/is_visible_test.js
@@ -7,8 +7,19 @@ import { computed } from "ember-metal/computed";
 
 var View, view, parentBecameVisible, childBecameVisible, grandchildBecameVisible;
 var parentBecameHidden, childBecameHidden, grandchildBecameHidden;
+var warnings, originalWarn;
 
 QUnit.module("EmberView#isVisible", {
+  setup() {
+    warnings = [];
+    originalWarn = Ember.warn;
+    Ember.warn = function(message, test) {
+      if (!test) {
+        warnings.push(message);
+      }
+    };
+  },
+
   teardown() {
     if (view) {
       run(function() { view.destroy(); });
@@ -35,6 +46,8 @@ QUnit.test("should hide views when isVisible is false", function() {
   run(function() {
     view.remove();
   });
+
+  deepEqual(warnings, [], 'no warnings were triggered');
 });
 
 QUnit.test("should hide element if isVisible is false before element is created", function() {
@@ -69,6 +82,8 @@ QUnit.test("should hide element if isVisible is false before element is created"
   run(function() {
     view.remove();
   });
+
+  deepEqual(warnings, [], 'no warnings were triggered');
 });
 
 QUnit.test("should hide views when isVisible is a CP returning false", function() {
@@ -92,6 +107,8 @@ QUnit.test("should hide views when isVisible is a CP returning false", function(
   run(function() {
     view.remove();
   });
+
+  deepEqual(warnings, [], 'no warnings were triggered');
 });
 
 QUnit.test("doesn't overwrite existing style attribute bindings", function() {


### PR DESCRIPTION
In the case when `isVisible` is false, `build-component-template` adds `display: none;` to the style attribute.  Ember currently warns whenver you set a `style` attribute on an element unless the value is a SafeString (because of XSS exploits that are possible with `style`).

This PR adds a new private helper that returns a SafeString, and then uses that for the `display: none;` that is added when `isVisible` is false.

Fixes #11295.
