### PR TITLE
[CLEANUP beta] Remove sendEvent hook.

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -312,11 +312,6 @@ export function watchedEvents(obj) {
   @public
 */
 export function sendEvent(obj, eventName, params, actions) {
-  // first give object a chance to handle it
-  if (obj !== Ember && 'function' === typeof obj.sendEvent) {
-    obj.sendEvent(eventName, params);
-  }
-
   if (!actions) {
     var meta = obj['__ember_meta__'];
     actions = meta && meta.listeners && meta.listeners[eventName];

--- a/packages/ember-metal/tests/events_test.js
+++ b/packages/ember-metal/tests/events_test.js
@@ -146,23 +146,6 @@ QUnit.test('calling sendEvent with extra params should be passed to listeners', 
   deepEqual(params, ['foo', 'bar'], 'params should be saved');
 });
 
-QUnit.test('implementing sendEvent on object should invoke', function() {
-  var obj = {
-    sendEvent(eventName, params) {
-      equal(eventName, 'event!', 'eventName');
-      deepEqual(params, ['foo', 'bar']);
-      this.count++;
-    },
-
-    count: 0
-  };
-
-  addListener(obj, 'event!', obj, function() { this.count++; });
-
-  sendEvent(obj, 'event!', ['foo', 'bar']);
-  equal(obj.count, 2, 'should have invoked method & listener');
-});
-
 QUnit.test('hasListeners tells you if there are listeners for a given event', function() {
   var obj = {};
   var F = function() {};

--- a/packages/ember-metal/tests/observer_test.js
+++ b/packages/ember-metal/tests/observer_test.js
@@ -477,32 +477,6 @@ testBoth('deferring property change notifications will not defer before observer
   equal(fooCount, 1, 'should not fire before observer twice');
 });
 
-testBoth('implementing sendEvent on object should invoke when deferring property change notifications ends', function(get, set) {
-  var count = 0;
-  var events = [];
-  var obj = {
-    sendEvent(eventName) {
-      events.push(eventName);
-    },
-    foo: 'baz'
-  };
-
-  addObserver(obj, 'foo', function() { count++; });
-
-  beginPropertyChanges(obj);
-  set(obj, 'foo', 'BAZ');
-
-  equal(count, 0, 'should have not invoked observer');
-  equal(events.length, 1, 'should have invoked sendEvent for before');
-
-  endPropertyChanges(obj);
-
-  equal(count, 1, 'should have invoked observer');
-  equal(events.length, 2, 'should have invoked sendEvent');
-  equal(events[0], 'foo:before');
-  equal(events[1], 'foo:change');
-});
-
 testBoth('addObserver should propagate through prototype', function(get, set) {
   var obj = { foo: 'foo', count: 0 };
   var obj2;


### PR DESCRIPTION
Remove sendEvent hook. This hook was for a legacy version of the Ember.StateManager.  This was made an add-on prior to Ember 1.0 and the current version of ember-states does not use this hook.
