### PR TITLE
[BUGFIX beta] Add deprecation to Ember.computed.any

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -502,6 +502,7 @@ export var or = generateComputedWithProperties(function(properties) {
   @public
 */
 export var any = generateComputedWithProperties(function(properties) {
+  Ember.deprecate('Usage of Ember.computed.any is deprecated, use `Ember.computed.or` instead.');
   for (var key in properties) {
     if (properties.hasOwnProperty(key) && properties[key]) {
       return properties[key];

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -315,7 +315,8 @@ testBoth('computed.or', function(get, set) {
   equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
 });
 
-testBoth('computed.any', function(get, set) {
+testBoth('computed.any (Deprecated)', function(get, set) {
+  expectDeprecation(/Usage of Ember.computed.any is deprecated, use `Ember.computed.or` instead/);
   var obj = { one: 'foo', two: 'bar' };
   defineProperty(obj, 'anyOf', any('one', 'two'));
 


### PR DESCRIPTION
It has been deprecated in the docs for a while, but no warning is thrown
when used. It has to throw a warning if we want to remove it in Ember
2.0
