### PR TITLE
[BUGFIX beta] improve errors when InjectedProperty is misused

### DIFF
--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -23,9 +23,9 @@ function InjectedProperty(type, name) {
 }
 
 function injectedPropertyGet(keyName) {
-  var possibleDesc = this[keyName];
-  var desc = (possibleDesc !== null && typeof possibleDesc === 'object' && possibleDesc.isDescriptor) ? possibleDesc : undefined;
+  var desc = this[keyName];
 
+  Ember.assert(`InjectedProperties should be defined with the Ember.inject computed property macros.`, desc && desc.isDescriptor && desc.type);
   Ember.assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, this.container);
 
   return this.container.lookup(desc.type + ':' + (desc.name || keyName));


### PR DESCRIPTION
Previously, if InjectedProperty was created improperly, it would fail with an obtuse "undefined has no property type" error. This introduces an assertion to improve the readability of that error case.

/cc @rwjblue 
