### PR TITLE
[FEATURE allow to check has action] added method hasAction to ActionHandler mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ publish_to_bower/
 bower_components/
 npm-debug.log
 .ember-cli
+/.idea

--- a/packages/ember-runtime/lib/mixins/action_handler.js
+++ b/packages/ember-runtime/lib/mixins/action_handler.js
@@ -209,6 +209,20 @@ var ActionHandler = Mixin.create({
                    ') does not have a `send` method', typeof target.send === 'function');
       target.send(...arguments);
     }
+  },
+
+  /**
+   Check if controller has any subscriptions for named event.
+
+   @method hasAction
+   @param {String} actionName The action to trigger
+   @public
+   */
+  hasAction(actionName) {
+    if (this._actions && actionName) {
+      return this._actions.hasOwnProperty(actionName);
+    }
+    return false;
   }
 });
 

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -23,6 +23,39 @@ QUnit.test('Action can be handled by a function on actions object', function() {
   controller.send('poke');
 });
 
+QUnit.test('Controller should have action', function() {
+  expect(1);
+  var TestController = Controller.extend({
+    actions: {
+      poke() {}
+    }
+  });
+  var controller = TestController.create({});
+  equal(controller.hasAction('poke'), true);
+});
+
+QUnit.test('Controller should not have action', function() {
+  expect(1);
+  var TestController = Controller.extend({
+    actions: {
+      poke() {}
+    }
+  });
+  var controller = TestController.create({});
+  equal(controller.hasAction('another-poke'), false);
+});
+
+QUnit.test('method `hasAction` with empty action name should return false', function() {
+  expect(1);
+  var TestController = Controller.extend({
+    actions: {
+      poke() {}
+    }
+  });
+  var controller = TestController.create({});
+  equal(controller.hasAction(), false);
+});
+
 // TODO: Can we support this?
 // QUnit.test("Actions handlers can be configured to use another name", function() {
 //   expect(1);
@@ -52,7 +85,6 @@ QUnit.test('When `_actions` is provided, `actions` is left alone', function() {
   controller.send('poke');
   equal('foo', controller.get('actions')[0], 'actions property is not untouched');
 });
-
 
 QUnit.test('A handled action can be bubbled to the target for continued processing', function() {
   expect(2);


### PR DESCRIPTION
It would be great to have method that could check - has controller subscription for action or no.
For now, when I try to trigger parent action I can check it by `_.has(controller._actions, actionName)` if expression  `true`  I trigger action with dependency data or no if I receive `false`.

For example my propose is create new method something like this:

`this.hasAction('actionName')` 
