### PR TITLE
‘in-favour’ -> ‘in favor’

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -404,7 +404,7 @@ if (Ember.__loader.registry['ember-debug']) {
   requireModule('ember-debug');
 }
 
-Ember.create = Ember.deprecateFunc('Ember.create is deprecated in-favour of Object.create', Object.create);
-Ember.keys = Ember.deprecateFunc('Ember.keys is deprecated in-favour of Object.keys', Object.keys);
+Ember.create = Ember.deprecateFunc('Ember.create is deprecated in favor of Object.create', Object.create);
+Ember.keys = Ember.deprecateFunc('Ember.keys is deprecated in favor of Object.keys', Object.keys);
 
 export default Ember;


### PR DESCRIPTION
"in favor" occurs a number of times already in the ember codebase.  The "favour" spelling appears only in  CHANGELOG.md aside from where I am tweaking it here.
