### PR TITLE
[BUGFIX beta] Fix subexpr stream labels.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -34,7 +34,7 @@ export default function emberElement(morph, env, scope, path, params, hash, visi
   var result;
   var helper = findHelper(path, scope.self, env);
   if (helper) {
-    var helperStream = buildHelperStream(helper, params, hash, { element: morph.element }, env, scope);
+    var helperStream = buildHelperStream(helper, params, hash, { element: morph.element }, env, scope, null, path);
     result = helperStream.value();
   } else {
     result = env.hooks.get(env, scope, path);

--- a/packages/ember-htmlbars/lib/hooks/subexpr.js
+++ b/packages/ember-htmlbars/lib/hooks/subexpr.js
@@ -21,7 +21,7 @@ export default function subexpr(env, scope, helperName, params, hash) {
   var label = labelForSubexpr(params, hash, helperName);
   var helper = lookupHelper(helperName, scope.self, env);
 
-  var helperStream = buildHelperStream(helper, params, hash, { template: {}, inverse: {} }, env, scope, label);
+  var helperStream = buildHelperStream(helper, params, hash, { template: {}, inverse: {} }, env, scope, null, label);
 
   for (var i = 0, l = params.length; i < l; i++) {
     helperStream.addDependency(params[i]);
@@ -35,14 +35,14 @@ export default function subexpr(env, scope, helperName, params, hash) {
 }
 
 function labelForSubexpr(params, hash, helperName) {
-  return function() {
-    var paramsLabels = labelsForParams(params);
-    var hashLabels = labelsForHash(hash);
-    var label = `(${helperName}`;
-    if (paramsLabels) { label += ` ${paramsLabels}`; }
-    if (hashLabels) { label += ` ${hashLabels}`; }
-    return `${label})`;
-  };
+  var paramsLabels = labelsForParams(params);
+  var hashLabels = labelsForHash(hash);
+  var label = `(${helperName}`;
+
+  if (paramsLabels) { label += ` ${paramsLabels}`; }
+  if (hashLabels) { label += ` ${hashLabels}`; }
+
+  return `${label})`;
 }
 
 function labelsForParams(params) {


### PR DESCRIPTION
- The `subexpr` hook was creating a label function for each sub-expression, but nothing in the system was doing anything with a function.
- The `element` and `subexpr` hooks were passing the generated `label` in the `context` slot.
