### PR TITLE
[BUGFIX release] add warnings to deprecated Enumerable methods

### DIFF
--- a/packages/ember-runtime/lib/mixins/enumerable.js
+++ b/packages/ember-runtime/lib/mixins/enumerable.js
@@ -50,6 +50,13 @@ function iter(key, value) {
   return i;
 }
 
+function deprecatingAliasMethod(oldName, newName) {
+  return function() {
+    Ember.deprecate(`Ember.Enumerable.${oldName} is deprecated. Use ${newName} instead.`);
+    return this[newName](...arguments);
+  };
+}
+
 /**
   This mixin defines the common interface implemented by enumerable objects
   in Ember. Most of these methods follow the standard Array iteration
@@ -369,8 +376,7 @@ export default Mixin.create({
     @deprecated Use `mapBy` instead
     @private
   */
-
-  mapProperty: aliasMethod('mapBy'),
+  mapProperty: deprecatingAliasMethod('mapProperty', 'mapBy'),
 
   /**
     Returns an array with all of the items in the enumeration that the passed
@@ -473,7 +479,7 @@ export default Mixin.create({
     @deprecated Use `filterBy` instead
     @private
   */
-  filterProperty: aliasMethod('filterBy'),
+  filterProperty: deprecatingAliasMethod('filterProperty', 'filterBy'),
 
   /**
     Returns an array with the items that do not have truthy values for
@@ -512,7 +518,7 @@ export default Mixin.create({
     @deprecated Use `rejectBy` instead
     @private
   */
-  rejectProperty: aliasMethod('rejectBy'),
+  rejectProperty: deprecatingAliasMethod('rejectProperty', 'rejectBy'),
 
   /**
     Returns the first item in the array for which the callback returns true.
@@ -602,7 +608,7 @@ export default Mixin.create({
     @deprecated Use `findBy` instead
     @private
   */
-  findProperty: aliasMethod('findBy'),
+  findProperty: deprecatingAliasMethod('findProperty', 'findBy'),
 
   /**
     Returns `true` if the passed function returns true for every item in the
@@ -653,7 +659,7 @@ export default Mixin.create({
     @return {Boolean}
     @public
   */
-  everyBy: aliasMethod('isEvery'),
+  everyBy: deprecatingAliasMethod('everyBy', 'isEvery'),
 
   /**
     @method everyProperty
@@ -663,7 +669,7 @@ export default Mixin.create({
     @return {Boolean}
     @private
   */
-  everyProperty: aliasMethod('isEvery'),
+  everyProperty: deprecatingAliasMethod('everyProperty', 'isEvery'),
 
   /**
     Returns `true` if the passed property resolves to the value of the second
@@ -776,7 +782,7 @@ export default Mixin.create({
     @deprecated Use `any` instead
     @private
   */
-  some: aliasMethod('any'),
+  some: deprecatingAliasMethod('some', 'any'),
 
   /**
     Returns `true` if the passed property resolves to the value of the second
@@ -802,7 +808,7 @@ export default Mixin.create({
     @deprecated Use `isAny` instead
     @private
   */
-  anyBy: aliasMethod('isAny'),
+  anyBy: deprecatingAliasMethod('anyBy', 'isAny'),
 
   /**
     @method someProperty
@@ -812,7 +818,7 @@ export default Mixin.create({
     @deprecated Use `isAny` instead
     @private
   */
-  someProperty: aliasMethod('isAny'),
+  someProperty: deprecatingAliasMethod('someProperty', 'isAny'),
 
   /**
     This will combine the values of the enumerator into a single value. It

--- a/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
+++ b/packages/ember-runtime/tests/computed/reduce_computed_macros_test.js
@@ -1521,9 +1521,9 @@ QUnit.test("it can filter and sort when both depend on the same item property", 
     todos = get(obj, 'todos');
   });
 
-  deepEqual(todos.mapProperty('name'), ['E', 'D', 'C', 'B', 'A'], "precond - todos initially correct");
-  deepEqual(sorted.mapProperty('name'), ['A', 'B', 'C', 'D', 'E'], "precond - sorted initially correct");
-  deepEqual(filtered.mapProperty('name'), ['A', 'C', 'E'], "precond - filtered initially correct");
+  deepEqual(todos.mapBy('name'), ['E', 'D', 'C', 'B', 'A'], "precond - todos initially correct");
+  deepEqual(sorted.mapBy('name'), ['A', 'B', 'C', 'D', 'E'], "precond - sorted initially correct");
+  deepEqual(filtered.mapBy('name'), ['A', 'C', 'E'], "precond - filtered initially correct");
 
   run(function() {
     beginPropertyChanges();
@@ -1539,9 +1539,9 @@ QUnit.test("it can filter and sort when both depend on the same item property", 
     endPropertyChanges();
   });
 
-  deepEqual(todos.mapProperty('name'), ['E', 'D', 'C', 'B', 'A'], "precond - todos remain correct");
-  deepEqual(sorted.mapProperty('name'), ['A', 'B', 'C', 'E', 'D'], "precond - sorted updated correctly");
-  deepEqual(filtered.mapProperty('name'), ['A', 'C', 'E', 'D'], "filtered updated correctly");
+  deepEqual(todos.mapBy('name'), ['E', 'D', 'C', 'B', 'A'], "precond - todos remain correct");
+  deepEqual(sorted.mapBy('name'), ['A', 'B', 'C', 'E', 'D'], "precond - sorted updated correctly");
+  deepEqual(filtered.mapBy('name'), ['A', 'C', 'E', 'D'], "filtered updated correctly");
 });
 
 QUnit.module('Chaining array and reduced CPs', {

--- a/packages/ember-runtime/tests/suites/enumerable/any.js
+++ b/packages/ember-runtime/tests/suites/enumerable/any.js
@@ -67,7 +67,7 @@ suite.test('any should produce correct results even if the matching element is u
   equal(result, true, 'return value of obj.any');
 });
 
-
+/*
 suite.test('any should be aliased to some', function() {
   var obj = this.newObject();
   var ary = this.toArray(obj);
@@ -102,5 +102,6 @@ suite.test('any should be aliased to some', function() {
 
   equal(someResult, anyResult);
 });
+*/
 
 export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable/every.js
+++ b/packages/ember-runtime/tests/suites/enumerable/every.js
@@ -77,6 +77,7 @@ suite.test('should return true if every property matches null', function() {
   equal(obj.isEvery('bar', null), false, "isEvery('bar', null)");
 });
 
+/*
 suite.test('everyBy should be aliased to isEvery', function() {
   var obj = this.newObject();
   equal(obj.isEvery, obj.everyBy);
@@ -86,6 +87,7 @@ suite.test('everyProperty should be aliased to isEvery', function() {
   var obj = this.newObject();
   equal(obj.isEvery, obj.everyProperty);
 });
+*/
 
 suite.test('should return true if every property is undefined', function() {
   var obj = this.newObject([

--- a/packages/ember-runtime/tests/suites/enumerable/filter.js
+++ b/packages/ember-runtime/tests/suites/enumerable/filter.js
@@ -137,10 +137,12 @@ suite.test('should not match undefined properties without second argument', func
   deepEqual(obj.filterBy('foo'), ary.slice(0, 2), "filterBy('foo', 3)')");
 });
 
+/*
 suite.test('should be aliased to filterProperty', function() {
   var ary = [];
 
   equal(ary.filterProperty, ary.filterBy);
 });
+*/
 
 export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable/find.js
+++ b/packages/ember-runtime/tests/suites/enumerable/find.js
@@ -102,6 +102,7 @@ suite.test('should return first undefined property match', function() {
   equal(obj.findBy('bar', undefined), ary[1], "findBy('bar', undefined)");
 });
 
+/*
 suite.test('should be aliased to findProperty', function() {
   var obj;
 
@@ -109,5 +110,6 @@ suite.test('should be aliased to findProperty', function() {
 
   equal(obj.findProperty, obj.findBy);
 });
+*/
 
 export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable/is_any.js
+++ b/packages/ember-runtime/tests/suites/enumerable/is_any.js
@@ -61,6 +61,7 @@ suite.test('should not match undefined properties without second argument', func
   equal(obj.isAny('foo'), false, "isAny('foo', undefined)");
 });
 
+/*
 suite.test('anyBy should be aliased to isAny', function() {
   var obj = this.newObject();
   equal(obj.isAny, obj.anyBy);
@@ -70,5 +71,6 @@ suite.test('isAny should be aliased to someProperty', function() {
   var obj = this.newObject();
   equal(obj.someProperty, obj.isAny);
 });
+*/
 
 export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable/mapBy.js
+++ b/packages/ember-runtime/tests/suites/enumerable/mapBy.js
@@ -14,9 +14,11 @@ suite.test('should work also through getEach alias', function() {
   equal(obj.getEach('a').join(''), '12');
 });
 
+/*
 suite.test('should be aliased to mapProperty', function() {
   var obj = this.newObject([]);
   equal(obj.mapProperty, obj.mapBy);
 });
+*/
 
 export default suite;

--- a/packages/ember-runtime/tests/suites/enumerable/reject.js
+++ b/packages/ember-runtime/tests/suites/enumerable/reject.js
@@ -144,10 +144,12 @@ suite.test('should match undefined, null, or false properties without second arg
   deepEqual(obj.rejectBy('foo'), ary.slice(2), "rejectBy('foo')')");
 });
 
+/*
 suite.test('should be aliased to rejectProperty', function() {
   var ary =[];
 
   equal(ary.rejectProperty, ary.rejectBy);
 });
+*/
 
 export default suite;

--- a/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
+++ b/packages/ember/tests/routing/query_params_test/model_dependent_state_with_query_params_test.js
@@ -345,7 +345,7 @@ QUnit.module('Model Dep Query Params', {
           deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedModelHookParams = null;
         }
-        return articles.findProperty('id', params.id);
+        return articles.findBy('id', params.id);
       }
     });
 
@@ -421,7 +421,7 @@ QUnit.module('Model Dep Query Params (nested)', {
           deepEqual(params, self.expectedModelHookParams, 'the ArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedModelHookParams = null;
         }
-        return site_articles.findProperty('id', params.id);
+        return site_articles.findBy('id', params.id);
       }
     });
 
@@ -511,7 +511,7 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
           deepEqual(params, self.expectedSiteModelHookParams, 'the SiteRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedSiteModelHookParams = null;
         }
-        return sites.findProperty('id', params.site_id);
+        return sites.findBy('id', params.site_id);
       }
     });
     App.SiteArticleRoute = Ember.Route.extend({
@@ -520,7 +520,7 @@ QUnit.module('Model Dep Query Params (nested & more than 1 dynamic segment)', {
           deepEqual(params, self.expectedArticleModelHookParams, 'the SiteArticleRoute model hook received the expected merged dynamic segment + query params hash');
           self.expectedArticleModelHookParams = null;
         }
-        return site_articles.findProperty('id', params.article_id);
+        return site_articles.findBy('id', params.article_id);
       }
     });
 


### PR DESCRIPTION
#11700 removes findProperty in Ember 2.0, but there are no deprecation warnings on soon-to-be-removed Enumerable methods in 1.x.

NOTE: the previous alias tests checked for equality of the aliased methods, which is impossible if we're adding deprecations to the aliases, hence I've just commented them out. Doesn't seem like it's worth the time to replace every last one of them with test cases that they're both 1) deprecated and 2) properly aliased given how simple the logic is, but someone let me know if I'm crazy/lazy.
