### PR TITLE
[DOC release] Mark `Ember.oneWay` as deprecated

### DIFF
--- a/packages/ember-metal/lib/binding.js
+++ b/packages/ember-metal/lib/binding.js
@@ -330,6 +330,7 @@ mixinProperties(Binding, {
       binding `oneWay`. You can instead pass `false` to disable `oneWay`, making the
       binding two way again.
     @return {Ember.Binding} `this`
+    @deprecated
     @public
   */
   oneWay(from, flag) {


### PR DESCRIPTION
[ci skip]
