### PR TITLE
[BUGFIX release] Remove unused intercept code from get/set.

### DIFF
--- a/packages/ember-metal/lib/property_get.js
+++ b/packages/ember-metal/lib/property_get.js
@@ -10,12 +10,8 @@ import {
   isPath,
   hasThis as pathHasThis
 } from 'ember-metal/path_cache';
-import { symbol } from 'ember-metal/utils';
 
 var FIRST_KEY = /^([^\.]+)/;
-
-export let INTERCEPT_GET = symbol('INTERCEPT_GET');
-export let UNHANDLED_GET = symbol('UNHANDLED_GET');
 
 // ..........................................................
 // GET AND SET
@@ -58,11 +54,6 @@ export function get(obj, keyName) {
   // Helpers that operate with 'this' within an #each
   if (keyName === '') {
     return obj;
-  }
-
-  if (typeof obj[INTERCEPT_GET] === 'function') {
-    let result = obj[INTERCEPT_GET](obj, keyName);
-    if (result !== UNHANDLED_GET) { return result; }
   }
 
   var meta = obj['__ember_meta__'];

--- a/packages/ember-metal/lib/property_set.js
+++ b/packages/ember-metal/lib/property_set.js
@@ -13,10 +13,6 @@ import {
   hasThis as pathHasThis
 } from 'ember-metal/path_cache';
 
-import { symbol } from 'ember-metal/utils';
-export let INTERCEPT_SET = symbol('INTERCEPT_SET');
-export let UNHANDLED_SET = symbol('UNHANDLED_SET');
-
 /**
   Sets the value of a property on an object, respecting computed properties
   and notifying observers and other listeners of the change. If the
@@ -38,14 +34,6 @@ export function set(obj, keyName, value, tolerant) {
   Ember.assert(`Cannot call set with '${keyName}' on an undefined object.`, obj !== undefined && obj !== null);
   Ember.assert(`The key provided to set must be a string, you passed ${keyName}`, typeof keyName === 'string');
   Ember.assert(`'this' in paths is not supported`, !pathHasThis(keyName));
-
-  // This path exists purely to implement backwards-compatible
-  // effects (specifically, setting a property on a view may
-  // invoke a mutator on `attrs`).
-  if (obj && typeof obj[INTERCEPT_SET] === 'function') {
-    let result = obj[INTERCEPT_SET](obj, keyName, value, tolerant);
-    if (result !== UNHANDLED_SET) { return result; }
-  }
 
   var meta, possibleDesc, desc;
   if (obj) {

--- a/packages/ember-metal/tests/accessors/get_test.js
+++ b/packages/ember-metal/tests/accessors/get_test.js
@@ -1,9 +1,7 @@
 import { testBoth } from 'ember-metal/tests/props_helper';
 import {
   get,
-  getWithDefault,
-  INTERCEPT_GET,
-  UNHANDLED_GET
+  getWithDefault
 } from 'ember-metal/property_get';
 import {
   Mixin,
@@ -27,53 +25,6 @@ QUnit.test('should get arbitrary properties on an object', function() {
       continue;
     }
     equal(get(obj, key), obj[key], key);
-  }
-});
-
-QUnit.test('should invoke INTERCEPT_GET even if the property exists', function() {
-  var obj = {
-    string: 'string',
-    number: 23,
-    boolTrue: true,
-    boolFalse: false,
-    nullValue: null
-  };
-
-  let calledWith;
-  obj[INTERCEPT_GET] = function(obj, key) {
-    calledWith = [obj, key];
-    return UNHANDLED_GET;
-  };
-
-  for (var key in obj) {
-    if (!obj.hasOwnProperty(key)) {
-      continue;
-    }
-    calledWith = undefined;
-    equal(get(obj, key), obj[key], key);
-    equal(calledWith[0], obj, 'the object was passed');
-    equal(calledWith[1], key, 'the key was passed');
-  }
-});
-
-QUnit.test('should invoke INTERCEPT_GET and accept a return value', function() {
-  var obj = {
-    string: 'string',
-    number: 23,
-    boolTrue: true,
-    boolFalse: false,
-    nullValue: null
-  };
-
-  obj[INTERCEPT_GET] = function(obj, key) {
-    return key;
-  };
-
-  for (var key in obj) {
-    if (!obj.hasOwnProperty(key) || key === INTERCEPT_GET) {
-      continue;
-    }
-    equal(get(obj, key), key, key);
   }
 });
 
@@ -252,4 +203,3 @@ QUnit.test('(regression) watched properties on unmodified inherited objects shou
 
   equal(getWithDefault(theRealObject, 'someProperty', 'fail'), 'foo', 'should return the set value, not false');
 });
-

--- a/packages/ember-metal/tests/accessors/set_test.js
+++ b/packages/ember-metal/tests/accessors/set_test.js
@@ -1,5 +1,5 @@
-import { get, INTERCEPT_GET } from 'ember-metal/property_get';
-import { set, INTERCEPT_SET, UNHANDLED_SET } from 'ember-metal/property_set';
+import { get } from 'ember-metal/property_get';
+import { set } from 'ember-metal/property_set';
 
 QUnit.module('set');
 
@@ -26,115 +26,6 @@ QUnit.test('should set arbitrary properties on an object', function() {
     equal(get(newObj, key), obj[key], 'should set value');
   }
 });
-
-QUnit.test('should call INTERCEPT_SET and support UNHANDLED_SET if INTERCEPT_SET is defined', function() {
-  var obj = {
-    string: 'string',
-    number: 23,
-    boolTrue: true,
-    boolFalse: false,
-    nullValue: null,
-    undefinedValue: undefined
-  };
-
-  var newObj = {
-    undefinedValue: 'emberjs'
-  };
-
-  let calledWith;
-  newObj[INTERCEPT_SET] = function(obj, key, value) {
-    calledWith = [key, value];
-    return UNHANDLED_SET;
-  };
-
-  for (var key in obj) {
-    if (!obj.hasOwnProperty(key)) {
-      continue;
-    }
-
-    calledWith = undefined;
-
-    equal(set(newObj, key, obj[key]), obj[key], 'should return value');
-    equal(calledWith[0], key, 'INTERCEPT_SET called with the key');
-    equal(calledWith[1], obj[key], 'INTERCEPT_SET called with the key');
-    equal(get(newObj, key), obj[key], 'should set value since UNHANDLED_SET was returned');
-  }
-});
-
-QUnit.test('should call INTERCEPT_SET and support handling the set if it is defined', function() {
-  var obj = {
-    string: 'string',
-    number: 23,
-    boolTrue: true,
-    boolFalse: false,
-    nullValue: null,
-    undefinedValue: undefined
-  };
-
-  var newObj = {
-    bucket: {}
-  };
-
-  let calledWith;
-  newObj[INTERCEPT_SET] = function(obj, key, value) {
-    set(obj.bucket, key, value);
-    return value;
-  };
-
-  for (var key in obj) {
-    if (!obj.hasOwnProperty(key)) {
-      continue;
-    }
-
-    calledWith = undefined;
-
-    equal(set(newObj, key, obj[key]), obj[key], 'should return value');
-    equal(get(newObj.bucket, key), obj[key], 'should have moved the value to `bucket`');
-    ok(newObj.bucket.hasOwnProperty(key), 'the key is defined in bucket');
-    ok(!newObj.hasOwnProperty(key), 'the key is not defined on the raw object');
-  }
-});
-
-QUnit.test('should call INTERCEPT_GET and INTERCEPT_SET', function() {
-  var obj = {
-    string: 'string',
-    number: 23,
-    boolTrue: true,
-    boolFalse: false,
-    nullValue: null,
-    undefinedValue: undefined
-  };
-
-  var newObj = {
-    string: null,
-    number: null,
-    boolTrue: null,
-    boolFalse: null,
-    nullValue: null,
-    undefinedValue: null,
-    bucket: {}
-  };
-
-  newObj[INTERCEPT_SET] = function(obj, key, value) {
-    set(obj.bucket, key, value);
-    return value;
-  };
-
-  newObj[INTERCEPT_GET] = function(obj, key) {
-    return get(obj.bucket, key);
-  };
-
-  for (var key in obj) {
-    if (!obj.hasOwnProperty(key)) {
-      continue;
-    }
-
-    equal(set(newObj, key, obj[key]), obj[key], 'should return value');
-    equal(get(newObj.bucket, key), obj[key], 'should have moved the value to `bucket`');
-    equal(get(newObj, key), obj[key], 'INTERCEPT_GET was called');
-  }
-});
-
 
 QUnit.test('should call setUnknownProperty if defined and value is undefined', function() {
   var obj = {


### PR DESCRIPTION
`INTERCEPT_GET` and `INTERCEPT_SET` were added to support the way the `AttrsProxy` worked initially. However, that mechanism was removed and replaced later, but this code was left in.

We can easily add this back if we end up wanting it, but it seems like we should avoid extra unused code in `Ember.get` and `Ember.set`.
