### PR TITLE
[BUGFIX release] Ember.View.views should be present

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -1506,22 +1506,24 @@ var View = CoreView.extend(
 // once the view has been inserted into the DOM, legal manipulations
 // are done on the DOM element.
 
-/**
-  Global views hash
+View.reopenClass({
+  /**
+    Global views hash
 
-  @property views
-  @static
-  @type Object
-  @private
-*/
-View.views = {};
+    @property views
+    @static
+    @type Object
+    @private
+  */
+  views: {},
 
-// If someone overrides the child views computed property when
-// defining their class, we want to be able to process the user's
-// supplied childViews and then restore the original computed property
-// at view initialization time. This happens in Ember.ContainerView's init
-// method.
-View.childViewsProperty = childViewsProperty;
+  // If someone overrides the child views computed property when
+  // defining their class, we want to be able to process the user's
+  // supplied childViews and then restore the original computed property
+  // at view initialization time. This happens in Ember.ContainerView's init
+  // method.
+  childViewsProperty
+});
 
 var DeprecatedView = View.extend({
   init() {

--- a/packages/ember-views/tests/views/exports_test.js
+++ b/packages/ember-views/tests/views/exports_test.js
@@ -30,3 +30,7 @@ QUnit.test('when legacy view support is enabled, Ember.View does not have deprec
     Ember.View.create();
   });
 });
+
+QUnit.test('Ember.View.views is accessible', function() {
+  ok(!!Ember.View.views);
+});


### PR DESCRIPTION
Since we are exposing an extended version of the View class (the DeprecatedView), we need to use `reopenClass` to set properties on the class.
