### PR TITLE
Make sure env doesn't lose properties

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -212,7 +212,7 @@ ComponentNodeManager.prototype.rerender = function(_env, attrs, visitor) {
   return instrument(component, function() {
     let env = _env;
 
-    env = assign({ view: component }, env);
+    env = assign(env, { view: component });
 
     var snapshot = takeSnapshot(attrs);
 


### PR DESCRIPTION
Some env properties like childWithView are defined in the prototype object. Assign was not copying these as they are non-enumerable.

@tomdale 

Fixed this problem in my app:

![image](https://cloud.githubusercontent.com/assets/474587/7979094/a8a567e4-0a9c-11e5-9c93-2003bb058732.png)
