### PR TITLE
[DOC release] Mark `Ember.merge` as public

### DIFF
--- a/packages/ember-metal/lib/merge.js
+++ b/packages/ember-metal/lib/merge.js
@@ -13,7 +13,7 @@
   @param {Object} original The object to merge into
   @param {Object} updates The object to copy properties from
   @return {Object}
-  @private
+  @public
 */
 export default function merge(original, updates) {
   if (!updates || typeof updates !== 'object') {


### PR DESCRIPTION
There are no alternative way to `Ember.merge` in Ember world.
But it is useful and widely used from other library.

For example:
- Ember Data: https://github.com/emberjs/data/blob/v1.13.7/packages/ember-data/lib/core.js#L29
- Liquid Fire: https://github.com/ef4/liquid-fire/blob/v0.21.0/app/transitions/scroll-then.js#L19

So this method may be public until `Object.assign` can be used natively.
