### PR TITLE
[DOC Release] Mark Enumerable.findBy as public

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -581,7 +581,7 @@ export default Mixin.create({
     @param {String} key the property to test
     @param {String} [value] optional value to test against.
     @return {Object} found item or `undefined`
-    @private
+    @public
   */
   findBy(key, value) {
     return this.find(iter.apply(this, arguments));


### PR DESCRIPTION
I think this might have been accidentally marked as private
