### PR TITLE
[FEATURE ember-metal-computed-macros-blank] Add `blank` and `present` computed macros

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -267,7 +267,7 @@ for a detailed explanation.
   {{/if}}
   ```
 
-  Addd in [#10461](https://github.com/emberjs/ember.js/pull/10461)
+  Added in [#10461](https://github.com/emberjs/ember.js/pull/10461)
 
 * `ember-routing-htmlbars-improved-actions`
 
@@ -309,7 +309,7 @@ for a detailed explanation.
   and `displayedPropertyKey` to render a list for a single property
   for each person.. E.g. a list of all `firstNames`, or `lastNames`, or `ages`.
 
-  Addd in [#11196](https://github.com/emberjs/ember.js/pull/11196)
+  Added in [#11196](https://github.com/emberjs/ember.js/pull/11196)
 
 * `ember-htmlbars-helper`
 
@@ -320,3 +320,9 @@ for a detailed explanation.
 
   Implements RFC https://github.com/emberjs/rfcs/pull/58, adding support for
   dashless helpers.
+
+* `ember-metal-computed-macros-blank`
+
+  Adds `Ember.computed.blank` and `Ember.computed.present` as computed property macros.
+
+  Added in [#11745](https://github.com/emberjs/ember.js/pull/11745)

--- a/features.json
+++ b/features.json
@@ -21,7 +21,8 @@
     "ember-routing-htmlbars-improved-actions": true,
     "ember-htmlbars-get-helper": true,
     "ember-htmlbars-helper": true,
-    "ember-htmlbars-dashless-helpers": true
+    "ember-htmlbars-dashless-helpers": true,
+    "ember-metal-computed-macros-blank": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -2,9 +2,12 @@ import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { computed } from 'ember-metal/computed';
+import isBlank from 'ember-metal/is_blank';
 import isEmpty from 'ember-metal/is_empty';
 import isNone from 'ember-metal/is_none';
+import isPresent from 'ember-metal/is_present';
 import alias from 'ember-metal/alias';
+import isEnabled from 'ember-metal/features';
 
 /**
 @module ember
@@ -93,6 +96,77 @@ export function notEmpty(dependentKey) {
     return !isEmpty(get(this, dependentKey));
   });
 }
+
+let blank, present;
+if (isEnabled('ember-metal-computed-macros-blank')) {
+  /**
+   A computed property that returns true if the value of the dependent
+   property is empty or a whitespace string
+
+   Example
+
+   ```javascript
+   var Hamster = Ember.Object.extend({
+    isNameless: Ember.computed.blank('name')
+  });
+
+   var hamster = Hamster.create({
+    name: 'Tomster'
+ });
+
+   todoList.get('isNameless'); // false
+   todoList.set('name', '   ');
+   todoList.get('isNameless'); // true
+   ```
+
+   @method blank
+   @for Ember.computed
+   @param {String} dependentKey
+   @return {Ember.ComputedProperty} computed property which returns true if
+   the original value for property is blank
+   @public
+   */
+  blank = function blank(dependentKey) {
+    return computed(dependentKey + '.length', function () {
+      return isBlank(get(this, dependentKey));
+    });
+  };
+
+  /**
+   A computed property that returns true if the value of the dependent
+   property is NOT empty or a whitespace string.
+
+   Example
+
+   ```javascript
+   var Hamster = Ember.Object.extend({
+    hasName: Ember.computed.present('name')
+  });
+
+   var hamster = Hamster.create({
+    name: 'Tomster'
+ });
+
+   todoList.get('isNameless'); // true
+   todoList.set('name', '   ');
+   todoList.get('isNameless'); // false
+   ```
+
+   @method present
+   @for Ember.computed
+   @param {String} dependentKey
+   @return {Ember.ComputedProperty} computed property which returns true if
+   original value for property is not blank.
+   @public
+   */
+  present = function present(dependentKey) {
+    return computed(dependentKey + '.length', function () {
+      return isPresent(get(this, dependentKey));
+    });
+  };
+}
+export default blank;
+export default present;
 
 /**
   A computed property that returns true if the value of the dependent

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -115,6 +115,8 @@ import alias from 'ember-metal/alias';
 import {
   empty,
   notEmpty,
+  blank,
+  present,
   none,
   not,
   bool,
@@ -136,6 +138,10 @@ import {
 
 computed.empty = empty;
 computed.notEmpty = notEmpty;
+if (isEnabled('ember-metal-computed-macros-blank')) {
+  computed.blank = blank;
+  computed.present = present;
+}
 computed.none = none;
 computed.not = not;
 computed.bool = bool;


### PR DESCRIPTION
We already have computed macros for `isEmpty`, 'isNone', and `notEmpty`, but no equivalent macros for `isBlank` and `isPresent`.
