### PR TITLE
[BUGFIX beta] Guard against trying to use a non-setup router.js instance.

### DIFF
--- a/packages/ember-routing/lib/services/routing.js
+++ b/packages/ember-routing/lib/services/routing.js
@@ -53,6 +53,7 @@ export default Service.extend({
 
   generateURL(routeName, models, queryParams) {
     var router = get(this, 'router');
+    if (!router.router) { return; }
 
     var visibleQueryParams = {};
     merge(visibleQueryParams, queryParams);

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -96,7 +96,7 @@ QUnit.module('The {{link-to}} helper', {
   teardown: sharedTeardown
 });
 
-// This test is designed to simulate the context of an ember-qunit/ember-test-helpers component integration test,
+// These two tests are designed to simulate the context of an ember-qunit/ember-test-helpers component integration test,
 // so the container is available but it does not boot the entire app
 QUnit.test('Using {{link-to}} does not cause an exception if it is rendered before the router has started routing', function(assert) {
   Router.map(function() {
@@ -112,6 +112,21 @@ QUnit.test('Using {{link-to}} does not cause an exception if it is rendered befo
 
   let router = container.lookup('router:main');
   router.setupRouter();
+
+  Ember.run(function() {
+    component.appendTo('#qunit-fixture');
+  });
+
+  assert.strictEqual(component.$('a').length, 1, 'the link is rendered');
+});
+
+QUnit.test('Using {{link-to}} does not cause an exception if it is rendered without a router.js instance', function(assert) {
+  registry.register('component-lookup:main', ComponentLookup);
+
+  let component = Ember.Component.extend({
+    layout: compile('{{#link-to "nonexistent"}}Does not work.{{/link-to}}'),
+    container: container
+  }).create();
 
   Ember.run(function() {
     component.appendTo('#qunit-fixture');


### PR DESCRIPTION
Cherry-picked from the stable branch. Related to #11610.
