### PR TITLE
Allow assertions to be overridden without mutating globals

### DIFF
--- a/packages/ember-debug/lib/main.js
+++ b/packages/ember-debug/lib/main.js
@@ -1,6 +1,7 @@
 /*global __fail__*/
 
 import Ember from 'ember-metal/core';
+import { registerDebugFunction } from 'ember-metal/assert';
 import isEnabled, { FEATURES } from 'ember-metal/features';
 import EmberError from 'ember-metal/error';
 import Logger from 'ember-metal/logger';
@@ -43,7 +44,7 @@ function isPlainFunction(test) {
     its return value will be used as condition.
   @public
 */
-Ember.assert = function(desc, test) {
+function assert(desc, test) {
   var throwAssertion;
 
   if (isPlainFunction(test)) {
@@ -55,7 +56,7 @@ Ember.assert = function(desc, test) {
   if (throwAssertion) {
     throw new EmberError('Assertion Failed: ' + desc);
   }
-};
+}
 
 
 /**
@@ -68,14 +69,14 @@ Ember.assert = function(desc, test) {
     will be displayed.
   @public
 */
-Ember.warn = function(message, test) {
+function warn(message, test) {
   if (!test) {
     Logger.warn('WARNING: ' + message);
     if ('trace' in Logger) {
       Logger.trace();
     }
   }
-};
+}
 
 /**
   Display a debug notice. Ember build tools will remove any calls to
@@ -89,9 +90,9 @@ Ember.warn = function(message, test) {
   @param {String} message A debug message to display.
   @public
 */
-Ember.debug = function(message) {
+function debug(message) {
   Logger.debug('DEBUG: ' + message);
-};
+}
 
 /**
   Display a deprecation warning with the provided message and a stack trace
@@ -110,7 +111,7 @@ Ember.debug = function(message) {
     The `id` should be namespaced by dots, e.g. "view.helper.select".
   @public
 */
-Ember.deprecate = function(message, test, options) {
+function deprecate(message, test, options) {
   if (Ember.ENV.RAISE_ON_DEPRECATION) {
     deprecationManager.setDefaultLevel(deprecationLevels.RAISE);
   }
@@ -169,7 +170,7 @@ Ember.deprecate = function(message, test, options) {
   }
 
   Logger.warn('DEPRECATION: ' + message);
-};
+}
 
 
 
@@ -193,7 +194,7 @@ Ember.deprecate = function(message, test, options) {
   @return {Function} a new function that wrapped the original function with a deprecation warning
   @private
 */
-Ember.deprecateFunc = function(...args) {
+function deprecateFunc(...args) {
   if (args.length === 3) {
     let [message, options, func] = args;
     return function() {
@@ -207,7 +208,7 @@ Ember.deprecateFunc = function(...args) {
       return func.apply(this, arguments);
     };
   }
-};
+}
 
 
 /**
@@ -229,9 +230,16 @@ Ember.deprecateFunc = function(...args) {
   @since 1.5.0
   @public
 */
-Ember.runInDebug = function(func) {
+function runInDebug(func) {
   func();
-};
+}
+
+registerDebugFunction('assert', assert);
+registerDebugFunction('warn', warn);
+registerDebugFunction('debug', debug);
+registerDebugFunction('deprecate', deprecate);
+registerDebugFunction('deprecateFunc', deprecateFunc);
+registerDebugFunction('runInDebug', runInDebug);
 
 /**
   Will call `Ember.warn()` if ENABLE_ALL_FEATURES, ENABLE_OPTIONAL_FEATURES, or

--- a/packages/ember-metal/lib/assert.js
+++ b/packages/ember-metal/lib/assert.js
@@ -1,0 +1,36 @@
+export let debugFunctions = {
+  assert() {},
+  warn() {},
+  debug() {},
+  deprecate() {},
+  deprecateFunc(...args) { return args[args.length - 1]; },
+  runInDebug() {}
+};
+
+export function registerDebugFunction(name, fn) {
+  debugFunctions[name] = fn;
+}
+
+export function assert() {
+  return debugFunctions.assert.apply(undefined, arguments);
+}
+
+export function warn() {
+  return debugFunctions.warn.apply(undefined, arguments);
+}
+
+export function debug() {
+  return debugFunctions.debug.apply(undefined, arguments);
+}
+
+export function deprecate() {
+  return debugFunctions.deprecate.apply(undefined, arguments);
+}
+
+export function deprecateFunc() {
+  return debugFunctions.deprecateFunc.apply(undefined, arguments);
+}
+
+export function runInDebug() {
+  return debugFunctions.runInDebug.apply(undefined, arguments);
+}

--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -3,7 +3,6 @@ import { get, normalizeTuple } from 'ember-metal/property_get';
 import { meta as metaFor } from 'ember-metal/utils';
 import { watchKey, unwatchKey } from 'ember-metal/watch_key';
 
-var warn = Ember.warn;
 var FIRST_KEY = /^([^\.]+)/;
 
 function firstKey(path) {
@@ -37,8 +36,11 @@ export function flushPendingChains() {
 
   queue.forEach((q) => q[0].add(q[1]));
 
-  warn('Watching an undefined global, Ember expects watched globals to be' +
-       ' setup by the time the run loop is flushed, check for typos', pendingQueue.length === 0);
+  Ember.warn(
+    'Watching an undefined global, Ember expects watched globals to be ' +
+    'setup by the time the run loop is flushed, check for typos',
+    pendingQueue.length === 0
+  );
 }
 
 function addChainWatcher(obj, keyName, node) {

--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -162,15 +162,4 @@ export { K };
 Ember.K = K;
 //TODO: ES6 GLOBAL TODO
 
-// Stub out the methods defined by the ember-debug package in case it's not loaded
-
-if ('undefined' === typeof Ember.assert) { Ember.assert = K; }
-if ('undefined' === typeof Ember.warn) { Ember.warn = K; }
-if ('undefined' === typeof Ember.debug) { Ember.debug = K; }
-if ('undefined' === typeof Ember.runInDebug) { Ember.runInDebug = K; }
-if ('undefined' === typeof Ember.deprecate) { Ember.deprecate = K; }
-if ('undefined' === typeof Ember.deprecateFunc) {
-  Ember.deprecateFunc = function(...args) { return args[args.length - 1]; };
-}
-
 export default Ember;

--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -394,6 +394,22 @@ Ember.FEATURES.isEnabled = isEnabled;
 Ember.onerror = null;
 // END EXPORTS
 
+import {
+  assert,
+  warn,
+  debug,
+  deprecate,
+  deprecateFunc,
+  runInDebug
+} from 'ember-metal/assert';
+
+Ember.assert = assert;
+Ember.warn = warn;
+Ember.debug = debug;
+Ember.deprecate = deprecate;
+Ember.deprecateFunc = deprecateFunc;
+Ember.runInDebug = runInDebug;
+
 // do this for side-effects of updating Ember.assert, warn, etc when
 // ember-debug is present
 // This needs to be called before any deprecateFunc


### PR DESCRIPTION
This is the first step for migration our assertions to be module-based.
