### PR TITLE
[DOC release] modelFor will never return a promise

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1610,13 +1610,14 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
   },
 
   /**
-    Returns the model of a parent (or any ancestor) route
+    Returns the resolved model of a parent (or any ancestor) route
     in a route hierarchy.  During a transition, all routes
     must resolve a model object, and if a route
     needs access to a parent route's model in order to
     resolve a model (or just reuse the model from a parent),
     it can call `this.modelFor(theNameOfParentRoute)` to
-    retrieve it.
+    retrieve it. If the ancestor route's model was a promise, 
+    its resolved result is returned.
 
     Example
 


### PR DESCRIPTION
I was confused by how parent/child routes work with promises and modelFor. I'd find it useful to have it written in the modelFor docs whether it might return a promise.

According to http://guides.emberjs.com/v1.11.0/routing/asynchronous-routing/ :

> If the promise fulfills, the transition will pick up where it left off and begin resolving the next (child) route's model, pausing if it too is a promise, and so on, until all destination route models have been resolved.

I'm assuming this covers modelFor, since the parent's model (promise) will be fully loaded before the child route where modelFor can be used.

Corrections welcome.
