### PR TITLE
[BUGFIX release] Properly strip debug statements in prod builds.

### DIFF
--- a/features.json
+++ b/features.json
@@ -35,6 +35,16 @@
     "Ember.Logger.info",
     "Ember.default.Logger.info",
     "Ember.runInDebug",
-    "Ember.default.runInDebug"
+    "Ember.default.runInDebug",
+    "_emberMetalCore.default.deprecate",
+    "_emberMetalCore.default.warn",
+    "_emberMetalCore.default.assert",
+    "_emberMetalCore.default.debug",
+    "_emberMetalCore.default.runInDebug",
+    "_emberMetal.default.deprecate",
+    "_emberMetal.default.warn",
+    "_emberMetal.default.assert",
+    "_emberMetal.default.debug",
+    "_emberMetal.default.runInDebug"
   ]
 }


### PR DESCRIPTION
In https://github.com/emberjs/ember.js/pull/11367 we swapped to using babel for module transpilation, which lead to the transpiled output being slightly different than previously with esperanto.

The long term solution is to use a babel transform to strip, this will have the benefit of not having this particular issue any longer (this is actually the second time we have had this issue).  https://github.com/ember-cli/babel-plugin-filter-imports has been created specifically for this purpose, and we have a roadmap to implementing soonish.

---

This adds the new formats to the list of debug statements for defeatureify.

Fixes #11494.
