### PR TITLE
[CLEANUP beta] Remove `metaPath`, `getMeta` and `setMeta`

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -21,13 +21,10 @@ import {
   applyStr,
   canInvoke,
   generateGuid,
-  getMeta,
   guidFor,
   inspect,
   makeArray,
   meta,
-  metaPath,
-  setMeta,
   deprecatedTryCatchFinally,
   tryInvoke,
   uuid,
@@ -232,9 +229,6 @@ Ember.guidFor         = guidFor;
 Ember.META_DESC       = META_DESC;
 Ember.EMPTY_META      = EMPTY_META;
 Ember.meta            = meta;
-Ember.getMeta         = getMeta;
-Ember.setMeta         = setMeta;
-Ember.metaPath        = metaPath;
 Ember.inspect         = inspect;
 Ember.tryCatchFinally = deprecatedTryCatchFinally;
 Ember.makeArray       = makeArray;

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -3,7 +3,6 @@
 //
 'REMOVE_USE_STRICT: true';
 
-import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 
 /**
@@ -369,73 +368,6 @@ function meta(obj, writable) {
   return ret;
 }
 
-export function getMeta(obj, property) {
-  var _meta = meta(obj, false);
-  return _meta[property];
-}
-
-export function setMeta(obj, property, value) {
-  var _meta = meta(obj, true);
-  _meta[property] = value;
-  return value;
-}
-
-/**
-  @deprecated
-  @private
-
-  In order to store defaults for a class, a prototype may need to create
-  a default meta object, which will be inherited by any objects instantiated
-  from the class's constructor.
-
-  However, the properties of that meta object are only shallow-cloned,
-  so if a property is a hash (like the event system's `listeners` hash),
-  it will by default be shared across all instances of that class.
-
-  This method allows extensions to deeply clone a series of nested hashes or
-  other complex objects. For instance, the event system might pass
-  `['listeners', 'foo:change', 'ember157']` to `prepareMetaPath`, which will
-  walk down the keys provided.
-
-  For each key, if the key does not exist, it is created. If it already
-  exists and it was inherited from its constructor, the constructor's
-  key is cloned.
-
-  You can also pass false for `writable`, which will simply return
-  undefined if `prepareMetaPath` discovers any part of the path that
-  shared or undefined.
-
-  @method metaPath
-  @for Ember
-  @param {Object} obj The object whose meta we are examining
-  @param {Array} path An array of keys to walk down
-  @param {Boolean} writable whether or not to create a new meta
-    (or meta property) if one does not already exist or if it's
-    shared with its constructor
-*/
-export function metaPath(obj, path, writable) {
-  Ember.deprecate('Ember.metaPath is deprecated and will be removed from future releases.');
-  var _meta = meta(obj, writable);
-  var keyName, value;
-
-  for (var i = 0, l = path.length; i < l; i++) {
-    keyName = path[i];
-    value = _meta[keyName];
-
-    if (!value) {
-      if (!writable) { return undefined; }
-      value = _meta[keyName] = { __ember_source__: obj };
-    } else if (value.__ember_source__ !== obj) {
-      if (!writable) { return undefined; }
-      value = _meta[keyName] = Object.create(value);
-      value.__ember_source__ = obj;
-    }
-
-    _meta = value;
-  }
-
-  return value;
-}
 
 /**
   Wraps the passed function so that `this._super` will point to the superFunc

--- a/packages/ember-metal/tests/utils/meta_test.js
+++ b/packages/ember-metal/tests/utils/meta_test.js
@@ -1,8 +1,5 @@
 import {
-  getMeta,
-  setMeta,
-  meta,
-  metaPath
+  meta
 } from 'ember-metal/utils';
 
 QUnit.module('Ember.meta');
@@ -13,37 +10,6 @@ QUnit.test('should return the same hash for an object', function() {
   meta(obj).foo = 'bar';
 
   equal(meta(obj).foo, 'bar', 'returns same hash with multiple calls to Ember.meta()');
-});
-
-QUnit.module('Ember.metaPath');
-
-QUnit.test('should not create nested objects if writable is false', function() {
-  var obj = {};
-
-  ok(!meta(obj).foo, 'precond - foo property on meta does not yet exist');
-  expectDeprecation(function() {
-    equal(metaPath(obj, ['foo', 'bar', 'baz'], false), undefined, 'should return undefined when writable is false and doesn\'t already exist');
-  });
-  equal(meta(obj).foo, undefined, 'foo property is not created');
-});
-
-QUnit.test('should create nested objects if writable is true', function() {
-  var obj = {};
-
-  ok(!meta(obj).foo, 'precond - foo property on meta does not yet exist');
-
-  expectDeprecation(function() {
-    equal(typeof metaPath(obj, ['foo', 'bar', 'baz'], true), 'object', 'should return hash when writable is true and doesn\'t already exist');
-  });
-  ok(meta(obj).foo.bar.baz['bat'] = true, 'can set a property on the newly created hash');
-});
-
-QUnit.test('getMeta and setMeta', function() {
-  var obj = {};
-
-  ok(!getMeta(obj, 'foo'), 'precond - foo property on meta does not yet exist');
-  setMeta(obj, 'foo', 'bar');
-  equal(getMeta(obj, 'foo'), 'bar', 'foo property on meta now exists');
 });
 
 QUnit.module('Ember.meta enumerable');


### PR DESCRIPTION
`metaPath` had been deprecated. `setMeta` and `getMeta` were not
being used at all... must of been leftover cruft.
