### PR TITLE
Deprecate legacy helper versions.

### DIFF
--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -125,8 +125,11 @@ QUnit.test('the default resolver resolves helpers on the namespace', function() 
   let CompleteHelper = Helper.extend();
   let LegacyBareFunctionHelper = function() {};
   let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(function() {});
-  let LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(function() {});
-  let ViewHelper;
+  let ViewHelper, LegacyHTMLBarsBoundHelper;
+
+  expectDeprecation(function() {
+    LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(function() {});
+  }, 'Using `Ember.HTMLBars.makeBoundHelper` is deprecated. Please refactor to using `Ember.Helper` or `Ember.Helper.helper`.');
 
   expectDeprecation(function() {
     ViewHelper = makeViewHelper(function() {});

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -126,7 +126,11 @@ QUnit.test('the default resolver resolves helpers on the namespace', function() 
   let LegacyBareFunctionHelper = function() {};
   let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(function() {});
   let LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(function() {});
-  let ViewHelper = makeViewHelper(function() {});
+  let ViewHelper;
+
+  expectDeprecation(function() {
+    ViewHelper = makeViewHelper(function() {});
+  }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
 
   application.ShorthandHelper = ShorthandHelper;
   application.CompleteHelper = CompleteHelper;

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -124,8 +124,11 @@ QUnit.test('the default resolver resolves helpers on the namespace', function() 
   let ShorthandHelper = makeHelper(function() {});
   let CompleteHelper = Helper.extend();
   let LegacyBareFunctionHelper = function() {};
-  let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(function() {});
-  let ViewHelper, LegacyHTMLBarsBoundHelper;
+  let ViewHelper, LegacyHandlebarsBoundHelper, LegacyHTMLBarsBoundHelper;
+
+  expectDeprecation(function() {
+    LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(function() {});
+  }, 'Using Ember.Handlebars.makeBoundHelper is deprecated. Please refactor to using `Ember.Helper.helper`.');
 
   expectDeprecation(function() {
     LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(function() {});

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -132,6 +132,12 @@ export function registerHandlebarsCompatibleHelper(name, value) {
 }
 
 export function handlebarsHelper(name, value) {
+  Ember.deprecate(
+    'Ember.Handlebars.helper is deprecated, please refactor to Ember.Helper.helper',
+    false,
+    { id: 'ember-htmlbars.handlebars-helper', until: '2.0.0' }
+  );
+
   Ember.assert(`You tried to register a component named '${name}', but component names must include a '-'`,
     !Component.detect(value) || name.match(/-/));
 

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -109,6 +109,12 @@ HandlebarsCompatibleHelper.prototype = {
 };
 
 export function registerHandlebarsCompatibleHelper(name, value) {
+  Ember.deprecate(
+    'Ember.Handlebars.registerHelper is deprecated, please refactor to Ember.Helper.helper.',
+    false,
+    { id: 'ember-htmlbars.handlebars-register-helper', until: '2.0.0' }
+  );
+
   if (value && value.isLegacyViewHelper) {
     registerKeyword(name, function(morph, env, scope, params, hash, template, inverse, visitor) {
       Ember.assert('You can only pass attributes (such as name=value) not bare ' +

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -37,7 +37,8 @@ import {
   @deprecated
   @private
 */
-export default function makeBoundHelper(fn, ...dependentKeys) {
+
+export function makeBoundHelper(fn, ...dependentKeys) {
   return {
     _dependentKeys: dependentKeys,
 
@@ -64,4 +65,14 @@ export default function makeBoundHelper(fn, ...dependentKeys) {
       return fn.apply(undefined, args);
     }
   };
+}
+
+export default function deprecatedMakeBoundHelper(fn, ...dependentKeys) {
+  Ember.deprecate(
+    'Using Ember.Handlebars.makeBoundHelper is deprecated. Please refactor to using `Ember.Helper.helper`.',
+    false,
+    { id: 'ember-htmlbars.handlebars-make-bound-helper', until: '2.0.0' }
+  );
+
+  return makeBoundHelper(...arguments);
 }

--- a/packages/ember-htmlbars/lib/compat/register-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/register-bound-helper.js
@@ -4,7 +4,7 @@
 */
 
 import helpers from 'ember-htmlbars/helpers';
-import makeBoundHelper from 'ember-htmlbars/compat/make-bound-helper';
+import { makeBoundHelper } from 'ember-htmlbars/compat/make-bound-helper';
 
 var slice = [].slice;
 

--- a/packages/ember-htmlbars/lib/compat/register-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/register-bound-helper.js
@@ -3,6 +3,7 @@
 @submodule ember-htmlbars
 */
 
+import Ember from 'ember-metal/core';
 import helpers from 'ember-htmlbars/helpers';
 import { makeBoundHelper } from 'ember-htmlbars/compat/make-bound-helper';
 
@@ -118,9 +119,20 @@ var slice = [].slice;
   @param {String} dependentKeys*
   @private
 */
-export default function registerBoundHelper(name, fn) {
+
+export function registerBoundHelper(name, fn) {
   var boundHelperArgs = slice.call(arguments, 1);
   var boundFn = makeBoundHelper.apply(this, boundHelperArgs);
 
   helpers[name] = boundFn;
+}
+
+export default function deprecatedRegisterBoundHelper() {
+  Ember.deprecate(
+    '`Ember.Handlebars.registerBoundHelper` is deprecated. Please refactor to use `Ember.Helpers.helper`.',
+    false,
+    { id: 'ember-htmlbars.register-bound-helper', until: '2.0.0' }
+  );
+
+  return registerBoundHelper(...arguments);
 }

--- a/packages/ember-htmlbars/lib/helpers.js
+++ b/packages/ember-htmlbars/lib/helpers.js
@@ -7,6 +7,8 @@
  @private
  @property helpers
 */
+import Ember from 'ember-metal/core';
+
 var helpers = Object.create(null);
 
 /**
@@ -24,5 +26,10 @@ var helpers = Object.create(null);
 export function registerHelper(name, helperFunc) {
   helpers[name] = helperFunc;
 }
+
+export let deprecatedRegisterHelper = Ember.deprecateFunc(
+  'Using Ember.HTMLBars._registerHelper is deprecated. Helpers (even dashless ones) are automatically resolved.',
+  { id: 'ember-htmlbars.register-helper', until: '2.0.0' },
+  registerHelper);
 
 export default helpers;

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -36,7 +36,8 @@ import makeViewHelper from 'ember-htmlbars/system/make-view-helper';
 import makeBoundHelper from 'ember-htmlbars/system/make_bound_helper';
 
 import {
-  registerHelper
+  registerHelper,
+  deprecatedRegisterHelper
 } from 'ember-htmlbars/helpers';
 import {
   ifHelper,
@@ -84,7 +85,7 @@ if (Ember.ENV._ENABLE_LEGACY_VIEW_SUPPORT) {
 }
 
 Ember.HTMLBars = {
-  _registerHelper: registerHelper,
+  _registerHelper: deprecatedRegisterHelper,
   template: template,
   compile: compile,
   precompile: precompile,

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -1,3 +1,5 @@
+import Ember from 'ember-metal/core';
+
 /**
 @module ember
 @submodule ember-htmlbars
@@ -15,6 +17,12 @@
   @since 1.2.0
 */
 export default function makeViewHelper(ViewClass) {
+  Ember.deprecate(
+    '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.',
+    false,
+    { id: 'ember-htmlbars.make-view-helper', until: '2.0.0' }
+  );
+
   return {
     isLegacyViewHelper: true,
     isHTMLBars: true,

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -2,7 +2,7 @@
 @module ember
 @submodule ember-htmlbars
 */
-
+import Ember from 'ember-metal/core';
 import { helper } from 'ember-htmlbars/helper';
 
 /**
@@ -49,5 +49,10 @@ import { helper } from 'ember-htmlbars/helper';
   @since 1.10.0
 */
 export default function makeBoundHelper(fn) {
+  Ember.deprecate(
+    'Using `Ember.HTMLBars.makeBoundHelper` is deprecated. Please refactor to using `Ember.Helper` or `Ember.Helper.helper`.',
+    false,
+    { id: 'ember-htmlbars.make-bound-helper', until: '3.0.0' }
+  );
   return helper(fn);
 }

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -1,5 +1,5 @@
 import {
-  registerHandlebarsCompatibleHelper
+  registerHandlebarsCompatibleHelper as registerHelper
 } from 'ember-htmlbars/compat/helper';
 
 import EmberView from 'ember-views/views/view';
@@ -17,6 +17,12 @@ import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
 
 var view, registry, container, originalViewKeyword;
+
+function registerHandlebarsCompatibleHelper() {
+  expectDeprecation('Ember.Handlebars.registerHelper is deprecated, please refactor to Ember.Helper.helper.');
+
+  return registerHelper(...arguments);
+}
 
 QUnit.module('ember-htmlbars: compat - Handlebars compatible helpers', {
   setup() {
@@ -40,7 +46,7 @@ QUnit.module('ember-htmlbars: compat - Handlebars compatible helpers', {
 });
 
 QUnit.test('wraps provided function so that original path params are provided to the helper', function() {
-  expect(2);
+  expect(3);
 
   function someHelper(param1, param2, options) {
     equal(param1, 'blammo');
@@ -60,7 +66,7 @@ QUnit.test('wraps provided function so that original path params are provided to
 });
 
 QUnit.test('combines `env` and `options` for the wrapped helper', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     equal(options.data.view, view);
@@ -79,7 +85,7 @@ QUnit.test('combines `env` and `options` for the wrapped helper', function() {
 });
 
 QUnit.test('combines `env` and `options` for the wrapped helper', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     equal(options.data.view, view);
@@ -122,7 +128,7 @@ QUnit.test('has the correct options.data.view within a components layout', funct
 });
 
 QUnit.test('adds `hash` into options `options` for the wrapped helper', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     equal(options.hash.bestFriend, 'Jacquie');
@@ -141,7 +147,7 @@ QUnit.test('adds `hash` into options `options` for the wrapped helper', function
 });
 
 QUnit.test('bound `hash` params are provided with their original paths', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     equal(options.hash.bestFriend, 'value');
@@ -160,7 +166,7 @@ QUnit.test('bound `hash` params are provided with their original paths', functio
 });
 
 QUnit.test('bound ordered params are provided with their original paths', function() {
-  expect(2);
+  expect(3);
 
   function someHelper(param1, param2, options) {
     equal(param1, 'first');
@@ -181,7 +187,7 @@ QUnit.test('bound ordered params are provided with their original paths', functi
 });
 
 QUnit.test('registering a helper created from `Ember.Handlebars.makeViewHelper` does not double wrap the helper', function() {
-  expect(2);
+  expect(3);
 
   var ViewHelperComponent = Component.extend({
     layout: compile('woot!')
@@ -204,7 +210,7 @@ QUnit.test('registering a helper created from `Ember.Handlebars.makeViewHelper` 
 });
 
 QUnit.test('makes helpful assertion when called with invalid arguments', function() {
-  expect(2);
+  expect(3);
 
   var ViewHelperComponent = Component.extend({
     layout: compile('woot!')
@@ -228,7 +234,7 @@ QUnit.test('makes helpful assertion when called with invalid arguments', functio
 });
 
 QUnit.test('does not add `options.fn` if no block was specified', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     ok(!options.fn, '`options.fn` is not present when block is not specified');
@@ -247,7 +253,7 @@ QUnit.test('does not add `options.fn` if no block was specified', function() {
 });
 
 QUnit.test('does not return helper result if block was specified', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     return 'asdf';
@@ -268,7 +274,7 @@ QUnit.test('does not return helper result if block was specified', function() {
 });
 
 QUnit.test('allows usage of the template fn', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     options.fn();
@@ -289,7 +295,7 @@ QUnit.test('allows usage of the template fn', function() {
 });
 
 QUnit.test('allows usage of the template inverse', function() {
-  expect(1);
+  expect(2);
 
   function someHelper(options) {
     options.inverse();
@@ -310,7 +316,7 @@ QUnit.test('allows usage of the template inverse', function() {
 });
 
 QUnit.test('ordered param types are added to options.types', function() {
-  expect(3);
+  expect(4);
 
   function someHelper(param1, param2, param3, options) {
     equal(options.types[0], 'NUMBER');
@@ -332,7 +338,7 @@ QUnit.test('ordered param types are added to options.types', function() {
 });
 
 QUnit.test('`hash` params are to options.hashTypes', function() {
-  expect(3);
+  expect(4);
 
   function someHelper(options) {
     equal(options.hashTypes.string, 'STRING');

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -181,13 +181,17 @@ QUnit.test('bound ordered params are provided with their original paths', functi
 });
 
 QUnit.test('registering a helper created from `Ember.Handlebars.makeViewHelper` does not double wrap the helper', function() {
-  expect(1);
+  expect(2);
 
   var ViewHelperComponent = Component.extend({
     layout: compile('woot!')
   });
 
-  var helper = makeViewHelper(ViewHelperComponent);
+  var helper;
+  expectDeprecation(function() {
+    helper = makeViewHelper(ViewHelperComponent);
+  }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
+
   registerHandlebarsCompatibleHelper('view-helper', helper);
 
   view = EmberView.extend({
@@ -200,7 +204,7 @@ QUnit.test('registering a helper created from `Ember.Handlebars.makeViewHelper` 
 });
 
 QUnit.test('makes helpful assertion when called with invalid arguments', function() {
-  expect(1);
+  expect(2);
 
   var ViewHelperComponent = Component.extend({
     layout: compile('woot!')
@@ -208,7 +212,10 @@ QUnit.test('makes helpful assertion when called with invalid arguments', functio
 
   ViewHelperComponent.toString = function() { return 'Some Random Class'; };
 
-  var helper = makeViewHelper(ViewHelperComponent);
+  var helper;
+  expectDeprecation(function() {
+    helper = makeViewHelper(ViewHelperComponent);
+  }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
   registerHandlebarsCompatibleHelper('view-helper', helper);
 
   view = EmberView.extend({

--- a/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
@@ -28,12 +28,17 @@ QUnit.module('ember-htmlbars: compat - makeViewHelper compat', {
 });
 
 QUnit.test('makeViewHelper', function() {
-  expect(1);
+  expect(2);
 
   var ViewHelperComponent = Component.extend({
     layout: compile('woot!')
   });
-  var helper = makeViewHelper(ViewHelperComponent);
+
+  var helper;
+  expectDeprecation(function() {
+    helper = makeViewHelper(ViewHelperComponent);
+  }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
+
   registry.register('helper:view-helper', helper);
 
   view = EmberView.extend({

--- a/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make_bound_helper_test.js
@@ -43,23 +43,12 @@ function expectDeprecationInHTMLBars() {
 
 QUnit.module('ember-htmlbars: compat - makeBoundHelper', {
   setup() {
+    expectDeprecation('Using Ember.Handlebars.makeBoundHelper is deprecated. Please refactor to using `Ember.Helper.helper`.');
   },
   teardown() {
     runDestroy(view);
     Ember.lookup = originalLookup;
   }
-});
-
-QUnit.test('primitives should work correctly [DEPRECATED]', function() {
-  view = EmberView.create({
-    prims: Ember.A(['string', 12]),
-
-    template: compile('{{#each view.prims as |prim|}}{{#if prim}}inside-if{{/if}}{{/each}}')
-  });
-
-  runAppend(view);
-
-  equal(view.$().text(), 'inside-ifinside-if');
 });
 
 QUnit.test('should update bound helpers when properties change', function() {

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -495,6 +495,7 @@ QUnit.module('ember-htmlbars: {{#unbound}} helper -- Container Lookup', {
 QUnit.test('should lookup helpers in the container', function() {
   expectDeprecationInHTMLBars();
 
+  expectDeprecation('Using Ember.Handlebars.makeBoundHelper is deprecated. Please refactor to using `Ember.Helper.helper`.');
   registry.register('helper:up-case', makeBoundHelper(function(value) {
     return value.toUpperCase();
   }));

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -134,6 +134,8 @@ QUnit.module('ember-htmlbars: {{#unbound}} subexpression', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
 
+    expectDeprecation('`Ember.Handlebars.registerBoundHelper` is deprecated. Please refactor to use `Ember.Helpers.helper`.');
+
     registerBoundHelper('capitalize', function(value) {
       return value.toUpperCase();
     });
@@ -178,6 +180,9 @@ QUnit.test('it should re-render if the parent view rerenders', function() {
 QUnit.module('ember-htmlbars: {{#unbound}} subexpression - helper form', {
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
+
+
+    expectDeprecation('`Ember.Handlebars.registerBoundHelper` is deprecated. Please refactor to use `Ember.Helpers.helper`.');
 
     registerBoundHelper('capitalize', function(value) {
       return value.toUpperCase();
@@ -229,6 +234,8 @@ QUnit.module('ember-htmlbars: {{#unbound boundHelper arg1 arg2... argN}} form: r
   setup() {
     Ember.lookup = lookup = { Ember: Ember };
     expectDeprecationInHTMLBars();
+
+    expectDeprecation('`Ember.Handlebars.registerBoundHelper` is deprecated. Please refactor to use `Ember.Helpers.helper`.');
 
     registerBoundHelper('surround', function(prefix, value, suffix) {
       return prefix + '-' + value + '-' + suffix;

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -15,7 +15,7 @@ import compile from 'ember-template-compiler/system/compile';
 import template from 'ember-template-compiler/system/template';
 import { observersFor } from 'ember-metal/observer';
 import Controller from 'ember-runtime/controllers/controller';
-import makeBoundHelper from 'ember-htmlbars/system/make_bound_helper';
+import { helper as makeHelper } from 'ember-htmlbars/helper';
 
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 import { set } from 'ember-metal/property_set';
@@ -392,7 +392,7 @@ QUnit.test('Should apply classes when bound property specified', function() {
 });
 
 QUnit.test('Should apply a class from a sub expression', function() {
-  registry.register('helper:string-concat', makeBoundHelper(function(params) {
+  registry.register('helper:string-concat', makeHelper(function(params) {
     return params.join('');
   }));
 

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -8,10 +8,6 @@ import { Registry } from 'ember-runtime/system/container';
 import { A } from 'ember-runtime/system/native_array';
 import Component from 'ember-views/views/component';
 import helpers from 'ember-htmlbars/helpers';
-import {
-  registerHelper
-} from 'ember-htmlbars/helpers';
-import makeViewHelper from 'ember-htmlbars/system/make-view-helper';
 import ComponentLookup from 'ember-views/component_lookup';
 
 import compile from 'ember-template-compiler/system/compile';

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -12,6 +12,7 @@ import {
   registerHelper
 } from 'ember-htmlbars/helpers';
 import makeViewHelper from 'ember-htmlbars/system/make-view-helper';
+import ComponentLookup from 'ember-views/component_lookup';
 
 import compile from 'ember-template-compiler/system/compile';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
@@ -21,20 +22,29 @@ import viewKeyword from 'ember-htmlbars/keywords/view';
 
 var view, registry, container, originalViewKeyword;
 
+function setupContainer() {
+  registry = new Registry();
+  container = registry.container();
+  registry.optionsForType('template', { instantiate: false });
+  registry.register('component-lookup:main', ComponentLookup);
+}
+
+function teardownContainer() {
+  runDestroy(container);
+  registry = container = view = null;
+}
+
 QUnit.module('ember-htmlbars: Support for {{yield}} helper', {
   setup() {
+    setupContainer();
     originalViewKeyword = registerKeyword('view',  viewKeyword);
-    registry = new Registry();
-    container = registry.container();
-    registry.optionsForType('template', { instantiate: false });
   },
   teardown() {
     run(function() {
       Ember.TEMPLATES = {};
     });
     runDestroy(view);
-    runDestroy(container);
-    registry = container = view = null;
+    teardownContainer();
     resetKeyword('view', originalViewKeyword);
   }
 });
@@ -264,6 +274,7 @@ QUnit.test('nested simple bindings inside of a yielded template should work prop
 
 QUnit.module('ember-htmlbars: Component {{yield}}', {
   setup() {
+    setupContainer();
     originalViewKeyword = registerKeyword('view',  viewKeyword);
   },
   teardown() {
@@ -279,15 +290,17 @@ QUnit.test('yield with nested components (#3220)', function() {
     layout: compile('{{yield}}')
   });
 
-  registerHelper('inner-component', makeViewHelper(InnerComponent));
+  registry.register('component:inner-component', InnerComponent);
 
   var OuterComponent = Component.extend({
     layout: compile('{{#inner-component}}<span>{{yield}}</span>{{/inner-component}}')
   });
 
-  registerHelper('outer-component', makeViewHelper(OuterComponent));
+  registry.register('component:outer-component', OuterComponent);
 
   view = EmberView.extend({
+    container,
+
     template: compile(
       '{{#outer-component}}Hello world{{/outer-component}}'
     )

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -17,6 +17,7 @@ function registerRepeatHelper() {
 
 QUnit.module('ember-htmlbars: makeBoundHelper', {
   setup() {
+    expectDeprecation('Using `Ember.HTMLBars.makeBoundHelper` is deprecated. Please refactor to using `Ember.Helper` or `Ember.Helper.helper`.');
     registry = new Registry();
     container = registry.container();
   },

--- a/packages/ember-htmlbars/tests/system/make_view_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_view_helper_test.js
@@ -30,7 +30,10 @@ QUnit.test('makes helpful assertion when called with invalid arguments', functio
     return 'Some Random Class';
   };
 
-  var helper = makeViewHelper(SomeRandom);
+  var helper;
+  expectDeprecation(function() {
+    helper = makeViewHelper(SomeRandom);
+  }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
   registry.register('helper:some-random', helper);
 
   view = EmberView.create({
@@ -48,7 +51,10 @@ QUnit.test('can properly yield', function() {
     layout: compile('Some Random Class - {{yield}}')
   });
 
-  var helper = makeViewHelper(SomeRandom);
+  var helper;
+  expectDeprecation(function() {
+    helper = makeViewHelper(SomeRandom);
+  }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
   registry.register('helper:some-random', helper);
 
   view = EmberView.create({

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -102,9 +102,11 @@ QUnit.test('Bound `makeViewHelper` helpers registered on the container can be us
       foo: 'alex'
     }));
 
-    registry.register('helper:x-foo', makeViewHelper(Ember.Component.extend({
-      layout: compile('woot!!{{attrs.name}}')
-    })));
+    expectDeprecation(function() {
+      registry.register('helper:x-foo', makeViewHelper(Ember.Component.extend({
+        layout: compile('woot!!{{attrs.name}}')
+      })));
+    }, '`Ember.Handlebars.makeViewHelper` and `Ember.HTMLBars.makeViewHelper` are deprecated. Please refactor to normal component usage.');
   });
 
   equal(Ember.$('#wrapper').text(), 'woot!! woot!!alex', 'The helper was invoked from the container');

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -7,10 +7,9 @@ import Helper from 'ember-htmlbars/helper';
 
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
-
-var compile, helpers, makeBoundHelper;
+import helpers from 'ember-htmlbars/helpers';
+var compile, makeBoundHelper;
 compile = EmberHandlebars.compile;
-helpers = EmberHandlebars.helpers;
 makeBoundHelper = EmberHandlebars.makeBoundHelper;
 var makeViewHelper = EmberHandlebars.makeViewHelper;
 
@@ -19,7 +18,6 @@ var App, registry, container, originalViewKeyword;
 function reverseHelper(value) {
   return arguments.length > 1 ? value.split('').reverse().join('') : '--';
 }
-
 
 QUnit.module('Application Lifecycle - Helper Registration', {
   setup() {
@@ -34,6 +32,7 @@ QUnit.module('Application Lifecycle - Helper Registration', {
       App = null;
       Ember.TEMPLATES = {};
     });
+    delete helpers['foo-bar-baz-widget'];
     resetKeyword('view', originalViewKeyword);
   }
 });
@@ -170,4 +169,12 @@ QUnit.test('Helpers can receive injections', function() {
   });
 
   ok(serviceCalled, 'service was injected, method called');
+});
+
+QUnit.test('Ember.HTMLBars._registerHelper is deprecated', function() {
+  expectDeprecation(function() {
+    Ember.HTMLBars._registerHelper('foo-bar-baz-widget', function() {});
+  });
+
+  ok(helpers['foo-bar-baz-widget'], 'helper was registered');
 });

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -3,21 +3,16 @@ import Ember from 'ember-metal/core';
 import isEnabled from 'ember-metal/features';
 import EmberHandlebars from 'ember-htmlbars/compat';
 import HandlebarsCompatibleHelper from 'ember-htmlbars/compat/helper';
-import Helper from 'ember-htmlbars/helper';
+import Helper, { helper } from 'ember-htmlbars/helper';
 
 import { registerKeyword, resetKeyword } from 'ember-htmlbars/tests/utils';
 import viewKeyword from 'ember-htmlbars/keywords/view';
 import helpers from 'ember-htmlbars/helpers';
-var compile, makeBoundHelper;
+var compile;
 compile = EmberHandlebars.compile;
-makeBoundHelper = EmberHandlebars.makeBoundHelper;
 var makeViewHelper = EmberHandlebars.makeViewHelper;
 
 var App, registry, container, originalViewKeyword;
-
-function reverseHelper(value) {
-  return arguments.length > 1 ? value.split('').reverse().join('') : '--';
-}
 
 QUnit.module('Application Lifecycle - Helper Registration', {
   setup() {
@@ -78,7 +73,6 @@ QUnit.test('Unbound dashed helpers registered on the container can be late-invok
   ok(!helpers['x-borf'], 'Container-registered helper doesn\'t wind up on global helpers hash');
 });
 
-// need to make `makeBoundHelper` for HTMLBars
 QUnit.test('Bound helpers registered on the container can be late-invoked', function() {
   Ember.TEMPLATES.application = compile('<div id=\'wrapper\'>{{x-reverse}} {{x-reverse foo}}</div>');
 
@@ -86,7 +80,10 @@ QUnit.test('Bound helpers registered on the container can be late-invoked', func
     registry.register('controller:application', Ember.Controller.extend({
       foo: 'alex'
     }));
-    registry.register('helper:x-reverse', makeBoundHelper(reverseHelper));
+
+    registry.register('helper:x-reverse', helper(function([ value ]) {
+      return value ? value.split('').reverse().join('') : '--';
+    }));
   });
 
   equal(Ember.$('#wrapper').text(), '-- xela', 'The bound helper was invoked from the container');
@@ -121,7 +118,7 @@ if (isEnabled('ember-htmlbars-dashless-helpers')) {
           return 'OMG';
         });
 
-        registry.register('helper:yorp', makeBoundHelper(function(value) {
+        registry.register('helper:yorp', helper(function([ value ]) {
           return value;
         }));
       }, /Please use Ember.Helper.build to wrap helper functions./);
@@ -142,7 +139,7 @@ if (isEnabled('ember-htmlbars-dashless-helpers')) {
         registry.register('helper:omg', function() {
           return 'OMG';
         });
-        registry.register('helper:yorp', makeBoundHelper(function() {
+        registry.register('helper:yorp', helper(function() {
           return 'YORP';
         }));
       });


### PR DESCRIPTION
This PR deprecates the following in favor of using `Ember.Helper` style helpers:
- `Ember.Handlebars.makeViewHelper`
- `Ember.HTMLBars.makeViewHelper`
- `Ember.HTMLBars._registerHelper`
- `Ember.HTMLBars.makeBoundHelper`
- `Ember.Handlebars.makeBoundHelper`
- `Ember.Handlebars.registerBoundHelper`
- `Ember.Handlebars.helper`
- `Ember.Handlebars.registerHelper`

Based on usage "in the wild" `Ember.HTMLBars.makeBoundHelper` should be kept around until 3.0.0 (but is deprecated).

Adds deprecations needed for https://github.com/emberjs/ember.js/pull/11858.

/cc @mixonic 
