### PR TITLE
[BUGFIX beta] Refactor deprecations to have a private log level API

### DIFF
--- a/packages/ember-debug/lib/deprecation-manager.js
+++ b/packages/ember-debug/lib/deprecation-manager.js
@@ -1,0 +1,26 @@
+import dictionary from 'ember-metal/dictionary';
+import { symbol } from "ember-metal/utils";
+
+export const deprecationLevels = {
+  RAISE: symbol('RAISE'),
+  LOG: symbol('LOG'),
+  SILENCE: symbol('SILENCE')
+};
+
+export default {
+  defaultLevel: deprecationLevels.LOG,
+  individualLevels: dictionary(null),
+  setDefaultLevel(level) {
+    this.defaultLevel = level;
+  },
+  setLevel(id, level) {
+    this.individualLevels[id] = level;
+  },
+  getLevel(id) {
+    let level = this.individualLevels[id];
+    if (!level) {
+      level = this.defaultLevel;
+    }
+    return level;
+  }
+};

--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -10,7 +10,7 @@ import objectKeys from "ember-metal/keys";
 
 export default {
   setupState(state, env, scope, params, hash) {
-    Ember.deprecate(`Using the "view" helper is deprecated.`, !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT, { url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view' });
+    Ember.deprecate(`Using the "view" helper is deprecated.`, !!Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT, { url: 'http://emberjs.com/deprecations/v1.x/#toc_ember-view', id: 'view-helper' });
     var read = env.hooks.getValue;
     var targetObject = read(scope.self);
     var viewClassOrInstance = state.viewClassOrInstance;

--- a/tests/index.html
+++ b/tests/index.html
@@ -68,9 +68,7 @@
         // Don't worry about jQuery version
         ENV['FORCE_JQUERY'] = true;
 
-        // FIXME Many tests need to be ported to not use "{{view}}" before this
-        // can be re-enabled
-        ENV['RAISE_ON_DEPRECATION'] = false;
+        ENV['RAISE_ON_DEPRECATION'] = true;
       })();
     </script>
 
@@ -148,6 +146,10 @@
         QUnit.config.urlConfig.push('nojshint');
         QUnit.config.urlConfig.push('forceskip');
       })();
+    </script>
+
+    <script>
+      Ember.Debug._addDeprecationLevel('view-helper', Ember.Debug._deprecationLevels.SILENCE);
     </script>
 
     <script>


### PR DESCRIPTION
On the path to 1.13, we're adding a few deprecations that will take more than several days to completely remove from Ember's own tests. Therefor we've added a private API for changing the level of these deprecation messages to "silence". This both keeps the dev process smooth, and allows Travis to process our builds without blowing the log buffer.
