### PR TITLE
[BUGFIX] Add return statement for extend.

### DIFF
--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -132,6 +132,15 @@ QUnit.test("reopening on LinkView actually reopens on LinkComponent", function()
 
 });
 
+QUnit.test("Extending a LinkView returns a LinkView.", function() {
+  expect(2);
+
+  expectDeprecation(function() {
+    var result = Ember.LinkView.extend({});
+    equal(result.toString(), '(subclass of Ember.LinkView)', 'Returns a subclass of the Ember.LinkView object.');
+  });
+});
+
 QUnit.test("unwraps controllers", function() {
   var template = "{{#link-to 'index' view.otherController}}Text{{/link-to}}";
 

--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -522,7 +522,7 @@ DeprecatedLinkView.reopen = function reopenWithDeprecation() {
 DeprecatedLinkView.reopenClass({
   extend: function () {
     Ember.deprecate('Ember.LinkView is deprecated. Please extend from Ember.LinkComponent.', false);
-    this._super.apply(this, arguments);
+    return this._super.apply(this, arguments);
   }
 });
 


### PR DESCRIPTION
Results in the value being `undefined` after an `extend` call.
