### PR TITLE
[CLEANUP beta] Remove {chainWatchers: null} from Meta.prototype

### DIFF
--- a/packages/ember-metal/lib/chains.js
+++ b/packages/ember-metal/lib/chains.js
@@ -51,7 +51,8 @@ function addChainWatcher(obj, keyName, node) {
   var m = metaFor(obj);
   var nodes = m.chainWatchers;
 
-  if (!m.hasOwnProperty('chainWatchers')) { // FIXME?!
+  // TODO remove hasOwnProperty check
+  if (nodes === undefined || !m.hasOwnProperty('chainWatchers')) {
     nodes = m.chainWatchers = new Chains();
   }
 

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -191,12 +191,14 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
 }
 
 function chainsWillChange(obj, keyName, m) {
-  if (!(m.hasOwnProperty('chainWatchers') &&
-        m.chainWatchers[keyName])) {
+  if (m.chainWatchers === undefined ||
+     !m.hasOwnProperty('chainWatchers')) {
     return;
   }
-
   var nodes = m.chainWatchers[keyName];
+  if (nodes === undefined) {
+    return;
+  }
   var events = [];
   var i, l;
 
@@ -210,12 +212,14 @@ function chainsWillChange(obj, keyName, m) {
 }
 
 function chainsDidChange(obj, keyName, m, suppressEvents) {
-  if (!(m && m.hasOwnProperty('chainWatchers') &&
-        m.chainWatchers[keyName])) {
+  if (m.chainWatchers === undefined ||
+     !m.hasOwnProperty('chainWatchers')) {
     return;
   }
-
   var nodes = m.chainWatchers[keyName];
+  if (nodes === undefined) {
+    return;
+  }
   var events = suppressEvents ? null : [];
   var i, l;
 

--- a/packages/ember-metal/lib/utils.js
+++ b/packages/ember-metal/lib/utils.js
@@ -286,20 +286,16 @@ export function guidFor(obj) {
 function Meta(obj) {
   this.watching = {};
   this.cache = undefined;
-  this.cacheMeta = undefined;
   this.source = obj;
   this.deps = undefined;
   this.listeners = undefined;
   this.mixins = undefined;
   this.bindings = undefined;
   this.chains = undefined;
+  this.chainWatchers = undefined;
   this.values = undefined;
   this.proto = undefined;
 }
-
-Meta.prototype = {
-  chainWatchers: null // FIXME
-};
 
 // Placeholder for non-writable metas.
 var EMPTY_META = new Meta(null);
@@ -356,7 +352,6 @@ function meta(obj, writable) {
     ret = Object.create(ret);
     ret.watching  = Object.create(ret.watching);
     ret.cache     = undefined;
-    ret.cacheMeta = undefined;
     ret.source    = obj;
 
     if (isEnabled('mandatory-setter')) {


### PR DESCRIPTION
Remove {chainWatchers: null} from Meta.prototype and just initialize it in the constructor.
