### PR TITLE
[DOC Release] Mark Controller.transitionTo as public

### DIFF
--- a/packages/ember-routing/lib/ext/controller.js
+++ b/packages/ember-routing/lib/ext/controller.js
@@ -122,7 +122,7 @@ ControllerMixin.reopen({
     @deprecated
     @for Ember.ControllerMixin
     @method transitionTo
-    @private
+    @public
   */
   transitionTo() {
     Ember.deprecate('transitionTo is deprecated. Please use transitionToRoute.');


### PR DESCRIPTION
#11362 Enforced marking docs explicitly to end confusion on what is Public/Private API. I'm having a look through and flagging code I think may have been incorrectly marked.

This function is deprecated, but I thought I was technically correct to remark it back to public for prosperity's sake.
