### PR TITLE
Added a link to Guidelines Page and Changelog

### DIFF
--- a/COC.md
+++ b/COC.md
@@ -1,0 +1,7 @@
+The Ember team and community are committed to everyone having a safe and inclusive experience. 
+
+**Our Community Guidelines / Code of Conduct can be found here**:
+http://emberjs.com/guidelines/
+
+For a history of updates, see the page history here:
+https://github.com/emberjs/website/commits/master/source/guidelines.html.erb


### PR DESCRIPTION
Practically, we should only be maintaining one copy of this. So I'm adding the missing links to places folks might go _looking_ for this :)
