### PR TITLE
[CLEANUP beta] remove unused _rerender function

### DIFF
--- a/packages/ember-views/lib/views/view.js
+++ b/packages/ember-views/lib/views/view.js
@@ -862,19 +862,6 @@ var View = CoreView.extend(
     return this.currentState.rerender(this);
   },
 
-  /*
-   * @private
-   *
-   * @method _rerender
-   */
-  _rerender() {
-    if (this.isDestroying || this.isDestroyed) {
-      return;
-    }
-
-    this._renderer.renderTree(this, this.parentView);
-  },
-
   /**
     Given a property name, returns a dasherized version of that
     property name if the property evaluates to a non-falsy value.


### PR DESCRIPTION
View._rerender is private and has not been called in the codebase since 1.12.1
