### PR TITLE
[CLEANUP beta] - Remove `filterProperty`

### DIFF
--- a/packages/ember-runtime/lib/computed/reduce_computed_macros.js
+++ b/packages/ember-runtime/lib/computed/reduce_computed_macros.js
@@ -311,20 +311,6 @@ export function filterBy(dependentKey, propertyKey, value) {
 }
 
 /**
-  @method filterProperty
-  @for Ember.computed
-  @param dependentKey
-  @param propertyKey
-  @param value
-  @deprecated Use `Ember.computed.filterBy` instead
-  @public
-*/
-export function filterProperty() {
-  Ember.deprecate('Ember.computed.filterProperty is deprecated. Please use Ember.computed.filterBy.');
-  return filterBy.apply(this, arguments);
-}
-
-/**
   A computed property which returns a new array with all the unique
   elements from one or more dependent arrays.
 

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -56,7 +56,6 @@ import {
   mapProperty,
   filter,
   filterBy,
-  filterProperty,
   uniq,
   union,
   intersect
@@ -119,7 +118,6 @@ EmComputed.mapBy = mapBy;
 EmComputed.mapProperty = mapProperty;
 EmComputed.filter = filter;
 EmComputed.filterBy = filterBy;
-EmComputed.filterProperty = filterProperty;
 EmComputed.uniq = uniq;
 EmComputed.union = union;
 EmComputed.intersect = intersect;

--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -461,20 +461,6 @@ export default Mixin.create({
   },
 
   /**
-    Returns an array with just the items with the matched property. You
-    can pass an optional second argument with the target value. Otherwise
-    this will match any property that evaluates to `true`.
-
-    @method filterProperty
-    @param {String} key the property to test
-    @param {String} [value] optional value to test against.
-    @return {Array} filtered array
-    @deprecated Use `filterBy` instead
-    @private
-  */
-  filterProperty: aliasMethod('filterBy'),
-
-  /**
     Returns an array with the items that do not have truthy values for
     key.  You can pass an optional second argument with the target value.  Otherwise
     this will match any property that evaluates to false.

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -137,10 +137,4 @@ suite.test('should not match undefined properties without second argument', func
   deepEqual(obj.filterBy('foo'), ary.slice(0, 2), 'filterBy(\'foo\', 3)\')');
 });
 
-suite.test('should be aliased to filterProperty', function() {
-  var ary = [];
-
-  equal(ary.filterProperty, ary.filterBy);
-});
-
 export default suite;


### PR DESCRIPTION
Deprecated since '13. See: #3227
