### PR TITLE
[DOC beta] Remove out-of-date docs

### DIFF
--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -198,19 +198,10 @@ export default Mixin.create({
     another object) will be placed in a queue and called at a later time in a
     coalesced manner.
 
-    ### Chaining
-
-    In addition to property changes, `set()` returns the value of the object
-    itself so you can do chaining like this:
-
-    ```javascript
-    record.set('firstName', 'Charles').set('lastName', 'Jolley');
-    ```
-
     @method set
     @param {String} keyName The property to set
     @param {Object} value The value to set or `null`.
-    @return {Ember.Observable}
+    @return {Object} The passed value
     @public
   */
   set(keyName, value) {

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -220,7 +220,7 @@ export default Mixin.create({
 
     @method setProperties
     @param {Object} hash the hash of keys and values to set
-    @return {Ember.Observable}
+    @return {Object} The passed in hash
     @public
   */
   setProperties(hash) {


### PR DESCRIPTION
With https://github.com/emberjs/ember.js/pull/11213 having just been merged, the bit about chaining in the docs became wrong.

This PR just deletes it and fixes up the specified return value (in the docs).
