### PR TITLE
[DOC Release] Mark Ember.Route#paramsFor as public

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -305,7 +305,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
 
     @method paramsFor
     @param {String} name
-    @private
+    @public
   */
   paramsFor(name) {
     var route = this.container.lookup(`route:${name}`);


### PR DESCRIPTION
In our application we use `paramsFor` in three ways:
- for child routes to be able to access parameters of a parent route. This is often required to get data for passing to the adapter to make the appropriate data request.
- for a route to get its own params to transition to itself in an action with slightly tweaked values. We do this via `this.paramsFor(this.routeName)`
- for a route to get a parent's params to transition to itself or another route with a parent's parameter changed

Some of these can probably be implemented through other mechanisms (or should be), but `paramsFor` provides a somewhat clean way of doing so today.
