### PR TITLE
[BUGFIX release] On re-render, ensure child views of non-dirty components get the correct parentView

### DIFF
--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -308,6 +308,7 @@ export function createComponent(_component, isAngleBracket, _props, renderNode, 
 
   component._renderNode = renderNode;
   renderNode.emberView = component;
+  renderNode.buildChildEnv = buildChildEnv;
   return component;
 }
 
@@ -359,4 +360,8 @@ function mergeBindings(target, attrs) {
   }
 
   return target;
+}
+
+function buildChildEnv(state, env) {
+  return env.childWithView(this.emberView);
 }

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -750,6 +750,37 @@ QUnit.test("components in template of a yielding component should have the prope
   equal(outer.parentView, view, 'x-outer receives the ambient scope as its parentView');
 });
 
+QUnit.test('newly-added sub-components get correct parentView', function() {
+  var outer, inner;
+
+  registry.register('component:x-outer', Component.extend({
+    init() {
+      this._super(...arguments);
+      outer = this;
+    }
+  }));
+
+  registry.register('component:x-inner', Component.extend({
+    init() {
+      this._super(...arguments);
+      inner = this;
+    }
+  }));
+
+  view = EmberView.extend({
+    template: compile('{{#x-outer}}{{#if view.showInner}}{{x-inner}}{{/if}}{{/x-outer}}'),
+    container: container,
+    showInner: false
+  }).create();
+
+  runAppend(view);
+
+  run(() => { view.set('showInner', true); });
+
+  equal(inner.parentView, outer, 'receives the wrapping component as its parentView in template blocks');
+  equal(outer.parentView, view, 'x-outer receives the ambient scope as its parentView');
+});
+
 QUnit.test("components should receive the viewRegistry from the parent view", function() {
   var outer, innerTemplate, innerLayout;
 


### PR DESCRIPTION
This is quite possibly a bad hack rather than a nice solution. I'd love suggestions for a cleaner approach.

On re-render of a non-dirty component, the `env` was simply passed down when
rendering the component's template, which means its parentView was wrong; this
patch mimics what keywords already do to solve this for components.

Fixes emberjs/ember.js#11554
