### PR TITLE
[DOCS] Changed docs Ember.Route#modelFor to public

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1774,7 +1774,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method modelFor
     @param {String} name the name of the route
     @return {Object} the model object
-    @private
+    @public
   */
   modelFor(name) {
     var route = this.container.lookup(`route:${name}`);


### PR DESCRIPTION
Shouldn’t the `modelFor` method of `Ember.Route` be public? Since the
code example is also using it in a public way.
