### PR TITLE
[BUGFIX release] Ensure `"use strict";` is properly added for modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-sauce": "^1.3.0",
     "ember-cli-yuidoc": "0.7.0",
     "ember-publisher": "0.0.7",
-    "emberjs-build": "0.2.1",
+    "emberjs-build": "0.2.2",
     "express": "^4.5.0",
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",


### PR DESCRIPTION
Esperanto would automatically add `"use strict";` to the beginning of every file. When we swapped to using Babel for module transpilation, we forgot to update the Babel whitelist to add `"use strict";` back.

This has been an issue since v1.13.0.

Thanks to @stefanpenner for reporting.
