### PR TITLE
[BUGFIX release] Deprecate Freezable and frozenCopy. Resolves #11452

### DIFF
--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -57,7 +57,7 @@ export default Mixin.create({
     @private
   */
   frozenCopy() {
-    Ember.deprecate('`frozenCopy` is deprecated, use Object.freeze instead.');
+    Ember.deprecate('`frozenCopy` is deprecated, use `Object.freeze` instead.');
     if (Freezable && Freezable.detect(this)) {
       return get(this, 'isFrozen') ? this : this.copy().freeze();
     } else {

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -3,6 +3,7 @@
 @submodule ember-runtime
 */
 
+import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { Mixin } from 'ember-metal/mixin';
 import { Freezable } from 'ember-runtime/mixins/freezable';
@@ -52,9 +53,11 @@ export default Mixin.create({
 
     @method frozenCopy
     @return {Object} copy of receiver or receiver
+    @deprecated Use `Object.freeze` instead.
     @private
   */
   frozenCopy() {
+    Ember.deprecate('`frozenCopy` is deprecated, use Object.freeze instead.');
     if (Freezable && Freezable.detect(this)) {
       return get(this, 'isFrozen') ? this : this.copy().freeze();
     } else {

--- a/packages/ember-runtime/lib/mixins/freezable.js
+++ b/packages/ember-runtime/lib/mixins/freezable.js
@@ -3,6 +3,7 @@
 @submodule ember-runtime
 */
 
+import Ember from 'ember-metal/core';
 import { Mixin } from 'ember-metal/mixin';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
@@ -62,9 +63,15 @@ import { set } from 'ember-metal/property_set';
   @class Freezable
   @namespace Ember
   @since Ember 0.9
+  @deprecated Use `Object.freeze` instead.
   @private
 */
 export var Freezable = Mixin.create({
+
+  init() {
+    Ember.deprecate('`Ember.Freezable` is deprecated, use `Object.freeze` instead.');
+    this._super.apply(this, arguments);
+  },
 
   /**
     Set to `true` when the object is frozen. Use this property to detect

--- a/packages/ember-runtime/tests/mixins/copyable_test.js
+++ b/packages/ember-runtime/tests/mixins/copyable_test.js
@@ -1,9 +1,24 @@
 import CopyableTests from 'ember-runtime/tests/suites/copyable';
 import Copyable from 'ember-runtime/mixins/copyable';
+import {Freezable} from 'ember-runtime/mixins/freezable';
 import EmberObject from 'ember-runtime/system/object';
 import {generateGuid} from 'ember-metal/utils';
 import {set} from 'ember-metal/property_set';
 import {get} from 'ember-metal/property_get';
+
+QUnit.module('Ember.Copyable.frozenCopy');
+
+QUnit.test('should be deprecated', function() {
+  expectDeprecation('`frozenCopy` is deprecated, use `Object.freeze` instead.');
+
+  var Obj = EmberObject.extend(Freezable, Copyable, {
+    copy() {
+      return Obj.create();
+    }
+  });
+
+  Obj.create().frozenCopy();
+});
 
 var CopyableObject = EmberObject.extend(Copyable, {
 

--- a/packages/ember-runtime/tests/mixins/freezable_test.js
+++ b/packages/ember-runtime/tests/mixins/freezable_test.js
@@ -1,0 +1,9 @@
+import EmberObject from 'ember-runtime/system/object';
+import {Freezable} from 'ember-runtime/mixins/freezable';
+
+QUnit.module('Ember.Freezable');
+
+QUnit.test('should be deprecated', function() {
+  expectDeprecation('`Ember.Freezable` is deprecated, use `Object.freeze` instead.');
+  EmberObject.extend(Freezable).create();
+});

--- a/packages/ember-runtime/tests/suites/copyable/frozenCopy.js
+++ b/packages/ember-runtime/tests/suites/copyable/frozenCopy.js
@@ -11,6 +11,8 @@ suite.test('frozen objects should return same instance', function() {
 
   obj = this.newObject();
   if (get(this, 'shouldBeFreezable')) {
+    expectDeprecation('`frozenCopy` is deprecated, use Object.freeze instead.');
+
     ok(!Freezable || Freezable.detect(obj), 'object should be freezable');
 
     copy = obj.frozenCopy();


### PR DESCRIPTION
Hold off on merging, putting this up so @stefanpenner can take a look.

Other stuff:
- [x] Can't get new freezable test file to run
- [ ] frozenCopy still needs a test for the deprecation (the existing tests aren't actually run)
