### PR TITLE
Transition feature flag infrastructure to modules

### DIFF
--- a/features.json
+++ b/features.json
@@ -2,7 +2,6 @@
   "features": {
     "features-stripped-test": null,
     "ember-routing-named-substates": true,
-    "mandatory-setter": "development-only",
     "ember-htmlbars-component-generation": null,
     "ember-htmlbars-component-helper": true,
     "ember-htmlbars-inline-if-helper": true,

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -7,7 +7,7 @@ module.exports = {
   'ember-views':                {trees: null,  requirements: ['ember-runtime', 'ember-metal-views']},
   'ember-extension-support':    {trees: null,  requirements: ['ember-application']},
   'ember-testing':              {trees: null,  requirements: ['ember-application', 'ember-routing'], testing: true},
-  'ember-template-compiler':    {trees: null,  vendorRequirements: ['htmlbars-runtime'], templateCompilerVendor: ['simple-html-tokenizer', 'morph-range', 'htmlbars-runtime', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers']},
+  'ember-template-compiler':    {trees: null,  requirements: ['ember-metal'], vendorRequirements: ['htmlbars-runtime'], templateCompilerVendor: ['simple-html-tokenizer', 'morph-range', 'htmlbars-runtime', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers', 'backburner']},
   'ember-htmlbars':             {trees: null,  vendorRequirements: ['htmlbars-util', 'htmlbars-runtime'], requirements: ['ember-metal-views'], testingVendorRequirements: [ 'htmlbars-test-helpers'], hasTemplates: true},
   'ember-routing':              {trees: null,  vendorRequirements: ['router', 'route-recognizer'],
                                                requirements: ['ember-runtime', 'ember-views']},

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "aws-sdk": "~2.1.5",
+    "babel-plugin-feature-flags": "~0.2.0",
     "bower": "~1.3.2",
     "chalk": "^0.5.1",
     "ember-cli": "^0.2.7",
@@ -19,7 +20,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "^0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.1.5",
+    "emberjs-build": "0.2.0",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",

--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -1,11 +1,12 @@
 import Ember from 'ember-metal/core'; // Ember.assert
+import isEnabled from "ember-metal/features";
 import dictionary from 'ember-metal/dictionary';
 import Container from './container';
 
 var VALID_FULL_NAME_REGEXP = /^[^:]+.+:[^:]+$/;
 
 var instanceInitializersFeatureEnabled;
-if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
+if (isEnabled('ember-application-instance-initializers')) {
   instanceInitializersFeatureEnabled = true;
 }
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -5,7 +5,8 @@
 import DAG from 'dag-map';
 import Registry from 'container/registry';
 
-import Ember from "ember-metal"; // Ember.FEATURES, Ember.deprecate, Ember.assert, Ember.libraries, LOG_VERSION, Namespace, BOOTED
+import Ember from "ember-metal"; // Ember.deprecate, Ember.assert, Ember.libraries, LOG_VERSION, Namespace, BOOTED
+import isEnabled from "ember-metal/features";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { runLoadHooks } from "ember-runtime/system/lazy_load";
@@ -293,7 +294,7 @@ var Application = Namespace.extend(DeferredMixin, {
     // decremented by the Application's own `initialize` method.
     this._readinessDeferrals = 1;
 
-    if (Ember.FEATURES.isEnabled('ember-application-visit')) {
+    if (isEnabled('ember-application-visit')) {
       if (this.autoboot) {
         // Create subclass of Ember.Router for this Application instance.
         // This is to ensure that someone reopening `App.Router` does not
@@ -686,7 +687,7 @@ var Application = Namespace.extend(DeferredMixin, {
     this._runInitializer('initializers', function(name, initializer) {
       Ember.assert("No application initializer named '" + name + "'", !!initializer);
 
-      if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
+      if (isEnabled("ember-application-initializer-context")) {
         initializer.initialize(registry, App);
       } else {
         var ref = initializer.initialize;
@@ -799,7 +800,7 @@ var Application = Namespace.extend(DeferredMixin, {
   }
 });
 
-if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
+if (isEnabled('ember-application-instance-initializers')) {
   Application.reopen({
     instanceInitializer(options) {
       this.constructor.instanceInitializer(options);
@@ -811,7 +812,7 @@ if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
   });
 }
 
-if (Ember.FEATURES.isEnabled('ember-application-visit')) {
+if (isEnabled('ember-application-visit')) {
   Application.reopen({
     /**
       Creates a new instance of the application and instructs it to route to the

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import { indexOf } from "ember-metal/array";
@@ -333,7 +334,7 @@ QUnit.test("initializers are per-app", function() {
   });
 });
 
-if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
+if (isEnabled("ember-application-initializer-context")) {
   QUnit.test("initializers should be executed in their own context", function() {
     expect(1);
     var MyApplication = Application.extend();
@@ -355,7 +356,7 @@ if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
   });
 }
 
-if (Ember.FEATURES.isEnabled("ember-application-instance-initializers")) {
+if (isEnabled("ember-application-instance-initializers")) {
   QUnit.test("initializers should throw a deprecation warning when performing a lookup on the registry", function() {
     expect(1);
 

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import ApplicationInstance from "ember-application/system/application-instance";
@@ -6,11 +7,11 @@ import jQuery from "ember-views/system/jquery";
 
 var app, initializeContextFeatureEnabled;
 
-if (Ember.FEATURES.isEnabled("ember-application-initializer-context")) {
+if (isEnabled("ember-application-initializer-context")) {
   initializeContextFeatureEnabled = true;
 }
 
-if (Ember.FEATURES.isEnabled('ember-application-instance-initializers')) {
+if (isEnabled('ember-application-instance-initializers')) {
   QUnit.module("Ember.Application instance initializers", {
     setup() {
     },

--- a/packages/ember-application/tests/system/visit_test.js
+++ b/packages/ember-application/tests/system/visit_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import Application from "ember-application/system/application";
 import ApplicationInstance from "ember-application/system/application-instance";
@@ -18,7 +19,7 @@ function createApplication() {
   return App;
 }
 
-if (Ember.FEATURES.isEnabled('ember-application-visit')) {
+if (isEnabled('ember-application-visit')) {
   QUnit.module("Ember.Application - visit()");
 
   // This tests whether the application is "autobooted" by registering an

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -1,6 +1,7 @@
 /*global __fail__*/
 
 import Ember from "ember-metal/core";
+import isEnabled, { FEATURES } from "ember-metal/features";
 import EmberError from "ember-metal/error";
 import Logger from "ember-metal/logger";
 
@@ -230,14 +231,14 @@ export function _warnIfUsingStrippedFeatureFlags(FEATURES, featuresWereStripped)
 
 if (!Ember.testing) {
   // Complain if they're using FEATURE flags in builds other than canary
-  Ember.FEATURES['features-stripped-test'] = true;
+  FEATURES['features-stripped-test'] = true;
   var featuresWereStripped = true;
 
-  if (Ember.FEATURES.isEnabled('features-stripped-test')) {
+  if (isEnabled('features-stripped-test')) {
     featuresWereStripped = false;
   }
 
-  delete Ember.FEATURES['features-stripped-test'];
+  delete FEATURES['features-stripped-test'];
   _warnIfUsingStrippedFeatureFlags(Ember.ENV.FEATURES, featuresWereStripped);
 
   // Inform the developer about the Ember Inspector if not installed.

--- a/packages/ember-htmlbars/lib/env.js
+++ b/packages/ember-htmlbars/lib/env.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import environment from "ember-metal/environment";
 
 import { hooks } from "htmlbars-runtime";
@@ -100,7 +101,7 @@ registerKeyword('mut', mut);
 registerKeyword('@mut', privateMut);
 registerKeyword('each', each);
 registerKeyword('readonly', readonly);
-if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+if (isEnabled('ember-htmlbars-get-helper')) {
   registerKeyword('get', getKeyword);
 }
 

--- a/packages/ember-htmlbars/lib/helpers/-get.js
+++ b/packages/ember-htmlbars/lib/helpers/-get.js
@@ -1,9 +1,11 @@
+import isEnabled from "ember-metal/features";
+
 /*
   This private helper is used in conjuntion with the get keyword
   @private
 */
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+if (isEnabled('ember-htmlbars-get-helper')) {
 
   var getHelper = function getHelper([value]) {
     return value;

--- a/packages/ember-htmlbars/lib/helpers/each-in.js
+++ b/packages/ember-htmlbars/lib/helpers/each-in.js
@@ -1,4 +1,6 @@
-if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
+import isEnabled from "ember-metal/features";
+
+if (isEnabled('ember-htmlbars-each-in')) {
   var shouldDisplay = function(object) {
     if (object === undefined || object === null) {
       return false;

--- a/packages/ember-htmlbars/lib/keywords/get.js
+++ b/packages/ember-htmlbars/lib/keywords/get.js
@@ -1,10 +1,11 @@
+import isEnabled from "ember-metal/features";
 import Stream from "ember-metal/streams/stream";
 import { labelFor } from "ember-metal/streams/utils";
 import { read, isStream } from "ember-metal/streams/utils";
 import create from "ember-metal/platform/create";
 import merge from "ember-metal/merge";
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+if (isEnabled('ember-htmlbars-get-helper')) {
 
   var getKeyword = function getKeyword(morph, env, scope, params, hash, template, inverse, visitor) {
     var objParam = params[0];

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 
 import {
   precompile,
@@ -47,7 +48,7 @@ registerHelper('with', withHelper);
 registerHelper('loc', locHelper);
 registerHelper('log', logHelper);
 registerHelper('each', eachHelper);
-if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
+if (isEnabled('ember-htmlbars-each-in')) {
   registerHelper('each-in', eachInHelper);
 }
 registerHelper('-bind-attr-class', bindAttrClassHelper);
@@ -56,7 +57,7 @@ registerHelper('concat', concatHelper);
 registerHelper('-join-classes', joinClassesHelper);
 registerHelper('-legacy-each-with-controller', legacyEachWithControllerHelper);
 registerHelper('-legacy-each-with-keyword', legacyEachWithKeywordHelper);
-if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+if (isEnabled('ember-htmlbars-get-helper')) {
   registerHelper('-get', getHelper);
 }
 registerHelper('-html-safe', htmlSafeHelper);
@@ -72,7 +73,7 @@ Ember.HTMLBars = {
   DOMHelper
 };
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-helper')) {
+if (isEnabled('ember-htmlbars-helper')) {
   Helper.helper = makeHelper;
   Ember.Helper = Helper;
 }

--- a/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/boolean_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
@@ -10,7 +11,7 @@ function appendView(view) {
 }
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 QUnit.module("ember-htmlbars: boolean attribute", {
   teardown() {

--- a/packages/ember-htmlbars/tests/attr_nodes/class_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/class_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
@@ -10,12 +11,12 @@ function appendView(view) {
 }
 
 var isInlineIfEnabled = false;
-if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
+if (isEnabled('ember-htmlbars-inline-if-helper')) {
   isInlineIfEnabled = true;
 }
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 QUnit.module("ember-htmlbars: class attribute", {
   teardown() {

--- a/packages/ember-htmlbars/tests/attr_nodes/data_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/data_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
@@ -9,7 +10,7 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 
 var view, originalSetAttribute, setAttributeCalls, renderer;
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
   QUnit.module("ember-htmlbars: data attribute", {
     teardown() {

--- a/packages/ember-htmlbars/tests/attr_nodes/href_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/href_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
@@ -10,7 +11,7 @@ function appendView(view) {
 }
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 QUnit.module("ember-htmlbars: href attribute", {
   teardown() {

--- a/packages/ember-htmlbars/tests/attr_nodes/property_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/property_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
@@ -16,7 +17,7 @@ function canSetFalsyMaxLength() {
 }
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 QUnit.module("ember-htmlbars: property", {
   teardown() {

--- a/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/sanitized_test.js
@@ -1,5 +1,6 @@
 /* jshint scripturl:true */
 
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import compile from "ember-template-compiler/system/compile";
 import { SafeString } from "ember-htmlbars/utils/string";
@@ -16,7 +17,7 @@ QUnit.module("ember-htmlbars: sanitized attribute", {
 
 // jscs:disable validateIndentation
 // jscs:disable disallowTrailingWhitespace
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 var badTags = [
   { tag: 'a', attr: 'href',

--- a/packages/ember-htmlbars/tests/attr_nodes/style_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/style_test.js
@@ -1,6 +1,7 @@
 /* globals EmberDev */
 
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import compile from "ember-template-compiler/system/compile";
 import { SafeString } from "ember-htmlbars/utils/string";
@@ -27,7 +28,7 @@ QUnit.module("ember-htmlbars: style attribute", {
 });
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 if (!EmberDev.runningProdBuild) {
   QUnit.test('specifying `<div style={{userValue}}></div>` generates a warning', function() {

--- a/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/svg_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
@@ -10,7 +11,7 @@ function appendView(view) {
 }
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 QUnit.module("ember-htmlbars: svg attribute", {
   teardown() {

--- a/packages/ember-htmlbars/tests/attr_nodes/value_test.js
+++ b/packages/ember-htmlbars/tests/attr_nodes/value_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
@@ -9,7 +10,7 @@ function appendView(view) {
 }
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-attribute-syntax')) {
+if (isEnabled('ember-htmlbars-attribute-syntax')) {
 
 QUnit.module("ember-htmlbars: value attribute", {
   teardown() {

--- a/packages/ember-htmlbars/tests/helpers/component_test.js
+++ b/packages/ember-htmlbars/tests/helpers/component_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
 import EmberView from "ember-views/views/view";
@@ -10,7 +11,7 @@ import Component from "ember-views/views/component";
 
 var view, registry, container;
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
+if (isEnabled('ember-htmlbars-component-helper')) {
   QUnit.module("ember-htmlbars: {{#component}} helper", {
     setup() {
       registry = new Registry();

--- a/packages/ember-htmlbars/tests/helpers/each_in_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_in_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import Component from "ember-views/views/component";
 import compile from "ember-template-compiler/system/compile";
 import run from "ember-metal/run_loop";
@@ -23,7 +24,7 @@ function renderTemplate(_template, props) {
   runAppend(component);
 }
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-each-in')) {
+if (isEnabled('ember-htmlbars-each-in')) {
   QUnit.test("it renders the template for each item in a hash", function(assert) {
     let categories = {
       "Smartphones": 8203,

--- a/packages/ember-htmlbars/tests/helpers/get_test.js
+++ b/packages/ember-htmlbars/tests/helpers/get_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import { Registry } from "ember-runtime/system/container";
 import compile from "ember-template-compiler/system/compile";
@@ -7,7 +8,7 @@ import EmberView from "ember-views/views/view";
 var view, registry, container;
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-get-helper')) {
+if (isEnabled('ember-htmlbars-get-helper')) {
 
 QUnit.module("ember-htmlbars: {{get}} helper", {
   setup() {

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import Namespace from 'ember-runtime/system/namespace';
 import { Registry } from "ember-runtime/system/container";
@@ -619,7 +620,7 @@ QUnit.test('edge case: rerender appearance of inner virtual view', function() {
   equal(Ember.$('#qunit-fixture').text(), 'test');
 });
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-inline-if-helper')) {
+if (isEnabled('ember-htmlbars-inline-if-helper')) {
   QUnit.test("`if` helper with inline form: renders the second argument when conditional is truthy", function() {
     view = EmberView.create({
       conditional: true,

--- a/packages/ember-htmlbars/tests/hooks/component_test.js
+++ b/packages/ember-htmlbars/tests/hooks/component_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
 import EmberView from "ember-views/views/view";
@@ -6,7 +7,7 @@ import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 
 var view, registry, container;
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-component-generation')) {
+if (isEnabled('ember-htmlbars-component-generation')) {
   QUnit.module("ember-htmlbars: component hook", {
     setup() {
       registry = new Registry();

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import Registry from "container/registry";
 import jQuery from "ember-views/system/jquery";
@@ -340,7 +341,7 @@ QUnit.test('template specified inline is available from Views looked up as compo
   equal(view.$().text(), 'Whoop, whoop!', 'template inline works properly');
 });
 
-if (Ember.FEATURES.isEnabled('ember-views-component-block-info')) {
+if (isEnabled('ember-views-component-block-info')) {
   QUnit.test('hasBlock is true when block supplied', function() {
     expect(1);
 
@@ -530,7 +531,7 @@ QUnit.test('moduleName is available on _renderNode when no layout is present', f
   runAppend(view);
 });
 
-if (Ember.FEATURES.isEnabled('ember-htmlbars-component-helper')) {
+if (isEnabled('ember-htmlbars-component-helper')) {
   QUnit.test('{{component}} helper works with positional params', function() {
     registry.register('template:components/sample-component', compile('{{attrs.name}}{{attrs.age}}'));
     registry.register('component:sample-component', Component.extend({
@@ -870,7 +871,7 @@ QUnit.test('non-block with each rendering child components', function() {
 });
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-component-generation')) {
+if (isEnabled('ember-htmlbars-component-generation')) {
 
 QUnit.module('component - invocation (angle brackets)', {
   setup() {

--- a/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
+++ b/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberView from "ember-views/views/view";
 import Registry from "container/registry";
 //import jQuery from "ember-views/system/jquery";
@@ -340,7 +341,7 @@ QUnit.test('automatic mutable bindings to constant non-streams tolerate attempts
 
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled('ember-htmlbars-component-generation')) {
+if (isEnabled('ember-htmlbars-component-generation')) {
 
 QUnit.test('mutable bindings work as angle-bracket component attributes', function(assert) {
   var middle;

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -87,61 +87,6 @@ if ('undefined' === typeof Ember.ENV.DISABLE_RANGE_API) {
   Ember.ENV.DISABLE_RANGE_API = true;
 }
 
-/**
-  The hash of enabled Canary features. Add to this, any canary features
-  before creating your application.
-
-  Alternatively (and recommended), you can also define `EmberENV.FEATURES`
-  if you need to enable features flagged at runtime.
-
-  @class FEATURES
-  @namespace Ember
-  @static
-  @since 1.1.0
-  @public
-*/
-Ember.FEATURES = DEFAULT_FEATURES; //jshint ignore:line
-
-if (Ember.ENV.FEATURES) {
-  for (var feature in Ember.ENV.FEATURES) {
-    if (Ember.ENV.FEATURES.hasOwnProperty(feature)) {
-      Ember.FEATURES[feature] = Ember.ENV.FEATURES[feature];
-    }
-  }
-}
-
-/**
-  Determine whether the specified `feature` is enabled. Used by Ember's
-  build tools to exclude experimental features from beta/stable builds.
-
-  You can define the following configuration options:
-
-  * `EmberENV.ENABLE_ALL_FEATURES` - force all features to be enabled.
-  * `EmberENV.ENABLE_OPTIONAL_FEATURES` - enable any features that have not been explicitly
-    enabled/disabled.
-
-  @method isEnabled
-  @param {String} feature The feature to check
-  @return {Boolean}
-  @for Ember.FEATURES
-  @since 1.1.0
-  @public
-*/
-
-Ember.FEATURES.isEnabled = function(feature) {
-  var featureValue = Ember.FEATURES[feature];
-
-  if (Ember.ENV.ENABLE_ALL_FEATURES) {
-    return true;
-  } else if (featureValue === true || featureValue === false || featureValue === undefined) {
-    return featureValue;
-  } else if (Ember.ENV.ENABLE_OPTIONAL_FEATURES) {
-    return true;
-  } else {
-    return false;
-  }
-};
-
 // ..........................................................
 // BOOTSTRAP
 //

--- a/packages/ember-metal/lib/features.js
+++ b/packages/ember-metal/lib/features.js
@@ -1,0 +1,46 @@
+import Ember from 'ember-metal/core';
+/**
+  The hash of enabled Canary features. Add to this, any canary features
+  before creating your application.
+
+  Alternatively (and recommended), you can also define `EmberENV.FEATURES`
+  if you need to enable features flagged at runtime.
+
+  @class FEATURES
+  @namespace Ember
+  @static
+  @since 1.1.0
+  @public
+*/
+export var FEATURES = Ember.ENV.FEATURES || {};
+
+/**
+  Determine whether the specified `feature` is enabled. Used by Ember's
+  build tools to exclude experimental features from beta/stable builds.
+
+  You can define the following configuration options:
+
+  * `EmberENV.ENABLE_ALL_FEATURES` - force all features to be enabled.
+  * `EmberENV.ENABLE_OPTIONAL_FEATURES` - enable any features that have not been explicitly
+    enabled/disabled.
+
+  @method isEnabled
+  @param {String} feature The feature to check
+  @return {Boolean}
+  @for Ember.FEATURES
+  @since 1.1.0
+  @public
+*/
+export default function isEnabled(feature) {
+  var featureValue = FEATURES[feature];
+
+  if (Ember.ENV.ENABLE_ALL_FEATURES) {
+    return true;
+  } else if (featureValue === true || featureValue === false || featureValue === undefined) {
+    return featureValue;
+  } else if (Ember.ENV.ENABLE_OPTIONAL_FEATURES) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/packages/ember-metal/lib/libraries.js
+++ b/packages/ember-metal/lib/libraries.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import {
   forEach,
   indexOf
@@ -67,7 +68,7 @@ Libraries.prototype = {
   }
 };
 
-if (Ember.FEATURES.isEnabled("ember-libraries-isregistered")) {
+if (isEnabled("ember-libraries-isregistered")) {
   Libraries.prototype.isRegistered = function(name) {
     return !!this._getLibraryByName(name);
   };

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -5,6 +5,7 @@
 
 // BEGIN IMPORTS
 import Ember from "ember-metal/core";
+import isEnabled, { FEATURES } from "ember-metal/features";
 import merge from "ember-metal/merge";
 import {
   instrument,
@@ -378,7 +379,7 @@ Ember.isPresent = isPresent;
 
 Ember.merge = merge;
 
-if (Ember.FEATURES.isEnabled('ember-metal-stream')) {
+if (isEnabled('ember-metal-stream')) {
   Ember.stream = {
     Stream: Stream,
 
@@ -394,6 +395,9 @@ if (Ember.FEATURES.isEnabled('ember-metal-stream')) {
     chain: chain
   };
 }
+
+Ember.FEATURES = FEATURES;
+Ember.FEATURES.isEnabled = isEnabled;
 
 /**
   A function may be assigned to `Ember.onerror` to be called when Ember

--- a/packages/ember-metal/lib/properties.js
+++ b/packages/ember-metal/lib/properties.js
@@ -3,6 +3,7 @@
 */
 
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import { meta as metaFor } from "ember-metal/utils";
 import {
   defineProperty as objectDefineProperty,
@@ -105,7 +106,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
   if (desc instanceof Descriptor) {
     value = desc;
 
-    if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+    if (isEnabled('mandatory-setter')) {
       if (watching && hasPropertyAccessors) {
         objectDefineProperty(obj, keyName, {
           configurable: true,
@@ -124,7 +125,7 @@ export function defineProperty(obj, keyName, desc, data, meta) {
     if (desc == null) {
       value = data;
 
-      if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+      if (isEnabled('mandatory-setter')) {
         if (watching && hasPropertyAccessors) {
           meta.values[keyName] = data;
           objectDefineProperty(obj, keyName, {

--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -3,6 +3,7 @@
 */
 
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import EmberError from "ember-metal/error";
 import {
   isGlobal as detectIsGlobal,
@@ -85,7 +86,7 @@ export function get(obj, keyName) {
   if (desc) {
     return desc.get(obj, keyName);
   } else {
-    if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+    if (isEnabled('mandatory-setter')) {
       if (hasPropertyAccessors && meta && meta.watching[keyName] > 0) {
         ret = meta.values[keyName];
       } else {

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import { _getPath as getPath } from "ember-metal/property_get";
 import {
   PROPERTY_DID_CHANGE,
@@ -85,7 +86,7 @@ export function set(obj, keyName, value, tolerant) {
       obj.setUnknownProperty(keyName, value);
     } else if (meta && meta.watching[keyName] > 0) {
       if (meta.proto !== obj) {
-        if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+        if (isEnabled('mandatory-setter')) {
           if (hasPropertyAccessors) {
             currentValue = meta.values[keyName];
           } else {
@@ -98,7 +99,7 @@ export function set(obj, keyName, value, tolerant) {
       // only trigger a change if the value has changed
       if (value !== currentValue) {
         propertyWillChange(obj, keyName);
-        if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+        if (isEnabled('mandatory-setter')) {
           if (hasPropertyAccessors) {
             if (
               (currentValue === undefined && !(keyName in obj)) ||

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -4,6 +4,7 @@
 "REMOVE_USE_STRICT: true";
 
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import o_create from 'ember-metal/platform/create';
 import {
   hasPropertyAccessors,
@@ -324,7 +325,7 @@ if (!canDefineNonEnumerableProperties) {
 // Placeholder for non-writable metas.
 var EMPTY_META = new Meta(null);
 
-if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+if (isEnabled('mandatory-setter')) {
   if (hasPropertyAccessors) {
     EMPTY_META.values = {};
   }
@@ -365,7 +366,7 @@ function meta(obj, writable) {
 
     ret = new Meta(obj);
 
-    if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+    if (isEnabled('mandatory-setter')) {
       if (hasPropertyAccessors) {
         ret.values = {};
       }
@@ -385,7 +386,7 @@ function meta(obj, writable) {
     ret.cacheMeta = undefined;
     ret.source    = obj;
 
-    if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+    if (isEnabled('mandatory-setter')) {
       if (hasPropertyAccessors) {
         ret.values = o_create(ret.values);
       }

--- a/packages/ember-metal/lib/watch_key.js
+++ b/packages/ember-metal/lib/watch_key.js
@@ -1,4 +1,4 @@
-import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import {
   meta as metaFor,
   isArray
@@ -31,7 +31,7 @@ export function watchKey(obj, keyName, meta) {
       obj.willWatchProperty(keyName);
     }
 
-    if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+    if (isEnabled('mandatory-setter')) {
       if (hasPropertyAccessors) {
         handleMandatorySetter(m, obj, keyName);
       }
@@ -42,7 +42,7 @@ export function watchKey(obj, keyName, meta) {
 }
 
 
-if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+if (isEnabled('mandatory-setter')) {
   var handleMandatorySetter = function handleMandatorySetter(m, obj, keyName) {
     var descriptor = Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor(obj, keyName);
     var configurable = descriptor ? descriptor.configurable : true;
@@ -85,7 +85,7 @@ export function unwatchKey(obj, keyName, meta) {
       obj.didUnwatchProperty(keyName);
     }
 
-    if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+    if (isEnabled('mandatory-setter')) {
       if (!desc && hasPropertyAccessors && keyName in obj) {
         o_defineProperty(obj, keyName, {
           configurable: true,

--- a/packages/ember-metal/tests/accessors/mandatory_setters_test.js
+++ b/packages/ember-metal/tests/accessors/mandatory_setters_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import { watch } from "ember-metal/watching";
@@ -16,7 +17,7 @@ function hasMandatorySetter(object, property) {
   return property in meta.values;
 }
 
-if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+if (isEnabled('mandatory-setter')) {
   if (hasPropertyAccessors) {
     QUnit.test('does not assert if property is not being watched', function() {
       var obj = {

--- a/packages/ember-metal/tests/features_test.js
+++ b/packages/ember-metal/tests/features_test.js
@@ -1,26 +1,31 @@
 import Ember from 'ember-metal/core';
+import isEnabled, { FEATURES } from 'ember-metal/features';
+import merge from "ember-metal/merge";
 
-var isEnabled = Ember.FEATURES.isEnabled;
 var origFeatures, origEnableAll, origEnableOptional;
 
-QUnit.module("Ember.FEATURES.isEnabled", {
+QUnit.module("isEnabled", {
   setup() {
-    origFeatures       = Ember.FEATURES;
-    origEnableAll      = Ember.ENV.ENABLE_ALL_FEATURES;
+    origFeatures = merge({}, FEATURES);
+    origEnableAll = Ember.ENV.ENABLE_ALL_FEATURES;
     origEnableOptional = Ember.ENV.ENABLE_OPTIONAL_FEATURES;
   },
 
   teardown() {
-    Ember.FEATURES                     = origFeatures;
-    Ember.ENV.ENABLE_ALL_FEATURES      = origEnableAll;
+    for (var feature in FEATURES) {
+      delete FEATURES[feature];
+    }
+    merge(FEATURES, origFeatures);
+
+    Ember.ENV.ENABLE_ALL_FEATURES = origEnableAll;
     Ember.ENV.ENABLE_OPTIONAL_FEATURES = origEnableOptional;
   }
 });
 
 QUnit.test("ENV.ENABLE_ALL_FEATURES", function() {
   Ember.ENV.ENABLE_ALL_FEATURES = true;
-  Ember.FEATURES['fred'] = false;
-  Ember.FEATURES['wilma'] = null;
+  FEATURES['fred'] = false;
+  FEATURES['wilma'] = null;
 
   equal(isEnabled('fred'), true, "overrides features set to false");
   equal(isEnabled('wilma'), true, "enables optional features");
@@ -29,9 +34,9 @@ QUnit.test("ENV.ENABLE_ALL_FEATURES", function() {
 
 QUnit.test("ENV.ENABLE_OPTIONAL_FEATURES", function() {
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = true;
-  Ember.FEATURES['fred'] = false;
-  Ember.FEATURES['barney'] = true;
-  Ember.FEATURES['wilma'] = null;
+  FEATURES['fred'] = false;
+  FEATURES['barney'] = true;
+  FEATURES['wilma'] = null;
 
   equal(isEnabled('fred'), false, "returns flag value if false");
   equal(isEnabled('barney'), true, "returns flag value if true");
@@ -43,9 +48,9 @@ QUnit.test("isEnabled without ENV options", function() {
   Ember.ENV.ENABLE_ALL_FEATURES = false;
   Ember.ENV.ENABLE_OPTIONAL_FEATURES = false;
 
-  Ember.FEATURES['fred'] = false;
-  Ember.FEATURES['barney'] = true;
-  Ember.FEATURES['wilma'] = null;
+  FEATURES['fred'] = false;
+  FEATURES['barney'] = true;
+  FEATURES['wilma'] = null;
 
   equal(isEnabled('fred'), false, "returns flag value if false");
   equal(isEnabled('barney'), true, "returns flag value if true");

--- a/packages/ember-metal/tests/libraries_test.js
+++ b/packages/ember-metal/tests/libraries_test.js
@@ -1,4 +1,5 @@
 /* globals EmberDev */
+import isEnabled from "ember-metal/features";
 import Libraries from "ember-metal/libraries";
 
 var libs, registry;
@@ -36,7 +37,7 @@ QUnit.test('only the first registration of a library is stored', function() {
   equal(registry.length, 1);
 });
 
-if (Ember.FEATURES.isEnabled('ember-libraries-isregistered')) {
+if (isEnabled('ember-libraries-isregistered')) {
   QUnit.test('isRegistered returns correct value', function() {
     expect(3);
 

--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -3,6 +3,7 @@
 @submodule ember-htmlbars
 */
 
+import isEnabled from "ember-metal/features";
 import { keyword } from "htmlbars-runtime/hooks";
 import closureAction from "ember-routing-htmlbars/keywords/closure-action";
 
@@ -168,7 +169,7 @@ import closureAction from "ember-routing-htmlbars/keywords/closure-action";
   @public
 */
 export default function(morph, env, scope, params, hash, template, inverse, visitor) {
-  if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+  if (isEnabled("ember-routing-htmlbars-improved-actions")) {
     if (morph) {
       keyword('@element_action', morph, env, scope, params, hash, template, inverse, visitor);
       return true;

--- a/packages/ember-routing-htmlbars/lib/keywords/element-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/element-action.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core"; // assert
+import isEnabled from "ember-metal/features";
 import { uuid } from "ember-metal/utils";
 import run from "ember-metal/run_loop";
 import { readUnwrappedModel } from "ember-views/streams/utils";
@@ -18,7 +19,7 @@ export default {
 
     var actionName = read(params[0]);
 
-    if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+    if (isEnabled("ember-routing-htmlbars-improved-actions")) {
       assert("You specified a quoteless path to the {{action}} helper " +
              "which did not resolve to an action name (a string). " +
              "Perhaps you meant to use a quoted actionName? (e.g. {{action 'save'}}).",
@@ -105,7 +106,7 @@ ActionHelper.registerAction = function({ actionId, node, eventName, preventDefau
       let { target, actionName, actionArgs } = node.state;
 
       run(function runRegisteredAction() {
-        if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+        if (isEnabled("ember-routing-htmlbars-improved-actions")) {
           if (typeof actionName === 'function') {
             actionName.apply(target, actionArgs);
             return;

--- a/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/closure_action_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import compile from "ember-template-compiler/system/compile";
 import EmberComponent from "ember-views/views/component";
@@ -10,7 +11,7 @@ import {
 
 var innerComponent, outerComponent;
 
-if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+if (isEnabled("ember-routing-htmlbars-improved-actions")) {
 
   QUnit.module("ember-routing-htmlbars: action helper", {
     setup() {

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember-metal/core'; // A, FEATURES, assert
+import isEnabled from "ember-metal/features";
 import { set } from "ember-metal/property_set";
 import run from "ember-metal/run_loop";
 import EventDispatcher from "ember-views/system/event_dispatcher";
@@ -1000,7 +1001,7 @@ QUnit.test("a quoteless string parameter should resolve actionName, including pa
   deepEqual(actionOrder, ['whompWhomp', 'sloopyDookie', 'biggityBoom'], 'action name was looked up properly');
 });
 
-if (Ember.FEATURES.isEnabled("ember-routing-htmlbars-improved-actions")) {
+if (isEnabled("ember-routing-htmlbars-improved-actions")) {
 
   QUnit.test("a quoteless function parameter should be called, including arguments", function() {
     expect(2);

--- a/packages/ember-routing-views/lib/main.js
+++ b/packages/ember-routing-views/lib/main.js
@@ -4,6 +4,7 @@
 */
 
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import LinkView from "ember-routing-views/views/link";
 import {
   OutletView,
@@ -12,7 +13,7 @@ import {
 
 Ember.LinkView = LinkView;
 Ember.OutletView = OutletView;
-if (Ember.FEATURES.isEnabled('ember-routing-core-outlet')) {
+if (isEnabled('ember-routing-core-outlet')) {
   Ember.CoreOutletView = CoreOutletView;
 }
 

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -4,6 +4,7 @@
 */
 
 import Ember from "ember-metal/core"; // FEATURES, Logger, assert
+import isEnabled from "ember-metal/features";
 
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
@@ -17,7 +18,7 @@ import linkToTemplate from "ember-htmlbars/templates/link-to";
 linkToTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
 var linkViewClassNameBindings = ['active', 'loading', 'disabled'];
-if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
+if (isEnabled('ember-routing-transitioning-classes')) {
   linkViewClassNameBindings = ['active', 'loading', 'disabled', 'transitioningIn', 'transitioningOut'];
 }
 

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core"; // FEATURES, assert
+import isEnabled from "ember-metal/features";
 import { indexOf } from "ember-metal/array";
 
 /**
@@ -35,7 +36,7 @@ DSL.prototype = {
       })()
     );
 
-    if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
+    if (isEnabled("ember-routing-named-substates")) {
       if (this.enableLoadingSubstates) {
         createRoute(this, `${name}_loading`, { resetNamespace: options.resetNamespace });
         createRoute(this, `${name}_error`, { path: dummyErrorRoute });

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core"; // FEATURES, A, deprecate, assert, Logger
+import isEnabled from "ember-metal/features";
 import EmberError from "ember-metal/error";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
@@ -119,7 +120,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       var normalizedControllerQueryParameterConfiguration = normalizeControllerQueryParams(controllerDefinedQueryParameterConfiguration);
       combinedQueryParameterConfiguration = mergeEachQueryParams(normalizedControllerQueryParameterConfiguration, queryParameterConfiguraton);
 
-      if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+      if (isEnabled('ember-routing-route-configured-query-params')) {
         if (controllerDefinedQueryParameterConfiguration.length) {
           Ember.deprecate(`Configuring query parameters on a controller is deprecated. Migrate the query parameters configuration from the '${controllerName}' controller to the '${this.routeName}' route: ${combinedQueryParameterConfiguration}`);
         }
@@ -150,7 +151,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
       var desc = combinedQueryParameterConfiguration[propName];
 
-      if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+      if (isEnabled('ember-routing-route-configured-query-params')) {
         // apply default values to controllers
         // detect that default value defined on router config
         if (desc.hasOwnProperty('defaultValue')) {
@@ -2214,7 +2215,7 @@ function mergeEachQueryParams(controllerQP, routeQP) {
   var keysAlreadyMergedOrSkippable;
   var qps = {};
 
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     keysAlreadyMergedOrSkippable = {};
   } else {
     keysAlreadyMergedOrSkippable = {

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core"; // FEATURES, Logger, assert
+import isEnabled from "ember-metal/features";
 import EmberError from "ember-metal/error";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
@@ -522,7 +523,7 @@ var EmberRouter = EmberObject.extend(Evented, {
       emberRouter.didTransition(infos);
     };
 
-    if (Ember.FEATURES.isEnabled('ember-router-willtransition')) {
+    if (isEnabled('ember-router-willtransition')) {
       router.willTransition = function(oldInfos, newInfos, transition) {
         emberRouter.willTransition(oldInfos, newInfos, transition);
       };
@@ -814,7 +815,7 @@ function findChildRouteName(parentRoute, originatingChildRoute, name) {
   var targetChildRouteName = originatingChildRoute.routeName.split('.').pop();
   var namespace = parentRoute.routeName === 'application' ? '' : parentRoute.routeName + '.';
 
-  if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
+  if (isEnabled("ember-routing-named-substates")) {
     // First, try a named loading state, e.g. 'foo_loading'
     childName = namespace + targetChildRouteName + '_' + name;
     if (routeHasBeenDefined(router, childName)) {

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import EmberRouter from "ember-routing/system/router";
 import { forEach } from "ember-metal/enumerable_utils";
 
@@ -79,7 +80,7 @@ QUnit.test("should retain resource namespace if nested with routes", function() 
 });
 
 // jscs:disable validateIndentation
-if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
+if (isEnabled("ember-routing-named-substates")) {
 
 QUnit.test("should add loading and error routes if _isRouterMapResult is true", function() {
   Router.map(function() {

--- a/packages/ember-runtime/lib/ext/string.js
+++ b/packages/ember-runtime/lib/ext/string.js
@@ -3,7 +3,7 @@
 @submodule ember-runtime
 */
 
-import Ember from 'ember-metal/core'; // Ember.EXTEND_PROTOTYPES, Ember.assert, Ember.FEATURES
+import Ember from 'ember-metal/core'; // Ember.EXTEND_PROTOTYPES, Ember.assert
 import {
   fmt,
   w,

--- a/packages/ember-runtime/lib/mixins/deferred.js
+++ b/packages/ember-runtime/lib/mixins/deferred.js
@@ -1,4 +1,4 @@
-import Ember from "ember-metal/core"; // Ember.FEATURES, Ember.Test
+import Ember from "ember-metal/core"; // Ember.Test
 import { get } from "ember-metal/property_get";
 import { Mixin } from "ember-metal/mixin";
 import { computed } from "ember-metal/computed";

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -11,6 +11,7 @@
 // using ember-metal/lib/main here to ensure that ember-debug is setup
 // if present
 import Ember from "ember-metal";
+import isEnabled from "ember-metal/features";
 import merge from "ember-metal/merge";
 // Ember.assert, Ember.config
 
@@ -157,7 +158,7 @@ function makeCtor() {
             if (typeof this.setUnknownProperty === 'function' && !(keyName in this)) {
               this.setUnknownProperty(keyName, value);
             } else {
-              if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+              if (isEnabled('mandatory-setter')) {
                 if (hasPropertyAccessors) {
                   defineProperty(this, keyName, null, value); // setup mandatory setter
                 } else {

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -2,7 +2,7 @@
 @module ember
 @submodule ember-runtime
 */
-import Ember from "ember-metal/core"; // Ember.STRINGS, Ember.FEATURES
+import Ember from "ember-metal/core"; // Ember.STRINGS
 import {
   inspect as emberInspect
 } from "ember-metal/utils";

--- a/packages/ember-runtime/tests/system/object/create_test.js
+++ b/packages/ember-runtime/tests/system/object/create_test.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import {get} from "ember-metal/property_get";
 import {set} from "ember-metal/property_set";
 import {guidFor} from "ember-metal/utils";
@@ -45,7 +46,7 @@ QUnit.test("calls computed property setters", function() {
   equal(o.get('foo'), 'bar');
 });
 
-if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+if (isEnabled('mandatory-setter')) {
   QUnit.test("sets up mandatory setters for watched simple properties", function() {
 
     var MyClass = EmberObject.extend({

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -1,3 +1,4 @@
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import { hasPropertyAccessors } from "ember-metal/platform/define_property";
 import { observer } from "ember-metal/mixin";
@@ -30,7 +31,7 @@ testBoth("should schedule objects to be destroyed at the end of the run loop", f
   ok(get(obj, 'isDestroyed'), "object is destroyed after run loop finishes");
 });
 
-if (Ember.FEATURES.isEnabled('mandatory-setter')) {
+if (isEnabled('mandatory-setter')) {
   if (hasPropertyAccessors) {
     // MANDATORY_SETTER moves value to meta.values
     // a destroyed object removes meta but leaves the accessor

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -1,4 +1,4 @@
-import _Ember from "ember-metal/core";
+import _Ember from "ember-metal";
 import precompile from "ember-template-compiler/system/precompile";
 import compile from "ember-template-compiler/system/compile";
 import template from "ember-template-compiler/system/template";

--- a/packages/ember-template-compiler/lib/system/compile_options.js
+++ b/packages/ember-template-compiler/lib/system/compile_options.js
@@ -3,7 +3,7 @@
 @submodule ember-template-compiler
 */
 
-import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import { assign } from "ember-metal/merge";
 import defaultPlugins from "ember-template-compiler/plugins";
 
@@ -13,7 +13,7 @@ import defaultPlugins from "ember-template-compiler/plugins";
 */
 export default function(_options) {
   var disableComponentGeneration = true;
-  if (Ember.FEATURES.isEnabled('ember-htmlbars-component-generation')) {
+  if (isEnabled('ember-htmlbars-component-generation')) {
     disableComponentGeneration = false;
   }
 

--- a/packages/ember-testing/lib/helpers.js
+++ b/packages/ember-testing/lib/helpers.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import { get } from "ember-metal/property_get";
 import EmberError from "ember-metal/error";
 import run from "ember-metal/run_loop";
@@ -278,7 +279,7 @@ asyncHelper('visit', visit);
 */
 asyncHelper('click', click);
 
-if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
+if (isEnabled('ember-testing-checkbox-helpers')) {
   /**
     Checks a checkbox. Ensures the presence of the `checked` attribute
 

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -1,4 +1,5 @@
 import Ember from "ember-metal/core";
+import isEnabled from "ember-metal/features";
 import run from "ember-metal/run_loop";
 import EmberObject from "ember-runtime/system/object";
 import RSVP from "ember-runtime/ext/rsvp";
@@ -58,7 +59,7 @@ function assertHelpers(application, helperContainer, expected) {
   checkHelperPresent('wait', expected);
   checkHelperPresent('triggerEvent', expected);
 
-  if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
+  if (isEnabled('ember-testing-checkbox-helpers')) {
     checkHelperPresent('check', expected);
     checkHelperPresent('uncheck', expected);
   }
@@ -581,7 +582,7 @@ QUnit.test("`fillIn` focuses on the element", function() {
   });
 });
 
-if (Ember.FEATURES.isEnabled('ember-testing-checkbox-helpers')) {
+if (isEnabled('ember-testing-checkbox-helpers')) {
   QUnit.test("`check` ensures checkboxes are `checked` state for checkboxes", function() {
     expect(2);
     var check, find, visit, andThen;

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -279,24 +279,3 @@ QUnit.test('component with target', function() {
 
   appComponent.send('foo', 'baz');
 });
-
-if (Ember.FEATURES.isEnabled('ember-views-component-has-block')) {
-  QUnit.test('component with a template will report hasBlock: true', function() {
-    expect(1);
-
-    var appComponent = Component.create({
-      template: 'some-thing-yolo'
-    });
-
-    equal(get(appComponent, 'hasBlock'), true);
-  });
-
-  QUnit.test('component without a template will report hasBlock: false', function() {
-    expect(1);
-
-    var appComponent = Component.create({
-    });
-
-    equal(get(appComponent, 'hasBlock'), false);
-  });
-}

--- a/packages/ember/tests/global-api-test.js
+++ b/packages/ember/tests/global-api-test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 
 QUnit.module("Global API Tests");
 
@@ -10,7 +11,7 @@ function confirmExport(property) {
 
 confirmExport('Ember.DefaultResolver');
 confirmExport('Ember.generateController');
-if (Ember.FEATURES.isEnabled('ember-htmlbars-helper')) {
+if (isEnabled('ember-htmlbars-helper')) {
   confirmExport('Ember.Helper');
   confirmExport('Ember.Helper.helper');
 }

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 
 import { objectControllerDeprecation } from "ember-runtime/controllers/object_controller";
 import EmberHandlebars from "ember-htmlbars/compat";
@@ -621,7 +622,7 @@ QUnit.test("Issue 4201 - Shorthand for route.index shouldn't throw errors about 
 
 QUnit.test("The {{link-to}} helper unwraps controllers", function() {
 
-  if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
+  if (isEnabled('ember-routing-transitioning-classes')) {
     expect(5);
   } else {
     expect(6);
@@ -1215,7 +1216,7 @@ QUnit.test("{{link-to}} active property respects changing parent route context",
 
 
 QUnit.test("{{link-to}} populates href with default query param values even without query-params object", function() {
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Ember.Route.extend({
       queryParams: {
         foo: {
@@ -1236,7 +1237,7 @@ QUnit.test("{{link-to}} populates href with default query param values even with
 });
 
 QUnit.test("{{link-to}} populates href with default query param values with empty query-params object", function() {
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Ember.Route.extend({
       queryParams: {
         foo: {
@@ -1257,7 +1258,7 @@ QUnit.test("{{link-to}} populates href with default query param values with empt
 });
 
 QUnit.test("{{link-to}} populates href with supplied query param values", function() {
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Ember.Route.extend({
       queryParams: {
         foo: {
@@ -1278,7 +1279,7 @@ QUnit.test("{{link-to}} populates href with supplied query param values", functi
 });
 
 QUnit.test("{{link-to}} populates href with partially supplied query param values", function() {
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Ember.Route.extend({
       queryParams: {
         foo: {
@@ -1303,7 +1304,7 @@ QUnit.test("{{link-to}} populates href with partially supplied query param value
 });
 
 QUnit.test("{{link-to}} populates href with partially supplied query param values, but omits if value is default value", function() {
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Ember.Route.extend({
       queryParams: {
         foo: {
@@ -1324,7 +1325,7 @@ QUnit.test("{{link-to}} populates href with partially supplied query param value
 });
 
 QUnit.test("{{link-to}} populates href with fully supplied query param values", function() {
-  if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+  if (isEnabled('ember-routing-route-configured-query-params')) {
     App.IndexRoute = Ember.Route.extend({
       queryParams: {
         foo: {

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -72,7 +73,7 @@ function sharedTeardown() {
   Ember.run(function() { App.destroy(); });
   Ember.TEMPLATES = {};
 }
-if (Ember.FEATURES.isEnabled('ember-routing-transitioning-classes')) {
+if (isEnabled('ember-routing-transitioning-classes')) {
   QUnit.module("The {{link-to}} helper: .transitioning-in .transitioning-out CSS classes", {
     setup() {
       Ember.run(function() {

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -61,7 +62,7 @@ function sharedTeardown() {
   Ember.TEMPLATES = {};
 }
 
-if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.module("The {{link-to}} helper: invoking with query params when defined on a route", {
     setup() {
       Ember.run(function() {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 import { forEach } from "ember-metal/enumerable_utils";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
@@ -2733,7 +2734,7 @@ QUnit.test("Route silently fails when cleaning an outlet from an inactive view",
   Ember.run(function() { router.send('hideModal'); });
 });
 
-if (Ember.FEATURES.isEnabled('ember-router-willtransition')) {
+if (isEnabled('ember-router-willtransition')) {
   QUnit.test("Router `willTransition` hook passes in cancellable transition", function() {
     // Should hit willTransition 3 times, once for the initial route, and then 2 more times
     // for the two handleURL calls below

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 import { computed } from "ember-metal/computed";
 import { canDefineNonEnumerableProperties } from 'ember-metal/platform/define_property';
 
@@ -119,7 +120,7 @@ QUnit.module("Routing with Query Params", {
   }
 });
 
-if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+if (isEnabled('ember-routing-route-configured-query-params')) {
 
   QUnit.test("Single query params can be set on the route", function() {
     Router.map(function() {

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 import { canDefineNonEnumerableProperties } from 'ember-metal/platform/define_property';
 
 import EmberHandlebars from "ember-htmlbars/compat";
@@ -107,7 +108,7 @@ function sharedTeardown() {
   });
 }
 
-if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.module("Model Dep Query Params with Route-based configuration", {
     setup() {
       sharedSetup();

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -86,7 +87,7 @@ function sharedTeardown() {
 }
 
 
-if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.module("Query Params - overlapping query param property names when configured on the route", {
     setup() {
       sharedSetup();

--- a/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
+++ b/packages/ember/tests/routing/query_params_test/query_params_paramless_link_to_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 import { capitalize } from "ember-runtime/system/string";
 
 import EmberHandlebars from "ember-htmlbars/compat";
@@ -132,7 +133,7 @@ var testParamlessLinksWithRouteConfig = function(routeName) {
   });
 };
 
-if (Ember.FEATURES.isEnabled('ember-routing-route-configured-query-params')) {
+if (isEnabled('ember-routing-route-configured-query-params')) {
   testParamlessLinksWithRouteConfig('application');
   testParamlessLinksWithRouteConfig('index');
 } else {

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -1,4 +1,5 @@
 import "ember";
+import isEnabled from "ember-metal/features";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -418,7 +419,7 @@ QUnit.test("Default error event moves into nested route", function() {
   equal(appController.get('currentPath'), 'grandma.error', "Initial route fully loaded");
 });
 
-if (Ember.FEATURES.isEnabled("ember-routing-named-substates")) {
+if (isEnabled("ember-routing-named-substates")) {
 
   QUnit.test("Slow promises returned from ApplicationRoute#model enter ApplicationLoadingRoute if present", function() {
 


### PR DESCRIPTION
Instead of

``` js
import Ember from 'ember';

if (Ember.FEATURES.isEnabled('my-feature)) { ... }
```

you must now use modules:

``` js
import isEnabled from 'ember-metal/features';

if (isEnabled('my-feature')) { ... }
```
