### PR TITLE
[DOC Release] Mark Controller.transitionToRoute() as public

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -109,7 +109,7 @@ ControllerMixin.reopen({
       containing a mapping of query parameters
     @for Ember.ControllerMixin
     @method transitionToRoute
-    @private
+    @public
   */
   transitionToRoute() {
     // target may be either another controller or a router


### PR DESCRIPTION
#11362 Enforced marking docs explicitly to end confusion on what is Public/Private API. I'm having a look through and flagging code I think may have been incorrectly marked.
