### PR TITLE
[BUGFIX release] Deprecate reverse argument ordering in Ember.observer

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -809,6 +809,7 @@ export function observer(...args) {
 
   if (typeof func !== 'function') {
     // revert to old, soft-deprecated argument ordering
+    Ember.deprecate('Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument.');
 
     func  = args[0];
     _paths = args.slice(1);

--- a/packages/ember-metal/tests/mixin/observer_test.js
+++ b/packages/ember-metal/tests/mixin/observer_test.js
@@ -45,7 +45,6 @@ testBoth('global observer helper takes multiple params', function(get, set) {
   equal(get(obj, 'count'), 2, 'should invoke observer after change');
 });
 
-
 testBoth('replacing observer should remove old observer', function(get, set) {
   var MyMixin = Mixin.create({
 
@@ -209,4 +208,15 @@ testBoth('observing chain with overriden property', function(get, set) {
 
   set(obj3, 'baz', 'BEAR');
   equal(get(obj, 'count'), 1, 'should invoke observer after change');
+});
+
+testBoth('providing the arguments in reverse order is deprecated', function(get, set) {
+  expectDeprecation(/Passing the dependentKeys after the callback function in Ember\.observer is deprecated. Ensure the callback function is the last argument/);
+
+  Mixin.create({
+    count: 0,
+    foo: observer(function() {
+      set(this, 'count', get(this, 'count') + 1);
+    }, 'bar.baz')
+  });
 });


### PR DESCRIPTION
A very unknown feature of Ember.observer that has been soft-deprecated
for a long time is to provide arguments in reverse order

Example:

``` js
Ember.observer(function() {
  // do something
}, 'prop1', 'prop2')
```

This feature explicitly deprecates this, and a subsequent PR will remove
the code that reverses the arguments
