### PR TITLE
Update action docs.

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -90,7 +90,7 @@ import closureAction from 'ember-routing-htmlbars/keywords/closure-action';
   supply an `on` option to the helper to specify a different DOM event name:
 
   ```handlebars
-  <div {{action "anActionName" on="doubleClick"}}>
+  <div {{action "anActionName" on="double-click"}}>
     click me
   </div>
   ```


### PR DESCRIPTION
Action documentation contains a event camelize instead of dasherize. This causes some problems when people read the guides.

See [guides#83](https://github.com/emberjs/guides/pull/83).
