### PR TITLE
[BUGFIX beta] Change the Ember.View global to have a deprecation warning on init

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -389,7 +389,7 @@ QUnit.test('should update the block when object passed to #if helper changes and
 QUnit.test('views within an if statement should be sane on re-render', function() {
   view = EmberView.create({
     template: compile('{{#if view.display}}{{view view.MyView}}{{/if}}'),
-    MyView: Ember.View.extend({
+    MyView: EmberView.extend({
       tagName: 'input'
     }),
     display: false

--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -20,7 +20,7 @@ import {
 
 import Renderer from 'ember-metal-views/renderer';
 import { DeprecatedCoreView } from "ember-views/views/core_view";
-import View from "ember-views/views/view";
+import { DeprecatedView } from "ember-views/views/view";
 import ContainerView from "ember-views/views/container_view";
 import CollectionView from "ember-views/views/collection_view";
 import Component from "ember-views/views/component";
@@ -63,7 +63,7 @@ ViewUtils.getViewClientRects = getViewClientRects;
 ViewUtils.getViewBoundingClientRect = getViewBoundingClientRect;
 
 Ember.CoreView = DeprecatedCoreView;
-Ember.View = View;
+Ember.View = DeprecatedView;
 Ember.View.states = states;
 Ember.View.cloneStates = cloneStates;
 Ember.View._Renderer = Renderer;

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -659,6 +659,7 @@ Ember.TEMPLATES = {};
   @class View
   @namespace Ember
   @extends Ember.CoreView
+  @deprecated See http://emberjs.com/deprecations/v1.x/#toc_ember-view
   @uses Ember.ViewContextSupport
   @uses Ember.ViewChildViewsSupport
   @uses Ember.TemplateRenderingSupport
@@ -1542,7 +1543,13 @@ View.views = {};
 // method.
 View.childViewsProperty = childViewsProperty;
 
+var DeprecatedView = View.extend({
+  init() {
+    this._super(...arguments);
+    Ember.deprecate(`Ember.View is deprecated. Consult the Deprecations Guide for a migration strategy.`, !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT, { url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view' });
+  }
+});
 
 export default View;
 
-export { ViewContextSupport, ViewChildViewsSupport, ViewStateSupport, TemplateRenderingSupport, ClassNamesSupport };
+export { ViewContextSupport, ViewChildViewsSupport, ViewStateSupport, TemplateRenderingSupport, ClassNamesSupport, DeprecatedView };

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -478,7 +478,7 @@ QUnit.test("should allow items to access to the CollectionView's current index i
 });
 
 QUnit.test("should allow declaration of itemViewClass as a string", function() {
-  registry.register('view:simple-view', Ember.View.extend());
+  registry.register('view:simple-view', View.extend());
 
   view = CollectionView.create({
     container: registry.container(),

--- a/packages/ember-views/tests/views/exports_test.js
+++ b/packages/ember-views/tests/views/exports_test.js
@@ -1,9 +1,32 @@
 import Ember from "ember-views";
 
-QUnit.module("ember-view exports");
+let originalSupport;
 
-QUnit.test("should export a disabled CoreView", function() {
+QUnit.module("ember-view exports", {
+  setup() {
+    originalSupport = Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT;
+  },
+  teardown() {
+    Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT = originalSupport;
+  }
+});
+
+QUnit.test("should export a deprecated CoreView", function() {
   expectDeprecation(function() {
     Ember.CoreView.create();
   }, 'Ember.CoreView is deprecated. Please use Ember.View.');
+});
+
+QUnit.test("should export a deprecated View", function() {
+  expectDeprecation(function() {
+    Ember.View.create();
+  }, /Ember.View is deprecated/);
+});
+
+QUnit.test("when legacy view support is enabled, Ember.View does not have deprecation", function() {
+  Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT = true;
+
+  expectNoDeprecation(function() {
+    Ember.View.create();
+  });
 });

--- a/packages/ember/tests/controller_test.js
+++ b/packages/ember/tests/controller_test.js
@@ -1,5 +1,6 @@
 import "ember";
 import EmberHandlebars from "ember-htmlbars/compat";
+import EmberView from "ember-views/views/view";
 
 /*
  In Ember 1.x, controllers subtly affect things like template scope
@@ -78,7 +79,7 @@ QUnit.test('the controller property is provided to route driven views', function
     }
   });
 
-  App.ApplicationView = Ember.View.extend({
+  App.ApplicationView = EmberView.extend({
     init: function() {
       this._super(...arguments);
       applicationViewController = this.get('controller');

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -3,6 +3,7 @@ import isEnabled from "ember-metal/features";
 
 import { objectControllerDeprecation } from "ember-runtime/controllers/object_controller";
 import EmberHandlebars from "ember-htmlbars/compat";
+import EmberView from "ember-views/views/view";
 
 var compile = EmberHandlebars.compile;
 
@@ -78,7 +79,7 @@ QUnit.module("The {{link-to}} helper", {
       Ember.TEMPLATES.about = compile("<h3>About</h3>{{#link-to 'index' id='home-link'}}Home{{/link-to}}{{#link-to 'about' id='self-link'}}Self{{/link-to}}");
       Ember.TEMPLATES.item = compile("<h3>Item</h3><p>{{model.name}}</p>{{#link-to 'index' id='home-link'}}Home{{/link-to}}");
 
-      AppView = Ember.View.extend({
+      AppView = EmberView.extend({
         templateName: 'app'
       });
 
@@ -664,7 +665,7 @@ QUnit.test("The {{link-to}} helper unwraps controllers", function() {
 });
 
 QUnit.test("The {{link-to}} helper doesn't change view context", function() {
-  App.IndexView = Ember.View.extend({
+  App.IndexView = EmberView.extend({
     elementId: 'index',
     name: 'test',
     isTrue: true
@@ -690,7 +691,7 @@ QUnit.test("Quoteless route param performs property lookup", function() {
     equal(normalizeUrl(Ember.$('#view-link', '#qunit-fixture').attr('href')), href);
   }
 
-  App.IndexView = Ember.View.extend({
+  App.IndexView = EmberView.extend({
     foo: 'index',
     elementId: 'index-view'
   });
@@ -710,7 +711,7 @@ QUnit.test("Quoteless route param performs property lookup", function() {
   assertEquality('/');
 
   var controller = container.lookup('controller:index');
-  var view = Ember.View.views['index-view'];
+  var view = EmberView.views['index-view'];
   Ember.run(function() {
     controller.set('foo', 'about');
     view.set('foo', 'about');
@@ -1076,7 +1077,7 @@ QUnit.test("The non-block form {{link-to}} performs property lookup", function()
     equal(normalizeUrl(Ember.$('#view-link', '#qunit-fixture').attr('href')), href);
   }
 
-  App.IndexView = Ember.View.extend({
+  App.IndexView = EmberView.extend({
     foo: 'index',
     elementId: 'index-view'
   });
@@ -1096,7 +1097,7 @@ QUnit.test("The non-block form {{link-to}} performs property lookup", function()
   assertEquality('/');
 
   var controller = container.lookup('controller:index');
-  var view = Ember.View.views['index-view'];
+  var view = EmberView.views['index-view'];
   Ember.run(function() {
     controller.set('foo', 'about');
     view.set('foo', 'about');

--- a/packages/ember/tests/integration/view_test.js
+++ b/packages/ember/tests/integration/view_test.js
@@ -1,5 +1,6 @@
 import compile from "ember-template-compiler/system/compile";
 import run from "ember-metal/run_loop";
+import EmberView from "ember-views/views/view";
 
 var App, registry;
 
@@ -49,7 +50,7 @@ QUnit.test("invoking `{{view}} from a non-view backed (aka only template) templa
 
   Ember.TEMPLATES.index = compile('{{view "my-foo"}}', { moduleName: 'my-foo' });
 
-  registry.register('view:my-foo', Ember.View.extend({
+  registry.register('view:my-foo', EmberView.extend({
     init() {
       this._super(...arguments);
 

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -4,6 +4,7 @@ import { forEach } from "ember-metal/enumerable_utils";
 import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
 import ActionManager from "ember-views/system/action_manager";
+import EmberView from "ember-views/views/view";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -316,7 +317,7 @@ QUnit.test("Renders correct view with slash notation", function() {
     }
   });
 
-  App.HomePageView = Ember.View.extend({
+  App.HomePageView = EmberView.extend({
     name: "Home/Page"
   });
 
@@ -338,7 +339,7 @@ QUnit.test("Renders the view given in the view option", function() {
     }
   });
 
-  App.HomePageView = Ember.View.extend({
+  App.HomePageView = EmberView.extend({
     name: "Home/Page"
   });
 
@@ -356,7 +357,7 @@ QUnit.test('render does not replace templateName if user provided', function() {
     "<p>THIS IS THE REAL HOME</p>"
   );
 
-  App.HomeView = Ember.View.extend({
+  App.HomeView = EmberView.extend({
     templateName: 'the_real_home_template'
   });
   App.HomeController = Ember.Controller.extend();
@@ -372,7 +373,7 @@ QUnit.test('render does not replace template if user provided', function () {
     this.route("home", { path: "/" });
   });
 
-  App.HomeView = Ember.View.extend({
+  App.HomeView = EmberView.extend({
     template: compile("<p>THIS IS THE REAL HOME</p>")
   });
   App.HomeController = Ember.Controller.extend();
@@ -459,7 +460,7 @@ QUnit.test('Specifying a name to render should have precedence over everything e
     }
   });
 
-  App.HomeView = Ember.View.extend({
+  App.HomeView = EmberView.extend({
     template: compile("<h3>This should not be rendered</h3><p>{{model.home}}</p>")
   });
 
@@ -468,7 +469,7 @@ QUnit.test('Specifying a name to render should have precedence over everything e
       home: 'Tinytroll'
     }
   });
-  App.HomepageView = Ember.View.extend({
+  App.HomepageView = EmberView.extend({
     layout: compile(
       "<span>Outer</span>{{yield}}<span>troll</span>"
     ),
@@ -2182,13 +2183,13 @@ QUnit.test("Only use route rendered into main outlet for default into property o
     this.resource("posts", function() {});
   });
 
-  App.PostsMenuView = Ember.View.extend({
+  App.PostsMenuView = EmberView.extend({
     tagName: 'div',
     templateName: 'posts/menu',
     classNames: ['posts-menu']
   });
 
-  App.PostsIndexView = Ember.View.extend({
+  App.PostsIndexView = EmberView.extend({
     tagName: 'p',
     classNames: ['posts-index']
   });
@@ -2335,7 +2336,7 @@ QUnit.test("The template is not re-rendered when the route's context changes", f
   });
 
   var insertionCount = 0;
-  App.PageView = Ember.View.extend({
+  App.PageView = EmberView.extend({
     didInsertElement() {
       insertionCount += 1;
     }
@@ -2395,7 +2396,7 @@ QUnit.test("The template is not re-rendered when two routes present the exact sa
   App.SharedController = Ember.Controller.extend();
 
   var insertionCount = 0;
-  App.SharedView = Ember.View.extend({
+  App.SharedView = EmberView.extend({
     templateName: 'shared',
     didInsertElement() {
       insertionCount += 1;
@@ -2496,18 +2497,18 @@ QUnit.test("Route should tear down multiple outlets", function() {
     this.resource("users", function() {});
   });
 
-  App.PostsMenuView = Ember.View.extend({
+  App.PostsMenuView = EmberView.extend({
     tagName: 'div',
     templateName: 'posts/menu',
     classNames: ['posts-menu']
   });
 
-  App.PostsIndexView = Ember.View.extend({
+  App.PostsIndexView = EmberView.extend({
     tagName: 'p',
     classNames: ['posts-index']
   });
 
-  App.PostsFooterView = Ember.View.extend({
+  App.PostsFooterView = EmberView.extend({
     tagName: 'div',
     templateName: 'posts/footer',
     classNames: ['posts-footer']
@@ -2575,16 +2576,16 @@ QUnit.test("Route supports clearing outlet explicitly", function() {
     this.resource("users", function() {});
   });
 
-  App.PostsIndexView = Ember.View.extend({
+  App.PostsIndexView = EmberView.extend({
     classNames: ['posts-index']
   });
 
-  App.PostsModalView = Ember.View.extend({
+  App.PostsModalView = EmberView.extend({
     templateName: 'posts/modal',
     classNames: ['posts-modal']
   });
 
-  App.PostsExtraView = Ember.View.extend({
+  App.PostsExtraView = EmberView.extend({
     templateName: 'posts/extra',
     classNames: ['posts-extra']
   });
@@ -2657,11 +2658,11 @@ QUnit.test("Route supports clearing outlet using string parameter", function() {
     this.resource("users", function() {});
   });
 
-  App.PostsIndexView = Ember.View.extend({
+  App.PostsIndexView = EmberView.extend({
     classNames: ['posts-index']
   });
 
-  App.PostsModalView = Ember.View.extend({
+  App.PostsModalView = EmberView.extend({
     templateName: 'posts/modal',
     classNames: ['posts-modal']
   });
@@ -3486,7 +3487,7 @@ QUnit.test("Can rerender application view multiple times when it contains an out
   Ember.TEMPLATES.application = compile("App{{outlet}}");
   Ember.TEMPLATES.index = compile("Hello world");
 
-  registry.register('view:application', Ember.View.extend({
+  registry.register('view:application', EmberView.extend({
     elementId: 'im-special'
   }));
 
@@ -3495,13 +3496,13 @@ QUnit.test("Can rerender application view multiple times when it contains an out
   equal(Ember.$('#qunit-fixture').text(), "AppHello world", "initial render");
 
   Ember.run(function() {
-    Ember.View.views['im-special'].rerender();
+    EmberView.views['im-special'].rerender();
   });
 
   equal(Ember.$('#qunit-fixture').text(), "AppHello world", "second render");
 
   Ember.run(function() {
-    Ember.View.views['im-special'].rerender();
+    EmberView.views['im-special'].rerender();
   });
 
   equal(Ember.$('#qunit-fixture').text(), "AppHello world", "third render");
@@ -3908,7 +3909,7 @@ QUnit.test("Can render with layout", function() {
   Ember.TEMPLATES.index = compile('index-template');
   Ember.TEMPLATES['my-layout'] = compile('my-layout [{{yield}}]');
 
-  App.IndexView = Ember.View.extend({
+  App.IndexView = EmberView.extend({
     layoutName: 'my-layout'
   });
 

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -2,6 +2,7 @@ import "ember";
 import isEnabled from "ember-metal/features";
 
 import EmberHandlebars from "ember-htmlbars/compat";
+import EmberView from "ember-views/views/view";
 
 var compile = EmberHandlebars.compile;
 
@@ -468,7 +469,7 @@ if (isEnabled("ember-routing-named-substates")) {
       }
     });
 
-    App.ApplicationLoadingView = Ember.View.extend({
+    App.ApplicationLoadingView = EmberView.extend({
       elementId: 'toplevel-loading'
     });
 

--- a/packages/ember/tests/routing/toplevel_dom_test.js
+++ b/packages/ember/tests/routing/toplevel_dom_test.js
@@ -1,5 +1,6 @@
 import "ember";
 import EmberHandlebars from "ember-htmlbars/compat";
+import EmberView from "ember-views/views/view";
 
 var compile = EmberHandlebars.compile;
 
@@ -57,7 +58,7 @@ QUnit.test("Topmost template always get an element", function() {
 });
 
 QUnit.test("If topmost view has its own element, it doesn't get wrapped in a higher element", function() {
-  App.registry.register('view:application', Ember.View.extend({
+  App.registry.register('view:application', EmberView.extend({
     classNames: ['im-special']
   }));
   bootApplication();


### PR DESCRIPTION
To do:
- [x] Make a PR to update the deprecation guide for Ember.View (https://github.com/emberjs/website/pull/2195)
- [x] Create and publish a compatibility addon that silences this deprecation (https://github.com/emberjs/ember-legacy-views)

Refs #11377
