### PR TITLE
[BUGFIX] Correctly alias properties on Container and ApplicationInstance

### DIFF
--- a/packages/container/lib/container.js
+++ b/packages/container/lib/container.js
@@ -335,7 +335,7 @@ function resetMember(container, fullName) {
 // Once registry / container reform is enabled, we no longer need to expose
 // Container#_registry, since Container itself will be fully private.
 if (!isEnabled('ember-registry-container-reform')) {
-  Object.defineProperty(Container, '_registry', {
+  Object.defineProperty(Container.prototype, '_registry', {
     configurable: true,
     enumerable: false,
     get() {

--- a/packages/container/tests/container_test.js
+++ b/packages/container/tests/container_test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember-metal/core';
 import Registry from 'container/registry';
 import { factory } from 'container/tests/container_helper';
+import isEnabled from 'ember-metal/features';
 
 var originalModelInjections;
 
@@ -519,3 +520,13 @@ QUnit.test('Lazy injection validations are cached', function() {
   container.lookup('apple:main');
   container.lookup('apple:main');
 });
+
+if (!isEnabled('ember-registry-container-reform')) {
+  QUnit.test('Container#_registry provides an alias to Container#registry while Container is pseudo-public', function() {
+    var registry = new Registry();
+    var container = registry.container();
+
+    strictEqual(container.registry, registry, '#registry points to the parent registry');
+    strictEqual(container._registry, registry, '#_registry is an alias to #registry');
+  });
+}

--- a/packages/ember-application/lib/system/application-instance.js
+++ b/packages/ember-application/lib/system/application-instance.js
@@ -98,6 +98,8 @@ let ApplicationInstance = EmberObject.extend(RegistryProxy, ContainerProxy, {
     // appended to the rootElement, in the case of apps, to the fixture harness
     // in tests, or rendered to a string in the case of FastBoot.
     this.register('-application-instance:main', this, { instantiate: false });
+
+    assignAliases(this);
   },
 
   router: computed(function() {
@@ -204,38 +206,27 @@ function isResolverModuleBased(applicationInstance) {
   return !!applicationInstance.application.__registry__.resolver.moduleBasedResolver;
 }
 
-if (isEnabled('ember-registry-container-reform')) {
-  Object.defineProperty(ApplicationInstance, 'container', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      var instance = this;
-      return {
-        lookup() {
-          Ember.deprecate('Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead.',
-                          false,
-                          { id: 'ember-application.app-instance-container', until: '3.0.0' });
-          return instance.lookup(...arguments);
-        }
-      };
-    }
-  });
-} else {
-  Object.defineProperty(ApplicationInstance, 'container', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      return this.__container__;
-    }
-  });
-
-  Object.defineProperty(ApplicationInstance, 'registry', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      return this.__registry__;
-    }
-  });
+function assignAliases(applicationInstance) {
+  if (isEnabled('ember-registry-container-reform')) {
+    Object.defineProperty(applicationInstance, 'container', {
+      configurable: true,
+      enumerable: false,
+      get() {
+        var instance = this;
+        return {
+          lookup() {
+            Ember.deprecate('Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead.',
+                            false,
+                            { id: 'ember-application.app-instance-container', until: '3.0.0' });
+            return instance.lookup(...arguments);
+          }
+        };
+      }
+    });
+  } else {
+    applicationInstance.container = applicationInstance.__container__;
+    applicationInstance.registry = applicationInstance.__registry__;
+  }
 }
 
 export default ApplicationInstance;

--- a/packages/ember-application/tests/system/application_instance_test.js
+++ b/packages/ember-application/tests/system/application_instance_test.js
@@ -1,0 +1,67 @@
+import Application from 'ember-application/system/application';
+import ApplicationInstance from 'ember-application/system/application-instance';
+import run from 'ember-metal/run_loop';
+import jQuery from 'ember-views/system/jquery';
+import isEnabled from 'ember-metal/features';
+
+let app, appInstance;
+
+QUnit.module('Ember.ApplicationInstance', {
+  setup() {
+    jQuery('#qunit-fixture').html('<div id=\'one\'><div id=\'one-child\'>HI</div></div><div id=\'two\'>HI</div>');
+    run(function() {
+      app = Application.create({ rootElement: '#one', router: null });
+    });
+  },
+
+  teardown() {
+    jQuery('#qunit-fixture').empty();
+
+    if (appInstance) {
+      run(appInstance, 'destroy');
+    }
+
+    if (app) {
+      run(app, 'destroy');
+    }
+  }
+});
+
+QUnit.test('an application instance can be created based upon an application', function() {
+  run(function() {
+    appInstance = ApplicationInstance.create({ application: app });
+  });
+
+  ok(appInstance, 'instance should be created');
+  equal(appInstance.application, app, 'application should be set to parent');
+});
+
+QUnit.test('properties (and aliases) are correctly assigned for accessing the container and registry', function() {
+  run(function() {
+    appInstance = ApplicationInstance.create({ application: app });
+  });
+
+  ok(appInstance, 'instance should be created');
+  ok(appInstance.__container__, '#__container__ is accessible');
+  ok(appInstance.__registry__, '#__registry__ is accessible');
+
+  if (isEnabled('ember-registry-container-reform')) {
+    expect(6);
+
+    ok(typeof appInstance.container.lookup === 'function', '#container.lookup is available as a function');
+
+    // stub `lookup` with a no-op to keep deprecation test simple
+    appInstance.__container__.lookup = function() {
+      ok(true, '#loookup alias is called correctly');
+    };
+
+    expectDeprecation(function() {
+      appInstance.container.lookup();
+    }, /Using `ApplicationInstance.container.lookup` is deprecated. Please use `ApplicationInstance.lookup` instead./);
+  } else {
+    expect(5);
+
+    strictEqual(appInstance.container, appInstance.__container__, '#container alias should be assigned');
+    strictEqual(appInstance.registry, appInstance.__registry__, '#registry alias should be assigned');
+  }
+});


### PR DESCRIPTION
Should now work regardless of the state of the `ember-registry-container-reform` flag.

Also introduces tests to prevent regressions.

[Fixes #11879]
