### PR TITLE
[BUGFIX beta] Deprecate {{view "string"}} and special case {{view "select"}}

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
     "rsvp": "https://github.com/tildeio/rsvp.js.git#3.0.14",
     "router.js": "https://github.com/tildeio/router.js.git#ed45bc5c5e055af0ab875ef2c52feda792ee23e4",
     "dag-map": "https://github.com/krisselden/dag-map.git#e307363256fe918f426e5a646cb5f5062d3245be",
-    "ember-dev": "https://github.com/emberjs/ember-dev.git#1a1ef3e1806be21dd554d285521abc0b13cdfe20"
+    "ember-dev": "https://github.com/emberjs/ember-dev.git#a064f0cd2f4c225ffd023b63d4cb31a79db04aaf"
   }
 }

--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -104,7 +104,10 @@ Ember.debug = function(message) {
     will be displayed. If this is a function, it will be executed and its return
     value will be used as condition.
   @param {Object} options An optional object that can be used to pass
-    in a `url` to the transition guide on the emberjs.com website.
+    in a `url` to the transition guide on the emberjs.com website, and a unique
+    `id` for this deprecation. The `id` can be used by Ember debugging tools
+    to change the behavior (raise, log or silence) for that specific deprecation.
+    The `id` should be namespaced by dots, e.g. "view.helper.select".
   @public
 */
 Ember.deprecate = function(message, test, options) {
@@ -121,6 +124,10 @@ Ember.deprecate = function(message, test, options) {
   }
 
   if (noDeprecation) { return; }
+
+  if (options && options.id) {
+    message = message + ` [deprecation id: ${options.id}]`;
+  }
 
   if (deprecationManager.getLevel(options && options.id) === deprecationLevels.RAISE) {
     throw new EmberError(message);

--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -10,7 +10,6 @@ import objectKeys from "ember-metal/keys";
 
 export default {
   setupState(state, env, scope, params, hash) {
-    Ember.deprecate(`Using the "view" helper is deprecated.`, !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT, { url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view', id: 'view-helper' });
     var read = env.hooks.getValue;
     var targetObject = read(scope.self);
     var viewClassOrInstance = state.viewClassOrInstance;

--- a/packages/ember-htmlbars/tests/compat/view_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/view_helper_test.js
@@ -1,0 +1,72 @@
+import EmberComponent from "ember-views/views/component";
+import EmberView from "ember-views/views/view";
+import EmberSelectView from "ember-views/views/select";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import compile from "ember-template-compiler/system/compile";
+import Registry from "container/registry";
+
+let component, registry, container;
+
+QUnit.module('ember-htmlbars: compat - view helper', {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+  },
+  teardown() {
+    runDestroy(component);
+    runDestroy(container);
+    registry = container = component = null;
+  }
+});
+
+QUnit.test('using the view helper with a string (inline form) is deprecated [DEPRECATED]', function(assert) {
+  const ViewClass = EmberView.extend({
+    template: compile('fooView')
+  });
+  registry.register('view:foo', ViewClass);
+
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      layout: compile("{{view 'foo'}}"),
+      container
+    }).create();
+
+    runAppend(component);
+  }, /Using the `{{view "string"}}` helper is deprecated/);
+
+  assert.equal(component.$().text(), 'fooView', 'view helper is still rendered');
+});
+
+QUnit.test('using the view helper with a string (block form) is deprecated [DEPRECATED]', function(assert) {
+  const ViewClass = EmberView.extend({
+    template: compile('Foo says: {{yield}}')
+  });
+  registry.register('view:foo', ViewClass);
+
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      layout: compile("{{#view 'foo'}}I am foo{{/view}}"),
+      container
+    }).create();
+
+    runAppend(component);
+  }, /Using the `{{view "string"}}` helper is deprecated/);
+
+  assert.equal(component.$().text(), 'Foo says: I am foo', 'view helper is still rendered');
+});
+
+QUnit.test('using the view helper with string "select" has its own deprecation message [DEPRECATED]', function(assert) {
+  registry.register('view:select', EmberSelectView);
+
+  expectDeprecation(function() {
+    component = EmberComponent.extend({
+      layout: compile("{{view 'select'}}"),
+      container
+    }).create();
+
+    runAppend(component);
+  }, /Using `{{view "select"}}` is deprecated/);
+
+  assert.ok(!!component.$('select').length, 'still renders select');
+});
+

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -143,21 +143,6 @@ QUnit.test("View lookup - App.FuView (DEPRECATED)", function() {
   equal(jQuery('#fu').text(), 'bro');
 });
 
-QUnit.test("View lookup in a template using 'view' helper is deprecated", function() {
-  var FuView = viewClass({});
-
-  registry.register('view:fu', FuView);
-
-  view = EmberView.extend({
-    template: compile("{{view 'fu'}}"),
-    container: container
-  }).create();
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, `Using the "view" helper is deprecated.`);
-});
-
 QUnit.test("View lookup - 'fu'", function() {
   var FuView = viewClass({
     elementId: "fu",

--- a/packages/ember-template-compiler/lib/main.js
+++ b/packages/ember-template-compiler/lib/main.js
@@ -17,6 +17,7 @@ import TransformComponentCurlyToReadonly from "ember-template-compiler/plugins/t
 import TransformAngleBracketComponents from "ember-template-compiler/plugins/transform-angle-bracket-components";
 import TransformInputOnToOnEvent from "ember-template-compiler/plugins/transform-input-on-to-onEvent";
 import DeprecateViewAndControllerPaths from "ember-template-compiler/plugins/deprecate-view-and-controller-paths";
+import DeprecateViewHelper from "ember-template-compiler/plugins/deprecate-view-helper";
 
 // used for adding Ember.Handlebars.compile for backwards compat
 import "ember-template-compiler/compat";
@@ -34,6 +35,7 @@ registerPlugin('ast', TransformComponentCurlyToReadonly);
 registerPlugin('ast', TransformAngleBracketComponents);
 registerPlugin('ast', TransformInputOnToOnEvent);
 registerPlugin('ast', DeprecateViewAndControllerPaths);
+registerPlugin('ast', DeprecateViewHelper);
 
 export {
   _Ember,

--- a/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-view-and-controller-paths.js
@@ -13,9 +13,6 @@ function DeprecateViewAndControllerPaths(options) {
   @param {AST} ast The AST to be transformed.
 */
 DeprecateViewAndControllerPaths.prototype.transform = function DeprecateViewAndControllerPaths_transform(ast) {
-  if (!!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
-    return;
-  }
   var walker = new this.syntax.Walker();
   var moduleName = this.options && this.options.moduleName;
 
@@ -55,7 +52,18 @@ function deprecatePaths(moduleName, node, paths) {
 }
 
 function deprecatePath(moduleName, node, path) {
-  Ember.deprecate(`Using \`{{${path && path.type === 'PathExpression' && path.parts[0]}}}\` or any path based on it ${calculateLocationDisplay(moduleName, node.loc)}has been deprecated.`, !(path && path.type === 'PathExpression' && (path.parts[0] === 'view' || path.parts[0] === 'controller')), { url: 'http://emberjs.com/deprecations/v1.x#toc_view-and-controller-template-keywords', id: 'view-controller-keyword' });
+  Ember.deprecate(`Using \`{{${path && path.type === 'PathExpression' && path.parts[0]}}}\` or any path based on it ${calculateLocationDisplay(moduleName, node.loc)}has been deprecated.`, function deprecatePath_test() {
+    let noDeprecate = true;
+
+    const viewKeyword = path && path.type === 'PathExpression' && path.parts && path.parts[0];
+    if (viewKeyword === 'view') {
+      noDeprecate = Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT;
+    } else if (viewKeyword === 'controller') {
+      noDeprecate = false;
+    }
+
+    return noDeprecate;
+  }, { url: 'http://emberjs.com/deprecations/v1.x#toc_view-and-controller-template-keywords', id: (path.parts && path.parts[0] === 'view' ? 'view.keyword.view' : 'view.keyword.controller') });
 }
 
 function validate(node) {

--- a/packages/ember-template-compiler/lib/plugins/deprecate-view-helper.js
+++ b/packages/ember-template-compiler/lib/plugins/deprecate-view-helper.js
@@ -1,0 +1,52 @@
+import Ember from "ember-metal/core";
+import calculateLocationDisplay from "ember-template-compiler/system/calculate-location-display";
+
+function DeprecateViewHelper(options) {
+  // set later within HTMLBars to the syntax package
+  this.syntax = null;
+  this.options = options || {};
+}
+
+/**
+  @private
+  @method transform
+  @param {AST} ast The AST to be transformed.
+*/
+DeprecateViewHelper.prototype.transform = function DeprecateViewHelper_transform(ast) {
+  if (!!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
+    return ast;
+  }
+  var walker = new this.syntax.Walker();
+  var moduleName = this.options && this.options.moduleName;
+
+  walker.visit(ast, function(node) {
+    if (!validate(node)) { return; }
+
+    deprecateHelper(moduleName, node);
+  });
+
+  return ast;
+};
+
+function deprecateHelper(moduleName, node) {
+  const paramValue = node.params.length && node.params[0].value;
+
+  if (!paramValue) {
+    return;
+  } else if (paramValue === 'select') {
+    deprecateSelect(moduleName, node);
+  } else {
+    Ember.deprecate(`Using the \`{{view "string"}}\` helper is deprecated. ${calculateLocationDisplay(moduleName, node.loc)}`, false, { url: 'http://emberjs.com/deprecations/v1.x#toc_ember-view', id: 'view.helper' });
+  }
+}
+
+function deprecateSelect(moduleName, node) {
+  Ember.deprecate(`Using \`{{view "select"}}\` is deprecated. ${calculateLocationDisplay(moduleName, node.loc)}`, false, { url: 'http://emberjs.com/deprecations/v1.x#toc_ember-select', id: 'view.helper.select' });
+}
+
+function validate(node) {
+  return (node.type === 'MustacheStatement' || node.type === 'BlockStatement') &&
+    (node.path.parts[0] === 'view');
+}
+
+export default DeprecateViewHelper;

--- a/tests/index.html
+++ b/tests/index.html
@@ -149,8 +149,11 @@
     </script>
 
     <script>
-      Ember.Debug._addDeprecationLevel('view-helper', Ember.Debug._deprecationLevels.SILENCE);
-      Ember.Debug._addDeprecationLevel('view-controller-keyword', Ember.Debug._deprecationLevels.SILENCE);
+      // Silence view-related deprecations in tests to avoid overflowing travis ci's log
+      Ember.Debug._addDeprecationLevel('view.helper', Ember.Debug._deprecationLevels.SILENCE);
+      Ember.Debug._addDeprecationLevel('view.helper.select', Ember.Debug._deprecationLevels.SILENCE);
+      Ember.Debug._addDeprecationLevel('view.keyword.view', Ember.Debug._deprecationLevels.SILENCE);
+      Ember.Debug._addDeprecationLevel('view.keyword.controller', Ember.Debug._deprecationLevels.SILENCE);
     </script>
 
     <script>


### PR DESCRIPTION
Use a template-compiler plugin to detect `{{view "string"}}` at compile-time
and issue a deprecation with location information. Has a special case
deprecation when the string === "select".

Removes a test from the view helper tests that was checking for the
deprecation at runtime (and removes the associated code in
the ember-htmlbars package's `keywords/view`).

Note: This does not catch a deprecation when the path is not a string,
e.g., `{{view view.someProperty}}`, however #11401 would catch and issue
a deprecation message for that case (at runtime).

Other changes:
- document `id` param to `Ember.deprecate`
- include deprecation id in log/error message
- Use dot-namespaced deprecation ids (more similar to how `instrument` works and paves the way to in the future changing deprecation log levels by paths ie `"view.*"`)
- globally silence view-related deprecations in tests to avoid overflowing travis ci's log
- update ember-dev dep in bower (pr: emberjs/ember-dev#153) to `a064f0cd2f4c225ffd023b63d4cb31a79db04aaf`
- change the view-and-controller-path template compiler plugin to always deprecate `{{controller}}`
- change the view-and-controller-path template compiler plugin to skip deprecating `{{view}}` when `Ember.ENV._ENABLE_LEGACY_VIW_SUPPORT` is true

refs #11377
