### PR TITLE
[BUGFIX release] Ensure rootURL is preserved in AutoLocation.

### DIFF
--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -131,6 +131,8 @@ export default EmberObject.extend({
     }
 
     var concrete = this.container.lookup(`location:${implementation}`);
+    set(concrete, 'rootURL', rootURL);
+
     Ember.assert(`Could not find location '${implementation}'.`, !!concrete);
 
     set(this, 'concreteImplementation', concrete);

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -215,6 +215,22 @@ QUnit.test("AutoLocation requires any rootURL given to end in a trailing forward
   }, expectedMsg);
 });
 
+QUnit.test("AutoLocation provides its rootURL to the concreteImplementation", function() {
+  expect(1);
+  var browserLocation = mockBrowserLocation({
+    pathname: '/some/subdir/derp'
+  });
+  var browserHistory = mockBrowserHistory();
+
+  location = createLocation(browserLocation, browserHistory);
+  location.rootURL = '/some/subdir/';
+
+  location.detect();
+
+  var concreteLocation = get(location, 'concreteImplementation');
+  equal(location.rootURL, concreteLocation.rootURL);
+});
+
 QUnit.test("getHistoryPath() should return a normalized, HistoryLocation-supported path", function() {
   expect(3);
 


### PR DESCRIPTION
When creating the concrete implementation we must also populate its `rootURL`.

Fixes #10943.
