### PR TITLE
[DOC Release] Mark ObjectProxy as public

### DIFF
--- a/packages/ember-runtime/lib/system/object_proxy.js
+++ b/packages/ember-runtime/lib/system/object_proxy.js
@@ -68,7 +68,7 @@ import _ProxyMixin from 'ember-runtime/mixins/-proxy';
   @namespace Ember
   @extends Ember.Object
   @extends Ember._ProxyMixin
-  @private
+  @public
 */
 
 export default EmberObject.extend(_ProxyMixin);


### PR DESCRIPTION
Maybe a controversial one, defiantly a "power user" feature. Seems to be used a lot in the real world, but I don't know if moving forward it will continue to be supported.

Also not sure of the relationship to ES6 Proxies, maybe a possible replacement moving forward?
