### PR TITLE
[BUGFIX release] `willRender` is called for `attributeBindings` changes.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/bind-shadow-scope.js
+++ b/packages/ember-htmlbars/lib/hooks/bind-shadow-scope.js
@@ -30,7 +30,7 @@ export default function bindShadowScope(env, parentScope, shadowScope, options) 
 
   shadowScope.view = view;
 
-  if (view && options.attrs) {
+  if (view && view.isComponent) {
     shadowScope.component = view;
   }
 

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -298,14 +298,14 @@ var LinkComponent = EmberComponent.extend({
   _invoke(event) {
     if (!isSimpleClick(event)) { return true; }
 
-    if (this.attrs.preventDefault !== false) {
-      var targetAttribute = this.attrs.target;
+    if (this.getAttr('preventDefault') !== false) {
+      var targetAttribute = this.getAttr('target');
       if (!targetAttribute || targetAttribute === '_self') {
         event.preventDefault();
       }
     }
 
-    if (this.attrs.bubbles === false) { event.stopPropagation(); }
+    if (this.getAttr('bubbles') === false) { event.stopPropagation(); }
 
     if (get(this, '_isDisabled')) { return false; }
 
@@ -314,7 +314,7 @@ var LinkComponent = EmberComponent.extend({
       return false;
     }
 
-    var targetAttribute2 = this.attrs.target;
+    var targetAttribute2 = this.getAttr('target');
     if (targetAttribute2 && targetAttribute2 !== '_self') {
       return false;
     }
@@ -398,7 +398,7 @@ var LinkComponent = EmberComponent.extend({
     var attrs = this.attrs;
 
     // Do not mutate params in place
-    var params = attrs.params.slice();
+    var params = this.getAttr('params').slice();
 
     Ember.assert('You must provide one or more parameters to the link-to helper.', params.length);
 
@@ -411,22 +411,22 @@ var LinkComponent = EmberComponent.extend({
     }
 
     if (attrs.disabledClass) {
-      this.set('disabledClass', attrs.disabledClass);
+      this.set('disabledClass', this.getAttr('disabledClass'));
     }
 
     if (attrs.activeClass) {
-      this.set('activeClass', attrs.activeClass);
+      this.set('activeClass', this.getAttr('activeClass'));
     }
 
     if (attrs.disabledWhen) {
-      this.set('disabled', attrs.disabledWhen);
+      this.set('disabled', this.getAttr('disabledWhen'));
     }
 
-    var currentWhen = attrs['current-when'];
+    var currentWhen = this.getAttr('current-when');
 
     if (attrs.currentWhen) {
       Ember.deprecate('Using currentWhen with {{link-to}} is deprecated in favor of `current-when`.', !attrs.currentWhen);
-      currentWhen = attrs.currentWhen;
+      currentWhen = this.getAttr('currentWhen');
     }
 
     if (currentWhen) {

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -652,9 +652,9 @@ QUnit.test('Issue 4201 - Shorthand for route.index shouldn\'t throw errors about
 QUnit.test('The {{link-to}} helper unwraps controllers', function() {
 
   if (isEnabled('ember-routing-transitioning-classes')) {
-    expect(5);
+    expect(7);
   } else {
-    expect(6);
+    expect(8);
   }
 
   Router.map(function() {


### PR DESCRIPTION
Depending on which node-manager was used, `scope.view` or `scope.component` might be used (but not both). For `attributeBindings` case `scope.component` was not set, therefore the various hooks were not being called properly.
