### PR TITLE
Fix canary build publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "ember build",
     "test": "bin/run-tests.js",
     "start": "ember serve",
-    "docs": "ember yuidoc"
+    "docs": "ember ember-cli-yuidoc"
   },
   "devDependencies": {
     "aws-sdk": "~2.1.5",


### PR DESCRIPTION
ember-cli-yuidoc was updated, but the docs script was not updated to the
new command name.  This caused the publishing of builds to fail.
