### PR TITLE
Lock ember-cli-yuidoc to 0.7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli": "^0.2.7",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-sauce": "^1.3.0",
-    "ember-cli-yuidoc": "^0.7.0",
+    "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
     "emberjs-build": "0.2.1",
     "express": "^4.5.0",


### PR DESCRIPTION
A bug was introduced upstream preventing S3 uploads from working. Should
be fixed upstream shortly with https://github.com/cibernox/ember-cli-yuidoc/pull/23.
