### PR TITLE
Implements RFC #60 (Component Unification)

### DIFF
--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -28,6 +28,7 @@ import lookupHelper from 'ember-htmlbars/hooks/lookup-helper';
 import hasHelper from 'ember-htmlbars/hooks/has-helper';
 import invokeHelper from 'ember-htmlbars/hooks/invoke-helper';
 import element from 'ember-htmlbars/hooks/element';
+import attributes from 'ember-htmlbars/hooks/attributes';
 
 import helpers from 'ember-htmlbars/helpers';
 import keywords, { registerKeyword } from 'ember-htmlbars/keywords';
@@ -38,30 +39,31 @@ var emberHooks = merge({}, hooks);
 emberHooks.keywords = keywords;
 
 merge(emberHooks, {
-  linkRenderNode: linkRenderNode,
-  createFreshScope: createFreshScope,
-  bindShadowScope: bindShadowScope,
-  bindSelf: bindSelf,
-  bindScope: bindScope,
-  bindLocal: bindLocal,
-  updateSelf: updateSelf,
-  getRoot: getRoot,
-  getChild: getChild,
-  getValue: getValue,
-  getCellOrValue: getCellOrValue,
-  subexpr: subexpr,
-  concat: concat,
-  cleanupRenderNode: cleanupRenderNode,
-  destroyRenderNode: destroyRenderNode,
-  willCleanupTree: willCleanupTree,
-  didCleanupTree: didCleanupTree,
-  didRenderNode: didRenderNode,
-  classify: classify,
-  component: component,
-  lookupHelper: lookupHelper,
-  hasHelper: hasHelper,
-  invokeHelper: invokeHelper,
-  element: element
+  linkRenderNode,
+  createFreshScope,
+  bindShadowScope,
+  bindSelf,
+  bindScope,
+  bindLocal,
+  updateSelf,
+  getRoot,
+  getChild,
+  getValue,
+  getCellOrValue,
+  subexpr,
+  concat,
+  cleanupRenderNode,
+  destroyRenderNode,
+  willCleanupTree,
+  didCleanupTree,
+  didRenderNode,
+  classify,
+  component,
+  lookupHelper,
+  hasHelper,
+  invokeHelper,
+  element,
+  attributes
 });
 
 import debuggerKeyword from 'ember-htmlbars/keywords/debugger';

--- a/packages/ember-htmlbars/lib/hooks/attributes.js
+++ b/packages/ember-htmlbars/lib/hooks/attributes.js
@@ -1,0 +1,50 @@
+import { render, internal } from 'htmlbars-runtime';
+
+export default function attributes(morph, env, scope, template, parentNode, visitor) {
+  let state = morph.state;
+  let block = state.block;
+
+  if (!block) {
+    let element = findRootElement(parentNode);
+    if (!element) { return; }
+
+    normalizeClassStatement(template.statements, element);
+
+    template.element = element;
+    block = morph.state.block = internal.blockFor(render, template, { scope });
+  }
+
+  block(env, [], undefined, morph, undefined, visitor);
+}
+
+function normalizeClassStatement(statements, element) {
+  let className = element.getAttribute('class');
+  if (!className) { return; }
+
+  for (let i=0, l=statements.length; i<l; i++) {
+    let statement = statements[i];
+
+    if (statement[1] === 'class') {
+      statement[2][2].unshift(className);
+    }
+  }
+}
+
+function findRootElement(parentNode) {
+  let node = parentNode.firstChild;
+  let found = null;
+
+  while (node) {
+    if (node.nodeType === 1) {
+      // found more than one top-level element, so there is no "root element"
+      if (found) { return null; }
+      found = node;
+    }
+    node = node.nextSibling;
+  }
+
+  let className = found && found.getAttribute('class');
+  if (!className || className.split(' ').indexOf('ember-view') === -1) {
+    return found;
+  }
+}

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -87,7 +87,7 @@ ComponentNodeManager.create = function(renderNode, env, options) {
 
   extractPositionalParams(renderNode, component, params, attrs);
 
-  var results = buildComponentTemplate(
+  let results = buildComponentTemplate(
     { layout, component, isAngleBracket }, attrs, { templates, scope: parentScope }
   );
 

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -17,6 +17,7 @@ import TransformComponentCurlyToReadonly from 'ember-template-compiler/plugins/t
 import TransformAngleBracketComponents from 'ember-template-compiler/plugins/transform-angle-bracket-components';
 import TransformInputOnToOnEvent from 'ember-template-compiler/plugins/transform-input-on-to-onEvent';
 import DeprecateViewAndControllerPaths from 'ember-template-compiler/plugins/deprecate-view-and-controller-paths';
+import TransformTopLevelComponents from 'ember-template-compiler/plugins/transform-top-level-components';
 import DeprecateViewHelper from 'ember-template-compiler/plugins/deprecate-view-helper';
 
 // used for adding Ember.Handlebars.compile for backwards compat
@@ -34,6 +35,7 @@ registerPlugin('ast', TransformComponentAttrsIntoMut);
 registerPlugin('ast', TransformComponentCurlyToReadonly);
 registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
+registerPlugin('ast', TransformTopLevelComponents);
 registerPlugin('ast', DeprecateViewAndControllerPaths);
 registerPlugin('ast', DeprecateViewHelper);
 

--- a/packages/ember-template-compiler/lib/plugins/transform-top-level-components.js
+++ b/packages/ember-template-compiler/lib/plugins/transform-top-level-components.js
@@ -1,0 +1,46 @@
+function TransformTopLevelComponents() {
+  // set later within HTMLBars to the syntax package
+  this.syntax = null;
+}
+
+/**
+  @private
+  @method transform
+  @param {AST} The AST to be transformed.
+*/
+TransformTopLevelComponents.prototype.transform = function TransformTopLevelComponents_transform(ast) {
+  hasSingleComponentNode(ast.body, component => {
+    component.tag = `@${component.tag}`;
+  });
+
+  return ast;
+};
+
+function hasSingleComponentNode(body, callback) {
+  let lastComponentNode;
+  let lastIndex;
+  let nodeCount = 0;
+
+  for (let i=0, l=body.length; i<l; i++) {
+    let curr = body[i];
+
+    // text node with whitespace only
+    if (curr.type === 'TextNode' && /^[\s]*$/.test(curr.chars)) { continue; }
+
+    // has multiple root elements if we've been here before
+    if (nodeCount++ > 0) { return false; }
+
+    if (curr.type === 'ComponentNode' || curr.type === 'ElementNode') {
+      lastComponentNode = curr;
+      lastIndex = i;
+    }
+  }
+
+  if (!lastComponentNode) { return; }
+
+  if (lastComponentNode.type === 'ComponentNode') {
+    callback(lastComponentNode);
+  }
+}
+
+export default TransformTopLevelComponents;

--- a/packages/ember-template-compiler/lib/system/compile_options.js
+++ b/packages/ember-template-compiler/lib/system/compile_options.js
@@ -40,6 +40,7 @@ export default function(_options) {
 
   options.buildMeta = function buildMeta(program) {
     return {
+      topLevel: detectTopLevel(program),
       revision: 'Ember@VERSION_STRING_PLACEHOLDER',
       loc: program.loc,
       moduleName: options.moduleName
@@ -47,4 +48,38 @@ export default function(_options) {
   };
 
   return options;
+}
+
+function detectTopLevel(program) {
+  let { loc, body } = program;
+  if (!loc || loc.start.line !== 1 || loc.start.column !== 0) { return null; }
+
+  let lastComponentNode;
+  let lastIndex;
+  let nodeCount = 0;
+
+  for (let i=0, l=body.length; i<l; i++) {
+    let curr = body[i];
+
+    // text node with whitespace only
+    if (curr.type === 'TextNode' && /^[\s]*$/.test(curr.chars)) { continue; }
+
+    // has multiple root elements if we've been here before
+    if (nodeCount++ > 0) { return false; }
+
+    if (curr.type === 'ComponentNode' || curr.type === 'ElementNode') {
+      lastComponentNode = curr;
+      lastIndex = i;
+    }
+  }
+
+  if (!lastComponentNode) { return null; }
+
+  if (lastComponentNode.type === 'ComponentNode') {
+    let tag = lastComponentNode.tag;
+    if (tag.charAt(0) !== '<') { return null; }
+    return tag.slice(1, -1);
+  }
+
+  return null;
 }

--- a/tests/node/template-compiler-test.js
+++ b/tests/node/template-compiler-test.js
@@ -2,12 +2,12 @@
 
 var path = require('path');
 var distPath = path.join(__dirname, '../../dist');
-var emberPath = path.join(distPath, 'ember.debug.cjs');
 var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
 
 var module = QUnit.module;
 var ok = QUnit.ok;
 var equal = QUnit.equal;
+var test = QUnit.test;
 
 var distPath = path.join(__dirname, '../../dist');
 var templateCompiler = require(path.join(distPath, 'ember-template-compiler'));
@@ -53,7 +53,7 @@ test('allows enabling of features', function() {
     templateCompiler._Ember.FEATURES['ember-htmlbars-component-generation'] = true;
 
     templateOutput = templateCompiler.precompile('<some-thing></some-thing>');
-    ok(templateOutput.indexOf('["component","<some-thing>",[],0]') > -1, 'component generation can be enabled');
+    ok(templateOutput.indexOf('["component","@<some-thing>",[],0]') > -1, 'component generation can be enabled');
   } else {
     ok(true, 'cannot test features in feature stripped build');
   }


### PR DESCRIPTION
https://github.com/emberjs/rfcs/pull/60

This commit implements the proposed semantics for angle-bracket
components. The TLDR is that a component’s template represents its
“outerHTML” rather than its “innerHTML”, which makes it easier to
configure the element itself using templating constructs.

Some salient points:
1. If there is a single root element, the attributes from the invocation
   are copied onto the root element.
2. The invocation’s attributes “win out” over the attributes from the
   root element in the component’s layout.
3. Classes are merged. If the invocation says `class=“a”` and the root
   element says `class=“b”`, the result is `class=“a b”`. The rationale
   is that when you say `class=“a”`, you are really saying “add the `a`
   class to this element”.

A few sticky issues:
1. If the root element for the `my-foo` component is `<my-foo>`, we
   insert an element with tag name of `my-foo`. While this is intuitive,
   note that in all other cases, `<my-foo>` represents an invocation of
   the component. In the root position, that makes no sense, since it
   would inevitably produce a stack overflow.
   a. This “identity element” case makes it idiomatic to reflect the
     name of the component onto the DOM.
   b. Unfortunately, when we compile a template, we do not yet know
     what component that template is used for, and, indeed, whether it
     is even a template for a component at all.
   c. To capture the semantic differences, we do a bit of analysis at
     compile time (to determine _candidates_ for top-level elements),
     and use runtime information (component invocation style and
     the name of the component looked up in the container) to
     disambiguate between a component’s element and an invocation of
     another component.
2. If the root element for the `my-foo` component is a regular HTML
   element, we use the `attachAttributes` functionality of HTMLBars to
   attach the attributes that the component was invoked with onto the
   root element.
3. In general, it is important that changes to attributes do not result
   in a change to the identity of the element that they are contained
   in. To achieve this, we reused much of the infrastructure built in
   `buildComponentTemplate`.

The consequence of (1) and (2) above is that the semantics are always
“a component’s layout represents its outerHTML”, even though the
implementation is quite different depending on whether the root element
is the same-named component or not.
