### PR TITLE
[CLEANUP beta] Abstract chainWatchers into an object.

### DIFF
--- a/packages/ember-metal/lib/computed.js
+++ b/packages/ember-metal/lib/computed.js
@@ -274,12 +274,6 @@ ComputedPropertyPrototype.didChange = function(obj, keyName) {
   }
 };
 
-function finishChains(chainNodes) {
-  for (var i = 0, l = chainNodes.length; i < l; i++) {
-    chainNodes[i].didChange(null);
-  }
-}
-
 /**
   Access the value of the function backing the computed property.
   If this property has already been cached, return the cached result.
@@ -308,7 +302,7 @@ function finishChains(chainNodes) {
   @public
 */
 ComputedPropertyPrototype.get = function(obj, keyName) {
-  var ret, cache, meta, chainNodes;
+  var ret, cache, meta;
   if (this._cacheable) {
     meta = metaFor(obj);
     cache = meta.cache;
@@ -332,9 +326,8 @@ ComputedPropertyPrototype.get = function(obj, keyName) {
       cache[keyName] = ret;
     }
 
-    chainNodes = meta.chainWatchers && meta.chainWatchers[keyName];
-    if (chainNodes) {
-      finishChains(chainNodes);
+    if (meta.chainWatchers) {
+      meta.chainWatchers.revalidate(keyName);
     }
     addDependentKeys(this, obj, keyName, meta);
   } else {

--- a/packages/ember-metal/lib/property_events.js
+++ b/packages/ember-metal/lib/property_events.js
@@ -191,53 +191,26 @@ function iterDeps(method, obj, deps, depKey, seen, meta) {
 }
 
 function chainsWillChange(obj, keyName, m) {
-  if (m.chainWatchers === undefined ||
-     !m.hasOwnProperty('chainWatchers')) {
+  if (m.chainWatchers === undefined || m.chainWatchers.obj !== obj) {
     return;
   }
-  var nodes = m.chainWatchers[keyName];
-  if (nodes === undefined) {
-    return;
-  }
-  var events = [];
-  var i, l;
 
-  for (i = 0, l = nodes.length; i < l; i++) {
-    nodes[i].willChange(events);
-  }
-
-  for (i = 0, l = events.length; i < l; i += 2) {
-    propertyWillChange(events[i], events[i + 1]);
-  }
+  m.chainWatchers.notify(keyName, false, propertyWillChange);
 }
 
-function chainsDidChange(obj, keyName, m, suppressEvents) {
-  if (m.chainWatchers === undefined ||
-     !m.hasOwnProperty('chainWatchers')) {
-    return;
-  }
-  var nodes = m.chainWatchers[keyName];
-  if (nodes === undefined) {
-    return;
-  }
-  var events = suppressEvents ? null : [];
-  var i, l;
-
-  for (i = 0, l = nodes.length; i < l; i++) {
-    nodes[i].didChange(events);
-  }
-
-  if (suppressEvents) {
+function chainsDidChange(obj, keyName, m) {
+  if (m.chainWatchers === undefined || m.chainWatchers.obj !== obj) {
     return;
   }
 
-  for (i = 0, l = events.length; i < l; i += 2) {
-    propertyDidChange(events[i], events[i + 1]);
-  }
+  m.chainWatchers.notify(keyName, true, propertyDidChange);
 }
 
 function overrideChains(obj, keyName, m) {
-  chainsDidChange(obj, keyName, m, true);
+  if (m.chainWatchers === undefined || m.chainWatchers.obj !== obj) {
+    return;
+  }
+  m.chainWatchers.revalidate(keyName);
 }
 
 /**

--- a/packages/ember-metal/tests/watching/watch_test.js
+++ b/packages/ember-metal/tests/watching/watch_test.js
@@ -204,16 +204,14 @@ QUnit.test('when watching a global object, destroy should remove chain watchers 
 
   var meta_Global = Ember.meta(Global);
   var chainNode = Ember.meta(obj).chains._chains.Global._chains.foo;
-  var index = meta_Global.chainWatchers.foo.indexOf(chainNode);
 
   equal(meta_Global.watching.foo, 1, 'should be watching foo');
-  strictEqual(meta_Global.chainWatchers.foo[index], chainNode, 'should have chain watcher');
+  equal(meta_Global.chainWatchers.has('foo', chainNode), true, 'should have chain watcher');
 
   destroy(obj);
 
-  index = meta_Global.chainWatchers.foo.indexOf(chainNode);
   equal(meta_Global.watching.foo, 0, 'should not be watching foo');
-  equal(index, -1, 'should not have chain watcher');
+  equal(meta_Global.chainWatchers.has('foo', chainNode), false, 'should not have chain watcher');
 
   lookup['Global'] = Global = null; // reset
 });
@@ -228,16 +226,14 @@ QUnit.test('when watching another object, destroy should remove chain watchers f
 
   var meta_objB = Ember.meta(objB);
   var chainNode = Ember.meta(objA).chains._chains.b._chains.foo;
-  var index = meta_objB.chainWatchers.foo.indexOf(chainNode);
 
   equal(meta_objB.watching.foo, 1, 'should be watching foo');
-  strictEqual(meta_objB.chainWatchers.foo[index], chainNode, 'should have chain watcher');
+  equal(meta_objB.chainWatchers.has('foo', chainNode), true, 'should have chain watcher');
 
   destroy(objA);
 
-  index = meta_objB.chainWatchers.foo.indexOf(chainNode);
   equal(meta_objB.watching.foo, 0, 'should not be watching foo');
-  equal(index, -1, 'should not have chain watcher');
+  equal(meta_objB.chainWatchers.has('foo', chainNode), false, 'should not have chain watcher');
 });
 
 // TESTS for length property


### PR DESCRIPTION
Abstracting chainWatchers into an Object, cleans up some shape deopts, helps make stuff more clear.  This is good to go, I haven't squashed yet just so it is easier for people to review updates.
