### PR TITLE
Test that {{each-in}} traversing from truthy to falsey works.

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/each_in_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_in_test.js
@@ -159,5 +159,12 @@ if (isEnabled('ember-htmlbars-each-in')) {
 
     assert.equal(component.$('li').length, 1, 'one li is rendered');
     assert.equal(component.$('li').text(), 'First Category: 123', 'the list is rendered after being set');
+
+    run(() => {
+      component.set('categories', null);
+    });
+
+    assert.equal(component.$('li').length, 1, 'one li is rendered');
+    assert.equal(component.$('li').text(), 'No categories.', 'the inverse is rendered when the value becomes falsey again');
   });
 }


### PR DESCRIPTION
Once {{each-in}} got rendered, set the content to an empty object doesn't renders the alternate block

Rebased and fixed up JSCS errors in #11384.
