### PR TITLE
Add repository field to package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,9 @@
 {
   "name": "ember",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/emberjs/ember.js.git"
+  },
   "dependencies": {
     "jquery": "~1.11.1",
     "qunit": "~1.17.1",

--- a/config/package_manager_files/bower.json
+++ b/config/package_manager_files/bower.json
@@ -5,6 +5,10 @@
     "./ember.debug.js",
     "./ember-template-compiler.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/emberjs/ember.js.git"
+  },
   "dependencies": {
     "jquery": ">= 1.7.0 < 2.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "docs": "ember ember-cli-yuidoc",
     "sauce:launch": "ember sauce:launch"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/emberjs/ember.js.git"
+  },
   "devDependencies": {
     "aws-sdk": "~2.1.5",
     "babel-plugin-feature-flags": "~0.2.0",


### PR DESCRIPTION
Prevent npm from complaining, and show on the site once it's published.
