### PR TITLE
[DOC release] Mark `Ember.getProperties` as `public`

### DIFF
--- a/packages/ember-metal/lib/get_properties.js
+++ b/packages/ember-metal/lib/get_properties.js
@@ -21,7 +21,7 @@ import { get } from 'ember-metal/property_get';
   @param {Object} obj
   @param {String...|Array} list of keys to get
   @return {Object}
-  @private
+  @public
 */
 export default function getProperties(obj) {
   var ret = {};


### PR DESCRIPTION
[ci skip]
