### PR TITLE
[BUGFIX release] Sticky query params for nested and for dynamic routes

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -2229,7 +2229,8 @@ function mergeEachQueryParams(controllerQP, routeQP) {
     if (!controllerQP.hasOwnProperty(cqpName)) { continue; }
 
     var newControllerParameterConfiguration = {};
-    merge(newControllerParameterConfiguration, controllerQP[cqpName], routeQP[cqpName]);
+    merge(newControllerParameterConfiguration, controllerQP[cqpName]);
+    merge(newControllerParameterConfiguration, routeQP[cqpName]);
 
     qps[cqpName] = newControllerParameterConfiguration;
 

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -99,190 +99,137 @@ function sharedTeardown() {
   });
 }
 
-if (isEnabled('ember-routing-route-configured-query-params')) {
-  QUnit.module('Model Dep Query Params with Route-based configuration', {
-    setup() {
-      sharedSetup();
-
-      App.Router.map(function() {
-        this.route('article', { path: '/a/:id' }, function() {
-          this.route('comments', { resetNamespace: true });
-        });
-      });
-
-      var articles = this.articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
-
-      App.ApplicationController = Ember.Controller.extend({
-        articles: this.articles
-      });
-
-      var self = this;
-      App.ArticleRoute = Ember.Route.extend({
-        queryParams: {
-          q: {
-            defaultValue: 'wat'
-          },
-          z: {
-            defaultValue: 0
-          }
-        },
-        model(params) {
-          if (self.expectedModelHookParams) {
-            deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
-            self.expectedModelHookParams = null;
-          }
-          return articles.findProperty('id', params.id);
-        }
-      });
-
-      App.CommentsRoute = Ember.Route.extend({
-        queryParams: {
-          page: {
-            defaultValue: 1
-          }
-        }
-      });
-
-      Ember.TEMPLATES.application = compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}');
-
-      this.boot = function() {
-        bootApplication();
-
-        self.$link1 = Ember.$('#a-1');
-        self.$link2 = Ember.$('#a-2');
-        self.$link3 = Ember.$('#a-3');
-
-        equal(self.$link1.attr('href'), '/a/a-1');
-        equal(self.$link2.attr('href'), '/a/a-2');
-        equal(self.$link3.attr('href'), '/a/a-3');
-
-        self.controller = container.lookup('controller:article');
-      };
-    },
-
-    teardown() {
-      sharedTeardown();
-      ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
-    }
-  });
-
-  QUnit.test('query params have \'model\' stickiness by default', function() {
+function queryParamsStickyTest1(urlPrefix) {
+  return function() {
     this.boot();
 
     Ember.run(this.$link1, 'click');
-    equal(router.get('location.path'), '/a/a-1');
+    equal(router.get('location.path'), `${urlPrefix}/a-1`);
 
     setAndFlush(this.controller, 'q', 'lol');
 
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
 
     Ember.run(this.$link2, 'click');
 
     equal(this.controller.get('q'), 'wat');
     equal(this.controller.get('z'), 0);
     deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
-  });
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
+  };
+}
 
-  QUnit.test('query params have \'model\' stickiness by default (url changes)', function() {
-
+function queryParamsStickyTest2(urlPrefix) {
+  return function() {
     this.boot();
 
     this.expectedModelHookParams = { id: 'a-1', q: 'lol', z: 0 };
-    handleURL('/a/a-1?q=lol');
+    handleURL(`${urlPrefix}/a-1?q=lol`);
 
     deepEqual(this.controller.get('model'), { id: 'a-1' });
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
-    handleURL('/a/a-2?q=lol');
+    handleURL(`${urlPrefix}/a-2?q=lol`);
 
     deepEqual(this.controller.get('model'), { id: 'a-2' }, 'controller\'s model changed to a-2');
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol'); // fail
-    equal(this.$link3.attr('href'), '/a/a-3');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`); // fail
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-3', q: 'lol', z: 123 };
-    handleURL('/a/a-3?q=lol&z=123');
+    handleURL(`${urlPrefix}/a-3?q=lol&z=123`);
 
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 123);
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=lol&z=123');
-  });
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol&z=123`);
+  };
+}
 
-  QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', function() {
-    Ember.TEMPLATES.application = compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a.id id=a.id}} {{/each}}');
+function queryParamsStickyTest3(urlPrefix, articleLookup) {
+  return function() {
+    Ember.TEMPLATES.application = compile(`{{#each articles as |a|}} {{link-to 'Article' '${articleLookup}' a.id id=a.id}} {{/each}}`);
 
     this.boot();
 
     this.expectedModelHookParams = { id: 'a-1', q: 'wat', z: 0 };
-    Ember.run(router, 'transitionTo', 'article', 'a-1');
+    Ember.run(router, 'transitionTo', articleLookup, 'a-1');
 
     deepEqual(this.controller.get('model'), { id: 'a-1' });
     equal(this.controller.get('q'), 'wat');
     equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
-    Ember.run(router, 'transitionTo', 'article', 'a-2', { queryParams: { q: 'lol' } });
+    Ember.run(router, 'transitionTo', articleLookup, 'a-2', { queryParams: { q: 'lol' } });
 
     deepEqual(this.controller.get('model'), { id: 'a-2' });
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3`);
 
     this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
-    Ember.run(router, 'transitionTo', 'article', 'a-3', { queryParams: { q: 'hay' } });
+    Ember.run(router, 'transitionTo', articleLookup, 'a-3', { queryParams: { q: 'hay' } });
 
     deepEqual(this.controller.get('model'), { id: 'a-3' });
     equal(this.controller.get('q'), 'hay');
     equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=hay');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
 
     this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
-    Ember.run(router, 'transitionTo', 'article', 'a-2', { queryParams: { z: 1 } });
+    Ember.run(router, 'transitionTo', articleLookup, 'a-2', { queryParams: { z: 1 } });
 
     deepEqual(this.controller.get('model'), { id: 'a-2' });
     equal(this.controller.get('q'), 'lol');
     equal(this.controller.get('z'), 1);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol&z=1');
-    equal(this.$link3.attr('href'), '/a/a-3?q=hay');
-  });
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol&z=1`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=hay`);
+  };
+}
 
-  QUnit.test('\'controller\' stickiness shares QP state between models', function() {
-    App.ArticleRoute.reopen({
-      queryParams: { q: { scope: 'controller' } }
-    });
+function queryParamsStickyTest4(urlPrefix, articleLookup) {
+  return function() {
+    var articleClass = Ember.String.classify(articleLookup);
+
+    if (isEnabled('ember-routing-route-configured-query-params')) {
+      App[`${articleClass}Route`].reopen({
+        queryParams: { q: { scope: 'controller' } }
+      });
+    } else {
+      App[`${articleClass}Controller`].reopen({
+        queryParams: { q: { scope: 'controller' } }
+      });
+    }
 
     this.boot();
 
     Ember.run(this.$link1, 'click');
-    equal(router.get('location.path'), '/a/a-1');
+    equal(router.get('location.path'), `${urlPrefix}/a-1`);
 
     setAndFlush(this.controller, 'q', 'lol');
 
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=lol');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
 
     Ember.run(this.$link2, 'click');
 
@@ -290,53 +237,101 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
     equal(this.controller.get('z'), 0);
     deepEqual(this.controller.get('model'), { id: 'a-2' });
 
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=lol');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=lol`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=lol`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=lol`);
 
     this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
-    handleURL('/a/a-3?q=haha&z=123');
+    handleURL(`${urlPrefix}/a-3?q=haha&z=123`);
 
     deepEqual(this.controller.get('model'), { id: 'a-3' });
     equal(this.controller.get('q'), 'haha');
     equal(this.controller.get('z'), 123);
 
-    equal(this.$link1.attr('href'), '/a/a-1?q=haha');
-    equal(this.$link2.attr('href'), '/a/a-2?q=haha');
-    equal(this.$link3.attr('href'), '/a/a-3?q=haha&z=123');
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=haha`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=haha`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=haha&z=123`);
 
     setAndFlush(this.controller, 'q', 'woot');
 
-    equal(this.$link1.attr('href'), '/a/a-1?q=woot');
-    equal(this.$link2.attr('href'), '/a/a-2?q=woot');
-    equal(this.$link3.attr('href'), '/a/a-3?q=woot&z=123');
-  });
+    equal(this.$link1.attr('href'), `${urlPrefix}/a-1?q=woot`);
+    equal(this.$link2.attr('href'), `${urlPrefix}/a-2?q=woot`);
+    equal(this.$link3.attr('href'), `${urlPrefix}/a-3?q=woot&z=123`);
+  };
+}
 
-  QUnit.test('\'model\' stickiness is scoped to current or first dynamic parent route', function() {
+function queryParamsStickyTest5(urlPrefix, commentsLookupKey) {
+  return function() {
     this.boot();
 
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
+    Ember.run(router, 'transitionTo', commentsLookupKey, 'a-1');
 
-    var commentsCtrl = container.lookup('controller:comments');
+    var commentsCtrl = container.lookup(`controller:${commentsLookupKey}`);
     equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), '/a/a-1/comments');
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments`);
 
     setAndFlush(commentsCtrl, 'page', 2);
-    equal(router.get('location.path'), '/a/a-1/comments?page=2');
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=2`);
 
     setAndFlush(commentsCtrl, 'page', 3);
-    equal(router.get('location.path'), '/a/a-1/comments?page=3');
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=3`);
 
-    Ember.run(router, 'transitionTo', 'comments', 'a-2');
+    Ember.run(router, 'transitionTo', commentsLookupKey, 'a-2');
     equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), '/a/a-2/comments');
+    equal(router.get('location.path'), `${urlPrefix}/a-2/comments`);
 
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
+    Ember.run(router, 'transitionTo', commentsLookupKey, 'a-1');
     equal(commentsCtrl.get('page'), 3);
-    equal(router.get('location.path'), '/a/a-1/comments?page=3');
-  });
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=3`);
+  };
+}
 
-  QUnit.test('can reset query params using the resetController hook', function() {
+function queryParamsStickyTest6(urlPrefix, articleLookup, commentsLookup) {
+  return function() {
+    var articleClass = Ember.String.classify(articleLookup);
+
+    App[`${articleClass}Route`].reopen({
+      resetController(controller, isExiting) {
+        this.controllerFor(commentsLookup).set('page', 1);
+        if (isExiting) {
+          controller.set('q', 'imdone');
+        }
+      }
+    });
+
+    Ember.TEMPLATES.about = compile(`{{link-to 'A' '${commentsLookup}' 'a-1' id='one'}} {{link-to 'B' '${commentsLookup}' 'a-2' id='two'}}`);
+
+    this.boot();
+
+    Ember.run(router, 'transitionTo', commentsLookup, 'a-1');
+
+    var commentsCtrl = container.lookup(`controller:${commentsLookup}`);
+    equal(commentsCtrl.get('page'), 1);
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments`);
+
+    setAndFlush(commentsCtrl, 'page', 2);
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments?page=2`);
+
+    Ember.run(router, 'transitionTo', commentsLookup, 'a-2');
+    equal(commentsCtrl.get('page'), 1);
+    equal(this.controller.get('q'), 'wat');
+
+    Ember.run(router, 'transitionTo', commentsLookup, 'a-1');
+
+    equal(router.get('location.path'), `${urlPrefix}/a-1/comments`);
+    equal(commentsCtrl.get('page'), 1);
+
+    Ember.run(router, 'transitionTo', 'about');
+
+    equal(Ember.$('#one').attr('href'), `${urlPrefix}/a-1/comments?q=imdone`);
+    equal(Ember.$('#two').attr('href'), `${urlPrefix}/a-2/comments`);
+  };
+}
+
+QUnit.module('Model Dep Query Params', {
+  setup() {
+    sharedSetup();
+
     App.Router.map(function() {
       this.route('article', { path: '/a/:id' }, function() {
         this.route('comments', { resetNamespace: true });
@@ -344,70 +339,37 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
       this.route('about');
     });
 
-    App.ArticleRoute.reopen({
-      resetController(controller, isExiting) {
-        this.controllerFor('comments').set('page', 1);
-        if (isExiting) {
-          controller.set('q', 'imdone');
+    var articles = this.articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+
+    App.ApplicationController = Ember.Controller.extend({
+      articles: this.articles
+    });
+
+    var self = this;
+    App.ArticleRoute = Ember.Route.extend({
+      model(params) {
+        if (self.expectedModelHookParams) {
+          deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
+          self.expectedModelHookParams = null;
         }
+        return articles.findProperty('id', params.id);
       }
     });
 
-    Ember.TEMPLATES.about = compile('{{link-to \'A\' \'comments\' \'a-1\' id=\'one\'}} {{link-to \'B\' \'comments\' \'a-2\' id=\'two\'}}');
-
-    this.boot();
-
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
-
-    var commentsCtrl = container.lookup('controller:comments');
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), '/a/a-1/comments');
-
-    setAndFlush(commentsCtrl, 'page', 2);
-    equal(router.get('location.path'), '/a/a-1/comments?page=2');
-
-    Ember.run(router, 'transitionTo', 'comments', 'a-2');
-    equal(commentsCtrl.get('page'), 1);
-    equal(this.controller.get('q'), 'wat');
-
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
-
-    equal(router.get('location.path'), '/a/a-1/comments');
-    equal(commentsCtrl.get('page'), 1);
-
-    Ember.run(router, 'transitionTo', 'about');
-
-    equal(Ember.$('#one').attr('href'), '/a/a-1/comments?q=imdone');
-    equal(Ember.$('#two').attr('href'), '/a/a-2/comments');
-  });
-} else {
-  QUnit.module('Model Dep Query Params', {
-    setup() {
-      sharedSetup();
-
-      App.Router.map(function() {
-        this.route('article', { path: '/a/:id' }, function() {
-          this.route('comments', { resetNamespace: true });
-        });
-      });
-
-      var articles = this.articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
-
-      App.ApplicationController = Ember.Controller.extend({
-        articles: this.articles
-      });
-
-      var self = this;
-      App.ArticleRoute = Ember.Route.extend({
-        model(params) {
-          if (self.expectedModelHookParams) {
-            deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
-            self.expectedModelHookParams = null;
-          }
-          return articles.findProperty('id', params.id);
+    if (isEnabled('ember-routing-route-configured-query-params')) {
+      App.ArticleRoute.reopen({
+        queryParams: {
+          q: { defaultValue: 'wat' },
+          z: { defaultValue: 0 }
         }
       });
 
+      App.CommentsRoute = Ember.Route.extend({
+        queryParams: {
+          page: { defaultValue: 1 }
+        }
+      });
+    } else {
       App.ArticleController = Ember.Controller.extend({
         queryParams: ['q', 'z'],
         q: 'wat',
@@ -418,249 +380,560 @@ if (isEnabled('ember-routing-route-configured-query-params')) {
         queryParams: 'page',
         page: 1
       });
-
-      Ember.TEMPLATES.application = compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}');
-
-      this.boot = function() {
-        bootApplication();
-
-        self.$link1 = Ember.$('#a-1');
-        self.$link2 = Ember.$('#a-2');
-        self.$link3 = Ember.$('#a-3');
-
-        equal(self.$link1.attr('href'), '/a/a-1');
-        equal(self.$link2.attr('href'), '/a/a-2');
-        equal(self.$link3.attr('href'), '/a/a-3');
-
-        self.controller = container.lookup('controller:article');
-      };
-    },
-
-    teardown() {
-      sharedTeardown();
-      ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
     }
-  });
 
-  QUnit.test('query params have \'model\' stickiness by default', function() {
-    this.boot();
+    Ember.TEMPLATES.application = compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a id=a.id}} {{/each}} {{outlet}}');
 
-    Ember.run(this.$link1, 'click');
-    equal(router.get('location.path'), '/a/a-1');
+    this.boot = function() {
+      bootApplication();
 
-    setAndFlush(this.controller, 'q', 'lol');
+      self.$link1 = Ember.$('#a-1');
+      self.$link2 = Ember.$('#a-2');
+      self.$link3 = Ember.$('#a-3');
 
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
+      equal(self.$link1.attr('href'), '/a/a-1');
+      equal(self.$link2.attr('href'), '/a/a-2');
+      equal(self.$link3.attr('href'), '/a/a-3');
 
-    Ember.run(this.$link2, 'click');
+      self.controller = container.lookup('controller:article');
+    };
+  },
 
-    equal(this.controller.get('q'), 'wat');
-    equal(this.controller.get('z'), 0);
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
-  });
+  teardown() {
+    sharedTeardown();
+    ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+  }
+});
 
-  QUnit.test('query params have \'model\' stickiness by default (url changes)', function() {
-    this.boot();
+QUnit.test('query params have \'model\' stickiness by default', queryParamsStickyTest1('/a'));
 
-    this.expectedModelHookParams = { id: 'a-1', q: 'lol', z: 0 };
-    handleURL('/a/a-1?q=lol');
+QUnit.test('query params have \'model\' stickiness by default (url changes)', queryParamsStickyTest2('/a'));
 
-    deepEqual(this.controller.get('model'), { id: 'a-1' });
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
+QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', queryParamsStickyTest3('/a', 'article'));
 
-    this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
-    handleURL('/a/a-2?q=lol');
+QUnit.test('\'controller\' stickiness shares QP state between models', queryParamsStickyTest4('/a', 'article'));
 
-    deepEqual(this.controller.get('model'), { id: 'a-2' }, 'controller\'s model changed to a-2');
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol'); // fail
-    equal(this.$link3.attr('href'), '/a/a-3');
+QUnit.test('\'model\' stickiness is scoped to current or first dynamic parent route', queryParamsStickyTest5('/a', 'comments'));
 
-    this.expectedModelHookParams = { id: 'a-3', q: 'lol', z: 123 };
-    handleURL('/a/a-3?q=lol&z=123');
+QUnit.test('can reset query params using the resetController hook', queryParamsStickyTest6('/a', 'article', 'comments'));
 
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 123);
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=lol&z=123');
-  });
+QUnit.module('Model Dep Query Params (nested)', {
+  setup() {
+    sharedSetup();
 
-  QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', function() {
-    Ember.TEMPLATES.application = compile('{{#each articles as |a|}} {{link-to \'Article\' \'article\' a.id id=a.id}} {{/each}}');
-
-    this.boot();
-
-    this.expectedModelHookParams = { id: 'a-1', q: 'wat', z: 0 };
-    Ember.run(router, 'transitionTo', 'article', 'a-1');
-
-    deepEqual(this.controller.get('model'), { id: 'a-1' });
-    equal(this.controller.get('q'), 'wat');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2');
-    equal(this.$link3.attr('href'), '/a/a-3');
-
-    this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 0 };
-    Ember.run(router, 'transitionTo', 'article', 'a-2', { queryParams: { q: 'lol' } });
-
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3');
-
-    this.expectedModelHookParams = { id: 'a-3', q: 'hay', z: 0 };
-    Ember.run(router, 'transitionTo', 'article', 'a-3', { queryParams: { q: 'hay' } });
-
-    deepEqual(this.controller.get('model'), { id: 'a-3' });
-    equal(this.controller.get('q'), 'hay');
-    equal(this.controller.get('z'), 0);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=hay');
-
-    this.expectedModelHookParams = { id: 'a-2', q: 'lol', z: 1 };
-    Ember.run(router, 'transitionTo', 'article', 'a-2', { queryParams: { z: 1 } });
-
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 1);
-    equal(this.$link1.attr('href'), '/a/a-1');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol&z=1');
-    equal(this.$link3.attr('href'), '/a/a-3?q=hay');
-  });
-
-  QUnit.test('\'controller\' stickiness shares QP state between models', function() {
-    App.ArticleController.reopen({
-      queryParams: { q: { scope: 'controller' } }
-    });
-
-    this.boot();
-
-    Ember.run(this.$link1, 'click');
-    equal(router.get('location.path'), '/a/a-1');
-
-    setAndFlush(this.controller, 'q', 'lol');
-
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=lol');
-
-    Ember.run(this.$link2, 'click');
-
-    equal(this.controller.get('q'), 'lol');
-    equal(this.controller.get('z'), 0);
-    deepEqual(this.controller.get('model'), { id: 'a-2' });
-
-    equal(this.$link1.attr('href'), '/a/a-1?q=lol');
-    equal(this.$link2.attr('href'), '/a/a-2?q=lol');
-    equal(this.$link3.attr('href'), '/a/a-3?q=lol');
-
-    this.expectedModelHookParams = { id: 'a-3', q: 'haha', z: 123 };
-    handleURL('/a/a-3?q=haha&z=123');
-
-    deepEqual(this.controller.get('model'), { id: 'a-3' });
-    equal(this.controller.get('q'), 'haha');
-    equal(this.controller.get('z'), 123);
-
-    equal(this.$link1.attr('href'), '/a/a-1?q=haha');
-    equal(this.$link2.attr('href'), '/a/a-2?q=haha');
-    equal(this.$link3.attr('href'), '/a/a-3?q=haha&z=123');
-
-    setAndFlush(this.controller, 'q', 'woot');
-
-    equal(this.$link1.attr('href'), '/a/a-1?q=woot');
-    equal(this.$link2.attr('href'), '/a/a-2?q=woot');
-    equal(this.$link3.attr('href'), '/a/a-3?q=woot&z=123');
-  });
-
-  QUnit.test('\'model\' stickiness is scoped to current or first dynamic parent route', function() {
-    this.boot();
-
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
-
-    var commentsCtrl = container.lookup('controller:comments');
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), '/a/a-1/comments');
-
-    setAndFlush(commentsCtrl, 'page', 2);
-    equal(router.get('location.path'), '/a/a-1/comments?page=2');
-
-    setAndFlush(commentsCtrl, 'page', 3);
-    equal(router.get('location.path'), '/a/a-1/comments?page=3');
-
-    Ember.run(router, 'transitionTo', 'comments', 'a-2');
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), '/a/a-2/comments');
-
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
-    equal(commentsCtrl.get('page'), 3);
-    equal(router.get('location.path'), '/a/a-1/comments?page=3');
-  });
-
-  QUnit.test('can reset query params using the resetController hook', function() {
     App.Router.map(function() {
-      this.route('article', { path: '/a/:id' }, function() {
-        this.route('comments', { resetNamespace: true });
+      this.route('site', function() {
+        this.route('article', { path: '/a/:id' }, function() {
+          this.route('comments');
+        });
       });
       this.route('about');
     });
 
-    App.ArticleRoute.reopen({
-      resetController(controller, isExiting) {
-        this.controllerFor('comments').set('page', 1);
-        if (isExiting) {
-          controller.set('q', 'imdone');
+    var site_articles = this.site_articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+
+    App.ApplicationController = Ember.Controller.extend({
+      articles: this.site_articles
+    });
+
+    var self = this;
+    App.SiteArticleRoute = Ember.Route.extend({
+      model(params) {
+        if (self.expectedModelHookParams) {
+          deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
+          self.expectedModelHookParams = null;
         }
+        return site_articles.findProperty('id', params.id);
       }
     });
 
-    Ember.TEMPLATES.about = compile('{{link-to \'A\' \'comments\' \'a-1\' id=\'one\'}} {{link-to \'B\' \'comments\' \'a-2\' id=\'two\'}}');
+    if (isEnabled('ember-routing-route-configured-query-params')) {
+      App.SiteArticleRoute.reopen({
+        queryParams: {
+          q: { defaultValue: 'wat' },
+          z: { defaultValue: 0 }
+        }
+      });
 
-    this.boot();
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
+      App.SiteArticleCommentsRoute = Ember.Route.extend({
+        queryParams: {
+          page: { defaultValue: 1 }
+        }
+      });
+    } else {
+      App.SiteArticleController = Ember.Controller.extend({
+        queryParams: ['q', 'z'],
+        q: 'wat',
+        z: 0
+      });
 
-    var commentsCtrl = container.lookup('controller:comments');
-    equal(commentsCtrl.get('page'), 1);
-    equal(router.get('location.path'), '/a/a-1/comments');
+      App.SiteArticleCommentsController = Ember.Controller.extend({
+        queryParams: 'page',
+        page: 1
+      });
+    }
+    Ember.TEMPLATES.application = compile('{{#each articles as |a|}} {{link-to \'Article\' \'site.article\' a id=a.id}} {{/each}} {{outlet}}');
 
-    setAndFlush(commentsCtrl, 'page', 2);
-    equal(router.get('location.path'), '/a/a-1/comments?page=2');
+    this.boot = function() {
+      bootApplication();
 
+      self.$link1 = Ember.$('#a-1');
+      self.$link2 = Ember.$('#a-2');
+      self.$link3 = Ember.$('#a-3');
 
-    Ember.run(router, 'transitionTo', 'comments', 'a-2');
-    equal(commentsCtrl.get('page'), 1);
-    equal(this.controller.get('q'), 'wat');
+      equal(self.$link1.attr('href'), '/site/a/a-1');
+      equal(self.$link2.attr('href'), '/site/a/a-2');
+      equal(self.$link3.attr('href'), '/site/a/a-3');
 
-    Ember.run(router, 'transitionTo', 'comments', 'a-1');
+      self.controller = container.lookup('controller:site.article');
+    };
+  },
 
-    equal(router.get('location.path'), '/a/a-1/comments');
-    equal(commentsCtrl.get('page'), 1);
+  teardown() {
+    sharedTeardown();
+    ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+  }
+});
 
-    Ember.run(router, 'transitionTo', 'about');
+QUnit.test('query params have \'model\' stickiness by default', queryParamsStickyTest1('/site/a'));
 
-    equal(Ember.$('#one').attr('href'), '/a/a-1/comments?q=imdone');
-    equal(Ember.$('#two').attr('href'), '/a/a-2/comments');
-  });
+QUnit.test('query params have \'model\' stickiness by default (url changes)', queryParamsStickyTest2('/site/a'));
 
-  QUnit.test('can unit test without bucket cache', function() {
-    var controller = container.lookup('controller:article');
-    controller._bucketCache = null;
+QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', queryParamsStickyTest3('/site/a', 'site.article'));
 
-    controller.set('q', 'i used to break');
-    equal(controller.get('q'), 'i used to break');
-  });
-}
+QUnit.test('\'controller\' stickiness shares QP state between models', queryParamsStickyTest4('/site/a', 'site.article'));
+
+QUnit.test('\'model\' stickiness is scoped to current or first dynamic parent route', queryParamsStickyTest5('/site/a', 'site.article.comments'));
+
+QUnit.test('can reset query params using the resetController hook', queryParamsStickyTest6('/site/a', 'site.article', 'site.article.comments'));
+
+QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
+  setup() {
+    sharedSetup();
+
+    App.Router.map(function() {
+      this.route('site', { path: '/site/:site_id' }, function() {
+        this.route('article', { path: '/a/:article_id' }, function() {
+          this.route('comments');
+        });
+      });
+    });
+
+    var sites = this.sites = Ember.A([{ id: 's-1' }, { id: 's-2' }, { id: 's-3' }]);
+    var site_articles = this.site_articles = Ember.A([{ id: 'a-1' }, { id: 'a-2' }, { id: 'a-3' }]);
+
+    App.ApplicationController = Ember.Controller.extend({
+      siteArticles: this.site_articles,
+      sites: this.sites,
+      allSitesAllArticles: Ember.computed({
+        get: function() {
+          var ret = [];
+          var siteArticles = this.siteArticles;
+          var sites = this.sites;
+          sites.forEach(function(site) {
+            ret = ret.concat(siteArticles.map((article) => {
+              return { id: `${site.id}-${article.id}`, site_id: site.id, article_id: article.id };
+            }));
+          });
+          return ret;
+        }
+      })
+    });
+
+    var self = this;
+    App.SiteRoute = Ember.Route.extend({
+      model(params) {
+        if (self.expectedSiteModelHookParams) {
+          deepEqual(params, self.expectedSiteModelHookParams, 'the SiteRoute model hook received the expected merged dynamic segment + query params hash');
+          self.expectedSiteModelHookParams = null;
+        }
+        return sites.findProperty('id', params.site_id);
+      }
+    });
+    App.SiteArticleRoute = Ember.Route.extend({
+      model(params) {
+        if (self.expectedArticleModelHookParams) {
+          deepEqual(params, self.expectedArticleModelHookParams, 'the SiteArticleRoute model hook received the expected merged dynamic segment + query params hash');
+          self.expectedArticleModelHookParams = null;
+        }
+        return site_articles.findProperty('id', params.article_id);
+      }
+    });
+
+    if (isEnabled('ember-routing-route-configured-query-params')) {
+      App.SiteRoute.reopen({
+        queryParams: {
+          country: { defaultValue: 'au' }
+        }
+      });
+
+      App.SiteArticleRoute.reopen({
+        queryParams: {
+          q: { defaultValue: 'wat' },
+          z: { defaultValue: 0 }
+        }
+      });
+
+      App.SiteArticleCommentsRoute = Ember.Route.extend({
+        queryParams: {
+          page: { defaultValue: 1 }
+        }
+      });
+    } else {
+      App.SiteController = Ember.Controller.extend({
+        queryParams: ['country'],
+        country: 'au'
+      });
+
+      App.SiteArticleController = Ember.Controller.extend({
+        queryParams: ['q', 'z'],
+        q: 'wat',
+        z: 0
+      });
+
+      App.SiteArticleCommentsController = Ember.Controller.extend({
+        queryParams: ['page'],
+        page: 1
+      });
+    }
+
+    Ember.TEMPLATES.application = compile('{{#each allSitesAllArticles as |a|}} {{#link-to \'site.article\' a.site_id a.article_id id=a.id}}Article [{{a.site_id}}] [{{a.article_id}}]{{/link-to}} {{/each}} {{outlet}}');
+
+    this.boot = function() {
+      bootApplication();
+      self.links = {};
+      self.links['s-1-a-1'] = Ember.$('#s-1-a-1');
+      self.links['s-1-a-2'] = Ember.$('#s-1-a-2');
+      self.links['s-1-a-3'] = Ember.$('#s-1-a-3');
+      self.links['s-2-a-1'] = Ember.$('#s-2-a-1');
+      self.links['s-2-a-2'] = Ember.$('#s-2-a-2');
+      self.links['s-2-a-3'] = Ember.$('#s-2-a-3');
+      self.links['s-3-a-1'] = Ember.$('#s-3-a-1');
+      self.links['s-3-a-2'] = Ember.$('#s-3-a-2');
+      self.links['s-3-a-3'] = Ember.$('#s-3-a-3');
+
+      equal(self.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+      equal(self.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+      equal(self.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+      equal(self.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+      equal(self.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+      equal(self.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+      equal(self.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+      equal(self.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+      equal(self.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+      self.site_controller = container.lookup('controller:site');
+      self.article_controller = container.lookup('controller:site.article');
+    };
+  },
+
+  teardown() {
+    sharedTeardown();
+    ok(!this.expectedModelHookParams, 'there should be no pending expectation of expected model hook params');
+  }
+});
+
+QUnit.test('query params have \'model\' stickiness by default', function() {
+  this.boot();
+
+  Ember.run(this.links['s-1-a-1'], 'click');
+  deepEqual(this.site_controller.get('model'), { id: 's-1' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-1' });
+  equal(router.get('location.path'), '/site/s-1/a/a-1');
+
+  setAndFlush(this.article_controller, 'q', 'lol');
+
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  setAndFlush(this.site_controller, 'country', 'us');
+
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  Ember.run(this.links['s-1-a-2'], 'click');
+
+  equal(this.site_controller.get('country'), 'us');
+  equal(this.article_controller.get('q'), 'wat');
+  equal(this.article_controller.get('z'), 0);
+  deepEqual(this.site_controller.get('model'), { id: 's-1' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  Ember.run(this.links['s-2-a-2'], 'click');
+
+  equal(this.site_controller.get('country'), 'au');
+  equal(this.article_controller.get('q'), 'wat');
+  equal(this.article_controller.get('z'), 0);
+  deepEqual(this.site_controller.get('model'), { id: 's-2' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?country=us&q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?country=us');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?country=us');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+});
+
+QUnit.test('query params have \'model\' stickiness by default (url changes)', function() {
+
+  this.boot();
+
+  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
+  handleURL('/site/s-1/a/a-1?q=lol');
+
+  deepEqual(this.site_controller.get('model'), { id: 's-1' }, 'site controller\'s model is s-1');
+  deepEqual(this.article_controller.get('model'), { id: 'a-1' }, 'article controller\'s model is a-1');
+  equal(this.site_controller.get('country'), 'au');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'lol', z: 0 };
+  handleURL('/site/s-2/a/a-1?country=us&q=lol');
+
+  deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
+  deepEqual(this.article_controller.get('model'), { id: 'a-1' }, 'article controller\'s model is a-1');
+  equal(this.site_controller.get('country'), 'us');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
+  handleURL('/site/s-2/a/a-2?country=us&q=lol');
+
+  deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
+  deepEqual(this.article_controller.get('model'), { id: 'a-2' }, 'article controller\'s model is a-2');
+  equal(this.site_controller.get('country'), 'us');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
+  handleURL('/site/s-2/a/a-3?country=us&q=lol&z=123');
+
+  deepEqual(this.site_controller.get('model'), { id: 's-2' }, 'site controller\'s model is s-2');
+  deepEqual(this.article_controller.get('model'), { id: 'a-3' }, 'article controller\'s model is a-3');
+  equal(this.site_controller.get('country'), 'us');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 123);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=lol&z=123');
+
+  this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
+  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'lol', z: 123 };
+  handleURL('/site/s-3/a/a-3?country=nz&q=lol&z=123');
+
+  deepEqual(this.site_controller.get('model'), { id: 's-3' }, 'site controller\'s model is s-3');
+  deepEqual(this.article_controller.get('model'), { id: 'a-3' }, 'article controller\'s model is a-3');
+  equal(this.site_controller.get('country'), 'nz');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 123);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=lol');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=lol&z=123');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=lol');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=lol&z=123');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=lol');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=lol&z=123');
+});
+
+QUnit.test('query params have \'model\' stickiness by default (params-based transitions)', function() {
+  this.boot();
+
+  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'wat', z: 0 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-1', 'a-1');
+
+  deepEqual(this.site_controller.get('model'), { id: 's-1' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-1' });
+  equal(this.site_controller.get('country'), 'au');
+  equal(this.article_controller.get('q'), 'wat');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 0 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-1', 'a-2', { queryParams: { q: 'lol' } });
+
+  deepEqual(this.site_controller.get('model'), { id: 's-1' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+  equal(this.site_controller.get('country'), 'au');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3');
+
+  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 0 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-1', 'a-3', { queryParams: { q: 'hay' } });
+
+  deepEqual(this.site_controller.get('model'), { id: 's-1' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-3' });
+  equal(this.site_controller.get('country'), 'au');
+  equal(this.article_controller.get('q'), 'hay');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+
+  this.expectedSiteModelHookParams = { site_id: 's-1', country: 'au' };
+  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-1', 'a-2', { queryParams: { z: 1 } });
+
+  deepEqual(this.site_controller.get('model'), { id: 's-1' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+  equal(this.site_controller.get('country'), 'au');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 1);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?q=lol&z=1');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?q=hay');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+
+  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+  this.expectedArticleModelHookParams = { article_id: 'a-2', q: 'lol', z: 1 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-2', 'a-2', { queryParams: { country: 'us' } });
+
+  deepEqual(this.site_controller.get('model'), { id: 's-2' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-2' });
+  equal(this.site_controller.get('country'), 'us');
+  equal(this.article_controller.get('q'), 'lol');
+  equal(this.article_controller.get('z'), 1);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+
+  this.expectedSiteModelHookParams = { site_id: 's-2', country: 'us' };
+  this.expectedArticleModelHookParams = { article_id: 'a-1', q: 'yeah', z: 0 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-2', 'a-1', { queryParams: { q: 'yeah' } });
+
+  deepEqual(this.site_controller.get('model'), { id: 's-2' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-1' });
+  equal(this.site_controller.get('country'), 'us');
+  equal(this.article_controller.get('q'), 'yeah');
+  equal(this.article_controller.get('z'), 0);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?q=yeah');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?q=lol&z=1');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?q=hay');
+
+  this.expectedSiteModelHookParams = { site_id: 's-3', country: 'nz' };
+  this.expectedArticleModelHookParams = { article_id: 'a-3', q: 'hay', z: 3 };
+  Ember.run(router, 'transitionTo', 'site.article', 's-3', 'a-3', { queryParams: { country: 'nz', z: 3 } });
+
+  deepEqual(this.site_controller.get('model'), { id: 's-3' });
+  deepEqual(this.article_controller.get('model'), { id: 'a-3' });
+  equal(this.site_controller.get('country'), 'nz');
+  equal(this.article_controller.get('q'), 'hay');
+  equal(this.article_controller.get('z'), 3);
+  equal(this.links['s-1-a-1'].attr('href'), '/site/s-1/a/a-1?q=yeah');
+  equal(this.links['s-1-a-2'].attr('href'), '/site/s-1/a/a-2?q=lol&z=1');
+  equal(this.links['s-1-a-3'].attr('href'), '/site/s-1/a/a-3?q=hay&z=3');
+  equal(this.links['s-2-a-1'].attr('href'), '/site/s-2/a/a-1?country=us&q=yeah');
+  equal(this.links['s-2-a-2'].attr('href'), '/site/s-2/a/a-2?country=us&q=lol&z=1');
+  equal(this.links['s-2-a-3'].attr('href'), '/site/s-2/a/a-3?country=us&q=hay&z=3');
+  equal(this.links['s-3-a-1'].attr('href'), '/site/s-3/a/a-1?country=nz&q=yeah');
+  equal(this.links['s-3-a-2'].attr('href'), '/site/s-3/a/a-2?country=nz&q=lol&z=1');
+  equal(this.links['s-3-a-3'].attr('href'), '/site/s-3/a/a-3?country=nz&q=hay&z=3');
+});


### PR DESCRIPTION
Fixed query params not being sticky for nested routes

Fixed query params not working for multiple routes that each have a dynamic segment (which fixes #10838)
Previously only 1 dynamic segment was working correctly 
