### PR TITLE
[CLEANUP beta] Remove deprecated registry behaviour

### DIFF
--- a/packages/container/lib/registry.js
+++ b/packages/container/lib/registry.js
@@ -1,15 +1,9 @@
 import Ember from 'ember-metal/core'; // Ember.assert
-import isEnabled from 'ember-metal/features';
 import dictionary from 'ember-metal/dictionary';
 import { assign } from 'ember-metal/merge';
 import Container from './container';
 
 var VALID_FULL_NAME_REGEXP = /^[^:]+.+:[^:]+$/;
-
-var instanceInitializersFeatureEnabled;
-if (isEnabled('ember-application-instance-initializers')) {
-  instanceInitializersFeatureEnabled = true;
-}
 
 /**
  A registry used to store factory and option information keyed
@@ -134,18 +128,6 @@ Registry.prototype = {
   _typeOptions: null,
 
   /**
-   The first container created for this registry.
-
-   This allows deprecated access to `lookup` and `lookupFactory` to avoid
-   breaking compatibility for Ember 1.x initializers.
-
-   @private
-   @property _defaultContainer
-   @type Container
-   */
-  _defaultContainer: null,
-
-  /**
    Creates a container based on this registry.
 
    @private
@@ -154,52 +136,7 @@ Registry.prototype = {
    @return {Container} created container
    */
   container(options) {
-    var container = new Container(this, options);
-
-    // 2.0TODO - remove `registerContainer`
-    this.registerContainer(container);
-
-    return container;
-  },
-
-  /**
-   Register the first container created for a registery to allow deprecated
-   access to its `lookup` and `lookupFactory` methods to avoid breaking
-   compatibility for Ember 1.x initializers.
-
-   2.0TODO: Remove this method. The bookkeeping is only needed to support
-            deprecated behavior.
-
-   @private
-   @param {Container} newly created container
-   */
-  registerContainer(container) {
-    if (!this._defaultContainer) {
-      this._defaultContainer = container;
-    }
-    if (this.fallback) {
-      this.fallback.registerContainer(container);
-    }
-  },
-
-  lookup(fullName, options) {
-    Ember.assert('Create a container on the registry (with `registry.container()`) before calling `lookup`.', this._defaultContainer);
-
-    if (instanceInitializersFeatureEnabled) {
-      Ember.deprecate('`lookup` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', false, { url: 'http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers' });
-    }
-
-    return this._defaultContainer.lookup(fullName, options);
-  },
-
-  lookupFactory(fullName) {
-    Ember.assert('Create a container on the registry (with `registry.container()`) before calling `lookupFactory`.', this._defaultContainer);
-
-    if (instanceInitializersFeatureEnabled) {
-      Ember.deprecate('`lookupFactory` was called on a Registry. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container.', false, { url: 'http://emberjs.com/guides/deprecations#toc_deprecate-access-to-instances-in-initializers' });
-    }
-
-    return this._defaultContainer.lookupFactory(fullName);
+    return new Container(this, options);
   },
 
   /**
@@ -455,11 +392,6 @@ Registry.prototype = {
     } else if (this.fallback) {
       return this.fallback.getOption(fullName, optionName);
     }
-  },
-
-  option(fullName, optionName) {
-    Ember.deprecate('`Registry.option()` has been deprecated. Call `Registry.getOption()` instead.');
-    return this.getOption(fullName, optionName);
   },
 
   /**

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -260,7 +260,7 @@ QUnit.test('factory for non extendables resolves are cached', function() {
   deepEqual(resolveWasCalled, ['foo:post']);
 });
 
-QUnit.test('registry.container creates an associated container', function() {
+QUnit.test('registry.container creates a container', function() {
   var registry = new Registry();
   var PostController = factory();
   registry.register('controller:post', PostController);
@@ -269,7 +269,6 @@ QUnit.test('registry.container creates an associated container', function() {
   var postController = container.lookup('controller:post');
 
   ok(postController instanceof PostController, 'The lookup is an instance of the registered factory');
-  strictEqual(registry._defaultContainer, container, '_defaultContainer is set to the first created container and used for Ember 1.x Container compatibility');
 });
 
 QUnit.test('`resolve` can be handled by a fallback registry', function() {

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -673,6 +673,15 @@ var Application = Namespace.extend({
     run.join(this, handleReset);
   },
 
+
+  /**
+    @private
+    @method instanceInitializer
+  */
+  instanceInitializer(options) {
+    this.constructor.instanceInitializer(options);
+  },
+
   /**
     @private
     @method runInitializers
@@ -681,13 +690,7 @@ var Application = Namespace.extend({
     var App = this;
     this._runInitializer('initializers', function(name, initializer) {
       Ember.assert('No application initializer named \'' + name + '\'', !!initializer);
-
-      if (isEnabled('ember-application-initializer-context')) {
-        initializer.initialize(registry, App);
-      } else {
-        var ref = initializer.initialize;
-        ref(registry, App);
-      }
+      initializer.initialize(registry, App);
     });
   },
 
@@ -793,17 +796,9 @@ var Application = Namespace.extend({
   }
 });
 
-if (isEnabled('ember-application-instance-initializers')) {
-  Application.reopen({
-    instanceInitializer(options) {
-      this.constructor.instanceInitializer(options);
-    }
-  });
-
-  Application.reopenClass({
-    instanceInitializer: buildInitializerMethod('instanceInitializers', 'instance initializer')
-  });
-}
+Application.reopenClass({
+  instanceInitializer: buildInitializerMethod('instanceInitializers', 'instance initializer')
+});
 
 if (isEnabled('ember-application-visit')) {
   Application.reopen({

--- a/packages/ember-application/tests/system/initializers_test.js
+++ b/packages/ember-application/tests/system/initializers_test.js
@@ -1,5 +1,4 @@
 import Ember from 'ember-metal/core';
-import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import Application from 'ember-application/system/application';
 import jQuery from 'ember-views/system/jquery';
@@ -333,70 +332,22 @@ QUnit.test('initializers are per-app', function() {
   });
 });
 
-if (isEnabled('ember-application-initializer-context')) {
-  QUnit.test('initializers should be executed in their own context', function() {
-    expect(1);
-    var MyApplication = Application.extend();
+QUnit.test('initializers should be executed in their own context', function() {
+  expect(1);
+  var MyApplication = Application.extend();
 
-    MyApplication.initializer({
-      name: 'coolBabeInitializer',
-      myProperty: 'coolBabe',
-      initialize(registry, application) {
-        equal(this.myProperty, 'coolBabe', 'should have access to its own context');
-      }
-    });
-
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
-    });
-  });
-}
-
-if (isEnabled('ember-application-instance-initializers')) {
-  QUnit.test('initializers should throw a deprecation warning when performing a lookup on the registry', function() {
-    expect(1);
-
-    var MyApplication = Application.extend();
-
-    MyApplication.initializer({
-      name: 'initializer',
-      initialize(registry, application) {
-        registry.lookup('router:main');
-      }
-    });
-
-    expectDeprecation(function() {
-      run(function() {
-        app = MyApplication.create({
-          router: false,
-          rootElement: '#qunit-fixture'
-        });
-      });
-    }, /`lookup` was called on a Registry\. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container\./);
+  MyApplication.initializer({
+    name: 'coolBabeInitializer',
+    myProperty: 'coolBabe',
+    initialize(registry, application) {
+      equal(this.myProperty, 'coolBabe', 'should have access to its own context');
+    }
   });
 
-  QUnit.test('initializers should throw a deprecation warning when performing a factory lookup on the registry', function() {
-    expect(1);
-
-    var MyApplication = Application.extend();
-
-    MyApplication.initializer({
-      name: 'initializer',
-      initialize(registry, application) {
-        registry.lookupFactory('application:controller');
-      }
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
-
-    expectDeprecation(function() {
-      run(function() {
-        app = MyApplication.create({
-          router: false,
-          rootElement: '#qunit-fixture'
-        });
-      });
-    }, /`lookupFactory` was called on a Registry\. The `initializer` API no longer receives a container, and you should use an `instanceInitializer` to look up objects from the container\./);
   });
-}
+});

--- a/packages/ember-application/tests/system/instance_initializers_test.js
+++ b/packages/ember-application/tests/system/instance_initializers_test.js
@@ -1,413 +1,404 @@
 import Ember from 'ember-metal/core';
-import isEnabled from 'ember-metal/features';
 import run from 'ember-metal/run_loop';
 import Application from 'ember-application/system/application';
 import ApplicationInstance from 'ember-application/system/application-instance';
 import jQuery from 'ember-views/system/jquery';
 
-var app, initializeContextFeatureEnabled;
+var app;
 
-if (isEnabled('ember-application-initializer-context')) {
-  initializeContextFeatureEnabled = true;
-}
+QUnit.module('Ember.Application instance initializers', {
+  setup() {
+  },
 
-if (isEnabled('ember-application-instance-initializers')) {
-  QUnit.module('Ember.Application instance initializers', {
-    setup() {
-    },
+  teardown() {
+    if (app) {
+      run(function() { app.destroy(); });
+    }
+  }
+});
 
-    teardown() {
-      if (app) {
-        run(function() { app.destroy(); });
-      }
+QUnit.test('initializers require proper \'name\' and \'initialize\' properties', function() {
+  var MyApplication = Application.extend();
+
+  expectAssertion(function() {
+    run(function() {
+      MyApplication.instanceInitializer({ name: 'initializer' });
+    });
+  });
+
+  expectAssertion(function() {
+    run(function() {
+      MyApplication.instanceInitializer({ initialize: Ember.K });
+    });
+  });
+});
+
+QUnit.test('initializers are passed an app instance', function() {
+  var MyApplication = Application.extend();
+
+  MyApplication.instanceInitializer({
+    name: 'initializer',
+    initialize(instance) {
+      ok(instance instanceof ApplicationInstance, 'initialize is passed an application instance');
     }
   });
 
-  QUnit.test('initializers require proper \'name\' and \'initialize\' properties', function() {
-    var MyApplication = Application.extend();
-
-    expectAssertion(function() {
-      run(function() {
-        MyApplication.instanceInitializer({ name: 'initializer' });
-      });
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
+  });
+});
 
-    expectAssertion(function() {
-      run(function() {
-        MyApplication.instanceInitializer({ initialize: Ember.K });
-      });
+QUnit.test('initializers can be registered in a specified order', function() {
+  var order = [];
+  var MyApplication = Application.extend();
+  MyApplication.instanceInitializer({
+    name: 'fourth',
+    after: 'third',
+    initialize(registry) {
+      order.push('fourth');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'second',
+    after: 'first',
+    before: 'third',
+    initialize(registry) {
+      order.push('second');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize(registry) {
+      order.push('fifth');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'first',
+    before: 'second',
+    initialize(registry) {
+      order.push('first');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'third',
+    initialize(registry) {
+      order.push('third');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'sixth',
+    initialize(registry) {
+      order.push('sixth');
+    }
+  });
+
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
   });
 
-  QUnit.test('initializers are passed an app instance', function() {
-    var MyApplication = Application.extend();
+  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+});
 
-    MyApplication.instanceInitializer({
-      name: 'initializer',
-      initialize(instance) {
-        ok(instance instanceof ApplicationInstance, 'initialize is passed an application instance');
-      }
-    });
+QUnit.test('initializers can be registered in a specified order as an array', function() {
+  var order = [];
+  var MyApplication = Application.extend();
 
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
+
+  MyApplication.instanceInitializer({
+    name: 'third',
+    initialize(registry) {
+      order.push('third');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'second',
+    after: 'first',
+    before: ['third', 'fourth'],
+    initialize(registry) {
+      order.push('second');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'fourth',
+    after: ['second', 'third'],
+    initialize(registry) {
+      order.push('fourth');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'fifth',
+    after: 'fourth',
+    before: 'sixth',
+    initialize(registry) {
+      order.push('fifth');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'first',
+    before: ['second'],
+    initialize(registry) {
+      order.push('first');
+    }
+  });
+
+  MyApplication.instanceInitializer({
+    name: 'sixth',
+    initialize(registry) {
+      order.push('sixth');
+    }
+  });
+
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
   });
 
-  QUnit.test('initializers can be registered in a specified order', function() {
-    var order = [];
-    var MyApplication = Application.extend();
-    MyApplication.instanceInitializer({
-      name: 'fourth',
-      after: 'third',
-      initialize(registry) {
-        order.push('fourth');
-      }
-    });
+  deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+});
 
-    MyApplication.instanceInitializer({
-      name: 'second',
-      after: 'first',
-      before: 'third',
-      initialize(registry) {
-        order.push('second');
-      }
-    });
+QUnit.test('initializers can have multiple dependencies', function () {
+  var order = [];
+  var a = {
+    name: 'a',
+    before: 'b',
+    initialize(registry) {
+      order.push('a');
+    }
+  };
+  var b = {
+    name: 'b',
+    initialize(registry) {
+      order.push('b');
+    }
+  };
+  var c = {
+    name: 'c',
+    after: 'b',
+    initialize(registry) {
+      order.push('c');
+    }
+  };
+  var afterB = {
+    name: 'after b',
+    after: 'b',
+    initialize(registry) {
+      order.push('after b');
+    }
+  };
+  var afterC = {
+    name: 'after c',
+    after: 'c',
+    initialize(registry) {
+      order.push('after c');
+    }
+  };
 
-    MyApplication.instanceInitializer({
-      name: 'fifth',
-      after: 'fourth',
-      before: 'sixth',
-      initialize(registry) {
-        order.push('fifth');
-      }
-    });
+  Application.instanceInitializer(b);
+  Application.instanceInitializer(a);
+  Application.instanceInitializer(afterC);
+  Application.instanceInitializer(afterB);
+  Application.instanceInitializer(c);
 
-    MyApplication.instanceInitializer({
-      name: 'first',
-      before: 'second',
-      initialize(registry) {
-        order.push('first');
-      }
+  run(function() {
+    app = Application.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
-
-    MyApplication.instanceInitializer({
-      name: 'third',
-      initialize(registry) {
-        order.push('third');
-      }
-    });
-
-    MyApplication.instanceInitializer({
-      name: 'sixth',
-      initialize(registry) {
-        order.push('sixth');
-      }
-    });
-
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
-    });
-
-    deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
   });
 
-  QUnit.test('initializers can be registered in a specified order as an array', function() {
-    var order = [];
-    var MyApplication = Application.extend();
+  ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
+  ok(order.indexOf(b.name) < order.indexOf(c.name), 'b < c');
+  ok(order.indexOf(b.name) < order.indexOf(afterB.name), 'b < afterB');
+  ok(order.indexOf(c.name) < order.indexOf(afterC.name), 'c < afterC');
+});
 
+QUnit.test('initializers set on Application subclasses should not be shared between apps', function() {
+  var firstInitializerRunCount = 0;
+  var secondInitializerRunCount = 0;
+  var FirstApp = Application.extend();
+  var firstApp, secondApp;
 
-    MyApplication.instanceInitializer({
-      name: 'third',
-      initialize(registry) {
-        order.push('third');
-      }
+  FirstApp.instanceInitializer({
+    name: 'first',
+    initialize(registry) {
+      firstInitializerRunCount++;
+    }
+  });
+  var SecondApp = Application.extend();
+  SecondApp.instanceInitializer({
+    name: 'second',
+    initialize(registry) {
+      secondInitializerRunCount++;
+    }
+  });
+  jQuery('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
+  run(function() {
+    firstApp = FirstApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #first'
     });
-
-    MyApplication.instanceInitializer({
-      name: 'second',
-      after: 'first',
-      before: ['third', 'fourth'],
-      initialize(registry) {
-        order.push('second');
-      }
+  });
+  equal(firstInitializerRunCount, 1, 'first initializer only was run');
+  equal(secondInitializerRunCount, 0, 'first initializer only was run');
+  run(function() {
+    secondApp = SecondApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #second'
     });
+  });
+  equal(firstInitializerRunCount, 1, 'second initializer only was run');
+  equal(secondInitializerRunCount, 1, 'second initializer only was run');
+  run(function() {
+  firstApp.destroy();
+  secondApp.destroy();
+});
+});
 
-    MyApplication.instanceInitializer({
-      name: 'fourth',
-      after: ['second', 'third'],
-      initialize(registry) {
-        order.push('fourth');
-      }
-    });
+QUnit.test('initializers are concatenated', function() {
+  var firstInitializerRunCount = 0;
+  var secondInitializerRunCount = 0;
+  var FirstApp = Application.extend();
+  var firstApp, secondApp;
 
-    MyApplication.instanceInitializer({
-      name: 'fifth',
-      after: 'fourth',
-      before: 'sixth',
-      initialize(registry) {
-        order.push('fifth');
-      }
-    });
-
-    MyApplication.instanceInitializer({
-      name: 'first',
-      before: ['second'],
-      initialize(registry) {
-        order.push('first');
-      }
-    });
-
-    MyApplication.instanceInitializer({
-      name: 'sixth',
-      initialize(registry) {
-        order.push('sixth');
-      }
-    });
-
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
-    });
-
-    deepEqual(order, ['first', 'second', 'third', 'fourth', 'fifth', 'sixth']);
+  FirstApp.instanceInitializer({
+    name: 'first',
+    initialize(registry) {
+      firstInitializerRunCount++;
+    }
   });
 
-  QUnit.test('initializers can have multiple dependencies', function () {
-    var order = [];
-    var a = {
-      name: 'a',
-      before: 'b',
-      initialize(registry) {
-        order.push('a');
-      }
-    };
-    var b = {
-      name: 'b',
-      initialize(registry) {
-        order.push('b');
-      }
-    };
-    var c = {
-      name: 'c',
-      after: 'b',
-      initialize(registry) {
-        order.push('c');
-      }
-    };
-    var afterB = {
-      name: 'after b',
-      after: 'b',
-      initialize(registry) {
-        order.push('after b');
-      }
-    };
-    var afterC = {
-      name: 'after c',
-      after: 'c',
-      initialize(registry) {
-        order.push('after c');
-      }
-    };
-
-    Application.instanceInitializer(b);
-    Application.instanceInitializer(a);
-    Application.instanceInitializer(afterC);
-    Application.instanceInitializer(afterB);
-    Application.instanceInitializer(c);
-
-    run(function() {
-      app = Application.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
-    });
-
-    ok(order.indexOf(a.name) < order.indexOf(b.name), 'a < b');
-    ok(order.indexOf(b.name) < order.indexOf(c.name), 'b < c');
-    ok(order.indexOf(b.name) < order.indexOf(afterB.name), 'b < afterB');
-    ok(order.indexOf(c.name) < order.indexOf(afterC.name), 'c < afterC');
+  var SecondApp = FirstApp.extend();
+  SecondApp.instanceInitializer({
+    name: 'second',
+    initialize(registry) {
+      secondInitializerRunCount++;
+    }
   });
 
-  QUnit.test('initializers set on Application subclasses should not be shared between apps', function() {
-    var firstInitializerRunCount = 0;
-    var secondInitializerRunCount = 0;
-    var FirstApp = Application.extend();
-    var firstApp, secondApp;
-
-    FirstApp.instanceInitializer({
-      name: 'first',
-      initialize(registry) {
-        firstInitializerRunCount++;
-      }
+  jQuery('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
+  run(function() {
+    firstApp = FirstApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #first'
     });
-    var SecondApp = Application.extend();
-    SecondApp.instanceInitializer({
-      name: 'second',
-      initialize(registry) {
-        secondInitializerRunCount++;
-      }
+  });
+  equal(firstInitializerRunCount, 1, 'first initializer only was run when base class created');
+  equal(secondInitializerRunCount, 0, 'first initializer only was run when base class created');
+  firstInitializerRunCount = 0;
+  run(function() {
+    secondApp = SecondApp.create({
+      router: false,
+      rootElement: '#qunit-fixture #second'
     });
-    jQuery('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
-    run(function() {
-      firstApp = FirstApp.create({
-        router: false,
-        rootElement: '#qunit-fixture #first'
-      });
-    });
-    equal(firstInitializerRunCount, 1, 'first initializer only was run');
-    equal(secondInitializerRunCount, 0, 'first initializer only was run');
-    run(function() {
-      secondApp = SecondApp.create({
-        router: false,
-        rootElement: '#qunit-fixture #second'
-      });
-    });
-    equal(firstInitializerRunCount, 1, 'second initializer only was run');
-    equal(secondInitializerRunCount, 1, 'second initializer only was run');
-    run(function() {
+  });
+  equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
+  equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
+  run(function() {
     firstApp.destroy();
     secondApp.destroy();
   });
+});
+
+QUnit.test('initializers are per-app', function() {
+  expect(0);
+  var FirstApp = Application.extend();
+  FirstApp.instanceInitializer({
+    name: 'shouldNotCollide',
+    initialize(registry) {}
   });
 
-  QUnit.test('initializers are concatenated', function() {
-    var firstInitializerRunCount = 0;
-    var secondInitializerRunCount = 0;
-    var FirstApp = Application.extend();
-    var firstApp, secondApp;
+  var SecondApp = Application.extend();
+  SecondApp.instanceInitializer({
+    name: 'shouldNotCollide',
+    initialize(registry) {}
+  });
+});
 
-    FirstApp.instanceInitializer({
-      name: 'first',
-      initialize(registry) {
-        firstInitializerRunCount++;
-      }
-    });
+QUnit.test('initializers are run before ready hook', function() {
+  expect(2);
 
-    var SecondApp = FirstApp.extend();
-    SecondApp.instanceInitializer({
-      name: 'second',
-      initialize(registry) {
-        secondInitializerRunCount++;
-      }
-    });
+  var readyWasCalled = false;
 
-    jQuery('#qunit-fixture').html('<div id="first"></div><div id="second"></div>');
-    run(function() {
-      firstApp = FirstApp.create({
-        router: false,
-        rootElement: '#qunit-fixture #first'
-      });
-    });
-    equal(firstInitializerRunCount, 1, 'first initializer only was run when base class created');
-    equal(secondInitializerRunCount, 0, 'first initializer only was run when base class created');
-    firstInitializerRunCount = 0;
-    run(function() {
-      secondApp = SecondApp.create({
-        router: false,
-        rootElement: '#qunit-fixture #second'
-      });
-    });
-    equal(firstInitializerRunCount, 1, 'first initializer was run when subclass created');
-    equal(secondInitializerRunCount, 1, 'second initializers was run when subclass created');
-    run(function() {
-      firstApp.destroy();
-      secondApp.destroy();
-    });
+  var MyApplication = Application.extend({
+    ready() {
+      ok(true, 'ready is called');
+      readyWasCalled = true;
+    }
   });
 
-  QUnit.test('initializers are per-app', function() {
-    expect(0);
-    var FirstApp = Application.extend();
-    FirstApp.instanceInitializer({
-      name: 'shouldNotCollide',
-      initialize(registry) {}
-    });
-
-    var SecondApp = Application.extend();
-    SecondApp.instanceInitializer({
-      name: 'shouldNotCollide',
-      initialize(registry) {}
-    });
+  MyApplication.instanceInitializer({
+    name: 'initializer',
+    initialize() {
+      ok(!readyWasCalled, 'ready is not yet called');
+    }
   });
 
-  QUnit.test('initializers are run before ready hook', function() {
-    expect(2);
-
-    var readyWasCalled = false;
-
-    var MyApplication = Application.extend({
-      ready() {
-        ok(true, 'ready is called');
-        readyWasCalled = true;
-      }
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
+  });
+});
 
-    MyApplication.instanceInitializer({
-      name: 'initializer',
-      initialize() {
-        ok(!readyWasCalled, 'ready is not yet called');
-      }
+QUnit.test('initializers should be executed in their own context', function() {
+  expect(1);
+
+  var MyApplication = Application.extend();
+
+  MyApplication.instanceInitializer({
+    name: 'coolBabeInitializer',
+    myProperty: 'coolBabe',
+    initialize(registry, application) {
+      equal(this.myProperty, 'coolBabe', 'should have access to its own context');
+    }
+  });
+
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
+  });
+});
 
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
+QUnit.test('Initializers get an instance on app reset', function() {
+  expect(2);
+
+  var MyApplication = Application.extend();
+
+  MyApplication.instanceInitializer({
+    name: 'giveMeAnInstance',
+    initialize(instance) {
+      ok(!!instance, 'Initializer got an instance');
+    }
+  });
+
+  run(function() {
+    app = MyApplication.create({
+      router: false,
+      rootElement: '#qunit-fixture'
     });
   });
 
-  if (initializeContextFeatureEnabled) {
-    QUnit.test('initializers should be executed in their own context', function() {
-      expect(1);
-
-      var MyApplication = Application.extend();
-
-      MyApplication.instanceInitializer({
-        name: 'coolBabeInitializer',
-        myProperty: 'coolBabe',
-        initialize(registry, application) {
-          equal(this.myProperty, 'coolBabe', 'should have access to its own context');
-        }
-      });
-
-      run(function() {
-        app = MyApplication.create({
-          router: false,
-          rootElement: '#qunit-fixture'
-        });
-      });
-    });
-  }
-
-  QUnit.test('Initializers get an instance on app reset', function() {
-    expect(2);
-
-    var MyApplication = Application.extend();
-
-    MyApplication.instanceInitializer({
-      name: 'giveMeAnInstance',
-      initialize(instance) {
-        ok(!!instance, 'Initializer got an instance');
-      }
-    });
-
-    run(function() {
-      app = MyApplication.create({
-        router: false,
-        rootElement: '#qunit-fixture'
-      });
-    });
-
-    run(app, 'reset');
-  });
-}
+  run(app, 'reset');
+});

--- a/tests/node/app-boot-test.js
+++ b/tests/node/app-boot-test.js
@@ -7,11 +7,8 @@ var templateCompilerPath = path.join(distPath, 'ember-template-compiler');
 
 var defeatureifyConfig = require(path.join(__dirname, '../../features.json'));
 
-var canUseInstanceInitializers, canUseApplicationVisit;
-
-if (defeatureifyConfig.features['ember-application-instance-initializers'] !== false) {
-  canUseInstanceInitializers = true;
-}
+var canUseInstanceInitializers = true;
+var canUseApplicationVisit;
 
 if (defeatureifyConfig.features['ember-application-visit'] !== false) {
   canUseApplicationVisit = true;
@@ -21,7 +18,6 @@ var features = {};
 for (var feature in defeatureifyConfig.features) {
   features[feature] = defeatureifyConfig.features[feature];
 }
-features['ember-application-instance-initializers'] = true;
 features['ember-application-visit'] =true;
 
 /*jshint -W079 */


### PR DESCRIPTION
- Registry no longer instantiates a container and forwards lookup/lookupFactory to it.
- Removed checks for `ember-application-instance-initializers` and `ember-application-initializer-context`
  since they have been enabled by default for ~4 months now.
