### PR TITLE
[BUGFIX beta] Update htmlbars to v0.14.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "finalhandler": "^0.4.0",
     "github": "^0.2.3",
     "glob": "~4.3.2",
-    "htmlbars": "0.13.34",
+    "htmlbars": "0.14.2",
     "qunit-extras": "^1.3.0",
     "qunitjs": "^1.16.0",
     "route-recognizer": "0.1.5",

--- a/packages/ember-htmlbars/tests/helpers/each_test.js
+++ b/packages/ember-htmlbars/tests/helpers/each_test.js
@@ -751,6 +751,29 @@ QUnit.test('pushing a new duplicate key will render properly with primitive item
   equal(view.$().text(), 'abca');
 });
 
+QUnit.test('pushing primitive item twice will render properly', function() {
+  runDestroy(view);
+  view = EmberView.create({
+    items: A(),
+    template: compile('{{#each view.items as |item|}}{{item}}{{/each}}')
+  });
+
+  runAppend(view);
+
+  run(function() {
+    view.get('items').pushObject('a');
+  });
+
+  equal(view.$().text(), 'a');
+
+  run(function() {
+    view.get('items').pushObject('a');
+  });
+
+  equal(view.$().text(), 'aa');
+});
+
+
 QUnit.test('duplicate keys work properly with objects', function() {
   runDestroy(view);
   let duplicateItem = { display: 'foo' };


### PR DESCRIPTION
Fixes #11949.

---

This fix will also be pulled into a 0.13.x branch of HTMLBars for the release channel (for 1.13.7) of Ember.
