### PR TITLE
[DOC release] Remove `{{bind-attr}}` in Component Docs

### DIFF
--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -48,7 +48,7 @@ function validateAction(component, actionName) {
   ```handlebars
   <!-- app-profile template -->
   <h1>{{person.title}}</h1>
-  <img {{bind-attr src=person.avatar}}>
+  <img src={{person.avatar}}>
   <p class='signature'>{{person.signature}}</p>
   ```
 


### PR DESCRIPTION
I believe this applies to both Ember 2.0-rcX and Ember 1.13, hopefully I've got the channel correct.
