### PR TITLE
Fix view destruction inside outlets

### DIFF
--- a/packages/ember-htmlbars/lib/keywords/real_outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/real_outlet.js
@@ -25,7 +25,11 @@ export default {
       toRender.template = topLevelViewTemplate;
     }
 
-    return { outletState: selectedOutletState, hasParentOutlet: env.hasParentOutlet };
+    return {
+      outletState: selectedOutletState,
+      hasParentOutlet: env.hasParentOutlet,
+      manager: state.manager
+    };
   },
 
   childEnv(state, env) {
@@ -66,6 +70,11 @@ export default {
 
     if (LOG_VIEW_LOOKUPS && ViewClass) {
       Ember.Logger.info('Rendering ' + toRender.name + ' with ' + ViewClass, { fullName: 'view:' + toRender.name });
+    }
+
+    if (state.manager) {
+      state.manager.destroy();
+      state.manager = null;
     }
 
     var nodeManager = ViewNodeManager.create(renderNode, env, {}, options, parentView, null, null, template);

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -150,7 +150,10 @@ ViewNodeManager.prototype.rerender = function(env, attrs, visitor) {
 };
 
 ViewNodeManager.prototype.destroy = function() {
-  this.component.destroy();
+  if (this.component) {
+    this.component.destroy();
+    this.component = null;
+  }
 };
 
 function getTemplate(componentOrView) {

--- a/packages/ember-metal-views/lib/renderer.js
+++ b/packages/ember-metal-views/lib/renderer.js
@@ -210,7 +210,7 @@ Renderer.prototype.renderElementRemoval =
     if (view._willRemoveElement) {
       view._willRemoveElement = false;
 
-      if (view._renderNode) {
+      if (view._renderNode && view.element && view.element.parentNode) {
         view._renderNode.clear();
       }
       this.didDestroyElement(view);

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -322,6 +322,31 @@ QUnit.test('{{outlet}} should rerender when bound name changes', function() {
   equal(top.$().text().trim(), 'second');
 });
 
+QUnit.test('views created by {{outlet}} should get destroyed', function() {
+  let inserted = 0;
+  let destroyed = 0;
+  var routerState = {
+    render: {
+      ViewClass: EmberView.extend({
+        didInsertElement() {
+          inserted++;
+        },
+        willDestroyElement() {
+          destroyed++;
+        }
+      })
+    },
+    outlets: {}
+  };
+  top.setOutletState(routerState);
+  runAppend(top);
+  equal(inserted, 1, 'expected to see view inserted');
+  run(function() {
+    top.setOutletState(withTemplate('hello world'));
+  });
+  equal(destroyed, 1, 'expected to see view destroyed');
+});
+
 
 function withTemplate(string) {
   return {


### PR DESCRIPTION
This fixes #11539. However, I think it's hacky and this needs review by @wycats and maybe @mmun.

I do not see who is truly responsible for view destruction. HTMLBars is clearing the DOM nodes without destroying corresponding views. This leaves a keyword like `outlet` in an awkward position of needing to destroy views that are already out-of-DOM, which is bad because the views will blindly nuke their original contextual element even though subsequent content may already be present.
