### PR TITLE
[DOC release] Remove references to Handlebars from the docs, add Ember.Helper docs

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -215,10 +215,10 @@ Ember.deprecateFunc = function(...args) {
   `Ember.runInDebug()` when doing a production build.
 
   ```javascript
-  Ember.runInDebug(function() {
-    Ember.Handlebars.EachView.reopen({
-      didInsertElement: function() {
-        console.log('I\'m happy');
+  Ember.runInDebug(() => {
+    Ember.Component.reopen({
+      didInsertElement() {
+        console.log("I'm happy");
       }
     });
   });

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -10,8 +10,6 @@ import {
 @submodule ember-htmlbars
 */
 
-//import Helper from "ember-htmlbars/system/helper";
-
 /**
   A helper function used by `registerBoundHelper`. Takes the
   provided Handlebars helper function fn and returns it in wrapped

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -1,18 +1,112 @@
+/**
+@module ember
+@submodule ember-templates
+*/
+
 import Object from 'ember-runtime/system/object';
 
-// Ember.Helper.extend({ compute(params, hash) {} });
+/**
+  Ember Helpers are functions that can compute values, and are used in templates.
+  For example, this code calls a helper named `format-currency`:
+
+  ```handlebars
+  <div>{{format-currency cents currency="$"}}</div>
+  ```
+
+  Additionally a helper can be called as a nested helper (sometimes called a
+  subexpression). In this example, the computed value of a helper is passed
+  to a component named `show-money`:
+
+  ```handlebars
+  {{show-money amount=(format-currency cents currency="$")}}
+  ```
+
+  Helpers defined using a class must provide a `compute` function. For example:
+
+  ```js
+  export default Ember.Helper.extend({
+    compute(params, hash) {
+      let cents = params[0];
+      let currency = hash.currency;
+      return `${currency}${cents * 0.01}`;
+    }
+  });
+  ```
+
+  Each time the input to a helper changes, the `compute` function will be
+  called again.
+
+  As instances, these helpers also have access to the container an will accept
+  injected dependencies.
+
+  Additionally, class helpers can call `recompute` to force a new computation.
+
+  @class Ember.Helper
+  @public
+*/
 var Helper = Object.extend({
   isHelper: true,
+
+  /**
+    On a class-based helper, it may be useful to force a recomputation of that
+    helpers value. This is akin to `rerender` on a component.
+
+    For example, this component will rerender when the `currentUser` on a
+    session service changes:
+
+    ```js
+    // app/helpers/current-user-email.js
+    export default Ember.Helper.extend({
+      session: Ember.inject.service(),
+      onNewUser: Ember.observer('session.currentUser', function() {
+        this.recompute();
+      }),
+      compute() {
+        return this.get('session.currentUser.email');
+      }
+    });
+    ```
+
+    @method recompute
+    @public
+  */
   recompute() {
     this._stream.notify();
   }
+
+  /**
+    Override this function when writing a class-based helper.
+
+    @method compute
+    @param {Array} params The positional arguments to the helper
+    @param {Object} hash The named arguments to the helper
+    @public
+  */
 });
 
 Helper.reopenClass({
   isHelperFactory: true
 });
 
-// Ember.Helper.helper(function(params, hash) {});
+/**
+  In many cases, the ceremony of a full `Ember.Helper` class is not required.
+  The `helper` method create pure-function helpers without instances. For
+  example:
+
+  ```js
+  // app/helpers/format-currency.js
+  export default Ember.Helper.helper(function(params, hash) {
+    let cents = params[0];
+    let currency = hash.currency;
+    return `${currency}${cents * 0.01}`;
+  });
+  ```
+
+  @static
+  @param {Function} helper The helper function
+  @method helper
+  @public
+*/
 export function helper(helperFn) {
   return {
     isHelperInstance: true,

--- a/packages/ember-htmlbars/lib/helpers/each.js
+++ b/packages/ember-htmlbars/lib/helpers/each.js
@@ -68,7 +68,7 @@ import decodeEachKey from 'ember-htmlbars/utils/decode-each-key';
   ```
 
   @method each
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @public
 */
 export default function eachHelper(params, hash, blocks) {

--- a/packages/ember-htmlbars/lib/helpers/if_unless.js
+++ b/packages/ember-htmlbars/lib/helpers/if_unless.js
@@ -1,6 +1,6 @@
 /**
 @module ember
-@submodule ember-htmlbars
+@submodule ember-templates
 */
 
 import Ember from 'ember-metal/core'; // Ember.assert
@@ -59,7 +59,7 @@ import shouldDisplay from 'ember-views/streams/should_display';
   ```
 
   @method if
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @public
 */
 function ifHelper(params, hash, options) {
@@ -72,7 +72,7 @@ function ifHelper(params, hash, options) {
   helper can also be used with `unless`.
 
   @method unless
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @public
 */
 function unlessHelper(params, hash, options) {

--- a/packages/ember-htmlbars/lib/helpers/loc.js
+++ b/packages/ember-htmlbars/lib/helpers/loc.js
@@ -2,32 +2,37 @@ import { loc } from 'ember-runtime/system/string';
 
 /**
 @module ember
-@submodule ember-htmlbars
+@submodule ember-templates
 */
 
 /**
   Calls [Ember.String.loc](/api/classes/Ember.String.html#method_loc) with the
-  provided string.
-  This is a convenient way to localize text within a template:
+  provided string. This is a convenient way to localize text within a template.
+  For example:
+
   ```javascript
   Ember.STRINGS = {
     '_welcome_': 'Bonjour'
   };
   ```
+
   ```handlebars
   <div class='message'>
     {{loc '_welcome_'}}
   </div>
   ```
+
   ```html
   <div class='message'>
     Bonjour
   </div>
   ```
+
   See [Ember.String.loc](/api/classes/Ember.String.html#method_loc) for how to
   set up localized string references.
+
   @method loc
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @param {String} str The string to format
   @see {Ember.String#loc}
   @public

--- a/packages/ember-htmlbars/lib/helpers/log.js
+++ b/packages/ember-htmlbars/lib/helpers/log.js
@@ -1,6 +1,6 @@
 /**
 @module ember
-@submodule ember-htmlbars
+@submodule ember-templates
 */
 
 import Logger from 'ember-metal/logger';
@@ -8,11 +8,13 @@ import Logger from 'ember-metal/logger';
 /**
   `log` allows you to output the value of variables in the current rendering
   context. `log` also accepts primitive types such as strings or numbers.
+
   ```handlebars
   {{log "myVariable:" myVariable }}
   ```
+
   @method log
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @param {*} values
   @public
 */

--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -1,6 +1,6 @@
 /**
 @module ember
-@submodule ember-htmlbars
+@submodule ember-templates
 */
 
 import normalizeSelf from 'ember-htmlbars/utils/normalize-self';
@@ -33,7 +33,7 @@ import shouldDisplay from 'ember-views/streams/should_display';
   the first part of the property path, `foo`. Instead, use `{{#with foo.bar as |baz|}}`.
 
   @method with
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @param {Object} options
   @return {String} HTML string
   @public

--- a/packages/ember-htmlbars/lib/keywords/debugger.js
+++ b/packages/ember-htmlbars/lib/keywords/debugger.js
@@ -45,7 +45,7 @@ import Logger from 'ember-metal/logger';
   ```
 
   @method debugger
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @public
 */
 export default function debuggerKeyword(morph, env, scope) {

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,3 +1,25 @@
+/**
+
+  &nbsp;
+
+@module ember
+@submodule ember-templates
+@main ember-templates
+*/
+
+/**
+
+  [HTMLBars](https://github.com/tildeio/htmlbars) is a [Handlebars](http://handlebarsjs.com/)
+  compatible templating engine used by Ember.js. The classes and namespaces
+  covered by this documentation attempt to focus on APIs for interacting
+  with HTMLBars itself. For more general guidance on Ember.js templates and
+  helpers, please see the [ember-templates](/api/modules/ember-templates.html)
+  package.
+
+@module ember
+@submodule ember-htmlbars
+@main ember-htmlbars
+*/
 import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 

--- a/packages/ember-htmlbars/lib/system/bootstrap.js
+++ b/packages/ember-htmlbars/lib/system/bootstrap.js
@@ -15,7 +15,7 @@ import environment from 'ember-metal/environment';
 
 /**
 @module ember
-@submodule ember-handlebars
+@submodule ember-htmlbars
 */
 
 /**
@@ -24,13 +24,13 @@ import environment from 'ember-metal/environment';
   as as jQuery DOM-ready callback.
 
   Script tags with `text/x-handlebars` will be compiled
-  with Ember's Handlebars and are suitable for use as a view's template.
+  with Ember's template compiler and are suitable for use as a view's template.
   Those with type `text/x-raw-handlebars` will be compiled with regular
   Handlebars and are suitable for use in views' computed properties.
 
   @private
   @method bootstrap
-  @for Ember.Handlebars
+  @for Ember.HTMLBars
   @static
   @param ctx
 */

--- a/packages/ember-htmlbars/lib/system/helper.js
+++ b/packages/ember-htmlbars/lib/system/helper.js
@@ -1,13 +1,8 @@
 /**
 @module ember
-@submodule ember-htmlbars
+@submodule ember-templates
 */
 
-/**
-  @class Helper
-  @namespace Ember.HTMLBars
-  @private
-*/
 function Helper(helper) {
   this.helperFunction = helper;
 

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -37,7 +37,7 @@ function isLegacyBareHelper(helper) {
   @private
   @method resolveHelper
   @param {String} name the name of the helper to lookup
-  @return {Handlebars Helper}
+  @return {Helper}
 */
 export function findHelper(name, view, env) {
   var helper = env.helpers[name];

--- a/packages/ember-htmlbars/lib/utils/string.js
+++ b/packages/ember-htmlbars/lib/utils/string.js
@@ -8,9 +8,9 @@ import EmberStringUtils from 'ember-runtime/system/string';
 import { SafeString, escapeExpression } from 'htmlbars-util';
 
 /**
-  Mark a string as safe for unescaped output with Handlebars. If you
-  return HTML from a Handlebars helper, use this function to
-  ensure Handlebars does not escape the HTML.
+  Mark a string as safe for unescaped output with Ember templates. If you
+  return HTML from a helper, use this function to
+  ensure Ember's rendering layer does not escape the HTML.
 
   ```javascript
   Ember.String.htmlSafe('<div>someString</div>')
@@ -35,20 +35,6 @@ function htmlSafe(str) {
 
 EmberStringUtils.htmlSafe = htmlSafe;
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
-  /**
-    Mark a string as being safe for unescaped output with Handlebars.
-
-    ```javascript
-    '<div>someString</div>'.htmlSafe()
-    ```
-
-    See [Ember.String.htmlSafe](/api/classes/Ember.String.html#method_htmlSafe).
-
-    @method htmlSafe
-    @for String
-    @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
-    @public
-  */
   String.prototype.htmlSafe = function() {
     return htmlSafe(this);
   };

--- a/packages/ember-routing-htmlbars/lib/helpers/query-params.js
+++ b/packages/ember-routing-htmlbars/lib/helpers/query-params.js
@@ -7,17 +7,19 @@ import Ember from 'ember-metal/core'; // assert
 import QueryParams from 'ember-routing/system/query_params';
 
 /**
-  This is a sub-expression to be used in conjunction with the link-to helper.
+  This is a helper to be used in conjunction with the link-to helper.
   It will supply url query parameters to the target route.
 
   Example
 
+  ```handlebars
   {{#link-to 'posts' (query-params direction="asc")}}Sort{{/link-to}}
+  ```
 
   @method query-params
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @param {Object} hash takes a hash of query parameters
-  @return {String} HTML string
+  @return {Object} A `QueryParams` object for `{{link-to}}`
   @public
 */
 export function queryParamsHelper(params, hash) {

--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -1,6 +1,6 @@
 /**
 @module ember
-@submodule ember-htmlbars
+@submodule ember-templates
 */
 
 import isEnabled from 'ember-metal/features';
@@ -165,7 +165,7 @@ import closureAction from 'ember-routing-htmlbars/keywords/closure-action';
   with the value of `person` as a parameter.
 
   @method action
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @public
 */
 export default function(morph, env, scope, params, hash, template, inverse, visitor) {

--- a/packages/ember-routing-htmlbars/lib/keywords/link-to.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/link-to.js
@@ -272,7 +272,7 @@ import merge from 'ember-metal/merge';
   ```
 
   @method link-to
-  @for Ember.Handlebars.helpers
+  @for Ember.Templates.helpers
   @param {String} routeName
   @param {Object} [context]*
   @param [options] {Object} Handlebars key/value pairs of options, you can override any property of Ember.LinkComponent

--- a/packages/ember-runtime/lib/system/lazy_load.js
+++ b/packages/ember-runtime/lib/system/lazy_load.js
@@ -12,14 +12,14 @@ var loadHooks = Ember.ENV.EMBER_LOAD_HOOKS || {};
 var loaded = {};
 
 /**
-  Detects when a specific package of Ember (e.g. 'Ember.Handlebars')
+  Detects when a specific package of Ember (e.g. 'Ember.Application')
   has fully loaded and is available for extension.
 
   The provided `callback` will be called with the `name` passed
   resolved from a string into the object:
 
   ``` javascript
-  Ember.onLoad('Ember.Handlebars' function(hbars) {
+  Ember.onLoad('Ember.Application' function(hbars) {
     hbars.registerHelper(...);
   });
   ```
@@ -42,7 +42,7 @@ export function onLoad(name, callback) {
 }
 
 /**
-  Called when an Ember.js package (e.g Ember.Handlebars) has finished
+  Called when an Ember.js package (e.g Ember.Application) has finished
   loading. Triggers any callbacks registered for this event.
 
   @method runLoadHooks

--- a/packages/ember-views/lib/views/checkbox.js
+++ b/packages/ember-views/lib/views/checkbox.js
@@ -11,7 +11,7 @@ import EmberComponent from 'ember-views/views/component';
   The internal class used to create text inputs when the `{{input}}`
   helper is used with `type` of `checkbox`.
 
-  See [handlebars.helpers.input](/api/classes/Ember.Handlebars.helpers.html#method_input)  for usage details.
+  See [Ember.Templates.helpers.input](/api/classes/Ember.Templates.helpers.html#method_input)  for usage details.
 
   ## Direct manipulation of `checked`
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -53,7 +53,7 @@ import EmptyViewSupport from 'ember-views/mixins/empty_view_support';
     classNames: ['a-collection'],
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
-      template: Ember.Handlebars.compile("the letter: {{view.content}}")
+      template: Ember.HTMLBars.compile("the letter: {{view.content}}")
     })
   });
   ```
@@ -88,7 +88,7 @@ import EmptyViewSupport from 'ember-views/mixins/empty_view_support';
     tagName: 'ul',
     content: ['A','B','C'],
     itemViewClass: Ember.View.extend({
-      template: Ember.Handlebars.compile("the letter: {{view.content}}")
+      template: Ember.HTMLBars.compile("the letter: {{view.content}}")
     })
   });
   ```
@@ -148,7 +148,7 @@ import EmptyViewSupport from 'ember-views/mixins/empty_view_support';
     classNames: ['nothing'],
     content: null,
     emptyView: Ember.View.extend({
-      template: Ember.Handlebars.compile("The collection is empty")
+      template: Ember.HTMLBars.compile("The collection is empty")
     })
   });
   ```

--- a/packages/ember-views/lib/views/container_view.js
+++ b/packages/ember-views/lib/views/container_view.js
@@ -71,10 +71,10 @@ containerViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
     aView: Ember.View.create({
-      template: Ember.Handlebars.compile("A")
+      template: Ember.HTMLBars.compile("A")
     }),
     bView: Ember.View.create({
-      template: Ember.Handlebars.compile("B")
+      template: Ember.HTMLBars.compile("B")
     })
   });
 
@@ -116,10 +116,10 @@ containerViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
     classNames: ['the-container'],
     childViews: ['aView', 'bView'],
     aView: Ember.View.create({
-      template: Ember.Handlebars.compile("A")
+      template: Ember.HTMLBars.compile("A")
     }),
     bView: Ember.View.create({
-      template: Ember.Handlebars.compile("B")
+      template: Ember.HTMLBars.compile("B")
     })
   });
 
@@ -139,7 +139,7 @@ containerViewTemplate.meta.revision = 'Ember@VERSION_STRING_PLACEHOLDER';
 
   ```javascript
   AnotherViewClass = Ember.View.extend({
-    template: Ember.Handlebars.compile("Another view")
+    template: Ember.HTMLBars.compile("Another view")
   });
 
   aContainer.toArray();  // [aContainer.aView, aContainer.bView]

--- a/packages/ember-views/lib/views/text_area.js
+++ b/packages/ember-views/lib/views/text_area.js
@@ -9,7 +9,7 @@ import TextSupport from 'ember-views/mixins/text_support';
   The internal class used to create textarea element when the `{{textarea}}`
   helper is used.
 
-  See [handlebars.helpers.textarea](/api/classes/Ember.Handlebars.helpers.html#method_textarea)  for usage details.
+  See [Ember.Templates.helpers.textarea](/api/classes/Ember.Templates.helpers.html#method_textarea)  for usage details.
 
   ## Layout and LayoutName properties
 

--- a/packages/ember-views/lib/views/text_field.js
+++ b/packages/ember-views/lib/views/text_field.js
@@ -38,7 +38,7 @@ function canSetTypeOfInput(type) {
   The internal class used to create text inputs when the `{{input}}`
   helper is used with `type` of `text`.
 
-  See [Handlebars.helpers.input](/api/classes/Ember.Handlebars.helpers.html#method_input)  for usage details.
+  See [Ember.Templates.helpers.input](/api/classes/Ember.Templates.helpers.html#method_input)  for usage details.
 
   ## Layout and LayoutName properties
 

--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -340,11 +340,11 @@ Ember.TEMPLATES = {};
   template. Templates can be any function that accepts an optional context
   parameter and returns a string of HTML that will be inserted within the
   view's tag. Most typically in Ember this function will be a compiled
-  `Ember.Handlebars` template.
+  template.
 
   ```javascript
   AView = Ember.View.extend({
-    template: Ember.Handlebars.compile('I am the template')
+    template: Ember.HTMLBars.compile('I am the template')
   });
   ```
 
@@ -387,18 +387,18 @@ Ember.TEMPLATES = {};
   });
   ```
 
-  Using a value for `templateName` that does not have a Handlebars template
+  Using a value for `templateName` that does not have a template
   with a matching `data-template-name` attribute will throw an error.
 
   For views classes that may have a template later defined (e.g. as the block
-  portion of a `{{view}}` Handlebars helper call in another template or in
+  portion of a `{{view}}` helper call in another template or in
   a subclass), you can provide a `defaultTemplate` property set to compiled
   template function. If a template is not later provided for the view instance
   the `defaultTemplate` value will be used:
 
   ```javascript
   AView = Ember.View.extend({
-    defaultTemplate: Ember.Handlebars.compile('I was the default'),
+    defaultTemplate: Ember.HTMLBars.compile('I was the default'),
     template: null,
     templateName: null
   });
@@ -415,11 +415,11 @@ Ember.TEMPLATES = {};
 
   ```javascript
   AView = Ember.View.extend({
-    defaultTemplate: Ember.Handlebars.compile('I was the default')
+    defaultTemplate: Ember.HTMLBars.compile('I was the default')
   });
 
   aView = AView.create({
-    template: Ember.Handlebars.compile('I was the template, not default')
+    template: Ember.HTMLBars.compile('I was the template, not default')
   });
   ```
 
@@ -435,7 +435,7 @@ Ember.TEMPLATES = {};
 
   ```javascript
   AView = Ember.View.extend({
-    template: Ember.Handlebars.compile('Hello {{excitedGreeting}}')
+    template: Ember.HTMLBars.compile('Hello {{excitedGreeting}}')
   });
 
   aController = Ember.Object.create({
@@ -468,20 +468,19 @@ Ember.TEMPLATES = {};
   view's tag. Views whose HTML element is self closing (e.g. `<input />`)
   cannot have a layout and this property will be ignored.
 
-  Most typically in Ember a layout will be a compiled `Ember.Handlebars`
-  template.
+  Most typically in Ember a layout will be a compiled template.
 
   A view's layout can be set directly with the `layout` property or reference
-  an existing Handlebars template by name with the `layoutName` property.
+  an existing template by name with the `layoutName` property.
 
-  A template used as a layout must contain a single use of the Handlebars
+  A template used as a layout must contain a single use of the
   `{{yield}}` helper. The HTML contents of a view's rendered `template` will be
   inserted at this location:
 
   ```javascript
   AViewWithLayout = Ember.View.extend({
-    layout: Ember.Handlebars.compile("<div class='my-decorative-class'>{{yield}}</div>"),
-    template: Ember.Handlebars.compile("I got wrapped")
+    layout: Ember.HTMLBars.compile("<div class='my-decorative-class'>{{yield}}</div>"),
+    template: Ember.HTMLBars.compile("I got wrapped")
   });
   ```
 
@@ -495,7 +494,7 @@ Ember.TEMPLATES = {};
   </div>
   ```
 
-  See [Ember.Handlebars.helpers.yield](/api/classes/Ember.Handlebars.helpers.html#method_yield)
+  See [Ember.Templates.helpers.yield](/api/classes/Ember.Templates.helpers.html#method_yield)
   for more information.
 
   ## Responding to Browser Events
@@ -569,7 +568,7 @@ Ember.TEMPLATES = {};
   ```javascript
   var App = Ember.Application.create();
   App.OuterView = Ember.View.extend({
-    template: Ember.Handlebars.compile("outer {{#view 'inner'}}inner{{/view}} outer"),
+    template: Ember.HTMLBars.compile("outer {{#view 'inner'}}inner{{/view}} outer"),
     eventManager: Ember.Object.create({
       mouseEnter: function(event, view) {
         // view might be instance of either
@@ -592,9 +591,9 @@ Ember.TEMPLATES = {};
   });
   ```
 
-  ### Handlebars `{{action}}` Helper
+  ### `{{action}}` Helper
 
-  See [Handlebars.helpers.action](/api/classes/Ember.Handlebars.helpers.html#method_action).
+  See [Ember.Templates.helpers.action](/api/classes/Ember.Templates.helpers.html#method_action).
 
   ### Event Names
 
@@ -647,10 +646,10 @@ Ember.TEMPLATES = {};
   * `dragEnd`
   * `drop`
 
-  ## Handlebars `{{view}}` Helper
+  ## `{{view}}` Helper
 
   Other `Ember.View` instances can be included as part of a view's template by
-  using the `{{view}}` Handlebars helper. See [Ember.Handlebars.helpers.view](/api/classes/Ember.Handlebars.helpers.html#method_view)
+  using the `{{view}}` helper. See [Ember.Templates.helpers.view](/api/classes/Ember.Templates.helpers.html#method_view)
   for additional information.
 
   @class View


### PR DESCRIPTION
"Write some docs" they said. "It will be easy" :grin: 
- Add Ember.Helper and Ember.Helper.helper docs
- Add stub package docs for ember-templates. Should later become basic
  template usage docs.
- Move all helper docs to ember-templates
- Drop references to Ember.Handlebars from doc examples
- Add a simple package docs for ember-htmlbars
