### PR TITLE
[DOC Release] Mark transitionTo as public

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1012,7 +1012,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
       containing a mapping of query parameters
     @return {Transition} the transition object associated with this
       attempted transition
-    @private
+    @public
   */
   transitionTo(name, context) {
     var router = this.router;


### PR DESCRIPTION
#11362 incorrectly (I think?) marked `Route.transitionTo()` as private.

I haven't seen or heard anything about deprecating this for 2.0? It's mentioned in the guides and the method itself has extensive documentation. If is is being depreciated, happy to work on updating the guides etc to reflect this.
