### PR TITLE
[DOC release] Add link to website in ArrayController deprecation

### DIFF
--- a/packages/ember-runtime/lib/controllers/array_controller.js
+++ b/packages/ember-runtime/lib/controllers/array_controller.js
@@ -208,7 +208,7 @@ export default ArrayProxy.extend(ControllerMixin, SortableMixin, {
   },
 
   init() {
-    Ember.deprecate(arrayControllerDeprecation, this.isGenerated);
+    Ember.deprecate(arrayControllerDeprecation, this.isGenerated, { url: 'http://emberjs.com/guides/deprecations#toc_arraycontroller' });
 
     this._super(...arguments);
     this._subControllers = [];


### PR DESCRIPTION
As requested here https://github.com/emberjs/website/pull/2258 this adds a link to the website in the ArrayController deprecation.

I believe this is the right branch to merge into. I am not sure what the best commit tag to use is in this case.

This should close #11450.
