### PR TITLE
Fix JSCS quoting issue with cherry-pick from stable branch.

### DIFF
--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -783,7 +783,7 @@ QUnit.test('newly-added sub-components get correct parentView', function() {
   equal(outer.parentView, view, 'x-outer receives the ambient scope as its parentView');
 });
 
-QUnit.test("components should receive the viewRegistry from the parent view", function() {
+QUnit.test('components should receive the viewRegistry from the parent view', function() {
   var outer, innerTemplate, innerLayout;
 
   var viewRegistry = {};


### PR DESCRIPTION
I cherry-picked https://github.com/emberjs/ember.js/pull/11651 into beta and master, but accidentally left some double quotes (therefore failing JSCS tests).
