### PR TITLE
Routable components: step one

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -337,3 +337,9 @@ for a detailed explanation.
 
   Likewise, `ApplicationInstance` initializers still receive a single argument
   to initialize: `applicationInstance`.
+
+* `ember-routing-routable-components`
+
+  Implemencts RFC https://github.com/emberjs/rfcs/pull/38, adding support for
+  routable components.
+

--- a/features.json
+++ b/features.json
@@ -23,7 +23,8 @@
     "ember-htmlbars-helper": true,
     "ember-htmlbars-dashless-helpers": true,
     "ember-debug-handlers": null,
-    "ember-registry-container-reform": null
+    "ember-registry-container-reform": null,
+    "ember-routing-routable-components": null
   },
   "debugStatements": [
     "Ember.warn",

--- a/packages/ember/tests/routing/basic_test.js
+++ b/packages/ember/tests/routing/basic_test.js
@@ -303,6 +303,116 @@ QUnit.test('Model passed via renderTemplate model is set as controller\'s model'
   equal(Ember.$('p:contains(emberjs)', '#qunit-fixture').length, 1, 'Passed model was set as controllers model');
 });
 
+if (isEnabled('ember-routing-routable-components')) {
+  QUnit.test('Renders the GlimmerComponent for the route', function() {
+    Ember.TEMPLATES['home'] = null;
+    Ember.TEMPLATES['components/home'] = compile('<p>{{name}}</p>');
+
+    Router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    App.HomeRoute = Ember.Route.extend();
+
+    App.HomeComponent = Ember.Component.extend({
+      isGlimmerComponent: true,
+      name: 'Home'
+    });
+
+    bootApplication();
+
+    equal(Ember.$('p:contains(Home)', '#qunit-fixture').length, 1, 'The home component was rendered');
+  });
+
+  QUnit.test('Must be a GlimmerComponent to prevent component naming collisions', function() {
+    Ember.TEMPLATES['home'] = null;
+    Ember.TEMPLATES['components/home'] = compile('<p>{{name}}</p>');
+
+    Router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    App.HomeRoute = Ember.Route.extend();
+
+    // Not a GlimmerComponent, shouldn't be rendered
+    App.HomeComponent = Ember.Component.extend({
+      name: 'Home'
+    });
+
+    bootApplication();
+
+    equal(Ember.$('p:contains(Home)', '#qunit-fixture').length, 0, 'The home component was not rendered');
+  });
+
+  QUnit.test('Favors existing templates/views over the component for the route', function() {
+    Ember.TEMPLATES['home'] = compile('PASS');
+    Ember.TEMPLATES['components/home'] = compile('FAIL');
+
+    Router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    App.HomeRoute = Ember.Route.extend();
+
+    App.HomeComponent = Ember.Component.extend({
+      isGlimmerComponent: true
+    });
+
+    bootApplication();
+
+    equal(Ember.$('#qunit-fixture').text(), 'PASS', 'The home view was rendered instead of the component');
+  });
+
+  QUnit.test('Renders the component given in the component option', function() {
+    Ember.TEMPLATES['home'] = null;
+    Ember.TEMPLATES['components/home'] = compile('<p>{{name}}</p>');
+
+    Router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    App.HomeRoute = Ember.Route.extend({
+      renderTemplate() {
+        this.render({ component: 'home' });
+      }
+    });
+
+    App.HomeComponent = Ember.Component.extend({
+      isGlimmerComponent: true,
+      name: 'Home'
+    });
+
+    bootApplication();
+
+    equal(Ember.$('p:contains(Home)', '#qunit-fixture').length, 1, 'The home component was rendered');
+  });
+
+  QUnit.test('Routable components get passed model in their attrs', function() {
+    Ember.TEMPLATES['home'] = null;
+    Ember.TEMPLATES['components/home'] = compile('<p>{{attrs.model.name}}</p>');
+
+    Router.map(function() {
+      this.route('home', { path: '/' });
+    });
+
+    App.HomeRoute = Ember.Route.extend({
+      model() {
+        return {
+          name: 'Home'
+        };
+      }
+    });
+
+    App.HomeComponent = Ember.Component.extend({
+      isGlimmerComponent: true
+    });
+
+    bootApplication();
+
+    equal(Ember.$('p:contains(Home)', '#qunit-fixture').length, 1, 'The model was present');
+  });
+}
+
 QUnit.test('Renders correct view with slash notation', function() {
   Ember.TEMPLATES['home/page'] = compile('<p>{{view.name}}</p>');
 


### PR DESCRIPTION
@ef4 @rwjblue @mmun 

I consider this a MVP of the [Routable Components RFC](https://github.com/emberjs/rfcs/pull/38).

Things of note: 
- Our current strategy for avoiding naming collisions with existing components is to require routable components to be `GlimmerComponent`s (`isGlimmerComponent` flag checks). Upon completion of the [glimmer-component](https://github.com/emberjs/ember.js/tree/glimmer-component) branch, the tests should be updated to use the new base class.
- This punts on the creation of the `Route#attrs` hook for now. These routable components just get created with an `attrs` hash containing `model`.
