### PR TITLE
[BUGFIX beta] Properly detect if the environment is Node.

### DIFF
--- a/packages/loader/lib/main.js
+++ b/packages/loader/lib/main.js
@@ -2,7 +2,8 @@ var define, requireModule, require, requirejs, Ember;
 var mainContext = this;
 
 (function() {
-  var isNode = typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
+  var isNode = typeof window === 'undefined' &&
+    typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
 
   if (!isNode) {
     Ember = this.Ember = this.Ember || {};


### PR DESCRIPTION
This fixes how we currently determine if the running environment is Node, by also ensuring that `window` is not defined. Simply checking for `process` is insufficient in browser environments such as those provided by [NW.js](http://nwjs.io/) or [Electron](http://electron.atom.io/), which also define a `window.process`.

I'll make a separate PR to [rsvp](https://github.com/tildeio/rsvp.js/blob/2136b263a72719a15d908c343e809df9fe604659/lib/rsvp/asap.js#L19) to get it fixed there as well.

Closes #11679

**Update:** Relates to https://github.com/tildeio/rsvp.js/pull/398
