### PR TITLE
[BUGFIX beta] deprecate view and controller keywords

### DIFF
--- a/packages/ember-htmlbars/tests/compat/controller_keyword_test.js
+++ b/packages/ember-htmlbars/tests/compat/controller_keyword_test.js
@@ -1,0 +1,62 @@
+import EmberComponent from "ember-views/views/component";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import compile from "ember-template-compiler/system/compile";
+
+let component;
+
+QUnit.module('ember-htmlbars: compat - controller keyword (use as a path)', {
+  setup() {
+    component = null;
+  },
+  teardown() {
+    runDestroy(component);
+  }
+});
+
+QUnit.test('reading the controller keyword is deprecated [DEPRECATED]', function() {
+  var text = 'a-prop';
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      prop: text,
+      layout: compile("{{controller.prop}}")
+    }).create();
+
+    runAppend(component);
+  }, /Using `{{controller}}` or any path based on it .* has been deprecated./);
+  equal(component.$().text(), text, 'controller keyword is read');
+});
+
+QUnit.test('reading the controller keyword for hash is deprecated [DEPRECATED]', function() {
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      prop: true,
+      layout: compile("{{if true 'hiho' option=controller.prop}}")
+    }).create();
+
+    runAppend(component);
+  }, /Using `{{controller}}` or any path based on it .* has been deprecated./);
+});
+
+QUnit.test('reading the controller keyword for param is deprecated [DEPRECATED]', function() {
+  var text = 'a-prop';
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      prop: true,
+      layout: compile(`{{if controller.prop '${text}'}}`)
+    }).create();
+
+    runAppend(component);
+  }, /Using `{{controller}}` or any path based on it .* has been deprecated./);
+  equal(component.$().text(), text, 'controller keyword is read');
+});
+
+QUnit.test('reading the controller keyword for param with block is deprecated [DEPRECATED]', function() {
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      prop: true,
+      layout: compile(`{{#each controller as |things|}}{{/each}}`)
+    }).create();
+
+    runAppend(component);
+  }, /Using `{{controller}}` or any path based on it .* has been deprecated./);
+});

--- a/packages/ember-htmlbars/tests/compat/view_keyword_test.js
+++ b/packages/ember-htmlbars/tests/compat/view_keyword_test.js
@@ -1,0 +1,29 @@
+import EmberComponent from "ember-views/views/component";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import compile from "ember-template-compiler/system/compile";
+
+let component;
+
+QUnit.module('ember-htmlbars: compat - view keyword (use as a path)', {
+  setup() {
+    component = null;
+  },
+  teardown() {
+    runDestroy(component);
+  }
+});
+
+QUnit.test('reading the view keyword is deprecated [DEPRECATED]', function() {
+  var text = 'a-prop';
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      prop: text,
+      layout: compile("{{view.prop}}")
+    }).create();
+
+    runAppend(component);
+  }, /Using `{{view}}` or any path based on it .* has been deprecated./);
+
+  equal(component.$().text(), text, 'view keyword is read');
+});
+

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -16,6 +16,7 @@ import TransformComponentAttrsIntoMut from "ember-template-compiler/plugins/tran
 import TransformComponentCurlyToReadonly from "ember-template-compiler/plugins/transform-component-curly-to-readonly";
 import TransformAngleBracketComponents from "ember-template-compiler/plugins/transform-angle-bracket-components";
 import TransformInputOnToOnEvent from "ember-template-compiler/plugins/transform-input-on-to-onEvent";
+import DeprecateViewAndControllerPaths from "ember-template-compiler/plugins/deprecate-view-and-controller-paths";
 
 // used for adding Ember.Handlebars.compile for backwards compat
 import "ember-template-compiler/compat";
@@ -32,6 +33,7 @@ registerPlugin('ast', TransformComponentAttrsIntoMut);
 registerPlugin('ast', TransformComponentCurlyToReadonly);
 registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
+registerPlugin('ast', DeprecateViewAndControllerPaths);
 
 export {
   _Ember,

--- a/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
@@ -1,0 +1,65 @@
+import Ember from "ember-metal/core";
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
+
+function DeprecateViewAndControllerPaths(options) {
+  // set later within HTMLBars to the syntax package
+  this.syntax = null;
+  this.options = options || {};
+}
+
+/**
+  @private
+  @method transform
+  @param {AST} ast The AST to be transformed.
+*/
+DeprecateViewAndControllerPaths.prototype.transform = function DeprecateViewAndControllerPaths_transform(ast) {
+  if (!!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
+    return;
+  }
+  var walker = new this.syntax.Walker();
+  var moduleName = this.options && this.options.moduleName;
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    deprecatePath(moduleName, node, node.path);
+    deprecatePaths(moduleName, node, node.params);
+    deprecateHash(moduleName, node, node.hash);
+
+  });
+
+  return ast;
+};
+
+function deprecateHash(moduleName, node, hash) {
+  if (!hash || !hash.pairs) {
+    return;
+  }
+  var i, l, pair, paths;
+  for (i=0, l=hash.pairs.length;i<l;i++) {
+    pair = hash.pairs[i];
+    paths = pair.value.params;
+    deprecatePaths(moduleName, pair, paths);
+  }
+}
+
+function deprecatePaths(moduleName, node, paths) {
+  if (!paths) {
+    return;
+  }
+  var i, l, path;
+  for (i=0, l=paths.length;i<l;i++) {
+    path = paths[i];
+    deprecatePath(moduleName, node, path);
+  }
+}
+
+function deprecatePath(moduleName, node, path) {
+  Ember.deprecate(`Using \`{{${path && path.type === 'PathExpression' && path.parts[0]}}}\` or any path based on it ${calculateLocationDisplay(moduleName, node.loc)}has been deprecated.`, !(path && path.type === 'PathExpression' && (path.parts[0] === 'view' || path.parts[0] === 'controller')), { url: 'http://emberjs.com/deprecations/v1.x#toc_view-and-controller-template-keywords', id: 'view-controller-keyword' });
+}
+
+function validate(node) {
+  return node.type === 'MustacheStatement' || node.type === 'BlockStatement';
+}
+
+export default DeprecateViewAndControllerPaths;

--- a/tests/index.html
+++ b/tests/index.html
@@ -150,6 +150,7 @@
 
     <script>
       Ember.Debug._addDeprecationLevel('view-helper', Ember.Debug._deprecationLevels.SILENCE);
+      Ember.Debug._addDeprecationLevel('view-controller-keyword', Ember.Debug._deprecationLevels.SILENCE);
     </script>
 
     <script>


### PR DESCRIPTION
Using `{{view}}` and `{{controller}}` is deprecated.

TODO:
- [x] Rewrite a failing assertion in ember-routing-htmlbars
