### PR TITLE
[ember-htmlbars-component-generation] Update test to assert attrs do not leak to state in component layout

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -756,7 +756,7 @@ QUnit.test('non-block with properties on attrs', function() {
 QUnit.test('attributes are not installed on the top level', function() {
   let component;
 
-  registry.register('template:components/non-block', compile('In layout - {{attrs.text}}'));
+  registry.register('template:components/non-block', compile('In layout - {{attrs.text}} -- {{text}}'));
   registry.register('component:non-block', Component.extend({
     text: null,
     dynamic: null,
@@ -773,7 +773,7 @@ QUnit.test('attributes are not installed on the top level', function() {
   let el = view.$('non-block.ember-view');
   ok(el, "precond - the view was rendered");
 
-  equal(el.text(), "In layout - texting");
+  equal(el.text(), "In layout - texting -- ");
   equal(component.attrs.text, "texting");
   equal(component.attrs.dynamic, "dynamic");
   strictEqual(get(component, 'text'), null);
@@ -781,7 +781,7 @@ QUnit.test('attributes are not installed on the top level', function() {
 
   run(() => view.rerender());
 
-  equal(el.text(), "In layout - texting");
+  equal(el.text(), "In layout - texting -- ");
   equal(component.attrs.text, "texting");
   equal(component.attrs.dynamic, "dynamic");
   strictEqual(get(component, 'text'), null);


### PR DESCRIPTION
Updated test fails with:

![](https://api.monosnap.com/rpc/file/download?id=1ZJpGG9h96lj5vTK8uo4IUAe55EJWt)

A value passed into the component as `attrs.text` is rendered in layout when referenced as `{{text}}`.
