### PR TITLE
Remove unused import to fix jshint

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -29,7 +29,6 @@ import {
   metaPath,
   setMeta,
   deprecatedTryCatchFinally,
-  deprecatedTryFinally,
   tryInvoke,
   uuid,
   wrap


### PR DESCRIPTION
This error snuck into the repo due to #11574.
