### PR TITLE
[BUGFIX beta] Add deprecation for view helper

### DIFF
--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -1,6 +1,29 @@
 import Ember from 'ember-metal/core';
 
-QUnit.module('ember-debug');
+let originalEnvValue;
+
+QUnit.module('ember-debug', {
+  setup() {
+    originalEnvValue = Ember.ENV.RAISE_ON_DEPRECATION;
+    Ember.ENV.RAISE_ON_DEPRECATION = true;
+  },
+
+  teardown() {
+    Ember.ENV.RAISE_ON_DEPRECATION = originalEnvValue;
+  }
+});
+
+QUnit.test('Ember.deprecate does not throw if RAISE_ON_DEPRECATION env value is false', function(assert) {
+  assert.expect(1);
+  Ember.ENV.RAISE_ON_DEPRECATION = false;
+
+  try {
+    Ember.deprecate('Should not throw', false);
+    assert.ok(true, 'Ember.deprecate did not throw');
+  } catch(e) {
+    assert.ok(false, `Expected Ember.deprecate not to throw but it did: ${e.message}`);
+  }
+});
 
 QUnit.test('Ember.deprecate throws deprecation if second argument is falsy', function() {
   expect(3);

--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -10,6 +10,7 @@ import objectKeys from "ember-metal/keys";
 
 export default {
   setupState(state, env, scope, params, hash) {
+    Ember.deprecate(`Using the "view" helper is deprecated.`, !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT, { url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view' });
     var read = env.hooks.getValue;
     var targetObject = read(scope.self);
     var viewClassOrInstance = state.viewClassOrInstance;

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -143,6 +143,21 @@ QUnit.test("View lookup - App.FuView (DEPRECATED)", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
+QUnit.test("View lookup in a template using 'view' helper is deprecated", function() {
+  var FuView = viewClass({});
+
+  registry.register('view:fu', FuView);
+
+  view = EmberView.extend({
+    template: compile("{{view 'fu'}}"),
+    container: container
+  }).create();
+
+  expectDeprecation(function() {
+    runAppend(view);
+  }, `Using the "view" helper is deprecated.`);
+});
+
 QUnit.test("View lookup - 'fu'", function() {
   var FuView = viewClass({
     elementId: "fu",

--- a/tests/index.html
+++ b/tests/index.html
@@ -68,7 +68,9 @@
         // Don't worry about jQuery version
         ENV['FORCE_JQUERY'] = true;
 
-        ENV['RAISE_ON_DEPRECATION'] = true;
+        // FIXME Many tests need to be ported to not use "{{view}}" before this
+        // can be re-enabled
+        ENV['RAISE_ON_DEPRECATION'] = false;
       })();
     </script>
 


### PR DESCRIPTION
There are many tests in the test suite that use the view helper (`{{view 'someview'}}`). In addition to adding the deprecation for this usage, this PR unsets `RAISE_ON_DEPRECATION` for the ember codebase. This allows the test suite to continue to pass for now until we have time to rewrite those tests to use components instead.

It also changes some tests in `ember-debug` that presumed that RAISE_ON_DEPRECATION would always be true.
- change env value RAISE_ON_DEPRECATION to false
- change tests for Ember.deprecate that relied on RAISE_ON_DEPRECATION being true

refs #11377
