### PR TITLE
[BUGFIX release] Don’t force invalidation of block param streams

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/bind-local.js
+++ b/packages/ember-htmlbars/lib/hooks/bind-local.js
@@ -8,15 +8,12 @@ import ProxyStream from 'ember-metal/streams/proxy-stream';
 
 export default function bindLocal(env, scope, key, value) {
   var isExisting = scope.locals.hasOwnProperty(key);
-
   if (isExisting) {
     var existing = scope.locals[key];
 
     if (existing !== value) {
       existing.setSource(value);
     }
-
-    existing.notify();
   } else {
     var newValue = Stream.wrap(value, ProxyStream, key);
     scope.locals[key] = newValue;


### PR DESCRIPTION
This commit removes the forced invalidation of block param streams on re-renders.

Previously, on re-renders, all block param streams were revalidated by calling `notify()` on them blindly.

While this often works, it creates a vector for light scopes to inadvertently invalidate their associated shadow scopes. In some cases, this leads to an infinite loop.

For example, imagine a component with the following template:

``` handlebars
{{! app/templates/components/block-with-yield.hbs }}
{{yield danger}}
```

(Here `danger` is a property on the component.)

Now we invoke it:

``` handlebars
{{#block-with-yield as |dangerBlockParam|}}
  {{dangerBlockParam}}
{{/block-with-yield}}
```

This works. The yielded block (light scope) receives a stream for the `danger` value. On re-renders, the stream is invalidated, but all that happens is the `{{dangerBlockParam}}` render node is dirtied again (which doesn’t matter, because we haven’t rendered and cleaned it yet).

However, imagine we change the component template to now display the same `{{danger}}` value:

``` handlebars
{{! app/templates/components/block-with-yield.hbs }}
{{danger}}
{{yield danger}}
```

Now, when the block param stream is invalidated, it goes back and dirties the render node _from the parent shadow scope_. Because the component is dirtied, its `{{yield}}` helper is dirtied, causing the block param streams to be dirtied, and so on in an infinite loop.

This commit removes the forced invalidation, which I believe is unnecessary and probably left over from an earlier implementation. Specifically, if we are yielded a stream (`{{yield danger}}`), the stream should notify us of any changes to the value. Any downstream consumers of that stream will be notified correctly.

In the case of `{{yield “hello”}}` or some other primitive, we already wrap those values in a `ProxyStream` and call `setSource` when it changes, which has the effect of invalidating the stream anyway.

Closes #11519
