### PR TITLE
[BUGFIX release] Ensure handleURL called after setURL in visit helper

### DIFF
--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -57,8 +57,14 @@ function focus(el) {
 
 function visit(app, url) {
   var router = app.__container__.lookup('router:main');
+  var shouldHandleURL = false;
+
   app.boot().then(function() {
     router.location.setURL(url);
+
+    if (shouldHandleURL) {
+      run(app.__deprecatedInstance__, 'handleURL', url);
+    }
   });
 
   if (app._readinessDeferrals > 0) {
@@ -66,7 +72,7 @@ function visit(app, url) {
     run(app, 'advanceReadiness');
     delete router['initialURL'];
   } else {
-    run(app.__deprecatedInstance__, 'handleURL', url);
+    shouldHandleURL = true;
   }
 
   return app.testHelpers.wait();

--- a/packages/ember-testing/tests/acceptance_test.js
+++ b/packages/ember-testing/tests/acceptance_test.js
@@ -30,6 +30,8 @@ QUnit.module("ember-testing Acceptance", {
         this.route('comments');
 
         this.route('abort_transition');
+
+        this.route('redirect');
       });
 
       App.IndexRoute = EmberRoute.extend({
@@ -64,6 +66,12 @@ QUnit.module("ember-testing Acceptance", {
       App.AbortTransitionRoute = EmberRoute.extend({
         beforeModel(transition) {
           transition.abort();
+        }
+      });
+
+      App.RedirectRoute = EmberRoute.extend({
+        beforeModel() {
+          this.transitionTo('comments');
         }
       });
 
@@ -354,4 +362,20 @@ QUnit.test("test must not finish while asyncHelpers are pending", function () {
       Test.adapter.asyncEnd();
     });
   }
+});
+
+QUnit.test('visiting a URL and then visiting a second URL with a transition should yield the correct URL', function () {
+  expect(2);
+
+  visit('/posts');
+
+  andThen(function () {
+    equal(currentURL(), '/posts', 'First visited URL is correct');
+  });
+
+  visit('/redirect');
+
+  andThen(function () {
+    equal(currentURL(), '/comments', 'Redirected to Comments URL');
+  });
 });


### PR DESCRIPTION
There's a regression in 1.12.1 where if you `visit()` a URL that has a transition (`this.transitionTo()` in a `beforeModel` hook) after already visiting some other URL that `handleURL` won't be invoked with the correct context and `currentURL()` will yield the "pre-transition" URL.

Here's a failing jsbin for 1.12.1: http://emberjs.jsbin.com/nafakuz/5/edit

And a working jsbin on 1.11.3: http://emberjs.jsbin.com/tosacu/2/edit
