### PR TITLE
[BUGFIX] Link to attribute bindings

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -115,6 +115,23 @@ QUnit.test("unescaped inline form (triple curlies) does not escape link title", 
   equal(view.$('b').length, 1, '<b> was found');
 });
 
+QUnit.test("reopening on LinkView actually reopens on LinkComponent", function() {
+  expect(2);
+  var oldreopen = Ember.LinkComponent.reopen;
+
+  Ember.LinkComponent.reopen = function () {
+    ok(true, 'reopen was called on LinkComponent');
+    return oldreopen.apply(this, arguments);
+  };
+
+  expectDeprecation(function () {
+    Ember.LinkView.reopen({});
+  });
+
+  Ember.LinkComponent.reopen = oldreopen;
+
+});
+
 QUnit.test("unwraps controllers", function() {
   var template = "{{#link-to 'index' view.otherController}}Text{{/link-to}}";
 

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -512,13 +512,20 @@ var DeprecatedLinkView = LinkComponent.extend({
     this._super.apply(this, arguments);
   }
 });
-var originalReopen = DeprecatedLinkView.reopen;
 
 DeprecatedLinkView.reopen = function reopenWithDeprecation() {
   Ember.deprecate('Ember.LinkView is deprecated. Please use Ember.LinkComponent.', false);
 
-  return originalReopen.apply(this, arguments);
+  return LinkComponent.reopen.apply(LinkComponent, arguments);
 };
+
+DeprecatedLinkView.reopenClass({
+  extend: function () {
+    Ember.deprecate('Ember.LinkView is deprecated. Please extend from Ember.LinkComponent.', false);
+    this._super.apply(this, arguments);
+  }
+});
+
 export { DeprecatedLinkView };
 /* DeprecatedLinkView - End*/
 


### PR DESCRIPTION
Fixes #11593 

**This is a 1.13.x PR, being pulled into the stable branch**

Currently, addons and apps that have code like this

``` js
  Ember.LinkView.reopen({
    attributeBindings: ['data-activates']
  });
```

may be breaking in 1.13. This is due to the fact that `{{link-to}}` maps to `LinkComponent` instead of `LinkView`.

This PR ensures that the above pattern works throughout the ember 1.x releases.
