### PR TITLE
[DOC Release] Made Ember.inject.controller() public

### DIFF
--- a/packages/ember-runtime/lib/controllers/controller.js
+++ b/packages/ember-runtime/lib/controllers/controller.js
@@ -51,7 +51,7 @@ function controllerInjectionHelper(factory) {
   @param {String} name (optional) name of the controller to inject, defaults
          to the property's name
   @return {Ember.InjectedProperty} injection descriptor instance
-  @private
+  @public
 */
 createInjectionHelper('controller', controllerInjectionHelper);
 


### PR DESCRIPTION
`DEPRECATION: Controller#needs is deprecated, please use Ember.inject.controller() instead` yet the docs have it marked as private.
