### PR TITLE
[BUGFIX beta] {{link-to}} before application boot

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -260,6 +260,8 @@ var LinkComponent = EmberComponent.extend({
   */
   active: computed('attrs.params', '_routing.currentState', function computeLinkComponentActive() {
     var currentState = get(this, '_routing.currentState');
+    if (!currentState) { return false; }
+
     return computeActive(this, currentState);
   }),
 

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1,5 +1,6 @@
 import 'ember';
 import Ember from 'ember-metal/core';
+import ComponentLookup from 'ember-views/component_lookup';
 import isEnabled from 'ember-metal/features';
 
 import { objectControllerDeprecation } from 'ember-runtime/controllers/object_controller';
@@ -93,6 +94,30 @@ QUnit.module('The {{link-to}} helper', {
   },
 
   teardown: sharedTeardown
+});
+
+// This test is designed to simulate the context of an ember-qunit/ember-test-helpers component integration test,
+// so the container is available but it does not boot the entire app
+QUnit.test('Using {{link-to}} does not cause an exception if it is rendered before the router has started routing', function(assert) {
+  Router.map(function() {
+    this.route('about');
+  });
+
+  registry.register('component-lookup:main', ComponentLookup);
+
+  let component = Ember.Component.extend({
+    layout: compile('{{#link-to "about"}}Go to About{{/link-to}}'),
+    container: container
+  }).create();
+
+  let router = container.lookup('router:main');
+  router.setupRouter();
+
+  Ember.run(function() {
+    component.appendTo('#qunit-fixture');
+  });
+
+  assert.strictEqual(component.$('a').length, 1, 'the link is rendered');
 });
 
 QUnit.test('The {{link-to}} helper moves into the named route', function() {


### PR DESCRIPTION
Previously, {{link-to}} would work even if the application had not been booted completely. This behavior is relied on by test harnesses like ember-qunit, since an “integration test” of a component may include a template that uses {{link-to}}. Many people have discovered that they would like to test a component that has a link without booting the entire app.

> You wanted a banana but what you got was a gorilla holding the banana and the entire jungle. –Joe Armstrong

During the Glimmer work, we refactored the interface between the LinkComponent and the router into a service. Unfortunately, this caused a regression where rendering the link before the router was completely initialized would raise an exception.

This commit adds a very stupid guard to ensure that we have enough router state to determine if a link is active or not. This whole path could be significantly cleaned up, and in particular, we should move towards using a stubbed routing service in tests that encapsulates all of these concerns.

Fixes #11150.
