### PR TITLE
Failing test for {{component}} keyword teardown.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -269,6 +269,9 @@ export function createComponent(_component, isAngleBracket, _props, renderNode, 
   }
 
   component._renderNode = renderNode;
+  if (renderNode.emberView && renderNode.emberView !== component) {
+    throw new Error('Need to clean up this view before blindly reassigning.');
+  }
   renderNode.emberView = component;
   return component;
 }

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -188,6 +188,10 @@ export function createOrUpdateComponent(component, options, createOptions, rende
   }
 
   component._renderNode = renderNode;
+
+  if (renderNode.emberView && renderNode.emberView !== component) {
+    throw new Error('Need to clean up this view before blindly reassigning.');
+  }
   renderNode.emberView = component;
   return component;
 }


### PR DESCRIPTION
Currently, the `{{component}}` keyword does not teardown previously created components when swapping.  This test demonstrates that.

JSBin Demo: http://emberjs.jsbin.com/rwjblue/571/edit.
