### PR TITLE
[CLEANUP beta] Removes `Enumerable.findProperty`.

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -561,22 +561,6 @@ export default Mixin.create({
   },
 
   /**
-    Returns the first item with a property matching the passed value. You
-    can pass an optional second argument with the target value. Otherwise
-    this will match any property that evaluates to `true`.
-
-    This method works much like the more generic `find()` method.
-
-    @method findProperty
-    @param {String} key the property to test
-    @param {String} [value] optional value to test against.
-    @return {Object} found item or `undefined`
-    @deprecated Use `findBy` instead
-    @private
-  */
-  findProperty: aliasMethod('findBy'),
-
-  /**
     Returns `true` if the passed function returns true for every item in the
     enumeration. This corresponds with the `every()` method in JavaScript 1.6.
 

--- a/packages/ember-runtime/tests/suites/enumerable/find.js
+++ b/packages/ember-runtime/tests/suites/enumerable/find.js
@@ -102,12 +102,4 @@ suite.test('should return first undefined property match', function() {
   equal(obj.findBy('bar', undefined), ary[1], 'findBy(\'bar\', undefined)');
 });
 
-suite.test('should be aliased to findProperty', function() {
-  var obj;
-
-  obj = this.newObject([]);
-
-  equal(obj.findProperty, obj.findBy);
-});
-
 export default suite;

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -352,7 +352,7 @@ QUnit.module('Model Dep Query Params', {
           deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedModelHookParams = null;
         }
-        return articles.findProperty('id', params.id);
+        return articles.findBy('id', params.id);
       }
     });
 
@@ -443,7 +443,7 @@ QUnit.module('Model Dep Query Params (nested)', {
           deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedModelHookParams = null;
         }
-        return site_articles.findProperty('id', params.id);
+        return site_articles.findBy('id', params.id);
       }
     });
 
@@ -547,7 +547,7 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
           deepEqual(params, self.expectedSiteModelHookParams, 'the SiteRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedSiteModelHookParams = null;
         }
-        return sites.findProperty('id', params.site_id);
+        return sites.findBy('id', params.site_id);
       }
     });
     App.SiteArticleRoute = Ember.Route.extend({
@@ -556,7 +556,7 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
           deepEqual(params, self.expectedArticleModelHookParams, 'the SiteArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedArticleModelHookParams = null;
         }
-        return site_articles.findProperty('id', params.article_id);
+        return site_articles.findBy('id', params.article_id);
       }
     });
 


### PR DESCRIPTION
- Updates tests to use `findBy`.
