### PR TITLE
[BUGFIX release] Prevent ArrayController deprecation on generated controllers.

### DIFF
--- a/packages/ember-routing/tests/system/controller_for_test.js
+++ b/packages/ember-routing/tests/system/controller_for_test.js
@@ -8,7 +8,7 @@ import Namespace from 'ember-runtime/system/namespace';
 import { classify } from 'ember-runtime/system/string';
 import Controller from 'ember-runtime/controllers/controller';
 import ObjectController from 'ember-runtime/controllers/object_controller';
-import ArrayController, { arrayControllerDeprecation } from 'ember-runtime/controllers/array_controller';
+import ArrayController from 'ember-runtime/controllers/array_controller';
 import controllerFor from 'ember-routing/system/controller_for';
 import generateController from 'ember-routing/system/generate_controller';
 import {
@@ -103,7 +103,6 @@ QUnit.test('generateController should create Ember.ObjectController [DEPRECATED]
 });
 
 QUnit.test('generateController should create Ember.ArrayController', function() {
-  expectDeprecation(arrayControllerDeprecation);
   var context = Ember.A();
   var controller = generateController(container, 'home', context);
 
@@ -131,7 +130,6 @@ QUnit.test('generateController should create App.ObjectController if provided', 
 });
 
 QUnit.test('generateController should create App.ArrayController if provided', function() {
-  expectDeprecation(arrayControllerDeprecation);
   var context = Ember.A();
   var controller;
   namespace.ArrayController = ArrayController.extend();

--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -202,7 +202,8 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
   },
 
   init() {
-    Ember.deprecate(arrayControllerDeprecation);
+    Ember.deprecate(arrayControllerDeprecation, this.isGenerated);
+
     this._super(...arguments);
     this._subControllers = [];
   },

--- a/packages/ember/tests/helpers/link_to_test.js
+++ b/packages/ember/tests/helpers/link_to_test.js
@@ -6,7 +6,6 @@ import isEnabled from 'ember-metal/features';
 import { objectControllerDeprecation } from 'ember-runtime/controllers/object_controller';
 import EmberHandlebars from 'ember-htmlbars/compat';
 import EmberView from 'ember-views/views/view';
-import { arrayControllerDeprecation } from 'ember-runtime/controllers/array_controller';
 
 var compile = EmberHandlebars.compile;
 
@@ -482,7 +481,6 @@ QUnit.test('The {{link-to}} helper supports bubbles=false', function() {
 });
 
 QUnit.test('The {{link-to}} helper moves into the named route with context', function() {
-  expectDeprecation(arrayControllerDeprecation);
   Router.map(function(match) {
     this.route('about');
     this.route('item', { path: '/item/:id' });
@@ -1048,8 +1046,7 @@ QUnit.test('The non-block form {{link-to}} helper updates the link text when it 
 });
 
 QUnit.test('The non-block form {{link-to}} helper moves into the named route with context', function() {
-  expect(6);
-  expectDeprecation(arrayControllerDeprecation);
+  expect(5);
   Router.map(function(match) {
     this.route('item', { path: '/item/:id' });
   });

--- a/packages/ember/tests/homepage_example_test.js
+++ b/packages/ember/tests/homepage_example_test.js
@@ -1,7 +1,6 @@
 import 'ember';
 import Ember from 'ember-metal/core';
 import EmberHandlebars from 'ember-htmlbars/compat';
-import { arrayControllerDeprecation } from 'ember-runtime/controllers/array_controller';
 
 var compile = EmberHandlebars.compile;
 
@@ -24,7 +23,6 @@ function setupExample() {
 
   App.IndexRoute = Ember.Route.extend({
     model() {
-      expectDeprecation(arrayControllerDeprecation);
       var people = Ember.A([
         App.Person.create({
           firstName: 'Tom',

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -654,8 +654,6 @@ QUnit.test('The Homepage with a computed context that does not get overridden', 
 });
 
 QUnit.test('The Homepage getting its controller context via model', function() {
-  expectDeprecation(arrayControllerDeprecation);
-
   Router.map(function() {
     this.route('home', { path: '/' });
   });
@@ -2289,8 +2287,6 @@ QUnit.test('Nested index route is not overriden by parent\'s implicit index rout
 });
 
 QUnit.test('Application template does not duplicate when re-rendered', function() {
-  expectDeprecation(arrayControllerDeprecation);
-
   Ember.TEMPLATES.application = compile('<h3>I Render Once</h3>{{outlet}}');
 
   Router.map(function() {


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember.js/issues/11657.
