### PR TITLE
[BUGFIX release] Rerender link on routing state change.

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -349,6 +349,8 @@ var LinkComponent = EmberComponent.extend({
 
     if (get(this, 'loading')) { return get(this, 'loadingHref'); }
 
+    targetRouteName = this._handleOnlyQueryParamsSupplied(targetRouteName);
+
     var routing = get(this, '_routing');
     var queryParams = get(this, 'queryParams.values');
     return routing.generateURL(targetRouteName, models, queryParams);
@@ -362,6 +364,22 @@ var LinkComponent = EmberComponent.extend({
       return get(this, 'loadingClass');
     }
   }),
+
+  _handleOnlyQueryParamsSupplied(route) {
+    var params = this.attrs.params.slice();
+    var lastParam = params[params.length - 1];
+    if (lastParam && lastParam.isQueryParams) {
+      params.pop();
+    }
+    let onlyQueryParamsSupplied = (params.length === 0);
+    if (onlyQueryParamsSupplied) {
+      var appController = this.container.lookup('controller:application');
+      if (appController) {
+        return get(appController, 'currentRouteName');
+      }
+    }
+    return route;
+  },
 
   /**
     The default href value to use while a link-to is loading.
@@ -437,19 +455,10 @@ var LinkComponent = EmberComponent.extend({
 
     let targetRouteName;
     let models = [];
-    let onlyQueryParamsSupplied = (params.length === 0);
+    targetRouteName = this._handleOnlyQueryParamsSupplied(params[0]);
 
-    if (onlyQueryParamsSupplied) {
-      var appController = this.container.lookup('controller:application');
-      if (appController) {
-        targetRouteName = get(appController, 'currentRouteName');
-      }
-    } else {
-      targetRouteName = params[0];
-
-      for (let i = 1; i < params.length; i++) {
-        models.push(params[i]);
-      }
+    for (let i = 1; i < params.length; i++) {
+      models.push(params[i]);
     }
 
     let resolvedQueryParams = getResolvedQueryParams(queryParams, targetRouteName);

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -1378,3 +1378,37 @@ QUnit.test('{{link-to}} populates href with fully supplied query param values', 
   bootApplication();
   equal(Ember.$('#the-link').attr('href'), '/?bar=NAW&foo=456', 'link has right href');
 });
+
+QUnit.test('{{link-to}} with only query-params updates when route changes', function() {
+  Router.map(function() {
+    this.route('about');
+  });
+
+  if (isEnabled('ember-routing-route-configured-query-params')) {
+    App.ApplicationRoute = Ember.Route.extend({
+      queryParams: {
+        foo: {
+          defaultValue: '123'
+        },
+        bar: {
+          defaultValue: 'yes'
+        }
+      }
+    });
+  } else {
+    App.ApplicationController = Ember.Controller.extend({
+      queryParams: ['foo', 'bar'],
+      foo: '123',
+      bar: 'yes'
+    });
+  }
+
+  Ember.TEMPLATES.application = compile('{{#link-to (query-params foo=\'456\' bar=\'NAW\') id=\'the-link\'}}Index{{/link-to}}');
+  bootApplication();
+  equal(Ember.$('#the-link').attr('href'), '/?bar=NAW&foo=456', 'link has right href');
+
+  Ember.run(function() {
+    router.handleURL('/about');
+  });
+  equal(Ember.$('#the-link').attr('href'), '/about?bar=NAW&foo=456', 'link has right href');
+});


### PR DESCRIPTION
Properly update the route when the routing current state change. This primarily deals with query-params only routes as noted in issue #11533 .
