### PR TITLE
Use forEach instead of while

### DIFF
--- a/packages/ember-runtime/lib/mixins/mutable_array.js
+++ b/packages/ember-runtime/lib/mixins/mutable_array.js
@@ -361,14 +361,11 @@ export default Mixin.create(EmberArray, MutableEnumerable, {
     @public
   */
   removeObject(obj) {
-    var loc = get(this, 'length') || 0;
-    while (--loc >= 0) {
-      var curObject = this.objectAt(loc);
-
-      if (curObject === obj) {
-        this.removeAt(loc);
+    this.forEach((currentObject, index) => {
+      if (currentObject === obj) {
+        this.removeAt(index);
       }
-    }
+    });
     return this;
   },
 


### PR DESCRIPTION
I notice this use of `while` and thought it could be replaced with `forEach`.  Looks like it's a pretty old area of Ember and there may have been a good reason to use `while`, though this version doesn't break any of the tests.

Close if it's not useful :smile: 
