### PR TITLE
[BUGFIX] fix component integration tests with {{link-to}}

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -299,7 +299,8 @@ var LinkView = EmberComponent.extend({
   **/
   active: computed('loadedParams', function computeLinkViewActive() {
     var router = get(this, 'router');
-    if (!router) { return; }
+    if (!router || !router.router) { return false; }
+
     return computeActive(this, router.currentState);
   }),
 
@@ -338,6 +339,9 @@ var LinkView = EmberComponent.extend({
     @property loading
   **/
   loading: computed('loadedParams', function computeLinkViewLoading() {
+    var router = get(this, 'router');
+    if (!router || !router.router) { return false; }
+
     if (!get(this, 'loadedParams')) { return get(this, 'loadingClass'); }
   }),
 
@@ -495,7 +499,7 @@ var LinkView = EmberComponent.extend({
   **/
   loadedParams: computed('resolvedParams', function computeLinkViewRouteArgs() {
     var router = get(this, 'router');
-    if (!router) { return; }
+    if (!router || !router.router) { return; }
 
     var resolvedParams = get(this, 'resolvedParams');
     var namedRoute = resolvedParams.targetRouteName;


### PR DESCRIPTION
Fixes #11825

The original plan suggested was to cherry-pick two commits from 1.13.x that fixed this problem. However, because the [routing service](https://github.com/nathanhammond/ember.js/commit/7cff945c04bf66b0c621b6b70042c51d8a5b2cdf) was introduced, this wasn't easy to do.

However, I tracked down where the issues were occurring and squashed them. I tested this build against a 1.12 example app and this works as it does in 1.13.
