### PR TITLE
[BUGFIX beta] Raise by default when `ENV.RAISE_ON_DEPRECATION` is true

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -108,6 +108,9 @@ Ember.debug = function(message) {
   @public
 */
 Ember.deprecate = function(message, test, options) {
+  if (Ember.ENV.RAISE_ON_DEPRECATION) {
+    deprecationManager.setDefaultLevel(deprecationLevels.RAISE);
+  }
   if (deprecationManager.getLevel(options && options.id) === deprecationLevels.SILENCE) {
     return;
   }
@@ -269,9 +272,6 @@ if (!Ember.testing) {
   }
 }
 
-if (Ember.ENV.RAISE_ON_DEPRECATION) {
-  deprecationManager.setDefaultLevel(deprecationLevels.RAISE);
-}
 Ember.Debug = {
   _addDeprecationLevel(id, level) {
     deprecationManager.setLevel(id, level);


### PR DESCRIPTION
Fixes an issue introduced by #11419 where the evaluation of
`ENV.RAISE_ON_DEPRECATION` was moved to boot-time rather than run-time.

Previously, it was possible to set `RAISE_ON_DEPRECATION` to true midway
through running an app, and all deprecations after that would throw
because `Ember.deprecate` would check the value of the env variable
every time it was called.

The code in #11419 changed to a [one-time evaulation at boot-time](https://github.com/emberjs/ember.js/blob/master/packages/ember-debug/lib/main.js#L279-L281),
breaking that original behavior. This commit restores the old behavior
while still allowing changing deprecation behavior for specific
deprecations by id.
