### PR TITLE
[CLEANUP beta] Remove deprecated macros

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -476,42 +476,6 @@ export var or = generateComputedWithProperties(function(properties) {
 });
 
 /**
-  A computed property that returns the first truthy value
-  from a list of dependent properties.
-
-  Example
-
-  ```javascript
-  var Hamster = Ember.Object.extend({
-    hasClothes: Ember.computed.any('hat', 'shirt')
-  });
-
-  var hamster = Hamster.create();
-
-  hamster.get('hasClothes'); // null
-  hamster.set('shirt', 'Hawaiian Shirt');
-  hamster.get('hasClothes'); // 'Hawaiian Shirt'
-  ```
-
-  @method any
-  @for Ember.computed
-  @param {String} dependentKey*
-  @return {Ember.ComputedProperty} computed property which returns
-  the first truthy value of given list of properties.
-  @deprecated Use `Ember.computed.or` instead.
-  @public
-*/
-export var any = generateComputedWithProperties(function(properties) {
-  Ember.deprecate('Usage of Ember.computed.any is deprecated, use `Ember.computed.or` instead.');
-  for (var key in properties) {
-    if (properties.hasOwnProperty(key) && properties[key]) {
-      return properties[key];
-    }
-  }
-  return null;
-});
-
-/**
   A computed property that returns the array of values
   for the provided dependent properties.
 
@@ -665,48 +629,6 @@ export function oneWay(dependentKey) {
 */
 export function readOnly(dependentKey) {
   return alias(dependentKey).readOnly();
-}
-
-/**
-  A computed property that acts like a standard getter and setter,
-  but returns the value at the provided `defaultPath` if the
-  property itself has not been set to a value
-
-  Example
-
-  ```javascript
-  var Hamster = Ember.Object.extend({
-    wishList: Ember.computed.defaultTo('favoriteFood')
-  });
-
-  var hamster = Hamster.create({ favoriteFood: 'Banana' });
-
-  hamster.get('wishList');                     // 'Banana'
-  hamster.set('wishList', 'More Unit Tests');
-  hamster.get('wishList');                     // 'More Unit Tests'
-  hamster.get('favoriteFood');                 // 'Banana'
-  ```
-
-  @method defaultTo
-  @for Ember.computed
-  @param {String} defaultPath
-  @return {Ember.ComputedProperty} computed property which acts like
-  a standard getter and setter, but defaults to the value from `defaultPath`.
-  @deprecated Use `Ember.computed.oneWay` or custom CP with default instead.
-  @public
-*/
-export function defaultTo(defaultPath) {
-  return computed({
-    get(key) {
-      Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
-      return get(this, defaultPath);
-    },
-
-    set(key, newValue, cachedValue) {
-      Ember.deprecate('Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
-      return newValue != null ? newValue : get(this, defaultPath);
-    }
-  });
 }
 
 /**

--- a/packages/ember-runtime/tests/computed/computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/computed_macros_test.js
@@ -12,11 +12,9 @@ import {
   lte,
   oneWay,
   readOnly,
-  defaultTo,
   deprecatingAlias,
   and,
   or,
-  any,
   collect
 } from "ember-metal/computed_macros";
 import alias from 'ember-metal/alias';
@@ -155,34 +153,6 @@ testBoth('computed.alias set', function(get, set) {
   equal(get(obj, 'aliased'), constantValue);
 });
 
-testBoth('computed.defaultTo', function(get, set) {
-  expect(6);
-
-  var obj = { source: 'original source value' };
-  defineProperty(obj, 'copy', defaultTo('source'));
-
-  ignoreDeprecation(function() {
-    equal(get(obj, 'copy'), 'original source value');
-
-    set(obj, 'copy', 'new copy value');
-    equal(get(obj, 'source'), 'original source value');
-    equal(get(obj, 'copy'), 'new copy value');
-
-    set(obj, 'source', 'new source value');
-    equal(get(obj, 'copy'), 'new copy value');
-
-    set(obj, 'copy', null);
-    equal(get(obj, 'copy'), 'new source value');
-  });
-
-  expectDeprecation(function() {
-    var obj = { source: 'original source value' };
-    defineProperty(obj, 'copy', defaultTo('source'));
-
-    get(obj, 'copy');
-  }, 'Usage of Ember.computed.defaultTo is deprecated, use `Ember.computed.oneWay` instead.');
-});
-
 testBoth('computed.match', function(get, set) {
   var obj = { name: 'Paul' };
   defineProperty(obj, 'isPaul', match('name', /Paul/));
@@ -313,18 +283,6 @@ testBoth('computed.or', function(get, set) {
   set(obj, 'one', 1);
 
   equal(get(obj, 'oneOrTwo'), 1, 'returns truthy value as in ||');
-});
-
-testBoth('computed.any (Deprecated)', function(get, set) {
-  expectDeprecation(/Usage of Ember.computed.any is deprecated, use `Ember.computed.or` instead/);
-  var obj = { one: 'foo', two: 'bar' };
-  defineProperty(obj, 'anyOf', any('one', 'two'));
-
-  equal(get(obj, 'anyOf'), 'foo', 'is foo');
-
-  set(obj, 'one', false);
-
-  equal(get(obj, 'anyOf'), 'bar', 'is bar');
 });
 
 testBoth('computed.collect', function(get, set) {


### PR DESCRIPTION
Remove `Ember.computed.defaultTo` and `Ember.computed.any`.

How should PRs removing deprecated functionality be tagged? `[BUGFIX beta]`?
