### PR TITLE
Deprecate Ember.deprecate test function argument

### DIFF
--- a/packages/ember-debug/lib/deprecate.js
+++ b/packages/ember-debug/lib/deprecate.js
@@ -4,6 +4,7 @@ import Ember from 'ember-metal/core';
 import EmberError from 'ember-metal/error';
 import Logger from 'ember-metal/logger';
 import { registerHandler as genericRegisterHandler, invoke } from 'ember-debug/handlers';
+import isPlainFunction from 'ember-debug/is-plain-function';
 
 export function registerHandler(handler) {
   genericRegisterHandler('deprecate', handler);
@@ -76,6 +77,9 @@ export let missingOptionsDeprecation = 'When calling `Ember.deprecate` you ' +
   '`options` should include `id` and `until` properties.';
 export let missingOptionsIdDeprecation = 'When calling `Ember.deprecate` you must provide `id` in options.';
 export let missingOptionsUntilDeprecation = 'When calling `Ember.deprecate` you must provide `until` in options.';
+export let testFunctionArgDeprecation = 'Functional arguments are ambiguous with constructors. ' +
+  'Please use !!Constructor for constructors, or an IIFE to compute the deprecation value. ' +
+  'In a future version of Ember functions will be treated as truthy values instead of being executed.';
 
 /**
   Display a deprecation warning with the provided message and a stack trace
@@ -84,9 +88,8 @@ export let missingOptionsUntilDeprecation = 'When calling `Ember.deprecate` you 
 
   @method deprecate
   @param {String} message A description of the deprecation.
-  @param {Boolean|Function} test A boolean. If falsy, the deprecation
-    will be displayed. If this is a function, it will be executed and its return
-    value will be used as condition.
+  @param {Boolean} test A boolean. If falsy, the deprecation
+    will be displayed.
   @param {Object} options An object that can be used to pass
     in a `url` to the transition guide on the emberjs.com website, and a unique
     `id` for this deprecation. The `id` can be used by Ember debugging tools
@@ -116,6 +119,14 @@ export default function deprecate(message, test, options) {
       missingOptionsUntilDeprecation,
       options && options.until,
       { id: 'ember-debug.deprecate-until-missing', until: '3.0.0' }
+    );
+  }
+
+  if (isPlainFunction(test)) {
+    deprecate(
+      testFunctionArgDeprecation,
+      false,
+      { id: 'ember-debug.deprecate-test-function', until: '2.0.0' }
     );
   }
 

--- a/packages/ember-debug/tests/main_test.js
+++ b/packages/ember-debug/tests/main_test.js
@@ -4,7 +4,8 @@ import {
   registerHandler,
   missingOptionsDeprecation,
   missingOptionsIdDeprecation,
-  missingOptionsUntilDeprecation
+  missingOptionsUntilDeprecation,
+  testFunctionArgDeprecation
 } from 'ember-debug/deprecate';
 
 import {
@@ -105,14 +106,13 @@ QUnit.test('Ember.deprecate throws deprecation if second argument is falsy', fun
   });
 });
 
-QUnit.test('Ember.deprecate does not throw deprecation if second argument is a function and it returns true', function() {
+QUnit.test('Ember.deprecate throws if second argument is a function and it returns true', function() {
   expect(1);
-
-  Ember.deprecate('Deprecation is thrown', function() {
-    return true;
-  }, { id: 'test', until: 'forever' });
-
-  ok(true, 'deprecation was not thrown');
+  throws(function() {
+    Ember.deprecate('Deprecation is thrown', function() {
+      return true;
+    }, { id: 'test', until: 'forever' });
+  });
 });
 
 QUnit.test('Ember.deprecate throws if second argument is a function and it returns false', function() {
@@ -271,6 +271,20 @@ QUnit.test('Ember.deprecate without options.until triggers a deprecation', funct
   });
 
   Ember.deprecate('foo', false, { id: 'test' });
+});
+
+QUnit.test('Ember.deprecate with test function argument triggers a deprecation', function(assert) {
+  assert.expect(1);
+
+  registerHandler(function(message) {
+    if (message === testFunctionArgDeprecation) {
+      assert.ok(true, 'proper deprecation is triggered when test is a function');
+    }
+  });
+
+  Ember.deprecate('foo', function() {
+    return true;
+  }, { id: 'test' });
 });
 
 QUnit.test('Ember.warn without options triggers a deprecation', function(assert) {


### PR DESCRIPTION
This PR deprecates:
- `Ember.deprecate` when `test` is supplied as a `function`

Partially resolving #11898. As mentioned, it should be kept around until 2.0.0.

Would like fully resolve #11898, however unsure how to handle the `assert`, etc. cases. Could use some guidance as this is my first contribution. Thanks!

/cc @mmun @rwjblue 
