### PR TITLE
[BUGFIX beta] deprecate this.resource() in Router.map()

### DIFF
--- a/packages/ember-application/lib/ext/controller.js
+++ b/packages/ember-application/lib/ext/controller.js
@@ -97,7 +97,7 @@ ControllerMixin.reopen({
     this.get('controllers.post'); // instance of App.PostController
     ```
 
-    Given that you have a nested controller (nested resource):
+    Given that you have a nested controller (nested routes):
 
     ```javascript
     App.CommentsNewController = Ember.ObjectController.extend({

--- a/packages/ember-application/tests/system/logging_test.js
+++ b/packages/ember-application/tests/system/logging_test.js
@@ -36,7 +36,7 @@ QUnit.module('Ember.Application – logging of generated classes', {
       });
 
       App.Router.map(function() {
-        this.resource('posts');
+        this.route('posts', { resetNamespace: true });
       });
 
       App.deferReadiness();
@@ -161,7 +161,7 @@ QUnit.module('Ember.Application – logging of view lookups', {
       });
 
       App.Router.map(function() {
-        this.resource('posts');
+        this.route('posts', { resetNamespace: true });
       });
 
       App.deferReadiness();

--- a/packages/ember-routing-htmlbars/lib/keywords/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/link-to.js
@@ -147,7 +147,7 @@ import merge from 'ember-metal/merge';
 
   ```javascript
   App.Router.map(function() {
-    this.resource("photoGallery", {path: "hamster-photos/:photo_id"});
+    this.route("photoGallery", {path: "hamster-photos/:photo_id"});
   });
   ```
 
@@ -172,7 +172,7 @@ import merge from 'ember-metal/merge';
 
   ```javascript
   App.Router.map(function() {
-    this.resource("photoGallery", {path: "hamster-photos/:photo_id"}, function() {
+    this.route("photoGallery", { path: "hamster-photos/:photo_id" }, function() {
       this.route("comment", {path: "comments/:comment_id"});
     });
   });
@@ -199,7 +199,7 @@ import merge from 'ember-metal/merge';
 
   ```javascript
   App.Router.map(function() {
-    this.resource("photoGallery", {path: "hamster-photos/:photo_id"});
+    this.route("photoGallery", { path: "hamster-photos/:photo_id" });
   });
   ```
 

--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -65,12 +65,12 @@ ControllerMixin.reopen({
     ```
 
     Multiple models will be applied last to first recursively up the
-    resource tree.
+    route tree.
 
     ```javascript
     App.Router.map(function() {
-      this.resource('blogPost', {path:':blogPostId'}, function() {
-        this.resource('blogComment', {path: ':blogCommentId'});
+      this.route('blogPost', { path: ':blogPostId' }, function() {
+        this.route('blogComment', { path: ':blogCommentId', resetNamespace: true });
       });
     });
 
@@ -156,12 +156,12 @@ ControllerMixin.reopen({
     ```
 
     Multiple models will be applied last to first recursively up the
-    resource tree.
+    route tree.
 
     ```javascript
     App.Router.map(function() {
-      this.resource('blogPost', {path:':blogPostId'}, function() {
-        this.resource('blogComment', {path: ':blogCommentId'});
+      this.route('blogPost', { path: ':blogPostId' }, function() {
+        this.route('blogComment', { path: ':blogCommentId', resetNamespace: true });
       });
     });
 

--- a/packages/ember-routing/lib/location/api.js
+++ b/packages/ember-routing/lib/location/api.js
@@ -26,7 +26,7 @@ import { getHash } from 'ember-routing/location/util';
 
   ```javascript
   App.Router.map(function() {
-    this.resource('posts', function() {
+    this.route('posts', function() {
       this.route('new');
     });
   });
@@ -47,7 +47,7 @@ import { getHash } from 'ember-routing/location/util';
 
   ```javascript
   App.Router.map(function() {
-    this.resource('posts', function() {
+    this.route('posts', function() {
       this.route('new');
     });
   });
@@ -75,7 +75,7 @@ import { getHash } from 'ember-routing/location/util';
 
   ```javascript
   App.Router.map(function() {
-    this.resource('posts', function() {
+    this.route('posts', function() {
       this.route('new');
     });
   });

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -77,6 +77,7 @@ DSL.prototype = {
     }
 
     options.resetNamespace = true;
+    Ember.deprecate('this.resource() is deprecated. Use this.route(\'name\', { resetNamespace: true }, function () {}) instead.');
     this.route(name, options, callback);
   },
 

--- a/packages/ember-routing/lib/system/dsl.js
+++ b/packages/ember-routing/lib/system/dsl.js
@@ -25,9 +25,8 @@ DSL.prototype = {
       options = {};
     }
 
-    var type = options.resetNamespace === true ? 'resource' : 'route';
     Ember.assert(
-      `'${name}' cannot be used as a ${type} name.`,
+      `'${name}' cannot be used as a route name.`,
       (function() {
         if (options.overrideNameAssertion === true) { return true; }
 

--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -886,12 +886,12 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     ```
 
     Multiple models will be applied last to first recursively up the
-    resource tree.
+    route tree.
 
     ```javascript
     App.Router.map(function() {
-      this.resource('blogPost', { path:':blogPostId' }, function() {
-        this.resource('blogComment', { path: ':blogCommentId' });
+      this.route('blogPost', { path:':blogPostId' }, function() {
+        this.route('blogComment', { path: ':blogCommentId', resetNamespace: true });
       });
     });
 
@@ -949,7 +949,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     App.Router.map(function() {
-      this.resource('articles', { path: '/articles' }, function() {
+      this.route('articles', { path: '/articles' }, function() {
         this.route('new');
       });
     });
@@ -969,8 +969,8 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     App.Router.map(function() {
       this.route('index');
 
-      this.resource('breakfast', { path: ':breakfastId' }, function() {
-        this.resource('cereal', { path: ':cerealId' });
+      this.route('breakfast', { path: ':breakfastId' }, function() {
+        this.route('cereal', { path: ':cerealId', resetNamespace: true });
       });
     });
 
@@ -990,7 +990,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     App.Router.map(function() {
-      this.resource('fruits', function() {
+      this.route('fruits', function() {
         this.route('apples');
       });
     });
@@ -1395,7 +1395,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     App.Router.map(function() {
-      this.resource('post', { path: '/posts/:post_id' });
+      this.route('post', { path: '/posts/:post_id' });
     });
     ```
 
@@ -1551,7 +1551,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     App.Router.map(function() {
-      this.resource('post', { path: '/posts/:post_id' });
+      this.route('post', { path: '/posts/:post_id' });
     });
 
     App.PostRoute = Ember.Route.extend({
@@ -1648,7 +1648,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     App.Router.map(function() {
-      this.resource('post', { path: '/posts/:post_id' });
+      this.route('post', { path: '/posts/:post_id' });
     });
     ```
 
@@ -1759,14 +1759,14 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     App.Router.map(function() {
-        this.resource('post', { path: '/post/:post_id' }, function() {
-            this.resource('comments');
+        this.route('post', { path: '/post/:post_id' }, function() {
+          this.route('comments', { resetNamespace: true });
         });
     });
 
     App.CommentsRoute = Ember.Route.extend({
         afterModel: function() {
-            this.set('post', this.modelFor('post'));
+          this.set('post', this.modelFor('post'));
         }
     });
     ```
@@ -1837,7 +1837,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     ```javascript
     Router.map(function() {
-      this.resource('photos');
+      this.route('photos');
     });
     ```
 
@@ -1902,7 +1902,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     // router
     Router.map(function() {
       this.route('index');
-      this.resource('post', { path: '/posts/:post_id' });
+      this.route('post', { path: '/posts/:post_id' });
     });
     ```
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -84,7 +84,7 @@ var EmberRouter = EmberObject.extend(Evented, {
     });
 
     function generateDSL() {
-      this.resource('application', { path: '/', overrideNameAssertion: true }, function() {
+      this.route('application', { path: '/', resetNamespace: true, overrideNameAssertion: true }, function() {
         for (var i=0; i < dslCallbacks.length; i++) {
           dslCallbacks[i].call(this);
         }
@@ -918,13 +918,13 @@ EmberRouter.reopenClass({
 
   /**
     The `Router.map` function allows you to define mappings from URLs to routes
-    and resources in your application. These mappings are defined within the
-    supplied callback function using `this.resource` and `this.route`.
+    in your application. These mappings are defined within the
+    supplied callback function using `this.route`.
 
     ```javascript
     App.Router.map(function(){
       this.route('about');
-      this.resource('article');
+      this.route('article', { resetNamespace: true });
     });
     ```
 

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -921,14 +921,36 @@ EmberRouter.reopenClass({
     in your application. These mappings are defined within the
     supplied callback function using `this.route`.
 
+    The first parameter is the name of the route which is used by default as the
+    path name as well.
+
+    The second parameter is the optional options hash. Available options are:
+      * `path`: allows you to provide your own path as well as mark dynamic
+        segments.
+      * `resetNamespace`: false by default; when nesting routes, ember will
+        combine the route names to form the fully-qualified route name, which is
+        used with `{{link-to}}` or manually transitioning to routes. Setting
+        `resetNamespace: true` will cause the route not to inherit from its
+        parent route's names. This is handy for resources which can be accessed
+        in multiple places as well as preventing extremely long route names.
+        Keep in mind that the actual URL path behavior is still retained.
+
+    The third parameter is a function, which can be used to nest routes.
+    Nested routes, by default, will have the parent route tree's route name and
+    path prepended to it's own.
+
     ```javascript
     App.Router.map(function(){
-      this.route('about');
-      this.route('article', { resetNamespace: true });
+      this.route('post', { path: '/post/:post_id' }, function() {
+        this.route('edit');
+        this.route('comments', { resetNamespace: true }, function() {
+          this.route('new');
+        });
+      });
     });
     ```
 
-    For more detailed examples please see
+    For more detailed documentation and examples please see
     [the guides](http://emberjs.com/guides/routing/defining-your-routes/).
 
     @method map

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -39,7 +39,7 @@ QUnit.test('should fail when using a reserved route name', function() {
 
       var router = Router.create();
       router._initRouterJs();
-    }, `'${reservedName}' cannot be used as a resource name.`);
+    }, `'${reservedName}' cannot be used as a route name.`);
 
   });
 });

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -13,9 +13,10 @@ QUnit.module('Ember Router DSL', {
 });
 
 QUnit.test('should fail when using a reserved route name', function() {
+  expectDeprecation('this.resource() is deprecated. Use this.route(\'name\', { resetNamespace: true }, function () {}) instead.');
   var reservedNames = ['array', 'basic', 'object', 'application'];
 
-  expect(reservedNames.length * 2);
+  expect((reservedNames.length * 2) + 1);
 
   reservedNames.forEach(function(reservedName) {
     expectAssertion(function() {
@@ -38,12 +39,14 @@ QUnit.test('should fail when using a reserved route name', function() {
 
       var router = Router.create();
       router._initRouterJs();
-    }, '\'' + reservedName + '\' cannot be used as a resource name.');
+    }, `'${reservedName}' cannot be used as a resource name.`);
 
   });
 });
 
 QUnit.test('should reset namespace if nested with resource', function() {
+  expectDeprecation('this.resource() is deprecated. Use this.route(\'name\', { resetNamespace: true }, function () {}) instead.');
+
   Router = Router.map(function() {
     this.resource('bleep', function() {
       this.resource('bloop', function() {

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -116,7 +116,7 @@ var ActionHandler = Mixin.create({
 
     ```js
     App.Router.map(function() {
-      this.resource("album", function() {
+      this.route("album", function() {
         this.route("song");
       });
     });

--- a/packages/ember-testing/tests/helpers_test.js
+++ b/packages/ember-testing/tests/helpers_test.js
@@ -741,7 +741,7 @@ QUnit.module('ember-testing routing helpers', {
       });
 
       App.Router.map(function() {
-        this.resource('posts', function() {
+        this.route('posts', { resetNamespace: true }, function() {
           this.route('new');
         });
       });
@@ -842,7 +842,7 @@ QUnit.module('ember-testing async router', {
       });
 
       App.Router.map(function() {
-        this.resource('user', function() {
+        this.route('user', { resetNamespace: true }, function() {
           this.route('profile');
           this.route('edit');
         });

--- a/packages/ember-testing/tests/integration_test.js
+++ b/packages/ember-testing/tests/integration_test.js
@@ -23,7 +23,7 @@ QUnit.module('ember-testing Integration', {
       });
 
       App.Router.map(function() {
-        this.resource('people', { path: '/' });
+        this.route('people', { path: '/' });
       });
 
       App.PeopleRoute = EmberRoute.extend({

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -371,7 +371,7 @@ Ember.TEMPLATES = {};
   });
   ```
 
-  If you have nested resources, your Handlebars template will look like this:
+  If you have nested routes, your Handlebars template will look like this:
 
   ```html
   <script type='text/x-handlebars' data-template-name='posts/new'>

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -253,7 +253,7 @@ QUnit.test('The {{link-to}} helper supports a custom activeClass', function() {
 
 QUnit.test('The {{link-to}} helper supports leaving off .index for nested routes', function() {
   Router.map(function() {
-    this.resource('about', function() {
+    this.route('about', function() {
       this.route('item');
     });
   });
@@ -273,7 +273,7 @@ QUnit.test('The {{link-to}} helper supports currentWhen (DEPRECATED)', function(
   expectDeprecation('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.');
 
   Router.map(function(match) {
-    this.resource('index', { path: '/' }, function() {
+    this.route('index', { path: '/' }, function() {
       this.route('about');
     });
 
@@ -294,7 +294,7 @@ QUnit.test('The {{link-to}} helper supports currentWhen (DEPRECATED)', function(
 
 QUnit.test('The {{link-to}} helper supports custom, nested, current-when', function() {
   Router.map(function(match) {
-    this.resource('index', { path: '/' }, function() {
+    this.route('index', { path: '/' }, function() {
       this.route('about');
     });
 
@@ -313,13 +313,13 @@ QUnit.test('The {{link-to}} helper supports custom, nested, current-when', funct
   equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, 'The link is active since current-when is a parent route');
 });
 
-QUnit.test('The {{link-to}} helper does not disregard current-when when it is given explicitly for a resource', function() {
+QUnit.test('The {{link-to}} helper does not disregard current-when when it is given explicitly for a route', function() {
   Router.map(function(match) {
-    this.resource('index', { path: '/' }, function() {
+    this.route('index', { path: '/' }, function() {
       this.route('about');
     });
 
-    this.resource('items', function() {
+    this.route('items', function() {
       this.route('item');
     });
   });
@@ -333,12 +333,12 @@ QUnit.test('The {{link-to}} helper does not disregard current-when when it is gi
     router.handleURL('/about');
   });
 
-  equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, 'The link is active when current-when is given for explicitly for a resource');
+  equal(Ember.$('#other-link.active', '#qunit-fixture').length, 1, 'The link is active when current-when is given for explicitly for a route');
 });
 
 QUnit.test('The {{link-to}} helper supports multiple current-when routes', function() {
   Router.map(function(match) {
-    this.resource('index', { path: '/' }, function() {
+    this.route('index', { path: '/' }, function() {
       this.route('about');
     });
     this.route('item');
@@ -376,7 +376,7 @@ QUnit.test('The {{link-to}} helper defaults to bubbling', function() {
   Ember.TEMPLATES['about/contact'] = compile('<h1 id=\'contact\'>Contact</h1>');
 
   Router.map(function() {
-    this.resource('about', function() {
+    this.route('about', function() {
       this.route('contact');
     });
   });
@@ -411,7 +411,7 @@ QUnit.test('The {{link-to}} helper supports bubbles=false', function() {
   Ember.TEMPLATES['about/contact'] = compile('<h1 id=\'contact\'>Contact</h1>');
 
   Router.map(function() {
-    this.resource('about', function() {
+    this.route('about', function() {
       this.route('contact');
     });
   });
@@ -445,7 +445,7 @@ QUnit.test('The {{link-to}} helper moves into the named route with context', fun
   expectDeprecation(arrayControllerDeprecation);
   Router.map(function(match) {
     this.route('about');
-    this.resource('item', { path: '/item/:id' });
+    this.route('item', { path: '/item/:id' });
   });
 
   Ember.TEMPLATES.about = compile('<h3>List</h3><ul>{{#each model as |person|}}<li>{{#link-to \'item\' person}}{{person.name}}{{/link-to}}</li>{{/each}}</ul>{{#link-to \'index\' id=\'home-link\'}}Home{{/link-to}}');
@@ -601,7 +601,7 @@ QUnit.test('The {{link-to}} helper accepts string/numeric arguments', function()
 QUnit.test('Issue 4201 - Shorthand for route.index shouldn\'t throw errors about context arguments', function() {
   expect(2);
   Router.map(function() {
-    this.resource('lobby', function() {
+    this.route('lobby', function() {
       this.route('index', { path: ':lobby_id' });
       this.route('list');
     });
@@ -894,9 +894,9 @@ QUnit.test('{{linkTo}} is aliased', function() {
   equal(container.lookup('controller:application').get('currentRouteName'), 'about', 'linkTo worked properly');
 });
 
-QUnit.test('The {{link-to}} helper is active when a resource is active', function() {
+QUnit.test('The {{link-to}} helper is active when a route is active', function() {
   Router.map(function() {
-    this.resource('about', function() {
+    this.route('about', function() {
       this.route('item');
     });
   });
@@ -909,12 +909,12 @@ QUnit.test('The {{link-to}} helper is active when a resource is active', functio
 
   Ember.run(router, 'handleURL', '/about');
 
-  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, 'The about resource link is active');
+  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, 'The about route link is active');
   equal(Ember.$('#item-link.active', '#qunit-fixture').length, 0, 'The item route link is inactive');
 
   Ember.run(router, 'handleURL', '/about/item');
 
-  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, 'The about resource link is active');
+  equal(Ember.$('#about-link.active', '#qunit-fixture').length, 1, 'The about route link is active');
   equal(Ember.$('#item-link.active', '#qunit-fixture').length, 1, 'The item route link is active');
 
 });
@@ -1202,7 +1202,7 @@ QUnit.test('{{link-to}} active property respects changing parent route context',
 
 
   Router.map(function() {
-    this.resource('things', { path: '/things/:name' }, function() {
+    this.route('things', { path: '/things/:name' }, function() {
       this.route('other');
     });
   });

--- a/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
+++ b/packages/ember/tests/helpers/link_to_test/link_to_with_query_params_test.js
@@ -243,7 +243,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     );
 
     Router.map(function() {
-      this.resource('search', function() {
+      this.route('search', function() {
         this.route('results');
       });
     });
@@ -378,7 +378,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
   QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
     App.Router.map(function() {
-      this.resource('parent', function() {
+      this.route('parent', function() {
         this.route('child');
       });
     });
@@ -610,7 +610,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     );
 
     Router.map(function() {
-      this.resource('search', function() {
+      this.route('search', function() {
         this.route('results');
       });
     });
@@ -722,7 +722,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
   QUnit.test('The {{link-to}} helper applies active class to parent route', function() {
     App.Router.map(function() {
-      this.resource('parent', function() {
+      this.route('parent', function() {
         this.route('child');
       });
     });

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -688,7 +688,7 @@ QUnit.test('The Homepage getting its controller context via model', function() {
 QUnit.test('The Specials Page getting its controller context by deserializing the params hash', function() {
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   App.SpecialRoute = Ember.Route.extend({
@@ -719,7 +719,7 @@ QUnit.test('The Specials Page getting its controller context by deserializing th
 QUnit.test('The Specials Page defaults to looking models up via `find`', function() {
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   App.MenuItem = Ember.Object.extend();
@@ -753,7 +753,7 @@ QUnit.test('The Specials Page defaults to looking models up via `find`', functio
 QUnit.test('The Special Page returning a promise puts the app into a loading state until the promise is resolved', function() {
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   var menuItem, resolve;
@@ -805,7 +805,7 @@ QUnit.test('The Special Page returning a promise puts the app into a loading sta
 QUnit.test('The loading state doesn\'t get entered for promises that resolve on the same run loop', function() {
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   App.MenuItem = Ember.Object.extend();
@@ -848,7 +848,7 @@ QUnit.test('The loading state doesn\'t get entered for promises that resolve on 
 asyncTest("The Special page returning an error fires the error hook on SpecialRoute", function() {
   Router.map(function() {
     this.route("home", { path: "/" });
-    this.resource("special", { path: "/specials/:menu_item_id" });
+    this.route("special", { path: "/specials/:menu_item_id" });
   });
 
   var menuItem;
@@ -883,7 +883,7 @@ asyncTest("The Special page returning an error fires the error hook on SpecialRo
 QUnit.test('The Special page returning an error invokes SpecialRoute\'s error handler', function() {
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   var menuItem, promise, resolve;
@@ -926,7 +926,7 @@ function testOverridableErrorHandler(handlersName) {
 
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   var menuItem, resolve;
@@ -980,7 +980,7 @@ asyncTest('Moving from one page to another triggers the correct callbacks', func
 
   Router.map(function() {
     this.route('home', { path: '/' });
-    this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('special', { path: '/specials/:menu_item_id' });
   });
 
   App.MenuItem = Ember.Object.extend();
@@ -1024,8 +1024,8 @@ asyncTest('Moving from one page to another triggers the correct callbacks', func
 
 asyncTest('Nested callbacks are not exited when moving to siblings', function() {
   Router.map(function() {
-    this.resource('root', { path: '/' }, function() {
-      this.resource('special', { path: '/specials/:menu_item_id' });
+    this.route('root', { path: '/' }, function() {
+      this.route('special', { path: '/specials/:menu_item_id', resetNamespace: true });
     });
   });
 
@@ -1212,7 +1212,7 @@ QUnit.asyncTest('Events are triggered on the current state when defined in `acti
 
 QUnit.asyncTest('Events defined in `actions` object are triggered on the current state when routes are nested', function() {
   Router.map(function() {
-    this.resource('root', { path: '/' }, function() {
+    this.route('root', { path: '/' }, function() {
       this.route('index', { path: '/' });
     });
   });
@@ -1285,7 +1285,7 @@ QUnit.asyncTest('Events are triggered on the current state when defined in `even
 
 QUnit.asyncTest('Events defined in `events` object are triggered on the current state when routes are nested (DEPRECATED)', function() {
   Router.map(function() {
-    this.resource('root', { path: '/' }, function() {
+    this.route('root', { path: '/' }, function() {
       this.route('index', { path: '/' });
     });
   });
@@ -1406,7 +1406,7 @@ QUnit.asyncTest('Actions are not triggered on the controller if a matching actio
 
 QUnit.asyncTest('actions can be triggered with multiple arguments', function() {
   Router.map(function() {
-    this.resource('root', { path: '/' }, function() {
+    this.route('root', { path: '/' }, function() {
       this.route('index', { path: '/' });
     });
   });
@@ -1563,10 +1563,10 @@ QUnit.test('Route inherits model from parent route', function() {
   expect(9);
 
   Router.map(function() {
-    this.resource('the_post', { path: '/posts/:post_id' }, function() {
+    this.route('the_post', { path: '/posts/:post_id' }, function() {
       this.route('comments');
 
-      this.resource('shares', { path: '/shares/:share_id' }, function() {
+      this.route('shares', { path: '/shares/:share_id', resetNamespace: true }, function() {
         this.route('share');
       });
     });
@@ -1634,12 +1634,12 @@ QUnit.test('Route inherits model from parent route', function() {
   handleURL('/posts/3/shares/3');
 });
 
-QUnit.test('Resource inherits model from parent resource', function() {
+QUnit.test('Routes with { resetNamespace: true } inherits model from parent route', function() {
   expect(6);
 
   Router.map(function() {
-    this.resource('the_post', { path: '/posts/:post_id' }, function() {
-      this.resource('comments', function() {
+    this.route('the_post', { path: '/posts/:post_id' }, function() {
+      this.route('comments', { resetNamespace: true }, function() {
       });
     });
   });
@@ -1685,8 +1685,8 @@ QUnit.test('It is possible to get the model from a parent route', function() {
   expect(9);
 
   Router.map(function() {
-    this.resource('the_post', { path: '/posts/:post_id' }, function() {
-      this.resource('comments');
+    this.route('the_post', { path: '/posts/:post_id' }, function() {
+      this.route('comments', { resetNamespace: true });
     });
   });
 
@@ -1762,8 +1762,8 @@ QUnit.test('Redirecting from the middle of a route aborts the remainder of the r
 
   Router.map(function() {
     this.route('home');
-    this.resource('foo', function() {
-      this.resource('bar', function() {
+    this.route('foo', function() {
+      this.route('bar', { resetNamespace: true }, function() {
         this.route('baz');
       });
     });
@@ -1797,8 +1797,8 @@ QUnit.test('Redirecting to the current target in the middle of a route does not 
 
   Router.map(function() {
     this.route('home');
-    this.resource('foo', function() {
-      this.resource('bar', function() {
+    this.route('foo', function() {
+      this.route('bar', { resetNamespace: true }, function() {
         this.route('baz');
       });
     });
@@ -1837,8 +1837,8 @@ QUnit.test('Redirecting to the current target with a different context aborts th
 
   Router.map(function() {
     this.route('home');
-    this.resource('foo', function() {
-      this.resource('bar', { path: 'bar/:id' }, function() {
+    this.route('foo', function() {
+      this.route('bar', { path: 'bar/:id', resetNamespace: true }, function() {
         this.route('baz');
       });
     });
@@ -1878,8 +1878,8 @@ QUnit.test('Redirecting to the current target with a different context aborts th
 
 QUnit.test('Transitioning from a parent event does not prevent currentPath from being set', function() {
   Router.map(function() {
-    this.resource('foo', function() {
-      this.resource('bar', function() {
+    this.route('foo', function() {
+      this.route('bar', { resetNamespace: true }, function() {
         this.route('baz');
       });
       this.route('qux');
@@ -1920,8 +1920,8 @@ QUnit.test('Generated names can be customized when providing routes with dot not
   Ember.TEMPLATES['bar/baz'] = compile('<p>{{name}}Bottom!</p>');
 
   Router.map(function() {
-    this.resource('foo', { path: '/top' }, function() {
-      this.resource('bar', { path: '/middle' }, function() {
+    this.route('foo', { path: '/top' }, function() {
+      this.route('bar', { path: '/middle', resetNamespace: true }, function() {
         this.route('baz', { path: '/bottom' });
       });
     });
@@ -1964,8 +1964,8 @@ QUnit.test('Child routes render into their parent route\'s template by default',
   Ember.TEMPLATES['middle/bottom'] = compile('<p>Bottom!</p>');
 
   Router.map(function() {
-    this.resource('top', function() {
-      this.resource('middle', function() {
+    this.route('top', function() {
+      this.route('middle', { resetNamespace: true }, function() {
         this.route('bottom');
       });
     });
@@ -1986,8 +1986,8 @@ QUnit.test('Child routes render into specified template', function() {
   Ember.TEMPLATES['middle/bottom'] = compile('<p>Bottom!</p>');
 
   Router.map(function() {
-    this.resource('top', function() {
-      this.resource('middle', function() {
+    this.route('top', function() {
+      this.route('middle', { resetNamespace: true }, function() {
         this.route('bottom');
       });
     });
@@ -2012,7 +2012,7 @@ QUnit.test('Rendering into specified template with slash notation', function() {
   Ember.TEMPLATES['person/details'] = compile('details!');
 
   Router.map(function() {
-    this.resource('home', { path: '/' });
+    this.route('home', { path: '/' });
   });
 
   App.HomeRoute = Ember.Route.extend({
@@ -2038,8 +2038,8 @@ QUnit.test('Parent route context change', function() {
   Ember.TEMPLATES['post/edit'] = compile('editing');
 
   Router.map(function() {
-    this.resource('posts', function() {
-      this.resource('post', { path: '/:postId' }, function() {
+    this.route('posts', function() {
+      this.route('post', { path: '/:postId', resetNamespace: true }, function() {
         this.route('edit');
       });
     });
@@ -2137,7 +2137,7 @@ QUnit.test('Router accounts for rootURL on page load when using history location
   });
 
   Router.map(function() {
-    this.resource('posts', { path: '/posts' });
+    this.route('posts', { path: '/posts' });
   });
 
   App.PostsRoute = Ember.Route.extend({
@@ -2185,7 +2185,7 @@ QUnit.test('Only use route rendered into main outlet for default into property o
   Ember.TEMPLATES['posts/menu'] = compile('postsMenu');
 
   Router.map(function() {
-    this.resource('posts', function() {});
+    this.route('posts', function() {});
   });
 
   App.PostsMenuView = EmberView.extend({
@@ -2268,7 +2268,7 @@ QUnit.test('Generated route should be an instance of App.Route if provided', fun
 
 QUnit.test('Nested index route is not overriden by parent\'s implicit index route', function() {
   Router.map(function() {
-    this.resource('posts', function() {
+    this.route('posts', function() {
       this.route('index', { path: ':category' });
     });
   });
@@ -2500,8 +2500,8 @@ QUnit.test('Route should tear down multiple outlets', function() {
   Ember.TEMPLATES['posts/footer'] = compile('postsFooter');
 
   Router.map(function() {
-    this.resource('posts', function() {});
-    this.resource('users', function() {});
+    this.route('posts', function() {});
+    this.route('users', function() {});
   });
 
   App.PostsMenuView = EmberView.extend({
@@ -2579,8 +2579,8 @@ QUnit.test('Route supports clearing outlet explicitly', function() {
   Ember.TEMPLATES['posts/extra'] = compile('postsExtra');
 
   Router.map(function() {
-    this.resource('posts', function() {});
-    this.resource('users', function() {});
+    this.route('posts', function() {});
+    this.route('users', function() {});
   });
 
   App.PostsIndexView = EmberView.extend({
@@ -2661,8 +2661,8 @@ QUnit.test('Route supports clearing outlet using string parameter', function() {
   Ember.TEMPLATES['posts/modal'] = compile('postsModal');
 
   Router.map(function() {
-    this.resource('posts', function() {});
-    this.resource('users', function() {});
+    this.route('posts', function() {});
+    this.route('users', function() {});
   });
 
   App.PostsIndexView = EmberView.extend({
@@ -3000,10 +3000,10 @@ QUnit.test('currentRouteName is a property installed on ApplicationController th
   expect(24);
 
   Router.map(function() {
-    this.resource('be', function() {
-      this.resource('excellent', function() {
-        this.resource('to', function() {
-          this.resource('each', function() {
+    this.route('be', function() {
+      this.route('excellent', { resetNamespace: true }, function() {
+        this.route('to', { resetNamespace: true }, function() {
+          this.route('each', { resetNamespace: true }, function() {
             this.route('other');
           });
         });
@@ -3087,7 +3087,7 @@ QUnit.test('Ember.Location.registerImplementation is deprecated', function() {
 
 QUnit.test('Routes can refresh themselves causing their model hooks to be re-run', function() {
   Router.map(function() {
-    this.resource('parent', { path: '/parent/:parent_id' }, function() {
+    this.route('parent', { path: '/parent/:parent_id' }, function() {
       this.route('child');
     });
   });
@@ -3352,9 +3352,9 @@ QUnit.test('Route#resetController gets fired when changing models and exiting ro
   expect(4);
 
   Router.map(function() {
-    this.resource('a', function() {
-      this.resource('b', { path: '/b/:id' }, function() { });
-      this.resource('c', { path: '/c/:id' }, function() { });
+    this.route('a', function() {
+      this.route('b', { path: '/b/:id', resetNamespace: true }, function() { });
+      this.route('c', { path: '/c/:id', resetNamespace: true }, function() { });
     });
     this.route('out');
   });
@@ -3624,7 +3624,7 @@ QUnit.test('Can render routes with no \'main\' outlet and their children', funct
 
   Router.map(function() {
     this.route('app', { path: '/app' }, function() {
-      this.resource('sub', { path: '/sub' });
+      this.route('sub', { path: '/sub', resetNamespace: true });
     });
   });
 

--- a/packages/ember/tests/routing/query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test.js
@@ -481,7 +481,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     Ember.TEMPLATES['parent/child'] = compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}');
 
     App.Router.map(function() {
-      this.resource('parent', function() {
+      this.route('parent', function() {
         this.route('child');
       });
     });
@@ -534,7 +534,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.test('Subresource naming style is supported when configuration is all on the route', function() {
 
     Router.map(function() {
-      this.resource('abc.def', { path: '/abcdef' }, function() {
+      this.route('abc.def', { path: '/abcdef' }, function() {
         this.route('zoo');
       });
     });
@@ -998,7 +998,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.test('controllers won\'t be eagerly instantiated by internal query params logic when configured on the route', function() {
     expect(10);
     Router.map(function() {
-      this.resource('cats', function() {
+      this.route('cats', function() {
         this.route('index', { path: '/' });
       });
       this.route('home', { path: '/' });
@@ -1389,7 +1389,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     Ember.TEMPLATES['parent/child'] = compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}');
 
     App.Router.map(function() {
-      this.resource('parent', function() {
+      this.route('parent', function() {
         this.route('child');
       });
     });
@@ -1504,7 +1504,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.test('Subresource naming style is supported when configured on the route', function() {
 
     Router.map(function() {
-      this.resource('abc.def', { path: '/abcdef' }, function() {
+      this.route('abc.def', { path: '/abcdef' }, function() {
         this.route('zoo');
       });
     });
@@ -2082,7 +2082,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.test('controllers won\'t be eagerly instantiated by internal query params logic', function() {
     expect(10);
     Router.map(function() {
-      this.resource('cats', function() {
+      this.route('cats', function() {
         this.route('index', { path: '/' });
       });
       this.route('home', { path: '/' });
@@ -2529,7 +2529,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     Ember.TEMPLATES['parent/child'] = compile('{{link-to \'Parent\' \'parent\' (query-params foo=\'change\') id=\'parent-link\'}}');
 
     App.Router.map(function() {
-      this.resource('parent', function() {
+      this.route('parent', function() {
         this.route('child');
       });
     });
@@ -2670,7 +2670,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
   QUnit.test('Subresource naming style is supported', function() {
 
     Router.map(function() {
-      this.resource('abc.def', { path: '/abcdef' }, function() {
+      this.route('abc.def', { path: '/abcdef' }, function() {
         this.route('zoo');
       });
     });

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -105,8 +105,8 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       sharedSetup();
 
       App.Router.map(function() {
-        this.resource('article', { path: '/a/:id' }, function() {
-          this.resource('comments');
+        this.route('article', { path: '/a/:id' }, function() {
+          this.route('comments', { resetNamespace: true });
         });
       });
 
@@ -338,8 +338,8 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
   QUnit.test('can reset query params using the resetController hook', function() {
     App.Router.map(function() {
-      this.resource('article', { path: '/a/:id' }, function() {
-        this.resource('comments');
+      this.route('article', { path: '/a/:id' }, function() {
+        this.route('comments', { resetNamespace: true });
       });
       this.route('about');
     });
@@ -386,8 +386,8 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       sharedSetup();
 
       App.Router.map(function() {
-        this.resource('article', { path: '/a/:id' }, function() {
-          this.resource('comments');
+        this.route('article', { path: '/a/:id' }, function() {
+          this.route('comments', { resetNamespace: true });
         });
       });
 
@@ -613,8 +613,8 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
 
   QUnit.test('can reset query params using the resetController hook', function() {
     App.Router.map(function() {
-      this.resource('article', { path: '/a/:id' }, function() {
-        this.resource('comments');
+      this.route('article', { path: '/a/:id' }, function() {
+        this.route('comments', { resetNamespace: true });
       });
       this.route('about');
     });

--- a/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/overlapping_query_params_test.js
@@ -94,7 +94,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       sharedSetup();
 
       App.Router.map(function() {
-        this.resource('parent', function() {
+        this.route('parent', function() {
           this.route('child');
         });
       });
@@ -191,7 +191,7 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       sharedSetup();
 
       App.Router.map(function() {
-        this.resource('parent', function() {
+        this.route('parent', function() {
           this.route('child');
         });
       });

--- a/packages/ember/tests/routing/substates_test.js
+++ b/packages/ember/tests/routing/substates_test.js
@@ -116,8 +116,8 @@ QUnit.test('Slow promises waterfall on startup', function() {
   var sallyDeferred = Ember.RSVP.defer();
 
   Router.map(function() {
-    this.resource('grandma', function() {
-      this.resource('mom', function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
         this.route('sally');
       });
     });
@@ -170,7 +170,7 @@ QUnit.test('ApplicationRoute#currentPath reflects loading state path', function(
   var momDeferred = Ember.RSVP.defer();
 
   Router.map(function() {
-    this.resource('grandma', function() {
+    this.route('grandma', function() {
       this.route('mom');
     });
   });
@@ -285,8 +285,8 @@ QUnit.test('Enter child loading state of pivot route', function() {
   var deferred = Ember.RSVP.defer();
 
   Router.map(function() {
-    this.resource('grandma', function() {
-      this.resource('mom', function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
         this.route('sally');
       });
       this.route('smells');
@@ -332,8 +332,8 @@ QUnit.test('Loading actions bubble to root, but don\'t enter substates above piv
   var smellsDeferred = Ember.RSVP.defer();
 
   Router.map(function() {
-    this.resource('grandma', function() {
-      this.resource('mom', function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
         this.route('sally');
       });
       this.route('smells');
@@ -386,8 +386,8 @@ QUnit.test('Default error event moves into nested route', function() {
   templates['grandma/error'] = 'ERROR: {{model.msg}}';
 
   Router.map(function() {
-    this.resource('grandma', function() {
-      this.resource('mom', function() {
+    this.route('grandma', function() {
+      this.route('mom', { resetNamespace: true }, function() {
         this.route('sally');
       });
     });
@@ -493,8 +493,8 @@ if (isEnabled('ember-routing-named-substates')) {
     templates['grandma/mom_error'] = 'MOM ERROR: {{model.msg}}';
 
     Router.map(function() {
-      this.resource('grandma', function() {
-        this.resource('mom', function() {
+      this.route('grandma', function() {
+        this.route('mom', { resetNamespace: true }, function() {
           this.route('sally');
         });
       });
@@ -528,7 +528,7 @@ if (isEnabled('ember-routing-named-substates')) {
     equal(appController.get('currentPath'), 'grandma.mom_error', 'Initial route fully loaded');
   });
 
-  QUnit.test('Prioritized substate entry works with preserved-namespace nested resources', function() {
+  QUnit.test('Prioritized substate entry works with preserved-namespace nested routes', function() {
 
     expect(2);
 
@@ -536,8 +536,8 @@ if (isEnabled('ember-routing-named-substates')) {
     templates['foo/bar/index'] = 'YAY';
 
     Router.map(function() {
-      this.resource('foo', function() {
-        this.resource('foo.bar', { path: '/bar' }, function() {
+      this.route('foo', function() {
+        this.route('foo.bar', { path: '/bar', resetNamespace: true }, function() {
         });
       });
     });
@@ -628,7 +628,7 @@ if (isEnabled('ember-routing-named-substates')) {
     templates['foo'] = '{{outlet}}';
 
     Router.map(function() {
-      this.resource('foo', function() {
+      this.route('foo', function() {
         this.route('bar');
       });
     });
@@ -665,7 +665,7 @@ if (isEnabled('ember-routing-named-substates')) {
     templates['foo'] = '{{outlet}}';
 
     Router.map(function() {
-      this.resource('foo', function() {
+      this.route('foo', function() {
         this.route('bar');
       });
     });


### PR DESCRIPTION
Use `this.route('name', { resetNamespace: true })` instead.

This has been talked about for months, but hadn't seen a PR so figured 2.0 beta it was time.

Back in March, `this.resource` was [removed](https://github.com/emberjs/guides/commit/fb7f74b507972c7e123ec516a9ccddcd8e8bf8ae) from the guides and released [as 1.11.0](http://guides.emberjs.com/v1.11.0/routing/defining-your-routes/#toc_nested-routes).
- [x] Deprecate `this.resource()`
- [x] Add API docs for `resetNamespace`
- [x] Add Guide docs for `resetNamespace` https://github.com/emberjs/guides/pull/373
