### PR TITLE
Revert "[CLEANUP beta] Remove support for reversed args in Ember.Obse…

### DIFF
--- a/packages/ember-metal/lib/mixin.js
+++ b/packages/ember-metal/lib/mixin.js
@@ -800,20 +800,32 @@ export function aliasMethod(methodName) {
   @return func
   @private
 */
-export function observer(...paths) {
-  var func  = paths.pop();
-  var expandedPaths = [];
-  var addWatchedProperty = function(path) { expandedPaths.push(path); };
+export function observer(...args) {
+  var func  = args.slice(-1)[0];
+  var paths;
 
-  for (var i = 0; i < paths.length; ++i) {
-    expandProperties(paths[i], addWatchedProperty);
+  var addWatchedProperty = function(path) { paths.push(path); };
+  var _paths = args.slice(0, -1);
+
+  if (typeof func !== 'function') {
+    // revert to old, soft-deprecated argument ordering
+    Ember.deprecate('Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument.');
+
+    func  = args[0];
+    _paths = args.slice(1);
+  }
+
+  paths = [];
+
+  for (var i = 0; i < _paths.length; ++i) {
+    expandProperties(_paths[i], addWatchedProperty);
   }
 
   if (typeof func !== 'function') {
     throw new Ember.Error('Ember.observer called without a function');
   }
 
-  func.__ember_observes__ = expandedPaths;
+  func.__ember_observes__ = paths;
   return func;
 }
 

--- a/packages/ember-metal/tests/mixin/observer_test.js
+++ b/packages/ember-metal/tests/mixin/observer_test.js
@@ -209,3 +209,14 @@ testBoth('observing chain with overriden property', function(get, set) {
   set(obj3, 'baz', 'BEAR');
   equal(get(obj, 'count'), 1, 'should invoke observer after change');
 });
+
+testBoth('providing the arguments in reverse order is deprecated', function(get, set) {
+  expectDeprecation(/Passing the dependentKeys after the callback function in Ember\.observer is deprecated. Ensure the callback function is the last argument/);
+
+  Mixin.create({
+    count: 0,
+    foo: observer(function() {
+      set(this, 'count', get(this, 'count') + 1);
+    }, 'bar.baz')
+  });
+});


### PR DESCRIPTION
Reverts emberjs/ember.js#11782.  The release version of the ember-inspector used the deprecated format.  It doesn't cost us much to keep the old version around with the deprecation.

Fixes https://github.com/emberjs/ember.js/issues/11803.
