### PR TITLE
[BUGFIX release] Return `Ember.LinkView.reopen()` properly.

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -507,7 +507,8 @@ var originalReopen = DeprecatedLinkView.reopen;
 
 DeprecatedLinkView.reopen = function reopenWithDeprecation() {
   Ember.deprecate('Ember.LinkView is deprecated. Please use Ember.LinkComponent.', false);
-  originalReopen.apply(this, arguments);
+
+  return originalReopen.apply(this, arguments);
 };
 export { DeprecatedLinkView };
 /* DeprecatedLinkView - End*/

--- a/packages/ember-routing-views/tests/main_test.js
+++ b/packages/ember-routing-views/tests/main_test.js
@@ -14,5 +14,6 @@ QUnit.test("Ember.LinkView throws a deprecation warning when instantiated", func
 
 QUnit.test("Ember.LinkView throws a deprecation warning when reopened", function() {
   expectDeprecation(/Ember.LinkView is deprecated. Please use Ember.LinkComponent/);
-  Ember.LinkView.reopen({});
+
+  ok(Ember.LinkView.reopen({}), 'maintains return value');
 });


### PR DESCRIPTION
`Ember.LinkView.reopen` was deprecated but the return value from the upstream `reopen` was not returned.
