### PR TITLE
[BUGFIX release] Fix `attributeBindings` for `id` attribute.

### DIFF
--- a/packages/ember-views/lib/system/build-component-template.js
+++ b/packages/ember-views/lib/system/build-component-template.js
@@ -139,6 +139,14 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
   var attributeBindings = component.attributeBindings;
   var i, l;
 
+  if (attrs.id && getValue(attrs.id)) {
+    // Do not allow binding to the `id`
+    normalized.id = getValue(attrs.id);
+    component.elementId = normalized.id;
+  } else {
+    normalized.id = component.elementId;
+  }
+
   if (attributeBindings) {
     for (i = 0, l = attributeBindings.length; i < l; i++) {
       var attr = attributeBindings[i];
@@ -176,14 +184,6 @@ function normalizeComponentAttributes(component, isAngleBracket, attrs) {
         normalized[prop] = ['value', val];
       }
     }
-  }
-
-  if (attrs.id && getValue(attrs.id)) {
-    // Do not allow binding to the `id`
-    normalized.id = getValue(attrs.id);
-    component.elementId = normalized.id;
-  } else {
-    normalized.id = component.elementId;
   }
 
   if (attrs.tagName) {

--- a/packages/ember-views/tests/views/view/attribute_bindings_test.js
+++ b/packages/ember-views/tests/views/view/attribute_bindings_test.js
@@ -466,3 +466,14 @@ QUnit.test('role attribute is not included if not provided', function() {
 
   ok(!view.element.hasAttribute('role'), 'role attribute is not present');
 });
+
+QUnit.test('can set id initially via attributeBindings', function() {
+  view = EmberView.create({
+    attributeBindings: ['specialSauce:id'],
+    specialSauce: 'special-sauces-id'
+  });
+
+  appendView();
+
+  equal(view.$().attr('id'), 'special-sauces-id', 'id properly used from attributeBindings');
+});


### PR DESCRIPTION
In prior versions of Ember you could customize `id` via
`attributeBindings` like so:

``` javascript
export default Ember.Component.extend({
  attributeBindings: [ 'someThing:id' ]
  someThing: 'asdfasdfasdf'
});
```

However, that was broken during the glimmer refactorings because we
process `attributeBindings` _before_ the defaults (meaning the default
`elementId` is used whenever `id` isn't passed in the template).

This fix is to process the default first, then process `attributeBindings`.

Fixes #11871
