### PR TITLE
[CLEANUP beta] Remove long deprecated {{linkTo}} helper.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/link-to.js
@@ -305,15 +305,3 @@ export default {
     this.render(morph, env, scope, params, hash, template, inverse, visitor);
   }
 };
-
-/**
-  See [link-to](/api/classes/Ember.Handlebars.helpers.html#method_link-to)
-
-  @method linkTo
-  @for Ember.Handlebars.helpers
-  @deprecated
-  @param {String} routeName
-  @param {Object} [context]*
-  @return {String} HTML string
-  @private
-*/

--- a/packages/ember-routing-htmlbars/lib/main.js
+++ b/packages/ember-routing-htmlbars/lib/main.js
@@ -4,7 +4,6 @@
 */
 
 import Ember from 'ember-metal/core';
-import merge from 'ember-metal/merge';
 
 import { registerHelper } from 'ember-htmlbars/helpers';
 import { registerKeyword } from 'ember-htmlbars/keywords';
@@ -21,16 +20,5 @@ registerKeyword('action', action);
 registerKeyword('@element_action', elementAction);
 registerKeyword('link-to', linkTo);
 registerKeyword('render', render);
-
-var deprecatedLinkTo = merge({}, linkTo);
-merge(deprecatedLinkTo, {
-  link(state, params, hash) {
-    linkTo.link.call(this, state, params, hash);
-    Ember.deprecate('The \'linkTo\' view helper is deprecated in favor of \'link-to\'');
-  }
-});
-
-
-registerKeyword('linkTo', deprecatedLinkTo);
 
 export default Ember;

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -897,28 +897,6 @@ QUnit.test('The {{link-to}} helper\'s bound parameter functionality works as exp
   equal(normalizeUrl($link.attr('href')), '/posts/2', 'self link updated to post 2');
 });
 
-QUnit.test('{{linkTo}} is aliased', function() {
-  Ember.TEMPLATES.index = compile('<h3>Home</h3>{{#linkTo \'about\' id=\'about-link\' replace=true}}About{{/linkTo}}');
-
-  Router.map(function() {
-    this.route('about');
-  });
-
-  expectDeprecation(function() {
-    bootApplication();
-  }, 'The \'linkTo\' view helper is deprecated in favor of \'link-to\'');
-
-  Ember.run(function() {
-    router.handleURL('/');
-  });
-
-  Ember.run(function() {
-    Ember.$('#about-link', '#qunit-fixture').click();
-  });
-
-  equal(container.lookup('controller:application').get('currentRouteName'), 'about', 'linkTo worked properly');
-});
-
 QUnit.test('The {{link-to}} helper is active when a route is active', function() {
   Router.map(function() {
     this.route('about', function() {


### PR DESCRIPTION
This was deprecated prior to 1.0.0.

This is **NOT** removing `{{link-to}}`.
