### PR TITLE
[BUGFIX beta] Fix Views with templates inline as component.

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -112,8 +112,14 @@ function extractComponentTemplates(component, _templates) {
   // respect (though this behavior is deprecated).
   let componentLayout = get(component, 'layout');
   let hasBlock = _templates && _templates.default;
-  let componentTemplate = hasBlock ? null : get(component, '_template');
-  let layout, templates;
+  let layout, templates, componentTemplate;
+  if (hasBlock) {
+    componentTemplate = null;
+  } else if (component.isComponent) {
+    componentTemplate = get(component, '_template');
+  } else {
+    componentTemplate = get(component, 'template');
+  }
 
   if (componentLayout) {
     layout = componentLayout;

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -321,6 +321,25 @@ QUnit.test('`template` specified in a component is overridden by block', functio
   equal(view.$().text(), 'Whoop, whoop!', 'block provided always overrides template property');
 });
 
+QUnit.test('template specified inline is available from Views looked up as components', function() {
+  expect(2);
+
+  registry.register('component:without-block', EmberView.extend({
+    template: compile('Whoop, whoop!')
+  }));
+
+  view = EmberView.extend({
+    template: compile('{{without-block}}'),
+    container: container
+  }).create();
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, 'Using deprecated `template` property on a Component.');
+
+  equal(view.$().text(), 'Whoop, whoop!', 'template inline works properly');
+});
+
 if (Ember.FEATURES.isEnabled('ember-views-component-block-info')) {
   QUnit.test('hasBlock is true when block supplied', function() {
     expect(1);


### PR DESCRIPTION
When using a `Ember.View` based factory from a component's location the new `_template` lookup will not work (because `Ember.View` does not have that specific fallback).

Fixes https://github.com/emberjs/ember.js/issues/11351.
