### PR TITLE
[DOC] Replace deprecated {{#each}} syntax

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -154,7 +154,7 @@ import closureAction from "ember-routing-htmlbars/keywords/closure-action";
   implementing the action.
 
   ```handlebars
-  {{#each person in people}}
+  {{#each people as |person|}}
     <div {{action "edit" person}}>
       click me
     </div>

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -40,7 +40,7 @@ import EmberArray from 'ember-runtime/mixins/array';
   Then, create a view that binds to your new controller:
 
   ```handlebars
-  {{#each person in MyApp.listController}}
+  {{#each MyApp.listController as |person|}}
     {{person.firstName}} {{person.lastName}}
   {{/each}}
   ```
@@ -57,7 +57,7 @@ import EmberArray from 'ember-runtime/mixins/array';
   For example:
 
   ```handlebars
-  {{#each post in controller}}
+  {{#each controller as |post|}}
     <li>{{post.title}} ({{post.titleLength}} characters)</li>
   {{/each}}
   ```


### PR DESCRIPTION
Replaces doc references to deprecated `{{#each blah in blahs}}` with `{{#each blahs as |blah|}}`
