### PR TITLE
Use model name instead of factory in data adapter

### DIFF
--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -93,6 +93,20 @@ export default EmberObject.extend({
   attributeLimit: 3,
 
   /**
+   * Ember Data > v1.0.0-beta.18
+   * requires string model names to be passed
+   * around instead of the actual factories.
+   *
+   * This is a stamp for the Ember Inspector
+   * to differentiate between the versions
+   * to be able to support older versions too.
+   *
+   * @public
+   * @property acceptsModelName
+   */
+  acceptsModelName: true,
+
+  /**
     Stores all methods that clear observers.
     These methods will be called on destruction.
 
@@ -138,7 +152,7 @@ export default EmberObject.extend({
     typesToSend = modelTypes.map((type) => {
       var klass = type.klass;
       var wrapped = this.wrapModelType(klass, type.name);
-      releaseMethods.push(this.observeModelType(klass, typesUpdated));
+      releaseMethods.push(this.observeModelType(type.name, typesUpdated));
       return wrapped;
     });
 
@@ -165,6 +179,8 @@ export default EmberObject.extend({
     @public
     @method watchRecords
 
+    @param {String} modelName The model name
+
     @param {Function} recordsAdded Callback to call to add records.
     Takes an array of objects containing wrapped records.
     The object should have the following properties:
@@ -181,9 +197,10 @@ export default EmberObject.extend({
 
     @return {Function} Method to call to remove all observers
   */
-  watchRecords(type, recordsAdded, recordsUpdated, recordsRemoved) {
+  watchRecords(modelName, recordsAdded, recordsUpdated, recordsRemoved) {
     var releaseMethods = emberA();
-    var records = this.getRecords(type);
+    var klass = this._nameToClass(modelName);
+    var records = this.getRecords(klass, modelName);
     var release;
 
     var recordUpdated = function(updatedRecord) {
@@ -270,16 +287,17 @@ export default EmberObject.extend({
 
     @private
     @method observeModelType
-    @param {Class} type The model type class
+    @param {String} modelName The model type name
     @param {Function} typesUpdated Called when a type is modified.
     @return {Function} The function to call to remove observers
   */
 
-  observeModelType(type, typesUpdated) {
-    var records = this.getRecords(type);
+  observeModelType(modelName, typesUpdated) {
+    var klass = this._nameToClass(modelName);
+    var records = this.getRecords(klass, modelName);
 
     var onChange = () => {
-      typesUpdated([this.wrapModelType(type)]);
+      typesUpdated([this.wrapModelType(klass, modelName)]);
     };
     var observer = {
       didChange() {
@@ -303,8 +321,8 @@ export default EmberObject.extend({
 
     @private
     @method wrapModelType
-    @param {Class} type A model class
-    @param {String}  Optional name of the class
+    @param {Class} klass A model class
+    @param {String} modelName Name of the class
     @return {Object} contains the wrapped type and the function to remove observers
     Format:
       type: {Object} the wrapped type
@@ -315,15 +333,15 @@ export default EmberObject.extend({
           object: {Class} the actual Model type class
       release: {Function} The function to remove observers
   */
-  wrapModelType(type, name) {
-    var records = this.getRecords(type);
+  wrapModelType(klass, name) {
+    var records = this.getRecords(klass, name);
     var typeToSend;
 
     typeToSend = {
-      name: name || type.toString(),
+      name,
       count: get(records, 'length'),
-      columns: this.columnsForType(type),
-      object: type
+      columns: this.columnsForType(klass),
+      object: klass
     };
 
 
@@ -378,7 +396,7 @@ export default EmberObject.extend({
       for (var key in namespace) {
         if (!namespace.hasOwnProperty(key)) { continue; }
         // Even though we will filter again in `getModelTypes`,
-        // we should not call `lookupContainer` on non-models
+        // we should not call `lookupFactory` on non-models
         // (especially when `Ember.MODEL_FACTORY_INJECTIONS` is `true`)
         if (!this.detect(namespace[key])) { continue; }
         var name = dasherize(key);

--- a/packages/ember-extension-support/tests/data_adapter_test.js
+++ b/packages/ember-extension-support/tests/data_adapter_test.js
@@ -65,6 +65,20 @@ QUnit.test("Model types added with DefaultResolver", function() {
   adapter.watchModelTypes(modelTypesAdded);
 });
 
+QUnit.test("getRecords gets a model name as second argument", function() {
+  App.Post = Model.extend();
+
+  adapter = App.__container__.lookup('data-adapter:main');
+  adapter.reopen({
+    getRecords(klass, name) {
+      equal(name, 'post');
+      return Ember.A([]);
+    }
+  });
+
+  adapter.watchModelTypes(function() { });
+});
+
 QUnit.test("Model types added with custom container-debug-adapter", function() {
   var PostClass = Model.extend();
   var StubContainerDebugAdapter = DefaultResolver.extend({


### PR DESCRIPTION
A [recent PR](https://github.com/emberjs/data/pull/3074) changed Ember Data to require passing model names to store methods instead of factories. 

This passes the model name as a second argument to `getRecords` to stay backwards compatible.
