### PR TITLE
Update {{each-in}} to use ember-metal/should-display

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/each-in.js
+++ b/packages/ember-htmlbars/lib/helpers/each-in.js
@@ -1,18 +1,14 @@
 import isEnabled from "ember-metal/features";
+import keys from "ember-metal/keys";
+import shouldDisplay from "ember-views/streams/should_display";
 
 if (isEnabled('ember-htmlbars-each-in')) {
-  var shouldDisplay = function(object) {
-    if (object === undefined || object === null) {
-      return false;
-    }
-
-    return true;
-  };
-
   var eachInHelper = function([ object ], hash, blocks) {
-    if (shouldDisplay(object)) {
-      for (var prop in object) {
-        if (!object.hasOwnProperty(prop)) { continue; }
+    var objKeys, prop, i;
+    objKeys = object ? keys(object) : [];
+    if (shouldDisplay(objKeys)) {
+      for (i = 0; i < objKeys.length; i++) {
+        prop = objKeys[i];
         blocks.template.yieldItem(prop, [prop, object[prop]]);
       }
     } else if (blocks.inverse.yield) {


### PR DESCRIPTION
This closes #11370 

Instead of extending `shouldDisplay` to handle objects probably I decided to pass the array with the keys of the object to it. It's more efficient, but I am under the assumption that an empty object must be considered falsey in the context of this helper.

I might have discovered a bug in the helper but that's a story for another PR
