### PR TITLE
[BUGFIX release] Allow recomputation for helpers with arguments

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -1,5 +1,6 @@
 import Ember from 'ember-metal/core'; // Ember.assert
 import { buildHelperStream } from "ember-htmlbars/system/invoke-helper";
+import subscribe from "ember-htmlbars/utils/subscribe";
 
 export default function invokeHelper(morph, env, scope, visitor, params, hash, helper, templates, context) {
 
@@ -16,6 +17,26 @@ export default function invokeHelper(morph, env, scope, visitor, params, hash, h
 
   // Ember.Helper helpers are pure values, thus linkable
   if (helperStream.linkable) {
+
+    if (morph) {
+      // When processing an inline expression the params and hash have already
+      // been linked. Thus, HTMLBars will not link the returned helperStream.
+      // We subscribe the morph to the helperStream here, and also subscribe
+      // the helperStream to any params.
+      let addedDependency = false;
+      for (var i = 0, l = params.length; i < l; i++) {
+        addedDependency = true;
+        helperStream.addDependency(params[i]);
+      }
+      for (var key in hash) {
+        addedDependency = true;
+        helperStream.addDependency(hash[key]);
+      }
+      if (addedDependency) {
+        subscribe(morph, env, scope, helperStream);
+      }
+    }
+
     return { link: true, value: helperStream };
   }
 

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -85,6 +85,38 @@ QUnit.test('dashed helper can recompute a new value', function() {
   equal(destroyCount, 0, 'destroy is not called on recomputation');
 });
 
+QUnit.test('dashed helper with arg can recompute a new value', function() {
+  var destroyCount = 0;
+  var count = 0;
+  var helper;
+  var HelloWorld = Helper.extend({
+    init() {
+      this._super(...arguments);
+      helper = this;
+    },
+    compute() {
+      return ++count;
+    },
+    destroy() {
+      destroyCount++;
+      this._super();
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world "whut"}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    helper.recompute();
+  });
+  equal(component.$().text(), '2');
+  equal(destroyCount, 0, 'destroy is not called on recomputation');
+});
+
 QUnit.test('dashed shorthand helper is called for param changes', function() {
   var count = 0;
   var HelloWorld = makeHelper(function() {


### PR DESCRIPTION
No unit test for helpers exercised the inline expression visitor (all used the content expression) with recomputation. The inline expression visitor links params before calling the inline hook. Linking params sets morph.linkedParams which disallows calling linkParams later with additional dependencies.

To work around this, here the morph subscribes to the helperStream in invoke-helper itself if there are any params or hash arguments (which means that there the call is an inline one). The helperStream in turn subscribes to the params and hash.

/cc @wycats @mmun @jamesarosen
