### PR TITLE
[DOC Release] Mark classNames as public

### DIFF
--- a/packages/ember-views/lib/mixins/class_names_support.js
+++ b/packages/ember-views/lib/mixins/class_names_support.js
@@ -34,7 +34,7 @@ export default Mixin.create({
     @property classNames
     @type Array
     @default ['ember-view']
-    @private
+    @public
   */
   classNames: ['ember-view'],
 


### PR DESCRIPTION
#11362 Enforced marking docs explicitly to end confusion on what is Public/Private API. I'm having a look through and flagging code I think may have been incorrectly marked.

I (think) that both `classNames` and `classNameBindings` are being depreciated with Angle Brackets, but since they aren't landing until 2.1, It seems that these need to be kept around?
