### PR TITLE
[DOC Release] Mark Route.deactivate() as public

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -847,7 +847,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     not executed when the model for the route changes.
 
     @method deactivate
-    @private
+    @public
   */
   deactivate: K,
 


### PR DESCRIPTION
#11362 Enforced marking docs explicitly to end confusion on what is Public/Private API. I'm having a look through and flagging code I think may have been incorrectly marked.
