### PR TITLE
[FEATURE ember-container-inject-owner]: Inject `owner` instead of `container` during `lookup`.

### DIFF
--- a/features.json
+++ b/features.json
@@ -8,6 +8,7 @@
     "ember-debug-handlers": true,
     "ember-routing-routable-components": null,
     "ember-metal-ember-assign": null,
-    "ember-contextual-components": true
+    "ember-contextual-components": true,
+    "ember-container-inject-owner": null
   }
 }

--- a/packages/container/lib/main.js
+++ b/packages/container/lib/main.js
@@ -20,5 +20,6 @@ if (Ember.ENV && typeof Ember.ENV.MODEL_FACTORY_INJECTIONS !== 'undefined') {
 
 import Registry from 'container/registry';
 import Container from 'container/container';
+import { getOwner, setOwner } from 'container/owner';
 
-export { Registry, Container };
+export { Registry, Container, getOwner, setOwner };

--- a/packages/container/lib/owner.js
+++ b/packages/container/lib/owner.js
@@ -1,0 +1,11 @@
+import { symbol } from 'ember-metal/utils';
+
+export const OWNER = symbol('OWNER');
+
+export function getOwner(object) {
+  return object[OWNER];
+}
+
+export function setOwner(object, owner) {
+  object[OWNER] = owner;
+}

--- a/packages/container/tests/owner_test.js
+++ b/packages/container/tests/owner_test.js
@@ -1,0 +1,16 @@
+import { getOwner, setOwner, OWNER } from 'container/owner';
+
+QUnit.module('Owner', {});
+
+QUnit.test('An owner can be set with `setOwner` and retrieved with `getOwner`', function() {
+  let owner = {};
+  let obj = {};
+
+  strictEqual(getOwner(obj), undefined, 'owner has not been set');
+
+  setOwner(obj, owner);
+
+  strictEqual(getOwner(obj), owner, 'owner has been set');
+
+  strictEqual(obj[OWNER], owner, 'owner has been set to the OWNER symbol');
+});

--- a/packages/container/tests/registry_test.js
+++ b/packages/container/tests/registry_test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember-metal/core';
 import { Registry } from 'container';
-import { factory } from 'container/tests/container_helper';
+import factory from 'container/tests/test-helpers/factory';
 
 var originalModelInjections;
 

--- a/packages/container/tests/test-helpers/build-owner.js
+++ b/packages/container/tests/test-helpers/build-owner.js
@@ -1,0 +1,15 @@
+import EmberObject from 'ember-runtime/system/object';
+import Registry from 'container/registry';
+import RegistryProxy from 'ember-runtime/mixins/registry_proxy';
+import ContainerProxy from 'ember-runtime/mixins/container_proxy';
+
+export default function buildOwner(props) {
+  let Owner = EmberObject.extend(RegistryProxy, ContainerProxy, {
+    init() {
+      this._super(...arguments);
+      const registry = this.__registry__ = new Registry();
+      this.__container__ = registry.container({ owner: this });
+    }
+  });
+  return Owner.create(props);
+}

--- a/packages/container/tests/test-helpers/factory.js
+++ b/packages/container/tests/test-helpers/factory.js
@@ -8,7 +8,7 @@ var setProperties = function(object, properties) {
 
 var guids = 0;
 
-var factory = function() {
+export default function factory() {
   /*jshint validthis: true */
 
   var Klass = function(options) {
@@ -61,9 +61,4 @@ var factory = function() {
 
     return Child;
   }
-};
-
-export {
-  factory,
-  setProperties
-};
+}

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -101,7 +101,7 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
     registry.makeToString = applicationRegistry.makeToString;
 
     // Create a per-instance container from the instance's registry
-    this.__container__ = registry.container();
+    this.__container__ = registry.container({ owner: this });
 
     // Register this instance in the per-instance registry.
     //

--- a/packages/ember-extension-support/lib/container_debug_adapter.js
+++ b/packages/ember-extension-support/lib/container_debug_adapter.js
@@ -50,17 +50,6 @@ import EmberObject from 'ember-runtime/system/object';
 */
 export default EmberObject.extend({
   /**
-    The container of the application being debugged.
-    This property will be injected
-    on creation.
-
-    @property container
-    @default null
-    @public
-  */
-  container: null,
-
-  /**
     The resolver instance of the application
     being debugged. This property will be injected
     on creation.

--- a/packages/ember-extension-support/lib/data_adapter.js
+++ b/packages/ember-extension-support/lib/data_adapter.js
@@ -5,6 +5,7 @@ import Namespace from 'ember-runtime/system/namespace';
 import EmberObject from 'ember-runtime/system/object';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import Application from 'ember-application/system/application';
+import { getOwner } from 'container/owner';
 
 /**
 @module ember
@@ -58,19 +59,6 @@ export default EmberObject.extend({
     this._super(...arguments);
     this.releaseMethods = emberA();
   },
-
-  /**
-    The container of the application being debugged.
-    This property will be injected
-    on creation.
-
-    @property container
-    @default null
-    @since 1.3.0
-    @public
-  */
-  container: null,
-
 
   /**
     The container-debug-adapter which is used
@@ -171,7 +159,7 @@ export default EmberObject.extend({
 
   _nameToClass(type) {
     if (typeof type === 'string') {
-      type = this.container.lookupFactory(`model:${type}`);
+      type = getOwner(this)._lookupFactory(`model:${type}`);
     }
     return type;
   },

--- a/packages/ember-extension-support/tests/container_debug_adapter_test.js
+++ b/packages/ember-extension-support/tests/container_debug_adapter_test.js
@@ -3,7 +3,7 @@ import EmberController from 'ember-runtime/controllers/controller';
 import 'ember-extension-support'; // Must be required to export Ember.ContainerDebugAdapter
 import Application from 'ember-application/system/application';
 
-var adapter, App;
+var adapter, App, appInstance;
 
 
 function boot() {
@@ -19,14 +19,16 @@ QUnit.module('Container Debug Adapter', {
     });
     boot();
     run(function() {
-      adapter = App.__container__.lookup('container-debug-adapter:main');
+      appInstance = App.__deprecatedInstance__;
+      adapter = appInstance.lookup('container-debug-adapter:main');
     });
   },
   teardown() {
     run(function() {
       adapter.destroy();
+      appInstance.destroy();
       App.destroy();
-      App = null;
+      App = appInstance = adapter = null;
     });
   }
 });

--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -81,7 +81,7 @@ export default function componentHook(renderNode, env, scope, _tagName, params, 
 
   let component, layout;
   if (isDasherized || !isAngleBracket) {
-    let result = lookupComponent(env.container, tagName);
+    let result = lookupComponent(env.owner, tagName);
     component = result.component;
     layout = result.layout;
 

--- a/packages/ember-htmlbars/lib/hooks/has-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/has-helper.js
@@ -5,10 +5,10 @@ export default function hasHelperHook(env, scope, helperName) {
     return true;
   }
 
-  var container = env.container;
-  if (validateLazyHelperName(helperName, container, env.hooks.keywords)) {
-    var containerName = 'helper:' + helperName;
-    if (container.registry.has(containerName)) {
+  const owner = env.owner;
+  if (validateLazyHelperName(helperName, owner, env.hooks.keywords)) {
+    var registrationName = 'helper:' + helperName;
+    if (owner.hasRegistration(registrationName)) {
       return true;
     }
   }

--- a/packages/ember-htmlbars/lib/keywords/closure-component.js
+++ b/packages/ember-htmlbars/lib/keywords/closure-component.js
@@ -64,7 +64,7 @@ function createClosureComponentCell(env, originalComponentPath, params, hash, la
 }
 
 function isValidComponentPath(env, path) {
-  const result = lookupComponent(env.container, path);
+  const result = lookupComponent(env.owner, path);
 
   return !!(result.component || result.layout);
 }
@@ -88,7 +88,7 @@ function createNestedClosureComponentCell(componentCell, params, hash) {
 }
 
 function createNewClosureComponentCell(env, componentPath, params, hash) {
-  let positionalParams = getPositionalParams(env.container, componentPath);
+  let positionalParams = getPositionalParams(env.owner, componentPath);
 
   // This needs to be done in each nesting level to avoid raising assertions
   processPositionalParams(null, positionalParams, params, hash);

--- a/packages/ember-htmlbars/lib/keywords/collection.js
+++ b/packages/ember-htmlbars/lib/keywords/collection.js
@@ -138,7 +138,7 @@ export default {
 
     return assign({}, state, {
       parentView: env.view,
-      viewClassOrInstance: getView(read(params[0]), env.container)
+      viewClassOrInstance: getView(read(params[0]), env.owner)
     });
   },
 

--- a/packages/ember-htmlbars/lib/keywords/outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/outlet.js
@@ -107,13 +107,13 @@ export default {
     var parentView = env.view;
     var outletState = state.outletState;
     var toRender = outletState.render;
-    var namespace = env.container.lookup('application:main');
+    var namespace = env.owner.lookup('application:main');
     var LOG_VIEW_LOOKUPS = get(namespace, 'LOG_VIEW_LOOKUPS');
 
     var ViewClass = outletState.render.ViewClass;
 
     if (!state.hasParentOutlet && !ViewClass) {
-      ViewClass = env.container.lookupFactory('view:toplevel');
+      ViewClass = env.owner._lookupFactory('view:toplevel');
     }
 
     var Component;

--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -191,7 +191,7 @@ export default {
     var targetObject = read(scope.getSelf());
     var viewClassOrInstance = state.viewClassOrInstance;
     if (!viewClassOrInstance) {
-      viewClassOrInstance = getView(read(params[0]), env.container);
+      viewClassOrInstance = getView(read(params[0]), env.owner);
     }
 
     // if parentView exists, use its controller (the default
@@ -258,17 +258,17 @@ export default {
   }
 };
 
-function getView(viewPath, container) {
+function getView(viewPath, owner) {
   var viewClassOrInstance;
 
   if (!viewPath) {
-    if (container) {
-      viewClassOrInstance = container.lookupFactory('view:toplevel');
+    if (owner) {
+      viewClassOrInstance = owner._lookupFactory('view:toplevel');
     } else {
       viewClassOrInstance = EmberView;
     }
   } else {
-    viewClassOrInstance = readViewFactory(viewPath, container);
+    viewClassOrInstance = readViewFactory(viewPath, owner);
   }
 
   return viewClassOrInstance;

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -9,6 +9,7 @@ import LegacyEmberComponent from 'ember-views/components/component';
 import GlimmerComponent from 'ember-htmlbars/glimmer-component';
 import extractPositionalParams from 'ember-htmlbars/utils/extract-positional-params';
 import { symbol } from 'ember-metal/utils';
+import { getOwner, setOwner } from 'container/owner';
 
 // These symbols will be used to limit link-to's public API surface area.
 export let HAS_BLOCK = symbol('HAS_BLOCK');
@@ -232,13 +233,15 @@ export function createComponent(_component, isAngleBracket, props, renderNode, e
     props._isAngleBracket = true;
   }
 
-  props.renderer = props.parentView ? props.parentView.renderer : env.container.lookup('renderer:-dom');
-  props._viewRegistry = props.parentView ? props.parentView._viewRegistry : env.container.lookup('-view-registry:main');
+  props.renderer = props.parentView ? props.parentView.renderer : env.owner.lookup('renderer:-dom');
+  props._viewRegistry = props.parentView ? props.parentView._viewRegistry : env.owner.lookup('-view-registry:main');
 
-  let component = _component.create(props);
+  const component = _component.create(props);
 
   // for the fallback case
-  component.container = component.container || env.container;
+  if (!getOwner(component)) {
+    setOwner(component, env.owner);
+  }
 
   if (props.parentView) {
     props.parentView.appendChild(component);

--- a/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/view-node-manager.js
@@ -9,6 +9,7 @@ import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 import getCellOrValue from 'ember-htmlbars/hooks/get-cell-or-value';
 import { instrument } from 'ember-htmlbars/system/instrumentation-support';
 import { takeLegacySnapshot } from 'ember-htmlbars/node-managers/component-node-manager';
+import { getOwner, setOwner } from 'container/owner';
 
 // In theory this should come through the env, but it should
 // be safe to import this until we make the hook system public
@@ -180,9 +181,12 @@ export function createOrUpdateComponent(component, options, createOptions, rende
     }
 
     mergeBindings(props, snapshot);
-    props.container = options.parentView ? options.parentView.container : env.container;
-    props.renderer = options.parentView ? options.parentView.renderer : props.container && props.container.lookup('renderer:-dom');
-    props._viewRegistry = options.parentView ? options.parentView._viewRegistry : props.container && props.container.lookup('-view-registry:main');
+
+    const owner = options.parentView ? getOwner(options.parentView) : env.owner;
+
+    setOwner(props, owner);
+    props.renderer = options.parentView ? options.parentView.renderer : owner && owner.lookup('renderer:-dom');
+    props._viewRegistry = options.parentView ? options.parentView._viewRegistry : owner && owner.lookup('-view-registry:main');
 
     if (proto.controller !== defaultController || hasSuppliedController) {
       delete props._context;

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -36,11 +36,11 @@ export function findHelper(name, view, env) {
   var helper = env.helpers[name];
 
   if (!helper) {
-    var container = env.container;
-    if (validateLazyHelperName(name, container, env.hooks.keywords)) {
+    const owner = env.owner;
+    if (validateLazyHelperName(name, owner, env.hooks.keywords)) {
       var helperName = 'helper:' + name;
-      if (container.registry.has(helperName)) {
-        helper = container.lookupFactory(helperName);
+      if (owner.hasRegistration(helperName)) {
+        helper = owner._lookupFactory(helperName);
         assert(`Expected to find an Ember.Helper with the name ${helperName}, but found an object of type ${typeof helper} instead.`, helper.isHelperFactory || helper.isHelperInstance);
       }
     }

--- a/packages/ember-htmlbars/lib/system/render-env.js
+++ b/packages/ember-htmlbars/lib/system/render-env.js
@@ -1,5 +1,6 @@
 import defaultEnv from 'ember-htmlbars/env';
 import { MorphSet } from 'ember-metal-views/renderer';
+import { getOwner } from 'container/owner';
 
 export default function RenderEnv(options) {
   this.lifecycleHooks = options.lifecycleHooks || [];
@@ -9,7 +10,7 @@ export default function RenderEnv(options) {
 
   this.view = options.view;
   this.outletState = options.outletState;
-  this.container = options.container;
+  this.owner = options.owner;
   this.renderer = options.renderer;
   this.dom = options.dom;
 
@@ -23,7 +24,7 @@ RenderEnv.build = function(view) {
   return new RenderEnv({
     view: view,
     outletState: view.outletState,
-    container: view.container,
+    owner: getOwner(view),
     renderer: view.renderer,
     dom: view.renderer._dom
   });
@@ -33,7 +34,7 @@ RenderEnv.prototype.childWithView = function(view) {
   return new RenderEnv({
     view: view,
     outletState: this.outletState,
-    container: this.container,
+    owner: this.owner,
     renderer: this.renderer,
     dom: this.dom,
     lifecycleHooks: this.lifecycleHooks,
@@ -47,7 +48,7 @@ RenderEnv.prototype.childWithOutletState = function(outletState, hasParentOutlet
   return new RenderEnv({
     view: this.view,
     outletState: outletState,
-    container: this.container,
+    owner: this.owner,
     renderer: this.renderer,
     dom: this.dom,
     lifecycleHooks: this.lifecycleHooks,

--- a/packages/ember-htmlbars/lib/utils/is-component.js
+++ b/packages/ember-htmlbars/lib/utils/is-component.js
@@ -15,8 +15,8 @@ import { isStream } from 'ember-metal/streams/utils';
  name was found in the container.
 */
 export default function isComponent(env, scope, path) {
-  var container = env.container;
-  if (!container) { return false; }
+  const owner = env.owner;
+  if (!owner) { return false; }
   if (typeof path === 'string') {
     if (CONTAINS_DOT_CACHE.get(path)) {
       let stream = env.hooks.get(env, scope, path);
@@ -28,7 +28,7 @@ export default function isComponent(env, scope, path) {
       }
     }
     if (!CONTAINS_DASH_CACHE.get(path)) { return false; }
-    return container.registry.has('component:' + path) ||
-           container.registry.has('template:components/' + path);
+    return owner.hasRegistration('component:' + path) ||
+           owner.hasRegistration('template:components/' + path);
   }
 }

--- a/packages/ember-htmlbars/tests/compat/view_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/view_helper_test.js
@@ -4,7 +4,8 @@ import EmberView from 'ember-views/views/view';
 import EmberSelectView from 'ember-views/views/select';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import compile from 'ember-template-compiler/system/compile';
-import Registry from 'container/registry';
+import { OWNER } from 'container/owner';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
 import { registerAstPlugin, removeAstPlugin } from 'ember-htmlbars/tests/utils';
 import AssertNoViewHelper from 'ember-template-compiler/plugins/assert-no-view-helper';
@@ -12,7 +13,7 @@ import AssertNoViewHelper from 'ember-template-compiler/plugins/assert-no-view-h
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
 
-let component, registry, container, originalViewKeyword;
+let component, owner, originalViewKeyword;
 
 QUnit.module('ember-htmlbars: compat - view helper', {
   setup() {
@@ -21,15 +22,14 @@ QUnit.module('ember-htmlbars: compat - view helper', {
 
     originalViewKeyword = registerKeyword('view',  viewKeyword);
 
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
   },
   teardown() {
     runDestroy(component);
-    runDestroy(container);
+    runDestroy(owner);
     removeAstPlugin(AssertNoViewHelper);
     Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT = true;
-    registry = container = component = null;
+    owner = component = null;
 
     resetKeyword('view', originalViewKeyword);
   }
@@ -39,12 +39,12 @@ QUnit.test('using the view helper fails assertion', function(assert) {
   const ViewClass = EmberView.extend({
     template: compile('fooView')
   });
-  registry.register('view:foo', ViewClass);
+  owner.register('view:foo', ViewClass);
 
   expectAssertion(function() {
     component = EmberComponent.extend({
-      layout: compile('{{view \'foo\'}}'),
-      container
+      [OWNER]: owner,
+      layout: compile('{{view \'foo\'}}')
     }).create();
 
     runAppend(component);
@@ -55,13 +55,12 @@ QUnit.module('ember-htmlbars: compat - view helper [LEGACY]', {
   setup() {
     originalViewKeyword = registerKeyword('view',  viewKeyword);
 
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
   },
   teardown() {
     runDestroy(component);
-    runDestroy(container);
-    registry = container = component = null;
+    runDestroy(owner);
+    owner = component = null;
 
     resetKeyword('view', originalViewKeyword);
   }
@@ -71,12 +70,12 @@ QUnit.test('using the view helper with a string (inline form) fails assertion [L
   const ViewClass = EmberView.extend({
     template: compile('fooView')
   });
-  registry.register('view:foo', ViewClass);
+  owner.register('view:foo', ViewClass);
 
   ignoreAssertion(function() {
     component = EmberComponent.extend({
-      layout: compile('{{view \'foo\'}}'),
-      container
+      [OWNER]: owner,
+      layout: compile('{{view \'foo\'}}')
     }).create();
 
     runAppend(component);
@@ -89,12 +88,12 @@ QUnit.test('using the view helper with a string (block form) fails assertion [LE
   const ViewClass = EmberView.extend({
     template: compile('Foo says: {{yield}}')
   });
-  registry.register('view:foo', ViewClass);
+  owner.register('view:foo', ViewClass);
 
   ignoreAssertion(function() {
     component = EmberComponent.extend({
-      layout: compile('{{#view \'foo\'}}I am foo{{/view}}'),
-      container
+      [OWNER]: owner,
+      layout: compile('{{#view \'foo\'}}I am foo{{/view}}')
     }).create();
 
     runAppend(component);
@@ -104,12 +103,12 @@ QUnit.test('using the view helper with a string (block form) fails assertion [LE
 });
 
 QUnit.test('using the view helper with string "select" fails assertion [LEGACY]', function(assert) {
-  registry.register('view:select', EmberSelectView);
+  owner.register('view:select', EmberSelectView);
 
   ignoreAssertion(function() {
     component = EmberComponent.extend({
-      layout: compile('{{view \'select\'}}'),
-      container
+      [OWNER]: owner,
+      layout: compile('{{view \'select\'}}')
     }).create();
 
     runAppend(component);

--- a/packages/ember-htmlbars/tests/glimmer-component/render-test.js
+++ b/packages/ember-htmlbars/tests/glimmer-component/render-test.js
@@ -1,10 +1,11 @@
-import Registry from 'container/registry';
 import View from 'ember-views/views/view';
 import GlimmerComponent from 'ember-htmlbars/glimmer-component';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import ComponentLookup from 'ember-views/component_lookup';
 import isEnabled from 'ember-metal/features';
+import { OWNER } from 'container/owner';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
 let view;
 
@@ -47,12 +48,12 @@ function renderComponent(tag, component) {
     .map(key => `${key}=${hash[key]}`)
     .join(' ');
 
-  let registry = new Registry();
-  registry.register('component-lookup:main', ComponentLookup);
-  registry.register(`component:${tag}`, implementation);
+  const owner = buildOwner();
+  owner.register('component-lookup:main', ComponentLookup);
+  owner.register(`component:${tag}`, implementation);
 
   view = View.extend({
-    container: registry.container(),
+    [OWNER]: owner,
     template: compile(`<${tag} ${stringParams} ${stringHash}>${yielded}</${tag}>`)
   }).create();
 

--- a/packages/ember-htmlbars/tests/helpers/concat-test.js
+++ b/packages/ember-htmlbars/tests/helpers/concat-test.js
@@ -1,30 +1,29 @@
 import run from 'ember-metal/run_loop';
-import { Registry } from 'ember-runtime/system/container';
 import Component from 'ember-views/components/component';
 import compile from 'ember-template-compiler/system/compile';
 import { helper as makeHelper } from 'ember-htmlbars/helper';
 
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var component, registry, container;
+var component, owner;
 
 QUnit.module('ember-htmlbars: {{concat}} helper', {
   setup() {
-    registry = new Registry();
-    container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
+    owner = buildOwner();
+    owner.registerOptionsForType('helper', { instantiate: false });
   },
 
   teardown() {
-    runDestroy(container);
+    runDestroy(owner);
     runDestroy(component);
   }
 });
 
 QUnit.test('concats provided params', function() {
   component = Component.create({
-    container,
-
+    [OWNER]: owner,
     layout: compile(`{{concat "foo" " " "bar" " " "baz"}}`)
   });
 
@@ -35,11 +34,9 @@ QUnit.test('concats provided params', function() {
 
 QUnit.test('updates for bound params', function() {
   component = Component.create({
-    container,
-
+    [OWNER]: owner,
     firstParam: 'one',
     secondParam: 'two',
-
     layout: compile(`{{concat firstParam secondParam}}`)
   });
 
@@ -64,11 +61,10 @@ QUnit.test('can be used as a sub-expression', function() {
   function eq([ actual, expected ]) {
     return actual === expected;
   }
-  registry.register('helper:x-eq', makeHelper(eq));
+  owner.register('helper:x-eq', makeHelper(eq));
 
   component = Component.create({
-    container,
-
+    [OWNER]: owner,
     firstParam: 'one',
     secondParam: 'two',
 

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -2,24 +2,24 @@ import Component from 'ember-views/components/component';
 import Helper, { helper as makeHelper } from 'ember-htmlbars/helper';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
-import Registry from 'container/registry';
 import run from 'ember-metal/run_loop';
 import ComponentLookup from 'ember-views/component_lookup';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-let registry, container, component;
+let owner, component;
 
 QUnit.module('ember-htmlbars: custom app helpers', {
   setup() {
-    registry = new Registry();
-    registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
-    container = registry.container();
+    owner = buildOwner();
+    owner.registerOptionsForType('template', { instantiate: false });
+    owner.registerOptionsForType('helper', { singleton: false });
   },
 
   teardown() {
     runDestroy(component);
-    runDestroy(container);
-    registry = container = component = null;
+    runDestroy(owner);
+    owner = component = null;
   }
 });
 
@@ -27,9 +27,9 @@ QUnit.test('dashed shorthand helper is resolved from container', function() {
   var HelloWorld = makeHelper(function() {
     return 'hello world';
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile('{{hello-world}}')
   }).create();
 
@@ -43,9 +43,9 @@ QUnit.test('dashed helper is resolved from container', function() {
       return 'hello world';
     }
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile('{{hello-world}}')
   }).create();
 
@@ -70,9 +70,9 @@ QUnit.test('dashed helper can recompute a new value', function() {
       this._super();
     }
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile('{{hello-world}}')
   }).create();
 
@@ -102,9 +102,9 @@ QUnit.test('dashed helper with arg can recompute a new value', function() {
       this._super();
     }
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile('{{hello-world "whut"}}')
   }).create();
 
@@ -122,9 +122,9 @@ QUnit.test('dashed shorthand helper is called for param changes', function() {
   var HelloWorld = makeHelper(function() {
     return ++count;
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     name: 'bob',
     layout: compile('{{hello-world name}}')
   }).create();
@@ -151,9 +151,9 @@ QUnit.test('dashed helper compute is called for param changes', function() {
       return ++count;
     }
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     name: 'bob',
     layout: compile('{{hello-world name}}')
   }).create();
@@ -173,9 +173,9 @@ QUnit.test('dashed shorthand helper receives params, hash', function() {
     params = _params;
     hash = _hash;
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     name: 'bob',
     layout: compile('{{hello-world name "rich" last="sam"}}')
   }).create();
@@ -195,9 +195,9 @@ QUnit.test('dashed helper receives params, hash', function() {
       hash = _hash;
     }
   });
-  registry.register('helper:hello-world', HelloWorld);
+  owner.register('helper:hello-world', HelloWorld);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     name: 'bob',
     layout: compile('{{hello-world name "rich" last="sam"}}')
   }).create();
@@ -215,9 +215,9 @@ QUnit.test('dashed helper usable in subexpressions', function() {
       return params.join(' ');
     }
   });
-  registry.register('helper:join-words', JoinWords);
+  owner.register('helper:join-words', JoinWords);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(
       `{{join-words "Who"
                    (join-words "overcomes" "by")
@@ -234,9 +234,9 @@ QUnit.test('dashed helper usable in subexpressions', function() {
 
 QUnit.test('dashed helper not usable with a block', function() {
   var SomeHelper = makeHelper(function() {});
-  registry.register('helper:some-helper', SomeHelper);
+  owner.register('helper:some-helper', SomeHelper);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(`{{#some-helper}}{{/some-helper}}`)
   }).create();
 
@@ -247,9 +247,9 @@ QUnit.test('dashed helper not usable with a block', function() {
 
 QUnit.test('dashed helper not usable within element', function() {
   var SomeHelper = makeHelper(function() {});
-  registry.register('helper:some-helper', SomeHelper);
+  owner.register('helper:some-helper', SomeHelper);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(`<div {{some-helper}}></div>`)
   }).create();
 
@@ -269,9 +269,9 @@ QUnit.test('dashed helper is torn down', function() {
       return 'must define a compute';
     }
   });
-  registry.register('helper:some-helper', SomeHelper);
+  owner.register('helper:some-helper', SomeHelper);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(`{{some-helper}}`)
   }).create();
 
@@ -298,10 +298,10 @@ QUnit.test('dashed helper used in subexpression can recompute', function() {
       return params.join(' ');
     }
   });
-  registry.register('helper:dynamic-segment', DynamicSegment);
-  registry.register('helper:join-words', JoinWords);
+  owner.register('helper:dynamic-segment', DynamicSegment);
+  owner.register('helper:join-words', JoinWords);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(
       `{{join-words "Who"
                    (dynamic-segment)
@@ -341,14 +341,14 @@ QUnit.test('dashed helper used in subexpression can recompute component', functi
       return params.join(' ');
     }
   });
-  registry.register('component-lookup:main', ComponentLookup);
-  registry.register('component:some-component', Component.extend({
+  owner.register('component-lookup:main', ComponentLookup);
+  owner.register('component:some-component', Component.extend({
     layout: compile('{{first}} {{second}} {{third}} {{fourth}} {{fifth}}')
   }));
-  registry.register('helper:dynamic-segment', DynamicSegment);
-  registry.register('helper:join-words', JoinWords);
+  owner.register('helper:dynamic-segment', DynamicSegment);
+  owner.register('helper:join-words', JoinWords);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(
       `{{some-component first="Who"
                    second=(dynamic-segment)
@@ -386,10 +386,10 @@ QUnit.test('dashed helper used in subexpression is destroyed', function() {
   var JoinWords = makeHelper(function(params) {
     return params.join(' ');
   });
-  registry.register('helper:dynamic-segment', DynamicSegment);
-  registry.register('helper:join-words', JoinWords);
+  owner.register('helper:dynamic-segment', DynamicSegment);
+  owner.register('helper:join-words', JoinWords);
   component = Component.extend({
-    container,
+    [OWNER]: owner,
     layout: compile(
       `{{join-words "Who"
                    (dynamic-segment)

--- a/packages/ember-htmlbars/tests/helpers/get_test.js
+++ b/packages/ember-htmlbars/tests/helpers/get_test.js
@@ -1,31 +1,30 @@
 import Ember from 'ember-metal/core';
 import EmberObject from 'ember-runtime/system/object';
 import run from 'ember-metal/run_loop';
-import { Registry } from 'ember-runtime/system/container';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import EmberView from 'ember-views/views/view';
 import ComponentLookup from 'ember-views/component_lookup';
 import TextField from 'ember-views/views/text_field';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var view, registry, container;
+var view, owner;
 
 QUnit.module('ember-htmlbars: {{get}} helper', {
   setup() {
-    registry = new Registry();
-    registry.register('component:-text-field', TextField);
-    registry.register('component-lookup:main', ComponentLookup);
-
-    container = registry.container();
-    registry.optionsForType('template', { instantiate: false });
+    owner = buildOwner();
+    owner.register('component:-text-field', TextField);
+    owner.register('component-lookup:main', ComponentLookup);
+    owner.registerOptionsForType('template', { instantiate: false });
   },
   teardown() {
     run(function() {
       Ember.TEMPLATES = {};
     });
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    runDestroy(owner);
+    owner = view = null;
   }
 });
 
@@ -403,8 +402,8 @@ QUnit.test('get helper value should be updatable using {{input}} and (mut) - dyn
   };
 
   view = EmberView.create({
+    [OWNER]: owner,
     context: context,
-    container: container,
     template: compile(`{{input type='text' value=(mut (get source key)) id='get-input'}}`)
   });
 
@@ -438,8 +437,8 @@ QUnit.test('get helper value should be updatable using {{input}} and (mut) - dyn
   };
 
   view = EmberView.create({
+    [OWNER]: owner,
     context: context,
-    container: container,
     template: compile(`{{input type='text' value=(mut (get source key)) id='get-input'}}`)
   });
 
@@ -471,8 +470,8 @@ QUnit.test('get helper value should be updatable using {{input}} and (mut) - sta
   };
 
   view = EmberView.create({
+    [OWNER]: owner,
     context: context,
-    container: container,
     template: compile(`{{input type='text' value=(mut (get source 'banana')) id='get-input'}}`)
   });
 

--- a/packages/ember-htmlbars/tests/helpers/input_test.js
+++ b/packages/ember-htmlbars/tests/helpers/input_test.js
@@ -3,24 +3,24 @@ import { set } from 'ember-metal/property_set';
 import View from 'ember-views/views/view';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import compile from 'ember-template-compiler/system/compile';
-import Registry from 'container/registry';
 import ComponentLookup from 'ember-views/component_lookup';
 import TextField from 'ember-views/views/text_field';
 import Checkbox from 'ember-views/views/checkbox';
 import EventDispatcher from 'ember-views/system/event_dispatcher';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
 var view;
-var controller, registry, container;
+var controller, owner;
 
 function commonSetup() {
-  registry = new Registry();
-  registry.register('component:-text-field', TextField);
-  registry.register('component:-checkbox', Checkbox);
-  registry.register('component-lookup:main', ComponentLookup);
-  registry.register('event_dispatcher:main', EventDispatcher);
-  container = registry.container();
+  owner = buildOwner();
+  owner.register('component:-text-field', TextField);
+  owner.register('component:-checkbox', Checkbox);
+  owner.register('component-lookup:main', ComponentLookup);
+  owner.register('event_dispatcher:main', EventDispatcher);
 
-  var dispatcher = container.lookup('event_dispatcher:main');
+  var dispatcher = owner.lookup('event_dispatcher:main');
   dispatcher.setup({}, '#qunit-fixture');
 }
 
@@ -38,8 +38,8 @@ QUnit.module('{{input type=\'text\'}}', {
     };
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input type="text" disabled=disabled value=val placeholder=place name=name maxlength=max size=size tabindex=tab}}')
     }).create();
 
@@ -48,7 +48,7 @@ QUnit.module('{{input type=\'text\'}}', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -156,7 +156,7 @@ QUnit.module('{{input type=\'text\'}} - static values', {
     controller = {};
 
     view = View.extend({
-      container: container,
+      [OWNER]: owner,
       controller: controller,
       template: compile('{{input type="text" disabled=true value="hello" placeholder="Enter some text" name="some-name" maxlength=30 size=30 tabindex=5}}')
     }).create();
@@ -166,7 +166,7 @@ QUnit.module('{{input type=\'text\'}} - static values', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -214,9 +214,8 @@ QUnit.test('specifying `on="someevent" action="foo"` triggers the action', funct
   };
 
   view = View.create({
-    container,
+    [OWNER]: owner,
     controller,
-
     template: compile('{{input type="text" on="focus-in" action="doFoo"}}', { moduleName: 'foo.hbs' })
   });
 
@@ -237,8 +236,8 @@ QUnit.module('{{input type=\'text\'}} - dynamic type', {
     };
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input type=someProperty}}')
     }).create();
 
@@ -247,7 +246,7 @@ QUnit.module('{{input type=\'text\'}} - dynamic type', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -272,8 +271,8 @@ QUnit.module('{{input}} - default type', {
     controller = {};
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input}}')
     }).create();
 
@@ -282,7 +281,7 @@ QUnit.module('{{input}} - default type', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -301,8 +300,8 @@ QUnit.module('{{input type=\'checkbox\'}}', {
     };
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input type="checkbox" disabled=disabled tabindex=tab name=name checked=val}}')
     }).create();
 
@@ -311,7 +310,7 @@ QUnit.module('{{input type=\'checkbox\'}}', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -348,15 +347,15 @@ QUnit.module('{{input type=\'checkbox\'}} - prevent value= usage', {
     commonSetup();
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input type="checkbox" disabled=disabled tabindex=tab name=name value=val}}')
     }).create();
   },
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -376,8 +375,8 @@ QUnit.module('{{input type=boundType}}', {
     };
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input type=inputType checked=isChecked}}')
     }).create();
 
@@ -386,7 +385,7 @@ QUnit.module('{{input type=boundType}}', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -411,8 +410,8 @@ QUnit.module('{{input type=\'checkbox\'}} - static values', {
     };
 
     view = View.extend({
-      container: container,
-      controller: controller,
+      [OWNER]: owner,
+      controller,
       template: compile('{{input type="checkbox" disabled=true tabindex=6 name="hello" checked=false}}')
     }).create();
 
@@ -421,7 +420,7 @@ QUnit.module('{{input type=\'checkbox\'}} - static values', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
@@ -448,13 +447,13 @@ QUnit.module('{{input type=\'text\'}} - null/undefined values', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
+    runDestroy(owner);
   }
 });
 
 QUnit.test('placeholder attribute bound to undefined is not present', function() {
   view = View.extend({
-    container: container,
+    [OWNER]: owner,
     controller: {},
     template: compile('{{input placeholder=someThingNotThere}}')
   }).create();
@@ -470,7 +469,7 @@ QUnit.test('placeholder attribute bound to undefined is not present', function()
 
 QUnit.test('placeholder attribute bound to null is not present', function() {
   view = View.extend({
-    container: container,
+    [OWNER]: owner,
     controller: {
       someNullProperty: null
     },

--- a/packages/ember-htmlbars/tests/helpers/text_area_test.js
+++ b/packages/ember-htmlbars/tests/helpers/text_area_test.js
@@ -4,10 +4,11 @@ import compile from 'ember-template-compiler/system/compile';
 import { set as o_set } from 'ember-metal/property_set';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import TextArea from 'ember-views/views/text_area';
-import Registry from 'container/registry';
 import ComponentLookup from 'ember-views/component_lookup';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var textArea, controller;
+var textArea, controller, owner;
 
 function set(object, key, value) {
   run(function() { o_set(object, key, value); });
@@ -19,12 +20,12 @@ QUnit.module('{{textarea}}', {
       val: 'Lorem ipsum dolor'
     };
 
-    var registry = new Registry();
-    registry.register('component:-text-area', TextArea);
-    registry.register('component-lookup:main', ComponentLookup);
+    owner = buildOwner();
+    owner.register('component:-text-area', TextArea);
+    owner.register('component-lookup:main', ComponentLookup);
 
     textArea = View.extend({
-      container: registry.container(),
+      [OWNER]: owner,
       controller: controller,
       template: compile('{{textarea disabled=disabled value=val}}')
     }).create();

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -10,20 +10,20 @@ import run from 'ember-metal/run_loop';
 import compile from 'ember-template-compiler/system/compile';
 import Helper, { helper } from 'ember-htmlbars/helper';
 
-import { Registry } from 'ember-runtime/system/container';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 
-var view, lookup, registry, container;
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
+
+var view, lookup, owner;
 var originalLookup = Ember.lookup;
 
 QUnit.module('ember-htmlbars: {{#unbound}} helper', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
-    registry = new Registry();
-    container = registry.container();
 
     view = EmberView.create({
-      container,
+      [OWNER]: owner,
       template: compile('{{unbound foo}} {{unbound bar}}'),
       context: EmberObject.create({
         foo: 'BORK',
@@ -36,8 +36,8 @@ QUnit.module('ember-htmlbars: {{#unbound}} helper', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    runDestroy(owner);
+    owner = view = null;
     Ember.lookup = originalLookup;
   }
 });
@@ -124,11 +124,10 @@ QUnit.test('should render on attributes', function(assert) {
 QUnit.module('ember-htmlbars: {{#unbound}} helper with container present', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
 
     view = EmberView.create({
-      container,
+      [OWNER]: owner,
       template: compile('{{unbound foo}}'),
       context: EmberObject.create({
         foo: 'bleep'
@@ -138,8 +137,8 @@ QUnit.module('ember-htmlbars: {{#unbound}} helper with container present', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
-    container = registry = view = null;
+    runDestroy(owner);
+    owner = view = null;
     Ember.lookup = originalLookup;
   }
 });
@@ -152,15 +151,14 @@ QUnit.test('it should render the current value of a property path on the context
 QUnit.module('ember-htmlbars: {{#unbound}} subexpression', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
 
-    registry.register('helper:-capitalize', helper(function(params) {
+    owner.register('helper:-capitalize', helper(function(params) {
       return params[0].toUpperCase();
     }));
 
     view = EmberView.create({
-      container,
+      [OWNER]: owner,
       template: compile('{{-capitalize (unbound foo)}}'),
       context: EmberObject.create({
         foo: 'bork'
@@ -172,8 +170,8 @@ QUnit.module('ember-htmlbars: {{#unbound}} subexpression', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    runDestroy(owner);
+    owner = view = null;
     Ember.lookup = originalLookup;
   }
 });
@@ -200,19 +198,18 @@ QUnit.test('it should not re-render if the parent view rerenders', function() {
 QUnit.module('ember-htmlbars: {{#unbound}} subexpression - helper form', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
 
-    registry.register('helper:-capitalize', helper(function(params) {
+    owner.register('helper:-capitalize', helper(function(params) {
       return params[0].toUpperCase();
     }));
 
-    registry.register('helper:-doublize', helper(function(params) {
+    owner.register('helper:-doublize', helper(function(params) {
       return `${params[0]} ${params[0]}`;
     }));
 
     view = EmberView.create({
-      container,
+      [OWNER]: owner,
       template: compile('{{-capitalize (unbound (-doublize foo))}}'),
       context: EmberObject.create({
         foo: 'bork'
@@ -224,8 +221,8 @@ QUnit.module('ember-htmlbars: {{#unbound}} subexpression - helper form', {
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    runDestroy(owner);
+    owner = view = null;
     Ember.lookup = originalLookup;
   }
 });
@@ -252,18 +249,17 @@ QUnit.test('it should re-render if the parent view rerenders', function() {
 QUnit.module('ember-htmlbars: {{#unbound boundHelper arg1 arg2... argN}} form: render unbound helper invocations', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
 
-    registry.register('helper:-surround', helper(function([prefix, value, suffix]) {
+    owner.register('helper:-surround', helper(function([prefix, value, suffix]) {
       return prefix + '-' + value + '-' + suffix;
     }));
 
-    registry.register('helper:-capitalize', helper(function([value]) {
+    owner.register('helper:-capitalize', helper(function([value]) {
       return value.toUpperCase();
     }));
 
-    registry.register('helper:-capitalizeName', Helper.extend({
+    owner.register('helper:-capitalizeName', Helper.extend({
       destroy() {
         this.removeObserver('value.firstName');
         this._super(...arguments);
@@ -278,11 +274,11 @@ QUnit.module('ember-htmlbars: {{#unbound boundHelper arg1 arg2... argN}} form: r
       }
     }));
 
-    registry.register('helper:-fauxconcat', helper(function(params) {
+    owner.register('helper:-fauxconcat', helper(function(params) {
       return params.join('');
     }));
 
-    registry.register('helper:-concatNames', Helper.extend({
+    owner.register('helper:-concatNames', Helper.extend({
       destroy() {
         this.teardown();
         this._super(...arguments);
@@ -305,14 +301,14 @@ QUnit.module('ember-htmlbars: {{#unbound boundHelper arg1 arg2... argN}} form: r
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    runDestroy(owner);
+    owner = view = null;
     Ember.lookup = originalLookup;
   }
 });
 
 QUnit.test('should be able to render an unbound helper invocation', function() {
-  registry.register('helper:-repeat', helper(function([value], { count }) {
+  owner.register('helper:-repeat', helper(function([value], { count }) {
     var a = [];
     while (a.length < count) {
       a.push(value);
@@ -321,7 +317,7 @@ QUnit.test('should be able to render an unbound helper invocation', function() {
   }));
 
   view = EmberView.create({
-    container,
+    [OWNER]: owner,
     template: compile('{{unbound (-repeat foo count=bar)}} {{-repeat foo count=bar}} {{unbound (-repeat foo count=2)}} {{-repeat foo count=4}}'),
     context: EmberObject.create({
       foo: 'X',
@@ -329,6 +325,7 @@ QUnit.test('should be able to render an unbound helper invocation', function() {
       bar: 5
     })
   });
+
   runAppend(view);
 
   equal(view.$().text(), 'XXXXX XXXXX XX XXXX', 'first render is correct');
@@ -342,7 +339,7 @@ QUnit.test('should be able to render an unbound helper invocation', function() {
 
 QUnit.test('should be able to render an bound helper invocation mixed with static values', function() {
   view = EmberView.create({
-    container,
+    [OWNER]: owner,
     template: compile('{{unbound (-surround prefix value "bar")}} {{-surround prefix value "bar"}} {{unbound (-surround "bar" value suffix)}} {{-surround "bar" value suffix}}'),
     context: EmberObject.create({
       prefix: 'before',
@@ -350,6 +347,7 @@ QUnit.test('should be able to render an bound helper invocation mixed with stati
       suffix: 'after'
     })
   });
+
   runAppend(view);
 
   equal(view.$().text(), 'before-core-bar before-core-bar bar-core-after bar-core-after', 'first render is correct');
@@ -363,7 +361,7 @@ QUnit.test('should be able to render an bound helper invocation mixed with stati
 
 QUnit.test('should be able to render unbound forms of multi-arg helpers', function() {
   view = EmberView.create({
-    container,
+    [OWNER]: owner,
     template: compile('{{-fauxconcat foo bar bing}} {{unbound (-fauxconcat foo bar bing)}}'),
     context: EmberObject.create({
       foo: 'a',
@@ -371,6 +369,7 @@ QUnit.test('should be able to render unbound forms of multi-arg helpers', functi
       bing: 'c'
     })
   });
+
   runAppend(view);
 
   equal(view.$().text(), 'abc abc', 'first render is correct');
@@ -384,7 +383,7 @@ QUnit.test('should be able to render unbound forms of multi-arg helpers', functi
 
 QUnit.test('should be able to render an unbound helper invocation for helpers with dependent keys', function() {
   view = EmberView.create({
-    container,
+    [OWNER]: owner,
     template: compile('{{-capitalizeName person}} {{unbound (-capitalizeName person)}} {{-concatNames person}} {{unbound (-concatNames person)}}'),
     context: EmberObject.create({
       person: EmberObject.create({
@@ -393,6 +392,7 @@ QUnit.test('should be able to render an unbound helper invocation for helpers wi
       })
     })
   });
+
   runAppend(view);
 
   equal(view.$().text(), 'SHOOBY SHOOBY shoobytaylor shoobytaylor', 'first render is correct');
@@ -406,7 +406,7 @@ QUnit.test('should be able to render an unbound helper invocation for helpers wi
 
 QUnit.test('should be able to render an unbound helper invocation in #each helper', function() {
   view = EmberView.create({
-    container,
+    [OWNER]: owner,
     template: compile(
       ['{{#each people as |person|}}',
        '{{-capitalize person.firstName}} {{unbound (-capitalize person.firstName)}}',
@@ -424,18 +424,19 @@ QUnit.test('should be able to render an unbound helper invocation in #each helpe
       ])
     }
   });
+
   runAppend(view);
 
   equal(view.$().text(), 'SHOOBY SHOOBYCINDY CINDY', 'unbound rendered correctly');
 });
 
 QUnit.test('should be able to render an unbound helper invocation with bound hash options', function() {
-  registry.register('helper:-repeat', helper(function([value]) {
+  owner.register('helper:-repeat', helper(function([value]) {
     return [].slice.call(arguments, 0, -1).join('');
   }));
 
   view = EmberView.create({
-    container,
+    [OWNER]: owner,
     template: compile('{{-capitalizeName person}} {{unbound (-capitalizeName person)}} {{-concatNames person}} {{unbound (-concatNames person)}}'),
     context: EmberObject.create({
       person: EmberObject.create({
@@ -444,6 +445,7 @@ QUnit.test('should be able to render an unbound helper invocation with bound has
       })
     })
   });
+
   runAppend(view);
 
   equal(view.$().text(), 'SHOOBY SHOOBY shoobytaylor shoobytaylor', 'first render is correct');
@@ -486,26 +488,25 @@ QUnit.test('should be able to render bound form of a helper inside unbound form 
 QUnit.module('ember-htmlbars: {{#unbound}} helper -- Container Lookup', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
   },
 
   teardown() {
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    runDestroy(owner);
+    owner = view = null;
     Ember.lookup = originalLookup;
   }
 });
 
 QUnit.test('should lookup helpers in the container', function() {
-  registry.register('helper:up-case', helper(function([value]) {
+  owner.register('helper:up-case', helper(function([value]) {
     return value.toUpperCase();
   }));
 
   view = EmberView.create({
+    [OWNER]: owner,
     template: compile('{{unbound (up-case displayText)}}'),
-    container,
     context: {
       displayText: 'such awesome'
     }
@@ -530,7 +531,7 @@ QUnit.test('should be able to output a property without binding', function() {
   };
 
   view = EmberView.create({
-    context: context,
+    context,
     template: compile('<div id="first">{{unbound content.anUnboundString}}</div>')
   });
 

--- a/packages/ember-htmlbars/tests/hooks/component_test.js
+++ b/packages/ember-htmlbars/tests/hooks/component_test.js
@@ -1,34 +1,34 @@
 import isEnabled from 'ember-metal/features';
 import ComponentLookup from 'ember-views/component_lookup';
-import Registry from 'container/registry';
 import EmberView from 'ember-views/views/view';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import { OWNER } from 'container/owner';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
-var view, registry, container;
+var view, owner;
 
 if (isEnabled('ember-htmlbars-component-generation')) {
   QUnit.module('ember-htmlbars: dasherized components that are not in the container ("web components")', {
     setup() {
-      registry = new Registry();
-      container = registry.container();
+      owner = buildOwner();
 
-      registry.optionsForType('template', { instantiate: false });
-      registry.register('component-lookup:main', ComponentLookup);
+      owner.registerOptionsForType('template', { instantiate: false });
+      owner.register('component-lookup:main', ComponentLookup);
     },
 
     teardown() {
       runDestroy(view);
-      runDestroy(container);
-      registry = container = view = null;
+      runDestroy(owner);
+      owner = view = null;
     }
   });
 
   QUnit.test('non-component dasherized elements can be used as top-level elements', function() {
-    registry.register('template:components/foo-bar', compile('<baz-bat>yippie!</baz-bat>'));
+    owner.register('template:components/foo-bar', compile('<baz-bat>yippie!</baz-bat>'));
 
     view = EmberView.create({
-      container: container,
+      [OWNER]: owner,
       template: compile('<foo-bar />')
     });
 
@@ -39,7 +39,7 @@ if (isEnabled('ember-htmlbars-component-generation')) {
 
   QUnit.test('falls back to web component when invoked with angles', function() {
     view = EmberView.create({
-      container: container,
+      [OWNER]: owner,
       template: compile('<foo-bar />')
     });
 

--- a/packages/ember-htmlbars/tests/integration/component_element_id_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_element_id_test.js
@@ -1,36 +1,36 @@
 import EmberView from 'ember-views/views/view';
-import { Registry } from 'ember-runtime/system/container';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import ComponentLookup from 'ember-views/component_lookup';
 import Component from 'ember-views/components/component';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var registry, container, view;
+var owner, view;
 
 QUnit.module('ember-htmlbars: component elementId', {
   setup() {
-    registry = new Registry();
-    container = registry.container();
-    registry.optionsForType('component', { singleton: false });
-    registry.optionsForType('view', { singleton: false });
-    registry.optionsForType('template', { instantiate: false });
-    registry.register('component-lookup:main', ComponentLookup);
+    owner = buildOwner();
+    owner.registerOptionsForType('component', { singleton: false });
+    owner.registerOptionsForType('view', { singleton: false });
+    owner.registerOptionsForType('template', { instantiate: false });
+    owner.register('component-lookup:main', ComponentLookup);
   },
 
   teardown() {
-    runDestroy(container);
+    runDestroy(owner);
     runDestroy(view);
-    registry = container = view = null;
+    owner = view = null;
   }
 });
 
 QUnit.test('passing undefined elementId results in a default elementId', function() {
-  registry.register('component:x-foo', Component.extend({
+  owner.register('component:x-foo', Component.extend({
     tagName: 'h1'
   }));
 
   view = EmberView.create({
-    container: container,
+    [OWNER]: owner,
     template: compile('{{x-foo id=somethingUndefined}}')
   });
 

--- a/packages/ember-htmlbars/tests/integration/helper-lookup-test.js
+++ b/packages/ember-htmlbars/tests/integration/helper-lookup-test.js
@@ -1,40 +1,40 @@
-import Registry from 'container/registry';
 import compile from 'ember-template-compiler/system/compile';
 import ComponentLookup from 'ember-views/component_lookup';
 import Component from 'ember-views/components/component';
 import { helper } from 'ember-htmlbars/helper';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var registry, container, component;
+var owner, component;
 
 QUnit.module('component - invocation', {
   setup() {
-    registry = new Registry();
-    container = registry.container();
-    registry.optionsForType('component', { singleton: false });
-    registry.optionsForType('view', { singleton: false });
-    registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
-    registry.register('component-lookup:main', ComponentLookup);
+    owner = buildOwner();
+    owner.registerOptionsForType('component', { singleton: false });
+    owner.registerOptionsForType('view', { singleton: false });
+    owner.registerOptionsForType('template', { instantiate: false });
+    owner.registerOptionsForType('helper', { instantiate: false });
+    owner.register('component-lookup:main', ComponentLookup);
   },
 
   teardown() {
-    runDestroy(container);
+    runDestroy(owner);
     runDestroy(component);
-    registry = container = component = null;
+    owner = component = null;
   }
 });
 
 QUnit.test('non-dashed helpers are found', function() {
   expect(1);
 
-  registry.register('helper:fullname', helper(function( [first, last]) {
+  owner.register('helper:fullname', helper(function( [first, last]) {
     return `${first} ${last}`;
   }));
 
   component = Component.extend({
-    layout: compile('{{fullname "Robert" "Jackson"}}'),
-    container: container
+    [OWNER]: owner,
+    layout: compile('{{fullname "Robert" "Jackson"}}')
   }).create();
 
   runAppend(component);

--- a/packages/ember-htmlbars/tests/integration/void-element-component-test.js
+++ b/packages/ember-htmlbars/tests/integration/void-element-component-test.js
@@ -1,32 +1,32 @@
 import EmberView from 'ember-views/views/view';
-import { Registry } from 'ember-runtime/system/container';
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import ComponentLookup from 'ember-views/component_lookup';
 import Component from 'ember-views/components/component';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var registry, container, view;
+var owner, view;
 
 QUnit.module('ember-htmlbars: components for void elements', {
   setup() {
-    registry = new Registry();
-    container = registry.container();
-    registry.optionsForType('component', { singleton: false });
-    registry.optionsForType('view', { singleton: false });
-    registry.optionsForType('template', { instantiate: false });
-    registry.register('component-lookup:main', ComponentLookup);
+    owner = buildOwner();
+    owner.registerOptionsForType('component', { singleton: false });
+    owner.registerOptionsForType('view', { singleton: false });
+    owner.registerOptionsForType('template', { instantiate: false });
+    owner.register('component-lookup:main', ComponentLookup);
   },
 
   teardown() {
-    runDestroy(container);
+    runDestroy(owner);
     runDestroy(view);
-    registry = container = view = null;
+    owner = view = null;
   }
 });
 
 QUnit.test('a void element does not have childNodes', function() {
   var component;
-  registry.register('component:x-foo', Component.extend({
+  owner.register('component:x-foo', Component.extend({
     tagName: 'input',
 
     init() {
@@ -36,7 +36,7 @@ QUnit.test('a void element does not have childNodes', function() {
   }));
 
   view = EmberView.create({
-    container: container,
+    [OWNER]: owner,
     template: compile('{{x-foo}}')
   });
 

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -1,24 +1,24 @@
 import lookupHelper, { findHelper } from 'ember-htmlbars/system/lookup-helper';
 import ComponentLookup from 'ember-views/component_lookup';
-import Registry from 'container/registry';
 import Helper, { helper as makeHelper } from 'ember-htmlbars/helper';
+import { OWNER } from 'container/owner';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
-function generateEnv(helpers, container) {
+function generateEnv(helpers, owner) {
   return {
-    container: container,
+    owner: owner,
     helpers: (helpers ? helpers : {}),
     hooks: { keywords: {} },
     knownHelpers: {}
   };
 }
 
-function generateContainer() {
-  var registry = new Registry();
-  var container = registry.container();
+function generateOwner() {
+  const owner = buildOwner();
 
-  registry.register('component-lookup:main', ComponentLookup);
+  owner.register('component-lookup:main', ComponentLookup);
 
-  return container;
+  return owner;
 }
 
 QUnit.module('ember-htmlbars: lookupHelper hook');
@@ -58,14 +58,14 @@ QUnit.test('does not lookup in the container if the name does not contain a dash
 });
 
 QUnit.test('does a lookup in the container if the name contains a dash (and helper is not found in env)', function() {
-  var container = generateContainer();
-  var env = generateEnv(null, container);
+  const owner = generateOwner();
+  var env = generateEnv(null, owner);
   var view = {
-    container: container
+    [OWNER]: owner
   };
 
   var someName = Helper.extend();
-  view.container.registry.register('helper:some-name', someName);
+  owner.register('helper:some-name', someName);
 
   var actual = lookupHelper('some-name', view, env);
 
@@ -73,15 +73,15 @@ QUnit.test('does a lookup in the container if the name contains a dash (and help
 });
 
 QUnit.test('does a lookup in the container if the name is found in knownHelpers', function() {
-  var container = generateContainer();
-  var env = generateEnv(null, container);
+  const owner = generateOwner();
+  var env = generateEnv(null, owner);
   var view = {
-    container: container
+    [OWNER]: owner
   };
 
   env.knownHelpers['t'] = true;
   var t = Helper.extend();
-  view.container.registry.register('helper:t', t);
+  owner.register('helper:t', t);
 
   var actual = lookupHelper('t', view, env);
 
@@ -90,17 +90,17 @@ QUnit.test('does a lookup in the container if the name is found in knownHelpers'
 
 QUnit.test('looks up a shorthand helper in the container', function() {
   expect(2);
-  var container = generateContainer();
-  var env = generateEnv(null, container);
+  const owner = generateOwner();
+  var env = generateEnv(null, owner);
   var view = {
-    container: container
+    [OWNER]: owner
   };
   var called;
 
   function someName() {
     called = true;
   }
-  view.container.registry.register('helper:some-name', makeHelper(someName));
+  owner.register('helper:some-name', makeHelper(someName));
 
   var actual = lookupHelper('some-name', view, env);
 
@@ -113,14 +113,14 @@ QUnit.test('looks up a shorthand helper in the container', function() {
 
 QUnit.test('fails with a useful error when resolving a function', function() {
   expect(1);
-  var container = generateContainer();
-  var env = generateEnv(null, container);
+  const owner = generateOwner();
+  var env = generateEnv(null, owner);
   var view = {
-    container: container
+    [OWNER]: owner
   };
 
   function someName() {}
-  view.container.registry.register('helper:some-name', someName);
+  owner.register('helper:some-name', someName);
 
   var actual;
   expectAssertion(function() {

--- a/packages/ember-metal/lib/injected_property.js
+++ b/packages/ember-metal/lib/injected_property.js
@@ -2,6 +2,7 @@ import { assert } from 'ember-metal/debug';
 import { ComputedProperty } from 'ember-metal/computed';
 import { AliasedProperty } from 'ember-metal/alias';
 import { Descriptor } from 'ember-metal/properties';
+import { getOwner } from 'container/owner';
 
 /**
   Read-only property that returns the result of a container lookup.
@@ -24,11 +25,12 @@ function InjectedProperty(type, name) {
 
 function injectedPropertyGet(keyName) {
   var desc = this[keyName];
+  const owner = getOwner(this);
 
   assert(`InjectedProperties should be defined with the Ember.inject computed property macros.`, desc && desc.isDescriptor && desc.type);
-  assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, this.container);
+  assert(`Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.`, owner);
 
-  return this.container.lookup(desc.type + ':' + (desc.name || keyName));
+  return owner.lookup(desc.type + ':' + (desc.name || keyName));
 }
 
 InjectedProperty.prototype = Object.create(Descriptor.prototype);

--- a/packages/ember-metal/tests/injected_property_test.js
+++ b/packages/ember-metal/tests/injected_property_test.js
@@ -5,6 +5,7 @@ import {
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import InjectedProperty from 'ember-metal/injected_property';
+import { setOwner } from 'container/owner';
 
 QUnit.module('InjectedProperty');
 
@@ -33,27 +34,29 @@ QUnit.test('getting on an object without a container should fail assertion', fun
 QUnit.test('getting should return a lookup on the container', function() {
   expect(2);
 
-  var obj = {
-    container: {
-      lookup(key) {
-        ok(true, 'should call container.lookup');
-        return key;
-      }
+  var obj = {};
+
+  setOwner(obj, {
+    lookup(key) {
+      ok(true, 'should call container.lookup');
+      return key;
     }
-  };
+  });
+
   defineProperty(obj, 'foo', new InjectedProperty('type', 'name'));
 
   equal(get(obj, 'foo'), 'type:name', 'should return the value of container.lookup');
 });
 
 QUnit.test('omitting the lookup name should default to the property name', function() {
-  var obj = {
-    container: {
-      lookup(key) {
-        return key;
-      }
+  var obj = {};
+
+  setOwner(obj, {
+    lookup(key) {
+      return key;
     }
-  };
+  });
+
   defineProperty(obj, 'foo', new InjectedProperty('type'));
 
   equal(get(obj, 'foo'), 'type:foo', 'should lookup the type using the property name');

--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -121,14 +121,14 @@ export default {
     var name = params[0];
     var context = params[1];
 
-    var container = env.container;
+    var owner = env.owner;
 
     // The render keyword presumes it can work without a router. This is really
     // only to satisfy the test:
     //
     //     {{view}} should not override class bindings defined on a child view"
     //
-    var router = container.lookup('router:main');
+    var router = owner.lookup('router:main');
 
     assert(
       'The second argument of {{render}} must be a path, e.g. {{render "post" post}}.',
@@ -150,16 +150,16 @@ export default {
     assert(
       'You used `{{render \'' + name + '\'}}`, but \'' + name + '\' can not be ' +
       'found as either a template or a view.',
-      container.registry.has('view:' + name) || container.registry.has(templateName) || !!template
+      owner.hasRegistration('view:' + name) || owner.hasRegistration(templateName) || !!template
     );
 
-    var view = container.lookup('view:' + name);
+    var view = owner.lookup('view:' + name);
     if (!view) {
-      view = container.lookup('view:default');
+      view = owner.lookup('view:default');
     }
     var viewHasTemplateSpecified = view && !!get(view, 'template');
     if (!template && !viewHasTemplateSpecified) {
-      template = container.lookup(templateName);
+      template = owner.lookup(templateName);
     }
 
     if (view) {
@@ -178,7 +178,7 @@ export default {
       assert(
         'The controller name you supplied \'' + controllerName + '\' ' +
         'did not resolve to a controller.',
-        container.registry.has(controllerFullName)
+        owner.hasRegistration(controllerFullName)
       );
     } else {
       controllerName = name;
@@ -190,8 +190,8 @@ export default {
 
     // choose name
     if (params.length > 1) {
-      var factory = container.lookupFactory(controllerFullName) ||
-                    generateControllerFactory(container, controllerName);
+      var factory = owner._lookupFactory(controllerFullName) ||
+                    generateControllerFactory(owner, controllerName);
 
       controller = factory.create({
         model: read(context),
@@ -201,8 +201,8 @@ export default {
 
       node.addDestruction(controller);
     } else {
-      controller = container.lookup(controllerFullName) ||
-                   generateController(container, controllerName);
+      controller = owner.lookup(controllerFullName) ||
+                   generateController(owner, controllerName);
 
       controller.setProperties({
         target: parentController,

--- a/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/link-to_test.js
@@ -4,40 +4,40 @@ import EmberView from 'ember-views/views/view';
 import compile from 'ember-template-compiler/system/compile';
 import { set } from 'ember-metal/property_set';
 import Controller from 'ember-runtime/controllers/controller';
-import { Registry } from 'ember-runtime/system/container';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import EmberObject from 'ember-runtime/system/object';
 import ComponentLookup from 'ember-views/component_lookup';
 import LinkComponent from 'ember-routing-views/components/link-to';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var view;
-var container;
-var registry = new Registry();
-
-// These tests don't rely on the routing service, but LinkComponent makes
-// some assumptions that it will exist. This small stub service ensures
-// that the LinkComponent can render without raising an exception.
-//
-// TODO: Add tests that test actual behavior. Currently, all behavior
-// is tested integration-style in the `ember` package.
-registry.register('service:-routing', EmberObject.extend({
-  availableRoutes() { return ['index']; },
-  hasRoute(name) { return name === 'index'; },
-  isActiveForRoute() { return true; },
-  generateURL() { return '/'; }
-}));
-
-registry.register('component-lookup:main', ComponentLookup);
-registry.register('component:link-to', LinkComponent);
-registry.register('component:custom-link-to', LinkComponent.extend());
+var owner, view;
 
 QUnit.module('ember-routing-htmlbars: link-to helper', {
   setup() {
-    container = registry.container();
+    owner = buildOwner();
+
+    // These tests don't rely on the routing service, but LinkComponent makes
+    // some assumptions that it will exist. This small stub service ensures
+    // that the LinkComponent can render without raising an exception.
+    //
+    // TODO: Add tests that test actual behavior. Currently, all behavior
+    // is tested integration-style in the `ember` package.
+    owner.register('service:-routing', EmberObject.extend({
+      availableRoutes() { return ['index']; },
+      hasRoute(name) { return name === 'index'; },
+      isActiveForRoute() { return true; },
+      generateURL() { return '/'; }
+    }));
+
+    owner.register('component-lookup:main', ComponentLookup);
+    owner.register('component:link-to', LinkComponent);
+    owner.register('component:custom-link-to', LinkComponent.extend());
   },
 
   teardown() {
     runDestroy(view);
+    runDestroy(owner);
   }
 });
 
@@ -45,8 +45,8 @@ QUnit.module('ember-routing-htmlbars: link-to helper', {
 QUnit.test('should be able to be inserted in DOM when the router is not present', function() {
   var template = '{{#link-to \'index\'}}Go to Index{{/link-to}}';
   view = EmberView.create({
-    template: compile(template),
-    container: container
+    [OWNER]: owner,
+    template: compile(template)
   });
 
   runAppend(view);
@@ -57,12 +57,12 @@ QUnit.test('should be able to be inserted in DOM when the router is not present'
 QUnit.test('re-renders when title changes', function() {
   var template = '{{link-to title routeName}}';
   view = EmberView.create({
+    [OWNER]: owner,
     controller: {
       title: 'foo',
       routeName: 'index'
     },
-    template: compile(template),
-    container: container
+    template: compile(template)
   });
 
   runAppend(view);
@@ -79,12 +79,12 @@ QUnit.test('re-renders when title changes', function() {
 QUnit.test('can read bound title', function() {
   var template = '{{link-to title routeName}}';
   view = EmberView.create({
+    [OWNER]: owner,
     controller: {
       title: 'foo',
       routeName: 'index'
     },
-    template: compile(template),
-    container: container
+    template: compile(template)
   });
 
   runAppend(view);
@@ -94,9 +94,9 @@ QUnit.test('can read bound title', function() {
 
 QUnit.test('escaped inline form (double curlies) escapes link title', function() {
   view = EmberView.create({
+    [OWNER]: owner,
     title: '<b>blah</b>',
-    template: compile('{{link-to view.title}}'),
-    container: container
+    template: compile('{{link-to view.title}}')
   });
 
   runAppend(view);
@@ -106,9 +106,9 @@ QUnit.test('escaped inline form (double curlies) escapes link title', function()
 
 QUnit.test('escaped inline form with (-html-safe) does not escape link title', function() {
   view = EmberView.create({
+    [OWNER]: owner,
     title: '<b>blah</b>',
-    template: compile('{{link-to (-html-safe view.title)}}'),
-    container: container
+    template: compile('{{link-to (-html-safe view.title)}}')
   });
 
   runAppend(view);
@@ -118,9 +118,9 @@ QUnit.test('escaped inline form with (-html-safe) does not escape link title', f
 
 QUnit.test('unescaped inline form (triple curlies) does not escape link title', function() {
   view = EmberView.create({
+    [OWNER]: owner,
     title: '<b>blah</b>',
-    template: compile('{{{link-to view.title}}}'),
-    container: container
+    template: compile('{{{link-to view.title}}}')
   });
 
   runAppend(view);
@@ -132,12 +132,11 @@ QUnit.test('unwraps controllers', function() {
   var template = '{{#link-to \'index\' view.otherController}}Text{{/link-to}}';
 
   view = EmberView.create({
+    [OWNER]: owner,
     otherController: Controller.create({
       model: 'foo'
     }),
-
-    template: compile(template),
-    container: container
+    template: compile(template)
   });
 
   expectDeprecation(function() {
@@ -149,9 +148,9 @@ QUnit.test('unwraps controllers', function() {
 
 QUnit.test('able to safely extend the built-in component and use the normal path', function() {
   view = EmberView.create({
+    [OWNER]: owner,
     title: 'my custom link-to component',
-    template: compile('{{custom-link-to view.title}}'),
-    container: container
+    template: compile('{{custom-link-to view.title}}')
   });
 
   runAppend(view);

--- a/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/outlet_test.js
@@ -1,32 +1,26 @@
 import run from 'ember-metal/run_loop';
-
-import Namespace from 'ember-runtime/system/namespace';
 import Controller from 'ember-runtime/controllers/controller';
 import EmberView from 'ember-views/views/view';
 import jQuery from 'ember-views/system/jquery';
-
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
-import { buildRegistry } from 'ember-routing-htmlbars/tests/utils';
+import { buildAppInstance } from 'ember-routing-htmlbars/tests/utils';
 
 var trim = jQuery.trim;
 
-var registry, container, top;
+var appInstance, top;
 
 QUnit.module('ember-routing-htmlbars: {{outlet}} helper', {
   setup() {
-    var namespace = Namespace.create();
-    registry = buildRegistry(namespace);
-    container = registry.container();
-
-    var CoreOutlet = container.lookupFactory('view:core-outlet');
+    appInstance = buildAppInstance();
+    var CoreOutlet = appInstance._lookupFactory('view:core-outlet');
     top = CoreOutlet.create();
   },
 
   teardown() {
-    runDestroy(container);
+    runDestroy(appInstance);
     runDestroy(top);
-    registry = container = top = null;
+    appInstance = top = null;
   }
 });
 
@@ -48,7 +42,7 @@ QUnit.test('view should render the outlet when set after dom insertion', functio
 });
 
 QUnit.test('a top-level outlet should always be a view', function() {
-  registry.register('view:toplevel', EmberView.extend({
+  appInstance.register('view:toplevel', EmberView.extend({
     elementId: 'top-level'
   }));
   var routerState = withTemplate('<h1>HI</h1>{{outlet}}');

--- a/packages/ember-routing/lib/location/auto_location.js
+++ b/packages/ember-routing/lib/location/auto_location.js
@@ -2,6 +2,7 @@ import { assert } from 'ember-metal/debug';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import { tryInvoke } from 'ember-metal/utils';
+import { getOwner } from 'container/owner';
 
 import EmberObject from 'ember-runtime/system/object';
 import environment from 'ember-metal/environment';
@@ -133,7 +134,7 @@ export default EmberObject.extend({
       implementation = 'none';
     }
 
-    var concrete = this.container.lookup(`location:${implementation}`);
+    var concrete = getOwner(this).lookup(`location:${implementation}`);
     set(concrete, 'rootURL', rootURL);
 
     assert(`Could not find location '${implementation}'.`, !!concrete);

--- a/packages/ember-routing/lib/system/generate_controller.js
+++ b/packages/ember-routing/lib/system/generate_controller.js
@@ -14,10 +14,10 @@ import { get } from 'ember-metal/property_get';
   @private
 */
 
-export function generateControllerFactory(container, controllerName, context) {
+export function generateControllerFactory(owner, controllerName, context) {
   var Factory, fullName;
 
-  Factory = container.lookupFactory('controller:basic').extend({
+  Factory = owner._lookupFactory('controller:basic').extend({
     isGenerated: true,
     toString() {
       return `(generated ${controllerName} controller)`;
@@ -26,7 +26,7 @@ export function generateControllerFactory(container, controllerName, context) {
 
   fullName = `controller:${controllerName}`;
 
-  container.registry.register(fullName, Factory);
+  owner.register(fullName, Factory);
 
   return Factory;
 }
@@ -44,11 +44,11 @@ export function generateControllerFactory(container, controllerName, context) {
   @private
   @since 1.3.0
 */
-export default function generateController(container, controllerName, context) {
-  generateControllerFactory(container, controllerName, context);
+export default function generateController(owner, controllerName, context) {
+  generateControllerFactory(owner, controllerName, context);
 
   var fullName = `controller:${controllerName}`;
-  var instance = container.lookup(fullName);
+  var instance = owner.lookup(fullName);
 
   if (get(instance, 'namespace.LOG_ACTIVE_GENERATION')) {
     info(`generated -> ${fullName}`, { fullName: fullName });

--- a/packages/ember-routing/tests/location/auto_location_test.js
+++ b/packages/ember-routing/tests/location/auto_location_test.js
@@ -9,8 +9,8 @@ import {
 import HistoryLocation from 'ember-routing/location/history_location';
 import HashLocation from 'ember-routing/location/hash_location';
 import NoneLocation from 'ember-routing/location/none_location';
-import Registry from 'container/registry';
-
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
 function mockBrowserLocation(overrides) {
   return assign({
@@ -36,18 +36,20 @@ function mockBrowserHistory(overrides) {
 }
 
 function createLocation(location, history) {
-  var registry = new Registry();
+  const owner = buildOwner();
 
-  registry.register('location:history', HistoryLocation);
-  registry.register('location:hash', HashLocation);
-  registry.register('location:none', NoneLocation);
+  owner.register('location:history', HistoryLocation);
+  owner.register('location:hash', HashLocation);
+  owner.register('location:none', NoneLocation);
 
-  return AutoLocation.create({
-    container: registry.container(),
+  const autolocation = AutoLocation.create({
+    [OWNER]: owner,
     location: location,
     history: history,
     global: {}
   });
+
+  return autolocation;
 }
 
 var location;

--- a/packages/ember-routing/tests/system/dsl_test.js
+++ b/packages/ember-routing/tests/system/dsl_test.js
@@ -5,8 +5,6 @@ import {
   registerHandler as registerWarnHandler
 } from 'ember-debug/warn';
 
-
-
 var Router, outerWarnHandler;
 
 QUnit.module('Ember Router DSL', {

--- a/packages/ember-runtime/lib/main.js
+++ b/packages/ember-runtime/lib/main.js
@@ -12,7 +12,7 @@ import inject from 'ember-runtime/inject';
 
 import Namespace from 'ember-runtime/system/namespace';
 import EmberObject from 'ember-runtime/system/object';
-import { Container, Registry } from 'ember-runtime/system/container';
+import { Container, Registry, getOwner, setOwner } from 'ember-runtime/system/container';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
 import ObjectProxy from 'ember-runtime/system/object_proxy';
 import CoreObject from 'ember-runtime/system/core_object';
@@ -67,6 +67,8 @@ import 'ember-runtime/ext/string';   // just for side effect of extending String
 import 'ember-runtime/ext/function'; // just for side effect of extending Function.prototype
 
 import { isArray, typeOf } from 'ember-runtime/utils';
+
+import isEnabled from 'ember-metal/features';
 // END IMPORTS
 
 // BEGIN EXPORTS
@@ -117,6 +119,12 @@ Ember.String = EmberStringUtils;
 Ember.Object = EmberObject;
 Ember.Container = Container;
 Ember.Registry = Registry;
+
+if (isEnabled('ember-container-inject-owner')) {
+  Ember.getOwner = getOwner;
+  Ember.setOwner = setOwner;
+}
+
 Ember.Namespace = Namespace;
 Ember.Enumerable = Enumerable;
 Ember.ArrayProxy = ArrayProxy;

--- a/packages/ember-runtime/lib/mixins/controller.js
+++ b/packages/ember-runtime/lib/mixins/controller.js
@@ -34,8 +34,6 @@ export default Mixin.create(ActionHandler, ControllerContentModelAliasDeprecatio
   */
   target: null,
 
-  container: null,
-
   parentController: null,
 
   store: null,

--- a/packages/ember-runtime/lib/system/container.js
+++ b/packages/ember-runtime/lib/system/container.js
@@ -1,8 +1,9 @@
 import { set } from 'ember-metal/property_set';
 import Registry from 'container/registry';
 import Container from 'container/container';
+import { getOwner, setOwner } from 'container/owner';
 
 Registry.set = set;
 Container.set = set;
 
-export { Registry, Container };
+export { Registry, Container, getOwner, setOwner };

--- a/packages/ember-runtime/tests/controllers/controller_test.js
+++ b/packages/ember-runtime/tests/controllers/controller_test.js
@@ -4,9 +4,9 @@ import Controller from 'ember-runtime/controllers/controller';
 import Service from 'ember-runtime/system/service';
 import Mixin from 'ember-metal/mixin';
 import Object from 'ember-runtime/system/object';
-import { Registry } from 'ember-runtime/system/container';
 import inject from 'ember-runtime/inject';
 import { get } from 'ember-metal/property_get';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
 QUnit.module('Controller event handling');
 
@@ -35,7 +35,7 @@ QUnit.test('Action can be handled by a function on actions object', function() {
       }
     }
   });
-  var controller = TestController.create({});
+  var controller = TestController.create();
   controller.send('poke');
 });
 
@@ -155,49 +155,45 @@ QUnit.module('Controller injected properties');
 if (!EmberDev.runningProdBuild) {
   QUnit.test('defining a controller on a non-controller should fail assertion', function() {
     expectAssertion(function() {
-      var registry = new Registry();
-      var container = registry.container();
+      const owner = buildOwner();
 
       var AnObject = Object.extend({
-        container: container,
         foo: inject.controller('bar')
       });
 
-      registry.register('foo:main', AnObject);
+      owner.register('foo:main', AnObject);
 
-      container.lookupFactory('foo:main');
+      owner._lookupFactory('foo:main');
     }, /Defining an injected controller property on a non-controller is not allowed./);
   });
 }
 
 QUnit.test('controllers can be injected into controllers', function() {
-  var registry = new Registry();
-  var container = registry.container();
+  const owner = buildOwner();
 
-  registry.register('controller:post', Controller.extend({
+  owner.register('controller:post', Controller.extend({
     postsController: inject.controller('posts')
   }));
 
-  registry.register('controller:posts', Controller.extend());
+  owner.register('controller:posts', Controller.extend());
 
-  var postController = container.lookup('controller:post');
-  var postsController = container.lookup('controller:posts');
+  var postController = owner.lookup('controller:post');
+  var postsController = owner.lookup('controller:posts');
 
   equal(postsController, postController.get('postsController'), 'controller.posts is injected');
 });
 
 QUnit.test('services can be injected into controllers', function() {
-  var registry = new Registry();
-  var container = registry.container();
+  const owner = buildOwner();
 
-  registry.register('controller:application', Controller.extend({
+  owner.register('controller:application', Controller.extend({
     authService: inject.service('auth')
   }));
 
-  registry.register('service:auth', Service.extend());
+  owner.register('service:auth', Service.extend());
 
-  var appController = container.lookup('controller:application');
-  var authService = container.lookup('service:auth');
+  var appController = owner.lookup('controller:application');
+  var authService = owner.lookup('service:auth');
 
   equal(authService, appController.get('authService'), 'service.auth is injected');
 });

--- a/packages/ember-runtime/tests/inject_test.js
+++ b/packages/ember-runtime/tests/inject_test.js
@@ -5,8 +5,8 @@ import inject from 'ember-runtime/inject';
 import {
   createInjectionHelper
 } from 'ember-runtime/inject';
-import { Registry } from 'ember-runtime/system/container';
 import Object from 'ember-runtime/system/object';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
 QUnit.module('inject');
 
@@ -26,32 +26,28 @@ if (!EmberDev.runningProdBuild) {
       ok(true, 'should call validation method');
     });
 
-    var registry = new Registry();
-    var container = registry.container();
+    const owner = buildOwner();
 
     var AnObject = Object.extend({
-      container: container,
       bar: inject.foo(),
       baz: inject.foo()
     });
 
-    registry.register('foo:main', AnObject);
-    container.lookupFactory('foo:main');
+    owner.register('foo:main', AnObject);
+    owner._lookupFactory('foo:main');
   });
 }
 
 QUnit.test('attempting to inject a nonexistent container key should error', function() {
-  var registry = new Registry();
-  var container = registry.container();
+  const owner = buildOwner();
   var AnObject = Object.extend({
-    container: container,
     foo: new InjectedProperty('bar', 'baz')
   });
 
-  registry.register('foo:main', AnObject);
+  owner.register('foo:main', AnObject);
 
   throws(function() {
-    container.lookup('foo:main');
+    owner.lookup('foo:main');
   }, /Attempting to inject an unknown injection: `bar:baz`/);
 });
 

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -2,6 +2,7 @@ import Ember from 'ember-metal/core';
 import { assert } from 'ember-metal/debug';
 import EmberObject from 'ember-runtime/system/object';
 import { CONTAINS_DASH_CACHE } from 'ember-htmlbars/system/lookup-helper';
+import { getOwner } from 'container/owner';
 
 export default EmberObject.extend({
   invalidName(name) {
@@ -11,45 +12,45 @@ export default EmberObject.extend({
     }
   },
 
-  lookupFactory(name, container) {
-    container = container || this.container;
+  lookupFactory(name, owner) {
+    owner = owner || getOwner(this);
 
     var fullName = 'component:' + name;
     var templateFullName = 'template:components/' + name;
-    var templateRegistered = container && container.registry.has(templateFullName);
+    var templateRegistered = owner && owner.hasRegistration(templateFullName);
 
     if (templateRegistered) {
-      container.registry.injection(fullName, 'layout', templateFullName);
+      owner.inject(fullName, 'layout', templateFullName);
     }
 
-    var Component = container.lookupFactory(fullName);
+    var Component = owner._lookupFactory(fullName);
 
     // Only treat as a component if either the component
     // or a template has been registered.
     if (templateRegistered || Component) {
       if (!Component) {
-        container.registry.register(fullName, Ember.Component);
-        Component = container.lookupFactory(fullName);
+        owner.register(fullName, Ember.Component);
+        Component = owner._lookupFactory(fullName);
       }
       return Component;
     }
   },
 
-  componentFor(name, container) {
+  componentFor(name, owner) {
     if (this.invalidName(name)) {
       return;
     }
 
     var fullName = 'component:' + name;
-    return container.lookupFactory(fullName);
+    return owner._lookupFactory(fullName);
   },
 
-  layoutFor(name, container) {
+  layoutFor(name, owner) {
     if (this.invalidName(name)) {
       return;
     }
 
     var templateFullName = 'template:components/' + name;
-    return container.lookup(templateFullName);
+    return owner.lookup(templateFullName);
   }
 });

--- a/packages/ember-views/lib/components/component.js
+++ b/packages/ember-views/lib/components/component.js
@@ -12,6 +12,8 @@ import { computed } from 'ember-metal/computed';
 
 import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
 
+import { getOwner } from 'container/owner';
+
 function validateAction(component, actionName) {
   if (actionName && actionName[MUTABLE_CELL]) {
     actionName = actionName.value;
@@ -136,7 +138,7 @@ var Component = View.extend(TargetActionSupport, {
     set(this, 'controller', this);
     set(this, 'context', this);
 
-    if (!this.layout && this.layoutName && this.container) {
+    if (!this.layout && this.layoutName && getOwner(this)) {
       let layoutName = get(this, 'layoutName');
 
       this.layout = this.templateForName(layoutName);

--- a/packages/ember-views/lib/mixins/legacy_child_views_support.js
+++ b/packages/ember-views/lib/mixins/legacy_child_views_support.js
@@ -1,10 +1,11 @@
 import { Mixin } from 'ember-metal/mixin';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
+import { getOwner, setOwner } from 'container/owner';
 
 export default Mixin.create({
   linkChild(instance) {
-    instance.container = this.container;
+    setOwner(instance, getOwner(this));
     if (get(instance, 'parentView') !== this) {
       // linkChild should be idempotent
       set(instance, 'parentView', this);

--- a/packages/ember-views/lib/mixins/view_child_views_support.js
+++ b/packages/ember-views/lib/mixins/view_child_views_support.js
@@ -8,6 +8,7 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import setProperties from 'ember-metal/set_properties';
 import { A as emberA } from 'ember-runtime/system/native_array';
+import { getOwner, setOwner } from 'container/owner';
 
 var EMPTY_ARRAY = [];
 
@@ -85,7 +86,9 @@ export default Mixin.create({
       throw new TypeError('createChildViews first argument must exist');
     }
 
-    if (maybeViewClass.isView && maybeViewClass.parentView === this && maybeViewClass.container === this.container) {
+    const owner = getOwner(this);
+
+    if (maybeViewClass.isView && maybeViewClass.parentView === this && getOwner(maybeViewClass) === owner) {
       return maybeViewClass;
     }
 
@@ -97,7 +100,7 @@ export default Mixin.create({
     attrs._viewRegistry = this._viewRegistry;
 
     if (maybeViewClass.isViewFactory) {
-      attrs.container = this.container;
+      setOwner(attrs, owner);
 
       view = maybeViewClass.create(attrs);
 
@@ -106,7 +109,7 @@ export default Mixin.create({
       }
     } else if ('string' === typeof maybeViewClass) {
       var fullName = 'view:' + maybeViewClass;
-      var ViewKlass = this.container.lookupFactory(fullName);
+      var ViewKlass = owner._lookupFactory(fullName);
 
       assert('Could not find view: \'' + fullName + '\'', !!ViewKlass);
 
@@ -115,7 +118,7 @@ export default Mixin.create({
       view = maybeViewClass;
       assert('You must pass instance or subclass of View', view.isView);
 
-      attrs.container = this.container;
+      setOwner(attrs, owner);
       setProperties(view, attrs);
     }
 
@@ -125,7 +128,7 @@ export default Mixin.create({
   },
 
   linkChild(instance) {
-    instance.container = this.container;
+    setOwner(instance, getOwner(this));
     instance.parentView = this;
     instance.ownerView = this.ownerView;
   },

--- a/packages/ember-views/lib/mixins/view_support.js
+++ b/packages/ember-views/lib/mixins/view_support.js
@@ -9,6 +9,7 @@ import { Mixin } from 'ember-metal/mixin';
 import { POST_INIT } from 'ember-runtime/system/core_object';
 import isEnabled from 'ember-metal/features';
 import { symbol } from 'ember-metal/utils';
+import { getOwner } from 'container/owner';
 
 const INIT_WAS_CALLED = symbol('INIT_WAS_CALLED');
 
@@ -117,13 +118,15 @@ export default Mixin.create({
     if (!name) { return; }
     assert('templateNames are not allowed to contain periods: ' + name, name.indexOf('.') === -1);
 
-    if (!this.container) {
+    const owner = getOwner(this);
+
+    if (!owner) {
       throw new EmberError('Container was not found when looking up a views template. ' +
                  'This is most likely due to manually instantiating an Ember.View. ' +
                  'See: http://git.io/EKPpnA');
     }
 
-    return this.container.lookup('template:' + name);
+    return owner.lookup('template:' + name);
   },
 
   /**

--- a/packages/ember-views/lib/streams/utils.js
+++ b/packages/ember-views/lib/streams/utils.js
@@ -3,13 +3,13 @@ import { get } from 'ember-metal/property_get';
 import { read, isStream } from 'ember-metal/streams/utils';
 import ControllerMixin from 'ember-runtime/mixins/controller';
 
-export function readViewFactory(object, container) {
+export function readViewFactory(object, owner) {
   var value = read(object);
   var viewClass;
 
   if (typeof value === 'string') {
-    assert('View requires a container to resolve views not passed in through the context', !!container);
-    viewClass = container.lookupFactory('view:' + value);
+    assert('View requires an owner to resolve views not passed in through the context', !!owner);
+    viewClass = owner._lookupFactory('view:' + value);
   } else {
     viewClass = value;
   }
@@ -21,16 +21,16 @@ export function readViewFactory(object, container) {
   return viewClass;
 }
 
-export function readComponentFactory(nameOrStream, container) {
+export function readComponentFactory(nameOrStream, owner) {
   var name = read(nameOrStream);
-  var componentLookup = container.lookup('component-lookup:main');
+  var componentLookup = owner.lookup('component-lookup:main');
   assert(
     'Could not find \'component-lookup:main\' on the provided container, ' +
     'which is necessary for performing component lookups',
     componentLookup
   );
 
-  return componentLookup.lookupFactory(name, container);
+  return componentLookup.lookupFactory(name, owner);
 }
 
 export function readUnwrappedModel(object) {

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -13,6 +13,7 @@ import jQuery from 'ember-views/system/jquery';
 import ActionManager from 'ember-views/system/action_manager';
 import View from 'ember-views/views/view';
 import assign from 'ember-metal/assign';
+import { getOwner } from 'container/owner';
 
 let ROOT_ELEMENT_CLASS = 'ember-application';
 let ROOT_ELEMENT_SELECTOR = '.' + ROOT_ELEMENT_CLASS;
@@ -188,7 +189,9 @@ export default EmberObject.extend({
   */
   setupHandler(rootElement, event, eventName) {
     var self = this;
-    var viewRegistry = this.container && this.container.lookup('-view-registry:main') || View.views;
+
+    const owner = getOwner(this);
+    const viewRegistry = owner && owner.lookup('-view-registry:main') || View.views;
 
     if (eventName === null) {
       return;

--- a/packages/ember-views/lib/system/lookup_partial.js
+++ b/packages/ember-views/lib/system/lookup_partial.js
@@ -24,11 +24,11 @@ function templateFor(env, underscored, name) {
   if (!name) { return; }
   assert('templateNames are not allowed to contain periods: ' + name, name.indexOf('.') === -1);
 
-  if (!env.container) {
+  if (!env.owner) {
     throw new EmberError('Container was not found when looking up a views template. ' +
                'This is most likely due to manually instantiating an Ember.View. ' +
                'See: http://git.io/EKPpnA');
   }
 
-  return env.container.lookup('template:' + underscored) || env.container.lookup('template:' + name);
+  return env.owner.lookup('template:' + underscored) || env.owner.lookup('template:' + name);
 }

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -14,6 +14,7 @@ import { computed } from 'ember-metal/computed';
 import { observer } from 'ember-metal/mixin';
 import { readViewFactory } from 'ember-views/streams/utils';
 import EmptyViewSupport from 'ember-views/mixins/empty_view_support';
+import { getOwner } from 'container/owner';
 
 /**
   `Ember.CollectionView` is an `Ember.View` descendent responsible for managing
@@ -311,7 +312,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
       itemViewProps = this._itemViewProps || {};
       itemViewClass = this.getAttr('itemViewClass') || get(this, 'itemViewClass');
 
-      itemViewClass = readViewFactory(itemViewClass, this.container);
+      itemViewClass = readViewFactory(itemViewClass, getOwner(this));
 
       for (idx = start; idx < start + added; idx++) {
         item = content.objectAt(idx);

--- a/packages/ember-views/tests/views/component_test.js
+++ b/packages/ember-views/tests/views/component_test.js
@@ -2,7 +2,6 @@ import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
 import EmberObject from 'ember-runtime/system/object';
 import Service from 'ember-runtime/system/service';
-import { Registry } from 'ember-runtime/system/container';
 import inject from 'ember-runtime/inject';
 import { get } from 'ember-metal/property_get';
 import Application from 'ember-application/system/application';
@@ -13,6 +12,7 @@ import EmberView from 'ember-views/views/view';
 import Component from 'ember-views/components/component';
 
 import { MUTABLE_CELL } from 'ember-views/compat/attrs-proxy';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
 var a_slice = Array.prototype.slice;
 
@@ -231,17 +231,16 @@ QUnit.test('Calling sendAction on a component with multiple parameters', functio
 QUnit.module('Ember.Component - injected properties');
 
 QUnit.test('services can be injected into components', function() {
-  var registry = new Registry();
-  var container = registry.container();
+  const owner = buildOwner();
 
-  registry.register('component:application', Component.extend({
+  owner.register('component:application', Component.extend({
     profilerService: inject.service('profiler')
   }));
 
-  registry.register('service:profiler', Service.extend());
+  owner.register('service:profiler', Service.extend());
 
-  var appComponent = container.lookup('component:application');
-  var profilerService = container.lookup('service:profiler');
+  var appComponent = owner.lookup('component:application');
+  var profilerService = owner.lookup('service:profiler');
 
   equal(profilerService, appComponent.get('profilerService'), 'service.profiler is injected');
 });

--- a/packages/ember-views/tests/views/view/child_views_test.js
+++ b/packages/ember-views/tests/views/view/child_views_test.js
@@ -6,6 +6,7 @@ import { A as emberA } from 'ember-runtime/system/native_array';
 
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
+import { setOwner } from 'container/owner';
 
 var originalViewKeyword;
 var parentView, childView;
@@ -80,25 +81,26 @@ QUnit.test('should remove childViews inside {{if}} on destroy', function() {
   var outerView = EmberView.extend({
     component: 'my-thing',
     value: false,
-    container: {
-      lookup() {
-        return {
-          componentFor() {
-            return Component.extend();
-          },
-
-          layoutFor() {
-            return null;
-          }
-        };
-      }
-    },
     template: compile(`
       {{#if view.value}}
         {{component view.component value=view.value}}
       {{/if}}
     `)
   }).create();
+
+  setOwner(outerView, {
+    lookup() {
+      return {
+        componentFor() {
+          return Component.extend();
+        },
+
+        layoutFor() {
+          return null;
+        }
+      };
+    }
+  });
 
   run(outerView, 'append');
   run(outerView, 'set', 'value', true);
@@ -121,19 +123,6 @@ QUnit.test('should remove childViews inside {{each}} on destroy', function() {
       this._super(...arguments);
       this.value = false;
     },
-    container: {
-      lookup() {
-        return {
-          componentFor() {
-            return Component.extend();
-          },
-
-          layoutFor() {
-            return null;
-          }
-        };
-      }
-    },
     template: compile(`
       {{#if view.value}}
         {{#each view.data as |item|}}
@@ -142,6 +131,20 @@ QUnit.test('should remove childViews inside {{each}} on destroy', function() {
       {{/if}}
     `)
   }).create();
+
+  setOwner(outerView, {
+    lookup() {
+      return {
+        componentFor() {
+          return Component.extend();
+        },
+
+        layoutFor() {
+          return null;
+        }
+      };
+    }
+  });
 
   run(outerView, 'append');
 

--- a/packages/ember-views/tests/views/view/inject_test.js
+++ b/packages/ember-views/tests/views/view/inject_test.js
@@ -1,22 +1,21 @@
 import Service from 'ember-runtime/system/service';
-import { Registry } from 'ember-runtime/system/container';
 import inject from 'ember-runtime/inject';
 import View from 'ember-views/views/view';
+import buildOwner from 'container/tests/test-helpers/build-owner';
 
 QUnit.module('EmberView - injected properties');
 
 QUnit.test('services can be injected into views', function() {
-  var registry = new Registry();
-  var container = registry.container();
+  const owner = buildOwner();
 
-  registry.register('view:application', View.extend({
+  owner.register('view:application', View.extend({
     profilerService: inject.service('profiler')
   }));
 
-  registry.register('service:profiler', Service.extend());
+  owner.register('service:profiler', Service.extend());
 
-  var appView = container.lookup('view:application');
-  var profilerService = container.lookup('service:profiler');
+  var appView = owner.lookup('view:application');
+  var profilerService = owner.lookup('service:profiler');
 
   equal(profilerService, appView.get('profilerService'), 'service.profiler is injected');
 });

--- a/packages/ember-views/tests/views/view/nested_view_ordering_test.js
+++ b/packages/ember-views/tests/views/view/nested_view_ordering_test.js
@@ -1,28 +1,26 @@
-import Registry from 'container/registry';
 import run from 'ember-metal/run_loop';
-
 import EmberView from 'ember-views/views/view';
 import compile from 'ember-template-compiler/system/compile';
-
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
+import buildOwner from 'container/tests/test-helpers/build-owner';
+import { OWNER } from 'container/owner';
 
-var registry, container, view;
+var owner, view;
 var originalViewKeyword;
 
 QUnit.module('EmberView - Nested View Ordering', {
   setup() {
     originalViewKeyword = registerKeyword('view',  viewKeyword);
-    registry = new Registry();
-    container = registry.container();
+    owner = buildOwner();
   },
   teardown() {
     run(function() {
       if (view) { view.destroy(); }
-      container.destroy();
+      owner.destroy();
     });
     resetKeyword('view', originalViewKeyword);
-    registry = container = view = null;
+    owner = view = null;
   }
 });
 
@@ -30,14 +28,14 @@ QUnit.test('should call didInsertElement on child views before parent', function
   var insertedLast;
 
   view = EmberView.create({
+    [OWNER]: owner,
     didInsertElement() {
       insertedLast = 'outer';
     },
-    container: container,
     template: compile('{{view "inner"}}')
   });
 
-  registry.register('view:inner', EmberView.extend({
+  owner.register('view:inner', EmberView.extend({
     didInsertElement() {
       insertedLast = 'inner';
     }

--- a/packages/ember/tests/application_lifecycle_test.js
+++ b/packages/ember/tests/application_lifecycle_test.js
@@ -7,7 +7,7 @@ import jQuery from 'ember-views/system/jquery';
 
 var compile = Ember.HTMLBars.compile;
 
-var App, container, router;
+var App, appInstance, router;
 
 function setupApp(klass) {
   run(function() {
@@ -21,7 +21,7 @@ function setupApp(klass) {
 
     App.deferReadiness();
 
-    container = App.__container__;
+    appInstance = App.__deprecatedInstance__;
   });
 }
 
@@ -38,7 +38,7 @@ QUnit.module('Application Lifecycle', {
 });
 
 function handleURL(path) {
-  router = container.lookup('router:main');
+  router = appInstance.lookup('router:main');
   return run(function() {
     return router.handleURL(path).then(function(value) {
       ok(true, 'url: `' + path + '` was handled');
@@ -49,7 +49,6 @@ function handleURL(path) {
     });
   });
 }
-
 
 QUnit.test('Resetting the application allows controller properties to be set when a route deactivates', function() {
   App.Router.map(function() {
@@ -73,22 +72,22 @@ QUnit.test('Resetting the application allows controller properties to be set whe
     }
   });
 
-  container.lookup('router:main');
+  appInstance.lookup('router:main');
 
   run(App, 'advanceReadiness');
 
   handleURL('/');
 
-  equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), 'home');
-  equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), 'home');
+  equal(Ember.controllerFor(appInstance, 'home').get('selectedMenuItem'), 'home');
+  equal(Ember.controllerFor(appInstance, 'application').get('selectedMenuItem'), 'home');
 
   App.reset();
 
-  equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), null);
-  equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), null);
+  equal(Ember.controllerFor(appInstance, 'home').get('selectedMenuItem'), null);
+  equal(Ember.controllerFor(appInstance, 'application').get('selectedMenuItem'), null);
 });
 
-QUnit.test('Destroying the application resets the router before the container is destroyed', function() {
+QUnit.test('Destroying the application resets the router before the appInstance is destroyed', function() {
   App.Router.map(function() {
     this.route('home', { path: '/' });
   });
@@ -110,19 +109,19 @@ QUnit.test('Destroying the application resets the router before the container is
     }
   });
 
-  container.lookup('router:main');
+  appInstance.lookup('router:main');
 
   run(App, 'advanceReadiness');
 
   handleURL('/');
 
-  equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), 'home');
-  equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), 'home');
+  equal(Ember.controllerFor(appInstance, 'home').get('selectedMenuItem'), 'home');
+  equal(Ember.controllerFor(appInstance, 'application').get('selectedMenuItem'), 'home');
 
   run(App, 'destroy');
 
-  equal(Ember.controllerFor(container, 'home').get('selectedMenuItem'), null);
-  equal(Ember.controllerFor(container, 'application').get('selectedMenuItem'), null);
+  equal(Ember.controllerFor(appInstance, 'home').get('selectedMenuItem'), null);
+  equal(Ember.controllerFor(appInstance, 'application').get('selectedMenuItem'), null);
 });
 
 QUnit.test('initializers can augment an applications customEvents hash', function(assert) {

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -18,6 +18,7 @@ import Application from 'ember-application/system/application';
 import { A as emberA } from 'ember-runtime/system/native_array';
 import NoneLocation from 'ember-routing/location/none_location';
 import HistoryLocation from 'ember-routing/location/history_location';
+import { getOwner } from 'container/owner';
 
 var trim = jQuery.trim;
 
@@ -1785,7 +1786,7 @@ QUnit.test('A redirection hook is provided', function() {
 
   equal(chooseFollowed, 0, 'The choose route wasn\'t entered since a transition occurred');
   equal(jQuery('h3:contains(Hours)', '#qunit-fixture').length, 1, 'The home template was rendered');
-  equal(router.container.lookup('controller:application').get('currentPath'), 'home');
+  equal(getOwner(router).lookup('controller:application').get('currentPath'), 'home');
 });
 
 QUnit.test('Redirecting from the middle of a route aborts the remainder of the routes', function() {
@@ -1819,7 +1820,7 @@ QUnit.test('Redirecting from the middle of a route aborts the remainder of the r
 
   handleURLAborts('/foo/bar/baz');
 
-  equal(router.container.lookup('controller:application').get('currentPath'), 'home');
+  equal(getOwner(router).lookup('controller:application').get('currentPath'), 'home');
   equal(router.get('location').getURL(), '/home');
 });
 
@@ -1858,7 +1859,7 @@ QUnit.test('Redirecting to the current target in the middle of a route does not 
 
   handleURL('/foo/bar/baz');
 
-  equal(router.container.lookup('controller:application').get('currentPath'), 'foo.bar.baz');
+  equal(getOwner(router).lookup('controller:application').get('currentPath'), 'foo.bar.baz');
   equal(successCount, 1, 'transitionTo success handler was called once');
 });
 
@@ -1902,7 +1903,7 @@ QUnit.test('Redirecting to the current target with a different context aborts th
 
   handleURLAborts('/foo/bar/1/baz');
 
-  equal(router.container.lookup('controller:application').get('currentPath'), 'foo.bar.baz');
+  equal(getOwner(router).lookup('controller:application').get('currentPath'), 'foo.bar.baz');
   equal(router.get('location').getURL(), '/foo/bar/2/baz');
 });
 
@@ -1926,7 +1927,7 @@ QUnit.test('Transitioning from a parent event does not prevent currentPath from 
 
   bootApplication();
 
-  var applicationController = router.container.lookup('controller:application');
+  var applicationController = getOwner(router).lookup('controller:application');
 
   handleURL('/foo/bar/baz');
 
@@ -3034,7 +3035,7 @@ QUnit.test('currentRouteName is a property installed on ApplicationController th
 
   bootApplication();
 
-  var appController = router.container.lookup('controller:application');
+  var appController = getOwner(router).lookup('controller:application');
 
   function transitionAndCheck(path, expectedPath, expectedRouteName) {
     if (path) { run(router, 'transitionTo', path); }


### PR DESCRIPTION
This change represents the final brick needed to wall off the 
`Container` as fully private.

The Container no longer injects itself into every object that it looks
up. Instead, the owner of the Container is injected as `owner` by the
ContainerProxy mixin.

The current net effect is that an app instance is injected into every 
looked up object instead of that app instance's container. This 
provides clean, public access to methods exposed by the app
instance's ContainerProxy and RegistryProxy methods. It also guarantees
that the only supported path to get to a Container or Registry is
through a proxied method. This guarantee is important because it allows
for owner-specific logic to be placed in proxy methods.

In the future, other classes, such as Engine (coming soon), may mix in
ContainerProxy and thus have the potential to be "owners".

Note 1: This work is behind the ember-registry-container-reform flag.

Note 2: Totally open to alternatives to the name `owner`. I was drawn
to this name because the owner of the container "owns" the instantiated
objects to the extent that its responsible for their cleanup.

Note 3: This is still a WIP and will require changes throughout the 
test suite for compatibility.

---
- [x] Move `owner` to `__owner__` (actually, use symbol instead).
- [x] Create `getOwner` / `setOwner` functions.
- [x] Add simple container tests for accessing `container` in an object looked up from the container.
- [x] Confirm the `Object.defineProperty` supporting deprecated access to `this.container` is called a single time per factory (and not once for every created instance).
- [x] Add a new feature flag (because `ember-container-registry-reform` is already enabled). Perhaps `ember-container-inject-owner`?
