### PR TITLE
[BUGFIX beta] Remove internal use of Em.String.fmt & mark as deprecated

### DIFF
--- a/packages/ember-htmlbars/tests/helpers/if_unless_test.js
+++ b/packages/ember-htmlbars/tests/helpers/if_unless_test.js
@@ -10,7 +10,6 @@ import compile from 'ember-template-compiler/system/compile';
 import ArrayProxy from 'ember-runtime/system/array_proxy';
 
 import { set } from 'ember-metal/property_set';
-import { fmt } from 'ember-runtime/system/string';
 import { typeOf } from 'ember-runtime/utils';
 import { runAppend, runDestroy } from 'ember-runtime/tests/utils';
 
@@ -279,7 +278,7 @@ QUnit.test('should update the block when object passed to #unless helper changes
       set(view, 'onDrugs', val);
     });
 
-    equal(view.$('h1').text(), 'Eat your vegetables', fmt('renders block when conditional is "%@"; %@', [String(val), typeOf(val)]));
+    equal(view.$('h1').text(), 'Eat your vegetables', `renders block when conditional is "${val}"; ${typeOf(val)}`);
     run(function() {
       set(view, 'onDrugs', true);
     });
@@ -333,7 +332,7 @@ QUnit.test('should update the block when object passed to #if helper changes', f
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), '', fmt('hides block when conditional is "%@"', [String(val)]));
+    equal(view.$('h1').text(), '', `hides block when conditional is "${val}"`);
 
     run(function() {
       set(view, 'inception', true);
@@ -368,7 +367,7 @@ QUnit.test('should update the block when object passed to #if helper changes and
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), 'BOONG?', fmt('renders alternate if %@', [String(val)]));
+    equal(view.$('h1').text(), 'BOONG?', `renders alternate if ${val}`);
 
     run(function() {
       set(view, 'inception', true);
@@ -444,7 +443,7 @@ QUnit.test('should update the block when object passed to #unless helper changes
       set(view, 'onDrugs', val);
     });
 
-    equal(view.$('h1').text(), 'Eat your vegetables', fmt('renders block when conditional is "%@"; %@', [String(val), typeOf(val)]));
+    equal(view.$('h1').text(), 'Eat your vegetables', `renders block when conditional is "${val}"; ${typeOf(val)}`);
 
     run(function() {
       set(view, 'onDrugs', true);
@@ -499,7 +498,7 @@ QUnit.test('should update the block when object passed to #if helper changes', f
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), '', fmt('hides block when conditional is "%@"', [String(val)]));
+    equal(view.$('h1').text(), '', `hides block when conditional is "${val}"`);
 
     run(function() {
       set(view, 'inception', true);
@@ -534,7 +533,7 @@ QUnit.test('should update the block when object passed to #if helper changes and
       set(view, 'inception', val);
     });
 
-    equal(view.$('h1').text(), 'BOONG?', fmt('renders alternate if %@', [String(val)]));
+    equal(view.$('h1').text(), 'BOONG?', `renders alternate if ${val}`);
 
     run(function() {
       set(view, 'inception', true);

--- a/packages/ember-routing/lib/system/router.js
+++ b/packages/ember-routing/lib/system/router.js
@@ -7,7 +7,6 @@ import { defineProperty } from 'ember-metal/properties';
 import { computed } from 'ember-metal/computed';
 import merge from 'ember-metal/merge';
 import run from 'ember-metal/run_loop';
-import { fmt } from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
 import Evented from 'ember-runtime/mixins/evented';
 import EmberRouterDSL from 'ember-routing/system/dsl';
@@ -546,12 +545,7 @@ var EmberRouter = EmberObject.extend(Evented, {
 
     for (var key in groupedByUrlKey) {
       var qps = groupedByUrlKey[key];
-      Ember.assert(fmt('You\'re not allowed to have more than one controller ' +
-                       'property map to the same query param key, but both ' +
-                       '`%@` and `%@` map to `%@`. You can fix this by mapping ' +
-                       'one of the controller properties to a different query ' +
-                       'param key via the `as` config option, e.g. `%@: { as: \'other-%@\' }`',
-                       [qps[0].qp.scopedPropertyName, qps[1] ? qps[1].qp.scopedPropertyName : '', qps[0].qp.urlKey, qps[0].qp.prop, qps[0].qp.prop]), qps.length <= 1);
+      Ember.assert(`You're not allowed to have more than one controller property map to the same query param key, but both \`${qps[0].qp.scopedPropertyName}\` and \`${qps[1] ? qps[1].qp.scopedPropertyName : ''}\` map to \`${qps[0].qp.urlKey}\`. You can fix this by mapping one of the controller properties to a different query param key via the \`as\` config option, e.g. \`${qps[0].qp.prop}: { as: \'other-${qps[0].qp.prop}\' }\``, qps.length <= 1);
       var qp = qps[0].qp;
       queryParams[qp.urlKey] = qp.route.serializeQueryParam(qps[0].value, qp.urlKey, qp.type);
     }

--- a/packages/ember-runtime/lib/mixins/-proxy.js
+++ b/packages/ember-runtime/lib/mixins/-proxy.js
@@ -20,7 +20,6 @@ import {
 import { computed } from 'ember-metal/computed';
 import { defineProperty } from 'ember-metal/properties';
 import { Mixin, observer } from 'ember-metal/mixin';
-import { fmt } from 'ember-runtime/system/string';
 
 function contentPropertyWillChange(content, contentKey) {
   var key = contentKey.slice(8); // remove "content."
@@ -75,9 +74,7 @@ export default Mixin.create({
   unknownProperty(key) {
     var content = get(this, 'content');
     if (content) {
-      Ember.deprecate(
-        fmt('You attempted to access `%@` from `%@`, but object proxying is deprecated. ' +
-            'Please use `model.%@` instead.', [key, this, key]),
+      Ember.deprecate(`You attempted to access \`${key}\` from \`${this}\`, but object proxying is deprecated. Please use \`model.${key}\` instead.`,
         !this.isController,
         { id: 'ember-runtime.controller-proxy', until: '3.0.0' }
       );
@@ -95,12 +92,9 @@ export default Mixin.create({
     }
 
     var content = get(this, 'content');
-    Ember.assert(fmt('Cannot delegate set(\'%@\', %@) to the \'content\' property of' +
-                     ' object proxy %@: its \'content\' is undefined.', [key, value, this]), content);
+    Ember.assert(`Cannot delegate set('${key}', ${value}) to the \'content\' property of object proxy ${this}: its 'content' is undefined.`, content);
 
-    Ember.deprecate(
-      fmt('You attempted to set `%@` from `%@`, but object proxying is deprecated. ' +
-          'Please use `model.%@` instead.', [key, this, key]),
+    Ember.deprecate(`You attempted to set \`${key}\` from \`${this}\`, but object proxying is deprecated. Please use \`model.${key}\` instead.`,
       !this.isController,
       { id: 'ember-runtime.controller-proxy', until: '3.0.0' }
     );

--- a/packages/ember-runtime/lib/mixins/copyable.js
+++ b/packages/ember-runtime/lib/mixins/copyable.js
@@ -7,7 +7,6 @@ import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
 import { Mixin } from 'ember-metal/mixin';
 import { Freezable } from 'ember-runtime/mixins/freezable';
-import { fmt } from 'ember-runtime/system/string';
 import EmberError from 'ember-metal/error';
 
 /**
@@ -63,7 +62,7 @@ export default Mixin.create({
     if (Freezable && Freezable.detect(this)) {
       return get(this, 'isFrozen') ? this : this.copy().freeze();
     } else {
-      throw new EmberError(fmt('%@ does not support freezing', [this]));
+      throw new EmberError(`${this} does not support freezing`);
     }
   }
 });

--- a/packages/ember-runtime/lib/system/array_proxy.js
+++ b/packages/ember-runtime/lib/system/array_proxy.js
@@ -16,7 +16,6 @@ import EmberError from 'ember-metal/error';
 import EmberObject from 'ember-runtime/system/object';
 import MutableArray from 'ember-runtime/mixins/mutable_array';
 import Enumerable from 'ember-runtime/mixins/enumerable';
-import { fmt } from 'ember-runtime/system/string';
 import alias from 'ember-metal/alias';
 
 /**
@@ -191,9 +190,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     var content = get(this, 'content');
 
     if (content) {
-      Ember.assert(fmt('ArrayProxy expects an Array or ' +
-        'Ember.ArrayProxy, but you passed %@', [typeof content]),
-        isArray(content) || content.isDestroyed);
+      Ember.assert(`ArrayProxy expects an Array or Ember.ArrayProxy, but you passed ${typeof content}`, isArray(content) || content.isDestroyed);
 
       content.addArrayObserver(this, {
         willChange: 'contentArrayWillChange',
@@ -228,8 +225,7 @@ var ArrayProxy = EmberObject.extend(MutableArray, {
     var arrangedContent = get(this, 'arrangedContent');
 
     if (arrangedContent) {
-      Ember.assert(fmt('ArrayProxy expects an Array or ' +
-        'Ember.ArrayProxy, but you passed %@', [typeof arrangedContent]),
+      Ember.assert(`ArrayProxy expects an Array or Ember.ArrayProxy, but you passed ${typeof arrangedContent}`,
         isArray(arrangedContent) || arrangedContent.isDestroyed);
 
       arrangedContent.addArrayObserver(this, {

--- a/packages/ember-runtime/lib/system/string.js
+++ b/packages/ember-runtime/lib/system/string.js
@@ -160,6 +160,7 @@ export default {
     @param {Array} formats An array of parameters to interpolate into string.
     @return {String} formatted string
     @public
+    @deprecated Use ES6 template strings instead: https://babeljs.io/docs/learn-es6/#template-strings');
   */
   fmt,
 

--- a/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/mixins/observable/observable_test.js
@@ -3,7 +3,7 @@ import { get } from 'ember-metal/property_get';
 import { computed } from 'ember-metal/computed';
 import run from 'ember-metal/run_loop';
 import { observer } from 'ember-metal/mixin';
-import { fmt, w } from 'ember-runtime/system/string';
+import { w } from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
 import Observable from 'ember-runtime/mixins/observable';
 
@@ -376,17 +376,17 @@ QUnit.test('getting values should call function return value', function() {
   var keys = w('computed computedCached dependent dependentFront dependentCached');
 
   keys.forEach(function(key) {
-    equal(object.get(key), key, fmt('Try #1: object.get(%@) should run function', [key]));
-    equal(object.get(key), key, fmt('Try #2: object.get(%@) should run function', [key]));
+    equal(object.get(key), key, `Try #1: object.get(${key}) should run function`);
+    equal(object.get(key), key, `Try #2: object.get(${key}) should run function`);
   });
 
   // verify each call count.  cached should only be called once
   w('computedCalls dependentFrontCalls dependentCalls').forEach((key) => {
-    equal(object[key].length, 2, fmt('non-cached property %@ should be called 2x', [key]));
+    equal(object[key].length, 2, `non-cached property ${key} should be called 2x`);
   });
 
   w('computedCachedCalls dependentCachedCalls').forEach((key) => {
-    equal(object[key].length, 1, fmt('non-cached property %@ should be called 1x', [key]));
+    equal(object[key].length, 1, `non-cached property ${key} should be called 1x`);
   });
 });
 
@@ -396,11 +396,11 @@ QUnit.test('setting values should call function return value', function() {
   var values = w('value1 value2');
 
   keys.forEach((key) => {
-    equal(object.set(key, values[0]), values[0], fmt('Try #1: object.set(%@, %@) should run function', [key, values[0]]));
+    equal(object.set(key, values[0]), values[0], `Try #1: object.set(${key}, ${values[0]}) should run function`);
 
-    equal(object.set(key, values[1]), values[1], fmt('Try #2: object.set(%@, %@) should run function', [key, values[1]]));
+    equal(object.set(key, values[1]), values[1], `Try #2: object.set(${key}, ${values[1]}) should run function`);
 
-    equal(object.set(key, values[1]), values[1], fmt('Try #3: object.set(%@, %@) should not run function since it is setting same value as before', [key, values[1]]));
+    equal(object.set(key, values[1]), values[1], `Try #3: object.set(${key}, ${values[1]}) should not run function since it is setting same value as before`);
   });
 
   // verify each call count.  cached should only be called once
@@ -411,9 +411,9 @@ QUnit.test('setting values should call function return value', function() {
     // Cached properties first check their cached value before setting the
     // property. Other properties blindly call set.
     expectedLength = 3;
-    equal(calls.length, expectedLength, fmt('set(%@) should be called the right amount of times', [key]));
+    equal(calls.length, expectedLength, `set(${key}) should be called the right amount of times`);
     for (idx = 0;idx < 2;idx++) {
-      equal(calls[idx], values[idx], fmt('call #%@ to set(%@) should have passed value %@', [idx + 1, key, values[idx]]));
+      equal(calls[idx], values[idx], `call #${idx + 1} to set(${key}) should have passed value ${values[idx]}`);
     }
   });
 });

--- a/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
+++ b/packages/ember-runtime/tests/legacy_1x/system/object/concatenated_test.js
@@ -1,5 +1,4 @@
 import {get} from 'ember-metal/property_get';
-import EmberStringUtils from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
 
 /*
@@ -36,7 +35,7 @@ QUnit.test('concatenates instances', function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt('should concatenate values property (expected: %@, got: %@)', [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test('concatenates subclasses', function() {
@@ -48,7 +47,7 @@ QUnit.test('concatenates subclasses', function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt('should concatenate values property (expected: %@, got: %@)', [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test('concatenates reopen', function() {
@@ -60,7 +59,7 @@ QUnit.test('concatenates reopen', function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt('should concatenate values property (expected: %@, got: %@)', [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test('concatenates mixin', function() {
@@ -75,7 +74,7 @@ QUnit.test('concatenates mixin', function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt('should concatenate values property (expected: %@, got: %@)', [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test('concatenates reopen, subclass, and instance', function() {
@@ -86,7 +85,7 @@ QUnit.test('concatenates reopen, subclass, and instance', function() {
   var values = get(obj, 'values');
   var expected = ['a', 'b', 'c', 'd', 'e', 'f'];
 
-  deepEqual(values, expected, EmberStringUtils.fmt('should concatenate values property (expected: %@, got: %@)', [expected, values]));
+  deepEqual(values, expected, `should concatenate values property (expected: ${expected}, got: ${values})`);
 });
 
 QUnit.test('concatenates subclasses when the values are functions', function() {
@@ -98,7 +97,7 @@ QUnit.test('concatenates subclasses when the values are functions', function() {
   var values = get(obj, 'functions');
   var expected = [K, K];
 
-  deepEqual(values, expected, EmberStringUtils.fmt('should concatenate functions property (expected: %@, got: %@)', [expected, values]));
+  deepEqual(values, expected, `should concatenate functions property (expected: ${expected}, got: ${values})`);
 });
 
 

--- a/packages/ember-runtime/tests/suites/array/indexOf.js
+++ b/packages/ember-runtime/tests/suites/array/indexOf.js
@@ -1,5 +1,4 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {fmt} from 'ember-runtime/system/string';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -12,7 +11,7 @@ suite.test('should return index of object', function() {
   var idx;
 
   for (idx = 0;idx < len;idx++) {
-    equal(obj.indexOf(expected[idx]), idx, fmt('obj.indexOf(%@) should match idx', [expected[idx]]));
+    equal(obj.indexOf(expected[idx]), idx, `obj.indexOf(${expected[idx]}) should match idx`);
   }
 });
 

--- a/packages/ember-runtime/tests/suites/array/lastIndexOf.js
+++ b/packages/ember-runtime/tests/suites/array/lastIndexOf.js
@@ -1,5 +1,4 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {fmt} from 'ember-runtime/system/string';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -12,8 +11,7 @@ suite.test('should return index of object\'s last occurrence', function() {
   var idx;
 
   for (idx = 0;idx < len;idx++) {
-    equal(obj.lastIndexOf(expected[idx]), idx,
-      fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
+    equal(obj.lastIndexOf(expected[idx]), idx, `obj.lastIndexOf(${expected[idx]}) should match idx`);
   }
 });
 
@@ -24,8 +22,7 @@ suite.test('should return index of object\'s last occurrence even startAt search
   var idx;
 
   for (idx = 0;idx < len;idx++) {
-    equal(obj.lastIndexOf(expected[idx], len), idx,
-      fmt('obj.lastIndexOfs(%@) should match idx', [expected[idx]]));
+    equal(obj.lastIndexOf(expected[idx], len), idx, `obj.lastIndexOfs(${expected[idx]}) should match idx`);
   }
 });
 
@@ -36,8 +33,7 @@ suite.test('should return index of object\'s last occurrence even startAt search
   var idx;
 
   for (idx = 0;idx < len;idx++) {
-    equal(obj.lastIndexOf(expected[idx], len + 1), idx,
-      fmt('obj.lastIndexOf(%@) should match idx', [expected[idx]]));
+    equal(obj.lastIndexOf(expected[idx], len + 1), idx, `obj.lastIndexOf(${expected[idx]}) should match idx`);
   }
 });
 

--- a/packages/ember-runtime/tests/suites/array/objectAt.js
+++ b/packages/ember-runtime/tests/suites/array/objectAt.js
@@ -1,5 +1,4 @@
 import {SuiteModuleBuilder} from 'ember-runtime/tests/suites/suite';
-import {fmt} from 'ember-runtime/system/string';
 
 var suite = SuiteModuleBuilder.create();
 
@@ -12,7 +11,7 @@ suite.test('should return object at specified index', function() {
   var idx;
 
   for (idx = 0;idx < len;idx++) {
-    equal(obj.objectAt(idx), expected[idx], fmt('obj.objectAt(%@) should match', [idx]));
+    equal(obj.objectAt(idx), expected[idx], `obj.objectAt(${idx}) should match`);
   }
 });
 

--- a/packages/ember-views/lib/streams/utils.js
+++ b/packages/ember-views/lib/streams/utils.js
@@ -1,6 +1,5 @@
 import Ember from 'ember-metal/core';
 import { get } from 'ember-metal/property_get';
-import { fmt } from 'ember-runtime/system/string';
 import { read, isStream } from 'ember-metal/streams/utils';
 import ControllerMixin from 'ember-runtime/mixins/controller';
 
@@ -15,7 +14,7 @@ export function readViewFactory(object, container) {
     viewClass = value;
   }
 
-  Ember.assert(fmt(value + ' must be a subclass or an instance of Ember.View, not %@', [viewClass]), (function(viewClass) {
+  Ember.assert(`${value} must be a subclass or an instance of Ember.View, not ${viewClass}`, (function(viewClass) {
     return viewClass && (viewClass.isViewFactory || viewClass.isView || viewClass.isComponentFactory || viewClass.isComponent);
   })(viewClass));
 

--- a/packages/ember-views/lib/system/event_dispatcher.js
+++ b/packages/ember-views/lib/system/event_dispatcher.js
@@ -8,7 +8,6 @@ import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
 import isNone from 'ember-metal/is_none';
 import run from 'ember-metal/run_loop';
-import { fmt } from 'ember-runtime/system/string';
 import EmberObject from 'ember-runtime/system/object';
 import jQuery from 'ember-views/system/jquery';
 import ActionManager from 'ember-views/system/action_manager';
@@ -140,7 +139,7 @@ export default EmberObject.extend({
 
     rootElement = jQuery(get(this, 'rootElement'));
 
-    Ember.assert(fmt('You cannot use the same root element (%@) multiple times in an Ember.Application', [rootElement.selector || rootElement[0].tagName]), !rootElement.is('.ember-application'));
+    Ember.assert(`You cannot use the same root element (${rootElement.selector || rootElement[0].tagName}) multiple times in an Ember.Application`, !rootElement.is('.ember-application'));
     Ember.assert('You cannot make a new Ember.Application using a root element that is a descendent of an existing Ember.Application', !rootElement.closest('.ember-application').length);
     Ember.assert('You cannot make a new Ember.Application using a root element that is an ancestor of an existing Ember.Application', !rootElement.find('.ember-application').length);
 

--- a/packages/ember-views/lib/views/collection_view.js
+++ b/packages/ember-views/lib/views/collection_view.js
@@ -9,7 +9,6 @@ import View from 'ember-views/views/view';
 import EmberArray from 'ember-runtime/mixins/array';
 import { get } from 'ember-metal/property_get';
 import { set } from 'ember-metal/property_set';
-import { fmt } from 'ember-runtime/system/string';
 import { computed } from 'ember-metal/computed';
 import {
   observer,
@@ -258,7 +257,7 @@ var CollectionView = ContainerView.extend(EmptyViewSupport, {
     @method _assertArrayLike
   */
   _assertArrayLike(content) {
-    Ember.assert(fmt('an Ember.CollectionView\'s content must implement Ember.Array. You passed %@', [content]), EmberArray.detect(content));
+    Ember.assert(`an Ember.CollectionView's content must implement Ember.Array. You passed ${content}`, EmberArray.detect(content));
   },
 
   /**

--- a/packages/ember-views/lib/views/states/destroying.js
+++ b/packages/ember-views/lib/views/states/destroying.js
@@ -1,5 +1,4 @@
 import merge from 'ember-metal/merge';
-import {fmt} from 'ember-runtime/system/string';
 import _default from 'ember-views/views/states/default';
 import EmberError from 'ember-metal/error';
 /**
@@ -7,19 +6,17 @@ import EmberError from 'ember-metal/error';
 @submodule ember-views
 */
 
-var destroyingError = 'You can\'t call %@ on a view being destroyed';
-
 var destroying = Object.create(_default);
 
 merge(destroying, {
   appendChild() {
-    throw new EmberError(fmt(destroyingError, ['appendChild']));
+    throw new EmberError('You can\'t call appendChild on a view being destroyed');
   },
   rerender() {
-    throw new EmberError(fmt(destroyingError, ['rerender']));
+    throw new EmberError('You can\'t call rerender on a view being destroyed');
   },
   destroyElement() {
-    throw new EmberError(fmt(destroyingError, ['destroyElement']));
+    throw new EmberError('You can\'t call destroyElement on a view being destroyed');
   }
 });
 

--- a/packages/ember-views/tests/views/collection_test.js
+++ b/packages/ember-views/tests/views/collection_test.js
@@ -2,7 +2,6 @@ import Ember from 'ember-metal/core'; // Ember.A
 import { set } from 'ember-metal/property_set';
 import run from 'ember-metal/run_loop';
 import { Mixin } from 'ember-metal/mixin';
-import { fmt } from 'ember-runtime/system/string';
 import jQuery from 'ember-views/system/jquery';
 import CollectionView, { DeprecatedCollectionView } from 'ember-views/views/collection_view';
 import View from 'ember-views/views/view';
@@ -181,7 +180,7 @@ QUnit.test('should remove an item from DOM when an item is removed from the cont
   run(() => content.removeAt(1));
 
   content.forEach((item, idx) => {
-    equal(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text(), item);
+    equal(view.$(`:nth-child(${idx + 1})`).text(), item);
   });
 });
 
@@ -209,7 +208,7 @@ QUnit.test('it updates the view if an item is replaced', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(`:nth-child(${idx + 1})`).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -236,7 +235,7 @@ QUnit.test('can add and replace in the same runloop', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(`:nth-child(${idx + 1})`).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -263,7 +262,7 @@ QUnit.test('can add and replace the object before the add in the same runloop', 
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(`:nth-child(${idx + 1})`).text()), item, 'postcond - correct array update');
   });
 });
 
@@ -292,7 +291,7 @@ QUnit.test('can add and replace complicatedly', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update: ' + item.name + '!=' + view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text());
+    equal(trim(view.$(`:nth-child(${idx + 1})`).text()), item, 'postcond - correct array update: ' + item.name + '!=' + view.$(`:nth-child(${idx + 1})`).text());
   });
 });
 
@@ -324,7 +323,7 @@ QUnit.test('can add and replace complicatedly harder', function() {
   });
 
   content.forEach((item, idx) => {
-    equal(trim(view.$(fmt(':nth-child(%@)', [String(idx + 1)])).text()), item, 'postcond - correct array update');
+    equal(trim(view.$(`:nth-child(${idx + 1})`).text()), item, 'postcond - correct array update');
   });
 });
 


### PR DESCRIPTION
Resurrection of #10861

Basically the rebase was so complex that was faster to just do it again.

I've removed all internal usages of `fmt` and documented it as `@deprecated`, but I haven't added any real deprecation because I wasn't sure if that was the desired thing. 
If you feel that we're are in time for removing this, I'll update this same PR with the deprecation warning and create another one removing the feature for good.
