### PR TITLE
[BUGFIX beta] Deprecate Ember.Select global

### DIFF
--- a/packages/ember-views/lib/main.js
+++ b/packages/ember-views/lib/main.js
@@ -34,7 +34,7 @@ import TextField from "ember-views/views/text_field";
 import TextArea from "ember-views/views/text_area";
 
 import {
-  Select,
+  DeprecatedSelect,
   SelectOption,
   SelectOptgroup
 } from "ember-views/views/select";
@@ -48,7 +48,7 @@ import LegacyEachView from "ember-views/views/legacy_each_view";
 
   @method $
   @for Ember
-  @public
+ @public
 */
 
 // BEGIN EXPORTS
@@ -71,7 +71,7 @@ Ember.Checkbox = Checkbox;
 Ember.TextField = TextField;
 Ember.TextArea = TextArea;
 
-Ember.Select = Select;
+Ember.Select = DeprecatedSelect;
 Ember.SelectOption = SelectOption;
 Ember.SelectOptgroup = SelectOptgroup;
 

--- a/packages/ember-views/lib/views/select.js
+++ b/packages/ember-views/lib/views/select.js
@@ -313,6 +313,7 @@ var SelectOptgroup = View.extend({
   @namespace Ember
   @extends Ember.View
   @public
+  @deprecated See http://emberjs.com/deprecations/v1.x/#toc_ember-select
 */
 var Select = View.extend({
   instrumentDisplay: 'Ember.Select',
@@ -674,9 +675,17 @@ var Select = View.extend({
   }
 });
 
+var DeprecatedSelect = Select.extend({
+  init() {
+    this._super(...arguments);
+    Ember.deprecate(`Ember.Select is deprecated. Consult the Deprecations Guide for a migration strategy.`, !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT, { url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-select' });
+  }
+});
+
 export default Select;
 export {
   Select,
+  DeprecatedSelect,
   SelectOption,
   SelectOptgroup
 };

--- a/packages/ember-views/tests/views/select_test.js
+++ b/packages/ember-views/tests/views/select_test.js
@@ -35,6 +35,12 @@ function selectedOptions() {
   return select.get('childViews').mapBy('selected');
 }
 
+QUnit.test('using the Ember.Select global is deprecated', function(assert) {
+  expectDeprecation(function() {
+    Ember.Select.create();
+  }, /Ember.Select is deprecated./);
+});
+
 QUnit.test("has 'ember-view' and 'ember-select' CSS classes", function() {
   deepEqual(select.get('classNames'), ['ember-view', 'ember-select']);
 });


### PR DESCRIPTION
Deprecates usage of `Ember.Select` global and references the Deprecations guide on the website (PR: https://github.com/emberjs/website/pull/2201) for details.

refs #11377
