### PR TITLE
[DOC Release] Mark Enumerable.find as public

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -541,7 +541,7 @@ export default Mixin.create({
     @param {Function} callback The callback to execute
     @param {Object} [target] The target object to use
     @return {Object} Found item or `undefined`.
-    @private
+    @public
   */
   find(callback, target) {
     var len = get(this, 'length');


### PR DESCRIPTION
I think this might have been accidentally marked as private
