### PR TITLE
[BUGFIX release] Fix element space helpers returning attributes with spaces.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -7,6 +7,24 @@ import Ember from "ember-metal/core";
 import { read } from "ember-metal/streams/utils";
 import lookupHelper from "ember-htmlbars/system/lookup-helper";
 
+var fakeElement;
+
+function updateElementAttributesFromString(dom, element, string) {
+  if (!fakeElement) {
+    fakeElement = document.createElement('div');
+  }
+
+  fakeElement.innerHTML = '<' + element.tagName + ' ' + string + '><' + '/' + element.tagName + '>';
+
+  var attrs = fakeElement.firstChild.attributes;
+  for (var i = 0, l = attrs.length; i < l; i++) {
+    var attr = attrs[i];
+    if (attr.specified) {
+      dom.setAttribute(element, attr.name, attr.value);
+    }
+  }
+}
+
 export default function element(env, domElement, view, path, params, hash) { //jshint ignore:line
   var helper = lookupHelper(path, view, env);
   var valueOrLazyValue;
@@ -23,17 +41,6 @@ export default function element(env, domElement, view, path, params, hash) { //j
   var value = read(valueOrLazyValue);
   if (value) {
     Ember.deprecate('Returning a string of attributes from a helper inside an element is deprecated.');
-
-    var parts = value.toString().split(/\s+/);
-    for (var i = 0, l = parts.length; i < l; i++) {
-      var attrParts = parts[i].split('=');
-      var attrName = attrParts[0];
-      var attrValue = attrParts[1];
-
-      attrValue = attrValue.replace(/^['"]/, '').replace(/['"]$/, '');
-
-      env.dom.setAttribute(domElement, attrName, attrValue);
-    }
+    updateElementAttributesFromString(env.dom, domElement, value);
   }
 }
-

--- a/packages/ember-htmlbars/tests/hooks/element_test.js
+++ b/packages/ember-htmlbars/tests/hooks/element_test.js
@@ -74,3 +74,20 @@ QUnit.test('allows unbound usage within an element creating multiple attributes'
 
   equal(view.$('.foo[data-foo="bar"]').length, 1, 'attributes added by helper');
 });
+
+QUnit.test('allows unbound usage within an element creating multiple attributes with spaces #11243', function() {
+  expect(2);
+
+  view = EmberView.create({
+    controller: {
+      someProp: 'class="foo" data-foo="bar baz biff"'
+    },
+    template: compile('<div {{someProp}}>Bar</div>')
+  });
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, 'Returning a string of attributes from a helper inside an element is deprecated.');
+
+  equal(view.$('.foo').attr('data-foo'), 'bar baz biff', 'attributes added by helper');
+});


### PR DESCRIPTION
This has already been fixed in 1.13+, but that fix needs to be backported to 1.12.x.

**Note: This PR targets Stable Branch**

Fixes #11243.
