### PR TITLE
[CLEANUP beta] Remove beforeObserver family from the public API

### DIFF
--- a/packages/ember-metal/lib/main.js
+++ b/packages/ember-metal/lib/main.js
@@ -157,22 +157,16 @@ computed.any = any;
 computed.collect = collect;
 
 import {
-  _suspendBeforeObserver,
-  _suspendBeforeObservers,
   _suspendObserver,
   _suspendObservers,
-  _addBeforeObserver,
   addObserver,
-  _beforeObserversFor,
   observersFor,
-  _removeBeforeObserver,
   removeObserver
 } from 'ember-metal/observer';
 import {
   IS_BINDING,
   Mixin,
   aliasMethod,
-  _beforeObserver,
   _immediateObserver,
   mixin,
   observer,
@@ -310,8 +304,6 @@ Ember.cacheFor = cacheFor;
 Ember.addObserver = addObserver;
 Ember.observersFor = observersFor;
 Ember.removeObserver = removeObserver;
-Ember._suspendBeforeObserver = _suspendBeforeObserver;
-Ember._suspendBeforeObservers = _suspendBeforeObservers;
 Ember._suspendObserver = _suspendObserver;
 Ember._suspendObservers = _suspendObservers;
 
@@ -403,10 +395,5 @@ if (Ember.__loader.registry['ember-debug']) {
 
 Ember.create = Ember.deprecateFunc('Ember.create is deprecated in favor of Object.create', Object.create);
 Ember.keys = Ember.deprecateFunc('Ember.keys is deprecated in favor of Object.keys', Object.keys);
-
-Ember.addBeforeObserver = Ember.deprecateFunc('Ember.addBeforeObserver is deprecated and will be removed in the near future.', { url: 'http://emberjs.com/deprecations/v1.x/#toc_beforeobserver' }, _addBeforeObserver);
-Ember.removeBeforeObserver = Ember.deprecateFunc('Ember.removeBeforeObserver is deprecated and will be removed in the near future.', { url: 'http://emberjs.com/deprecations/v1.x/#toc_beforeobserver' }, _removeBeforeObserver);
-Ember.beforeObserversFor = Ember.deprecateFunc('Ember.beforeObserversFor is deprecated and will be removed in the near future.', { url: 'http://emberjs.com/deprecations/v1.x/#toc_beforeobserver' }, _beforeObserversFor);
-Ember.beforeObserver = Ember.deprecateFunc('Ember.beforeObserver is deprecated and will be removed in the near future.', { url: 'http://emberjs.com/deprecations/v1.x/#toc_beforeobserver' }, _beforeObserver);
 
 export default Ember;

--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -868,10 +868,6 @@ export function _immediateObserver() {
   App.PersonView = Ember.View.extend({
     friends: [{ name: 'Tom' }, { name: 'Stefan' }, { name: 'Kris' }],
 
-    valueWillChange: Ember.beforeObserver('content.value', function(obj, keyName) {
-      this.changingFrom = obj.get(keyName);
-    }),
-
     valueDidChange: Ember.observer('content.value', function(obj, keyName) {
         // only run if updating a value already in the DOM
         if (this.get('state') === 'inDOM') {

--- a/packages/ember-metal/lib/observer.js
+++ b/packages/ember-metal/lib/observer.js
@@ -81,26 +81,13 @@ export function _addBeforeObserver(obj, path, target, method) {
 //
 // This should only be used by the target of the observer
 // while it is setting the observed path.
-export function _suspendBeforeObserver(obj, path, target, method, callback) {
-  return suspendListener(obj, beforeEvent(path), target, method, callback);
-}
-
 export function _suspendObserver(obj, path, target, method, callback) {
   return suspendListener(obj, changeEvent(path), target, method, callback);
-}
-
-export function _suspendBeforeObservers(obj, paths, target, method, callback) {
-  var events = paths.map(beforeEvent);
-  return suspendListeners(obj, events, target, method, callback);
 }
 
 export function _suspendObservers(obj, paths, target, method, callback) {
   var events = paths.map(changeEvent);
   return suspendListeners(obj, events, target, method, callback);
-}
-
-export function _beforeObserversFor(obj, path) {
-  return listenersFor(obj, beforeEvent(path));
 }
 
 /**

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -705,57 +705,6 @@ testBoth('observer should fire before dependent property is modified', function(
   equal(count, 1, 'should have invoked observer');
 });
 
-if (Ember.EXTEND_PROTOTYPES) {
-  testBoth('before observer added declaratively via brace expansion should fire when property changes', function (get, set) {
-    expectDeprecation(/Function#observesBefore is deprecated and will be removed in the near future/);
-    var obj = {};
-    var count = 0;
-
-    mixin(obj, {
-      fooAndBarWatcher: function () {
-        count++;
-      }.observesBefore('{foo,bar}')
-    });
-
-    set(obj, 'foo', 'foo');
-    equal(count, 1, 'observer specified via brace expansion invoked on property change');
-
-    set(obj, 'bar', 'bar');
-    equal(count, 2, 'observer specified via brace expansion invoked on property change');
-
-    set(obj, 'baz', 'baz');
-    equal(count, 2, 'observer not invoked on unspecified property');
-  });
-
-  testBoth('before observer specified declaratively via brace expansion should fire when dependent property changes', function (get, set) {
-    expectDeprecation(/Function#observesBefore is deprecated and will be removed in the near future/);
-    var obj = { baz: 'Initial' };
-    var count = 0;
-
-    defineProperty(obj, 'foo', computed(function() {
-      return get(this, 'bar').toLowerCase();
-    }).property('bar'));
-
-    defineProperty(obj, 'bar', computed(function() {
-      return get(this, 'baz').toUpperCase();
-    }).property('baz'));
-
-    mixin(obj, {
-      fooAndBarWatcher: function () {
-        count++;
-      }.observesBefore('{foo,bar}')
-    });
-
-    get(obj, 'foo');
-    set(obj, 'baz', 'Baz');
-    // fire once for foo, once for bar
-    equal(count, 2, 'observer specified via brace expansion invoked on dependent property change');
-
-    set(obj, 'quux', 'Quux');
-    equal(count, 2, 'observer not fired on unspecified property');
-  });
-}
-
 testBoth('before observer watching multiple properties via brace expansion should fire when properties change', function (get, set) {
   var obj = {};
   var count = 0;

--- a/packages/ember-runtime/lib/ext/function.js
+++ b/packages/ember-runtime/lib/ext/function.js
@@ -4,7 +4,6 @@
 */
 
 import Ember from 'ember-metal/core'; // Ember.EXTEND_PROTOTYPES, Ember.assert
-import expandProperties from 'ember-metal/expand_properties';
 import { computed } from 'ember-metal/computed';
 import { observer } from 'ember-metal/mixin';
 
@@ -151,46 +150,6 @@ if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.Function) {
     @private
   */
   FunctionPrototype.observesImmediately = Ember.deprecateFunc('Function#observesImmediately is deprecated. Use Function#observes instead', FunctionPrototype._observesImmediately);
-
-
-  FunctionPrototype._observesBefore = function () {
-    var watched = [];
-    var addWatchedProperty = function (obs) {
-      watched.push(obs);
-    };
-
-    for (var i = 0, l = arguments.length; i < l; ++i) {
-      expandProperties(arguments[i], addWatchedProperty);
-    }
-
-    this.__ember_observesBefore__ = watched;
-
-    return this;
-  };
-  /**
-    The `observesBefore` extension of Javascript's Function prototype is
-    available when `Ember.EXTEND_PROTOTYPES` or
-    `Ember.EXTEND_PROTOTYPES.Function` is true, which is the default.
-
-    You can get notified when a property change is about to happen by
-    adding the `observesBefore` call to the end of your method
-    declarations in classes that you write. For example:
-
-    ```javascript
-    Ember.Object.extend({
-      valueObserver: function() {
-        // Executes whenever the "value" property is about to change
-      }.observesBefore('value')
-    });
-    ```
-
-    See `Ember.beforeObserver`.
-
-    @method observesBefore
-    @for Function
-    @private
-  */
-  FunctionPrototype.observesBefore = Ember.deprecateFunc('Function#observesBefore is deprecated and will be removed in the near future.', { url: 'http://emberjs.com/deprecations/v1.x/#toc_beforeobserver' }, FunctionPrototype._observesBefore);
 
   /**
     The `on` extension of Javascript's Function prototype is available

--- a/packages/ember-runtime/lib/mixins/observable.js
+++ b/packages/ember-runtime/lib/mixins/observable.js
@@ -21,7 +21,6 @@ import {
 } from 'ember-metal/property_events';
 import {
   addObserver,
-  _addBeforeObserver,
   removeObserver,
   observersFor
 } from 'ember-metal/observer';
@@ -327,11 +326,6 @@ export default Mixin.create({
     this.propertyWillChange(keyName);
     this.propertyDidChange(keyName);
     return this;
-  },
-
-  _addBeforeObserver(key, target, method) {
-    Ember.deprecate('Before observers are deprecated and will be removed in a future release. If you want to keep track of previous values you have to implement it yourself.', false, { url: 'http://emberjs.com/guides/deprecations/#toc_deprecate-beforeobservers' });
-    _addBeforeObserver(this, key, target, method);
   },
 
   /**


### PR DESCRIPTION
- family inclides `Ember.beforeObserver`, `Ember.addBeforeObserver`,
  `Ember.removeBeforeObserver`, `Ember.beforeObserversFor`,
  `Ember._suspendBeforeObserver`, `Ember._suspendBeforeObservers`
- I noticed that `beforeObserversFor`, `_suspendBeforeObserver` and `_suspendBeforeObserves`
  were not used at all, not even internally. I've also checked for
  usages of it in ember-data, liquid-fire and other "official" porjects.
  Nothing. So those two are removed completely.
- For symetry, I've also removed the `Function.prototype.observesBefore`
  counterpart.
