### PR TITLE
Routing Namespaces - this.namespace() for defining routes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -267,3 +267,38 @@ for a detailed explanation.
   Implemencts RFC https://github.com/emberjs/rfcs/pull/38, adding support for
   routable components.
 
+* `ember-routing-namespace`
+
+  Adds `this.namespace()` to Router DSL  along side `this.route()` and `this.resource()`.
+
+  The new namespace function allows you to define a set of routes that exist under the
+  one namespace which isn't a parent route.
+
+  The following 2 examples produce the same results:
+
+  ```js
+  this.route('admin.users', { path: 'admin/users' });
+  this.route('admin.groups', { path: 'admin/groups' });
+  this.route('admin.environments', { path: 'admin/environments' });
+  ```
+
+  ```js
+  this.namespace('admin', function() {
+    this.route('users');
+    this.route('groups');
+    this.route('environments');
+  });
+  ```
+
+  The above code examples create the following 3 routes:
+
+  1. `admin.users` at the URL `/admin/users`
+  2. `admin.groups` at the URL `/admin/groups`
+  3. `admin.environments` at the URL `/admin/environments`
+
+  This differs to nested routes in that the following routes are not created/resolved/used:
+
+  1. The parent route, `admin`
+  2. `admin.index`
+  3. `admin.error`
+  4. `admin.loading`

--- a/features.json
+++ b/features.json
@@ -23,7 +23,8 @@
     "ember-htmlbars-dashless-helpers": true,
     "ember-debug-handlers": null,
     "ember-registry-container-reform": null,
-    "ember-routing-routable-components": null
+    "ember-routing-routable-components": null,
+    "ember-routing-namespace": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -143,4 +143,96 @@ if (isEnabled('ember-routing-named-substates')) {
   ok(!router.router.recognizer.names['blork_error'], 'error route was not added');
 });
 }
+
+if (isEnabled('ember-routing-namespace')) {
+QUnit.test('should retain namespace if nested with routes but only have one handler', function() {
+  Router.map(function() {
+    this.namespace('bleep', function() {
+      this.route('blork');
+      this.route('bloop');
+    });
+  });
+
+  var router = Router.create();
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['bleep.blork'], 'parent name was used as base of nested routes');
+  ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+
+  ok(!router.router.recognizer.names['bleep'], 'parent name was not added');
+  ok(!router.router.recognizer.names['bleep.error'], 'error name under the parent name was not added');
+  ok(!router.router.recognizer.names['bleep.loading'], 'loading name under the parent name was not added');
+  ok(!router.router.recognizer.names['bleep.index'], 'index name under the parent name was not added');
+});
+
+QUnit.test('calling route should have higher priority then calling namespace (calling route after namespace)', function() {
+  Router.map(function() {
+    this.namespace('bleep', function() {
+      this.route('blork');
+      this.route('bloop');
+    });
+    this.route('bleep', function() {
+      this.route('blork');
+      this.route('bloop');
+    });
+  });
+
+  var router = Router.create();
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['bleep.blork'], 'parent name was used as base of nested routes');
+  ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+
+  ok(router.router.recognizer.names['bleep'], 'parent name was not added');
+  ok(router.router.recognizer.names['bleep.error'], 'error name under the parent name was not added');
+  ok(router.router.recognizer.names['bleep.loading'], 'loading name under the parent name was not added');
+  ok(router.router.recognizer.names['bleep.index'], 'index name under the parent name was not added');
+});
+
+QUnit.test('calling route should have higher priority then calling namespace (calling route before namespace)', function() {
+  Router.map(function() {
+    this.route('bleep', function() {
+      this.route('blork');
+      this.route('bloop');
+    });
+    this.namespace('bleep', function() {
+      this.route('blork');
+      this.route('bloop');
+    });
+  });
+
+  var router = Router.create();
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['bleep.blork'], 'parent name was used as base of nested routes');
+  ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+
+  ok(router.router.recognizer.names['bleep'], 'parent name was not added');
+  ok(router.router.recognizer.names['bleep.error'], 'error name under the parent name was not added');
+  ok(router.router.recognizer.names['bleep.loading'], 'loading name under the parent name was not added');
+  ok(router.router.recognizer.names['bleep.index'], 'index name under the parent name was not added');
+});
+
+QUnit.test('calls to this.route and this.namespace with the same route should concatenate child routes', function() {
+  Router.map(function() {
+    this.route('bleep', function() {
+      this.route('blork');
+    });
+    this.namespace('bleep', function() {
+      this.route('bloop');
+    });
+  });
+
+  var router = Router.create();
+  router._initRouterJs();
+
+  ok(router.router.recognizer.names['bleep.blork'], 'parent name was used as base of nested routes');
+  ok(router.router.recognizer.names['bleep.bloop'], 'parent name was used as base of nested routes');
+
+  ok(router.router.recognizer.names['bleep'], 'parent name was not added');
+  ok(router.router.recognizer.names['bleep.error'], 'error name under the parent name was not added');
+  ok(router.router.recognizer.names['bleep.loading'], 'loading name under the parent name was not added');
+  ok(router.router.recognizer.names['bleep.index'], 'index name under the parent name was not added');
+});
+}
 // jscs:enable validateIndentation


### PR DESCRIPTION
Adds `this.namespace()` to Router DSL  along side `this.route()` and `this.resource()`.

The new namespace function allows you to define a set of routes that exist under the
one namespace which isn't a parent route.

The following 2 examples produce the same results:

``` js
this.route('admin.users', { path: 'admin/users' });
this.route('admin.groups', { path: 'admin/groups' });
this.route('admin.environments', { path: 'admin/environments' });
```

``` js
this.namespace('admin', function() {
  this.route('users');
  this.route('groups');
  this.route('environments');
});
```

The above code examples create the following 3 routes:
1. `admin.users` at the URL `/admin/users`
2. `admin.groups` at the URL `/admin/groups`
3. `admin.environments` at the URL `/admin/environments`

This differs to nested routes in that the following routes are not created/resolved/used:
1. The parent route, `admin`
2. `admin.index`
3. `admin.error`
4. `admin.loading`
