### PR TITLE
Update bin/changelog to deal with cherry-picked commits.

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -15,16 +15,18 @@ var EOL       = require('os').EOL;
 var RSVP      = require('rsvp');
 var Promise   = RSVP.Promise;
 var GitHubApi = require('github');
+var execSync  = require('child_process').execSync;
 
 var github         = new GitHubApi({version: '3.0.0'});
 var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 var currentVersion = process.env.PRIOR_VERSION;
+var head = process.env.HEAD || 'master';
 
 compareCommits({
   user: 'emberjs',
   repo: 'ember.js',
   base: currentVersion,
-  head: 'master'
+  head: head
 })
 .then(processPages)
 .then(console.log)
@@ -32,37 +34,61 @@ compareCommits({
   console.error(err);
 })
 
+function getCommitMessage(commitInfo) {
+  var message = commitInfo.commit.message;
+
+  if (message.indexOf('cherry picked from commit') > -1) {
+    var originalCommit = message.split('cherry picked from commit ').slice(-1); // find the last instance of `cherry picked from`
+    originalCommit = originalCommit[0].slice(0, -1); // remove the trailing `)`
+
+    try {
+      // command from http://stackoverflow.com/questions/8475448/find-merge-commit-which-include-a-specific-commit
+      message = execSync('commit=$((git rev-list ' + originalCommit + '..origin/master --ancestry-path | cat -n; git rev-list ' + originalCommit + '..origin/master --first-parent | cat -n) | sort -k2 | uniq -f1 -d | sort -n | tail -1 | cut -f2) && git show --format="%s\n\n%b" $commit', { encoding: 'utf8' });
+    } catch(e) { }
+  }
+
+  return message;
+}
+
 function processPages(res) {
-  var contributions = res.commits.map(function(commitInfo) {
-    return commitInfo.commit.message
+  var contributions = res.commits.filter(function(commitInfo) {
+    var message = commitInfo.commit.message;
 
-  }).filter(function(message) {
-    return message.indexOf('Merge pull request #') > -1;
-  }).map(function(message) {
-    var numAndAuthor = message.match(/#(\d+) from (.*)\//).slice(1,3);
-    var title        = message.split('\n\n')[1];
-
-    return {
-      number:  +numAndAuthor[0],
-      author:  numAndAuthor[1],
-      title:   title
+    return message.indexOf('Merge pull request #') > -1 || message.indexOf('cherry picked from') > -1;
+  }).map(function(commitInfo) {
+    var message = getCommitMessage(commitInfo);
+    var match = message.match(/#(\d+) from (.*)\//);
+    var result = {
+      sha: commitInfo.sha
     };
+
+    if (match) {
+      var numAndAuthor = match.slice(1, 3);
+
+      result.number =numAndAuthor[0];
+      result.title = message.split('\n\n')[1];
+    } else {
+      result.title = message.split('\n\n')[0];
+    }
+
+    return result;
   }).sort(function(a, b) {
     return a.number > b.number;
   }).map(function(pr) {
-    var link   = '[#' + pr.number + ']' +
-                 '(https://github.com/emberjs/ember.js/pull/' + pr.number + ')';
     var title  = pr.title;
-    var author = '[@' + pr.author + ']' +
-                 '(https://github.com/' + pr.author +')';
+    var link;
+    if (pr.number) {
+      link = '[#' + pr.number + ']' + '(https://github.com/emberjs/ember.js/pull/' + pr.number + ')';
+    } else {
+      link = '[' + pr.sha.slice(0, 8) + '](https://github.com/emberjs/ember.js/commit/' + pr.sha + ')';
+    }
 
-    return '- ' + link + ' ' + title + ' ' + author;
+    return '- ' + link + ' ' + title;
   }).join('\n');
 
   if (github.hasNextPage(res)) {
     return github.getNextPage(res)
       .then(function(nextPage) {
-        console.log('getting next page!');
         contributions += processPages(nextPage);
       });
   } else {


### PR DESCRIPTION
This allows the `bin/changelog` script to be useful in my normal beta/stable workflow (of using `git cherry-pick -x <sha>`).
- Made script aware of `git cherry-pick -x <sha>`'s addition of `(cherry picked from commit <sha>)` to track down the upstream PR.
- Remove author from output.

---

Might be ugly, but has "Works for Me" status and saves me an hour or more per beta release....
