### PR TITLE
[Bugfix Release] deprecate createWithMixins

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
+++ b/packages/ember-htmlbars/tests/helpers/bind_attr_test.js
@@ -97,11 +97,12 @@ QUnit.test('should be able to bind element attributes using {{bind-attr}}', func
   equal(view.$('img').attr('alt'), 'The SproutCore Logo', 'updates alt attribute when content object is a hash');
 
   run(function() {
-    set(view, 'content', EmberObject.createWithMixins({
-      url: 'http://www.emberjs.com/assets/images/logo.png',
+    set(view, 'content', EmberObject.extend({
       title: computed(function() {
         return 'Nanananana Ember!';
       })
+    }).create({
+      url: 'http://www.emberjs.com/assets/images/logo.png'
     }));
   });
 
@@ -202,11 +203,12 @@ QUnit.test('should be able to bind use {{bind-attr}} more than once on an elemen
   equal(view.$('img').attr('alt'), 'The SproutCore Logo', 'updates alt attribute when content object is a hash');
 
   run(function() {
-    set(view, 'content', EmberObject.createWithMixins({
-      url: 'http://www.emberjs.com/assets/images/logo.png',
+    set(view, 'content', EmberObject.extend({
       title: computed(function() {
         return 'Nanananana Ember!';
       })
+    }).create({
+      url: 'http://www.emberjs.com/assets/images/logo.png'
     }));
   });
 

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -1260,11 +1260,12 @@ QUnit.test('should respect keywords', function() {
 });
 
 QUnit.test('should bind to the property if no registered helper found for a mustache without parameters', function() {
-  view = EmberView.createWithMixins({
-    template: compile('{{view.foobarProperty}}'),
+  view = EmberView.extend({
     foobarProperty: computed(function() {
       return 'foobarProperty';
     })
+  }).create({
+    template: compile('{{view.foobarProperty}}')
   });
 
   runAppend(view);

--- a/packages/ember-htmlbars/tests/integration/binding_integration_test.js
+++ b/packages/ember-htmlbars/tests/integration/binding_integration_test.js
@@ -49,11 +49,12 @@ QUnit.test('should call a registered helper for mustache without parameters', fu
 });
 
 QUnit.test('should bind to the property if no registered helper found for a mustache without parameters', function() {
-  view = EmberView.createWithMixins({
-    template: compile('{{view.foobarProperty}}'),
+  view = EmberView.extend({
     foobarProperty: computed(function() {
       return 'foobarProperty';
     })
+  }).create({
+    template: compile('{{view.foobarProperty}}')
   });
 
   runAppend(view);

--- a/packages/ember-routing-htmlbars/tests/helpers/render_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/render_test.js
@@ -346,7 +346,7 @@ QUnit.test('{{render}} helper should not treat invocations with falsy contexts a
 
   view = EmberView.create({
     container: container,
-    controller: EmberController.createWithMixins({
+    controller: EmberController.create({
       container: container,
       zero: false
     }),

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -152,7 +152,7 @@ QUnit.test('modelFor doesn\'t require the router', function() {
 
 QUnit.test('.send just calls an action if the router is absent', function() {
   expect(7);
-  var route = EmberRoute.createWithMixins({
+  var route = EmberRoute.extend({
     actions: {
       returnsTrue(foo, bar) {
         equal(foo, 1);
@@ -166,7 +166,7 @@ QUnit.test('.send just calls an action if the router is absent', function() {
         return false;
       }
     }
-  });
+  }).create();
 
   equal(true, route.send('returnsTrue', 1, 2));
   equal(false, route.send('returnsFalse'));

--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -454,10 +454,11 @@ export var union = uniq;
   Example
 
   ```javascript
-  var obj = Ember.Object.createWithMixins({
-    adaFriends: ['Charles Babbage', 'John Hobhouse', 'William King', 'Mary Somerville'],
-    charlesFriends: ['William King', 'Mary Somerville', 'Ada Lovelace', 'George Peacock'],
+  var obj = Ember.Object.extend({
     friendsInCommon: Ember.computed.intersect('adaFriends', 'charlesFriends')
+  }).create({
+    adaFriends: ['Charles Babbage', 'John Hobhouse', 'William King', 'Mary Somerville'],
+    charlesFriends: ['William King', 'Mary Somerville', 'Ada Lovelace', 'George Peacock']
   });
 
   obj.get('friendsInCommon'); // ['William King', 'Mary Somerville']

--- a/packages/ember-runtime/lib/system/core_object.js
+++ b/packages/ember-runtime/lib/system/core_object.js
@@ -90,7 +90,7 @@ function makeCtor() {
       for (var i = 0, l = props.length; i < l; i++) {
         var properties = props[i];
 
-        Ember.assert('Ember.Object.create no longer supports mixing in other definitions, use createWithMixins instead.', !(properties instanceof Mixin));
+        Ember.assert('Ember.Object.create no longer supports mixing in other definitions, use .extend & .create seperately instead.', !(properties instanceof Mixin));
 
         if (typeof properties !== 'object' && properties !== undefined) {
           throw new EmberError('Ember.Object.create only accepts objects.');
@@ -582,14 +582,15 @@ var ClassMixinProps = {
     @static
     @param [arguments]*
     @private
+    @deprecated
   */
-  createWithMixins(...args) {
+  createWithMixins: Ember.deprecateFunc('.createWithMixins is deprecated, please use .create or .extend accordingly', function(...args) {
     var C = this;
     if (args.length > 0) {
       this._initMixins(args);
     }
     return new C();
-  },
+  }),
 
   /**
     Creates an instance of a class. Accepts either no arguments, or an object
@@ -622,7 +623,7 @@ var ClassMixinProps = {
 
     NOTE: For performance reasons, you cannot declare methods or computed
     properties during `create`. You should instead declare methods and computed
-    properties when using `extend` or use the `createWithMixins` shorthand.
+    properties when using `extend`.
 
     @method create
     @static

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -32,8 +32,7 @@ QUnit.module('computedMap', {
   setup() {
     run(function() {
       userFnCalls = 0;
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }]),
+      obj = EmberObject.extend({
 
         mapped: computedMap('array.@each.v', function(item) {
           ++userFnCalls;
@@ -48,6 +47,8 @@ QUnit.module('computedMap', {
             name: item.v.name
           };
         })
+      }).create({
+        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }])
       });
     });
   },
@@ -95,9 +96,10 @@ QUnit.test('it maps simple unshifted properties', function() {
   var array = Ember.A([]);
 
   run(function() {
-    obj = EmberObject.createWithMixins({
-      array: array,
-      mapped: computedMap('array', function (item) { return item.toUpperCase(); })
+    obj = EmberObject.extend({
+      mapped: computedMap('array', (item) => item.toUpperCase())
+    }).create({
+      array
     });
     get(obj, 'mapped');
   });
@@ -117,9 +119,10 @@ QUnit.test('it passes the index to the callback', function() {
   var array = Ember.A(['a', 'b', 'c']);
 
   run(function() {
-    obj = EmberObject.createWithMixins({
-      array: array,
-      mapped: computedMap('array', function (item, index) { return index; })
+    obj = EmberObject.extend({
+      mapped: computedMap('array', (item, index) => index)
+    }).create({
+      array
     });
     get(obj, 'mapped');
   });
@@ -154,11 +157,12 @@ QUnit.test('it maps unshifted objects with property observers', function() {
   var cObj = { v: 'c' };
 
   run(function() {
-    obj = EmberObject.createWithMixins({
-      array: array,
+    obj = EmberObject.extend({
       mapped: computedMap('array.@each.v', function (item) {
         return get(item, 'v').toUpperCase();
       })
+    }).create({
+      array
     });
     get(obj, 'mapped');
   });
@@ -178,9 +182,10 @@ QUnit.test('it maps unshifted objects with property observers', function() {
 QUnit.module('computedMapBy', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }]),
+      obj = EmberObject.extend({
         mapped: computedMapBy('array', 'v')
+      }).create({
+        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }])
       });
     });
   },
@@ -231,12 +236,13 @@ QUnit.module('computedFilter', {
   setup() {
     run(function() {
       userFnCalls = 0;
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([1, 2, 3, 4, 5, 6, 7, 8]),
+      obj = EmberObject.extend({
         filtered: computedFilter('array', function(item) {
           ++userFnCalls;
           return item % 2 === 0;
         })
+      }).create({
+        array: Ember.A([1, 2, 3, 4, 5, 6, 7, 8])
       });
     });
   },
@@ -257,9 +263,10 @@ QUnit.test('it passes the index to the callback', function() {
   var array = Ember.A(['a', 'b', 'c']);
 
   run(function() {
-    obj = EmberObject.createWithMixins({
-      array: array,
+    obj = EmberObject.extend({
       filtered: computedFilter('array', function (item, index) { return index === 1; })
+    }).create({
+      array
     });
     get(obj, 'filtered');
   });
@@ -271,9 +278,10 @@ QUnit.test('it passes the array to the callback', function() {
   var array = Ember.A(['a', 'b', 'c']);
 
   run(function() {
-    obj = EmberObject.createWithMixins({
-      array: array,
+    obj = EmberObject.extend({
       filtered: computedFilter('array', function (item, index, array) { return index === array.get('length') - 2; })
+    }).create({
+      array
     });
     get(obj, 'filtered');
   });
@@ -369,16 +377,17 @@ QUnit.test('it updates as the array is replaced', function() {
 
 QUnit.module('computedFilterBy', {
   setup() {
-    obj = EmberObject.createWithMixins({
+    obj = EmberObject.extend({
+      a1s: computedFilterBy('array', 'a', 1),
+      as: computedFilterBy('array', 'a'),
+      bs: computedFilterBy('array', 'b')
+    }).create({
       array: Ember.A([
         { name: 'one', a: 1, b: false },
         { name: 'two', a: 2, b: false },
         { name: 'three', a: 1, b: true },
         { name: 'four', b: true }
-      ]),
-      a1s: computedFilterBy('array', 'a', 1),
-      as: computedFilterBy('array', 'a'),
-      bs: computedFilterBy('array', 'b')
+      ])
     });
   },
   teardown() {
@@ -449,10 +458,11 @@ QUnit.test('properties can be filtered by values', function() {
 });
 
 QUnit.test('properties values can be replaced', function() {
-  obj = EmberObject.createWithMixins({
-      array: Ember.A([]),
+  obj = EmberObject.extend({
       a1s: computedFilterBy('array', 'a', 1),
       a1bs: computedFilterBy('a1s', 'b')
+    }).create({
+      array: Ember.A([])
     });
 
   var a1bs = get(obj, 'a1bs');
@@ -474,11 +484,12 @@ QUnit.test('properties values can be replaced', function() {
     setup() {
       run(function() {
         union = testedFunc('array', 'array2', 'array3');
-        obj = EmberObject.createWithMixins({
+        obj = EmberObject.extend({
+          union: union
+        }).create({
           array: Ember.A([1,2,3,4,5,6]),
           array2: Ember.A([4,5,6,7,8,9,4,5,6,7,8,9]),
-          array3: Ember.A([1,8,10]),
-          union: union
+          array3: Ember.A([1,8,10])
         });
       });
     },
@@ -563,11 +574,12 @@ QUnit.test('properties values can be replaced', function() {
 QUnit.module('computed.intersect', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
+      obj = EmberObject.extend({
+        intersection: computedIntersect('array', 'array2', 'array3')
+      }).create({
         array: Ember.A([1,2,3,4,5,6]),
         array2: Ember.A([3,3,3,4,5]),
-        array3: Ember.A([3,5,6,7,8]),
-        intersection: computedIntersect('array', 'array2', 'array3')
+        array3: Ember.A([3,5,6,7,8])
       });
     });
   },
@@ -616,10 +628,11 @@ QUnit.test('it has set-intersection semantics', function() {
 QUnit.module('computedSetDiff', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([1,2,3,4,5,6,7]),
-        array2: Ember.A([3,4,5,10]),
+      obj = EmberObject.extend({
         diff: computedSetDiff('array', 'array2')
+      }).create({
+        array: Ember.A([1,2,3,4,5,6,7]),
+        array2: Ember.A([3,4,5,10])
       });
     });
   },
@@ -632,19 +645,21 @@ QUnit.module('computedSetDiff', {
 
 QUnit.test('it throws an error if given fewer or more than two dependent properties', function() {
   throws(function () {
-    EmberObject.createWithMixins({
-      array: Ember.A([1,2,3,4,5,6,7]),
-      array2: Ember.A([3,4,5]),
+    EmberObject.extend({
       diff: computedSetDiff('array')
+    }).create({
+      array: Ember.A([1,2,3,4,5,6,7]),
+      array2: Ember.A([3,4,5])
     });
   }, /requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 
   throws(function () {
-    EmberObject.createWithMixins({
+    EmberObject.extend({
+      diff: computedSetDiff('array', 'array2', 'array3')
+    }).create({
       array: Ember.A([1,2,3,4,5,6,7]),
       array2: Ember.A([3,4,5]),
-      array3: Ember.A([7]),
-      diff: computedSetDiff('array', 'array2', 'array3')
+      array3: Ember.A([7])
     });
   }, /requires exactly two dependent arrays/, 'setDiff requires two dependent arrays');
 });
@@ -811,7 +826,9 @@ function commonSortTests() {
 QUnit.module('computedSort - sortProperties', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
+      obj = EmberObject.extend({
+        sortedItems: computedSort('items', 'itemSorting')
+      }).create({
         itemSorting: Ember.A(['lname', 'fname']),
         items: Ember.A([{
           fname: 'Jaime', lname: 'Lannister', age: 34
@@ -821,9 +838,7 @@ QUnit.module('computedSort - sortProperties', {
           fname: 'Robb', lname: 'Stark', age: 16
         }, {
           fname: 'Bran', lname: 'Stark', age: 8
-        }]),
-
-        sortedItems: computedSort('items', 'itemSorting')
+        }])
       });
     });
   },
@@ -985,10 +1000,11 @@ QUnit.test('updating an item\'s sort properties does not error when binary searc
       status: 2
     });
 
-    obj = EmberObject.createWithMixins({
-      people: Ember.A([jaime, cersei]),
-      sortProps: Ember.A(['status']),
+    obj = EmberObject.extend({
       sortedPeople: computedSort('people', 'sortProps')
+    }).create({
+      people: Ember.A([jaime, cersei]),
+      sortProps: Ember.A(['status'])
     });
   });
 
@@ -1023,10 +1039,11 @@ QUnit.test('array observers do not leak', function() {
 
   run(function() {
     sortProps = Ember.A(['name']);
-    jaime = EmberObject.createWithMixins({
-      sisters: sisters,
+    jaime = EmberObject.extend({
       sortedPeople: computedSort('sisters', 'sortProps'),
       sortProps: sortProps
+    }).create({
+      sisters: sisters
     });
   });
 
@@ -1061,10 +1078,11 @@ QUnit.test('property paths in sort properties update the sorted array', function
       relatedObj: EmberObject.create({ status: 3, firstName: 'Sansa', lastName: 'Stark' })
     });
 
-    obj = EmberObject.createWithMixins({
-      people: Ember.A([jaime, cersei, sansa]),
-      sortProps: Ember.A(['relatedObj.status']),
+    obj = EmberObject.extend({
       sortedPeople: computedSort('people', 'sortProps')
+    }).create({
+      people: Ember.A([jaime, cersei, sansa]),
+      sortProps: Ember.A(['relatedObj.status'])
     });
   });
 
@@ -1119,7 +1137,9 @@ function sortByFnameAsc(a, b) {
 QUnit.module('computedSort - sort function', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
+      obj = EmberObject.extend({
+        sortedItems: computedSort('items.@each.fname', sortByLnameFname)
+      }).create({
         items: Ember.A([{
           fname: 'Jaime', lname: 'Lannister', age: 34
         }, {
@@ -1128,9 +1148,7 @@ QUnit.module('computedSort - sort function', {
           fname: 'Robb', lname: 'Stark', age: 16
         }, {
           fname: 'Bran', lname: 'Stark', age: 8
-        }]),
-
-        sortedItems: computedSort('items.@each.fname', sortByLnameFname)
+        }])
       });
     });
   },
@@ -1187,7 +1205,10 @@ QUnit.test('changing item properties not specified via @each does not trigger a 
 QUnit.module('computedSort - stability', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
+      obj = EmberObject.extend({
+        sortProps: Ember.A(['count', 'name']),
+        sortedItems: computedSort('items', 'sortProps')
+      }).create({
         items: Ember.A(Ember.A([{
           name: 'A', count: 1
         }, {
@@ -1196,12 +1217,7 @@ QUnit.module('computedSort - stability', {
           name: 'C', count: 1
         }, {
           name: 'D', count: 1
-        }]).map(function(elt) {
-          return EmberObject.create(elt);
-        })),
-
-        sortProps: Ember.A(['count', 'name']),
-        sortedItems: computedSort('items', 'sortProps')
+        }]).map((elt) => EmberObject.create(elt)))
       });
     });
   },
@@ -1228,7 +1244,13 @@ QUnit.test('sorts correctly as only one property changes', function() {
 QUnit.module('computedSort - concurrency', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
+      obj = EmberObject.extend({
+        sortProps: Ember.A(['count']),
+        sortedItems: computedSort('items', 'sortProps'),
+        customSortedItems: computedSort('items.@each.count', function(a, b) {
+          return get(a, 'count') - get(b, 'count');
+        })
+      }).create({
         items: Ember.A(Ember.A([{
           name: 'A', count: 1
         }, {
@@ -1237,15 +1259,7 @@ QUnit.module('computedSort - concurrency', {
           name: 'C', count: 3
         }, {
           name: 'D', count: 4
-        }]).map(function(elt) {
-          return EmberObject.create(elt);
-        })),
-
-        sortProps: Ember.A(['count']),
-        sortedItems: computedSort('items', 'sortProps'),
-        customSortedItems: computedSort('items.@each.count', function(a, b) {
-          return get(a, 'count') - get(b, 'count');
-        })
+        }]).map((elt) => EmberObject.create(elt)))
       });
     });
   },
@@ -1294,9 +1308,10 @@ QUnit.test('sorts correctly with a user-provided comparator when there are concu
 QUnit.module('computedMax', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
-        items: Ember.A([1,2,3]),
+      obj = EmberObject.extend({
         max: computedMax('items')
+      }).create({
+        items: Ember.A([1,2,3])
       });
     });
   },
@@ -1347,9 +1362,10 @@ QUnit.test('max recomputes when the current max is removed', function() {
 QUnit.module('computedMin', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
-        items: Ember.A([1,2,3]),
+      obj = EmberObject.extend({
         min: computedMin('items')
+      }).create({
+        items: Ember.A([1,2,3])
       });
     });
   },
@@ -1400,7 +1416,14 @@ QUnit.test('min recomputes when the current min is removed', function() {
 QUnit.module('Ember.arrayComputed - mixed sugar', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
+      obj = EmberObject.extend({
+        lannisters: computedFilterBy('items', 'lname', 'Lannister'),
+        sortedLannisters: computedSort('lannisters', 'lannisterSorting'),
+        starks: computedFilterBy('items', 'lname', 'Stark'),
+        starkAges: computedMapBy('starks', 'age'),
+        oldestStarkAge: computedMax('starkAges')
+      }).create({
+        lannisterSorting: Ember.A(['fname']),
         items: Ember.A([{
           fname: 'Jaime', lname: 'Lannister', age: 34
         }, {
@@ -1409,16 +1432,7 @@ QUnit.module('Ember.arrayComputed - mixed sugar', {
           fname: 'Robb', lname: 'Stark', age: 16
         }, {
           fname: 'Bran', lname: 'Stark', age: 8
-        }]),
-
-        lannisters: computedFilterBy('items', 'lname', 'Lannister'),
-        lannisterSorting: Ember.A(['fname']),
-        sortedLannisters: computedSort('lannisters', 'lannisterSorting'),
-
-
-        starks: computedFilterBy('items', 'lname', 'Stark'),
-        starkAges: computedMapBy('starks', 'age'),
-        oldestStarkAge: computedMax('starkAges')
+        }])
       });
     });
   },
@@ -1485,10 +1499,11 @@ function evenPriorities(todo) {
 
 QUnit.module('Ember.arrayComputed - chains', {
   setup() {
-    obj = EmberObject.createWithMixins({
-      todos: Ember.A([todo('E', 4), todo('D', 3), todo('C', 2), todo('B', 1), todo('A', 0)]),
-      sorted: computedSort('todos.@each.priority', priorityComparator),
-      filtered: computedFilter('sorted.@each.priority', evenPriorities)
+    obj = EmberObject.extend({
+      filtered: computedFilter('sorted.@each.priority', evenPriorities),
+      sorted: computedSort('todos.@each.priority', priorityComparator)
+    }).create({
+      todos: Ember.A([todo('E', 4), todo('D', 3), todo('C', 2), todo('B', 1), todo('A', 0)])
     });
   },
   teardown() {
@@ -1532,13 +1547,14 @@ QUnit.module('Chaining array and reduced CPs', {
   setup() {
     run(function() {
       userFnCalls = 0;
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }]),
+      obj = EmberObject.extend({
         mapped: computedMapBy('array', 'v'),
         max: computedMax('mapped'),
         maxDidChange: observer('max', function() {
           userFnCalls++;
         })
+      }).create({
+        array: Ember.A([{ v: 1 }, { v: 3 }, { v: 2 }, { v: 1 }])
       });
     });
   },
@@ -1572,9 +1588,10 @@ QUnit.test('it computes interdependent array computed properties', function() {
 QUnit.module('computedSum', {
   setup() {
     run(function() {
-      obj = EmberObject.createWithMixins({
-        array: Ember.A([1, 2, 3]),
+      obj = EmberObject.extend({
         total: computedSum('array')
+      }).create({
+        array: Ember.A([1, 2, 3])
       });
     });
   },

--- a/packages/ember-runtime/tests/computed/reduce_computed_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_test.js
@@ -25,10 +25,7 @@ QUnit.module('arrayComputed - [DEPRECATED]', {
 
     expectDeprecation(function() {
 
-      obj = EmberObject.createWithMixins({
-        numbers:  Ember.A([1, 2, 3, 4, 5, 6]),
-        otherNumbers: Ember.A([7, 8, 9]),
-
+      obj = EmberObject.extend({
         // Users would obviously just use `Ember.computed.map`
         // This implementation is fine for these tests, but doesn't properly work as
         // it's not index based.
@@ -56,8 +53,6 @@ QUnit.module('arrayComputed - [DEPRECATED]', {
           }
         }),
 
-        nestedNumbers:  Ember.A([1,2,3,4,5,6].map((n) => EmberObject.create({ p: 'otherProperty', v: n }))),
-
         evenNestedNumbers: arrayComputed({
           addedItem(array, item, keyName) {
             var value = item.get('v');
@@ -71,6 +66,10 @@ QUnit.module('arrayComputed - [DEPRECATED]', {
             return array;
           }
         }).property('nestedNumbers.@each.v')
+      }).create({
+        numbers:  Ember.A([1, 2, 3, 4, 5, 6]),
+        otherNumbers: Ember.A([7, 8, 9]),
+        nestedNumbers:  Ember.A([1,2,3,4,5,6].map((n) => EmberObject.create({ p: 'otherProperty', v: n })))
       });
 
     }, 'Ember.arrayComputed is deprecated. Replace it with plain array methods');
@@ -103,8 +102,7 @@ QUnit.test('array computed properties are instances of ComputedProperty', functi
 QUnit.test('when the dependent array is null or undefined, `addedItem` is not called and only the initial value is returned', function() {
   expectDeprecation(/Ember.arrayComputed is deprecated/);
 
-  obj = EmberObject.createWithMixins({
-    numbers: null,
+  obj = EmberObject.extend({
     doubledNumbers: arrayComputed('numbers', {
       addedItem(array, n) {
         addCalls++;
@@ -112,6 +110,8 @@ QUnit.test('when the dependent array is null or undefined, `addedItem` is not ca
         return array;
       }
     })
+  }).create({
+    numbers: null
   });
 
   deepEqual(get(obj, 'doubledNumbers'), [], 'When the dependent array is null, the initial value is returned');
@@ -189,9 +189,7 @@ QUnit.test('changes to array computed properties happen synchronously', function
 });
 
 QUnit.test('multiple dependent keys can be specified via brace expansion', function() {
-  var obj = EmberObject.createWithMixins({
-    bar: Ember.A(),
-    baz: Ember.A(),
+  var obj = EmberObject.extend({
     foo: reduceComputed({
       initialValue: Ember.A(),
       addedItem(array, item) {
@@ -203,6 +201,9 @@ QUnit.test('multiple dependent keys can be specified via brace expansion', funct
         return array;
       }
     }).property('{bar,baz}')
+  }).create({
+    bar: Ember.A(),
+    baz: Ember.A()
   });
 
   deepEqual(get(obj, 'foo'), [], 'initially empty');
@@ -227,8 +228,7 @@ QUnit.test('multiple dependent keys can be specified via brace expansion', funct
 QUnit.test('multiple item property keys can be specified via brace expansion', function() {
   var expected = Ember.A();
   var item = { propA: 'A', propB: 'B', propC: 'C' };
-  var obj = EmberObject.createWithMixins({
-    bar: Ember.A([item]),
+  var obj = EmberObject.extend({
     foo: reduceComputed({
       initialValue: Ember.A(),
       addedItem(array, item, changeMeta) {
@@ -240,6 +240,8 @@ QUnit.test('multiple item property keys can be specified via brace expansion', f
         return array;
       }
     }).property('bar.@each.{propA,propB}')
+  }).create({
+    bar: Ember.A([item])
   });
 
   expected.pushObjects(['a:A:B:C']);
@@ -262,8 +264,7 @@ QUnit.test('multiple item property keys can be specified via brace expansion', f
 
 QUnit.test('doubly nested item property keys (@each.foo.@each) are not supported', function() {
   run(function() {
-    obj = EmberObject.createWithMixins({
-      peopleByOrdinalPosition: Ember.A([{ first: Ember.A([EmberObject.create({ name: 'Jaime Lannister' })]) }]),
+    obj = EmberObject.extend({
       people: arrayComputed({
         addedItem(array, item) {
           array.pushObject(get(item, 'first.firstObject'));
@@ -277,20 +278,23 @@ QUnit.test('doubly nested item property keys (@each.foo.@each) are not supported
           return array;
         }
       }).property('people.@each.name')
+    }).create({
+      peopleByOrdinalPosition: Ember.A([{ first: Ember.A([EmberObject.create({ name: 'Jaime Lannister' })]) }])
     });
   });
 
   equal(obj.get('names.firstObject'), 'Jaime Lannister', 'Doubly nested item properties can be retrieved manually');
 
   throws(function() {
-    obj = EmberObject.createWithMixins({
-      people: [{ first: Ember.A([EmberObject.create({ name: 'Jaime Lannister' })]) }],
+    obj = EmberObject.extend({
       names: arrayComputed({
         addedItem(array, item) {
           array.pushObject(item);
           return array;
         }
       }).property('people.@each.first.@each.name')
+    }).create({
+      people: [{ first: Ember.A([EmberObject.create({ name: 'Jaime Lannister' })]) }]
     });
   }, /Nested @each/, 'doubly nested item property keys are not supported');
 });
@@ -362,8 +366,7 @@ QUnit.test('multiple array computed properties on the same object can observe de
 
 QUnit.test('an error is thrown when a reduceComputed is defined without an initialValue property', function() {
   var defineExploder = function() {
-    EmberObject.createWithMixins({
-      collection: Ember.A(),
+    EmberObject.extend({
       exploder: reduceComputed('collection', {
         initialize(initialValue, changeMeta, instanceMeta) {},
 
@@ -375,6 +378,8 @@ QUnit.test('an error is thrown when a reduceComputed is defined without an initi
           return item;
         }
       })
+    }).create({
+      collection: Ember.A()
     });
   };
 
@@ -603,8 +608,7 @@ QUnit.module('Ember.arryComputed - self chains', {
 
     expectDeprecation(function() {
 
-      obj = ArrayProxy.createWithMixins({
-        content: Ember.A([a, b]),
+      obj = ArrayProxy.extend({
         names: arrayComputed('@this.@each.name', {
           addedItem(array, item, changeMeta, instanceMeta) {
             var mapped = get(item, 'name');
@@ -616,6 +620,8 @@ QUnit.module('Ember.arryComputed - self chains', {
             return array;
           }
         })
+      }).create({
+        content: Ember.A([a, b])
       });
     }, 'Ember.arrayComputed is deprecated. Replace it with plain array methods');
   },
@@ -649,9 +655,7 @@ QUnit.module('arrayComputed - changeMeta property observers', {
     callbackItems = [];
     run(function() {
       expectDeprecation(function() {
-
-        obj = EmberObject.createWithMixins({
-          items: Ember.A([EmberObject.create({ n: 'zero' }), EmberObject.create({ n: 'one' })]),
+        obj = EmberObject.extend({
           itemsN: arrayComputed('items.@each.n', {
             addedItem(array, item, changeMeta, instanceMeta) {
               callbackItems.push('add:' + changeMeta.index + ':' + get(changeMeta.item, 'n'));
@@ -660,6 +664,8 @@ QUnit.module('arrayComputed - changeMeta property observers', {
               callbackItems.push('remove:' + changeMeta.index + ':' + get(changeMeta.item, 'n'));
             }
           })
+        }).create({
+          items: Ember.A([EmberObject.create({ n: 'zero' }), EmberObject.create({ n: 'one' })])
         });
       }, 'Ember.arrayComputed is deprecated. Replace it with plain array methods');
     });
@@ -751,8 +757,7 @@ QUnit.test('changeMeta includes item and index', function() {
 });
 
 QUnit.test('changeMeta includes changedCount and arrayChanged', function() {
-  var obj = EmberObject.createWithMixins({
-    letters: Ember.A(['a', 'b']),
+  var obj = EmberObject.extend({
     lettersArrayComputed: arrayComputed('letters', {
       addedItem(array, item, changeMeta, instanceMeta) {
         callbackItems.push('add:' + changeMeta.changedCount + ':' + changeMeta.arrayChanged.join(''));
@@ -761,6 +766,8 @@ QUnit.test('changeMeta includes changedCount and arrayChanged', function() {
         callbackItems.push('remove:' + changeMeta.changedCount + ':' + changeMeta.arrayChanged.join(''));
       }
     })
+  }).create({
+    letters: Ember.A(['a', 'b'])
   });
 
   var letters = get(obj, 'letters');
@@ -813,8 +820,7 @@ QUnit.test('`updateIndexes` is not over-eager about skipping retain:n (#4620)', 
 });
 
 QUnit.test('when initialValue is undefined, everything works as advertised', function() {
-  var chars = EmberObject.createWithMixins({
-    letters: Ember.A(),
+  var chars = EmberObject.extend({
     firstUpper: reduceComputed('letters', {
       initialValue: undefined,
 
@@ -843,6 +849,8 @@ QUnit.test('when initialValue is undefined, everything works as advertised', fun
         return instanceMeta.firstMatch();
       }
     })
+  }).create({
+    letters: Ember.A()
   });
   equal(get(chars, 'firstUpper'), undefined, 'initialValue is undefined');
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -45,23 +45,18 @@ var originalLookup = Ember.lookup;
 QUnit.module('object.get()', {
 
   setup() {
-    object = ObservableObject.createWithMixins(Observable, {
-
-      normal: 'value',
-      numberVal: 24,
-      toggleVal: true,
-
+    object = ObservableObject.extend(Observable, {
       computed: computed(function() { return 'value'; }).volatile(),
-
       method() { return 'value'; },
-
-      nullProperty: null,
-
       unknownProperty(key, value) {
         this.lastUnknownProperty = key;
         return 'unknown';
       }
-
+    }).create({
+      normal: 'value',
+      numberVal: 24,
+      toggleVal: true,
+      nullProperty: null
     });
   }
 
@@ -94,28 +89,22 @@ QUnit.test('should call unknownProperty when value is undefined', function() {
 //
 QUnit.module('Ember.get()', {
   setup() {
-    objectA = ObservableObject.createWithMixins({
-
-      normal: 'value',
-      numberVal: 24,
-      toggleVal: true,
-
+    objectA = ObservableObject.extend({
       computed: computed(function() { return 'value'; }).volatile(),
-
       method() { return 'value'; },
-
-      nullProperty: null,
-
       unknownProperty(key, value) {
         this.lastUnknownProperty = key;
         return 'unknown';
       }
-
+    }).create({
+      normal: 'value',
+      numberVal: 24,
+      toggleVal: true,
+      nullProperty: null
     });
 
     objectB = {
       normal: 'value',
-
       nullProperty: null
     };
   }
@@ -181,20 +170,20 @@ QUnit.module('Ember.get() with paths', {
 });
 
 QUnit.test('should return a property at a given path relative to the lookup', function() {
-  lookup.Foo = ObservableObject.create({
-    Bar: ObservableObject.createWithMixins({
+  lookup.Foo = ObservableObject.extend({
+    Bar: ObservableObject.extend({
       Baz: computed(function() { return 'blargh'; }).volatile()
-    })
-  });
+    }).create()
+  }).create();
 
   equal(get('Foo.Bar.Baz'), 'blargh');
 });
 
 QUnit.test('should return a property at a given path relative to the passed object', function() {
   var foo = ObservableObject.create({
-    bar: ObservableObject.createWithMixins({
+    bar: ObservableObject.extend({
       baz: computed(function() { return 'blargh'; }).volatile()
-    })
+    }).create()
   });
 
   equal(get(foo, 'bar.baz'), 'blargh');
@@ -227,25 +216,17 @@ QUnit.test('should return a property at a given path relative to the passed obje
 QUnit.module('object.set()', {
 
   setup() {
-    object = ObservableObject.createWithMixins({
-
-      // normal property
-      normal: 'value',
-
-      // computed property
-      _computed: 'computed',
+    object = ObservableObject.extend({
       computed: computed({
-        get: function(key) {
+        get(key) {
           return this._computed;
         },
-        set: function(key, value) {
+        set(key, value) {
           this._computed = value;
           return this._computed;
         }
       }).volatile(),
 
-      // method, but not a property
-      _method: 'method',
       method(key, value) {
         if (value !== undefined) {
           this._method = value;
@@ -253,11 +234,6 @@ QUnit.module('object.set()', {
         return this._method;
       },
 
-      // null property
-      nullProperty: null,
-
-      // unknown property
-      _unknown: 'unknown',
       unknownProperty(key) {
         return this._unknown;
       },
@@ -265,46 +241,59 @@ QUnit.module('object.set()', {
       setUnknownProperty(key, value) {
         this._unknown = value;
         return this._unknown;
-      }
-    });
+      },
+
+      // normal property
+      normal: 'value',
+
+      // computed property
+      _computed: 'computed',
+      // method, but not a property
+      _method: 'method',
+      // null property
+      nullProperty: null,
+
+      // unknown property
+      _unknown: 'unknown'
+    }).create();
   }
 
 });
 
 QUnit.test('should change normal properties and return the value', function() {
   var ret = object.set('normal', 'changed');
-  equal(object.normal, 'changed');
+  equal(object.get('normal'), 'changed');
   equal(ret, 'changed');
 });
 
 QUnit.test('should call computed properties passing value and return the value', function() {
   var ret = object.set('computed', 'changed');
-  equal(object._computed, 'changed');
+  equal(object.get('_computed'), 'changed');
   equal(ret, 'changed');
 });
 
 QUnit.test('should change normal properties when passing undefined', function() {
   var ret = object.set('normal', undefined);
-  equal(object.normal, undefined);
+  equal(object.get('normal'), undefined);
   equal(ret, undefined);
 });
 
 QUnit.test('should replace the function for a non-computed property and return the value', function() {
   var ret = object.set('method', 'changed');
-  equal(object._method, 'method'); // make sure this was NOT run
-  ok(typeof object.method !== 'function');
+  equal(object.get('_method'), 'method'); // make sure this was NOT run
+  ok(typeof object.get('method') !== 'function');
   equal(ret, 'changed');
 });
 
 QUnit.test('should replace prover when property value is null', function() {
   var ret = object.set('nullProperty', 'changed');
-  equal(object.nullProperty, 'changed');
+  equal(object.get('nullProperty'), 'changed');
   equal(ret, 'changed');
 });
 
 QUnit.test('should call unknownProperty with value when property is undefined', function() {
   var ret = object.set('unknown', 'changed');
-  equal(object._unknown, 'changed');
+  equal(object.get('_unknown'), 'changed');
   equal(ret, 'changed');
 });
 
@@ -316,24 +305,19 @@ QUnit.module('Computed properties', {
   setup() {
     lookup = Ember.lookup = {};
 
-    object = ObservableObject.createWithMixins({
-
-      // REGULAR
-
-      computedCalls: [],
+    object = ObservableObject.extend({
       computed: computed({
-        get: function() {
+        get() {
           this.computedCalls.push('getter-called');
           return 'computed';
         },
-        set: function(key, value) {
+        set(key, value) {
           this.computedCalls.push(value);
         }
       }).volatile(),
 
-      computedCachedCalls: [],
       computedCached: computed({
-        get: function() {
+        get() {
           this.computedCachedCalls.push('getter-called');
           return 'computedCached';
         },
@@ -342,78 +326,73 @@ QUnit.module('Computed properties', {
         }
       }),
 
-      // DEPENDENT KEYS
-
-      changer: 'foo',
-
-      dependentCalls: [],
       dependent: computed({
-        get: function() {
+        get() {
           this.dependentCalls.push('getter-called');
           return 'dependent';
         },
-        set: function(key, value) {
+        set(key, value) {
           this.dependentCalls.push(value);
         }
       }).property('changer').volatile(),
-
-      dependentFrontCalls: [],
       dependentFront: computed('changer', {
-        get: function() {
+        get() {
           this.dependentFrontCalls.push('getter-called');
           return 'dependentFront';
         },
-        set: function(key, value) {
+        set(key, value) {
           this.dependentFrontCalls.push(value);
         }
       }).volatile(),
-
-      dependentCachedCalls: [],
       dependentCached: computed({
-        get: function() {
+        get() {
           this.dependentCachedCalls.push('getter-called!');
           return 'dependentCached';
         },
-        set: function(key, value) {
+        set(key, value) {
           this.dependentCachedCalls.push(value);
         }
       }).property('changer'),
 
-      // every time it is recomputed, increments call
-      incCallCount: 0,
-      inc: computed(function() {
+      inc: computed('changer', function() {
         return this.incCallCount++;
-      }).property('changer'),
+      }),
 
-      // depends on cached property which depends on another property...
-      nestedIncCallCount: 0,
       nestedInc: computed(function(key) {
         get(this, 'inc');
         return this.nestedIncCallCount++;
       }).property('inc'),
 
-      // two computed properties that depend on a third property
-      state: 'on',
       isOn: computed({
-        get: function() {
+        get() {
           return this.get('state') === 'on';
         },
-        set: function(key, value) {
+        set(key, value) {
           this.set('state', 'on');
           return this.get('state') === 'on';
         }
       }).property('state').volatile(),
 
       isOff: computed({
-        get: function() {
+        get() {
           return this.get('state') === 'off';
         },
-        set: function(key, value) {
+        set(key, value) {
           this.set('state', 'off');
           return this.get('state') === 'off';
         }
       }).property('state').volatile()
 
+    }).create({
+      computedCalls: [],
+      computedCachedCalls: [],
+      changer: 'foo',
+      dependentCalls: [],
+      dependentFrontCalls: [],
+      dependentCachedCalls: [],
+      incCallCount: 0,
+      nestedIncCallCount: 0,
+      state: 'on'
     });
   },
   teardown() {
@@ -564,14 +543,14 @@ QUnit.test('setting one of two computed properties that depend on a third proper
 });
 
 QUnit.test('dependent keys should be able to be specified as property paths', function() {
-  var depObj = ObservableObject.createWithMixins({
-    menu: ObservableObject.create({
-      price: 5
-    }),
-
+  var depObj = ObservableObject.extend({
     menuPrice: computed(function() {
       return this.get('menu.price');
     }).property('menu.price')
+  }).create({
+    menu: ObservableObject.create({
+      price: 5
+    })
   });
 
   equal(depObj.get('menuPrice'), 5, 'precond - initial value returns 5');
@@ -584,21 +563,21 @@ QUnit.test('dependent keys should be able to be specified as property paths', fu
 QUnit.test('nested dependent keys should propagate after they update', function() {
   var bindObj;
   run(function () {
-    lookup.DepObj = ObservableObject.createWithMixins({
+    lookup.DepObj = ObservableObject.extend({
+      price: computed(function() {
+        return this.get('restaurant.menu.price');
+      }).property('restaurant.menu.price')
+    }).create({
       restaurant: ObservableObject.create({
         menu: ObservableObject.create({
           price: 5
         })
-      }),
-
-      price: computed(function() {
-        return this.get('restaurant.menu.price');
-      }).property('restaurant.menu.price')
+      })
     });
 
-    bindObj = ObservableObject.createWithMixins({
+    bindObj = ObservableObject.extend({
       priceBinding: 'DepObj.price'
-    });
+    }).create();
   });
 
   equal(bindObj.get('price'), 5, 'precond - binding propagates');
@@ -624,16 +603,16 @@ QUnit.test('cacheable nested dependent keys should clear after their dependencie
   var DepObj;
 
   run(function() {
-    lookup.DepObj = DepObj = ObservableObject.createWithMixins({
+    lookup.DepObj = DepObj = ObservableObject.extend({
+      price: computed('restaurant.menu.price', function() {
+        return this.get('restaurant.menu.price');
+      })
+    }).create({
       restaurant: ObservableObject.create({
         menu: ObservableObject.create({
           price: 5
         })
-      }),
-
-      price: computed(function() {
-        return this.get('restaurant.menu.price');
-      }).property('restaurant.menu.price')
+      })
     });
   });
 
@@ -677,16 +656,7 @@ QUnit.test('cacheable nested dependent keys should clear after their dependencie
 QUnit.module('Observable objects & object properties ', {
 
   setup() {
-    object = ObservableObject.createWithMixins({
-
-      normal: 'value',
-      abnormal: 'zeroValue',
-      numberVal: 24,
-      toggleVal: true,
-      observedProperty: 'beingWatched',
-      testRemove: 'observerToBeRemoved',
-      normalArray: Ember.A([1,2,3,4,5]),
-
+    object = ObservableObject.extend({
       getEach() {
         var keys = ['normal','abnormal'];
         var ret = [];
@@ -707,7 +677,14 @@ QUnit.module('Observable objects & object properties ', {
       testArrayObserver: observer('normalArray.[]', function() {
         this.abnormal = 'notifiedObserver';
       })
-
+    }).create({
+      normal: 'value',
+      abnormal: 'zeroValue',
+      numberVal: 24,
+      toggleVal: true,
+      observedProperty: 'beingWatched',
+      testRemove: 'observerToBeRemoved',
+      normalArray: Ember.A([1,2,3,4,5])
     });
   }
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/propertyChanges_test.js
@@ -29,17 +29,10 @@ var ObjectA;
 
 QUnit.module('object.propertyChanges', {
   setup() {
-    ObjectA = ObservableObject.createWithMixins({
-      foo  : 'fooValue',
-      prop : 'propValue',
-
+    ObjectA = ObservableObject.extend({
       action: observer('foo', function() {
         this.set('prop', 'changedPropValue');
       }),
-
-      newFoo : 'newFooValue',
-      newProp: 'newPropValue',
-
       notifyAction: observer('newFoo', function() {
         this.set('newProp', 'changedNewPropValue');
       }),
@@ -48,12 +41,18 @@ QUnit.module('object.propertyChanges', {
         this.set('newFoo', 'changedNewFooValue');
       }),
 
-      starProp: null,
       starObserver(target, key, value, rev) {
         revMatches = (rev === target.propertyRevision);
         this.starProp = key;
       }
+    }).create({
+      starProp: null,
 
+      foo  : 'fooValue',
+      prop : 'propValue',
+
+      newFoo : 'newFooValue',
+      newProp: 'newPropValue'
     });
   }
 });
@@ -121,15 +120,16 @@ QUnit.test('should notify that the property of an object has changed', function(
 
 QUnit.test('should invalidate function property cache when notifyPropertyChange is called', function() {
 
-  var a = ObservableObject.createWithMixins({
-    _b: null,
+  var a = ObservableObject.extend({
     b: computed({
-      get: function() { return this._b; },
-      set: function(key, value) {
+      get() { return this._b; },
+      set(key, value) {
         this._b = value;
         return this;
       }
     }).volatile()
+  }).create({
+    _b: null
   });
 
   a.set('b', 'foo');

--- a/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/binding_test.js
@@ -86,17 +86,17 @@ QUnit.test('deferred observing during bindings', function() {
     value2: 'value2'
   });
 
-  toObject = EmberObject.createWithMixins({
-    value1: 'value1',
-    value2: 'value2',
-
-    callCount: 0,
-
+  toObject = EmberObject.extend({
     observer: emberObserver('value1', 'value2', function() {
       equal(get(this, 'value1'), 'CHANGED', 'value1 when observer fires');
       equal(get(this, 'value2'), 'CHANGED', 'value2 when observer fires');
       this.callCount++;
     })
+  }).create({
+    value1: 'value1',
+    value2: 'value2',
+
+    callCount: 0
   });
 
   var root = { fromObject: fromObject, toObject: toObject };
@@ -168,13 +168,13 @@ QUnit.module('chained binding', {
     run(function() {
       first = EmberObject.create({ output: 'first' });
 
-      second = EmberObject.createWithMixins({
-        input: 'second',
-        output: 'second',
-
+      second = EmberObject.extend({
         inputDidChange: emberObserver('input', function() {
           set(this, 'output', get(this, 'input'));
         })
+      }).create({
+        input: 'second',
+        output: 'second'
       });
 
       third = EmberObject.create({ input: 'third' });
@@ -243,12 +243,7 @@ QUnit.test('two bindings to the same value should sync in the order they are ini
     foo: 'bar'
   });
 
-  var b = EmberObject.createWithMixins({
-    foo: 'baz',
-    fooBinding: 'a.foo',
-
-    a: a,
-
+  var b = EmberObject.extend({
     C: EmberObject.extend({
       foo: 'bee',
       fooBinding: 'owner.foo'
@@ -258,7 +253,10 @@ QUnit.test('two bindings to the same value should sync in the order they are ini
       this._super.apply(this, arguments);
       set(this, 'c', this.C.create({ owner: this }));
     }
-
+  }).create({
+    foo: 'baz',
+    fooBinding: 'a.foo',
+    a: a
   });
 
   run.end();
@@ -283,10 +281,11 @@ QUnit.module('propertyNameBinding with longhand', {
         value: 'originalValue'
       });
 
-      TestNamespace.toObject = EmberObject.createWithMixins({
+      TestNamespace.toObject = EmberObject.extend({
         valueBinding: Binding.from('TestNamespace.fromObject.value'),
-        localValue: 'originalLocal',
         relativeBinding: Binding.from('localValue')
+      }).create({
+        localValue: 'originalLocal'
       });
     });
   },

--- a/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/base_test.js
@@ -77,9 +77,7 @@ QUnit.module('EmberObject observers', {
     };
 
     // create an object
-    obj = EmberObject.createWithMixins({
-      prop1: null,
-
+    obj = EmberObject.extend({
       // normal observer
       observer: emberObserver('prop1', function() {
         this._normal = true;
@@ -92,6 +90,8 @@ QUnit.module('EmberObject observers', {
       bothObserver: emberObserver('prop1', 'TestNamespace.obj.value', function() {
         this._both = true;
       })
+    }).create({
+      prop1: null
     });
 
   },

--- a/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/bindings_test.js
@@ -126,9 +126,9 @@ QUnit.module('fooBinding method', fooBindingModuleOpts);
 QUnit.test('fooBinding: TestNamespace.fromObject.bar should follow absolute path', function() {
   // create binding
   run(function() {
-    testObject = TestObject.createWithMixins({
+    testObject = TestObject.extend({
       fooBinding: 'TestNamespace.fromObject.bar'
-    });
+    }).create();
 
     // now make a change to see if the binding triggers.
     set(fromObject, 'bar', 'changedValue');
@@ -139,9 +139,9 @@ QUnit.test('fooBinding: TestNamespace.fromObject.bar should follow absolute path
 
 QUnit.test('fooBinding: .bar should bind to relative path', function() {
   run(function() {
-    testObject = TestObject.createWithMixins({
+    testObject = TestObject.extend({
       fooBinding: 'bar'
-    });
+    }).create();
     // now make a change to see if the binding triggers.
     set(testObject, 'bar', 'changedValue');
   });
@@ -151,9 +151,9 @@ QUnit.test('fooBinding: .bar should bind to relative path', function() {
 
 QUnit.test('fooBinding: should disconnect bindings when destroyed', function () {
   run(function() {
-    testObject = TestObject.createWithMixins({
+    testObject = TestObject.extend({
       fooBinding: 'TestNamespace.fromObject.bar'
-    });
+    }).create();
 
     set(TestNamespace.fromObject, 'bar', 'BAZ');
   });

--- a/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/run_loop_test.js
@@ -23,21 +23,20 @@ var MyApp, binding1, binding2;
 QUnit.module('System:run_loop() - chained binding', {
   setup() {
     MyApp = {};
-    MyApp.first = EmberObject.createWithMixins(Observable, {
+    MyApp.first = EmberObject.extend(Observable).create({
       output: 'MyApp.first'
     });
 
-    MyApp.second = EmberObject.createWithMixins(Observable, {
-      input: 'MyApp.second',
-      output: 'MyApp.second',
-
+    MyApp.second = EmberObject.extend(Observable, {
       inputDidChange: emberObserver('input', function() {
         this.set('output', this.get('input'));
       })
-
+    }).create({
+      input: 'MyApp.second',
+      output: 'MyApp.second'
     });
 
-    MyApp.third = EmberObject.createWithMixins(Observable, {
+    MyApp.third = EmberObject.extend(Observable).create({
       input: 'MyApp.third'
     });
   }

--- a/packages/ember-runtime/tests/mixins/array_test.js
+++ b/packages/ember-runtime/tests/mixins/array_test.js
@@ -68,7 +68,7 @@ ArrayTests.extend({
 }).run();
 
 QUnit.test('the return value of slice has Ember.Array applied', function() {
-  var x = EmberObject.createWithMixins(EmberArray, {
+  var x = EmberObject.extend(EmberArray).create({
     length: 0
   });
   var y = x.slice(1);
@@ -114,11 +114,12 @@ QUnit.module('mixins/array/arrayContent[Will|Did]Change');
 
 QUnit.test('should notify observers of []', function() {
 
-  obj = DummyArray.createWithMixins({
-    _count: 0,
+  obj = DummyArray.extend({
     enumerablePropertyDidChange: emberObserver('[]', function() {
       this._count++;
     })
+  }).create({
+    _count: 0
   });
 
   equal(obj._count, 0, 'should not have invoked yet');
@@ -136,12 +137,12 @@ QUnit.test('should notify observers of []', function() {
 
 QUnit.module('notify observers of length', {
   setup() {
-    obj = DummyArray.createWithMixins({
-      _after: 0,
+    obj = DummyArray.extend({
       lengthDidChange: emberObserver('length', function() {
         this._after++;
       })
-
+    }).create({
+      _after: 0
     });
 
     equal(obj._after, 0, 'should not have fired yet');
@@ -186,10 +187,7 @@ QUnit.module('notify array observers', {
   setup() {
     obj = DummyArray.create();
 
-    observer = EmberObject.createWithMixins({
-      _before: null,
-      _after: null,
-
+    observer = EmberObject.extend({
       arrayWillChange() {
         equal(this._before, null); // should only call once
         this._before = Array.prototype.slice.call(arguments);
@@ -199,6 +197,9 @@ QUnit.module('notify array observers', {
         equal(this._after, null); // should only call once
         this._after = Array.prototype.slice.call(arguments);
       }
+    }).create({
+      _before: null,
+      _after: null
     });
 
     obj.addArrayObserver(observer);
@@ -251,10 +252,7 @@ QUnit.module('notify enumerable observers as well', {
   setup() {
     obj = DummyArray.create();
 
-    observer = EmberObject.createWithMixins({
-      _before: null,
-      _after: null,
-
+    observer = EmberObject.extend({
       enumerableWillChange() {
         equal(this._before, null); // should only call once
         this._before = Array.prototype.slice.call(arguments);
@@ -264,6 +262,9 @@ QUnit.module('notify enumerable observers as well', {
         equal(this._after, null); // should only call once
         this._after = Array.prototype.slice.call(arguments);
       }
+    }).create({
+      _before: null,
+      _after: null
     });
 
     obj.addEnumerableObserver(observer);
@@ -419,15 +420,16 @@ QUnit.test('modifying the array should also indicate the isDone prop itself has 
 
 
 testBoth('should be clear caches for computed properties that have dependent keys on arrays that are changed after object initialization', function(get, set) {
-  var obj = EmberObject.createWithMixins({
+  var obj = EmberObject.extend({
     init() {
+      this._super(...arguments);
       set(this, 'resources', Ember.A());
     },
 
-    common: computed(function() {
+    common: computed('resources.@each.common', function() {
       return get(get(this, 'resources').objectAt(0), 'common');
-    }).property('resources.@each.common')
-  });
+    })
+  }).create();
 
   get(obj, 'resources').pushObject(EmberObject.create({ common: 'HI!' }));
   equal('HI!', get(obj, 'common'));
@@ -439,8 +441,9 @@ testBoth('should be clear caches for computed properties that have dependent key
 testBoth('observers that contain @each in the path should fire only once the first time they are accessed', function(get, set) {
   var count = 0;
 
-  var obj = EmberObject.createWithMixins({
+  var obj = EmberObject.extend({
     init() {
+      this._super(...arguments);
       // Observer does not fire on init
       set(this, 'resources', Ember.A());
     },
@@ -448,7 +451,7 @@ testBoth('observers that contain @each in the path should fire only once the fir
     commonDidChange: emberObserver('resources.@each.common', function() {
       count++;
     })
-  });
+  }).create();
 
   // Observer fires second time when new object is added
   get(obj, 'resources').pushObject(EmberObject.create({ common: 'HI!' }));

--- a/packages/ember-runtime/tests/mixins/enumerable_test.js
+++ b/packages/ember-runtime/tests/mixins/enumerable_test.js
@@ -70,41 +70,41 @@ EnumerableTests.extend({
 QUnit.module('Ember.Enumerable');
 
 QUnit.test('should apply Ember.Array to return value of map', function() {
-  var x = EmberObject.createWithMixins(Enumerable);
+  var x = EmberObject.extend(Enumerable).create();
   var y = x.map(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
 QUnit.test('should apply Ember.Array to return value of filter', function() {
-  var x = EmberObject.createWithMixins(Enumerable);
+  var x = EmberObject.extend(Enumerable).create();
   var y = x.filter(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
 QUnit.test('should apply Ember.Array to return value of invoke', function() {
-  var x = EmberObject.createWithMixins(Enumerable);
+  var x = EmberObject.extend(Enumerable).create();
   var y = x.invoke(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
 QUnit.test('should apply Ember.Array to return value of toArray', function() {
-  var x = EmberObject.createWithMixins(Enumerable);
+  var x = EmberObject.extend(Enumerable).create();
   var y = x.toArray(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
 QUnit.test('should apply Ember.Array to return value of without', function() {
-  var x = EmberObject.createWithMixins(Enumerable, {
+  var x = EmberObject.extend(Enumerable, {
     contains() {
       return true;
     }
-  });
+  }).create();
   var y = x.without(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
 
 QUnit.test('should apply Ember.Array to return value of uniq', function() {
-  var x = EmberObject.createWithMixins(Enumerable);
+  var x = EmberObject.extend(Enumerable).create();
   var y = x.uniq(K);
   equal(EmberArray.detect(y), true, 'should have mixin applied');
 });
@@ -184,13 +184,14 @@ QUnit.module('mixins/enumerable/enumerableContentDidChange');
 
 QUnit.test('should notify observers of []', function() {
 
-  var obj = EmberObject.createWithMixins(Enumerable, {
+  var obj = EmberObject.extend(Enumerable, {
     nextObject() {}, // avoid exceptions
 
-    _count: 0,
     enumerablePropertyDidChange: emberObserver('[]', function() {
       this._count++;
     })
+  }).create({
+    _count: 0
   });
 
   equal(obj._count, 0, 'should not have invoked yet');
@@ -206,12 +207,12 @@ QUnit.test('should notify observers of []', function() {
 
 QUnit.module('notify observers of length', {
   setup() {
-    obj = DummyEnum.createWithMixins({
-      _after: 0,
+    obj = DummyEnum.extend({
       lengthDidChange: emberObserver('length', function() {
         this._after++;
       })
-
+    }).create({
+      _after: 0
     });
 
     equal(obj._after, 0, 'should not have fired yet');
@@ -279,10 +280,7 @@ QUnit.module('notify enumerable observers', {
   setup() {
     obj = DummyEnum.create();
 
-    observer = EmberObject.createWithMixins({
-      _before: null,
-      _after: null,
-
+    observer = EmberObject.extend({
       enumerableWillChange() {
         equal(this._before, null); // should only call once
         this._before = Array.prototype.slice.call(arguments);
@@ -292,6 +290,9 @@ QUnit.module('notify enumerable observers', {
         equal(this._after, null); // should only call once
         this._after = Array.prototype.slice.call(arguments);
       }
+    }).create({
+      _before: null,
+      _after: null
     });
 
     obj.addEnumerableObserver(observer);

--- a/packages/ember-runtime/tests/mixins/observable_test.js
+++ b/packages/ember-runtime/tests/mixins/observable_test.js
@@ -43,13 +43,14 @@ QUnit.test('should be able to use setProperties to set multiple properties at on
 
 testBoth('calling setProperties completes safely despite exceptions', function(get, set) {
   var exc = new Error('Something unexpected happened!');
-  var obj = EmberObject.createWithMixins({
-    firstName: 'Steve',
-    lastName: 'Jobs',
+  var obj = EmberObject.extend({
     companyName: computed({
-      get: function() { return 'Apple, Inc.'; },
-      set: function(key, value) { throw exc; }
+      get() { return 'Apple, Inc.'; },
+      set(key, value) { throw exc; }
     })
+  }).create({
+    firstName: 'Steve',
+    lastName: 'Jobs'
   });
 
   var firstNameChangedCount = 0;
@@ -72,11 +73,11 @@ testBoth('calling setProperties completes safely despite exceptions', function(g
 });
 
 testBoth('should be able to retrieve cached values of computed properties without invoking the computed property', function(get) {
-  var obj = EmberObject.createWithMixins({
+  var obj = EmberObject.extend({
     foo: computed(function() {
       return 'foo';
-    }),
-
+    })
+  }).create({
     bar: 'bar'
   });
 

--- a/packages/ember-runtime/tests/mixins/sortable_test.js
+++ b/packages/ember-runtime/tests/mixins/sortable_test.js
@@ -19,7 +19,7 @@ QUnit.module('Ember.Sortable with content', {
 
       unsortedArray = Ember.A(Ember.A(array).copy());
 
-      sortedArrayController = ArrayProxy.createWithMixins(SortableMixin, {
+      sortedArrayController = ArrayProxy.extend(SortableMixin).create({
         content: unsortedArray
       });
     });
@@ -70,11 +70,12 @@ QUnit.test('you can change sorted properties', function() {
 QUnit.test('changing sort order triggers observers', function() {
   var observer;
   var changeCount = 0;
-  observer = EmberObject.createWithMixins({
-    array: sortedArrayController,
+  observer = EmberObject.extend({
     arrangedDidChange: emberObserver('array.[]', function() {
       changeCount++;
     })
+  }).create({
+    array: sortedArrayController
   });
 
   equal(changeCount, 0, 'precond - changeCount starts at 0');
@@ -224,7 +225,7 @@ QUnit.test('you can unshift objects in sorted order', function() {
 QUnit.test('addObject does not insert duplicates', function() {
   var sortedArrayProxy;
   var obj = {};
-  sortedArrayProxy = ArrayProxy.createWithMixins(SortableMixin, {
+  sortedArrayProxy = ArrayProxy.extend(SortableMixin).create({
     content: Ember.A([obj])
   });
 
@@ -355,7 +356,7 @@ QUnit.test('you can sort with custom sorting function', function() {
 
 QUnit.test('Ember.Sortable with sortFunction on ArrayProxy should work like ArrayController', function() {
   run(function() {
-    sortedArrayController = ArrayProxy.createWithMixins(SortableMixin, {
+    sortedArrayController = ArrayProxy.extend(SortableMixin).create({
       sortProperties: ['name'],
       sortFunction(v, w) {
         var lowerV = v.toLowerCase();

--- a/packages/ember-runtime/tests/mixins/target_action_support_test.js
+++ b/packages/ember-runtime/tests/mixins/target_action_support_test.js
@@ -16,7 +16,7 @@ QUnit.module('TargetActionSupport', {
 QUnit.test('it should return false if no target or action are specified', function() {
   expect(1);
 
-  var obj = EmberObject.createWithMixins(TargetActionSupport);
+  var obj = EmberObject.extend(TargetActionSupport).create();
 
   ok(false === obj.triggerAction(), 'no target or action was specified');
 });
@@ -24,7 +24,7 @@ QUnit.test('it should return false if no target or action are specified', functi
 QUnit.test('it should support actions specified as strings', function() {
   expect(2);
 
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
+  var obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent() {
         ok(true, 'anEvent method was called');
@@ -40,7 +40,7 @@ QUnit.test('it should support actions specified as strings', function() {
 QUnit.test('it should invoke the send() method on objects that implement it', function() {
   expect(3);
 
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
+  var obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       send(evt, context) {
         equal(evt, 'anEvent', 'send() method was invoked with correct event name');
@@ -66,7 +66,7 @@ QUnit.test('it should find targets specified using a property path', function() 
     }
   });
 
-  var myObj = EmberObject.createWithMixins(TargetActionSupport, {
+  var myObj = EmberObject.extend(TargetActionSupport).create({
     target: 'Test.targetObj',
     action: 'anEvent'
   });
@@ -76,15 +76,15 @@ QUnit.test('it should find targets specified using a property path', function() 
 
 QUnit.test('it should use an actionContext object specified as a property on the object', function() {
   expect(2);
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
-        action: 'anEvent',
-        actionContext: {},
-        target: EmberObject.create({
-          anEvent(ctx) {
-            ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
-          }
-        })
-      });
+  var obj = EmberObject.extend(TargetActionSupport).create({
+    action: 'anEvent',
+    actionContext: {},
+    target: EmberObject.create({
+      anEvent(ctx) {
+        ok(obj.actionContext === ctx, 'anEvent method was called with the expected context');
+      }
+    })
+  });
   ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
@@ -95,28 +95,29 @@ QUnit.test('it should find an actionContext specified as a property path', funct
   Ember.lookup = { Test: Test };
   Test.aContext = {};
 
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
-        action: 'anEvent',
-        actionContext: 'Test.aContext',
-        target: EmberObject.create({
-          anEvent(ctx) {
-            ok(Test.aContext === ctx, 'anEvent method was called with the expected context');
-          }
-        })
-      });
+  var obj = EmberObject.extend(TargetActionSupport).create({
+    action: 'anEvent',
+    actionContext: 'Test.aContext',
+    target: EmberObject.create({
+      anEvent(ctx) {
+        ok(Test.aContext === ctx, 'anEvent method was called with the expected context');
+      }
+    })
+  });
+
   ok(true === obj.triggerAction(), 'a valid target and action were specified');
 });
 
 QUnit.test('it should use the target specified in the argument', function() {
   expect(2);
   var targetObj = EmberObject.create({
-        anEvent() {
-          ok(true, 'anEvent method was called');
-        }
-      });
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
-        action: 'anEvent'
-      });
+    anEvent() {
+      ok(true, 'anEvent method was called');
+    }
+  });
+  var obj = EmberObject.extend(TargetActionSupport).create({
+    action: 'anEvent'
+  });
 
   ok(true === obj.triggerAction({ target: targetObj }), 'a valid target and action were specified');
 });
@@ -124,7 +125,7 @@ QUnit.test('it should use the target specified in the argument', function() {
 QUnit.test('it should use the action specified in the argument', function() {
   expect(2);
 
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
+  var obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent() {
         ok(true, 'anEvent method was called');
@@ -137,7 +138,7 @@ QUnit.test('it should use the action specified in the argument', function() {
 QUnit.test('it should use the actionContext specified in the argument', function() {
   expect(2);
   var context = {};
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
+  var obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent(ctx) {
         ok(context === ctx, 'anEvent method was called with the expected context');
@@ -153,7 +154,7 @@ QUnit.test('it should allow multiple arguments from actionContext', function() {
   expect(3);
   var param1 = 'someParam';
   var param2 = 'someOtherParam';
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
+  var obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent(first, second) {
         ok(first === param1, 'anEvent method was called with the expected first argument');
@@ -168,7 +169,7 @@ QUnit.test('it should allow multiple arguments from actionContext', function() {
 
 QUnit.test('it should use a null value specified in the actionContext argument', function() {
   expect(2);
-  var obj = EmberObject.createWithMixins(TargetActionSupport, {
+  var obj = EmberObject.extend(TargetActionSupport).create({
     target: EmberObject.create({
       anEvent(ctx) {
         ok(null === ctx, 'anEvent method was called with the expected context (null)');

--- a/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/arranged_content_test.js
@@ -8,16 +8,17 @@ var array;
 QUnit.module('ArrayProxy - arrangedContent', {
   setup() {
     run(function() {
-      array = ArrayProxy.createWithMixins({
-        content: Ember.A([1,2,4,5]),
-        arrangedContent: computed(function() {
+      array = ArrayProxy.extend({
+        arrangedContent: computed('content.[]', function() {
           var content = this.get('content');
           return content && Ember.A(content.slice().sort(function(a, b) {
             if (a == null) { a = -1; }
             if (b == null) { b = -1; }
             return b - a;
           }));
-        }).property('content.[]')
+        })
+      }).create({
+        content: Ember.A([1,2,4,5])
       });
     });
   },
@@ -175,7 +176,7 @@ QUnit.test('firstObject - returns first arranged object', function() {
 QUnit.module('ArrayProxy - arrangedContent matching content', {
   setup() {
     run(function() {
-      array = ArrayProxy.createWithMixins({
+      array = ArrayProxy.create({
         content: Ember.A([1,2,4,5])
       });
     });
@@ -205,9 +206,7 @@ QUnit.test('reverseObjects - reverses content', function() {
 QUnit.module('ArrayProxy - arrangedContent with transforms', {
   setup() {
     run(function() {
-      array = ArrayProxy.createWithMixins({
-        content: Ember.A([1,2,4,5]),
-
+      array = ArrayProxy.extend({
         arrangedContent: computed(function() {
           var content = this.get('content');
           return content && Ember.A(content.slice().sort(function(a, b) {
@@ -221,6 +220,8 @@ QUnit.module('ArrayProxy - arrangedContent with transforms', {
           var obj = this.get('arrangedContent').objectAt(idx);
           return obj && obj.toString();
         }
+      }).create({
+        content: Ember.A([1,2,4,5])
       });
     });
   },

--- a/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
+++ b/packages/ember-runtime/tests/system/array_proxy/content_update_test.js
@@ -9,9 +9,7 @@ QUnit.test('The `contentArrayDidChange` method is invoked after `content` is upd
   var proxy;
   var observerCalled = false;
 
-  proxy = ArrayProxy.createWithMixins({
-    content: Ember.A(),
-
+  proxy = ArrayProxy.extend({
     arrangedContent: computed('content', function(key) {
       return Ember.A(this.get('content').slice());
     }),
@@ -20,6 +18,8 @@ QUnit.test('The `contentArrayDidChange` method is invoked after `content` is upd
       observerCalled = true;
       return this._super(array, idx, removedCount, addedCount);
     }
+  }).create({
+    content: Ember.A()
   });
 
   proxy.pushObject(1);

--- a/packages/ember-runtime/tests/system/object/destroy_test.js
+++ b/packages/ember-runtime/tests/system/object/destroy_test.js
@@ -34,9 +34,10 @@ if (isEnabled('mandatory-setter')) {
   // a destroyed object removes meta but leaves the accessor
   // that looks it up
   QUnit.test('should raise an exception when modifying watched properties on a destroyed object', function() {
-    var obj = EmberObject.createWithMixins({
-      foo: 'bar',
+    var obj = EmberObject.extend({
       fooDidChange: observer('foo', function() { })
+    }).create({
+      foo: 'bar'
     });
 
     run(function() {
@@ -51,11 +52,11 @@ if (isEnabled('mandatory-setter')) {
 
 QUnit.test('observers should not fire after an object has been destroyed', function() {
   var count = 0;
-  var obj = EmberObject.createWithMixins({
+  var obj = EmberObject.extend({
     fooDidChange: observer('foo', function() {
       count++;
     })
-  });
+  }).create();
 
   obj.set('foo', 'bar');
 

--- a/packages/ember-runtime/tests/system/object/events_test.js
+++ b/packages/ember-runtime/tests/system/object/events_test.js
@@ -7,7 +7,7 @@ QUnit.test('a listener can be added to an object', function() {
   var count = 0;
   var F = function() { count++; };
 
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
 
   obj.on('event!', F);
   obj.trigger('event!');
@@ -23,7 +23,7 @@ QUnit.test('a listener can be added and removed automatically the first time it 
   var count = 0;
   var F = function() { count++; };
 
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
 
   obj.one('event!', F);
   obj.trigger('event!');
@@ -38,7 +38,7 @@ QUnit.test('a listener can be added and removed automatically the first time it 
 QUnit.test('triggering an event can have arguments', function() {
   var self, args;
 
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
 
   obj.on('event!', function() {
     args = [].slice.call(arguments);
@@ -55,7 +55,7 @@ QUnit.test('a listener can be added and removed automatically and have arguments
   var self, args;
   var count = 0;
 
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
 
   obj.one('event!', function() {
     args = [].slice.call(arguments);
@@ -79,7 +79,7 @@ QUnit.test('a listener can be added and removed automatically and have arguments
 QUnit.test('binding an event can specify a different target', function() {
   var self, args;
 
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
   var target = {};
 
   obj.on('event!', target, function() {
@@ -98,7 +98,7 @@ QUnit.test('a listener registered with one can take method as string and can be 
   var target = {};
   target.fn = function() { count++; };
 
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
 
   obj.one('event!', target, 'fn');
   obj.trigger('event!');
@@ -111,9 +111,9 @@ QUnit.test('a listener registered with one can take method as string and can be 
 });
 
 QUnit.test('a listener registered with one can be removed with off', function() {
-  var obj = EmberObject.createWithMixins(Evented, {
+  var obj = EmberObject.extend(Evented, {
     F() {}
-  });
+  }).create();
   var F = function() {};
 
   obj.one('event!', F);
@@ -128,7 +128,7 @@ QUnit.test('a listener registered with one can be removed with off', function() 
 });
 
 QUnit.test('adding and removing listeners should be chainable', function() {
-  var obj = EmberObject.createWithMixins(Evented);
+  var obj = EmberObject.extend(Evented).create();
   var F = function() {};
 
   var ret = obj.on('event!', F);

--- a/packages/ember-runtime/tests/system/object/extend_test.js
+++ b/packages/ember-runtime/tests/system/object/extend_test.js
@@ -50,12 +50,12 @@ QUnit.test('Overriding a method several layers deep', function() {
   equal(obj.barCnt, 2, 'should invoke both');
 
   // Try overriding on create also
-  obj = FinalClass.createWithMixins({
+  obj = FinalClass.extend({
     foo() {
       this.fooCnt++;
       this._super.apply(this, arguments);
     }
-  });
+  }).create();
 
   obj.foo();
   obj.bar();

--- a/packages/ember-runtime/tests/system/object/observer_test.js
+++ b/packages/ember-runtime/tests/system/object/observer_test.js
@@ -57,14 +57,12 @@ testBoth('observer on subclass', function(get, set) {
 
 testBoth('observer on instance', function(get, set) {
 
-  var obj = EmberObject.createWithMixins({
-
-    count: 0,
-
+  var obj = EmberObject.extend({
     foo: observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
     })
-
+  }).create({
+    count: 0
   });
 
   equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
@@ -77,20 +75,18 @@ testBoth('observer on instance', function(get, set) {
 testBoth('observer on instance overriding class', function(get, set) {
 
   var MyClass = EmberObject.extend({
-
     count: 0,
 
     foo: observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
     })
-
   });
 
-  var obj = MyClass.createWithMixins({
+  var obj = MyClass.extend({
     foo: observer('baz', function() { // <-- change property we observe
       set(this, 'count', get(this, 'count')+1);
     })
-  });
+  }).create();
 
   equal(get(obj, 'count'), 0, 'should not invoke observer immediately');
 
@@ -104,12 +100,12 @@ testBoth('observer on instance overriding class', function(get, set) {
 
 testBoth('observer should not fire after being destroyed', function(get, set) {
 
-  var obj = EmberObject.createWithMixins({
+  var obj = EmberObject.extend({
     count: 0,
     foo: observer('bar', function() {
       set(this, 'count', get(this, 'count')+1);
     })
-  });
+  }).create();
 
   equal(get(obj, 'count'), 0, 'precond - should not invoke observer immediately');
 
@@ -171,17 +167,17 @@ testBoth('chain observer on class', function(get, set) {
     })
   });
 
-  var obj1 = MyClass.createWithMixins({
+  var obj1 = MyClass.extend().create({
     bar: { baz: 'biff' }
   });
 
-  var obj2 = MyClass.createWithMixins({
-    bar: { baz: 'biff2' },
-    bar2: { baz: 'biff3' },
-
+  var obj2 = MyClass.extend({
     foo: observer('bar2.baz', function() {
       set(this, 'count', get(this, 'count')+1);
     })
+  }).create({
+    bar: { baz: 'biff2' },
+    bar2: { baz: 'biff3' }
   });
 
   equal(get(obj1, 'count'), 0, 'should not invoke yet');

--- a/packages/ember-views/tests/mixins/view_target_action_support_test.js
+++ b/packages/ember-views/tests/mixins/view_target_action_support_test.js
@@ -7,7 +7,7 @@ QUnit.module('ViewTargetActionSupport');
 QUnit.test('it should return false if no action is specified', function() {
   expect(1);
 
-  var view = View.createWithMixins(ViewTargetActionSupport, {
+  var view = View.extend(ViewTargetActionSupport).create({
     controller: EmberObject.create()
   });
 
@@ -17,7 +17,7 @@ QUnit.test('it should return false if no action is specified', function() {
 QUnit.test('it should support actions specified as strings', function() {
   expect(2);
 
-  var view = View.createWithMixins(ViewTargetActionSupport, {
+  var view = View.extend(ViewTargetActionSupport).create({
     controller: EmberObject.create({
       anEvent() {
         ok(true, 'anEvent method was called');
@@ -32,14 +32,15 @@ QUnit.test('it should support actions specified as strings', function() {
 QUnit.test('it should invoke the send() method on the controller with the view\'s context', function() {
   expect(3);
 
-  var view = View.createWithMixins(ViewTargetActionSupport, {
-    context: {},
+  var view = View.extend(ViewTargetActionSupport, {
     controller: EmberObject.create({
       send(evt, context) {
         equal(evt, 'anEvent', 'send() method was invoked with correct event name');
-        equal(context, view.context, 'send() method was invoked with correct context');
+        equal(context, view.get('context'), 'send() method was invoked with correct context');
       }
-    }),
+    })
+  }).create({
+    context: {},
     action: 'anEvent'
   });
 

--- a/packages/ember-views/tests/system/event_dispatcher_test.js
+++ b/packages/ember-views/tests/system/event_dispatcher_test.js
@@ -34,20 +34,17 @@ QUnit.test('should dispatch events to views', function() {
   var childKeyDownCalled = 0;
   var parentKeyDownCalled = 0;
 
-  var childView = View.createWithMixins({
-    template: compile('<span id="wot">ewot</span>'),
-
+  var childView = View.extend({
     keyDown(evt) {
       childKeyDownCalled++;
 
       return false;
     }
+  }).create({
+    template: compile('<span id="wot">ewot</span>')
   });
 
-  view = View.createWithMixins({
-    template: compile('some <span id="awesome">awesome</span> content {{view view.childView}}'),
-    childView: childView,
-
+  view = View.extend({
     mouseDown(evt) {
       parentMouseDownCalled++;
       receivedEvent = evt;
@@ -56,6 +53,9 @@ QUnit.test('should dispatch events to views', function() {
     keyDown(evt) {
       parentKeyDownCalled++;
     }
+  }).create({
+    template: compile('some <span id="awesome">awesome</span> content {{view view.childView}}'),
+    childView: childView
   });
 
   run(function() {
@@ -84,12 +84,12 @@ QUnit.test('should dispatch events to views', function() {
 QUnit.test('should not dispatch events to views not inDOM', function() {
   var receivedEvent;
 
-  view = View.createWithMixins({
-    template: compile('some <span id="awesome">awesome</span> content'),
-
+  view = View.extend({
     mouseDown(evt) {
       receivedEvent = evt;
     }
+  }).create({
+    template: compile('some <span id="awesome">awesome</span> content')
   });
 
   run(function() {
@@ -196,10 +196,9 @@ QUnit.test('event manager should be able to re-dispatch events to view', functio
   expectDeprecation('Setting `childViews` on a Container is deprecated.');
 
   var receivedEvent=0;
-  view = ContainerView.createWithMixins({
-    elementId: 'containerView',
+  view = ContainerView.extend({
 
-    eventManager: EmberObject.create({
+    eventManager: EmberObject.extend({
       mouseDown(evt, view) {
         // Re-dispatch event when you get it.
         //
@@ -211,9 +210,7 @@ QUnit.test('event manager should be able to re-dispatch events to view', functio
         // re-dispatching works
         view.$().trigger('mousedown', this);
       }
-    }),
-
-    childViews: ['child'],
+    }).create(),
 
     child: View.extend({
       elementId: 'nestedView',
@@ -226,6 +223,9 @@ QUnit.test('event manager should be able to re-dispatch events to view', functio
     mouseDown(evt) {
       receivedEvent++;
     }
+  }).create({
+    elementId: 'containerView',
+    childViews: ['child']
   });
 
   run(function() { view.append(); });
@@ -237,14 +237,14 @@ QUnit.test('event manager should be able to re-dispatch events to view', functio
 QUnit.test('event handlers should be wrapped in a run loop', function() {
   expect(1);
 
-  view = View.createWithMixins({
-    elementId: 'test-view',
-
-    eventManager: EmberObject.create({
+  view = View.extend({
+    eventManager: EmberObject.extend({
       mouseDown() {
         ok(run.currentRunLoop, 'a run loop should have started');
       }
-    })
+    }).create()
+  }).create({
+    elementId: 'test-view'
   });
 
   run(function() { view.append(); });

--- a/packages/ember-views/tests/system/jquery_ext_test.js
+++ b/packages/ember-views/tests/system/jquery_ext_test.js
@@ -62,12 +62,12 @@ if (canDataTransfer) {
     var receivedEvent;
     var dropCalled = 0;
 
-    view = View.createWithMixins({
+    view = View.extend({
       drop(evt) {
         receivedEvent = evt;
         dropCalled++;
       }
-    });
+    }).create();
 
     run(function() {
       view.append();

--- a/packages/ember-views/tests/views/container_view_test.js
+++ b/packages/ember-views/tests/views/container_view_test.js
@@ -781,13 +781,13 @@ QUnit.test('should allow hX tags as tagName', function() {
 QUnit.test('renders contained view with omitted start tag and parent view context', function() {
   expectDeprecation('Setting `childViews` on a Container is deprecated.');
 
-  view = ContainerView.createWithMixins({
+  view = ContainerView.extend({
     tagName: 'table',
     childViews: ['row'],
-    row: View.createWithMixins({
+    row: View.create({
       tagName: 'tr'
     })
-  });
+  }).create();
 
   run(view, view.append);
 

--- a/packages/ember-views/tests/views/text_area_test.js
+++ b/packages/ember-views/tests/views/text_area_test.js
@@ -157,7 +157,7 @@ QUnit.test('input title is updated when setting title property of view', functio
 QUnit.test('value binding works properly for inputs that haven\'t been created', function() {
   run(function() {
     textArea.destroy(); // destroy existing textarea
-    textArea = TextArea.createWithMixins({
+    textArea = TextArea.create({
       valueBinding: 'TestObject.value'
     });
   });

--- a/packages/ember-views/tests/views/text_field_test.js
+++ b/packages/ember-views/tests/views/text_field_test.js
@@ -201,7 +201,7 @@ QUnit.test('value binding works properly for inputs that haven\'t been created',
 
   run(function() {
     textField.destroy(); // destroy existing textField
-    textField = TextField.createWithMixins({
+    textField = TextField.create({
       valueBinding: 'TestObject.value'
     });
   });
@@ -224,7 +224,7 @@ QUnit.test('value binding works properly for inputs that haven\'t been created',
 QUnit.test('value binding sets value on the element', function() {
   run(function() {
     textField.destroy(); // destroy existing textField
-    textField = TextField.createWithMixins({
+    textField = TextField.create({
       valueBinding: 'TestObject.value'
     });
     textField.append();

--- a/packages/ember-views/tests/views/view/init_test.js
+++ b/packages/ember-views/tests/views/view/init_test.js
@@ -29,27 +29,27 @@ QUnit.test('registers view in the global views hash using layerId for event targ
   equal(EmberView.views[get(view, 'elementId')], view, 'registers view');
 });
 
-QUnit.module('EmberView.createWithMixins');
+QUnit.module('EmberView.extend');
 
 QUnit.test('should warn if a computed property is used for classNames', function() {
   expectAssertion(function() {
-    EmberView.createWithMixins({
+    EmberView.extend({
       elementId: 'test',
       classNames: computed(function() {
         return ['className'];
       }).volatile()
-    });
+    }).create();
   }, /Only arrays of static class strings.*For dynamic classes/i);
 });
 
 QUnit.test('should warn if a non-array is used for classNameBindings', function() {
   expectAssertion(function() {
-    EmberView.createWithMixins({
+    EmberView.extend({
       elementId: 'test',
       classNameBindings: computed(function() {
         return ['className'];
       }).volatile()
-    });
+    }).create();
   }, /Only arrays are allowed/i);
 });
 

--- a/packages/ember-views/tests/views/view/view_lifecycle_test.js
+++ b/packages/ember-views/tests/views/view/view_lifecycle_test.js
@@ -34,7 +34,7 @@ QUnit.test('should create and append a DOM element after bindings have synced', 
       fakeThing: 'controllerPropertyValue'
     });
 
-    view = EmberView.createWithMixins({
+    view = EmberView.create({
       fooBinding: 'ViewTest.fakeController.fakeThing',
       template: compile('{{view.foo}}')
     });
@@ -207,11 +207,12 @@ QUnit.test('should throw an exception when calling appendChild when DOM element 
 
 QUnit.test('should replace DOM representation if rerender() is called after element is created', function() {
   run(function() {
-    view = EmberView.createWithMixins({
-      template: compile('Do not taunt happy fun {{unbound view.shape}}'),
+    view = EmberView.extend({
       rerender() {
         this._super.apply(this, arguments);
-      },
+      }
+    }).create({
+      template: compile('Do not taunt happy fun {{unbound view.shape}}'),
       shape: 'sphere'
     });
 

--- a/packages/ember-views/tests/views/view_test.js
+++ b/packages/ember-views/tests/views/view_test.js
@@ -80,7 +80,7 @@ QUnit.test('should re-render if the context is changed', function() {
 });
 
 QUnit.test('renders a contained view with omitted start tag and tagless parent view context', function() {
-  view = EmberView.createWithMixins({
+  view = EmberView.create({
     tagName: 'table',
     template: compile('{{view view.pivot}}'),
     pivot: EmberView.extend({
@@ -107,7 +107,7 @@ QUnit.test('propagates dependent-key invalidated sets upstream', function() {
   view = EmberView.create({
     parentProp: 'parent-value',
     template: compile('{{view view.childView childProp=view.parentProp}}'),
-    childView: EmberView.createWithMixins({
+    childView: EmberView.create({
       template: compile('child template'),
       childProp: 'old-value'
     })
@@ -129,7 +129,7 @@ QUnit.test('propagates dependent-key invalidated bindings upstream', function() 
   view = EmberView.create({
     parentProp: 'parent-value',
     template: compile('{{view view.childView childProp=view.parentProp}}'),
-    childView: EmberView.createWithMixins({
+    childView: EmberView.extend({
       template: compile('child template'),
       childProp: Ember.computed('dependencyProp', {
         get(key) {
@@ -141,7 +141,7 @@ QUnit.test('propagates dependent-key invalidated bindings upstream', function() 
         }
       }),
       dependencyProp: 'old-value'
-    })
+    }).create()
   });
 
   run(view, view.append);

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -47,7 +47,7 @@ function sharedSetup() {
 
   updateCount = replaceCount = 0;
   App.Router.reopen({
-    location: Ember.NoneLocation.createWithMixins({
+    location: Ember.NoneLocation.create({
       setURL(path) {
         updateCount++;
         set(this, 'path', path);

--- a/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_transitioning_classes_test.js
@@ -52,7 +52,7 @@ function sharedSetup() {
 
   updateCount = replaceCount = 0;
   App.Router.reopen({
-    location: Ember.NoneLocation.createWithMixins({
+    location: Ember.NoneLocation.create({
       setURL(path) {
         updateCount++;
         set(this, 'path', path);

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -40,7 +40,7 @@ function sharedSetup() {
 
   updateCount = replaceCount = 0;
   App.Router.reopen({
-    location: Ember.NoneLocation.createWithMixins({
+    location: Ember.NoneLocation.create({
       setURL(path) {
         updateCount++;
         set(this, 'path', path);

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -1498,7 +1498,7 @@ QUnit.test('using replaceWith calls location.replaceURL if available', function(
   var replaceCount = 0;
 
   Router.reopen({
-    location: Ember.NoneLocation.createWithMixins({
+    location: Ember.NoneLocation.create({
       setURL(path) {
         setCount++;
         set(this, 'path', path);
@@ -1534,7 +1534,7 @@ QUnit.test('using replaceWith calls setURL if location.replaceURL is not defined
   var setCount = 0;
 
   Router.reopen({
-    location: Ember.NoneLocation.createWithMixins({
+    location: Ember.NoneLocation.create({
       setURL(path) {
         setCount++;
         set(this, 'path', path);


### PR DESCRIPTION
- it’s private
- easily replaced with extend(…).create(…)
- embers own tests should likely not rely on these private APIs
