### PR TITLE
[BUGFIX beta] Prevent `unsafe:` protocol popups in test suite.

### DIFF
--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -3,7 +3,7 @@
 import EmberView from "ember-views/views/view";
 import compile from "ember-template-compiler/system/compile";
 import { SafeString } from "ember-htmlbars/utils/string";
-import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import { runDestroy } from "ember-runtime/tests/utils";
 import environment from "ember-metal/environment";
 
 var view;
@@ -71,7 +71,8 @@ for (var i=0, l=badTags.length; i<l; i++) {
         context: { url: 'javascript://example.com' },
         template: subject.unquotedTemplate
       });
-      runAppend(view);
+
+      view.createElement();
 
       equal(view.element.firstChild.getAttribute(subject.attr),
              "unsafe:javascript://example.com",
@@ -83,7 +84,8 @@ for (var i=0, l=badTags.length; i<l; i++) {
         context: { url: 'javascript://example.com' },
         template: subject.quotedTemplate
       });
-      runAppend(view);
+
+      view.createElement();
 
       equal(view.element.firstChild.getAttribute(subject.attr),
              "unsafe:javascript://example.com",
@@ -97,7 +99,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
       });
 
       try {
-        runAppend(view);
+        view.createElement();
 
         equal(view.element.firstChild.getAttribute(subject.attr),
                "javascript://example.com",
@@ -113,7 +115,7 @@ for (var i=0, l=badTags.length; i<l; i++) {
         context: { protocol: 'javascript:', path: '//example.com' },
         template: subject.multipartTemplate
       });
-      runAppend(view);
+      view.createElement();
 
       equal(view.element.firstChild.getAttribute(subject.attr),
              "unsafe:javascript://example.com",


### PR DESCRIPTION
When running the test suite under Safari (before these changes) you would have a number of popups regarding the `unsafe:` protocol not having an application associated.

The warning was triggered on Safari when the element is inserted into the DOM, this change swaps from `view.appendTo` to `view.createElement()`. `createElement()` adds the element but does not insert into the DOM (allowing us to do the assertions we need but preventing this annoying popup).
