### PR TITLE
[CLEANUP BETA] Remove context switching `{{with foo}}` support

### DIFF
--- a/packages/ember-htmlbars/lib/helpers/with.js
+++ b/packages/ember-htmlbars/lib/helpers/with.js
@@ -3,7 +3,6 @@
 @submodule ember-templates
 */
 
-import normalizeSelf from 'ember-htmlbars/utils/normalize-self';
 import shouldDisplay from 'ember-views/streams/should_display';
 
 /**
@@ -41,26 +40,7 @@ import shouldDisplay from 'ember-views/streams/should_display';
 
 export default function withHelper(params, hash, options) {
   if (shouldDisplay(params[0])) {
-    var preserveContext = false;
-
-    if (options.template.arity !== 0) {
-      preserveContext = true;
-    }
-
-    if (preserveContext) {
-      this.yield([params[0]]);
-    } else {
-      let self = normalizeSelf(params[0]);
-      if (hash.controller) {
-        self = {
-          hasBoundController: true,
-          controller: hash.controller,
-          self: self
-        };
-      }
-
-      this.yield([], self);
-    }
+    this.yield([params[0]]);
   } else if (options.inverse && options.inverse.yield) {
     options.inverse.yield([]);
   }

--- a/packages/ember-htmlbars/lib/keywords/with.js
+++ b/packages/ember-htmlbars/lib/keywords/with.js
@@ -60,15 +60,6 @@ export default {
       !!template
     );
 
-    if (template && template.arity === 0) {
-      Ember.deprecate(
-        'Using the context switching form of `{{with}}` is deprecated. ' +
-          'Please use the block param form (`{{#with bar as |foo|}}`) instead.',
-        false,
-        { url: 'http://emberjs.com/guides/deprecations/#toc_more-consistent-handlebars-scope' }
-      );
-    }
-
     internal.continueBlock(morph, env, scope, 'with', params, hash, template, inverse, visitor);
   },
 

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -53,17 +53,16 @@ QUnit.module('ember-htmlbars: compat - makeBoundHelper', {
 
 QUnit.test('primitives should work correctly [DEPRECATED]', function() {
   expectDeprecation(eachDeprecation);
-  expectDeprecation('Using the context switching form of `{{with}}` is deprecated. Please use the keyword form (`{{with foo as bar}}`) instead.');
 
   view = EmberView.create({
     prims: Ember.A(['string', 12]),
 
-    template: compile('{{#each view.prims}}{{#if this}}inside-if{{/if}}{{#with this}}inside-with{{/with}}{{/each}}')
+    template: compile('{{#each view.prims}}{{#if this}}inside-if{{/if}}{{/each}}')
   });
 
   runAppend(view);
 
-  equal(view.$().text(), 'inside-ifinside-withinside-ifinside-with');
+  equal(view.$().text(), 'inside-ifinside-if');
 });
 
 QUnit.test('should update bound helpers when properties change', function() {

--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -38,20 +38,6 @@ QUnit.module('ember-htmlbars: {{#if}} and {{#unless}} helpers', {
   }
 });
 
-QUnit.test('unless should keep the current context (#784) [DEPRECATED]', function() {
-  view = EmberView.create({
-    o: EmberObject.create({ foo: '42' }),
-
-    template: compile('{{#with view.o}}{{#view}}{{#unless view.doesNotExist}}foo: {{foo}}{{/unless}}{{/view}}{{/with}}')
-  });
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  equal(view.$().text(), 'foo: 42');
-});
-
 QUnit.test('The `if` helper tests for `isTruthy` if available', function() {
   view = EmberView.create({
     truthy: EmberObject.create({ isTruthy: true }),

--- a/packages/ember-htmlbars/tests/helpers/with_test.js
+++ b/packages/ember-htmlbars/tests/helpers/with_test.js
@@ -219,43 +219,7 @@ QUnit.test('it should support #with this as qux', function() {
   runDestroy(view);
 });
 
-QUnit.module('Handlebars {{#with foo}} with defined controller');
-
-QUnit.test('destroys the controller generated with {{with foo controller=\'blah\'}} [DEPRECATED]', function() {
-  var destroyed = false;
-  var Controller = EmberController.extend({
-    willDestroy() {
-      this._super.apply(this, arguments);
-      destroyed = true;
-    }
-  });
-
-  var person = EmberObject.create({ name: 'Steve Holt' });
-  var registry = new Registry();
-  var container = registry.container();
-
-  var parentController = EmberObject.create({
-    container: container,
-    person: person,
-    name: 'Bob Loblaw'
-  });
-
-  view = EmberView.create({
-    container: container,
-    template: compile('{{#with person controller="person"}}{{controllerName}}{{/with}}'),
-    controller: parentController
-  });
-
-  registry.register('controller:person', Controller);
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  runDestroy(view);
-
-  ok(destroyed, 'controller was destroyed properly');
-});
+QUnit.module('Handlebars {{#with foo as bar}} with defined controller');
 
 QUnit.test('destroys the controller generated with {{with foo as bar controller=\'blah\'}}', function() {
   var destroyed = false;

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -138,27 +138,6 @@ QUnit.test('yield uses the outer context', function() {
   equal(view.$('div p:contains(inner) + p:contains(outer)').length, 1, 'Yield points at the right context');
 });
 
-
-QUnit.test('yield inside a conditional uses the outer context [DEPRECATED]', function() {
-  var component = Component.extend({
-    boundText: 'inner',
-    truthy: true,
-    obj: {},
-    layout: compile('<p>{{boundText}}</p><p>{{#if truthy}}{{#with obj}}{{yield}}{{/with}}{{/if}}</p>')
-  });
-
-  view = EmberView.create({
-    controller: { boundText: 'outer', truthy: true, obj: { component: component, truthy: true, boundText: 'insideWith' } },
-    template: compile('{{#with obj}}{{#if truthy}}{{#view component}}{{#if truthy}}{{boundText}}{{/if}}{{/view}}{{/if}}{{/with}}')
-  });
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  equal(view.$('div p:contains(inner) + p:contains(insideWith)').length, 1, 'Yield points at the right context');
-});
-
 QUnit.test('outer keyword doesn\'t mask inner component property', function () {
   var component = Component.extend({
     item: 'inner',

--- a/packages/ember-htmlbars/tests/integration/with_view_test.js
+++ b/packages/ember-htmlbars/tests/integration/with_view_test.js
@@ -1,5 +1,3 @@
-import run from 'ember-metal/run_loop';
-import jQuery from 'ember-views/system/jquery';
 import EmberView from 'ember-views/views/view';
 import { Registry } from 'ember-runtime/system/container';
 import EmberObject from 'ember-runtime/system/object';
@@ -9,7 +7,6 @@ import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import { set } from 'ember-metal/property_set';
 
 var view, registry, container;
-var trim = jQuery.trim;
 
 QUnit.module('ember-htmlbars: {{#with}} and {{#view}} integration', {
   setup() {
@@ -24,80 +21,6 @@ QUnit.module('ember-htmlbars: {{#with}} and {{#view}} integration', {
     runDestroy(view);
     registry = container = view = null;
   }
-});
-
-QUnit.test('View should update when the property used with the #with helper changes [DEPRECATED]', function() {
-  registry.register('template:foo', compile('<h1 id="first">{{#with view.content}}{{wham}}{{/with}}</h1>'));
-
-  view = EmberView.create({
-    container: container,
-    templateName: 'foo',
-
-    content: EmberObject.create({
-      wham: 'bam',
-      thankYou: 'ma\'am'
-    })
-  });
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  equal(view.$('#first').text(), 'bam', 'precond - view renders Handlebars template');
-
-  run(function() {
-    set(view, 'content', EmberObject.create({
-      wham: 'bazam'
-    }));
-  });
-
-  equal(view.$('#first').text(), 'bazam', 'view updates when a bound property changes');
-});
-
-QUnit.test('should expose a view keyword [DEPRECATED]', function() {
-  var templateString = '{{#with view.differentContent}}{{view.foo}}{{#view baz="bang"}}{{view.baz}}{{/view}}{{/with}}';
-  view = EmberView.create({
-    container: container,
-    differentContent: {
-      view: {
-        foo: 'WRONG',
-        baz: 'WRONG'
-      }
-    },
-
-    foo: 'bar',
-
-    template: compile(templateString)
-  });
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  equal(view.$().text(), 'barbang', 'renders values from view and child view');
-});
-
-QUnit.test('bindings can be `this`, in which case they *are* the current context [DEPRECATED]', function() {
-  view = EmberView.create({
-    museumOpen: true,
-
-    museumDetails: EmberObject.create({
-      name: 'SFMoMA',
-      price: 20,
-      museumView: EmberView.extend({
-        template: compile('Name: {{view.museum.name}} Price: ${{view.museum.price}}')
-      })
-    }),
-
-
-    template: compile('{{#if view.museumOpen}} {{#with view.museumDetails}}{{view museumView museum=this}} {{/with}}{{/if}}')
-  });
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  equal(trim(view.$().text()), 'Name: SFMoMA Price: $20', 'should print baz twice');
 });
 
 QUnit.test('child views can be inserted inside a bind block', function() {

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -5,7 +5,6 @@ import run from 'ember-metal/run_loop';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
 import ActionManager from 'ember-views/system/action_manager';
 
-import { Registry } from 'ember-runtime/system/container';
 import EmberObject from 'ember-runtime/system/object';
 import EmberController from 'ember-runtime/controllers/controller';
 
@@ -129,37 +128,6 @@ QUnit.test('Inside a yield, the target points at the original target', function(
 
   equal(watted, true, 'The action was called on the right context');
 });
-
-QUnit.test('should target the with-controller inside an {{#with controller=\'person\'}} [DEPRECATED]', function() {
-  var registeredTarget;
-
-  ActionHelper.registerAction = function({ node }) {
-    registeredTarget = node.state.target;
-  };
-
-  var PersonController = EmberController.extend();
-  var registry = new Registry();
-  var container = registry.container();
-  var parentController = EmberObject.create({
-    container: container
-  });
-
-  view = EmberView.create({
-    container: container,
-    template: compile('{{#with view.person controller="person"}}<div {{action "editTodo"}}></div>{{/with}}'),
-    person: EmberObject.create(),
-    controller: parentController
-  });
-
-  registry.register('controller:person', PersonController);
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
-
-  ok(registeredTarget instanceof PersonController, 'the with-controller is the target of action');
-});
-
 
 QUnit.test('should allow a target to be specified', function() {
   var registeredTarget;
@@ -405,28 +373,6 @@ QUnit.test('should work properly in a {{#with foo as |bar|}} block', function() 
   });
 
   runAppend(view);
-
-  view.$('a').trigger('click');
-
-  ok(eventHandlerWasCalled, 'The event handler was called');
-});
-
-QUnit.test('should work properly in a #with block [DEPRECATED]', function() {
-  var eventHandlerWasCalled = false;
-
-  var controller = EmberController.extend({
-    actions: { edit() { eventHandlerWasCalled = true; } }
-  }).create();
-
-  view = EmberView.create({
-    controller: controller,
-    something: { ohai: 'there' },
-    template: compile('{{#with view.something}}<a href="#" {{action "edit"}}>click me</a>{{/with}}')
-  });
-
-  expectDeprecation(function() {
-    runAppend(view);
-  }, 'Using the context switching form of `{{with}}` is deprecated. Please use the block param form (`{{#with bar as |foo|}}`) instead.');
 
   view.$('a').trigger('click');
 


### PR DESCRIPTION
Fixes #11784 

I'm not a 100% sure, but I might have killed off too much unit-tests?
They did seem to relate to `{{#with}}` though.
