### PR TITLE
[DOC release] Fix JSDoc for `Ember.K`

### DIFF
--- a/packages/ember-metal/lib/core.js
+++ b/packages/ember-metal/lib/core.js
@@ -153,7 +153,6 @@ Ember.LOG_VERSION = (Ember.ENV.LOG_VERSION === false) ? false : true;
   An empty function useful for some operations. Always returns `this`.
 
   @method K
-  @private
   @return {Object}
   @public
 */


### PR DESCRIPTION
`Ember.K` should be a public method in favor of 6e1ad907.
