### PR TITLE
Change view and component resolver assertions to deprecations

### DIFF
--- a/packages/ember-application/lib/utils/validate-type.js
+++ b/packages/ember-application/lib/utils/validate-type.js
@@ -4,10 +4,10 @@
 */
 
 let VALIDATED_TYPES = {
-  route:     ['isRouteFactory',     'Ember.Route'],
-  component: ['isComponentFactory', 'Ember.Component'],
-  view:      ['isViewFactory',      'Ember.View'],
-  service:   ['isServiceFactory',   'Ember.Service']
+  route:     ['assert',    'isRouteFactory',     'Ember.Route'],
+  component: ['deprecate', 'isComponentFactory', 'Ember.Component'],
+  view:      ['deprecate', 'isViewFactory',      'Ember.View'],
+  service:   ['deprecate', 'isServiceFactory',   'Ember.Service']
 };
 
 export default function validateType(resolvedType, parsedName) {
@@ -17,21 +17,23 @@ export default function validateType(resolvedType, parsedName) {
     return;
   }
 
-  // 2.0TODO: Remove this deprecation warning
-  if (parsedName.type === 'service') {
+  let [action, factoryFlag, expectedType] = validationAttributes;
+
+  if (action === 'deprecate') {
     Ember.deprecate(
-      "In Ember 2.0 service factories must have an `isServiceFactory` " +
-      `property set to true. You registered ${resolvedType} as a service ` +
-      "factory. Either add the `isServiceFactory` property to this factory or " +
-      "extend from Ember.Service.",
-      resolvedType.isServiceFactory
+      `In Ember 2.0 ${parsedName.type} factories must have an \`${factoryFlag}\` ` +
+      `property set to true. You registered ${resolvedType} as a ${parsedName.type} ` +
+      `factory. Either add the \`${factoryFlag}\` property to this factory or ` +
+      `extend from ${expectedType}.`,
+      resolvedType[factoryFlag]
     );
-    return;
+  } else {
+    Ember.assert(
+      `Expected ${parsedName.fullName} to resolve to an ${expectedType} but ` +
+      `instead it was ${resolvedType}.`,
+      function() {
+        return resolvedType[factoryFlag];
+      }
+    );
   }
-
-  let [factoryFlag, expectedType] = validationAttributes;
-
-  Ember.assert(`Expected ${parsedName.fullName} to resolve to an ${expectedType} but instead it was ${resolvedType}.`, function() {
-    return resolvedType[factoryFlag];
-  });
 }

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -1,7 +1,5 @@
 import Ember from "ember-metal/core"; // Ember.TEMPLATES
 import run from "ember-metal/run_loop";
-import { forEach } from "ember-metal/enumerable_utils";
-import { capitalize } from "ember-runtime/system/string";
 import Logger from "ember-metal/logger";
 import Controller from "ember-runtime/controllers/controller";
 import Route from "ember-routing/system/route";
@@ -177,47 +175,52 @@ QUnit.test("lookup description", function() {
 
 });
 
-QUnit.test("validating resolved objects", function() {
-  // 2.0TODO: Add service to this list
-  let types = ['route', 'component', 'view'];
-
-  // Valid setup
-  application.FooRoute = Route.extend();
-  application.FooComponent = Component.extend();
-  application.FooView = View.extend();
-  application.FooService = Service.extend();
-
-  forEach(types, function(type) {
-    // No errors when resolving correct object types
-    registry.resolve(`${type}:foo`);
-
-    // Unregister to clear cache
-    registry.unregister(`${type}:foo`);
-  });
-
-  // Invalid setup
+QUnit.test("assertion for routes without isRouteFactory property", function() {
   application.FooRoute = Component.extend();
-  application.FooComponent = View.extend();
-  application.FooView = Service.extend();
-  application.FooService = Route.extend();
 
-  forEach(types, function(type) {
-    let matcher = new RegExp(`to resolve to an Ember.${capitalize(type)}`);
-    expectAssertion(function() {
-      registry.resolve(`${type}:foo`);
-    }, matcher, `Should assert for ${type}`);
-  });
+  expectAssertion(function() {
+    registry.resolve(`route:foo`);
+  }, /to resolve to an Ember.Route/, 'Should assert');
+});
+
+QUnit.test("no assertion for routes that extend from Ember.Route", function() {
+  expect(0);
+  application.FooRoute = Route.extend();
+  registry.resolve(`route:foo`);
 });
 
 QUnit.test("deprecation warning for service factories without isServiceFactory property", function() {
   expectDeprecation(/service factories must have an `isServiceFactory` property/);
   application.FooService = EmberObject.extend();
   registry.resolve('service:foo');
-
 });
 
 QUnit.test("no deprecation warning for service factories that extend from Ember.Service", function() {
   expectNoDeprecation();
   application.FooService = Service.extend();
   registry.resolve('service:foo');
+});
+
+QUnit.test("deprecation warning for view factories without isViewFactory property", function() {
+  expectDeprecation(/view factories must have an `isViewFactory` property/);
+  application.FooView = EmberObject.extend();
+  registry.resolve('view:foo');
+});
+
+QUnit.test("no deprecation warning for view factories that extend from Ember.View", function() {
+  expectNoDeprecation();
+  application.FooView = View.extend();
+  registry.resolve('view:foo');
+});
+
+QUnit.test("deprecation warning for component factories without isComponentFactory property", function() {
+  expectDeprecation(/component factories must have an `isComponentFactory` property/);
+  application.FooComponent = View.extend();
+  registry.resolve('component:foo');
+});
+
+QUnit.test("no deprecation warning for component factories that extend from Ember.Component", function() {
+  expectNoDeprecation();
+  application.FooView = Component.extend();
+  registry.resolve('component:foo');
 });


### PR DESCRIPTION
As @raytiley brought up in https://github.com/emberjs/ember.js/pull/11261#issuecomment-106156215, the original PR was breaking for components that extend from views. With this change, only the validation on the Route class (the original use case) results in an assertion. Validation for View, Component, and Service result in a deprecation.

cc @rwjblue @stefanpenner 
