### PR TITLE
[DOC release] Mark some LinkComponent properties public

### DIFF
--- a/packages/ember-routing-views/lib/views/link.js
+++ b/packages/ember-routing-views/lib/views/link.js
@@ -54,7 +54,7 @@ var LinkComponent = EmberComponent.extend({
     Used to determine when this LinkComponent is active.
 
     @property currentWhen
-    @private
+    @public
   */
   'current-when': null,
 
@@ -63,7 +63,7 @@ var LinkComponent = EmberComponent.extend({
 
     @property title
     @default null
-    @private
+    @public
   **/
   title: null,
 
@@ -72,7 +72,7 @@ var LinkComponent = EmberComponent.extend({
 
     @property rel
     @default null
-    @private
+    @public
   **/
   rel: null,
 
@@ -81,7 +81,7 @@ var LinkComponent = EmberComponent.extend({
 
     @property tabindex
     @default null
-    @private
+    @public
   **/
   tabindex: null,
 
@@ -91,7 +91,7 @@ var LinkComponent = EmberComponent.extend({
     @since 1.8.0
     @property target
     @default null
-    @private
+    @public
   **/
   target: null,
 
@@ -136,7 +136,7 @@ var LinkComponent = EmberComponent.extend({
     @property replace
     @type Boolean
     @default false
-    @private
+    @public
   **/
   replace: false,
 
@@ -148,7 +148,7 @@ var LinkComponent = EmberComponent.extend({
     @property attributeBindings
     @type Array | String
     @default ['title', 'rel', 'tabindex', 'target']
-     @private
+    @public
   */
   attributeBindings: ['href', 'title', 'rel', 'tabindex', 'target'],
 
@@ -159,7 +159,7 @@ var LinkComponent = EmberComponent.extend({
     @property classNameBindings
     @type Array
     @default ['active', 'loading', 'disabled']
-     @private
+    @public
   */
   classNameBindings: linkComponentClassNameBindings,
 


### PR DESCRIPTION
Following #11793, I went to make `current-when` public and I've realized that there were more private properties that should be (according to the documentation and examples) public.

I was not sure about `activeClass`, `disabledClass` and `loadingClass` so those are still private.
