### PR TITLE
make linkChild idempotent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"
   - "npm --version"
+  - "phantomjs --version"
 
 install:
   - "npm install"

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -10,7 +10,7 @@ import setProperties from 'ember-metal/set_properties';
 
 var EMPTY_ARRAY = [];
 
-var ViewChildViewsSupport = Mixin.create({
+export default Mixin.create({
   /**
     Array of child views. You should never edit this array directly.
     Instead, use `appendChild` and `removeFromParent`.
@@ -90,6 +90,8 @@ var ViewChildViewsSupport = Mixin.create({
 
     var attrs = _attrs || {};
     var view;
+
+    attrs.parentView = this;
     attrs.renderer = this.renderer;
     attrs._viewRegistry = this._viewRegistry;
 
@@ -123,8 +125,11 @@ var ViewChildViewsSupport = Mixin.create({
 
   linkChild(instance) {
     instance.container = this.container;
-    set(instance, 'parentView', this);
-    instance.trigger('parentViewDidChange');
+    if (get(instance, 'parentView') !== this) {
+      // linkChild should be idempotentj
+      set(instance, 'parentView', this);
+      instance.trigger('parentViewDidChange');
+    }
     instance.ownerView = this.ownerView;
   },
 
@@ -133,5 +138,3 @@ var ViewChildViewsSupport = Mixin.create({
     instance.trigger('parentViewDidChange');
   }
 });
-
-export default ViewChildViewsSupport;

--- a/packages/ember-views/tests/views/view/create_child_view_test.js
+++ b/packages/ember-views/tests/views/view/create_child_view_test.js
@@ -1,6 +1,8 @@
 import { get } from 'ember-metal/property_get';
 import run from 'ember-metal/run_loop';
 import EmberView from 'ember-views/views/view';
+import { on } from 'ember-metal/events';
+import { observer } from 'ember-metal/mixin';
 
 var view, myViewClass, newView, container;
 
@@ -33,7 +35,28 @@ QUnit.test('should create view from class with any passed attributes', function(
   equal(newView.container, container, 'expects to share container with parent');
   ok(get(newView, 'isMyView'), 'newView is instance of myView');
   equal(get(newView, 'foo'), 'baz', 'view did get custom attributes');
-  ok(!attrs.parentView, 'the original attributes hash was not mutated');
+});
+
+QUnit.test('creating a childView, (via createChildView) should make parentView initial state and not emit change events nore helper actions', function() {
+  expect(2);
+
+  newView = view.createChildView(EmberView.extend({
+    init() {
+      this._super(...arguments);
+      ok(true, 'did init');
+    },
+    parentViewDidReallyChange: on('parentViewDidChange', function() {
+      ok(false, 'expected to NOT emit parentViewDidChange');
+    }),
+    controllerDidChange: observer('controller', function() {
+      ok(false, 'expected to NOT expect controller to change');
+    }),
+    parentViewDidChange: observer('parentView', function() {
+      ok(false, 'expected to NOT expect  parentViewto change');
+    })
+  }));
+
+  equal(newView.get('parentView'), view, 'expected the correct parentView');
 });
 
 QUnit.test('should set newView.parentView to receiver', function() {


### PR DESCRIPTION
- [x]  find related tests
- [x]  add a test to ensure we don't regress

while looking at @sandstrom https://github.com/sandstrom/initial-render-components I noticed, copious amounts of u needed changes events where happening. 

That example although synthetic, does indicate death a a thousand papercuts scenario. With a large 15 -> 20% GC cycle. GC is just the result of us allocating to much.

Anyways, back on topic. to many change events where happening.These changes have additional side-affects, but the main one is `sendEvent` itself, which seems to have drop by 15% -> 25% with this change.

I really wouldn't call home about this one, but it helps a teeny tiny bit.
