### PR TITLE
Unlists action as a public helper at Ember.Templates.helpers

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/action.js
@@ -233,10 +233,6 @@ import closureAction from 'ember-routing-htmlbars/keywords/closure-action';
     someService: Ember.inject.service()
   });
   ```
-
-  @method action
-  @for Ember.Templates.helpers
-  @public
 */
 export default function(morph, env, scope, params, hash, template, inverse, visitor) {
   if (isEnabled('ember-routing-htmlbars-improved-actions')) {


### PR DESCRIPTION
It came up today that Ember.Handlebars.helpers no longer exposes the action helper. Likewise, in 2.0, Ember.Templates.helpers no longer exposes the action helper.

This updates the docs. Well I think it updates the docs, this is my first ember PR, so it's likely I messed something up.
