### PR TITLE
Glimmer optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.22",
+    "htmlbars": "0.13.25",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -17,8 +17,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
     isAngleBracket = true;
   }
 
-  var read = env.hooks.getValue;
-  var parentView = read(scope.view);
+  var parentView = env.view;
 
   var manager = ComponentNodeManager.create(renderNode, env, {
     tagName,

--- a/packages/ember-htmlbars/lib/keywords/real_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/real_outlet.js
@@ -27,8 +27,8 @@ export default {
     return { outletState: selectedOutletState, hasParentOutlet: env.hasParentOutlet };
   },
 
-  childEnv(state) {
-    return { outletState: state.outletState && state.outletState.outlets, hasParentOutlet: true };
+  childEnv(state, env) {
+    return env.childWithOutletState(state.outletState && state.outletState.outlets, true);
   },
 
   isStable(lastState, nextState) {

--- a/packages/ember-htmlbars/lib/morphs/attr-morph.js
+++ b/packages/ember-htmlbars/lib/morphs/attr-morph.js
@@ -12,6 +12,8 @@ export var styleWarning = '' +
 
 function EmberAttrMorph(element, attrName, domHelper, namespace) {
   HTMLBarsAttrMorph.call(this, element, attrName, domHelper, namespace);
+
+  this.streamUnsubscribers = null;
 }
 
 var proto = EmberAttrMorph.prototype = o_create(HTMLBarsAttrMorph.prototype);

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -157,9 +157,7 @@ ComponentNodeManager.prototype.render = function(_env, visitor) {
   var { component, attrs } = this;
 
   return instrument(component, function() {
-    let env = _env;
-
-    env = assign({ view: component }, env);
+    let env = _env.childWithView(component);
 
     var snapshot = takeSnapshot(attrs);
     env.renderer.componentInitAttrs(this.component, snapshot);
@@ -210,7 +208,7 @@ ComponentNodeManager.prototype.rerender = function(_env, attrs, visitor) {
     var snapshot = takeSnapshot(attrs);
 
     if (component._renderNode.shouldReceiveAttrs) {
-      env.renderer.componentUpdateAttrs(component, component.attrs, snapshot);
+      env.renderer.componentUpdateAttrs(component, snapshot);
 
       if (!component._isAngleBracket) {
         setProperties(component, mergeBindings({}, shadowedAttrs(component, snapshot)));

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -91,8 +91,7 @@ ViewNodeManager.prototype.render = function(env, attrs, visitor) {
 
     var newEnv = env;
     if (component) {
-      newEnv = merge({}, env);
-      newEnv.view = component;
+      newEnv = env.childWithView(component);
     }
 
     if (component) {
@@ -124,8 +123,7 @@ ViewNodeManager.prototype.rerender = function(env, attrs, visitor) {
   return instrument(component, function() {
     var newEnv = env;
     if (component) {
-      newEnv = merge({}, env);
-      newEnv.view = component;
+      newEnv = env.childWithView(component);
 
       var snapshot = takeSnapshot(attrs);
 

--- a/packages/ember-htmlbars/lib/system/render-env.js
+++ b/packages/ember-htmlbars/lib/system/render-env.js
@@ -1,0 +1,56 @@
+import defaultEnv from "ember-htmlbars/env";
+
+export default function RenderEnv(options) {
+  this.lifecycleHooks = options.lifecycleHooks || [];
+  this.renderedViews = options.renderedViews || [];
+  this.renderedNodes = options.renderedNodes || {};
+  this.hasParentOutlet = options.hasParentOutlet || false;
+
+  this.view = options.view;
+  this.outletState = options.outletState;
+  this.container = options.container;
+  this.renderer = options.renderer;
+  this.dom = options.dom;
+
+  this.hooks = defaultEnv.hooks;
+  this.helpers = defaultEnv.helpers;
+  this.useFragmentCache = defaultEnv.useFragmentCache;
+}
+
+RenderEnv.build = function(view) {
+  return new RenderEnv({
+    view: view,
+    outletState: view.outletState,
+    container: view.container,
+    renderer: view.renderer,
+    dom: view.renderer._dom
+  });
+};
+
+RenderEnv.prototype.childWithView = function(view) {
+  return new RenderEnv({
+    view: view,
+    outletState: this.outletState,
+    container: this.container,
+    renderer: this.renderer,
+    dom: this.dom,
+    lifecycleHooks: this.lifecycleHooks,
+    renderedViews: this.renderedViews,
+    renderedNodes: this.renderedNodes,
+    hasParentOutlet: this.hasParentOutlet
+  });
+};
+
+RenderEnv.prototype.childWithOutletState = function(outletState, hasParentOutlet=this.hasParentOutlet) {
+  return new RenderEnv({
+    view: this.view,
+    outletState: outletState,
+    container: this.container,
+    renderer: this.renderer,
+    dom: this.dom,
+    lifecycleHooks: this.lifecycleHooks,
+    renderedViews: this.renderedViews,
+    renderedNodes: this.renderedNodes,
+    hasParentOutlet: hasParentOutlet
+  });
+};

--- a/packages/ember-htmlbars/lib/system/render-view.js
+++ b/packages/ember-htmlbars/lib/system/render-view.js
@@ -1,22 +1,10 @@
-import defaultEnv from "ember-htmlbars/env";
 import ViewNodeManager, { createOrUpdateComponent } from "ember-htmlbars/node-managers/view-node-manager";
+import RenderEnv from "ember-htmlbars/system/render-env";
 
 // This function only gets called once per render of a "root view" (`appendTo`). Otherwise,
 // HTMLBars propagates the existing env and renders templates for a given render node.
 export function renderHTMLBarsBlock(view, block, renderNode) {
-  var env = {
-    lifecycleHooks: [],
-    renderedViews: [],
-    renderedNodes: {},
-    view: view,
-    outletState: view.outletState,
-    container: view.container,
-    renderer: view.renderer,
-    dom: view.renderer._dom,
-    hooks: defaultEnv.hooks,
-    helpers: defaultEnv.helpers,
-    useFragmentCache: defaultEnv.useFragmentCache
-  };
+  var env = RenderEnv.build(view);
 
   view.env = env;
   createOrUpdateComponent(view, {}, null, renderNode, env);

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -1,6 +1,8 @@
 import run from "ember-metal/run_loop";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
+import { assign } from "ember-metal/merge";
+import setProperties from "ember-metal/set_properties";
 import buildComponentTemplate from "ember-views/system/build-component-template";
 import { indexOf } from "ember-metal/enumerable_utils";
 //import { deprecation } from "ember-views/compat/attrs-proxy";
@@ -161,8 +163,15 @@ Renderer.prototype.updateAttrs = function (view, attrs) {
   this.setAttrs(view, attrs);
 }; // setting new attrs
 
-Renderer.prototype.componentUpdateAttrs = function (component, oldAttrs, newAttrs) {
-  set(component, 'attrs', newAttrs);
+Renderer.prototype.componentUpdateAttrs = function (component, newAttrs) {
+  let oldAttrs = null;
+
+  if (component.attrs) {
+    oldAttrs = assign({}, component.attrs);
+    setProperties(component.attrs, newAttrs);
+  } else {
+    set(component, 'attrs', newAttrs);
+  }
 
   component.trigger('didUpdateAttrs', { oldAttrs, newAttrs });
   component.trigger('didReceiveAttrs', { oldAttrs, newAttrs });

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -38,8 +38,11 @@ export function assign(original, ...args) {
     let arg = args[i];
     if (!arg) { continue; }
 
-    for (let prop in arg) {
-      if (arg.hasOwnProperty(prop)) { original[prop] = arg[prop]; }
+    let updates = keys(arg);
+
+    for (let i=0, l=updates.length; i<l; i++) {
+      let prop = updates[i];
+      original[prop] = arg[prop];
     }
   }
 

--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -32,8 +32,8 @@ export default {
     };
   },
 
-  childEnv(state) {
-    return { outletState: state.childOutletState };
+  childEnv(state, env) {
+    return env.childWithOutletState(state.childOutletState);
   },
 
   isStable(lastState, nextState) {


### PR DESCRIPTION
A handful of optimizations for Glimmer. Several of these are tweak that help the V8 JIT to maintain the shape of internal bookkeeping structures. We also fixed a bug that fixes several related issues, where `parentView`/`ownerView` were not maintained properly. There were likely teardown bugs related to this. Lastly, we made an improvement to the algorithm used by `{{#each}}` and other helpers on subsequent re-renders that should reduce the number of DOM operations needed in most situations. (That work happened in the tildeio/htmlbars.)
