### PR TITLE
Make ComponentNodeManager.rerender use RenderEnv

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -210,9 +210,7 @@ ComponentNodeManager.prototype.rerender = function(_env, attrs, visitor) {
   var component = this.component;
 
   return instrument(component, function() {
-    let env = _env;
-
-    env = assign({ view: component }, env);
+    let env = _env.childWithView(component);
 
     var snapshot = takeSnapshot(attrs);
 

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -780,6 +780,31 @@ QUnit.test("comopnent should rerender when a property (with a default) is change
 
 });
 
+QUnit.test('non-block with each rendering child components', function() {
+  expect(2);
+
+  registry.register('template:components/non-block', compile('In layout. {{#each attrs.items as |item|}}[{{child-non-block item=item}}]{{/each}}'));
+  registry.register('template:components/child-non-block', compile('Child: {{attrs.item}}.'));
+
+  var items = Ember.A(['Tom', 'Dick', 'Harry']);
+
+  view = EmberView.extend({
+    template: compile('{{non-block items=view.items}}'),
+    container: container,
+    items: items
+  }).create();
+
+  runAppend(view);
+
+  equal(jQuery('#qunit-fixture').text(), 'In layout. [Child: Tom.][Child: Dick.][Child: Harry.]');
+
+  run(function() {
+    items.pushObject('James');
+  });
+
+  equal(jQuery('#qunit-fixture').text(), 'In layout. [Child: Tom.][Child: Dick.][Child: Harry.][Child: James.]');
+});
+
 // jscs:disable validateIndentation
 if (Ember.FEATURES.isEnabled('ember-htmlbars-component-generation')) {
 

--- a/packages/ember-htmlbars/tests/system/render_env_test.js
+++ b/packages/ember-htmlbars/tests/system/render_env_test.js
@@ -1,0 +1,117 @@
+import EmberView from "ember-views/views/view";
+import Registry from "container/registry";
+import compile from "ember-template-compiler/system/compile";
+import ComponentLookup from 'ember-views/component_lookup';
+import Component from "ember-views/views/component";
+import RenderEnv from "ember-htmlbars/system/render-env";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import run from "ember-metal/run_loop";
+
+var registry, container, view, components;
+
+function commonSetup() {
+  registry = new Registry();
+  container = registry.container();
+  registry.optionsForType('component', { singleton: false });
+  registry.optionsForType('view', { singleton: false });
+  registry.optionsForType('template', { instantiate: false });
+  registry.optionsForType('helper', { instantiate: false });
+  registry.register('component-lookup:main', ComponentLookup);
+}
+
+function commonTeardown() {
+  runDestroy(container);
+  runDestroy(view);
+  registry = container = view = null;
+}
+
+function appendViewFor(template, hash={}) {
+  let view = EmberView.extend({
+    template: compile(template),
+    container: container
+  }).create(hash);
+
+  runAppend(view);
+
+  return view;
+}
+
+function constructComponent(label) {
+  return Component.extend({
+    init() {
+      this.label = label;
+      components[label] = this;
+      this._super.apply(this, arguments);
+    }
+  });
+}
+
+function extractEnv(component) {
+  return component._renderNode.lastResult.env;
+}
+
+QUnit.module('ember-htmlbars: RenderEnv', {
+  setup() {
+    commonSetup();
+  },
+
+  teardown() {
+    commonTeardown();
+  }
+});
+
+QUnit.test('non-block component test', function() {
+  components = {};
+
+  registry.register('component:non-block', constructComponent('nonblock'));
+  registry.register('template:components/non-block', compile('In layout'));
+
+  view = appendViewFor('{{non-block}}');
+
+  ok(view.env instanceof RenderEnv, 'initial render: View environment should be an instance of RenderEnv');
+  ok(extractEnv(components.nonblock) instanceof RenderEnv, 'initial render: {{#non-block}} environment should be an instance of RenderEnv');
+
+  run(components.nonblock, 'rerender');
+
+  ok(view.env instanceof RenderEnv, 'rerender: View environment should be an instance of RenderEnv');
+  ok(extractEnv(components.nonblock) instanceof RenderEnv, 'rerender: {{#non-block}} environment should be an instance of RenderEnv');
+});
+
+QUnit.test('block component test', function() {
+  components = {};
+
+  registry.register('component:block-component', constructComponent('block'));
+  registry.register('template:components/block-component', compile('In layout {{yield}}'));
+
+  view = appendViewFor('{{#block-component}}content{{/block-component}}');
+
+  ok(view.env instanceof RenderEnv, 'initial render: View environment should be an instance of RenderEnv');
+  ok(extractEnv(components.block) instanceof RenderEnv, 'initial render: {{#block-component}} environment should be an instance of RenderEnv');
+
+  run(components.block, 'rerender');
+
+  ok(view.env instanceof RenderEnv, 'rerender: View environment should be an instance of RenderEnv');
+  ok(extractEnv(components.block) instanceof RenderEnv, 'rerender: {{#block-component}} environment should be an instance of RenderEnv');
+});
+
+QUnit.test('block component with child component test', function() {
+  components = {};
+
+  registry.register('component:block-component', constructComponent('block'));
+  registry.register('component:child-component', constructComponent('child'));
+
+  registry.register('template:components/block-component', compile('In layout {{yield}}'));
+  registry.register('template:components/child-component', compile('Child Component'));
+
+  view = appendViewFor('{{#block-component}}{{child-component}}{{/block-component}}');
+
+  ok(view.env instanceof RenderEnv, 'initial render: View environment should be an instance of RenderEnv');
+  ok(extractEnv(components.block) instanceof RenderEnv, 'initial render: {{#block-component}} environment should be an instance of RenderEnv');
+  ok(extractEnv(components.child) instanceof RenderEnv, 'initial render: {{child-component}} environment should be an instance of RenderEnv');
+
+  run(components.block, 'rerender');
+
+  ok(view.env instanceof RenderEnv, 'rerender: View environment should be an instance of RenderEnv');
+  ok(extractEnv(components.block) instanceof RenderEnv, 'rerender: {{#block-component}} environment should be an instance of RenderEnv');
+  ok(extractEnv(components.child) instanceof RenderEnv, 'rerender: {{child-component}} environment should be an instance of RenderEnv');
+});


### PR DESCRIPTION
Fixes #11340.

`ComponentNodeManager.render()`

```
let env = _env.childWithView(component);
```

`ComponentNodeManager.rerender()`

```
let env = _env;
env = assign({ view: component }, env);
```

This causes issues in later steps where something calls `childWithView` on `env` - which no longer exists.
