### PR TITLE
[BUGFIX beta] Do not require a view being rendered to have `_transitionTo`.

### DIFF
--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -221,7 +221,9 @@ Renderer.prototype.willDestroyElement = function (view) {
     view.trigger('willClearRender');
   }
 
-  view._transitionTo('destroying', false);
+  if (view._transitionTo) {
+    view._transitionTo('destroying', false);
+  }
 
   var childViews = view.childViews;
   if (childViews) {
@@ -238,7 +240,7 @@ Renderer.prototype.didDestroyElement = function (view) {
   // However if we're just destroying an element on a view (as is the case when
   // using View#remove) then the view should go to a preRender state so that
   // it can be rendered again later.
-  if (view._state !== 'destroying') {
+  if (view._state !== 'destroying' && view._transitionTo) {
     view._transitionTo('preRender');
   }
 


### PR DESCRIPTION
In the majority of places in the renderer we were already guarding for `_transitionTo`
being undefined, but these didn't guard.

Added the guard for consistency.
