### PR TITLE
[DOC beta] Enforce public/private declaration for API docs.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -56,5 +56,6 @@
   "requireSpacesAfterClosingParenthesisInFunctionDeclaration": {
     "beforeOpeningRoundBrace": false,
     "beforeOpeningCurlyBrace": true
-  }
+  },
+  "requireCommentsToIncludeAccess": true
 }

--- a/lib/jscs-rules/require-comments-to-include-access.js
+++ b/lib/jscs-rules/require-comments-to-include-access.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+
+function isDocComment(comment) {
+  return comment.value[0] === '*';
+}
+
+function isModuleOnlyComment(comment) {
+  return comment.value.match(/^\*\n\s*@module.+\n(?:\s*@submodule.+\n)?$/);
+}
+
+function includesAccessDeclaration(comment) {
+  return comment.value.match(/\n\s*(@private|@public)\s/);
+}
+
+function RequireCommentsToIncludeAccess() { }
+
+RequireCommentsToIncludeAccess.prototype = {
+  configure: function(value) {
+    assert(
+      value === true,
+      this.getOptionName() + ' option requires a true value or should be removed'
+    );
+  },
+
+  getOptionName: function() {
+    return 'requireCommentsToIncludeAccess';
+  },
+
+  check: function(file, errors) {
+    file.iterateTokensByType('Block', function(comment) {
+      if (isDocComment(comment) && !isModuleOnlyComment(comment) && !includesAccessDeclaration(comment)) {
+        errors.add('You must supply `@public` or `@private` for block comments.', comment.loc.end);
+      }
+    });
+  }
+};
+
+module.exports = RequireCommentsToIncludeAccess;

--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -45,18 +45,22 @@ Container.prototype = {
   _registry: null,
 
   /**
+   @private
+
    @property cache
    @type InheritingDict
    */
   cache: null,
 
   /**
+   @private
    @property factoryCache
    @type InheritingDict
    */
   factoryCache: null,
 
   /**
+   @private
    @property validationCache
    @type InheritingDict
    */
@@ -100,6 +104,7 @@ Container.prototype = {
    twitter === twitter2; //=> false
    ```
 
+   @private
    @method lookup
    @param {String} fullName
    @param {Object} options
@@ -113,6 +118,7 @@ Container.prototype = {
   /**
    Given a fullName return the corresponding factory.
 
+   @private
    @method lookupFactory
    @param {String} fullName
    @return {any}
@@ -126,6 +132,7 @@ Container.prototype = {
    A depth first traversal, destroying the container, its descendant containers and all
    their managed objects.
 
+   @private
    @method destroy
    */
   destroy() {
@@ -141,6 +148,7 @@ Container.prototype = {
   /**
    Clear either the entire cache or just the cache for a particular key.
 
+   @private
    @method reset
    @param {String} fullName optional key to reset; if missing, resets everything
    */

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -47,18 +47,21 @@ Registry.prototype = {
   /**
    A backup registry for resolving registrations when no matches can be found.
 
+   @private
    @property fallback
    @type Registry
    */
   fallback: null,
 
   /**
+   @private
    @property resolver
    @type function
    */
   resolver: null,
 
   /**
+   @private
    @property registrations
    @type InheritingDict
    */
@@ -143,6 +146,7 @@ Registry.prototype = {
   /**
    Creates a container based on this registry.
 
+   @private
    @method container
    @param {Object} options
    @return {Container} created container
@@ -164,6 +168,7 @@ Registry.prototype = {
    2.0TODO: Remove this method. The bookkeeping is only needed to support
             deprecated behavior.
 
+   @private
    @param {Container} newly created container
    */
   registerContainer(container) {
@@ -208,6 +213,7 @@ Registry.prototype = {
    registry.register('communication:main', Email, {singleton: false});
    ```
 
+   @private
    @method register
    @param {String} fullName
    @param {Function} factory
@@ -244,6 +250,7 @@ Registry.prototype = {
    registry.resolve('model:user') === undefined //=> true
    ```
 
+   @private
    @method unregister
    @param {String} fullName
    */
@@ -286,6 +293,7 @@ Registry.prototype = {
    registry.resolve('api:twitter') // => Twitter
    ```
 
+   @private
    @method resolve
    @param {String} fullName
    @return {Function} fullName's factory
@@ -307,6 +315,7 @@ Registry.prototype = {
    class name (including namespace) where Ember's resolver expects
    to find the `fullName`.
 
+   @private
    @method describe
    @param {String} fullName
    @return {string} described fullName
@@ -318,6 +327,7 @@ Registry.prototype = {
   /**
    A hook to enable custom fullName normalization behaviour
 
+   @private
    @method normalizeFullName
    @param {String} fullName
    @return {string} normalized fullName
@@ -329,6 +339,7 @@ Registry.prototype = {
   /**
    normalize a fullName based on the applications conventions
 
+   @private
    @method normalize
    @param {String} fullName
    @return {string} normalized fullName
@@ -342,6 +353,7 @@ Registry.prototype = {
   /**
    @method makeToString
 
+   @private
    @param {any} factory
    @param {string} fullName
    @return {function} toString function
@@ -354,6 +366,7 @@ Registry.prototype = {
    Given a fullName check if the container is aware of its factory
    or singleton instance.
 
+   @private
    @method has
    @param {String} fullName
    @return {Boolean}
@@ -387,6 +400,7 @@ Registry.prototype = {
    facebook === facebook2; // => false
    ```
 
+   @private
    @method optionsForType
    @param {String} type
    @param {Object} options
@@ -404,6 +418,7 @@ Registry.prototype = {
   },
 
   /**
+   @private
    @method options
    @param {String} fullName
    @param {Object} options
@@ -540,6 +555,7 @@ Registry.prototype = {
    user.source === post.source; //=> true
    ```
 
+   @private
    @method injection
    @param {String} factoryName
    @param {String} property
@@ -650,6 +666,7 @@ Registry.prototype = {
    UserFactory.store === PostFactory.store; //=> true
    ```
 
+   @private
    @method factoryInjection
    @param {String} factoryName
    @param {String} property

--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -1,6 +1,7 @@
 /**
 @module ember
 @submodule ember-application
+@public
 */
 
 import Ember from "ember-metal/core"; // Ember.assert
@@ -70,6 +71,7 @@ var defaultControllersComputedProperty = computed(function() {
 /**
   @class ControllerMixin
   @namespace Ember
+  @public
 */
 ControllerMixin.reopen({
   concatenatedProperties: ['needs'],
@@ -118,8 +120,10 @@ ControllerMixin.reopen({
 
     This is only available for singleton controllers.
 
+    @deprecated Use `Ember.inject.controller()` instead.
     @property {Array} needs
     @default []
+    @public
   */
   needs: [],
 
@@ -148,6 +152,7 @@ ControllerMixin.reopen({
     @method controllerFor
     @see {Ember.Route#controllerFor}
     @deprecated Use `needs` instead
+    @public
   */
   controllerFor(controllerName) {
     Ember.deprecate("Controller#controllerFor is deprecated, please use Controller#needs instead");
@@ -172,6 +177,7 @@ ControllerMixin.reopen({
     @see {Ember.ControllerMixin#needs}
     @property {Object} controllers
     @default null
+    @public
   */
   controllers: defaultControllersComputedProperty
 });

--- a/packages/ember-application/lib/main.js
+++ b/packages/ember-application/lib/main.js
@@ -2,11 +2,8 @@ import Ember from 'ember-metal/core';
 import { runLoadHooks } from 'ember-runtime/system/lazy_load';
 
 /**
-Ember Application
-
 @module ember
 @submodule ember-application
-@requires ember-views, ember-routing
 */
 
 import DefaultResolver from 'ember-application/system/resolver';

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -30,6 +30,8 @@ import Registry from 'container/registry';
   That state is what the `ApplicationInstance` manages: it is responsible for
   creating the container that contains all application state, and disposing of
   it once the particular test run or FastBoot request has finished.
+
+  @public
 */
 
 export default EmberObject.extend({
@@ -38,6 +40,7 @@ export default EmberObject.extend({
     instance-specific state for this application run.
 
     @property {Ember.Container} container
+    @public
   */
   container: null,
 
@@ -46,6 +49,7 @@ export default EmberObject.extend({
     and other code that makes up the application.
 
     @property {Ember.Registry} registry
+    @private
   */
   applicationRegistry: null,
 
@@ -54,6 +58,7 @@ export default EmberObject.extend({
     `applicationRegistry` as a fallback.
 
     @property {Ember.Registry} registry
+    @private
   */
   registry: null,
 
@@ -156,7 +161,9 @@ export default EmberObject.extend({
     this._didSetupRouter = true;
   },
 
-  /** @private
+  /**
+    @private
+
     Sets up the router, initializing the child router and configuring the
     location before routing begins.
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -195,6 +195,7 @@ var librariesRegistered = false;
   @class Application
   @namespace Ember
   @extends Ember.Namespace
+  @public
 */
 
 var Application = Namespace.extend(DeferredMixin, {
@@ -212,6 +213,7 @@ var Application = Namespace.extend(DeferredMixin, {
     @property rootElement
     @type DOMElement
     @default 'body'
+    @public
   */
   rootElement: 'body',
 
@@ -228,6 +230,7 @@ var Application = Namespace.extend(DeferredMixin, {
     @property eventDispatcher
     @type Ember.EventDispatcher
     @default null
+    @public
   */
   eventDispatcher: null,
 
@@ -256,6 +259,7 @@ var Application = Namespace.extend(DeferredMixin, {
     @property customEvents
     @type Object
     @default null
+    @public
   */
   customEvents: null,
 
@@ -398,6 +402,7 @@ var Application = Namespace.extend(DeferredMixin, {
     to use the router for this purpose.
 
     @method deferReadiness
+    @public
   */
   deferReadiness() {
     Ember.assert("You must call deferReadiness on an instance of Ember.Application", this instanceof Application);
@@ -412,6 +417,7 @@ var Application = Namespace.extend(DeferredMixin, {
 
     @method advanceReadiness
     @see {Ember.Application#deferReadiness}
+    @public
   */
   advanceReadiness() {
     Ember.assert("You must call advanceReadiness on an instance of Ember.Application", this instanceof Application);
@@ -479,6 +485,7 @@ var Application = Namespace.extend(DeferredMixin, {
     @param  fullName {String} type:name (e.g., 'model:user')
     @param  factory {Function} (e.g., App.Person)
     @param  options {Object} (optional) disable instantiation or singleton usage
+    @public
   **/
   register() {
     this.registry.register(...arguments);
@@ -532,6 +539,7 @@ var Application = Namespace.extend(DeferredMixin, {
     @param  factoryNameOrType {String}
     @param  property {String}
     @param  injectionName {String}
+    @public
   **/
   inject() {
     this.registry.injection(...arguments);
@@ -651,6 +659,7 @@ var Application = Namespace.extend(DeferredMixin, {
     ```
 
     @method reset
+    @public
   **/
   reset() {
     var instance = this.__deprecatedInstance__;
@@ -740,15 +749,17 @@ var Application = Namespace.extend(DeferredMixin, {
     begins. The call will be delayed until the DOM has become ready.
 
     @event ready
+    @public
   */
   ready() { return this; },
 
   /**
-    @deprecated Use 'Resolver' instead
     Set this to provide an alternate class to `Ember.DefaultResolver`
 
 
+    @deprecated Use 'Resolver' instead
     @property resolver
+    @public
   */
   resolver: null,
 
@@ -756,6 +767,7 @@ var Application = Namespace.extend(DeferredMixin, {
     Set this to provide an alternate class to `Ember.DefaultResolver`
 
     @property resolver
+    @public
   */
   Resolver: null,
 
@@ -962,6 +974,7 @@ Application.reopenClass({
 
     @method initializer
     @param initializer {Object}
+    @public
    */
   initializer: buildInitializerMethod('initializers', 'initializer'),
 
@@ -989,6 +1002,7 @@ Application.reopenClass({
     @param {Ember.Application} namespace the application for which to
       build the registry
     @return {Ember.Registry} the built registry
+    @public
   */
   buildRegistry(namespace) {
     var registry = new Registry();

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -17,7 +17,7 @@ import helpers from 'ember-htmlbars/helpers';
 import validateType from 'ember-application/utils/validate-type';
 
 export var Resolver = EmberObject.extend({
-  /**
+  /*
     This will be set to the Application instance when it is
     created.
 
@@ -102,6 +102,7 @@ export var Resolver = EmberObject.extend({
   @class DefaultResolver
   @namespace Ember
   @extends Ember.Object
+  @public
 */
 import dictionary from 'ember-metal/dictionary';
 
@@ -111,6 +112,7 @@ export default EmberObject.extend({
     created.
 
     @property namespace
+    @public
   */
   namespace: null,
 
@@ -157,6 +159,7 @@ export default EmberObject.extend({
     @method resolve
     @param {String} fullName the lookup string
     @return {Object} the resolved factory
+    @public
   */
   resolve(fullName) {
     var parsedName = this.parseName(fullName);
@@ -188,6 +191,7 @@ export default EmberObject.extend({
     @protected
     @param {String} fullName the lookup string
     @method parseName
+    @public
   */
 
   parseName(fullName) {
@@ -242,6 +246,7 @@ export default EmberObject.extend({
     @protected
     @param {String} fullName the lookup string
     @method lookupDescription
+    @public
   */
   lookupDescription(fullName) {
     var parsedName = this.parseName(fullName);
@@ -272,6 +277,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method useRouterNaming
+    @public
   */
   useRouterNaming(parsedName) {
     parsedName.name = parsedName.name.replace(/\./g, '_');
@@ -286,6 +292,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveTemplate
+    @public
   */
   resolveTemplate(parsedName) {
     var templateName = parsedName.fullNameWithoutType.replace(/\./g, '/');
@@ -307,6 +314,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveView
+    @public
   */
   resolveView(parsedName) {
     this.useRouterNaming(parsedName);
@@ -320,6 +328,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveController
+    @public
   */
   resolveController(parsedName) {
     this.useRouterNaming(parsedName);
@@ -332,6 +341,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveRoute
+    @public
   */
   resolveRoute(parsedName) {
     this.useRouterNaming(parsedName);
@@ -345,6 +355,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveModel
+    @public
   */
   resolveModel(parsedName) {
     var className = classify(parsedName.name);
@@ -360,6 +371,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveHelper
+    @public
   */
   resolveHelper(parsedName) {
     return this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
@@ -372,6 +384,7 @@ export default EmberObject.extend({
     @param {Object} parsedName a parseName object with the parsed
       fullName lookup string
     @method resolveOther
+    @public
   */
   resolveOther(parsedName) {
     var className = classify(parsedName.name) + classify(parsedName.type);

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -7,8 +7,6 @@ import Logger from "ember-metal/logger";
 import environment from "ember-metal/environment";
 
 /**
-Ember Debug
-
 @module ember
 @submodule ember-debug
 */

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -46,6 +46,7 @@ import EmberObject from "ember-runtime/system/object";
   @namespace Ember
   @extends Ember.Object
   @since 1.5.0
+  @public
 */
 export default EmberObject.extend({
   /**
@@ -55,6 +56,7 @@ export default EmberObject.extend({
 
     @property container
     @default null
+    @public
   */
   container: null,
 
@@ -65,6 +67,7 @@ export default EmberObject.extend({
 
     @property resolver
     @default null
+    @public
   */
   resolver: null,
 
@@ -75,6 +78,7 @@ export default EmberObject.extend({
     @method canCatalogEntriesByType
     @param {String} type The type. e.g. "model", "controller", "route"
     @return {boolean} whether a list is available for this type.
+    @public
   */
   canCatalogEntriesByType(type) {
     if (type === 'model' || type === 'template') {
@@ -90,6 +94,7 @@ export default EmberObject.extend({
     @method catalogEntriesByType
     @param {String} type The type. e.g. "model", "controller", "route"
     @return {Array} An array of strings.
+    @public
   */
   catalogEntriesByType(type) {
     var namespaces = emberA(Namespace.NAMESPACES);

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -51,6 +51,7 @@ import Application from "ember-application/system/application";
   @class DataAdapter
   @namespace Ember
   @extends EmberObject
+  @public
 */
 export default EmberObject.extend({
   init() {
@@ -66,6 +67,7 @@ export default EmberObject.extend({
     @property container
     @default null
     @since 1.3.0
+    @public
   */
   container: null,
 
@@ -77,6 +79,7 @@ export default EmberObject.extend({
     @property containerDebugAdapter
     @default undefined
     @since 1.5.0
+    @public
   **/
   containerDebugAdapter: undefined,
 
@@ -93,16 +96,16 @@ export default EmberObject.extend({
   attributeLimit: 3,
 
   /**
-   * Ember Data > v1.0.0-beta.18
-   * requires string model names to be passed
-   * around instead of the actual factories.
-   *
-   * This is a stamp for the Ember Inspector
-   * to differentiate between the versions
-   * to be able to support older versions too.
-   *
-   * @public
-   * @property acceptsModelName
+     Ember Data > v1.0.0-beta.18
+     requires string model names to be passed
+     around instead of the actual factories.
+
+     This is a stamp for the Ember Inspector
+     to differentiate between the versions
+     to be able to support older versions too.
+
+     @public
+     @property acceptsModelName
    */
   acceptsModelName: true,
 

--- a/packages/ember-extension-support/lib/main.js
+++ b/packages/ember-extension-support/lib/main.js
@@ -1,9 +1,6 @@
 /**
-Ember Extension Support
-
 @module ember
 @submodule ember-extension-support
-@requires ember-application
 */
 
 import Ember from "ember-metal/core";

--- a/packages/ember-htmlbars/lib/compat/handlebars-get.js
+++ b/packages/ember-htmlbars/lib/compat/handlebars-get.js
@@ -14,6 +14,7 @@
   @param {String} path The path to be lookedup
   @param {Object} options The template's option hash
   @deprecated
+  @public
 */
 export default function handlebarsGet(root, path, options) {
   Ember.deprecate('Usage of Ember.Handlebars.get is deprecated, use a Component or Ember.Handlebars.makeBoundHelper instead.');

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -36,6 +36,7 @@ import {
   @param {String} dependentKeys*
   @since 1.2.0
   @deprecated
+  @private
 */
 export default function makeBoundHelper(fn, ...dependentKeys) {
   return {

--- a/packages/ember-htmlbars/lib/compat/register-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/register-bound-helper.js
@@ -116,6 +116,7 @@ var slice = [].slice;
   @param {String} name
   @param {Function} fn
   @param {String} dependentKeys*
+  @private
 */
 export default function registerBoundHelper(name, fn) {
   var boundHelperArgs = slice.call(arguments, 1);

--- a/packages/ember-htmlbars/lib/helpers/-get.js
+++ b/packages/ember-htmlbars/lib/helpers/-get.js
@@ -1,5 +1,6 @@
-/** @private
-  this private helper is used in conjuntion with the get keyword
+/*
+  This private helper is used in conjuntion with the get keyword
+  @private
 */
 
 if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {

--- a/packages/ember-htmlbars/lib/helpers/-join-classes.js
+++ b/packages/ember-htmlbars/lib/helpers/-join-classes.js
@@ -1,5 +1,7 @@
-/** @private
+/*
   this private helper is used to join and compact a list of class names
+
+  @private
 */
 
 export default function joinClasses(classNames) {
@@ -14,5 +16,3 @@ export default function joinClasses(classNames) {
 
   return result.join(' ');
 }
-
-

--- a/packages/ember-htmlbars/lib/helpers/-normalize-class.js
+++ b/packages/ember-htmlbars/lib/helpers/-normalize-class.js
@@ -1,12 +1,14 @@
 import { dasherize } from "ember-runtime/system/string";
 import { isPath } from "ember-metal/path_cache";
 
-/** @private
+/*
   This private helper is used by ComponentNode to convert the classNameBindings
   microsyntax into a class name.
 
   When a component or view is created, we normalize class name bindings into a
   series of attribute nodes that use this helper.
+
+  @private
 */
 export default function normalizeClass(params, hash) {
   var [propName, value] = params;

--- a/packages/ember-htmlbars/lib/helpers/bind-attr.js
+++ b/packages/ember-htmlbars/lib/helpers/bind-attr.js
@@ -126,6 +126,7 @@
   @deprecated
   @param {Object} options
   @return {String} HTML string
+  @public
 */
 
 /**
@@ -137,4 +138,5 @@
   @param {Function} context
   @param {Object} options
   @return {String} HTML string
+  @public
 */

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -72,6 +72,7 @@ import decodeEachKey from "ember-htmlbars/utils/decode-each-key";
 
   @method each
   @for Ember.Handlebars.helpers
+  @public
 */
 export default function eachHelper(params, hash, blocks) {
   var list = params[0];

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -60,6 +60,7 @@ import shouldDisplay from "ember-views/streams/should_display";
 
   @method if
   @for Ember.Handlebars.helpers
+  @public
 */
 function ifHelper(params, hash, options) {
   return ifUnless(params, hash, options, shouldDisplay(params[0]));
@@ -72,6 +73,7 @@ function ifHelper(params, hash, options) {
 
   @method unless
   @for Ember.Handlebars.helpers
+  @public
 */
 function unlessHelper(params, hash, options) {
   return ifUnless(params, hash, options, !shouldDisplay(params[0]));

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -30,6 +30,7 @@ import { loc } from 'ember-runtime/system/string';
   @for Ember.Handlebars.helpers
   @param {String} str The string to format
   @see {Ember.String#loc}
+  @public
 */
 export default function locHelper(params) {
   return loc.apply(null, params);

--- a/packages/ember-htmlbars/lib/helpers/log.js
+++ b/packages/ember-htmlbars/lib/helpers/log.js
@@ -14,6 +14,7 @@ import Logger from "ember-metal/logger";
   @method log
   @for Ember.Handlebars.helpers
   @param {*} values
+  @public
 */
 export default function logHelper(values) {
   Logger.log.apply(null, values);

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -36,6 +36,7 @@ import shouldDisplay from "ember-views/streams/should_display";
   @for Ember.Handlebars.helpers
   @param {Object} options
   @return {String} HTML string
+  @public
 */
 
 export default function withHelper(params, hash, options) {

--- a/packages/ember-htmlbars/lib/hooks/concat.js
+++ b/packages/ember-htmlbars/lib/hooks/concat.js
@@ -10,4 +10,3 @@ import {
 export default function concat(env, parts) {
   return streamConcat(parts, '');
 }
-

--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -1,7 +1,7 @@
 /**
- @module ember
- @submodule ember-htmlbars
- */
+@module ember
+@submodule ember-htmlbars
+*/
 
 import { findHelper } from "ember-htmlbars/system/lookup-helper";
 import { handleRedirect } from "htmlbars-runtime/hooks";

--- a/packages/ember-htmlbars/lib/keywords/debugger.js
+++ b/packages/ember-htmlbars/lib/keywords/debugger.js
@@ -8,34 +8,45 @@ import Logger from "ember-metal/logger";
 
 /**
   Execute the `debugger` statement in the current template's context.
+
   ```handlebars
   {{debugger}}
   ```
+
   When using the debugger helper you will have access to a `get` function. This
   function retrieves values available in the context of the template.
   For example, if you're wondering why a value `{{foo}}` isn't rendering as
   expected within a template, you could place a `{{debugger}}` statement and,
   when the `debugger;` breakpoint is hit, you can attempt to retrieve this value:
+
   ```
   > get('foo')
   ```
+
   `get` is also aware of keywords. So in this situation
+
   ```handlebars
   {{#each items as |item|}}
     {{debugger}}
   {{/each}}
   ```
-  you'll be able to get values from the current item:
+
+  You'll be able to get values from the current item:
+
   ```
   > get('item.name')
   ```
+
   You can also access the context of the view to make sure it is the object that
   you expect:
+
   ```
   > context
   ```
+
   @method debugger
   @for Ember.Handlebars.helpers
+  @public
 */
 export default function debuggerKeyword(morph, env, scope) {
   /* jshint unused: false, debug: true */

--- a/packages/ember-htmlbars/lib/system/helper.js
+++ b/packages/ember-htmlbars/lib/system/helper.js
@@ -6,6 +6,7 @@
 /**
   @class Helper
   @namespace Ember.HTMLBars
+  @private
 */
 function Helper(helper) {
   this.helperFunction = helper;

--- a/packages/ember-htmlbars/lib/system/instrumentation-support.js
+++ b/packages/ember-htmlbars/lib/system/instrumentation-support.js
@@ -4,16 +4,17 @@ import {
 } from "ember-metal/instrumentation";
 
 /**
- * Provides instrumentation for node managers.
- *
- * Wrap your node manager's render and re-render methods
- * with this function.
- *
- * @param {Object} component Component or View instance (optional)
- * @param {Function} callback The function to instrument
- * @param {Object} context The context to call the function with
- * @return {Object} Return value from the invoked callback
- */
+  Provides instrumentation for node managers.
+
+  Wrap your node manager's render and re-render methods
+  with this function.
+
+  @param {Object} component Component or View instance (optional)
+  @param {Function} callback The function to instrument
+  @param {Object} context The context to call the function with
+  @return {Object} Return value from the invoked callback
+  @private
+*/
 export function instrument(component, callback, context) {
   var instrumentName, val, details, end;
   // Only instrument if there's at least one subscriber.

--- a/packages/ember-htmlbars/lib/utils/string.js
+++ b/packages/ember-htmlbars/lib/utils/string.js
@@ -23,6 +23,7 @@ import EmberStringUtils from "ember-runtime/system/string";
   @for Ember.String
   @static
   @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
+  @public
 */
 function htmlSafe(str) {
   if (str === null || str === undefined) {
@@ -50,6 +51,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
     @method htmlSafe
     @for String
     @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
+    @public
   */
   String.prototype.htmlSafe = function() {
     return htmlSafe(this);

--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -20,7 +20,7 @@ var view;
 var originalLookup = Ember.lookup;
 var TemplateTests, registry, container, lookup, warnings, originalWarn;
 
-/**
+/*
   This module specifically tests integration with Handlebars and Ember-specific
   Handlebars extensions.
 

--- a/packages/ember-metal/lib/array.js
+++ b/packages/ember-metal/lib/array.js
@@ -1,5 +1,6 @@
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 var ArrayPrototype = Array.prototype;
@@ -123,6 +124,7 @@ if (Ember.SHIM_ES5) {
 
   @namespace Ember
   @property ArrayPolyfills
+  @public
 */
 export {
   map,

--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -15,7 +15,8 @@ import {
 
 // ES6TODO: where is Ember.lookup defined?
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 // ..........................................................
@@ -31,6 +32,7 @@ import {
   @for Ember
   @type Boolean
   @default false
+  @public
 */
 Ember.LOG_BINDINGS = false || !!Ember.ENV.LOG_BINDINGS;
 
@@ -62,8 +64,9 @@ function Binding(toPath, fromPath) {
 }
 
 /**
-@class Binding
-@namespace Ember
+  @class Binding
+  @namespace Ember
+  @public
 */
 
 Binding.prototype = {
@@ -72,6 +75,7 @@ Binding.prototype = {
 
     @method copy
     @return {Ember.Binding} `this`
+    @public
   */
   copy() {
     var copy = new Binding(this._to, this._from);
@@ -95,6 +99,7 @@ Binding.prototype = {
     @method from
     @param {String} path the property path to connect to
     @return {Ember.Binding} `this`
+    @public
   */
   from(path) {
     this._from = path;
@@ -113,6 +118,7 @@ Binding.prototype = {
     @method to
     @param {String|Tuple} path A property path or tuple
     @return {Ember.Binding} `this`
+    @public
   */
   to(path) {
     this._to = path;
@@ -127,6 +133,7 @@ Binding.prototype = {
 
     @method oneWay
     @return {Ember.Binding} `this`
+    @public
   */
   oneWay() {
     this._oneWay = true;
@@ -136,6 +143,7 @@ Binding.prototype = {
   /**
     @method toString
     @return {String} string representation of binding
+    @public
   */
   toString() {
     var oneWay = this._oneWay ? '[oneWay]' : '';
@@ -154,6 +162,7 @@ Binding.prototype = {
     @method connect
     @param {Object} obj The root object for this binding.
     @return {Ember.Binding} `this`
+    @public
   */
   connect(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.connect()', !!obj);
@@ -182,6 +191,7 @@ Binding.prototype = {
     @method disconnect
     @param {Object} obj The root object you passed when connecting the binding.
     @return {Ember.Binding} `this`
+    @public
   */
   disconnect(obj) {
     Ember.assert('Must pass a valid object to Ember.Binding.disconnect()', !!obj);
@@ -320,6 +330,7 @@ mixinProperties(Binding, {
       binding `oneWay`. You can instead pass `false` to disable `oneWay`, making the
       binding two way again.
     @return {Ember.Binding} `this`
+    @public
   */
   oneWay(from, flag) {
     var C = this;
@@ -455,6 +466,7 @@ mixinProperties(Binding, {
   @class Binding
   @namespace Ember
   @since Ember 0.9
+  @public
 */
 // Ember.Binding = Binding; ES6TODO: where to put this?
 
@@ -471,6 +483,7 @@ mixinProperties(Binding, {
   @param {String} from The path to the 'from' side of the binding.
     Must be relative to obj or a global path.
   @return {Ember.Binding} binding instance
+  @public
 */
 export function bind(obj, to, from) {
   return new Binding(to, from).connect(obj);
@@ -485,6 +498,7 @@ export function bind(obj, to, from) {
   @param {String} from The path to the 'from' side of the binding.
     Must be relative to obj or a global path.
   @return {Ember.Binding} binding instance
+  @public
 */
 export function oneWay(obj, to, from) {
   return new Binding(to, from).oneWay().connect(obj);

--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -19,7 +19,8 @@ import {
 } from "ember-metal/dependent_keys";
 
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 var metaFor = meta;
@@ -109,6 +110,7 @@ function UNDEFINED() { }
   @class ComputedProperty
   @namespace Ember
   @constructor
+  @public
 */
 function ComputedProperty(config, opts) {
   this.isDescriptor = true;
@@ -159,6 +161,7 @@ var ComputedPropertyPrototype = ComputedProperty.prototype;
   @return {Ember.ComputedProperty} this
   @chainable
   @deprecated All computed properties are cacheble by default. Use `volatile()` instead to opt-out to caching.
+  @public
 */
 ComputedPropertyPrototype.cacheable = function(aFlag) {
   Ember.deprecate('ComputedProperty.cacheable() is deprecated. All computed properties are cacheable by default.');
@@ -181,6 +184,7 @@ ComputedPropertyPrototype.cacheable = function(aFlag) {
   @method volatile
   @return {Ember.ComputedProperty} this
   @chainable
+  @public
 */
 ComputedPropertyPrototype.volatile = function() {
   this._cacheable = false;
@@ -206,6 +210,7 @@ ComputedPropertyPrototype.volatile = function() {
   @method readOnly
   @return {Ember.ComputedProperty} this
   @chainable
+  @public
 */
 ComputedPropertyPrototype.readOnly = function(readOnly) {
   Ember.deprecate('Passing arguments to ComputedProperty.readOnly() is deprecated.', arguments.length === 0);
@@ -240,6 +245,7 @@ ComputedPropertyPrototype.readOnly = function(readOnly) {
   @param {String} path* zero or more property paths
   @return {Ember.ComputedProperty} this
   @chainable
+  @public
 */
 ComputedPropertyPrototype.property = function() {
   var args;
@@ -280,6 +286,7 @@ ComputedPropertyPrototype.property = function() {
   @method meta
   @param {Object} meta
   @chainable
+  @public
 */
 
 ComputedPropertyPrototype.meta = function(meta) {
@@ -335,6 +342,7 @@ function finishChains(chainNodes) {
   @method get
   @param {String} keyName The key being accessed.
   @return {Object} The return value of the function backing the CP.
+  @public
 */
 ComputedPropertyPrototype.get = function(obj, keyName) {
   var ret, cache, meta, chainNodes;
@@ -419,6 +427,7 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
   @param {Object} newValue The new value being assigned.
   @param {String} oldValue The old value being replaced.
   @return {Object} The return value of the function backing the CP.
+  @public
 */
 ComputedPropertyPrototype.set = function computedPropertySetWithSuspend(obj, keyName, value) {
   var oldSuspended = this._suspended;
@@ -565,6 +574,7 @@ ComputedPropertyPrototype.teardown = function(obj, keyName) {
   @param {String} [dependentKeys*] Optional dependent keys that trigger this computed property.
   @param {Function} func The computed property function.
   @return {Ember.ComputedProperty} property descriptor instance
+  @public
 */
 function computed(func) {
   var args;
@@ -595,6 +605,7 @@ function computed(func) {
   @param {String} key the name of the property whose cached value you want
     to return
   @return {Object} the cached value
+  @public
 */
 function cacheFor(obj, key) {
   var meta = obj['__ember_meta__'];

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -7,7 +7,8 @@ import isNone from 'ember-metal/is_none';
 import alias from 'ember-metal/alias';
 
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 function getProperties(self, propertyNames) {
@@ -54,6 +55,7 @@ function generateComputedWithProperties(macro) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which negate
   the original value for property
+  @public
 */
 export function empty(dependentKey) {
   return computed(dependentKey + '.length', function() {
@@ -84,6 +86,7 @@ export function empty(dependentKey) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which returns true if
   original value for property is not empty.
+  @public
 */
 export function notEmpty(dependentKey) {
   return computed(dependentKey + '.length', function() {
@@ -117,6 +120,7 @@ export function notEmpty(dependentKey) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which
   returns true if original value for property is null or undefined.
+  @public
 */
 export function none(dependentKey) {
   return computed(dependentKey, function() {
@@ -147,6 +151,7 @@ export function none(dependentKey) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which returns
   inverse of the original value for property
+  @public
 */
 export function not(dependentKey) {
   return computed(dependentKey, function() {
@@ -179,6 +184,7 @@ export function not(dependentKey) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which converts
   to boolean the original value for property
+  @public
 */
 export function bool(dependentKey) {
   return computed(dependentKey, function() {
@@ -213,6 +219,7 @@ export function bool(dependentKey) {
   @param {RegExp} regexp
   @return {Ember.ComputedProperty} computed property which match
   the original value for property against a given RegExp
+  @public
 */
 export function match(dependentKey, regexp) {
   return computed(dependentKey, function() {
@@ -248,6 +255,7 @@ export function match(dependentKey, regexp) {
   @param {String|Number|Object} value
   @return {Ember.ComputedProperty} computed property which returns true if
   the original value for property is equal to the given value.
+  @public
 */
 export function equal(dependentKey, value) {
   return computed(dependentKey, function() {
@@ -281,6 +289,7 @@ export function equal(dependentKey, value) {
   @param {Number} value
   @return {Ember.ComputedProperty} computed property which returns true if
   the original value for property is greater than given value.
+  @public
 */
 export function gt(dependentKey, value) {
   return computed(dependentKey, function() {
@@ -314,6 +323,7 @@ export function gt(dependentKey, value) {
   @param {Number} value
   @return {Ember.ComputedProperty} computed property which returns true if
   the original value for property is greater or equal then given value.
+  @public
 */
 export function gte(dependentKey, value) {
   return computed(dependentKey, function() {
@@ -347,6 +357,7 @@ export function gte(dependentKey, value) {
   @param {Number} value
   @return {Ember.ComputedProperty} computed property which returns true if
   the original value for property is less then given value.
+  @public
 */
 export function lt(dependentKey, value) {
   return computed(dependentKey, function() {
@@ -380,6 +391,7 @@ export function lt(dependentKey, value) {
   @param {Number} value
   @return {Ember.ComputedProperty} computed property which returns true if
   the original value for property is less or equal than given value.
+  @public
 */
 export function lte(dependentKey, value) {
   return computed(dependentKey, function() {
@@ -414,6 +426,7 @@ export function lte(dependentKey, value) {
   @param {String} dependentKey*
   @return {Ember.ComputedProperty} computed property which performs
   a logical `and` on the values of all the original values for properties.
+  @public
 */
 export var and = generateComputedWithProperties(function(properties) {
   var value;
@@ -451,6 +464,7 @@ export var and = generateComputedWithProperties(function(properties) {
   @param {String} dependentKey*
   @return {Ember.ComputedProperty} computed property which performs
   a logical `or` on the values of all the original values for properties.
+  @public
 */
 export var or = generateComputedWithProperties(function(properties) {
   for (var key in properties) {
@@ -485,6 +499,7 @@ export var or = generateComputedWithProperties(function(properties) {
   @return {Ember.ComputedProperty} computed property which returns
   the first truthy value of given list of properties.
   @deprecated Use `Ember.computed.or` instead.
+  @public
 */
 export var any = generateComputedWithProperties(function(properties) {
   for (var key in properties) {
@@ -519,6 +534,7 @@ export var any = generateComputedWithProperties(function(properties) {
   @param {String} dependentKey*
   @return {Ember.ComputedProperty} computed property which maps
   values of all passed in properties to an array.
+  @public
 */
 export var collect = generateComputedWithProperties(function(properties) {
   var res = Ember.A();
@@ -559,6 +575,7 @@ export var collect = generateComputedWithProperties(function(properties) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which creates an
   alias to the original value for property.
+  @public
 */
 
 /**
@@ -592,6 +609,7 @@ export var collect = generateComputedWithProperties(function(properties) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which creates a
   one way computed property to the original value for property.
+  @public
 */
 export function oneWay(dependentKey) {
   return alias(dependentKey).oneWay();
@@ -606,6 +624,7 @@ export function oneWay(dependentKey) {
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which creates a
     one way computed property to the original value for property.
+  @public
  */
 
 /**
@@ -641,6 +660,7 @@ export function oneWay(dependentKey) {
   @return {Ember.ComputedProperty} computed property which creates a
   one way computed property to the original value for property.
   @since 1.5.0
+  @public
 */
 export function readOnly(dependentKey) {
   return alias(dependentKey).readOnly();
@@ -672,6 +692,7 @@ export function readOnly(dependentKey) {
   @return {Ember.ComputedProperty} computed property which acts like
   a standard getter and setter, but defaults to the value from `defaultPath`.
   @deprecated Use `Ember.computed.oneWay` or custom CP with default instead.
+  @public
 */
 export function defaultTo(defaultPath) {
   return computed({
@@ -699,6 +720,7 @@ export function defaultTo(defaultPath) {
   @return {Ember.ComputedProperty} computed property which creates an
   alias with a deprecation to the original value for property.
   @since 1.7.0
+  @public
 */
 export function deprecatingAlias(dependentKey) {
   return computed(dependentKey, {

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -21,6 +21,7 @@
   @class Ember
   @static
   @version VERSION_STRING_PLACEHOLDER
+  @public
 */
 
 if ('undefined' === typeof Ember) {
@@ -52,6 +53,7 @@ Ember.toString = function() { return 'Ember'; };
   @type String
   @default 'VERSION_STRING_PLACEHOLDER'
   @static
+  @public
 */
 Ember.VERSION = 'VERSION_STRING_PLACEHOLDER';
 
@@ -64,6 +66,7 @@ Ember.VERSION = 'VERSION_STRING_PLACEHOLDER';
 
   @property ENV
   @type Object
+  @public
 */
 
 if (Ember.ENV) {
@@ -95,6 +98,7 @@ if ('undefined' === typeof Ember.ENV.DISABLE_RANGE_API) {
   @namespace Ember
   @static
   @since 1.1.0
+  @public
 */
 Ember.FEATURES = DEFAULT_FEATURES; //jshint ignore:line
 
@@ -121,6 +125,7 @@ if (Ember.ENV.FEATURES) {
   @return {Boolean}
   @for Ember.FEATURES
   @since 1.1.0
+  @public
 */
 
 Ember.FEATURES.isEnabled = function(feature) {
@@ -158,6 +163,7 @@ Ember.FEATURES.isEnabled = function(feature) {
   @type Boolean
   @default true
   @for Ember
+  @public
 */
 Ember.EXTEND_PROTOTYPES = Ember.ENV.EXTEND_PROTOTYPES;
 
@@ -172,6 +178,7 @@ if (typeof Ember.EXTEND_PROTOTYPES === 'undefined') {
   @property LOG_STACKTRACE_ON_DEPRECATION
   @type Boolean
   @default true
+  @public
 */
 Ember.LOG_STACKTRACE_ON_DEPRECATION = (Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION !== false);
 
@@ -182,6 +189,7 @@ Ember.LOG_STACKTRACE_ON_DEPRECATION = (Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION !
   @property SHIM_ES5
   @type Boolean
   @default Ember.EXTEND_PROTOTYPES
+  @public
 */
 Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPES;
 
@@ -192,6 +200,7 @@ Ember.SHIM_ES5 = (Ember.ENV.SHIM_ES5 === false) ? false : Ember.EXTEND_PROTOTYPE
   @property LOG_VERSION
   @type Boolean
   @default true
+  @public
 */
 Ember.LOG_VERSION = (Ember.ENV.LOG_VERSION === false) ? false : true;
 
@@ -201,6 +210,7 @@ Ember.LOG_VERSION = (Ember.ENV.LOG_VERSION === false) ? false : true;
   @method K
   @private
   @return {Object}
+  @public
 */
 function K() { return this; }
 export { K };

--- a/packages/ember-metal/lib/dependent_keys.js
+++ b/packages/ember-metal/lib/dependent_keys.js
@@ -10,7 +10,8 @@ import {
 } from "ember-metal/watching";
 
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 // ..........................................................

--- a/packages/ember-metal/lib/deprecate_property.js
+++ b/packages/ember-metal/lib/deprecate_property.js
@@ -1,5 +1,6 @@
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 import Ember from "ember-metal/core";

--- a/packages/ember-metal/lib/enumerable_utils.js
+++ b/packages/ember-metal/lib/enumerable_utils.js
@@ -9,101 +9,105 @@ import {
 var splice = Array.prototype.splice;
 
 /**
- * Defines some convenience methods for working with Enumerables.
- * `Ember.EnumerableUtils` uses `Ember.ArrayPolyfills` when necessary.
- *
- * @class EnumerableUtils
- * @namespace Ember
- * @deprecated
- * @static
- * */
+ Defines some convenience methods for working with Enumerables.
+ `Ember.EnumerableUtils` uses `Ember.ArrayPolyfills` when necessary.
+
+ @class EnumerableUtils
+ @namespace Ember
+ @deprecated
+ @static
+ @public
+*/
 
 /**
- * Calls the map function on the passed object with a specified callback. This
- * uses `Ember.ArrayPolyfill`'s-map method when necessary.
- *
- * @method map
- * @deprecated Use ES5's Array.prototype.map instead.
- * @param {Object} obj The object that should be mapped
- * @param {Function} callback The callback to execute
- * @param {Object} thisArg Value to use as this when executing *callback*
- *
- * @return {Array} An array of mapped values.
- */
+  Calls the map function on the passed object with a specified callback. This
+  uses `Ember.ArrayPolyfill`'s-map method when necessary.
+
+  @method map
+  @deprecated Use ES5's Array.prototype.map instead.
+  @param {Object} obj The object that should be mapped
+  @param {Function} callback The callback to execute
+  @param {Object} thisArg Value to use as this when executing *callback*
+
+  @return {Array} An array of mapped values.
+  @public
+*/
 export function map(obj, callback, thisArg) {
   return obj.map ? obj.map(callback, thisArg) : _map.call(obj, callback, thisArg);
 }
 var deprecatedMap = Ember.deprecateFunc('Ember.EnumberableUtils.map is deprecated, please refactor to use Array.prototype.map.', map);
 
 /**
- * Calls the forEach function on the passed object with a specified callback. This
- * uses `Ember.ArrayPolyfill`'s-forEach method when necessary.
- *
- * @method forEach
- * @deprecated Use ES5's Array.prototype.forEach instead.
- * @param {Object} obj The object to call forEach on
- * @param {Function} callback The callback to execute
- * @param {Object} thisArg Value to use as this when executing *callback*
- *
- */
+  Calls the forEach function on the passed object with a specified callback. This
+  uses `Ember.ArrayPolyfill`'s-forEach method when necessary.
+
+  @method forEach
+  @deprecated Use ES5's Array.prototype.forEach instead.
+  @param {Object} obj The object to call forEach on
+  @param {Function} callback The callback to execute
+  @param {Object} thisArg Value to use as this when executing *callback*
+  @public
+*/
 export function forEach(obj, callback, thisArg) {
   return obj.forEach ? obj.forEach(callback, thisArg) : a_forEach.call(obj, callback, thisArg);
 }
 var deprecatedForEach = Ember.deprecateFunc('Ember.EnumberableUtils.forEach is deprecated, please refactor to use Array.prototype.forEach.', forEach);
 
 /**
- * Calls the filter function on the passed object with a specified callback. This
- * uses `Ember.ArrayPolyfill`'s-filter method when necessary.
- *
- * @method filter
- * @deprecated Use ES5's Array.prototype.filter instead.
- * @param {Object} obj The object to call filter on
- * @param {Function} callback The callback to execute
- * @param {Object} thisArg Value to use as this when executing *callback*
- *
- * @return {Array} An array containing the filtered values
- * @since 1.4.0
- */
+  Calls the filter function on the passed object with a specified callback. This
+  uses `Ember.ArrayPolyfill`'s-filter method when necessary.
+
+  @method filter
+  @deprecated Use ES5's Array.prototype.filter instead.
+  @param {Object} obj The object to call filter on
+  @param {Function} callback The callback to execute
+  @param {Object} thisArg Value to use as this when executing *callback*
+
+  @return {Array} An array containing the filtered values
+  @since 1.4.0
+  @public
+*/
 export function filter(obj, callback, thisArg) {
   return obj.filter ? obj.filter(callback, thisArg) : _filter.call(obj, callback, thisArg);
 }
 var deprecatedFilter = Ember.deprecateFunc('Ember.EnumberableUtils.filter is deprecated, please refactor to use Array.prototype.filter.', filter);
 
 /**
- * Calls the indexOf function on the passed object with a specified callback. This
- * uses `Ember.ArrayPolyfill`'s-indexOf method when necessary.
- *
- * @method indexOf
- * @deprecated Use ES5's Array.prototype.indexOf instead.
- * @param {Object} obj The object to call indexOn on
- * @param {Object} index The index to start searching from
- *
- */
+  Calls the indexOf function on the passed object with a specified callback. This
+  uses `Ember.ArrayPolyfill`'s-indexOf method when necessary.
+
+  @method indexOf
+  @deprecated Use ES5's Array.prototype.indexOf instead.
+  @param {Object} obj The object to call indexOn on
+  @param {Object} index The index to start searching from
+
+  @public
+*/
 export function indexOf(obj, element, index) {
   return obj.indexOf ? obj.indexOf(element, index) : _indexOf.call(obj, element, index);
 }
 var deprecatedIndexOf = Ember.deprecateFunc('Ember.EnumberableUtils.indexOf is deprecated, please refactor to use Array.prototype.indexOf.', indexOf);
 
 /**
- * Returns an array of indexes of the first occurrences of the passed elements
- * on the passed object.
- *
- * ```javascript
- *  var array = [1, 2, 3, 4, 5];
- *  Ember.EnumerableUtils.indexesOf(array, [2, 5]); // [1, 4]
- *
- *  var fubar = "Fubarr";
- *  Ember.EnumerableUtils.indexesOf(fubar, ['b', 'r']); // [2, 4]
- * ```
- *
- * @method indexesOf
- * @deprecated
- * @param {Object} obj The object to check for element indexes
- * @param {Array} elements The elements to search for on *obj*
- *
- * @return {Array} An array of indexes.
- *
- */
+  Returns an array of indexes of the first occurrences of the passed elements
+  on the passed object.
+
+  ```javascript
+   var array = [1, 2, 3, 4, 5];
+   Ember.EnumerableUtils.indexesOf(array, [2, 5]); // [1, 4]
+
+   var fubar = "Fubarr";
+   Ember.EnumerableUtils.indexesOf(fubar, ['b', 'r']); // [2, 4]
+  ```
+
+  @method indexesOf
+  @deprecated
+  @param {Object} obj The object to check for element indexes
+  @param {Array} elements The elements to search for on *obj*
+
+  @return {Array} An array of indexes.
+  @public
+*/
 export function indexesOf(obj, elements) {
   return elements === undefined ? [] : map(elements, (item) => {
     return indexOf(obj, item);
@@ -112,16 +116,17 @@ export function indexesOf(obj, elements) {
 var deprecatedIndexesOf = Ember.deprecateFunc('Ember.EnumerableUtils.indexesOf is deprecated.', indexesOf);
 
 /**
- * Adds an object to an array. If the array already includes the object this
- * method has no effect.
- *
- * @method addObject
- * @deprecated
- * @param {Array} array The array the passed item should be added to
- * @param {Object} item The item to add to the passed array
- *
- * @return 'undefined'
- */
+  Adds an object to an array. If the array already includes the object this
+  method has no effect.
+
+  @method addObject
+  @deprecated
+  @param {Array} array The array the passed item should be added to
+  @param {Object} item The item to add to the passed array
+
+  @return 'undefined'
+  @public
+*/
 export function addObject(array, item) {
   var index = indexOf(array, item);
   if (index === -1) { array.push(item); }
@@ -129,16 +134,17 @@ export function addObject(array, item) {
 var deprecatedAddObject = Ember.deprecateFunc('Ember.EnumerableUtils.addObject is deprecated.', addObject);
 
 /**
- * Removes an object from an array. If the array does not contain the passed
- * object this method has no effect.
- *
- * @method removeObject
- * @deprecated
- * @param {Array} array The array to remove the item from.
- * @param {Object} item The item to remove from the passed array.
- *
- * @return 'undefined'
- */
+  Removes an object from an array. If the array does not contain the passed
+  object this method has no effect.
+
+  @method removeObject
+  @deprecated
+  @param {Array} array The array to remove the item from.
+  @param {Object} item The item to remove from the passed array.
+
+  @return 'undefined'
+  @public
+*/
 export function removeObject(array, item) {
   var index = indexOf(array, item);
   if (index !== -1) { array.splice(index, 1); }
@@ -170,31 +176,32 @@ export function _replace(array, idx, amt, objects) {
 }
 
 /**
- * Replaces objects in an array with the passed objects.
- *
- * ```javascript
- *   var array = [1,2,3];
- *   Ember.EnumerableUtils.replace(array, 1, 2, [4, 5]); // [1, 4, 5]
- *
- *   var array = [1,2,3];
- *   Ember.EnumerableUtils.replace(array, 1, 1, [4, 5]); // [1, 4, 5, 3]
- *
- *   var array = [1,2,3];
- *   Ember.EnumerableUtils.replace(array, 10, 1, [4, 5]); // [1, 2, 3, 4, 5]
- * ```
- *
- * @method replace
- * @deprecated
- * @param {Array} array The array the objects should be inserted into.
- * @param {Number} idx Starting index in the array to replace. If *idx* >=
- * length, then append to the end of the array.
- * @param {Number} amt Number of elements that should be removed from the array,
- * starting at *idx*
- * @param {Array} objects An array of zero or more objects that should be
- * inserted into the array at *idx*
- *
- * @return {Array} The modified array.
- */
+  Replaces objects in an array with the passed objects.
+
+  ```javascript
+    var array = [1,2,3];
+    Ember.EnumerableUtils.replace(array, 1, 2, [4, 5]); // [1, 4, 5]
+
+    var array = [1,2,3];
+    Ember.EnumerableUtils.replace(array, 1, 1, [4, 5]); // [1, 4, 5, 3]
+
+    var array = [1,2,3];
+    Ember.EnumerableUtils.replace(array, 10, 1, [4, 5]); // [1, 2, 3, 4, 5]
+  ```
+
+  @method replace
+  @deprecated
+  @param {Array} array The array the objects should be inserted into.
+  @param {Number} idx Starting index in the array to replace. If *idx* >=
+  length, then append to the end of the array.
+  @param {Number} amt Number of elements that should be removed from the array,
+  starting at *idx*
+  @param {Array} objects An array of zero or more objects that should be
+  inserted into the array at *idx*
+
+  @return {Array} The modified array.
+  @public
+*/
 export function replace(array, idx, amt, objects) {
   if (array.replace) {
     return array.replace(idx, amt, objects);
@@ -205,29 +212,30 @@ export function replace(array, idx, amt, objects) {
 var deprecatedReplace = Ember.deprecateFunc('Ember.EnumerableUtils.replace is deprecated.', replace);
 
 /**
- * Calculates the intersection of two arrays. This method returns a new array
- * filled with the records that the two passed arrays share with each other.
- * If there is no intersection, an empty array will be returned.
- *
- * ```javascript
- * var array1 = [1, 2, 3, 4, 5];
- * var array2 = [1, 3, 5, 6, 7];
- *
- * Ember.EnumerableUtils.intersection(array1, array2); // [1, 3, 5]
- *
- * var array1 = [1, 2, 3];
- * var array2 = [4, 5, 6];
- *
- * Ember.EnumerableUtils.intersection(array1, array2); // []
- * ```
- *
- * @method intersection
- * @deprecated
- * @param {Array} array1 The first array
- * @param {Array} array2 The second array
- *
- * @return {Array} The intersection of the two passed arrays.
- */
+  Calculates the intersection of two arrays. This method returns a new array
+  filled with the records that the two passed arrays share with each other.
+  If there is no intersection, an empty array will be returned.
+
+  ```javascript
+  var array1 = [1, 2, 3, 4, 5];
+  var array2 = [1, 3, 5, 6, 7];
+
+  Ember.EnumerableUtils.intersection(array1, array2); // [1, 3, 5]
+
+  var array1 = [1, 2, 3];
+  var array2 = [4, 5, 6];
+
+  Ember.EnumerableUtils.intersection(array1, array2); // []
+  ```
+
+  @method intersection
+  @deprecated
+  @param {Array} array1 The first array
+  @param {Array} array2 The second array
+
+  @return {Array} The intersection of the two passed arrays.
+  @public
+*/
 export function intersection(array1, array2) {
   var result = [];
   forEach(array1, (element) => {

--- a/packages/ember-metal/lib/error.js
+++ b/packages/ember-metal/lib/error.js
@@ -17,6 +17,7 @@ var errorProps = [
   @namespace Ember
   @extends Error
   @constructor
+  @public
 */
 function EmberError() {
   var tmp = Error.apply(this, arguments);

--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -4,7 +4,8 @@
 "REMOVE_USE_STRICT: true";
 
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 import Ember from "ember-metal/core";
 import {
@@ -113,6 +114,7 @@ export function accumulateListeners(obj, eventName, otherActions) {
   @param {Object|Function} target A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
   @param {Boolean} once A flag whether a function should only be called once
+  @public
 */
 export function addListener(obj, eventName, target, method, once) {
   Ember.assert("You must pass at least an object and event name to Ember.addListener", !!obj && !!eventName);
@@ -152,6 +154,7 @@ export function addListener(obj, eventName, target, method, once) {
   @param {String} eventName
   @param {Object|Function} target A target object or a function
   @param {Function|String} method A function or the name of a function to be called on `target`
+  @public
 */
 function removeListener(obj, eventName, target, method) {
   Ember.assert("You must pass at least an object and event name to Ember.removeListener", !!obj && !!eventName);
@@ -308,6 +311,7 @@ export function watchedEvents(obj) {
   @param {Array} params Optional parameters for each listener.
   @param {Array} actions Optional array of actions (listeners).
   @return true
+  @public
 */
 export function sendEvent(obj, eventName, params, actions) {
   // first give object a chance to handle it
@@ -407,6 +411,7 @@ export function listenersFor(obj, eventName) {
   @param {String} eventNames*
   @param {Function} func
   @return func
+  @public
 */
 export function on(...args) {
   var func = args.pop();

--- a/packages/ember-metal/lib/expand_properties.js
+++ b/packages/ember-metal/lib/expand_properties.js
@@ -2,8 +2,9 @@ import EmberError from 'ember-metal/error';
 import { forEach } from 'ember-metal/array';
 
 /**
-  @module ember-metal
-  */
+@module ember
+@submodule ember-metal
+*/
 
 var SPLIT_REGEX = /\{|\}/;
 
@@ -32,7 +33,7 @@ var SPLIT_REGEX = /\{|\}/;
   @param {String} pattern The property pattern to expand.
   @param {Function} callback The callback to invoke.  It is invoked once per
   expansion, and is passed the expansion.
-  */
+*/
 export default function expandProperties(pattern, callback) {
   if (pattern.indexOf(' ') > -1) {
     throw new EmberError(`Brace expanded properties cannot contain spaces, e.g. 'user.{firstName, lastName}' should be 'user.{firstName,lastName}'`);

--- a/packages/ember-metal/lib/get_properties.js
+++ b/packages/ember-metal/lib/get_properties.js
@@ -22,6 +22,7 @@ import { isArray } from "ember-metal/utils";
   @param {Object} obj
   @param {String...|Array} list of keys to get
   @return {Object}
+  @private
 */
 export default function getProperties(obj) {
   var ret = {};

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -13,6 +13,7 @@ import create from "ember-metal/platform/create";
   @param {String} type The container type the property will lookup
   @param {String} name (optional) The name the property will lookup, defaults
          to the property's name
+  @private
 */
 function InjectedProperty(type, name) {
   this.type = type;

--- a/packages/ember-metal/lib/instrumentation.js
+++ b/packages/ember-metal/lib/instrumentation.js
@@ -46,6 +46,7 @@ import { tryCatchFinally } from "ember-metal/utils";
   @class Instrumentation
   @namespace Ember
   @static
+  @private
 */
 export var subscribers = [];
 var cache = {};
@@ -84,6 +85,7 @@ var time = (function() {
   @param {Object} _payload
   @param {Function} callback Function that you're instrumenting.
   @param {Object} binding Context that instrument function is called with.
+  @private
 */
 export function instrument(name, _payload, callback, binding) {
   if (arguments.length <= 3 && typeof _payload === 'function') {
@@ -165,6 +167,7 @@ export function _instrumentStart(name, _payload) {
   @param {Object} [object] Before and After hooks.
 
   @return {Subscriber}
+  @private
 */
 export function subscribe(pattern, object) {
   var paths = pattern.split(".");
@@ -202,6 +205,7 @@ export function subscribe(pattern, object) {
   @namespace Ember.Instrumentation
 
   @param {Object} [subscriber]
+  @private
 */
 export function unsubscribe(subscriber) {
   var index;
@@ -221,6 +225,7 @@ export function unsubscribe(subscriber) {
 
   @method reset
   @namespace Ember.Instrumentation
+  @private
 */
 export function reset() {
   subscribers.length = 0;

--- a/packages/ember-metal/lib/is_blank.js
+++ b/packages/ember-metal/lib/is_blank.js
@@ -22,7 +22,8 @@ import isEmpty from 'ember-metal/is_empty';
   @param {Object} obj Value to test
   @return {Boolean}
   @since 1.5.0
-  */
+  @public
+*/
 export default function isBlank(obj) {
   return isEmpty(obj) || (typeof obj === 'string' && obj.match(/\S/) === null);
 }

--- a/packages/ember-metal/lib/is_empty.js
+++ b/packages/ember-metal/lib/is_empty.js
@@ -23,6 +23,7 @@ import isNone from 'ember-metal/is_none';
   @for Ember
   @param {Object} obj Value to test
   @return {Boolean}
+  @public
 */
 function isEmpty(obj) {
   var none = isNone(obj);

--- a/packages/ember-metal/lib/is_none.js
+++ b/packages/ember-metal/lib/is_none.js
@@ -16,6 +16,7 @@
   @for Ember
   @param {Object} obj Value to test
   @return {Boolean}
+  @public
 */
 export default function isNone(obj) {
   return obj === null || obj === undefined;

--- a/packages/ember-metal/lib/is_present.js
+++ b/packages/ember-metal/lib/is_present.js
@@ -22,7 +22,8 @@ import isBlank from 'ember-metal/is_blank';
   @param {Object} obj Value to test
   @return {Boolean}
   @since 1.8.0
-  */
+  @public
+*/
 export default function isPresent(obj) {
   return !isBlank(obj);
 }

--- a/packages/ember-metal/lib/keys.js
+++ b/packages/ember-metal/lib/keys.js
@@ -9,6 +9,7 @@ import { canDefineNonEnumerableProperties } from 'ember-metal/platform/define_pr
   @for Ember
   @param {Object} obj
   @return {Array} Array containing keys of obj
+  @private
 */
 var keys = Object.keys;
 

--- a/packages/ember-metal/lib/logger.js
+++ b/packages/ember-metal/lib/logger.js
@@ -53,6 +53,7 @@ function assertPolyfill(test, message) {
 
   @class Logger
   @namespace Ember
+  @private
 */
 export default {
   /**
@@ -68,6 +69,7 @@ export default {
    @method log
    @for Ember.Logger
    @param {*} arguments
+   @private
   */
   log:   consoleMethod('log')   || K,
 
@@ -83,6 +85,7 @@ export default {
    @method warn
    @for Ember.Logger
    @param {*} arguments
+   @private
   */
   warn:  consoleMethod('warn')  || K,
 
@@ -98,6 +101,7 @@ export default {
    @method error
    @for Ember.Logger
    @param {*} arguments
+   @private
   */
   error: consoleMethod('error') || K,
 
@@ -114,6 +118,7 @@ export default {
    @method info
    @for Ember.Logger
    @param {*} arguments
+   @private
   */
   info:  consoleMethod('info')  || K,
 
@@ -130,6 +135,7 @@ export default {
    @method debug
    @for Ember.Logger
    @param {*} arguments
+   @private
   */
   debug: consoleMethod('debug') || consoleMethod('info') || K,
 
@@ -144,6 +150,7 @@ export default {
    @method assert
    @for Ember.Logger
    @param {Boolean} bool Value to test
+   @private
   */
   assert: consoleMethod('assert') || assertPolyfill
 };

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -1,6 +1,4 @@
 /**
-Ember Metal
-
 @module ember
 @submodule ember-metal
 */
@@ -413,6 +411,7 @@ if (Ember.FEATURES.isEnabled('ember-metal-stream')) {
   @event onerror
   @for Ember
   @param {Exception} error the error object
+  @public
 */
 Ember.onerror = null;
 // END EXPORTS

--- a/packages/ember-metal/lib/map.js
+++ b/packages/ember-metal/lib/map.js
@@ -1,5 +1,6 @@
 /**
-@module ember-metal
+@module ember
+@submodule ember-metal
 */
 
 /*
@@ -79,6 +80,7 @@ function OrderedSet() {
   @method create
   @static
   @return {Ember.OrderedSet}
+  @private
 */
 OrderedSet.create = function() {
   var Constructor = this;
@@ -90,6 +92,7 @@ OrderedSet.prototype = {
   constructor: OrderedSet,
   /**
     @method clear
+    @private
   */
   clear() {
     this.presenceSet = create(null);
@@ -102,6 +105,7 @@ OrderedSet.prototype = {
     @param obj
     @param guid (optional, and for internal use)
     @return {Ember.OrderedSet}
+    @private
   */
   add(obj, _guid) {
     var guid = _guid || guidFor(obj);
@@ -123,6 +127,7 @@ OrderedSet.prototype = {
     @param obj
     @param _guid (optional and for internal use only)
     @return {Boolean}
+    @private
   */
   remove(obj, _guid) {
     Ember.deprecate('Calling `OrderedSet.prototype.remove` has been deprecated, please use `OrderedSet.prototype.delete` instead.', this._silenceRemoveDeprecation);
@@ -136,6 +141,7 @@ OrderedSet.prototype = {
     @param obj
     @param _guid (optional and for internal use only)
     @return {Boolean}
+    @private
   */
   delete(obj, _guid) {
     var guid = _guid || guidFor(obj);
@@ -158,6 +164,7 @@ OrderedSet.prototype = {
   /**
     @method isEmpty
     @return {Boolean}
+    @private
   */
   isEmpty() {
     return this.size === 0;
@@ -167,6 +174,7 @@ OrderedSet.prototype = {
     @method has
     @param obj
     @return {Boolean}
+    @private
   */
   has(obj) {
     if (this.size === 0) { return false; }
@@ -181,6 +189,7 @@ OrderedSet.prototype = {
     @method forEach
     @param {Function} fn
     @param self
+    @private
   */
   forEach(fn /*, ...thisArg*/) {
     if (typeof fn !== 'function') {
@@ -207,6 +216,7 @@ OrderedSet.prototype = {
   /**
     @method toArray
     @return {Array}
+    @private
   */
   toArray() {
     return this.list.slice();
@@ -215,6 +225,7 @@ OrderedSet.prototype = {
   /**
     @method copy
     @return {Ember.OrderedSet}
+    @private
   */
   copy() {
     var Constructor = this.constructor;
@@ -267,6 +278,7 @@ Ember.Map = Map;
 /**
   @method create
   @static
+  @private
 */
 Map.create = function() {
   var Constructor = this;
@@ -283,6 +295,7 @@ Map.prototype = {
     @property size
     @type number
     @default 0
+    @private
   */
   size: 0,
 
@@ -292,6 +305,7 @@ Map.prototype = {
     @method get
     @param {*} key
     @return {*} the value associated with the key, or `undefined`
+    @private
   */
   get(key) {
     if (this.size === 0) { return; }
@@ -310,6 +324,7 @@ Map.prototype = {
     @param {*} key
     @param {*} value
     @return {Ember.Map}
+    @private
   */
   set(key, value) {
     var keys = this._keys;
@@ -335,6 +350,7 @@ Map.prototype = {
     @method remove
     @param {*} key
     @return {Boolean} true if an item was removed, false otherwise
+    @private
   */
   remove(key) {
     Ember.deprecate('Calling `Map.prototype.remove` has been deprecated, please use `Map.prototype.delete` instead.');
@@ -349,6 +365,7 @@ Map.prototype = {
     @method delete
     @param {*} key
     @return {Boolean} true if an item was removed, false otherwise
+    @private
   */
   delete(key) {
     if (this.size === 0) { return false; }
@@ -373,6 +390,7 @@ Map.prototype = {
     @method has
     @param {*} key
     @return {Boolean} true if the item was present, false otherwise
+    @private
   */
   has(key) {
     return this._keys.has(key);
@@ -389,6 +407,7 @@ Map.prototype = {
     @param {Function} callback
     @param {*} self if passed, the `this` value inside the
       callback. By default, `this` is the map.
+    @private
   */
   forEach(callback/*, ...thisArg*/) {
     if (typeof callback !== 'function') {
@@ -417,6 +436,7 @@ Map.prototype = {
 
   /**
     @method clear
+    @private
   */
   clear() {
     this._keys.clear();
@@ -427,6 +447,7 @@ Map.prototype = {
   /**
     @method copy
     @return {Ember.Map}
+    @private
   */
   copy() {
     return copyMap(this, new Map());
@@ -456,6 +477,7 @@ function MapWithDefault(options) {
     @param {*} [options.defaultValue]
   @return {Ember.MapWithDefault|Ember.Map} If options are passed, returns
     `Ember.MapWithDefault` otherwise returns `Ember.Map`
+  @private
 */
 MapWithDefault.create = function(options) {
   if (options) {
@@ -476,6 +498,7 @@ MapWithDefault.prototype._super$get = Map.prototype.get;
   @method get
   @param {*} key
   @return {*} the value associated with the key, or the default value
+  @private
 */
 MapWithDefault.prototype.get = function(key) {
   var hasValue = this.has(key);
@@ -492,6 +515,7 @@ MapWithDefault.prototype.get = function(key) {
 /**
   @method copy
   @return {Ember.MapWithDefault}
+  @private
 */
 MapWithDefault.prototype.copy = function() {
   var Constructor = this.constructor;

--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -15,6 +15,7 @@ import keys from 'ember-metal/keys';
   @param {Object} original The object to merge into
   @param {Object} updates The object to copy properties from
   @return {Object}
+  @private
 */
 export default function merge(original, updates) {
   if (!updates || typeof updates !== 'object') {

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -486,6 +486,7 @@ function applyMixin(obj, mixins, partial) {
   @param obj
   @param mixins*
   @return obj
+  @private
 */
 export function mixin(obj, ...args) {
   applyMixin(obj, args, false);
@@ -545,6 +546,7 @@ export function mixin(obj, ...args) {
 
   @class Mixin
   @namespace Ember
+  @public
 */
 export default Mixin;
 function Mixin(args, properties) {
@@ -587,6 +589,7 @@ Ember.anyUnprocessedMixins = false;
   @method create
   @static
   @param arguments*
+  @public
 */
 Mixin.create = function(...args) {
   // ES6TODO: this relies on a global state?
@@ -600,6 +603,7 @@ var MixinPrototype = Mixin.prototype;
 /**
   @method reopen
   @param arguments*
+  @private
 */
 MixinPrototype.reopen = function() {
   var currentMixin;
@@ -636,6 +640,7 @@ MixinPrototype.reopen = function() {
   @method apply
   @param obj
   @return applied object
+  @private
 */
 MixinPrototype.apply = function(obj) {
   return applyMixin(obj, [this], false);
@@ -664,6 +669,7 @@ function _detect(curMixin, targetMixin, seen) {
   @method detect
   @param obj
   @return {Boolean}
+  @private
 */
 MixinPrototype.detect = function(obj) {
   if (!obj) { return false; }
@@ -738,6 +744,7 @@ REQUIRED.toString = function() { return '(Required Property)'; };
 
   @method required
   @for Ember
+  @private
 */
 export function required() {
   Ember.deprecate('Ember.required is deprecated as its behavior is inconsistent and unreliable.', false);
@@ -771,6 +778,7 @@ Alias.prototype = new Descriptor();
   @method aliasMethod
   @for Ember
   @param {String} methodName name of the method to alias
+  @private
 */
 export function aliasMethod(methodName) {
   return new Alias(methodName);
@@ -802,6 +810,7 @@ export function aliasMethod(methodName) {
   @param {String} propertyNames*
   @param {Function} func
   @return func
+  @private
 */
 export function observer(...args) {
   var func  = args.slice(-1)[0];
@@ -853,6 +862,7 @@ export function observer(...args) {
   @param {String} propertyNames*
   @param {Function} func
   @return func
+  @private
 */
 export function immediateObserver() {
   for (var i=0, l=arguments.length; i<l; i++) {
@@ -905,6 +915,7 @@ export function immediateObserver() {
   @param {String} propertyNames*
   @param {Function} func
   @return func
+  @private
 */
 export function beforeObserver(...args) {
   var func  = args.slice(-1)[0];

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -32,6 +32,7 @@ function beforeEvent(keyName) {
   @param {String} _path
   @param {Object|Function} target
   @param {Function|String} [method]
+  @public
 */
 export function addObserver(obj, _path, target, method) {
   addListener(obj, changeEvent(_path), target, method);
@@ -51,6 +52,7 @@ export function observersFor(obj, path) {
   @param {String} path
   @param {Object|Function} target
   @param {Function|String} [method]
+  @public
 */
 export function removeObserver(obj, path, target, method) {
   unwatch(obj, path);
@@ -66,6 +68,7 @@ export function removeObserver(obj, path, target, method) {
   @param {String} path
   @param {Object|Function} target
   @param {Function|String} [method]
+  @private
 */
 export function addBeforeObserver(obj, path, target, method) {
   addListener(obj, beforeEvent(path), target, method);
@@ -107,6 +110,7 @@ export function beforeObserversFor(obj, path) {
   @param {String} path
   @param {Object|Function} target
   @param {Function|String} [method]
+  @private
 */
 export function removeBeforeObserver(obj, path, target, method) {
   unwatch(obj, path);

--- a/packages/ember-metal/lib/platform/create.js
+++ b/packages/ember-metal/lib/platform/create.js
@@ -9,6 +9,7 @@ import defineProperties from 'ember-metal/platform/define_properties';
 @class platform
 @namespace Ember
 @static
+@private
 */
 
 /**
@@ -17,6 +18,7 @@ import defineProperties from 'ember-metal/platform/define_properties';
   @since 1.8.0
   @method create
   @for Ember
+  @public
 */
 var create;
 // ES5 15.2.3.5

--- a/packages/ember-metal/lib/platform/define_property.js
+++ b/packages/ember-metal/lib/platform/define_property.js
@@ -4,6 +4,7 @@
 @class platform
 @namespace Ember
 @static
+@private
 */
 
 /**
@@ -11,6 +12,7 @@
 
   @property hasPropertyAccessors
   @final
+  @private
 */
 
 /**
@@ -22,6 +24,7 @@
   @param {String} keyName property name to modify
   @param {Object} desc descriptor hash
   @return {void}
+  @public
 */
 var defineProperty = (function checkCompliance(defineProperty) {
   if (!defineProperty) {

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -16,6 +16,9 @@ import { overrideChains } from "ember-metal/property_events";
 /**
   Objects of this type can implement an interface to respond to requests to
   get and set. The default implementation handles simple properties.
+
+  @class Descriptor
+  @private
 */
 export function Descriptor() {
   this.isDescriptor = true;

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -33,6 +33,7 @@ var deferred = 0;
   @param {Object} obj The object with the property that will change
   @param {String} keyName The property key (or path) that will change.
   @return {void}
+  @private
 */
 function propertyWillChange(obj, keyName) {
   var m = obj['__ember_meta__'];
@@ -72,6 +73,7 @@ function propertyWillChange(obj, keyName) {
   @param {Object} obj The object with the property that will change
   @param {String} keyName The property key (or path) that will change.
   @return {void}
+  @private
 */
 function propertyDidChange(obj, keyName) {
   var m = obj['__ember_meta__'];
@@ -270,6 +272,7 @@ function endPropertyChanges() {
   @method changeProperties
   @param {Function} callback
   @param [binding]
+  @private
 */
 function changeProperties(callback, binding) {
   beginPropertyChanges();

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -48,6 +48,7 @@ export let UNHANDLED_GET = symbol("UNHANDLED_GET");
   @param {Object} obj The object to retrieve from.
   @param {String} keyName The property key to retrieve
   @return {Object} the property value or `null`.
+  @public
 */
 export function get(obj, keyName) {
   // Helpers that operate with 'this' within an #each

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -29,6 +29,7 @@ export let UNHANDLED_SET = symbol("UNHANDLED_SET");
   @param {String} keyName The property key to set
   @param {Object} value The value to set
   @return {Object} the passed value.
+  @public
 */
 export function set(obj, keyName, value, tolerant) {
   if (typeof obj === 'string') {
@@ -167,6 +168,7 @@ function setPath(root, path, value, tolerant) {
   @param {Object} root The object to modify.
   @param {String} path The property path to set
   @param {Object} value The value to set
+  @public
 */
 export function trySet(root, path, value) {
   return set(root, path, value, true);

--- a/packages/ember-metal/lib/run_loop.js
+++ b/packages/ember-metal/lib/run_loop.js
@@ -61,6 +61,7 @@ var backburner = new Backburner(['sync', 'actions', 'destroy'], {
     then it will be looked up on the passed target.
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
   @return {Object} return value from invoking the passed function.
+  @public
 */
 export default run;
 function run() {
@@ -103,6 +104,7 @@ function run() {
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
   @return {Object} Return value from invoking the passed function. Please note,
   when called within an existing loop, no return value is possible.
+  @public
 */
 run.join = function() {
   return backburner.join(...arguments);
@@ -156,6 +158,7 @@ run.join = function() {
   @param {Object} [args*] Any additional arguments you wish to pass to the method.
   @return {Function} returns a new function that will always have a particular context
   @since 1.4.0
+  @public
 */
 run.bind = function(...curried) {
   return function(...args) {
@@ -180,6 +183,7 @@ run.queues = backburner.queueNames;
 
   @method begin
   @return {void}
+  @public
 */
 run.begin = function() {
   backburner.begin();
@@ -198,6 +202,7 @@ run.begin = function() {
 
   @method end
   @return {void}
+  @public
 */
 run.end = function() {
   backburner.end();
@@ -212,6 +217,7 @@ run.end = function() {
   @property queues
   @type Array
   @default ['sync', 'actions', 'destroy']
+  @private
 */
 
 /**
@@ -250,6 +256,7 @@ run.end = function() {
     invoked allowing you to change the target function.
   @param {Object} [arguments*] Optional arguments to be passed to the queued method.
   @return {void}
+  @public
 */
 run.schedule = function(/* queue, target, method */) {
   checkAutoRun();
@@ -281,6 +288,7 @@ run.cancelTimers = function() {
 
   @method sync
   @return {void}
+  @private
 */
 run.sync = function() {
   if (backburner.currentInstance) {
@@ -312,6 +320,7 @@ run.sync = function() {
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @param {Number} wait Number of milliseconds to wait.
   @return {*} Timer information for use in cancelling, see `run.cancel`.
+  @public
 */
 run.later = function(/*target, method*/) {
   return backburner.later(...arguments);
@@ -328,6 +337,7 @@ run.later = function(/*target, method*/) {
     target at the time the method is invoked.
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @return {Object} Timer information for use in cancelling, see `run.cancel`.
+  @public
 */
 run.once = function(...args) {
   checkAutoRun();
@@ -385,6 +395,7 @@ run.once = function(...args) {
     target at the time the method is invoked.
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @return {Object} Timer information for use in cancelling, see `run.cancel`.
+  @public
 */
 run.scheduleOnce = function(/*queue, target, method*/) {
   checkAutoRun();
@@ -448,6 +459,7 @@ run.scheduleOnce = function(/*queue, target, method*/) {
     target at the time the method is invoked.
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @return {Object} Timer information for use in cancelling, see `run.cancel`.
+  @public
 */
 run.next = function(...args) {
   args.push(1);
@@ -501,6 +513,7 @@ run.next = function(...args) {
   @method cancel
   @param {Object} timer Timer object to cancel
   @return {Boolean} true if cancelled or false/undefined if it wasn't found
+  @public
 */
 run.cancel = function(timer) {
   return backburner.cancel(timer);
@@ -573,6 +586,7 @@ run.cancel = function(timer) {
   @param {Boolean} immediate Trigger the function on the leading instead
     of the trailing edge of the wait interval. Defaults to false.
   @return {Array} Timer information for use in cancelling, see `run.cancel`.
+  @public
 */
 run.debounce = function() {
   return backburner.debounce(...arguments);
@@ -615,6 +629,7 @@ run.debounce = function() {
   @param {Boolean} immediate Trigger the function on the leading instead
     of the trailing edge of the wait interval. Defaults to true.
   @return {Array} Timer information for use in cancelling, see `run.cancel`.
+  @public
 */
 run.throttle = function() {
   return backburner.throttle(...arguments);

--- a/packages/ember-metal/lib/set_properties.js
+++ b/packages/ember-metal/lib/set_properties.js
@@ -21,6 +21,7 @@ import keys from "ember-metal/keys";
   @param obj
   @param {Object} properties
   @return obj
+  @public
 */
 export default function setProperties(obj, properties) {
   if (!properties || typeof properties !== "object") { return obj; }

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -532,6 +532,7 @@ export function wrap(func, superFunc) {
   @param {Object} obj The object to check for the method
   @param {String} methodName The method name to check for
   @return {Boolean}
+  @private
 */
 function canInvoke(obj, methodName) {
   return !!(obj && typeof obj[methodName] === 'function');
@@ -555,6 +556,7 @@ function canInvoke(obj, methodName) {
   @param {String} methodName The method name to check for
   @param {Array} [args] The arguments to pass to the method
   @return {*} the return value of the invoked method or undefined if it cannot be invoked
+  @public
 */
 export function tryInvoke(obj, methodName, args) {
   if (canInvoke(obj, methodName)) {
@@ -604,6 +606,7 @@ var needsFinallyFix = (function() {
   @return {*} The return value is the that of the finalizer,
   unless that value is undefined, in which case it is the return value
   of the tryable
+  @private
 */
 
 var tryFinally;
@@ -687,6 +690,7 @@ var deprecatedTryFinally = function() {
   @return {*} The return value is the that of the finalizer,
   unless that value is undefined, in which case it is the return value
   of the tryable.
+  @private
 */
 var tryCatchFinally;
 if (needsFinallyFix) {
@@ -769,6 +773,7 @@ var isArray = Array.isArray || function(value) {
   @for Ember
   @param {Object} obj the object
   @return {Array}
+  @private
 */
 export function makeArray(obj) {
   if (obj === null || obj === undefined) { return []; }
@@ -787,6 +792,7 @@ export function makeArray(obj) {
   @param {Object} obj The object you want to inspect.
   @return {String} A description of the object
   @since 1.4.0
+  @private
 */
 export function inspect(obj) {
   if (obj === null) {
@@ -833,6 +839,7 @@ export function inspect(obj) {
   @param {Object} t target
   @param {Function} m method
   @param {Array} a args
+  @private
 */
 export function apply(t, m, a) {
   var l = a && a.length;
@@ -851,6 +858,7 @@ export function apply(t, m, a) {
   @param {Object} t target
   @param {String} m method
   @param {Array} a args
+  @private
 */
 export function applyStr(t, m, a) {
   var l = a && a.length;

--- a/packages/ember-metal/lib/watching.js
+++ b/packages/ember-metal/lib/watching.js
@@ -76,6 +76,7 @@ var NODE_STACK = [];
   @for Ember
   @param {Object} obj  the object to destroy
   @return {void}
+  @private
 */
 export function destroy(obj) {
   var meta = obj['__ember_meta__'];

--- a/packages/ember-routing-htmlbars/lib/helpers/query-params.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/query-params.js
@@ -18,6 +18,7 @@ import QueryParams from "ember-routing/system/query_params";
   @for Ember.Handlebars.helpers
   @param {Object} hash takes a hash of query parameters
   @return {String} HTML string
+  @public
 */
 export function queryParamsHelper(params, hash) {
   Ember.assert("The `query-params` helper only accepts hash parameters, e.g. (query-params queryParamPropertyName='foo') as opposed to just (query-params 'foo')", params.length === 0);
@@ -26,4 +27,3 @@ export function queryParamsHelper(params, hash) {
     values: hash
   });
 }
-

--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -165,6 +165,7 @@ import closureAction from "ember-routing-htmlbars/keywords/closure-action";
 
   @method action
   @for Ember.Handlebars.helpers
+  @public
 */
 export default function(morph, env, scope, params, hash, template, inverse, visitor) {
   if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {

--- a/packages/ember-routing-htmlbars/lib/keywords/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/link-to.js
@@ -278,6 +278,7 @@ import merge from "ember-metal/merge";
   @param [options] {Object} Handlebars key/value pairs of options, you can override any property of Ember.LinkView
   @return {String} HTML string
   @see {Ember.LinkView}
+  @public
 */
 export default {
   link(state, params, hash) {
@@ -314,4 +315,5 @@ export default {
   @param {String} routeName
   @param {Object} [context]*
   @return {String} HTML string
+  @private
 */

--- a/packages/ember-routing-htmlbars/lib/main.js
+++ b/packages/ember-routing-htmlbars/lib/main.js
@@ -1,9 +1,6 @@
 /**
-Ember Routing HTMLBars Helpers
-
 @module ember
 @submodule ember-routing-htmlbars
-@requires ember-routing
 */
 
 import Ember from "ember-metal/core";

--- a/packages/ember-routing-views/lib/main.js
+++ b/packages/ember-routing-views/lib/main.js
@@ -1,9 +1,6 @@
 /**
-Ember Routing Views
-
 @module ember
 @submodule ember-routing-views
-@requires ember-routing
 */
 
 import Ember from "ember-metal/core";

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -34,6 +34,7 @@ if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
   @namespace Ember
   @extends Ember.View
   @see {Handlebars.helpers.link-to}
+  @private
 **/
 var LinkComponent = EmberComponent.extend({
   defaultLayout: linkToTemplate,
@@ -43,6 +44,7 @@ var LinkComponent = EmberComponent.extend({
   /**
     @deprecated Use current-when instead.
     @property currentWhen
+    @private
   */
   currentWhen: null,
 
@@ -50,6 +52,7 @@ var LinkComponent = EmberComponent.extend({
     Used to determine when this LinkView is active.
 
     @property currentWhen
+    @private
   */
   'current-when': null,
 
@@ -58,6 +61,7 @@ var LinkComponent = EmberComponent.extend({
 
     @property title
     @default null
+    @private
   **/
   title: null,
 
@@ -66,6 +70,7 @@ var LinkComponent = EmberComponent.extend({
 
     @property rel
     @default null
+    @private
   **/
   rel: null,
 
@@ -74,6 +79,7 @@ var LinkComponent = EmberComponent.extend({
 
     @property tabindex
     @default null
+    @private
   **/
   tabindex: null,
 
@@ -83,6 +89,7 @@ var LinkComponent = EmberComponent.extend({
     @since 1.8.0
     @property target
     @default null
+    @private
   **/
   target: null,
 
@@ -93,6 +100,7 @@ var LinkComponent = EmberComponent.extend({
     @property activeClass
     @type String
     @default active
+    @private
   **/
   activeClass: 'active',
 
@@ -103,6 +111,7 @@ var LinkComponent = EmberComponent.extend({
     @property loadingClass
     @type String
     @default loading
+    @private
   **/
   loadingClass: 'loading',
 
@@ -113,6 +122,7 @@ var LinkComponent = EmberComponent.extend({
     @property disabledClass
     @type String
     @default disabled
+    @private
   **/
   disabledClass: 'disabled',
   _isDisabled: false,
@@ -124,6 +134,7 @@ var LinkComponent = EmberComponent.extend({
     @property replace
     @type Boolean
     @default false
+    @private
   **/
   replace: false,
 
@@ -135,7 +146,8 @@ var LinkComponent = EmberComponent.extend({
     @property attributeBindings
     @type Array | String
     @default ['title', 'rel', 'tabindex', 'target']
-   **/
+     @private
+  */
   attributeBindings: ['href', 'title', 'rel', 'tabindex', 'target'],
 
   /**
@@ -145,7 +157,8 @@ var LinkComponent = EmberComponent.extend({
     @property classNameBindings
     @type Array
     @default ['active', 'loading', 'disabled']
-   **/
+     @private
+  */
   classNameBindings: linkViewClassNameBindings,
 
   /**
@@ -159,6 +172,7 @@ var LinkComponent = EmberComponent.extend({
     @property eventName
     @type String
     @default click
+    @private
   */
   eventName: 'click',
 
@@ -172,7 +186,8 @@ var LinkComponent = EmberComponent.extend({
     instead.
 
     @event click
-  **/
+    @private
+  */
 
   /**
     An overridable method called when LinkView objects are instantiated.
@@ -195,6 +210,7 @@ var LinkComponent = EmberComponent.extend({
     application.
 
     @method init
+    @private
   */
   init() {
     this._super(...arguments);
@@ -214,6 +230,7 @@ var LinkComponent = EmberComponent.extend({
 
     When `true` interactions with the element will not trigger route changes.
     @property disabled
+    @private
   */
   disabled: computed({
     get(key, value) {
@@ -238,7 +255,8 @@ var LinkComponent = EmberComponent.extend({
     route names using the ` ` (space) character.
 
     @property active
-  **/
+    @private
+  */
   active: computed('attrs.params', '_routing.currentState', function computeLinkViewActive() {
     var currentState = get(this, '_routing.currentState');
     return computeActive(this, currentState);
@@ -272,6 +290,7 @@ var LinkComponent = EmberComponent.extend({
     @private
     @method _invoke
     @param {Event} event
+    @private
   */
   _invoke(event) {
     if (!isSimpleClick(event)) { return true; }
@@ -310,7 +329,8 @@ var LinkComponent = EmberComponent.extend({
     than `a`, this property will be ignored.
 
     @property href
-  **/
+    @private
+  */
   href: computed('models', 'targetRouteName', '_routing.currentState', function computeLinkViewHref() {
     if (get(this, 'tagName') !== 'a') { return; }
 
@@ -339,6 +359,7 @@ var LinkComponent = EmberComponent.extend({
     @property loadingHref
     @type String
     @default #
+    @private
   */
   loadingHref: '#',
 

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -226,6 +226,7 @@ ControllerMixin.reopen({
       containing a mapping of query parameters
     @for Ember.ControllerMixin
     @method transitionToRoute
+    @private
   */
   transitionToRoute() {
     // target may be either another controller or a router
@@ -238,6 +239,7 @@ ControllerMixin.reopen({
     @deprecated
     @for Ember.ControllerMixin
     @method transitionTo
+    @private
   */
   transitionTo() {
     Ember.deprecate("transitionTo is deprecated. Please use transitionToRoute.");
@@ -298,6 +300,7 @@ ControllerMixin.reopen({
     while transitioning to the route.
     @for Ember.ControllerMixin
     @method replaceRoute
+    @private
   */
   replaceRoute() {
     // target may be either another controller or a router
@@ -310,6 +313,7 @@ ControllerMixin.reopen({
     @deprecated
     @for Ember.ControllerMixin
     @method replaceWith
+    @private
   */
   replaceWith() {
     Ember.deprecate("replaceWith is deprecated. Please use replaceRoute.");

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -122,6 +122,7 @@ import { getHash } from "ember-routing/location/util";
   @class Location
   @namespace Ember
   @static
+  @private
 */
 export default {
   /**
@@ -143,6 +144,7 @@ export default {
     @return {Object} an instance of an implementation of the `location` API
     @deprecated Use the container to lookup the location implementation that you
     need.
+    @private
   */
   create(options) {
     var implementation = options && options.implementation;
@@ -175,6 +177,7 @@ export default {
    @param {Object} implementation of the `location` API
    @deprecated Register your custom location implementation with the
    container directly.
+   @private
   */
   registerImplementation(name, implementation) {
     Ember.deprecate(`Using the Ember.Location.registerImplementation is no longer supported. Register your custom location implementation with the container instead.`, false);

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -34,6 +34,7 @@ import {
   @class AutoLocation
   @namespace Ember
   @static
+  @private
 */
 export default EmberObject.extend({
   /**
@@ -109,6 +110,8 @@ export default EmberObject.extend({
    Called by the router to instruct the location to do any feature detection
    necessary. In the case of AutoLocation, we detect whether to use history
    or hash concrete implementations.
+
+   @private
   */
   detect() {
     var rootURL = this.rootURL;
@@ -162,7 +165,7 @@ function delegateToConcreteImplementation(methodName) {
   };
 }
 
-/**
+/*
   Given the browser's `location`, `history` and `userAgent`, and a configured
   root URL, this function detects whether the browser supports the [History
   API](https://developer.mozilla.org/en-US/docs/Web/API/History) and returns a

--- a/packages/ember-routing/lib/location/hash_location.js
+++ b/packages/ember-routing/lib/location/hash_location.js
@@ -20,6 +20,7 @@ import EmberLocation from "ember-routing/location/api";
   @class HashLocation
   @namespace Ember
   @extends Ember.Object
+  @private
 */
 export default EmberObject.extend({
   implementation: 'hash',

--- a/packages/ember-routing/lib/location/history_location.js
+++ b/packages/ember-routing/lib/location/history_location.js
@@ -20,6 +20,7 @@ var popstateFired = false;
   @class HistoryLocation
   @namespace Ember
   @extends Ember.Object
+  @private
 */
 export default EmberObject.extend({
   implementation: 'history',
@@ -52,6 +53,7 @@ export default EmberObject.extend({
 
     @property rootURL
     @default '/'
+    @private
   */
   rootURL: '/',
 

--- a/packages/ember-routing/lib/location/none_location.js
+++ b/packages/ember-routing/lib/location/none_location.js
@@ -16,6 +16,7 @@ import EmberObject from "ember-runtime/system/object";
   @class NoneLocation
   @namespace Ember
   @extends Ember.Object
+  @private
 */
 export default EmberObject.extend({
   implementation: 'none',

--- a/packages/ember-routing/lib/main.js
+++ b/packages/ember-routing/lib/main.js
@@ -1,9 +1,6 @@
 /**
-Ember Routing
-
 @module ember
 @submodule ember-routing
-@requires ember-views
 */
 
 import Ember from "ember-metal/core";

--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -11,15 +11,17 @@ import { routeArgs } from "ember-routing/utils";
 import keys from "ember-metal/keys";
 import merge from "ember-metal/merge";
 
-/** @private
+/**
   The Routing service is used by LinkView, and provides facilities for
   the component/view layer to interact with the router.
 
   While still private, this service can eventually be opened up, and provides
   the set of API needed for components to control routing without interacting
   with router internals.
-*/
 
+  @private
+  @class RoutingService
+*/
 var RoutingService = Service.extend({
   router: null,
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -41,6 +41,7 @@ function K() { return this; }
   @extends Ember.Object
   @uses Ember.ActionHandler
   @uses Ember.Evented
+  @public
 */
 var Route = EmberObject.extend(ActionHandler, Evented, {
   /**
@@ -83,6 +84,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @property queryParams
     @for Ember.Route
     @type Object
+    @public
   */
   queryParams: {},
 
@@ -233,7 +235,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @method paramsFor
     @param {String} name
-
+    @private
   */
   paramsFor(name) {
     var route = this.container.lookup(`route:${name}`);
@@ -257,6 +259,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @method serializeQueryParamKey
     @param {String} controllerPropertyName
+    @private
   */
   serializeQueryParamKey(controllerPropertyName) {
     return controllerPropertyName;
@@ -269,6 +272,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @param {Object} value
     @param {String} urlKey
     @param {String} defaultValueType
+    @private
   */
   serializeQueryParam(value, urlKey, defaultValueType) {
     // urlKey isn't used here, but anyone overriding
@@ -287,6 +291,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @param {Object} value
     @param {String} urlKey
     @param {String} defaultValueType
+    @private
   */
   deserializeQueryParam(value, urlKey, defaultValueType) {
     // urlKey isn't used here, but anyone overriding
@@ -345,6 +350,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @param {Boolean} isExiting
     @param {Object} transition
     @since 1.7.0
+    @public
   */
   resetController: K,
 
@@ -408,6 +414,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @type String
     @default null
     @since 1.4.0
+    @public
   */
   viewName: null,
 
@@ -431,6 +438,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @type String
     @default null
     @since 1.4.0
+    @public
   */
   templateName: null,
 
@@ -452,6 +460,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @type String
     @default null
     @since 1.4.0
+    @public
   */
   controllerName: null,
 
@@ -488,6 +497,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @event willTransition
     @param {Transition} transition
+    @public
   */
 
   /**
@@ -511,6 +521,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @event didTransition
     @since 1.2.0
+    @public
   */
 
   /**
@@ -542,6 +553,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @param {Transition} transition
     @param {Ember.Route} route The route that triggered the loading event
     @since 1.2.0
+    @public
   */
 
   /**
@@ -596,6 +608,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @event error
     @param {Error} error
     @param {Transition} transition
+    @public
   */
 
   /**
@@ -612,6 +625,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @event activate
     @since 1.9.0
+    @public
   */
 
   /**
@@ -628,6 +642,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @event deactivate
     @since 1.9.0
+    @public
   */
 
   /**
@@ -655,6 +670,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @property controller
     @type Ember.Controller
     @since 1.6.0
+    @private
   */
 
   _actions: {
@@ -762,6 +778,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     Please use `actions` instead.
     @method events
+    @private
   */
   events: null,
 
@@ -770,6 +787,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     not executed when the model for the route changes.
 
     @method deactivate
+    @private
   */
   deactivate: K,
 
@@ -778,6 +796,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     when the model for the route changes.
 
     @method activate
+    @private
   */
   activate: K,
 
@@ -933,6 +952,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       containing a mapping of query parameters
     @return {Transition} the transition object associated with this
       attempted transition
+    @private
   */
   transitionTo(name, context) {
     var router = this.router;
@@ -954,6 +974,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @param {...Object} models the model(s) to be used while transitioning
     to the route.
     @since 1.2.0
+    @private
    */
   intermediateTransitionTo() {
     var router = this.router;
@@ -980,6 +1001,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @return {Transition} the transition object associated with this
       attempted transition
     @since 1.4.0
+    @private
    */
   refresh() {
     return this.router.router.refresh(this);
@@ -1014,6 +1036,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       transitioning to the route.
     @return {Transition} the transition object associated with this
       attempted transition
+    @private
   */
   replaceWith() {
     var router = this.router;
@@ -1053,6 +1076,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method send
     @param {String} name the name of the action to trigger
     @param {...*} args
+    @public
   */
   send(...args) {
     if (this.router || !Ember.testing) {
@@ -1186,6 +1210,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       a promise, the transition will pause until the transition
       resolves. Otherwise, non-promise return values are not
       utilized in any way.
+    @public
   */
   beforeModel: K,
 
@@ -1219,6 +1244,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       a promise, the transition will pause until the transition
       resolves. Otherwise, non-promise return values are not
       utilized in any way.
+    @public
    */
   afterModel: K,
 
@@ -1245,6 +1271,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method redirect
     @param {Object} model the model for this route
     @param {Transition} transition the transition object associated with the current transition
+    @private
   */
   redirect: K,
 
@@ -1323,6 +1350,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       a promise is returned, the transition will pause until
       the promise resolves, and the resolved value of the promise
       will be used as the model for this route.
+    @public
   */
   model(params, transition) {
     var match, name, sawParams, value;
@@ -1372,6 +1400,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method findModel
     @param {String} type the model type
     @param {Object} value the value passed to find
+    @private
   */
   findModel() {
     var store = get(this, 'store');
@@ -1390,6 +1419,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @method store
     @param {Object} store
+    @private
   */
   store: computed(function() {
     var container = this.container;
@@ -1447,6 +1477,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @param {Array} params an Array of parameter names for the current
       route (in the example, `['post_id']`.
     @return {Object} the serialized parameters
+    @public
   */
   serialize(model, params) {
     if (params.length < 1) { return; }
@@ -1535,6 +1566,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method setupController
     @param {Controller} controller instance
     @param {Object} model
+    @public
   */
   setupController(controller, context, transition) {
     if (controller && (context !== undefined)) {
@@ -1560,6 +1592,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method controllerFor
     @param {String} name the name of the route or controller
     @return {Ember.Controller}
+    @public
   */
   controllerFor(name, _skipAssert) {
     var container = this.container;
@@ -1600,6 +1633,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method generateController
     @param {String} name the name of the controller
     @param {Object} model the model to infer the type of the controller (optional)
+    @private
   */
   generateController(name, model) {
     var container = this.container;
@@ -1637,6 +1671,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method modelFor
     @param {String} name the name of the route
     @return {Object} the model object
+    @private
   */
   modelFor(name) {
     var route = this.container.lookup(`route:${name}`);
@@ -1683,6 +1718,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method renderTemplate
     @param {Object} controller the route's controller
     @param {Object} model the route's model
+    @private
   */
   renderTemplate(controller, model) {
     this.render();
@@ -1805,6 +1841,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
                     referenced by name or as a controller instance. Defaults to the Route's paired controller
     @param {Object} [options.model] the model object to set on `options.controller`.
                     Defaults to the return value of the Route's model hook
+    @public
   */
   render(_name, options) {
     Ember.assert("The name in the given arguments is undefined", arguments.length > 0 ? !isNone(arguments[0]) : true);
@@ -1867,6 +1904,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @method disconnectOutlet
     @param {Object|String} options the options hash or outlet name
+    @private
   */
   disconnectOutlet(options) {
     var outletName;

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -41,6 +41,7 @@ var slice = [].slice;
   @namespace Ember
   @extends Ember.Object
   @uses Ember.Evented
+  @public
 */
 var EmberRouter = EmberObject.extend(Evented, {
   /**
@@ -57,6 +58,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     @property location
     @default 'hash'
     @see {Ember.Location}
+    @public
   */
   location: 'hash',
 
@@ -66,6 +68,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
    @property rootURL
    @default '/'
+   @public
   */
   rootURL: '/',
 
@@ -109,6 +112,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     @method url
     @return {String} The current URL.
+    @private
   */
   url: computed(function() {
     return get(this, 'location').getURL();
@@ -548,6 +552,8 @@ var EmberRouter = EmberObject.extend(Evented, {
   /**
     Returns a merged query params meta object for a given route.
     Useful for asking a route what its known query params are.
+
+    @private
    */
   _queryParamsFor(leafRouteName) {
     if (this._qpCache[leafRouteName]) {
@@ -902,6 +908,7 @@ EmberRouter.reopenClass({
 
     @method map
     @param callback
+    @public
   */
   map(callback) {
 

--- a/packages/ember-runtime/lib/compare.js
+++ b/packages/ember-runtime/lib/compare.js
@@ -45,6 +45,7 @@ function spaceship(a, b) {
  @param {Object} v First value to compare
  @param {Object} w Second value to compare
  @return {Number} -1 if v < w, 0 if v = w and 1 if v > w.
+ @private
 */
 export default function compare(v, w) {
   if (v === w) {

--- a/packages/ember-runtime/lib/computed/array_computed.js
+++ b/packages/ember-runtime/lib/computed/array_computed.js
@@ -163,6 +163,7 @@ ArrayComputedProperty.prototype.didChange = function (obj, keyName) {
   @param {String} [dependentKeys*]
   @param {Object} options
   @return {Ember.ComputedProperty}
+  @private
 */
 function arrayComputed(options) {
   var args;

--- a/packages/ember-runtime/lib/computed/reduce_computed.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed.js
@@ -470,6 +470,7 @@ ReduceComputedPropertyInstanceMeta.prototype = {
   @namespace Ember
   @extends Ember.ComputedProperty
   @constructor
+  @private
 */
 
 export { ReduceComputedProperty }; // TODO: default export
@@ -840,6 +841,7 @@ ReduceComputedProperty.prototype.property = function () {
   @param {String} [dependentKeys*]
   @param {Object} options
   @return {Ember.ComputedProperty}
+  @public
 */
 export function reduceComputed(options) {
   var args;

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -24,16 +24,16 @@ import compare from 'ember-runtime/compare';
 var a_slice = [].slice;
 
 /**
- A computed property that returns the sum of the value
- in the dependent array.
+  A computed property that returns the sum of the value
+  in the dependent array.
 
- @method sum
- @for Ember.computed
- @param {String} dependentKey
- @return {Ember.ComputedProperty} computes the sum of all values in the dependentKey's array
- @since 1.4.0
+  @method sum
+  @for Ember.computed
+  @param {String} dependentKey
+  @return {Ember.ComputedProperty} computes the sum of all values in the dependentKey's array
+  @since 1.4.0
+  @public
 */
-
 export function sum(dependentKey) {
   return reduceComputed(dependentKey, {
     initialValue: 0,
@@ -80,6 +80,7 @@ export function sum(dependentKey) {
   @for Ember.computed
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computes the largest value in the dependentKey's array
+  @public
 */
 export function max(dependentKey) {
   return reduceComputed(dependentKey, {
@@ -129,6 +130,7 @@ export function max(dependentKey) {
   @for Ember.computed
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computes the smallest value in the dependentKey's array
+  @public
 */
 export function min(dependentKey) {
   return reduceComputed(dependentKey, {
@@ -178,6 +180,7 @@ export function min(dependentKey) {
   @param {String} dependentKey
   @param {Function} callback
   @return {Ember.ComputedProperty} an array mapped via the callback
+  @public
 */
 export function map(dependentKey, callback) {
   var options = {
@@ -223,6 +226,7 @@ export function map(dependentKey, callback) {
   @param {String} dependentKey
   @param {String} propertyKey
   @return {Ember.ComputedProperty} an array mapped to the specified key
+  @public
 */
 export function mapBy(dependentKey, propertyKey) {
   var callback = function(item) { return get(item, propertyKey); };
@@ -235,6 +239,7 @@ export function mapBy(dependentKey, propertyKey) {
   @deprecated Use `Ember.computed.mapBy` instead
   @param dependentKey
   @param propertyKey
+  @public
 */
 export var mapProperty = mapBy;
 
@@ -273,6 +278,7 @@ export var mapProperty = mapBy;
   @param {String} dependentKey
   @param {Function} callback
   @return {Ember.ComputedProperty} the filtered array
+  @public
 */
 export function filter(dependentKey, callback) {
   var options = {
@@ -330,6 +336,7 @@ export function filter(dependentKey, callback) {
   @param {String} propertyKey
   @param {*} value
   @return {Ember.ComputedProperty} the filtered array
+  @public
 */
 export function filterBy(dependentKey, propertyKey, value) {
   var callback;
@@ -354,6 +361,7 @@ export function filterBy(dependentKey, propertyKey, value) {
   @param propertyKey
   @param value
   @deprecated Use `Ember.computed.filterBy` instead
+  @public
 */
 export var filterProperty = filterBy;
 
@@ -385,6 +393,7 @@ export var filterProperty = filterBy;
   @param {String} propertyKey*
   @return {Ember.ComputedProperty} computes a new array with all the
   unique elements from the dependent array
+  @public
 */
 export function uniq() {
   var args = a_slice.call(arguments);
@@ -429,6 +438,7 @@ export function uniq() {
   @param {String} propertyKey*
   @return {Ember.ComputedProperty} computes a new array with all the
   unique elements from the dependent array
+  @public
 */
 export var union = uniq;
 
@@ -453,6 +463,7 @@ export var union = uniq;
   @param {String} propertyKey*
   @return {Ember.ComputedProperty} computes a new array with all the
   duplicated elements from the dependent arrays
+  @public
 */
 export function intersect() {
   var args = a_slice.call(arguments);
@@ -542,6 +553,7 @@ export function intersect() {
   @return {Ember.ComputedProperty} computes a new array with all the
   items from the first dependent array that are not in the second
   dependent array
+  @public
 */
 export function setDiff(setAProperty, setBProperty) {
   if (arguments.length !== 2) {
@@ -686,6 +698,7 @@ function binarySearch(array, item, low, high) {
   array of sort properties (add `:desc` to the arrays sort properties to sort descending) or a function to use when sorting
   @return {Ember.ComputedProperty} computes a new sorted array based
   on the sort property array or callback function
+  @public
 */
 export function sort(itemsKey, sortDefinition) {
   Ember.assert('Ember.computed.sort requires two arguments: an array key to sort and ' +

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -101,6 +101,7 @@ import EmberArray from 'ember-runtime/mixins/array';
   @extends Ember.ArrayProxy
   @uses Ember.SortableMixin
   @uses Ember.ControllerMixin
+  @public
 */
 
 export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
@@ -119,6 +120,7 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
     @property itemController
     @type String
     @default null
+    @private
   */
   itemController: null,
 
@@ -145,6 +147,7 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
     @method lookupItemController
     @param {Object} object
     @return {String}
+    @private
   */
   lookupItemController(object) {
     return get(this, 'itemController');
@@ -220,13 +223,13 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
   }),
 
   /**
-   * Flag to mark as being "virtual". Used to keep this instance
-   * from participating in the parentController hierarchy.
-   *
-   * @private
-   * @property _isVirtual
-   * @type Boolean
-   */
+    Flag to mark as being "virtual". Used to keep this instance
+    from participating in the parentController hierarchy.
+
+    @private
+    @property _isVirtual
+    @type Boolean
+  */
   _isVirtual: false,
 
   controllerAt(idx, object, controllerClass) {

--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -13,6 +13,7 @@ import { createInjectionHelper } from 'ember-runtime/inject';
   @namespace Ember
   @extends Ember.Object
   @uses Ember.ControllerMixin
+  @public
 */
 var Controller = EmberObject.extend(Mixin);
 
@@ -50,7 +51,8 @@ function controllerInjectionHelper(factory) {
   @param {String} name (optional) name of the controller to inject, defaults
          to the property's name
   @return {Ember.InjectedProperty} injection descriptor instance
-  */
+  @private
+*/
 createInjectionHelper('controller', controllerInjectionHelper);
 
 export default Controller;

--- a/packages/ember-runtime/lib/controllers/object_controller.js
+++ b/packages/ember-runtime/lib/controllers/object_controller.js
@@ -23,6 +23,7 @@ export var objectControllerDeprecation = 'Ember.ObjectController is deprecated, 
   @extends Ember.ObjectProxy
   @uses Ember.ControllerMixin
   @deprecated
+  @public
 **/
 export default ObjectProxy.extend(ControllerMixin, {
   init() {

--- a/packages/ember-runtime/lib/copy.js
+++ b/packages/ember-runtime/lib/copy.js
@@ -76,6 +76,7 @@ function _copy(obj, deep, seen, copies) {
   @param {Object} obj The object to clone
   @param {Boolean} deep If true, a deep copy of the object is made
   @return {Object} The cloned object
+  @public
 */
 export default function copy(obj, deep) {
   // fast paths

--- a/packages/ember-runtime/lib/core.js
+++ b/packages/ember-runtime/lib/core.js
@@ -20,6 +20,7 @@
   @param {Object} a first object to compare
   @param {Object} b second object to compare
   @return {Boolean}
+  @public
 */
 export function isEqual(a, b) {
   if (a && typeof a.isEqual === 'function') {

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -70,6 +70,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
     @method property
     @for Function
+    @public
   */
   FunctionPrototype.property = function () {
     var ret = computed(this);
@@ -102,6 +103,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
     @method observes
     @for Function
+    @public
   */
   FunctionPrototype.observes = function(...args) {
     args.push(this);
@@ -132,6 +134,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
     @method observesImmediately
     @for Function
+    @private
   */
   FunctionPrototype.observesImmediately = function () {
     Ember.assert('Immediate observers must observe internal properties only, ' +
@@ -169,6 +172,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
     @method observesBefore
     @for Function
+    @private
   */
   FunctionPrototype.observesBefore = function () {
     var watched = [];
@@ -205,6 +209,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
 
     @method on
     @for Function
+    @public
   */
   FunctionPrototype.on = function () {
     var events = a_slice.call(arguments);

--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -25,6 +25,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method fmt
     @for String
+    @private
   */
   StringPrototype.fmt = function () {
     return fmt(this, arguments);
@@ -35,6 +36,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method w
     @for String
+    @private
   */
   StringPrototype.w = function () {
     return w(this);
@@ -45,6 +47,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method loc
     @for String
+    @private
   */
   StringPrototype.loc = function () {
     return loc(this, arguments);
@@ -55,6 +58,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method camelize
     @for String
+    @private
   */
   StringPrototype.camelize = function () {
     return camelize(this);
@@ -65,6 +69,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method decamelize
     @for String
+    @private
   */
   StringPrototype.decamelize = function () {
     return decamelize(this);
@@ -75,6 +80,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method dasherize
     @for String
+    @private
   */
   StringPrototype.dasherize = function () {
     return dasherize(this);
@@ -85,6 +91,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method underscore
     @for String
+    @private
   */
   StringPrototype.underscore = function () {
     return underscore(this);
@@ -95,6 +102,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method classify
     @for String
+    @private
   */
   StringPrototype.classify = function () {
     return classify(this);
@@ -105,6 +113,7 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
     @method capitalize
     @for String
+    @private
   */
   StringPrototype.capitalize = function () {
     return capitalize(this);

--- a/packages/ember-runtime/lib/inject.js
+++ b/packages/ember-runtime/lib/inject.js
@@ -9,7 +9,8 @@ import keys from "ember-metal/keys";
   @class inject
   @namespace Ember
   @static
-  */
+  @public
+*/
 function inject() {
   Ember.assert("Injected properties must be created through helpers, see `" +
                keys(inject).join("`, `") + "`");

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -1,9 +1,6 @@
 /**
-Ember Runtime
-
 @module ember
 @submodule ember-runtime
-@requires ember-metal
 */
 
 // BEGIN IMPORTS

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -40,6 +40,7 @@ function contentPropertyDidChange(content, contentKey) {
 
   @class ProxyMixin
   @namespace Ember
+  @private
 */
 export default Mixin.create({
   /**
@@ -48,6 +49,7 @@ export default Mixin.create({
     @property content
     @type Ember.Object
     @default null
+    @private
   */
   content: null,
   _contentDidChange: observer('content', function() {

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -20,6 +20,7 @@ import { get } from "ember-metal/property_get";
 
   @class ActionHandler
   @namespace Ember
+  @private
 */
 var ActionHandler = Mixin.create({
   mergedProperties: ['_actions'],
@@ -142,6 +143,7 @@ var ActionHandler = Mixin.create({
     @property actions
     @type Object
     @default null
+    @public
   */
 
   /**
@@ -202,6 +204,7 @@ var ActionHandler = Mixin.create({
     @method send
     @param {String} actionName The action to trigger
     @param {*} context a context to send with the action
+    @public
   */
   send(actionName, ...args) {
     var target;

--- a/packages/ember-runtime/lib/mixins/array.js
+++ b/packages/ember-runtime/lib/mixins/array.js
@@ -86,6 +86,7 @@ function arrayObserversHelper(obj, target, opts, operation, notify) {
   @namespace Ember
   @uses Ember.Enumerable
   @since Ember 0.9.0
+  @public
 */
 export default Mixin.create(Enumerable, {
 
@@ -96,6 +97,7 @@ export default Mixin.create(Enumerable, {
     set this property whenever it changes.
 
     @property {Number} length
+    @public
   */
   length: null,
 
@@ -121,6 +123,7 @@ export default Mixin.create(Enumerable, {
     @method objectAt
     @param {Number} idx The index of the item to return.
     @return {*} item at index or undefined
+    @public
   */
   objectAt(idx) {
     if (idx < 0 || idx >= get(this, 'length')) {
@@ -143,6 +146,7 @@ export default Mixin.create(Enumerable, {
     @method objectsAt
     @param {Array} indexes An array of indexes of items to return.
     @return {Array}
+    @public
    */
   objectsAt(indexes) {
     var self = this;
@@ -166,6 +170,7 @@ export default Mixin.create(Enumerable, {
 
     @property []
     @return this
+    @public
   */
   '[]': computed({
     get(key) {
@@ -208,6 +213,7 @@ export default Mixin.create(Enumerable, {
     @param {Number} beginIndex (Optional) index to begin slicing from.
     @param {Number} endIndex (Optional) index to end the slice at (but not included).
     @return {Array} New array with specified slice
+    @public
   */
   slice(beginIndex, endIndex) {
     var ret = Ember.A();
@@ -257,6 +263,7 @@ export default Mixin.create(Enumerable, {
     @param {Object} object the item to search for
     @param {Number} startAt optional starting location to search, default 0
     @return {Number} index or -1 if not found
+    @public
   */
   indexOf(object, startAt) {
     var len = get(this, 'length');
@@ -300,6 +307,7 @@ export default Mixin.create(Enumerable, {
     @param {Object} object the item to search for
     @param {Number} startAt optional starting location to search, default 0
     @return {Number} index or -1 if not found
+    @public
   */
   lastIndexOf(object, startAt) {
     var len = get(this, 'length');
@@ -349,6 +357,7 @@ export default Mixin.create(Enumerable, {
     @param {Object} opts Optional hash of configuration options including
       `willChange` and `didChange` option.
     @return {Ember.Array} receiver
+    @public
   */
 
   addArrayObserver(target, opts) {
@@ -365,6 +374,7 @@ export default Mixin.create(Enumerable, {
     @param {Object} opts Optional hash of configuration options including
       `willChange` and `didChange` option.
     @return {Ember.Array} receiver
+    @public
   */
   removeArrayObserver(target, opts) {
     return arrayObserversHelper(this, target, opts, removeListener, true);
@@ -375,6 +385,7 @@ export default Mixin.create(Enumerable, {
     on the array.
 
     @property {Boolean} hasArrayObservers
+    @public
   */
   hasArrayObservers: computed(function() {
     return hasListeners(this, '@array:change') || hasListeners(this, '@array:before');
@@ -393,6 +404,7 @@ export default Mixin.create(Enumerable, {
     @param {Number} addAmt The number of items that will be added. If you
       pass `null` assumes 0.
     @return {Ember.Array} receiver
+    @public
   */
   arrayContentWillChange(startIdx, removeAmt, addAmt) {
     var removing, lim;
@@ -447,6 +459,7 @@ export default Mixin.create(Enumerable, {
     @param {Number} addAmt The number of items that were added. If you
       pass `null` assumes 0.
     @return {Ember.Array} receiver
+    @public
   */
   arrayContentDidChange(startIdx, removeAmt, addAmt) {
     var adding, lim;
@@ -510,6 +523,7 @@ export default Mixin.create(Enumerable, {
     use the `[]` property instead of `@each`.
 
     @property @each
+    @public
   */
   '@each': computed(function() {
     if (!this.__each) {

--- a/packages/ember-runtime/lib/mixins/comparable.js
+++ b/packages/ember-runtime/lib/mixins/comparable.js
@@ -14,6 +14,7 @@ import { Mixin } from "ember-metal/mixin";
   @class Comparable
   @namespace Ember
   @since Ember 0.9
+  @private
 */
 export default Mixin.create({
 
@@ -33,6 +34,7 @@ export default Mixin.create({
     @param a {Object} the first object to compare
     @param b {Object} the second object to compare
     @return {Number} the result of the comparison
+    @private
   */
   compare: null
 });

--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -11,6 +11,7 @@ import ControllerContentModelAliasDeprecation from "ember-runtime/mixins/control
   @class ControllerMixin
   @namespace Ember
   @uses Ember.ActionHandler
+  @private
 */
 export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecation, {
   /* ducktype as a controller */
@@ -33,6 +34,7 @@ export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecatio
 
     @property target
     @default null
+    @private
   */
   target: null,
 
@@ -53,9 +55,7 @@ export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecatio
 
   /**
     @private
-   */
+  */
   content: alias('model')
 
 });
-
-

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -3,13 +3,11 @@
 @submodule ember-runtime
 */
 
-
 import { get } from "ember-metal/property_get";
 import { Mixin } from "ember-metal/mixin";
 import { Freezable } from "ember-runtime/mixins/freezable";
 import { fmt } from "ember-runtime/system/string";
 import EmberError from 'ember-metal/error';
-
 
 /**
   Implements some standard methods for copying an object. Add this mixin to
@@ -25,6 +23,7 @@ import EmberError from 'ember-metal/error';
   @class Copyable
   @namespace Ember
   @since Ember 0.9
+  @private
 */
 export default Mixin.create({
   /**
@@ -36,6 +35,7 @@ export default Mixin.create({
     @method copy
     @param {Boolean} deep if `true`, a deep copy of the object should be made
     @return {Object} copy of receiver
+    @private
   */
   copy: null,
 
@@ -52,6 +52,7 @@ export default Mixin.create({
 
     @method frozenCopy
     @return {Object} copy of receiver or receiver
+    @private
   */
   frozenCopy() {
     if (Freezable && Freezable.detect(this)) {

--- a/packages/ember-runtime/lib/mixins/deferred.js
+++ b/packages/ember-runtime/lib/mixins/deferred.js
@@ -13,7 +13,8 @@ import RSVP from "ember-runtime/ext/rsvp";
 /**
   @class Deferred
   @namespace Ember
- */
+  @private
+*/
 export default Mixin.create({
   /**
     Add handlers to be called when the Deferred object is resolved or rejected.
@@ -21,6 +22,7 @@ export default Mixin.create({
     @method then
     @param {Function} resolve a callback function to be called when done
     @param {Function} reject  a callback function to be called when failed
+    @private
   */
   then(resolve, reject, label) {
     var deferred, promise, entity;
@@ -44,6 +46,7 @@ export default Mixin.create({
     Resolve a Deferred object and call any `doneCallbacks` with the given args.
 
     @method resolve
+    @private
   */
   resolve(value) {
     var deferred, promise;
@@ -62,6 +65,7 @@ export default Mixin.create({
     Reject a Deferred object and call any `failCallbacks` with the given args.
 
     @method reject
+    @private
   */
   reject(value) {
     get(this, '_deferred').reject(value);

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -86,6 +86,7 @@ function iter(key, value) {
   @class Enumerable
   @namespace Ember
   @since Ember 0.9
+  @private
 */
 export default Mixin.create({
 
@@ -123,6 +124,7 @@ export default Mixin.create({
       `nextObject`.
     @param {Object} context a context object you can use to maintain state.
     @return {Object} the next object in the iteration or undefined
+    @private
   */
   nextObject: null,
 
@@ -146,6 +148,7 @@ export default Mixin.create({
 
     @property firstObject
     @return {Object} the object or undefined
+    @private
   */
   firstObject: computed('[]', function() {
     if (get(this, 'length') === 0) {
@@ -176,6 +179,7 @@ export default Mixin.create({
 
     @property lastObject
     @return {Object} the last object or undefined
+    @private
   */
   lastObject: computed('[]', function() {
     var len = get(this, 'length');
@@ -214,6 +218,7 @@ export default Mixin.create({
     @method contains
     @param {Object} obj The object to search for.
     @return {Boolean} `true` if object is found in enumerable.
+    @private
   */
   contains(obj) {
     var found = this.find(function(item) {
@@ -247,6 +252,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Object} receiver
+    @private
   */
   forEach(callback, target) {
     if (typeof callback !== 'function') {
@@ -279,6 +285,7 @@ export default Mixin.create({
     @method getEach
     @param {String} key name of the property
     @return {Array} The mapped array.
+    @private
   */
   getEach: aliasMethod('mapBy'),
 
@@ -292,6 +299,7 @@ export default Mixin.create({
     @param {String} key The key to set
     @param {Object} value The object to set
     @return {Object} receiver
+    @private
   */
   setEach(key, value) {
     return this.forEach(function(item) {
@@ -324,6 +332,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Array} The mapped array.
+    @private
   */
   map(callback, target) {
     var ret = Ember.A();
@@ -342,6 +351,7 @@ export default Mixin.create({
     @method mapBy
     @param {String} key name of the property
     @return {Array} The mapped array.
+    @private
   */
   mapBy(key) {
     return this.map(function(next) {
@@ -357,6 +367,7 @@ export default Mixin.create({
     @param {String} key name of the property
     @return {Array} The mapped array.
     @deprecated Use `mapBy` instead
+    @private
   */
 
   mapProperty: aliasMethod('mapBy'),
@@ -388,6 +399,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Array} A filtered array.
+    @private
   */
   filter(callback, target) {
     var ret = Ember.A();
@@ -426,7 +438,8 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Array} A rejected array.
-   */
+     @private
+  */
   reject(callback, target) {
     return this.filter(function() {
       return !(callback.apply(target, arguments));
@@ -442,6 +455,7 @@ export default Mixin.create({
     @param {String} key the property to test
     @param {*} [value] optional value to test against.
     @return {Array} filtered array
+    @private
   */
   filterBy(key, value) {
     return this.filter(iter.apply(this, arguments));
@@ -457,6 +471,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Array} filtered array
     @deprecated Use `filterBy` instead
+    @private
   */
   filterProperty: aliasMethod('filterBy'),
 
@@ -469,6 +484,7 @@ export default Mixin.create({
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
     @return {Array} rejected array
+    @private
   */
   rejectBy(key, value) {
     var exactValue = function(item) {
@@ -494,6 +510,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Array} rejected array
     @deprecated Use `rejectBy` instead
+    @private
   */
   rejectProperty: aliasMethod('rejectBy'),
 
@@ -524,6 +541,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Object} Found item or `undefined`.
+    @private
   */
   find(callback, target) {
     var len = get(this, 'length');
@@ -564,6 +582,7 @@ export default Mixin.create({
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
     @return {Object} found item or `undefined`
+    @private
   */
   findBy(key, value) {
     return this.find(iter.apply(this, arguments));
@@ -581,6 +600,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Object} found item or `undefined`
     @deprecated Use `findBy` instead
+    @private
   */
   findProperty: aliasMethod('findBy'),
 
@@ -617,6 +637,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Boolean}
+    @private
   */
   every(callback, target) {
     return !this.find(function(x, idx, i) {
@@ -630,6 +651,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @deprecated Use `isEvery` instead
     @return {Boolean}
+    @private
   */
   everyBy: aliasMethod('isEvery'),
 
@@ -639,6 +661,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @deprecated Use `isEvery` instead
     @return {Boolean}
+    @private
   */
   everyProperty: aliasMethod('isEvery'),
 
@@ -651,6 +674,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Boolean}
     @since 1.3.0
+    @private
   */
   isEvery(key, value) {
     return this.every(iter.apply(this, arguments));
@@ -690,6 +714,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Boolean} `true` if the passed function returns `true` for any item
+    @private
   */
   any(callback, target) {
     var len = get(this, 'length');
@@ -748,6 +773,7 @@ export default Mixin.create({
     @param {Object} [target] The target object to use
     @return {Boolean} `true` if the passed function returns `true` for any item
     @deprecated Use `any` instead
+    @private
   */
   some: aliasMethod('any'),
 
@@ -760,6 +786,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Boolean}
     @since 1.3.0
+    @private
   */
   isAny(key, value) {
     return this.any(iter.apply(this, arguments));
@@ -771,6 +798,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Boolean}
     @deprecated Use `isAny` instead
+    @private
   */
   anyBy: aliasMethod('isAny'),
 
@@ -780,6 +808,7 @@ export default Mixin.create({
     @param {String} [value] optional value to test against.
     @return {Boolean}
     @deprecated Use `isAny` instead
+    @private
   */
   someProperty: aliasMethod('isAny'),
 
@@ -815,6 +844,7 @@ export default Mixin.create({
     @param {Object} initialValue Initial value for the reduce
     @param {String} reducerProperty internal use only.
     @return {Object} The reduced value.
+    @private
   */
   reduce(callback, initialValue, reducerProperty) {
     if (typeof callback !== 'function') {
@@ -839,6 +869,7 @@ export default Mixin.create({
     @param {String} methodName the name of the method
     @param {Object...} args optional arguments to pass as well.
     @return {Array} return values from calling invoke.
+    @private
   */
   invoke(methodName, ...args) {
     var ret = Ember.A();
@@ -860,6 +891,7 @@ export default Mixin.create({
 
     @method toArray
     @return {Array} the enumerable as an array.
+    @private
   */
   toArray() {
     var ret = Ember.A();
@@ -881,6 +913,7 @@ export default Mixin.create({
 
     @method compact
     @return {Array} the array without null and undefined elements.
+    @private
   */
   compact() {
     return this.filter(function(value) {
@@ -901,6 +934,7 @@ export default Mixin.create({
     @method without
     @param {Object} value
     @return {Ember.Enumerable}
+    @private
   */
   without(value) {
     if (!this.contains(value)) {
@@ -931,6 +965,7 @@ export default Mixin.create({
 
     @method uniq
     @return {Ember.Enumerable}
+    @private
   */
   uniq() {
     var ret = Ember.A();
@@ -955,6 +990,7 @@ export default Mixin.create({
     @property []
     @type Array
     @return this
+    @private
   */
   '[]': computed({
     get(key) { return this; }
@@ -972,6 +1008,7 @@ export default Mixin.create({
     @param {Object} target
     @param {Object} [opts]
     @return this
+    @private
   */
   addEnumerableObserver(target, opts) {
     var willChange = (opts && opts.willChange) || 'enumerableWillChange';
@@ -999,6 +1036,7 @@ export default Mixin.create({
     @param {Object} target
     @param {Object} [opts]
     @return this
+    @private
   */
   removeEnumerableObserver(target, opts) {
     var willChange = (opts && opts.willChange) || 'enumerableWillChange';
@@ -1025,6 +1063,7 @@ export default Mixin.create({
 
     @property hasEnumerableObservers
     @type Boolean
+    @private
   */
   hasEnumerableObservers: computed(function() {
     return hasListeners(this, '@enumerable:change') || hasListeners(this, '@enumerable:before');
@@ -1042,6 +1081,7 @@ export default Mixin.create({
     @param {Ember.Enumerable|Number} adding An enumerable of the objects to be
       added or the number of items to be added.
     @chainable
+    @private
   */
   enumerableContentWillChange(removing, adding) {
     var removeCnt, addCnt, hasDelta;
@@ -1096,6 +1136,7 @@ export default Mixin.create({
     @param {Ember.Enumerable|Number} adding  An enumerable of the objects to
       be added or the number of items to be added.
     @chainable
+    @private
   */
   enumerableContentDidChange(removing, adding) {
     var removeCnt, addCnt, hasDelta;
@@ -1147,7 +1188,8 @@ export default Mixin.create({
     @param {String} property name(s) to sort on
     @return {Array} The sorted array.
     @since 1.2.0
-    */
+    @private
+  */
   sortBy() {
     var sortKeys = arguments;
 

--- a/packages/ember-runtime/lib/mixins/evented.js
+++ b/packages/ember-runtime/lib/mixins/evented.js
@@ -45,6 +45,7 @@ import {
 
   @class Evented
   @namespace Ember
+  @public
  */
 export default Mixin.create({
 
@@ -67,6 +68,7 @@ export default Mixin.create({
    @param {Object} [target] The "this" binding for the callback
    @param {Function} method The callback to execute
    @return this
+   @public
   */
   on(name, target, method) {
     addListener(this, name, target, method);
@@ -87,6 +89,7 @@ export default Mixin.create({
     @param {Object} [target] The "this" binding for the callback
     @param {Function} method The callback to execute
     @return this
+    @public
   */
   one(name, target, method) {
     if (!method) {
@@ -115,6 +118,7 @@ export default Mixin.create({
     @method trigger
     @param {String} name The name of the event
     @param {Object...} args Optional arguments to pass on
+    @public
   */
   trigger(name, ...args) {
     sendEvent(this, name, args);
@@ -128,6 +132,7 @@ export default Mixin.create({
     @param {Object} target The target of the subscription
     @param {Function} method The function of the subscription
     @return this
+    @public
   */
   off(name, target, method) {
     removeListener(this, name, target, method);
@@ -140,6 +145,7 @@ export default Mixin.create({
     @method has
     @param {String} name The name of the event
     @return {Boolean} does the object have a subscription for event
+    @public
    */
   has(name) {
     return hasListeners(this, name);

--- a/packages/ember-runtime/lib/mixins/freezable.js
+++ b/packages/ember-runtime/lib/mixins/freezable.js
@@ -62,6 +62,7 @@ import { set } from "ember-metal/property_set";
   @class Freezable
   @namespace Ember
   @since Ember 0.9
+  @private
 */
 export var Freezable = Mixin.create({
 
@@ -71,6 +72,7 @@ export var Freezable = Mixin.create({
 
     @property isFrozen
     @type Boolean
+    @private
   */
   isFrozen: false,
 
@@ -80,6 +82,7 @@ export var Freezable = Mixin.create({
 
     @method freeze
     @return {Object} receiver
+    @private
   */
   freeze() {
     if (get(this, 'isFrozen')) {

--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -44,6 +44,7 @@ import Enumerable from "ember-runtime/mixins/enumerable";
   @namespace Ember
   @uses Ember.Array
   @uses Ember.MutableEnumerable
+  @public
 */
 export default Mixin.create(EmberArray, MutableEnumerable, {
 
@@ -61,6 +62,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
       the array, starting at *idx*.
     @param {Array} objects An array of zero or more objects that should be
       inserted into the array at *idx*
+    @public
   */
   replace: null,
 
@@ -78,6 +80,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
 
     @method clear
     @return {Ember.Array} An empty Array.
+    @public
   */
   clear() {
     var len = get(this, 'length');
@@ -104,6 +107,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @param {Number} idx index of insert the object at.
     @param {Object} object object to insert
     @return {Ember.Array} receiver
+    @public
   */
   insertAt(idx, object) {
     if (idx > get(this, 'length')) {
@@ -133,6 +137,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @param {Number} start index, start of range
     @param {Number} len length of passing range
     @return {Ember.Array} receiver
+    @public
   */
   removeAt(start, len) {
     if ('number' === typeof start) {
@@ -166,6 +171,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @method pushObject
     @param {*} obj object to push
     @return object same object passed as a param
+    @public
   */
   pushObject(obj) {
     this.insertAt(get(this, 'length'), obj);
@@ -185,6 +191,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @method pushObjects
     @param {Ember.Enumerable} objects the objects to add
     @return {Ember.Array} receiver
+    @public
   */
   pushObjects(objects) {
     if (!(Enumerable.detect(objects) || isArray(objects))) {
@@ -207,6 +214,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
 
     @method popObject
     @return object
+    @public
   */
   popObject() {
     var len = get(this, 'length');
@@ -232,6 +240,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
 
     @method shiftObject
     @return object
+    @public
   */
   shiftObject() {
     if (get(this, 'length') === 0) {
@@ -257,6 +266,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @method unshiftObject
     @param {*} obj object to unshift
     @return object same object passed as a param
+    @public
   */
   unshiftObject(obj) {
     this.insertAt(0, obj);
@@ -277,6 +287,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @method unshiftObjects
     @param {Ember.Enumerable} objects the objects to add
     @return {Ember.Array} receiver
+    @public
   */
   unshiftObjects(objects) {
     this.replace(0, 0, objects);
@@ -289,7 +300,8 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
 
     @method reverseObjects
     @return {Ember.Array} receiver
-   */
+     @public
+  */
   reverseObjects() {
     var len = get(this, 'length');
     if (len === 0) {
@@ -316,7 +328,8 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @param {Ember.Array} objects array whose content will be used for replacing
         the content of the receiver
     @return {Ember.Array} receiver with the new content
-   */
+    @public
+  */
   setObjects(objects) {
     if (objects.length === 0) {
       return this.clear();
@@ -345,6 +358,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @method removeObject
     @param {*} obj object to remove
     @return {Ember.Array} receiver
+    @public
   */
   removeObject(obj) {
     var loc = get(this, 'length') || 0;
@@ -372,6 +386,7 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @method addObject
     @param {*} obj object to add, if not already present
     @return {Ember.Array} receiver
+    @public
   */
   addObject(obj) {
     if (!this.contains(obj)) {

--- a/packages/ember-runtime/lib/mixins/mutable_enumerable.js
+++ b/packages/ember-runtime/lib/mixins/mutable_enumerable.js
@@ -46,6 +46,7 @@ import {beginPropertyChanges, endPropertyChanges} from "ember-metal/property_eve
   @class MutableEnumerable
   @namespace Ember
   @uses Ember.Enumerable
+  @public
 */
 export default Mixin.create(Enumerable, {
 
@@ -62,6 +63,7 @@ export default Mixin.create(Enumerable, {
     @method addObject
     @param {Object} object The object to add to the enumerable.
     @return {Object} the passed object
+    @public
   */
   addObject: null,
 
@@ -71,6 +73,7 @@ export default Mixin.create(Enumerable, {
     @method addObjects
     @param {Ember.Enumerable} objects the objects to add.
     @return {Object} receiver
+    @public
   */
   addObjects(objects) {
     beginPropertyChanges(this);
@@ -92,6 +95,7 @@ export default Mixin.create(Enumerable, {
     @method removeObject
     @param {Object} object The object to remove from the enumerable.
     @return {Object} the passed object
+    @public
   */
   removeObject: null,
 
@@ -102,6 +106,7 @@ export default Mixin.create(Enumerable, {
     @method removeObjects
     @param {Ember.Enumerable} objects the objects to remove
     @return {Object} receiver
+    @public
   */
   removeObjects(objects) {
     beginPropertyChanges(this);

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -92,6 +92,7 @@ import isNone from "ember-metal/is_none";
 
   @class Observable
   @namespace Ember
+  @public
 */
 export default Mixin.create({
 
@@ -132,6 +133,7 @@ export default Mixin.create({
     @method get
     @param {String} keyName The property to retrieve
     @return {Object} The property value or undefined.
+    @public
   */
   get(keyName) {
     return get(this, keyName);
@@ -156,6 +158,7 @@ export default Mixin.create({
     @method getProperties
     @param {String...|Array} list of keys to get
     @return {Object}
+    @public
   */
   getProperties(...args) {
     return getProperties.apply(null, [this].concat(args));
@@ -208,6 +211,7 @@ export default Mixin.create({
     @param {String} keyName The property to set
     @param {Object} value The value to set or `null`.
     @return {Ember.Observable}
+    @public
   */
   set(keyName, value) {
     set(this, keyName, value);
@@ -227,6 +231,7 @@ export default Mixin.create({
     @method setProperties
     @param {Object} hash the hash of keys and values to set
     @return {Ember.Observable}
+    @public
   */
   setProperties(hash) {
     return setProperties(this, hash);
@@ -245,6 +250,7 @@ export default Mixin.create({
 
     @method beginPropertyChanges
     @return {Ember.Observable}
+    @private
   */
   beginPropertyChanges() {
     beginPropertyChanges();
@@ -263,6 +269,7 @@ export default Mixin.create({
 
     @method endPropertyChanges
     @return {Ember.Observable}
+    @private
   */
   endPropertyChanges() {
     endPropertyChanges();
@@ -286,6 +293,7 @@ export default Mixin.create({
     @method propertyWillChange
     @param {String} keyName The property key that is about to change.
     @return {Ember.Observable}
+    @private
   */
   propertyWillChange(keyName) {
     propertyWillChange(this, keyName);
@@ -309,6 +317,7 @@ export default Mixin.create({
     @method propertyDidChange
     @param {String} keyName The property key that has just changed.
     @return {Ember.Observable}
+    @private
   */
   propertyDidChange(keyName) {
     propertyDidChange(this, keyName);
@@ -322,6 +331,7 @@ export default Mixin.create({
     @method notifyPropertyChange
     @param {String} keyName The property key to be notified about.
     @return {Ember.Observable}
+    @private
   */
   notifyPropertyChange(keyName) {
     this.propertyWillChange(keyName);
@@ -380,6 +390,7 @@ export default Mixin.create({
     @param {String} key The key to observer
     @param {Object} target The target object to invoke
     @param {String|Function} method The method to invoke.
+    @public
   */
   addObserver(key, target, method) {
     addObserver(this, key, target, method);
@@ -394,6 +405,7 @@ export default Mixin.create({
     @param {String} key The key to observer
     @param {Object} target The target object to invoke
     @param {String|Function} method The method to invoke.
+    @public
   */
   removeObserver(key, target, method) {
     removeObserver(this, key, target, method);
@@ -408,6 +420,7 @@ export default Mixin.create({
     @method hasObserverFor
     @param {String} key Key to check
     @return {Boolean}
+    @private
   */
   hasObserverFor(key) {
     return hasListeners(this, key+':change');
@@ -425,6 +438,7 @@ export default Mixin.create({
     @param {String} keyName The name of the property to retrieve
     @param {Object} defaultValue The value to return if the property value is undefined
     @return {Object} The property value or the defaultValue.
+    @public
   */
   getWithDefault(keyName, defaultValue) {
     return getWithDefault(this, keyName, defaultValue);
@@ -442,6 +456,7 @@ export default Mixin.create({
     @param {String} keyName The name of the property to increment
     @param {Number} increment The amount to increment by. Defaults to 1
     @return {Number} The new property value
+    @public
   */
   incrementProperty(keyName, increment) {
     if (isNone(increment)) { increment = 1; }
@@ -462,6 +477,7 @@ export default Mixin.create({
     @param {String} keyName The name of the property to decrement
     @param {Number} decrement The amount to decrement by. Defaults to 1
     @return {Number} The new property value
+    @public
   */
   decrementProperty(keyName, decrement) {
     if (isNone(decrement)) { decrement = 1; }
@@ -481,6 +497,7 @@ export default Mixin.create({
     @method toggleProperty
     @param {String} keyName The name of the property to toggle
     @return {Object} The new property value
+    @public
   */
   toggleProperty(keyName) {
     set(this, keyName, !get(this, keyName));
@@ -496,6 +513,7 @@ export default Mixin.create({
     @method cacheFor
     @param {String} keyName
     @return {Object} The cached value of the computed property, if any
+    @public
   */
   cacheFor(keyName) {
     return cacheFor(this, keyName);

--- a/packages/ember-runtime/lib/mixins/promise_proxy.js
+++ b/packages/ember-runtime/lib/mixins/promise_proxy.js
@@ -10,7 +10,7 @@ var or = computed.or;
 /**
   @module ember
   @submodule ember-runtime
- */
+*/
 
 function tap(proxy, promise) {
   setProperties(proxy, {
@@ -97,6 +97,7 @@ function tap(proxy, promise) {
   {{/if}}
   ```
   @class Ember.PromiseProxyMixin
+  @public
 */
 export default Mixin.create({
   /**
@@ -105,6 +106,7 @@ export default Mixin.create({
 
     @property reason
     @default null
+    @public
   */
   reason:  null,
 
@@ -113,6 +115,7 @@ export default Mixin.create({
 
     @property isPending
     @default true
+    @public
   */
   isPending:  not('isSettled').readOnly(),
 
@@ -121,6 +124,7 @@ export default Mixin.create({
 
     @property isSettled
     @default false
+    @public
   */
   isSettled:  or('isRejected', 'isFulfilled').readOnly(),
 
@@ -129,6 +133,7 @@ export default Mixin.create({
 
     @property isRejected
     @default false
+    @public
   */
   isRejected:  false,
 
@@ -137,6 +142,7 @@ export default Mixin.create({
 
     @property isFulfilled
     @default false
+    @public
   */
   isFulfilled: false,
 
@@ -155,6 +161,7 @@ export default Mixin.create({
     ```
 
     @property promise
+    @public
   */
   promise: computed({
     get() {
@@ -173,6 +180,7 @@ export default Mixin.create({
     @method then
     @param {Function} callback
     @return {RSVP.Promise}
+    @public
   */
   then: promiseAlias('then'),
 
@@ -185,6 +193,7 @@ export default Mixin.create({
     @param {Function} callback
     @return {RSVP.Promise}
     @since 1.3.0
+    @public
   */
   'catch': promiseAlias('catch'),
 
@@ -197,6 +206,7 @@ export default Mixin.create({
     @param {Function} callback
     @return {RSVP.Promise}
     @since 1.3.0
+    @public
   */
   'finally': promiseAlias('finally')
 

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -72,6 +72,7 @@ import {
   @class SortableMixin
   @namespace Ember
   @uses Ember.MutableEnumerable
+  @private
 */
 export default Mixin.create(MutableEnumerable, {
 
@@ -82,6 +83,7 @@ export default Mixin.create(MutableEnumerable, {
     from the `sortProperties` array prioritized from first to last.
 
     @property {Array} sortProperties
+    @private
   */
   sortProperties: null,
 
@@ -92,6 +94,7 @@ export default Mixin.create(MutableEnumerable, {
 
     @property {Boolean} sortAscending
     @default true
+    @private
   */
   sortAscending: true,
 
@@ -115,6 +118,7 @@ export default Mixin.create(MutableEnumerable, {
     @property sortFunction
     @type {Function}
     @default Ember.compare
+    @private
   */
   sortFunction: compare,
 
@@ -160,6 +164,7 @@ export default Mixin.create(MutableEnumerable, {
     Also sets up observers for each `sortProperty` on each item in the content Array.
 
     @property arrangedContent
+    @private
   */
   arrangedContent: computed('content', 'sortProperties.@each', {
     get(key) {

--- a/packages/ember-runtime/lib/mixins/target_action_support.js
+++ b/packages/ember-runtime/lib/mixins/target_action_support.js
@@ -21,6 +21,7 @@ view-aware defaults for target and actionContext.
 @class TargetActionSupport
 @namespace Ember
 @extends Ember.Mixin
+@private
 */
 var TargetActionSupport = Mixin.create({
   target: null,
@@ -109,6 +110,7 @@ var TargetActionSupport = Mixin.create({
   @method triggerAction
   @param opts {Object} (optional, with the optional keys action, target and/or actionContext)
   @return {Boolean} true if the action was sent successfully and did not return false
+  @private
   */
   triggerAction(opts) {
     opts = opts || {};

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -66,6 +66,7 @@ function K() { return this; }
   @namespace Ember
   @extends Ember.Object
   @uses Ember.MutableArray
+  @private
 */
 var ArrayProxy = EmberObject.extend(MutableArray, {
 
@@ -75,6 +76,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
 
     @property content
     @type Ember.Array
+    @private
   */
   content: null,
 
@@ -84,6 +86,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
    can override this property to provide things like sorting and filtering.
 
    @property arrangedContent
+   @private
   */
   arrangedContent: alias('content'),
 
@@ -97,6 +100,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     @method objectAtContent
     @param {Number} idx The index to retrieve.
     @return {Object} the value or undefined if none found
+    @private
   */
   objectAtContent(idx) {
     return get(this, 'arrangedContent').objectAt(idx);
@@ -115,6 +119,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     @param {Array} objects Optional array of objects to insert or null if no
       objects.
     @return {void}
+    @private
   */
   replaceContent(idx, amt, objects) {
     get(this, 'content').replace(idx, amt, objects);
@@ -151,7 +156,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     @param {Number} start starting index of the change
     @param {Number} removeCount count of items removed
     @param {Number} addCount count of items added
-
+    @private
   */
   contentArrayWillChange: K,
   /**
@@ -163,6 +168,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     @param {Number} start starting index of the change
     @param {Number} removeCount count of items removed
     @param {Number} addCount count of items added
+    @private
   */
   contentArrayDidChange: K,
 

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -225,6 +225,7 @@ function makeCtor() {
 /**
   @class CoreObject
   @namespace Ember
+  @public
 */
 var CoreObject = makeCtor();
 CoreObject.toString = function() { return "Ember.CoreObject"; };
@@ -261,6 +262,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     application.
 
     @method init
+    @public
   */
   init() {},
   __defineNonEnumerable(property) {
@@ -333,6 +335,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     @property concatenatedProperties
     @type Array
     @default null
+    @public
   */
   concatenatedProperties: null,
 
@@ -344,6 +347,7 @@ CoreObject.PrototypeMixin = Mixin.create({
 
     @property isDestroyed
     @default false
+    @public
   */
   isDestroyed: false,
 
@@ -355,6 +359,7 @@ CoreObject.PrototypeMixin = Mixin.create({
 
     @property isDestroying
     @default false
+    @public
   */
   isDestroying: false,
 
@@ -370,6 +375,7 @@ CoreObject.PrototypeMixin = Mixin.create({
 
     @method destroy
     @return {Ember.Object} receiver
+    @public
   */
   destroy() {
     if (this.isDestroying) { return; }
@@ -384,7 +390,8 @@ CoreObject.PrototypeMixin = Mixin.create({
     Override to implement teardown.
 
     @method willDestroy
-   */
+    @public
+  */
   willDestroy: K,
 
   /**
@@ -441,6 +448,7 @@ CoreObject.PrototypeMixin = Mixin.create({
 
     @method toString
     @return {String} string representation
+    @public
   */
   toString() {
     var hasToStringExtension = typeof this.toStringExtension === 'function';
@@ -549,6 +557,7 @@ var ClassMixinProps = {
 
     @param {Mixin} [mixins]* One or more Mixin classes
     @param {Object} [arguments]* Object containing values to use within the new class
+    @public
   */
   extend() {
     var Class = makeCtor();
@@ -580,6 +589,7 @@ var ClassMixinProps = {
     @method createWithMixins
     @static
     @param [arguments]*
+    @private
   */
   createWithMixins(...args) {
     var C = this;
@@ -625,6 +635,7 @@ var ClassMixinProps = {
     @method create
     @static
     @param [arguments]*
+    @public
   */
   create(...args) {
     var C = this;
@@ -662,6 +673,7 @@ var ClassMixinProps = {
     see `reopenClass`
 
     @method reopen
+    @public
   */
   reopen() {
     this.willReopen();
@@ -723,6 +735,7 @@ var ClassMixinProps = {
     see `reopen`
 
     @method reopenClass
+    @public
   */
   reopenClass() {
     reopen.apply(this.ClassMixin, arguments);
@@ -770,6 +783,7 @@ var ClassMixinProps = {
     @static
     @method metaForProperty
     @param key {String} property name
+    @private
   */
   metaForProperty(key) {
     var proto = this.proto();
@@ -807,6 +821,7 @@ var ClassMixinProps = {
     @method eachComputedProperty
     @param {Function} callback
     @param {Object} binding
+    @private
   */
   eachComputedProperty(callback, binding) {
     var property, name;
@@ -832,7 +847,7 @@ Ember.runInDebug(function() {
 
     @private
     @method _onLookup
-    */
+  */
   ClassMixinProps._onLookup = injectedPropertyAssertion;
 });
 
@@ -842,6 +857,7 @@ Ember.runInDebug(function() {
 
   @method _lazyInjections
   @return {Object} Hash of all lazy injected property keys to container names
+  @private
 */
 ClassMixinProps._lazyInjections = function() {
   var injections = {};

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -103,6 +103,8 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
   This is the object instance returned when you get the `@each` property on an
   array. It uses the unknownProperty handler to automatically create
   EachArray instances for property names.
+  @class EachProxy
+  @private
 */
 var EachProxy = EmberObject.extend({
 
@@ -125,6 +127,7 @@ var EachProxy = EmberObject.extend({
     @method unknownProperty
     @param keyName {String}
     @param value {*}
+    @private
   */
   unknownProperty(keyName, value) {
     var ret = new EachArray(this._content, keyName, this);

--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -29,6 +29,7 @@ var loaded = {};
   @for Ember
   @param name {String} name of hook
   @param callback {Function} callback to be called
+  @private
 */
 export function onLoad(name, callback) {
   var object;
@@ -49,6 +50,7 @@ export function onLoad(name, callback) {
   @for Ember
   @param name {String} name of hook
   @param object {Object} object to pass to callbacks
+  @private
 */
 export function runLoadHooks(name, object) {
   loaded[name] = object;

--- a/packages/ember-runtime/lib/system/namespace.js
+++ b/packages/ember-runtime/lib/system/namespace.js
@@ -31,6 +31,7 @@ import EmberObject from "ember-runtime/system/object";
   @class Namespace
   @namespace Ember
   @extends Ember.Object
+  @public
 */
 var Namespace = EmberObject.extend({
   isNamespace: true,

--- a/packages/ember-runtime/lib/system/native_array.js
+++ b/packages/ember-runtime/lib/system/native_array.js
@@ -35,6 +35,7 @@ import copy from "ember-runtime/copy";
   @uses Ember.MutableArray
   @uses Ember.Observable
   @uses Ember.Copyable
+  @public
 */
 var NativeArray = Mixin.create(MutableArray, Observable, Copyable, {
 
@@ -137,6 +138,7 @@ NativeArray = NativeArray.without.apply(NativeArray, ignore);
   @method A
   @for Ember
   @return {Ember.NativeArray}
+  @public
 */
 var A = function(arr) {
   if (arr === undefined) { arr = []; }
@@ -161,6 +163,7 @@ var A = function(arr) {
   @for Ember.NativeArray
   @static
   @return {void}
+  @private
 */
 NativeArray.activate = function() {
   NativeArray.apply(Array.prototype);

--- a/packages/ember-runtime/lib/system/object.js
+++ b/packages/ember-runtime/lib/system/object.js
@@ -15,6 +15,7 @@ import Observable from "ember-runtime/mixins/observable";
   @namespace Ember
   @extends Ember.CoreObject
   @uses Ember.Observable
+  @public
 */
 var EmberObject = CoreObject.extend(Observable);
 EmberObject.toString = function() {

--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -68,6 +68,7 @@ import _ProxyMixin from "ember-runtime/mixins/-proxy";
   @namespace Ember
   @extends Ember.Object
   @extends Ember._ProxyMixin
+  @private
 */
 
 export default EmberObject.extend(_ProxyMixin);

--- a/packages/ember-runtime/lib/system/service.js
+++ b/packages/ember-runtime/lib/system/service.js
@@ -28,6 +28,7 @@ import { createInjectionHelper } from 'ember-runtime/inject';
   @param {String} name (optional) name of the service to inject, defaults to
          the property's name
   @return {Ember.InjectedProperty} injection descriptor instance
+  @public
 */
 createInjectionHelper('service');
 
@@ -36,6 +37,7 @@ createInjectionHelper('service');
   @namespace Ember
   @extends Ember.Object
   @since 1.10.0
+  @public
 */
 const Service = Object.extend();
 

--- a/packages/ember-runtime/lib/system/set.js
+++ b/packages/ember-runtime/lib/system/set.js
@@ -122,6 +122,7 @@ import { computed } from "ember-metal/computed";
   @uses Ember.Freezable
   @since Ember 0.9
   @deprecated
+  @private
 */
 export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
@@ -135,6 +136,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     @property length
     @type number
     @default 0
+    @private
   */
   length: 0,
 
@@ -151,6 +153,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
     @method clear
     @return {Ember.Set} An empty Set
+    @private
   */
   clear() {
     if (this.isFrozen) { throw new EmberError(FROZEN_ERROR); }
@@ -194,6 +197,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     @method isEqual
     @param {Ember.Set} obj the other object.
     @return {Boolean}
+    @private
   */
   isEqual(obj) {
     // fail fast
@@ -234,6 +238,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     @method add
     @param {Object} obj The object to add.
     @return {Ember.Set} The set itself.
+    @private
   */
   add: aliasMethod('addObject'),
 
@@ -252,6 +257,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     @method remove
     @param {Object} obj The object to remove
     @return {Ember.Set} The set itself.
+    @private
   */
   remove: aliasMethod('removeObject'),
 
@@ -267,6 +273,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
     @method pop
     @return {Object} The removed object from the set or null.
+    @private
   */
   pop() {
     if (get(this, 'isFrozen')) {
@@ -293,6 +300,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
     @method push
     @return {Ember.Set} The set itself.
+    @private
   */
   push: aliasMethod('addObject'),
 
@@ -310,6 +318,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
     @method shift
     @return {Object} The removed object from the set or null.
+    @private
   */
   shift: aliasMethod('pop'),
 
@@ -328,6 +337,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
 
     @method unshift
     @return {Ember.Set} The set itself.
+    @private
   */
   unshift: aliasMethod('push'),
 
@@ -344,6 +354,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     @method addEach
     @param {Ember.Enumerable} objects the objects to add.
     @return {Ember.Set} The set itself.
+    @private
   */
   addEach: aliasMethod('addObjects'),
 
@@ -360,6 +371,7 @@ export default CoreObject.extend(MutableEnumerable, Copyable, Freezable, {
     @method removeEach
     @param {Ember.Enumerable} objects the objects to remove.
     @return {Ember.Set} The set itself.
+    @private
   */
   removeEach: aliasMethod('removeObjects'),
 

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -125,6 +125,7 @@ function capitalize(str) {
   @property STRINGS
   @for Ember
   @type Object
+  @private
 */
 Ember.STRINGS = {};
 
@@ -136,6 +137,7 @@ Ember.STRINGS = {};
   @class String
   @namespace Ember
   @static
+  @public
 */
 export default {
   /**
@@ -157,6 +159,7 @@ export default {
     @param {String} str The string to format
     @param {Array} formats An array of parameters to interpolate into string.
     @return {String} formatted string
+    @public
   */
   fmt: fmt,
 
@@ -183,6 +186,7 @@ export default {
     @param {String} str The string to format
     @param {Array} formats Optional array of parameters to interpolate into string.
     @return {String} formatted string
+    @public
   */
   loc: loc,
 
@@ -204,6 +208,7 @@ export default {
     @method w
     @param {String} str The string to split
     @return {Array} array containing the split strings
+    @public
   */
   w: w,
 
@@ -220,6 +225,7 @@ export default {
     @method decamelize
     @param {String} str The string to decamelize.
     @return {String} the decamelized string.
+    @public
   */
   decamelize: decamelize,
 
@@ -237,6 +243,7 @@ export default {
     @method dasherize
     @param {String} str The string to dasherize.
     @return {String} the dasherized string.
+    @public
   */
   dasherize: dasherize,
 
@@ -255,6 +262,7 @@ export default {
     @method camelize
     @param {String} str The string to camelize.
     @return {String} the camelized string.
+    @public
   */
   camelize: camelize,
 
@@ -272,6 +280,7 @@ export default {
     @method classify
     @param {String} str the string to classify
     @return {String} the classified string
+    @public
   */
   classify: classify,
 
@@ -290,6 +299,7 @@ export default {
     @method underscore
     @param {String} str The string to underscore.
     @return {String} the underscored string.
+    @public
   */
   underscore: underscore,
 
@@ -307,6 +317,7 @@ export default {
     @method capitalize
     @param {String} str The string to capitalize.
     @return {String} The capitalized string.
+    @public
   */
   capitalize: capitalize
 };

--- a/packages/ember-runtime/lib/system/subarray.js
+++ b/packages/ember-runtime/lib/system/subarray.js
@@ -18,6 +18,7 @@ export default SubArray;
 
   @class SubArray
   @namespace Ember
+  @private
 */
 function SubArray(length) {
   if (arguments.length < 1) { length = 0; }
@@ -40,6 +41,7 @@ SubArray.prototype = {
     @param {Boolean} match `true` iff the item is included in the subarray.
 
     @return {number} The index of the item in the subarray.
+    @private
   */
   addItem(index, match) {
     var returnValue = -1;
@@ -93,6 +95,7 @@ SubArray.prototype = {
 
     @return {number} The index of the item in the subarray, or `-1` if the item
     was not in the subarray.
+    @private
   */
   removeItem(index) {
     var returnValue = -1;

--- a/packages/ember-runtime/lib/system/tracked_array.js
+++ b/packages/ember-runtime/lib/system/tracked_array.js
@@ -16,6 +16,7 @@ export default TrackedArray;
   @namespace Ember
   @param {Array} [items=[]] The array to be tracked.  This is used just to get
   the initial items for the starting state of retain:n.
+  @private
 */
 function TrackedArray(items) {
   if (arguments.length < 1) { items = []; }
@@ -41,6 +42,7 @@ TrackedArray.prototype = {
     @method addItems
     @param index
     @param newItems
+    @private
   */
   addItems(index, newItems) {
     var count = get(newItems, 'length');
@@ -78,6 +80,7 @@ TrackedArray.prototype = {
     @method removeItems
     @param index
     @param count
+    @private
   */
   removeItems(index, count) {
     if (count < 1) { return; }
@@ -114,6 +117,7 @@ TrackedArray.prototype = {
 
     @method apply
     @param {Function} callback
+    @private
   */
   apply(callback) {
     var items = [];
@@ -297,6 +301,7 @@ TrackedArray.prototype = {
   @param {Number} count The number of items in this operation.
   @param {Array} items The items of the operation, if included.  RETAIN and
   INSERT include their items, DELETE does not.
+  @private
 */
 function ArrayOperation(operation, count, items) {
   this.type = operation; // RETAIN | INSERT | DELETE
@@ -317,6 +322,7 @@ function ArrayOperation(operation, count, items) {
   @param {Number} rangeStart The index of the first item in the operation,
   with respect to the tracked array.  The index of the last item can be computed
   from `rangeStart` and `operation.count`.
+  @private
 */
 function ArrayOperationMatch(operation, index, split, rangeStart) {
   this.operation = operation;

--- a/packages/ember-runtime/lib/utils.js
+++ b/packages/ember-runtime/lib/utils.js
@@ -40,6 +40,7 @@ var toString = Object.prototype.toString;
   @for Ember
   @param {Object} obj The object to test
   @return {Boolean} true if the passed object is an array or Array-like
+  @public
 */
 export function isArray(obj) {
   if (!obj || obj.setInterval) { return false; }
@@ -103,6 +104,7 @@ export function isArray(obj) {
   @for Ember
   @param {Object} item the item to check
   @return {String} the type
+  @public
 */
 export function typeOf(item) {
   if (item === null) { return 'null'; }

--- a/packages/ember-runtime/tests/suites/copyable.js
+++ b/packages/ember-runtime/tests/suites/copyable.js
@@ -2,7 +2,7 @@ import { Suite } from 'ember-runtime/tests/suites/suite';
 
 var CopyableTests = Suite.extend({
 
-  /**
+  /*
     __Required.__ You must implement this method to apply this mixin.
 
     Must be able to create a new object for testing.
@@ -11,7 +11,7 @@ var CopyableTests = Suite.extend({
   */
   newObject: null,
 
-  /**
+  /*
     __Required.__ You must implement this method to apply this mixin.
 
     Compares the two passed in objects.  Returns true if the two objects
@@ -27,7 +27,7 @@ var CopyableTests = Suite.extend({
   */
   isEqual: null,
 
-  /**
+  /*
     Set this to true if you expect the objects you test to be freezable.
     The suite will verify that your objects actually match this.  (i.e. if
     you say you can't test freezable it will verify that your objects really

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -26,7 +26,7 @@ var ObserverClass = EmberObject.extend({
     this._keysBefore[key]++;
   },
 
-  /**
+  /*
     Invoked when the property changes.  Just records the parameters for
     later analysis.
   */
@@ -36,7 +36,7 @@ var ObserverClass = EmberObject.extend({
     this._values[key] = value;
   },
 
-  /**
+  /*
     Resets the recorded results for another run.
 
     @returns {Object} receiver
@@ -61,7 +61,7 @@ var ObserverClass = EmberObject.extend({
     return this;
   },
 
-  /**
+  /*
     Begins observing the passed key names on the passed object.  Any changes
     on the named properties will be recorded.
 
@@ -84,7 +84,7 @@ var ObserverClass = EmberObject.extend({
     return this;
   },
 
-  /**
+  /*
     Returns true if the passed key was invoked.  If you pass a value as
     well then validates that the values match.
 
@@ -112,7 +112,7 @@ var ObserverClass = EmberObject.extend({
     }
   },
 
-  /**
+  /*
     Returns times the before observer as invoked.
 
     @param {String} key
@@ -122,7 +122,7 @@ var ObserverClass = EmberObject.extend({
     return this._keysBefore[key] || 0;
   },
 
-  /**
+  /*
     Returns times the observer as invoked.
 
     @param {String} key
@@ -132,7 +132,7 @@ var ObserverClass = EmberObject.extend({
     return this._keys[key] || 0;
   },
 
-  /**
+  /*
     begins acting as an enumerable observer.
   */
   observeEnumerable(obj) {
@@ -159,7 +159,7 @@ var ObserverClass = EmberObject.extend({
 
 
 var EnumerableTests = Suite.extend({
-  /**
+  /*
     __Required.__ You must implement this method to apply this mixin.
 
     Implement to return a new enumerable object for testing.  Should accept
@@ -173,7 +173,7 @@ var EnumerableTests = Suite.extend({
   */
   newObject: null,
 
-  /**
+  /*
     Implement to return a set of new fixture strings that can be applied to
     the enumerable.  This may be passed into the newObject method.
 
@@ -191,7 +191,7 @@ var EnumerableTests = Suite.extend({
     return ret;
   },
 
-  /**
+  /*
     Implement to return a set of new fixture objects that can be applied to
     the enumerable.  This may be passed into the newObject method.
 
@@ -211,7 +211,7 @@ var EnumerableTests = Suite.extend({
     return ret;
   },
 
-  /**
+  /*
     __Required.__ You must implement this method to apply this mixin.
 
     Implement accept an instance of the enumerable and return an array
@@ -225,7 +225,7 @@ var EnumerableTests = Suite.extend({
   */
   toArray: null,
 
-  /**
+  /*
     Implement this method if your object can mutate internally (even if it
     does not support the MutableEnumerable API).  The method should accept
     an object of your desired type and modify it somehow.  Suite tests will
@@ -242,7 +242,7 @@ var EnumerableTests = Suite.extend({
   */
   mutate() {},
 
-  /**
+  /*
     Becomes true when you define a new mutate() method, indicating that
     mutation tests should run.  This is calculated automatically.
 
@@ -252,13 +252,13 @@ var EnumerableTests = Suite.extend({
     return this.mutate !== EnumerableTests.prototype.mutate;
   }),
 
-  /**
+  /*
     Invoked to actually run the test - overridden by mixins
   */
   run() {},
 
 
-  /**
+  /*
     Creates a new observer object for testing.  You can add this object as an
     observer on an array and it will record results anytime it is invoked.
     After running the test, call the validate() method on the observer to

--- a/packages/ember-runtime/tests/suites/suite.js
+++ b/packages/ember-runtime/tests/suites/suite.js
@@ -5,7 +5,7 @@ import {
 import { get } from "ember-metal/property_get";
 import { forEach } from "ember-metal/enumerable_utils";
 
-/**
+/*
   @class
   A Suite can be used to define a reusable set of unit tests that can be
   applied to any object.  Suites are most useful for defining tests that
@@ -38,7 +38,7 @@ import { forEach } from "ember-metal/enumerable_utils";
 */
 var Suite = EmberObject.extend({
 
-  /**
+  /*
     __Required.__ You must implement this method to apply this mixin.
 
     Define a name for these tests - all modules are prefixed w/ it.
@@ -47,7 +47,7 @@ var Suite = EmberObject.extend({
   */
   name: null,
 
-  /**
+  /*
     Invoked to actually run the test - overridden by mixins
   */
   run() {}

--- a/packages/ember-testing/lib/adapters/adapter.js
+++ b/packages/ember-testing/lib/adapters/adapter.js
@@ -13,6 +13,7 @@ function K() { return this; }
 
   @class Adapter
   @namespace Ember.Test
+  @public
 */
 var Adapter = EmberObject.extend({
   /**

--- a/packages/ember-testing/lib/adapters/qunit.js
+++ b/packages/ember-testing/lib/adapters/qunit.js
@@ -8,6 +8,7 @@ import { inspect } from "ember-metal/utils";
   @class QUnitAdapter
   @namespace Ember.Test
   @extends Ember.Test.Adapter
+  @public
 */
 export default Adapter.extend({
   asyncStart() {

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -7,8 +7,8 @@ import Test from "ember-testing/test";
 import RSVP from "ember-runtime/ext/rsvp";
 
 /**
-* @module ember
-* @submodule ember-testing
+@module ember
+@submodule ember-testing
 */
 
 var helper = Test.registerHelper;
@@ -240,148 +240,156 @@ function wait(app, value) {
 
 
 /**
-* Loads a route, sets up any controllers, and renders any templates associated
-* with the route as though a real user had triggered the route change while
-* using your app.
-*
-* Example:
-*
-* ```javascript
-* visit('posts/index').then(function() {
-*   // assert something
-* });
-* ```
-*
-* @method visit
-* @param {String} url the name of the route
-* @return {RSVP.Promise}
+  Loads a route, sets up any controllers, and renders any templates associated
+  with the route as though a real user had triggered the route change while
+  using your app.
+
+  Example:
+
+  ```javascript
+  visit('posts/index').then(function() {
+    // assert something
+  });
+  ```
+
+  @method visit
+  @param {String} url the name of the route
+  @return {RSVP.Promise}
+  @public
 */
 asyncHelper('visit', visit);
 
 /**
-* Clicks an element and triggers any actions triggered by the element's `click`
-* event.
-*
-* Example:
-*
-* ```javascript
-* click('.some-jQuery-selector').then(function() {
-*   // assert something
-* });
-* ```
-*
-* @method click
-* @param {String} selector jQuery selector for finding element on the DOM
-* @return {RSVP.Promise}
+  Clicks an element and triggers any actions triggered by the element's `click`
+  event.
+
+  Example:
+
+  ```javascript
+  click('.some-jQuery-selector').then(function() {
+    // assert something
+  });
+  ```
+
+  @method click
+  @param {String} selector jQuery selector for finding element on the DOM
+  @return {RSVP.Promise}
+  @public
 */
 asyncHelper('click', click);
 
 if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
   /**
-  * Checks a checkbox. Ensures the presence of the `checked` attribute
-  *
-  * Example:
-  *
-  * ```javascript
-  * check('#remember-me').then(function() {
-  *   // assert something
-  * });
-  * ```
-  *
-  * @method check
-  * @param {String} selector jQuery selector finding an `input[type="checkbox"]`
-  * element on the DOM to check
-  * @return {RSVP.Promise}
+    Checks a checkbox. Ensures the presence of the `checked` attribute
+
+    Example:
+
+    ```javascript
+    check('#remember-me').then(function() {
+      // assert something
+    });
+    ```
+
+    @method check
+    @param {String} selector jQuery selector finding an `input[type="checkbox"]`
+    element on the DOM to check
+    @return {RSVP.Promise}
+    @private
   */
   asyncHelper('check', check);
 
   /**
-  * Unchecks a checkbox. Ensures the absence of the `checked` attribute
-  *
-  * Example:
-  *
-  * ```javascript
-  * uncheck('#remember-me').then(function() {
-  *   // assert something
-  * });
-  * ```
-  *
-  * @method check
-  * @param {String} selector jQuery selector finding an `input[type="checkbox"]`
-  * element on the DOM to uncheck
-  * @return {RSVP.Promise}
+    Unchecks a checkbox. Ensures the absence of the `checked` attribute
+
+    Example:
+
+    ```javascript
+    uncheck('#remember-me').then(function() {
+     // assert something
+    });
+    ```
+
+    @method check
+    @param {String} selector jQuery selector finding an `input[type="checkbox"]`
+    element on the DOM to uncheck
+    @return {RSVP.Promise}
+    @private
   */
   asyncHelper('uncheck', uncheck);
 }
 /**
-* Simulates a key event, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode
-*
-* Example:
-*
-* ```javascript
-* keyEvent('.some-jQuery-selector', 'keypress', 13).then(function() {
-*  // assert something
-* });
-* ```
-*
-* @method keyEvent
-* @param {String} selector jQuery selector for finding element on the DOM
-* @param {String} type the type of key event, e.g. `keypress`, `keydown`, `keyup`
-* @param {Number} keyCode the keyCode of the simulated key event
-* @return {RSVP.Promise}
-* @since 1.5.0
+  Simulates a key event, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode
+
+  Example:
+
+  ```javascript
+  keyEvent('.some-jQuery-selector', 'keypress', 13).then(function() {
+   // assert something
+  });
+  ```
+
+  @method keyEvent
+  @param {String} selector jQuery selector for finding element on the DOM
+  @param {String} type the type of key event, e.g. `keypress`, `keydown`, `keyup`
+  @param {Number} keyCode the keyCode of the simulated key event
+  @return {RSVP.Promise}
+  @since 1.5.0
+  @public
 */
 asyncHelper('keyEvent', keyEvent);
 
 /**
-* Fills in an input element with some text.
-*
-* Example:
-*
-* ```javascript
-* fillIn('#email', 'you@example.com').then(function() {
-*   // assert something
-* });
-* ```
-*
-* @method fillIn
-* @param {String} selector jQuery selector finding an input element on the DOM
-* to fill text with
-* @param {String} text text to place inside the input element
-* @return {RSVP.Promise}
+  Fills in an input element with some text.
+
+  Example:
+
+  ```javascript
+  fillIn('#email', 'you@example.com').then(function() {
+    // assert something
+  });
+  ```
+
+  @method fillIn
+  @param {String} selector jQuery selector finding an input element on the DOM
+  to fill text with
+  @param {String} text text to place inside the input element
+  @return {RSVP.Promise}
+  @public
 */
 asyncHelper('fillIn', fillIn);
 
 /**
-* Finds an element in the context of the app's container element. A simple alias
-* for `app.$(selector)`.
-*
-* Example:
-*
-* ```javascript
-* var $el = find('.my-selector');
-* ```
-*
-* @method find
-* @param {String} selector jQuery string selector for element lookup
-* @return {Object} jQuery object representing the results of the query
+  Finds an element in the context of the app's container element. A simple alias
+  for `app.$(selector)`.
+
+  Example:
+
+  ```javascript
+  var $el = find('.my-selector');
+  ```
+
+  @method find
+  @param {String} selector jQuery string selector for element lookup
+  @return {Object} jQuery object representing the results of the query
+  @public
 */
 helper('find', find);
 
 /**
-* Like `find`, but throws an error if the element selector returns no results.
-*
-* Example:
-*
-* ```javascript
-* var $el = findWithAssert('.doesnt-exist'); // throws error
-* ```
-*
-* @method findWithAssert
-* @param {String} selector jQuery selector string for finding an element within
-* the DOM
-* @return {Object} jQuery object representing the results of the query
-* @throws {Error} throws error if jQuery object returned has a length of 0
+  Like `find`, but throws an error if the element selector returns no results.
+
+  Example:
+
+  ```javascript
+  var $el = findWithAssert('.doesnt-exist'); // throws error
+  ```
+
+  @method findWithAssert
+  @param {String} selector jQuery selector string for finding an element within
+  the DOM
+  @return {Object} jQuery object representing the results of the query
+  @throws {Error} throws error if jQuery object returned has a length of 0
+  @private
 */
 helper('findWithAssert', findWithAssert);
 
@@ -407,6 +415,7 @@ helper('findWithAssert', findWithAssert);
   @method wait
   @param {Object} value The value to be returned.
   @return {RSVP.Promise}
+  @public
 */
 asyncHelper('wait', wait);
 asyncHelper('andThen', andThen);
@@ -428,6 +437,7 @@ visit('/some/path').then(validateRouteName)
 @method currentRouteName
 @return {Object} The name of the currently active route.
 @since 1.5.0
+@public
 */
 helper('currentRouteName', currentRouteName);
 
@@ -447,6 +457,7 @@ click('#some-link-id').then(validateURL);
 @method currentPath
 @return {Object} The currently active path.
 @since 1.5.0
+@public
 */
 helper('currentPath', currentPath);
 
@@ -466,6 +477,7 @@ click('#some-link-id').then(validateURL);
 @method currentURL
 @return {Object} The currently active URL.
 @since 1.5.0
+@public
 */
 helper('currentURL', currentURL);
 
@@ -485,7 +497,8 @@ helper('currentURL', currentURL);
  @since 1.9.0
  @method pauseTest
  @return {Object} A promise that will never resolve
- */
+ @public
+*/
 helper('pauseTest', pauseTest);
 
 /**
@@ -511,5 +524,6 @@ helper('pauseTest', pauseTest);
  @param {Object} [options] The options to be passed to jQuery.Event.
  @return {RSVP.Promise}
  @since 1.5.0
+ @public
 */
 asyncHelper('triggerEvent', triggerEvent);

--- a/packages/ember-testing/lib/main.js
+++ b/packages/ember-testing/lib/main.js
@@ -10,11 +10,8 @@ import QUnitAdapter from "ember-testing/adapters/qunit";
 import "ember-testing/helpers";      // adds helpers to helpers object in Test
 
 /**
-  Ember Testing
-
   @module ember
   @submodule ember-testing
-  @requires ember-application
 */
 
 Ember.Test = Test;

--- a/packages/ember-testing/lib/setup_for_testing.js
+++ b/packages/ember-testing/lib/setup_for_testing.js
@@ -29,6 +29,7 @@ function decrementAjaxPendingRequests(_, xhr) {
   @method setupForTesting
   @namespace Ember
   @since 1.5.0
+  @private
 */
 export default function setupForTesting() {
   if (!Test) { Test = requireModule('ember-testing/test')['default']; }

--- a/packages/ember-testing/lib/support.js
+++ b/packages/ember-testing/lib/support.js
@@ -6,7 +6,7 @@ import environment from "ember-metal/environment";
 /**
   @module ember
   @submodule ember-testing
- */
+*/
 
 var $ = jQuery;
 

--- a/packages/ember-testing/lib/test.js
+++ b/packages/ember-testing/lib/test.js
@@ -8,7 +8,7 @@ import EmberApplication from "ember-application/system/application";
 /**
   @module ember
   @submodule ember-testing
- */
+*/
 var helpers = {};
 var injectHelpersCallbacks = [];
 
@@ -22,6 +22,7 @@ var injectHelpersCallbacks = [];
 
   @class Test
   @namespace Ember
+  @public
 */
 var Test = {
   /**
@@ -327,6 +328,7 @@ EmberApplication.reopen({
     @property testHelpers
     @type {Object}
     @default {}
+    @public
   */
   testHelpers: {},
 
@@ -355,23 +357,25 @@ EmberApplication.reopen({
   @type {Boolean}
   @default false
   @since 1.3.0
+  @public
   */
   testing: false,
 
   /**
-   This hook defers the readiness of the application, so that you can start
-   the app when your tests are ready to run. It also sets the router's
-   location to 'none', so that the window's location will not be modified
-   (preventing both accidental leaking of state between tests and interference
-   with your testing framework).
+    This hook defers the readiness of the application, so that you can start
+    the app when your tests are ready to run. It also sets the router's
+    location to 'none', so that the window's location will not be modified
+    (preventing both accidental leaking of state between tests and interference
+    with your testing framework).
 
-   Example:
+    Example:
 
-  ```
-  App.setupForTesting();
-  ```
+    ```
+    App.setupForTesting();
+    ```
 
     @method setupForTesting
+    @public
   */
   setupForTesting() {
     setupForTesting();
@@ -391,6 +395,7 @@ EmberApplication.reopen({
     @type {Object} The object to be used for test helpers.
     @default window
     @since 1.2.0
+    @private
   */
   helperContainer: null,
 
@@ -401,15 +406,16 @@ EmberApplication.reopen({
     (so that it can be reset if the helper is removed with `unregisterHelper` or
     `removeTestHelpers`).
 
-   Any callbacks registered with `onInjectHelpers` will be called once the
-   helpers have been injected.
+    Any callbacks registered with `onInjectHelpers` will be called once the
+    helpers have been injected.
 
-  Example:
-  ```
-  App.injectTestHelpers();
-  ```
+    Example:
+    ```
+    App.injectTestHelpers();
+    ```
 
     @method injectTestHelpers
+    @public
   */
   injectTestHelpers(helperContainer) {
     if (helperContainer) {

--- a/packages/ember-views/lib/compat/metamorph_view.js
+++ b/packages/ember-views/lib/compat/metamorph_view.js
@@ -7,7 +7,7 @@ import { Mixin } from "ember-metal/mixin";
 /**
  @module ember
  @submodule ember-views
- */
+*/
 
 // The `morph` and `outerHTML` properties are internal only
 // and not observable.
@@ -16,7 +16,7 @@ import { Mixin } from "ember-metal/mixin";
  @class _Metamorph
  @namespace Ember
  @private
- */
+*/
 export var _Metamorph = Mixin.create({
   tagName: '',
   __metamorphType: 'Ember._Metamorph',
@@ -38,7 +38,7 @@ export var _Metamorph = Mixin.create({
  @extends Ember.View
  @uses Ember._Metamorph
  @private
- */
+*/
 export default View.extend(_Metamorph, {
   __metamorphType: 'Ember._MetamorphView'
 });

--- a/packages/ember-views/lib/compat/render_buffer.js
+++ b/packages/ember-views/lib/compat/render_buffer.js
@@ -125,8 +125,9 @@ export function renderComponentWithBuffer(component, contextualElement, dom) {
    var buffer = new Ember.RenderBuffer('div', contextualElement);
   ```
 
-  @method renderBuffer
+  @class RenderBuffer
   @namespace Ember
+  @private
 */
 
 var RenderBuffer = function(domHelper) {
@@ -183,6 +184,7 @@ RenderBuffer.prototype = {
     @property classes
     @type Array
     @default null
+    @private
   */
   classes: null,
 
@@ -195,6 +197,7 @@ RenderBuffer.prototype = {
     @property elementId
     @type String
     @default null
+    @private
   */
   elementId: null,
 
@@ -210,6 +213,7 @@ RenderBuffer.prototype = {
     @property elementAttributes
     @type Hash
     @default {}
+    @private
   */
   elementAttributes: null,
 
@@ -225,6 +229,7 @@ RenderBuffer.prototype = {
     @property elementProperties
     @type Hash
     @default {}
+    @private
   */
   elementProperties: null,
 
@@ -241,6 +246,7 @@ RenderBuffer.prototype = {
     @property elementTag
     @type String
     @default null
+    @private
   */
   elementTag: null,
 
@@ -256,6 +262,7 @@ RenderBuffer.prototype = {
     @property elementStyle
     @type Hash
     @default {}
+    @private
   */
   elementStyle: null,
 
@@ -299,6 +306,7 @@ RenderBuffer.prototype = {
     @method push
     @param {String} string HTML to push into the buffer
     @chainable
+    @private
   */
   push(content) {
     if (typeof content === 'string') {
@@ -320,6 +328,7 @@ RenderBuffer.prototype = {
     @method addClass
     @param {String} className Class name to add to the buffer
     @chainable
+    @private
   */
   addClass(className) {
     // lazily create elementClasses
@@ -345,6 +354,7 @@ RenderBuffer.prototype = {
     @method id
     @param {String} id
     @chainable
+    @private
   */
   id(id) {
     this.elementId = id;
@@ -362,6 +372,7 @@ RenderBuffer.prototype = {
     @param {String} value The value to add to the attribute
     @chainable
     @return {Ember.RenderBuffer|String} this or the current attribute value
+    @private
   */
   attr(name, value) {
     var attributes = this.elementAttributes = (this.elementAttributes || {});
@@ -381,6 +392,7 @@ RenderBuffer.prototype = {
     @method removeAttr
     @param {String} name The name of the attribute
     @chainable
+    @private
   */
   removeAttr(name) {
     var attributes = this.elementAttributes;
@@ -397,6 +409,7 @@ RenderBuffer.prototype = {
     @param {String} value The value to add to the property
     @chainable
     @return {Ember.RenderBuffer|String} this or the current property value
+    @private
   */
   prop(name, value) {
     var properties = this.elementProperties = (this.elementProperties || {});
@@ -416,6 +429,7 @@ RenderBuffer.prototype = {
     @method removeProp
     @param {String} name The name of the property
     @chainable
+    @private
   */
   removeProp(name) {
     var properties = this.elementProperties;
@@ -431,6 +445,7 @@ RenderBuffer.prototype = {
     @param {String} name Name of the style
     @param {String} value
     @chainable
+    @private
   */
   style(name, value) {
     this.elementStyle = (this.elementStyle || {});
@@ -503,6 +518,7 @@ RenderBuffer.prototype = {
     @method element
     @return {DOMElement} The element corresponding to the generated HTML
       of this buffer
+    @private
   */
   element() {
 
@@ -549,6 +565,7 @@ RenderBuffer.prototype = {
 
     @method string
     @return {String} The generated HTML
+    @private
   */
   string() {
     if (this._element) {

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -1,10 +1,6 @@
 /**
-Ember Views
-
 @module ember
 @submodule ember-views
-@requires ember-runtime
-@main ember-views
 */
 
 // BEGIN IMPORTS
@@ -52,6 +48,7 @@ import LegacyEachView from "ember-views/views/legacy_each_view";
 
   @method $
   @for Ember
+  @public
 */
 
 // BEGIN EXPORTS

--- a/packages/ember-views/lib/mixins/aria_role_support.js
+++ b/packages/ember-views/lib/mixins/aria_role_support.js
@@ -1,14 +1,15 @@
 /**
  @module ember
  @submodule ember-views
- */
+*/
 
 import { Mixin } from "ember-metal/mixin";
 
 /**
  @class AriaRoleSupport
  @namespace Ember
- */
+ @private
+*/
 export default Mixin.create({
   attributeBindings: ['ariaRole:role'],
 
@@ -24,6 +25,7 @@ export default Mixin.create({
    @property ariaRole
    @type String
    @default null
-   */
+   @public
+  */
   ariaRole: null
 });

--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -14,6 +14,7 @@ var EMPTY_ARRAY = [];
 /**
   @class ClassNamesSupport
   @namespace Ember
+  @private
 */
 var ClassNamesSupport = Mixin.create({
   concatenatedProperties: ['classNames', 'classNameBindings'],
@@ -36,6 +37,7 @@ var ClassNamesSupport = Mixin.create({
     @property classNames
     @type Array
     @default ['ember-view']
+    @private
   */
   classNames: ['ember-view'],
 
@@ -79,6 +81,7 @@ var ClassNamesSupport = Mixin.create({
     @property classNameBindings
     @type Array
     @default []
+    @private
   */
   classNameBindings: EMPTY_ARRAY
 });

--- a/packages/ember-views/lib/mixins/empty_view_support.js
+++ b/packages/ember-views/lib/mixins/empty_view_support.js
@@ -1,7 +1,7 @@
 /**
  @module ember
  @submodule ember-views
- */
+*/
 
 import { Mixin } from "ember-metal/mixin";
 import View from "ember-views/views/view";
@@ -12,7 +12,8 @@ import { computed } from "ember-metal/computed";
 /**
  @class EmptyViewSupport
  @namespace Ember
- */
+ @private
+*/
 export default Mixin.create({
   /**
    This provides metadata about what kind of empty view class this
@@ -21,7 +22,7 @@ export default Mixin.create({
 
    @private
    @property emptyViewClass
-   */
+  */
   emptyViewClass: View,
 
   /**
@@ -30,7 +31,8 @@ export default Mixin.create({
    @property emptyView
    @type Ember.View
    @default null
-   */
+   @private
+  */
   emptyView: null,
 
   _emptyView: computed('emptyView', 'attrs.emptyViewClass', 'emptyViewClass', function() {

--- a/packages/ember-views/lib/mixins/instrumentation_support.js
+++ b/packages/ember-views/lib/mixins/instrumentation_support.js
@@ -9,6 +9,7 @@ import { get } from "ember-metal/property_get";
 /**
   @class InstrumentationSupport
   @namespace Ember
+  @public
 */
 var InstrumentationSupport = Mixin.create({
   /**
@@ -16,6 +17,7 @@ var InstrumentationSupport = Mixin.create({
 
     @property instrumentDisplay
     @type String
+    @public
   */
   instrumentDisplay: computed(function() {
     if (this.helperName) {

--- a/packages/ember-views/lib/mixins/legacy_view_support.js
+++ b/packages/ember-views/lib/mixins/legacy_view_support.js
@@ -9,6 +9,7 @@ import { get } from "ember-metal/property_get";
 /**
   @class LegacyViewSupport
   @namespace Ember
+  @private
 */
 var LegacyViewSupport = Mixin.create({
   beforeRender(buffer) {},
@@ -43,6 +44,7 @@ var LegacyViewSupport = Mixin.create({
 
     @method removeAllChildren
     @return {Ember.View} receiver
+    @private
   */
   removeAllChildren() {
     return this.mutateChildViews(function(parentView, view) {
@@ -64,6 +66,7 @@ var LegacyViewSupport = Mixin.create({
     @param {Class} klass Subclass of Ember.View (or Ember.View itself)
     @return Ember.View
     @deprecated
+    @private
   */
   nearestChildOf(klass) {
     Ember.deprecate("nearestChildOf has been deprecated.");
@@ -84,6 +87,7 @@ var LegacyViewSupport = Mixin.create({
     @param {Class} klass Subclass of Ember.View (or Ember.View itself)
     @return Ember.View
     @deprecated
+    @private
   */
   nearestInstanceOf(klass) {
     Ember.deprecate("nearestInstanceOf is deprecated and will be removed from future releases. Use nearestOfType.");

--- a/packages/ember-views/lib/mixins/template_rendering_support.js
+++ b/packages/ember-views/lib/mixins/template_rendering_support.js
@@ -10,6 +10,7 @@ var _renderView;
 /**
   @class TemplateRenderingSupport
   @namespace Ember
+  @private
 */
 var TemplateRenderingSupport = Mixin.create({
   /**
@@ -21,8 +22,9 @@ var TemplateRenderingSupport = Mixin.create({
     property and invoke it with the value of `context`. The value of
     `context` will be the view's controller unless you override it.
 
-    @method render
+    @method renderBlock
     @param {Ember.RenderBuffer} buffer The render buffer
+    @private
   */
 
   renderBlock(block, renderNode) {

--- a/packages/ember-views/lib/mixins/text_support.js
+++ b/packages/ember-views/lib/mixins/text_support.js
@@ -145,6 +145,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     @property action
     @type String
     @default null
+    @private
   */
   action: null,
 
@@ -159,6 +160,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     @property onEvent
     @type String
     @default enter
+    @private
   */
   onEvent: 'enter',
 
@@ -176,6 +178,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
     @property bubbles
     @type Boolean
     @default false
+    @private
   */
   bubbles: false,
 
@@ -209,6 +212,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method insertNewline
     @param {Event} event
+    @private
   */
   insertNewline(event) {
     sendAction('enter', this, event);
@@ -226,6 +230,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method cancel
     @param {Event} event
+    @private
   */
   cancel(event) {
     sendAction('escape-press', this, event);
@@ -242,6 +247,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method focusIn
     @param {Event} event
+    @private
   */
   focusIn(event) {
     sendAction('focus-in', this, event);
@@ -258,6 +264,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method focusOut
     @param {Event} event
+    @private
   */
   focusOut(event) {
     this._elementValueDidChange(event);
@@ -275,6 +282,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method keyPress
     @param {Event} event
+    @private
   */
   keyPress(event) {
     sendAction('key-press', this, event);
@@ -291,6 +299,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method keyUp
     @param {Event} event
+    @private
   */
   keyUp(event) {
     this.interpretKeyEvents(event);
@@ -309,6 +318,7 @@ var TextSupport = Mixin.create(TargetActionSupport, {
 
     @method keyDown
     @param {Event} event
+    @private
   */
   keyDown(event) {
     this.sendAction('key-down', get(this, 'value'), event);

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -47,6 +47,7 @@ var ViewChildViewsSupport = Mixin.create({
     @method removeChild
     @param {Ember.View} view
     @return {Ember.View} receiver
+    @private
   */
   removeChild(view) {
     // If we're destroying, the entire subtree will be
@@ -76,6 +77,7 @@ var ViewChildViewsSupport = Mixin.create({
     @param {Class|String} viewClass
     @param {Object} [attrs] Attributes to add
     @return {Ember.View} new instance
+    @private
   */
   createChildView(maybeViewClass, _attrs) {
     if (!maybeViewClass) {

--- a/packages/ember-views/lib/mixins/view_context_support.js
+++ b/packages/ember-views/lib/mixins/view_context_support.js
@@ -22,6 +22,7 @@ var ViewContextSupport = Mixin.create(LegacyViewSupport, {
 
     @property context
     @type Object
+    @private
   */
   context: computed({
     get() {
@@ -78,6 +79,7 @@ var ViewContextSupport = Mixin.create(LegacyViewSupport, {
 
     @property controller
     @type Object
+    @private
   */
   controller: computed({
     get() {

--- a/packages/ember-views/lib/mixins/view_target_action_support.js
+++ b/packages/ember-views/lib/mixins/view_target_action_support.js
@@ -42,14 +42,17 @@ App.SaveButtonView = Ember.View.extend(Ember.ViewTargetActionSupport, {
 @class ViewTargetActionSupport
 @namespace Ember
 @extends Ember.TargetActionSupport
+@private
 */
 export default Mixin.create(TargetActionSupport, {
   /**
-  @property target
+   @property target
+   @private
   */
   target: alias('controller'),
   /**
-  @property actionContext
+   @property actionContext
+   @private
   */
   actionContext: alias('context')
 });

--- a/packages/ember-views/lib/mixins/visibility_support.js
+++ b/packages/ember-views/lib/mixins/visibility_support.js
@@ -1,7 +1,7 @@
 /**
  @module ember
  @submodule ember-views
- */
+*/
 import {
   Mixin,
   observer
@@ -14,7 +14,8 @@ function K() { return this; }
 /**
  @class VisibilitySupport
  @namespace Ember
- */
+ @public
+*/
 var VisibilitySupport = Mixin.create({
   /**
     If `false`, the view will appear hidden in DOM.
@@ -22,6 +23,7 @@ var VisibilitySupport = Mixin.create({
     @property isVisible
     @type Boolean
     @default null
+    @public
   */
   isVisible: true,
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -38,6 +38,7 @@ export default EmberObject.extend({
 
     @property events
     @type Object
+    @private
   */
   events: {
     touchstart  : 'touchStart',
@@ -111,6 +112,7 @@ export default EmberObject.extend({
     @type boolean
     @default 'true'
     @since 1.7.0
+    @private
   */
   canDispatchToEventManager: true,
 

--- a/packages/ember-views/lib/system/jquery.js
+++ b/packages/ember-views/lib/system/jquery.js
@@ -4,15 +4,6 @@ import Ember from 'ember-metal/core'; // Ember.assert
 import { forEach } from 'ember-metal/enumerable_utils';
 import environment from 'ember-metal/environment';
 
-/**
-Ember Views
-
-@module ember
-@submodule ember-views
-@requires ember-runtime
-@main ember-views
-*/
-
 var jQuery;
 
 if (environment.hasDOM) {
@@ -26,10 +17,6 @@ if (environment.hasDOM) {
                (jQuery().jquery.match(/^((1\.(7|8|9|10|11))|(2\.(0|1)))(\.\d+)?(pre|rc\d?)?/) ||
                 Ember.ENV.FORCE_JQUERY));
 
-  /**
-  @module ember
-  @submodule ember-views
-  */
   if (jQuery) {
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#dndevents
     var dragEvents = [

--- a/packages/ember-views/lib/views/checkbox.js
+++ b/packages/ember-views/lib/views/checkbox.js
@@ -30,6 +30,7 @@ import View from "ember-views/views/view";
   @class Checkbox
   @namespace Ember
   @extends Ember.View
+  @public
 */
 // 2.0TODO: Subclass Component rather than View
 export default View.extend({

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -181,6 +181,7 @@ import EmptyViewSupport from "ember-views/mixins/empty_view_support";
   @extends Ember.ContainerView
   @uses Ember.EmptyViewSupport
   @since Ember 0.9
+  @private
 */
 var CollectionView = ContainerView.extend(EmptyViewSupport, {
 
@@ -190,6 +191,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @property content
     @type Ember.Array
     @default null
+    @private
   */
   content: null,
 
@@ -197,6 +199,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @property itemViewClass
     @type Ember.View
     @default Ember.View
+    @private
   */
   itemViewClass: View,
 
@@ -204,6 +207,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     Setup a CollectionView
 
     @method init
+    @private
   */
   init() {
     var ret = this._super(...arguments);
@@ -261,6 +265,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     Removes the content and content observers.
 
     @method destroy
+    @private
   */
   destroy() {
     if (!this._super(...arguments)) { return; }
@@ -287,6 +292,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @param {Array} content the managed collection of objects
     @param {Number} start the index at which the changes will occur
     @param {Number} removed number of object to be removed from content
+    @private
   */
   arrayWillChange(content, start, removedCount) {
     this.replace(start, removedCount, []);
@@ -305,6 +311,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @param {Number} start the index at which the changes occurred
     @param {Number} removed number of object removed from content
     @param {Number} added number of object added to content
+    @private
   */
   arrayDidChange(content, start, removed, added) {
     var addedViews = [];
@@ -347,6 +354,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @param {Class} viewClass
     @param {Object} [attrs] Attributes to add
     @return {Ember.View} new instance
+    @private
   */
   createChildView(_view, attrs) {
     var view = this._super(_view, attrs);
@@ -395,6 +403,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
   @type Object
   @static
   @final
+  @private
 */
 CollectionView.CONTAINER_MAP = {
   ul: 'li',

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -111,6 +111,7 @@ function validateAction(component, actionName) {
   @class Component
   @namespace Ember
   @extends Ember.View
+  @public
 */
 var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
   isComponent: true,
@@ -152,6 +153,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
 
   @deprecated
   @property template
+  @public
   */
   template: computed('_template', {
     get() {
@@ -187,6 +189,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
 
   @deprecated
   @property templateName
+  @public
   */
   templateName: null,
 
@@ -197,6 +200,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     @property targetObject
     @type Ember.Controller
     @default null
+    @private
   */
   targetObject: computed('controller', function(key) {
     if (this._targetObject) { return this._targetObject; }
@@ -284,6 +288,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
     @method sendAction
     @param [action] {String} the action to trigger
     @param [context] {*} a context to send with the action
+    @public
   */
   sendAction(action, ...contexts) {
     var actionName;

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -167,6 +167,7 @@ containerViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
   @class ContainerView
   @namespace Ember
   @extends Ember.View
+  @private
 */
 var ContainerView = View.extend(MutableArray, {
   willWatchProperty(prop) {

--- a/packages/ember-views/lib/views/core_view.js
+++ b/packages/ember-views/lib/views/core_view.js
@@ -36,6 +36,7 @@ var renderer;
   @deprecated Use `Ember.View` instead.
   @uses Ember.Evented
   @uses Ember.ActionHandler
+  @private
 */
 var CoreView = EmberObject.extend(Evented, ActionHandler, {
   isView: true,
@@ -67,6 +68,7 @@ var CoreView = EmberObject.extend(Evented, ActionHandler, {
     @property parentView
     @type Ember.View
     @default null
+    @private
   */
   parentView: null,
 

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -312,6 +312,7 @@ var SelectOptgroup = View.extend({
   @class Select
   @namespace Ember
   @extends Ember.View
+  @public
 */
 var Select = View.extend({
   instrumentDisplay: 'Ember.Select',
@@ -338,6 +339,7 @@ var Select = View.extend({
     @property multiple
     @type Boolean
     @default false
+    @public
   */
   multiple: false,
 
@@ -348,6 +350,7 @@ var Select = View.extend({
     @property disabled
     @type Boolean
     @default false
+    @public
   */
   disabled: false,
 
@@ -359,6 +362,7 @@ var Select = View.extend({
     @type Boolean
     @default false
     @since 1.5.0
+    @public
   */
   required: false,
 
@@ -385,6 +389,7 @@ var Select = View.extend({
     @property content
     @type Array
     @default null
+    @public
   */
   content: null,
 
@@ -397,6 +402,7 @@ var Select = View.extend({
     @property selection
     @type Object or Array
     @default null
+    @public
   */
   selection: null,
 
@@ -409,6 +415,7 @@ var Select = View.extend({
     @property value
     @type String
     @default null
+    @public
   */
   value: computed({
     get(key) {
@@ -427,6 +434,7 @@ var Select = View.extend({
     @property prompt
     @type String
     @default null
+    @public
   */
   prompt: null,
 
@@ -436,6 +444,7 @@ var Select = View.extend({
     @property optionLabelPath
     @type String
     @default 'content'
+    @public
   */
   optionLabelPath: 'content',
 
@@ -445,6 +454,7 @@ var Select = View.extend({
     @property optionValuePath
     @type String
     @default 'content'
+    @public
   */
   optionValuePath: 'content',
 
@@ -455,6 +465,7 @@ var Select = View.extend({
     @property optionGroupPath
     @type String
     @default null
+    @public
   */
   optionGroupPath: null,
 
@@ -464,6 +475,7 @@ var Select = View.extend({
     @property groupView
     @type Ember.View
     @default Ember.SelectOptgroup
+    @public
   */
   groupView: SelectOptgroup,
 
@@ -494,6 +506,7 @@ var Select = View.extend({
     @property optionView
     @type Ember.View
     @default Ember.SelectOption
+    @private
   */
   optionView: SelectOption,
 

--- a/packages/ember-views/lib/views/text_area.js
+++ b/packages/ember-views/lib/views/text_area.js
@@ -21,6 +21,7 @@ import TextSupport from "ember-views/mixins/text_support";
   @namespace Ember
   @extends Ember.Component
   @uses Ember.TextSupport
+  @public
 */
 export default Component.extend(TextSupport, {
   instrumentDisplay: '{{textarea}}',

--- a/packages/ember-views/lib/views/text_field.js
+++ b/packages/ember-views/lib/views/text_field.js
@@ -51,6 +51,7 @@ function canSetTypeOfInput(type) {
   @namespace Ember
   @extends Ember.Component
   @uses Ember.TextSupport
+  @public
 */
 export default Component.extend(TextSupport, {
   instrumentDisplay: '{{input type="text"}}',
@@ -92,6 +93,7 @@ export default Component.extend(TextSupport, {
     @property value
     @type String
     @default ""
+    @public
   */
   value: "",
 
@@ -101,6 +103,7 @@ export default Component.extend(TextSupport, {
     @property type
     @type String
     @default "text"
+    @public
   */
   type: computed({
     get() {
@@ -124,6 +127,7 @@ export default Component.extend(TextSupport, {
     @property size
     @type String
     @default null
+    @public
   */
   size: null,
 
@@ -133,6 +137,7 @@ export default Component.extend(TextSupport, {
     @property pattern
     @type String
     @default null
+    @public
   */
   pattern: null,
 
@@ -143,6 +148,7 @@ export default Component.extend(TextSupport, {
     @type String
     @default null
     @since 1.4.0
+    @public
   */
   min: null,
 
@@ -153,6 +159,7 @@ export default Component.extend(TextSupport, {
     @type String
     @default null
     @since 1.4.0
+    @public
   */
   max: null
 });

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -53,6 +53,7 @@ Ember.warn("The VIEW_PRESERVES_CONTEXT flag has been removed and the functionali
   @property TEMPLATES
   @for Ember
   @type Object
+  @private
 */
 Ember.TEMPLATES = {};
 
@@ -667,6 +668,7 @@ Ember.TEMPLATES = {};
   @uses Ember.InstrumentationSupport
   @uses Ember.VisibilitySupport
   @uses Ember.AriaRoleSupport
+  @public
 */
 // jscs:disable validateIndentation
 var View = CoreView.extend(
@@ -687,6 +689,7 @@ var View = CoreView.extend(
     @type Boolean
     @default true
     @static
+    @private
   */
   isView: true,
 
@@ -703,6 +706,7 @@ var View = CoreView.extend(
     @property templateName
     @type String
     @default null
+    @private
   */
   templateName: null,
 
@@ -715,6 +719,7 @@ var View = CoreView.extend(
     @property layoutName
     @type String
     @default null
+    @private
   */
   layoutName: null,
 
@@ -728,6 +733,7 @@ var View = CoreView.extend(
 
     @property template
     @type Function
+    @private
   */
   template: computed('templateName', {
     get() {
@@ -755,6 +761,7 @@ var View = CoreView.extend(
 
     @property layout
     @type Function
+    @private
   */
   layout: computed('layoutName', {
     get(key) {
@@ -790,6 +797,7 @@ var View = CoreView.extend(
 
     @method _contextDidChange
     @private
+    @private
   */
   _contextDidChange: observer('context', function() {
     this.rerender();
@@ -803,6 +811,7 @@ var View = CoreView.extend(
     @param {Class,Mixin} klass Subclass of Ember.View (or Ember.View itself),
            or an instance of Ember.Mixin.
     @return Ember.View
+    @private
   */
   nearestOfType(klass) {
     var view = get(this, 'parentView');
@@ -822,6 +831,7 @@ var View = CoreView.extend(
     @method nearestWithProperty
     @param {String} property A property name
     @return Ember.View
+    @private
   */
   nearestWithProperty(property) {
     var view = get(this, 'parentView');
@@ -847,6 +857,7 @@ var View = CoreView.extend(
     be slow.
 
     @method rerender
+    @public
   */
   rerender() {
     return this.currentState.rerender(this);
@@ -889,6 +900,7 @@ var View = CoreView.extend(
 
     @property element
     @type DOMElement
+    @public
   */
   element: null,
 
@@ -903,6 +915,7 @@ var View = CoreView.extend(
     @method $
     @param {String} [selector] a jQuery-compatible selector string
     @return {jQuery} the jQuery object for the DOM node
+    @public
   */
   $(sel) {
     Ember.assert('You cannot access this.$() on a component with `tagName: \'\'` specified.', this.tagName !== '');
@@ -944,6 +957,7 @@ var View = CoreView.extend(
     @method appendTo
     @param {String|DOMElement|jQuery} A selector, element, HTML string, or jQuery object
     @return {Ember.View} receiver
+    @private
   */
   appendTo(selector) {
     var target = jQuery(selector);
@@ -998,6 +1012,7 @@ var View = CoreView.extend(
     @method renderToElement
     @param {String} tagName The tag of the element to create and render into. Defaults to "body".
     @return {HTMLBodyElement} element
+    @private
   */
   renderToElement(tagName) {
     tagName = tagName || 'body';
@@ -1020,6 +1035,7 @@ var View = CoreView.extend(
     @method replaceIn
     @param {String|DOMElement|jQuery} target A selector, element, HTML string, or jQuery object
     @return {Ember.View} received
+    @private
   */
   replaceIn(selector) {
     var target = jQuery(selector);
@@ -1047,6 +1063,7 @@ var View = CoreView.extend(
 
     @method append
     @return {Ember.View} receiver
+    @private
   */
   append() {
     return this.appendTo(document.body);
@@ -1057,6 +1074,7 @@ var View = CoreView.extend(
 
     @method remove
     @return {Ember.View} receiver
+    @private
   */
   remove() {
     // What we should really do here is wait until the end of the run loop
@@ -1096,6 +1114,7 @@ var View = CoreView.extend(
 
     @property elementId
     @type String
+    @public
   */
   elementId: null,
 
@@ -1109,6 +1128,7 @@ var View = CoreView.extend(
     @method findElementInParentElement
     @param {DOMElement} parentElement The parent's DOM element
     @return {DOMElement} The discovered element
+    @private
   */
   findElementInParentElement(parentElem) {
     var id = "#" + this.elementId;
@@ -1125,6 +1145,7 @@ var View = CoreView.extend(
 
     @method createElement
     @return {Ember.View} receiver
+    @private
   */
   createElement() {
     if (this.element) { return this; }
@@ -1138,6 +1159,7 @@ var View = CoreView.extend(
     Called when a view is going to insert an element into the DOM.
 
     @event willInsertElement
+    @public
   */
   willInsertElement: K,
 
@@ -1150,6 +1172,7 @@ var View = CoreView.extend(
     child view(s) first, bubbling upwards through the hierarchy.
 
     @event didInsertElement
+    @public
   */
   didInsertElement: K,
 
@@ -1159,6 +1182,7 @@ var View = CoreView.extend(
     observers you have installed based on the DOM state
 
     @event willClearRender
+    @public
   */
   willClearRender: K,
 
@@ -1179,6 +1203,7 @@ var View = CoreView.extend(
 
     @method destroyElement
     @return {Ember.View} receiver
+    @private
   */
   destroyElement() {
     return this.currentState.destroyElement(this);
@@ -1193,6 +1218,7 @@ var View = CoreView.extend(
     effect on object observers.
 
     @event willDestroyElement
+    @public
   */
   willDestroyElement: K,
 
@@ -1200,6 +1226,7 @@ var View = CoreView.extend(
     Called when the parentView property has changed.
 
     @event parentViewDidChange
+    @private
   */
   parentViewDidChange: K,
 
@@ -1217,6 +1244,7 @@ var View = CoreView.extend(
     @property tagName
     @type String
     @default null
+    @public
   */
 
   // We leave this null by default so we can tell the difference between
@@ -1261,6 +1289,7 @@ var View = CoreView.extend(
     @method readDOMAttr
     @param {String} name the name of the attribute
     @return String
+    @public
   */
   readDOMAttr(name) {
     let attr = this._renderNode.childNodes.filter(node => node.attrName === name)[0];
@@ -1336,6 +1365,7 @@ var View = CoreView.extend(
 
     @method removeFromParent
     @return {Ember.View} receiver
+    @private
   */
   removeFromParent() {
     var parent = this.parentView;
@@ -1354,6 +1384,7 @@ var View = CoreView.extend(
     memory manager.
 
     @method destroy
+    @private
   */
   destroy() {
     // get parentView before calling super because it'll be destroyed
@@ -1500,6 +1531,7 @@ View.notifyMutationListeners = function() {
   @property views
   @static
   @type Object
+  @private
 */
 View.views = {};
 

--- a/packages/ember/lib/main.js
+++ b/packages/ember/lib/main.js
@@ -26,8 +26,6 @@ if (Ember.__loader.registry['ember-testing']) {
 runLoadHooks('Ember');
 
 /**
-Ember
-
 @module ember
 */
 


### PR DESCRIPTION
This PR ensures that all YUIDoc comment blocks (those starting with `/**`) are properly marked as either `@private` or `@public`.

A number of times throughout the Ember 1.x cycle we have internally struggled with what things are or are not public. This PR "solves" that by making it extremely clear.

In addition to documenting each comment block, a new JSCS rule has been added to ensure **all** documentation blocks are labeled properly in the future.

---

Please note: This PR makes an initial attempt based on my best understanding. These `@public` and `@private` declarations can absolutely be reviewed and changed as needed.
