### PR TITLE
[BUGFIX release] Ensure local state can shadow attrs.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/get-root.js
+++ b/packages/ember-htmlbars/lib/hooks/get-root.js
@@ -30,12 +30,12 @@ function getKey(scope, key) {
 
   var self = scope.self || scope.locals.view;
 
-  if (scope.attrs && key in scope.attrs) {
+  if (self) {
+    return self.getKey(key);
+  } else if (scope.attrs && key in scope.attrs) {
     // TODO: attrs
     // Ember.deprecate("You accessed the `" + key + "` attribute directly. Please use `attrs." + key + "` instead.");
     return scope.attrs[key];
-  } else if (self) {
-    return self.getKey(key);
   }
 }
 

--- a/packages/ember-htmlbars/lib/templates/legacy-each.hbs
+++ b/packages/ember-htmlbars/lib/templates/legacy-each.hbs
@@ -1,5 +1,5 @@
-{{~#each view._arrangedContent -legacy-keyword=keyword as |item|~}}
-  {{~#if keyword}}
+{{~#each view._arrangedContent -legacy-keyword=view.keyword as |item|~}}
+  {{~#if view.keyword}}
     {{~#if attrs.itemViewClass~}}
       {{~#view attrs.itemViewClass _defaultTagName=view._itemTagName~}}
         {{~legacy-yield item~}}

--- a/packages/ember-htmlbars/tests/integration/attrs_lookup_test.js
+++ b/packages/ember-htmlbars/tests/integration/attrs_lookup_test.js
@@ -1,0 +1,84 @@
+import Registry from 'container/registry';
+import compile from 'ember-template-compiler/system/compile';
+import ComponentLookup from 'ember-views/component_lookup';
+import Component from 'ember-views/views/component';
+import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import EmberView from 'ember-views/views/view';
+
+var registry, container, view;
+
+QUnit.module('component - attrs lookup', {
+  setup() {
+    registry = new Registry();
+    container = registry.container();
+    registry.optionsForType('component', { singleton: false });
+    registry.optionsForType('view', { singleton: false });
+    registry.optionsForType('template', { instantiate: false });
+    registry.register('component-lookup:main', ComponentLookup);
+  },
+
+  teardown() {
+    runDestroy(container);
+    runDestroy(view);
+    registry = container = view = null;
+  }
+});
+
+QUnit.test('should be able to lookup attrs without `attrs.` - template access', function() {
+  registry.register('template:components/foo-bar', compile('{{first}}'));
+
+  view = EmberView.extend({
+    template: compile('{{foo-bar first="first attr"}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  equal(view.$().text(), 'first attr');
+});
+
+QUnit.test('should be able to lookup attrs without `attrs.` - component access', function() {
+  var component;
+
+  registry.register('component:foo-bar', Component.extend({
+    init() {
+      this._super(...arguments);
+      component = this;
+    }
+  }));
+
+  view = EmberView.extend({
+    template: compile('{{foo-bar first="first attr"}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  equal(component.get('first'), 'first attr');
+});
+
+QUnit.test('should be able to modify a provided attr into local state #11571 / #11559', function() {
+  var component;
+
+  registry.register('component:foo-bar', Component.extend({
+    init() {
+      this._super(...arguments);
+      component = this;
+    },
+
+    didReceiveAttrs() {
+      this.set('first', this.getAttr('first').toUpperCase());
+    }
+  }));
+  registry.register('template:components/foo-bar', compile('{{first}}'));
+
+  view = EmberView.extend({
+    template: compile('{{foo-bar first="first attr"}}'),
+    container: container
+  }).create();
+
+  runAppend(view);
+
+  equal(view.$().text(), 'FIRST ATTR', 'template lookup uses local state');
+  equal(component.get('first'), 'FIRST ATTR', 'component lookup uses local state');
+});


### PR DESCRIPTION
We initially intended to deprecate access to local state (ala proxying to attrs) at this location, but we have decided to hold off on that deprecation until angle bracket component invocation is available.

Later in the integration efforts, we added an AttrsProxy to handle most of this functionality for us (when using a View inheritor). In the future, the deprecation will almost certainly be added in the `AttrsProxy` (not `getRoot` hook).

---

Prior to this change local state could never use the same name as a value in `attrs` (because the `attrs` always "won").

The else case is still present, when a given template is not backed by a view/component instance.

Fixes #11559
Fixes #11571
