### PR TITLE
[BUGFIX release] deprecateFunc in production

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -170,7 +170,7 @@ if ('undefined' === typeof Ember.debug) { Ember.debug = K; }
 if ('undefined' === typeof Ember.runInDebug) { Ember.runInDebug = K; }
 if ('undefined' === typeof Ember.deprecate) { Ember.deprecate = K; }
 if ('undefined' === typeof Ember.deprecateFunc) {
-  Ember.deprecateFunc = function(_, func) { return func; };
+  Ember.deprecateFunc = function(...args) { return args[args.length - 1]; };
 }
 
 export default Ember;


### PR DESCRIPTION
- it can take 2 or 3 args
- last arg is always the function to call
- bypass the deprecate call in prod
