### PR TITLE
Remove unnecessary property access with `get`.

### DIFF
--- a/packages/ember-runtime/lib/mixins/container_proxy.js
+++ b/packages/ember-runtime/lib/mixins/container_proxy.js
@@ -1,5 +1,4 @@
 import run from 'ember-metal/run_loop';
-import { get } from 'ember-metal/property_get';
 import { Mixin } from 'ember-metal/mixin';
 
 export default Mixin.create({
@@ -81,7 +80,6 @@ export default Mixin.create({
 
 function containerAlias(name) {
   return function () {
-    var container = get(this, '__container__');
-    return container[name](...arguments);
+    return this.__container__[name](...arguments);
   };
 }

--- a/packages/ember-runtime/lib/mixins/registry_proxy.js
+++ b/packages/ember-runtime/lib/mixins/registry_proxy.js
@@ -1,4 +1,3 @@
-import { get } from 'ember-metal/property_get';
 import { Mixin } from 'ember-metal/mixin';
 
 export default Mixin.create({
@@ -244,7 +243,6 @@ export default Mixin.create({
 
 function registryAlias(name) {
   return function () {
-    var registry = get(this, '__registry__');
-    return registry[name](...arguments);
+    return this.__registry__[name](...arguments);
   };
 }


### PR DESCRIPTION
Cleans up proxy methods in ContainerProxy and RegistryProxy.

cc @stefanpenner 
