### PR TITLE
[DOC release] notes Ember.computed.oneWay doesn't work for objects

### DIFF
--- a/packages/ember-metal/lib/computed_macros.js
+++ b/packages/ember-metal/lib/computed_macros.js
@@ -548,7 +548,7 @@ export var collect = generateComputedWithProperties(function(properties) {
   data flow, `computed.oneWay` only provides an aliased `get`. The `set` will
   not mutate the upstream property, rather causes the current property to
   become the value set. This causes the downstream property to permanently
-  diverge from the upstream property.
+  diverge from the upstream property. This can only be used on a property, not an object.
 
   Example
 


### PR DESCRIPTION
Much confusion, discussion and twiddling could be avoided by making it clear that `Ember.computed.oneWay` only works for properties, not objects.
