### PR TITLE
[DOC release] Mark Route.renderTemplate() as public

### DIFF
--- a/packages/ember-routing/lib/system/route.js
+++ b/packages/ember-routing/lib/system/route.js
@@ -1814,7 +1814,7 @@ var Route = EmberObject.extend(ActionHandler, Evented, {
     @method renderTemplate
     @param {Object} controller the route's controller
     @param {Object} model the route's model
-    @private
+    @public
   */
   renderTemplate(controller, model) {
     this.render();


### PR DESCRIPTION
I think this is supposed to be public?
