### PR TITLE
[BUGFIX release] Privatize beforeObserver & deprecate public APIs

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -161,18 +161,18 @@ import {
   _suspendBeforeObservers,
   _suspendObserver,
   _suspendObservers,
-  addBeforeObserver,
+  _addBeforeObserver,
   addObserver,
-  beforeObserversFor,
+  _beforeObserversFor,
   observersFor,
-  removeBeforeObserver,
+  _removeBeforeObserver,
   removeObserver
 } from 'ember-metal/observer';
 import {
   IS_BINDING,
   Mixin,
   aliasMethod,
-  beforeObserver,
+  _beforeObserver,
   immediateObserver,
   mixin,
   observer,
@@ -310,20 +310,20 @@ Ember.cacheFor = cacheFor;
 Ember.addObserver = addObserver;
 Ember.observersFor = observersFor;
 Ember.removeObserver = removeObserver;
-Ember.addBeforeObserver = addBeforeObserver;
+Ember.addBeforeObserver = Ember.deprecateFunc('Ember.addBeforeObserver is deprecated and will be removed in the near future. See http://emberjs.com/deprecations/v1.x/#toc_beforeobserver', _addBeforeObserver);
 Ember._suspendBeforeObserver = _suspendBeforeObserver;
 Ember._suspendBeforeObservers = _suspendBeforeObservers;
 Ember._suspendObserver = _suspendObserver;
 Ember._suspendObservers = _suspendObservers;
-Ember.beforeObserversFor = beforeObserversFor;
-Ember.removeBeforeObserver = removeBeforeObserver;
+Ember.beforeObserversFor = Ember.deprecateFunc('Ember.beforeObserversFor is deprecated and will be removed in the near future. See http://emberjs.com/deprecations/v1.x/#toc_beforeobserver', _beforeObserversFor);
+Ember.removeBeforeObserver = Ember.deprecateFunc('Ember.removeBeforeObserver is deprecated and will be removed in the near future. See http://emberjs.com/deprecations/v1.x/#toc_beforeobserver', _removeBeforeObserver);
 
 Ember.IS_BINDING = IS_BINDING;
 Ember.required = required;
 Ember.aliasMethod = aliasMethod;
 Ember.observer = observer;
 Ember.immediateObserver = immediateObserver;
-Ember.beforeObserver = beforeObserver;
+Ember.beforeObserver = Ember.deprecateFunc('Ember.beforeObserver is deprecated and will be removed in the near future. See http://emberjs.com/deprecations/v1.x/#toc_beforeobserver', _beforeObserver);
 Ember.mixin = mixin;
 Ember.Mixin = Mixin;
 

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -28,8 +28,8 @@ import { Binding } from 'ember-metal/binding';
 import {
   addObserver,
   removeObserver,
-  addBeforeObserver,
-  removeBeforeObserver,
+  _addBeforeObserver,
+  _removeBeforeObserver,
   _suspendObserver
 } from 'ember-metal/observer';
 import {
@@ -415,13 +415,13 @@ function replaceObserversAndListeners(obj, key, observerOrListener) {
   var prev = obj[key];
 
   if ('function' === typeof prev) {
-    updateObserversAndListeners(obj, key, prev, '__ember_observesBefore__', removeBeforeObserver);
+    updateObserversAndListeners(obj, key, prev, '__ember_observesBefore__', _removeBeforeObserver);
     updateObserversAndListeners(obj, key, prev, '__ember_observes__', removeObserver);
     updateObserversAndListeners(obj, key, prev, '__ember_listens__', removeListener);
   }
 
   if ('function' === typeof observerOrListener) {
-    updateObserversAndListeners(obj, key, observerOrListener, '__ember_observesBefore__', addBeforeObserver);
+    updateObserversAndListeners(obj, key, observerOrListener, '__ember_observesBefore__', _addBeforeObserver);
     updateObserversAndListeners(obj, key, observerOrListener, '__ember_observes__', addObserver);
     updateObserversAndListeners(obj, key, observerOrListener, '__ember_listens__', addListener);
   }
@@ -871,9 +871,9 @@ export function immediateObserver() {
   Note, `@each.property` observer is called per each add or replace of an element
   and it's not called with a specific enumeration item.
 
-  A `beforeObserver` fires before a property changes.
+  A `_beforeObserver` fires before a property changes.
 
-  A `beforeObserver` is an alternative form of `.observesBefore()`.
+  A `_beforeObserver` is an alternative form of `.observesBefore()`.
 
   ```javascript
   App.PersonView = Ember.View.extend({
@@ -906,9 +906,10 @@ export function immediateObserver() {
   @param {String} propertyNames*
   @param {Function} func
   @return func
+  @deprecated
   @private
 */
-export function beforeObserver(...args) {
+export function _beforeObserver(...args) {
   var func  = args.slice(-1)[0];
   var paths;
 

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -61,15 +61,16 @@ export function removeObserver(obj, path, target, method) {
 }
 
 /**
-  @method addBeforeObserver
+  @method _addBeforeObserver
   @for Ember
   @param obj
   @param {String} path
   @param {Object|Function} target
   @param {Function|String} [method]
+  @deprecated
   @private
 */
-export function addBeforeObserver(obj, path, target, method) {
+export function _addBeforeObserver(obj, path, target, method) {
   addListener(obj, beforeEvent(path), target, method);
   watch(obj, path);
 
@@ -98,7 +99,7 @@ export function _suspendObservers(obj, paths, target, method, callback) {
   return suspendListeners(obj, events, target, method, callback);
 }
 
-export function beforeObserversFor(obj, path) {
+export function _beforeObserversFor(obj, path) {
   return listenersFor(obj, beforeEvent(path));
 }
 
@@ -109,9 +110,10 @@ export function beforeObserversFor(obj, path) {
   @param {String} path
   @param {Object|Function} target
   @param {Function|String} [method]
+  @deprecated
   @private
 */
-export function removeBeforeObserver(obj, path, target, method) {
+export function _removeBeforeObserver(obj, path, target, method) {
   unwatch(obj, path);
   removeListener(obj, beforeEvent(path), target, method);
 

--- a/packages/ember-metal/tests/computed_test.js
+++ b/packages/ember-metal/tests/computed_test.js
@@ -15,7 +15,7 @@ import { set } from 'ember-metal/property_set';
 import { isWatching } from 'ember-metal/watching';
 import {
   addObserver,
-  addBeforeObserver
+  _addBeforeObserver
 } from 'ember-metal/observer';
 
 var originalLookup = Ember.lookup;
@@ -716,19 +716,19 @@ testBoth('setting a watched computed property', function(get, set) {
   var firstNameDidChange = 0;
   var lastNameWillChange = 0;
   var lastNameDidChange = 0;
-  addBeforeObserver(obj, 'fullName', function () {
+  _addBeforeObserver(obj, 'fullName', function () {
     fullNameWillChange++;
   });
   addObserver(obj, 'fullName', function () {
     fullNameDidChange++;
   });
-  addBeforeObserver(obj, 'firstName', function () {
+  _addBeforeObserver(obj, 'firstName', function () {
     firstNameWillChange++;
   });
   addObserver(obj, 'firstName', function () {
     firstNameDidChange++;
   });
-  addBeforeObserver(obj, 'lastName', function () {
+  _addBeforeObserver(obj, 'lastName', function () {
     lastNameWillChange++;
   });
   addObserver(obj, 'lastName', function () {
@@ -767,7 +767,7 @@ testBoth('setting a cached computed property that modifies the value you give it
   );
   var plusOneWillChange = 0;
   var plusOneDidChange = 0;
-  addBeforeObserver(obj, 'plusOne', function () {
+  _addBeforeObserver(obj, 'plusOne', function () {
     plusOneWillChange++;
   });
   addObserver(obj, 'plusOne', function () {

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -3,10 +3,10 @@ import { testBoth } from 'ember-metal/tests/props_helper';
 import {
   addObserver,
   removeObserver,
-  addBeforeObserver,
+  _addBeforeObserver,
   _suspendObserver,
   _suspendObservers,
-  removeBeforeObserver
+  _removeBeforeObserver
 } from 'ember-metal/observer';
 import {
   propertyWillChange,
@@ -21,7 +21,7 @@ import {
   Mixin,
   mixin,
   observer,
-  beforeObserver,
+  _beforeObserver,
   immediateObserver
 } from 'ember-metal/mixin';
 import run from 'ember-metal/run_loop';
@@ -251,16 +251,16 @@ testBoth('removing an chain before observer on change should not fail', function
   function observer2() { count2++; }
   function observer3() {
     count3++;
-    removeBeforeObserver(obj1, 'foo.bar', observer1);
-    removeBeforeObserver(obj2, 'foo.bar', observer2);
-    removeBeforeObserver(obj4, 'foo.bar', observer4);
+    _removeBeforeObserver(obj1, 'foo.bar', observer1);
+    _removeBeforeObserver(obj2, 'foo.bar', observer2);
+    _removeBeforeObserver(obj4, 'foo.bar', observer4);
   }
   function observer4() { count4++; }
 
-  addBeforeObserver(obj1, 'foo.bar' , observer1);
-  addBeforeObserver(obj2, 'foo.bar' , observer2);
-  addBeforeObserver(obj3, 'foo.bar' , observer3);
-  addBeforeObserver(obj4, 'foo.bar' , observer4);
+  _addBeforeObserver(obj1, 'foo.bar' , observer1);
+  _addBeforeObserver(obj2, 'foo.bar' , observer2);
+  _addBeforeObserver(obj3, 'foo.bar' , observer3);
+  _addBeforeObserver(obj4, 'foo.bar' , observer4);
 
   set(foo, 'bar', 'baz');
 
@@ -468,7 +468,7 @@ testBoth('deferring property change notifications will not defer before observer
   var obj = { foo: 'foo' };
   var fooCount = 0;
 
-  addBeforeObserver(obj, 'foo', function() { fooCount++; });
+  _addBeforeObserver(obj, 'foo', function() { fooCount++; });
 
   beginPropertyChanges(obj);
   set(obj, 'foo', 'BIFF');
@@ -676,14 +676,14 @@ testBoth('removeObserver should respect targets with methods', function(get, set
 // BEFORE OBSERVER
 //
 
-QUnit.module('addBeforeObserver');
+QUnit.module('_addBeforeObserver');
 
 testBoth('observer should fire before a property is modified', function(get, set) {
 
   var obj = { foo: 'foo' };
   var count = 0;
 
-  addBeforeObserver(obj, 'foo', function() {
+  _addBeforeObserver(obj, 'foo', function() {
     equal(get(obj, 'foo'), 'foo', 'should invoke before value changed');
     count++;
   });
@@ -701,7 +701,7 @@ testBoth('observer should fire before dependent property is modified', function(
   get(obj, 'foo');
 
   var count = 0;
-  addBeforeObserver(obj, 'foo', function() {
+  _addBeforeObserver(obj, 'foo', function() {
     equal(get(obj, 'foo'), 'BAR', 'should have invoked after prop change');
     count++;
   });
@@ -764,7 +764,7 @@ testBoth('before observer watching multiple properties via brace expansion shoul
   var count = 0;
 
   mixin(obj, {
-    fooAndBarWatcher: beforeObserver('{foo,bar}', function () {
+    fooAndBarWatcher: _beforeObserver('{foo,bar}', function () {
       count++;
     })
   });
@@ -792,7 +792,7 @@ testBoth('before observer watching multiple properties via brace expansion shoul
   }).property('baz'));
 
   mixin(obj, {
-    fooAndBarWatcher: beforeObserver('{foo,bar}', function () {
+    fooAndBarWatcher: _beforeObserver('{foo,bar}', function () {
       count++;
     })
   });
@@ -806,11 +806,11 @@ testBoth('before observer watching multiple properties via brace expansion shoul
   equal(count, 2, 'observer not fired on unspecified property');
 });
 
-testBoth('addBeforeObserver should propagate through prototype', function(get, set) {
+testBoth('_addBeforeObserver should propagate through prototype', function(get, set) {
   var obj = { foo: 'foo', count: 0 };
   var obj2;
 
-  addBeforeObserver(obj, 'foo', function() { this.count++; });
+  _addBeforeObserver(obj, 'foo', function() { this.count++; });
   obj2 = Object.create(obj);
 
   set(obj2, 'foo', 'bar');
@@ -823,7 +823,7 @@ testBoth('addBeforeObserver should propagate through prototype', function(get, s
   equal(obj2.count, 0, 'should not have invoked observer on inherited');
 });
 
-testBoth('addBeforeObserver should respect targets with methods', function(get, set) {
+testBoth('_addBeforeObserver should respect targets with methods', function(get, set) {
   var observed = { foo: 'foo' };
 
   var target1 = {
@@ -852,8 +852,8 @@ testBoth('addBeforeObserver should respect targets with methods', function(get, 
     }
   };
 
-  addBeforeObserver(observed, 'foo', target1, 'willChange');
-  addBeforeObserver(observed, 'foo', target2, target2.willChange);
+  _addBeforeObserver(observed, 'foo', target1, 'willChange');
+  _addBeforeObserver(observed, 'foo', target2, target2.willChange);
 
   set(observed, 'foo', 'BAZ');
   equal(target1.count, 1, 'target1 observer should have fired');
@@ -996,7 +996,7 @@ testBoth('depending on a Global chain', function(get, set) {
   equal(count, 6, 'should be not have invoked observer');
 });
 
-QUnit.module('removeBeforeObserver');
+QUnit.module('_removeBeforeObserver');
 
 // ..........................................................
 // SETTING IDENTICAL VALUES
@@ -1169,11 +1169,11 @@ testBoth('observers added/removed during changeProperties should do the right th
   }
   Observer.prototype = {
     add() {
-      addBeforeObserver(obj, 'foo', this, 'willChange');
+      _addBeforeObserver(obj, 'foo', this, 'willChange');
       addObserver(obj, 'foo', this, 'didChange');
     },
     remove() {
-      removeBeforeObserver(obj, 'foo', this, 'willChange');
+      _removeBeforeObserver(obj, 'foo', this, 'willChange');
       removeObserver(obj, 'foo', this, 'didChange');
     },
     willChange() {
@@ -1198,7 +1198,7 @@ testBoth('observers added/removed during changeProperties should do the right th
 
     set(obj, 'foo', 1);
 
-    equal(addedBeforeFirstChangeObserver.willChangeCount, 1, 'addBeforeObserver called before the first change invoked immediately');
+    equal(addedBeforeFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called before the first change invoked immediately');
     equal(addedBeforeFirstChangeObserver.didChangeCount, 0, 'addObserver called before the first change is deferred');
 
     addedAfterFirstChangeObserver.add();
@@ -1206,23 +1206,23 @@ testBoth('observers added/removed during changeProperties should do the right th
 
     set(obj, 'foo', 2);
 
-    equal(addedAfterFirstChangeObserver.willChangeCount, 1, 'addBeforeObserver called after the first change invoked immediately');
+    equal(addedAfterFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called after the first change invoked immediately');
     equal(addedAfterFirstChangeObserver.didChangeCount, 0, 'addObserver called after the first change is deferred');
 
     addedAfterLastChangeObserver.add();
     removedAfterLastChangeObserver.remove();
   });
 
-  equal(removedBeforeFirstChangeObserver.willChangeCount, 0, 'removeBeforeObserver called before the first change sees none');
+  equal(removedBeforeFirstChangeObserver.willChangeCount, 0, '_removeBeforeObserver called before the first change sees none');
   equal(removedBeforeFirstChangeObserver.didChangeCount, 0, 'removeObserver called before the first change sees none');
-  equal(addedBeforeFirstChangeObserver.willChangeCount, 1, 'addBeforeObserver called before the first change sees only 1');
+  equal(addedBeforeFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called before the first change sees only 1');
   equal(addedBeforeFirstChangeObserver.didChangeCount, 1, 'addObserver called before the first change sees only 1');
-  equal(addedAfterFirstChangeObserver.willChangeCount, 1, 'addBeforeObserver called after the first change sees 1');
+  equal(addedAfterFirstChangeObserver.willChangeCount, 1, '_addBeforeObserver called after the first change sees 1');
   equal(addedAfterFirstChangeObserver.didChangeCount, 1, 'addObserver called after the first change sees 1');
-  equal(addedAfterLastChangeObserver.willChangeCount, 0, 'addBeforeObserver called after the last change sees none');
+  equal(addedAfterLastChangeObserver.willChangeCount, 0, '_addBeforeObserver called after the last change sees none');
   equal(addedAfterLastChangeObserver.didChangeCount, 0, 'addObserver called after the last change sees none');
-  equal(removedBeforeLastChangeObserver.willChangeCount, 1, 'removeBeforeObserver called before the last change still sees 1');
+  equal(removedBeforeLastChangeObserver.willChangeCount, 1, '_removeBeforeObserver called before the last change still sees 1');
   equal(removedBeforeLastChangeObserver.didChangeCount, 1, 'removeObserver called before the last change still sees 1');
-  equal(removedAfterLastChangeObserver.willChangeCount, 1, 'removeBeforeObserver called after the last change still sees 1');
+  equal(removedAfterLastChangeObserver.willChangeCount, 1, '_removeBeforeObserver called after the last change still sees 1');
   equal(removedAfterLastChangeObserver.didChangeCount, 1, 'removeObserver called after the last change still sees 1');
 });

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -10,8 +10,8 @@ import { meta } from 'ember-metal/utils';
 import {
   addObserver,
   removeObserver,
-  addBeforeObserver,
-  removeBeforeObserver
+  _addBeforeObserver,
+  _removeBeforeObserver
 } from 'ember-metal/observer';
 import {
   propertyWillChange,
@@ -62,13 +62,13 @@ export default Mixin.create({
 
   willWatchProperty(key) {
     var contentKey = 'content.' + key;
-    addBeforeObserver(this, contentKey, null, contentPropertyWillChange);
+    _addBeforeObserver(this, contentKey, null, contentPropertyWillChange);
     addObserver(this, contentKey, null, contentPropertyDidChange);
   },
 
   didUnwatchProperty(key) {
     var contentKey = 'content.' + key;
-    removeBeforeObserver(this, contentKey, null, contentPropertyWillChange);
+    _removeBeforeObserver(this, contentKey, null, contentPropertyWillChange);
     removeObserver(this, contentKey, null, contentPropertyDidChange);
   },
 

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -21,7 +21,7 @@ import {
 } from 'ember-metal/property_events';
 import {
   addObserver,
-  addBeforeObserver,
+  _addBeforeObserver,
   removeObserver,
   observersFor
 } from 'ember-metal/observer';
@@ -329,9 +329,9 @@ export default Mixin.create({
     return this;
   },
 
-  addBeforeObserver(key, target, method) {
+  _addBeforeObserver(key, target, method) {
     Ember.deprecate('Before observers are deprecated and will be removed in a future release. If you want to keep track of previous values you have to implement it yourself.', false, { url: 'http://emberjs.com/guides/deprecations/#toc_deprecate-beforeobservers' });
-    addBeforeObserver(this, key, target, method);
+    _addBeforeObserver(this, key, target, method);
   },
 
   /**

--- a/packages/ember-runtime/lib/mixins/sortable.js
+++ b/packages/ember-runtime/lib/mixins/sortable.js
@@ -16,7 +16,7 @@ import { computed } from 'ember-metal/computed';
 import { notEmpty } from 'ember-metal/computed_macros';
 import {
   Mixin,
-  beforeObserver,
+  _beforeObserver,
   observer
 } from 'ember-metal/mixin'; //ES6TODO: should we access these directly from their package or from how their exposed in ember-metal?
 
@@ -188,7 +188,7 @@ export default Mixin.create(MutableEnumerable, {
     }
   }),
 
-  _contentWillChange: beforeObserver('content', function() {
+  _contentWillChange: _beforeObserver('content', function() {
     var content = get(this, 'content');
     var sortProperties = get(this, 'sortProperties');
 
@@ -203,7 +203,7 @@ export default Mixin.create(MutableEnumerable, {
     this._super(...arguments);
   }),
 
-  sortPropertiesWillChange: beforeObserver('sortProperties', function() {
+  sortPropertiesWillChange: _beforeObserver('sortProperties', function() {
     this._lastSortAscending = undefined;
   }),
 
@@ -211,7 +211,7 @@ export default Mixin.create(MutableEnumerable, {
     this._lastSortAscending = undefined;
   }),
 
-  sortAscendingWillChange: beforeObserver('sortAscending', function() {
+  sortAscendingWillChange: _beforeObserver('sortAscending', function() {
     this._lastSortAscending = get(this, 'sortAscending');
   }),
 

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -5,7 +5,7 @@ import {
 } from 'ember-runtime/utils';
 import { computed } from 'ember-metal/computed';
 import {
-  beforeObserver,
+  _beforeObserver,
   observer
 } from 'ember-metal/mixin';
 import {
@@ -132,7 +132,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     @private
     @method _contentWillChange
   */
-  _contentWillChange: beforeObserver('content', function() {
+  _contentWillChange: _beforeObserver('content', function() {
     this._teardownContent();
   }),
 
@@ -202,7 +202,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     }
   },
 
-  _arrangedContentWillChange: beforeObserver('arrangedContent', function() {
+  _arrangedContentWillChange: _beforeObserver('arrangedContent', function() {
     var arrangedContent = get(this, 'arrangedContent');
     var len = arrangedContent ? get(arrangedContent, 'length') : 0;
 

--- a/packages/ember-runtime/lib/system/each_proxy.js
+++ b/packages/ember-runtime/lib/system/each_proxy.js
@@ -13,8 +13,8 @@ import EmberObject from 'ember-runtime/system/object';
 import { computed } from 'ember-metal/computed';
 import {
   addObserver,
-  addBeforeObserver,
-  removeBeforeObserver,
+  _addBeforeObserver,
+  _removeBeforeObserver,
   removeObserver
 } from 'ember-metal/observer';
 import { watchedEvents } from 'ember-metal/events';
@@ -61,7 +61,7 @@ function addObserverForContentKey(content, keyName, proxy, idx, loc) {
     var item = content.objectAt(loc);
     if (item) {
       Ember.assert('When using @each to observe the array ' + content + ', the array must return an object', typeOf(item) === 'instance' || typeOf(item) === 'object');
-      addBeforeObserver(item, keyName, proxy, 'contentKeyWillChange');
+      _addBeforeObserver(item, keyName, proxy, 'contentKeyWillChange');
       addObserver(item, keyName, proxy, 'contentKeyDidChange');
 
       // keep track of the index each item was found at so we can map
@@ -87,7 +87,7 @@ function removeObserverForContentKey(content, keyName, proxy, idx, loc) {
   while (--loc >= idx) {
     var item = content.objectAt(loc);
     if (item) {
-      removeBeforeObserver(item, keyName, proxy, 'contentKeyWillChange');
+      _removeBeforeObserver(item, keyName, proxy, 'contentKeyWillChange');
       removeObserver(item, keyName, proxy, 'contentKeyDidChange');
 
       guid = guidFor(item);

--- a/packages/ember-runtime/tests/suites/enumerable.js
+++ b/packages/ember-runtime/tests/suites/enumerable.js
@@ -3,7 +3,7 @@ import EmberObject from 'ember-runtime/system/object';
 import {guidFor, generateGuid} from 'ember-metal/utils';
 import {computed} from 'ember-metal/computed';
 import {get} from 'ember-metal/property_get';
-import { addBeforeObserver } from 'ember-metal/observer';
+import { _addBeforeObserver } from 'ember-metal/observer';
 
 var ObserverClass = EmberObject.extend({
 
@@ -55,7 +55,7 @@ var ObserverClass = EmberObject.extend({
     var keys = Array.prototype.slice.call(arguments, 1);
     var loc  = keys.length;
     while (--loc>=0) {
-      addBeforeObserver(obj, keys[loc], this, 'propertyWillChange');
+      _addBeforeObserver(obj, keys[loc], this, 'propertyWillChange');
     }
 
     return this;

--- a/packages/ember-views/lib/compat/attrs-proxy.js
+++ b/packages/ember-views/lib/compat/attrs-proxy.js
@@ -7,8 +7,8 @@ import { PROPERTY_DID_CHANGE } from 'ember-metal/property_events';
 import {
   addObserver,
   removeObserver,
-  addBeforeObserver,
-  removeBeforeObserver
+  _addBeforeObserver,
+  _removeBeforeObserver
 } from 'ember-metal/observer';
 
 export function deprecation(key) {
@@ -60,7 +60,7 @@ let AttrsProxyMixin = {
     if (this._isAngleBracket || key === 'attrs') { return; }
 
     let attrsKey = `attrs.${key}`;
-    addBeforeObserver(this, attrsKey, null, attrsWillChange);
+    _addBeforeObserver(this, attrsKey, null, attrsWillChange);
     addObserver(this, attrsKey, null, attrsDidChange);
   },
 
@@ -68,7 +68,7 @@ let AttrsProxyMixin = {
     if (this._isAngleBracket || key === 'attrs') { return; }
 
     let attrsKey = `attrs.${key}`;
-    removeBeforeObserver(this, attrsKey, null, attrsWillChange);
+    _removeBeforeObserver(this, attrsKey, null, attrsWillChange);
     removeObserver(this, attrsKey, null, attrsDidChange);
   },
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -13,7 +13,7 @@ import { fmt } from 'ember-runtime/system/string';
 import { computed } from 'ember-metal/computed';
 import {
   observer,
-  beforeObserver
+  _beforeObserver
 } from 'ember-metal/mixin';
 import { readViewFactory } from 'ember-views/streams/utils';
 import EmptyViewSupport from 'ember-views/mixins/empty_view_support';
@@ -222,7 +222,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @private
     @method _contentWillChange
   */
-  _contentWillChange: beforeObserver('content', function() {
+  _contentWillChange: _beforeObserver('content', function() {
     var content = this.get('content');
 
     if (content) { content.removeArrayObserver(this); }

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -6,7 +6,7 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import {
   observer,
-  beforeObserver
+  _beforeObserver
 } from 'ember-metal/mixin';
 import { on } from 'ember-metal/events';
 
@@ -224,7 +224,7 @@ var ContainerView = View.extend(MutableArray, {
     }
   },
 
-  _currentViewWillChange: beforeObserver('currentView', function() {
+  _currentViewWillChange: _beforeObserver('currentView', function() {
     var currentView = get(this, 'currentView');
     if (currentView) {
       currentView.destroy();

--- a/packages/ember-views/lib/views/states/in_dom.js
+++ b/packages/ember-views/lib/views/states/in_dom.js
@@ -1,7 +1,7 @@
 import Ember from 'ember-metal/core';
 import merge from 'ember-metal/merge';
 import EmberError from 'ember-metal/error';
-import { addBeforeObserver } from 'ember-metal/observer';
+import { _addBeforeObserver } from 'ember-metal/observer';
 
 import hasElement from 'ember-views/views/states/has_element';
 /**
@@ -20,7 +20,7 @@ merge(inDOM, {
     }
 
     Ember.runInDebug(function() {
-      addBeforeObserver(view, 'elementId', function() {
+      _addBeforeObserver(view, 'elementId', function() {
         throw new EmberError('Changing a view\'s elementId after creation is not allowed');
       });
     });


### PR DESCRIPTION
Prefixed with underscore `beforeObserver`, `addBeforeObserver`, `removeBeforeObserver` and `beforeObserversFor`
Public API remains the same, but all functions are deprecated.
