### PR TITLE
[BUGFIX beta] Update emberjs-build to 0.2.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "^0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.2.0",
+    "emberjs-build": "0.2.1",
     "express": "^4.5.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",


### PR DESCRIPTION
Fixes super annoying Babel deprecation:

`The transformer es6.parameters.rest has been renamed`
