### PR TITLE
Lock down simple-dom version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "route-recognizer": "0.1.5",
     "rsvp": "~3.0.6",
     "serve-static": "^1.10.0",
-    "simple-dom": "^0.2.4",
+    "simple-dom": "0.2.4",
     "testem": "^0.8.0-1"
   }
 }


### PR DESCRIPTION
There is an issue with https://github.com/krisselden/simple-dom/compare/v0.2.4...v0.2.5 causing the node tests to fail with simple-dom@0.2.5. Locking them down here so we can fix that issue (either upstream or in our test suite) out of band.
