### PR TITLE
[BUGFIX release] Ensure Route actions can be unit tested.

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1139,7 +1139,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @public
   */
   send(...args) {
-    if (this.router || !Ember.testing) {
+    if ((this.router && this.router.router) || !Ember.testing) {
       this.router.send(...args);
     } else {
       var name = args[0];

--- a/packages/ember-routing/tests/system/route_test.js
+++ b/packages/ember-routing/tests/system/route_test.js
@@ -173,6 +173,29 @@ QUnit.test('.send just calls an action if the router is absent', function() {
   equal(undefined, route.send('nonexistent', 1, 2, 3));
 });
 
+QUnit.test('.send just calls an action if the routers internal router property is absent', function() {
+  expect(7);
+  var route = EmberRoute.extend({
+    router: { },
+    actions: {
+      returnsTrue(foo, bar) {
+        equal(foo, 1);
+        equal(bar, 2);
+        equal(this, route);
+        return true;
+      },
+
+      returnsFalse() {
+        ok(true, 'returnsFalse was called');
+        return false;
+      }
+    }
+  }).create();
+
+  equal(true, route.send('returnsTrue', 1, 2));
+  equal(false, route.send('returnsFalse'));
+  equal(undefined, route.send('nonexistent', 1, 2, 3));
+});
 
 QUnit.module('Ember.Route serialize', {
   setup: setup,


### PR DESCRIPTION
With ember-qunit@0.3.x the normal `router` injection for all Routes looked up from the container was not set, so the guarding `this.router` was enough to force us down the `else` path in `Ember.Route#send`.

ember-qunit@0.4.x fixes many bugs with the previous manual container setup, by doing exactly what a "normal" app would do and use its registry/container pair. This is a **huge** improvement, but unfortunately broke the guard that previously existed (since `this.router` was now the `Ember.Router` instance due to the aforementioned injection rule).

---

Fixes #11663.
